### PR TITLE
Define metadata for the rest of the TLS CipherSuites.

### DIFF
--- a/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Ssl.cs
+++ b/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Ssl.cs
@@ -64,7 +64,8 @@ internal static partial class Interop
 
             SSL_RSA_EXPORT_WITH_RC2_CBC_40_MD5 = 0x0006,
 
-            SSL_RSA_WITH_IDEA_CBC_SHA = 0x0007,
+            //Windows has no value for IDEA, so .NET Framework didn't get one.
+            //SSL_RSA_WITH_IDEA_CBC_SHA = 0x0007,
 
             SSL_RSA_EXPORT_WITH_DES40_CBC_SHA = 0x0008,
 
@@ -113,9 +114,11 @@ internal static partial class Interop
             TLS_DH_anon_WITH_3DES_EDE_CBC_SHA = 0x001B,
             SSL_DH_anon_WITH_3DES_EDE_CBC_SHA = 0x001B,
 
-            SSL_FORTEZZA_DMS_WITH_NULL_SHA = 0x001C,
+            // Windows doesn't support FORTEZZA_DMS, so unclear what value to use.
+            //SSL_FORTEZZA_DMS_WITH_NULL_SHA = 0x001C,
 
-            SSL_FORTEZZA_DMS_WITH_FORTEZZA_CBC_SHA = 0x001D,
+            // Windows doesn't support FORTEZZA_DMS, so unclear what value to use.
+            //SSL_FORTEZZA_DMS_WITH_FORTEZZA_CBC_SHA = 0x001D,
 
             TLS_PSK_WITH_NULL_SHA = 0x002C,
 
@@ -257,7 +260,8 @@ internal static partial class Interop
 
             TLS_RSA_PSK_WITH_NULL_SHA384 = 0x00B9,
 
-            TLS_EMPTY_RENEGOTIATION_INFO_SCSV = 0x00FF,
+            // Not a real CipherSuite
+            //TLS_EMPTY_RENEGOTIATION_INFO_SCSV = 0x00FF,
 
             TLS_ECDH_ECDSA_WITH_NULL_SHA = 0xC001,
 
@@ -330,16 +334,6 @@ internal static partial class Interop
             TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256 = 0xC031,
 
             TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384 = 0xC032,
-
-            SSL_RSA_WITH_RC2_CBC_MD5 = 0xFF80,
-
-            SSL_RSA_WITH_IDEA_CBC_MD5 = 0xFF81,
-
-            SSL_RSA_WITH_DES_CBC_MD5 = 0xFF82,
-
-            SSL_RSA_WITH_3DES_EDE_CBC_MD5 = 0xFF83,
-
-            SSL_NO_SUCH_CIPHERSUITE = 0xFFFF
         }
 
         [DllImport(Interop.Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_SslCreateContext")]

--- a/src/System.Net.Security/src/System/Net/Security/SslConnectionInfo.OSX.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslConnectionInfo.OSX.cs
@@ -29,19 +29,12 @@ namespace System.Net.Security
                 s_tlsLookup.Count == LookupMapCount,
                 $"Lookup dictionary was of size {s_tlsLookup.Count} instead of {LookupMapCount}");
 
-#if DEBUG_VERBOSE
-            // Check every value to see that it's present.
-            // Since TlsCipherSuite defines both SSL_ and TLS_ versions of the same values
-            // the returned array is longer than the dictionary, so only true walk can identify it.
-            //
-            // But this is a fairly high cost if the enum isn't changing.
             Array enumValues = Enum.GetValues(typeof(TlsCipherSuite));
 
             foreach (TlsCipherSuite val in enumValues)
             {
                 Debug.Assert(s_tlsLookup.ContainsKey(val), $"No mapping found for {val} ({(int)val})");
             }
-#endif
         }
 #endif
 
@@ -91,65 +84,41 @@ namespace System.Net.Security
             internal HashAlgorithmType HashAlgorithm;
             internal int HashAlgorithmStrength;
 
-            public static TlsMapping DhEphem(CipherAlgorithmType cipher, HashAlgorithmType hash)
-            {
-                return Build(ExchangeAlgorithmType.DiffieHellman, cipher, GetCipherSize(cipher), hash);
-            }
+            internal static TlsMapping DhEphem(CipherAlgorithmType cipher, HashAlgorithmType hash) =>
+                Build(ExchangeAlgorithmType.DiffieHellman, cipher, GetCipherSize(cipher), hash);
 
-            public static TlsMapping DhEphem(CipherAlgorithmType cipher, int cipherSize, HashAlgorithmType hash)
-            {
-                return Build(ExchangeAlgorithmType.DiffieHellman, cipher, cipherSize, hash);
-            }
+            internal static TlsMapping DhEphem(CipherAlgorithmType cipher, int cipherSize, HashAlgorithmType hash) =>
+                Build(ExchangeAlgorithmType.DiffieHellman, cipher, cipherSize, hash);
 
-            public static TlsMapping DhStatic(CipherAlgorithmType cipher, HashAlgorithmType hash)
-            {
-                return Build(DiffieHellmanStatic, cipher, GetCipherSize(cipher), hash);
-            }
+            internal static TlsMapping DhStatic(CipherAlgorithmType cipher, HashAlgorithmType hash) =>
+                Build(DiffieHellmanStatic, cipher, GetCipherSize(cipher), hash);
 
-            public static TlsMapping DhStatic(CipherAlgorithmType cipher, int cipherSize, HashAlgorithmType hash)
-            {
-                return Build(DiffieHellmanStatic, cipher, cipherSize, hash);
-            }
+            internal static TlsMapping DhStatic(CipherAlgorithmType cipher, int cipherSize, HashAlgorithmType hash) =>
+                Build(DiffieHellmanStatic, cipher, cipherSize, hash);
 
-            internal static TlsMapping EcDhEphem(CipherAlgorithmType cipher, HashAlgorithmType hash)
-            {
-                return Build(EcDheAlgorithm, cipher, GetCipherSize(cipher), hash);
-            }
+            internal static TlsMapping EcDhEphem(CipherAlgorithmType cipher, HashAlgorithmType hash) =>
+                Build(EcDheAlgorithm, cipher, GetCipherSize(cipher), hash);
 
-            internal static TlsMapping EcDhEphem(CipherAlgorithmType cipher, int cipherSize, HashAlgorithmType hash)
-            {
-                return Build(EcDheAlgorithm, cipher, cipherSize, hash);
-            }
+            internal static TlsMapping EcDhEphem(CipherAlgorithmType cipher, int cipherSize, HashAlgorithmType hash) =>
+                Build(EcDheAlgorithm, cipher, cipherSize, hash);
 
-            public static TlsMapping EcDhStatic(CipherAlgorithmType cipher, HashAlgorithmType hash)
-            {
-                return Build(EcDhAlgorithm, cipher, GetCipherSize(cipher), hash);
-            }
+            internal static TlsMapping EcDhStatic(CipherAlgorithmType cipher, HashAlgorithmType hash) =>
+                Build(EcDhAlgorithm, cipher, GetCipherSize(cipher), hash);
 
-            public static TlsMapping EcDhStatic(CipherAlgorithmType cipher, int cipherSize, HashAlgorithmType hash)
-            {
-                return Build(EcDhAlgorithm, cipher, cipherSize, hash);
-            }
+            internal static TlsMapping EcDhStatic(CipherAlgorithmType cipher, int cipherSize, HashAlgorithmType hash) =>
+                Build(EcDhAlgorithm, cipher, cipherSize, hash);
 
-            public static TlsMapping NoExchange(CipherAlgorithmType cipher, HashAlgorithmType hash)
-            {
-                return Build(ExchangeAlgorithmType.None, cipher, GetCipherSize(cipher), hash);
-            }
+            internal static TlsMapping NoExchange(CipherAlgorithmType cipher, HashAlgorithmType hash) =>
+                Build(ExchangeAlgorithmType.None, cipher, GetCipherSize(cipher), hash);
 
-            public static TlsMapping NoExchange(CipherAlgorithmType cipher, int cipherSize, HashAlgorithmType hash)
-            {
-                return Build(ExchangeAlgorithmType.None, cipher, cipherSize, hash);
-            }
+            internal static TlsMapping NoExchange(CipherAlgorithmType cipher, int cipherSize, HashAlgorithmType hash) =>
+                Build(ExchangeAlgorithmType.None, cipher, cipherSize, hash);
 
-            public static TlsMapping Rsa(CipherAlgorithmType cipher, HashAlgorithmType hash)
-            {
-                return Build(ExchangeAlgorithmType.RsaKeyX, cipher, GetCipherSize(cipher), hash);
-            }
+            internal static TlsMapping Rsa(CipherAlgorithmType cipher, HashAlgorithmType hash) =>
+                Build(ExchangeAlgorithmType.RsaKeyX, cipher, GetCipherSize(cipher), hash);
 
-            public static TlsMapping Rsa(CipherAlgorithmType cipher, int cipherSize, HashAlgorithmType hash)
-            {
-                return Build(ExchangeAlgorithmType.RsaKeyX, cipher, cipherSize, hash);
-            }
+            internal static TlsMapping Rsa(CipherAlgorithmType cipher, int cipherSize, HashAlgorithmType hash) =>
+                Build(ExchangeAlgorithmType.RsaKeyX, cipher, cipherSize, hash);
 
             private static TlsMapping Build(
                 ExchangeAlgorithmType exchange,

--- a/src/System.Net.Security/src/System/Net/Security/SslConnectionInfo.OSX.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslConnectionInfo.OSX.cs
@@ -12,7 +12,38 @@ namespace System.Net.Security
 {
     internal partial class SslConnectionInfo
     {
-        private const ExchangeAlgorithmType EcDheAlgorithm = (ExchangeAlgorithmType)44550;
+        private const int LookupMapCount = 133;
+
+        // https://msdn.microsoft.com/en-us/library/windows/desktop/aa375549(v=vs.85).aspx
+        // CALG_DH_SF
+        private const ExchangeAlgorithmType DiffieHellmanStatic = (ExchangeAlgorithmType)0xAA01;
+        // CALG_ECDH
+        private const ExchangeAlgorithmType EcDhAlgorithm = (ExchangeAlgorithmType)0xAA05;
+        // CALG_ECDH_EPHEM
+        private const ExchangeAlgorithmType EcDheAlgorithm = (ExchangeAlgorithmType)0xAA06;
+
+#if DEBUG
+        static SslConnectionInfo()
+        {
+            Debug.Assert(
+                s_tlsLookup.Count == LookupMapCount,
+                $"Lookup dictionary was of size {s_tlsLookup.Count} instead of {LookupMapCount}");
+
+#if DEBUG_VERBOSE
+            // Check every value to see that it's present.
+            // Since TlsCipherSuite defines both SSL_ and TLS_ versions of the same values
+            // the returned array is longer than the dictionary, so only true walk can identify it.
+            //
+            // But this is a fairly high cost if the enum isn't changing.
+            Array enumValues = Enum.GetValues(typeof(TlsCipherSuite));
+
+            foreach (TlsCipherSuite val in enumValues)
+            {
+                Debug.Assert(s_tlsLookup.ContainsKey(val), $"No mapping found for {val} ({(int)val})");
+            }
+#endif
+        }
+#endif
 
         public SslConnectionInfo(SafeSslHandle sslContext)
         {
@@ -60,56 +91,134 @@ namespace System.Net.Security
             internal HashAlgorithmType HashAlgorithm;
             internal int HashAlgorithmStrength;
 
-            internal static TlsMapping EcDhe(CipherAlgorithmType cipher, HashAlgorithmType hash)
+            public static TlsMapping DhEphem(CipherAlgorithmType cipher, HashAlgorithmType hash)
             {
-                int cipherSize;
-                int hashSize;
+                return Build(ExchangeAlgorithmType.DiffieHellman, cipher, GetCipherSize(cipher), hash);
+            }
 
-                switch (cipher)
-                {
-                    case CipherAlgorithmType.Aes128:
-                        cipherSize = 128;
-                        break;
-                    case CipherAlgorithmType.Aes192:
-                        cipherSize = 192;
-                        break;
-                    case CipherAlgorithmType.Aes256:
-                        cipherSize = 256;
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(cipher));
-                }
+            public static TlsMapping DhEphem(CipherAlgorithmType cipher, int cipherSize, HashAlgorithmType hash)
+            {
+                return Build(ExchangeAlgorithmType.DiffieHellman, cipher, cipherSize, hash);
+            }
 
-                switch (hash)
-                {
-                    case HashAlgorithmType.Sha1:
-                        hashSize = 160;
-                        break;
-                    case HashAlgorithmType.Sha256:
-                        hashSize = 256;
-                        break;
-                    case HashAlgorithmType.Sha384:
-                        hashSize = 384;
-                        break;
-                    case HashAlgorithmType.Sha512:
-                        hashSize = 512;
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(hash));
-                }
+            public static TlsMapping DhStatic(CipherAlgorithmType cipher, HashAlgorithmType hash)
+            {
+                return Build(DiffieHellmanStatic, cipher, GetCipherSize(cipher), hash);
+            }
+
+            public static TlsMapping DhStatic(CipherAlgorithmType cipher, int cipherSize, HashAlgorithmType hash)
+            {
+                return Build(DiffieHellmanStatic, cipher, cipherSize, hash);
+            }
+
+            internal static TlsMapping EcDhEphem(CipherAlgorithmType cipher, HashAlgorithmType hash)
+            {
+                return Build(EcDheAlgorithm, cipher, GetCipherSize(cipher), hash);
+            }
+
+            internal static TlsMapping EcDhEphem(CipherAlgorithmType cipher, int cipherSize, HashAlgorithmType hash)
+            {
+                return Build(EcDheAlgorithm, cipher, cipherSize, hash);
+            }
+
+            public static TlsMapping EcDhStatic(CipherAlgorithmType cipher, HashAlgorithmType hash)
+            {
+                return Build(EcDhAlgorithm, cipher, GetCipherSize(cipher), hash);
+            }
+
+            public static TlsMapping EcDhStatic(CipherAlgorithmType cipher, int cipherSize, HashAlgorithmType hash)
+            {
+                return Build(EcDhAlgorithm, cipher, cipherSize, hash);
+            }
+
+            public static TlsMapping NoExchange(CipherAlgorithmType cipher, HashAlgorithmType hash)
+            {
+                return Build(ExchangeAlgorithmType.None, cipher, GetCipherSize(cipher), hash);
+            }
+
+            public static TlsMapping NoExchange(CipherAlgorithmType cipher, int cipherSize, HashAlgorithmType hash)
+            {
+                return Build(ExchangeAlgorithmType.None, cipher, cipherSize, hash);
+            }
+
+            public static TlsMapping Rsa(CipherAlgorithmType cipher, HashAlgorithmType hash)
+            {
+                return Build(ExchangeAlgorithmType.RsaKeyX, cipher, GetCipherSize(cipher), hash);
+            }
+
+            public static TlsMapping Rsa(CipherAlgorithmType cipher, int cipherSize, HashAlgorithmType hash)
+            {
+                return Build(ExchangeAlgorithmType.RsaKeyX, cipher, cipherSize, hash);
+            }
+
+            private static TlsMapping Build(
+                ExchangeAlgorithmType exchange,
+                CipherAlgorithmType cipher,
+                int cipherSize,
+                HashAlgorithmType hash)
+            {
+                int hashSize = GetHashSize(hash);
 
                 return new TlsMapping
                 {
-                    KeyExchangeAlgorithm = EcDheAlgorithm,
+                    KeyExchangeAlgorithm = exchange,
                     CipherAlgorithm = cipher,
                     CipherAlgorithmStrength = cipherSize,
                     HashAlgorithm = hash,
                     HashAlgorithmStrength = hashSize,
                 };
             }
+
+            private static int GetHashSize(HashAlgorithmType hash)
+            {
+                switch (hash)
+                {
+                    case HashAlgorithmType.Md5:
+                        return 128;
+                    case HashAlgorithmType.Sha1:
+                        return 160;
+                    case HashAlgorithmType.Sha256:
+                        return 256;
+                    case HashAlgorithmType.Sha384:
+                        return 384;
+                    case HashAlgorithmType.Sha512:
+                        return 512;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(hash));
+                }
+            }
+
+            private static int GetCipherSize(CipherAlgorithmType cipher)
+            {
+                switch (cipher)
+                {
+                    case CipherAlgorithmType.None:
+                    case CipherAlgorithmType.Null:
+                        return 0;
+                    case CipherAlgorithmType.Rc2:
+                        Debug.Fail($"RC2 should always include the keysize");
+                        return 0;
+                    case CipherAlgorithmType.Des:
+                        return 56;
+                    case CipherAlgorithmType.Rc4:
+                        Debug.Fail($"RC4 should always include the keysize");
+                        return 0;
+                    case CipherAlgorithmType.TripleDes:
+                        return 168;
+                    case CipherAlgorithmType.Aes128:
+                        return 128;
+                    case CipherAlgorithmType.Aes192:
+                        return 192;
+                    case CipherAlgorithmType.Aes256:
+                        return 256;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(cipher));
+                }
+            }
         }
 
-        private static readonly Dictionary<TlsCipherSuite, TlsMapping> s_tlsLookup = new Dictionary<TlsCipherSuite, TlsMapping>
+        private static readonly Dictionary<TlsCipherSuite, TlsMapping> s_tlsLookup =
+            new Dictionary<TlsCipherSuite, TlsMapping>(LookupMapCount)
         {
             {
                 TlsCipherSuite.TLS_NULL_WITH_NULL_NULL,
@@ -117,28 +226,662 @@ namespace System.Net.Security
             },
 
             {
+                TlsCipherSuite.TLS_RSA_WITH_NULL_MD5,
+                TlsMapping.Rsa(CipherAlgorithmType.None, HashAlgorithmType.Md5)
+            },
+
+            {
+                TlsCipherSuite.TLS_RSA_WITH_NULL_SHA,
+                TlsMapping.Rsa(CipherAlgorithmType.None, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.SSL_RSA_EXPORT_WITH_RC4_40_MD5,
+                TlsMapping.Rsa(CipherAlgorithmType.Rc4, 40, HashAlgorithmType.Md5)
+            },
+
+            {
+                TlsCipherSuite.TLS_RSA_WITH_RC4_128_MD5,
+                TlsMapping.Rsa(CipherAlgorithmType.Rc4, 128, HashAlgorithmType.Md5)
+            },
+
+            {
+                TlsCipherSuite.TLS_RSA_WITH_RC4_128_SHA,
+                TlsMapping.Rsa(CipherAlgorithmType.Rc4, 128, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.SSL_RSA_EXPORT_WITH_RC2_CBC_40_MD5,
+                TlsMapping.Rsa(CipherAlgorithmType.Rc2, 40, HashAlgorithmType.Md5)
+            },
+
+            {
+                TlsCipherSuite.SSL_RSA_EXPORT_WITH_DES40_CBC_SHA,
+                TlsMapping.Rsa(CipherAlgorithmType.Des, 40, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.SSL_RSA_WITH_DES_CBC_SHA,
+                TlsMapping.Rsa(CipherAlgorithmType.Des, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+                TlsMapping.Rsa(CipherAlgorithmType.TripleDes, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.SSL_DH_DSS_EXPORT_WITH_DES40_CBC_SHA,
+                TlsMapping.DhStatic(CipherAlgorithmType.Des, 40, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.SSL_DH_DSS_WITH_DES_CBC_SHA,
+                TlsMapping.DhStatic(CipherAlgorithmType.Des, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_DH_DSS_WITH_3DES_EDE_CBC_SHA,
+                TlsMapping.DhStatic(CipherAlgorithmType.TripleDes, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.SSL_DH_RSA_EXPORT_WITH_DES40_CBC_SHA,
+                TlsMapping.DhStatic(CipherAlgorithmType.Des, 40, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.SSL_DH_RSA_WITH_DES_CBC_SHA,
+                TlsMapping.DhStatic(CipherAlgorithmType.Des, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_DH_RSA_WITH_3DES_EDE_CBC_SHA,
+                TlsMapping.DhStatic(CipherAlgorithmType.TripleDes, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.SSL_DHE_DSS_EXPORT_WITH_DES40_CBC_SHA,
+                TlsMapping.DhEphem(CipherAlgorithmType.Des, 40, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.SSL_DHE_DSS_WITH_DES_CBC_SHA,
+                TlsMapping.DhEphem(CipherAlgorithmType.Des, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA,
+                TlsMapping.DhEphem(CipherAlgorithmType.TripleDes, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.SSL_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA,
+                TlsMapping.DhEphem(CipherAlgorithmType.Des, 40, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.SSL_DHE_RSA_WITH_DES_CBC_SHA,
+                TlsMapping.DhEphem(CipherAlgorithmType.Des, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA,
+                TlsMapping.DhEphem(CipherAlgorithmType.TripleDes, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.SSL_DH_anon_EXPORT_WITH_RC4_40_MD5,
+                TlsMapping.DhStatic(CipherAlgorithmType.Rc4, 40, HashAlgorithmType.Md5)
+            },
+
+            {
+                TlsCipherSuite.TLS_DH_anon_WITH_RC4_128_MD5,
+                TlsMapping.DhStatic(CipherAlgorithmType.Rc4, 128, HashAlgorithmType.Md5)
+            },
+
+            {
+                TlsCipherSuite.SSL_DH_anon_EXPORT_WITH_DES40_CBC_SHA,
+                TlsMapping.DhStatic(CipherAlgorithmType.Des, 40, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.SSL_DH_anon_WITH_DES_CBC_SHA,
+                TlsMapping.DhStatic(CipherAlgorithmType.Des, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_DH_anon_WITH_3DES_EDE_CBC_SHA,
+                TlsMapping.DhStatic(CipherAlgorithmType.TripleDes, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_PSK_WITH_NULL_SHA,
+                TlsMapping.NoExchange(CipherAlgorithmType.None, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_DHE_PSK_WITH_NULL_SHA,
+                TlsMapping.DhEphem(CipherAlgorithmType.None, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_RSA_PSK_WITH_NULL_SHA,
+                TlsMapping.Rsa(CipherAlgorithmType.None, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
+                TlsMapping.Rsa(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_DH_DSS_WITH_AES_128_CBC_SHA,
+                TlsMapping.DhStatic(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_DH_RSA_WITH_AES_128_CBC_SHA,
+                TlsMapping.DhStatic(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_DHE_DSS_WITH_AES_128_CBC_SHA,
+                TlsMapping.DhEphem(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
+                TlsMapping.DhEphem(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_DH_anon_WITH_AES_128_CBC_SHA,
+                TlsMapping.DhStatic(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_RSA_WITH_AES_256_CBC_SHA,
+                TlsMapping.Rsa(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_DH_DSS_WITH_AES_256_CBC_SHA,
+                TlsMapping.DhStatic(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_DH_RSA_WITH_AES_256_CBC_SHA,
+                TlsMapping.DhStatic(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_DHE_DSS_WITH_AES_256_CBC_SHA,
+                TlsMapping.DhEphem(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_DHE_RSA_WITH_AES_256_CBC_SHA,
+                TlsMapping.DhEphem(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_DH_anon_WITH_AES_256_CBC_SHA,
+                TlsMapping.DhStatic(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_RSA_WITH_NULL_SHA256,
+                TlsMapping.Rsa(CipherAlgorithmType.None, HashAlgorithmType.Sha256)
+            },
+
+            {
+                TlsCipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA256,
+                TlsMapping.Rsa(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha256)
+            },
+
+            {
+                TlsCipherSuite.TLS_RSA_WITH_AES_256_CBC_SHA256,
+                TlsMapping.Rsa(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha256)
+            },
+
+            {
+                TlsCipherSuite.TLS_DH_DSS_WITH_AES_128_CBC_SHA256,
+                TlsMapping.DhStatic(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha256)
+            },
+
+            {
+                TlsCipherSuite.TLS_DH_RSA_WITH_AES_128_CBC_SHA256,
+                TlsMapping.DhStatic(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha256)
+            },
+
+            {
+                TlsCipherSuite.TLS_DHE_DSS_WITH_AES_128_CBC_SHA256,
+                TlsMapping.DhEphem(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha256)
+            },
+
+            {
+                TlsCipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,
+                TlsMapping.DhEphem(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha256)
+            },
+
+            {
+                TlsCipherSuite.TLS_DH_DSS_WITH_AES_256_CBC_SHA256,
+                TlsMapping.DhStatic(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha256)
+            },
+
+            {
+                TlsCipherSuite.TLS_DH_RSA_WITH_AES_256_CBC_SHA256,
+                TlsMapping.DhStatic(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha256)
+            },
+
+            {
+                TlsCipherSuite.TLS_DHE_DSS_WITH_AES_256_CBC_SHA256,
+                TlsMapping.DhEphem(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha256)
+            },
+
+            {
+                TlsCipherSuite.TLS_DHE_RSA_WITH_AES_256_CBC_SHA256,
+                TlsMapping.DhEphem(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha256)
+            },
+
+            {
+                TlsCipherSuite.TLS_DH_anon_WITH_AES_128_CBC_SHA256,
+                TlsMapping.DhStatic(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha256)
+            },
+
+            {
+                TlsCipherSuite.TLS_DH_anon_WITH_AES_256_CBC_SHA256,
+                TlsMapping.DhStatic(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha256)
+            },
+
+            {
+                TlsCipherSuite.TLS_PSK_WITH_RC4_128_SHA,
+                TlsMapping.NoExchange(CipherAlgorithmType.Rc4, 128, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_PSK_WITH_3DES_EDE_CBC_SHA,
+                TlsMapping.NoExchange(CipherAlgorithmType.TripleDes, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_PSK_WITH_AES_128_CBC_SHA,
+                TlsMapping.NoExchange(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_PSK_WITH_AES_256_CBC_SHA,
+                TlsMapping.NoExchange(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_DHE_PSK_WITH_RC4_128_SHA,
+                TlsMapping.DhEphem(CipherAlgorithmType.Rc4, 128, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_DHE_PSK_WITH_3DES_EDE_CBC_SHA,
+                TlsMapping.DhEphem(CipherAlgorithmType.TripleDes, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_DHE_PSK_WITH_AES_128_CBC_SHA,
+                TlsMapping.DhEphem(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_DHE_PSK_WITH_AES_256_CBC_SHA,
+                TlsMapping.DhEphem(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_RSA_PSK_WITH_RC4_128_SHA,
+                TlsMapping.Rsa(CipherAlgorithmType.Rc4, 128, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_RSA_PSK_WITH_3DES_EDE_CBC_SHA,
+                TlsMapping.Rsa(CipherAlgorithmType.TripleDes, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_RSA_PSK_WITH_AES_128_CBC_SHA,
+                TlsMapping.Rsa(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_RSA_PSK_WITH_AES_256_CBC_SHA,
+                TlsMapping.Rsa(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_RSA_WITH_AES_128_GCM_SHA256,
+                TlsMapping.Rsa(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha256)
+            },
+
+            {
+                TlsCipherSuite.TLS_RSA_WITH_AES_256_GCM_SHA384,
+                TlsMapping.Rsa(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha384)
+            },
+
+            {
+                TlsCipherSuite.TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,
+                TlsMapping.DhEphem(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha256)
+            },
+
+            {
+                TlsCipherSuite.TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,
+                TlsMapping.DhEphem(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha384)
+            },
+
+            {
+                TlsCipherSuite.TLS_DH_RSA_WITH_AES_128_GCM_SHA256,
+                TlsMapping.DhStatic(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha256)
+            },
+
+            {
+                TlsCipherSuite.TLS_DH_RSA_WITH_AES_256_GCM_SHA384,
+                TlsMapping.DhStatic(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha384)
+            },
+
+            {
+                TlsCipherSuite.TLS_DHE_DSS_WITH_AES_128_GCM_SHA256,
+                TlsMapping.DhEphem(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha256)
+            },
+
+            {
+                TlsCipherSuite.TLS_DHE_DSS_WITH_AES_256_GCM_SHA384,
+                TlsMapping.DhEphem(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha384)
+            },
+
+            {
+                TlsCipherSuite.TLS_DH_DSS_WITH_AES_128_GCM_SHA256,
+                TlsMapping.DhStatic(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha256)
+            },
+
+            {
+                TlsCipherSuite.TLS_DH_DSS_WITH_AES_256_GCM_SHA384,
+                TlsMapping.DhStatic(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha384)
+            },
+
+            {
+                TlsCipherSuite.TLS_DH_anon_WITH_AES_128_GCM_SHA256,
+                TlsMapping.DhStatic(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha256)
+            },
+
+            {
+                TlsCipherSuite.TLS_DH_anon_WITH_AES_256_GCM_SHA384,
+                TlsMapping.DhStatic(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha384)
+            },
+
+            {
+                TlsCipherSuite.TLS_PSK_WITH_AES_128_GCM_SHA256,
+                TlsMapping.NoExchange(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha256)
+            },
+
+            {
+                TlsCipherSuite.TLS_PSK_WITH_AES_256_GCM_SHA384,
+                TlsMapping.NoExchange(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha384)
+            },
+
+            {
+                TlsCipherSuite.TLS_DHE_PSK_WITH_AES_128_GCM_SHA256,
+                TlsMapping.DhEphem(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha256)
+            },
+
+            {
+                TlsCipherSuite.TLS_DHE_PSK_WITH_AES_256_GCM_SHA384,
+                TlsMapping.DhEphem(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha384)
+            },
+
+            {
+                TlsCipherSuite.TLS_RSA_PSK_WITH_AES_128_GCM_SHA256,
+                TlsMapping.Rsa(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha256)
+            },
+
+            {
+                TlsCipherSuite.TLS_RSA_PSK_WITH_AES_256_GCM_SHA384,
+                TlsMapping.Rsa(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha384)
+            },
+
+            {
+                TlsCipherSuite.TLS_PSK_WITH_AES_128_CBC_SHA256,
+                TlsMapping.NoExchange(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha256)
+            },
+
+            {
+                TlsCipherSuite.TLS_PSK_WITH_AES_256_CBC_SHA384,
+                TlsMapping.NoExchange(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha384)
+            },
+
+            {
+                TlsCipherSuite.TLS_PSK_WITH_NULL_SHA256,
+                TlsMapping.NoExchange(CipherAlgorithmType.None, HashAlgorithmType.Sha256)
+            },
+
+            {
+                TlsCipherSuite.TLS_PSK_WITH_NULL_SHA384,
+                TlsMapping.NoExchange(CipherAlgorithmType.None, HashAlgorithmType.Sha384)
+            },
+
+            {
+                TlsCipherSuite.TLS_DHE_PSK_WITH_AES_128_CBC_SHA256,
+                TlsMapping.DhEphem(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha256)
+            },
+
+            {
+                TlsCipherSuite.TLS_DHE_PSK_WITH_AES_256_CBC_SHA384,
+                TlsMapping.DhEphem(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha384)
+            },
+
+            {
+                TlsCipherSuite.TLS_DHE_PSK_WITH_NULL_SHA256,
+                TlsMapping.DhEphem(CipherAlgorithmType.None, HashAlgorithmType.Sha256)
+            },
+
+            {
+                TlsCipherSuite.TLS_DHE_PSK_WITH_NULL_SHA384,
+                TlsMapping.DhEphem(CipherAlgorithmType.None, HashAlgorithmType.Sha384)
+            },
+
+            {
+                TlsCipherSuite.TLS_RSA_PSK_WITH_AES_128_CBC_SHA256,
+                TlsMapping.Rsa(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha256)
+            },
+
+            {
+                TlsCipherSuite.TLS_RSA_PSK_WITH_AES_256_CBC_SHA384,
+                TlsMapping.Rsa(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha384)
+            },
+
+            {
+                TlsCipherSuite.TLS_RSA_PSK_WITH_NULL_SHA256,
+                TlsMapping.Rsa(CipherAlgorithmType.None, HashAlgorithmType.Sha256)
+            },
+
+            {
+                TlsCipherSuite.TLS_RSA_PSK_WITH_NULL_SHA384,
+                TlsMapping.Rsa(CipherAlgorithmType.None, HashAlgorithmType.Sha384)
+            },
+
+            {
+                TlsCipherSuite.TLS_ECDH_ECDSA_WITH_NULL_SHA,
+                TlsMapping.EcDhStatic(CipherAlgorithmType.None, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_ECDH_ECDSA_WITH_RC4_128_SHA,
+                TlsMapping.EcDhStatic(CipherAlgorithmType.Rc4, 128, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA,
+                TlsMapping.EcDhStatic(CipherAlgorithmType.TripleDes, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA,
+                TlsMapping.EcDhStatic(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA,
+                TlsMapping.EcDhStatic(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_ECDHE_ECDSA_WITH_NULL_SHA,
+                TlsMapping.EcDhEphem(CipherAlgorithmType.None, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,
+                TlsMapping.EcDhEphem(CipherAlgorithmType.Rc4, 128, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA,
+                TlsMapping.EcDhEphem(CipherAlgorithmType.TripleDes, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+                TlsMapping.EcDhEphem(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha1)
+            },
+
+            {
                 TlsCipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
-                TlsMapping.EcDhe(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha1)
+                TlsMapping.EcDhEphem(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_ECDH_RSA_WITH_NULL_SHA,
+                TlsMapping.EcDhStatic(CipherAlgorithmType.None, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_ECDH_RSA_WITH_RC4_128_SHA,
+                TlsMapping.EcDhStatic(CipherAlgorithmType.Rc4, 128, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA,
+                TlsMapping.EcDhStatic(CipherAlgorithmType.TripleDes, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+                TlsMapping.EcDhEphem(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+                TlsMapping.EcDhEphem(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_ECDH_anon_WITH_NULL_SHA,
+                TlsMapping.EcDhStatic(CipherAlgorithmType.None, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_ECDH_anon_WITH_RC4_128_SHA,
+                TlsMapping.EcDhStatic(CipherAlgorithmType.Rc4, 128, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_ECDH_anon_WITH_3DES_EDE_CBC_SHA,
+                TlsMapping.EcDhStatic(CipherAlgorithmType.TripleDes, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_ECDH_anon_WITH_AES_128_CBC_SHA,
+                TlsMapping.EcDhStatic(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_ECDH_anon_WITH_AES_256_CBC_SHA,
+                TlsMapping.EcDhStatic(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha1)
+            },
+
+            {
+                TlsCipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+                TlsMapping.EcDhEphem(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha256)
+            },
+
+            {
+                TlsCipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,
+                TlsMapping.EcDhEphem(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha384)
+            },
+
+            {
+                TlsCipherSuite.TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256,
+                TlsMapping.EcDhStatic(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha256)
+            },
+
+            {
+                TlsCipherSuite.TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384,
+                TlsMapping.EcDhStatic(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha384)
+            },
+
+            {
+                TlsCipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+                TlsMapping.EcDhEphem(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha256)
             },
 
             {
                 TlsCipherSuite.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,
-                TlsMapping.EcDhe(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha384)
+                TlsMapping.EcDhEphem(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha384)
+            },
+
+            {
+                TlsCipherSuite.TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256,
+                TlsMapping.EcDhStatic(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha256)
+            },
+
+            {
+                TlsCipherSuite.TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384,
+                TlsMapping.EcDhStatic(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha384)
+            },
+
+            {
+                TlsCipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+                TlsMapping.EcDhEphem(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha256)
             },
 
             {
                 TlsCipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-                TlsMapping.EcDhe(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha384)
+                TlsMapping.EcDhEphem(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha384)
             },
 
             {
+                TlsCipherSuite.TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256,
+                TlsMapping.EcDhStatic(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha256)
+            },
+
+            {
+                TlsCipherSuite.TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384,
+                TlsMapping.EcDhStatic(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha384)
+            },
+            {
                 TlsCipherSuite.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-                TlsMapping.EcDhe(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha256)
+                TlsMapping.EcDhEphem(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha256)
             },
 
             {
                 TlsCipherSuite.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-                TlsMapping.EcDhe(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha384)
+                TlsMapping.EcDhEphem(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha384)
+            },
+
+            {
+                TlsCipherSuite.TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256,
+                TlsMapping.EcDhStatic(CipherAlgorithmType.Aes128, HashAlgorithmType.Sha256)
+            },
+
+            {
+                TlsCipherSuite.TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384,
+                TlsMapping.EcDhStatic(CipherAlgorithmType.Aes256, HashAlgorithmType.Sha384)
             },
         };
     }


### PR DESCRIPTION
The non-ciphersuite ciphersuite values were removed, as were the SSL2-only
values, and the values that have unknown values (Cipher:IDEA, KEA:Fortezza).

The dictionary is asserted as fully populated with a fixed-length cctor test, and
the additional test of ensuring all defined values have defined metadata has
been performed.

TlsMapping calls were built by regex substitution expressions, and have been
checked manually for consistency.