### PR TITLE
Set Duration in StopActivity before calling Write.

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceActivity.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceActivity.cs
@@ -38,8 +38,12 @@
         /// <seealso cref="Activity"/>
         public void StopActivity(Activity activity, object args)
         {
+            // Stop sets the end time if it was unset, but we want it set before we issue the write
+            // so we do it now.   
+            if (activity.Duration == TimeSpan.Zero)
+                activity.SetEndTime(DateTime.UtcNow);
             Write(activity.OperationName + ".Stop", args);
-            activity.Stop();
+            activity.Stop();    // Resets Activity.Current (we want this after the Write)
         }
     }
 }

--- a/src/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
@@ -356,15 +356,27 @@ namespace System.Diagnostics.Tests
 
                     var activity = new Activity("activity");
 
+                    // Test Activity.Stop
                     source.StartActivity(activity, arguments);
                     Assert.Equal(activity.OperationName + ".Start", observer.EventName);
                     Assert.Equal(arguments, observer.EventObject);
 
+                    Assert.NotNull(observer.Activity);
+                    Assert.True(DateTime.UtcNow - new TimeSpan(0, 1, 0) <= observer.Activity.StartTimeUtc);
+                    Assert.True(observer.Activity.StartTimeUtc <= DateTime.UtcNow);
+                    Assert.True(observer.Activity.Duration == TimeSpan.Zero);
+
                     observer.Reset();
 
+                    // Test Activity.Stop
                     source.StopActivity(activity, arguments);
                     Assert.Equal(activity.OperationName + ".Stop", observer.EventName);
                     Assert.Equal(arguments, observer.EventObject);
+
+                    // Confirm that duration is set. 
+                    Assert.NotNull(observer.Activity);
+                    Assert.True(TimeSpan.Zero < observer.Activity.Duration);
+                    Assert.True(observer.Activity.StartTimeUtc + observer.Activity.Duration < DateTime.UtcNow);
                 } 
             }
         }
@@ -430,16 +442,20 @@ namespace System.Diagnostics.Tests
             public string EventName { get; private set; }
             public object EventObject { get; private set; }
 
+            public Activity Activity { get; private set; }
+
             public void OnNext(KeyValuePair<string, object> value)
             {
                 EventName = value.Key;
                 EventObject = value.Value;
+                Activity = Activity.Current;
             }
 
             public void Reset()
             {
                 EventName = null;
                 EventObject = null;
+                Activity = null;
             }
 
             public void OnCompleted() { }


### PR DESCRIPTION
Currently we call DiagnosticSource.Write before the Duration property is necessarily set, which means that subscribers don't see the duration.   Fix this.  

Updated to tests to check for this. 