### PR TITLE
Use 64-bit file I/O functions, for Android compatibility

### DIFF
--- a/src/Native/Unix/Common/pal_config.h.in
+++ b/src/Native/Unix/Common/pal_config.h.in
@@ -1,6 +1,11 @@
 #pragma once
 
 #cmakedefine PAL_UNIX_NAME @PAL_UNIX_NAME@
+#cmakedefine01 HAVE_LSEEK64
+#cmakedefine01 HAVE_MMAP64
+#cmakedefine01 HAVE_FTRUNCATE64
+#cmakedefine01 HAVE_POSIX_FADVISE64
+#cmakedefine01 HAVE_FLOCK64
 #cmakedefine01 HAVE_STAT64
 #cmakedefine01 HAVE_PIPE2
 #cmakedefine01 HAVE_STAT_BIRTHTIME

--- a/src/Native/Unix/System.Native/pal_io.cpp
+++ b/src/Native/Unix/System.Native/pal_io.cpp
@@ -1179,9 +1179,9 @@ extern "C" int32_t SystemNative_CopyFile(intptr_t sourceFd, intptr_t destination
         // futimes is not a POSIX function, and not available on Android,
         // but futimens is
         struct timespec origTimes[2];
-        origTimes[0].tv_sec = static_cast<__kernel_time_t>(sourceStat.st_atime);
+        origTimes[0].tv_sec = static_cast<time_t>(sourceStat.st_atime);
         origTimes[0].tv_nsec = 0;
-        origTimes[1].tv_sec = static_cast<__kernel_time_t>(sourceStat.st_mtime);
+        origTimes[1].tv_sec = static_cast<time_t>(sourceStat.st_mtime);
         origTimes[1].tv_nsec = 0;
         while (CheckInterrupted(ret = futimens(outFd, origTimes)));
 #endif

--- a/src/Native/Unix/System.Native/pal_io.cpp
+++ b/src/Native/Unix/System.Native/pal_io.cpp
@@ -939,7 +939,7 @@ extern "C" int32_t SystemNative_PosixFAdvise(intptr_t fd, int64_t offset, int64_
     int32_t result;
     while (CheckInterrupted(
         result =
-#if HAVE_POSIX_ADVISE64
+#if HAVE_POSIX_FADVISE64
             posix_fadvise64(
 #else
             posix_fadvise(

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -72,7 +72,7 @@ check_function_exists(
     mmap64
     HAVE_MMAP64)
 
-check_function_exists
+check_function_exists(
     ftruncate64
     HAVE_FTRUNCATE64)
 

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -53,6 +53,33 @@ check_type_size(
 set(CMAKE_EXTRA_INCLUDE_FILES) # reset CMAKE_EXTRA_INCLUDE_FILES
 # /in_pktinfo
 
+check_c_source_compiles(
+    "
+    #include <fcntl.h>
+    int main()
+    {
+        struct flock64 l;
+        return 0;
+    }
+    "
+    HAVE_FLOCK64)
+
+check_function_exists(
+    lseek64
+    HAVE_LSEEK64)
+
+check_function_exists(
+    mmap64
+    HAVE_MMAP64)
+
+check_function_exists
+    ftruncate64
+    HAVE_FTRUNCATE64)
+
+check_function_Exists(
+    posix_fadvise64
+    HAVE_POSIX_FADVISE64)
+
 check_function_exists(
     stat64
     HAVE_STAT64)


### PR DESCRIPTION
On 32-bit Android, the file functions like lseek also operate on 32-bit values. `_FILE_OFFSET_BITS` and friends have no impact on Android, see the 32-bit notes at the end of the [bionic README.md](https://android.googlesource.com/platform/bionic.git/+/master/README.md)

This PR updates the codebase to always use 64-bit file I/O functions like `lseek64`. This effectively reverts #736.