### PR TITLE
Improve CI: disable socket eventarg test

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketAsyncEventArgsTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketAsyncEventArgsTest.cs
@@ -277,6 +277,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [ActiveIssue(16765)]
         [Fact]
         public void CancelConnectAsync_InstanceConnect_CancelsInProgressConnect()
         {


### PR DESCRIPTION
Disabling new test CancelConnectAsync_InstanceConnect_CancelsInProgressConnect since it is failing in CI

Applies to issue https://github.com/dotnet/corefx/issues/16765