### PR TITLE
System.Net.Security tests fix

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
@@ -38,6 +38,7 @@ namespace System.Net.Security.Tests
 
         [Theory]
         [ClassData(typeof(SslProtocolSupport.SupportedSslProtocolsTestData))]
+        [ActiveIssue(16534, TestPlatforms.Windows)]
         public async Task ClientAsyncAuthenticate_EachSupportedProtocol_Success(SslProtocols protocol)
         {
             await ClientAsyncSslHelper(protocol, protocol);

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -18,6 +18,7 @@ namespace System.Net.Security.Tests
     {
 
         [Fact]
+        [ActiveIssue(16516, TestPlatforms.Windows)]
         public async void SslStream_SendReceiveOverNetworkStream_Ok()
         {
             TcpListener listener = new TcpListener(IPAddress.Any, 0);

--- a/src/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
@@ -14,7 +14,7 @@ namespace System.Net.Security.Tests
 {
     internal static class TestConfiguration
     {
-        public const int PassingTestTimeoutMilliseconds = 1 * 60 * 1000;
+        public const int PassingTestTimeoutMilliseconds = 4 * 60 * 1000;
         public const int FailingTestTimeoutMiliseconds = 250;
 
         public const string Realm = "TEST.COREFX.NET";


### PR DESCRIPTION
Disables a few tests that are failing for known issues and increases the timeout on some tests that are failing on Unix because they're hitting that timeout.

cc: @steveharter @Priya91 

resolves https://github.com/dotnet/corefx/issues/16741