### PR TITLE
System.Net.Requests: Avoid unnecessary box allocations in TimerThread

### DIFF
--- a/src/System.Net.Requests/src/System/Net/TimerThread.cs
+++ b/src/System.Net.Requests/src/System/Net/TimerThread.cs
@@ -4,8 +4,6 @@
 
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Threading;
 
@@ -31,21 +29,12 @@ namespace System.Net
             /// <summary>
             /// <para>The duration in milliseconds of timers in this queue.</para>
             /// </summary>
-            internal int Duration
-            {
-                get
-                {
-                    return _durationMilliseconds;
-                }
-            }
+            internal int Duration => _durationMilliseconds;
 
             /// <summary>
             /// <para>Creates and returns a handle to a new polled timer.</para>
             /// </summary>
-            internal Timer CreateTimer()
-            {
-                return CreateTimer(null, null);
-            }
+            internal Timer CreateTimer() => CreateTimer(null, null);
 
             /// <summary>
             /// <para>Creates and returns a handle to a new timer with attached context.</para>
@@ -70,35 +59,17 @@ namespace System.Net
             /// <summary>
             /// <para>The duration in milliseconds of timer.</para>
             /// </summary>
-            internal int Duration
-            {
-                get
-                {
-                    return _durationMilliseconds;
-                }
-            }
+            internal int Duration => _durationMilliseconds;
 
             /// <summary>
             /// <para>The time (relative to Environment.TickCount) when the timer started.</para>
             /// </summary>
-            internal int StartTime
-            {
-                get
-                {
-                    return _startTimeMilliseconds;
-                }
-            }
+            internal int StartTime => _startTimeMilliseconds;
 
             /// <summary>
             /// <para>The time (relative to Environment.TickCount) when the timer will expire.</para>
             /// </summary>
-            internal int Expiration
-            {
-                get
-                {
-                    return unchecked(_startTimeMilliseconds + _durationMilliseconds);
-                }
-            }
+            internal int Expiration => unchecked(_startTimeMilliseconds + _durationMilliseconds);
 
             /// <summary>
             /// <para>The amount of time left on the timer.  0 means it has fired.  1 means it has expired but
@@ -135,10 +106,7 @@ namespace System.Net
             /// </summary>
             internal abstract bool HasExpired { get; }
 
-            public void Dispose()
-            {
-                Cancel();
-            }
+            public void Dispose() => Cancel();
         }
 
         /// <summary>
@@ -146,23 +114,18 @@ namespace System.Net
         /// </summary>
         internal delegate void Callback(Timer timer, int timeNoticed, object context);
 
-        private const int c_ThreadIdleTimeoutMilliseconds = 30 * 1000;
-        private const int c_CacheScanPerIterations = 32;
-        private const int c_TickCountResolution = 15;
+        private const int ThreadIdleTimeoutMilliseconds = 30 * 1000;
+        private const int CacheScanPerIterations = 32;
+        private const int TickCountResolution = 15;
 
-        private static LinkedList<WeakReference> s_Queues = new LinkedList<WeakReference>();
-        private static LinkedList<WeakReference> s_NewQueues = new LinkedList<WeakReference>();
-        private static int s_ThreadState = (int)TimerThreadState.Idle;  // Really a TimerThreadState, but need an int for Interlocked.
-        private static AutoResetEvent s_ThreadReadyEvent = new AutoResetEvent(false);
-        private static ManualResetEvent s_ThreadShutdownEvent = new ManualResetEvent(false);
-        private static WaitHandle[] s_ThreadEvents;
-        private static int s_CacheScanIteration;
-        private static Hashtable s_QueuesCache = new Hashtable();
-
-        static TimerThread()
-        {
-            s_ThreadEvents = new WaitHandle[] { s_ThreadShutdownEvent, s_ThreadReadyEvent };
-        }
+        private static readonly LinkedList<WeakReference> s_queues = new LinkedList<WeakReference>();
+        private static readonly LinkedList<WeakReference> s_newQueues = new LinkedList<WeakReference>();
+        private static int s_threadState = (int)TimerThreadState.Idle;  // Really a TimerThreadState, but need an int for Interlocked.
+        private static readonly AutoResetEvent s_threadReadyEvent = new AutoResetEvent(false);
+        private static readonly ManualResetEvent s_threadShutdownEvent = new ManualResetEvent(false);
+        private static readonly WaitHandle[] s_threadEvents = { s_threadShutdownEvent, s_threadReadyEvent };
+        private static int s_cacheScanIteration;
+        private static readonly Hashtable s_queuesCache = new Hashtable();
 
         /// <summary>
         /// <para>The possible states of the timer thread.</para>
@@ -190,24 +153,24 @@ namespace System.Net
             }
 
             TimerQueue queue;
-            WeakReference weakQueue = (WeakReference)s_QueuesCache[durationMilliseconds];
+            WeakReference weakQueue = (WeakReference)s_queuesCache[durationMilliseconds];
             if (weakQueue == null || (queue = (TimerQueue)weakQueue.Target) == null)
             {
-                lock (s_NewQueues)
+                lock (s_newQueues)
                 {
-                    weakQueue = (WeakReference)s_QueuesCache[durationMilliseconds];
+                    weakQueue = (WeakReference)s_queuesCache[durationMilliseconds];
                     if (weakQueue == null || (queue = (TimerQueue)weakQueue.Target) == null)
                     {
                         queue = new TimerQueue(durationMilliseconds);
                         weakQueue = new WeakReference(queue);
-                        s_NewQueues.AddLast(weakQueue);
-                        s_QueuesCache[durationMilliseconds] = weakQueue;
+                        s_newQueues.AddLast(weakQueue);
+                        s_queuesCache[durationMilliseconds] = weakQueue;
 
                         // Take advantage of this lock to periodically scan the table for garbage.
-                        if (++s_CacheScanIteration % c_CacheScanPerIterations == 0)
+                        if (++s_cacheScanIteration % CacheScanPerIterations == 0)
                         {
                             List<int> garbage = new List<int>();
-                            foreach (DictionaryEntry pair in s_QueuesCache)
+                            foreach (DictionaryEntry pair in s_queuesCache)
                             {
                                 if (((WeakReference)pair.Value).Target == null)
                                 {
@@ -216,7 +179,7 @@ namespace System.Net
                             }
                             for (int i = 0; i < garbage.Count; i++)
                             {
-                                s_QueuesCache.Remove(garbage[i]);
+                                s_queuesCache.Remove(garbage[i]);
                             }
                         }
                     }
@@ -347,10 +310,7 @@ namespace System.Net
             /// <summary>
             /// <para>Always returns a dummy infinite timer.</para>
             /// </summary>
-            internal override Timer CreateTimer(Callback callback, object context)
-            {
-                return new InfiniteTimer();
-            }
+            internal override Timer CreateTimer(Callback callback, object context) => new InfiniteTimer();
         }
 
         /// <summary>
@@ -394,38 +354,18 @@ namespace System.Net
                 _timerState = TimerState.Sentinel;
             }
 
-            internal override bool HasExpired
-            {
-                get
-                {
-                    return _timerState == TimerState.Fired;
-                }
-            }
+            internal override bool HasExpired => _timerState == TimerState.Fired;
 
             internal TimerNode Next
             {
-                get
-                {
-                    return _next;
-                }
-
-                set
-                {
-                    _next = value;
-                }
+                get { return _next; }
+                set { _next = value; }
             }
 
             internal TimerNode Prev
             {
-                get
-                {
-                    return _prev;
-                }
-
-                set
-                {
-                    _prev = value;
-                }
+                get { return _prev; }
+                set { _prev = value; }
             }
 
             /// <summary>
@@ -544,21 +484,12 @@ namespace System.Net
 
             private int _cancelled;
 
-            internal override bool HasExpired
-            {
-                get
-                {
-                    return false;
-                }
-            }
+            internal override bool HasExpired => false;
 
             /// <summary>
             /// <para>Cancels the timer.  Returns true the first time, false after that.</para>
             /// </summary>
-            internal override bool Cancel()
-            {
-                return Interlocked.Exchange(ref _cancelled, 1) == 0;
-            }
+            internal override bool Cancel() => Interlocked.Exchange(ref _cancelled, 1) == 0;
         }
 
         /// <summary>
@@ -566,9 +497,9 @@ namespace System.Net
         /// </summary>
         private static void Prod()
         {
-            s_ThreadReadyEvent.Set();
+            s_threadReadyEvent.Set();
             TimerThreadState oldState = (TimerThreadState)Interlocked.CompareExchange(
-                ref s_ThreadState,
+                ref s_threadState,
                 (int)TimerThreadState.Running,
                 (int)TimerThreadState.Idle);
 
@@ -594,10 +525,10 @@ namespace System.Net
                 Thread.CurrentThread.IsBackground = true;
 
                 // Keep a permanent lock on s_Queues.  This lets for example Shutdown() know when this thread isn't running.
-                lock (s_Queues)
+                lock (s_queues)
                 {
                     // If shutdown was recently called, abort here.
-                    if (Interlocked.CompareExchange(ref s_ThreadState, (int)TimerThreadState.Running, (int)TimerThreadState.Running) !=
+                    if (Interlocked.CompareExchange(ref s_threadState, (int)TimerThreadState.Running, (int)TimerThreadState.Running) !=
                         (int)TimerThreadState.Running)
                     {
                         return;
@@ -608,19 +539,19 @@ namespace System.Net
                     {
                         try
                         {
-                            s_ThreadReadyEvent.Reset();
+                            s_threadReadyEvent.Reset();
 
                             while (true)
                             {
                                 // Copy all the new queues to the real queues.  Since only this thread modifies the real queues, it doesn't have to lock it.
-                                if (s_NewQueues.Count > 0)
+                                if (s_newQueues.Count > 0)
                                 {
-                                    lock (s_NewQueues)
+                                    lock (s_newQueues)
                                     {
-                                        for (LinkedListNode<WeakReference> node = s_NewQueues.First; node != null; node = s_NewQueues.First)
+                                        for (LinkedListNode<WeakReference> node = s_newQueues.First; node != null; node = s_newQueues.First)
                                         {
-                                            s_NewQueues.Remove(node);
-                                            s_Queues.AddLast(node);
+                                            s_newQueues.Remove(node);
+                                            s_queues.AddLast(node);
                                         }
                                     }
                                 }
@@ -628,13 +559,13 @@ namespace System.Net
                                 int now = Environment.TickCount;
                                 int nextTick = 0;
                                 bool haveNextTick = false;
-                                for (LinkedListNode<WeakReference> node = s_Queues.First; node != null; /* node = node.Next must be done in the body */)
+                                for (LinkedListNode<WeakReference> node = s_queues.First; node != null; /* node = node.Next must be done in the body */)
                                 {
                                     TimerQueue queue = (TimerQueue)node.Value.Target;
                                     if (queue == null)
                                     {
                                         LinkedListNode<WeakReference> next = node.Next;
-                                        s_Queues.Remove(node);
+                                        s_queues.Remove(node);
                                         node = next;
                                         continue;
                                     }
@@ -657,13 +588,13 @@ namespace System.Net
                                 int newNow = Environment.TickCount;
                                 int waitDuration = haveNextTick ?
                                     (int)(IsTickBetween(now, nextTick, newNow) ?
-                                        Math.Min(unchecked((uint)(nextTick - newNow)), (uint)(Int32.MaxValue - c_TickCountResolution)) + c_TickCountResolution :
+                                        Math.Min(unchecked((uint)(nextTick - newNow)), (uint)(Int32.MaxValue - TickCountResolution)) + TickCountResolution :
                                         0) :
-                                    c_ThreadIdleTimeoutMilliseconds;
+                                    ThreadIdleTimeoutMilliseconds;
 
                                 if (NetEventSource.IsEnabled) NetEventSource.Info(null, $"Waiting for {waitDuration}ms");
 
-                                int waitResult = WaitHandle.WaitAny(s_ThreadEvents, waitDuration, false);
+                                int waitResult = WaitHandle.WaitAny(s_threadEvents, waitDuration, false);
 
                                 // 0 is s_ThreadShutdownEvent - die.
                                 if (waitResult == 0)
@@ -678,11 +609,11 @@ namespace System.Net
                                 // If we timed out with nothing to do, shut down. 
                                 if (waitResult == WaitHandle.WaitTimeout && !haveNextTick)
                                 {
-                                    Interlocked.CompareExchange(ref s_ThreadState, (int)TimerThreadState.Idle, (int)TimerThreadState.Running);
+                                    Interlocked.CompareExchange(ref s_threadState, (int)TimerThreadState.Idle, (int)TimerThreadState.Running);
                                     // There could have been one more prod between the wait and the exchange.  Check, and abort if necessary.
-                                    if (s_ThreadReadyEvent.WaitOne(0, false))
+                                    if (s_threadReadyEvent.WaitOne(0, false))
                                     {
-                                        if (Interlocked.CompareExchange(ref s_ThreadState, (int)TimerThreadState.Running, (int)TimerThreadState.Idle) ==
+                                        if (Interlocked.CompareExchange(ref s_threadState, (int)TimerThreadState.Running, (int)TimerThreadState.Idle) ==
                                             (int)TimerThreadState.Idle)
                                         {
                                             continue;


### PR DESCRIPTION
I noticed that some box allocations could be avoided in `System.Net.TimerThread` (used by `FtpWebRequest`).

First commit is some minor cleanup while I'm making changes here: cleanup naming, make fields readonly, use expression bodied members where appropriate, and remove the static constructor.

Second commit reduces box allocations.