### PR TITLE
Delete commented out Socket assert

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -103,8 +103,6 @@ namespace System.Net.Sockets
             _socketType = socketType;
             _protocolType = protocolType;
 
-            // TODO: Investigate this problematic assertion: Issue #4500.
-            // Debug.Assert(addressFamily != AddressFamily.InterNetworkV6 || !DualMode);
             if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
         }
 


### PR DESCRIPTION
Closes https://github.com/dotnet/corefx/issues/4500
cc: @cipop, @davidsh, @geoffkizer 

This assert doesn't exist in desktop, and it's faulty. It was previously commented out. I'm simply deleting it.  We could put the assert back and special case Raw, but doing so doesn't seem to add any value; we're just picking up OS defaults.

This little program shows DualMode values for various sockets:
```
using System;
using System.Net.Sockets;

class Program
{
    static void Main()
    {
        foreach (SocketType sock in Enum.GetValues(typeof(SocketType)))
        {
            foreach (ProtocolType prot in Enum.GetValues(typeof(ProtocolType)))
            {
                try
                {
                    using (var s = new Socket(AddressFamily.InterNetworkV6, sock, prot))
                    {
                        Console.WriteLine($"{sock,10}\t{prot,40}\tDualMode:{s.DualMode}");
                    }
                }
                catch (SocketException) { }
            }
        }
    }
}
```

Results on desktop on my Windows 10 box:
```
    Stream                                   Unspecified        DualMode:False
    Stream                                   Unspecified        DualMode:False
    Stream                                   Unspecified        DualMode:False
    Stream                                           Tcp        DualMode:False
     Dgram                                   Unspecified        DualMode:False
     Dgram                                   Unspecified        DualMode:False
     Dgram                                   Unspecified        DualMode:False
     Dgram                                           Udp        DualMode:False
       Raw                                   Unspecified        DualMode:True
       Raw                                   Unspecified        DualMode:True
       Raw                                   Unspecified        DualMode:True
       Raw                                          Icmp        DualMode:True
       Raw                                          Igmp        DualMode:True
       Raw                                           Ggp        DualMode:True
       Raw                                          IPv4        DualMode:True
       Raw                                           Tcp        DualMode:True
       Raw                                           Pup        DualMode:True
       Raw                                           Udp        DualMode:True
       Raw                                           Idp        DualMode:True
       Raw                                          IPv6        DualMode:True
       Raw                             IPv6RoutingHeader        DualMode:True
       Raw                            IPv6FragmentHeader        DualMode:True
       Raw             IPSecEncapsulatingSecurityPayload        DualMode:True
       Raw                     IPSecAuthenticationHeader        DualMode:True
       Raw                                        IcmpV6        DualMode:True
       Raw                              IPv6NoNextHeader        DualMode:True
       Raw                        IPv6DestinationOptions        DualMode:True
       Raw                                            ND        DualMode:True
       Raw                                           Raw        DualMode:True
```

Results on core on my Windows 10 box:
```
    Stream                                   Unspecified        DualMode:False
    Stream                                   Unspecified        DualMode:False
    Stream                                   Unspecified        DualMode:False
    Stream                                           Tcp        DualMode:False
     Dgram                                   Unspecified        DualMode:False
     Dgram                                   Unspecified        DualMode:False
     Dgram                                   Unspecified        DualMode:False
     Dgram                                           Udp        DualMode:False
       Raw                                   Unspecified        DualMode:True
       Raw                                   Unspecified        DualMode:True
       Raw                                   Unspecified        DualMode:True
       Raw                                          Icmp        DualMode:True
       Raw                                          Igmp        DualMode:True
       Raw                                           Ggp        DualMode:True
       Raw                                          IPv4        DualMode:True
       Raw                                           Tcp        DualMode:True
       Raw                                           Pup        DualMode:True
       Raw                                           Udp        DualMode:True
       Raw                                           Idp        DualMode:True
       Raw                                          IPv6        DualMode:True
       Raw                             IPv6RoutingHeader        DualMode:True
       Raw                            IPv6FragmentHeader        DualMode:True
       Raw             IPSecEncapsulatingSecurityPayload        DualMode:True
       Raw                     IPSecAuthenticationHeader        DualMode:True
       Raw                                        IcmpV6        DualMode:True
       Raw                              IPv6NoNextHeader        DualMode:True
       Raw                        IPv6DestinationOptions        DualMode:True
       Raw                                            ND        DualMode:True
       Raw                                           Raw        DualMode:True
```