### PR TITLE
fix pinning bug in SocketPal.SendToAsync on Windows

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/OverlappedAsyncResult.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/OverlappedAsyncResult.Windows.cs
@@ -42,11 +42,11 @@ namespace System.Net.Sockets
         // These calls are outside the runtime and are unmanaged code, so we need
         // to prepare specific structures and ints that lie in unmanaged memory
         // since the overlapped calls may complete asynchronously.
-        internal void SetUnmanagedStructures(byte[] buffer, int offset, int size, Internals.SocketAddress socketAddress, bool pinSocketAddress)
+        internal void SetUnmanagedStructures(byte[] buffer, int offset, int size, Internals.SocketAddress socketAddress)
         {
             // Fill in Buffer Array structure that will be used for our send/recv Buffer
             _socketAddress = socketAddress;
-            if (pinSocketAddress && _socketAddress != null)
+            if (_socketAddress != null)
             {
                 object[] objectsToPin = null;
                 objectsToPin = new object[2];

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
@@ -823,7 +823,7 @@ namespace System.Net.Sockets
         public static unsafe SocketError SendAsync(SafeCloseSocket handle, byte[] buffer, int offset, int count, SocketFlags socketFlags, OverlappedAsyncResult asyncResult)
         {
             // Set up unmanaged structures for overlapped WSASend.
-            asyncResult.SetUnmanagedStructures(buffer, offset, count, null, false /*don't pin null remoteEP*/);
+            asyncResult.SetUnmanagedStructures(buffer, offset, count, null);
             try
             {
                 // This can throw ObjectDisposedException.
@@ -930,7 +930,7 @@ namespace System.Net.Sockets
         public static unsafe SocketError SendToAsync(SafeCloseSocket handle, byte[] buffer, int offset, int count, SocketFlags socketFlags, Internals.SocketAddress socketAddress, OverlappedAsyncResult asyncResult)
         {
             // Set up asyncResult for overlapped WSASendTo.
-            asyncResult.SetUnmanagedStructures(buffer, offset, count, socketAddress, false /* don't pin RemoteEP*/);
+            asyncResult.SetUnmanagedStructures(buffer, offset, count, socketAddress);
             try
             {
                 int bytesTransferred;
@@ -957,7 +957,7 @@ namespace System.Net.Sockets
         public static unsafe SocketError ReceiveAsync(SafeCloseSocket handle, byte[] buffer, int offset, int count, SocketFlags socketFlags, OverlappedAsyncResult asyncResult)
         {
             // Set up asyncResult for overlapped WSARecv.
-            asyncResult.SetUnmanagedStructures(buffer, offset, count, null, false /* don't pin null RemoteEP*/);
+            asyncResult.SetUnmanagedStructures(buffer, offset, count, null);
             try
             {
                 // This can throw ObjectDisposedException.
@@ -1009,7 +1009,7 @@ namespace System.Net.Sockets
         public static unsafe SocketError ReceiveFromAsync(SafeCloseSocket handle, byte[] buffer, int offset, int count, SocketFlags socketFlags, Internals.SocketAddress socketAddress, OverlappedAsyncResult asyncResult)
         {
             // Set up asyncResult for overlapped WSARecvFrom.
-            asyncResult.SetUnmanagedStructures(buffer, offset, count, socketAddress, true);
+            asyncResult.SetUnmanagedStructures(buffer, offset, count, socketAddress);
             try
             {
                 int bytesTransferred;


### PR DESCRIPTION
We weren't pinning the socketAddress before passing a pointer to it into WSASendTo.

Fixed this, and modified SetUnmanagedStructures to always pin when using a socketAddress.

Fixes #16306.
