### PR TITLE
Fixed a bug of using ReflectionAsBackup.

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonClassDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonClassDataContract.cs
@@ -37,14 +37,14 @@ namespace System.Runtime.Serialization.Json
 #if NET_NATIVE
                             else if (DataContractSerializer.Option == SerializationOption.ReflectionAsBackup)
                             {
-                                tempDelegate = JsonDataContract.TryGetReadWriteDelegatesFromGeneratedAssembly(TraditionalClassDataContract).ClassReaderDelegate;
+                                tempDelegate = JsonDataContract.TryGetReadWriteDelegatesFromGeneratedAssembly(TraditionalClassDataContract)?.ClassReaderDelegate;
                                 tempDelegate = tempDelegate ?? new ReflectionJsonClassReader(TraditionalClassDataContract).ReflectionReadClass;
 
                                 if (tempDelegate == null)
                                     throw new InvalidDataContractException(SR.Format(SR.SerializationCodeIsMissingForType, TraditionalClassDataContract.UnderlyingType.ToString()));
                             }
 #endif
-                            else 
+                            else
                             {
 #if NET_NATIVE
                                 tempDelegate = JsonDataContract.GetReadWriteDelegatesFromGeneratedAssembly(TraditionalClassDataContract).ClassReaderDelegate;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonCollectionDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonCollectionDataContract.cs
@@ -36,7 +36,7 @@ namespace System.Runtime.Serialization.Json
 #if NET_NATIVE
                             else if (DataContractSerializer.Option == SerializationOption.ReflectionAsBackup)
                             {
-                                tempDelegate = JsonDataContract.TryGetReadWriteDelegatesFromGeneratedAssembly(TraditionalCollectionDataContract).CollectionReaderDelegate;
+                                tempDelegate = JsonDataContract.TryGetReadWriteDelegatesFromGeneratedAssembly(TraditionalCollectionDataContract)?.CollectionReaderDelegate;
                                 tempDelegate = tempDelegate ?? new ReflectionJsonCollectionReader().ReflectionReadCollection;
 
                                 if (tempDelegate == null)
@@ -85,7 +85,7 @@ namespace System.Runtime.Serialization.Json
 #if NET_NATIVE
                             else if (DataContractSerializer.Option == SerializationOption.ReflectionAsBackup)
                             {
-                                tempDelegate = JsonDataContract.TryGetReadWriteDelegatesFromGeneratedAssembly(TraditionalCollectionDataContract).GetOnlyCollectionReaderDelegate;
+                                tempDelegate = JsonDataContract.TryGetReadWriteDelegatesFromGeneratedAssembly(TraditionalCollectionDataContract)?.GetOnlyCollectionReaderDelegate;
                                 tempDelegate = tempDelegate ?? new ReflectionJsonCollectionReader().ReflectionReadGetOnlyCollection;
 
                                 if (tempDelegate == null)
@@ -128,7 +128,7 @@ namespace System.Runtime.Serialization.Json
 #if NET_NATIVE
                             else if (DataContractSerializer.Option == SerializationOption.ReflectionAsBackup)
                             {
-                                tempDelegate = JsonDataContract.TryGetReadWriteDelegatesFromGeneratedAssembly(TraditionalCollectionDataContract).CollectionWriterDelegate;
+                                tempDelegate = JsonDataContract.TryGetReadWriteDelegatesFromGeneratedAssembly(TraditionalCollectionDataContract)?.CollectionWriterDelegate;
                                 tempDelegate = tempDelegate ?? new ReflectionJsonFormatWriter().ReflectionWriteCollection;
 
                                 if (tempDelegate == null)


### PR DESCRIPTION
The call to TryGetReadWriteDelegatesFromGeneratedAssembly returns null (which it should as the test I’m running don’t invoke sgen at all). The problem is that the code above calls .ClassReaderDelegate on it immediately without checking for null.

I was able to repro the issue in corefx by building and running the serialization tests using `S.P.DataContractSerialization.dll` of Uapaot flavor. I verified that the fix fixed the bug.

Fix #16859 