### PR TITLE
Account for hostnotfound error from getaddrinfo.

### DIFF
--- a/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
+++ b/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
@@ -164,6 +164,14 @@ namespace System.Net.NameResolution.PalTests
             IPHostEntry hostEntry;
             int nativeErrorCode;
             SocketError error = NameResolutionPal.TryGetAddrInfo(hostName, out hostEntry, out nativeErrorCode);
+            if (error == SocketError.HostNotFound)
+            {
+                // On Unix, getaddrinfo returns host not found, if all the machine discovery settings on the local network
+                // is turned off. Hence dns lookup for it's own hostname fails.
+                Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX));
+                return;
+            }
+
             Assert.Equal(SocketError.Success, error);
             Assert.NotNull(hostEntry);
 
@@ -171,7 +179,7 @@ namespace System.Net.NameResolution.PalTests
             if (error == SocketError.HostNotFound)
             {
                 // On Unix, getaddrinfo returns private ipv4 address for hostname. If the OS doesn't have the
-                // dns lookup entry for this address, getnameinfo returns host not found.
+                // reverse dns lookup entry for this address, getnameinfo returns host not found.
                 Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX));
                 return;
             }

--- a/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
+++ b/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
@@ -189,6 +189,18 @@ namespace System.Net.NameResolution.PalTests
         }
 
         [Fact]
+        public void TryGetAddrInfo_ExternalHost()
+        {
+            string hostName = "microsoft.com";
+
+            IPHostEntry hostEntry;
+            int nativeErrorCode;
+            SocketError error = NameResolutionPal.TryGetAddrInfo(hostName, out hostEntry, out nativeErrorCode);
+            Assert.Equal(SocketError.Success, error);
+            Assert.NotNull(hostEntry);
+        }
+
+        [Fact]
         public void TryGetNameInfo_LocalHost_IPv4_TryGetAddrInfo()
         {
             SocketError error;


### PR DESCRIPTION
On Unix, getaddrinfo returns host not found, if all the machine discovery settings on the local network
is turned off. Hence dns lookup for it's own hostname fails.

Refer investigation with native code on the issue #13309 [here](https://github.com/dotnet/corefx/issues/13309#issuecomment-281827936)

fixes #10764 

cc @karelz @steveharter @ianhays 