### PR TITLE
Remove Encoding.RegisterProvider from TdsParser

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
@@ -37,6 +37,9 @@ namespace System.Data.SqlClient
         static TdsParser()
         {
             // For CoreCLR, we need to register the ANSI Code Page encoding provider before attempting to get an Encoding from a CodePage
+            // For a default installation of SqlServer the encoding exchanged during Login is 1252. This encoding is not loaded by default
+            // See Remarks at https://msdn.microsoft.com/en-us/library/system.text.encodingprovider(v=vs.110).aspx 
+            // SqlClient needs to register the encoding providers to make sure that even basic scenarios work with Sql Server.
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
         }
 


### PR DESCRIPTION
The Encoding providers should be registered by the Application and not the library. 
If the library registers the providers for all the scenarios, this could lead to more data being loaded for encoding than what the application needs. 

 Fixes : #16842 
