### PR TITLE
Check for crossgen in shared framework before trying to restore it

### DIFF
--- a/Tools-Override/crossgen.sh
+++ b/Tools-Override/crossgen.sh
@@ -13,6 +13,11 @@ usage()
 
 restore_crossgen()
 {
+    __crossgen=$__sharedFxDir/crossgen
+    if [ -e $__crossgen ]; then
+        return
+    fi
+
     __pjDir=$__toolsDir/crossgen
     mkdir -p $__pjDir
     echo "{\"frameworks\":{\"netcoreapp1.1\":{\"dependencies\":{\"Microsoft.NETCore.Runtime.CoreCLR\":\"$__CoreClrVersion\", \"Microsoft.NETCore.Platforms\": \"$__CoreClrVersion\"}}},\"runtimes\":{\"$__rid\":{}}}" > "$__pjDir/project.json"


### PR DESCRIPTION
We are considering to include crossgen with the shared framework
so if it exists we should use it instead of pulling from the runtime
package. For some distro's like Alpine we don't have the matching
runtime version because we had to build a manual CLI but we did
include crossgen in the shared framework we manually created so
this will enable crossgen for our alpine builds.

cc @mellinoe 