### PR TITLE
Fixed a bug with serializing Dictionary<K,T>.

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
@@ -2094,7 +2094,6 @@ namespace System.Runtime.Serialization
                     }
                 }
 
-#if !NET_NATIVE
                 //For Json we need to add KeyValuePair<K,T> to KnownTypes if the UnderLyingType is a Dictionary<K,T>
                 try
                 {
@@ -2120,7 +2119,6 @@ namespace System.Runtime.Serialization
                     //types that may not be valid DC. This step is purely for KeyValuePair and shouldn't fail the (de)serialization.
                     //Any IDCE in this case fails the serialization/deserialization process which is not the optimal experience.
                 }
-#endif
 
                 type = type.BaseType;
             }

--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -946,9 +946,6 @@ public static partial class DataContractJsonSerializerTests
         var dict0 = new Dictionary<string, object> { { "Key0", dict1 } };
 
         var y = SerializeAndDeserialize<Dictionary<string, object>>(dict0, @"[{""Key"":""Key0"",""Value"":[{""__type"":""KeyValuePairOfstringanyType:#System.Collections.Generic"",""key"":""Key1-0"",""value"":""Value1-0""},{""__type"":""KeyValuePairOfstringanyType:#System.Collections.Generic"",""key"":""Key1-1"",""value"":[{""__type"":""KeyValuePairOfstringanyType:#System.Collections.Generic"",""key"":""Key2-0"",""value"":""Value2-0""}]}]}]"
-#if NET_NATIVE
-            , null, () => { return new DataContractJsonSerializer(typeof(Dictionary<string, object>), new Type[] { typeof(KeyValuePair<string, object>) }); }
-#endif
         );
         Assert.NotNull(y);
         Assert.StrictEqual(y.Count, 1);


### PR DESCRIPTION
For Json we need to add KeyValuePair<K,T> to KnownTypes if the UnderLyingType is a Dictionary<K,T>. We have code adding KeyValuePair<K,T> as KnownType, but the code was excluded if #NET_Native.

Fix #16864 