### PR TITLE
Change Ssl test to determine if results vary

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -63,8 +63,10 @@ namespace System.Net.Security.Tests
                     byte[] writeBuffer = new byte[256];
                     Task writeTask = clientStream.WriteAsync(writeBuffer, 0, writeBuffer.Length);
 
-                    bool result = Task.WaitAll(
-                        new Task[1] { writeTask }, 
+                    byte[] readBuffer = new byte[256];
+                    Task<int> readTask = serverStream.ReadAsync(readBuffer, 0, readBuffer.Length);
+
+                    bool result = Task.WaitAll(new[] { writeTask, readTask }, 
                         TestConfiguration.PassingTestTimeoutMilliseconds);
 
                     Assert.True(result, "WriteAsync timed-out.");

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -16,12 +16,10 @@ namespace System.Net.Security.Tests
 
     public class SslStreamNetworkStreamTest
     {
-
         [Fact]
-        [ActiveIssue(16516, TestPlatforms.Windows)]
-        public async void SslStream_SendReceiveOverNetworkStream_Ok()
+        public async Task SslStream_SendReceiveOverNetworkStream_Ok()
         {
-            TcpListener listener = new TcpListener(IPAddress.Any, 0);
+            TcpListener listener = new TcpListener(IPAddress.Loopback, 0);
 
             using (X509Certificate2 serverCertificate = Configuration.Certificates.GetServerCertificate())
             using (TcpClient client = new TcpClient())
@@ -62,9 +60,6 @@ namespace System.Net.Security.Tests
 
                     await Task.WhenAll(clientAuthenticationTask, serverAuthenticationTask);
 
-                    byte[] readBuffer = new byte[256];
-                    Task<int> readTask = clientStream.ReadAsync(readBuffer, 0, readBuffer.Length);
-
                     byte[] writeBuffer = new byte[256];
                     Task writeTask = clientStream.WriteAsync(writeBuffer, 0, writeBuffer.Length);
 
@@ -75,6 +70,8 @@ namespace System.Net.Security.Tests
                     Assert.True(result, "WriteAsync timed-out.");
                 }
             }
+
+            listener.Stop();
         }
 
         private static bool ValidateServerCertificate(


### PR DESCRIPTION
Update this single test to determine impact; per https://github.com/dotnet/corefx/issues/16516

Will monitor for failures.

The IPAddress.Any to .Loopback change is subtle, assuming the test machines only have a single network card\interface. However, I believe .Any goes through a different code path as it doesn't short-circuit like using Loopback does.

The readBuffer was removed as it just throws an exception on background thread as connection is closed before it can finish.

Also change to close TcpListener.

cc @Priya91 @stephentoub 