### PR TITLE
Fix XPathEvaluate bug on XNode

### DIFF
--- a/src/Common/tests/System/Xml/XPath/XPathExpressionTests/EvaluateTests.cs
+++ b/src/Common/tests/System/Xml/XPath/XPathExpressionTests/EvaluateTests.cs
@@ -3,6 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections;
+using System.Linq;
+using System.Xml.Linq;
 using System.Xml.XPath;
 using Xunit;
 using XPathTests.Common;
@@ -193,6 +196,46 @@ namespace XPathTests.XPathExpressionTests
 
             navigator.Select("/DocumentElement/child::*");
             Assert.Throws<XPathException>(() => navigator.Select(String.Empty));
+        }
+    }
+
+    public class XPathEvaluateTests
+    {
+        [Fact]
+        public static void EvaluateTextNode_1()
+        {
+            XElement element = XElement.Parse("<element>Text.</element>");
+            IEnumerable result = (IEnumerable)element.XPathEvaluate("/text()");
+            Assert.Equal(1, result.Cast<XText>().Count());
+            Assert.Equal("Text.", result.Cast<XText>().First().ToString());
+        }
+
+        [Fact]
+        public static void EvaluateTextNode_2()
+        {
+            XElement element = XElement.Parse("<root>1<element></element>2</root>");
+            IEnumerable result = (IEnumerable)element.XPathEvaluate("/text()[1]");
+            Assert.Equal(1, result.Cast<XText>().Count());
+            Assert.Equal("1", result.Cast<XText>().First().ToString());
+        }
+
+        [Fact]
+        public static void EvaluateTextNode_3()
+        {
+            XElement element = XElement.Parse("<root>1<element></element>2</root>");
+            IEnumerable result = (IEnumerable)element.XPathEvaluate("/text()[2]");
+            Assert.Equal(1, result.Cast<XText>().Count());
+            Assert.Equal("2", result.Cast<XText>().First().ToString());
+        }
+
+        [Fact]
+        public static void EvaluateTextNode_4()
+        {
+            XElement element = XElement.Parse("<root>1<element>2</element><element>3</element>4</root>");
+            IEnumerable result = (IEnumerable)element.XPathEvaluate("/element/text()[1]");
+            Assert.Equal(2, result.Cast<XText>().Count());
+            Assert.Equal("2", result.Cast<XText>().First().ToString());
+            Assert.Equal("3", result.Cast<XText>().Last().ToString());
         }
     }
 }

--- a/src/System.Private.Xml.Linq/src/System/Xml/XPath/XNodeNavigator.cs
+++ b/src/System.Private.Xml.Linq/src/System/Xml/XPath/XNodeNavigator.cs
@@ -878,12 +878,12 @@ namespace System.Xml.XPath
                 XText t = r as XText;
                 if (t != null && t.GetParent() != null)
                 {
-                    while (t != t.parent.content)
+                    do
                     {
-                        t = t.next as XText;
+                        t = t.NextNode as XText;
                         if (t == null) break;
                         yield return (T)(object)t;
-                    }
+                    } while (t != t.GetParent().LastNode);
                 }
             }
         }

--- a/src/System.Private.Xml.Linq/src/System/Xml/XPath/XNodeNavigator.cs
+++ b/src/System.Private.Xml.Linq/src/System/Xml/XPath/XNodeNavigator.cs
@@ -878,9 +878,9 @@ namespace System.Xml.XPath
                 XText t = r as XText;
                 if (t != null && t.GetParent() != null)
                 {
-                    foreach (XNode node in t.GetParent().Nodes())
+                    while (t != t.parent.content)
                     {
-                        t = node as XText;
+                        t = t.next as XText;
                         if (t == null) break;
                         yield return (T)(object)t;
                     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/16749

XPathEvaluate extension method for XNode returned incorrect results for XPath query of text nodes.

The bug was introduced in .Net Core. The behavior difference is due to new code `foreach on t.parent.Nodes()` not being equivalent to the Desktop version. 

In the .NET Core version, `t.GetParent().Nodes()` returns all the nodes in `t`'s parent, including `t` itself which was previously returned in the method, causing this value to be returned twice.

cc: @danmosemsft @krwq 