### PR TITLE
Use field for ConcurrentDictionary.Count

### DIFF
--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -67,6 +67,8 @@ namespace System.Collections.Concurrent
         private KeyValuePair<TKey, TValue>[] _serializationArray; // Used for custom serialization
         private int _serializationConcurrencyLevel; // used to save the concurrency level in serialization
         private int _serializationCapacity; // used to save the capacity in serialization
+        [NonSerialized]
+        private long _count; // use to increment/decrement the total items count
 
         // The default capacity, i.e. the initial # of buckets. When choosing this value, we are making
         // a trade-off between the size of a very small dictionary, and the number of resizes when
@@ -455,6 +457,7 @@ namespace System.Collections.Concurrent
 
                             value = curr._value;
                             tables._countPerLock[lockNo]--;
+                            Interlocked.Decrement(ref _count);
                             return true;
                         }
                         prev = curr;
@@ -627,6 +630,7 @@ namespace System.Collections.Concurrent
                 Tables newTables = new Tables(new Node[DefaultCapacity], _tables._locks, new int[_tables._countPerLock.Length]);
                 _tables = newTables;
                 _budget = Math.Max(1, newTables._buckets.Length / newTables._locks.Length);
+                Interlocked.Exchange(ref _count, 0L);
             }
             finally
             {
@@ -876,6 +880,7 @@ namespace System.Collections.Concurrent
                     {
                         tables._countPerLock[lockNo]++;
                     }
+                    Interlocked.Increment(ref _count);
 
                     //
                     // If the number of elements guarded by this lock has exceeded the budget, resize the bucket table.
@@ -974,19 +979,8 @@ namespace System.Collections.Concurrent
         {
             get
             {
-                int acquiredLocks = 0;
-                try
-                {
-                    // Acquire all locks
-                    AcquireAllLocks(ref acquiredLocks);
-
-                    return GetCountInternal();
-                }
-                finally
-                {
-                    // Release locks that have been acquired earlier
-                    ReleaseLocks(0, acquiredLocks);
-                }
+                // ToInt32 checks for overflow
+                return Convert.ToInt32(Volatile.Read(ref _count));
             }
         }
 
@@ -1261,30 +1255,7 @@ namespace System.Collections.Concurrent
         /// false.</value>
         public bool IsEmpty
         {
-            get
-            {
-                int acquiredLocks = 0;
-                try
-                {
-                    // Acquire all locks
-                    AcquireAllLocks(ref acquiredLocks);
-
-                    for (int i = 0; i < _tables._countPerLock.Length; i++)
-                    {
-                        if (_tables._countPerLock[i] != 0)
-                        {
-                            return false;
-                        }
-                    }
-                }
-                finally
-                {
-                    // Release locks that have been acquired earlier
-                    ReleaseLocks(0, acquiredLocks);
-                }
-
-                return true;
-            }
+            get { return Volatile.Read(ref _count) == 0L; }
         }
 
         #region IDictionary<TKey,TValue> members


### PR DESCRIPTION
Atomically increment/decrement a field to give the moment-in-time length of the total items in the dictionary without locking.

`ConcurrentDictionary<T>.Count` calls are common pitfalls in concurrent programming (I fell for that one more than once). The workaround from the user perspective is to maintain a separate field to get a moment-in-time snapshot of the length.

The proposed solution is consistent with the documentation of the method:

> `Count` has snapshot semantics and represents the number of items in the `ConcurrentDictionary<TKey,TValue>` at the moment when `Count` was accessed.