### PR TITLE
Audit System.Net throws losing stack traces

### DIFF
--- a/src/System.Net.HttpListener/src/System/Net/Managed/ListenerAsyncResult.Managed.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/ListenerAsyncResult.Managed.cs
@@ -30,6 +30,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+using System.Runtime.ExceptionServices;
 using System.Threading;
 
 namespace System.Net
@@ -147,9 +148,14 @@ namespace System.Net
         internal HttpListenerContext GetContext()
         {
             if (_forward != null)
+            {
                 return _forward.GetContext();
+            }
+
             if (_exception != null)
-                throw _exception;
+            {
+                ExceptionDispatchInfo.Capture(_exception).Throw();
+            }
 
             return _context;
         }

--- a/src/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Net.Security;
+using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Security.Authentication.ExtendedProtection;
@@ -949,7 +950,7 @@ namespace System.Net
                 if (httpContext == null)
                 {
                     Debug.Assert(castedAsyncResult.Result is Exception, "EndGetContext|The result is neither a HttpListenerContext nor an Exception.");
-                    throw castedAsyncResult.Result as Exception;
+                    ExceptionDispatchInfo.Capture(castedAsyncResult.Result as Exception).Throw();
                 }
             }
             catch (Exception exception)

--- a/src/System.Net.HttpListener/src/System/Net/Windows/HttpRequestStream.Windows.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/HttpRequestStream.Windows.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
+using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -357,7 +358,7 @@ namespace System.Net
                     NetEventSource.Info(this, "Rethrowing exception:" + exception);
                     NetEventSource.Error(this, exception.ToString());
                 }
-                throw exception;
+                ExceptionDispatchInfo.Capture(exception).Throw();
             }
 
             uint dataRead = (uint)returnValue;

--- a/src/System.Net.HttpListener/src/System/Net/Windows/HttpResponseStream.Windows.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/HttpResponseStream.Windows.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
+using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Globalization;
@@ -366,7 +367,7 @@ namespace System.Net
                 if (NetEventSource.IsEnabled) NetEventSource.Error(this, "Rethrowing exception:" + exception);
                 _closed = true;
                 _httpContext.Abort();
-                throw exception;
+                ExceptionDispatchInfo.Capture(exception).Throw();
             }
 
             if (NetEventSource.IsEnabled) NetEventSource.Exit(this);

--- a/src/System.Net.Mail/src/System/Net/Mail/MailPriority.cs
+++ b/src/System.Net.Mail/src/System/Net/Mail/MailPriority.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Net.Mime;
+using System.Runtime.ExceptionServices;
 using System.Text;
 
 namespace System.Net.Mail
@@ -372,9 +373,9 @@ namespace System.Net.Mail
 
                 castedAsyncResult.InternalWaitForCompletion();
                 castedAsyncResult.EndCalled = true;
-                if (castedAsyncResult.Result is Exception)
+                if (castedAsyncResult.Result is Exception e)
                 {
-                    throw (Exception)castedAsyncResult.Result;
+                    ExceptionDispatchInfo.Capture(e).Throw();
                 }
             }
         }

--- a/src/System.Net.Mail/src/System/Net/Mail/SmtpCommands.cs
+++ b/src/System.Net.Mail/src/System/Net/Mail/SmtpCommands.cs
@@ -7,6 +7,7 @@ using System.Collections;
 using System.Globalization;
 using System.IO;
 using System.Net.Mime;
+using System.Runtime.ExceptionServices;
 using System.Text;
 
 namespace System.Net.Mail
@@ -46,8 +47,10 @@ namespace System.Net.Mail
         internal static object EndSend(IAsyncResult result, out string response)
         {
             object commandResult = MultiAsyncResult.End(result);
-            if (commandResult is Exception)
-                throw (Exception)commandResult;
+            if (commandResult is Exception e)
+            {
+                ExceptionDispatchInfo.Capture(e).Throw();
+            }
 
             LineInfo info = (LineInfo)commandResult;
             response = info.Line;
@@ -135,8 +138,10 @@ namespace System.Net.Mail
         internal static LineInfo[] EndSend(IAsyncResult result)
         {
             object commandResult = MultiAsyncResult.End(result);
-            if (commandResult is Exception)
-                throw (Exception)commandResult;
+            if (commandResult is Exception e)
+            {
+                ExceptionDispatchInfo.Capture(e).Throw();
+            }
             return (LineInfo[])commandResult;
         }
 

--- a/src/System.Net.Mail/src/System/Net/Mail/SmtpConnection.cs
+++ b/src/System.Net.Mail/src/System/Net/Mail/SmtpConnection.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Net;
 using System.Net.Security;
 using System.Net.Sockets;
+using System.Runtime.ExceptionServices;
 using System.Security.Authentication;
 using System.Security.Authentication.ExtendedProtection;
 using System.Security.Cryptography.X509Certificates;
@@ -221,7 +222,7 @@ namespace System.Net.Mail
                 if ((e.StatusCode != SmtpStatusCode.CommandUnrecognized)
                     && (e.StatusCode != SmtpStatusCode.CommandNotImplemented))
                 {
-                    throw e;
+                    throw;
                 }
 
                 HelloCommand.Send(this, _client.clientDomain);
@@ -453,9 +454,9 @@ namespace System.Net.Mail
             {
                 ConnectAndHandshakeAsyncResult thisPtr = (ConnectAndHandshakeAsyncResult)result;
                 object connectResult = thisPtr.InternalWaitForCompletion();
-                if (connectResult is Exception)
+                if (connectResult is Exception e)
                 {
-                    throw (Exception)connectResult;
+                    ExceptionDispatchInfo.Capture(e).Throw();
                 }
             }
 
@@ -641,7 +642,7 @@ namespace System.Net.Mail
                             if ((e.StatusCode != SmtpStatusCode.CommandUnrecognized)
                                 && (e.StatusCode != SmtpStatusCode.CommandNotImplemented))
                             {
-                                throw e;
+                                throw;
                             }
 
                             if (!thisPtr.SendHello())

--- a/src/System.Net.Mail/src/System/Net/Mail/SmtpTransport.cs
+++ b/src/System.Net.Mail/src/System/Net/Mail/SmtpTransport.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Mime;
+using System.Runtime.ExceptionServices;
 using System.Security.Cryptography.X509Certificates;
 
 namespace System.Net.Mail
@@ -318,11 +319,11 @@ namespace System.Net.Mail
 
             // Note the difference between the singular and plural FailedRecipient exceptions.
             // Only fail immediately if we couldn't send to any recipients.
-            if ((sendMailResult is Exception)
+            if ((sendMailResult is Exception e)
                 && (!(sendMailResult is SmtpFailedRecipientException)
                     || ((SmtpFailedRecipientException)sendMailResult).fatal))
             {
-                throw (Exception)sendMailResult;
+                ExceptionDispatchInfo.Capture(e).Throw();
             }
 
             return new MailWriter(thisPtr._stream);

--- a/src/System.Net.Mail/src/System/Net/Mime/BaseWriter.cs
+++ b/src/System.Net.Mail/src/System/Net/Mime/BaseWriter.cs
@@ -5,6 +5,7 @@
 using System.IO;
 using System.Collections.Specialized;
 using System.Net.Mail;
+using System.Runtime.ExceptionServices;
 
 namespace System.Net.Mime
 {
@@ -146,9 +147,9 @@ namespace System.Net.Mime
         internal Stream EndGetContentStream(IAsyncResult result)
         {
             object o = MultiAsyncResult.End(result);
-            if (o is Exception)
+            if (o is Exception e)
             {
-                throw (Exception)o;
+                ExceptionDispatchInfo.Capture(e).Throw();
             }
             return (Stream)o;
         }

--- a/src/System.Net.Mail/src/System/Net/Mime/MimeMultiPart.cs
+++ b/src/System.Net.Mail/src/System/Net/Mime/MimeMultiPart.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 
 namespace System.Net.Mime
@@ -62,7 +63,7 @@ namespace System.Net.Mime
 
             if (context._completed)
             {
-                throw e;
+                ExceptionDispatchInfo.Capture(e).Throw();
             }
 
             try

--- a/src/System.Net.Mail/src/System/Net/Mime/MimePart.cs
+++ b/src/System.Net.Mail/src/System/Net/Mime/MimePart.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Collections;
 using System.Globalization;
 using System.Net.Mail;
+using System.Runtime.ExceptionServices;
 
 namespace System.Net.Mime
 {
@@ -161,7 +162,7 @@ namespace System.Net.Mime
             MimePartContext context = (MimePartContext)result.AsyncState;
             if (context._completed)
             {
-                throw e;
+                ExceptionDispatchInfo.Capture(e).Throw();
             }
 
             try

--- a/src/System.Net.NameResolution/src/System/Net/DNS.cs
+++ b/src/System.Net.NameResolution/src/System/Net/DNS.cs
@@ -5,6 +5,7 @@
 using System.Globalization;
 using System.Net.Internals;
 using System.Net.Sockets;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -416,7 +417,7 @@ namespace System.Net
             Exception exception = castedResult.Result as Exception;
             if (exception != null)
             {
-                throw exception;
+                ExceptionDispatchInfo.Capture(exception).Throw();
             }
 
             return (IPHostEntry)castedResult.Result;

--- a/src/System.Net.Requests/src/System/Net/FtpDataStream.cs
+++ b/src/System.Net.Requests/src/System/Net/FtpDataStream.cs
@@ -4,6 +4,7 @@
 
 using System.IO;
 using System.Net.Sockets;
+using System.Runtime.ExceptionServices;
 
 namespace System.Net
 {
@@ -255,8 +256,10 @@ namespace System.Net
             {
                 object result = ((LazyAsyncResult)ar).InternalWaitForCompletion();
 
-                if (result is Exception)
-                    throw (Exception)result;
+                if (result is Exception e)
+                {
+                    ExceptionDispatchInfo.Capture(e).Throw();
+                }
 
                 return (int)result;
             }

--- a/src/System.Net.Requests/src/System/Net/FtpWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/FtpWebRequest.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Net.Cache;
 using System.Net.Sockets;
 using System.Security;
+using System.Runtime.ExceptionServices;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
@@ -1231,7 +1232,7 @@ namespace System.Net
         {
             if (_exception != null)
             {
-                throw _exception;
+                ExceptionDispatchInfo.Capture(_exception).Throw();
             }
         }
 

--- a/src/System.Net.Security/src/System/Net/Security/NegoState.cs
+++ b/src/System.Net.Security/src/System/Net/Security/NegoState.cs
@@ -8,6 +8,7 @@ using System.Security;
 using System.Security.Principal;
 using System.Threading;
 using System.ComponentModel;
+using System.Runtime.ExceptionServices;
 using System.Security.Authentication;
 using System.Security.Authentication.ExtendedProtection;
 
@@ -112,7 +113,7 @@ namespace System.Net.Security
         {
             if (_exception != null && !_canRetryAuthentication)
             {
-                throw _exception;
+                ExceptionDispatchInfo.Capture(_exception).Throw();
             }
 
             if (_context != null && _context.IsValidContext)
@@ -313,7 +314,7 @@ namespace System.Net.Security
         {
             if (_exception != null)
             {
-                throw _exception;
+                ExceptionDispatchInfo.Capture(_exception).Throw();
             }
 
             if (authSucessCheck && !IsAuthenticated)
@@ -398,7 +399,7 @@ namespace System.Net.Security
             {
                 // Round-trip it through the SetException().
                 e = SetException(e);
-                throw e;
+                ExceptionDispatchInfo.Capture(e).Throw();
             }
         }
 
@@ -689,7 +690,7 @@ namespace System.Net.Security
             }
 
             _canRetryAuthentication = true;
-            throw exception;
+            ExceptionDispatchInfo.Capture(exception).Throw();
         }
 
         private static void WriteCallback(IAsyncResult transportResult)
@@ -713,10 +714,10 @@ namespace System.Net.Security
                 authState._framer.EndWriteMessage(transportResult);
 
                 // Special case for an error notification.
-                if (lazyResult.Result is Exception)
+                if (lazyResult.Result is Exception e)
                 {
                     authState._canRetryAuthentication = true;
-                    throw (Exception)lazyResult.Result;
+                    ExceptionDispatchInfo.Capture(e).Throw();
                 }
 
                 authState.CheckCompletionBeforeNextReceive(lazyResult);

--- a/src/System.Net.Security/src/System/Net/Security/NegotiateStream.cs
+++ b/src/System.Net.Security/src/System/Net/Security/NegotiateStream.cs
@@ -5,6 +5,7 @@
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Runtime.ExceptionServices;
 using System.Security.Authentication.ExtendedProtection;
 using System.Security.Principal;
 
@@ -620,14 +621,14 @@ namespace System.Net.Security
                 // No "artificial" timeouts implemented so far, InnerStream controls timeout.
                 bufferResult.InternalWaitForCompletion();
 
-                if (bufferResult.Result is Exception)
+                if (bufferResult.Result is Exception e)
                 {
-                    if (bufferResult.Result is IOException)
+                    if (e is IOException)
                     {
-                        throw (Exception)bufferResult.Result;
+                        ExceptionDispatchInfo.Capture(e).Throw();
                     }
 
-                    throw new IOException(SR.net_io_read, (Exception)bufferResult.Result);
+                    throw new IOException(SR.net_io_read, e);
                 }
 
                 return bufferResult.Int32Result;
@@ -693,14 +694,14 @@ namespace System.Net.Security
                 // No "artificial" timeouts implemented so far, InnerStream controls timeout.
                 bufferResult.InternalWaitForCompletion();
 
-                if (bufferResult.Result is Exception)
+                if (bufferResult.Result is Exception e)
                 {
-                    if (bufferResult.Result is IOException)
+                    if (e is IOException)
                     {
-                        throw (Exception)bufferResult.Result;
+                        ExceptionDispatchInfo.Capture(e).Throw();
                     }
 
-                    throw new IOException(SR.net_io_write, (Exception)bufferResult.Result);
+                    throw new IOException(SR.net_io_write, e);
                 }
 #if DEBUG
             }

--- a/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using System.Runtime.ExceptionServices;
 using System.Security;
 using System.Security.Authentication;
 using System.Security.Authentication.ExtendedProtection;
@@ -1097,7 +1098,7 @@ namespace System.Net.Security
 
                 if (status.Exception != null)
                 {
-                    throw status.Exception;
+                    ExceptionDispatchInfo.Capture(status.Exception).Throw();
                 }
 
                 return null;
@@ -1121,7 +1122,7 @@ namespace System.Net.Security
 
                 if (status.Exception != null)
                 {
-                    throw status.Exception;
+                    ExceptionDispatchInfo.Capture(status.Exception).Throw();
                 }
 
                 return null;

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -201,14 +202,14 @@ namespace System.Net.Security
             // No "artificial" timeouts implemented so far, InnerStream controls timeout.
             lazyResult.InternalWaitForCompletion();
 
-            if (lazyResult.Result is Exception)
+            if (lazyResult.Result is Exception e)
             {
-                if (lazyResult.Result is IOException)
+                if (e is IOException)
                 {
-                    throw (Exception)lazyResult.Result;
+                    ExceptionDispatchInfo.Capture(e).Throw();
                 }
 
-                throw new IOException(SR.net_io_write, (Exception)lazyResult.Result);
+                throw new IOException(SR.net_io_write, e);
             }
         }
 

--- a/src/System.Net.Security/src/System/Net/StreamFramer.cs
+++ b/src/System.Net.Security/src/System/Net/StreamFramer.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics;
 using System.IO;
 using System.Globalization;
+using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 
 namespace System.Net
@@ -302,9 +303,9 @@ namespace System.Net
                 workerResult.InternalWaitForCompletion();
             }
 
-            if (workerResult.Result is Exception)
+            if (workerResult.Result is Exception e)
             {
-                throw (Exception)(workerResult.Result);
+                ExceptionDispatchInfo.Capture(e).Throw();
             }
 
             int size = (int)workerResult.Result;
@@ -448,9 +449,9 @@ namespace System.Net
                     workerResult.InternalWaitForCompletion();
                 }
 
-                if (workerResult.Result is Exception)
+                if (workerResult.Result is Exception e)
                 {
-                    throw (Exception)(workerResult.Result);
+                    ExceptionDispatchInfo.Capture(e).Throw();
                 }
             }
             else

--- a/src/System.Net.Sockets/src/System/Net/Sockets/MultipleConnectAsync.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/MultipleConnectAsync.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -322,7 +323,7 @@ namespace System.Net.Sockets
             }
             else
             {
-                throw e;
+                ExceptionDispatchInfo.Capture(e).Throw();
             }
         }
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
@@ -5,6 +5,7 @@
 using Microsoft.Win32.SafeHandles;
 using System.Collections;
 using System.IO;
+using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 
@@ -224,10 +225,7 @@ namespace System.Net.Sockets
 
             if (errorCode != SocketError.Success)
             {
-                SocketException socketException = new SocketException((int)errorCode);
-                UpdateStatusAfterSocketError(socketException);
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, socketException);
-                throw socketException;
+                UpdateStatusAfterSocketErrorAndThrowException(errorCode);
             }
 
             // If the user passed the Disconnect and/or ReuseSocket flags, then TransmitFile disconnected the socket.
@@ -285,10 +283,7 @@ namespace System.Net.Sockets
 
             if ((SocketError)castedAsyncResult.ErrorCode != SocketError.Success)
             {
-                SocketException socketException = new SocketException(castedAsyncResult.ErrorCode);
-                UpdateStatusAfterSocketError(socketException);
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, socketException);
-                throw socketException;
+                UpdateStatusAfterSocketErrorAndThrowException((SocketError)castedAsyncResult.ErrorCode);
             }
 
         }


### PR DESCRIPTION
There are a bunch of places throughout the System.Net libraries where exceptions are captured and later thrown, using `throw e;`.  This overwrites their stack trace and bucket information, making it harder to diagnose problems when they occur.  Over time we've chipped away at these, so there are many fewer now than there used to be, but some still remain.

I've audited all of the System.Net libs, and fixed all the locations I found where this pattern was being employed, replacing them with usage of ExceptionDispatchInfo to avoid losing the call stack data.  There are still some `throw e`s I left, but those were typically of a form where it was obvious no data would be lost, e.g. the exception was just instantiated a few lines earlier.  There are likely also a few straggling cases, e.g. where `throw SomeFunction()` is used and `SomeFunction()` returns a cached exception instance, but we can address those on a case-by-case basis as we find them.

Fixes https://github.com/dotnet/corefx/issues/5606
cc: @geoffkizer, @cipop, @davidsh, @Priya91 