### PR TITLE
Mark SqlClient test server threads as background threads

### DIFF
--- a/src/System.Data.SqlClient/tests/Tools/TDS/TDS.EndPoint/TDSServerEndPoint.cs
+++ b/src/System.Data.SqlClient/tests/Tools/TDS/TDS.EndPoint/TDSServerEndPoint.cs
@@ -95,7 +95,7 @@ namespace Microsoft.SqlServer.TDS.EndPoint
             ServerEndPoint = (IPEndPoint)ListenerSocket.LocalEndpoint;
 
             // Initialize the listener
-            ListenerThread = new Thread(new ThreadStart(_RequestListener));
+            ListenerThread = new Thread(new ThreadStart(_RequestListener)) { IsBackground = true };
             ListenerThread.Name = "TDS Server EndPoint Listener";
             ListenerThread.Start();
         }

--- a/src/System.Data.SqlClient/tests/Tools/TDS/TDS.EndPoint/TDSServerEndPointConnection.cs
+++ b/src/System.Data.SqlClient/tests/Tools/TDS/TDS.EndPoint/TDSServerEndPointConnection.cs
@@ -128,7 +128,7 @@ namespace Microsoft.SqlServer.TDS.EndPoint
             StopRequested = false;
 
             // Prepare and start a thread
-            ProcessorThread = new Thread(new ThreadStart(_ConnectionHandler));
+            ProcessorThread = new Thread(new ThreadStart(_ConnectionHandler)) { IsBackground = true };
             ProcessorThread.Name = string.Format("TDS Server Connection {0} Thread", Connection.Client.RemoteEndPoint);
             ProcessorThread.Start();
         }


### PR DESCRIPTION
cc: @saurabh500 
I'm hopeful this will take care of the hangs noted in https://github.com/dotnet/corefx/issues/16421 and https://github.com/dotnet/corefx/issues/16430, but we'll see.