### PR TITLE
Modify RemoteExecutorConsoleApp to use Environment.Exit

### DIFF
--- a/src/Common/tests/System/Diagnostics/RemoteExecutorConsoleApp/RemoteExecutorConsoleApp.cs
+++ b/src/Common/tests/System/Diagnostics/RemoteExecutorConsoleApp/RemoteExecutorConsoleApp.cs
@@ -13,7 +13,7 @@ namespace RemoteExecutorConsoleApp
     /// </summary>
     internal static class Program
     {
-        static int Main(string[] args)
+        static void Main(string[] args)
         {
             // The program expects to be passed the target assembly name to load, the type
             // from that assembly to find, and the method from that assembly to invoke.
@@ -21,8 +21,9 @@ namespace RemoteExecutorConsoleApp
             if (args.Length < 3)
             {
                 Console.Error.WriteLine("Usage: {0} assemblyName typeName methodName", typeof(Program).GetTypeInfo().Assembly.GetName().Name);
-                return -1;
+                Environment.Exit(-1);
             }
+
             string assemblyName = args[0];
             string typeName = args[1];
             string methodName = args[2];
@@ -36,8 +37,10 @@ namespace RemoteExecutorConsoleApp
             Type t = null;
             MethodInfo mi = null;
             object instance = null;
+            int exitCode;
             try
             {
+                // Create the test class if necessary
                 a = Assembly.Load(new AssemblyName(assemblyName));
                 t = a.GetType(typeName);
                 mi = t.GetTypeInfo().GetDeclaredMethod(methodName);
@@ -45,9 +48,11 @@ namespace RemoteExecutorConsoleApp
                 {
                     instance = Activator.CreateInstance(t);
                 }
+
+                // Invoke the test
                 object result = mi.Invoke(instance, additionalArgs);
-                return result is Task<int> ?
-                    ((Task<int>)result).GetAwaiter().GetResult() :
+                exitCode = result is Task<int> task ?
+                    task.GetAwaiter().GetResult() :
                     (int)result;
             }
             catch (Exception exc)
@@ -61,12 +66,13 @@ namespace RemoteExecutorConsoleApp
             }
             finally
             {
-                IDisposable d = instance as IDisposable;
-                if (d != null)
-                {
-                    d.Dispose();
-                }
+                (instance as IDisposable)?.Dispose();
             }
+
+            // Use Exit rather than simply returning the exit code so that we forcibly shut down
+            // the process even if there are foreground threads created by the operation that would
+            // end up keeping the process alive potentially indefinitely.
+            Environment.Exit(exitCode);
         }
 
         private static MethodInfo GetMethod(this Type type, string methodName)


### PR DESCRIPTION
The purpose of RemoteExecutorConsoleApp is to invoke a single test method, wait for it to complete, and then exit.  If that test method ends up creating some foreground threads, though, and they don't exit, the app will remain alive even after the test has completed, potentially causing the test invoker to fail due to timeouts.  So instead of returning an exit code from Main, we use Environment.Exit to avoid blocking the process' completion while waiting for foreground threads.

cc: @Priya91, @ianhays, @saurabh500 