### PR TITLE
Fix for issue 16856 (Test fails because duration is 0)

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -227,6 +227,8 @@ namespace System.Diagnostics
                 throw new InvalidOperationException($"{nameof(endTimeUtc)} is not UTC");
 
             Duration = endTimeUtc - StartTimeUtc;
+            if (Duration.Ticks <= 0)
+                Duration = new TimeSpan(1); // We want Duration of 0 to mean  'EndTime not set)
             return this;
         }
 


### PR DESCRIPTION
The problem seems to be that time granularity rounds down to zero.
However we really do want 0 durations to mean 'EndTime was not set, so
when we set the end time we want to insure it is postitive under all contidions.