### PR TITLE
Fix marshaling/pinning in GetSignerInPKCS7Store to avoid corrupted data

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.Import.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.Import.cs
@@ -104,41 +104,37 @@ namespace Internal.Cryptography.Pal
             }
         }
 
-        private static SafeCertContextHandle GetSignerInPKCS7Store(SafeCertStoreHandle hCertStore, SafeCryptMsgHandle hCryptMsg)
+        private static unsafe SafeCertContextHandle GetSignerInPKCS7Store(SafeCertStoreHandle hCertStore, SafeCryptMsgHandle hCryptMsg)
         {
             // make sure that there is at least one signer of the certificate store
             int dwSigners;
             int cbSigners = sizeof(int);
             if (!Interop.crypt32.CryptMsgGetParam(hCryptMsg, CryptMessageParameterType.CMSG_SIGNER_COUNT_PARAM, 0, out dwSigners, ref cbSigners))
-                throw Marshal.GetHRForLastWin32Error().ToCryptographicException();;
+                throw Marshal.GetHRForLastWin32Error().ToCryptographicException();
             if (dwSigners == 0)
                 throw ErrorCode.CRYPT_E_SIGNER_NOT_FOUND.ToCryptographicException();
 
             // get the first signer from the store, and use that as the loaded certificate
             int cbData = 0;
             if (!Interop.crypt32.CryptMsgGetParam(hCryptMsg, CryptMessageParameterType.CMSG_SIGNER_INFO_PARAM, 0, null, ref cbData))
-                throw Marshal.GetHRForLastWin32Error().ToCryptographicException();;
+                throw Marshal.GetHRForLastWin32Error().ToCryptographicException();
 
-            byte[] cmsgSignerBytes = new byte[cbData];
-            if (!Interop.crypt32.CryptMsgGetParam(hCryptMsg, CryptMessageParameterType.CMSG_SIGNER_INFO_PARAM, 0, cmsgSignerBytes, ref cbData))
-                throw Marshal.GetHRForLastWin32Error().ToCryptographicException();;
-
-            CERT_INFO certInfo = default(CERT_INFO);
-            unsafe
+            fixed (byte* pCmsgSignerBytes = new byte[cbData])
             {
-                fixed (byte* pCmsgSignerBytes = cmsgSignerBytes)
-                {
-                    CMSG_SIGNER_INFO_Partial* pCmsgSignerInfo = (CMSG_SIGNER_INFO_Partial*)pCmsgSignerBytes;
-                    certInfo.Issuer.cbData = pCmsgSignerInfo->Issuer.cbData;
-                    certInfo.Issuer.pbData = pCmsgSignerInfo->Issuer.pbData;
-                    certInfo.SerialNumber.cbData = pCmsgSignerInfo->SerialNumber.cbData;
-                    certInfo.SerialNumber.pbData = pCmsgSignerInfo->SerialNumber.pbData;
-                }
+                if (!Interop.crypt32.CryptMsgGetParam(hCryptMsg, CryptMessageParameterType.CMSG_SIGNER_INFO_PARAM, 0, pCmsgSignerBytes, ref cbData))
+                    throw Marshal.GetHRForLastWin32Error().ToCryptographicException();
+
+                CMSG_SIGNER_INFO_Partial* pCmsgSignerInfo = (CMSG_SIGNER_INFO_Partial*)pCmsgSignerBytes;
+
+                CERT_INFO certInfo = default(CERT_INFO);
+                certInfo.Issuer.cbData = pCmsgSignerInfo->Issuer.cbData;
+                certInfo.Issuer.pbData = pCmsgSignerInfo->Issuer.pbData;
+                certInfo.SerialNumber.cbData = pCmsgSignerInfo->SerialNumber.cbData;
+                certInfo.SerialNumber.pbData = pCmsgSignerInfo->SerialNumber.pbData;
 
                 SafeCertContextHandle pCertContext = null;
                 if (!Interop.crypt32.CertFindCertificateInStore(hCertStore, CertFindType.CERT_FIND_SUBJECT_CERT, &certInfo, ref pCertContext))
-                    throw Marshal.GetHRForLastWin32Error().ToCryptographicException();;
-
+                    throw Marshal.GetHRForLastWin32Error().ToCryptographicException();
                 return pCertContext;
             }
         }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Interop.crypt32.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Interop.crypt32.cs
@@ -139,7 +139,7 @@ internal static partial class Interop
         public static extern SafeCertStoreHandle PFXImportCertStore([In] ref CRYPTOAPI_BLOB pPFX, SafePasswordHandle password, PfxCertStoreFlags dwFlags);
 
         [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true)]
-        public static extern bool CryptMsgGetParam(SafeCryptMsgHandle hCryptMsg, CryptMessageParameterType dwParamType, int dwIndex, [Out] byte[] pvData, [In, Out] ref int pcbData);
+        public static extern unsafe bool CryptMsgGetParam(SafeCryptMsgHandle hCryptMsg, CryptMessageParameterType dwParamType, int dwIndex, byte* pvData, [In, Out] ref int pcbData);
 
         [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true)]
         public static extern bool CryptMsgGetParam(SafeCryptMsgHandle hCryptMsg, CryptMessageParameterType dwParamType, int dwIndex, out int pvData, [In, Out] ref int pcbData);

--- a/src/System.Security.Cryptography.X509Certificates/tests/LoadFromFileTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/LoadFromFileTests.cs
@@ -126,7 +126,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [Fact]
         [ActiveIssue(2910, TestPlatforms.AnyUnix)]
-        [ActiveIssue(2667, TestPlatforms.Windows)]
         public static void TestLoadSignedFile()
         {
             // X509Certificate2 can also extract the certificate from a signed file.


### PR DESCRIPTION
CryptMsgGetParam stores its output data at the provided address, and this data includes pointers into regions of the data written.  Since the array we've provided isn't pinned, it can be moved after the call, effectively invalidating the pointers in the byte[] into which the data was stored before then effectively pass those (now invalid) pointers back to the OS for it to get data from.

Fixes https://github.com/dotnet/corefx/issues/2667
cc: @bartonjs, @steveharter 