### PR TITLE
Add better error message for failing ping test

### DIFF
--- a/src/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -399,7 +399,10 @@ namespace System.Net.NetworkInformation.Tests
                     p.SendAsyncCancel(); // will block until operation can be started again
                 }
                 await tcs.Task;
-                Assert.True(ea.Cancelled ^ (ea.Error != null) ^ (ea.Reply != null));
+                Assert.True(ea.Cancelled ^ (ea.Error != null) ^ (ea.Reply != null),
+                    "Cancelled: " + ea.Cancelled +
+                    (ea.Error == null ? "" : (Environment.NewLine + "Error Message: " + ea.Error.Message + Environment.NewLine + "Error Inner Exception: " + ea.Error.InnerException)) +
+                    (ea.Reply == null ? "" : (Environment.NewLine + "Reply Address: " + ea.Reply.Address + Environment.NewLine + "Reply Status: " + ea.Reply.Status)));
             }
         }
 


### PR DESCRIPTION
I'm adding some better logging to the failure in this test since we don't really know why it failed. It looks race-conditiony but I'd rather be sure about it before modifying the test.

Related to https://github.com/dotnet/corefx/issues/16401.

@steveharter @Priya91 