### PR TITLE
Fix Console WindowWidth/Height paramName

### DIFF
--- a/src/System.Console/src/System/Console.cs
+++ b/src/System.Console/src/System/Console.cs
@@ -225,7 +225,7 @@ namespace System
             {
                 if (value <= 0)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(value), value, SR.ArgumentOutOfRange_NeedPosNum);
+                    throw new ArgumentOutOfRangeException("width", value, SR.ArgumentOutOfRange_NeedPosNum);
                 }
                 ConsolePal.WindowWidth = value;
             }
@@ -241,7 +241,7 @@ namespace System
             {
                 if (value <= 0)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(value), value, SR.ArgumentOutOfRange_NeedPosNum);
+                    throw new ArgumentOutOfRangeException("height", value, SR.ArgumentOutOfRange_NeedPosNum);
                 }
                 ConsolePal.WindowHeight = value;
             }

--- a/src/System.Console/tests/WindowAndCursorProps.cs
+++ b/src/System.Console/tests/WindowAndCursorProps.cs
@@ -31,19 +31,10 @@ public class WindowAndCursorProps : RemoteExecutorTestBase
     }
 
     [Fact]
-    [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp | TargetFrameworkMonikers.Uap)]
-    public static void WindowWidth_WindowHeight_InvalidSize_net46()
-    {
-        Assert.Throws<IOException>(() => Console.WindowWidth = 0);
-        Assert.Throws<IOException>(() => Console.WindowHeight = 0);
-    }
-
-    [Fact]
-    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
     public static void WindowWidth_WindowHeight_InvalidSize()
     {
-        Assert.Throws<ArgumentOutOfRangeException>("value", () => Console.WindowWidth = 0);
-        Assert.Throws<ArgumentOutOfRangeException>("value", () => Console.WindowHeight = 0);
+        Assert.Throws<ArgumentOutOfRangeException>("width", () => Console.WindowWidth = 0);
+        Assert.Throws<ArgumentOutOfRangeException>("height", () => Console.WindowHeight = 0);
     }
 
     [Fact]


### PR DESCRIPTION
Looks like we messed up the paramname when we did the switch to nameof in netcore. It used to be "width"/"height" in full framework but we set it to "value" which is both less helpful and the cause of a desktop test failure/discrepancy.

resolves https://github.com/dotnet/corefx/issues/15114

cc: @tarekgh @stephentoub 