### PR TITLE
X509Certificate2.PrivateKey should not return ECDSA

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/ICertificatePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/ICertificatePal.cs
@@ -31,7 +31,6 @@ namespace Internal.Cryptography
         X500DistinguishedName SubjectName { get; }
         X500DistinguishedName IssuerName { get; }
         IEnumerable<X509Extension> Extensions { get; }
-        AsymmetricAlgorithm GetPrivateKey();
         RSA GetRSAPrivateKey();
         DSA GetDSAPrivateKey();
         ECDsa GetECDsaPrivateKey();

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
@@ -255,21 +255,6 @@ namespace Internal.Cryptography.Pal
             get { return _privateKey; }
         }
 
-        public AsymmetricAlgorithm GetPrivateKey()
-        {
-            switch (KeyAlgorithm)
-            {
-                case Oids.RsaRsa:
-                    return GetRSAPrivateKey();
-                case Oids.DsaDsa:
-                    return GetDSAPrivateKey();
-                case Oids.Ecc:
-                    return GetECDsaPrivateKey();
-            }
-
-            throw new NotSupportedException(SR.NotSupported_KeyAlgorithm);
-        }
-
         public RSA GetRSAPrivateKey()
         {
             if (_privateKey == null || _privateKey.IsInvalid)

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.PrivateKey.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.PrivateKey.cs
@@ -22,21 +22,6 @@ namespace Internal.Cryptography.Pal
             }
         }
 
-        public AsymmetricAlgorithm GetPrivateKey()
-        {
-            switch (KeyAlgorithm)
-            {
-                case Oids.RsaRsa:
-                    return GetRSAPrivateKey();
-                case Oids.DsaDsa:
-                    return GetDSAPrivateKey();
-                case Oids.Ecc:
-                    return GetECDsaPrivateKey();
-            }
-
-            throw new NotSupportedException(SR.NotSupported_KeyAlgorithm);
-        }
-
         public RSA GetRSAPrivateKey()
         {
             return GetPrivateKey<RSA>(

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/PublicKey.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/PublicKey.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Internal.Cryptography;
 using Internal.Cryptography.Pal;
 
 namespace System.Security.Cryptography.X509Certificates
@@ -28,8 +29,22 @@ namespace System.Security.Cryptography.X509Certificates
             {
                 if (_key == null)
                 {
-                    _key = X509Pal.Instance.DecodePublicKey(_oid, EncodedKeyValue.RawData, EncodedParameters.RawData, null);
+                    switch (_oid.Value)
+                    {
+                        case Oids.RsaRsa:
+                        case Oids.DsaDsa:
+                            _key = X509Pal.Instance.DecodePublicKey(_oid, EncodedKeyValue.RawData, EncodedParameters.RawData, null);
+                            break;
+
+                        default:
+                            // This includes ECDSA, because an Oids.Ecc key can be
+                            // many different algorithm kinds, not necessarily with mutual exclusion.
+                            //
+                            // Plus, .NET Framework only supports RSA and DSA in this property.
+                            throw new NotSupportedException(SR.NotSupported_KeyAlgorithm);
+                    }
                 }
+
                 return _key;
             }
         }

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
@@ -197,10 +197,28 @@ namespace System.Security.Cryptography.X509Certificates
             {
                 ThrowIfInvalid();
 
+                if (!HasPrivateKey)
+                    return null;
+
                 if (_lazyPrivateKey == null)
                 {
-                    _lazyPrivateKey = Pal.GetPrivateKey();
+                    switch (GetKeyAlgorithm())
+                    {
+                        case Oids.RsaRsa:
+                            _lazyPrivateKey = Pal.GetRSAPrivateKey();
+                            break;
+                        case Oids.DsaDsa:
+                            _lazyPrivateKey = Pal.GetDSAPrivateKey();
+                            break;
+                        default:
+                            // This includes ECDSA, because an Oids.Ecc key can be
+                            // many different algorithm kinds, not necessarily with mutual exclusion.
+                            //
+                            // Plus, .NET Framework only supports RSA and DSA in this property.
+                            throw new NotSupportedException(SR.NotSupported_KeyAlgorithm);
+                    }
                 }
+
                 return _lazyPrivateKey;
             }
             set

--- a/src/System.Security.Cryptography.X509Certificates/tests/PfxTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/PfxTests.cs
@@ -185,16 +185,22 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         public static void ECDsaPrivateKeyProperty_WindowsPfx()
         {
             using (var cert = new X509Certificate2(TestData.ECDsaP256_DigitalSignature_Pfx_Windows, "Test", X509KeyStorageFlags.EphemeralKeySet))
+            using (var pubOnly = new X509Certificate2(cert.RawData))
             {
-                AsymmetricAlgorithm alg = cert.PrivateKey;
-                Assert.NotNull(alg);
-                Assert.Same(alg, cert.PrivateKey);
-                Assert.IsAssignableFrom(typeof(ECDsa), alg);
-                Verify_ECDsaPrivateKey_WindowsPfx((ECDsa)alg);
+                Assert.True(cert.HasPrivateKey, "cert.HasPrivateKey");
+                Assert.Throws<NotSupportedException>(() => cert.PrivateKey);
+
+                Assert.False(pubOnly.HasPrivateKey, "pubOnly.HasPrivateKey");
+                Assert.Null(pubOnly.PrivateKey);
 
                 // Currently unable to set PrivateKey
                 Assert.Throws<PlatformNotSupportedException>(() => cert.PrivateKey = null);
-                Assert.Throws<PlatformNotSupportedException>(() => cert.PrivateKey = alg);
+
+                using (var privKey = cert.GetECDsaPrivateKey())
+                {
+                    Assert.Throws<PlatformNotSupportedException>(() => cert.PrivateKey = privKey);
+                    Assert.Throws<PlatformNotSupportedException>(() => pubOnly.PrivateKey = privKey);
+                }
             }
         }
 #endif


### PR DESCRIPTION
Make the PrivateKey property match netfx in not returning ECDSA, fix that it
should return null (regardless of algorithm) when HasPrivateKey is false, and
move redundant code in the PAL into the PAL-calling layer.

Fixes #14283.