### PR TITLE
Make Managed SNI the default network impl in SqlClient

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.Windows.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.Windows.cs
@@ -13,7 +13,7 @@ namespace System.Data.SqlClient
 
         internal void PostReadAsyncForMars()
         {
-            if (TdsParserStateObjectFactory.UseManagedSni)
+            if (TdsParserStateObjectFactory.UseManagedSNI)
                 return;
 
             // HACK HACK HACK - for Async only
@@ -44,7 +44,7 @@ namespace System.Data.SqlClient
 
         private void LoadSSPILibrary()
         {
-            if (TdsParserStateObjectFactory.UseManagedSni)
+            if (TdsParserStateObjectFactory.UseManagedSNI)
                 return;
             // Outer check so we don't acquire lock once it's loaded.
             if (!s_fSSPILoaded)
@@ -74,7 +74,7 @@ namespace System.Data.SqlClient
 
         private void WaitForSSLHandShakeToComplete(ref uint error)
         {
-            if (TdsParserStateObjectFactory.UseManagedSni)
+            if (TdsParserStateObjectFactory.UseManagedSNI)
                 return;
             // in the case where an async connection is made, encryption is used and Windows Authentication is used, 
             // wait for SSL handshake to complete, so that the SSL context is fully negotiated before we try to use its 
@@ -92,7 +92,7 @@ namespace System.Data.SqlClient
         {
             SNIErrorDetails details = new SNIErrorDetails();
 
-            if (TdsParserStateObjectFactory.UseManagedSni)
+            if (TdsParserStateObjectFactory.UseManagedSNI)
             {
                 SNIError sniError = SNIProxy.Singleton.GetLastError();
                 details.sniErrorNumber = sniError.sniError;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.Windows.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.Windows.cs
@@ -13,7 +13,7 @@ namespace System.Data.SqlClient
 
         internal void PostReadAsyncForMars()
         {
-            if (TdsParserStateObjectFactory.useManagedSni)
+            if (TdsParserStateObjectFactory.UseManagedSni)
                 return;
 
             // HACK HACK HACK - for Async only
@@ -44,7 +44,7 @@ namespace System.Data.SqlClient
 
         private void LoadSSPILibrary()
         {
-            if (TdsParserStateObjectFactory.useManagedSni)
+            if (TdsParserStateObjectFactory.UseManagedSni)
                 return;
             // Outer check so we don't acquire lock once it's loaded.
             if (!s_fSSPILoaded)
@@ -74,7 +74,7 @@ namespace System.Data.SqlClient
 
         private void WaitForSSLHandShakeToComplete(ref uint error)
         {
-            if (TdsParserStateObjectFactory.useManagedSni)
+            if (TdsParserStateObjectFactory.UseManagedSni)
                 return;
             // in the case where an async connection is made, encryption is used and Windows Authentication is used, 
             // wait for SSL handshake to complete, so that the SSL context is fully negotiated before we try to use its 
@@ -92,7 +92,7 @@ namespace System.Data.SqlClient
         {
             SNIErrorDetails details = new SNIErrorDetails();
 
-            if (TdsParserStateObjectFactory.useManagedSni)
+            if (TdsParserStateObjectFactory.UseManagedSni)
             {
                 SNIError sniError = SNIProxy.Singleton.GetLastError();
                 details.sniErrorNumber = sniError.sniError;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
@@ -437,7 +437,7 @@ namespace System.Data.SqlClient
                 // Cache physical stateObj and connection.
                 _pMarsPhysicalConObj = _physicalStateObj;
 
-                if(TdsParserStateObjectFactory.useManagedSni) _pMarsPhysicalConObj.IncrementPendingCallbacks();
+                if(TdsParserStateObjectFactory.UseManagedSni) _pMarsPhysicalConObj.IncrementPendingCallbacks();
 
                 UInt32 info = 0;
                 uint error = _pMarsPhysicalConObj.EnableMars(ref info);
@@ -1164,7 +1164,7 @@ namespace System.Data.SqlClient
             // !=null       | == 0     | replace text left of errorMessage
             //
 
-            if (TdsParserStateObjectFactory.useManagedSni)
+            if (TdsParserStateObjectFactory.UseManagedSni)
                 Debug.Assert(!string.IsNullOrEmpty(details.errorMessage) || details.sniErrorNumber != 0, "Empty error message received from SNI");
             else
                 Debug.Assert(!string.IsNullOrEmpty(details.errorMessage), "Empty error message received from SNI");
@@ -1206,7 +1206,7 @@ namespace System.Data.SqlClient
             else
             {
 
-                if (TdsParserStateObjectFactory.useManagedSni)
+                if (TdsParserStateObjectFactory.UseManagedSni)
                 {
                     // SNI error. Append additional error message info if available.
                     //
@@ -5936,7 +5936,7 @@ namespace System.Data.SqlClient
                     _physicalStateObj.SniContext = SniContext.Snix_LoginSspi;
 
                     SSPIData(null, 0, outSSPIBuff, ref outSSPILength);
-                    if (TdsParserStateObjectFactory.useManagedSni)
+                    if (TdsParserStateObjectFactory.UseManagedSni)
                     {
                         outSSPILength = outSSPIBuff != null ? (uint)outSSPIBuff.Length : 0;
                     }
@@ -6201,7 +6201,7 @@ namespace System.Data.SqlClient
 
         private void SNISSPIData(byte[] receivedBuff, UInt32 receivedLength, byte[] sendBuff, ref UInt32 sendLength)
         {
-            if (TdsParserStateObjectFactory.useManagedSni)
+            if (TdsParserStateObjectFactory.UseManagedSni)
             {
                 try
                 {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
@@ -437,7 +437,7 @@ namespace System.Data.SqlClient
                 // Cache physical stateObj and connection.
                 _pMarsPhysicalConObj = _physicalStateObj;
 
-                if(TdsParserStateObjectFactory.UseManagedSni) _pMarsPhysicalConObj.IncrementPendingCallbacks();
+                if(TdsParserStateObjectFactory.UseManagedSNI) _pMarsPhysicalConObj.IncrementPendingCallbacks();
 
                 UInt32 info = 0;
                 uint error = _pMarsPhysicalConObj.EnableMars(ref info);
@@ -1164,7 +1164,7 @@ namespace System.Data.SqlClient
             // !=null       | == 0     | replace text left of errorMessage
             //
 
-            if (TdsParserStateObjectFactory.UseManagedSni)
+            if (TdsParserStateObjectFactory.UseManagedSNI)
                 Debug.Assert(!string.IsNullOrEmpty(details.errorMessage) || details.sniErrorNumber != 0, "Empty error message received from SNI");
             else
                 Debug.Assert(!string.IsNullOrEmpty(details.errorMessage), "Empty error message received from SNI");
@@ -1206,7 +1206,7 @@ namespace System.Data.SqlClient
             else
             {
 
-                if (TdsParserStateObjectFactory.UseManagedSni)
+                if (TdsParserStateObjectFactory.UseManagedSNI)
                 {
                     // SNI error. Append additional error message info if available.
                     //
@@ -5936,7 +5936,7 @@ namespace System.Data.SqlClient
                     _physicalStateObj.SniContext = SniContext.Snix_LoginSspi;
 
                     SSPIData(null, 0, outSSPIBuff, ref outSSPILength);
-                    if (TdsParserStateObjectFactory.UseManagedSni)
+                    if (TdsParserStateObjectFactory.UseManagedSNI)
                     {
                         outSSPILength = outSSPIBuff != null ? (uint)outSSPIBuff.Length : 0;
                     }
@@ -6201,7 +6201,7 @@ namespace System.Data.SqlClient
 
         private void SNISSPIData(byte[] receivedBuff, UInt32 receivedLength, byte[] sendBuff, ref UInt32 sendLength)
         {
-            if (TdsParserStateObjectFactory.UseManagedSni)
+            if (TdsParserStateObjectFactory.UseManagedSNI)
             {
                 try
                 {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObject.cs
@@ -2358,7 +2358,7 @@ namespace System.Data.SqlClient
             }
             finally
             {
-                if (!TdsParserStateObjectFactory.useManagedSni)
+                if (!TdsParserStateObjectFactory.UseManagedSni)
                 {
                     if (!IsPacketEmpty(readPacket))
                     {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObject.cs
@@ -2358,7 +2358,7 @@ namespace System.Data.SqlClient
             }
             finally
             {
-                if (!TdsParserStateObjectFactory.UseManagedSni)
+                if (!TdsParserStateObjectFactory.UseManagedSNI)
                 {
                     if (!IsPacketEmpty(readPacket))
                     {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectFactory.Unix.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectFactory.Unix.cs
@@ -9,7 +9,7 @@ namespace System.Data.SqlClient
     internal sealed class TdsParserStateObjectFactory
     {
 
-        public static bool useManagedSni = true;
+        public static bool UseManagedSni => true;
 
         public static readonly TdsParserStateObjectFactory Singleton = new TdsParserStateObjectFactory();
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectFactory.Unix.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectFactory.Unix.cs
@@ -9,7 +9,7 @@ namespace System.Data.SqlClient
     internal sealed class TdsParserStateObjectFactory
     {
 
-        public static bool UseManagedSni => true;
+        public static bool UseManagedSNI => true;
 
         public static readonly TdsParserStateObjectFactory Singleton = new TdsParserStateObjectFactory();
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectFactory.Windows.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectFactory.Windows.cs
@@ -11,21 +11,21 @@ namespace System.Data.SqlClient
 
         private const string UseLegacyNetworkingOnWindows = "System.Data.SqlClient.UseLegacyNetworkingOnWindows";
 
+        public static readonly TdsParserStateObjectFactory Singleton = new TdsParserStateObjectFactory();
+
         static TdsParserStateObjectFactory()
         {
+            bool shouldUseLegacyNetorking;
             // If The appcontext switch is set then Use Managed SNI based on the value. Otherwise Managed SNI should always be used.
             UseManagedSni = AppContext.TryGetSwitch(UseLegacyNetworkingOnWindows, out shouldUseLegacyNetorking) ? !shouldUseLegacyNetorking : true;
         }
 
-        private static bool shouldUseLegacyNetorking;
-
         public static bool UseManagedSni
         {
-            get; private set;
+            get;
+            private set;
         }
-
-        public static readonly TdsParserStateObjectFactory Singleton = new TdsParserStateObjectFactory();
-
+        
         public EncryptionOptions EncryptionOptions
         {
             get

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectFactory.Windows.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectFactory.Windows.cs
@@ -8,7 +8,20 @@ namespace System.Data.SqlClient
 {
     internal sealed class TdsParserStateObjectFactory
     {
-        public static bool useManagedSni = false;
+
+        private const string UseLegacyNetworkingOnWindows = "System.Data.SqlClient.UseLegacyNetworkingOnWindows";
+
+        static TdsParserStateObjectFactory()
+        {
+            UseManagedSni = AppContext.TryGetSwitch(UseLegacyNetworkingOnWindows, out shouldUseLegacyNetorking) ? !shouldUseLegacyNetorking : true;
+        }
+
+        private static bool shouldUseLegacyNetorking;
+
+        public static bool UseManagedSni
+        {
+            get; private set;
+        }
 
         public static readonly TdsParserStateObjectFactory Singleton = new TdsParserStateObjectFactory();
 
@@ -16,7 +29,7 @@ namespace System.Data.SqlClient
         {
             get
             {
-                return useManagedSni ? SNI.SNILoadHandle.SingletonInstance.Options : SNILoadHandle.SingletonInstance.Options;
+                return UseManagedSni ? SNI.SNILoadHandle.SingletonInstance.Options : SNILoadHandle.SingletonInstance.Options;
             }
         }
 
@@ -24,13 +37,13 @@ namespace System.Data.SqlClient
         {
             get
             {
-                return useManagedSni ? SNI.SNILoadHandle.SingletonInstance.Status : SNILoadHandle.SingletonInstance.Status;
+                return UseManagedSni ? SNI.SNILoadHandle.SingletonInstance.Status : SNILoadHandle.SingletonInstance.Status;
             }
         }
 
         public TdsParserStateObject CreateTdsParserStateObject(TdsParser parser)
         {
-            if (useManagedSni)
+            if (UseManagedSni)
             {
                 return new TdsParserStateObjectManaged(parser);
             }
@@ -42,7 +55,7 @@ namespace System.Data.SqlClient
 
         internal TdsParserStateObject CreateSessionObject(TdsParser tdsParser, TdsParserStateObject _pMarsPhysicalConObj, bool v)
         {
-            if (TdsParserStateObjectFactory.useManagedSni)
+            if (TdsParserStateObjectFactory.UseManagedSni)
             {
                 return new TdsParserStateObjectManaged(tdsParser, _pMarsPhysicalConObj, true);
             }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectFactory.Windows.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectFactory.Windows.cs
@@ -13,6 +13,7 @@ namespace System.Data.SqlClient
 
         static TdsParserStateObjectFactory()
         {
+            // If The appcontext switch is set then Use Managed SNI based on the value. Otherwise Managed SNI should always be used.
             UseManagedSni = AppContext.TryGetSwitch(UseLegacyNetworkingOnWindows, out shouldUseLegacyNetorking) ? !shouldUseLegacyNetorking : true;
         }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectFactory.Windows.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectFactory.Windows.cs
@@ -17,10 +17,10 @@ namespace System.Data.SqlClient
         {
             bool shouldUseLegacyNetorking;
             // If The appcontext switch is set then Use Managed SNI based on the value. Otherwise Managed SNI should always be used.
-            UseManagedSni = AppContext.TryGetSwitch(UseLegacyNetworkingOnWindows, out shouldUseLegacyNetorking) ? !shouldUseLegacyNetorking : true;
+            UseManagedSNI = AppContext.TryGetSwitch(UseLegacyNetworkingOnWindows, out shouldUseLegacyNetorking) ? !shouldUseLegacyNetorking : true;
         }
 
-        public static bool UseManagedSni
+        public static bool UseManagedSNI
         {
             get;
             private set;
@@ -30,7 +30,7 @@ namespace System.Data.SqlClient
         {
             get
             {
-                return UseManagedSni ? SNI.SNILoadHandle.SingletonInstance.Options : SNILoadHandle.SingletonInstance.Options;
+                return UseManagedSNI ? SNI.SNILoadHandle.SingletonInstance.Options : SNILoadHandle.SingletonInstance.Options;
             }
         }
 
@@ -38,13 +38,13 @@ namespace System.Data.SqlClient
         {
             get
             {
-                return UseManagedSni ? SNI.SNILoadHandle.SingletonInstance.Status : SNILoadHandle.SingletonInstance.Status;
+                return UseManagedSNI ? SNI.SNILoadHandle.SingletonInstance.Status : SNILoadHandle.SingletonInstance.Status;
             }
         }
 
         public TdsParserStateObject CreateTdsParserStateObject(TdsParser parser)
         {
-            if (UseManagedSni)
+            if (UseManagedSNI)
             {
                 return new TdsParserStateObjectManaged(parser);
             }
@@ -56,7 +56,7 @@ namespace System.Data.SqlClient
 
         internal TdsParserStateObject CreateSessionObject(TdsParser tdsParser, TdsParserStateObject _pMarsPhysicalConObj, bool v)
         {
-            if (TdsParserStateObjectFactory.UseManagedSni)
+            if (TdsParserStateObjectFactory.UseManagedSNI)
             {
                 return new TdsParserStateObjectManaged(tdsParser, _pMarsPhysicalConObj, true);
             }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectFactory.Windows.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectFactory.Windows.cs
@@ -13,19 +13,11 @@ namespace System.Data.SqlClient
 
         public static readonly TdsParserStateObjectFactory Singleton = new TdsParserStateObjectFactory();
 
-        static TdsParserStateObjectFactory()
-        {
-            bool shouldUseLegacyNetorking;
-            // If The appcontext switch is set then Use Managed SNI based on the value. Otherwise Managed SNI should always be used.
-            UseManagedSNI = AppContext.TryGetSwitch(UseLegacyNetworkingOnWindows, out shouldUseLegacyNetorking) ? !shouldUseLegacyNetorking : true;
-        }
+        private static bool shouldUseLegacyNetorking;
 
-        public static bool UseManagedSNI
-        {
-            get;
-            private set;
-        }
-        
+        // If The appcontext switch is set then Use Managed SNI based on the value. Otherwise Managed SNI should always be used.
+        public static bool UseManagedSNI { get; } = AppContext.TryGetSwitch(UseLegacyNetworkingOnWindows, out shouldUseLegacyNetorking) ? !shouldUseLegacyNetorking : true;
+
         public EncryptionOptions EncryptionOptions
         {
             get


### PR DESCRIPTION
The change changes the default implementation of SNI on Windows to Managed SNI. 
The behavior can be changed back to Native SNI by toggling the AppContext Switch `System.Data.SqlClient.UseLegacyNetworkingOnWindows`

cc @corivera 