### PR TITLE
Properly start a CFRunLoop on Mono

### DIFF
--- a/src/Common/src/Interop/OSX/Interop.RunLoop.cs
+++ b/src/Common/src/Interop/OSX/Interop.RunLoop.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
 
 using Microsoft.Win32.SafeHandles;
 
@@ -26,7 +27,11 @@ internal static partial class Interop
         /// <summary>
         /// Starts the current thread's RunLoop. If the RunLoop is already running, creates a new, nested, RunLoop in the same stack.
         /// </summary>
+#if MONO
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+#else
         [DllImport(Interop.Libraries.CoreFoundationLibrary)]
+#endif
         internal extern static void CFRunLoopRun();
 
         /// <summary>


### PR DESCRIPTION
In Mono, all threads that are calling into indefinitely blocking native code must configure for themselves a method to interrupt them from another thread. We wrap the CFRunLoopRun() P/Invoke in an internal call in order to do that. (internally we simply save the RunLoop handle, which we can then use with CFRunLoopStop() from another thread)