### PR TITLE
Fix pinning in BaseOverlappedAsyncResult.CompletionCallback

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Windows.cs
@@ -133,10 +133,10 @@ namespace System.Net.Sockets
         // Called either synchronously from SocketPal async routines or asynchronously via CompletionPortCallback above. 
         private void CompletionCallback(int numBytes, SocketError socketError)
         {
-            ReleaseUnmanagedStructures();
-
             ErrorCode = (int)socketError;
-            InvokeCallback(PostCompletion(numBytes));
+            object result = PostCompletion(numBytes);
+            ReleaseUnmanagedStructures();
+            InvokeCallback(result);
         }
 
         // The following property returns the Win32 unsafe pointer to

--- a/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Windows.cs
@@ -135,7 +135,7 @@ namespace System.Net.Sockets
         {
             ErrorCode = (int)socketError;
             object result = PostCompletion(numBytes);
-            ReleaseUnmanagedStructures();
+            ReleaseUnmanagedStructures(); // must come after PostCompletion, as overrides may use these resources
             InvokeCallback(result);
         }
 


### PR DESCRIPTION
Some overloads of PostCompletion rely on the pinning configured by SetUnmanagedStructures, which means the call to it needs to come before the call to ReleaseUmanagedStructures, or else it could end up relying on the addresses of unpinned objects.

Fixes https://github.com/dotnet/corefx/issues/16953
cc: @geoffkizer, @cipop, @Priya91 