### PR TITLE
Change tests that use async void to async Task

### DIFF
--- a/src/System.IO.Compression/tests/Performance/Perf.DeflateStream.cs
+++ b/src/System.IO.Compression/tests/Performance/Perf.DeflateStream.cs
@@ -6,6 +6,7 @@ using Xunit;
 using Microsoft.Xunit.Performance;
 using System.Collections.Generic;
 using System.Security.Cryptography;
+using System.Threading.Tasks;
 
 namespace System.IO.Compression.Tests
 {
@@ -100,7 +101,7 @@ namespace System.IO.Compression.Tests
         [InlineData(CompressionType.CryptoRandom)]
         [InlineData(CompressionType.RepeatedSegments)]
         [InlineData(CompressionType.NormalData)]
-        public async void Decompress(CompressionType type)
+        public async Task Decompress(CompressionType type)
         {
             string testFilePath = CreateCompressedFile(type);
             int _bufferSize = 1024;

--- a/src/System.IO.FileSystem/tests/FileStream/WriteAsync.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/WriteAsync.cs
@@ -257,7 +257,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public async void WriteAsyncInternalBufferOverflow()
+        public async Task WriteAsyncInternalBufferOverflow()
         {
             using (FileStream fs = new FileStream(GetTestFilePath(), FileMode.Create, FileAccess.Write, FileShare.None, 3, useAsync: true))
             {

--- a/src/System.IO/tests/Stream/Stream.CopyToTests.cs
+++ b/src/System.IO/tests/Stream/Stream.CopyToTests.cs
@@ -42,7 +42,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public async void AsyncIfCanSeekIsFalseLengthAndPositionShouldNotBeCalled()
+        public async Task AsyncIfCanSeekIsFalseLengthAndPositionShouldNotBeCalled()
         {
             var baseStream = new DelegateStream(
                 canReadFunc: () => true,
@@ -82,7 +82,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public async void AsyncIfCanSeekIsTrueLengthAndPositionShouldOnlyBeCalledOnce()
+        public async Task AsyncIfCanSeekIsTrueLengthAndPositionShouldOnlyBeCalledOnce()
         {
             var baseStream = new DelegateStream(
                 canReadFunc: () => true,
@@ -136,7 +136,7 @@ namespace System.IO.Tests
 
         [Theory]
         [MemberData(nameof(LengthIsLessThanOrEqualToPosition))]
-        public async void AsyncIfLengthIsLessThanOrEqualToPositionCopyToShouldStillBeCalledWithAPositiveBufferSize(long length, long position)
+        public async Task AsyncIfLengthIsLessThanOrEqualToPositionCopyToShouldStillBeCalledWithAPositiveBufferSize(long length, long position)
         {
             var baseStream = new DelegateStream(
                 canReadFunc: () => true,
@@ -191,7 +191,7 @@ namespace System.IO.Tests
 
         [Theory]
         [MemberData(nameof(LengthMinusPositionPositiveOverflows))]
-        public async void AsyncIfLengthMinusPositionPositiveOverflowsBufferSizeShouldStillBePositive(long length, long position)
+        public async Task AsyncIfLengthMinusPositionPositiveOverflowsBufferSizeShouldStillBePositive(long length, long position)
         {
             var baseStream = new DelegateStream(
                 canReadFunc: () => true,
@@ -270,7 +270,7 @@ namespace System.IO.Tests
 
         [Theory]
         [MemberData(nameof(LengthIsGreaterThanPositionAndDoesNotOverflow))]
-        public async void AsyncIfLengthIsGreaterThanPositionAndDoesNotOverflowEverythingShouldGoNormally(long length, long position)
+        public async Task AsyncIfLengthIsGreaterThanPositionAndDoesNotOverflowEverythingShouldGoNormally(long length, long position)
         {
             const int ReadLimit = 7;
 

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpHandlerTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpHandlerTest.cs
@@ -130,7 +130,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         }
 
         [Fact]
-        public async void CookieUsePolicy_UseSpecifiedCookieContainerAndNullContainer_ThrowsInvalidOperationException()
+        public async Task CookieUsePolicy_UseSpecifiedCookieContainerAndNullContainer_ThrowsInvalidOperationException()
         {
             var handler = new WinHttpHandler();
             Assert.Null(handler.CookieContainer);

--- a/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -297,7 +297,7 @@ namespace System.Net.Mail.Tests
         }
 
         [Fact]
-        public async void TestMailDeliveryAsync()
+        public async Task TestMailDeliveryAsync()
         {
             SmtpServer server = new SmtpServer();
             SmtpClient client = new SmtpClient("localhost", server.EndPoint.Port);
@@ -322,7 +322,7 @@ namespace System.Net.Mail.Tests
         }
 
         [Fact]
-        public async void TestCredentialsCopyInAsyncContext()
+        public async Task TestCredentialsCopyInAsyncContext()
         {
             SmtpServer server = new SmtpServer();
             SmtpClient client = new SmtpClient("localhost", server.EndPoint.Port);

--- a/src/System.Net.Primitives/tests/UnitTests/CookieContainerTest.cs
+++ b/src/System.Net.Primitives/tests/UnitTests/CookieContainerTest.cs
@@ -406,7 +406,7 @@ namespace System.Net.Primitives.Unit.Tests
         }
 
         [Fact]
-        public async void Add_ReachedMaxCountWithExpiredCookies_Added()
+        public async Task Add_ReachedMaxCountWithExpiredCookies_Added()
         {
             Cookie c1 = new Cookie("name1", "value", "", ".domain1.com");
             Cookie c2 = new Cookie("name2", "value", "", ".domain2.com");
@@ -518,7 +518,7 @@ namespace System.Net.Primitives.Unit.Tests
         }
 
         [Fact]
-        public async void GetCookies_RemovesExpired_Cookies()
+        public async Task GetCookies_RemovesExpired_Cookies()
         {
             Cookie c1 = new Cookie("name1", "value", "", ".url1.com");
             Cookie c2 = new Cookie("name2", "value", "", ".url2.com");


### PR DESCRIPTION
Async tests should always return Task instead of void; XUnit apparently has some issues with it. Changing all existing 'async void' tests to 'async Task' to mitigate any potential side affects.

FYI I added this temporary test to socket test class AccessAsync:
```
        [Fact]
        public async void DoIt()
        {
            await new Task(() => { });
        }
```
and then in all socket test runs after this, the tests hung after successfully running all 4 variants (from 4 Theory inputs) of System.Net.Sockets.Tests.SendReceiveApm.SendRecv_Stream_TCP_MultipleConcurrentReceives

No specific tests were running when debugger attached to hung corerun process; I didn't debug further.

This is a possible XUnit issue, although other test frameworks don't even allow 'async void' because it is difficult to get the test results back. FWIW XUnit apparently creates a different SynchronizationContext specifically for async void tests.

CC @ianhays @Priya91 
