### PR TITLE
Fix System.Diagnostics.TraceSource tests to stop showing debug assert windows in desktop

### DIFF
--- a/src/System.Diagnostics.TraceSource/src/Resources/Strings.resx
+++ b/src/System.Diagnostics.TraceSource/src/Resources/Strings.resx
@@ -59,7 +59,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ExceptionOccurred" xml:space="preserve">
-    <value>An exception ocurred while writing to the log file {0}: {1}.</value>
+    <value>An exception occurred while writing to the log file {0}: {1}.</value>
   </data>
   <data name="MustAddListener" xml:space="preserve">
     <value>Only TraceListeners can be added to a TraceListenerCollection.</value>

--- a/src/System.Diagnostics.TraceSource/src/Resources/Strings.resx
+++ b/src/System.Diagnostics.TraceSource/src/Resources/Strings.resx
@@ -58,6 +58,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="ExceptionOccurred" xml:space="preserve">
+    <value>An exception ocurred while writing to the log file {0}: {1}.</value>
+  </data>
   <data name="MustAddListener" xml:space="preserve">
     <value>Only TraceListeners can be added to a TraceListenerCollection.</value>
   </data>

--- a/src/System.Diagnostics.TraceSource/src/System.Diagnostics.TraceSource.csproj
+++ b/src/System.Diagnostics.TraceSource/src/System.Diagnostics.TraceSource.csproj
@@ -65,6 +65,7 @@
     <Reference Include="System.Collections.Specialized" />
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.Diagnostics.Tools" />
+    <Reference Include="System.IO.FileSystem" />
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />

--- a/src/System.Diagnostics.TraceSource/src/System/Diagnostics/DefaultTraceListener.cs
+++ b/src/System.Diagnostics.TraceSource/src/System/Diagnostics/DefaultTraceListener.cs
@@ -115,7 +115,7 @@ namespace System.Diagnostics
         /// </devdoc>
         public override void Write(string message)
         {
-            Write(message, true);
+            Write(message, useLogFile: true);
         }
 
         /// <devdoc>
@@ -125,7 +125,7 @@ namespace System.Diagnostics
         /// </devdoc>
         public override void WriteLine(string message)
         {
-            WriteLine(message, true);
+            WriteLine(message, useLogFile: true);
         }
 
         private void WriteLine(string message, bool useLogFile)
@@ -133,8 +133,7 @@ namespace System.Diagnostics
             if (NeedIndent) 
                 WriteIndent();
 
-            // I do the concat here to make sure it goes as one call to the output.
-            // we would save a stringbuilder operation by calling Write twice.
+            // The concat is done here to enable a single call to Write
             Write(message + Environment.NewLine, useLogFile); 
             NeedIndent = true;
         }
@@ -168,18 +167,11 @@ namespace System.Diagnostics
         {
             try
             {
-                using (FileStream stream = File.OpenWrite(LogFileName))
-                {
-                    using (StreamWriter writer = new StreamWriter(stream)) 
-                    {
-                        stream.Position = stream.Length;
-                        writer.Write(message);
-                    }
-                }
+                File.AppendAllText(LogFileName, message);
             }
             catch (Exception e)
             {
-                WriteLine(string.Format(SR.ExceptionOccurred, LogFileName, e.ToString()), false);
+                WriteLine(string.Format(SR.ExceptionOccurred, LogFileName, e.ToString()), useLogFile: false);
             }
         }
     }

--- a/src/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceInternal.cs
+++ b/src/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceInternal.cs
@@ -236,7 +236,7 @@ namespace System.Diagnostics
                 {
                     foreach (TraceListener listener in Listeners)
                     {
-                        listener.Dispose();
+                        listener.Close();
                     }
                 }
             }

--- a/src/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceSource.cs
+++ b/src/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceSource.cs
@@ -104,7 +104,7 @@ namespace System.Diagnostics
                 {
                     foreach (TraceListener listener in _listeners)
                     {
-                        listener.Dispose();
+                        listener.Close();
                     }
                 }
             }

--- a/src/System.Diagnostics.TraceSource/tests/DefaultTraceListenerClassTests.cs
+++ b/src/System.Diagnostics.TraceSource/tests/DefaultTraceListenerClassTests.cs
@@ -12,6 +12,7 @@ namespace System.Diagnostics.TraceSourceTests
         private class TestDefaultTraceListener : DefaultTraceListener
         {
             private StringWriter _writer;
+            public bool ShouldOverrideWriteLine { get; set; } = true;
 
             public TestDefaultTraceListener()
             {
@@ -31,7 +32,8 @@ namespace System.Diagnostics.TraceSourceTests
 
             public override void WriteLine(string message)
             {
-                _writer.WriteLine(message);
+                if (ShouldOverrideWriteLine)
+                    _writer.WriteLine(message);
             }
         }
 
@@ -48,6 +50,16 @@ namespace System.Diagnostics.TraceSourceTests
             var listener = new TestDefaultTraceListener();
             listener.Fail("FAIL");
             Assert.Contains("FAIL", listener.Output);
+        }
+
+        [Fact]
+        public void Fail_WithoutWriteLineOverride()
+        {
+            var listener = new TestDefaultTraceListener();
+            listener.ShouldOverrideWriteLine = false;
+            listener.Fail("FAIL");
+            listener.ShouldOverrideWriteLine = true;
+            Assert.False(listener.Output.Contains("FAIL"));
         }
 
         [Fact]

--- a/src/System.Diagnostics.TraceSource/tests/DefaultTraceListenerClassTests.cs
+++ b/src/System.Diagnostics.TraceSource/tests/DefaultTraceListenerClassTests.cs
@@ -16,6 +16,7 @@ namespace System.Diagnostics.TraceSourceTests
             public TestDefaultTraceListener()
             {
                 _writer = new StringWriter();
+                AssertUiEnabled = false;
             }
 
             public String Output
@@ -26,6 +27,11 @@ namespace System.Diagnostics.TraceSourceTests
             public override void Write(string message)
             {
                 _writer.Write(message);
+            }
+
+            public override void WriteLine(string message)
+            {
+                _writer.WriteLine(message);
             }
         }
 

--- a/src/System.Diagnostics.TraceSource/tests/DefaultTraceListenerClassTests.cs
+++ b/src/System.Diagnostics.TraceSource/tests/DefaultTraceListenerClassTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace System.Diagnostics.TraceSourceTests
 {
-    public class DefaultTraceListenerClassTests
+    public class DefaultTraceListenerClassTests : FileCleanupTestBase
     {
         private class TestDefaultTraceListener : DefaultTraceListener
         {
@@ -65,7 +65,6 @@ namespace System.Diagnostics.TraceSourceTests
             var listener = new TestDefaultTraceListener();
             listener.ShouldOverrideWriteLine = false;
             listener.Fail("FAIL");
-            listener.ShouldOverrideWriteLine = true;
             Assert.False(listener.Output.Contains("FAIL"));
         }
 
@@ -73,18 +72,14 @@ namespace System.Diagnostics.TraceSourceTests
         public void Fail_WithLogFile()
         {
             var listener = new TestDefaultTraceListener();
-            listener.LogFileName = "LogFile.txt";
+            string pathToLogFile = GetTestFilePath();
 
-            string pathToLogFile = Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), listener.LogFileName);
-
+            listener.LogFileName = pathToLogFile;
             listener.ShouldOverrideWriteLine = false;
             listener.Fail("FAIL");
-            listener.ShouldOverrideWriteLine = true;
             
             Assert.True(File.Exists(pathToLogFile));
             Assert.Contains("FAIL", File.ReadAllText(pathToLogFile));
-
-            File.Delete(pathToLogFile);
         }
 
         [Fact]
@@ -92,11 +87,10 @@ namespace System.Diagnostics.TraceSourceTests
         {
             // Exception should be handled by DefaultTraceListener.WriteLine so no need to assert.
             var listener = new TestDefaultTraceListener();
-            listener.LogFileName = @"testfiles\LogFile.txt";
+            listener.LogFileName = $"{Guid.NewGuid().ToString("N")}\\LogFile.txt";
 
             listener.ShouldOverrideWriteLine = false;
             listener.Fail("FAIL");
-            listener.ShouldOverrideWriteLine = true;
         }
 
         [Fact]

--- a/src/System.Diagnostics.TraceSource/tests/System.Diagnostics.TraceSource.Tests.csproj
+++ b/src/System.Diagnostics.TraceSource/tests/System.Diagnostics.TraceSource.Tests.csproj
@@ -31,6 +31,9 @@
     <Compile Include="TraceSwitchClassTests.cs" />
     <Compile Include="TraceTestHelper.cs" />
     <Compile Include="CorrelationManagerTests.cs" />
+    <Compile Include="$(CommonTestPath)\System\IO\FileCleanupTestBase.cs">
+      <Link>Common\System\IO\FileCleanupTestBase.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Diagnostics.TraceSource/tests/TestTraceListener.cs
+++ b/src/System.Diagnostics.TraceSource/tests/TestTraceListener.cs
@@ -119,5 +119,10 @@ namespace System.Diagnostics.TraceSourceTests
         {
             Call(Method.WriteLine);
         }
+
+        public override void Close()
+        {
+            Dispose(); // In desktop Trace.Close() calls listener.Close() on every listener and in Core we call listener.Dispose() so the tests would fail in desktop without this override. 
+        }
     }
 }

--- a/src/System.Diagnostics.TraceSource/tests/TestTraceListener.cs
+++ b/src/System.Diagnostics.TraceSource/tests/TestTraceListener.cs
@@ -19,10 +19,11 @@ namespace System.Diagnostics.TraceSourceTests
             WriteLine,
             Flush,
             Fail,
+            Close
             //NOTE: update MethodEnumCount if values are added
         }
 
-        private const int MethodEnumCount = 8;
+        private const int MethodEnumCount = 9;
 
         public TestTraceListener(bool threadSafe = false)
             : this(null, threadSafe)
@@ -122,7 +123,7 @@ namespace System.Diagnostics.TraceSourceTests
 
         public override void Close()
         {
-            Dispose(); // In desktop Trace.Close() calls listener.Close() on every listener and in Core we call listener.Dispose() so the tests would fail in desktop without this override. 
+            Call(Method.Close);
         }
     }
 }

--- a/src/System.Diagnostics.TraceSource/tests/TraceInternalClassTests.cs
+++ b/src/System.Diagnostics.TraceSource/tests/TraceInternalClassTests.cs
@@ -233,6 +233,8 @@ namespace System.Diagnostics.TraceSourceTests
         public void FailTest()
         {
             var listener = GetTraceListener();
+            // We have to clear the listeners list on Trace since there is a trace listener by default with AssertUiEnabled = true in Desktop and that will pop up an assert window with Trace.Fail
+            Trace.Listeners.Clear();
             Trace.Listeners.Add(listener);
             Trace.Fail("Message");
             Assert.Equal(1, listener.GetCallCount(Method.Fail));
@@ -244,6 +246,8 @@ namespace System.Diagnostics.TraceSourceTests
         public void Fail2Test()
         {
             var listener = GetTraceListener();
+            // We have to clear the listeners list on Trace since there is a trace listener by default with AssertUiEnabled = true in Desktop and that will pop up an assert window with Trace.Fail
+            Trace.Listeners.Clear();
             Trace.Listeners.Add(listener);
             Trace.Fail("Message", "Category");
             Assert.Equal(1, listener.GetCallCount(Method.Fail));

--- a/src/System.Diagnostics.TraceSource/tests/TraceSourceClassTests.cs
+++ b/src/System.Diagnostics.TraceSource/tests/TraceSourceClassTests.cs
@@ -134,7 +134,6 @@ namespace System.Diagnostics.TraceSourceTests
             ArgumentException exception1 = Assert.Throws<ArgumentException>(() => new TraceSource(string.Empty));
             ArgumentException exception2 = Assert.Throws<ArgumentException>(() => new TraceSource(string.Empty, SourceLevels.All));
 
-
             // In Desktop in TraceSource.ctor we create the ArgumentException without param name, just with Message = "name", so ParamName is null
             if (TraceTestHelper.IsFullFramework)
             {

--- a/src/System.Diagnostics.TraceSource/tests/TraceSourceClassTests.cs
+++ b/src/System.Diagnostics.TraceSource/tests/TraceSourceClassTests.cs
@@ -131,10 +131,19 @@ namespace System.Diagnostics.TraceSourceTests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "In Desktop in TraceSource.ctor we create the ArgumentException without param name, just with Message = name, so the param name is null.")]
         public void EmptySourceName()
         {
             Assert.Throws<ArgumentException>("name", () => new TraceSource(string.Empty));
             Assert.Throws<ArgumentException>("name", () => new TraceSource(string.Empty, SourceLevels.All));
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "In Desktop in TraceSource.ctor we create the ArgumentException without param name, just with Message = name, so the param name is null.")]
+        public void EmptySourceName_Desktop()
+        {
+            Assert.Throws<ArgumentException>(() => new TraceSource(string.Empty));
+            Assert.Throws<ArgumentException>(() => new TraceSource(string.Empty, SourceLevels.All));
         }
     }
 

--- a/src/System.Diagnostics.TraceSource/tests/TraceTestHelper.cs
+++ b/src/System.Diagnostics.TraceSource/tests/TraceTestHelper.cs
@@ -3,11 +3,14 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Text;
+using System.Runtime.InteropServices;
 
 namespace System.Diagnostics.TraceSourceTests
 {
     static class TraceTestHelper
     {
+        internal static bool IsFullFramework => RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
+
         /// <summary>
         /// Resets the static state of the trace objects before a unit test.
         /// </summary>


### PR DESCRIPTION
Some of the tests where showing Assert failures windows because in desktop trace listeners `AssertUiEnabled` is set to true by default. 

I also fixed some tests small compat issues with desktop so that they pass. 

cc: @tarekgh @danmosemsft @weshaggard 