### PR TITLE
Adding tests for System.Configuration.ConfigurationManager.UrlPath

### DIFF
--- a/src/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
+++ b/src/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -86,6 +86,7 @@
     <Compile Include="System\Configuration\ImplicitMachineConfigTests.cs" />
     <Compile Include="System\Configuration\KeyValueConfigurationCollectionTests.cs" />
     <Compile Include="System\Configuration\LocalFileSettingsProviderTests.cs" />
+    <Compile Include="System\Configuration\UrlPathTests.cs" />
     <Compile Include="System\Configuration\NameValueConfigurationCollectionTests.cs" />
     <Compile Include="System\Configuration\SectionGroupsTests.cs" />
     <Compile Include="System\Configuration\SmokeTest.cs" />

--- a/src/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
+++ b/src/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
@@ -86,7 +86,6 @@
     <Compile Include="System\Configuration\ImplicitMachineConfigTests.cs" />
     <Compile Include="System\Configuration\KeyValueConfigurationCollectionTests.cs" />
     <Compile Include="System\Configuration\LocalFileSettingsProviderTests.cs" />
-    <Compile Include="System\Configuration\UrlPathTests.cs" />
     <Compile Include="System\Configuration\NameValueConfigurationCollectionTests.cs" />
     <Compile Include="System\Configuration\SectionGroupsTests.cs" />
     <Compile Include="System\Configuration\SmokeTest.cs" />
@@ -95,6 +94,7 @@
     <Compile Include="System\Configuration\TestData.cs" />
     <Compile Include="System\Configuration\TypeUtilTests.cs" />
     <Compile Include="System\Configuration\UriSectionTests.cs" />
+	<Compile Include="System\Configuration\UrlPathTests.cs" />
     <Compile Include="System\Configuration\ValidatiorUtilsTests.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/UrlPathTests.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/UrlPathTests.cs
@@ -14,7 +14,7 @@ namespace System.ConfigurationTests
         private const string TEST_DIRECTORY_PATH = "C:\\Directory";
         private const string TEST_SUBDIRECTORY_PATH = TEST_DIRECTORY_PATH + "\\SubDirectory";
 
-        public const string TEST_DIRECTORY_PATH_WITH_BACKSLASK = TEST_DIRECTORY_PATH + "\\";
+        public const string TEST_DIRECTORY_PATH_WITH_BACKSLASH = TEST_DIRECTORY_PATH + "\\";
         public const string TEST_SUBDIRECTORY_PATH_WITH_BACKSLASH = TEST_SUBDIRECTORY_PATH + "\\";
 
         [Fact]
@@ -77,7 +77,7 @@ namespace System.ConfigurationTests
         }
 
         [Fact]
-        public void IsEqualOrSubDIrectory_EmptyDir()
+        public void IsEqualOrSubDirectory_EmptyDir()
         {
             bool test = UrlPath.IsEqualOrSubdirectory("", null);
             Assert.Equal(true, test);
@@ -104,6 +104,54 @@ namespace System.ConfigurationTests
             Assert.Equal(true, test);
         }
 
+        [Fact]
+        public void IsEqualOrSubDirectory_True_TrailingBackslashOnBoth()
+        {
+            bool test = UrlPath.IsEqualOrSubdirectory(TEST_DIRECTORY_PATH_WITH_BACKSLASH, TEST_SUBDIRECTORY_PATH_WITH_BACKSLASH);
+            Assert.Equal(true, test);
+        }
+
+        [Fact]
+        public void IsEqualOrSubDirectory_True_DirBacksalsh()
+        {
+            bool test = UrlPath.IsEqualOrSubdirectory(TEST_DIRECTORY_PATH_WITH_BACKSLASH, TEST_SUBDIRECTORY_PATH);
+            Assert.Equal(true, test);
+        }
+
+        [Fact]
+        public void IsEqualOrSubDirectory_True_SubDirBackslash()
+        {
+            bool test = UrlPath.IsEqualOrSubdirectory(TEST_DIRECTORY_PATH, TEST_SUBDIRECTORY_PATH_WITH_BACKSLASH);
+            Assert.Equal(true, test);
+        }
+
+        [Fact]
+        public void IsEqualOrSubDirectory_Equal_NoBackslashes()
+        {
+            bool test = UrlPath.IsEqualOrSubdirectory(TEST_DIRECTORY_PATH, TEST_DIRECTORY_PATH);
+            Assert.Equal(true, test);
+        }
+
+        [Fact]
+        public void IsEqualOrSubDirectory_Equal_BothBackslashes()
+        {
+            bool test = UrlPath.IsEqualOrSubdirectory(TEST_DIRECTORY_PATH_WITH_BACKSLASH, TEST_DIRECTORY_PATH_WITH_BACKSLASH);
+            Assert.Equal(true, test);
+        }
+
+        [Fact]
+        public void IsEqualOrSubDirectory_Equal_FirstHasBackslash()
+        {
+            bool test = UrlPath.IsEqualOrSubdirectory(TEST_DIRECTORY_PATH_WITH_BACKSLASH, TEST_DIRECTORY_PATH);
+            Assert.Equal(true, test);
+        }
+
+        [Fact]
+        public void IsEqualOrSubDirectory_Equal_SeconHasBackslash()
+        {
+            bool test = UrlPath.IsEqualOrSubdirectory(TEST_DIRECTORY_PATH, TEST_DIRECTORY_PATH_WITH_BACKSLASH);
+            Assert.Equal(true, test);
+        }
         
     }
 }

--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/UrlPathTests.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/UrlPathTests.cs
@@ -10,12 +10,12 @@ namespace System.ConfigurationTests
 {
     public class UrlPathTests
     {
-        private const string TEST_FILE_NAME = "TestFileForUrlPathTests.txt";
-        private const string TEST_DIRECTORY_PATH = "C:\\Directory";
-        private const string TEST_SUBDIRECTORY_PATH = TEST_DIRECTORY_PATH + "\\SubDirectory";
+        private const string TestFileName = "TestFileForUrlPathTests.txt";
+        private const string TestDirectoryPath = "C:\\Directory";
+        private const string TestSubdirectoryPath = TestDirectoryPath + "\\SubDirectory";
 
-        public const string TEST_DIRECTORY_PATH_WITH_BACKSLASH = TEST_DIRECTORY_PATH + "\\";
-        public const string TEST_SUBDIRECTORY_PATH_WITH_BACKSLASH = TEST_SUBDIRECTORY_PATH + "\\";
+        public const string TestDirectoryPathWithBackslash = TestDirectoryPath + "\\";
+        public const string TestSubdirectoryPathWithBackslash = TestSubdirectoryPath + "\\";
 
         [Fact]
         public void GetDirectoOrRootName_Null()
@@ -34,16 +34,15 @@ namespace System.ConfigurationTests
         [Fact]
         public void GetDirectoryOrRootName_FileExists()
         {
-            string exePath = AppDomain.CurrentDomain.BaseDirectory;
-            Stream fileStream = File.Create(TEST_FILE_NAME);
-            fileStream.Close();
+            
+            string test = string.Empty;
+            using (TempDirectory tempDirectory = new TempDirectory())
+            using (TempFile tempFile = new TempFile(tempDirectory.Path + "\\" + TestFileName))
+            {
+                string test = UrlPath.GetDirectoryOrRootName(tempFile.Path);
 
-            string test = UrlPath.GetDirectoryOrRootName(exePath + TEST_FILE_NAME);
-
-            File.Delete(TEST_FILE_NAME);
-
-            //exePath has the trailing \.  Gotta get rid of it.
-            Assert.Equal(exePath.Substring(0, exePath.Length - 1), test);
+                Assert.Equal(tempDirectory.Path, test);
+            }
         }
 
         [Fact]
@@ -93,63 +92,63 @@ namespace System.ConfigurationTests
         [Fact]
         public void IsEqualOrSubDirectory_SubDirAndDirAreReversed_NoTrailingBackslash()
         {
-            bool test = UrlPath.IsEqualOrSubdirectory(TEST_SUBDIRECTORY_PATH, TEST_DIRECTORY_PATH);
+            bool test = UrlPath.IsEqualOrSubdirectory(TestSubdirectoryPath, TestDirectoryPath);
             Assert.Equal(false, test);
         }
 
         [Fact]
         public void IsEqualOrSubDirectory_SubDirIsASubDirOfDir_NoTrailingBackslash()
         {
-            bool test = UrlPath.IsEqualOrSubdirectory(TEST_DIRECTORY_PATH, TEST_SUBDIRECTORY_PATH);
+            bool test = UrlPath.IsEqualOrSubdirectory(TestDirectoryPath, TestSubdirectoryPath);
             Assert.Equal(true, test);
         }
 
         [Fact]
         public void IsEqualOrSubDirectory_True_TrailingBackslashOnBoth()
         {
-            bool test = UrlPath.IsEqualOrSubdirectory(TEST_DIRECTORY_PATH_WITH_BACKSLASH, TEST_SUBDIRECTORY_PATH_WITH_BACKSLASH);
+            bool test = UrlPath.IsEqualOrSubdirectory(TestDirectoryPathWithBackslash, TestSubdirectoryPathWithBackslash);
             Assert.Equal(true, test);
         }
 
         [Fact]
         public void IsEqualOrSubDirectory_True_DirBacksalsh()
         {
-            bool test = UrlPath.IsEqualOrSubdirectory(TEST_DIRECTORY_PATH_WITH_BACKSLASH, TEST_SUBDIRECTORY_PATH);
+            bool test = UrlPath.IsEqualOrSubdirectory(TestDirectoryPathWithBackslash, TestSubdirectoryPath);
             Assert.Equal(true, test);
         }
 
         [Fact]
         public void IsEqualOrSubDirectory_True_SubDirBackslash()
         {
-            bool test = UrlPath.IsEqualOrSubdirectory(TEST_DIRECTORY_PATH, TEST_SUBDIRECTORY_PATH_WITH_BACKSLASH);
+            bool test = UrlPath.IsEqualOrSubdirectory(TestDirectoryPath, TestSubdirectoryPathWithBackslash);
             Assert.Equal(true, test);
         }
 
         [Fact]
         public void IsEqualOrSubDirectory_Equal_NoBackslashes()
         {
-            bool test = UrlPath.IsEqualOrSubdirectory(TEST_DIRECTORY_PATH, TEST_DIRECTORY_PATH);
+            bool test = UrlPath.IsEqualOrSubdirectory(TestDirectoryPath, TestDirectoryPath);
             Assert.Equal(true, test);
         }
 
         [Fact]
         public void IsEqualOrSubDirectory_Equal_BothBackslashes()
         {
-            bool test = UrlPath.IsEqualOrSubdirectory(TEST_DIRECTORY_PATH_WITH_BACKSLASH, TEST_DIRECTORY_PATH_WITH_BACKSLASH);
+            bool test = UrlPath.IsEqualOrSubdirectory(TestDirectoryPathWithBackslash, TestDirectoryPathWithBackslash);
             Assert.Equal(true, test);
         }
 
         [Fact]
         public void IsEqualOrSubDirectory_Equal_FirstHasBackslash()
         {
-            bool test = UrlPath.IsEqualOrSubdirectory(TEST_DIRECTORY_PATH_WITH_BACKSLASH, TEST_DIRECTORY_PATH);
+            bool test = UrlPath.IsEqualOrSubdirectory(TestDirectoryPathWithBackslash, TestDirectoryPath);
             Assert.Equal(true, test);
         }
 
         [Fact]
         public void IsEqualOrSubDirectory_Equal_SeconHasBackslash()
         {
-            bool test = UrlPath.IsEqualOrSubdirectory(TEST_DIRECTORY_PATH, TEST_DIRECTORY_PATH_WITH_BACKSLASH);
+            bool test = UrlPath.IsEqualOrSubdirectory(TestDirectoryPath, TestDirectoryPathWithBackslash);
             Assert.Equal(true, test);
         }
         

--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/UrlPathTests.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/UrlPathTests.cs
@@ -27,23 +27,23 @@ namespace System.ConfigurationTests
         [Fact]
         public void GetDirectoryOrRootName_FileExists()
         {
-            using (TempDirectory tempDirectory = new TempDirectory())
-            using (TempFile tempFile = new TempFile(tempDirectory.Path + "\\TestFileForUrlPathTests.txt"))
-            {
-                string test = UrlPath.GetDirectoryOrRootName(tempFile.Path);
-                Assert.Equal(tempDirectory.Path, test);
-            }
+            string exePath = AppDomain.CurrentDomain.BaseDirectory;
+            string pathToNonexistentFile = exePath + "TestFileForUrlPathTests.txt";
+
+            //GetDirectoryOrRootName removes the trailing backslash.  We need to add it again.
+            string test = UrlPath.GetDirectoryOrRootName(pathToNonexistentFile) + "\\";
+            Assert.Equal(exePath, test);
         }
 
         [Fact]
         public void GetDirectoryOrRootName_ofRoot()
         {
-            using (TempDirectory tempDirectory = new TempDirectory())
-            {
-                string root = Path.GetPathRoot(tempDirectory.Path);
-                string test = UrlPath.GetDirectoryOrRootName(root);
-                Assert.Equal(root, test);
-            }
+
+            string exePath = AppDomain.CurrentDomain.BaseDirectory;
+            string root = Path.GetPathRoot(exePath);
+            string test = UrlPath.GetDirectoryOrRootName(root);
+
+            Assert.Equal(root, test);
         }
 
         [Fact]

--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/UrlPathTests.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/UrlPathTests.cs
@@ -10,6 +10,13 @@ namespace System.ConfigurationTests
 {
     public class UrlPathTests
     {
+        private const string TEST_FILE_NAME = "TestFileForUrlPathTests.txt";
+        private const string TEST_DIRECTORY_PATH = "C:\\Directory";
+        private const string TEST_SUBDIRECTORY_PATH = TEST_DIRECTORY_PATH + "\\SubDirectory";
+
+        public const string TEST_DIRECTORY_PATH_WITH_BACKSLASK = TEST_DIRECTORY_PATH + "\\";
+        public const string TEST_SUBDIRECTORY_PATH_WITH_BACKSLASH = TEST_SUBDIRECTORY_PATH + "\\";
+
         [Fact]
         public void GetDirectoOrRootName_Null()
         {
@@ -28,12 +35,12 @@ namespace System.ConfigurationTests
         public void GetDirectoryOrRootName_FileExists()
         {
             string exePath = AppDomain.CurrentDomain.BaseDirectory;
-            Stream fileStream = File.Create("TestFileForUrlPathTests.txt");
+            Stream fileStream = File.Create(TEST_FILE_NAME);
             fileStream.Close();
 
-            string test = UrlPath.GetDirectoryOrRootName(exePath +"TestFileForUrlPathTests.txt");
+            string test = UrlPath.GetDirectoryOrRootName(exePath + TEST_FILE_NAME);
 
-            File.Delete("TestFileForUrlPathTests.txt");
+            File.Delete(TEST_FILE_NAME);
 
             //exePath has the trailing \.  Gotta get rid of it.
             Assert.Equal(exePath.Substring(0, exePath.Length - 1), test);
@@ -51,6 +58,52 @@ namespace System.ConfigurationTests
         public void IsEqualOrSubDirectory_NullDir()
         {
             bool test = UrlPath.IsEqualOrSubdirectory(null, "Hello");
+            Assert.Equal(true, test);
         }
+
+        [Fact]
+        public void IsEqualOrSubDirectory_NullSubDir()
+        {
+            bool test = UrlPath.IsEqualOrSubdirectory("Hello", null);
+            Assert.Equal(false, test);
+        }
+
+        [Fact]
+        public void IsEqualOrSubDirectory_NullDirAndSubDir()
+        {
+            bool test = UrlPath.IsEqualOrSubdirectory(null, null);
+
+            Assert.Equal(true, test);
+        }
+
+        [Fact]
+        public void IsEqualOrSubDIrectory_EmptyDir()
+        {
+            bool test = UrlPath.IsEqualOrSubdirectory("", null);
+            Assert.Equal(true, test);
+        }
+
+        [Fact]
+        public void IsEqualOrSubDirectory_NotEmptyDir_EmptySubDir()
+        {
+            bool test = UrlPath.IsEqualOrSubdirectory("Hello", "");
+            Assert.Equal(false, test);
+        }
+
+        [Fact]
+        public void IsEqualOrSubDirectory_SubDirAndDirAreReversed_NoTrailingBackslash()
+        {
+            bool test = UrlPath.IsEqualOrSubdirectory(TEST_SUBDIRECTORY_PATH, TEST_DIRECTORY_PATH);
+            Assert.Equal(false, test);
+        }
+
+        [Fact]
+        public void IsEqualOrSubDirectory_SubDirIsASubDirOfDir_NoTrailingBackslash()
+        {
+            bool test = UrlPath.IsEqualOrSubdirectory(TEST_DIRECTORY_PATH, TEST_SUBDIRECTORY_PATH);
+            Assert.Equal(true, test);
+        }
+
+        
     }
 }

--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/UrlPathTests.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/UrlPathTests.cs
@@ -10,22 +10,15 @@ namespace System.ConfigurationTests
 {
     public class UrlPathTests
     {
-        private const string TestFileName = "TestFileForUrlPathTests.txt";
-        private const string TestDirectoryPath = "C:\\Directory";
-        private const string TestSubdirectoryPath = TestDirectoryPath + "\\SubDirectory";
-
-        public const string TestDirectoryPathWithBackslash = TestDirectoryPath + "\\";
-        public const string TestSubdirectoryPathWithBackslash = TestSubdirectoryPath + "\\";
-
         [Fact]
-        public void GetDirectoOrRootName_Null()
+        public void GetDirectoryOrRootName_Null()
         {
             string test = UrlPath.GetDirectoryOrRootName(null);
             Assert.Equal(null, null);
         }
 
         [Fact]
-        public void GetDirectoryOrRootName_NotDIrectoryOrRoot()
+        public void GetDirectoryOrRootName_NotDirectoryOrRoot()
         {
             string test = UrlPath.GetDirectoryOrRootName("Hello");
             Assert.Equal("", test);
@@ -35,7 +28,7 @@ namespace System.ConfigurationTests
         public void GetDirectoryOrRootName_FileExists()
         {
             using (TempDirectory tempDirectory = new TempDirectory())
-            using (TempFile tempFile = new TempFile(tempDirectory.Path + "\\" + TestFileName))
+            using (TempFile tempFile = new TempFile(tempDirectory.Path + "\\TestFileForUrlPathTests.txt"))
             {
                 string test = UrlPath.GetDirectoryOrRootName(tempFile.Path);
                 Assert.Equal(tempDirectory.Path, test);
@@ -43,10 +36,14 @@ namespace System.ConfigurationTests
         }
 
         [Fact]
-        public void GetDirectoryOrRootName_ofC()
+        public void GetDirectoryOrRootName_ofRoot()
         {
-            string test = UrlPath.GetDirectoryOrRootName("C:\\");
-            Assert.Equal("C:\\", test);
+            using (TempDirectory tempDirectory = new TempDirectory())
+            {
+                string root = Path.GetPathRoot(tempDirectory.Path);
+                string test = UrlPath.GetDirectoryOrRootName(root);
+                Assert.Equal(root, test);
+            }
         }
 
         [Fact]
@@ -68,85 +65,84 @@ namespace System.ConfigurationTests
         {
             bool test = UrlPath.IsEqualOrSubdirectory(null, null);
 
-            Assert.Equal(true, test);
+            Assert.True(test);
         }
 
         [Fact]
         public void IsEqualOrSubDirectory_EmptyDir()
         {
             bool test = UrlPath.IsEqualOrSubdirectory("", null);
-            Assert.Equal(true, test);
+            Assert.True(test);
         }
 
         [Fact]
         public void IsEqualOrSubDirectory_NotEmptyDir_EmptySubDir()
         {
             bool test = UrlPath.IsEqualOrSubdirectory("Hello", "");
-            Assert.Equal(false, test);
+            Assert.False(test);
         }
 
         [Fact]
         public void IsEqualOrSubDirectory_SubDirAndDirAreReversed_NoTrailingBackslash()
         {
-            bool test = UrlPath.IsEqualOrSubdirectory(TestSubdirectoryPath, TestDirectoryPath);
-            Assert.Equal(false, test);
+            bool test = UrlPath.IsEqualOrSubdirectory("C:\\Directory\\SubDirectory", "C:\\Directory");
+            Assert.False(test);
         }
 
         [Fact]
         public void IsEqualOrSubDirectory_SubDirIsASubDirOfDir_NoTrailingBackslash()
         {
-            bool test = UrlPath.IsEqualOrSubdirectory(TestDirectoryPath, TestSubdirectoryPath);
-            Assert.Equal(true, test);
+            bool test = UrlPath.IsEqualOrSubdirectory("C:\\Directory", "C:\\Directory\\SubDirectory");
+            Assert.True(test);
         }
 
         [Fact]
         public void IsEqualOrSubDirectory_True_TrailingBackslashOnBoth()
         {
-            bool test = UrlPath.IsEqualOrSubdirectory(TestDirectoryPathWithBackslash, TestSubdirectoryPathWithBackslash);
-            Assert.Equal(true, test);
+            bool test = UrlPath.IsEqualOrSubdirectory("C:\\Directory\\", "C:\\Directory\\SubDirectory");
+            Assert.True(test);
         }
 
         [Fact]
-        public void IsEqualOrSubDirectory_True_DirBacksalsh()
+        public void IsEqualOrSubDirectory_True_DirBackslash()
         {
-            bool test = UrlPath.IsEqualOrSubdirectory(TestDirectoryPathWithBackslash, TestSubdirectoryPath);
-            Assert.Equal(true, test);
+            bool test = UrlPath.IsEqualOrSubdirectory("C:\\Directory\\", "C:\\Directory\\SubDirectory");
+            Assert.True(test);
         }
 
         [Fact]
         public void IsEqualOrSubDirectory_True_SubDirBackslash()
         {
-            bool test = UrlPath.IsEqualOrSubdirectory(TestDirectoryPath, TestSubdirectoryPathWithBackslash);
-            Assert.Equal(true, test);
+            bool test = UrlPath.IsEqualOrSubdirectory("C:\\Directory", "C:\\Directory\\SubDirectory\\");
+            Assert.True(test);
         }
 
         [Fact]
         public void IsEqualOrSubDirectory_Equal_NoBackslashes()
         {
-            bool test = UrlPath.IsEqualOrSubdirectory(TestDirectoryPath, TestDirectoryPath);
-            Assert.Equal(true, test);
+            bool test = UrlPath.IsEqualOrSubdirectory("C:\\Directory", "C:\\Directory");
+            Assert.True(test);
         }
 
         [Fact]
         public void IsEqualOrSubDirectory_Equal_BothBackslashes()
         {
-            bool test = UrlPath.IsEqualOrSubdirectory(TestDirectoryPathWithBackslash, TestDirectoryPathWithBackslash);
-            Assert.Equal(true, test);
+            bool test = UrlPath.IsEqualOrSubdirectory("C:\\Directory\\", "C:\\Directory\\");
+            Assert.True(test);
         }
 
         [Fact]
         public void IsEqualOrSubDirectory_Equal_FirstHasBackslash()
         {
-            bool test = UrlPath.IsEqualOrSubdirectory(TestDirectoryPathWithBackslash, TestDirectoryPath);
-            Assert.Equal(true, test);
+            bool test = UrlPath.IsEqualOrSubdirectory("C:\\Directory\\", "C:\\Directory");
+            Assert.True(test);
         }
 
         [Fact]
         public void IsEqualOrSubDirectory_Equal_SecondHasBackslash()
         {
-            bool test = UrlPath.IsEqualOrSubdirectory(TestDirectoryPath, TestDirectoryPathWithBackslash);
-            Assert.Equal(true, test);
+            bool test = UrlPath.IsEqualOrSubdirectory("C:\\Directory", "C:\\Directory\\");
+            Assert.True(test);
         }
-        
     }
 }

--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/UrlPathTests.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/UrlPathTests.cs
@@ -25,14 +25,18 @@ namespace System.ConfigurationTests
         }
 
         [Fact]
-        public void GetDirectoryOrRootName_FileExists()
+        public void GetDirectoryOrRootName_GettingDIrectoryFromAFilePath()
         {
+
             string exePath = AppDomain.CurrentDomain.BaseDirectory;
+            //Remove the trailing slash.  Different OS's use a different slash.
+            //This is to make the test pass without worrying about adding a slash 
+            //and which kind of slash.
+            string exePathWithoutTrailingSlash = exePath.Substring(0, exePath.Length - 1);
             string pathToNonexistentFile = exePath + "TestFileForUrlPathTests.txt";
 
-            //GetDirectoryOrRootName removes the trailing backslash.  We need to add it again.
-            string test = UrlPath.GetDirectoryOrRootName(pathToNonexistentFile) + "\\";
-            Assert.Equal(exePath, test);
+            string test = UrlPath.GetDirectoryOrRootName(pathToNonexistentFile);
+            Assert.Equal(exePathWithoutTrailingSlash, test);
         }
 
         [Fact]

--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/UrlPathTests.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/UrlPathTests.cs
@@ -34,13 +34,10 @@ namespace System.ConfigurationTests
         [Fact]
         public void GetDirectoryOrRootName_FileExists()
         {
-            
-            string test = string.Empty;
             using (TempDirectory tempDirectory = new TempDirectory())
             using (TempFile tempFile = new TempFile(tempDirectory.Path + "\\" + TestFileName))
             {
                 string test = UrlPath.GetDirectoryOrRootName(tempFile.Path);
-
                 Assert.Equal(tempDirectory.Path, test);
             }
         }
@@ -49,7 +46,6 @@ namespace System.ConfigurationTests
         public void GetDirectoryOrRootName_ofC()
         {
             string test = UrlPath.GetDirectoryOrRootName("C:\\");
-
             Assert.Equal("C:\\", test);
         }
 
@@ -146,7 +142,7 @@ namespace System.ConfigurationTests
         }
 
         [Fact]
-        public void IsEqualOrSubDirectory_Equal_SeconHasBackslash()
+        public void IsEqualOrSubDirectory_Equal_SecondHasBackslash()
         {
             bool test = UrlPath.IsEqualOrSubdirectory(TestDirectoryPath, TestDirectoryPathWithBackslash);
             Assert.Equal(true, test);

--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/UrlPathTests.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/UrlPathTests.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Configuration;
+using System.IO;
+using Xunit;
+
+namespace System.ConfigurationTests
+{
+    public class UrlPathTests
+    {
+        [Fact]
+        public void GetDirectoOrRootName_Null()
+        {
+            string test = UrlPath.GetDirectoryOrRootName(null);
+            Assert.Equal(null, null);
+        }
+
+        [Fact]
+        public void GetDirectoryOrRootName_NotDIrectoryOrRoot()
+        {
+            string test = UrlPath.GetDirectoryOrRootName("Hello");
+            Assert.Equal("", test);
+        }
+
+        [Fact]
+        public void GetDirectoryOrRootName_FileExists()
+        {
+            string exePath = AppDomain.CurrentDomain.BaseDirectory;
+            Stream fileStream = File.Create("TestFileForUrlPathTests.txt");
+            fileStream.Close();
+
+            string test = UrlPath.GetDirectoryOrRootName(exePath +"TestFileForUrlPathTests.txt");
+
+            File.Delete("TestFileForUrlPathTests.txt");
+
+            //exePath has the trailing \.  Gotta get rid of it.
+            Assert.Equal(exePath.Substring(0, exePath.Length - 1), test);
+        }
+
+        [Fact]
+        public void GetDirectoryOrRootName_ofC()
+        {
+            string test = UrlPath.GetDirectoryOrRootName("C:\\");
+
+            Assert.Equal("C:\\", test);
+        }
+
+        [Fact]
+        public void IsEqualOrSubDirectory_NullDir()
+        {
+            bool test = UrlPath.IsEqualOrSubdirectory(null, "Hello");
+        }
+    }
+}

--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/UrlPathTests.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/UrlPathTests.cs
@@ -25,13 +25,12 @@ namespace System.ConfigurationTests
         }
 
         [Fact]
-        public void GetDirectoryOrRootName_GettingDIrectoryFromAFilePath()
+        public void GetDirectoryOrRootName_GettingDirectoryFromAFilePath()
         {
-
             string exePath = AppDomain.CurrentDomain.BaseDirectory;
-            //Remove the trailing slash.  Different OS's use a different slash.
-            //This is to make the test pass without worrying about adding a slash 
-            //and which kind of slash.
+            // Remove the trailing slash.  Different OS's use a different slash.
+            // This is to make the test pass without worrying about adding a slash 
+            // and which kind of slash.
             string exePathWithoutTrailingSlash = exePath.Substring(0, exePath.Length - 1);
             string pathToNonexistentFile = exePath + "TestFileForUrlPathTests.txt";
 
@@ -40,9 +39,8 @@ namespace System.ConfigurationTests
         }
 
         [Fact]
-        public void GetDirectoryOrRootName_ofRoot()
+        public void GetDirectoryOrRootName_OfRoot()
         {
-
             string exePath = AppDomain.CurrentDomain.BaseDirectory;
             string root = Path.GetPathRoot(exePath);
             string test = UrlPath.GetDirectoryOrRootName(root);

--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/UrlPathTests.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/UrlPathTests.cs
@@ -66,7 +66,6 @@ namespace System.ConfigurationTests
         public void IsEqualOrSubDirectory_NullDirAndSubDir()
         {
             bool test = UrlPath.IsEqualOrSubdirectory(null, null);
-
             Assert.True(test);
         }
 


### PR DESCRIPTION
Wrote unit tests for UrlPath.cs. UrlPath is not a public class, thus does not directly impact the code coverage, but it is good to have all classes tested.