### PR TITLE
Restore usage of GetDSAPublicKey in Utils.GetAnyPublicKey

### DIFF
--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/Utils.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/Utils.cs
@@ -742,8 +742,7 @@ namespace System.Security.Cryptography.Xml
 
         internal static AsymmetricAlgorithm GetAnyPublicKey(X509Certificate2 certificate)
         {
-            // TODO: Add ?? certificate.GetDSAPublicKey(), when available (dotnet/corefx#11802).
-            return certificate.GetRSAPublicKey();
+            return (AsymmetricAlgorithm)certificate.GetRSAPublicKey() ?? certificate.GetDSAPublicKey();
         }
     }
 }


### PR DESCRIPTION
Relates to dotnet/corefx#11802 (DSA support was previously missing, and so functionality was removed until DSA support was restored).