### PR TITLE
Add support for System.Net.Sockets.Socket.Disconnect on Unix

### DIFF
--- a/src/System.Net.Sockets/src/Resources/Strings.resx
+++ b/src/System.Net.Sockets/src/Resources/Strings.resx
@@ -205,9 +205,6 @@
   <data name="net_sockets_duplicateandclose_notsupported" xml:space="preserve">
     <value>This platform does not support Socket.DuplicateAndClose.  Instead, create a new socket.</value>
   </data>
-  <data name="net_sockets_disconnect_notsupported" xml:space="preserve">
-    <value>This platform does not support disconnecting a Socket.  Instead, close the Socket and create a new one.</value>
-  </data>
   <data name="net_sockets_transmitfileoptions_notsupported" xml:space="preserve">
     <value>This platform does not support TransmitFileOptions other than TransmitFileOptions.UseDefaultWorkerThread.</value>
   </data>

--- a/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Unix.cs
@@ -23,7 +23,7 @@ namespace System.Net.Sockets
             if (NetEventSource.IsEnabled) NetEventSource.Info(this, socket);
         }
 
-        protected void CompletionCallback(int numBytes, SocketError errorCode)
+        internal void CompletionCallback(int numBytes, SocketError errorCode)
         {
             ErrorCode = (int)errorCode;
             InvokeCallback(PostCompletion(numBytes));

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Unix.cs
@@ -39,6 +39,17 @@ namespace System.Net.Sockets
                 return;
             }
 
+            SocketError errorCode = ReplaceHandle();
+            if (errorCode != SocketError.Success)
+            {
+                throw new SocketException((int) errorCode);
+            }
+
+            _handle.LastConnectFailed = false;
+        }
+
+        internal SocketError ReplaceHandle()
+        {
             // Copy out values from key options. The copied values should be kept in sync with the
             // handling in SafeCloseSocket.TrackOption.  Note that we copy these values out first, before
             // we change _handle, so that we can use the helpers on Socket which internally access _handle.
@@ -65,7 +76,7 @@ namespace System.Net.Sockets
             oldHandle.Dispose();
             if (errorCode != SocketError.Success)
             {
-                throw new SocketException((int)errorCode);
+                return errorCode;
             }
 
             // And put back the copied settings.  For DualMode, we use the value stored in the _handle
@@ -82,7 +93,7 @@ namespace System.Net.Sockets
             if (_handle.IsTrackedOption(TrackedSocketOptions.SendTimeout)) SendTimeout = sendTimeout;
             if (_handle.IsTrackedOption(TrackedSocketOptions.Ttl)) Ttl = ttl;
 
-            _handle.LastConnectFailed = false;
+            return SocketError.Success;
         }
 
         private static void ThrowMultiConnectNotSupported()

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
@@ -122,12 +122,13 @@ namespace System.Net.Sockets
 
         internal SocketError DoOperationDisconnect(Socket socket, SafeCloseSocket handle)
         {
-            throw new PlatformNotSupportedException(SR.net_sockets_disconnect_notsupported);
+            SocketError socketError = SocketPal.Disconnect(socket, handle, _disconnectReuseSocket);
+            FinishOperationSync(socketError, 0, SocketFlags.None);
+            return socketError;
         }
 
         private void InnerStartOperationDisconnect()
         {
-            throw new PlatformNotSupportedException(SR.net_sockets_disconnect_notsupported);
         }
 
         private Action<int, byte[], int, SocketFlags, SocketError> TransferCompletionCallback =>

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -1566,12 +1566,19 @@ namespace System.Net.Sockets
 
         internal static SocketError DisconnectAsync(Socket socket, SafeCloseSocket handle, bool reuseSocket, DisconnectOverlappedAsyncResult asyncResult)
         {
-            throw new PlatformNotSupportedException(SR.net_sockets_disconnect_notsupported);
+            SocketError socketError = Disconnect(socket, handle, reuseSocket);
+            asyncResult.CompletionCallback(0, SocketError.Success);
+            return socketError;
         }
 
         internal static SocketError Disconnect(Socket socket, SafeCloseSocket handle, bool reuseSocket)
         {
-            throw new PlatformNotSupportedException(SR.net_sockets_disconnect_notsupported);
+            if (reuseSocket)
+            {
+                return socket.ReplaceHandle();
+            }
+
+            return SocketError.Success;
         }
     }
 }

--- a/src/System.Net.Sockets/tests/FunctionalTests/DisconnectTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DisconnectTest.cs
@@ -40,10 +40,11 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [Fact]
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
         [OuterLoop("Issue #11345")]
-        [PlatformSpecific(TestPlatforms.Windows)]  // Disconnect only supported on Windows
-        public void Disconnect_Success()
+        public void Disconnect_Success(bool reuseSocket)
         {
             AutoResetEvent completed = new AutoResetEvent(false);
 
@@ -55,29 +56,36 @@ namespace System.Net.Sockets.Tests
                 args.Completed += OnCompleted;
                 args.UserToken = completed;
                 args.RemoteEndPoint = server1.EndPoint;
-                args.DisconnectReuseSocket = true;
+                args.DisconnectReuseSocket = reuseSocket;
 
                 using (Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
                 {
-                    Assert.True(client.ConnectAsync(args));
-                    completed.WaitOne();
+                    if (client.ConnectAsync(args))
+                    {
+                        completed.WaitOne();
+                    }
+
                     Assert.Equal(SocketError.Success, args.SocketError);
 
-                    client.Disconnect(true);
+                    client.Disconnect(reuseSocket);
 
                     args.RemoteEndPoint = server2.EndPoint;
 
-                    Assert.True(client.ConnectAsync(args));
-                    completed.WaitOne();
-                    Assert.Equal(SocketError.Success, args.SocketError);
+                    if (client.ConnectAsync(args))
+                    {
+                        completed.WaitOne();
+                    }
+
+                    Assert.Equal(reuseSocket ? SocketError.Success : SocketError.IsConnected, args.SocketError);
                 }
             }
         }
 
-        [Fact]
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
         [OuterLoop("Issue #11345")]
-        [PlatformSpecific(TestPlatforms.Windows)]  // DisconnectAsync only supported on Windows
-        public void DisconnectAsync_Success()
+        public void DisconnectAsync_Success(bool reuseSocket)
         {
             AutoResetEvent completed = new AutoResetEvent(false);
 
@@ -89,31 +97,41 @@ namespace System.Net.Sockets.Tests
                 args.Completed += OnCompleted;
                 args.UserToken = completed;
                 args.RemoteEndPoint = server1.EndPoint;
-                args.DisconnectReuseSocket = true;
+                args.DisconnectReuseSocket = reuseSocket;
 
                 using (Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
                 {
-                    Assert.True(client.ConnectAsync(args));
-                    completed.WaitOne();
+                    if (client.ConnectAsync(args))
+                    {
+                        completed.WaitOne();
+                    }
+
                     Assert.Equal(SocketError.Success, args.SocketError);
 
-                    Assert.True(client.DisconnectAsync(args));
-                    completed.WaitOne();
+                    if (client.DisconnectAsync(args))
+                    {
+                        completed.WaitOne();
+                    }
+
                     Assert.Equal(SocketError.Success, args.SocketError);
 
                     args.RemoteEndPoint = server2.EndPoint;
 
-                    Assert.True(client.ConnectAsync(args));
-                    completed.WaitOne();
-                    Assert.Equal(SocketError.Success, args.SocketError);
+                    if (client.ConnectAsync(args))
+                    {
+                        completed.WaitOne();
+                    }
+
+                    Assert.Equal(reuseSocket ? SocketError.Success : SocketError.IsConnected, args.SocketError);
                 }
             }
         }
 
-        [Fact]
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
         [OuterLoop("Issue #11345")]
-        [PlatformSpecific(TestPlatforms.Windows)]  // BeginDisconnect only supported on Windows
-        public void BeginDisconnect_Success()
+        public void BeginDisconnect_Success(bool reuseSocket)
         {
             AutoResetEvent completed = new AutoResetEvent(false);
 
@@ -128,52 +146,26 @@ namespace System.Net.Sockets.Tests
 
                 using (Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
                 {
-                    Assert.True(client.ConnectAsync(args));
-                    completed.WaitOne();
+                    if (client.ConnectAsync(args))
+                    {
+                        completed.WaitOne();
+                    }
+
                     Assert.Equal(SocketError.Success, args.SocketError);
 
-                    IAsyncResult ar = client.BeginDisconnect(true, null, null);
+                    IAsyncResult ar = client.BeginDisconnect(reuseSocket, null, null);
                     client.EndDisconnect(ar);
                     Assert.Throws<InvalidOperationException>(() => client.EndDisconnect(ar));
 
                     args.RemoteEndPoint = server2.EndPoint;
 
-                    Assert.True(client.ConnectAsync(args));
-                    completed.WaitOne();
-                    Assert.Equal(SocketError.Success, args.SocketError);
+                    if (client.ConnectAsync(args))
+                    {
+                        completed.WaitOne();
+                    }
+
+                    Assert.Equal(reuseSocket ? SocketError.Success : SocketError.IsConnected, args.SocketError);
                 }
-            }
-        }
-
-        [Fact]
-        [PlatformSpecific(~TestPlatforms.Windows)]  // Disconnect only supported on Windows
-        public void Disconnect_NonWindows_NotSupported()
-        {
-            using (Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
-            {
-                Assert.Throws<PlatformNotSupportedException>(() => client.Disconnect(true));
-            }
-        }
-
-        [Fact]
-        [PlatformSpecific(~TestPlatforms.Windows)]  // DisconnectAsync only supported on Windows
-        public void DisconnectAsync_NonWindows_NotSupported()
-        {
-            using (Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
-            {
-                SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-                args.DisconnectReuseSocket = true;
-                Assert.Throws<PlatformNotSupportedException>(() => client.DisconnectAsync(args));
-            }
-        }
-
-        [Fact]
-        [PlatformSpecific(~TestPlatforms.Windows)]  // BeginDisconnect only supported on Windows
-        public void BeginDisconnect_NonWindows_NotSupported()
-        {
-            using (Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
-            {
-                Assert.Throws<PlatformNotSupportedException>(() => client.BeginDisconnect(true, null, null));
             }
         }
     }


### PR DESCRIPTION
This copies the way it is done in Mono (see https://github.com/mono/mono/blob/65025fe/mono/metadata/w32socket-unix.c#L928)