### PR TITLE
Make Environment.StackTrace more predictable

### DIFF
--- a/src/System.Diagnostics.TraceSource/tests/TraceEventCacheClassTests.cs
+++ b/src/System.Diagnostics.TraceSource/tests/TraceEventCacheClassTests.cs
@@ -55,12 +55,10 @@ namespace System.Diagnostics.TraceSourceTests
             Assert.NotEmpty(cache.Callstack);
         }
 
-        [ActiveIssue("https://github.com/dotnet/coreclr/issues/6209")]
         [Fact]
         public void CallstackTest_ContainsExpectedFrames()
         {
             var cache = new TraceEventCache();
-            Assert.Contains("at System.Environment.GetStackTrace(Exception e, Boolean needFileInfo)", cache.Callstack);
             Assert.Contains("at System.Environment.get_StackTrace()", cache.Callstack);
         }
 

--- a/src/System.Runtime.Extensions/src/System/Environment.cs
+++ b/src/System.Runtime.Extensions/src/System/Environment.cs
@@ -6,6 +6,7 @@ using Internal.Runtime.Augments;
 using System.Collections;
 using System.IO;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace System
@@ -154,7 +155,14 @@ namespace System
 
         public static OperatingSystem OSVersion => s_osVersion.Value;
 
-        public static string StackTrace => EnvironmentAugments.StackTrace;
+        public static string StackTrace
+        {
+            [MethodImpl(MethodImplOptions.NoInlining)] // Prevent inlining from affecting where the stacktrace starts
+            get
+            {
+                return EnvironmentAugments.StackTrace;
+            }
+        }
 
         public static int TickCount => EnvironmentAugments.TickCount;
 

--- a/src/System.Runtime.Extensions/tests/System/Environment.StackTrace.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.StackTrace.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.IO;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
@@ -64,6 +65,18 @@ namespace System.Tests
             {
                 EnvironmentStackTrace.StaticFrame(null);
             }
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "On Desktop, Environment.StackTrace contains internal frames")]
+        public void StackTraceDoesNotStartWithInternalFrame()
+        {
+             string stackTrace = Environment.StackTrace;
+
+             // Find first line of the stacktrace and verify that it is Environment.get_StackTrace itself, not an internal frame
+             string firstFrame = new StringReader(stackTrace).ReadLine();
+
+             Assert.True(firstFrame.IndexOf("System.Environment.get_StackTrace()") != -1);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/coreclr/issues/6209