### PR TITLE
Send request in System.Net.Http.Activity.Stop event payload

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
@@ -118,10 +118,13 @@ namespace System.Net.Http
                 //always stop activity if it was started
                 if (activity != null)
                 {
-                    activity.SetEndTime(DateTime.UtcNow);
                     s_diagnosticListener.StopActivity(activity, new
                     {
                         Response = responseTask.Status == TaskStatus.RanToCompletion ? responseTask.Result : null,
+                        //If request is failed or cancelled, there is no reponse, therefore no information about request;
+                        //pass the request in the payload, so consumers can have it in Stop for failed/canceled requests
+                        //and not retain all requests in Start 
+                        Request = request,
                         RequestTaskStatus = responseTask.Status
                     });
                 }

--- a/src/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
@@ -473,11 +473,7 @@ namespace System.Net.Http.Functional.Tests
                 bool activityLogged = false;
                 var diagnosticListenerObserver = new FakeDiagnosticListenerObserver(kvp =>
                 {
-                    if (kvp.Key.Equals("System.Net.Http.Activity.Stop"))
-                    {
-                        GetPropertyValueFromAnonymousTypeInstance<HttpResponseMessage>(kvp.Value, "Request");
-                        activityLogged = true;
-                    }
+                    if (kvp.Key.Equals("System.Net.Http.Activity.Stop")) { activityLogged = true; }
                     else if (kvp.Key.Equals("System.Net.Http.Exception"))
                     {
                         Assert.NotNull(kvp.Value);

--- a/src/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
@@ -338,7 +338,10 @@ namespace System.Net.Http.Functional.Tests
                         Assert.NotNull(Activity.Current);
                         Assert.Equal(parentActivity, Activity.Current.Parent);
                         Assert.True(Activity.Current.Duration != TimeSpan.Zero);
+                        GetPropertyValueFromAnonymousTypeInstance<HttpRequestMessage>(kvp.Value, "Request");
                         GetPropertyValueFromAnonymousTypeInstance<HttpResponseMessage>(kvp.Value, "Response");
+                        var requestStatus = GetPropertyValueFromAnonymousTypeInstance<TaskStatus>(kvp.Value, "RequestTaskStatus");
+                        Assert.Equal(TaskStatus.RanToCompletion, requestStatus);
 
                         activityStopLogged = true;
                     }
@@ -427,6 +430,7 @@ namespace System.Net.Http.Functional.Tests
                     if (kvp.Key.Equals("System.Net.Http.Activity.Stop"))
                     {
                         Assert.NotNull(kvp.Value);
+                        GetPropertyValueFromAnonymousTypeInstance<HttpRequestMessage>(kvp.Value, "Request");
                         var requestStatus = GetPropertyValueFromAnonymousTypeInstance<TaskStatus>(kvp.Value, "RequestTaskStatus");
                         Assert.Equal(TaskStatus.Faulted, requestStatus);
 
@@ -469,7 +473,11 @@ namespace System.Net.Http.Functional.Tests
                 bool activityLogged = false;
                 var diagnosticListenerObserver = new FakeDiagnosticListenerObserver(kvp =>
                 {
-                    if (kvp.Key.Equals("System.Net.Http.Activity.Stop")) { activityLogged = true; }
+                    if (kvp.Key.Equals("System.Net.Http.Activity.Stop"))
+                    {
+                        GetPropertyValueFromAnonymousTypeInstance<HttpResponseMessage>(kvp.Value, "Request");
+                        activityLogged = true;
+                    }
                     else if (kvp.Key.Equals("System.Net.Http.Exception"))
                     {
                         Assert.NotNull(kvp.Value);
@@ -546,6 +554,7 @@ namespace System.Net.Http.Functional.Tests
                     if (kvp.Key == "System.Net.Http.Activity.Stop")
                     {
                         Assert.NotNull(kvp.Value);
+                        GetPropertyValueFromAnonymousTypeInstance<HttpRequestMessage>(kvp.Value, "Request");
                         var status = GetPropertyValueFromAnonymousTypeInstance<TaskStatus>(kvp.Value, "RequestTaskStatus");
                         Assert.Equal(TaskStatus.Canceled, status);
                         cancelLogged = true;


### PR DESCRIPTION
If request processing throws an exception or is cancelled, "System.Net.Http.Activity.Stop" event has null Response property in the payload.

In order to log so such requests, consumers either need to retain request from "System.Net.Http.Activity.Start"  just in case it will fail before "Stop".

We should allow to listen to Stop event only, so Stop event should always all necessary information including Request.

Even if consumer listen to Start event, it's not always useful to tunnel request properties through Activity.Tags.