### PR TITLE
Fixes #2751 Use per-thread IndentLevel for tracing.

### DIFF
--- a/src/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceInternal.cs
+++ b/src/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceInternal.cs
@@ -40,7 +40,6 @@ namespace System.Diagnostics
                             // DefaultTraceListener to the listener collection.
                             s_listeners = new TraceListenerCollection();
                             TraceListener defaultListener = new DefaultTraceListener();
-                            defaultListener.IndentLevel = t_indentLevel;
                             defaultListener.IndentSize = s_indentSize;
                             s_listeners.Add(defaultListener);
                         }
@@ -109,13 +108,6 @@ namespace System.Diagnostics
                     }
                     t_indentLevel = value;
 
-                    if (s_listeners != null)
-                    {
-                        foreach (TraceListener listener in Listeners)
-                        {
-                            listener.IndentLevel = t_indentLevel;
-                        }
-                    }
                 }
             }
         }
@@ -169,10 +161,6 @@ namespace System.Diagnostics
                 {
                     t_indentLevel++;
                 }
-                foreach (TraceListener listener in Listeners)
-                {
-                    listener.IndentLevel = t_indentLevel;
-                }
             }
         }
 
@@ -185,10 +173,6 @@ namespace System.Diagnostics
                 if (t_indentLevel > 0)
                 {
                     t_indentLevel--;
-                }
-                foreach (TraceListener listener in Listeners)
-                {
-                    listener.IndentLevel = t_indentLevel;
                 }
             }
         }
@@ -371,6 +355,7 @@ namespace System.Diagnostics
                     {
                         foreach (TraceListener listener in Listeners)
                         {
+                            listener.IndentLevel = t_indentLevel;
                             listener.TraceEvent(EventCache, AppName, eventType, id, format);
                             if (AutoFlush) listener.Flush();
                         }
@@ -379,6 +364,7 @@ namespace System.Diagnostics
                     {
                         foreach (TraceListener listener in Listeners)
                         {
+                            listener.IndentLevel = t_indentLevel;
                             listener.TraceEvent(EventCache, AppName, eventType, id, format, args);
                             if (AutoFlush) listener.Flush();
                         }
@@ -391,6 +377,7 @@ namespace System.Diagnostics
                 {
                     foreach (TraceListener listener in Listeners)
                     {
+                        listener.IndentLevel = t_indentLevel;
                         if (!listener.IsThreadSafe)
                         {
                             lock (listener)
@@ -410,6 +397,7 @@ namespace System.Diagnostics
                 {
                     foreach (TraceListener listener in Listeners)
                     {
+                        listener.IndentLevel = t_indentLevel;
                         if (!listener.IsThreadSafe)
                         {
                             lock (listener)
@@ -437,6 +425,7 @@ namespace System.Diagnostics
                 {
                     foreach (TraceListener listener in Listeners)
                     {
+                        listener.IndentLevel = t_indentLevel;
                         listener.Write(message);
                         if (AutoFlush) listener.Flush();
                     }
@@ -446,6 +435,7 @@ namespace System.Diagnostics
             {
                 foreach (TraceListener listener in Listeners)
                 {
+                    listener.IndentLevel = t_indentLevel;
                     if (!listener.IsThreadSafe)
                     {
                         lock (listener)
@@ -471,6 +461,7 @@ namespace System.Diagnostics
                 {
                     foreach (TraceListener listener in Listeners)
                     {
+                        listener.IndentLevel = t_indentLevel;
                         listener.Write(value);
                         if (AutoFlush) listener.Flush();
                     }
@@ -480,6 +471,7 @@ namespace System.Diagnostics
             {
                 foreach (TraceListener listener in Listeners)
                 {
+                    listener.IndentLevel = t_indentLevel;
                     if (!listener.IsThreadSafe)
                     {
                         lock (listener)
@@ -505,6 +497,7 @@ namespace System.Diagnostics
                 {
                     foreach (TraceListener listener in Listeners)
                     {
+                        listener.IndentLevel = t_indentLevel;
                         listener.Write(message, category);
                         if (AutoFlush) listener.Flush();
                     }
@@ -514,6 +507,7 @@ namespace System.Diagnostics
             {
                 foreach (TraceListener listener in Listeners)
                 {
+                    listener.IndentLevel = t_indentLevel;
                     if (!listener.IsThreadSafe)
                     {
                         lock (listener)
@@ -539,6 +533,7 @@ namespace System.Diagnostics
                 {
                     foreach (TraceListener listener in Listeners)
                     {
+                        listener.IndentLevel = t_indentLevel;
                         listener.Write(value, category);
                         if (AutoFlush) listener.Flush();
                     }
@@ -548,6 +543,7 @@ namespace System.Diagnostics
             {
                 foreach (TraceListener listener in Listeners)
                 {
+                    listener.IndentLevel = t_indentLevel;
                     if (!listener.IsThreadSafe)
                     {
                         lock (listener)
@@ -573,6 +569,7 @@ namespace System.Diagnostics
                 {
                     foreach (TraceListener listener in Listeners)
                     {
+                        listener.IndentLevel = t_indentLevel;
                         listener.WriteLine(message);
                         if (AutoFlush) listener.Flush();
                     }
@@ -582,6 +579,7 @@ namespace System.Diagnostics
             {
                 foreach (TraceListener listener in Listeners)
                 {
+                    listener.IndentLevel = t_indentLevel;
                     if (!listener.IsThreadSafe)
                     {
                         lock (listener)
@@ -607,6 +605,7 @@ namespace System.Diagnostics
                 {
                     foreach (TraceListener listener in Listeners)
                     {
+                        listener.IndentLevel = t_indentLevel;
                         listener.WriteLine(value);
                         if (AutoFlush) listener.Flush();
                     }
@@ -616,6 +615,7 @@ namespace System.Diagnostics
             {
                 foreach (TraceListener listener in Listeners)
                 {
+                    listener.IndentLevel = t_indentLevel;
                     if (!listener.IsThreadSafe)
                     {
                         lock (listener)
@@ -641,6 +641,7 @@ namespace System.Diagnostics
                 {
                     foreach (TraceListener listener in Listeners)
                     {
+                        listener.IndentLevel = t_indentLevel;
                         listener.WriteLine(message, category);
                         if (AutoFlush) listener.Flush();
                     }
@@ -650,6 +651,7 @@ namespace System.Diagnostics
             {
                 foreach (TraceListener listener in Listeners)
                 {
+                    listener.IndentLevel = t_indentLevel;
                     if (!listener.IsThreadSafe)
                     {
                         lock (listener)
@@ -675,6 +677,7 @@ namespace System.Diagnostics
                 {
                     foreach (TraceListener listener in Listeners)
                     {
+                        listener.IndentLevel = t_indentLevel;
                         listener.WriteLine(value, category);
                         if (AutoFlush) listener.Flush();
                     }
@@ -684,6 +687,7 @@ namespace System.Diagnostics
             {
                 foreach (TraceListener listener in Listeners)
                 {
+                    listener.IndentLevel = t_indentLevel;
                     if (!listener.IsThreadSafe)
                     {
                         lock (listener)

--- a/src/System.Diagnostics.TraceSource/tests/TraceClassTests.cs
+++ b/src/System.Diagnostics.TraceSource/tests/TraceClassTests.cs
@@ -6,6 +6,10 @@ using Xunit;
 
 namespace System.Diagnostics.TraceSourceTests
 {
+    using Collections.Generic;
+    using Text;
+    using Threading;
+    using Threading.Tasks;
     using Method = TestTraceListener.Method;
 
     public class TraceClassTests : IDisposable
@@ -55,10 +59,6 @@ namespace System.Diagnostics.TraceSourceTests
             Trace.Listeners.Add(new DefaultTraceListener());
             Trace.IndentLevel = indent;
             Assert.Equal(expected, Trace.IndentLevel);
-            foreach (TraceListener listener in Trace.Listeners)
-            {
-                Assert.Equal(expected, listener.IndentLevel);
-            }
         }
 
         [Theory]
@@ -367,6 +367,71 @@ namespace System.Diagnostics.TraceSourceTests
             String newLine = Environment.NewLine;
             var expected = "Message start." + newLine + "    This message should be indented.This should not be indented." + newLine + "      Fail: This failure is reported with a detailed message" + newLine + "      Fail: " + newLine + "      Fail: This assert is reported" + newLine + "Message end." + newLine;
             Assert.Equal(expected, textTL.Output);
+        }
+
+        static readonly Barrier barrier = new Barrier(2);
+
+        static string Thread_1()
+        {
+            StringBuilder output = new StringBuilder();
+            output.Append("2,2,2,0|");
+
+            Trace.Indent();
+            Trace.Indent();
+            output.Append(Trace.IndentLevel + ",");
+
+            barrier.SignalAndWait();
+            barrier.SignalAndWait();
+            output.Append(Trace.IndentLevel + ",");
+
+            Trace.IndentLevel = Trace.IndentLevel;
+            output.Append(Trace.IndentLevel + ",");
+
+            Trace.Unindent();
+            Trace.Unindent();
+            output.Append(Trace.IndentLevel + ",");
+
+            return output.ToString().Trim(',');
+        }
+
+        static string Thread_2()
+        {
+            StringBuilder output = new StringBuilder();
+            output.Append("0,0,2,1|");
+
+            output.Append(Trace.IndentLevel + ",");
+
+            barrier.SignalAndWait();
+            output.Append(Trace.IndentLevel + ",");
+
+            Trace.Indent();
+            Trace.Indent();
+            output.Append(Trace.IndentLevel + ",");
+
+            Trace.Unindent();
+            output.Append(Trace.IndentLevel + ",");
+
+            barrier.SignalAndWait();
+
+            return output.ToString().Trim(',');
+        }
+
+        [Fact]
+        public void TraceMutiThreadedTest()
+        {
+            List<Task<string>> tasks = new List<Task<string>>
+            {
+                new Task<string>(Thread_1),
+                new Task<string>(Thread_2)
+            };
+            tasks.ForEach(task => task.Start());
+            Task<string[]> resultsTask = Task.WhenAll(tasks.ToArray());
+            foreach (var result in resultsTask.Result)
+            {
+                var resultParts = result.Split('|');
+                Assert.Equal(2, resultParts.Length);
+                Assert.Equal(resultParts[0], resultParts[1]);
+            }
         }
     }
 }


### PR DESCRIPTION
The fix is to lazily set per-thread IndentLevel into each trace listener just before effecting a trace output.

Fixes #2751.

@stephentoub @karelz @svick Please review.