### PR TITLE
Span performance improvements

### DIFF
--- a/src/System.Memory/src/System.Memory.csproj
+++ b/src/System.Memory/src/System.Memory.csproj
@@ -7,6 +7,7 @@
     <CLSCompliant>false</CLSCompliant>
     <DocumentationFile>$(OutputPath)$(MSBuildProjectName).xml</DocumentationFile>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netcoreapp' OR '$(TargetGroup)' == 'uap'">true</IsPartialFacadeAssembly>
+    <DefineConstants Condition="'$(TargetGroup)'=='netstandard1.0'">$(DefineConstants);netstandard10</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Release|AnyCPU'" />
@@ -37,6 +38,7 @@
     <Reference Include="System.Reflection" />
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />
+    <Reference Condition="'$(TargetGroup)' != 'netstandard1.0'" Include="System.Numerics.Vectors" />
     <Reference Condition="'$(TargetGroup)' != 'netstandard1.0'" Include="System.Runtime.CompilerServices.Unsafe" />
     <ProjectReference Condition="'$(TargetGroup)' == 'netstandard1.0'" Include="..\..\System.Runtime.CompilerServices.Unsafe\ref\System.Runtime.CompilerServices.Unsafe.csproj" />
   </ItemGroup>
@@ -45,6 +47,7 @@
     <ReferenceFromRuntime Include="System.Private.CoreLib" />
     <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj" />
     <ProjectReference Include="..\..\System.Diagnostics.Debug\src\System.Diagnostics.Debug.csproj" />
+    <ProjectReference Include="..\..\System.Numerics.Vectors\src\System.Numerics.Vectors.csproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Memory/src/System/SpanHelpers.T.cs
+++ b/src/System.Memory/src/System/SpanHelpers.T.cs
@@ -45,60 +45,76 @@ namespace System
             return -1;
         }
 
-        public static int IndexOf<T>(ref T searchSpace, T value, int length)
+        public static unsafe int IndexOf<T>(ref T searchSpace, T value, int length)
             where T : struct, IEquatable<T>
         {
             Debug.Assert(length >= 0);
 
-            int index = -1;
-            int remainingLength = length;
-            while (remainingLength >= 8)
+            IntPtr index = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
+            while (length >= 8)
             {
-                if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
+                if (value.Equals(Unsafe.Add(ref searchSpace, index)))
                     goto Found;
-                if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
-                    goto Found;
-                if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
-                    goto Found;
-                if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
-                    goto Found;
-                if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
-                    goto Found;
-                if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
-                    goto Found;
-                if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
-                    goto Found;
-                if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
-                    goto Found;
+                if (value.Equals(Unsafe.Add(ref searchSpace, index + 1)))
+                    goto Found1;
+                if (value.Equals(Unsafe.Add(ref searchSpace, index + 2)))
+                    goto Found2;
+                if (value.Equals(Unsafe.Add(ref searchSpace, index + 3)))
+                    goto Found3;
+                if (value.Equals(Unsafe.Add(ref searchSpace, index + 4)))
+                    goto Found4;
+                if (value.Equals(Unsafe.Add(ref searchSpace, index + 5)))
+                    goto Found5;
+                if (value.Equals(Unsafe.Add(ref searchSpace, index + 6)))
+                    goto Found6;
+                if (value.Equals(Unsafe.Add(ref searchSpace, index + 7)))
+                    goto Found7;
 
-                remainingLength -= 8;
+                length -= 8;
+                index += 8;
             }
 
-            if (remainingLength >= 4)
+            if (length >= 4)
             {
-                if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
+                if (value.Equals(Unsafe.Add(ref searchSpace, index)))
                     goto Found;
-                if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
-                    goto Found;
-                if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
-                    goto Found;
-                if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
-                    goto Found;
+                if (value.Equals(Unsafe.Add(ref searchSpace, index + 1)))
+                    goto Found1;
+                if (value.Equals(Unsafe.Add(ref searchSpace, index + 2)))
+                    goto Found2;
+                if (value.Equals(Unsafe.Add(ref searchSpace, index + 3)))
+                    goto Found3;
 
-                remainingLength -= 4;
+                length -= 4;
+                index += 4;
             }
 
-            while (remainingLength > 0)
+            while (length > 0)
             {
-                if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
+                if (value.Equals(Unsafe.Add(ref searchSpace, index)))
                     goto Found;
 
-                remainingLength--;
+                index += 1;
+                length--;
             }
             return -1;
 
         Found: // Workaround for https://github.com/dotnet/coreclr/issues/9692
-            return index;
+            return (int)(byte*)index;
+        Found1:
+            return (int)(byte*)(index + 1);
+        Found2:
+            return (int)(byte*)(index + 2);
+        Found3:
+            return (int)(byte*)(index + 3);
+        Found4:
+            return (int)(byte*)(index + 4);
+        Found5:
+            return (int)(byte*)(index + 5);
+        Found6:
+            return (int)(byte*)(index + 6);
+        Found7:
+            return (int)(byte*)(index + 7);
         }
 
         public static bool SequenceEqual<T>(ref T first, ref T second, int length)
@@ -109,70 +125,50 @@ namespace System
             if (Unsafe.AreSame(ref first, ref second))
                 goto Equal;
 
-            int index = 0;
+            IntPtr index = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
             while (length >= 8)
             {
                 if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
                     goto NotEqual;
-                index++;
-
-                if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
+                if (!Unsafe.Add(ref first, index + 1).Equals(Unsafe.Add(ref second, index + 1)))
                     goto NotEqual;
-                index++;
-
-                if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
+                if (!Unsafe.Add(ref first, index + 2).Equals(Unsafe.Add(ref second, index + 2)))
                     goto NotEqual;
-                index++;
-
-                if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
+                if (!Unsafe.Add(ref first, index + 3).Equals(Unsafe.Add(ref second, index + 3)))
                     goto NotEqual;
-                index++;
-
-                if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
+                if (!Unsafe.Add(ref first, index + 4).Equals(Unsafe.Add(ref second, index + 4)))
                     goto NotEqual;
-                index++;
-
-                if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
+                if (!Unsafe.Add(ref first, index + 5).Equals(Unsafe.Add(ref second, index + 5)))
                     goto NotEqual;
-                index++;
-
-                if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
+                if (!Unsafe.Add(ref first, index + 6).Equals(Unsafe.Add(ref second, index + 6)))
                     goto NotEqual;
-                index++;
-
-                if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
+                if (!Unsafe.Add(ref first, index + 7).Equals(Unsafe.Add(ref second, index + 7)))
                     goto NotEqual;
-                index++;
 
                 length -= 8;
+                index += 8;
             }
 
-            while (length >= 4)
+            if (length >= 4)
             {
                 if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
                     goto NotEqual;
-                index++;
-
-                if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
+                if (!Unsafe.Add(ref first, index + 1).Equals(Unsafe.Add(ref second, index + 1)))
                     goto NotEqual;
-                index++;
-
-                if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
+                if (!Unsafe.Add(ref first, index + 2).Equals(Unsafe.Add(ref second, index + 2)))
                     goto NotEqual;
-                index++;
-
-                if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
+                if (!Unsafe.Add(ref first, index + 3).Equals(Unsafe.Add(ref second, index + 3)))
                     goto NotEqual;
-                index++;
 
                 length -= 4;
+                index += 4;
             }
 
             while (length > 0)
             {
                 if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
                     goto NotEqual;
-                index++;
+                index += 1;
                 length--;
             }
 

--- a/src/System.Memory/src/System/SpanHelpers.T.cs
+++ b/src/System.Memory/src/System/SpanHelpers.T.cs
@@ -53,6 +53,8 @@ namespace System
             IntPtr index = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
             while (length >= 8)
             {
+                length -= 8;
+
                 if (value.Equals(Unsafe.Add(ref searchSpace, index)))
                     goto Found;
                 if (value.Equals(Unsafe.Add(ref searchSpace, index + 1)))
@@ -70,12 +72,13 @@ namespace System
                 if (value.Equals(Unsafe.Add(ref searchSpace, index + 7)))
                     goto Found7;
 
-                length -= 8;
                 index += 8;
             }
 
             if (length >= 4)
             {
+                length -= 4;
+
                 if (value.Equals(Unsafe.Add(ref searchSpace, index)))
                     goto Found;
                 if (value.Equals(Unsafe.Add(ref searchSpace, index + 1)))
@@ -85,7 +88,6 @@ namespace System
                 if (value.Equals(Unsafe.Add(ref searchSpace, index + 3)))
                     goto Found3;
 
-                length -= 4;
                 index += 4;
             }
 
@@ -128,6 +130,8 @@ namespace System
             IntPtr index = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
             while (length >= 8)
             {
+                length -= 8;
+
                 if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
                     goto NotEqual;
                 if (!Unsafe.Add(ref first, index + 1).Equals(Unsafe.Add(ref second, index + 1)))
@@ -145,12 +149,13 @@ namespace System
                 if (!Unsafe.Add(ref first, index + 7).Equals(Unsafe.Add(ref second, index + 7)))
                     goto NotEqual;
 
-                length -= 8;
                 index += 8;
             }
 
             if (length >= 4)
             {
+                length -= 4;
+
                 if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
                     goto NotEqual;
                 if (!Unsafe.Add(ref first, index + 1).Equals(Unsafe.Add(ref second, index + 1)))
@@ -160,7 +165,6 @@ namespace System
                 if (!Unsafe.Add(ref first, index + 3).Equals(Unsafe.Add(ref second, index + 3)))
                     goto NotEqual;
 
-                length -= 4;
                 index += 4;
             }
 

--- a/src/System.Memory/src/System/SpanHelpers.T.cs
+++ b/src/System.Memory/src/System/SpanHelpers.T.cs
@@ -28,12 +28,12 @@ namespace System
                 Debug.Assert(0 <= index && index <= searchSpaceLength); // Ensures no deceptive underflows in the computation of "remainingSearchSpaceLength".
                 int remainingSearchSpaceLength = searchSpaceLength - index - valueTailLength;
                 if (remainingSearchSpaceLength <= 0)
-                    return -1;  // The unsearched portion is now shorter than the sequence we're looking for. So it can't be there.
+                    break;  // The unsearched portion is now shorter than the sequence we're looking for. So it can't be there.
 
                 // Do a quick search for the first element of "value".
                 int relativeIndex = IndexOf(ref Unsafe.Add(ref searchSpace, index), valueHead, remainingSearchSpaceLength);
                 if (relativeIndex == -1)
-                    return -1;
+                    break;
                 index += relativeIndex;
 
                 // Found the first element of "value". See if the tail matches.
@@ -42,6 +42,7 @@ namespace System
 
                 index++;
             }
+            return -1;
         }
 
         public static int IndexOf<T>(ref T searchSpace, T value, int length)
@@ -54,35 +55,35 @@ namespace System
             while (remainingLength >= 8)
             {
                 if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
-                    return index;
+                    goto Found;
                 if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
-                    return index;
+                    goto Found;
                 if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
-                    return index;
+                    goto Found;
                 if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
-                    return index;
+                    goto Found;
                 if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
-                    return index;
+                    goto Found;
                 if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
-                    return index;
+                    goto Found;
                 if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
-                    return index;
+                    goto Found;
                 if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
-                    return index;
+                    goto Found;
 
                 remainingLength -= 8;
             }
 
-            while (remainingLength >= 4)
+            if (remainingLength >= 4)
             {
                 if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
-                    return index;
+                    goto Found;
                 if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
-                    return index;
+                    goto Found;
                 if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
-                    return index;
+                    goto Found;
                 if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
-                    return index;
+                    goto Found;
 
                 remainingLength -= 4;
             }
@@ -90,11 +91,14 @@ namespace System
             while (remainingLength > 0)
             {
                 if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
-                    return index;
+                    goto Found;
 
                 remainingLength--;
             }
             return -1;
+
+        Found: // Workaround for https://github.com/dotnet/coreclr/issues/9692
+            return index;
         }
 
         public static bool SequenceEqual<T>(ref T first, ref T second, int length)
@@ -103,41 +107,41 @@ namespace System
             Debug.Assert(length >= 0);
 
             if (Unsafe.AreSame(ref first, ref second))
-                return true;
+                goto Equal;
 
             int index = 0;
             while (length >= 8)
             {
                 if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
-                    return false;
+                    goto NotEqual;
                 index++;
 
                 if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
-                    return false;
+                    goto NotEqual;
                 index++;
 
                 if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
-                    return false;
+                    goto NotEqual;
                 index++;
 
                 if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
-                    return false;
+                    goto NotEqual;
                 index++;
 
                 if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
-                    return false;
+                    goto NotEqual;
                 index++;
 
                 if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
-                    return false;
+                    goto NotEqual;
                 index++;
 
                 if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
-                    return false;
+                    goto NotEqual;
                 index++;
 
                 if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
-                    return false;
+                    goto NotEqual;
                 index++;
 
                 length -= 8;
@@ -146,19 +150,19 @@ namespace System
             while (length >= 4)
             {
                 if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
-                    return false;
+                    goto NotEqual;
                 index++;
 
                 if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
-                    return false;
+                    goto NotEqual;
                 index++;
 
                 if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
-                    return false;
+                    goto NotEqual;
                 index++;
 
                 if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
-                    return false;
+                    goto NotEqual;
                 index++;
 
                 length -= 4;
@@ -167,12 +171,16 @@ namespace System
             while (length > 0)
             {
                 if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
-                    return false;
+                    goto NotEqual;
                 index++;
                 length--;
             }
 
+        Equal:
             return true;
+
+        NotEqual: // Workaround for https://github.com/dotnet/coreclr/issues/9692
+            return false;
         }
     }
 }

--- a/src/System.Memory/src/System/SpanHelpers.byte.cs
+++ b/src/System.Memory/src/System/SpanHelpers.byte.cs
@@ -48,59 +48,75 @@ namespace System
             return -1;
         }
 
-        public static int IndexOf(ref byte searchSpace, byte value, int length)
+        public static unsafe int IndexOf(ref byte searchSpace, byte value, int length)
         {
             Debug.Assert(length >= 0);
 
-            int index = -1;
-            int remainingLength = length;
-            while (remainingLength >= 8)
+            IntPtr index = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
+            while (length >= 8)
             {
-                if (value == Unsafe.Add(ref searchSpace, ++index))
+                if (value == Unsafe.Add(ref searchSpace, index))
                     goto Found;
-                if (value == Unsafe.Add(ref searchSpace, ++index))
-                    goto Found;
-                if (value == Unsafe.Add(ref searchSpace, ++index))
-                    goto Found;
-                if (value == Unsafe.Add(ref searchSpace, ++index))
-                    goto Found;
-                if (value == Unsafe.Add(ref searchSpace, ++index))
-                    goto Found;
-                if (value == Unsafe.Add(ref searchSpace, ++index))
-                    goto Found;
-                if (value == Unsafe.Add(ref searchSpace, ++index))
-                    goto Found;
-                if (value == Unsafe.Add(ref searchSpace, ++index))
-                    goto Found;
+                if (value == Unsafe.Add(ref searchSpace, index + 1))
+                    goto Found1;
+                if (value == Unsafe.Add(ref searchSpace, index + 2))
+                    goto Found2;
+                if (value == Unsafe.Add(ref searchSpace, index + 3))
+                    goto Found3;
+                if (value == Unsafe.Add(ref searchSpace, index + 4))
+                    goto Found4;
+                if (value == Unsafe.Add(ref searchSpace, index + 5))
+                    goto Found5;
+                if (value == Unsafe.Add(ref searchSpace, index + 6))
+                    goto Found6;
+                if (value == Unsafe.Add(ref searchSpace, index + 7))
+                    goto Found7;
 
-                remainingLength -= 8;
+                length -= 8;
+                index += 8;
             }
 
-            if (remainingLength >= 4)
+            if (length >= 4)
             {
-                if (value == Unsafe.Add(ref searchSpace, ++index))
+                if (value == Unsafe.Add(ref searchSpace, index))
                     goto Found;
-                if (value == Unsafe.Add(ref searchSpace, ++index))
-                    goto Found;
-                if (value == Unsafe.Add(ref searchSpace, ++index))
-                    goto Found;
-                if (value == Unsafe.Add(ref searchSpace, ++index))
-                    goto Found;
+                if (value == Unsafe.Add(ref searchSpace, index + 1))
+                    goto Found1;
+                if (value == Unsafe.Add(ref searchSpace, index + 2))
+                    goto Found2;
+                if (value == Unsafe.Add(ref searchSpace, index + 3))
+                    goto Found3;
 
-                remainingLength -= 4;
+                length -= 4;
+                index += 4;
             }
 
-            while (remainingLength > 0)
+            while (length > 0)
             {
-                if (value == Unsafe.Add(ref searchSpace, ++index))
+                if (value == Unsafe.Add(ref searchSpace, index))
                     goto Found;
 
-                remainingLength--;
+                index += 1;
+                length--;
             }
             return -1;
 
         Found: // Workaround for https://github.com/dotnet/coreclr/issues/9692
-            return index;
+            return (int)(byte*)index;
+        Found1:
+            return (int)(byte*)(index + 1);
+        Found2:
+            return (int)(byte*)(index + 2);
+        Found3:
+            return (int)(byte*)(index + 3);
+        Found4:
+            return (int)(byte*)(index + 4);
+        Found5:
+            return (int)(byte*)(index + 5);
+        Found6:
+            return (int)(byte*)(index + 6);
+        Found7:
+            return (int)(byte*)(index + 7);
         }
 
         public static unsafe bool SequenceEqual(ref byte first, ref byte second, int length)

--- a/src/System.Memory/src/System/SpanHelpers.byte.cs
+++ b/src/System.Memory/src/System/SpanHelpers.byte.cs
@@ -55,6 +55,8 @@ namespace System
             IntPtr index = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
             while (length >= 8)
             {
+                length -= 8;
+
                 if (value == Unsafe.Add(ref searchSpace, index))
                     goto Found;
                 if (value == Unsafe.Add(ref searchSpace, index + 1))
@@ -72,12 +74,13 @@ namespace System
                 if (value == Unsafe.Add(ref searchSpace, index + 7))
                     goto Found7;
 
-                length -= 8;
                 index += 8;
             }
 
             if (length >= 4)
             {
+                length -= 4;
+
                 if (value == Unsafe.Add(ref searchSpace, index))
                     goto Found;
                 if (value == Unsafe.Add(ref searchSpace, index + 1))
@@ -87,7 +90,6 @@ namespace System
                 if (value == Unsafe.Add(ref searchSpace, index + 3))
                     goto Found3;
 
-                length -= 4;
                 index += 4;
             }
 

--- a/src/System.Memory/src/System/SpanHelpers.char.cs
+++ b/src/System.Memory/src/System/SpanHelpers.char.cs
@@ -100,7 +100,7 @@ namespace System
             return -1;
 
         Found: // Workaround for https://github.com/dotnet/coreclr/issues/9692
-            goto Found;
+            return index;
         }
 
         public static unsafe bool SequenceEqual(ref char firstAsChar, ref char secondAsChar, int length)

--- a/src/System.Memory/src/System/SpanHelpers.char.cs
+++ b/src/System.Memory/src/System/SpanHelpers.char.cs
@@ -55,6 +55,8 @@ namespace System
             IntPtr index = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
             while (length >= 8)
             {
+                length -= 8;
+
                 if (value == Unsafe.Add(ref searchSpace, index))
                     goto Found;
                 if (value == Unsafe.Add(ref searchSpace, index + 1))
@@ -72,12 +74,13 @@ namespace System
                 if (value == Unsafe.Add(ref searchSpace, index + 7))
                     goto Found7;
 
-                length -= 8;
                 index += 8;
             }
 
             if (length >= 4)
             {
+                length -= 4;
+
                 if (value == Unsafe.Add(ref searchSpace, index))
                     goto Found;
                 if (value == Unsafe.Add(ref searchSpace, index + 1))
@@ -87,7 +90,6 @@ namespace System
                 if (value == Unsafe.Add(ref searchSpace, index + 3))
                     goto Found3;
 
-                length -= 4;
                 index += 4;
             }
 

--- a/src/System.Memory/src/System/SpanHelpers.char.cs
+++ b/src/System.Memory/src/System/SpanHelpers.char.cs
@@ -48,59 +48,75 @@ namespace System
             return -1;
         }
 
-        public static int IndexOf(ref char searchSpace, char value, int length)
+        public static unsafe int IndexOf(ref char searchSpace, char value, int length)
         {
             Debug.Assert(length >= 0);
 
-            int index = -1;
-            int remainingLength = length;
-            while (remainingLength >= 8)
+            IntPtr index = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
+            while (length >= 8)
             {
-                if (value == Unsafe.Add(ref searchSpace, ++index))
+                if (value == Unsafe.Add(ref searchSpace, index))
                     goto Found;
-                if (value == Unsafe.Add(ref searchSpace, ++index))
-                    goto Found;
-                if (value == Unsafe.Add(ref searchSpace, ++index))
-                    goto Found;
-                if (value == Unsafe.Add(ref searchSpace, ++index))
-                    goto Found;
-                if (value == Unsafe.Add(ref searchSpace, ++index))
-                    goto Found;
-                if (value == Unsafe.Add(ref searchSpace, ++index))
-                    goto Found;
-                if (value == Unsafe.Add(ref searchSpace, ++index))
-                    goto Found;
-                if (value == Unsafe.Add(ref searchSpace, ++index))
-                    goto Found;
+                if (value == Unsafe.Add(ref searchSpace, index + 1))
+                    goto Found1;
+                if (value == Unsafe.Add(ref searchSpace, index + 2))
+                    goto Found2;
+                if (value == Unsafe.Add(ref searchSpace, index + 3))
+                    goto Found3;
+                if (value == Unsafe.Add(ref searchSpace, index + 4))
+                    goto Found4;
+                if (value == Unsafe.Add(ref searchSpace, index + 5))
+                    goto Found5;
+                if (value == Unsafe.Add(ref searchSpace, index + 6))
+                    goto Found6;
+                if (value == Unsafe.Add(ref searchSpace, index + 7))
+                    goto Found7;
 
-                remainingLength -= 8;
+                length -= 8;
+                index += 8;
             }
 
-            if (remainingLength >= 4)
+            if (length >= 4)
             {
-                if (value == Unsafe.Add(ref searchSpace, ++index))
+                if (value == Unsafe.Add(ref searchSpace, index))
                     goto Found;
-                if (value == Unsafe.Add(ref searchSpace, ++index))
-                    goto Found;
-                if (value == Unsafe.Add(ref searchSpace, ++index))
-                    goto Found;
-                if (value == Unsafe.Add(ref searchSpace, ++index))
-                    goto Found;
+                if (value == Unsafe.Add(ref searchSpace, index + 1))
+                    goto Found1;
+                if (value == Unsafe.Add(ref searchSpace, index + 2))
+                    goto Found2;
+                if (value == Unsafe.Add(ref searchSpace, index + 3))
+                    goto Found3;
 
-                remainingLength -= 4;
+                length -= 4;
+                index += 4;
             }
 
-            while (remainingLength > 0)
+            while (length > 0)
             {
-                if (value == Unsafe.Add(ref searchSpace, ++index))
+                if (value == Unsafe.Add(ref searchSpace, index))
                     goto Found;
 
-                remainingLength--;
+                index += 1;
+                length--;
             }
             return -1;
 
         Found: // Workaround for https://github.com/dotnet/coreclr/issues/9692
-            return index;
+            return (int)(byte*)index;
+        Found1:
+            return (int)(byte*)(index + 1);
+        Found2:
+            return (int)(byte*)(index + 2);
+        Found3:
+            return (int)(byte*)(index + 3);
+        Found4:
+            return (int)(byte*)(index + 4);
+        Found5:
+            return (int)(byte*)(index + 5);
+        Found6:
+            return (int)(byte*)(index + 6);
+        Found7:
+            return (int)(byte*)(index + 7);
         }
 
         public static unsafe bool SequenceEqual(ref char firstAsChar, ref char secondAsChar, int length)

--- a/src/System.Memory/src/System/SpanHelpers.char.cs
+++ b/src/System.Memory/src/System/SpanHelpers.char.cs
@@ -5,6 +5,10 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
+#if !netstandard10
+using System.Numerics;
+#endif
+
 namespace System
 {
     internal static partial class SpanHelpers
@@ -27,12 +31,12 @@ namespace System
                 Debug.Assert(0 <= index && index <= searchSpaceLength); // Ensures no deceptive underflows in the computation of "remainingSearchSpaceLength".
                 int remainingSearchSpaceLength = searchSpaceLength - index - valueTailLength;
                 if (remainingSearchSpaceLength <= 0)
-                    return -1;  // The unsearched portion is now shorter than the sequence we're looking for. So it can't be there.
+                    break;  // The unsearched portion is now shorter than the sequence we're looking for. So it can't be there.
 
                 // Do a quick search for the first element of "value".
                 int relativeIndex = IndexOf(ref Unsafe.Add(ref searchSpace, index), valueHead, remainingSearchSpaceLength);
                 if (relativeIndex == -1)
-                    return -1;
+                    break;
                 index += relativeIndex;
 
                 // Found the first element of "value". See if the tail matches.
@@ -41,6 +45,7 @@ namespace System
 
                 index++;
             }
+            return -1;
         }
 
         public static int IndexOf(ref char searchSpace, char value, int length)
@@ -52,35 +57,35 @@ namespace System
             while (remainingLength >= 8)
             {
                 if (value == Unsafe.Add(ref searchSpace, ++index))
-                    return index;
+                    goto Found;
                 if (value == Unsafe.Add(ref searchSpace, ++index))
-                    return index;
+                    goto Found;
                 if (value == Unsafe.Add(ref searchSpace, ++index))
-                    return index;
+                    goto Found;
                 if (value == Unsafe.Add(ref searchSpace, ++index))
-                    return index;
+                    goto Found;
                 if (value == Unsafe.Add(ref searchSpace, ++index))
-                    return index;
+                    goto Found;
                 if (value == Unsafe.Add(ref searchSpace, ++index))
-                    return index;
+                    goto Found;
                 if (value == Unsafe.Add(ref searchSpace, ++index))
-                    return index;
+                    goto Found;
                 if (value == Unsafe.Add(ref searchSpace, ++index))
-                    return index;
+                    goto Found;
 
                 remainingLength -= 8;
             }
 
-            while (remainingLength >= 4)
+            if (remainingLength >= 4)
             {
                 if (value == Unsafe.Add(ref searchSpace, ++index))
-                    return index;
+                    goto Found;
                 if (value == Unsafe.Add(ref searchSpace, ++index))
-                    return index;
+                    goto Found;
                 if (value == Unsafe.Add(ref searchSpace, ++index))
-                    return index;
+                    goto Found;
                 if (value == Unsafe.Add(ref searchSpace, ++index))
-                    return index;
+                    goto Found;
 
                 remainingLength -= 4;
             }
@@ -88,89 +93,78 @@ namespace System
             while (remainingLength > 0)
             {
                 if (value == Unsafe.Add(ref searchSpace, ++index))
-                    return index;
+                    goto Found;
 
                 remainingLength--;
             }
             return -1;
+
+        Found: // Workaround for https://github.com/dotnet/coreclr/issues/9692
+            goto Found;
         }
 
-        public static bool SequenceEqual(ref char first, ref char second, int length)
+        public static unsafe bool SequenceEqual(ref char firstAsChar, ref char secondAsChar, int length)
         {
             Debug.Assert(length >= 0);
 
+            ref byte first = ref Unsafe.As<char, byte>(ref firstAsChar);
+            ref byte second = ref Unsafe.As<char, byte>(ref secondAsChar);
+
             if (Unsafe.AreSame(ref first, ref second))
-                return true;
+                goto Equal;
 
-            int index = 0;
-            while (length >= 8)
+            IntPtr i = (IntPtr)0; // Use IntPtr and byte* for arithmetic to avoid unnecessary 64->32->64 truncations
+            IntPtr n = (IntPtr)length + length; // sizeof(char) * length;
+
+#if !netstandard10
+            if (Vector.IsHardwareAccelerated && (byte*)n >= (byte*)Vector<byte>.Count)
             {
-                if (Unsafe.Add(ref first, index) != Unsafe.Add(ref second, index))
-                    return false;
-                index++;
+                n -= Vector<byte>.Count;
+                while ((byte*)n > (byte*)i)
+                {
+                    if (Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref first, i)) !=
+                        Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref second, i)))
+                    {
+                        goto NotEqual;
+                    }
+                    i += Vector<byte>.Count;
+                }
+                return Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref first, n)) ==
+                       Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref second, n));
+            }
+#endif
 
-                if (Unsafe.Add(ref first, index) != Unsafe.Add(ref second, index))
-                    return false;
-                index++;
-
-                if (Unsafe.Add(ref first, index) != Unsafe.Add(ref second, index))
-                    return false;
-                index++;
-
-                if (Unsafe.Add(ref first, index) != Unsafe.Add(ref second, index))
-                    return false;
-                index++;
-
-                if (Unsafe.Add(ref first, index) != Unsafe.Add(ref second, index))
-                    return false;
-                index++;
-
-                if (Unsafe.Add(ref first, index) != Unsafe.Add(ref second, index))
-                    return false;
-                index++;
-
-                if (Unsafe.Add(ref first, index) != Unsafe.Add(ref second, index))
-                    return false;
-                index++;
-
-                if (Unsafe.Add(ref first, index) != Unsafe.Add(ref second, index))
-                    return false;
-                index++;
-
-
-                length -= 8;
+            if ((byte*)n >= (byte*)sizeof(UIntPtr))
+            {
+                n -= sizeof(UIntPtr);
+                while ((byte*)n > (byte*)i)
+                {
+                    if (Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref first, i)) !=
+                        Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref second, i)))
+                    {
+                        goto NotEqual;
+                    }
+                    i += sizeof(UIntPtr);
+                }
+                return Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref first, n)) ==
+                       Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref second, n));
             }
 
-            while (length >= 4)
+            while ((byte*)n > (byte*)i)
             {
-                if (Unsafe.Add(ref first, index) != Unsafe.Add(ref second, index))
-                    return false;
-                index++;
-
-                if (Unsafe.Add(ref first, index) != Unsafe.Add(ref second, index))
-                    return false;
-                index++;
-
-                if (Unsafe.Add(ref first, index) != Unsafe.Add(ref second, index))
-                    return false;
-                index++;
-
-                if (Unsafe.Add(ref first, index) != Unsafe.Add(ref second, index))
-                    return false;
-                index++;
-
-                length -= 4;
+                if (Unsafe.As<byte, char>(ref Unsafe.AddByteOffset(ref first, i)) !=
+                    Unsafe.As<byte, char>(ref Unsafe.AddByteOffset(ref second, i)))
+                {
+                    goto NotEqual;
+                }
+                i += sizeof(char);
             }
 
-            while (length > 0)
-            {
-                if (Unsafe.Add(ref first, index) != Unsafe.Add(ref second, index))
-                    return false;
-                index++;
-                length--;
-            }
-
+        Equal:
             return true;
+
+        NotEqual: // Workaround for https://github.com/dotnet/coreclr/issues/9692
+            return false;
         }
     }
 }


### PR DESCRIPTION
- Add System.Memory dependency on System.Vectors for !netstandard10 build configurations
- Vectorized SequenceEquals for `Span<byte>` and `Span<char>`
- Add workarounds for https://github.com/dotnet/coreclr/issues/9692