### PR TITLE
Add tests for ArraySegment slicing APIs and GetEnumerator

### DIFF
--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -346,14 +346,24 @@ namespace System
         public ArraySegment(T[] array, int offset, int count) { throw null; }
         public T[] Array { get { throw null; } }
         public int Count { get { throw null; } }
+        public static ArraySegment<T> Empty { get { throw null; } }
         public int Offset { get { throw null; } }
+        public T this[int index] { get { throw null; } set { } }
         bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
         T System.Collections.Generic.IList<T>.this[int index] { get { throw null; } set { } }
         T System.Collections.Generic.IReadOnlyList<T>.this[int index] { get { throw null; } }
+        public void CopyTo(T[] destination) { throw null; }
+        public void CopyTo(T[] destination, int destinationIndex) { throw null; }
+        public void CopyTo(ArraySegment<T> destination) { throw null; }
         public bool Equals(System.ArraySegment<T> obj) { throw null; }
         public override bool Equals(object obj) { throw null; }
+        public Enumerator GetEnumerator() { throw null; }
         public override int GetHashCode() { throw null; }
+        public ArraySegment<T> Slice(int index) { throw null; }
+        public ArraySegment<T> Slice(int index, int count) { throw null; }
+        public T[] ToArray() { throw null; }
         public static bool operator ==(System.ArraySegment<T> a, System.ArraySegment<T> b) { throw null; }
+        public static implicit operator ArraySegment<T>(T[] array) { throw null; }
         public static bool operator !=(System.ArraySegment<T> a, System.ArraySegment<T> b) { throw null; }
         void System.Collections.Generic.ICollection<T>.Add(T item) { }
         void System.Collections.Generic.ICollection<T>.Clear() { }
@@ -365,6 +375,15 @@ namespace System
         void System.Collections.Generic.IList<T>.Insert(int index, T item) { }
         void System.Collections.Generic.IList<T>.RemoveAt(int index) { }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+        {
+            public T Current { get { throw null; } }
+            object System.Collections.IEnumerator.Current { get { throw null; } }
+            public void Dispose() { }
+            public bool MoveNext() { throw null; }
+            void System.Collections.IEnumerator.Reset() { }
+        }
     }
     public partial class ArrayTypeMismatchException : System.SystemException
     {

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -125,6 +125,7 @@
     <Compile Include="Helpers.netcoreapp.cs" />
     <Compile Include="System\ActivatorTests.netcoreapp.cs" />
     <Compile Include="System\ArrayTests.netcoreapp.cs" />
+    <Compile Include="System\ArraySegmentTests.netcoreapp.cs" />
     <Compile Include="System\EnumTests.netcoreapp.cs" />
     <Compile Include="System\GCTests.netcoreapp.cs" />
     <Compile Include="System\IntPtrTests.netcoreapp.cs" />

--- a/src/System.Runtime/tests/System/ArraySegmentTests.cs
+++ b/src/System.Runtime/tests/System/ArraySegmentTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace System.Tests
 {
-    public abstract class ArraySegment_Tests<T>: IList_Generic_Tests<T>
+    public abstract partial class ArraySegment_Tests<T> : IList_Generic_Tests<T>
     {
         #region IList<T> Helper Methods
 
@@ -112,7 +112,7 @@ namespace System.Tests
     }
 
 
-    public static class ArraySegment_Tests
+    public static partial class ArraySegment_Tests
     {
         public static IEnumerable<object[]> Equals_TestData()
         {

--- a/src/System.Runtime/tests/System/ArraySegmentTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/ArraySegmentTests.netcoreapp.cs
@@ -1,0 +1,139 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace System.Tests
+{
+    public abstract partial class ArraySegment_Tests<T>
+    {
+        [Fact]
+        public void GetEnumerator_TypeProperties()
+        {
+            var arraySegment = new ArraySegment<T>(new T[1], 0, 1);
+            var ienumerableoft = (IEnumerable<T>)arraySegment;
+            var ienumerable = (IEnumerable)arraySegment;
+
+            var enumerator = arraySegment.GetEnumerator();
+            Assert.IsType<ArraySegment<T>.Enumerator>(enumerator);
+            Assert.IsAssignableFrom<IEnumerator<T>>(enumerator);
+            Assert.IsAssignableFrom<IEnumerator>(enumerator);
+
+            var ienumeratoroft = ienumerableoft.GetEnumerator();
+            var ienumerator = ienumerable.GetEnumerator();
+
+            Assert.Equal(enumerator.GetType(), ienumeratoroft.GetType());
+            Assert.Equal(ienumeratoroft.GetType(), ienumerator.GetType());
+        }
+
+        [Fact]
+        public void GetEnumerator_Default_ThrowsInvalidOperationException()
+        {
+            Assert.Throws<InvalidOperationException>(() => default(ArraySegment<T>).GetEnumerator());
+        }
+    }
+
+    public static partial class ArraySegment_Tests
+    {
+        [Theory]
+        [MemberData(nameof(GetEnumerator_TestData))]
+        public static void GetEnumerator(int[] array, int index, int count)
+        {
+            var arraySegment = new ArraySegment<int>(array, index, count);
+            var enumerator = arraySegment.GetEnumerator();
+
+            var actual = new List<int>();
+
+            while (enumerator.MoveNext())
+            {
+                actual.Add(enumerator.Current);
+            }
+
+            // After MoveNext returns false once, it should return false the second time.
+            Assert.False(enumerator.MoveNext());
+
+            var expected = array.Skip(index).Take(count);
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetEnumerator_TestData))]
+        public static void GetEnumerator_Dispose(int[] array, int index, int count)
+        {
+            var arraySegment = new ArraySegment<int>(array, index, count);
+            var enumerator = arraySegment.GetEnumerator();
+
+            bool expected = arraySegment.Count > 0;
+            
+            // Dispose shouldn't do anything. Call it twice and then assert like nothing happened.
+            enumerator.Dispose();
+            enumerator.Dispose();
+
+            Assert.Equal(expected, enumerator.MoveNext());
+            if (expected)
+            {
+                Assert.Equal(array[index], enumerator.Current);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetEnumerator_TestData))]
+        public static void GetEnumerator_Reset(int[] array, int index, int count)
+        {
+            var arraySegment = new ArraySegment<int>(array, index, count);
+            var enumerator = (IEnumerator<int>)arraySegment.GetEnumerator();
+
+            var expected = array.Skip(index).Take(count).ToArray();
+            
+            // Reset at a variety of different positions to ensure the implementation
+            // isn't something like `position -= CONSTANT`.
+            for (int i = 0; i < 3; i++)
+            {
+                for (int j = 0; j < i; j++)
+                {
+                    if (enumerator.MoveNext())
+                    {
+                        Assert.Equal(expected[j], enumerator.Current);
+                    }
+                }
+
+                enumerator.Reset();
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetEnumerator_TestData))]
+        public static void GetEnumerator_Invalid(int[] array, int index, int count)
+        {
+            var arraySegment = new ArraySegment<int>(array, index, count);
+            var enumerator = arraySegment.GetEnumerator();
+
+            // Before beginning
+            Assert.Throws<InvalidOperationException>(() => enumerator.Current);
+            Assert.Throws<InvalidOperationException>(() => ((IEnumerator<int>)enumerator).Current);
+            Assert.Throws<InvalidOperationException>(() => ((IEnumerator)enumerator).Current);
+
+            while (enumerator.MoveNext()) ;
+            
+            // After end
+            Assert.Throws<InvalidOperationException>(() => enumerator.Current);
+            Assert.Throws<InvalidOperationException>(() => ((IEnumerator<int>)enumerator).Current);
+            Assert.Throws<InvalidOperationException>(() => ((IEnumerator)enumerator).Current);
+        }
+
+        public static IEnumerable<object[]> GetEnumerator_TestData() =>
+            new[]
+            {
+                new object[] { new int[0], 0, 0 }, // Empty array
+                new object[] { new[] { 3, 4, 5 }, 0, 3 }, // Full span of non-empty array
+                new object[] { new[] { 3, 4, 5 }, 0, 2 }, // Starts at beginning, ends in middle
+                new object[] { new[] { 3, 4, 5 }, 1, 2 }, // Starts in middle, ends at end
+                new object[] { new[] { 3, 4, 5 }, 1, 1 }, // Starts in middle, ends in middle
+                new object[] { new[] { 3, 4, 5 }, 1, 0 } // Non-empty array, count == 0
+            };
+    }
+}

--- a/src/System.Runtime/tests/System/ArraySegmentTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/ArraySegmentTests.netcoreapp.cs
@@ -183,6 +183,8 @@ namespace System.Tests
         [MemberData(nameof(ArraySegment_TestData))]
         public static void CopyTo_Invalid(ArraySegment<int> arraySegment)
         {
+            int count = arraySegment.Count;
+
             // ArraySegment.CopyTo calls Array.Copy internally, so the exception parameter names come from there.
 
             // Destination is null
@@ -199,6 +201,10 @@ namespace System.Tests
                 Assert.Throws<ArgumentOutOfRangeException>("destinationArray", () => arraySegment.CopyTo(new int[count - 1]));
                 Assert.Throws<ArgumentOutOfRangeException>("destinationArray", () => arraySegment.CopyTo(new int[count - 1], 0));
                 Assert.Throws<ArgumentOutOfRangeException>("destinationArray", () => arraySegment.CopyTo(new ArraySegment<int>(new int[count - 1])));
+
+                // Don't write beyond the limits of the destination in cases where source.Count > destination.Count
+                Assert.Throws<ArgumentException>(() => arraySegment.CopyTo(new ArraySegment<int>(new int[count], 1, 0))); // destination.Array can't fit source at destination.Offset
+                Assert.Throws<ArgumentException>(() => arraySegment.CopyTo(new ArraySegment<int>(new int[count], 0, count - 1))); // destination.Array can fit source at destination.Offset, but destination can't
             }
         }
 

--- a/src/System.Runtime/tests/System/ArraySegmentTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/ArraySegmentTests.netcoreapp.cs
@@ -14,10 +14,14 @@ namespace System.Tests
         [Fact]
         public void CopyTo_Default_ThrowsInvalidOperationException()
         {
+            // Source is default
             Assert.Throws<InvalidOperationException>(() => default(ArraySegment<T>).CopyTo(new T[0]));
             Assert.Throws<InvalidOperationException>(() => default(ArraySegment<T>).CopyTo(new T[0], 0));
             Assert.Throws<InvalidOperationException>(() => ((ICollection<T>)default(ArraySegment<T>)).CopyTo(new T[0], 0));
             Assert.Throws<InvalidOperationException>(() => default(ArraySegment<T>).CopyTo(new ArraySegment<T>(new T[0])));
+
+            // Destination is default
+            Assert.Throws<InvalidOperationException>(() => new ArraySegment<T>(new T[0]).CopyTo(default(ArraySegment<T>)));
         }
 
         [Fact]
@@ -79,12 +83,11 @@ namespace System.Tests
     {
         [Theory]
         [MemberData(nameof(ArraySegment_TestData))]
-        public static void CopyTo(int[] array, int index, int count)
+        public static void CopyTo(ArraySegment<int> arraySegment)
         {
             const int CopyLining = 5;
             const int DestinationSegmentLining = 3;
 
-            var arraySegment = new ArraySegment<int>(array, index, count);
             var destinationModel = new int[count + 2 * CopyLining];
 
             // CopyTo(T[])
@@ -143,10 +146,9 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(ArraySegment_TestData))]
-        public static void CopyTo_Invalid(int[] array, int index, int count)
+        public static void CopyTo_Invalid(ArraySegment<int> arraySegment)
         {
             // ArraySegment.CopyTo calls Array.Copy internally, so the exception parameter names come from there.
-            var arraySegment = new ArraySegment<int>(array, index, count);
 
             // Destination is null
             Assert.Throws<ArgumentNullException>("destinationArray", () => arraySegment.CopyTo(null));
@@ -167,9 +169,8 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(ArraySegment_TestData))]
-        public static void GetEnumerator(int[] array, int index, int count)
+        public static void GetEnumerator(ArraySegment<int> arraySegment)
         {
-            var arraySegment = new ArraySegment<int>(array, index, count);
             var enumerator = arraySegment.GetEnumerator();
 
             var actual = new List<int>();
@@ -188,9 +189,8 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(ArraySegment_TestData))]
-        public static void GetEnumerator_Dispose(int[] array, int index, int count)
+        public static void GetEnumerator_Dispose(ArraySegment<int> arraySegment)
         {
-            var arraySegment = new ArraySegment<int>(array, index, count);
             var enumerator = arraySegment.GetEnumerator();
 
             bool expected = arraySegment.Count > 0;
@@ -208,9 +208,8 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(ArraySegment_TestData))]
-        public static void GetEnumerator_Reset(int[] array, int index, int count)
+        public static void GetEnumerator_Reset(ArraySegment<int> arraySegment)
         {
-            var arraySegment = new ArraySegment<int>(array, index, count);
             var enumerator = (IEnumerator<int>)arraySegment.GetEnumerator();
 
             int[] expected = array.Skip(index).Take(count).ToArray();
@@ -233,9 +232,8 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(ArraySegment_TestData))]
-        public static void GetEnumerator_Invalid(int[] array, int index, int count)
+        public static void GetEnumerator_Invalid(ArraySegment<int> arraySegment)
         {
-            var arraySegment = new ArraySegment<int>(array, index, count);
             var enumerator = arraySegment.GetEnumerator();
 
             // Before beginning
@@ -253,9 +251,8 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(ArraySegment_TestData))]
-        public static void GetSetItem_InRange(int[] array, int index, int count)
+        public static void GetSetItem_InRange(ArraySegment<int> arraySegment)
         {
-            var arraySegment = new ArraySegment<int>(array, index, count);
             int[] expected = array.Skip(index).Take(count).ToArray();
 
             for (int i = 0; i < count; i++)
@@ -283,9 +280,8 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(ArraySegment_TestData))]
-        public static void GetSetItem_NotInRange(int[] array, int index, int count)
+        public static void GetSetItem_NotInRange(ArraySegment<int> arraySegment)
         {
-            var arraySegment = new ArraySegment<int>(array, index, count);
             TestGetSetItem_NotInRange(arraySegment, start: -arraySegment.Offset, end: 0); // Check values before start
             TestGetSetItem_NotInRange(arraySegment, start: arraySegment.Count, end: arraySegment.Offset + array.Length); // Check values after end
         }
@@ -312,10 +308,8 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(ArraySegment_TestData))]
-        public static void GetSetItem_Invalid(int[] array, int index, int count)
+        public static void GetSetItem_Invalid(ArraySegment<int> arraySegment)
         {
-            var arraySegment = new ArraySegment<int>(array, index, count);
-
             // Before start of array
             Assert.Throws<IndexOutOfRangeException>(() => arraySegment[-arraySegment.Offset - 1]);
             Assert.Throws<IndexOutOfRangeException>(() => arraySegment[-arraySegment.Offset - 1] = default(int));
@@ -325,15 +319,68 @@ namespace System.Tests
             Assert.Throws<IndexOutOfRangeException>(() => arraySegment[arraySegment.Offset + array.Length] = default(int));
         }
 
-        public static IEnumerable<object[]> ArraySegment_TestData() =>
-            new[]
+        [Theory]
+        [MemberData(nameof(ArraySegment_TestData))]
+        public static void Slice_Index_Count(ArraySegment<int> arraySegment, int index, int count)
+        {
+
+        }
+
+        public static IEnumerable<object[]> Slice_TestData()
+        {
+            var arraySegments = ArraySegment_TestData().Select(array => array.Single()).Cast<ArraySegment<int>>();
+
+            foreach (ArraySegment<int> arraySegment in arraySegments)
             {
-                new object[] { new int[0], 0, 0 }, // Empty array
-                new object[] { new[] { 3, 4, 5, 6 }, 0, 4 }, // Full span of non-empty array
-                new object[] { new[] { 3, 4, 5, 6 }, 0, 3 }, // Starts at beginning, ends in middle
-                new object[] { new[] { 3, 4, 5, 6 }, 1, 3 }, // Starts in middle, ends at end
-                new object[] { new[] { 3, 4, 5, 6 }, 1, 2 }, // Starts in middle, ends in middle
-                new object[] { new[] { 3, 4, 5, 6 }, 1, 0 } // Non-empty array, count == 0
+                yield return new object[] { arraySegment, 0, 0 }; // Preserve start, no items
+                yield return new object[] { arraySegment, 0, arraySegment.Count }; // Preserve start, preserve count (noop)
+                yield return new object[] { arraySegment, arraySegment.Count, 0 }; // Start at end, no items
+                
+                if (arraySegment.Any())
+                {
+                    yield return new object[] { arraySegment, 1, 0 }; // Start at middle or end, no items
+                    yield return new object[] { arraySegment, 1, arraySegment.Count - 1 }; // Start at middle or end, rest of items
+                    yield return new object[] { arraySegment, arraySegment.Count - 1, 1 }; // Preserve start or start at middle, one item
+                }
+
+                yield return new object[] { arraySegment, 0, arraySegment.Count / 2 }; // Preserve start, multiple items, end at middle
+                yield return new object[] { arraySegment, arraySegment.Count / 2, arraySegment.Count / 2 }; // Start at middle, multiple items, end at middle (due to integer division truncation) or preserve end
+                yield return new object[] { arraySegment, arraySegment.Count / 4, arraySegment.Count / 2 }; // Start at middle, multiple items, end at middle
+
+                // ArraySegment.Slice permits negative indices. This allows the user to backtrack the start of the ArraySegment within the array.
+                // It also allows users to pass in counts larger than the count of the ArraySegment, provided that it will be able to fit within
+                // the ArraySegment's array.
+
+                yield return new object[] { arraySegment, -arraySegment.Offset, arraySegment.Offset }; // Previous segment
+                yield return new object[] { arraySegment, -arraySegment.Offset, arraySegment.Offset + arraySegment.Count }; // Previous + This segment
+                yield return new object[] { arraySegment, -arraySegment.Offset, arraySegment.Array.Length }; // Previous + This + Next segment
+                yield return new object[] { arraySegment, 0, arraySegment.Array.Length - arraySegment.Offset }; // This + Next segment
+                yield return new object[] { arraySegment, arraySegment.Count, arraySegment.Array.Length - arraySegment.Offset - arraySegment.Count }; // Next segment
+
+                // TODO: More work here?
+            }
+        }
+
+        public static IEnumerable<object[]> ArraySegment_TestData()
+        {
+            var arraySegments = new (int[] array, int index, int count)[]
+            {
+                (array: new int[0], index: 0, 0), // Empty array
+                (array: new[] { 3, 4, 5, 6 }, index: 0, count: 4), // Full span of non-empty array
+                (array: new[] { 3, 4, 5, 6 }, index: 0, count: 3), // Starts at beginning, ends in middle
+                (array: new[] { 3, 4, 5, 6 }, index: 1, count: 3), // Starts in middle, ends at end
+                (array: new[] { 3, 4, 5, 6 }, index: 1, count: 2), // Starts in middle, ends in middle
+                (array: new[] { 3, 4, 5, 6 }, index: 1, count: 0) // Non-empty array, count == 0
             };
+            
+            return arraySegments.Select(as => new object[] { new ArraySegment<int>(as.array, as.index, as.count) });
+        }
+        
+        private static void ValidateArraySegment<T>(ArraySegment<T> arraySegment, T[] array, int offset, int count)
+        {
+            Assert.Same(array, arraySegment.Array);
+            Assert.Equal(offset, arraySegment.Offset);
+            Assert.Equal(count, arraySegment.Count);
+        }
     }
 }

--- a/src/System.Runtime/tests/System/ArraySegmentTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/ArraySegmentTests.netcoreapp.cs
@@ -315,43 +315,23 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(ArraySegment_TestData))]
-        public static void GetSetItem_NotInRange(ArraySegment<int> arraySegment)
+        public static void GetSetItem_NotInRange_Invalid(ArraySegment<int> arraySegment)
         {
-            TestGetSetItem_NotInRange(arraySegment, start: -arraySegment.Offset, end: 0); // Check values before start
-            TestGetSetItem_NotInRange(arraySegment, start: arraySegment.Count, end: arraySegment.Offset + array.Length); // Check values after end
-        }
-        
-        private static void TestGetSetItem_NotInRange(ArraySegment<int> arraySegment, int start, int end)
-        {
-            int[] array = arraySegment.Array;
-            var r = new Random(1);
-
-            for (int i = start; i < end; i++)
-            {
-                Assert.Equal(array[arraySegment.Offset + i], arraySegment[i]);
-
-                int next = r.Next(int.MinValue, int.MaxValue);
-                int oldValue = arraySegment[i];
-
-                array[arraySegment.Offset + i] ^= next;
-                Assert.Equal(oldValue ^ next, arraySegment[i]);
-
-                arraySegment[i] ^= next;
-                Assert.Equal(oldValue, array[arraySegment.Offset + i]);
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(ArraySegment_TestData))]
-        public static void GetSetItem_Invalid(ArraySegment<int> arraySegment)
-        {
-            // Before start of array
+            // Before array start
             Assert.Throws<IndexOutOfRangeException>(() => arraySegment[-arraySegment.Offset - 1]);
             Assert.Throws<IndexOutOfRangeException>(() => arraySegment[-arraySegment.Offset - 1] = default(int));
 
-            // After end of array
-            Assert.Throws<IndexOutOfRangeException>(() => arraySegment[arraySegment.Offset + array.Length]);
-            Assert.Throws<IndexOutOfRangeException>(() => arraySegment[arraySegment.Offset + array.Length] = default(int));
+            // After array start (if Offset > 0), before start
+            Assert.Throws<IndexOutOfRangeException>(() => arraySegment[-1]);
+            Assert.Throws<IndexOutOfRangeException>(() => arraySegment[-1] = default(int));
+
+            // Before array end (if Offset + Count < Array.Length), after end
+            Assert.Throws<IndexOutOfRangeException>(() => arraySegment[arraySegment.Count]);
+            Assert.Throws<IndexOutOfRangeException>(() => arraySegment[arraySegment.Count] = default(int));
+
+            // After array end
+            Assert.Throws<IndexOutOfRangeException>(() => arraySegment[-arraySegment.Offset + arraySegment.Array.Length]);
+            Assert.Throws<IndexOutOfRangeException>(() => arraySegment[-arraySegment.Offset + arraySegment.Array.Length] = default(int));
         }
 
         [Theory]

--- a/src/System.Runtime/tests/System/ArraySegmentTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/ArraySegmentTests.netcoreapp.cs
@@ -27,7 +27,7 @@ namespace System.Tests
         [Fact]
         public void Empty()
         {
-            var empty = ArraySegment<T>.Empty;
+            ArraySegment<T> empty = ArraySegment<T>.Empty;
 
             Assert.NotEqual(default(ArraySegment<T>), empty);
             // Check that two Empty invocations return equal ArraySegments.
@@ -47,13 +47,13 @@ namespace System.Tests
             var ienumerableoft = (IEnumerable<T>)arraySegment;
             var ienumerable = (IEnumerable)arraySegment;
 
-            var enumerator = arraySegment.GetEnumerator();
+            ArraySegment<T>.Enumerator enumerator = arraySegment.GetEnumerator();
             Assert.IsType<ArraySegment<T>.Enumerator>(enumerator);
             Assert.IsAssignableFrom<IEnumerator<T>>(enumerator);
             Assert.IsAssignableFrom<IEnumerator>(enumerator);
 
-            var ienumeratoroft = ienumerableoft.GetEnumerator();
-            var ienumerator = ienumerable.GetEnumerator();
+            IEnumerator<T> ienumeratoroft = ienumerableoft.GetEnumerator();
+            IEnumerator ienumerator = ienumerable.GetEnumerator();
 
             Assert.Equal(enumerator.GetType(), ienumeratoroft.GetType());
             Assert.Equal(ienumeratoroft.GetType(), ienumerator.GetType());
@@ -206,7 +206,7 @@ namespace System.Tests
         [MemberData(nameof(ArraySegment_TestData))]
         public static void GetEnumerator(ArraySegment<int> arraySegment)
         {
-            var enumerator = arraySegment.GetEnumerator();
+            ArraySegment<int>.Enumerator enumerator = arraySegment.GetEnumerator();
 
             var actual = new List<int>();
 
@@ -226,7 +226,7 @@ namespace System.Tests
         [MemberData(nameof(ArraySegment_TestData))]
         public static void GetEnumerator_Dispose(ArraySegment<int> arraySegment)
         {
-            var enumerator = arraySegment.GetEnumerator();
+            ArraySegment<int>.Enumerator enumerator = arraySegment.GetEnumerator();
 
             bool expected = arraySegment.Count > 0;
             
@@ -269,7 +269,7 @@ namespace System.Tests
         [MemberData(nameof(ArraySegment_TestData))]
         public static void GetEnumerator_Invalid(ArraySegment<int> arraySegment)
         {
-            var enumerator = arraySegment.GetEnumerator();
+            ArraySegment<int>.Enumerator enumerator = arraySegment.GetEnumerator();
 
             // Before beginning
             Assert.Throws<InvalidOperationException>(() => enumerator.Current);
@@ -370,7 +370,7 @@ namespace System.Tests
 
         public static IEnumerable<object[]> Slice_TestData()
         {
-            var arraySegments = ArraySegment_TestData().Select(array => array.Single()).Cast<ArraySegment<int>>();
+            IEnumerable<ArraySegment<int>> arraySegments = ArraySegment_TestData().Select(array => array.Single()).Cast<ArraySegment<int>>();
 
             foreach (ArraySegment<int> arraySegment in arraySegments)
             {
@@ -406,7 +406,7 @@ namespace System.Tests
         public static void ToArray(ArraySegment<int> arraySegment)
         {
             // ToList is called here so we copy the data and raise an assert if ToArray modifies the underlying array.
-            var expected = arraySegment.Array.Skip(arraySegment.Offset).Take(arraySegment.Count).ToList();
+            List<int> expected = arraySegment.Array.Skip(arraySegment.Offset).Take(arraySegment.Count).ToList();
             Assert.Equal(expected, arraySegment.ToArray());
         }
 
@@ -422,7 +422,7 @@ namespace System.Tests
                 (array: new[] { 3, 4, 5, 6 }, index: 1, count: 0) // Non-empty array, count == 0
             };
             
-            return arraySegments.Select(as => new object[] { new ArraySegment<int>(as.array, as.index, as.count) });
+            return arraySegments.Select(aseg => new object[] { new ArraySegment<int>(aseg.array, aseg.index, aseg.count) });
         }
     }
 }

--- a/src/System.Runtime/tests/System/ArraySegmentTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/ArraySegmentTests.netcoreapp.cs
@@ -122,6 +122,8 @@ namespace System.Tests
         {
             const int CopyPadding = 5;
             const int DestinationSegmentPadding = 3;
+            
+            int count = arraySegment.Count;
 
             var destinationModel = new int[count + 2 * CopyPadding];
 
@@ -212,6 +214,10 @@ namespace System.Tests
         [MemberData(nameof(ArraySegment_TestData))]
         public static void GetEnumerator(ArraySegment<int> arraySegment)
         {
+            int[] array = arraySegment.Array;
+            int index = arraySegment.Offset;
+            int count = arraySegment.Count;
+            
             ArraySegment<int>.Enumerator enumerator = arraySegment.GetEnumerator();
 
             var actual = new List<int>();
@@ -232,6 +238,9 @@ namespace System.Tests
         [MemberData(nameof(ArraySegment_TestData))]
         public static void GetEnumerator_Dispose(ArraySegment<int> arraySegment)
         {
+            int[] array = arraySegment.Array;
+            int index = arraySegment.Offset;
+            
             ArraySegment<int>.Enumerator enumerator = arraySegment.GetEnumerator();
 
             bool expected = arraySegment.Count > 0;
@@ -294,6 +303,10 @@ namespace System.Tests
         [MemberData(nameof(ArraySegment_TestData))]
         public static void GetSetItem_InRange(ArraySegment<int> arraySegment)
         {
+            int[] array = arraySegment.Array;
+            int index = arraySegment.Offset;
+            int count = arraySegment.Count;
+            
             int[] expected = array.Skip(index).Take(count).ToArray();
 
             for (int i = 0; i < count; i++)
@@ -323,6 +336,8 @@ namespace System.Tests
         [MemberData(nameof(ArraySegment_TestData))]
         public static void GetSetItem_NotInRange_Invalid(ArraySegment<int> arraySegment)
         {
+            int[] array = arraySegment.Array;
+            
             // Before array start
             Assert.Throws<IndexOutOfRangeException>(() => arraySegment[-arraySegment.Offset - 1]);
             Assert.Throws<IndexOutOfRangeException>(() => arraySegment[-arraySegment.Offset - 1] = default(int));
@@ -336,8 +351,8 @@ namespace System.Tests
             Assert.Throws<IndexOutOfRangeException>(() => arraySegment[arraySegment.Count] = default(int));
 
             // After array end
-            Assert.Throws<IndexOutOfRangeException>(() => arraySegment[-arraySegment.Offset + arraySegment.Array.Length]);
-            Assert.Throws<IndexOutOfRangeException>(() => arraySegment[-arraySegment.Offset + arraySegment.Array.Length] = default(int));
+            Assert.Throws<IndexOutOfRangeException>(() => arraySegment[-arraySegment.Offset + array.Length]);
+            Assert.Throws<IndexOutOfRangeException>(() => arraySegment[-arraySegment.Offset + array.Length] = default(int));
         }
 
         [Theory]

--- a/src/System.Runtime/tests/System/ArraySegmentTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/ArraySegmentTests.netcoreapp.cs
@@ -60,6 +60,19 @@ namespace System.Tests
         {
             Assert.Throws<InvalidOperationException>(() => default(ArraySegment<T>).GetEnumerator());
         }
+
+        [Fact]
+        public void Slice_Default_ThrowsInvalidOperationException()
+        {
+            Assert.Throws<InvalidOperationException>(() => default(ArraySegment<T>).Slice(0));
+            Assert.Throws<InvalidOperationException>(() => default(ArraySegment<T>).Slice(0, 0));
+        }
+
+        [Fact]
+        public void ToArray_Default_ThrowsInvalidOperationException()
+        {
+            Assert.Throws<InvalidOperationException>(() => default(ArraySegment<T>).ToArray());
+        }
     }
 
     public static partial class ArraySegment_Tests

--- a/src/System.Runtime/tests/System/ArraySegmentTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/ArraySegmentTests.netcoreapp.cs
@@ -388,17 +388,30 @@ namespace System.Tests
                 yield return new object[] { arraySegment, 0, arraySegment.Count / 2 }; // Preserve start, multiple items, end at middle
                 yield return new object[] { arraySegment, arraySegment.Count / 2, arraySegment.Count / 2 }; // Start at middle, multiple items, end at middle (due to integer division truncation) or preserve end
                 yield return new object[] { arraySegment, arraySegment.Count / 4, arraySegment.Count / 2 }; // Start at middle, multiple items, end at middle
-
-                // ArraySegment.Slice permits negative indices. This allows the user to backtrack the start of the ArraySegment within the array.
-                // It also allows users to pass in counts larger than the count of the ArraySegment, provided that it will be able to fit within
-                // the ArraySegment's array.
-
-                yield return new object[] { arraySegment, -arraySegment.Offset, arraySegment.Offset }; // Previous segment
-                yield return new object[] { arraySegment, -arraySegment.Offset, arraySegment.Offset + arraySegment.Count }; // Previous + This segment
-                yield return new object[] { arraySegment, -arraySegment.Offset, arraySegment.Array.Length }; // Previous + This + Next segment
-                yield return new object[] { arraySegment, 0, arraySegment.Array.Length - arraySegment.Offset }; // This + Next segment
-                yield return new object[] { arraySegment, arraySegment.Count, arraySegment.Array.Length - arraySegment.Offset - arraySegment.Count }; // Next segment
             }
+        }
+
+        [Theory]
+        [MemberData(nameof(Slice_Invalid_TestData))]
+        public static void Slice_Invalid(ArraySegment<int> arraySegment, int index, int count)
+        {
+            if (index + count == arraySegment.Count)
+            {
+                Assert.Throws<ArgumentOutOfRangeException>("index", () => arraySegment.Slice(index));
+            }
+
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => arraySegment.Slice(index, count));
+        }
+
+        public static IEnumerable<object[]> Slice_Invalid_TestData()
+        {
+            var arraySegment = new ArraySegment<int>(new int[3], offset: 1, count: 1);
+
+            yield return new object[] { arraySegment, -arraySegment.Offset, arraySegment.Offset };
+            yield return new object[] { arraySegment, -arraySegment.Offset, arraySegment.Offset + arraySegment.Count };
+            yield return new object[] { arraySegment, -arraySegment.Offset, arraySegment.Array.Length };
+            yield return new object[] { arraySegment, 0, arraySegment.Array.Length - arraySegment.Offset };
+            yield return new object[] { arraySegment, arraySegment.Count, arraySegment.Array.Length - arraySegment.Offset - arraySegment.Count };
         }
 
         [Theory]

--- a/src/System.Runtime/tests/System/ArraySegmentTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/ArraySegmentTests.netcoreapp.cs
@@ -120,17 +120,17 @@ namespace System.Tests
         [MemberData(nameof(ArraySegment_TestData))]
         public static void CopyTo(ArraySegment<int> arraySegment)
         {
-            const int CopyLining = 5;
-            const int DestinationSegmentLining = 3;
+            const int CopyPadding = 5;
+            const int DestinationSegmentPadding = 3;
 
-            var destinationModel = new int[count + 2 * CopyLining];
+            var destinationModel = new int[count + 2 * CopyPadding];
 
             // CopyTo(T[])
             CopyAndInvoke(destinationModel, destination =>
             {
                 arraySegment.CopyTo(destination);
                 
-                Assert.Equal(Enumerable.Repeat(default(int), 2 * CopyLining), destination.Skip(count));
+                Assert.Equal(Enumerable.Repeat(default(int), 2 * CopyPadding), destination.Skip(count));
 
                 Assert.Equal(arraySegment, destination.Take(count));
             });
@@ -138,23 +138,23 @@ namespace System.Tests
             // CopyTo(T[], int)
             CopyAndInvoke(destinationModel, destination =>
             {
-                arraySegment.CopyTo(destination, CopyLining);
+                arraySegment.CopyTo(destination, CopyPadding);
                 
-                Assert.Equal(Enumerable.Repeat(default(int), CopyLining), destination.Take(CopyLining));
-                Assert.Equal(Enumerable.Repeat(default(int), CopyLining), destination.Skip(CopyLining + count));
+                Assert.Equal(Enumerable.Repeat(default(int), CopyPadding), destination.Take(CopyPadding));
+                Assert.Equal(Enumerable.Repeat(default(int), CopyPadding), destination.Skip(CopyPadding + count));
 
-                Assert.Equal(arraySegment, destination.Skip(CopyLining).Take(count));
+                Assert.Equal(arraySegment, destination.Skip(CopyPadding).Take(count));
             });
 
             // ICollection<T>.CopyTo(T[], int)
             CopyAndInvoke(destinationModel, destination =>
             {
-                ((ICollection<int>)arraySegment).CopyTo(destination, CopyLining);
+                ((ICollection<int>)arraySegment).CopyTo(destination, CopyPadding);
                 
-                Assert.Equal(Enumerable.Repeat(default(int), CopyLining), destination.Take(CopyLining));
-                Assert.Equal(Enumerable.Repeat(default(int), CopyLining), destination.Skip(CopyLining + count));
+                Assert.Equal(Enumerable.Repeat(default(int), CopyPadding), destination.Take(CopyPadding));
+                Assert.Equal(Enumerable.Repeat(default(int), CopyPadding), destination.Skip(CopyPadding + count));
 
-                Assert.Equal(arraySegment, destination.Skip(CopyLining).Take(count));
+                Assert.Equal(arraySegment, destination.Skip(CopyPadding).Take(count));
             });
 
             // CopyTo(ArraySegment<T>)
@@ -163,8 +163,8 @@ namespace System.Tests
                 // We want to make sure this overload is handling edge cases correctly, like ArraySegments that
                 // do not begin at the array's start, do not end at the array's end, or have a bigger count than
                 // the source ArraySegment. Construct an ArraySegment that will test all of these conditions.
-                int destinationIndex = DestinationSegmentLining;
-                int destinationCount = destination.Length - 2 * DestinationSegmentLining;
+                int destinationIndex = DestinationSegmentPadding;
+                int destinationCount = destination.Length - 2 * DestinationSegmentPadding;
                 var destinationSegment = new ArraySegment<int>(destination, destinationIndex, destinationCount);
 
                 arraySegment.CopyTo(destinationSegment);

--- a/src/System.Runtime/tests/System/ArraySegmentTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/ArraySegmentTests.netcoreapp.cs
@@ -260,6 +260,10 @@ namespace System.Tests
         [MemberData(nameof(ArraySegment_TestData))]
         public static void GetEnumerator_Reset(ArraySegment<int> arraySegment)
         {
+            int[] array = arraySegment.Array;
+            int index = arraySegment.Offset;
+            int count = arraySegment.Count;
+            
             var enumerator = (IEnumerator<int>)arraySegment.GetEnumerator();
 
             int[] expected = array.Skip(index).Take(count).ToArray();

--- a/src/System.Runtime/tests/System/ArraySegmentTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/ArraySegmentTests.netcoreapp.cs
@@ -12,6 +12,31 @@ namespace System.Tests
     public abstract partial class ArraySegment_Tests<T>
     {
         [Fact]
+        public void CopyTo_Default_ThrowsInvalidOperationException()
+        {
+            Assert.Throws<InvalidOperationException>(() => default(ArraySegment<T>).CopyTo(new T[0]));
+            Assert.Throws<InvalidOperationException>(() => default(ArraySegment<T>).CopyTo(new T[0], 0));
+            Assert.Throws<InvalidOperationException>(() => ((ICollection<T>)default(ArraySegment<T>)).CopyTo(new T[0], 0));
+            Assert.Throws<InvalidOperationException>(() => default(ArraySegment<T>).CopyTo(new ArraySegment<T>(new T[0])));
+        }
+
+        [Fact]
+        public void Empty()
+        {
+            var empty = ArraySegment<T>.Empty;
+
+            Assert.NotEqual(default(ArraySegment<T>), empty);
+            // Check that two Empty invocations return equal ArraySegments.
+            Assert.Equal(empty, ArraySegment<T>.Empty);
+            // Check that two Empty invocations return ArraySegments with a cached empty array.
+            // An empty array is necessary to ensure that someone doesn't use the indexer to store data in the array Empty refers to.
+            Assert.Same(empty.Array, ArraySegment<T>.Empty.Array);
+            Assert.Equal(0, empty.Array.Length);
+            Assert.Equal(0, empty.Offset);
+            Assert.Equal(0, empty.Count);
+        }
+
+        [Fact]
         public void GetEnumerator_TypeProperties()
         {
             var arraySegment = new ArraySegment<T>(new T[1], 0, 1);
@@ -40,7 +65,95 @@ namespace System.Tests
     public static partial class ArraySegment_Tests
     {
         [Theory]
-        [MemberData(nameof(GetEnumerator_TestData))]
+        [MemberData(nameof(ArraySegment_TestData))]
+        public static void CopyTo(int[] array, int index, int count)
+        {
+            const int CopyLining = 5;
+            const int DestinationSegmentLining = 3;
+
+            var arraySegment = new ArraySegment<int>(array, index, count);
+            var destinationModel = new int[count + 2 * CopyLining];
+
+            // CopyTo(T[])
+            CopyAndInvoke(destinationModel, destination =>
+            {
+                arraySegment.CopyTo(destination);
+                
+                Assert.Equal(Enumerable.Repeat(default(int), 2 * CopyLining), destination.Skip(count));
+
+                Assert.Equal(arraySegment, destination.Take(count));
+            });
+
+            // CopyTo(T[], int)
+            CopyAndInvoke(destinationModel, destination =>
+            {
+                arraySegment.CopyTo(destination, CopyLining);
+                
+                Assert.Equal(Enumerable.Repeat(default(int), CopyLining), destination.Take(CopyLining));
+                Assert.Equal(Enumerable.Repeat(default(int), CopyLining), destination.Skip(CopyLining + count));
+
+                Assert.Equal(arraySegment, destination.Skip(CopyLining).Take(count));
+            });
+
+            // ICollection<T>.CopyTo(T[], int)
+            CopyAndInvoke(destinationModel, destination =>
+            {
+                ((ICollection<int>)arraySegment).CopyTo(destination, CopyLining);
+                
+                Assert.Equal(Enumerable.Repeat(default(int), CopyLining), destination.Take(CopyLining));
+                Assert.Equal(Enumerable.Repeat(default(int), CopyLining), destination.Skip(CopyLining + count));
+
+                Assert.Equal(arraySegment, destination.Skip(CopyLining).Take(count));
+            });
+
+            // CopyTo(ArraySegment<T>)
+            CopyAndInvoke(destinationModel, destination =>
+            {
+                // We want to make sure this overload is handling edge cases correctly, like ArraySegments that
+                // do not begin at the array's start, do not end at the array's end, or have a bigger count than
+                // the source ArraySegment. Construct an ArraySegment that will test all of these conditions.
+                int destinationIndex = DestinationSegmentLining;
+                int destinationCount = destination.Length - 2 * DestinationSegmentLining;
+                var destinationSegment = new ArraySegment<int>(destination, destinationIndex, destinationCount);
+
+                arraySegment.CopyTo(destinationSegment);
+
+                Assert.Equal(Enumerable.Repeat(default(int), destinationIndex), destination.Take(destinationIndex));
+                int remainder = destination.Length - destinationIndex - count;
+                Assert.Equal(Enumerable.Repeat(default(int), remainder), destination.Skip(destinationIndex + count));
+
+                Assert.Equal(arraySegment, destination.Skip(destinationIndex).Take(count));
+            });
+        }
+
+        private static void CopyAndInvoke<T>(T[] array, Action<T[]> action) => action(array.ToArray());
+
+        [Theory]
+        [MemberData(nameof(ArraySegment_TestData))]
+        public static void CopyTo_Invalid(int[] array, int index, int count)
+        {
+            // ArraySegment.CopyTo calls Array.Copy internally, so the exception parameter names come from there.
+            var arraySegment = new ArraySegment<int>(array, index, count);
+
+            // Destination is null
+            Assert.Throws<ArgumentNullException>("destinationArray", () => arraySegment.CopyTo(null));
+            Assert.Throws<ArgumentNullException>("destinationArray", () => arraySegment.CopyTo(null, 0));
+
+            // Destination index not within range
+            Assert.Throws<ArgumentOutOfRangeException>("destinationIndex", () => arraySegment.CopyTo(new int[0], -1));
+            Assert.Throws<ArgumentOutOfRangeException>("destinationIndex", () => arraySegment.CopyTo(new int[0], 1));
+
+            if (arraySegment.Any())
+            {
+                // Destination not large enough
+                Assert.Throws<ArgumentOutOfRangeException>("destinationArray", () => arraySegment.CopyTo(new int[count - 1]));
+                Assert.Throws<ArgumentOutOfRangeException>("destinationArray", () => arraySegment.CopyTo(new int[count - 1], 0));
+                Assert.Throws<ArgumentOutOfRangeException>("destinationArray", () => arraySegment.CopyTo(new ArraySegment<int>(new int[count - 1])));
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(ArraySegment_TestData))]
         public static void GetEnumerator(int[] array, int index, int count)
         {
             var arraySegment = new ArraySegment<int>(array, index, count);
@@ -56,12 +169,12 @@ namespace System.Tests
             // After MoveNext returns false once, it should return false the second time.
             Assert.False(enumerator.MoveNext());
 
-            var expected = array.Skip(index).Take(count);
+            IEnumerable<int> expected = array.Skip(index).Take(count);
             Assert.Equal(expected, actual);
         }
 
         [Theory]
-        [MemberData(nameof(GetEnumerator_TestData))]
+        [MemberData(nameof(ArraySegment_TestData))]
         public static void GetEnumerator_Dispose(int[] array, int index, int count)
         {
             var arraySegment = new ArraySegment<int>(array, index, count);
@@ -81,13 +194,13 @@ namespace System.Tests
         }
 
         [Theory]
-        [MemberData(nameof(GetEnumerator_TestData))]
+        [MemberData(nameof(ArraySegment_TestData))]
         public static void GetEnumerator_Reset(int[] array, int index, int count)
         {
             var arraySegment = new ArraySegment<int>(array, index, count);
             var enumerator = (IEnumerator<int>)arraySegment.GetEnumerator();
 
-            var expected = array.Skip(index).Take(count).ToArray();
+            int[] expected = array.Skip(index).Take(count).ToArray();
             
             // Reset at a variety of different positions to ensure the implementation
             // isn't something like `position -= CONSTANT`.
@@ -106,7 +219,7 @@ namespace System.Tests
         }
 
         [Theory]
-        [MemberData(nameof(GetEnumerator_TestData))]
+        [MemberData(nameof(ArraySegment_TestData))]
         public static void GetEnumerator_Invalid(int[] array, int index, int count)
         {
             var arraySegment = new ArraySegment<int>(array, index, count);
@@ -125,15 +238,89 @@ namespace System.Tests
             Assert.Throws<InvalidOperationException>(() => ((IEnumerator)enumerator).Current);
         }
 
-        public static IEnumerable<object[]> GetEnumerator_TestData() =>
+        [Theory]
+        [MemberData(nameof(ArraySegment_TestData))]
+        public static void GetSetItem_InRange(int[] array, int index, int count)
+        {
+            var arraySegment = new ArraySegment<int>(array, index, count);
+            int[] expected = array.Skip(index).Take(count).ToArray();
+
+            for (int i = 0; i < count; i++)
+            {
+                Assert.Equal(expected[i], arraySegment[i]);
+                Assert.Equal(expected[i], ((IList<int>)arraySegment)[i]);
+                Assert.Equal(expected[i], ((IReadOnlyList<int>)arraySegment)[i]);
+            }
+
+            var r = new Random(0);
+
+            for (int i = 0; i < count; i++)
+            {
+                int next = r.Next(int.MinValue, int.MaxValue);
+
+                // When we modify the underlying array, the indexer should return the updated values.
+                array[arraySegment.Offset + i] ^= next;
+                Assert.Equal(expected[i] ^ next, arraySegment[i]);
+
+                // When the indexer's set method is called, the underlying array should be modified.
+                arraySegment[i] ^= next;
+                Assert.Equal(expected[i], array[arraySegment.Offset + i]);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(ArraySegment_TestData))]
+        public static void GetSetItem_NotInRange(int[] array, int index, int count)
+        {
+            var arraySegment = new ArraySegment<int>(array, index, count);
+            TestGetSetItem_NotInRange(arraySegment, start: -arraySegment.Offset, end: 0); // Check values before start
+            TestGetSetItem_NotInRange(arraySegment, start: arraySegment.Count, end: arraySegment.Offset + array.Length); // Check values after end
+        }
+        
+        private static void TestGetSetItem_NotInRange(ArraySegment<int> arraySegment, int start, int end)
+        {
+            int[] array = arraySegment.Array;
+            var r = new Random(1);
+
+            for (int i = start; i < end; i++)
+            {
+                Assert.Equal(array[arraySegment.Offset + i], arraySegment[i]);
+
+                int next = r.Next(int.MinValue, int.MaxValue);
+                int oldValue = arraySegment[i];
+
+                array[arraySegment.Offset + i] ^= next;
+                Assert.Equal(oldValue ^ next, arraySegment[i]);
+
+                arraySegment[i] ^= next;
+                Assert.Equal(oldValue, array[arraySegment.Offset + i]);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(ArraySegment_TestData))]
+        public static void GetSetItem_Invalid(int[] array, int index, int count)
+        {
+            var arraySegment = new ArraySegment<int>(array, index, count);
+
+            // Before start of array
+            Assert.Throws<IndexOutOfRangeException>(() => arraySegment[-arraySegment.Offset - 1]);
+            Assert.Throws<IndexOutOfRangeException>(() => arraySegment[-arraySegment.Offset - 1] = default(int));
+
+            // After end of array
+            Assert.Throws<IndexOutOfRangeException>(() => arraySegment[arraySegment.Offset + array.Length]);
+            Assert.Throws<IndexOutOfRangeException>(() => arraySegment[arraySegment.Offset + array.Length] = default(int));
+        }
+
+        public static IEnumerable<object[]> ArraySegment_TestData() =>
             new[]
             {
                 new object[] { new int[0], 0, 0 }, // Empty array
-                new object[] { new[] { 3, 4, 5 }, 0, 3 }, // Full span of non-empty array
-                new object[] { new[] { 3, 4, 5 }, 0, 2 }, // Starts at beginning, ends in middle
-                new object[] { new[] { 3, 4, 5 }, 1, 2 }, // Starts in middle, ends at end
-                new object[] { new[] { 3, 4, 5 }, 1, 1 }, // Starts in middle, ends in middle
-                new object[] { new[] { 3, 4, 5 }, 1, 0 } // Non-empty array, count == 0
+                new object[] { new[] { 3, 4, 5, 6 }, 0, 4 }, // Full span of non-empty array
+                new object[] { new[] { 3, 4, 5, 6 }, 0, 3 }, // Starts at beginning, ends in middle
+                new object[] { new[] { 3, 4, 5, 6 }, 1, 3 }, // Starts in middle, ends at end
+                new object[] { new[] { 3, 4, 5, 6 }, 1, 2 }, // Starts in middle, ends in middle
+                new object[] { new[] { 3, 4, 5, 6 }, 1, 0 } // Non-empty array, count == 0
             };
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/14170
Fixes https://github.com/dotnet/corefx/issues/10528

This adds tests for the implementation of slicing APIs for `ArraySegment<T>` in coreclr (https://github.com/dotnet/coreclr/pull/9926) and additionally exposes the strongly-typed `GetEnumerator()` overload.

/cc @KrzysztofCwalina, @stephentoub 