### PR TITLE
Use EnvironmentAugments instead of System.Environment from corelib. 

### DIFF
--- a/src/Common/src/System/Diagnostics/Debug.Unix.cs
+++ b/src/Common/src/System/Diagnostics/Debug.Unix.cs
@@ -11,6 +11,8 @@ namespace System.Diagnostics
     // another version of this partial class with the public visibility 
     static partial class Debug
     {
+        private static string NewLine => "\n"; 
+
         // internal and not readonly so that the tests can swap this out.
         internal static IDebugLogger s_logger = new UnixDebugLogger();
 

--- a/src/Common/src/System/Diagnostics/Debug.Windows.cs
+++ b/src/Common/src/System/Diagnostics/Debug.Windows.cs
@@ -11,6 +11,8 @@ namespace System.Diagnostics
     // another version of this partial class with the public visibility 
     static partial class Debug
     {
+        private static string NewLine => "\r\n";
+
         // internal and not read only so that the tests can swap this out.
         internal static IDebugLogger s_logger = new WindowsDebugLogger();
 

--- a/src/Common/src/System/Diagnostics/Debug.cs
+++ b/src/Common/src/System/Diagnostics/Debug.cs
@@ -97,7 +97,7 @@ namespace System.Diagnostics
 
                 try
                 {
-                    stackTrace = Environment.StackTrace;
+                    stackTrace = Internal.Runtime.Augments.EnvironmentAugments.StackTrace;
                 }
                 catch
                 {
@@ -123,7 +123,7 @@ namespace System.Diagnostics
 
         private static string FormatAssert(string stackTrace, string message, string detailMessage)
         {
-            var newLine = GetIndentString() + Environment.NewLine;
+            string newLine = GetIndentString() + NewLine;
             return SR.DebugAssertBanner + newLine
                    + SR.DebugAssertShortMessage + newLine
                    + message + newLine
@@ -141,7 +141,7 @@ namespace System.Diagnostics
         [System.Diagnostics.Conditional("DEBUG")]
         public static void WriteLine(string message)
         {
-            Write(message + Environment.NewLine);
+            Write(message + NewLine);
         }
 
         [System.Diagnostics.Conditional("DEBUG")]
@@ -160,7 +160,7 @@ namespace System.Diagnostics
                     s_needIndent = false;
                 }
                 WriteCore(message);
-                if (message.EndsWith(Environment.NewLine))
+                if (message.EndsWith(NewLine))
                 {
                     s_needIndent = true;
                 }
@@ -323,7 +323,7 @@ namespace System.Diagnostics
         private sealed class DebugAssertException : Exception
         {
             internal DebugAssertException(string message, string detailMessage, string stackTrace) :
-                base(message + Environment.NewLine + detailMessage + Environment.NewLine + stackTrace)
+                base(message + NewLine + detailMessage + NewLine + stackTrace)
             {
             }
         }


### PR DESCRIPTION
System.Environment in corelib is not going to be public anymore