### PR TITLE
Use vectors in managed ClientWebSocket for mask application

### DIFF
--- a/src/Common/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/Common/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -1216,9 +1216,9 @@ namespace System.Net.WebSockets
                 Vector<byte> maskVector = Vector.AsVectorByte(new Vector<int>(shiftedMask));
                 while (count >= Vector<byte>.Count)
                 {
+                    count -= Vector<byte>.Count;
                     (maskVector ^ new Vector<byte>(toMask, toMaskOffset)).CopyTo(toMask, toMaskOffset);
                     toMaskOffset += Vector<byte>.Count;
-                    count -= Vector<byte>.Count;
                 }
 
                 // Fall through to processing any remaining bytes that were less than a vector width.
@@ -1240,9 +1240,9 @@ namespace System.Net.WebSockets
                     {
                         while (count >= sizeof(int))
                         {
+                            count -= sizeof(int);
                             *((int*)p) ^= shiftedMask;
                             p += sizeof(int);
-                            count -= sizeof(int);
                         }
 
                         // We don't need to update the maskIndex, as its mod-4 value won't have changed.
@@ -1256,8 +1256,7 @@ namespace System.Net.WebSockets
                         byte* end = p + count;
                         while (p < end)
                         {
-                            byte b = maskPtr[maskIndex];
-                            *p++ ^= b;
+                            *p++ ^= maskPtr[maskIndex];
                             maskIndex = (maskIndex + 1) & 3;
                         }
                     }

--- a/src/Common/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/Common/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -5,6 +5,7 @@
 using System.Buffers;
 using System.Diagnostics;
 using System.IO;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
@@ -1202,21 +1203,69 @@ namespace System.Net.WebSockets
         /// <returns>The next index into the mask to be used for future applications of the mask.</returns>
         private static unsafe int ApplyMask(byte[] toMask, int toMaskOffset, int mask, int maskIndex, long count)
         {
-            Debug.Assert(toMaskOffset <= toMask.Length - count, $"Unexpected inputs: {toMaskOffset}, {toMask.Length}, {count}");
-            Debug.Assert(maskIndex < sizeof(int), $"Unexpected {nameof(maskIndex)}: {maskIndex}");
+            int maskShift = maskIndex * 8;
+            int shiftedMask = (int)(((uint)mask >> maskShift) | ((uint)mask << (32 - maskShift)));
 
-            byte* maskPtr = (byte*)&mask;
-            fixed (byte* toMaskPtr = toMask)
+            // Try to use SIMD.  We can if the number of bytes we're trying to mask is at least as much
+            // as the width of a vector and if the width is an even multiple of the mask.
+            if (Vector.IsHardwareAccelerated &&
+                Vector<byte>.Count % sizeof(int) == 0 &&
+                count >= Vector<byte>.Count)
             {
-                byte* p = toMaskPtr + toMaskOffset;
-                byte* end = p + count;
-                while (p < end)
+                // Mask bytes a vector at a time.
+                Vector<byte> maskVector = Vector.AsVectorByte(new Vector<int>(shiftedMask));
+                while (count >= Vector<byte>.Count)
                 {
-                    *p++ ^= maskPtr[maskIndex];
-                    maskIndex = (maskIndex + 1) & 3; // & 3 == faster % MaskLength
+                    (maskVector ^ new Vector<byte>(toMask, toMaskOffset)).CopyTo(toMask, toMaskOffset);
+                    toMaskOffset += Vector<byte>.Count;
+                    count -= Vector<byte>.Count;
                 }
-                return maskIndex;
+
+                // Fall through to processing any remaining bytes that were less than a vector width.
+                // Since we processed full masks at a time, we don't need to update maskIndex, and
+                // toMaskOffset has already been updated to point to the correct location.
             }
+
+            // If there are any bytes remaining (either we couldn't use vectors, or the count wasn't
+            // an even multiple of the vector width), process them without vectors.
+            if (count > 0)
+            {
+                fixed (byte* toMaskPtr = toMask)
+                {
+                    // Get the location in the target array to continue processing.
+                    byte* p = toMaskPtr + toMaskOffset;
+
+                    // Try to go an int at a time if the remaining data is 4-byte aligned and there's enough remaining.
+                    if (((long)p % sizeof(int)) == 0)
+                    {
+                        while (count >= sizeof(int))
+                        {
+                            *((int*)p) ^= shiftedMask;
+                            p += sizeof(int);
+                            count -= sizeof(int);
+                        }
+
+                        // We don't need to update the maskIndex, as its mod-4 value won't have changed.
+                        // `p` points to the remainder.
+                    }
+
+                    // Process any remaining data a byte at a time.
+                    if (count > 0)
+                    {
+                        byte* maskPtr = (byte*)&mask;
+                        byte* end = p + count;
+                        while (p < end)
+                        {
+                            byte b = maskPtr[maskIndex];
+                            *p++ ^= b;
+                            maskIndex = (maskIndex + 1) & 3;
+                        }
+                    }
+                }
+            }
+
+            // Return the updated index.
+            return maskIndex;
         }
 
         /// <summary>Aborts the websocket and throws an exception if an existing operation is in progress.</summary>

--- a/src/System.Net.HttpListener/src/System.Net.HttpListener.csproj
+++ b/src/System.Net.HttpListener/src/System.Net.HttpListener.csproj
@@ -25,8 +25,10 @@
     <Reference Include="System.Net.WebHeaderCollection" />
     <Reference Include="System.Net.WebSockets" />
     <Reference Include="System.Net.WebSockets.Client" />
+    <Reference Include="System.Numerics.Vectors" />
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Runtime.InteropServices" />
     <Reference Include="System.Security.Claims" />

--- a/src/System.Net.WebSockets.Client/src/System.Net.WebSockets.Client.csproj
+++ b/src/System.Net.WebSockets.Client/src/System.Net.WebSockets.Client.csproj
@@ -133,14 +133,16 @@
     <Reference Include="System.Threading.Tasks" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
+    <Reference Include="System.Buffers" />
     <Reference Include="System.Net.NameResolution" />
     <Reference Include="System.Net.Security" />
     <Reference Include="System.Net.Sockets" />
+    <Reference Include="System.Numerics.Vectors" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe" />
     <Reference Include="System.Security.Cryptography.Algorithms" />
     <Reference Include="System.Security.Cryptography.Primitives" />
     <Reference Include="System.Text.Encoding.Extensions" />
     <Reference Include="System.Threading.Timer" />
-    <Reference Include="System.Buffers" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
@@ -245,8 +245,9 @@ namespace System.Net.WebSockets.Client.Tests
                 var rand = new Random();
                 var ctsDefault = new CancellationTokenSource(TimeOutMilliseconds);
 
-                // Values chosen close to boundaries in websockets message length handling.
-                foreach (int bufferSize in new int[] { 1, 125, 126, 127, 128, ushort.MaxValue - 1, ushort.MaxValue, ushort.MaxValue + 1, ushort.MaxValue * 2 })
+                // Values chosen close to boundaries in websockets message length handling as well
+                // as in vectors used in mask application.
+                foreach (int bufferSize in new int[] { 1, 3, 4, 5, 31, 32, 33, 125, 126, 127, 128, ushort.MaxValue - 1, ushort.MaxValue, ushort.MaxValue + 1, ushort.MaxValue * 2 })
                 {
                     byte[] sendBuffer = new byte[bufferSize];
                     rand.NextBytes(sendBuffer);


### PR DESCRIPTION
The web socket protocol uses a 4-byte mask sent from client to server and xor'd with the payload data.  In the managed web socket implementation, that mask is currently applied byte-by-byte.  This commit changes it to be done using SIMD.

Micro-benchmarks on the ApplyMask function itself show a regression for payload lengths under 4 bytes, but above that it's a clear win:
```
1: 0.44x
3: 0.64x
4: 1.15x
7: 1.16x
31: 1.73x
32: 6.06x
63: 3.37x
64: 10.40x
1024: 20.36x
```
This doesn't have a measurable affect on small payloads in the overall context of sending/receiving data, but the larger the payload, the more it applies.  Locally I measured upwards of a 10% improvement for payloads several-K in size.

cc: @benaadams, @geoffkizer, @davidsh, @anurse ,@mellinoe