### PR TITLE
Use optional tooling to merge optimization data during the build

### DIFF
--- a/Tools-Override/Build.Common.targets
+++ b/Tools-Override/Build.Common.targets
@@ -147,6 +147,21 @@
   <Import Project="$(MSBuildThisFileDirectory)packageresolve.targets" Condition="'$(ExcludePackageResolveImport)'!='true'" />
 
   <!--
+    Import the optional tooling restore and resolve targets
+
+      Inputs:
+        OptionalToolSource - If not set, optional tools are not restored
+        OptionalToolSourceUser - If not set, no authentication is used to access the feed
+        OptionalToolSourcePassword - If not set, no authentication is used to access the feed
+
+      Depends on properties:
+        DnuRestoreCommand - Used to restore the optional tool packages
+        PackagesDir - Location to resolve optional tool package assets
+        ToolsDir - Location to find optional-tool-runtime project.json
+  -->
+  <Import Project="$(MSBuildThisFileDirectory)OptionalTooling.targets" />
+
+  <!-- 
     Import the partial facade generation targets
 
       Inputs:

--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
@@ -105,7 +105,7 @@
       },
       "inputs": {
         "filename": "$(Build.SourcesDirectory)\\corefx\\sync.cmd",
-        "arguments": "$(PB_SyncArguments)",
+        "arguments": "$(PB_SyncArguments) $(PB_OptionalToolingSyncArguments)",
         "workingFolder": "corefx",
         "failOnStandardError": "false"
       }
@@ -141,7 +141,7 @@
       },
       "inputs": {
         "filename": "$(Build.SourcesDirectory)\\corefx\\build.cmd",
-        "arguments": "$(PB_BuildArguments)",
+        "arguments": "$(PB_BuildArguments) $(PB_PipelineBuildMSBuildArguments)",
         "workingFolder": "corefx",
         "failOnStandardError": "false"
       }
@@ -465,6 +465,28 @@
     },
     "PB_CreateHelixArguments": {
       "value": "/t:CloudBuild /p:ArchGroup=x64 /p:ConfigurationGroup=Release /p:\"EnableCloudTest=true\" /p:\"BuildMoniker=none\" /p:\"TargetQueue=Windows.10.Amd64\" /p:\"TestProduct=corefx\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:FilterToOSGroup=Windows_NT",
+      "allowOverride": true
+    },
+    "PB_OptionalToolSource": {
+      "value": null,
+      "allowOverride": true,
+      "isSecret": true
+    },
+    "PB_OptionalToolSourceUser": {
+      "value": null,
+      "allowOverride": true,
+      "isSecret": true
+    },
+    "PB_OptionalToolSourcePAT": {
+      "value": null,
+      "allowOverride": true,
+      "isSecret": true
+    },
+    "PB_OptionalToolingSyncArguments": {
+      "value": "/p:OptionalToolSource=$(PB_OptionalToolSource) /p:OptionalToolSourceUser=$(PB_OptionalToolSourceUser);OptionalToolSourcePassword=$(PB_OptionalToolSourcePAT)"
+    },
+    "PB_PipelineBuildMSBuildArguments": {
+      "value": "",
       "allowOverride": true
     }
   },

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -213,7 +213,8 @@
         "TreatWarningsAsErrors": "false"
       },
       "BuildParameters": {
-        "PB_ConfigurationGroup": "Release"
+        "PB_ConfigurationGroup": "Release",
+        "PB_PipelineBuildMSBuildArguments": "/p:EnableProfileGuidedOptimization=true"
       },
       "Definitions": [
         {


### PR DESCRIPTION
Uses tooling implemented in https://github.com/dotnet/buildtools/pull/1322 to merge IBC optimization data during the build pipeline build. We need to pass in secret values for the `OptionalToolSource*` vars: I'll set that up after merging.

In my testing, the result was packages with signed DLLs with the optimization data merged.

/cc @dpodder (working on this for CoreCLR)