### PR TITLE
Enable four test projects outside of Windows

### DIFF
--- a/src/System.IO.FileSystem.DriveInfo/System.IO.FileSystem.DriveInfo.sln
+++ b/src/System.IO.FileSystem.DriveInfo/System.IO.FileSystem.DriveInfo.sln
@@ -26,10 +26,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{7D9E5F2F-5677-40FC-AD04-FA7D603E4806}.Debug|Any CPU.ActiveCfg = netstandard-Windows_NT-Debug|Any CPU
-		{7D9E5F2F-5677-40FC-AD04-FA7D603E4806}.Debug|Any CPU.Build.0 = netstandard-Windows_NT-Debug|Any CPU
-		{7D9E5F2F-5677-40FC-AD04-FA7D603E4806}.Release|Any CPU.ActiveCfg = netstandard-Windows_NT-Release|Any CPU
-		{7D9E5F2F-5677-40FC-AD04-FA7D603E4806}.Release|Any CPU.Build.0 = netstandard-Windows_NT-Release|Any CPU
+		{7D9E5F2F-5677-40FC-AD04-FA7D603E4806}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{7D9E5F2F-5677-40FC-AD04-FA7D603E4806}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{7D9E5F2F-5677-40FC-AD04-FA7D603E4806}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{7D9E5F2F-5677-40FC-AD04-FA7D603E4806}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
 		{29C14AD7-DC03-45DC-897D-8DACC762707E}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
 		{29C14AD7-DC03-45DC-897D-8DACC762707E}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
 		{29C14AD7-DC03-45DC-897D-8DACC762707E}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU

--- a/src/System.IO.FileSystem.DriveInfo/tests/Configurations.props
+++ b/src/System.IO.FileSystem.DriveInfo/tests/Configurations.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
-      netstandard-Windows_NT;
+      netstandard;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.FileSystem.DriveInfo/tests/System.IO.FileSystem.DriveInfo.Tests.csproj
+++ b/src/System.IO.FileSystem.DriveInfo/tests/System.IO.FileSystem.DriveInfo.Tests.csproj
@@ -5,8 +5,8 @@
     <ProjectGuid>{7D9E5F2F-5677-40FC-AD04-FA7D603E4806}</ProjectGuid>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="DriveInfo.Unix.Tests.cs" />
     <Compile Include="DriveInfo.Windows.Tests.cs" />

--- a/src/System.Net.HttpListener/ref/System.Net.HttpListener.csproj
+++ b/src/System.Net.HttpListener/ref/System.Net.HttpListener.csproj
@@ -6,6 +6,8 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="System.Net.HttpListener.cs" />
   </ItemGroup>

--- a/src/System.Net.HttpListener/src/System.Net.HttpListener.csproj
+++ b/src/System.Net.HttpListener/src/System.Net.HttpListener.csproj
@@ -6,10 +6,12 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netcoreapp-Windows_NT-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netcoreapp-Windows_NT-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netcoreapp-Unix-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netcoreapp-Unix-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
     <Reference Include="Microsoft.Win32.Primitives" />
     <Reference Include="System.Collections" />

--- a/src/System.Net.WebHeaderCollection/System.Net.WebHeaderCollection.sln
+++ b/src/System.Net.WebHeaderCollection/System.Net.WebHeaderCollection.sln
@@ -26,10 +26,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{F8C21EE8-B271-4014-B9D9-B2C31520AF3F}.Debug|Any CPU.ActiveCfg = netstandard-Windows_NT-Debug|Any CPU
-		{F8C21EE8-B271-4014-B9D9-B2C31520AF3F}.Debug|Any CPU.Build.0 = netstandard-Windows_NT-Debug|Any CPU
-		{F8C21EE8-B271-4014-B9D9-B2C31520AF3F}.Release|Any CPU.ActiveCfg = netstandard-Windows_NT-Release|Any CPU
-		{F8C21EE8-B271-4014-B9D9-B2C31520AF3F}.Release|Any CPU.Build.0 = netstandard-Windows_NT-Release|Any CPU
+		{F8C21EE8-B271-4014-B9D9-B2C31520AF3F}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{F8C21EE8-B271-4014-B9D9-B2C31520AF3F}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{F8C21EE8-B271-4014-B9D9-B2C31520AF3F}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{F8C21EE8-B271-4014-B9D9-B2C31520AF3F}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
 		{C7DB0DF2-9CF2-42FB-89A7-450550B52C48}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
 		{C7DB0DF2-9CF2-42FB-89A7-450550B52C48}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
 		{C7DB0DF2-9CF2-42FB-89A7-450550B52C48}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU

--- a/src/System.Net.WebHeaderCollection/tests/Configurations.props
+++ b/src/System.Net.WebHeaderCollection/tests/Configurations.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
-      netstandard-Windows_NT;
+      netstandard;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Net.WebHeaderCollection/tests/System.Net.WebHeaderCollection.Tests.csproj
+++ b/src/System.Net.WebHeaderCollection/tests/System.Net.WebHeaderCollection.Tests.csproj
@@ -5,8 +5,8 @@
     <ProjectGuid>{F8C21EE8-B271-4014-B9D9-B2C31520AF3F}</ProjectGuid>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="WebHeaderCollectionTest.cs" />
     <Compile Include="LoggingTest.cs" />

--- a/src/System.Security.Cryptography.Primitives/System.Security.Cryptography.Primitives.sln
+++ b/src/System.Security.Cryptography.Primitives/System.Security.Cryptography.Primitives.sln
@@ -26,10 +26,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{101EB757-55A4-4F48-841C-C088640B8F57}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
-		{101EB757-55A4-4F48-841C-C088640B8F57}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
-		{101EB757-55A4-4F48-841C-C088640B8F57}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
-		{101EB757-55A4-4F48-841C-C088640B8F57}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
+		{101EB757-55A4-4F48-841C-C088640B8F57}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
+		{101EB757-55A4-4F48-841C-C088640B8F57}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
+		{101EB757-55A4-4F48-841C-C088640B8F57}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
+		{101EB757-55A4-4F48-841C-C088640B8F57}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
 		{DF73E985-E143-4BF5-9FA4-E199E7D36235}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
 		{DF73E985-E143-4BF5-9FA4-E199E7D36235}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
 		{DF73E985-E143-4BF5-9FA4-E199E7D36235}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU

--- a/src/System.Security.Cryptography.Primitives/tests/Configurations.props
+++ b/src/System.Security.Cryptography.Primitives/tests/Configurations.props
@@ -2,8 +2,8 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
-      netcoreapp-Windows_NT;;
-      netstandard-Windows_NT;;
+      netcoreapp;
+      netstandard;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Cryptography.Primitives/tests/System.Security.Cryptography.Primitives.Tests.csproj
+++ b/src/System.Security.Cryptography.Primitives/tests/System.Security.Cryptography.Primitives.Tests.csproj
@@ -6,10 +6,10 @@
     <ProjectGuid>{101EB757-55A4-4F48-841C-C088640B8F57}</ProjectGuid>
     <DefineConstants Condition="'$(TargetGroup)' == 'netcoreapp'">$(DefineConstants);netcoreapp</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="AsymmetricAlgorithm\Trivial.cs" />
     <Compile Include="CryptoStream.cs" />

--- a/src/System.Text.Encoding.CodePages/System.Text.Encoding.CodePages.sln
+++ b/src/System.Text.Encoding.CodePages/System.Text.Encoding.CodePages.sln
@@ -26,10 +26,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{835AD07B-7C9A-406F-B16F-59B3B0D017A4}.Debug|Any CPU.ActiveCfg = netstandard-Windows_NT-Debug|Any CPU
-		{835AD07B-7C9A-406F-B16F-59B3B0D017A4}.Debug|Any CPU.Build.0 = netstandard-Windows_NT-Debug|Any CPU
-		{835AD07B-7C9A-406F-B16F-59B3B0D017A4}.Release|Any CPU.ActiveCfg = netstandard-Windows_NT-Release|Any CPU
-		{835AD07B-7C9A-406F-B16F-59B3B0D017A4}.Release|Any CPU.Build.0 = netstandard-Windows_NT-Release|Any CPU
+		{835AD07B-7C9A-406F-B16F-59B3B0D017A4}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{835AD07B-7C9A-406F-B16F-59B3B0D017A4}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{835AD07B-7C9A-406F-B16F-59B3B0D017A4}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{835AD07B-7C9A-406F-B16F-59B3B0D017A4}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
 		{16EE6633-F557-5C9E-9EF3-B5334B044F47}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
 		{16EE6633-F557-5C9E-9EF3-B5334B044F47}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
 		{16EE6633-F557-5C9E-9EF3-B5334B044F47}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU

--- a/src/System.Text.Encoding.CodePages/tests/Configurations.props
+++ b/src/System.Text.Encoding.CodePages/tests/Configurations.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
-      netstandard-Windows_NT;
+      netstandard;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Text.Encoding.CodePages/tests/System.Text.Encoding.CodePages.Tests.csproj
+++ b/src/System.Text.Encoding.CodePages/tests/System.Text.Encoding.CodePages.Tests.csproj
@@ -5,8 +5,8 @@
     <ProjectGuid>{835AD07B-7C9A-406F-B16F-59B3B0D017A4}</ProjectGuid>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="EncodingCodePages.cs" />
     <Compile Include="EncodingCodePages.netstandard.cs" />


### PR DESCRIPTION
This enables the following test projects outside of Windows:

src/System.IO.FileSystem.DriveInfo/tests/Configurations.props
src/System.Net.WebHeaderCollection/tests/Configurations.props
src/System.Security.Cryptography.Primitives/tests/Configurations.props
src/System.Text.Encoding.CodePages/tests/Configurations.props

@stephentoub 

Part of #17058 