### PR TITLE
Make use of CopyBlock for non-overlapping spans

### DIFF
--- a/src/System.Memory/src/System/Span.cs
+++ b/src/System.Memory/src/System/Span.cs
@@ -342,7 +342,9 @@ namespace System
                     bool isOverlapped = (sizeof(IntPtr) == sizeof(int)) ? tailDiff.ToInt32() < 0 : tailDiff.ToInt64() < 0;
                     if (!isOverlapped)
                     {
-                        Unsafe.CopyBlock<T>(ref dst, ref src, (uint)length);
+                        void* pSrc = Unsafe.AsPointer<T>(ref src);
+                        void* pDst = Unsafe.AsPointer<T>(ref dst);
+                        Unsafe.CopyBlockUnaligned(pDst, pSrc, (uint)(length * Unsafe.SizeOf<T>()));
                     }
                     else
                     {
@@ -363,7 +365,9 @@ namespace System
                     bool isOverlapped = (sizeof(IntPtr) == sizeof(int)) ? tailDiff.ToInt32() < 0 : tailDiff.ToInt64() < 0;
                     if (!isOverlapped)
                     {
-                        Unsafe.CopyBlock<T>(ref dst, ref src, (uint)length);
+                        void* pSrc = Unsafe.AsPointer<T>(ref src);
+                        void* pDst = Unsafe.AsPointer<T>(ref dst);
+                        Unsafe.CopyBlockUnaligned(pDst, pSrc, (uint)(length * Unsafe.SizeOf<T>()));
                     }
                     else
                     {

--- a/src/System.Memory/src/System/Span.cs
+++ b/src/System.Memory/src/System/Span.cs
@@ -325,6 +325,9 @@ namespace System
             int length = _length;
             int destLength = destination._length;
 
+            if ((uint)length == 0)
+                return true;
+
             if ((uint)length > (uint)destLength)
                 return false;
 
@@ -363,19 +366,27 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private unsafe bool TryFastCopy(ref T dst, int dstLength, ref T src, int srcLength)
         {
+            Debug.Assert(dstLength >= srcLength);
+
             IntPtr srcMinusDst = Unsafe.ByteOffset<T>(ref dst, ref src);
             bool srcGreaterThanDst = (sizeof(IntPtr) == sizeof(int)) ? srcMinusDst.ToInt32() >= 0 : srcMinusDst.ToInt64() >= 0;
             IntPtr tailDiff;
 
             if (srcGreaterThanDst)
             {
+                // If the start of source is greater than the start of destination, then we need to calculate
+                // the different between the end of destination relative to the start of source.
                 tailDiff = Unsafe.ByteOffset<T>(ref Unsafe.Add<T>(ref dst, dstLength), ref src);
             }
             else
             {
+                // If the start of source is less than the start of destination, then we need to calculate
+                // the different between the end of source relative to the start of destunation.
                 tailDiff = Unsafe.ByteOffset<T>(ref Unsafe.Add<T>(ref src, srcLength), ref dst);
             }
 
+            // If the source is entirely before or entirely after the destination and the type inside the span is not
+            // itself a reference type or containing reference types, then we can do a simple block copy of the data.
             bool isOverlapped = (sizeof(IntPtr) == sizeof(int)) ? tailDiff.ToInt32() < 0 : tailDiff.ToInt64() < 0;
             if (!isOverlapped && !SpanHelpers.IsReferenceOrContainsReferences<T>())
             {
@@ -389,6 +400,8 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private unsafe void CopyBlocks(ref T dst, ref T src, int length)
         {
+            Debug.Assert(length > 0);
+
             ref byte dstBytes = ref Unsafe.As<T, byte>(ref dst);
             ref byte srcBytes = ref Unsafe.As<T, byte>(ref src);
             ulong byteCount = (ulong)length * (ulong)Unsafe.SizeOf<T>();

--- a/src/System.Memory/src/System/Span.cs
+++ b/src/System.Memory/src/System/Span.cs
@@ -336,10 +336,45 @@ namespace System
                 ref T src = ref DangerousGetPinnableReference();
                 ref T dst = ref destination.DangerousGetPinnableReference();
 
-                if (!TryFastCopy(ref dst, destLength, ref src, length))
+                IntPtr srcMinusDst = Unsafe.ByteOffset<T>(ref dst, ref src);
+                bool srcGreaterThanDst = (sizeof(IntPtr) == sizeof(int)) ? srcMinusDst.ToInt32() >= 0 : srcMinusDst.ToInt64() >= 0;
+                IntPtr tailDiff;
+
+                if (srcGreaterThanDst)
                 {
-                    IntPtr srcMinusDst = Unsafe.ByteOffset<T>(ref dst, ref src);
-                    bool srcGreaterThanDst = (sizeof(IntPtr) == sizeof(int)) ? srcMinusDst.ToInt32() >= 0 : srcMinusDst.ToInt64() >= 0;
+                    // If the start of source is greater than the start of destination, then we need to calculate
+                    // the different between the end of destination relative to the start of source.
+                    tailDiff = Unsafe.ByteOffset<T>(ref Unsafe.Add<T>(ref dst, destLength), ref src);
+                }
+                else
+                {
+                    // If the start of source is less than the start of destination, then we need to calculate
+                    // the different between the end of source relative to the start of destunation.
+                    tailDiff = Unsafe.ByteOffset<T>(ref Unsafe.Add<T>(ref src, length), ref dst);
+                }
+
+                // If the source is entirely before or entirely after the destination and the type inside the span is not
+                // itself a reference type or containing reference types, then we can do a simple block copy of the data.
+                bool isOverlapped = (sizeof(IntPtr) == sizeof(int)) ? tailDiff.ToInt32() < 0 : tailDiff.ToInt64() < 0;
+                if (!isOverlapped && !SpanHelpers.IsReferenceOrContainsReferences<T>())
+                {
+                    ref byte dstBytes = ref Unsafe.As<T, byte>(ref dst);
+                    ref byte srcBytes = ref Unsafe.As<T, byte>(ref src);
+                    ulong byteCount = (ulong)length * (ulong)Unsafe.SizeOf<T>();
+                    ulong index = 0;
+
+                    while (index < byteCount)
+                    {
+                        uint blockSize = byteCount > uint.MaxValue ? uint.MaxValue : (uint)byteCount;
+                        Unsafe.CopyBlock(
+                            ref Unsafe.Add(ref dstBytes, (IntPtr)index),
+                            ref Unsafe.Add(ref srcBytes, (IntPtr)index),
+                            blockSize);
+                        index += blockSize;
+                    }
+                }
+                else
+                {
                     if (srcGreaterThanDst)
                     {
                         // Source address greater than or equal to destination address. Can do normal copy.
@@ -360,61 +395,6 @@ namespace System
                 }
 
                 return true;
-            }
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private unsafe bool TryFastCopy(ref T dst, int dstLength, ref T src, int srcLength)
-        {
-            Debug.Assert(dstLength >= srcLength);
-
-            IntPtr srcMinusDst = Unsafe.ByteOffset<T>(ref dst, ref src);
-            bool srcGreaterThanDst = (sizeof(IntPtr) == sizeof(int)) ? srcMinusDst.ToInt32() >= 0 : srcMinusDst.ToInt64() >= 0;
-            IntPtr tailDiff;
-
-            if (srcGreaterThanDst)
-            {
-                // If the start of source is greater than the start of destination, then we need to calculate
-                // the different between the end of destination relative to the start of source.
-                tailDiff = Unsafe.ByteOffset<T>(ref Unsafe.Add<T>(ref dst, dstLength), ref src);
-            }
-            else
-            {
-                // If the start of source is less than the start of destination, then we need to calculate
-                // the different between the end of source relative to the start of destunation.
-                tailDiff = Unsafe.ByteOffset<T>(ref Unsafe.Add<T>(ref src, srcLength), ref dst);
-            }
-
-            // If the source is entirely before or entirely after the destination and the type inside the span is not
-            // itself a reference type or containing reference types, then we can do a simple block copy of the data.
-            bool isOverlapped = (sizeof(IntPtr) == sizeof(int)) ? tailDiff.ToInt32() < 0 : tailDiff.ToInt64() < 0;
-            if (!isOverlapped && !SpanHelpers.IsReferenceOrContainsReferences<T>())
-            {
-                CopyBlocks(ref dst, ref src, srcLength);
-                return true;
-            }
-
-            return false;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private unsafe void CopyBlocks(ref T dst, ref T src, int length)
-        {
-            Debug.Assert(length > 0);
-
-            ref byte dstBytes = ref Unsafe.As<T, byte>(ref dst);
-            ref byte srcBytes = ref Unsafe.As<T, byte>(ref src);
-            ulong byteCount = (ulong)length * (ulong)Unsafe.SizeOf<T>();
-            ulong index = 0;
-
-            while (index < byteCount)
-            {
-                uint blockSize = byteCount > uint.MaxValue ? uint.MaxValue : (uint)byteCount;
-                Unsafe.CopyBlock(
-                    ref Unsafe.Add(ref dstBytes, (IntPtr)index),
-                    ref Unsafe.Add(ref srcBytes, (IntPtr)index),
-                    blockSize);
-                index += blockSize;
             }
         }
 

--- a/src/System.Memory/src/System/Span.cs
+++ b/src/System.Memory/src/System/Span.cs
@@ -340,7 +340,7 @@ namespace System
                 {
                     IntPtr tailDiff = Unsafe.ByteOffset<T>(ref Unsafe.Add<T>(ref dst, destLength), ref src);
                     bool isOverlapped = (sizeof(IntPtr) == sizeof(int)) ? tailDiff.ToInt32() < 0 : tailDiff.ToInt64() < 0;
-                    if (!isOverlapped)
+                    if (!isOverlapped && !SpanHelpers.IsReferenceOrContainsReferences<T>())
                     {
                         CopyBlocks(ref dst, ref src, length);
                     }
@@ -361,7 +361,7 @@ namespace System
                 {
                     IntPtr tailDiff = Unsafe.ByteOffset<T>(ref Unsafe.Add<T>(ref src, length), ref dst);
                     bool isOverlapped = (sizeof(IntPtr) == sizeof(int)) ? tailDiff.ToInt32() < 0 : tailDiff.ToInt64() < 0;
-                    if (!isOverlapped)
+                    if (!isOverlapped && !SpanHelpers.IsReferenceOrContainsReferences<T>())
                     {
                         CopyBlocks(ref dst, ref src, length);
                     }


### PR DESCRIPTION
Fix for #16840.

For non-overlapping spans, this makes copy about 9-10x faster. For overlapping spans, we still take the slow paths.

[Edit] 9-10x for sufficiently large blocks (> 2 KB). Though a 256 byte block was still about 4x faster. A 16 byte block was only marginally faster.