### PR TITLE
Re-enable disabled tests for CI.

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/CancellationTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/CancellationTest.cs
@@ -22,7 +22,6 @@ namespace System.Net.Http.Functional.Tests
             _output = output;
         }
 
-        [ActiveIssue(10504)]
         [OuterLoop] // includes seconds of delay
         [Theory]
         [InlineData(false, false)]
@@ -72,7 +71,7 @@ namespace System.Net.Http.Functional.Tests
                     _output.WriteLine("GetAsync() completed at: {0}", stopwatch.Elapsed.ToString());
 
                     triggerResponseWrite.SetResult(true);
-                    Assert.True(stopwatch.Elapsed < new TimeSpan(0, 0, 10), "Elapsed time should be short");
+                    Assert.True(stopwatch.Elapsed < new TimeSpan(0, 0, 10), $"Elapsed time {stopwatch.Elapsed} should be short");
                 });
             }
         }

--- a/src/System.Net.Http/tests/FunctionalTests/SchSendAuxRecordHttpTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SchSendAuxRecordHttpTest.cs
@@ -24,7 +24,6 @@ namespace System.Net.Http.Functional.Tests
             _output = output;
         }
 
-        [ActiveIssue(11623)]
         [OuterLoop] // TODO: Issue #11345
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]


### PR DESCRIPTION
These tests don't fail locally run in a loop, and they were disabled long time back after a single test failure. Hence re-enabling them for CI. These tests affect windows only.

#10504 #11623 

cc @steveharter @ianhays @karelz 