### PR TITLE
Added tests for XmlMembersMapping.

### DIFF
--- a/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -3000,6 +3000,74 @@ string.Format(@"<?xml version=""1.0"" encoding=""utf-8""?>
         var cg = new MycodeGenerator();
         Assert.NotNull(cg);
     }
+
+#if ReflectionOnly
+    [ActiveIssue(10675)]
+#endif
+    [Fact]
+    public static void XmlMembersMapping_SimpleType()
+    {
+        string memberName = "GetData";
+        var getDataRequestBodyValue = new GetDataRequestBody(3);
+        var getDataRequestBodyActual = RoundTripWithXmlMembersMapping<GetDataRequestBody>(getDataRequestBodyValue, memberName, "<?xml version=\"1.0\"?>\r\n<GetData xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"http://tempuri.org/\">\r\n  <value>3</value>\r\n</GetData>");
+
+        Assert.NotNull(getDataRequestBodyActual);
+        Assert.Equal(getDataRequestBodyValue.value, getDataRequestBodyActual.value);
+    }
+
+#if ReflectionOnly
+    [ActiveIssue(10675)]
+#endif
+    [Fact]
+    public static void XmlMembersMapping_CompositeType()
+    {
+        string memberName = "GetDataUsingDataContract";
+        var requestBodyValue = new GetDataUsingDataContractRequestBody() { composite = new CompositeTypeForXmlMembersMapping() { BoolValue = true, StringValue = "foo" } };
+        var requestBodyActual = RoundTripWithXmlMembersMapping<GetDataUsingDataContractRequestBody>(requestBodyValue, memberName, "<?xml version=\"1.0\"?>\r\n<GetDataUsingDataContract xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"http://tempuri.org/\">\r\n  <composite>\r\n    <BoolValue>true</BoolValue>\r\n    <StringValue>foo</StringValue>\r\n  </composite>\r\n</GetDataUsingDataContract>");
+
+        Assert.NotNull(requestBodyActual);
+        Assert.Equal(requestBodyValue.composite.BoolValue, requestBodyActual.composite.BoolValue);
+        Assert.Equal(requestBodyValue.composite.StringValue, requestBodyActual.composite.StringValue);
+    }
+
+    private static T RoundTripWithXmlMembersMapping<T>(object requestBodyValue, string memberName, string baseline, bool skipStringCompare = false) where T : class
+    {
+        var member = new XmlReflectionMember();
+        member.MemberName = memberName;
+        member.MemberType = typeof(T);
+        member.XmlAttributes = new XmlAttributes();
+        var elementAttribute = new XmlElementAttribute();
+        elementAttribute.ElementName = memberName;
+        string ns = "http://tempuri.org/";
+        elementAttribute.Namespace = ns;
+        member.XmlAttributes.XmlElements.Add(elementAttribute);
+
+        var importer = new XmlReflectionImporter(null, ns);
+        var membersMapping = importer.ImportMembersMapping(null, ns, new XmlReflectionMember[] { member }, false);
+        var serializer = XmlSerializer.FromMappings(new XmlMapping[] { membersMapping })[0];
+        using (var ms = new MemoryStream())
+        {
+            object[] value = new object[] { requestBodyValue };
+            serializer.Serialize(ms, value);
+            ms.Flush();
+            ms.Position = 0;
+            string actualOutput = new StreamReader(ms).ReadToEnd();
+            if (!skipStringCompare)
+            {
+                Utils.CompareResult result = Utils.Compare(baseline, actualOutput);
+                Assert.True(result.Equal, string.Format("{1}{0}Test failed for input: {2}{0}Expected: {3}{0}Actual: {4}",
+                    Environment.NewLine, result.ErrorMessage, value, baseline, actualOutput));
+            }
+
+            ms.Position = 0;
+            var actual = serializer.Deserialize(ms) as object[];
+            Assert.NotNull(actual);
+            Assert.Equal(value.Length, actual.Length);
+            var requestBodyActual = actual[0] as T;
+            return requestBodyActual;
+        }
+    }
+
     private static Stream GenerateStreamFromString(string s)
     {
         var stream = new MemoryStream();

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -4233,3 +4233,79 @@ public class MySpecialOrder2 : MyOrder
 {
     public int SecondaryID;
 }
+
+[System.Runtime.Serialization.DataContractAttribute(Namespace = "http://tempuri.org/")]
+public partial class GetDataRequestBody
+{
+
+    [System.Runtime.Serialization.DataMemberAttribute(Order = 0)]
+    public int value;
+
+    public GetDataRequestBody()
+    {
+    }
+
+    public GetDataRequestBody(int value)
+    {
+        this.value = value;
+    }
+}
+
+[System.Runtime.Serialization.DataContractAttribute(Namespace = "http://tempuri.org/")]
+public partial class GetDataUsingDataContractRequestBody
+{
+
+    [System.Runtime.Serialization.DataMemberAttribute(EmitDefaultValue = false, Order = 0)]
+    public CompositeTypeForXmlMembersMapping composite;
+
+    public GetDataUsingDataContractRequestBody()
+    {
+    }
+
+    public GetDataUsingDataContractRequestBody(CompositeTypeForXmlMembersMapping composite)
+    {
+        this.composite = composite;
+    }
+}
+
+[System.Runtime.Serialization.DataContractAttribute(Name = "CompositeType", Namespace = "http://tempuri.org/")]
+[System.SerializableAttribute()]
+public partial class CompositeTypeForXmlMembersMapping
+{
+    private bool BoolValueField;
+
+    [System.Runtime.Serialization.OptionalFieldAttribute()]
+    private string StringValueField;
+
+    [System.Runtime.Serialization.DataMemberAttribute(IsRequired = true)]
+    public bool BoolValue
+    {
+        get
+        {
+            return this.BoolValueField;
+        }
+        set
+        {
+            if ((this.BoolValueField.Equals(value) != true))
+            {
+                this.BoolValueField = value;
+            }
+        }
+    }
+
+    [System.Runtime.Serialization.DataMemberAttribute(EmitDefaultValue = false)]
+    public string StringValue
+    {
+        get
+        {
+            return this.StringValueField;
+        }
+        set
+        {
+            if ((object.ReferenceEquals(this.StringValueField, value) != true))
+            {
+                this.StringValueField = value;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR added tests for serializing objects using XmlMembersMapping. The tests passed in ILGen mode, but failed in reflection only mode. 

Ref #10675.