### PR TITLE
Fix build of native components on FreeBSD.

### DIFF
--- a/src/Native/Unix/System.Native/pal_errno.cpp
+++ b/src/Native/Unix/System.Native/pal_errno.cpp
@@ -8,8 +8,8 @@
 
 #include <errno.h>
 
-// ENODATA is not defined on FreeBSD.
-#if defined(__FreeBSD__)
+// ENODATA is not defined in FreeBSD 10.3 but is defined in 11.0
+#if defined(__FreeBSD__) & !defined(ENODATA)
 #define ENODATA ENOATTR
 #endif
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/openssl.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/openssl.cpp
@@ -1271,7 +1271,7 @@ static void LockingCallback(int mode, int n, const char* file, int line)
         result = pthread_mutex_unlock(&g_locks[n]);
     }
 
-#pragma clang diagnostic push
+#pragma clang diagnostic pop
 
     if (result != 0)
     {

--- a/src/Native/Unix/System.Security.Cryptography.Native/openssl.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/openssl.cpp
@@ -1257,6 +1257,10 @@ static void LockingCallback(int mode, int n, const char* file, int line)
 {
     (void)file, (void)line; // deliberately unused parameters
 
+// Clang complains about releasing locks that are not held.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wthread-safety-analysis"
+
     int result;
     if (mode & CRYPTO_LOCK)
     {
@@ -1266,6 +1270,8 @@ static void LockingCallback(int mode, int n, const char* file, int line)
     {
         result = pthread_mutex_unlock(&g_locks[n]);
     }
+
+#pragma clang diagnostic push
 
     if (result != 0)
     {


### PR DESCRIPTION
I tried building the native components on FreeBSD and got two build errors:

FreeBSD 11 started to define ENODATA, which was not defined in 10.3:
```
[  6%] Building CXX object System.Native/CMakeFiles/System.Native-Static.dir/pal_errno.cpp.o
/usr/home/austin/corefx/src/Native/Unix/System.Native/pal_errno.cpp:13:9: error: 'ENODATA' macro redefined [-Werror,-Wmacro-redefined]
#define ENODATA ENOATTR
        ^
/usr/include/c++/v1/errno.h:155:9: note: previous definition is here
#define ENODATA 9919
        ^
1 error generated.
```

The both clang3.5 and clang3.7 from `pkg` complains about the callback that OpenSSL calls to do locking:

```
/usr/home/austin/corefx/src/Native/Unix/System.Security.Cryptography.Native/openssl.cpp:1267:18: error: releasing mutex 'g_locks[n]' that was not held [-Werror,-Wthread-safety-analysis]
        result = pthread_mutex_unlock(&g_locks[n]);
                 ^
/usr/home/austin/corefx/src/Native/Unix/System.Security.Cryptography.Native/openssl.cpp:1270:9: error: mutex 'g_locks[n]' is not held on every path through here [-Werror,-Wthread-safety-analysis]
    if (result != 0)
        ^
/usr/home/austin/corefx/src/Native/Unix/System.Security.Cryptography.Native/openssl.cpp:1263:18: note: mutex acquired here
        result = pthread_mutex_lock(&g_locks[n]);
                 ^
2 errors generated.
```