### PR TITLE
Use IsSZArray in S.Linq.Expressions

### DIFF
--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
@@ -746,12 +746,5 @@ namespace System.Dynamic.Utils
         }
 #endif
 
-        public static bool IsVector(this Type type)
-        {
-            // Unfortunately, the IsSzArray property of System.Type is inaccessible to us,
-            // so we use a little equality comparison trick instead. This omission is being
-            // tracked at https://github.com/dotnet/coreclr/issues/1877.
-            return type == type.GetElementType().MakeArrayType();
-        }
     }
 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -1076,7 +1076,7 @@ namespace System.Linq.Expressions.Compiler
             Debug.Assert(arrayType != null);
             Debug.Assert(arrayType.IsArray);
 
-            if (arrayType.IsVector())
+            if (arrayType.IsSZArray)
             {
                 il.Emit(OpCodes.Newarr, arrayType.GetElementType());
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
@@ -304,15 +304,15 @@ namespace System.Linq.Expressions.Compiler
 
         private void EmitGetArrayElement(Type arrayType)
         {
-            if (!arrayType.IsVector())
-            {
-                // Multidimensional arrays, call get
-                _ilg.Emit(OpCodes.Call, arrayType.GetMethod("Get", BindingFlags.Public | BindingFlags.Instance));
-            }
-            else
+            if (arrayType.IsSZArray)
             {
                 // For one dimensional arrays, emit load
                 _ilg.EmitLoadElement(arrayType.GetElementType());
+            }
+            else
+            {
+                // Multidimensional arrays, call get
+                _ilg.Emit(OpCodes.Call, arrayType.GetMethod("Get", BindingFlags.Public | BindingFlags.Instance));
             }
         }
 
@@ -332,15 +332,15 @@ namespace System.Linq.Expressions.Compiler
 
         private void EmitSetArrayElement(Type arrayType)
         {
-            if (!arrayType.IsVector())
-            {
-                // Multidimensional arrays, call set
-                _ilg.Emit(OpCodes.Call, arrayType.GetMethod("Set", BindingFlags.Public | BindingFlags.Instance));
-            }
-            else
+            if (arrayType.IsSZArray)
             {
                 // For one dimensional arrays, emit store
                 _ilg.EmitStoreElement(arrayType.GetElementType());
+            }
+            else
+            {
+                // Multidimensional arrays, call set
+                _ilg.Emit(OpCodes.Call, arrayType.GetMethod("Set", BindingFlags.Public | BindingFlags.Instance));
             }
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
@@ -864,14 +864,16 @@ namespace System.Linq.Expressions
         public static UnaryExpression ArrayLength(Expression array)
         {
             RequiresCanRead(array, nameof(array));
-            if (!array.Type.IsArray || !typeof(Array).IsAssignableFrom(array.Type))
+            if (!array.Type.IsSZArray)
             {
-                throw Error.ArgumentMustBeArray(nameof(array));
-            }
-            if (!array.Type.IsVector())
-            {
+                if (!array.Type.IsArray || !typeof(Array).IsAssignableFrom(array.Type))
+                {
+                    throw Error.ArgumentMustBeArray(nameof(array));
+                }
+
                 throw Error.ArgumentMustBeSingleDimensionalArrayType(nameof(array));
             }
+
             return new UnaryExpression(ExpressionType.ArrayLength, array, typeof(int), null);
         }
 

--- a/src/System.Linq.Expressions/tests/Array/ArrayLengthTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayLengthTests.cs
@@ -1584,10 +1584,28 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void ArrayTypeArrayAllowed(bool useInterpreter)
         {
-            Array arr = new[] {1, 2, 3};
+            Array arr = new[] { 1, 2, 3 };
             Func<int> func =
                 Expression.Lambda<Func<int>>(Expression.ArrayLength(Expression.Constant(arr))).Compile(useInterpreter);
             Assert.Equal(3, func());
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ArrayExplicitlyTypeArrayNotAllowed(bool useInterpreter)
+        {
+            Array arr = new[] { 1, 2, 3 };
+            Expression arrayExpression = Expression.Constant(arr, typeof(Array));
+            Assert.Throws<ArgumentException>("array", () => Expression.ArrayLength(arrayExpression));
+        }
+
+        [Fact]
+        public static void ArrayTypeArrayNotAllowedIfNotSZArray()
+        {
+            Array arr = new[,] { { 1, 2, 3 }, { 1, 2, 2 } };
+            Assert.Throws<ArgumentException>("array", () => Expression.ArrayLength(Expression.Constant(arr)));
+
+            arr = Array.CreateInstance(typeof(int), new[] { 3 }, new[] { -1 });
+            Assert.Throws<ArgumentException>("array", () => Expression.ArrayLength(Expression.Constant(arr)));
         }
 
         [Fact]


### PR DESCRIPTION
Expressions had a `IsVector()` method that was a workaround for the unavailability of `IsSZArray`. Now that we have that, use that instead.

Flip a some `if(!exp){}else{}` to `if(exp){}else{}`. Slightly more readable

Do test for non-array passed to `ArrayLength()` only if `IsSZArray` fails, since anything that will fail the array check will fail that subsequent `IsSZArray` check anyway, avoiding one check in the non-exceptional case.

Add a few more tests covering the cases hit by that last change, for confidence it doesn't change behaviour.