### PR TITLE
Disable more recently failing Net.Security tests.

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
@@ -89,6 +89,7 @@ namespace System.Net.Security.Tests
 
         [Theory]
         [ClassData(typeof(SslProtocolSupport.SupportedSslProtocolsTestData))]
+        [ActiveIssue(16534, TestPlatforms.Windows)]
         public async Task ClientAsyncAuthenticate_AllServerVsIndividualClientSupportedProtocols_Success(
             SslProtocols clientProtocol)
         {

--- a/src/System.Net.Security/tests/FunctionalTests/LoggingTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/LoggingTest.cs
@@ -24,6 +24,7 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
+        [ActiveIssue(16516, TestPlatforms.Windows)]
         public void EventSource_EventsRaisedAsExpected()
         {
             RemoteInvoke(() =>

--- a/src/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
@@ -45,6 +45,7 @@ namespace System.Net.Security.Tests
 
         [Theory]
         [ClassData(typeof(SslProtocolSupport.UnsupportedSslProtocolsTestData))]
+        [ActiveIssue(16516, TestPlatforms.Windows)]
         public async Task ServerAsyncAuthenticate_EachServerUnsupportedProtocol_Fail(SslProtocols protocol)
         {
             await Assert.ThrowsAsync<NotSupportedException>(() =>
@@ -76,6 +77,7 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
+        [ActiveIssue(16516, TestPlatforms.Windows)]
         public async Task ServerAsyncAuthenticate_UnsupportedAllServer_Fail()
         {
             await Assert.ThrowsAsync<NotSupportedException>(() =>

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
@@ -23,6 +23,7 @@ namespace System.Net.Security.Tests
         protected abstract bool DoHandshake(SslStream clientSslStream, SslStream serverSslStream);
 
         [Fact]
+        [ActiveIssue(16516, TestPlatforms.Windows)]
         public void SslStream_StreamToStream_Authentication_Success()
         {
             VirtualNetwork network = new VirtualNetwork();


### PR DESCRIPTION
closes https://github.com/dotnet/corefx/issues/17103
closes https://github.com/dotnet/corefx/issues/17083

Adds to the list of tests disabled by #16516 #16534