### PR TITLE
Rewrite System.Net.Security's FixedSizeReader.AsyncReadPacket as an async method

### DIFF
--- a/src/System.Net.Security/src/System.Net.Security.csproj
+++ b/src/System.Net.Security/src/System.Net.Security.csproj
@@ -401,6 +401,7 @@
     <Reference Include="System.Security.Principal" />
     <Reference Include="System.Security.Principal.Windows" />
     <Reference Include="System.Threading" />
+    <Reference Include="System.Threading.Tasks" />
     <Reference Include="System.Threading.ThreadPool" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' == 'true'">

--- a/src/System.Net.Security/src/System/Net/FixedSizeReader.cs
+++ b/src/System.Net.Security/src/System/Net/FixedSizeReader.cs
@@ -46,7 +46,7 @@ namespace System.Net
         /// Completes "request" with 0 if 0 bytes was requested or legitimate EOF received.
         /// Otherwise, reads as directed or completes "request" with an Exception.
         /// </summary>
-        public static async void ReadPacketAsync(Stream transport, AsyncProtocolRequest request)
+        public static async void ReadPacketAsync(Stream transport, AsyncProtocolRequest request) // "async Task" might result in additional, unnecessary allocation
         {
             try
             {

--- a/src/System.Net.Security/src/System/Net/FixedSizeReader.cs
+++ b/src/System.Net.Security/src/System/Net/FixedSizeReader.cs
@@ -4,41 +4,29 @@
 
 using System.Diagnostics;
 using System.IO;
-using System.Threading.Tasks;
+using System.Threading;
 
 namespace System.Net
 {
-    //
-    // The class is a simple wrapper on top of a read stream. It will read the exact number of bytes requested.
-    // It will throw if EOF is reached before the expected number of bytes is returned.
-    //
-    internal class FixedSizeReader
+    /// <summary>
+    /// The class is a simple wrapper on top of a read stream. It will read the exact number of bytes requested.
+    /// It will throw if EOF is reached before the expected number of bytes is returned.
+    /// </summary>
+    internal static class FixedSizeReader
     {
-        private static readonly AsyncCallback s_readCallback = new AsyncCallback(ReadCallback);
-
-        private readonly Stream _transport;
-        private AsyncProtocolRequest _request;
-        private int _totalRead;
-
-        public FixedSizeReader(Stream transport)
+        /// <summary>
+        /// Returns 0 on legitimate EOF or if 0 bytes were requested, otherwise reads as directed or throws.
+        /// Returns count on success.
+        /// </summary>
+        public static int ReadPacket(Stream transport, byte[] buffer, int offset, int count)
         {
-            _transport = transport;
-        }
-
-        //
-        // Returns 0 on legitimate EOF or if 0 bytes were requested, otherwise reads as directed or throws.
-        // Returns count on success.
-        //
-        public int ReadPacket(byte[] buffer, int offset, int count)
-        {
-            int tempCount = count;
+            int remainingCount = count;
             do
             {
-                int bytes = _transport.Read(buffer, offset, tempCount);
-
+                int bytes = transport.Read(buffer, offset, remainingCount);
                 if (bytes == 0)
                 {
-                    if (tempCount != count)
+                    if (remainingCount != count)
                     {
                         throw new IOException(SR.net_io_eof);
                     }
@@ -46,121 +34,45 @@ namespace System.Net
                     return 0;
                 }
 
-                tempCount -= bytes;
+                remainingCount -= bytes;
                 offset += bytes;
-            } while (tempCount != 0);
+            } while (remainingCount > 0);
 
+            Debug.Assert(remainingCount == 0);
             return count;
         }
 
-        //
-        // Completes "_Request" with 0 if 0 bytes was requested or legitimate EOF received.
-        // Otherwise, reads as directed or completes "_Request" with an Exception or throws.
-        //
-        public void AsyncReadPacket(AsyncProtocolRequest request)
+        /// <summary>
+        /// Completes "request" with 0 if 0 bytes was requested or legitimate EOF received.
+        /// Otherwise, reads as directed or completes "request" with an Exception.
+        /// </summary>
+        public static async void ReadPacketAsync(Stream transport, AsyncProtocolRequest request)
         {
-            _request = request;
-            _totalRead = 0;
-            StartReading();
-        }
-
-        //
-        // Loops while subsequent completions are sync.
-        //
-        private void StartReading()
-        {
-            while (true)
-            {
-                int bytes;
-
-                Task<int> t = _transport.ReadAsync(_request.Buffer, _request.Offset + _totalRead, _request.Count - _totalRead);
-                if (t.IsCompleted)
-                {
-                    bytes = t.GetAwaiter().GetResult();
-                }
-                else
-                {
-                    IAsyncResult ar = TaskToApm.Begin(t, s_readCallback, this);
-                    if (!ar.CompletedSynchronously)
-                    {
-#if DEBUG
-                        _request._DebugAsyncChain = ar;
-#endif
-                        break;
-                    }
-                    bytes = TaskToApm.End<int>(ar);
-                }
-
-                if (CheckCompletionBeforeNextRead(bytes))
-                {
-                    break;
-                }
-            }
-        }
-
-        private bool CheckCompletionBeforeNextRead(int bytes)
-        {
-            if (bytes == 0)
-            {
-                // 0 bytes was requested or EOF in the beginning of a frame, the caller should decide whether it's OK.
-                if (_totalRead == 0)
-                {
-                    _request.CompleteRequest(0);
-                    return true;
-                }
-
-                // EOF in the middle of a frame.
-                throw new IOException(SR.net_io_eof);
-            }
-
-            if (_totalRead + bytes > _request.Count)
-            {
-                NetEventSource.Fail(this, $"State got out of range. Total:{_totalRead + bytes} Count:{_request.Count}");
-            }
-
-            if ((_totalRead += bytes) == _request.Count)
-            {
-                _request.CompleteRequest(_request.Count);
-                return true;
-            }
-
-            return false;
-        }
-
-        private static void ReadCallback(IAsyncResult transportResult)
-        {
-            if (!(transportResult.AsyncState is FixedSizeReader))
-            {
-                NetEventSource.Fail(null, "State type is wrong, expected FixedSizeReader.");
-            }
-
-            if (transportResult.CompletedSynchronously)
-            {
-                return;
-            }
-
-            FixedSizeReader reader = (FixedSizeReader)transportResult.AsyncState;
-            AsyncProtocolRequest request = reader._request;
-
-            // Async completion.
             try
             {
-                int bytes = TaskToApm.End<int>(transportResult);
-
-                if (reader.CheckCompletionBeforeNextRead(bytes))
+                int remainingCount = request.Count, offset = request.Offset;
+                do
                 {
-                    return;
-                }
+                    int bytes = await transport.ReadAsync(request.Buffer, offset, remainingCount, CancellationToken.None).ConfigureAwait(false);
+                    if (bytes == 0)
+                    {
+                        if (remainingCount != request.Count)
+                        {
+                            throw new IOException(SR.net_io_eof);
+                        }
+                        request.CompleteRequest(0);
+                        return;
+                    }
 
-                reader.StartReading();
+                    offset += bytes;
+                    remainingCount -= bytes;
+                } while (remainingCount > 0);
+
+                Debug.Assert(remainingCount == 0);
+                request.CompleteRequest(request.Count);
             }
             catch (Exception e)
             {
-                if (request.IsUserCompleted)
-                {
-                    throw;
-                }
-
                 request.CompleteUserWithError(e);
             }
         }

--- a/src/System.Net.Security/src/System/Net/Security/InternalNegotiateStream.cs
+++ b/src/System.Net.Security/src/System/Net/Security/InternalNegotiateStream.cs
@@ -27,12 +27,9 @@ namespace System.Net.Security
         private int _InternalOffset;
         private int _InternalBufferCount;
 
-        private FixedSizeReader _FrameReader;
-
         private void InitializeStreamPart()
         {
             _ReadHeader = new byte[4];
-            _FrameReader = new FixedSizeReader(InnerStream);
         }
 
         private byte[] InternalBuffer
@@ -267,7 +264,7 @@ namespace System.Net.Security
             if (asyncRequest != null)
             {
                 asyncRequest.SetNextRequest(_ReadHeader, 0, _ReadHeader.Length, s_readCallback);
-                _FrameReader.AsyncReadPacket(asyncRequest);
+                FixedSizeReader.ReadPacketAsync(InnerStream, asyncRequest);
                 if (!asyncRequest.MustCompleteSynchronously)
                 {
                     return 0;
@@ -277,7 +274,7 @@ namespace System.Net.Security
             }
             else
             {
-                readBytes = _FrameReader.ReadPacket(_ReadHeader, 0, _ReadHeader.Length);
+                readBytes = FixedSizeReader.ReadPacket(InnerStream, _ReadHeader, 0, _ReadHeader.Length);
             }
 
             return StartFrameBody(readBytes, buffer, offset, count, asyncRequest);
@@ -321,7 +318,7 @@ namespace System.Net.Security
             {
                 asyncRequest.SetNextRequest(InternalBuffer, 0, readBytes, s_readCallback);
 
-                _FrameReader.AsyncReadPacket(asyncRequest);
+                FixedSizeReader.ReadPacketAsync(InnerStream, asyncRequest);
 
                 if (!asyncRequest.MustCompleteSynchronously)
                 {
@@ -332,7 +329,7 @@ namespace System.Net.Security
             }
             else //Sync
             {
-                readBytes = _FrameReader.ReadPacket(InternalBuffer, 0, readBytes);
+                readBytes = FixedSizeReader.ReadPacket(InnerStream, InternalBuffer, 0, readBytes);
             }
 
             return ProcessFrameBody(readBytes, buffer, offset, count, asyncRequest);

--- a/src/System.Net.Security/src/System/Net/Security/SslState.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslState.cs
@@ -29,8 +29,6 @@ namespace System.Net.Security
 
         private SslStreamInternal _secureStream;
 
-        private FixedSizeReader _reader;
-
         private int _nestedAuth;
         private SecureChannel _context;
 
@@ -81,7 +79,6 @@ namespace System.Net.Security
         internal SslState(Stream innerStream, RemoteCertValidationCallback certValidationCallback, LocalCertSelectionCallback certSelectionCallback, EncryptionPolicy encryptionPolicy)
         {
             _innerStream = innerStream;
-            _reader = new FixedSizeReader(innerStream);
             _certValidationDelegate = certValidationCallback;
             _certSelectionDelegate = certSelectionCallback;
             _encryptionPolicy = encryptionPolicy;
@@ -868,12 +865,12 @@ namespace System.Net.Security
             int readBytes = 0;
             if (asyncRequest == null)
             {
-                readBytes = _reader.ReadPacket(buffer, 0, SecureChannel.ReadHeaderSize);
+                readBytes = FixedSizeReader.ReadPacket(_innerStream, buffer, 0, SecureChannel.ReadHeaderSize);
             }
             else
             {
                 asyncRequest.SetNextRequest(buffer, 0, SecureChannel.ReadHeaderSize, s_partialFrameCallback);
-                _reader.AsyncReadPacket(asyncRequest);
+                FixedSizeReader.ReadPacketAsync(_innerStream, asyncRequest);
                 if (!asyncRequest.MustCompleteSynchronously)
                 {
                     return;
@@ -916,12 +913,12 @@ namespace System.Net.Security
 
             if (asyncRequest == null)
             {
-                restBytes = _reader.ReadPacket(buffer, readBytes, restBytes);
+                restBytes = FixedSizeReader.ReadPacket(_innerStream, buffer, readBytes, restBytes);
             }
             else
             {
                 asyncRequest.SetNextRequest(buffer, readBytes, restBytes, s_readFrameCallback);
-                _reader.AsyncReadPacket(asyncRequest);
+                FixedSizeReader.ReadPacketAsync(_innerStream, asyncRequest);
                 if (!asyncRequest.MustCompleteSynchronously)
                 {
                     return;

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.cs
@@ -42,8 +42,6 @@ namespace System.Net.Security
         private int _internalOffset;
         private int _internalBufferCount;
 
-        private FixedSizeReader _reader;
-
         internal SslStreamInternal(SslState sslState)
         {
             if (PinnableBufferCacheEventSource.Log.IsEnabled())
@@ -52,7 +50,6 @@ namespace System.Net.Security
             }
 
             _sslState = sslState;
-            _reader = new FixedSizeReader(_sslState.InnerStream);
         }
 
         // If we have a read buffer from the pinnable cache, return it.
@@ -613,7 +610,7 @@ namespace System.Net.Security
             if (asyncRequest != null)
             {
                 asyncRequest.SetNextRequest(InternalBuffer, 0, SecureChannel.ReadHeaderSize, s_readHeaderCallback);
-                _reader.AsyncReadPacket(asyncRequest);
+                FixedSizeReader.ReadPacketAsync(_sslState.InnerStream, asyncRequest);
 
                 if (!asyncRequest.MustCompleteSynchronously)
                 {
@@ -624,7 +621,7 @@ namespace System.Net.Security
             }
             else
             {
-                readBytes = _reader.ReadPacket(InternalBuffer, 0, SecureChannel.ReadHeaderSize);
+                readBytes = FixedSizeReader.ReadPacket(_sslState.InnerStream, InternalBuffer, 0, SecureChannel.ReadHeaderSize);
             }
 
             return StartFrameBody(readBytes, buffer, offset, count, asyncRequest);
@@ -655,7 +652,7 @@ namespace System.Net.Security
             {
                 asyncRequest.SetNextRequest(InternalBuffer, SecureChannel.ReadHeaderSize, readBytes, s_readFrameCallback);
 
-                _reader.AsyncReadPacket(asyncRequest);
+                FixedSizeReader.ReadPacketAsync(_sslState.InnerStream, asyncRequest);
 
                 if (!asyncRequest.MustCompleteSynchronously)
                 {
@@ -666,7 +663,7 @@ namespace System.Net.Security
             }
             else
             {
-                readBytes = _reader.ReadPacket(InternalBuffer, SecureChannel.ReadHeaderSize, readBytes);
+                readBytes = FixedSizeReader.ReadPacket(_sslState.InnerStream, InternalBuffer, SecureChannel.ReadHeaderSize, readBytes);
             }
             
             return ProcessFrameBody(readBytes, buffer, offset, count, asyncRequest);


### PR DESCRIPTION
Rewrite the FixedSizeReader.AsyncReadPacket as an async void method.  It's still allocation-free if the delegated ReadAsync completes synchronously, but if it completes asynchronously, there's now less allocation (fewer and smaller objects); there's slightly less if a single read is required, but those same allocations are then reused across all reads, so if multiple reads are needed, there's a significant decrease. And the code is easier to read. Also changes FixedSizeReader to be a static class, avoiding several being allocations per SslStream.

cc: @geoffkizer, @cipop, @davidsh, @Priya91 