### PR TITLE
Fix secannotate errors introduced by #17076 in DiagnosticSource

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
@@ -15,6 +15,9 @@
   <PropertyGroup Condition="'$(TargetGroup)' == 'netstandard1.1'">
     <DefineConstants>;NO_EVENTSOURCE_COMPLEX_TYPE_SUPPORT</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetGroup)' == 'net46' OR '$(TargetGroup)' == 'netfx'">
+    <DefineConstants>;ALLOW_PARTIALLY_TRUSTED_CALLERS</DefineConstants>
+  </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46-Windows_NT-Release|AnyCPU'" />  
@@ -55,7 +58,6 @@
     <Reference Include="System.Threading" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'net46' OR '$(TargetGroup)' == 'netfx'">
-    <Compile Include="AssemblyInfo.Net46.cs" />
     <Reference Include="mscorlib" />
     <Reference Include="System" />
   </ItemGroup>      

--- a/src/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
@@ -58,6 +58,7 @@
     <Reference Include="System.Threading" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'net46' OR '$(TargetGroup)' == 'netfx'">
+    <Compile Include="AssemblyInfo.Net46.cs" />  
     <Reference Include="mscorlib" />
     <Reference Include="System" />
   </ItemGroup>      

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -409,8 +409,9 @@ namespace System.Diagnostics
 #endif
             return ret;
         }
-
+#if ALLOW_PARTIALLY_TRUSTED_CALLERS
         [SecuritySafeCritical]
+#endif
         private static unsafe long GetRandomNumber()
         {
             Guid g = Guid.NewGuid();


### PR DESCRIPTION
On the target that do not declare AllowPartiallyTrustedCallers (all except net46 and netfx), secannotate shows a critical error 

```c#
      <type name="System.Diagnostics.Activity">
        <method name="GetRandomNumber()">
          <annotations>
            <critical>
              <rule name="TransparencyAnnotationsShouldNotConflict">
                <reason pass="1" sourceFile="c:\repo\corefx\src\System.Diagnostics.DiagnosticSource\src\System\Diagnostics\Activity.cs" sourceLine="415">'System.Diagnostics.Activity.GetRandomNumber()', a security critical member, is marked with a safe-critical annotation.  This annotation should be removed.</reason>
              </rule>
            </critical>
          </annotations>
        </method>
      </type>
```

This change uses `SecuritySafeCritical` attribute only on net46 and netfx.