### PR TITLE
System.CodeDom.Tests fix for desktop

### DIFF
--- a/src/Common/tests/System/Collections/ICollection.NonGeneric.Tests.cs
+++ b/src/Common/tests/System/Collections/ICollection.NonGeneric.Tests.cs
@@ -234,7 +234,7 @@ namespace System.Collections.Tests
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
-        public void ICollection_NonGeneric_CopyTo_ArrayOfIncorrectReferenceType(int count)
+        public virtual void ICollection_NonGeneric_CopyTo_ArrayOfIncorrectReferenceType(int count)
         {
             if (count > 0)
             {

--- a/src/Common/tests/System/Collections/IList.NonGeneric.Tests.cs
+++ b/src/Common/tests/System/Collections/IList.NonGeneric.Tests.cs
@@ -1067,7 +1067,7 @@ namespace System.Collections.Tests
         // Test Enumerator.Current at end after new elements was added
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
-        public void IList_NonGeneric_CurrentAtEnd_AfterAdd(int count)
+        public virtual void IList_NonGeneric_CurrentAtEnd_AfterAdd(int count)
         {
             if (!IsReadOnly && !ExpectedFixedSize)
             {

--- a/src/System.CodeDom/tests/CodeCollections/CodeNamespaceImportCollectionTests.cs
+++ b/src/System.CodeDom/tests/CodeCollections/CodeNamespaceImportCollectionTests.cs
@@ -113,6 +113,38 @@ namespace System.CodeDom.Tests
             Assert.Same(value2, collection[0]);
         }
 
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17130")]
+        public override void ICollection_NonGeneric_CopyTo_ArrayOfIncorrectValueType(int count)
+        {
+            base.ICollection_NonGeneric_CopyTo_ArrayOfIncorrectValueType(count);
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17130")]
+        public override void ICollection_NonGeneric_CopyTo_ArrayOfEnumType(int count)
+        {
+            base.ICollection_NonGeneric_CopyTo_ArrayOfEnumType(count);
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17130")]
+        public override void IList_NonGeneric_CurrentAtEnd_AfterAdd(int count)
+        {
+            base.IList_NonGeneric_CurrentAtEnd_AfterAdd(count);   
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17130")]
+        public override void ICollection_NonGeneric_CopyTo_ArrayOfIncorrectReferenceType(int count)
+        {
+            base.ICollection_NonGeneric_CopyTo_ArrayOfIncorrectReferenceType(count);
+        }
+
         private static void VerifyCollection(CodeNamespaceCollection collection, CodeNamespace[] contents)
         {
             Assert.Equal(contents.Length, collection.Count);


### PR DESCRIPTION
As stated in issue #17130 there is a difference in behavior in `CodeNamespaceImportCollection` in desktop vs Core. 

This fixes the tests in System.CodeDom to test as expected in desktop an core considering those differences. 

cc: @tarekgh @danmosemsft @stephentoub 