### PR TITLE
Instrument HttpClientHandler on netfx with DiagnosticSource/Activity

### DIFF
--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -40,6 +40,8 @@
     <Compile Include="System\Net\Http\ByteArrayContent.cs" />
     <Compile Include="System\Net\Http\ClientCertificateOption.cs" />
     <Compile Include="System\Net\Http\DelegatingHandler.cs" />
+    <Compile Include="System\Net\Http\DiagnosticsHandler.cs" />    
+    <Compile Include="System\Net\Http\DiagnosticsHandlerLoggingStrings.cs"/>        
     <Compile Include="System\Net\Http\FormUrlEncodedContent.cs" />
     <Compile Include="System\Net\Http\HttpClient.cs" />
     <Compile Include="System\Net\Http\HttpCompletionOption.cs" />
@@ -119,8 +121,6 @@
   </ItemGroup>
   <!-- Common, except for Windows net46 build -->
   <ItemGroup Condition="'$(TargetGroup)' != 'net46'  And '$(TargetGroup)' != 'netfx'">
-    <Compile Include="System\Net\Http\DiagnosticsHandler.cs" />    
-    <Compile Include="System\Net\Http\DiagnosticsHandlerLoggingStrings.cs"/>    
     <Compile Include="$(CommonPath)\System\Net\Mail\DomainLiteralReader.cs">
       <Link>Common\System\Net\Mail\DomainLiteralReader.cs</Link>
     </Compile>
@@ -179,6 +179,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime" />
+    <ProjectReference Include="..\..\System.Diagnostics.DiagnosticSource\src\System.Diagnostics.DiagnosticSource.csproj" />
   </ItemGroup>
   <!-- Unix -->
   <PropertyGroup Condition=" '$(TargetsUnix)' == 'true' ">

--- a/src/System.Net.Http/src/System/Net/Http/DiagnosticsHandlerLoggingStrings.cs
+++ b/src/System.Net.Http/src/System/Net/Http/DiagnosticsHandlerLoggingStrings.cs
@@ -10,8 +10,11 @@ namespace System.Net.Http
     internal static class DiagnosticsHandlerLoggingStrings
     {
         public const string DiagnosticListenerName = "HttpHandlerDiagnosticListener";
+
+#if !NET46
         public const string RequestWriteNameDeprecated = "System.Net.Http.Request";
         public const string ResponseWriteNameDeprecated = "System.Net.Http.Response";
+#endif
 
         public const string ExceptionEventName = "System.Net.Http.Exception";
         public const string ActivityName = "System.Net.Http.Activity";

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Net46.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Net46.cs
@@ -58,6 +58,8 @@ namespace System.Net.Http
             SslPolicyErrors,
             bool> _serverCertificateCustomValidationCallback;
 
+        private readonly DiagnosticsHandler _diagnosticsPipeline;
+
         #endregion Fields
 
         #region Properties
@@ -446,6 +448,7 @@ namespace System.Net.Http
             _properties = null; // only create collection when required.
             _maxConnectionsPerServer = ServicePointManager.DefaultConnectionLimit;
             _serverCertificateCustomValidationCallback = null;
+            _diagnosticsPipeline = new DiagnosticsHandler(this.SendAsyncImpl);
         }
 
         protected override void Dispose(bool disposing)
@@ -753,8 +756,18 @@ namespace System.Net.Http
         #endregion Message Setup
 
         #region Request Processing
-
+        
         protected internal override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            if (DiagnosticsHandler.IsEnabled())
+            {
+                return _diagnosticsPipeline.SendAsync(request, cancellationToken);
+            }
+            return SendAsyncImpl(request, cancellationToken);
+        }
+
+        internal Task<HttpResponseMessage> SendAsyncImpl(HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
             if (request == null)

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Unix.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Unix.cs
@@ -143,7 +143,7 @@ namespace System.Net.Http
         public HttpClientHandler()
         {
             _curlHandler = new CurlHandler();
-            _diagnosticsPipeline = new DiagnosticsHandler(_curlHandler);
+            _diagnosticsPipeline = new DiagnosticsHandler(_curlHandler.SendAsync);
         }
 
         protected override void Dispose(bool disposing)

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
@@ -194,7 +194,7 @@ namespace System.Net.Http
         public HttpClientHandler()
         {
             _winHttpHandler = new WinHttpHandler();
-            _diagnosticsPipeline = new DiagnosticsHandler(_winHttpHandler);
+            _diagnosticsPipeline = new DiagnosticsHandler(_winHttpHandler.SendAsync);
 
             // Adjust defaults to match current .NET Desktop HttpClientHandler (based on HWR stack).
             AllowAutoRedirect = true;

--- a/src/System.Net.Http/src/netcore50/System/Net/HttpClientHandler.cs
+++ b/src/System.Net.Http/src/netcore50/System/Net/HttpClientHandler.cs
@@ -37,7 +37,7 @@ namespace System.Net.Http
 
         private readonly RTHttpBaseProtocolFilter rtFilter;
         private readonly HttpHandlerToFilter handlerToFilter;
-        private readonly HttpMessageHandler diagnosticsPipeline;
+        private readonly DiagnosticsHandler diagnosticsPipeline;
 
         private volatile bool operationStarted;
         private volatile bool disposed;
@@ -422,7 +422,7 @@ namespace System.Net.Http
         {
             this.rtFilter = new RTHttpBaseProtocolFilter();
             this.handlerToFilter = new HttpHandlerToFilter(this.rtFilter);
-            this.diagnosticsPipeline = new DiagnosticsHandler(handlerToFilter);
+            this.diagnosticsPipeline = new DiagnosticsHandler(handlerToFilter.SendAsync);
 
             this.clientCertificateOptions = ClientCertificateOption.Manual;
 


### PR DESCRIPTION
This changes enables instrumentation for outgoing Http requests with DiagnosticSource and Activity API on netfx.

It was previously introduced for .net core in #16393.
/cc @vancem 

