### PR TITLE
Added HttpStatusCode.TooManyRequests (429)

### DIFF
--- a/src/System.Net.Primitives/src/System/Net/HttpStatusCode.cs
+++ b/src/System.Net.Primitives/src/System/Net/HttpStatusCode.cs
@@ -56,6 +56,8 @@ namespace System.Net
         ExpectationFailed = 417,
 
         UpgradeRequired = 426,
+        
+        TooManyRequests = 429,
 
         // Server Error 5xx
         InternalServerError = 500,


### PR DESCRIPTION
This statuscode is often returned when quotas or throttling limits are being applied to an API. This is often done using an API platform such as Azure API Management or Nginx. Since API's are gaining popularity and more companies are introducing these limits, this statuscode will appear more often in real live scenarios and therefore deserves a representation in this enum.