### PR TITLE
Revert CodeNamespaceImportCollection to using ArrayList

### DIFF
--- a/src/System.CodeDom/src/System/CodeDom/CodeNamespaceImportCollection.cs
+++ b/src/System.CodeDom/src/System/CodeDom/CodeNamespaceImportCollection.cs
@@ -10,12 +10,12 @@ namespace System.CodeDom
     [Serializable]
     public class CodeNamespaceImportCollection : IList
     {
-        private readonly List<CodeNamespaceImport> _data = new List<CodeNamespaceImport>();
+        private readonly ArrayList _data = new ArrayList(); // not List<CodeNamespaceImport> to provide desktop-consistent semantics for CopyTo
         private readonly Dictionary<string, CodeNamespaceImport> _keys = new Dictionary<string, CodeNamespaceImport>(StringComparer.OrdinalIgnoreCase);
 
         public CodeNamespaceImport this[int index]
         {
-            get { return _data[index]; }
+            get { return (CodeNamespaceImport)_data[index]; }
             set
             {
                 _data[index] = value;
@@ -84,15 +84,15 @@ namespace System.CodeDom
 
         object ICollection.SyncRoot => null;
 
-        void ICollection.CopyTo(Array array, int index) => ((IList)_data).CopyTo(array, index);
+        void ICollection.CopyTo(Array array, int index) => _data.CopyTo(array, index);
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-        int IList.Add(object value) => ((IList)_data).Add((CodeNamespaceImport)value);
+        int IList.Add(object value) => _data.Add((CodeNamespaceImport)value);
 
         void IList.Clear() => Clear();
 
-        bool IList.Contains(object value) => ((IList)_data).Contains(value);
+        bool IList.Contains(object value) => _data.Contains(value);
 
         int IList.IndexOf(object value) => _data.IndexOf((CodeNamespaceImport)value);
 

--- a/src/System.CodeDom/tests/CodeCollections/CodeNamespaceImportCollectionTests.cs
+++ b/src/System.CodeDom/tests/CodeCollections/CodeNamespaceImportCollectionTests.cs
@@ -17,11 +17,11 @@ namespace System.CodeDom.Tests
 
         protected override bool NullAllowed => false;
         protected override bool Enumerator_Current_UndefinedOperation_Throws => true;
-        protected override bool IList_CurrentAfterAdd_Throws => false;
         protected override bool ICollection_NonGeneric_HasNullSyncRoot => true;
 
         protected override Type ICollection_NonGeneric_CopyTo_NonZeroLowerBound_ThrowType => typeof(ArgumentOutOfRangeException);
-        protected override Type ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowType => typeof(ArgumentException);
+        protected override Type ICollection_NonGeneric_CopyTo_ArrayOfIncorrectReferenceType_ThrowType => typeof(InvalidCastException);
+        protected override Type ICollection_NonGeneric_CopyTo_ArrayOfIncorrectValueType_ThrowType => typeof(InvalidCastException);
 
         [Fact]
         public void Add()


### PR DESCRIPTION
When I brought CodeDom to corefx, in response to PR feedback I changed CodeNamespaceImportCollection's storage from using an ArrayList to using a List.  But this breaks behavioral compatibility on CopyTo for exceptional cases, so I'm changing it back.

Fixes https://github.com/dotnet/corefx/issues/17130
cc: @safern, @tarekgh 