### PR TITLE
Add netfx ParamName values in SortedListTests

### DIFF
--- a/src/System.Collections.NonGeneric/tests/SortedListTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedListTests.cs
@@ -855,7 +855,7 @@ namespace System.Collections.Tests
             {
                 IList keys = sortList2.GetKeyList();
                 AssertExtensions.Throws<ArgumentNullException>("destinationArray", "dest", () => keys.CopyTo(null, 0)); // Array is null
-                Assert.Throws<ArgumentException>("array", () => keys.CopyTo(new object[10, 10], 0)); // Array is multidimensional
+                AssertExtensions.Throws<ArgumentException>("array", null, () => keys.CopyTo(new object[10, 10], 0)); // Array is multidimensional -- in netfx ParamName is null
 
                 // Index < 0
                 AssertExtensions.Throws<ArgumentOutOfRangeException>("destinationIndex", "dstIndex", () => keys.CopyTo(new object[100], -1));
@@ -1097,7 +1097,7 @@ namespace System.Collections.Tests
             {
                 IList values = sortList2.GetValueList();
                 AssertExtensions.Throws<ArgumentNullException>("destinationArray", "dest", () => values.CopyTo(null, 0)); // Array is null
-                Assert.Throws<ArgumentException>("array", () => values.CopyTo(new object[10, 10], 0)); // Array is multidimensional
+                AssertExtensions.Throws<ArgumentException>("array", null, () => values.CopyTo(new object[10, 10], 0)); // Array is multidimensional -- in netfx ParamName is null
 
                 AssertExtensions.Throws<ArgumentOutOfRangeException>("destinationIndex", "dstIndex", () => values.CopyTo(new object[100], -1)); // Index < 0
                 AssertExtensions.Throws<ArgumentException>("destinationArray", string.Empty, () => values.CopyTo(new object[150], 51)); // Index + list.Count > array.Count


### PR DESCRIPTION
When doing `Array.CopyTo` and the destination array is multidimensional it throws an `ArgumentException` in desktop we don't assign a `ParamName` so it is null. Changed to use in those cases `AssertExtensions` that accept both, Core and desktop expected `ParamName` and with the `RuntimeInformation` if it is running in netfx does the `Assert` against the desktop expected `ParamName` if not uses the Core one.

This tests where failing in netfx, this will fix them. 

cc: @tarekgh @danmosemsft 