### PR TITLE
System collections specialized add netfx ParamName

### DIFF
--- a/src/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.CopyToTests.cs
+++ b/src/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.CopyToTests.cs
@@ -59,7 +59,7 @@ namespace System.Collections.Specialized.Tests
         {
             NameValueCollection nameValueCollection = Helpers.CreateNameValueCollection(count);
             Assert.Throws<ArgumentNullException>("dest", () => nameValueCollection.CopyTo(null, 0));
-            Assert.Throws<ArgumentException>("dest", () => nameValueCollection.CopyTo(new string[count, count], 0));
+            AssertExtensions.Throws<ArgumentException>("dest", null, () => nameValueCollection.CopyTo(new string[count, count], 0)); // in netfx when passing multidimensional arrays Exception.ParamName is null.
 
             Assert.Throws<ArgumentOutOfRangeException>("index", () => nameValueCollection.CopyTo(new string[count], -1));
 

--- a/src/System.Collections.Specialized/tests/System.Collections.Specialized.Tests.csproj
+++ b/src/System.Collections.Specialized/tests/System.Collections.Specialized.Tests.csproj
@@ -8,6 +8,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <ItemGroup>
+    <Compile Include="$(CommonTestPath)\System\AssertExtensions.cs">
+      <Link>Common\System\AssertExtensions.cs</Link>
+    </Compile>
     <!-- Common Collections tests -->
     <Compile Include="$(CommonTestPath)\System\Collections\CollectionAsserts.cs">
       <Link>Common\System\Collections\CollectionAsserts.cs</Link>


### PR DESCRIPTION
When doing Array.CopyTo and the destination array is multidimensional it throws an ArgumentException in desktop we don't assign a ParamName so it is null.

This fixes failing tests in `System.Collections.Specialized` in netfx.

cc: @tarekgh @danmosemsft 