### PR TITLE
Implement Socket.SendPacketsAsync on Unix

### DIFF
--- a/src/System.Net.Sockets/src/System.Net.Sockets.csproj
+++ b/src/System.Net.Sockets/src/System.Net.Sockets.csproj
@@ -268,6 +268,7 @@
     <Compile Include="System\Net\Sockets\AcceptOverlappedAsyncResult.Unix.cs" />
     <Compile Include="System\Net\Sockets\BaseOverlappedAsyncResult.Unix.cs" />
     <Compile Include="System\Net\Sockets\ConnectOverlappedAsyncResult.Unix.cs" />
+    <Compile Include="System\Net\Sockets\DisconnectOverlappedAsyncResult.Unix.cs" />
     <Compile Include="System\Net\Sockets\OverlappedAsyncResult.Unix.cs" />
     <Compile Include="System\Net\Sockets\ReceiveMessageOverlappedAsyncResult.Unix.cs" />
     <Compile Include="System\Net\Sockets\SendPacketsElementFlags.Unix.cs" />

--- a/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Unix.cs
@@ -23,7 +23,7 @@ namespace System.Net.Sockets
             if (NetEventSource.IsEnabled) NetEventSource.Info(this, socket);
         }
 
-        internal void CompletionCallback(int numBytes, SocketError errorCode)
+        protected void CompletionCallback(int numBytes, SocketError errorCode)
         {
             ErrorCode = (int)errorCode;
             InvokeCallback(PostCompletion(numBytes));

--- a/src/System.Net.Sockets/src/System/Net/Sockets/DisconnectOverlappedAsyncResult.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/DisconnectOverlappedAsyncResult.Unix.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Net.Sockets
+{
+    // DisconnectOverlappedAsyncResult - used to take care of storage for async Socket BeginDisconnect call.
+    internal sealed partial class DisconnectOverlappedAsyncResult : BaseOverlappedAsyncResult
+    {
+        internal void PostCompletion(SocketError errorCode) => CompletionCallback(0, errorCode);
+    }
+}

--- a/src/System.Net.Sockets/src/System/Net/Sockets/DisconnectOverlappedAsyncResult.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/DisconnectOverlappedAsyncResult.cs
@@ -4,10 +4,10 @@
 
 namespace System.Net.Sockets
 {
-    // DisconnectOverlappedAsyncResult - used to take care of storage for async Socket BeginAccept call.
-    internal sealed class DisconnectOverlappedAsyncResult : BaseOverlappedAsyncResult
+    // DisconnectOverlappedAsyncResult - used to take care of storage for async Socket BeginDisconnect call.
+    internal sealed partial class DisconnectOverlappedAsyncResult : BaseOverlappedAsyncResult
     {
-        internal DisconnectOverlappedAsyncResult(Socket socket, Object asyncState, AsyncCallback asyncCallback) :
+        internal DisconnectOverlappedAsyncResult(Socket socket, object asyncState, AsyncCallback asyncCallback) :
             base(socket, asyncState, asyncCallback)
         {
         }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -1567,18 +1567,16 @@ namespace System.Net.Sockets
         internal static SocketError DisconnectAsync(Socket socket, SafeCloseSocket handle, bool reuseSocket, DisconnectOverlappedAsyncResult asyncResult)
         {
             SocketError socketError = Disconnect(socket, handle, reuseSocket);
-            asyncResult.CompletionCallback(0, SocketError.Success);
+            asyncResult.PostCompletion(socketError);
             return socketError;
         }
 
         internal static SocketError Disconnect(Socket socket, SafeCloseSocket handle, bool reuseSocket)
         {
-            if (reuseSocket)
-            {
-                return socket.ReplaceHandle();
-            }
-
-            return SocketError.Success;
+            socket.Shutdown(SocketShutdown.Both);
+            return reuseSocket ?
+                socket.ReplaceHandle() :
+                SocketError.Success;
         }
     }
 }

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendPacketsAsync.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendPacketsAsync.cs
@@ -57,24 +57,6 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
-        [PlatformSpecific(TestPlatforms.AnyUnix)]  // SendPacketAsync not supported on Unix
-        public void Unix_NotSupported_ThrowsPlatformNotSupportedException(SocketImplementationType type)
-        {
-            int port;
-            using (SocketTestServer.SocketTestServerFactory(type, _serverAddress, out port))
-            using (var sock = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp))
-            using (var args = new SocketAsyncEventArgs())
-            {
-                sock.Connect(new IPEndPoint(_serverAddress, port));
-                args.SendPacketsElements = new SendPacketsElement[1];
-                Assert.Throws<PlatformNotSupportedException>(() => sock.SendPacketsAsync(args));
-            }
-        }
-
-        [OuterLoop] // TODO: Issue #11345
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
         public void Disposed_Throw(SocketImplementationType type)
         {
             int port;
@@ -146,7 +128,6 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
-        [PlatformSpecific(TestPlatforms.Windows)]  // SendPacketAsync not supported on Unix
         public void NullElement_Ignored(SocketImplementationType type)
         {
             SendPackets(type, (SendPacketsElement)null, 0);
@@ -156,7 +137,6 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
-        [PlatformSpecific(TestPlatforms.Windows)]  // SendPacketAsync not supported on Unix
         public void EmptyList_Ignored(SocketImplementationType type)
         {
             SendPackets(type, new SendPacketsElement[0], SocketError.Success, 0);
@@ -177,7 +157,6 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
-        [PlatformSpecific(TestPlatforms.Windows)]  // SendPacketAsync not supported on Unix
         public void NormalBuffer_Success(SocketImplementationType type)
         {
             SendPackets(type, new SendPacketsElement(new byte[10]), 10);
@@ -186,7 +165,6 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
-        [PlatformSpecific(TestPlatforms.Windows)]  // SendPacketAsync not supported on Unix
         public void NormalBufferRange_Success(SocketImplementationType type)
         {
             SendPackets(type, new SendPacketsElement(new byte[10], 5, 5), 5);
@@ -195,7 +173,6 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
-        [PlatformSpecific(TestPlatforms.Windows)]  // SendPacketAsync not supported on Unix
         public void EmptyBuffer_Ignored(SocketImplementationType type)
         {
             SendPackets(type, new SendPacketsElement(new byte[0]), 0);
@@ -204,7 +181,6 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
-        [PlatformSpecific(TestPlatforms.Windows)]  // SendPacketAsync not supported on Unix
         public void BufferZeroCount_Ignored(SocketImplementationType type)
         {
             SendPackets(type, new SendPacketsElement(new byte[10], 4, 0), 0);
@@ -213,7 +189,6 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
-        [PlatformSpecific(TestPlatforms.Windows)]  // SendPacketAsync not supported on Unix
         public void BufferMixedBuffers_ZeroCountBufferIgnored(SocketImplementationType type)
         {
             SendPacketsElement[] elements = new SendPacketsElement[]
@@ -228,7 +203,6 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
-        [PlatformSpecific(TestPlatforms.Windows)]  // SendPacketAsync not supported on Unix
         public void BufferZeroCountThenNormal_ZeroCountIgnored(SocketImplementationType type)
         {
             Assert.True(Capability.IPv6Support());
@@ -283,7 +257,6 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
-        [PlatformSpecific(TestPlatforms.Windows)]  // SendPacketAsync not supported on Unix
         public void SocketDisconnected_TransmitFileOptionDisconnect(SocketImplementationType type)
         {
             SendPackets(type, new SendPacketsElement(new byte[10], 4, 4), TransmitFileOptions.Disconnect, 4);
@@ -292,7 +265,6 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
-        [PlatformSpecific(TestPlatforms.Windows)]  // SendPacketAsync not supported on Unix
         public void SocketDisconnectedAndReusable_TransmitFileOptionReuseSocket(SocketImplementationType type)
         {
             SendPackets(type, new SendPacketsElement(new byte[10], 4, 4), TransmitFileOptions.Disconnect | TransmitFileOptions.ReuseSocket, 4);
@@ -304,7 +276,6 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
-        [PlatformSpecific(TestPlatforms.Windows)]  // SendPacketAsync not supported on Unix
         public void SendPacketsElement_EmptyFileName_Throws(SocketImplementationType type)
         {
             Assert.Throws<ArgumentException>(() =>
@@ -316,7 +287,7 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
-        [PlatformSpecific(TestPlatforms.Windows)]  // SendPacketAsync not supported on Unix
+        [PlatformSpecific(TestPlatforms.Windows)] // whitespace-only is a valid name on Unix
         public void SendPacketsElement_BlankFileName_Throws(SocketImplementationType type)
         {
             Assert.Throws<ArgumentException>(() =>
@@ -329,7 +300,7 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
-        [PlatformSpecific(TestPlatforms.Windows)]  // SendPacketAsync not supported on Unix
+        [PlatformSpecific(TestPlatforms.Windows)] // valid filename chars on Unix
         public void SendPacketsElement_BadCharactersFileName_Throws(SocketImplementationType type)
         {
             Assert.Throws<ArgumentException>(() =>
@@ -342,7 +313,6 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
-        [PlatformSpecific(TestPlatforms.Windows)]  // SendPacketAsync not supported on Unix
         public void SendPacketsElement_MissingDirectoryName_Throws(SocketImplementationType type)
         {
             Assert.Throws<DirectoryNotFoundException>(() =>
@@ -355,7 +325,6 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
-        [PlatformSpecific(TestPlatforms.Windows)]  // SendPacketAsync not supported on Unix
         public void SendPacketsElement_MissingFile_Throws(SocketImplementationType type)
         {
             Assert.Throws<FileNotFoundException>(() =>
@@ -368,7 +337,6 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
-        [PlatformSpecific(TestPlatforms.Windows)]  // SendPacketAsync not supported on Unix
         public void SendPacketsElement_File_Success(SocketImplementationType type)
         {
             SendPackets(type, new SendPacketsElement(TestFileName), s_testFileSize); // Whole File
@@ -377,7 +345,6 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
-        [PlatformSpecific(TestPlatforms.Windows)]  // SendPacketAsync not supported on Unix
         public void SendPacketsElement_FileZeroCount_Success(SocketImplementationType type)
         {
             SendPackets(type, new SendPacketsElement(TestFileName, 0, 0), s_testFileSize);  // Whole File
@@ -386,7 +353,6 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
-        [PlatformSpecific(TestPlatforms.Windows)]  // SendPacketAsync not supported on Unix
         public void SendPacketsElement_FilePart_Success(SocketImplementationType type)
         {
             SendPackets(type, new SendPacketsElement(TestFileName, 10, 20), 20);
@@ -395,7 +361,6 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
-        [PlatformSpecific(TestPlatforms.Windows)]  // SendPacketAsync not supported on Unix
         public void SendPacketsElement_FileMultiPart_Success(SocketImplementationType type)
         {
             SendPacketsElement[] elements = new SendPacketsElement[]
@@ -410,7 +375,6 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
-        [PlatformSpecific(TestPlatforms.Windows)]  // SendPacketAsync not supported on Unix
         public void SendPacketsElement_FileLargeOffset_Throws(SocketImplementationType type)
         {
             // Length is validated on Send
@@ -420,7 +384,6 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
-        [PlatformSpecific(TestPlatforms.Windows)]  // SendPacketAsync not supported on Unix
         public void SendPacketsElement_FileLargeCount_Throws(SocketImplementationType type)
         {
             // Length is validated on Send


### PR DESCRIPTION
There's no built-in API equivalent to this on Unix, so we just approximate it with a basic implementation on top of other Socket functionality.

Fixes https://github.com/dotnet/corefx/issues/4007
cc: @geoffkizer, @Priya91, @cipop