### PR TITLE
Fix error handling in SendFile{Async} on Unix

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,13 +13,19 @@ namespace System.Net.Sockets.Tests
 {
     public class SendFileTest
     {
-        public static readonly object[][] SendFile_MemberData = new object[][]
+        public static IEnumerable<object[]> SendFile_MemberData()
         {
-            new object[] { IPAddress.IPv6Loopback, true },
-            new object[] { IPAddress.IPv6Loopback, false },
-            new object[] { IPAddress.Loopback, true },
-            new object[] { IPAddress.Loopback, false },
-        };
+            foreach (IPAddress listenAt in new[] { IPAddress.Loopback, IPAddress.IPv6Loopback })
+            {
+                foreach (bool sendPreAndPostBuffers in new[] { true, false })
+                {
+                    foreach (int bytesToSend in new[] { 1024, 12345678 })
+                    {
+                        yield return new object[] { listenAt, sendPreAndPostBuffers, bytesToSend };
+                    }
+                }
+            }
+        }
 
         private string CreateFileToSend(int size, bool sendPreAndPostBuffers, out byte[] preBuffer, out byte[] postBuffer, out Fletcher32 checksum)
         {
@@ -91,9 +98,8 @@ namespace System.Net.Sockets.Tests
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(SendFile_MemberData))]
-        private void SendFile_Synchronous(IPAddress listenAt, bool sendPreAndPostBuffers)
+        public void SendFile_Synchronous(IPAddress listenAt, bool sendPreAndPostBuffers, int bytesToSend)
         {
-            const int BytesToSend = 123456;
             const int ListenBacklog = 1;
             const int LingerTime = 10;
             const int TestTimeout = 30000;
@@ -102,7 +108,7 @@ namespace System.Net.Sockets.Tests
             byte[] preBuffer;
             byte[] postBuffer;
             Fletcher32 sentChecksum;
-            string filename = CreateFileToSend(BytesToSend, sendPreAndPostBuffers, out preBuffer, out postBuffer, out sentChecksum);
+            string filename = CreateFileToSend(bytesToSend, sendPreAndPostBuffers, out preBuffer, out postBuffer, out sentChecksum);
 
             // Start server
             var server = new Socket(listenAt.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
@@ -152,7 +158,7 @@ namespace System.Net.Sockets.Tests
 
             Assert.True(serverThread.Join(TestTimeout), "Completed within allowed time");
 
-            Assert.Equal(BytesToSend, bytesReceived);
+            Assert.Equal(bytesToSend, bytesReceived);
             Assert.Equal(sentChecksum.Sum, receivedChecksum.Sum);
 
             // Clean up the file we created
@@ -162,9 +168,8 @@ namespace System.Net.Sockets.Tests
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(SendFile_MemberData))]
-        private void SendFile_APM(IPAddress listenAt, bool sendPreAndPostBuffers)
+        public void SendFile_APM(IPAddress listenAt, bool sendPreAndPostBuffers, int bytesToSend)
         {
-            const int BytesToSend = 123456;
             const int ListenBacklog = 1;
             const int LingerTime = 10;
             const int TestTimeout = 30000;
@@ -173,7 +178,7 @@ namespace System.Net.Sockets.Tests
             byte[] preBuffer;
             byte[] postBuffer;
             Fletcher32 sentChecksum;
-            string filename = CreateFileToSend(BytesToSend, sendPreAndPostBuffers, out preBuffer, out postBuffer, out sentChecksum);
+            string filename = CreateFileToSend(bytesToSend, sendPreAndPostBuffers, out preBuffer, out postBuffer, out sentChecksum);
 
             // Start server
             var server = new Socket(listenAt.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
@@ -221,18 +226,29 @@ namespace System.Net.Sockets.Tests
             EndPoint clientEndpoint = server.LocalEndPoint;
             var client = new Socket(clientEndpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 
+            var clientFinished = new TaskCompletionSource<bool>();
             client.ConnectAPM(clientEndpoint, () =>
             {
-                client.SendFileAPM(filename, preBuffer, postBuffer, TransmitFileOptions.UseDefaultWorkerThread, () =>
+                client.SendFileAPM(filename, preBuffer, postBuffer, TransmitFileOptions.UseDefaultWorkerThread, ex =>
                 {
                     client.LingerState = new LingerOption(true, LingerTime);
                     client.Dispose();
+
+                    if (ex != null)
+                    {
+                        clientFinished.SetException(ex);
+                    }
+                    else
+                    {
+                        clientFinished.SetResult(true);
+                    }
                 });
             });
 
+            Assert.True(clientFinished.Task.Wait(TestTimeout), "Completed within allowed time");
             Assert.True(serverFinished.Task.Wait(TestTimeout), "Completed within allowed time");
 
-            Assert.Equal(BytesToSend, bytesReceived);
+            Assert.Equal(bytesToSend, bytesReceived);
             Assert.Equal(sentChecksum.Sum, receivedChecksum.Sum);
 
             // Clean up the file we created

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
@@ -13,16 +13,17 @@ namespace System.Net.Sockets.Tests
 {
     public class SendFileTest
     {
-        public static IEnumerable<object[]> SendFile_MemberData()
+        public static IEnumerable<object[]> SendFile_MemberData_Small() => SendFile_MemberData(1024);
+
+        public static IEnumerable<object[]> SendFile_MemberData_Large() => SendFile_MemberData(12345678);
+
+        public static IEnumerable<object[]> SendFile_MemberData(int bytesToSend)
         {
             foreach (IPAddress listenAt in new[] { IPAddress.Loopback, IPAddress.IPv6Loopback })
             {
                 foreach (bool sendPreAndPostBuffers in new[] { true, false })
                 {
-                    foreach (int bytesToSend in new[] { 1024, 12345678 })
-                    {
-                        yield return new object[] { listenAt, sendPreAndPostBuffers, bytesToSend };
-                    }
+                    yield return new object[] { listenAt, sendPreAndPostBuffers, bytesToSend };
                 }
             }
         }
@@ -97,7 +98,8 @@ namespace System.Net.Sockets.Tests
 
         [OuterLoop] // TODO: Issue #11345
         [Theory]
-        [MemberData(nameof(SendFile_MemberData))]
+        [MemberData(nameof(SendFile_MemberData_Small))]
+        [MemberData(nameof(SendFile_MemberData_Large))]
         public void SendFile_Synchronous(IPAddress listenAt, bool sendPreAndPostBuffers, int bytesToSend)
         {
             const int ListenBacklog = 1;
@@ -167,7 +169,14 @@ namespace System.Net.Sockets.Tests
 
         [OuterLoop] // TODO: Issue #11345
         [Theory]
-        [MemberData(nameof(SendFile_MemberData))]
+        [MemberData(nameof(SendFile_MemberData_Large))]
+        [ActiveIssue(17188, TestPlatforms.OSX)] // recombine into SendFile_APM once fixed
+        public void SendFile_APM_Large(IPAddress listenAt, bool sendPreAndPostBuffers, int bytesToSend) =>
+            SendFile_APM(listenAt, sendPreAndPostBuffers, bytesToSend);
+
+        [OuterLoop] // TODO: Issue #11345
+        [Theory]
+        [MemberData(nameof(SendFile_MemberData_Small))]
         public void SendFile_APM(IPAddress listenAt, bool sendPreAndPostBuffers, int bytesToSend)
         {
             const int ListenBacklog = 1;

--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketAPMExtensions.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketAPMExtensions.cs
@@ -29,12 +29,17 @@ namespace System.Net.Sockets.Tests
             socket.BeginReceive(buffer, offset, count, flags, callback, socket);
         }
 
-        public static void SendFileAPM(this Socket socket, string filename, byte[] preBuffer, byte[] postBuffer, TransmitFileOptions flags, Action handler)
+        public static void SendFileAPM(this Socket socket, string filename, byte[] preBuffer, byte[] postBuffer, TransmitFileOptions flags, Action<Exception> handler)
         {
             var callback = new AsyncCallback(asyncResult =>
             {
-                ((Socket)asyncResult.AsyncState).EndSendFile(asyncResult);
-                handler();
+                Exception exc = null;
+                try
+                {
+                    ((Socket)asyncResult.AsyncState).EndSendFile(asyncResult);
+                }
+                catch (Exception e) { exc = e; }
+                handler(exc);
             });
             socket.BeginSendFile(filename, preBuffer, postBuffer, flags, callback, socket);
         }


### PR DESCRIPTION
- If Begin/EndSendFile actually resulted in asynchronous handling (none of the current test inputs were causing that to happen), the operation would fail because it would treat IOPending as an error and throw a SocketException for it.
- The callback is checking/storing the wrong error, using the closed over errorCode instead of the passed in socketError.
- If an error did get handled by the callback, it would complete the tcs with an exception and then try to complete it again with a result, which would result in an exception getting thrown as the task would already be completed.

cc: @geoffkizer, @Priya91 