### PR TITLE
Consolidate Data Source Parsing in SNI

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
@@ -508,7 +508,7 @@ namespace System.Data.SqlClient.SNI
                 SNICommon.ReportSNIError(SNIProviders.NP_PROV, 0, SNICommon.MultiSubnetFailoverWithNonTcpProtocol, string.Empty);
                 return null;
             }
-            return new SNINpHandle(details.ServerName, pipeName, timerExpire, callbackObject);
+            return new SNINpHandle(details.ServerName, details.PipeName, timerExpire, callbackObject);
         }
 
         /// <summary>

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
@@ -325,7 +325,7 @@ namespace System.Data.SqlClient.SNI
 
             return sniHandle;
         }
-        
+
         private static byte[] MakeMsSqlServerSPN(string fullyQualifiedDomainName, int port = DefaultSqlServerPort)
         {
             string serverSpn = SqlServerSpnHeader + "/" + fullyQualifiedDomainName + ":" + port;
@@ -368,9 +368,7 @@ namespace System.Data.SqlClient.SNI
                     return null;
                 }
             }
-
             
-
             if (hostName != null && port > 0 && isIntegratedSecurity)
             {
                 try
@@ -385,13 +383,9 @@ namespace System.Data.SqlClient.SNI
                 }
             }
 
-            SNITCPHandle sniTcpHandle = null;
-            if (hostName != null && port > 0)
-            {
-                sniTcpHandle = new SNITCPHandle(hostName, port, timerExpire, callbackObject, parallel);
-            }
+            return (hostName != null && port > 0) ?
+                 new SNITCPHandle(hostName, port, timerExpire, callbackObject, parallel) : null;
             
-            return sniTcpHandle;
         }
 
         /// <summary>
@@ -613,7 +607,7 @@ namespace System.Data.SqlClient.SNI
 
             PopulateProtocol();
 
-            _dataSourceAfterTrimmingProtocol = (firstIndexOfColon >= -1) && ConnectionProtocol != DataSource.Protocol.None
+            _dataSourceAfterTrimmingProtocol = (firstIndexOfColon > -1) && ConnectionProtocol != DataSource.Protocol.None
                 ? _workingDataSource.Substring(firstIndexOfColon + 1).Trim() : _workingDataSource;
 
             if (_dataSourceAfterTrimmingProtocol.Contains("/")) // Pipe paths only allow back slashes

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
@@ -508,7 +508,6 @@ namespace System.Data.SqlClient.SNI
                 SNICommon.ReportSNIError(SNIProviders.NP_PROV, 0, SNICommon.MultiSubnetFailoverWithNonTcpProtocol, string.Empty);
                 return null;
             }
-            string pipeName = string.IsNullOrEmpty(details.PipeName) ? SNINpHandle.DefaultPipePath : details.PipeName;
             return new SNINpHandle(details.ServerName, pipeName, timerExpire, callbackObject);
         }
 
@@ -681,11 +680,6 @@ namespace System.Data.SqlClient.SNI
                 return null;
             }
 
-            if (!details.InferLocalServerName() && details.IsBadDataSource)
-            {
-                return null;
-            }
-
             return details;
         }
 
@@ -767,6 +761,9 @@ namespace System.Data.SqlClient.SNI
                     return ReportSNIError(SNIProviders.INVALID_PROV);
                 }
             }
+
+            InferLocalServerName();
+            
             return true;
         }
 
@@ -787,7 +784,7 @@ namespace System.Data.SqlClient.SNI
                 if (!_dataSourceAfterTrimmingProtocol.Contains(BackSlashSeparator))
                 {
                     ServerName = _dataSourceAfterTrimmingProtocol;
-                    ServerName = IsLocalHost(_dataSourceAfterTrimmingProtocol) ? Environment.MachineName : _dataSourceAfterTrimmingProtocol;
+                    InferLocalServerName();
                     PipeName = SNINpHandle.DefaultPipePath;
                     return true;
                 }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
@@ -355,20 +355,20 @@ namespace System.Data.SqlClient.SNI
             string hostName = details.ServerName;
             int port = details.Port;
 
-            if(port == -1)
+            if (port == -1)
             {
                 try
                 {
                     port = string.IsNullOrEmpty(details.InstanceName) ? DefaultSqlServerPort : GetPortByInstanceName(hostName, details.InstanceName);
                 }
                 // The GetPortByInstanceName can throw a SocketException
-                catch(SocketException se)
+                catch (SocketException se)
                 {
                     SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.TCP_PROV, SNICommon.InvalidConnStringError, se);
                     return null;
                 }
             }
-            
+
             if (hostName != null && port > 0 && isIntegratedSecurity)
             {
                 try
@@ -385,7 +385,6 @@ namespace System.Data.SqlClient.SNI
 
             return (hostName != null && port > 0) ?
                  new SNITCPHandle(hostName, port, timerExpire, callbackObject, parallel) : null;
-            
         }
 
         /// <summary>
@@ -702,10 +701,8 @@ namespace System.Data.SqlClient.SNI
             // If Comma exists, the try to get the port number
             if (commaIndex > -1)
             {
-                bool commaAfterSlash = commaIndex > backSlashIndex ? true : false;
-
                 string parameter = backSlashIndex > -1
-                        ? commaIndex > backSlashIndex ? tokensByCommaAndSlash[2].Trim() : tokensByCommaAndSlash[1].Trim()
+                        ? ((commaIndex > backSlashIndex) ? tokensByCommaAndSlash[2].Trim() : tokensByCommaAndSlash[1].Trim())
                         : tokensByCommaAndSlash[1].Trim();
 
                 // Bad Data Source like "server, "
@@ -822,7 +819,7 @@ namespace System.Data.SqlClient.SNI
         }
 
         private static bool IsLocalHost(string serverName)
-            => serverName.CompareTo(".") == 0 || serverName.CompareTo("(local)") == 0 || serverName.CompareTo("localhost") == 0;
+            => ".".Equals(serverName) || "(local)".Equals(serverName) || "localhost".Equals(serverName);
 
     }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
@@ -660,7 +660,7 @@ namespace System.Data.SqlClient.SNI
                 return null;
             }
 
-            if (details.InferNamedPipesInformation() && !details.IsBadDataSource)
+            if (details.InferNamedPipesInformation())
             {
                 return details;
             }
@@ -670,12 +670,12 @@ namespace System.Data.SqlClient.SNI
                 return null;
             }
 
-            if (!details.InferConnectionDetails() && details.IsBadDataSource)
+            if (details.InferConnectionDetails())
             {
-                return null;
+                return details;
             }
 
-            return details;
+            return null;
         }
 
         private bool InferLocalServerName()

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
@@ -742,7 +742,7 @@ namespace System.Data.SqlClient.SNI
                     return ReportSNIError(SNIProviders.INVALID_PROV);
                 }
 
-                if (DefaultSqlServerInstanceName.CompareTo(InstanceName) == 0)
+                if (DefaultSqlServerInstanceName.Equals(InstanceName))
                 {
                     return ReportSNIError(SNIProviders.INVALID_PROV);
                 }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
@@ -802,8 +802,9 @@ namespace System.Data.SqlClient.SNI
                         return false;
                     }
 
-                    // There should be 4 parts in the pipename e.g /pipe/sql/query [0]/[1]/[2]/[3]
-                    if (absolutePathParts.Length != 4)
+                    // There should be at least 4 parts in the pipename e.g /pipe/sql/query [0]/[1]/[2]/[3]
+                    // Another valid Sql named pipe for an named instance is \\.\pipe\MSSQL$MYINSTANCE\sql\query
+                    if (absolutePathParts.Length < 4)
                     {
                         ReportSNIError(SNIProviders.NP_PROV);
                         return false;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsEnums.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsEnums.cs
@@ -38,6 +38,7 @@ namespace System.Data.SqlClient
         public const string SPX = "spx";
         public const string VIA = "via";
         public const string LPC = "lpc";
+        public const string ADMIN = "admin";
 
         // network function string constants
         public const string INIT_SSPI_PACKAGE = "InitSSPIPackage";

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlNamedPipesTest/SqlNamedPipesTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlNamedPipesTest/SqlNamedPipesTest.cs
@@ -69,10 +69,6 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             // Nothing but slashes
             builder.DataSource = @"np:\\\\\";
             OpenBadConnection<SqlException>(builder.ConnectionString, invalidConnStringError);
-
-            // Empty string
-            builder.DataSource = "np:";
-            OpenBadConnection<SqlException>(builder.ConnectionString, invalidConnStringError);
         }
 #endif
 

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlNamedPipesTest/SqlNamedPipesTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlNamedPipesTest/SqlNamedPipesTest.cs
@@ -99,8 +99,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                 {
                     throw new InvalidOperationException("Connection string did not contain expected NP token in Server Name string!");
                 }
-
-                return (new Uri(dataSource.Substring(colonIndex + 1))).Host;
+                return dataSource.Contains(@"\") ? (new Uri(dataSource.Substring(colonIndex + 1))).Host : dataSource.Substring(colonIndex+1);
             }
             else
             {


### PR DESCRIPTION
The changes consolidate and move the data source parsing login for SNI into a single class. 
I looked into the native sni parsing and brought in some extra capabilities like connecting to `np:` `(local)` etc.

This also adds capability to handle the admin protocol used to connect to DAC in data source. The connectivity logic for DAC connectivity still needs to be worked out. 

Fixes https://github.com/dotnet/corefx/issues/16125 
