### PR TITLE
Improve NetworkStream.WriteAsync synchronous caching

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/NetworkStream.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/NetworkStream.cs
@@ -686,7 +686,7 @@ namespace System.Net.Sockets
                 return _streamSocket.ReceiveAsync(
                     new ArraySegment<byte>(buffer, offset, size),
                     SocketFlags.None,
-                    wrapExceptionsInIOExceptions: true);
+                    fromNetworkStream: true);
             }
             catch (Exception exception) when (!(exception is OutOfMemoryException))
             {
@@ -747,7 +747,7 @@ namespace System.Net.Sockets
                 return _streamSocket.SendAsync(
                     new ArraySegment<byte>(buffer, offset, size),
                     SocketFlags.None,
-                    wrapExceptionsInIOExceptions: true);
+                    fromNetworkStream: true);
             }
             catch (Exception exception) when (!(exception is OutOfMemoryException))
             {

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketTaskExtensions.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketTaskExtensions.cs
@@ -10,7 +10,7 @@ namespace System.Net.Sockets
     public static class SocketTaskExtensions
     {
         public static Task<Socket> AcceptAsync(this Socket socket) =>
-            socket.AcceptAsync();
+            socket.AcceptAsync((Socket)null);
         public static Task<Socket> AcceptAsync(this Socket socket, Socket acceptSocket) =>
             socket.AcceptAsync(acceptSocket);
 
@@ -24,7 +24,7 @@ namespace System.Net.Sockets
             socket.ConnectAsync(host, port);
 
         public static Task<int> ReceiveAsync(this Socket socket, ArraySegment<byte> buffer, SocketFlags socketFlags) =>
-            socket.ReceiveAsync(buffer, socketFlags, wrapExceptionsInIOExceptions: false);
+            socket.ReceiveAsync(buffer, socketFlags, fromNetworkStream: false);
         public static Task<int> ReceiveAsync(this Socket socket, IList<ArraySegment<byte>> buffers, SocketFlags socketFlags) =>
             socket.ReceiveAsync(buffers, socketFlags);
         public static Task<SocketReceiveFromResult> ReceiveFromAsync(this Socket socket, ArraySegment<byte> buffer, SocketFlags socketFlags, EndPoint remoteEndPoint) =>
@@ -33,7 +33,7 @@ namespace System.Net.Sockets
             socket.ReceiveMessageFromAsync(buffer, socketFlags, remoteEndPoint);
 
         public static Task<int> SendAsync(this Socket socket, ArraySegment<byte> buffer, SocketFlags socketFlags) =>
-            socket.SendAsync(buffer, socketFlags, wrapExceptionsInIOExceptions: false);
+            socket.SendAsync(buffer, socketFlags, fromNetworkStream: false);
         public static Task<int> SendAsync(this Socket socket, IList<ArraySegment<byte>> buffers, SocketFlags socketFlags) =>
             socket.SendAsync(buffers, socketFlags);
         public static Task<int> SendToAsync(this Socket socket, ArraySegment<byte> buffer, SocketFlags socketFlags, EndPoint remoteEP) =>


### PR DESCRIPTION
Socket.SendAsync caches the last successfully completed task and returns that same task on subsequent writes if the same number of bytes were written.  NetworkStream.WriteAsync then just delegates to SendAsync.  But WriteAsync returns a non-generic task, and doesn't actually care or surface the result value, which means we can effectively use any task, regardless of its value, and can thus use a single cached task for all synchronous completions, regardless of how much data is written.  With this change, then, the common-case of synchronously completing NetworkStream.WriteAsync calls don't allocate (amortized).

cc: @geoffkizer, @cipop, @Priya91 