### PR TITLE
Fix TFM exclusions for UAP

### DIFF
--- a/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -129,7 +129,7 @@ namespace System.Net.Mail.Tests
             }
         }
 
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp | TargetFrameworkMonikers.Uap)]
         [Fact]
         public void ServicePoint_NetFramework_AddressIsInaccessible()
         {

--- a/src/System.Private.Xml/tests/XmlDocument/XmlAttributeCollectionTests/InsertAfterTests.cs
+++ b/src/System.Private.Xml/tests/XmlDocument/XmlAttributeCollectionTests/InsertAfterTests.cs
@@ -231,7 +231,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp | TargetFrameworkMonikers.Uap)]
         public void InsertAfterThrowsArgumentOutOfRangeExceptionForDupRefAttrAtTheEnd_OldBehavior()
         {
             const string attributeName = "existingAttr";
@@ -276,7 +276,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp | TargetFrameworkMonikers.Uap)]
         public void InsertAfterDoesNotReplaceDupRefAttr_OldBehavior()
         {
             const string attributeName = "existingAttr";

--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -1650,7 +1650,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Join_ObjectArray_TestData))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp | TargetFrameworkMonikers.Uap)]
         public static void Join_ObjectArray_WithNullIssue(string separator, object[] values, string expected)
         {
             string enumerableExpected = expected;


### PR DESCRIPTION
These cases are showing up as failures in the new UAP runs. Generally we expect UAP behavior to match netcoreapp, including in these cases. This leaves no remaining instances of 
`[SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp)]` in our code.

Right now TFM is defined like this
```
    public enum TargetFrameworkMonikers
    { ...
        NetFramework = 0x800,
        Netcoreapp = 0x1000,
        Uap = 0x2000,
        UapAot = 0x4000,
```
and these map 1:1 to the XUnit traits passed to the runs:
```
        internal static string NonNetfxTest = "nonnetfxtests";
        internal static string NonUapTest = "nonuaptests";
        internal static string NonUapAotTest = "nonuapaottests";
        internal static string NonNetcoreappTest = "nonnetcoreapptests";
```

We ought to have a TFM for "netcoreapp and uapXX". 
Also we also ought to consider making TFM.Uap automatically imply UapAot. I'll open an issue for both.

@AlexGhiondea 
