### PR TITLE
Re-disable failing Net.Security test

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -17,6 +17,7 @@ namespace System.Net.Security.Tests
     public class SslStreamNetworkStreamTest
     {
         [Fact]
+        [ActiveIssue(16516, TestPlatforms.Windows)]
         public async Task SslStream_SendReceiveOverNetworkStream_Ok()
         {
             TcpListener listener = new TcpListener(IPAddress.Loopback, 0);


### PR DESCRIPTION
Test was enabled in #16877 

affects https://github.com/dotnet/corefx/issues/16516