### PR TITLE
Fix Managed SNI Integrated Auth

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
@@ -5938,7 +5938,7 @@ namespace System.Data.SqlClient
                     Debug.Assert(SniContext.Snix_Login == _physicalStateObj.SniContext, String.Format((IFormatProvider)null, "Unexpected SniContext. Expecting Snix_Login, actual value is '{0}'", _physicalStateObj.SniContext));
                     _physicalStateObj.SniContext = SniContext.Snix_LoginSspi;
 
-                    SSPIData(null, 0, outSSPIBuff, ref outSSPILength);
+                    SSPIData(null, 0, ref outSSPIBuff, ref outSSPILength);
                     if (TdsParserStateObjectFactory.UseManagedSNI)
                     {
                         outSSPILength = outSSPIBuff != null ? (uint)outSSPIBuff.Length : 0;
@@ -6196,19 +6196,19 @@ namespace System.Data.SqlClient
             _physicalStateObj._messageStatus = 0;
         }// tdsLogin
 
-        private void SSPIData(byte[] receivedBuff, UInt32 receivedLength, byte[] sendBuff, ref UInt32 sendLength)
+        private void SSPIData(byte[] receivedBuff, UInt32 receivedLength, ref byte[] sendBuff, ref UInt32 sendLength)
         {
-            SNISSPIData(receivedBuff, receivedLength, sendBuff, ref sendLength);
+            SNISSPIData(receivedBuff, receivedLength, ref sendBuff, ref sendLength);
         }
 
 
-        private void SNISSPIData(byte[] receivedBuff, UInt32 receivedLength, byte[] sendBuff, ref UInt32 sendLength)
+        private void SNISSPIData(byte[] receivedBuff, UInt32 receivedLength, ref byte[] sendBuff, ref UInt32 sendLength)
         {
             if (TdsParserStateObjectFactory.UseManagedSNI)
             {
                 try
                 {
-                    _physicalStateObj.GenerateSspiClientContext(receivedBuff, receivedLength, sendBuff, ref sendLength, _sniSpnBuffer);
+                    _physicalStateObj.GenerateSspiClientContext(receivedBuff, receivedLength, ref sendBuff, ref sendLength, _sniSpnBuffer);
                 }
                 catch (Exception e)
                 {
@@ -6224,7 +6224,7 @@ namespace System.Data.SqlClient
                 }
 
                 // we need to respond to the server's message with SSPI data
-                if (0 != _physicalStateObj.GenerateSspiClientContext(receivedBuff, receivedLength, sendBuff, ref sendLength, _sniSpnBuffer))
+                if (0 != _physicalStateObj.GenerateSspiClientContext(receivedBuff, receivedLength, ref sendBuff, ref sendLength, _sniSpnBuffer))
                 {
                     SSPIError(SQLMessage.SSPIGenerateError(), TdsEnums.GEN_CLIENT_CONTEXT);
                 }
@@ -6249,7 +6249,7 @@ namespace System.Data.SqlClient
 
             // make call for SSPI data
 
-            SSPIData(receivedBuff, (UInt32)receivedLength, sendBuff, ref sendLength);
+            SSPIData(receivedBuff, (UInt32)receivedLength, ref sendBuff, ref sendLength);
 
             // DO NOT SEND LENGTH - TDS DOC INCORRECT!  JUST SEND SSPI DATA!
             _physicalStateObj.WriteByteArray(sendBuff, (int)sendLength, 0);

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObject.cs
@@ -774,7 +774,7 @@ namespace System.Data.SqlClient
 
         protected abstract void RemovePacketFromPendingList(object pointer);
 
-        internal abstract uint GenerateSspiClientContext(byte[] receivedBuff, uint receivedLength, byte[] sendBuff, ref uint sendLength, byte[] _sniSpnBuffer);
+        internal abstract uint GenerateSspiClientContext(byte[] receivedBuff, uint receivedLength, ref byte[] sendBuff, ref uint sendLength, byte[] _sniSpnBuffer);
 
         internal bool Deactivate()
         {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectManaged.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectManaged.cs
@@ -224,7 +224,7 @@ namespace System.Data.SqlClient.SNI
 
         internal override uint SetConnectionBufferSize(ref uint unsignedPacketSize) => SNIProxy.Singleton.SetConnectionBufferSize(Handle, unsignedPacketSize);
 
-        internal override uint GenerateSspiClientContext(byte[] receivedBuff, uint receivedLength, byte[] sendBuff, ref uint sendLength, byte[] _sniSpnBuffer)
+        internal override uint GenerateSspiClientContext(byte[] receivedBuff, uint receivedLength, ref byte[] sendBuff, ref uint sendLength, byte[] _sniSpnBuffer)
         {
             SNIProxy.Singleton.GenSspiClientContext(sspiClientContextStatus, receivedBuff, ref sendBuff, _sniSpnBuffer);
             return 0;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectNative.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectNative.cs
@@ -277,7 +277,7 @@ namespace System.Data.SqlClient
         internal override uint SetConnectionBufferSize(ref uint unsignedPacketSize) 
             => SNINativeMethodWrapper.SNISetInfo(Handle, SNINativeMethodWrapper.QTypes.SNI_QUERY_CONN_BUFSIZE, ref unsignedPacketSize);
 
-        internal override uint GenerateSspiClientContext(byte[] receivedBuff, uint receivedLength, byte[] sendBuff, ref uint sendLength, byte[] _sniSpnBuffer) 
+        internal override uint GenerateSspiClientContext(byte[] receivedBuff, uint receivedLength, ref byte[] sendBuff, ref uint sendLength, byte[] _sniSpnBuffer) 
             => SNINativeMethodWrapper.SNISecGenClientContext(Handle, receivedBuff, receivedLength, sendBuff, ref sendLength, _sniSpnBuffer);
         
 


### PR DESCRIPTION
Adding the sspi buffer pass by ref so that the retrieved value for buffer gets propagated all the way up.
 This is needed by Managed SNI. In case of Native SNI, the native call doesn't need a pass by ref to the native layer. 

The tests which are now passing after this change are in `System.Data.SqlClient.ManualTesting.Tests.IntegratedAuthenticationTest`
These tests were failing earlier. 

cc @geleems 