### PR TITLE
Reduce AcceptAsync allocations by 20% for IPv4/6

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -3730,7 +3730,7 @@ namespace System.Net.Sockets
 
             if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"AcceptSocket:{acceptSocket}");
 
-            int socketAddressSize = _rightEndPoint.Serialize().Size;
+            int socketAddressSize = GetAddressSize(_rightEndPoint);
             SocketError errorCode = SocketPal.AcceptAsync(this, _handle, acceptHandle, receiveSize, socketAddressSize, asyncResult);
 
             if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Interop.Winsock.AcceptEx returns:{errorCode} {asyncResult}");
@@ -4470,6 +4470,15 @@ namespace System.Net.Sockets
             bool isIPv4MappedToIPv6 = socketAddress.Family == AddressFamily.InterNetworkV6 && socketAddress.GetIPAddress().IsIPv4MappedToIPv6;
             isIPv4 = addressFamily == AddressFamily.InterNetwork || isIPv4MappedToIPv6; // DualMode
             isIPv6 = addressFamily == AddressFamily.InterNetworkV6;
+        }
+
+        internal static int GetAddressSize(EndPoint endPoint)
+        {
+            AddressFamily fam = endPoint.AddressFamily;
+            return
+                fam == AddressFamily.InterNetwork ? SocketAddressPal.IPv4AddressSize :
+                fam == AddressFamily.InterNetworkV6 ? SocketAddressPal.IPv6AddressSize :
+                endPoint.Serialize().Size;
         }
 
         private Internals.SocketAddress SnapshotAndSerialize(ref EndPoint remoteEP)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
@@ -469,14 +469,10 @@ namespace System.Net.Sockets
             // Remember the operation type.
             _completedOperation = SocketAsyncOperation.Accept;
 
-            // AcceptEx needs a single buffer with room for two special sockaddr data structures.
-            // It can also take additional buffer space in front of those special sockaddr 
-            // structures that can be filled in with initial data coming in on a connection.
-
-            // First calculate the special AcceptEx address buffer size.
-            // It is the size of two native sockaddr buffers with 16 extra bytes each.
-            // The native sockaddr buffers vary by address family so must reference the current socket.
-            _acceptAddressBufferCount = 2 * (_currentSocket._rightEndPoint.Serialize().Size + 16);
+            // AcceptEx needs a single buffer that's the size of two native sockaddr buffers with 16
+            // extra bytes each. It can also take additional buffer space in front of those special
+            // sockaddr structures that can be filled in with initial data coming in on a connection.
+            _acceptAddressBufferCount = 2 * (Socket.GetAddressSize(_currentSocket._rightEndPoint) + 16);
 
             // If our caller specified a buffer (willing to get received data with the Accept) then
             // it needs to be large enough for the two special sockaddr buffers that AcceptEx requires.


### PR DESCRIPTION
Every AcceptAsync with a SocketAsyncEventArgs ends up calculating the buffer size necessary to store the address (either to create a buffer if one wasn't supplied, or to verify that the one supplied is large enough).  To do that, it's currently serializing the EndPoint into a SocketAddress, which entails allocating both a SocketAddress and the byte[] that backs it.  But for IPv4 and IPv6, the two most common families, we know the address size in advance, and can simply use those values rather than allocating to get them.  If in the future other families become more common, we could cache those dynamically after computing them once.

cc: @geoffkizer, @pgavlin, @KrzysztofCwalina, @cipop, @davidsh