### PR TITLE
Add missing [Browsable(false)] attributes to Drawing primitives

### DIFF
--- a/src/System.Drawing.Primitives/ref/System.Drawing.Primitives.cs
+++ b/src/System.Drawing.Primitives/ref/System.Drawing.Primitives.cs
@@ -362,6 +362,7 @@ namespace System.Drawing
         public Point(System.Drawing.Size sz) { throw null; }
         public Point(int dw) { throw null; }
         public Point(int x, int y) { throw null; }
+        [System.ComponentModel.Browsable(false)]
         public bool IsEmpty { get { throw null; } }
         public int X { get { throw null; } set { } }
         public int Y { get { throw null; } set { } }
@@ -387,6 +388,7 @@ namespace System.Drawing
     {
         public static readonly System.Drawing.PointF Empty;
         public PointF(float x, float y) { throw null; }
+        [System.ComponentModel.Browsable(false)]
         public bool IsEmpty { get { throw null; } }
         public float X { get { throw null; } set { } }
         public float Y { get { throw null; } set { } }
@@ -410,13 +412,20 @@ namespace System.Drawing
         public static readonly System.Drawing.Rectangle Empty;
         public Rectangle(System.Drawing.Point location, System.Drawing.Size size) { throw null; }
         public Rectangle(int x, int y, int width, int height) { throw null; }
+        [System.ComponentModel.Browsable(false)]
         public int Bottom { get { throw null; } }
         public int Height { get { throw null; } set { } }
+        [System.ComponentModel.Browsable(false)]
         public bool IsEmpty { get { throw null; } }
+        [System.ComponentModel.Browsable(false)]
         public int Left { get { throw null; } }
+        [System.ComponentModel.Browsable(false)]
         public System.Drawing.Point Location { get { throw null; } set { } }
+        [System.ComponentModel.Browsable(false)]
         public int Right { get { throw null; } }
+        [System.ComponentModel.Browsable(false)]
         public System.Drawing.Size Size { get { throw null; } set { } }
+        [System.ComponentModel.Browsable(false)]
         public int Top { get { throw null; } }
         public int Width { get { throw null; } set { } }
         public int X { get { throw null; } set { } }
@@ -449,13 +458,20 @@ namespace System.Drawing
         public static readonly System.Drawing.RectangleF Empty;
         public RectangleF(System.Drawing.PointF location, System.Drawing.SizeF size) { throw null; }
         public RectangleF(float x, float y, float width, float height) { throw null; }
+        [System.ComponentModel.Browsable(false)]
         public float Bottom { get { throw null; } }
         public float Height { get { throw null; } set { } }
+        [System.ComponentModel.Browsable(false)]
         public bool IsEmpty { get { throw null; } }
+        [System.ComponentModel.Browsable(false)]
         public float Left { get { throw null; } }
+        [System.ComponentModel.Browsable(false)]
         public System.Drawing.PointF Location { get { throw null; } set { } }
+        [System.ComponentModel.Browsable(false)]
         public float Right { get { throw null; } }
+        [System.ComponentModel.Browsable(false)]
         public System.Drawing.SizeF Size { get { throw null; } set { } }
+        [System.ComponentModel.Browsable(false)]
         public float Top { get { throw null; } }
         public float Width { get { throw null; } set { } }
         public float X { get { throw null; } set { } }
@@ -487,6 +503,7 @@ namespace System.Drawing
         public Size(System.Drawing.Point pt) { throw null; }
         public Size(int width, int height) { throw null; }
         public int Height { get { throw null; } set { } }
+        [System.ComponentModel.Browsable(false)]
         public bool IsEmpty { get { throw null; } }
         public int Width { get { throw null; } set { } }
         public static System.Drawing.Size Add(System.Drawing.Size sz1, System.Drawing.Size sz2) { throw null; }
@@ -512,6 +529,7 @@ namespace System.Drawing
         public SizeF(System.Drawing.SizeF size) { throw null; }
         public SizeF(float width, float height) { throw null; }
         public float Height { get { throw null; } set { } }
+        [System.ComponentModel.Browsable(false)]
         public bool IsEmpty { get { throw null; } }
         public float Width { get { throw null; } set { } }
         public static System.Drawing.SizeF Add(System.Drawing.SizeF sz1, System.Drawing.SizeF sz2) { throw null; }

--- a/src/System.Drawing.Primitives/ref/System.Drawing.Primitives.csproj
+++ b/src/System.Drawing.Primitives/ref/System.Drawing.Primitives.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />
+    <ProjectReference Include="..\..\System.ComponentModel.Primitives\ref\System.ComponentModel.Primitives.csproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Drawing.Primitives/src/System.Drawing.Primitives.csproj
+++ b/src/System.Drawing.Primitives/src/System.Drawing.Primitives.csproj
@@ -19,6 +19,7 @@
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />
+    <Reference Include="System.ComponentModel.Primitives" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="System\Drawing\Point.cs" />

--- a/src/System.Drawing.Primitives/src/System/Drawing/Point.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Point.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
 using System.Numerics.Hashing;
 
 namespace System.Drawing
@@ -59,6 +60,7 @@ namespace System.Drawing
         ///       Gets a value indicating whether this <see cref='System.Drawing.Point'/> is empty.
         ///    </para>
         /// </summary>
+        [Browsable(false)]
         public bool IsEmpty => _x == 0 && _y == 0;
 
         /// <summary>

--- a/src/System.Drawing.Primitives/src/System/Drawing/PointF.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/PointF.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
 using System.Numerics.Hashing;
 
 namespace System.Drawing
@@ -40,6 +41,7 @@ namespace System.Drawing
         ///       Gets a value indicating whether this <see cref='System.Drawing.PointF'/> is empty.
         ///    </para>
         /// </summary>
+        [Browsable(false)]
         public bool IsEmpty => _x == 0f && _y == 0f;
 
         /// <summary>

--- a/src/System.Drawing.Primitives/src/System/Drawing/Rectangle.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Rectangle.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
 using System.Diagnostics.Contracts;
 using System.Numerics.Hashing;
 
@@ -63,6 +64,7 @@ namespace System.Drawing
         ///       upper-left corner of the rectangular region represented by this <see cref='System.Drawing.Rectangle'/>.
         ///    </para>
         /// </summary>
+        [Browsable(false)]
         public Point Location
         {
             get { return new Point(X, Y); }
@@ -76,6 +78,7 @@ namespace System.Drawing
         /// <summary>
         ///    Gets or sets the size of this <see cref='System.Drawing.Rectangle'/>.
         /// </summary>
+        [Browsable(false)]
         public Size Size
         {
             get { return new Size(Width, Height); }
@@ -132,6 +135,7 @@ namespace System.Drawing
         ///       rectangular region defined by this <see cref='System.Drawing.Rectangle'/> .
         ///    </para>
         /// </summary>
+        [Browsable(false)]
         public int Left => X;
 
         /// <summary>
@@ -140,6 +144,7 @@ namespace System.Drawing
         ///       rectangular region defined by this <see cref='System.Drawing.Rectangle'/>.
         ///    </para>
         /// </summary>
+        [Browsable(false)]
         public int Top => Y;
 
         /// <summary>
@@ -148,6 +153,7 @@ namespace System.Drawing
         ///       rectangular region defined by this <see cref='System.Drawing.Rectangle'/>.
         ///    </para>
         /// </summary>
+        [Browsable(false)]
         public int Right => unchecked(X + Width);
 
         /// <summary>
@@ -156,6 +162,7 @@ namespace System.Drawing
         ///       rectangular region defined by this <see cref='System.Drawing.Rectangle'/>.
         ///    </para>
         /// </summary>
+        [Browsable(false)]
         public int Bottom => unchecked(Y + Height);
 
         /// <summary>
@@ -164,6 +171,7 @@ namespace System.Drawing
         ///       or a <see cref='System.Drawing.Rectangle.Height'/> of 0.
         ///    </para>
         /// </summary>
+        [Browsable(false)]
         public bool IsEmpty => _height == 0 && _width == 0 && _x == 0 && _y == 0;
 
         /// <summary>

--- a/src/System.Drawing.Primitives/src/System/Drawing/RectangleF.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/RectangleF.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
 using System.Diagnostics.Contracts;
 using System.Numerics.Hashing;
 
@@ -70,6 +71,7 @@ namespace System.Drawing
         ///       the rectangular region represented by this <see cref='System.Drawing.RectangleF'/>.
         ///    </para>
         /// </summary>
+        [Browsable(false)]
         public PointF Location
         {
             get { return new PointF(X, Y); }
@@ -85,6 +87,7 @@ namespace System.Drawing
         ///       Gets or sets the size of this <see cref='System.Drawing.RectangleF'/>.
         ///    </para>
         /// </summary>
+        [Browsable(false)]
         public SizeF Size
         {
             get { return new SizeF(Width, Height); }
@@ -149,6 +152,7 @@ namespace System.Drawing
         ///       rectangular region defined by this <see cref='System.Drawing.RectangleF'/> .
         ///    </para>
         /// </summary>
+        [Browsable(false)]
         public float Left => X;
 
         /// <summary>
@@ -157,6 +161,7 @@ namespace System.Drawing
         ///       rectangular region defined by this <see cref='System.Drawing.RectangleF'/>.
         ///    </para>
         /// </summary>
+        [Browsable(false)]
         public float Top => Y;
 
         /// <summary>
@@ -165,6 +170,7 @@ namespace System.Drawing
         ///       rectangular region defined by this <see cref='System.Drawing.RectangleF'/>.
         ///    </para>
         /// </summary>
+        [Browsable(false)]
         public float Right => X + Width;
 
         /// <summary>
@@ -173,6 +179,7 @@ namespace System.Drawing
         ///       rectangular region defined by this <see cref='System.Drawing.RectangleF'/>.
         ///    </para>
         /// </summary>
+        [Browsable(false)]
         public float Bottom => Y + Height;
 
         /// <summary>
@@ -180,6 +187,7 @@ namespace System.Drawing
         ///       Tests whether this <see cref='System.Drawing.RectangleF'/> has a <see cref='System.Drawing.RectangleF.Width'/> or a <see cref='System.Drawing.RectangleF.Height'/> of 0.
         ///    </para>
         /// </summary>
+        [Browsable(false)]
         public bool IsEmpty => (Width <= 0) || (Height <= 0);
 
         /// <summary>

--- a/src/System.Drawing.Primitives/src/System/Drawing/Size.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Size.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
 using System.Numerics.Hashing;
 
 namespace System.Drawing
@@ -95,6 +96,7 @@ namespace System.Drawing
         ///    Tests whether this <see cref='System.Drawing.Size'/> has zero
         ///    width and height.
         /// </summary>
+        [Browsable(false)]
         public bool IsEmpty => _width == 0 && _height == 0;
 
         /**

--- a/src/System.Drawing.Primitives/src/System/Drawing/SizeF.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/SizeF.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
 using System.Numerics.Hashing;
 
 namespace System.Drawing
@@ -109,6 +110,7 @@ namespace System.Drawing
         ///       width and height.
         ///    </para>
         /// </summary>
+        [Browsable(false)]
         public bool IsEmpty => _width == 0 && _height == 0;
 
         /**


### PR DESCRIPTION
These attributes are present on Desktop .NET but are missing from .NET Core. 

Fixes #17184