### PR TITLE
Reduce memory load of ConcurrentCollections test

### DIFF
--- a/src/System.Collections.Concurrent/tests/ProducerConsumerCollectionTests.cs
+++ b/src/System.Collections.Concurrent/tests/ProducerConsumerCollectionTests.cs
@@ -731,7 +731,8 @@ namespace System.Collections.Concurrent.Tests
         }
 
         [Theory]
-        [InlineData(1000)]
+        [InlineData(3000000)]
+        [OuterLoop]
         public void ManyConcurrentAddsTakes_CollectionRemainsConsistent(int operations)
         {
             IProducerConsumerCollection<int> c = CreateProducerConsumerCollection();


### PR DESCRIPTION
This test was hitting an OOM on the CI machines because it adds new items to a collection in a loop until a timeout is met. I modified the test to instead add a fixed number of items, regardless of time. This also reduces the total runtime of the Concurrent Collections tests from ~15 seconds to ~10 seconds on my local box.

@safern 

resolves https://github.com/dotnet/corefx/issues/15837