### PR TITLE
Fix System.ComponentModel.TypeConverter failing tests

### DIFF
--- a/src/Common/tests/System/PlatformDetection.cs
+++ b/src/Common/tests/System/PlatformDetection.cs
@@ -12,6 +12,8 @@ namespace System
 {
     public static class PlatformDetection
     {
+        public static bool IsFullFramework => RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
+
         public static bool IsWindows { get; } = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
         public static bool IsWindows7 { get; } = IsWindows && GetWindowsVersion() == 6 && GetWindowsMinorVersion() == 1;
         public static bool IsWindows8x { get; } = IsWindows && GetWindowsVersion() == 6 && (GetWindowsMinorVersion() == 2 || GetWindowsMinorVersion() == 3);

--- a/src/System.ComponentModel.TypeConverter/dir.props
+++ b/src/System.ComponentModel.TypeConverter/dir.props
@@ -2,8 +2,8 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
+  	<!-- don't change the Asssembly Version as one test would break -->
     <AssemblyVersion>9.9.9.9</AssemblyVersion>
-    <SkipSigning>true</SkipSigning>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>
   </PropertyGroup>

--- a/src/System.ComponentModel.TypeConverter/dir.props
+++ b/src/System.ComponentModel.TypeConverter/dir.props
@@ -2,7 +2,8 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.2.0.0</AssemblyVersion>
+    <AssemblyVersion>9.9.9.9</AssemblyVersion>
+    <SkipSigning>true</SkipSigning>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>
   </PropertyGroup>

--- a/src/System.ComponentModel.TypeConverter/tests/MemberDescriptorTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/MemberDescriptorTests.cs
@@ -24,6 +24,12 @@ namespace System.ComponentModel.Tests
             Assert.Equal(firstDescriptor.Category, copiedDescriptor.Category);
             Assert.Equal(firstDescriptor.Description, copiedDescriptor.Description);
 
+            if(PlatformDetection.IsFullFramework)
+            {
+                // This quirk set to true in the tests is causing the Equals to behave different.
+                AppContext.SetSwitch(@"Switch.System.MemberDescriptorEqualsReturnsFalseIfEquivalent", false);
+            }
+
             Assert.True(firstDescriptor.Equals(copiedDescriptor));
         }
 

--- a/src/System.ComponentModel.TypeConverter/tests/MemberDescriptorTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/MemberDescriptorTests.cs
@@ -26,8 +26,10 @@ namespace System.ComponentModel.Tests
 
             if(PlatformDetection.IsFullFramework)
             {
-                // This quirk set to true in the tests is causing the Equals to behave different.
+                // MethodDescriptor.Equals checks for this quirk and if it is set to true the behavior will be different to what we expect and the test will fail.
+                // This quirk is set to true by default on .NET versions earlier than 4.6.1 and Xunit runner was built against 4.5, so we override the quirk value to have the expected behavior.
                 AppContext.SetSwitch(@"Switch.System.MemberDescriptorEqualsReturnsFalseIfEquivalent", false);
+                
             }
 
             Assert.True(firstDescriptor.Equals(copiedDescriptor));

--- a/src/System.ComponentModel.TypeConverter/tests/MemberDescriptorTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/MemberDescriptorTests.cs
@@ -29,7 +29,6 @@ namespace System.ComponentModel.Tests
                 // MethodDescriptor.Equals checks for this quirk and if it is set to true the behavior will be different to what we expect and the test will fail.
                 // This quirk is set to true by default on .NET versions earlier than 4.6.1 and Xunit runner was built against 4.5, so we override the quirk value to have the expected behavior.
                 AppContext.SetSwitch(@"Switch.System.MemberDescriptorEqualsReturnsFalseIfEquivalent", false);
-                
             }
 
             Assert.True(firstDescriptor.Equals(copiedDescriptor));

--- a/src/System.ComponentModel.TypeConverter/tests/MemberDescriptorTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/MemberDescriptorTests.cs
@@ -9,6 +9,16 @@ namespace System.ComponentModel.Tests
 {
     public class MemberDescriptorTests
     {
+        static MemberDescriptorTests()
+        {
+            if(PlatformDetection.IsFullFramework)
+            {
+                // MethodDescriptor.Equals checks for this quirk and if it is set to true the behavior will be different to what we expect and the test will fail.
+                // This quirk is set to true by default on .NET versions earlier than 4.6.1 and Xunit runner was built against 4.5, so we override the quirk value to have the expected behavior.
+                AppContext.SetSwitch(@"Switch.System.MemberDescriptorEqualsReturnsFalseIfEquivalent", false);
+            }
+        }
+
         [Fact]
         public void CopiedMemberDescriptorEqualsItsSource()
         {
@@ -23,13 +33,6 @@ namespace System.ComponentModel.Tests
             // call getters to ensure their backing fields aren't null
             Assert.Equal(firstDescriptor.Category, copiedDescriptor.Category);
             Assert.Equal(firstDescriptor.Description, copiedDescriptor.Description);
-
-            if(PlatformDetection.IsFullFramework)
-            {
-                // MethodDescriptor.Equals checks for this quirk and if it is set to true the behavior will be different to what we expect and the test will fail.
-                // This quirk is set to true by default on .NET versions earlier than 4.6.1 and Xunit runner was built against 4.5, so we override the quirk value to have the expected behavior.
-                AppContext.SetSwitch(@"Switch.System.MemberDescriptorEqualsReturnsFalseIfEquivalent", false);
-            }
 
             Assert.True(firstDescriptor.Equals(copiedDescriptor));
         }

--- a/src/System.ComponentModel.TypeConverter/tests/MemberDescriptorTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/MemberDescriptorTests.cs
@@ -11,7 +11,7 @@ namespace System.ComponentModel.Tests
     {
         static MemberDescriptorTests()
         {
-            if(PlatformDetection.IsFullFramework)
+            if (PlatformDetection.IsFullFramework)
             {
                 // MethodDescriptor.Equals checks for this quirk and if it is set to true the behavior will be different to what we expect and the test will fail.
                 // This quirk is set to true by default on .NET versions earlier than 4.6.1 and Xunit runner was built against 4.5, so we override the quirk value to have the expected behavior.

--- a/src/System.ComponentModel.TypeConverter/tests/SampleClasses.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/SampleClasses.cs
@@ -82,13 +82,7 @@ namespace System.ComponentModel.Tests
         }
     }
 
-#if FUNCTIONAL_TESTS
-    [TypeConverter("System.ComponentModel.Tests.BaseClassConverter, System.ComponentModel.TypeConverter.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
-#elif PERFORMANCE_TESTS
-    [TypeConverter("System.ComponentModel.Tests.BaseClassConverter, System.ComponentModel.TypeConverter.Performance.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
-#else
-#error Define FUNCTIONAL_TESTS or PERFORMANCE_TESTS
-#endif
+    [TypeConverter(typeof(BaseClassConverter))]
     public class BaseClass
     {
         public BaseClass()

--- a/src/System.ComponentModel.TypeConverter/tests/SampleClasses.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/SampleClasses.cs
@@ -82,7 +82,13 @@ namespace System.ComponentModel.Tests
         }
     }
 
-    [TypeConverter(typeof(BaseClassConverter))]
+#if FUNCTIONAL_TESTS
+    [TypeConverter("System.ComponentModel.Tests.BaseClassConverter, System.ComponentModel.TypeConverter.Tests, Version=9.9.9.9, Culture=neutral, PublicKeyToken=null")]
+#elif PERFORMANCE_TESTS
+    [TypeConverter("System.ComponentModel.Tests.BaseClassConverter, System.ComponentModel.TypeConverter.Performance.Tests, Version=9.9.9.9, Culture=neutral, PublicKeyToken=null")]
+#else
+#error Define FUNCTIONAL_TESTS or PERFORMANCE_TESTS
+#endif
     public class BaseClass
     {
         public BaseClass()

--- a/src/System.ComponentModel.TypeConverter/tests/SampleClasses.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/SampleClasses.cs
@@ -83,9 +83,9 @@ namespace System.ComponentModel.Tests
     }
 
 #if FUNCTIONAL_TESTS
-    [TypeConverter("System.ComponentModel.Tests.BaseClassConverter, System.ComponentModel.TypeConverter.Tests, Version=9.9.9.9, Culture=neutral, PublicKeyToken=null")]
+    [TypeConverter("System.ComponentModel.Tests.BaseClassConverter, System.ComponentModel.TypeConverter.Tests, Version=9.9.9.9, Culture=neutral, PublicKeyToken=9d77cc7ad39b68eb")]
 #elif PERFORMANCE_TESTS
-    [TypeConverter("System.ComponentModel.Tests.BaseClassConverter, System.ComponentModel.TypeConverter.Performance.Tests, Version=9.9.9.9, Culture=neutral, PublicKeyToken=null")]
+    [TypeConverter("System.ComponentModel.Tests.BaseClassConverter, System.ComponentModel.TypeConverter.Performance.Tests, Version=9.9.9.9, Culture=neutral, PublicKeyToken=9d77cc7ad39b68eb")]
 #else
 #error Define FUNCTIONAL_TESTS or PERFORMANCE_TESTS
 #endif

--- a/src/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj
+++ b/src/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj
@@ -19,6 +19,9 @@
     <Compile Include="Drawing\SizeFConverterTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>Common\tests\System\PlatformDetection.cs</Link>
+    </Compile>
     <Compile Include="ArrayConverterTests.cs" />
     <Compile Include="AttributeCollectionTests.cs" />
     <Compile Include="AttributeProviderAttributeTests.cs" />

--- a/src/System.Diagnostics.TraceSource/tests/System.Diagnostics.TraceSource.Tests.csproj
+++ b/src/System.Diagnostics.TraceSource/tests/System.Diagnostics.TraceSource.Tests.csproj
@@ -34,6 +34,9 @@
     <Compile Include="$(CommonTestPath)\System\IO\FileCleanupTestBase.cs">
       <Link>Common\System\IO\FileCleanupTestBase.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>Common\tests\System\PlatformDetection.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Diagnostics.TraceSource/tests/TraceClassTests.cs
+++ b/src/System.Diagnostics.TraceSource/tests/TraceClassTests.cs
@@ -12,7 +12,7 @@ namespace System.Diagnostics.TraceSourceTests
 
     public class TraceClassTests : IDisposable
     {
-        private readonly string TestRunnerAssemblyName = TraceTestHelper.IsFullFramework ? 
+        private readonly string TestRunnerAssemblyName = PlatformDetection.IsFullFramework ? 
             Path.GetFileName(Environment.GetCommandLineArgs()[0]) : Assembly.GetEntryAssembly().GetName().Name;
 
         void IDisposable.Dispose()

--- a/src/System.Diagnostics.TraceSource/tests/TraceSourceClassTests.cs
+++ b/src/System.Diagnostics.TraceSource/tests/TraceSourceClassTests.cs
@@ -135,7 +135,7 @@ namespace System.Diagnostics.TraceSourceTests
             ArgumentException exception2 = Assert.Throws<ArgumentException>(() => new TraceSource(string.Empty, SourceLevels.All));
 
             // In Desktop in TraceSource.ctor we create the ArgumentException without param name, just with Message = "name", so ParamName is null
-            if (TraceTestHelper.IsFullFramework)
+            if (PlatformDetection.IsFullFramework)
             {
                 Assert.Null(exception1.ParamName);
                 Assert.Null(exception2.ParamName);

--- a/src/System.Diagnostics.TraceSource/tests/TraceTestHelper.cs
+++ b/src/System.Diagnostics.TraceSource/tests/TraceTestHelper.cs
@@ -9,8 +9,6 @@ namespace System.Diagnostics.TraceSourceTests
 {
     static class TraceTestHelper
     {
-        internal static bool IsFullFramework => RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
-
         /// <summary>
         /// Resets the static state of the trace objects before a unit test.
         /// </summary>

--- a/src/System.Reflection.Emit/tests/AssemblyBuilderTests.cs
+++ b/src/System.Reflection.Emit/tests/AssemblyBuilderTests.cs
@@ -125,7 +125,7 @@ namespace System.Reflection.Emit.Tests
             Assert.Equal("<In Memory Module>", module.Name);
 
             // The coreclr ignores the name passed to AssemblyBuilder.DefineDynamicModule
-            if (RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework"))
+            if (PlatformDetection.IsFullFramework)
             {
                 Assert.Equal(name, module.FullyQualifiedName);
             }

--- a/src/System.Reflection.Emit/tests/System.Reflection.Emit.Tests.csproj
+++ b/src/System.Reflection.Emit/tests/System.Reflection.Emit.Tests.csproj
@@ -8,6 +8,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
   <ItemGroup>
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>Common\tests\System\PlatformDetection.cs</Link>
+    </Compile>
     <Compile Include="AssemblyBuilderTests.cs" />
     <Compile Include="ConstructorBuilder\ConstructorBuilderDefineParameter.cs" />
     <Compile Include="ConstructorBuilder\ConstructorBuilderGetILGenerator.cs" />

--- a/src/System.Text.RegularExpressions/tests/Regex.Ctor.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Ctor.Tests.cs
@@ -272,7 +272,7 @@ namespace System.Text.RegularExpressions.Tests
         [InlineData(" (?(?n))", RegexOptions.None, typeof(OutOfMemoryException))]
         public void Ctor_InvalidPattern(string pattern, RegexOptions options, Type exceptionType)
         {
-            if (RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework"))
+            if (PlatformDetection.IsFullFramework)
             {
                 Assert.Throws(exceptionType, () => new Regex(pattern, options));
             }

--- a/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
@@ -12,6 +12,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <ItemGroup>
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>Common\tests\System\PlatformDetection.cs</Link>
+    </Compile>
     <Compile Include="CaptureCollectionTests.cs" />
     <Compile Include="GroupCollectionTests.cs" />
     <Compile Include="MatchCollectionTests.cs" />


### PR DESCRIPTION
This PR fixes 2 tests that where failing in System.ComponentModel.TypeConverter

Also I made a cleanup moving to the common path `IsFullFramework` property that I previously added. 

cc: @tarekgh @stephentoub @danmosemsft @AlexGhiondea 