### PR TITLE
Fix HttpClientHandler.ClientCertificates behavior

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/Resources/Strings.resx
+++ b/src/System.Net.Http.WinHttpHandler/src/Resources/Strings.resx
@@ -91,6 +91,9 @@
   <data name="net_http_chunked_not_allowed_with_empty_content" xml:space="preserve">
     <value>'Transfer-Encoding: chunked' header can not be used when content object is not specified.</value>
   </data>
+  <data name="net_http_invalid_enable_first" xml:space="preserve">
+    <value>The {0} property must be set to '{1}' to use this property.</value>
+  </data>
   <data name="net_http_value_must_be_greater_than" xml:space="preserve">
     <value>The specified value must be greater than {0}.</value>
   </data>

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -65,7 +65,7 @@ namespace System.Net.Http
     // time still allowing the native code to continue using its GCHandle and lookup the associated state as long as it's alive.
     // Yet then when an async read is made on the response message, we want to postpone such finalization and ensure that the async
     // read can be appropriately completed with control and reference ownership given back to the reader. As such, we do two things:
-    // we make the response stream finalizable, and we make the GCHandle be to a wrapper object for the EasyRequest rather than to 
+    // we make the response stream finalizable, and we make the GCHandle be to a wrapper object for the EasyRequest rather than to
     // the EasyRequest itself.  That wrapper object maintains a weak reference to the EasyRequest as well as sometimes maintaining
     // a strong reference.  When the request starts out, the GCHandle is created to the wrapper, which has a strong reference to
     // the EasyRequest (which also back references to the wrapper so that the wrapper can be accessed via it).  The GCHandle is
@@ -97,7 +97,7 @@ namespace System.Net.Http
         private const string UriSchemeHttps = "https";
         private const string EncodingNameGzip = "gzip";
         private const string EncodingNameDeflate = "deflate";
-        
+
         private const int MaxRequestBufferSize = 16384; // Default used by libcurl
         private const string NoTransferEncoding = HttpKnownHeaderNames.TransferEncoding + ":";
         private const string NoContentType = HttpKnownHeaderNames.ContentType + ":";
@@ -154,7 +154,7 @@ namespace System.Net.Http
 
         private object LockObject { get { return _agent; } }
 
-        #endregion        
+        #endregion
 
         static CurlHandler()
         {
@@ -247,7 +247,23 @@ namespace System.Net.Http
             }
         }
 
-        internal X509Certificate2Collection ClientCertificates => _clientCertificates ?? (_clientCertificates = new X509Certificate2Collection());
+        internal X509Certificate2Collection ClientCertificates
+        {
+            get
+            {
+                if (_clientCertificateOption != ClientCertificateOption.Manual)
+                {
+                    throw new InvalidOperationException(SR.Format(SR.net_http_invalid_enable_first, "ClientCertificateOptions", "Manual"));
+                }
+
+                if (_clientCertificates == null)
+                {
+                    _clientCertificates = new X509Certificate2Collection();
+                }
+
+                return _clientCertificates;
+            }
+        }
 
         internal Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> ServerCertificateValidationCallback
         {
@@ -310,7 +326,7 @@ namespace System.Net.Http
         {
             get { return _useCookie; }
             set
-            {               
+            {
                 CheckDisposedOrStarted();
                 _useCookie = value;
             }
@@ -560,7 +576,7 @@ namespace System.Net.Http
             catch (CookieException e)
             {
                 EventSourceTrace(
-                    "Malformed cookie parsing failed: {0}, server: {1}, cookie: {2}", 
+                    "Malformed cookie parsing failed: {0}, server: {1}, cookie: {2}",
                     e.Message, state._requestMessage.RequestUri, cookieHeader,
                     easy: state);
             }
@@ -698,7 +714,7 @@ namespace System.Net.Http
         }
 
         private static void EventSourceTrace(
-            string message, 
+            string message,
             MultiAgent agent = null, EasyRequest easy = null, [CallerMemberName] string memberName = null)
         {
             if (NetEventSource.IsEnabled)
@@ -757,7 +773,7 @@ namespace System.Net.Http
             }
             else if (!chunkedMode)
             {
-                // Make sure Transfer-Encoding: chunked header is set, 
+                // Make sure Transfer-Encoding: chunked header is set,
                 // as we have content to send but no known length for it.
                 request.Headers.TransferEncodingChunked = true;
             }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
@@ -48,13 +48,12 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [Theory]
-        [InlineData(ClientCertificateOption.Automatic)]
-        public void ClientCertificates_ClientCertificateOptionsAutomatic_ThrowsException(ClientCertificateOption option)
+        [Fact]
+        public void ClientCertificates_ClientCertificateOptionsAutomatic_ThrowsException()
         {
             using (var handler = new HttpClientHandler())
             {
-                handler.ClientCertificateOptions = option;
+                handler.ClientCertificateOptions = ClientCertificateOption.Automatic;
                 Assert.Throws<InvalidOperationException>(() => handler.ClientCertificates);
             }
         }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
@@ -48,6 +48,17 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [Theory]
+        [InlineData(ClientCertificateOption.Automatic)]
+        public void ClientCertificates_ClientCertificateOptionsAutomatic_ThrowsException(ClientCertificateOption option)
+        {
+            using (var handler = new HttpClientHandler())
+            {
+                handler.ClientCertificateOptions = option;
+                Assert.Throws<InvalidOperationException>(() => handler.ClientCertificates);
+            }
+        }
+
         [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(BackendDoesNotSupportCustomCertificateHandling))]
         public async Task Automatic_SSLBackendNotSupported_ThrowsPlatformNotSupportedException()


### PR DESCRIPTION
Change the ClientCertificates' getter to throw InvalidOperationException, when ClientCertificateOption.Automatic is set, to match the same behavior in .Net Desktop.

Fix #11743 