### PR TITLE
Enable building of System.Linq.Expression without expression compiler

### DIFF
--- a/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
+++ b/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
@@ -10,10 +10,6 @@
     <AssemblyName>System.Linq.Expressions</AssemblyName>
     <RootNamespace>System.Linq.Expressions</RootNamespace>
     <IsInterpreting Condition="'$(TargetGroup)' == 'uap'">true</IsInterpreting>
-    <!-- Temporarily disable IsInterpreting build as it's broken and needs investigation 
-         https://github.com/dotnet/corefx/issues/16910
-    -->
-    <IsInterpreting>false</IsInterpreting>
     <DefineConstants Condition=" '$(IsInterpreting)' != 'true' ">$(DefineConstants);FEATURE_COMPILE</DefineConstants>
     <DefineConstants Condition=" '$(FeatureInterpret)' == 'true' ">$(DefineConstants);FEATURE_INTERPRET</DefineConstants>
   </PropertyGroup>
@@ -75,6 +71,9 @@
     </Compile>
     <Compile Include="$(CommonPath)\System\Dynamic\Utils\ContractUtils.cs">
       <Link>Common\System\Dynamic\Utils\ContractUtils.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Dynamic\Utils\ContractUtils.RequiresArrayRange.cs">
+      <Link>Common\System\Dynamic\Utils\ContractUtils.RequiresArrayRange.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\Dynamic\Utils\Error.cs">
       <Link>Common\System\Dynamic\Utils\Error.cs</Link>
@@ -214,9 +213,6 @@
   <ItemGroup Condition=" '$(IsInterpreting)' != 'true'">
     <Compile Include="$(CommonPath)\System\Collections\Generic\ReferenceEqualityComparer.cs">
       <Link>Common\System\Collections\Generic\ReferenceEqualityComparer.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\System\Dynamic\Utils\ContractUtils.RequiresArrayRange.cs">
-      <Link>Common\System\Dynamic\Utils\ContractUtils.RequiresArrayRange.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\Linq\Expressions\Compiler\AssemblyGen.cs">
       <Link>Common\System\Linq\Expressions\Compiler\AssemblyGen.cs</Link>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Common/CachedReflectionInfo.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Common/CachedReflectionInfo.cs
@@ -61,21 +61,6 @@ namespace System.Linq.Expressions
         public static FieldInfo Decimal_MaxValue
             => s_Decimal_MaxValue ?? (s_Decimal_MaxValue = typeof(decimal).GetField(nameof(decimal.MaxValue)));
 
-        private static ConstructorInfo s_Closure_ObjectArray_ObjectArray;
-        public  static ConstructorInfo   Closure_ObjectArray_ObjectArray =>
-                                       s_Closure_ObjectArray_ObjectArray ??
-                                      (s_Closure_ObjectArray_ObjectArray = typeof(Closure).GetConstructor(new[] { typeof(object[]), typeof(object[]) }));
-
-        private static FieldInfo s_Closure_Constants;
-        public  static FieldInfo   Closure_Constants =>
-                                 s_Closure_Constants ??
-                                (s_Closure_Constants = typeof(Closure).GetField(nameof(Closure.Constants)));
-
-        private static FieldInfo s_Closure_Locals;
-        public  static FieldInfo   Closure_Locals =>
-                                 s_Closure_Locals ??
-                                (s_Closure_Locals = typeof(Closure).GetField(nameof(Closure.Locals)));
-
         private static FieldInfo s_Decimal_Zero;
         public static FieldInfo Decimal_Zero
             => s_Decimal_Zero ?? (s_Decimal_Zero = typeof(decimal).GetField(nameof(decimal.Zero)));
@@ -103,26 +88,6 @@ namespace System.Linq.Expressions
         public  static MethodInfo   String_op_Equality_String_String =>
                                   s_String_op_Equality_String_String ??
                                  (s_String_op_Equality_String_String = typeof(string).GetMethod("op_Equality", new[] { typeof(string), typeof(string) }));
-
-        private static MethodInfo s_RuntimeOps_CreateRuntimeVariables_ObjectArray_Int64Array;
-        public  static MethodInfo   RuntimeOps_CreateRuntimeVariables_ObjectArray_Int64Array =>
-                                  s_RuntimeOps_CreateRuntimeVariables_ObjectArray_Int64Array ??
-                                 (s_RuntimeOps_CreateRuntimeVariables_ObjectArray_Int64Array = typeof(RuntimeOps).GetMethod(nameof(RuntimeOps.CreateRuntimeVariables), new[] { typeof(object[]), typeof(long[]) }));
-
-        private static MethodInfo s_RuntimeOps_CreateRuntimeVariables;
-        public  static MethodInfo   RuntimeOps_CreateRuntimeVariables =>
-                                  s_RuntimeOps_CreateRuntimeVariables ??
-                                 (s_RuntimeOps_CreateRuntimeVariables = typeof(RuntimeOps).GetMethod(nameof(RuntimeOps.CreateRuntimeVariables), Type.EmptyTypes));
-
-        private static MethodInfo s_RuntimeOps_MergeRuntimeVariables;
-        public  static MethodInfo   RuntimeOps_MergeRuntimeVariables =>
-                                  s_RuntimeOps_MergeRuntimeVariables ??
-                                 (s_RuntimeOps_MergeRuntimeVariables = typeof(RuntimeOps).GetMethod(nameof(RuntimeOps.MergeRuntimeVariables)));
-
-        private static MethodInfo s_RuntimeOps_Quote;
-        public  static MethodInfo   RuntimeOps_Quote =>
-                                  s_RuntimeOps_Quote ??
-                                 (s_RuntimeOps_Quote = typeof(RuntimeOps).GetMethod(nameof(RuntimeOps.Quote)));
 
         private static MethodInfo s_DictionaryOfStringInt32_Add_String_Int32;
         public  static MethodInfo   DictionaryOfStringInt32_Add_String_Int32 =>
@@ -193,5 +158,43 @@ namespace System.Linq.Expressions
         public  static MethodInfo   Math_Pow_Double_Double =>
                                   s_Math_Pow_Double_Double ??
                                  (s_Math_Pow_Double_Double = typeof(Math).GetMethod(nameof(Math.Pow), new[] { typeof(double), typeof(double) }));
+
+        // Closure and RuntimeOps helpers are used only in the compiler.
+#if FEATURE_COMPILE
+        private static ConstructorInfo s_Closure_ObjectArray_ObjectArray;
+        public static ConstructorInfo Closure_ObjectArray_ObjectArray =>
+                                       s_Closure_ObjectArray_ObjectArray ??
+                                      (s_Closure_ObjectArray_ObjectArray = typeof(Closure).GetConstructor(new[] { typeof(object[]), typeof(object[]) }));
+
+        private static FieldInfo s_Closure_Constants;
+        public static FieldInfo Closure_Constants =>
+                                 s_Closure_Constants ??
+                                (s_Closure_Constants = typeof(Closure).GetField(nameof(Closure.Constants)));
+
+        private static FieldInfo s_Closure_Locals;
+        public static FieldInfo Closure_Locals =>
+                                 s_Closure_Locals ??
+                                (s_Closure_Locals = typeof(Closure).GetField(nameof(Closure.Locals)));
+
+        private static MethodInfo s_RuntimeOps_CreateRuntimeVariables_ObjectArray_Int64Array;
+        public static MethodInfo RuntimeOps_CreateRuntimeVariables_ObjectArray_Int64Array =>
+                                  s_RuntimeOps_CreateRuntimeVariables_ObjectArray_Int64Array ??
+                                 (s_RuntimeOps_CreateRuntimeVariables_ObjectArray_Int64Array = typeof(RuntimeOps).GetMethod(nameof(RuntimeOps.CreateRuntimeVariables), new[] { typeof(object[]), typeof(long[]) }));
+
+        private static MethodInfo s_RuntimeOps_CreateRuntimeVariables;
+        public static MethodInfo RuntimeOps_CreateRuntimeVariables =>
+                                  s_RuntimeOps_CreateRuntimeVariables ??
+                                 (s_RuntimeOps_CreateRuntimeVariables = typeof(RuntimeOps).GetMethod(nameof(RuntimeOps.CreateRuntimeVariables), Type.EmptyTypes));
+
+        private static MethodInfo s_RuntimeOps_MergeRuntimeVariables;
+        public static MethodInfo RuntimeOps_MergeRuntimeVariables =>
+                                  s_RuntimeOps_MergeRuntimeVariables ??
+                                 (s_RuntimeOps_MergeRuntimeVariables = typeof(RuntimeOps).GetMethod(nameof(RuntimeOps.MergeRuntimeVariables)));
+
+        private static MethodInfo s_RuntimeOps_Quote;
+        public static MethodInfo RuntimeOps_Quote =>
+                                  s_RuntimeOps_Quote ??
+                                 (s_RuntimeOps_Quote = typeof(RuntimeOps).GetMethod(nameof(RuntimeOps.Quote)));
+#endif
     }
 }

--- a/src/System.Linq.Expressions/tests/HelperTypes.cs
+++ b/src/System.Linq.Expressions/tests/HelperTypes.cs
@@ -457,7 +457,9 @@ namespace System.Linq.Expressions.Tests
             expression.VerifyIL(il);
 #endif
 
-#if FEATURE_INTERPRET
+            // FEATURE_COMPILE is not directly required, 
+            // but this functionality relies on private reflection and that would not work with AOT
+#if FEATURE_INTERPRET && FEATURE_COMPILE
             expression.VerifyInstructions(instructions);
 #endif
         }

--- a/src/System.Linq.Expressions/tests/InterpreterTests.cs
+++ b/src/System.Linq.Expressions/tests/InterpreterTests.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if FEATURE_INTERPRET
+// FEATURE_COMPILE is not directly required, 
+// but this functionality relies on private reflection and that would not work with AOT
+#if FEATURE_INTERPRET && FEATURE_COMPILE
 
 using System.Linq.Expressions.Interpreter;
 using System.Reflection;

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -8,10 +8,6 @@
   <PropertyGroup>
     <ProjectGuid>{4B4AA59B-89F9-4A34-B3C3-C97EF531EE00}</ProjectGuid>
     <IsInterpreting Condition="'$(TargetGroup)' == 'uap'">true</IsInterpreting>
-    <!-- Temporarily disable IsInterpreting build as it's broken and needs investigation
-         https://github.com/dotnet/corefx/issues/16910
-    -->
-    <IsInterpreting>false</IsInterpreting>
     <DefineConstants Condition=" '$(IsInterpreting)' != 'true' ">$(DefineConstants);FEATURE_COMPILE</DefineConstants>
     <DefineConstants Condition=" '$(FeatureInterpret)' == 'true' ">$(DefineConstants);FEATURE_INTERPRET</DefineConstants>
     <IncludeDefaultReferences Condition="'$(TargetGroup)'=='uapaot'">false</IncludeDefaultReferences>

--- a/src/System.Linq.Expressions/tests/TestExtensions/PerCompilationTypeAttribute.cs
+++ b/src/System.Linq.Expressions/tests/TestExtensions/PerCompilationTypeAttribute.cs
@@ -33,25 +33,40 @@ namespace System.Linq.Expressions.Tests
             // we'd therefore end up with multiple copies of the last result.
             foreach (object[] received in delegatedTo.GetData(testMethod))
             {
+#if FEATURE_COMPILE
                 object[] withFalse = new object[received.Length + 1];
-#if FEATURE_COMPILE && FEATURE_INTERPRET
+#endif
+
+#if FEATURE_INTERPRET
                 object[] withTrue = new object[received.Length + 1];
 #endif
 
+#if FEATURE_COMPILE
                 withFalse[received.Length] = s_boxedFalse;
-#if FEATURE_COMPILE && FEATURE_INTERPRET
+#endif
+
+#if FEATURE_INTERPRET
                 withTrue[received.Length] = s_boxedTrue;
 #endif
 
                 for (int i = 0; i != received.Length; ++i)
                 {
                     object arg = received[i];
+
+#if FEATURE_COMPILE
                     withFalse[i] = arg;
+#endif
+
+#if FEATURE_INTERPRET
                     withTrue[i] = arg;
+#endif
                 }
 
+#if FEATURE_COMPILE
                 yield return withFalse;
-#if FEATURE_COMPILE && FEATURE_INTERPRET
+#endif
+
+#if  FEATURE_INTERPRET
                 yield return withTrue;
 #endif
             }


### PR DESCRIPTION
Enable building of System.Linq.Expression without expression compiler in AOT target group.

Fixes:https://github.com/dotnet/corefx/issues/16910
