### PR TITLE
Adding additional test coverage for the System.Math and System.MathF functions implemented by FCalls.

### DIFF
--- a/src/System.Runtime.Extensions/tests/System/Math.cs
+++ b/src/System.Runtime.Extensions/tests/System/Math.cs
@@ -1,304 +1,135 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
+using Xunit.Sdk;
 
 namespace System.Tests
 {
     public static partial class MathTests
     {
-        [Fact]
-        public static void Cos()
+        // binary64 (double) has a machine epsilon of 2^-52 (approx. 2.22e-16). However, this 
+        // is slightly too accurate when writing tests meant to run against libm implementations
+        // for various platforms. 2^-50 (approx. 8.88e-16) seems to be as accurate as we can get.
+        //
+        // The tests themselves will take CrossPlatformMachineEpsilon and adjust it according to the expected result
+        // so that the delta used for comparison will compare the most significant digits and ignore
+        // any digits that are outside the double precision range (15-17 digits).
+        //
+        // For example, a test with an expect result in the format of 0.xxxxxxxxxxxxxxxxx will use
+        // CrossPlatformMachineEpsilon for the variance, while an expected result in the format of 0.0xxxxxxxxxxxxxxxxx
+        // will use CrossPlatformMachineEpsilon / 10 and and expected result in the format of x.xxxxxxxxxxxxxxxx will
+        // use CrossPlatformMachineEpsilon * 10.
+        private const double CrossPlatformMachineEpsilon = 8.8817841970012523e-16;
+
+        /// <summary>Verifies that two <see cref="double"/> values are equal, within the <paramref name="allowedVariance"/>.</summary>
+        /// <param name="expected">The expected value</param>
+        /// <param name="actual">The value to be compared against</param>
+        /// <param name="allowedVariance">The total variance allowed between the expected and actual results.</param>
+        /// <exception cref="EqualException">Thrown when the values are not equal</exception>
+        public static void AssertEqual(double expected, double actual, double variance)
         {
-            Assert.Equal(0.54030230586814, Math.Cos(1.0), 10);
-            Assert.Equal(1.0, Math.Cos(0.0));
-            Assert.Equal(0.54030230586814, Math.Cos(-1.0), 10);
-            Assert.Equal(double.NaN, Math.Cos(double.NaN));
-            Assert.Equal(double.NaN, Math.Cos(double.PositiveInfinity));
-            Assert.Equal(double.NaN, Math.Cos(double.NegativeInfinity));
+            if (double.IsNaN(expected))
+            {
+                if (double.IsNaN(actual))
+                {
+                    return;
+                }
+
+                throw new EqualException($"{"NaN",20}", $"{actual,20:G17}");
+            }
+            else if (double.IsNaN(actual))
+            {
+                throw new EqualException($"{expected,20:G17}", $"{"NaN",20}");
+            }
+
+            if (double.IsNegativeInfinity(expected))
+            {
+                if (double.IsNegativeInfinity(actual))
+                {
+                    return;
+                }
+
+                throw new EqualException($"{"-∞",20}", $"{actual,20:G17}");
+            }
+            else if (double.IsNegativeInfinity(actual))
+            {
+                throw new EqualException($"{expected,20:G17}", $"{"-∞",20}");
+            }
+
+            if (double.IsPositiveInfinity(expected))
+            {
+                if (double.IsPositiveInfinity(actual))
+                {
+                    return;
+                }
+
+                throw new EqualException($"{"+∞",20}", $"{actual,20:G17}");
+            }
+            else if (double.IsPositiveInfinity(actual))
+            {
+                throw new EqualException($"{expected,20:G17}", $"{"+∞",20}");
+            }
+
+            if (IsNegativeZero(expected))
+            {
+                if (IsNegativeZero(actual))
+                {
+                    return;
+                }
+
+                if (IsPositiveZero(variance) || IsNegativeZero(variance))
+                {
+                    throw new EqualException($"{"-0.0",20}", $"{actual,20:G17}");
+                }
+
+                // When the variance is not ±0.0, then we are handling a case where
+                // the actual result is expected to not be exactly -0.0 on some platforms
+                // and we should fallback to checking if it is within the allowed variance instead.
+            }
+            else if (IsNegativeZero(actual))
+            {
+                // Do nothing, since the actual result could still be within the allowed variance
+            }
+
+            if (IsPositiveZero(expected))
+            {
+                if (IsPositiveZero(actual))
+                {
+                    return;
+                }
+
+                if (IsPositiveZero(variance))
+                {
+                    throw new EqualException($"{"+0.0",20}", $"{actual,20:G17}");
+                }
+
+                // When the variance is not ±0.0, then we are handling a case where
+                // the actual result is expected to not be exactly +0.0 on some platforms
+                // and we should fallback to checking if it is within the allowed variance instead.
+            }
+            else if (IsPositiveZero(actual))
+            {
+                // Do nothing, since the actual result could still be within the allowed variance
+            }
+
+            var delta = Math.Abs(actual - expected);
+
+            if (delta > variance)
+            {
+                throw new EqualException($"{expected,10:G9}", $"{actual,10:G9}");
+            }
         }
 
-        [Fact]
-        public static void Sin()
+        private unsafe static bool IsNegativeZero(double value)
         {
-            Assert.Equal(0.841470984807897, Math.Sin(1.0), 10);
-            Assert.Equal(0.0, Math.Sin(0.0));
-            Assert.Equal(-0.841470984807897, Math.Sin(-1.0), 10);
-            Assert.Equal(double.NaN, Math.Sin(double.NaN));
-            Assert.Equal(double.NaN, Math.Sin(double.PositiveInfinity));
-            Assert.Equal(double.NaN, Math.Sin(double.NegativeInfinity));
+            return (*(ulong*)(&value)) == 0x8000000000000000;
         }
 
-        [Fact]
-        public static void Tan()
+        private unsafe static bool IsPositiveZero(double value)
         {
-            Assert.Equal(1.5574077246549, Math.Tan(1.0), 10);
-            Assert.Equal(0.0, Math.Tan(0.0));
-            Assert.Equal(-1.5574077246549, Math.Tan(-1.0), 10);
-            Assert.Equal(double.NaN, Math.Tan(double.NaN));
-            Assert.Equal(double.NaN, Math.Tan(double.PositiveInfinity));
-            Assert.Equal(double.NaN, Math.Tan(double.NegativeInfinity));
-        }
-
-        [Fact]
-        public static void Cosh()
-        {
-            Assert.Equal(1.54308063481524, Math.Cosh(1.0), 10);
-            Assert.Equal(1.0, Math.Cosh(0.0));
-            Assert.Equal(1.54308063481524, Math.Cosh(-1.0), 10);
-            Assert.Equal(double.NaN, Math.Cosh(double.NaN));
-            Assert.Equal(double.PositiveInfinity, Math.Cosh(double.PositiveInfinity));
-            Assert.Equal(double.PositiveInfinity, Math.Cosh(double.NegativeInfinity));
-        }
-
-        [Fact]
-        public static void Sinh()
-        {
-            Assert.Equal(1.1752011936438, Math.Sinh(1.0), 10);
-            Assert.Equal(0.0, Math.Sinh(0.0));
-            Assert.Equal(-1.1752011936438, Math.Sinh(-1.0), 10);
-            Assert.Equal(double.NaN, Math.Sinh(double.NaN));
-            Assert.Equal(double.PositiveInfinity, Math.Sinh(double.PositiveInfinity));
-            Assert.Equal(double.NegativeInfinity, Math.Sinh(double.NegativeInfinity));
-        }
-
-        [Fact]
-        public static void Tanh()
-        {
-            Assert.Equal(0.761594155955765, Math.Tanh(1.0), 10);
-            Assert.Equal(0.0, Math.Tanh(0.0));
-            Assert.Equal(-0.761594155955765, Math.Tanh(-1.0), 10);
-            Assert.Equal(double.NaN, Math.Tanh(double.NaN));
-            Assert.Equal(1.0, Math.Tanh(double.PositiveInfinity));
-            Assert.Equal(-1.0, Math.Tanh(double.NegativeInfinity));
-        }
-
-        [Fact]
-        public static void Acos()
-        {
-            Assert.Equal(0.0, Math.Acos(1.0));
-            Assert.Equal(1.5707963267949, Math.Acos(0.0), 10);
-            Assert.Equal(3.14159265358979, Math.Acos(-1.0), 10);
-            Assert.Equal(double.NaN, Math.Acos(double.NaN));
-            Assert.Equal(double.NaN, Math.Acos(double.PositiveInfinity));
-            Assert.Equal(double.NaN, Math.Acos(double.NegativeInfinity));
-        }
-
-        [Fact]
-        public static void Asin()
-        {
-            Assert.Equal(1.5707963267949, Math.Asin(1.0), 10);
-            Assert.Equal(0.0, Math.Asin(0.0));
-            Assert.Equal(-1.5707963267949, Math.Asin(-1.0), 10);
-            Assert.Equal(double.NaN, Math.Asin(double.NaN));
-            Assert.Equal(double.NaN, Math.Asin(double.PositiveInfinity));
-            Assert.Equal(double.NaN, Math.Asin(double.NegativeInfinity));
-        }
-
-        [Fact]
-        public static void Atan()
-        {
-            Assert.Equal(0.785398163397448, Math.Atan(1.0), 10);
-            Assert.Equal(0.0, Math.Atan(0.0));
-            Assert.Equal(-0.785398163397448, Math.Atan(-1.0), 10);
-            Assert.Equal(double.NaN, Math.Atan(double.NaN));
-            Assert.Equal(1.5707963267949, Math.Atan(double.PositiveInfinity), 4);
-            Assert.Equal(-1.5707963267949, Math.Atan(double.NegativeInfinity), 4);
-        }
-
-        [ActiveIssue("https://github.com/dotnet/coreclr/issues/9806")]
-        [Fact]
-        public static void Atan2()
-        {
-            Assert.Equal(-Math.PI, Math.Atan2(-0.0, -0.0));
-            Assert.Equal(-0.0, Math.Atan2(-0.0, 0.0));
-            Assert.Equal(Math.PI, Math.Atan2(0.0, -0.0));
-            Assert.Equal(0.0, Math.Atan2(0.0, 0.0));
-            Assert.Equal(1.5707963267949, Math.Atan2(1.0, 0.0), 10);
-            Assert.Equal(0.588002603547568, Math.Atan2(2.0, 3.0), 10);
-            Assert.Equal(0.0, Math.Atan2(0.0, 3.0));
-            Assert.Equal(-0.588002603547568, Math.Atan2(-2.0, 3.0), 10);
-            Assert.Equal(double.NaN, Math.Atan2(double.NaN, 1.0));
-            Assert.Equal(double.NaN, Math.Atan2(1.0, double.NaN));
-            Assert.Equal(1.5707963267949, Math.Atan2(double.PositiveInfinity, 1.0), 10);
-            Assert.Equal(-1.5707963267949, Math.Atan2(double.NegativeInfinity, 1.0), 10);
-            Assert.Equal(0.0, Math.Atan2(1.0, double.PositiveInfinity));
-            Assert.Equal(3.14159265358979, Math.Atan2(1.0, double.NegativeInfinity), 10);
-            Assert.Equal(double.NaN, Math.Atan2(double.NegativeInfinity, double.NegativeInfinity));
-            Assert.Equal(double.NaN, Math.Atan2(double.NegativeInfinity, double.PositiveInfinity));
-            Assert.Equal(double.NaN, Math.Atan2(double.PositiveInfinity, double.NegativeInfinity));
-            Assert.Equal(double.NaN, Math.Atan2(double.PositiveInfinity, double.PositiveInfinity));
-        }
-
-        [Fact]
-        public static void Ceiling_Decimal()
-        {
-            Assert.Equal(2.0m, Math.Ceiling(1.1m));
-            Assert.Equal(2.0m, Math.Ceiling(1.9m));
-            Assert.Equal(-1.0m, Math.Ceiling(-1.1m));
-        }
-
-        [Fact]
-        public static void Ceiling_Double()
-        {
-            Assert.Equal(2.0, Math.Ceiling(1.1));
-            Assert.Equal(2.0, Math.Ceiling(1.9));
-            Assert.Equal(-1.0, Math.Ceiling(-1.1));
-            Assert.Equal(double.NaN, Math.Ceiling(double.NaN));
-            Assert.Equal(double.PositiveInfinity, Math.Ceiling(double.PositiveInfinity));
-            Assert.Equal(double.NegativeInfinity, Math.Ceiling(double.NegativeInfinity));
-        }
-
-        [Fact]
-        public static void Floor_Decimal()
-        {
-            Assert.Equal(1.0m, Math.Floor(1.1m));
-            Assert.Equal(1.0m, Math.Floor(1.9m));
-            Assert.Equal(-2.0m, Math.Floor(-1.1m));
-        }
-
-        [Fact]
-        public static void Floor_Double()
-        {
-            Assert.Equal(1.0, Math.Floor(1.1));
-            Assert.Equal(1.0, Math.Floor(1.9));
-            Assert.Equal(-2.0, Math.Floor(-1.1));
-            Assert.Equal(double.NaN, Math.Floor(double.NaN));
-            Assert.Equal(double.PositiveInfinity, Math.Floor(double.PositiveInfinity));
-            Assert.Equal(double.NegativeInfinity, Math.Floor(double.NegativeInfinity));
-        }
-
-        [Fact]
-        public static void Round_Decimal()
-        {
-            Assert.Equal(0.0m, Math.Round(0.0m));
-            Assert.Equal(1.0m, Math.Round(1.4m));
-            Assert.Equal(2.0m, Math.Round(1.5m));
-            Assert.Equal(2e16m, Math.Round(2e16m));
-            Assert.Equal(0.0m, Math.Round(-0.0m));
-            Assert.Equal(-1.0m, Math.Round(-1.4m));
-            Assert.Equal(-2.0m, Math.Round(-1.5m));
-            Assert.Equal(-2e16m, Math.Round(-2e16m));
-        }
-
-        [Fact]
-        public static void Round_Decimal_Digits()
-        {
-            Assert.Equal(3.422m, Math.Round(3.42156m, 3, MidpointRounding.AwayFromZero));
-            Assert.Equal(-3.422m, Math.Round(-3.42156m, 3, MidpointRounding.AwayFromZero));
-            Assert.Equal(Decimal.Zero, Math.Round(Decimal.Zero, 3, MidpointRounding.AwayFromZero));
-        }
-
-        [Fact]
-        public static void Round_Double()
-        {
-            Assert.Equal(0.0, Math.Round(0.0));
-            Assert.Equal(1.0, Math.Round(1.4));
-            Assert.Equal(2.0, Math.Round(1.5));
-            Assert.Equal(2e16, Math.Round(2e16));
-            Assert.Equal(0.0, Math.Round(-0.0));
-            Assert.Equal(-1.0, Math.Round(-1.4));
-            Assert.Equal(-2.0, Math.Round(-1.5));
-            Assert.Equal(-2e16, Math.Round(-2e16));
-        }
-
-        [Fact]
-        public static void Round_Double_Digits()
-        {
-            Assert.Equal(3.422, Math.Round(3.42156, 3, MidpointRounding.AwayFromZero), 10);
-            Assert.Equal(-3.422, Math.Round(-3.42156, 3, MidpointRounding.AwayFromZero), 10);
-            Assert.Equal(0.0, Math.Round(0.0, 3, MidpointRounding.AwayFromZero));
-            Assert.Equal(double.NaN, Math.Round(double.NaN, 3, MidpointRounding.AwayFromZero));
-            Assert.Equal(double.PositiveInfinity, Math.Round(double.PositiveInfinity, 3, MidpointRounding.AwayFromZero));
-            Assert.Equal(double.NegativeInfinity, Math.Round(double.NegativeInfinity, 3, MidpointRounding.AwayFromZero));
-        }
-
-        [Fact]
-        public static void Sqrt()
-        {
-            Assert.Equal(1.73205080756888, Math.Sqrt(3.0), 10);
-            Assert.Equal(0.0, Math.Sqrt(0.0));
-            Assert.Equal(double.NaN, Math.Sqrt(-3.0));
-            Assert.Equal(double.NaN, Math.Sqrt(double.NaN));
-            Assert.Equal(double.PositiveInfinity, Math.Sqrt(double.PositiveInfinity));
-            Assert.Equal(double.NaN, Math.Sqrt(double.NegativeInfinity));
-        }
-
-        [Fact]
-        public static void Log()
-        {
-            Assert.Equal(1.09861228866811, Math.Log(3.0), 10);
-            Assert.Equal(double.NegativeInfinity, Math.Log(0.0));
-            Assert.Equal(double.NaN, Math.Log(-3.0));
-            Assert.Equal(double.NaN, Math.Log(double.NaN));
-            Assert.Equal(double.PositiveInfinity, Math.Log(double.PositiveInfinity));
-            Assert.Equal(double.NaN, Math.Log(double.NegativeInfinity));
-        }
-
-        [Fact]
-        public static void LogWithBase()
-        {
-            Assert.Equal(1.0, Math.Log(3.0, 3.0));
-            Assert.Equal(2.40217350273, Math.Log(14, 3.0), 10);
-            Assert.Equal(double.NegativeInfinity, Math.Log(0.0, 3.0));
-            Assert.Equal(double.NaN, Math.Log(-3.0, 3.0));
-            Assert.Equal(double.NaN, Math.Log(double.NaN, 3.0));
-            Assert.Equal(double.PositiveInfinity, Math.Log(double.PositiveInfinity, 3.0));
-            Assert.Equal(double.NaN, Math.Log(double.NegativeInfinity, 3.0));
-        }
-
-        [Fact]
-        public static void Log10()
-        {
-            Assert.Equal(0.477121254719662, Math.Log10(3.0), 10);
-            Assert.Equal(double.NegativeInfinity, Math.Log10(0.0));
-            Assert.Equal(double.NaN, Math.Log10(-3.0));
-            Assert.Equal(double.NaN, Math.Log10(double.NaN));
-            Assert.Equal(double.PositiveInfinity, Math.Log10(double.PositiveInfinity));
-            Assert.Equal(double.NaN, Math.Log10(double.NegativeInfinity));
-        }
-
-        [ActiveIssue("https://github.com/dotnet/coreclr/issues/9806")]
-        [Fact]
-        public static void Pow()
-        {
-            Assert.Equal(1.0, Math.Pow(0.0, 0.0));
-            Assert.Equal(1.0, Math.Pow(1.0, 0.0));
-            Assert.Equal(8.0, Math.Pow(2.0, 3.0));
-            Assert.Equal(0.0, Math.Pow(0.0, 3.0));
-            Assert.Equal(-8.0, Math.Pow(-2.0, 3.0));
-            Assert.Equal(double.NaN, Math.Pow(double.NaN, 1.0));
-            Assert.Equal(double.NaN, Math.Pow(1.0, double.NaN));
-            Assert.Equal(double.PositiveInfinity, Math.Pow(double.PositiveInfinity, 1.0));
-            Assert.Equal(double.NegativeInfinity, Math.Pow(double.NegativeInfinity, 1.0));
-            Assert.Equal(1.0, Math.Pow(1.0, double.PositiveInfinity));
-            Assert.Equal(1.0, Math.Pow(1.0, double.NegativeInfinity));
-            Assert.Equal(0.0, Math.Pow(0.0, double.PositiveInfinity));
-            Assert.Equal(double.PositiveInfinity, Math.Pow(0.0, -1.0));
-            Assert.Equal(double.PositiveInfinity, Math.Pow(0.0, double.NegativeInfinity));
-            Assert.Equal(double.NaN, Math.Pow(-1.0, double.PositiveInfinity));
-            Assert.Equal(double.NaN, Math.Pow(-1.0, double.NegativeInfinity));
-            Assert.Equal(double.PositiveInfinity, Math.Pow(1.1, double.PositiveInfinity));
-            Assert.Equal(0.0, Math.Pow(1.1, double.NegativeInfinity));
-            Assert.Equal(double.PositiveInfinity, Math.Pow(-1.1, double.PositiveInfinity));
-            Assert.Equal(0.0, Math.Pow(-1.1, double.NegativeInfinity));
-            Assert.Equal(0.0, Math.Pow(1.1, double.NegativeInfinity));
-            Assert.Equal(double.NaN, Math.Pow(double.NaN, 0.0));
-            Assert.Equal(double.PositiveInfinity, Math.Pow(-3.5, 3e100));
-            Assert.Equal(double.NegativeInfinity, Math.Pow(-3.2e-10, -5e14 + 1));
-            Assert.Equal(1.0, Math.Pow(0.0, -0.0));
-            Assert.Equal(0.0, Math.Pow(0.0, 1.0));
-            Assert.Equal(double.PositiveInfinity, Math.Pow(-0.0, double.NegativeInfinity));
-            Assert.Equal(double.NegativeInfinity, Math.Pow(-0.0, -1.0));
-            Assert.Equal(1.0, Math.Pow(-0.0, -0.0));
-            Assert.Equal(1.0, Math.Pow(-0.0, 0.0));
-            Assert.Equal(-0.0, Math.Pow(-0.0, 1.0));
-            Assert.Equal(0.0, Math.Pow(-0.0, double.PositiveInfinity));
-            Assert.Equal(0.0, Math.Pow(double.NegativeInfinity, double.NegativeInfinity));
-            Assert.Equal(double.PositiveInfinity, Math.Pow(double.NegativeInfinity, double.PositiveInfinity));
-            Assert.Equal(0.0, Math.Pow(double.PositiveInfinity, double.NegativeInfinity));
-            Assert.Equal(double.PositiveInfinity, Math.Pow(double.PositiveInfinity, double.PositiveInfinity));
+            return (*(ulong*)(&value)) == 0x0000000000000000;
         }
 
         [Fact]
@@ -308,22 +139,50 @@ namespace System.Tests
             Assert.Equal(0.0m, Math.Abs(0.0m));
             Assert.Equal(0.0m, Math.Abs(-0.0m));
             Assert.Equal(3.0m, Math.Abs(-3.0m));
-            Assert.Equal(Decimal.MaxValue, Math.Abs(Decimal.MinValue));
+            Assert.Equal(decimal.MaxValue, Math.Abs(decimal.MinValue));
         }
 
-        [Fact]
-        public static void Abs_Double()
+        [Theory]
+        [InlineData( double.NegativeInfinity, double.PositiveInfinity, 0.0)]
+        [InlineData(-3.1415926535897932,      3.1415926535897932,      CrossPlatformMachineEpsilon * 10)]     // value: -(pi)             expected: (pi)
+        [InlineData(-2.7182818284590452,      2.7182818284590452,      CrossPlatformMachineEpsilon * 10)]     // value: -(e)              expected: (e)
+        [InlineData(-2.3025850929940457,      2.3025850929940457,      CrossPlatformMachineEpsilon * 10)]     // value: -(ln(10))         expected: (ln(10))
+        [InlineData(-1.5707963267948966,      1.5707963267948966,      CrossPlatformMachineEpsilon * 10)]     // value: -(pi / 2)         expected: (pi / 2)
+        [InlineData(-1.4426950408889634,      1.4426950408889634,      CrossPlatformMachineEpsilon * 10)]     // value: -(log2(e))        expected: (log2(e))
+        [InlineData(-1.4142135623730950,      1.4142135623730950,      CrossPlatformMachineEpsilon * 10)]     // value: -(sqrt(2))        expected: (sqrt(2))
+        [InlineData(-1.1283791670955126,      1.1283791670955126,      CrossPlatformMachineEpsilon * 10)]     // value: -(2 / sqrt(pi))   expected: (2 / sqrt(pi))
+        [InlineData(-1.0,                     1.0,                     CrossPlatformMachineEpsilon * 10)]
+        [InlineData(-0.78539816339744831,     0.78539816339744831,     CrossPlatformMachineEpsilon)]          // value: -(pi / 4)         expected: (pi / 4)
+        [InlineData(-0.70710678118654752,     0.70710678118654752,     CrossPlatformMachineEpsilon)]          // value: -(1 / sqrt(2))    expected: (1 / sqrt(2))
+        [InlineData(-0.69314718055994531,     0.69314718055994531,     CrossPlatformMachineEpsilon)]          // value: -(ln(2))          expected: (ln(2))
+        [InlineData(-0.63661977236758134,     0.63661977236758134,     CrossPlatformMachineEpsilon)]          // value: -(2 / pi)         expected: (2 / pi)
+        [InlineData(-0.43429448190325183,     0.43429448190325183,     CrossPlatformMachineEpsilon)]          // value: -(log10(e))       expected: (log10(e))
+        [InlineData(-0.31830988618379067,     0.31830988618379067,     CrossPlatformMachineEpsilon)]          // value: -(1 / pi)         expected: (1 / pi)
+        [InlineData(-0.0,                     0.0,                     0.0)]
+        [InlineData( double.NaN,              double.NaN,              0.0)]
+        [InlineData( 0.0,                     0.0,                     0.0)]
+        [InlineData( 0.31830988618379067,     0.31830988618379067,     CrossPlatformMachineEpsilon)]          // value:  (1 / pi)         expected: (1 / pi)
+        [InlineData( 0.43429448190325183,     0.43429448190325183,     CrossPlatformMachineEpsilon)]          // value:  (log10(e))       expected: (log10(e))
+        [InlineData( 0.63661977236758134,     0.63661977236758134,     CrossPlatformMachineEpsilon)]          // value:  (2 / pi)         expected: (2 / pi)
+        [InlineData( 0.69314718055994531,     0.69314718055994531,     CrossPlatformMachineEpsilon)]          // value:  (ln(2))          expected: (ln(2))
+        [InlineData( 0.70710678118654752,     0.70710678118654752,     CrossPlatformMachineEpsilon)]          // value:  (1 / sqrt(2))    expected: (1 / sqrt(2))
+        [InlineData( 0.78539816339744831,     0.78539816339744831,     CrossPlatformMachineEpsilon)]          // value:  (pi / 4)         expected: (pi / 4)
+        [InlineData( 1.0,                     1.0,                     CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 1.1283791670955126,      1.1283791670955126,      CrossPlatformMachineEpsilon * 10)]     // value:  (2 / sqrt(pi))   expected: (2 / sqrt(pi))
+        [InlineData( 1.4142135623730950,      1.4142135623730950,      CrossPlatformMachineEpsilon * 10)]     // value:  (sqrt(2))        expected: (sqrt(2))
+        [InlineData( 1.4426950408889634,      1.4426950408889634,      CrossPlatformMachineEpsilon * 10)]     // value:  (log2(e))        expected: (log2(e))
+        [InlineData( 1.5707963267948966,      1.5707963267948966,      CrossPlatformMachineEpsilon * 10)]     // value:  (pi / 2)         expected: (pi / 2)
+        [InlineData( 2.3025850929940457,      2.3025850929940457,      CrossPlatformMachineEpsilon * 10)]     // value:  (ln(10))         expected: (ln(10))
+        [InlineData( 2.7182818284590452,      2.7182818284590452,      CrossPlatformMachineEpsilon * 10)]     // value:  (e)              expected: (e)
+        [InlineData( 3.1415926535897932,      3.1415926535897932,      CrossPlatformMachineEpsilon * 10)]     // value:  (pi)             expected: (pi)
+        [InlineData( double.PositiveInfinity, double.PositiveInfinity, 0.0)]
+        public static void Abs_Double(double value, double expectedResult, double allowedVariance)
         {
-            Assert.Equal(3.0, Math.Abs(3.0));
-            Assert.Equal(0.0, Math.Abs(0.0));
-            Assert.Equal(3.0, Math.Abs(-3.0));
-            Assert.Equal(double.NaN, Math.Abs(double.NaN));
-            Assert.Equal(double.PositiveInfinity, Math.Abs(double.PositiveInfinity));
-            Assert.Equal(double.PositiveInfinity, Math.Abs(double.NegativeInfinity));
+            AssertEqual(expectedResult, Math.Abs(value), allowedVariance);
         }
 
         [Fact]
-        public static void Abs_Short()
+        public static void Abs_Int16()
         {
             Assert.Equal((short)3, Math.Abs((short)3));
             Assert.Equal((short)0, Math.Abs((short)0));
@@ -332,7 +191,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void Abs_Int()
+        public static void Abs_Int32()
         {
             Assert.Equal(3, Math.Abs(3));
             Assert.Equal(0, Math.Abs(0));
@@ -341,7 +200,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void Abs_Long()
+        public static void Abs_Int64()
         {
             Assert.Equal(3L, Math.Abs(3L));
             Assert.Equal(0L, Math.Abs(0L));
@@ -358,27 +217,456 @@ namespace System.Tests
             Assert.Throws<OverflowException>(() => Math.Abs(sbyte.MinValue));
         }
 
-        [Fact]
-        public static void Abs_Float()
+        [Theory]
+        [InlineData( float.NegativeInfinity, float.PositiveInfinity, 0.0f)]
+        [InlineData(-3.14159265f,            3.14159265f,            CrossPlatformMachineEpsilon * 10)]     // value: -(pi)             expected: (pi)
+        [InlineData(-2.71828183f,            2.71828183f,            CrossPlatformMachineEpsilon * 10)]     // value: -(e)              expected: (e)
+        [InlineData(-2.30258509f,            2.30258509f,            CrossPlatformMachineEpsilon * 10)]     // value: -(ln(10))         expected: (ln(10))
+        [InlineData(-1.57079633f,            1.57079633f,            CrossPlatformMachineEpsilon * 10)]     // value: -(pi / 2)         expected: (pi / 2)
+        [InlineData(-1.44269504f,            1.44269504f,            CrossPlatformMachineEpsilon * 10)]     // value: -(log2(e))        expected: (log2(e))
+        [InlineData(-1.41421356f,            1.41421356f,            CrossPlatformMachineEpsilon * 10)]     // value: -(sqrt(2))        expected: (sqrt(2))
+        [InlineData(-1.12837917f,            1.12837917f,            CrossPlatformMachineEpsilon * 10)]     // value: -(2 / sqrt(pi))   expected: (2 / sqrt(pi))
+        [InlineData(-1.0f,                   1.0f,                   CrossPlatformMachineEpsilon * 10)]
+        [InlineData(-0.785398163f,           0.785398163f,           CrossPlatformMachineEpsilon)]          // value: -(pi / 4)         expected: (pi / 4)
+        [InlineData(-0.707106781f,           0.707106781f,           CrossPlatformMachineEpsilon)]          // value: -(1 / sqrt(2))    expected: (1 / sqrt(2))
+        [InlineData(-0.693147181f,           0.693147181f,           CrossPlatformMachineEpsilon)]          // value: -(ln(2))          expected: (ln(2))
+        [InlineData(-0.636619772f,           0.636619772f,           CrossPlatformMachineEpsilon)]          // value: -(2 / pi)         expected: (2 / pi)
+        [InlineData(-0.434294482f,           0.434294482f,           CrossPlatformMachineEpsilon)]          // value: -(log10(e))       expected: (log10(e))
+        [InlineData(-0.318309886f,           0.318309886f,           CrossPlatformMachineEpsilon)]          // value: -(1 / pi)         expected: (1 / pi)
+        [InlineData(-0.0f,                   0.0f,                   0.0f)]
+        [InlineData( float.NaN,              float.NaN,              0.0f)]
+        [InlineData( 0.0f,                   0.0f,                   0.0f)]
+        [InlineData( 0.318309886f,           0.318309886f,           CrossPlatformMachineEpsilon)]          // value:  (1 / pi)         expected: (1 / pi)
+        [InlineData( 0.434294482f,           0.434294482f,           CrossPlatformMachineEpsilon)]          // value:  (log10(e))       expected: (log10(e))
+        [InlineData( 0.636619772f,           0.636619772f,           CrossPlatformMachineEpsilon)]          // value:  (2 / pi)         expected: (2 / pi)
+        [InlineData( 0.693147181f,           0.693147181f,           CrossPlatformMachineEpsilon)]          // value:  (ln(2))          expected: (ln(2))
+        [InlineData( 0.707106781f,           0.707106781f,           CrossPlatformMachineEpsilon)]          // value:  (1 / sqrt(2))    expected: (1 / sqrt(2))
+        [InlineData( 0.785398163f,           0.785398163f,           CrossPlatformMachineEpsilon)]          // value:  (pi / 4)         expected: (pi / 4)
+        [InlineData( 1.0f,                   1.0f,                   CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 1.12837917f,            1.12837917f,            CrossPlatformMachineEpsilon * 10)]     // value:  (2 / sqrt(pi))   expected: (2 / sqrt(pi))
+        [InlineData( 1.41421356f,            1.41421356f,            CrossPlatformMachineEpsilon * 10)]     // value:  (sqrt(2))        expected: (sqrt(2))
+        [InlineData( 1.44269504f,            1.44269504f,            CrossPlatformMachineEpsilon * 10)]     // value:  (log2(e))        expected: (log2(e))
+        [InlineData( 1.57079633f,            1.57079633f,            CrossPlatformMachineEpsilon * 10)]     // value:  (pi / 2)         expected: (pi / 2)
+        [InlineData( 2.30258509f,            2.30258509f,            CrossPlatformMachineEpsilon * 10)]     // value:  (ln(10))         expected: (ln(10))
+        [InlineData( 2.71828183f,            2.71828183f,            CrossPlatformMachineEpsilon * 10)]     // value:  (e)              expected: (e)
+        [InlineData( 3.14159265f,            3.14159265f,            CrossPlatformMachineEpsilon * 10)]     // value:  (pi)             expected: (pi)
+        [InlineData( float.PositiveInfinity, float.PositiveInfinity, 0.0f)]
+        public static void Abs_Single(float value, float expectedResult, float allowedVariance)
         {
-            Assert.Equal(3.0, Math.Abs(3.0f));
-            Assert.Equal(0.0, Math.Abs(0.0f));
-            Assert.Equal(3.0, Math.Abs(-3.0f));
-            Assert.Equal(float.NaN, Math.Abs(float.NaN));
-            Assert.Equal(float.PositiveInfinity, Math.Abs(float.PositiveInfinity));
-            Assert.Equal(float.PositiveInfinity, Math.Abs(float.NegativeInfinity));
+            MathFTests.AssertEqual(expectedResult, MathF.Abs(value), allowedVariance);
+        }
+
+        [Theory]
+        [InlineData( double.NegativeInfinity, double.NaN,          0.0)]
+        [InlineData(-1.0,                     3.1415926535897932,  CrossPlatformMachineEpsilon * 10)]   // expected:  (pi)
+        [InlineData(-0.91173391478696510,     2.7182818284590452,  CrossPlatformMachineEpsilon * 10)]   // expected:  (e)
+        [InlineData(-0.66820151019031295,     2.3025850929940457,  CrossPlatformMachineEpsilon * 10)]   // expected:  (ln(10))
+        [InlineData( 0.0,                     1.5707963267948966,  CrossPlatformMachineEpsilon * 10)]   // expected:  (pi / 2)
+        [InlineData( double.NaN,              double.NaN,          0.0)]
+        [InlineData( 0.0,                     1.5707963267948966,  CrossPlatformMachineEpsilon * 10)]   // expected:  (pi / 2)
+        [InlineData( 0.12775121753523991,     1.4426950408889634,  CrossPlatformMachineEpsilon * 10)]   // expected:  (log2(e))
+        [InlineData( 0.15594369476537447,     1.4142135623730950,  CrossPlatformMachineEpsilon * 10)]   // expected:  (sqrt(2))
+        [InlineData( 0.42812514788535792,     1.1283791670955126,  CrossPlatformMachineEpsilon * 10)]   // expected:  (2 / sqrt(pi))
+        [InlineData( 0.54030230586813972,     1.0,                 CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 0.70710678118654752,     0.78539816339744831, CrossPlatformMachineEpsilon)]        // expected:  (pi / 4),         value:  (1 / sqrt(2))
+        [InlineData( 0.76024459707563015,     0.70710678118654752, CrossPlatformMachineEpsilon)]        // expected:  (1 / sqrt(2))
+        [InlineData( 0.76923890136397213,     0.69314718055994531, CrossPlatformMachineEpsilon)]        // expected:  (ln(2))
+        [InlineData( 0.80410982822879171,     0.63661977236758134, CrossPlatformMachineEpsilon)]        // expected:  (2 / pi)
+        [InlineData( 0.90716712923909839,     0.43429448190325183, CrossPlatformMachineEpsilon)]        // expected:  (log10(e))
+        [InlineData( 0.94976571538163866,     0.31830988618379067, CrossPlatformMachineEpsilon)]        // expected:  (1 / pi)
+        [InlineData( 1.0,                     0.0,                 0.0 )]
+        [InlineData( double.PositiveInfinity, double.NaN,          0.0 )]
+        public static void Acos(double value, double expectedResult, double allowedVariance)
+        {
+            AssertEqual(expectedResult, Math.Acos(value), allowedVariance);
+        }
+
+        [Theory]
+        [InlineData( double.NegativeInfinity,  double.NaN,          0.0)]
+        [InlineData(-1.0,                     -1.5707963267948966,  CrossPlatformMachineEpsilon * 10)]  // expected: -(pi / 2)
+        [InlineData(-0.99180624439366372,     -1.4426950408889634,  CrossPlatformMachineEpsilon * 10)]  // expected: -(log2(e))
+        [InlineData(-0.98776594599273553,     -1.4142135623730950,  CrossPlatformMachineEpsilon * 10)]  // expected: -(sqrt(2))
+        [InlineData(-0.90371945743584630,     -1.1283791670955126,  CrossPlatformMachineEpsilon * 10)]  // expected: -(2 / sqrt(pi))
+        [InlineData(-0.84147098480789651,     -1.0,                 CrossPlatformMachineEpsilon * 10)]
+        [InlineData(-0.74398033695749319,     -0.83900756059574755, CrossPlatformMachineEpsilon)]       // expected: -(pi - ln(10))
+        [InlineData(-0.70710678118654752,     -0.78539816339744831, CrossPlatformMachineEpsilon)]       // expected: -(pi / 4),         value: (1 / sqrt(2))
+        [InlineData(-0.64963693908006244,     -0.70710678118654752, CrossPlatformMachineEpsilon)]       // expected: -(1 / sqrt(2))
+        [InlineData(-0.63896127631363480,     -0.69314718055994531, CrossPlatformMachineEpsilon)]       // expected: -(ln(2))
+        [InlineData(-0.59448076852482208,     -0.63661977236758134, CrossPlatformMachineEpsilon)]       // expected: -(2 / pi)
+        [InlineData(-0.42077048331375735,     -0.43429448190325183, CrossPlatformMachineEpsilon)]       // expected: -(log10(e))
+        [InlineData(-0.41078129050290870,     -0.42331082513074800, CrossPlatformMachineEpsilon)]       // expected: -(pi - e)
+        [InlineData(-0.31296179620778659,     -0.31830988618379067, CrossPlatformMachineEpsilon)]       // expected: -(1 / pi)
+        [InlineData(-0.0,                     -0.0,                 0.0)]
+        [InlineData( double.NaN,               double.NaN,          0.0)]
+        [InlineData( 0.0,                      0.0,                 0.0)]
+        [InlineData( 0.31296179620778659,      0.31830988618379067, CrossPlatformMachineEpsilon)]       // expected:  (1 / pi)
+        [InlineData( 0.41078129050290870,      0.42331082513074800, CrossPlatformMachineEpsilon)]       // expected:  (pi - e)
+        [InlineData( 0.42077048331375735,      0.43429448190325183, CrossPlatformMachineEpsilon)]       // expected:  (log10(e))
+        [InlineData( 0.59448076852482208,      0.63661977236758134, CrossPlatformMachineEpsilon)]       // expected:  (2 / pi)
+        [InlineData( 0.63896127631363480,      0.69314718055994531, CrossPlatformMachineEpsilon)]       // expected:  (ln(2))
+        [InlineData( 0.64963693908006244,      0.70710678118654752, CrossPlatformMachineEpsilon)]       // expected:  (1 / sqrt(2))
+        [InlineData( 0.70710678118654752,      0.78539816339744831, CrossPlatformMachineEpsilon)]       // expected:  (pi / 4),         value: (1 / sqrt(2))
+        [InlineData( 0.74398033695749319,      0.83900756059574755, CrossPlatformMachineEpsilon)]       // expected:  (pi - ln(10))
+        [InlineData( 0.84147098480789651,      1.0,                 CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 0.90371945743584630,      1.1283791670955126,  CrossPlatformMachineEpsilon * 10)]  // expected:  (2 / sqrt(pi))
+        [InlineData( 0.98776594599273553,      1.4142135623730950,  CrossPlatformMachineEpsilon * 10)]  // expected:  (sqrt(2))
+        [InlineData( 0.99180624439366372,      1.4426950408889634,  CrossPlatformMachineEpsilon * 10)]  // expected:  (log2(e))
+        [InlineData( 1.0,                      1.5707963267948966,  CrossPlatformMachineEpsilon * 10)]  // expected:  (pi / 2)
+        [InlineData( double.PositiveInfinity,  double.NaN,          0.0)]
+        public static void Asin(double value, double expectedResult, double allowedVariance)
+        {
+            AssertEqual(expectedResult, Math.Asin(value), allowedVariance);
+        }
+
+        [Theory]
+        [InlineData( double.NegativeInfinity, -1.5707963267948966,  CrossPlatformMachineEpsilon * 10)]  // expected: -(pi / 2)
+        [InlineData(-7.7635756709721848,      -1.4426950408889634,  CrossPlatformMachineEpsilon * 10)]  // expected: -(log2(e))
+        [InlineData(-6.3341191670421916,      -1.4142135623730950,  CrossPlatformMachineEpsilon * 10)]  // expected: -(sqrt(2))
+        [InlineData(-2.1108768356626451,      -1.1283791670955126,  CrossPlatformMachineEpsilon * 10)]  // expected: -(2 / sqrt(pi))
+        [InlineData(-1.5574077246549022,      -1.0,                 CrossPlatformMachineEpsilon * 10)]
+        [InlineData(-1.1134071468135374,      -0.83900756059574755, CrossPlatformMachineEpsilon)]       // expected: -(pi - ln(10))
+        [InlineData(-1.0,                     -0.78539816339744831, CrossPlatformMachineEpsilon)]       // expected: -(pi / 4)
+        [InlineData(-0.85451043200960189,     -0.70710678118654752, CrossPlatformMachineEpsilon)]       // expected: -(1 / sqrt(2))
+        [InlineData(-0.83064087786078395,     -0.69314718055994531, CrossPlatformMachineEpsilon)]       // expected: -(ln(2))
+        [InlineData(-0.73930295048660405,     -0.63661977236758134, CrossPlatformMachineEpsilon)]       // expected: -(2 / pi)
+        [InlineData(-0.46382906716062964,     -0.43429448190325183, CrossPlatformMachineEpsilon)]       // expected: -(log10(e))
+        [InlineData(-0.45054953406980750,     -0.42331082513074800, CrossPlatformMachineEpsilon)]       // expected: -(pi - e)
+        [InlineData(-0.32951473309607836,     -0.31830988618379067, CrossPlatformMachineEpsilon)]       // expected: -(1 / pi)
+        [InlineData(-0.0,                     -0.0,                 0.0)]
+        [InlineData( double.NaN,               double.NaN,          0.0)]
+        [InlineData( 0.0,                      0.0,                 0.0)]
+        [InlineData( 0.32951473309607836,      0.31830988618379067, CrossPlatformMachineEpsilon)]       // expected:  (1 / pi)
+        [InlineData( 0.45054953406980750,      0.42331082513074800, CrossPlatformMachineEpsilon)]       // expected:  (pi - e)
+        [InlineData( 0.46382906716062964,      0.43429448190325183, CrossPlatformMachineEpsilon)]       // expected:  (log10(e))
+        [InlineData( 0.73930295048660405,      0.63661977236758134, CrossPlatformMachineEpsilon)]       // expected:  (2 / pi)
+        [InlineData( 0.83064087786078395,      0.69314718055994531, CrossPlatformMachineEpsilon)]       // expected:  (ln(2))
+        [InlineData( 0.85451043200960189,      0.70710678118654752, CrossPlatformMachineEpsilon)]       // expected:  (1 / sqrt(2))
+        [InlineData( 1.0,                      0.78539816339744831, CrossPlatformMachineEpsilon)]       // expected:  (pi / 4)
+        [InlineData( 1.1134071468135374,       0.83900756059574755, CrossPlatformMachineEpsilon)]       // expected:  (pi - ln(10))
+        [InlineData( 1.5574077246549022,       1.0,                 CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 2.1108768356626451,       1.1283791670955126,  CrossPlatformMachineEpsilon * 10)]  // expected:  (2 / sqrt(pi))
+        [InlineData( 6.3341191670421916,       1.4142135623730950,  CrossPlatformMachineEpsilon * 10)]  // expected:  (sqrt(2))
+        [InlineData( 7.7635756709721848,       1.4426950408889634,  CrossPlatformMachineEpsilon * 10)]  // expected:  (log2(e))
+        [InlineData( double.PositiveInfinity,  1.5707963267948966,  CrossPlatformMachineEpsilon * 10)]  // expected:  (pi / 2)
+        public static void Atan(double value, double expectedResult, double allowedVariance)
+        {
+            AssertEqual(expectedResult, Math.Atan(value), allowedVariance);
+        }
+
+        [Theory]
+        [InlineData( double.NegativeInfinity,  double.NegativeInfinity,  double.NaN,          0.0)]
+        [InlineData( double.NegativeInfinity,  double.NegativeInfinity, -2.3561944901923449,  CrossPlatformMachineEpsilon * 10, Skip = "https://github.com/dotnet/coreclr/issues/9806")]     // expected: -(3 * pi / 4)
+        [InlineData( double.NegativeInfinity, -1.0,                     -1.5707963267948966,  CrossPlatformMachineEpsilon * 10)]    // expected: -(pi / 2)
+        [InlineData( double.NegativeInfinity, -0.0,                     -1.5707963267948966,  CrossPlatformMachineEpsilon * 10)]    // expected: -(pi / 2)
+        [InlineData( double.NegativeInfinity,  double.NaN,               double.NaN,          0.0)]
+        [InlineData( double.NegativeInfinity,  0.0,                     -1.5707963267948966,  CrossPlatformMachineEpsilon * 10)]    // expected: -(pi / 2)
+        [InlineData( double.NegativeInfinity,  1.0,                     -1.5707963267948966,  CrossPlatformMachineEpsilon * 10)]    // expected: -(pi / 2)
+        [InlineData( double.NegativeInfinity,  double.PositiveInfinity,  double.NaN,          0.0)]
+        [InlineData( double.NegativeInfinity,  double.PositiveInfinity, -0.78539816339744831, CrossPlatformMachineEpsilon, Skip = "https://github.com/dotnet/coreclr/issues/9806")]          // expected: -(pi / 4)
+        [InlineData(-1.0,                     -1.0,                     -2.3561944901923449,  CrossPlatformMachineEpsilon * 10)]    // expected: -(3 * pi / 4)
+        [InlineData(-1.0,                     -0.0,                     -1.5707963267948966,  CrossPlatformMachineEpsilon * 10)]    // expected: -(pi / 2)
+        [InlineData(-1.0,                      double.NaN,               double.NaN,          0.0)]
+        [InlineData(-1.0,                      0.0,                     -1.5707963267948966,  CrossPlatformMachineEpsilon * 10)]    // expected: -(pi / 2)
+        [InlineData(-1.0,                      1.0,                     -0.78539816339744831, CrossPlatformMachineEpsilon)]         // expected: -(pi / 4)
+        [InlineData(-1.0,                      double.PositiveInfinity, -0.0,                 0.0)]
+        [InlineData(-0.99180624439366372,     -0.12775121753523991,     -1.6988976127008298,  CrossPlatformMachineEpsilon * 10)]    // expected: -(pi - log2(e))
+        [InlineData(-0.99180624439366372,      0.12775121753523991,     -1.4426950408889634,  CrossPlatformMachineEpsilon * 10)]    // expected: -(log2(e))
+        [InlineData(-0.98776594599273553,     -0.15594369476537447,     -1.7273790912166982,  CrossPlatformMachineEpsilon * 10)]    // expected: -(pi - sqrt(2))
+        [InlineData(-0.98776594599273553,      0.15594369476537447,     -1.4142135623730950,  CrossPlatformMachineEpsilon * 10)]    // expected: -(sqrt(2))
+        [InlineData(-0.90371945743584630,     -0.42812514788535792,     -2.0132134864942807,  CrossPlatformMachineEpsilon * 10)]    // expected: -(pi - (2 / sqrt(pi))
+        [InlineData(-0.90371945743584630,      0.42812514788535792,     -1.1283791670955126,  CrossPlatformMachineEpsilon * 10)]    // expected: -(2 / sqrt(pi)
+        [InlineData(-0.84147098480789651,     -0.54030230586813972,     -2.1415926535897932,  CrossPlatformMachineEpsilon * 10)]    // expected: -(pi - 1)
+        [InlineData(-0.84147098480789651,      0.54030230586813972,     -1.0,                 CrossPlatformMachineEpsilon * 10)]
+        [InlineData(-0.74398033695749319,     -0.66820151019031295,     -2.3025850929940457,  CrossPlatformMachineEpsilon * 10)]    // expected: -(ln(10))
+        [InlineData(-0.74398033695749319,      0.66820151019031295,     -0.83900756059574755, CrossPlatformMachineEpsilon)]         // expected: -(pi - ln(10))
+        [InlineData(-0.70710678118654752,     -0.70710678118654752,     -2.3561944901923449,  CrossPlatformMachineEpsilon * 10)]    // expected: -(3 * pi / 4),         y: -(1 / sqrt(2))   x: -(1 / sqrt(2))
+        [InlineData(-0.70710678118654752,      0.70710678118654752,     -0.78539816339744831, CrossPlatformMachineEpsilon)]         // expected: -(pi / 4),             y: -(1 / sqrt(2))   x:  (1 / sqrt(2))
+        [InlineData(-0.64963693908006244,     -0.76024459707563015,     -2.4344858724032457,  CrossPlatformMachineEpsilon * 10)]    // expected: -(pi - (1 / sqrt(2))
+        [InlineData(-0.64963693908006244,      0.76024459707563015,     -0.70710678118654752, CrossPlatformMachineEpsilon)]         // expected: -(1 / sqrt(2))
+        [InlineData(-0.63896127631363480,     -0.76923890136397213,     -2.4484454730298479,  CrossPlatformMachineEpsilon * 10)]    // expected: -(pi - ln(2))
+        [InlineData(-0.63896127631363480,      0.76923890136397213,     -0.69314718055994531, CrossPlatformMachineEpsilon)]         // expected: -(ln(2))
+        [InlineData(-0.59448076852482208,     -0.80410982822879171,     -2.5049728812222119,  CrossPlatformMachineEpsilon * 10)]    // expected: -(pi - (2 / pi))
+        [InlineData(-0.59448076852482208,      0.80410982822879171,     -0.63661977236758134, CrossPlatformMachineEpsilon)]         // expected: -(2 / pi)
+        [InlineData(-0.42077048331375735,     -0.90716712923909839,     -2.7072981716865414,  CrossPlatformMachineEpsilon * 10)]    // expected: -(pi - log10(e))
+        [InlineData(-0.42077048331375735,      0.90716712923909839,     -0.43429448190325183, CrossPlatformMachineEpsilon)]         // expected: -(log10(e))
+        [InlineData(-0.41078129050290870,     -0.91173391478696510,     -2.7182818284590452,  CrossPlatformMachineEpsilon * 10)]    // expected: -(e)
+        [InlineData(-0.41078129050290870,      0.91173391478696510,     -0.42331082513074800, CrossPlatformMachineEpsilon)]         // expected: -(pi - e)
+        [InlineData(-0.31296179620778659,     -0.94976571538163866,     -2.8232827674060026,  CrossPlatformMachineEpsilon * 10)]    // expected: -(pi - (1 / pi))
+        [InlineData(-0.31296179620778659,      0.94976571538163866,     -0.31830988618379067, CrossPlatformMachineEpsilon)]         // expected: -(1 / pi)
+        [InlineData(-0.0,                      double.NegativeInfinity, -3.1415926535897932,  CrossPlatformMachineEpsilon * 10)]    // expected: -(pi)
+        [InlineData(-0.0,                     -1.0,                     -3.1415926535897932,  CrossPlatformMachineEpsilon * 10)]    // expected: -(pi)
+        [InlineData(-0.0,                     -0.0,                     -3.1415926535897932,  CrossPlatformMachineEpsilon * 10)]    // expected: -(pi)
+        [InlineData(-0.0,                      double.NaN,               double.NaN,          0.0)]
+        [InlineData(-0.0,                      0.0,                     -0.0,                 0.0)]
+        [InlineData(-0.0,                      1.0,                     -0.0,                 0.0)]
+        [InlineData(-0.0,                      double.PositiveInfinity, -0.0,                 0.0)]
+        [InlineData( double.NaN,               double.NegativeInfinity,  double.NaN,          0.0)]
+        [InlineData( double.NaN,              -1.0,                      double.NaN,          0.0)]
+        [InlineData( double.NaN,              -0.0,                      double.NaN,          0.0)]
+        [InlineData( double.NaN,               double.NaN,               double.NaN,          0.0)]
+        [InlineData( double.NaN,               0.0,                      double.NaN,          0.0)]
+        [InlineData( double.NaN,               1.0,                      double.NaN,          0.0)]
+        [InlineData( double.NaN,               double.PositiveInfinity,  double.NaN,          0.0)]
+        [InlineData( 0.0,                      double.NegativeInfinity,  3.1415926535897932,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi)
+        [InlineData( 0.0,                     -1.0,                      3.1415926535897932,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi)
+        [InlineData( 0.0,                     -0.0,                      3.1415926535897932,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi)
+        [InlineData( 0.0,                      double.NaN,               double.NaN,          0.0)]
+        [InlineData( 0.0,                      0.0,                      0.0,                 0.0)]
+        [InlineData( 0.0,                      1.0,                      0.0,                 0.0)]
+        [InlineData( 0.0,                      double.PositiveInfinity,  0.0,                 0.0)]
+        [InlineData( 0.31296179620778659,     -0.94976571538163866,      2.8232827674060026,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi - (1 / pi))
+        [InlineData( 0.31296179620778659,      0.94976571538163866,      0.31830988618379067, CrossPlatformMachineEpsilon)]          // expected:  (1 / pi)
+        [InlineData( 0.41078129050290870,     -0.91173391478696510,      2.7182818284590452,  CrossPlatformMachineEpsilon * 10)]     // expected:  (e)
+        [InlineData( 0.41078129050290870,      0.91173391478696510,      0.42331082513074800, CrossPlatformMachineEpsilon)]          // expected:  (pi - e)
+        [InlineData( 0.42077048331375735,     -0.90716712923909839,      2.7072981716865414,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi - log10(e))
+        [InlineData( 0.42077048331375735,      0.90716712923909839,      0.43429448190325183, CrossPlatformMachineEpsilon)]          // expected:  (log10(e))
+        [InlineData( 0.59448076852482208,     -0.80410982822879171,      2.5049728812222119,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi - (2 / pi))
+        [InlineData( 0.59448076852482208,      0.80410982822879171,      0.63661977236758134, CrossPlatformMachineEpsilon)]          // expected:  (2 / pi)
+        [InlineData( 0.63896127631363480,     -0.76923890136397213,      2.4484454730298479,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi - ln(2))
+        [InlineData( 0.63896127631363480,      0.76923890136397213,      0.69314718055994531, CrossPlatformMachineEpsilon)]          // expected:  (ln(2))
+        [InlineData( 0.64963693908006244,     -0.76024459707563015,      2.4344858724032457,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi - (1 / sqrt(2))
+        [InlineData( 0.64963693908006244,      0.76024459707563015,      0.70710678118654752, CrossPlatformMachineEpsilon)]          // expected:  (1 / sqrt(2))
+        [InlineData( 0.70710678118654752,     -0.70710678118654752,      2.3561944901923449,  CrossPlatformMachineEpsilon * 10)]     // expected:  (3 * pi / 4),         y:  (1 / sqrt(2))   x: -(1 / sqrt(2))
+        [InlineData( 0.70710678118654752,      0.70710678118654752,      0.78539816339744831, CrossPlatformMachineEpsilon)]          // expected:  (pi / 4),             y:  (1 / sqrt(2))   x:  (1 / sqrt(2))
+        [InlineData( 0.74398033695749319,     -0.66820151019031295,      2.3025850929940457,  CrossPlatformMachineEpsilon * 10)]     // expected:  (ln(10))
+        [InlineData( 0.74398033695749319,      0.66820151019031295,      0.83900756059574755, CrossPlatformMachineEpsilon)]          // expected:  (pi - ln(10))
+        [InlineData( 0.84147098480789651,     -0.54030230586813972,      2.1415926535897932,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi - 1)
+        [InlineData( 0.84147098480789651,      0.54030230586813972,      1.0,                 CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 0.90371945743584630,     -0.42812514788535792,      2.0132134864942807,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi - (2 / sqrt(pi))
+        [InlineData( 0.90371945743584630,      0.42812514788535792,      1.1283791670955126,  CrossPlatformMachineEpsilon * 10)]     // expected:  (2 / sqrt(pi))
+        [InlineData( 0.98776594599273553,     -0.15594369476537447,      1.7273790912166982,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi - sqrt(2))
+        [InlineData( 0.98776594599273553,      0.15594369476537447,      1.4142135623730950,  CrossPlatformMachineEpsilon * 10)]     // expected:  (sqrt(2))
+        [InlineData( 0.99180624439366372,     -0.12775121753523991,      1.6988976127008298,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi - log2(e))
+        [InlineData( 0.99180624439366372,      0.12775121753523991,      1.4426950408889634,  CrossPlatformMachineEpsilon * 10)]     // expected:  (log2(e))
+        [InlineData( 1.0,                     -1.0,                      2.3561944901923449,  CrossPlatformMachineEpsilon * 10)]     // expected:  (3 * pi / 4)
+        [InlineData( 1.0,                     -0.0,                      1.5707963267948966,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi / 2)
+        [InlineData( 1.0,                      double.NaN,               double.NaN,          0.0)]
+        [InlineData( 1.0,                      0.0,                      1.5707963267948966,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi / 2)
+        [InlineData( 1.0,                      1.0,                      0.78539816339744831, CrossPlatformMachineEpsilon)]          // expected:  (pi / 4)
+        [InlineData( 1.0,                      double.PositiveInfinity,  0.0,                 0.0)]
+        [InlineData( double.PositiveInfinity,  double.NegativeInfinity,  double.NaN,          0.0)]
+        [InlineData( double.PositiveInfinity,  double.NegativeInfinity,  2.3561944901923449,  CrossPlatformMachineEpsilon * 10, Skip = "https://github.com/dotnet/coreclr/issues/9806")]     // expected:  (3 * pi / 4)
+        [InlineData( double.PositiveInfinity, -1.0,                      1.5707963267948966,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi / 2)
+        [InlineData( double.PositiveInfinity, -0.0,                      1.5707963267948966,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi / 2)
+        [InlineData( double.PositiveInfinity,  double.NaN,               double.NaN,          0.0)]
+        [InlineData( double.PositiveInfinity,  0.0,                      1.5707963267948966,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi / 2)
+        [InlineData( double.PositiveInfinity,  1.0,                      1.5707963267948966,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi / 2)
+        [InlineData( double.PositiveInfinity,  double.PositiveInfinity,  double.NaN,          0.0)]
+        [InlineData( double.PositiveInfinity,  double.PositiveInfinity,  0.78539816339744831, CrossPlatformMachineEpsilon, Skip = "https://github.com/dotnet/coreclr/issues/9806")]          // expected:  (pi / 4)
+        public static void Atan2(double y, double x, double expectedResult, double allowedVariance)
+        {
+            AssertEqual(expectedResult, Math.Atan2(y, x), allowedVariance);
         }
 
         [Fact]
-        public static void Exp()
+        public static void Ceiling_Decimal()
         {
-            Assert.Equal(20.0855369231877, Math.Exp(3.0), 10);
-            Assert.Equal(1.0, Math.Exp(0.0));
-            Assert.Equal(Math.E, Math.Exp(1.0));
-            Assert.Equal(0.0497870683678639, Math.Exp(-3.0), 10);
-            Assert.Equal(double.NaN, Math.Exp(double.NaN));
-            Assert.Equal(double.PositiveInfinity, Math.Exp(double.PositiveInfinity));
-            Assert.Equal(0.0, Math.Exp(double.NegativeInfinity));
+            Assert.Equal(2.0m, Math.Ceiling(1.1m));
+            Assert.Equal(2.0m, Math.Ceiling(1.9m));
+            Assert.Equal(-1.0m, Math.Ceiling(-1.1m));
+        }
+
+        [Theory]
+        [InlineData(double.NegativeInfinity,  double.NegativeInfinity, 0.0)]
+        [InlineData(-3.1415926535897932,     -3.0,                     0.0)]    // value: -(pi)
+        [InlineData(-2.7182818284590452,     -2.0,                     0.0)]    // value: -(e)
+        [InlineData(-2.3025850929940457,     -2.0,                     0.0)]    // value: -(ln(10))
+        [InlineData(-1.5707963267948966,     -1.0,                     0.0)]    // value: -(pi / 2)
+        [InlineData(-1.4426950408889634,     -1.0,                     0.0)]    // value: -(log2(e))
+        [InlineData(-1.4142135623730950,     -1.0,                     0.0)]    // value: -(sqrt(2))
+        [InlineData(-1.1283791670955126,     -1.0,                     0.0)]    // value: -(2 / sqrt(pi))
+        [InlineData(-1.0,                    -1.0,                     0.0)]
+        [InlineData(-0.78539816339744831,     0.0,                     0.0)]    // value: -(pi / 4)
+        [InlineData(-0.70710678118654752,     0.0,                     0.0)]    // value: -(1 / sqrt(2))
+        [InlineData(-0.69314718055994531,     0.0,                     0.0)]    // value: -(ln(2))
+        [InlineData(-0.63661977236758134,     0.0,                     0.0)]    // value: -(2 / pi)
+        [InlineData(-0.43429448190325183,     0.0,                     0.0)]    // value: -(log10(e))
+        [InlineData(-0.31830988618379067,     0.0,                     0.0)]    // value: -(1 / pi)
+        [InlineData(-0.0,                    -0.0,                     0.0)]
+        [InlineData( double.NaN,              double.NaN,              0.0)]
+        [InlineData( 0.0,                     0.0,                     0.0)]
+        [InlineData( 0.31830988618379067,     1.0,                     0.0)]    // value:  (1 / pi)
+        [InlineData( 0.43429448190325183,     1.0,                     0.0)]    // value:  (log10(e))
+        [InlineData( 0.63661977236758134,     1.0,                     0.0)]    // value:  (2 / pi)
+        [InlineData( 0.69314718055994531,     1.0,                     0.0)]    // value:  (ln(2))
+        [InlineData( 0.70710678118654752,     1.0,                     0.0)]    // value:  (1 / sqrt(2))
+        [InlineData( 0.78539816339744831,     1.0,                     0.0)]    // value:  (pi / 4)
+        [InlineData( 1.0,                     1.0,                     0.0)]
+        [InlineData( 1.1283791670955126,      2.0,                     0.0)]    // value:  (2 / sqrt(pi))
+        [InlineData( 1.4142135623730950,      2.0,                     0.0)]    // value:  (sqrt(2))
+        [InlineData( 1.4426950408889634,      2.0,                     0.0)]    // value:  (log2(e))
+        [InlineData( 1.5707963267948966,      2.0,                     0.0)]    // value:  (pi / 2)
+        [InlineData( 2.3025850929940457,      3.0,                     0.0)]    // value:  (ln(10))
+        [InlineData( 2.7182818284590452,      3.0,                     0.0)]    // value:  (e)
+        [InlineData( 3.1415926535897932,      4.0,                     0.0)]    // value:  (pi)
+        [InlineData(double.PositiveInfinity, double.PositiveInfinity,  0.0)]
+        public static void Ceiling_Double(double value, double expectedResult, double allowedVariance)
+        {
+            AssertEqual(expectedResult, Math.Ceiling(value), allowedVariance);
+        }
+
+        [Theory]
+        [InlineData( double.NegativeInfinity,  double.NaN,          0.0)]
+        [InlineData(-3.1415926535897932,      -1.0,                 CrossPlatformMachineEpsilon * 10)]  // value: -(pi)
+        [InlineData(-2.7182818284590452,      -0.91173391478696510, CrossPlatformMachineEpsilon)]       // value: -(e)
+        [InlineData(-2.3025850929940457,      -0.66820151019031295, CrossPlatformMachineEpsilon)]       // value: -(ln(10))
+        [InlineData(-1.5707963267948966,       0.0,                 CrossPlatformMachineEpsilon)]       // value: -(pi / 2)
+        [InlineData(-1.4426950408889634,       0.12775121753523991, CrossPlatformMachineEpsilon)]       // value: -(log2(e))
+        [InlineData(-1.4142135623730950,       0.15594369476537447, CrossPlatformMachineEpsilon)]       // value: -(sqrt(2))
+        [InlineData(-1.1283791670955126,       0.42812514788535792, CrossPlatformMachineEpsilon)]       // value: -(2 / sqrt(pi))
+        [InlineData(-1.0,                      0.54030230586813972, CrossPlatformMachineEpsilon)]
+        [InlineData(-0.78539816339744831,      0.70710678118654752, CrossPlatformMachineEpsilon)]       // value: -(pi / 4),        expected:  (1 / sqrt(2))
+        [InlineData(-0.70710678118654752,      0.76024459707563015, CrossPlatformMachineEpsilon)]       // value: -(1 / sqrt(2))
+        [InlineData(-0.69314718055994531,      0.76923890136397213, CrossPlatformMachineEpsilon)]       // value: -(ln(2))
+        [InlineData(-0.63661977236758134,      0.80410982822879171, CrossPlatformMachineEpsilon)]       // value: -(2 / pi)
+        [InlineData(-0.43429448190325183,      0.90716712923909839, CrossPlatformMachineEpsilon)]       // value: -(log10(e))
+        [InlineData(-0.31830988618379067,      0.94976571538163866, CrossPlatformMachineEpsilon)]       // value: -(1 / pi)
+        [InlineData(-0.0,                      1.0,                 CrossPlatformMachineEpsilon * 10)]
+        [InlineData( double.NaN,               double.NaN,          0.0)]
+        [InlineData( 0.0,                      1.0,                 CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 0.31830988618379067,      0.94976571538163866, CrossPlatformMachineEpsilon)]       // value:  (1 / pi)
+        [InlineData( 0.43429448190325183,      0.90716712923909839, CrossPlatformMachineEpsilon)]       // value:  (log10(e))
+        [InlineData( 0.63661977236758134,      0.80410982822879171, CrossPlatformMachineEpsilon)]       // value:  (2 / pi)
+        [InlineData( 0.69314718055994531,      0.76923890136397213, CrossPlatformMachineEpsilon)]       // value:  (ln(2))
+        [InlineData( 0.70710678118654752,      0.76024459707563015, CrossPlatformMachineEpsilon)]       // value:  (1 / sqrt(2))
+        [InlineData( 0.78539816339744831,      0.70710678118654752, CrossPlatformMachineEpsilon)]       // value:  (pi / 4),        expected:  (1 / sqrt(2))
+        [InlineData( 1.0,                      0.54030230586813972, CrossPlatformMachineEpsilon)]
+        [InlineData( 1.1283791670955126,       0.42812514788535792, CrossPlatformMachineEpsilon)]       // value:  (2 / sqrt(pi))
+        [InlineData( 1.4142135623730950,       0.15594369476537447, CrossPlatformMachineEpsilon)]       // value:  (sqrt(2))
+        [InlineData( 1.4426950408889634,       0.12775121753523991, CrossPlatformMachineEpsilon)]       // value:  (log2(e))
+        [InlineData( 1.5707963267948966,       0.0,                 CrossPlatformMachineEpsilon)]       // value:  (pi / 2)
+        [InlineData( 2.3025850929940457,      -0.66820151019031295, CrossPlatformMachineEpsilon)]       // value:  (ln(10))
+        [InlineData( 2.7182818284590452,      -0.91173391478696510, CrossPlatformMachineEpsilon)]       // value:  (e)
+        [InlineData( 3.1415926535897932,      -1.0,                 CrossPlatformMachineEpsilon * 10)]  // value:  (pi)
+        [InlineData( double.PositiveInfinity,  double.NaN,          0.0)]
+        public static void Cos(double value, double expectedResult, double allowedVariance)
+        {
+            AssertEqual(expectedResult, Math.Cos(value), allowedVariance);
+        }
+
+        [Theory]
+        [InlineData( double.NegativeInfinity, double.PositiveInfinity, 0.0)]
+        [InlineData(-3.1415926535897932,      11.591953275521521,      CrossPlatformMachineEpsilon * 100)]  // value:  (pi)
+        [InlineData(-2.7182818284590452,      7.6101251386622884,      CrossPlatformMachineEpsilon * 10)]   // value:  (e)
+        [InlineData(-2.3025850929940457,      5.05,                    CrossPlatformMachineEpsilon * 10)]   // value:  (ln(10))
+        [InlineData(-1.5707963267948966,      2.5091784786580568,      CrossPlatformMachineEpsilon * 10)]   // value:  (pi / 2)
+        [InlineData(-1.4426950408889634,      2.2341880974508023,      CrossPlatformMachineEpsilon * 10)]   // value:  (log2(e))
+        [InlineData(-1.4142135623730950,      2.1781835566085709,      CrossPlatformMachineEpsilon * 10)]   // value:  (sqrt(2))
+        [InlineData(-1.1283791670955126,      1.7071001431069344,      CrossPlatformMachineEpsilon * 10)]   // value:  (2 / sqrt(pi))
+        [InlineData(-1.0,                     1.5430806348152438,      CrossPlatformMachineEpsilon * 10)]
+        [InlineData(-0.78539816339744831,     1.3246090892520058,      CrossPlatformMachineEpsilon * 10)]   // value:  (pi / 4)
+        [InlineData(-0.70710678118654752,     1.2605918365213561,      CrossPlatformMachineEpsilon * 10)]   // value:  (1 / sqrt(2))
+        [InlineData(-0.69314718055994531,     1.25,                    CrossPlatformMachineEpsilon * 10)]   // value:  (ln(2))
+        [InlineData(-0.63661977236758134,     1.2095794864199787,      CrossPlatformMachineEpsilon * 10)]   // value:  (2 / pi)
+        [InlineData(-0.43429448190325183,     1.0957974645564909,      CrossPlatformMachineEpsilon * 10)]   // value:  (log10(e))
+        [InlineData(-0.31830988618379067,     1.0510897883672876,      CrossPlatformMachineEpsilon * 10)]   // value:  (1 / pi)
+        [InlineData(-0.0,                     1.0,                     CrossPlatformMachineEpsilon * 10)]
+        [InlineData( double.NaN,              double.NaN,              0.0)]
+        [InlineData( 0.0,                     1.0,                     CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 0.31830988618379067,     1.0510897883672876,      CrossPlatformMachineEpsilon * 10)]   // value:  (1 / pi)
+        [InlineData( 0.43429448190325183,     1.0957974645564909,      CrossPlatformMachineEpsilon * 10)]   // value:  (log10(e))
+        [InlineData( 0.63661977236758134,     1.2095794864199787,      CrossPlatformMachineEpsilon * 10)]   // value:  (2 / pi)
+        [InlineData( 0.69314718055994531,     1.25,                    CrossPlatformMachineEpsilon * 10)]   // value:  (ln(2))
+        [InlineData( 0.70710678118654752,     1.2605918365213561,      CrossPlatformMachineEpsilon * 10)]   // value:  (1 / sqrt(2))
+        [InlineData( 0.78539816339744831,     1.3246090892520058,      CrossPlatformMachineEpsilon * 10)]   // value:  (pi / 4)
+        [InlineData( 1.0,                     1.5430806348152438,      CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 1.1283791670955126,      1.7071001431069344,      CrossPlatformMachineEpsilon * 10)]   // value:  (2 / sqrt(pi))
+        [InlineData( 1.4142135623730950,      2.1781835566085709,      CrossPlatformMachineEpsilon * 10)]   // value:  (sqrt(2))
+        [InlineData( 1.4426950408889634,      2.2341880974508023,      CrossPlatformMachineEpsilon * 10)]   // value:  (log2(e))
+        [InlineData( 1.5707963267948966,      2.5091784786580568,      CrossPlatformMachineEpsilon * 10)]   // value:  (pi / 2)
+        [InlineData( 2.3025850929940457,      5.05,                    CrossPlatformMachineEpsilon * 10)]   // value:  (ln(10))
+        [InlineData( 2.7182818284590452,      7.6101251386622884,      CrossPlatformMachineEpsilon * 10)]   // value:  (e)
+        [InlineData( 3.1415926535897932,      11.591953275521521,      CrossPlatformMachineEpsilon * 100)]  // value:  (pi)
+        [InlineData( double.PositiveInfinity, double.PositiveInfinity, 0.0)]
+        public static void Cosh(double value, double expectedResult, double allowedVariance)
+        {
+            AssertEqual(expectedResult, Math.Cosh(value), allowedVariance);
+        }
+
+        [Theory]
+        [InlineData( double.NegativeInfinity, 0.0,                     CrossPlatformMachineEpsilon)]
+        [InlineData(-3.1415926535897932,      0.043213918263772250,    CrossPlatformMachineEpsilon / 10)]   // value: -(pi)
+        [InlineData(-2.7182818284590452,      0.065988035845312537,    CrossPlatformMachineEpsilon / 10)]   // value: -(e)
+        [InlineData(-2.3025850929940457,      0.1,                     CrossPlatformMachineEpsilon)]        // value: -(ln(10))
+        [InlineData(-1.5707963267948966,      0.20787957635076191,     CrossPlatformMachineEpsilon)]        // value: -(pi / 2)
+        [InlineData(-1.4426950408889634,      0.23629008834452270,     CrossPlatformMachineEpsilon)]        // value: -(log2(e))
+        [InlineData(-1.4142135623730950,      0.24311673443421421,     CrossPlatformMachineEpsilon)]        // value: -(sqrt(2))
+        [InlineData(-1.1283791670955126,      0.32355726390307110,     CrossPlatformMachineEpsilon)]        // value: -(2 / sqrt(pi))
+        [InlineData(-1.0,                     0.36787944117144232,     CrossPlatformMachineEpsilon)]
+        [InlineData(-0.78539816339744831,     0.45593812776599624,     CrossPlatformMachineEpsilon)]        // value: -(pi / 4)
+        [InlineData(-0.70710678118654752,     0.49306869139523979,     CrossPlatformMachineEpsilon)]        // value: -(1 / sqrt(2))
+        [InlineData(-0.69314718055994531,     0.5,                     CrossPlatformMachineEpsilon)]        // value: -(ln(2))
+        [InlineData(-0.63661977236758134,     0.52907780826773535,     CrossPlatformMachineEpsilon)]        // value: -(2 / pi)
+        [InlineData(-0.43429448190325183,     0.64772148514180065,     CrossPlatformMachineEpsilon)]        // value: -(log10(e))
+        [InlineData(-0.31830988618379067,     0.72737734929521647,     CrossPlatformMachineEpsilon)]        // value: -(1 / pi)
+        [InlineData(-0.0,                     1.0,                     CrossPlatformMachineEpsilon * 10)]
+        [InlineData( double.NaN,              double.NaN,              0.0)]
+        [InlineData( 0.0,                     1.0,                     CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 0.31830988618379067,     1.3748022274393586,      CrossPlatformMachineEpsilon * 10)]   // value:  (1 / pi)
+        [InlineData( 0.43429448190325183,     1.5438734439711811,      CrossPlatformMachineEpsilon * 10)]   // value:  (log10(e))
+        [InlineData( 0.63661977236758134,     1.8900811645722220,      CrossPlatformMachineEpsilon * 10)]   // value:  (2 / pi)
+        [InlineData( 0.69314718055994531,     2.0,                     CrossPlatformMachineEpsilon * 10)]   // value:  (ln(2))
+        [InlineData( 0.70710678118654752,     2.0281149816474725,      CrossPlatformMachineEpsilon * 10)]   // value:  (1 / sqrt(2))
+        [InlineData( 0.78539816339744831,     2.1932800507380155,      CrossPlatformMachineEpsilon * 10)]   // value:  (pi / 4)
+        [InlineData( 1.0,                     2.7182818284590452,      CrossPlatformMachineEpsilon * 10)]   //                          expected: (e)
+        [InlineData( 1.1283791670955126,      3.0906430223107976,      CrossPlatformMachineEpsilon * 10)]   // value:  (2 / sqrt(pi))
+        [InlineData( 1.4142135623730950,      4.1132503787829275,      CrossPlatformMachineEpsilon * 10)]   // value:  (sqrt(2))
+        [InlineData( 1.4426950408889634,      4.2320861065570819,      CrossPlatformMachineEpsilon * 10)]   // value:  (log2(e))
+        [InlineData( 1.5707963267948966,      4.8104773809653517,      CrossPlatformMachineEpsilon * 10)]   // value:  (pi / 2)
+        [InlineData( 2.3025850929940457,      10.0,                    CrossPlatformMachineEpsilon * 100)]  // value:  (ln(10))
+        [InlineData( 2.7182818284590452,      15.154262241479264,      CrossPlatformMachineEpsilon * 100)]  // value:  (e)
+        [InlineData( 3.1415926535897932,      23.140692632779269,      CrossPlatformMachineEpsilon * 100)]  // value:  (pi)
+        [InlineData( double.PositiveInfinity, double.PositiveInfinity, 0.0)]
+        public static void Exp(double value, double expectedResult, double allowedVariance)
+        {
+            AssertEqual(expectedResult, Math.Exp(value), allowedVariance);
+        }
+
+        [Fact]
+        public static void Floor_Decimal()
+        {
+            Assert.Equal(1.0m, Math.Floor(1.1m));
+            Assert.Equal(1.0m, Math.Floor(1.9m));
+            Assert.Equal(-2.0m, Math.Floor(-1.1m));
+        }
+
+        [Theory]
+        [InlineData(double.NegativeInfinity,  double.NegativeInfinity, 0.0)]
+        [InlineData(-3.1415926535897932,     -4.0,                     0.0)]    // value: -(pi)
+        [InlineData(-2.7182818284590452,     -3.0,                     0.0)]    // value: -(e)
+        [InlineData(-2.3025850929940457,     -3.0,                     0.0)]    // value: -(ln(10))
+        [InlineData(-1.5707963267948966,     -2.0,                     0.0)]    // value: -(pi / 2)
+        [InlineData(-1.4426950408889634,     -2.0,                     0.0)]    // value: -(log2(e))
+        [InlineData(-1.4142135623730950,     -2.0,                     0.0)]    // value: -(sqrt(2))
+        [InlineData(-1.1283791670955126,     -2.0,                     0.0)]    // value: -(2 / sqrt(pi))
+        [InlineData(-1.0,                    -1.0,                     0.0)]
+        [InlineData(-0.78539816339744831,    -1.0,                     0.0)]    // value: -(pi / 4)
+        [InlineData(-0.70710678118654752,    -1.0,                     0.0)]    // value: -(1 / sqrt(2))
+        [InlineData(-0.69314718055994531,    -1.0,                     0.0)]    // value: -(ln(2))
+        [InlineData(-0.63661977236758134,    -1.0,                     0.0)]    // value: -(2 / pi)
+        [InlineData(-0.43429448190325183,    -1.0,                     0.0)]    // value: -(log10(e))
+        [InlineData(-0.31830988618379067,    -1.0,                     0.0)]    // value: -(1 / pi)
+        [InlineData(-0.0,                    -0.0,                     0.0)]
+        [InlineData( double.NaN,              double.NaN,              0.0)]
+        [InlineData( 0.0,                     0.0,                     0.0)]
+        [InlineData( 0.31830988618379067,     0.0,                     0.0)]    // value:  (1 / pi)
+        [InlineData( 0.43429448190325183,     0.0,                     0.0)]    // value:  (log10(e))
+        [InlineData( 0.63661977236758134,     0.0,                     0.0)]    // value:  (2 / pi)
+        [InlineData( 0.69314718055994531,     0.0,                     0.0)]    // value:  (ln(2))
+        [InlineData( 0.70710678118654752,     0.0,                     0.0)]    // value:  (1 / sqrt(2))
+        [InlineData( 0.78539816339744831,     0.0,                     0.0)]    // value:  (pi / 4)
+        [InlineData( 1.0,                     1.0,                     0.0)]
+        [InlineData( 1.1283791670955126,      1.0,                     0.0)]    // value:  (2 / sqrt(pi))
+        [InlineData( 1.4142135623730950,      1.0,                     0.0)]    // value:  (sqrt(2))
+        [InlineData( 1.4426950408889634,      1.0,                     0.0)]    // value:  (log2(e))
+        [InlineData( 1.5707963267948966,      1.0,                     0.0)]    // value:  (pi / 2)
+        [InlineData( 2.3025850929940457,      2.0,                     0.0)]    // value:  (ln(10))
+        [InlineData( 2.7182818284590452,      2.0,                     0.0)]    // value:  (e)
+        [InlineData( 3.1415926535897932,      3.0,                     0.0)]    // value:  (pi)
+        [InlineData(double.PositiveInfinity,  double.PositiveInfinity, 0.0)]
+        public static void Floor_Double(double value, double expectedResult, double allowedVariance)
+        {
+            AssertEqual(expectedResult, Math.Floor(value), allowedVariance);
         }
 
         [Fact]
@@ -396,87 +684,96 @@ namespace System.Tests
             Assert.Equal(-1.4, Math.IEEERemainder(-17.8, -4.1), 10);
         }
 
-        [Fact]
-        public static void Min_Byte()
+        [Theory]
+        [InlineData( double.NegativeInfinity,  double.NaN,              0.0)]
+        [InlineData(-0.0,                      double.NegativeInfinity, 0.0)]
+        [InlineData( double.NaN,               double.NaN,              0.0)]
+        [InlineData( 0.0,                      double.NegativeInfinity, 0.0)]
+        [InlineData( 0.043213918263772250,    -3.1415926535897932,      CrossPlatformMachineEpsilon * 10)]  // expected: -(pi)
+        [InlineData( 0.065988035845312537,    -2.7182818284590452,      CrossPlatformMachineEpsilon * 10)]  // expected: -(e)
+        [InlineData( 0.1,                     -2.3025850929940457,      CrossPlatformMachineEpsilon * 10)]  // expected: -(ln(10))
+        [InlineData( 0.20787957635076191,     -1.5707963267948966,      CrossPlatformMachineEpsilon * 10)]  // expected: -(pi / 2)
+        [InlineData( 0.23629008834452270,     -1.4426950408889634,      CrossPlatformMachineEpsilon * 10)]  // expected: -(log2(e))
+        [InlineData( 0.24311673443421421,     -1.4142135623730950,      CrossPlatformMachineEpsilon * 10)]  // expected: -(sqrt(2))
+        [InlineData( 0.32355726390307110,     -1.1283791670955126,      CrossPlatformMachineEpsilon * 10)]  // expected: -(2 / sqrt(pi))
+        [InlineData( 0.36787944117144232,     -1.0,                     CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 0.45593812776599624,     -0.78539816339744831,     CrossPlatformMachineEpsilon)]       // expected: -(pi / 4)
+        [InlineData( 0.49306869139523979,     -0.70710678118654752,     CrossPlatformMachineEpsilon)]       // expected: -(1 / sqrt(2))
+        [InlineData( 0.5,                     -0.69314718055994531,     CrossPlatformMachineEpsilon)]       // expected: -(ln(2))
+        [InlineData( 0.52907780826773535,     -0.63661977236758134,     CrossPlatformMachineEpsilon)]       // expected: -(2 / pi)
+        [InlineData( 0.64772148514180065,     -0.43429448190325183,     CrossPlatformMachineEpsilon)]       // expected: -(log10(e))
+        [InlineData( 0.72737734929521647,     -0.31830988618379067,     CrossPlatformMachineEpsilon)]       // expected: -(1 / pi)
+        [InlineData( 1.0,                      0.0,                     0.0)]
+        [InlineData( 1.3748022274393586,       0.31830988618379067,     CrossPlatformMachineEpsilon)]       // expected:  (1 / pi)
+        [InlineData( 1.5438734439711811,       0.43429448190325183,     CrossPlatformMachineEpsilon)]       // expected:  (log10(e))
+        [InlineData( 1.8900811645722220,       0.63661977236758134,     CrossPlatformMachineEpsilon)]       // expected:  (2 / pi)
+        [InlineData( 2.0,                      0.69314718055994531,     CrossPlatformMachineEpsilon)]       // expected:  (ln(2))
+        [InlineData( 2.0281149816474725,       0.70710678118654752,     CrossPlatformMachineEpsilon)]       // expected:  (1 / sqrt(2))
+        [InlineData( 2.1932800507380155,       0.78539816339744831,     CrossPlatformMachineEpsilon)]       // expected:  (pi / 4)
+        [InlineData( 2.7182818284590452,       1.0,                     CrossPlatformMachineEpsilon * 10)]  //                              value: (e)
+        [InlineData( 3.0906430223107976,       1.1283791670955126,      CrossPlatformMachineEpsilon * 10)]  // expected:  (2 / sqrt(pi))
+        [InlineData( 4.1132503787829275,       1.4142135623730950,      CrossPlatformMachineEpsilon * 10)]  // expected:  (sqrt(2))
+        [InlineData( 4.2320861065570819,       1.4426950408889634,      CrossPlatformMachineEpsilon * 10)]  // expected:  (log2(e))
+        [InlineData( 4.8104773809653517,       1.5707963267948966,      CrossPlatformMachineEpsilon * 10)]  // expected:  (pi / 2)
+        [InlineData( 10.0,                     2.3025850929940457,      CrossPlatformMachineEpsilon * 10)]  // expected:  (ln(10))
+        [InlineData( 15.154262241479264,       2.7182818284590452,      CrossPlatformMachineEpsilon * 10)]  // expected:  (e)
+        [InlineData( 23.140692632779269,       3.1415926535897932,      CrossPlatformMachineEpsilon * 10)]  // expected:  (pi)
+        [InlineData( double.PositiveInfinity,  double.PositiveInfinity, 0.0)]
+        public static void Log(double value, double expectedResult, double allowedVariance)
         {
-            Assert.Equal((byte)2, Math.Min((byte)3, (byte)2));
-            Assert.Equal(byte.MinValue, Math.Min(byte.MinValue, byte.MaxValue));
+            AssertEqual(expectedResult, Math.Log(value), allowedVariance);
         }
 
         [Fact]
-        public static void Min_Decimal()
+        public static void LogWithBase()
         {
-            Assert.Equal(-2.0m, Math.Min(3.0m, -2.0m));
-            Assert.Equal(decimal.MinValue, Math.Min(decimal.MinValue, decimal.MaxValue));
+            Assert.Equal(1.0, Math.Log(3.0, 3.0));
+            Assert.Equal(2.40217350273, Math.Log(14, 3.0), 10);
+            Assert.Equal(double.NegativeInfinity, Math.Log(0.0, 3.0));
+            Assert.Equal(double.NaN, Math.Log(-3.0, 3.0));
+            Assert.Equal(double.NaN, Math.Log(double.NaN, 3.0));
+            Assert.Equal(double.PositiveInfinity, Math.Log(double.PositiveInfinity, 3.0));
+            Assert.Equal(double.NaN, Math.Log(double.NegativeInfinity, 3.0));
         }
 
-        [Fact]
-        public static void Min_Double()
+        [Theory]
+        [InlineData( double.NegativeInfinity,  double.NaN,              0.0)]
+        [InlineData(-0.0,                      double.NegativeInfinity, 0.0)]
+        [InlineData( double.NaN,               double.NaN,              0.0)]
+        [InlineData( 0.0,                      double.NegativeInfinity, 0.0)]
+        [InlineData( 0.00072178415907472774,  -3.1415926535897932,      CrossPlatformMachineEpsilon * 10)]  // expected: -(pi)
+        [InlineData( 0.0019130141022243176,   -2.7182818284590452,      CrossPlatformMachineEpsilon * 10)]  // expected: -(e)
+        [InlineData( 0.0049821282964407206,   -2.3025850929940457,      CrossPlatformMachineEpsilon * 10)]  // expected: -(ln(10))
+        [InlineData( 0.026866041001136132,    -1.5707963267948966,      CrossPlatformMachineEpsilon * 10)]  // expected: -(pi / 2)
+        [InlineData( 0.036083192820787210,    -1.4426950408889634,      CrossPlatformMachineEpsilon * 10)]  // expected: -(log2(e))
+        [InlineData( 0.038528884700322026,    -1.4142135623730950,      CrossPlatformMachineEpsilon * 10)]  // expected: -(sqrt(2))
+        [InlineData( 0.074408205860642723,    -1.1283791670955126,      CrossPlatformMachineEpsilon * 10)]  // expected: -(2 / sqrt(pi))
+        [InlineData( 0.1,                     -1.0,                     CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 0.16390863613957665,     -0.78539816339744831,     CrossPlatformMachineEpsilon)]       // expected: -(pi / 4)
+        [InlineData( 0.19628775993505562,     -0.70710678118654752,     CrossPlatformMachineEpsilon)]       // expected: -(1 / sqrt(2))
+        [InlineData( 0.20269956628651730,     -0.69314718055994531,     CrossPlatformMachineEpsilon)]       // expected: -(ln(2))
+        [InlineData( 0.23087676451600055,     -0.63661977236758134,     CrossPlatformMachineEpsilon)]       // expected: -(2 / pi)
+        [InlineData( 0.36787944117144232,     -0.43429448190325183,     CrossPlatformMachineEpsilon)]       // expected: -(log10(e))
+        [InlineData( 0.48049637305186868,     -0.31830988618379067,     CrossPlatformMachineEpsilon)]       // expected: -(1 / pi)
+        [InlineData( 1.0,                      0.0,                     0.0)]
+        [InlineData( 2.0811811619898573,       0.31830988618379067,     CrossPlatformMachineEpsilon)]       // expected:  (1 / pi)
+        [InlineData( 2.7182818284590452,       0.43429448190325183,     CrossPlatformMachineEpsilon)]       // expected:  (log10(e))        value: (e)
+        [InlineData( 4.3313150290214525,       0.63661977236758134,     CrossPlatformMachineEpsilon)]       // expected:  (2 / pi)
+        [InlineData( 4.9334096679145963,       0.69314718055994531,     CrossPlatformMachineEpsilon)]       // expected:  (ln(2))
+        [InlineData( 5.0945611704512962,       0.70710678118654752,     CrossPlatformMachineEpsilon)]       // expected:  (1 / sqrt(2))
+        [InlineData( 6.1009598002416937,       0.78539816339744831,     CrossPlatformMachineEpsilon)]       // expected:  (pi / 4)
+        [InlineData( 10.0,                     1.0,                     CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 13.439377934644400,       1.1283791670955126,      CrossPlatformMachineEpsilon * 10)]  // expected:  (2 / sqrt(pi))
+        [InlineData( 25.954553519470081,       1.4142135623730950,      CrossPlatformMachineEpsilon * 10)]  // expected:  (sqrt(2))
+        [InlineData( 27.713733786437790,       1.4426950408889634,      CrossPlatformMachineEpsilon * 10)]  // expected:  (log2(e))
+        [InlineData( 37.221710484165167,       1.5707963267948966,      CrossPlatformMachineEpsilon * 10)]  // expected:  (pi / 2)
+        [InlineData( 200.71743249053009,       2.3025850929940457,      CrossPlatformMachineEpsilon * 10)]  // expected:  (ln(10))
+        [InlineData( 522.73529967043665,       2.7182818284590452,      CrossPlatformMachineEpsilon * 10)]  // expected:  (e)
+        [InlineData( 1385.4557313670111,       3.1415926535897932,      CrossPlatformMachineEpsilon * 10)]  // expected:  (pi)
+        [InlineData( double.PositiveInfinity,  double.PositiveInfinity, 0.0)]
+        public static void Log10(double value, double expectedResult, double allowedVariance)
         {
-            Assert.Equal(-2.0, Math.Min(3.0, -2.0));
-            Assert.Equal(double.MinValue, Math.Min(double.MinValue, double.MaxValue));
-            Assert.Equal(double.NegativeInfinity, Math.Min(double.NegativeInfinity, double.PositiveInfinity));
-            Assert.Equal(double.NaN, Math.Min(double.NegativeInfinity, double.NaN));
-            Assert.Equal(double.NaN, Math.Min(double.NaN, double.NaN));
-        }
-
-        [Fact]
-        public static void Min_Short()
-        {
-            Assert.Equal((short)(-2), Math.Min((short)3, (short)(-2)));
-            Assert.Equal(short.MinValue, Math.Min(short.MinValue, short.MaxValue));
-        }
-
-        [Fact]
-        public static void Min_Int()
-        {
-            Assert.Equal(-2, Math.Min(3, -2));
-            Assert.Equal(int.MinValue, Math.Min(int.MinValue, int.MaxValue));
-        }
-
-        [Fact]
-        public static void Min_Long()
-        {
-            Assert.Equal(-2L, Math.Min(3L, -2L));
-            Assert.Equal(long.MinValue, Math.Min(long.MinValue, long.MaxValue));
-        }
-
-        [Fact]
-        public static void Min_SByte()
-        {
-            Assert.Equal((sbyte)(-2), Math.Min((sbyte)3, (sbyte)(-2)));
-            Assert.Equal(sbyte.MinValue, Math.Min(sbyte.MinValue, sbyte.MaxValue));
-        }
-
-        [Fact]
-        public static void Min_Float()
-        {
-            Assert.Equal(-2.0f, Math.Min(3.0f, -2.0f));
-            Assert.Equal(float.MinValue, Math.Min(float.MinValue, float.MaxValue));
-            Assert.Equal(float.NegativeInfinity, Math.Min(float.NegativeInfinity, float.PositiveInfinity));
-            Assert.Equal(float.NaN, Math.Min(float.NegativeInfinity, float.NaN));
-            Assert.Equal(float.NaN, Math.Min(float.NaN, float.NaN));
-        }
-
-        [Fact]
-        public static void Min_UShort()
-        {
-            Assert.Equal((ushort)2, Math.Min((ushort)3, (ushort)2));
-            Assert.Equal(ushort.MinValue, Math.Min(ushort.MinValue, ushort.MaxValue));
-        }
-
-        [Fact]
-        public static void Min_UInt()
-        {
-            Assert.Equal((uint)2, Math.Min((uint)3, (uint)2));
-            Assert.Equal(uint.MinValue, Math.Min(uint.MinValue, uint.MaxValue));
-        }
-
-        [Fact]
-        public static void Min_ULong()
-        {
-            Assert.Equal((ulong)2, Math.Min((ulong)3, (ulong)2));
-            Assert.Equal(ulong.MinValue, Math.Min(ulong.MinValue, ulong.MaxValue));
+            AssertEqual(expectedResult, Math.Log10(value), allowedVariance);
         }
 
         [Fact]
@@ -504,21 +801,21 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void Max_Short()
+        public static void Max_Int16()
         {
             Assert.Equal((short)3, Math.Max((short)(-2), (short)3));
             Assert.Equal(short.MaxValue, Math.Max(short.MinValue, short.MaxValue));
         }
 
         [Fact]
-        public static void Max_Int()
+        public static void Max_Int32()
         {
             Assert.Equal(3, Math.Max(-2, 3));
             Assert.Equal(int.MaxValue, Math.Max(int.MinValue, int.MaxValue));
         }
 
         [Fact]
-        public static void Max_Long()
+        public static void Max_Int64()
         {
             Assert.Equal(3L, Math.Max(-2L, 3L));
             Assert.Equal(long.MaxValue, Math.Max(long.MinValue, long.MaxValue));
@@ -532,7 +829,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void Max_Float()
+        public static void Max_Single()
         {
             Assert.Equal(3.0f, Math.Max(3.0f, -2.0f));
             Assert.Equal(float.MaxValue, Math.Max(float.MinValue, float.MaxValue));
@@ -542,24 +839,312 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void Max_UShort()
+        public static void Max_UInt16()
         {
             Assert.Equal((ushort)3, Math.Max((ushort)2, (ushort)3));
             Assert.Equal(ushort.MaxValue, Math.Max(ushort.MinValue, ushort.MaxValue));
         }
 
         [Fact]
-        public static void Max_UInt()
+        public static void Max_UInt32()
         {
             Assert.Equal((uint)3, Math.Max((uint)2, (uint)3));
             Assert.Equal(uint.MaxValue, Math.Max(uint.MinValue, uint.MaxValue));
         }
 
         [Fact]
-        public static void Max_ULong()
+        public static void Max_UInt64()
         {
             Assert.Equal((ulong)3, Math.Max((ulong)2, (ulong)3));
             Assert.Equal(ulong.MaxValue, Math.Max(ulong.MinValue, ulong.MaxValue));
+        }
+
+        [Fact]
+        public static void Min_Byte()
+        {
+            Assert.Equal((byte)2, Math.Min((byte)3, (byte)2));
+            Assert.Equal(byte.MinValue, Math.Min(byte.MinValue, byte.MaxValue));
+        }
+
+        [Fact]
+        public static void Min_Decimal()
+        {
+            Assert.Equal(-2.0m, Math.Min(3.0m, -2.0m));
+            Assert.Equal(decimal.MinValue, Math.Min(decimal.MinValue, decimal.MaxValue));
+        }
+
+        [Fact]
+        public static void Min_Double()
+        {
+            Assert.Equal(-2.0, Math.Min(3.0, -2.0));
+            Assert.Equal(double.MinValue, Math.Min(double.MinValue, double.MaxValue));
+            Assert.Equal(double.NegativeInfinity, Math.Min(double.NegativeInfinity, double.PositiveInfinity));
+            Assert.Equal(double.NaN, Math.Min(double.NegativeInfinity, double.NaN));
+            Assert.Equal(double.NaN, Math.Min(double.NaN, double.NaN));
+        }
+
+        [Fact]
+        public static void Min_Int16()
+        {
+            Assert.Equal((short)(-2), Math.Min((short)3, (short)(-2)));
+            Assert.Equal(short.MinValue, Math.Min(short.MinValue, short.MaxValue));
+        }
+
+        [Fact]
+        public static void Min_Int32()
+        {
+            Assert.Equal(-2, Math.Min(3, -2));
+            Assert.Equal(int.MinValue, Math.Min(int.MinValue, int.MaxValue));
+        }
+
+        [Fact]
+        public static void Min_Int64()
+        {
+            Assert.Equal(-2L, Math.Min(3L, -2L));
+            Assert.Equal(long.MinValue, Math.Min(long.MinValue, long.MaxValue));
+        }
+
+        [Fact]
+        public static void Min_SByte()
+        {
+            Assert.Equal((sbyte)(-2), Math.Min((sbyte)3, (sbyte)(-2)));
+            Assert.Equal(sbyte.MinValue, Math.Min(sbyte.MinValue, sbyte.MaxValue));
+        }
+
+        [Fact]
+        public static void Min_Single()
+        {
+            Assert.Equal(-2.0f, Math.Min(3.0f, -2.0f));
+            Assert.Equal(float.MinValue, Math.Min(float.MinValue, float.MaxValue));
+            Assert.Equal(float.NegativeInfinity, Math.Min(float.NegativeInfinity, float.PositiveInfinity));
+            Assert.Equal(float.NaN, Math.Min(float.NegativeInfinity, float.NaN));
+            Assert.Equal(float.NaN, Math.Min(float.NaN, float.NaN));
+        }
+
+        [Fact]
+        public static void Min_UInt16()
+        {
+            Assert.Equal((ushort)2, Math.Min((ushort)3, (ushort)2));
+            Assert.Equal(ushort.MinValue, Math.Min(ushort.MinValue, ushort.MaxValue));
+        }
+
+        [Fact]
+        public static void Min_UInt32()
+        {
+            Assert.Equal((uint)2, Math.Min((uint)3, (uint)2));
+            Assert.Equal(uint.MinValue, Math.Min(uint.MinValue, uint.MaxValue));
+        }
+
+        [Fact]
+        public static void Min_UInt64()
+        {
+            Assert.Equal((ulong)2, Math.Min((ulong)3, (ulong)2));
+            Assert.Equal(ulong.MinValue, Math.Min(ulong.MinValue, ulong.MaxValue));
+        }
+
+        [Theory]
+        [InlineData( double.NegativeInfinity,  double.NegativeInfinity,  0.0,                     0.0)]
+        [InlineData( double.NegativeInfinity, -1.0,                     -0.0,                     0.0)]
+        [InlineData( double.NegativeInfinity, -0.0,                      1.0,                     CrossPlatformMachineEpsilon * 10)]
+        [InlineData( double.NegativeInfinity,  double.NaN,               double.NaN,              0.0)]
+        [InlineData( double.NegativeInfinity,  0.0,                      1.0,                     CrossPlatformMachineEpsilon * 10)]
+        [InlineData( double.NegativeInfinity,  1.0,                      double.NegativeInfinity, 0.0)]
+        [InlineData( double.NegativeInfinity,  double.PositiveInfinity,  double.PositiveInfinity, 0.0)]
+        [InlineData(-10.0,                     double.NegativeInfinity,  0.0,                     0.0)]
+        [InlineData(-10.0,                    -1.5707963267948966,       double.NaN,              0.0)]                                     //          y: -(pi / 2)
+        [InlineData(-10.0,                    -1.0,                     -0.1,                     CrossPlatformMachineEpsilon)]
+        [InlineData(-10.0,                    -0.78539816339744831,      double.NaN,              0.0)]                                     //          y: -(pi / 4)
+        [InlineData(-10.0,                    -0.0,                      1.0,                     CrossPlatformMachineEpsilon * 10)]
+        [InlineData(-10.0,                     double.NaN,               double.NaN,              0.0)]
+        [InlineData(-10.0,                     0.0,                      1.0,                     CrossPlatformMachineEpsilon * 10)]
+        [InlineData(-10.0,                     0.78539816339744831,      double.NaN,              0.0)]                                     //          y:  (pi / 4)
+        [InlineData(-10.0,                     1.0,                     -10.0,                    CrossPlatformMachineEpsilon * 100)]
+        [InlineData(-10.0,                     1.5707963267948966,       double.NaN,              0.0)]                                     //          y:  (pi / 2)
+        [InlineData(-10.0,                     double.PositiveInfinity,  double.PositiveInfinity, 0.0)]
+        [InlineData(-2.7182818284590452,       double.NegativeInfinity,  0.0,                     0.0)]                                     // x: -(e)
+        [InlineData(-2.7182818284590452,      -1.5707963267948966,       double.NaN,              0.0)]                                     // x: -(e)  y: -(pi / 2)
+        [InlineData(-2.7182818284590452,      -1.0,                     -0.36787944117144232,     CrossPlatformMachineEpsilon)]             // x: -(e)
+        [InlineData(-2.7182818284590452,      -0.78539816339744831,      double.NaN,              0.0)]                                     // x: -(e)  y: -(pi / 4)
+        [InlineData(-2.7182818284590452,      -0.0,                      1.0,                     CrossPlatformMachineEpsilon * 10)]        // x: -(e)
+        [InlineData(-2.7182818284590452,       double.NaN,               double.NaN,              0.0)]
+        [InlineData(-2.7182818284590452,       0.0,                      1.0,                     CrossPlatformMachineEpsilon * 10)]        // x: -(e)
+        [InlineData(-2.7182818284590452,       0.78539816339744831,      double.NaN,              0.0)]                                     // x: -(e)  y:  (pi / 4)
+        [InlineData(-2.7182818284590452,       1.0,                     -2.7182818284590452,      CrossPlatformMachineEpsilon * 10)]        // x: -(e)  expected: (e)
+        [InlineData(-2.7182818284590452,       1.5707963267948966,       double.NaN,              0.0)]                                     // x: -(e)  y:  (pi / 2)
+        [InlineData(-2.7182818284590452,       double.PositiveInfinity,  double.PositiveInfinity, 0.0)]
+        [InlineData(-1.0,                      double.NegativeInfinity,  double.NaN,              0.0)]
+        [InlineData(-1.0,                      double.NegativeInfinity,  1.0,                     CrossPlatformMachineEpsilon * 10, Skip = "https://github.com/dotnet/coreclr/issues/9807")]
+        [InlineData(-1.0,                     -1.0,                     -1.0,                     CrossPlatformMachineEpsilon * 10)]
+        [InlineData(-1.0,                     -0.0,                      1.0,                     CrossPlatformMachineEpsilon * 10)]
+        [InlineData(-1.0,                      double.NaN,               double.NaN,              0.0)]
+        [InlineData(-1.0,                      0.0,                      1.0,                     CrossPlatformMachineEpsilon * 10)]
+        [InlineData(-1.0,                      1.0,                     -1.0,                     CrossPlatformMachineEpsilon * 10)]
+        [InlineData(-1.0,                      double.PositiveInfinity,  double.NaN,              0.0)]
+        [InlineData(-1.0,                      double.PositiveInfinity,  1.0,                     CrossPlatformMachineEpsilon * 10, Skip = "https://github.com/dotnet/coreclr/issues/9807")]
+        [InlineData(-0.0,                      double.NegativeInfinity,  double.PositiveInfinity, 0.0)]
+        [InlineData(-0.0,                     -3.0,                      double.NegativeInfinity, 0.0)]
+        [InlineData(-0.0,                     -2.0,                      double.PositiveInfinity, 0.0)]
+        [InlineData(-0.0,                     -1.5707963267948966,       double.PositiveInfinity, 0.0)]                                     //          y: -(pi / 2)
+        [InlineData(-0.0,                     -1.0,                      double.NegativeInfinity, 0.0)]
+        [InlineData(-0.0,                     -0.0,                      1.0,                     CrossPlatformMachineEpsilon * 10)]
+        [InlineData(-0.0,                      double.NaN,               double.NaN,              0.0)]
+        [InlineData(-0.0,                      0.0,                      1.0,                     CrossPlatformMachineEpsilon * 10)]
+        [InlineData(-0.0,                      1.0,                     -0.0,                     0.0)]
+        [InlineData(-0.0,                      1.5707963267948966,       0.0,                     0.0)]                                     //          y: -(pi / 2)
+        [InlineData(-0.0,                      2.0,                      0.0,                     0.0)]
+        [InlineData(-0.0,                      3.0,                     -0.0,                     0.0)]
+        [InlineData(-0.0,                      double.PositiveInfinity,  0.0,                     0.0)]
+        [InlineData( double.NaN,               double.NegativeInfinity,  double.NaN,              0.0)]
+        [InlineData( double.NaN,              -1.0,                      double.NaN,              0.0)]
+        [InlineData( double.NaN,              -0.0,                      double.NaN,              0.0)]
+        [InlineData( double.NaN,              -0.0,                      1.0,                     CrossPlatformMachineEpsilon * 10, Skip = "https://github.com/dotnet/coreclr/issues/9807")]
+        [InlineData( double.NaN,               double.NaN,               double.NaN,              0.0)]
+        [InlineData( double.NaN,               0.0,                      double.NaN,              0.0)]
+        [InlineData( double.NaN,               0.0,                      1.0,                     CrossPlatformMachineEpsilon * 10, Skip = "https://github.com/dotnet/coreclr/issues/9807")]
+        [InlineData( double.NaN,               1.0,                      double.NaN,              0.0)]
+        [InlineData( double.NaN,               double.PositiveInfinity,  double.NaN,              0.0)]
+        [InlineData( 0.0,                      double.NegativeInfinity,  double.PositiveInfinity, 0.0)]
+        [InlineData( 0.0,                     -3.0,                      double.PositiveInfinity, 0.0)]
+        [InlineData( 0.0,                     -2.0,                      double.PositiveInfinity, 0.0)]
+        [InlineData( 0.0,                     -1.5707963267948966,       double.PositiveInfinity, 0.0)]                                     //          y: -(pi / 2)
+        [InlineData( 0.0,                     -1.0,                      double.PositiveInfinity, 0.0)]
+        [InlineData( 0.0,                     -0.0,                      1.0,                     CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 0.0,                      double.NaN,               double.NaN,              0.0)]
+        [InlineData( 0.0,                      0.0,                      1.0,                     CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 0.0,                      1.0,                      0.0,                     0.0)]
+        [InlineData( 0.0,                      1.5707963267948966,       0.0,                     0.0)]                                     //          y: -(pi / 2)
+        [InlineData( 0.0,                      2.0,                      0.0,                     0.0)]
+        [InlineData( 0.0,                      3.0,                      0.0,                     0.0)]
+        [InlineData( 0.0,                      double.PositiveInfinity,  0.0,                     0.0)]
+        [InlineData( 1.0,                      double.NegativeInfinity,  1.0,                     CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 1.0,                     -1.0,                      1.0,                     CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 1.0,                     -0.0,                      1.0,                     CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 1.0,                      double.NaN,               double.NaN,              0.0)]
+        [InlineData( 1.0,                      double.NaN,               1.0,                     CrossPlatformMachineEpsilon * 10, Skip = "https://github.com/dotnet/coreclr/issues/9807")]
+        [InlineData( 1.0,                      0.0,                      1.0,                     CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 1.0,                      1.0,                      1.0,                     CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 1.0,                      double.PositiveInfinity,  1.0,                     CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 2.7182818284590452,       double.NegativeInfinity,  0.0,                     0.0)]
+        [InlineData( 2.7182818284590452,      -3.1415926535897932,       0.043213918263772250,    CrossPlatformMachineEpsilon / 10)]        // x:  (e)  y: -(pi)
+        [InlineData( 2.7182818284590452,      -2.7182818284590452,       0.065988035845312537,    CrossPlatformMachineEpsilon / 10)]        // x:  (e)  y: -(e)
+        [InlineData( 2.7182818284590452,      -2.3025850929940457,       0.1,                     CrossPlatformMachineEpsilon)]             // x:  (e)  y: -(ln(10))
+        [InlineData( 2.7182818284590452,      -1.5707963267948966,       0.20787957635076191,     CrossPlatformMachineEpsilon)]             // x:  (e)  y: -(pi / 2)
+        [InlineData( 2.7182818284590452,      -1.4426950408889634,       0.23629008834452270,     CrossPlatformMachineEpsilon)]             // x:  (e)  y: -(log2(e))
+        [InlineData( 2.7182818284590452,      -1.4142135623730950,       0.24311673443421421,     CrossPlatformMachineEpsilon)]             // x:  (e)  y: -(sqrt(2))
+        [InlineData( 2.7182818284590452,      -1.1283791670955126,       0.32355726390307110,     CrossPlatformMachineEpsilon)]             // x:  (e)  y: -(2 / sqrt(pi))
+        [InlineData( 2.7182818284590452,      -1.0,                      0.36787944117144232,     CrossPlatformMachineEpsilon)]             // x:  (e)
+        [InlineData( 2.7182818284590452,      -0.78539816339744831,      0.45593812776599624,     CrossPlatformMachineEpsilon)]             // x:  (e)  y: -(pi / 4)
+        [InlineData( 2.7182818284590452,      -0.70710678118654752,      0.49306869139523979,     CrossPlatformMachineEpsilon)]             // x:  (e)  y: -(1 / sqrt(2))
+        [InlineData( 2.7182818284590452,      -0.69314718055994531,      0.5,                     CrossPlatformMachineEpsilon)]             // x:  (e)  y: -(ln(2))
+        [InlineData( 2.7182818284590452,      -0.63661977236758134,      0.52907780826773535,     CrossPlatformMachineEpsilon)]             // x:  (e)  y: -(2 / pi)
+        [InlineData( 2.7182818284590452,      -0.43429448190325183,      0.64772148514180065,     CrossPlatformMachineEpsilon)]             // x:  (e)  y: -(log10(e))
+        [InlineData( 2.7182818284590452,      -0.31830988618379067,      0.72737734929521647,     CrossPlatformMachineEpsilon)]             // x:  (e)  y: -(1 / pi)
+        [InlineData( 2.7182818284590452,      -0.0,                      1.0,                     CrossPlatformMachineEpsilon * 10)]        // x:  (e)
+        [InlineData( 2.7182818284590452,       double.NaN,               double.NaN,              0.0)]
+        [InlineData( 2.7182818284590452,       0.0,                      1.0,                     CrossPlatformMachineEpsilon * 10)]        // x:  (e)
+        [InlineData( 2.7182818284590452,       0.31830988618379067,      1.3748022274393586,      CrossPlatformMachineEpsilon * 10)]        // x:  (e)  y:  (1 / pi)
+        [InlineData( 2.7182818284590452,       0.43429448190325183,      1.5438734439711811,      CrossPlatformMachineEpsilon * 10)]        // x:  (e)  y:  (log10(e))
+        [InlineData( 2.7182818284590452,       0.63661977236758134,      1.8900811645722220,      CrossPlatformMachineEpsilon * 10)]        // x:  (e)  y:  (2 / pi)
+        [InlineData( 2.7182818284590452,       0.69314718055994531,      2.0,                     CrossPlatformMachineEpsilon * 10)]        // x:  (e)  y:  (ln(2))
+        [InlineData( 2.7182818284590452,       0.70710678118654752,      2.0281149816474725,      CrossPlatformMachineEpsilon * 10)]        // x:  (e)  y:  (1 / sqrt(2))
+        [InlineData( 2.7182818284590452,       0.78539816339744831,      2.1932800507380155,      CrossPlatformMachineEpsilon * 10)]        // x:  (e)  y:  (pi / 4)
+        [InlineData( 2.7182818284590452,       1.0,                      2.7182818284590452,      CrossPlatformMachineEpsilon * 10)]        // x:  (e)                      expected: (e)
+        [InlineData( 2.7182818284590452,       1.1283791670955126,       3.0906430223107976,      CrossPlatformMachineEpsilon * 10)]        // x:  (e)  y:  (2 / sqrt(pi))
+        [InlineData( 2.7182818284590452,       1.4142135623730950,       4.1132503787829275,      CrossPlatformMachineEpsilon * 10)]        // x:  (e)  y:  (sqrt(2))
+        [InlineData( 2.7182818284590452,       1.4426950408889634,       4.2320861065570819,      CrossPlatformMachineEpsilon * 10)]        // x:  (e)  y:  (log2(e))
+        [InlineData( 2.7182818284590452,       1.5707963267948966,       4.8104773809653517,      CrossPlatformMachineEpsilon * 10)]        // x:  (e)  y:  (pi / 2)
+        [InlineData( 2.7182818284590452,       2.3025850929940457,       10.0,                    CrossPlatformMachineEpsilon * 100)]       // x:  (e)  y:  (ln(10))
+        [InlineData( 2.7182818284590452,       2.7182818284590452,       15.154262241479264,      CrossPlatformMachineEpsilon * 100)]       // x:  (e)  y:  (e)
+        [InlineData( 2.7182818284590452,       3.1415926535897932,       23.140692632779269,      CrossPlatformMachineEpsilon * 100)]       // x:  (e)  y:  (pi)
+        [InlineData( 2.7182818284590452,       double.PositiveInfinity,  double.PositiveInfinity, 0.0)]                                     // x:  (e)
+        [InlineData( 10.0,                     double.NegativeInfinity,  0.0,                     0.0)]
+        [InlineData( 10.0,                    -3.1415926535897932,       0.00072178415907472774,  CrossPlatformMachineEpsilon / 1000)]      //          y: -(pi)
+        [InlineData( 10.0,                    -2.7182818284590452,       0.0019130141022243176,   CrossPlatformMachineEpsilon / 100)]       //          y: -(e)
+        [InlineData( 10.0,                    -2.3025850929940457,       0.0049821282964407206,   CrossPlatformMachineEpsilon / 100)]       //          y: -(ln(10))
+        [InlineData( 10.0,                    -1.5707963267948966,       0.026866041001136132,    CrossPlatformMachineEpsilon / 10)]        //          y: -(pi / 2)
+        [InlineData( 10.0,                    -1.4426950408889634,       0.036083192820787210,    CrossPlatformMachineEpsilon / 10)]        //          y: -(log2(e))
+        [InlineData( 10.0,                    -1.4142135623730950,       0.038528884700322026,    CrossPlatformMachineEpsilon / 10)]        //          y: -(sqrt(2))
+        [InlineData( 10.0,                    -1.1283791670955126,       0.074408205860642723,    CrossPlatformMachineEpsilon / 10)]        //          y: -(2 / sqrt(pi))
+        [InlineData( 10.0,                    -1.0,                      0.1,                     CrossPlatformMachineEpsilon)]
+        [InlineData( 10.0,                    -0.78539816339744831,      0.16390863613957665,     CrossPlatformMachineEpsilon)]             //          y: -(pi / 4)
+        [InlineData( 10.0,                    -0.70710678118654752,      0.19628775993505562,     CrossPlatformMachineEpsilon)]             //          y: -(1 / sqrt(2))
+        [InlineData( 10.0,                    -0.69314718055994531,      0.20269956628651730,     CrossPlatformMachineEpsilon)]             //          y: -(ln(2))
+        [InlineData( 10.0,                    -0.63661977236758134,      0.23087676451600055,     CrossPlatformMachineEpsilon)]             //          y: -(2 / pi)
+        [InlineData( 10.0,                    -0.43429448190325183,      0.36787944117144232,     CrossPlatformMachineEpsilon)]             //          y: -(log10(e))
+        [InlineData( 10.0,                    -0.31830988618379067,      0.48049637305186868,     CrossPlatformMachineEpsilon)]             //          y: -(1 / pi)
+        [InlineData( 10.0,                    -0.0,                      1.0,                     CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 10.0,                     double.NaN,               double.NaN,              0.0)]
+        [InlineData( 10.0,                     0.0,                      1.0,                     CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 10.0,                     0.31830988618379067,      2.0811811619898573,      CrossPlatformMachineEpsilon * 10)]        //          y:  (1 / pi)
+        [InlineData( 10.0,                     0.43429448190325183,      2.7182818284590452,      CrossPlatformMachineEpsilon * 10)]        //          y:  (log10(e))      expected: (e)
+        [InlineData( 10.0,                     0.63661977236758134,      4.3313150290214525,      CrossPlatformMachineEpsilon * 10)]        //          y:  (2 / pi)
+        [InlineData( 10.0,                     0.69314718055994531,      4.9334096679145963,      CrossPlatformMachineEpsilon * 10)]        //          y:  (ln(2))
+        [InlineData( 10.0,                     0.70710678118654752,      5.0945611704512962,      CrossPlatformMachineEpsilon * 10)]        //          y:  (1 / sqrt(2))
+        [InlineData( 10.0,                     0.78539816339744831,      6.1009598002416937,      CrossPlatformMachineEpsilon * 10)]        //          y:  (pi / 4)
+        [InlineData( 10.0,                     1.0,                      10.0,                    CrossPlatformMachineEpsilon * 100)]
+        [InlineData( 10.0,                     1.1283791670955126,       13.439377934644400,      CrossPlatformMachineEpsilon * 100)]       //          y:  (2 / sqrt(pi))
+        [InlineData( 10.0,                     1.4142135623730950,       25.954553519470081,      CrossPlatformMachineEpsilon * 100)]       //          y:  (sqrt(2))
+        [InlineData( 10.0,                     1.4426950408889634,       27.713733786437790,      CrossPlatformMachineEpsilon * 100)]       //          y:  (log2(e))
+        [InlineData( 10.0,                     1.5707963267948966,       37.221710484165167,      CrossPlatformMachineEpsilon * 100)]       //          y:  (pi / 2)
+        [InlineData( 10.0,                     2.3025850929940457,       200.71743249053009,      CrossPlatformMachineEpsilon * 1000)]      //          y:  (ln(10))
+        [InlineData( 10.0,                     2.7182818284590452,       522.73529967043665,      CrossPlatformMachineEpsilon * 1000)]      //          y:  (e)
+        [InlineData( 10.0,                     3.1415926535897932,       1385.4557313670111,      CrossPlatformMachineEpsilon * 10000)]     //          y:  (pi)
+        [InlineData( 10.0,                     double.PositiveInfinity,  double.PositiveInfinity, 0.0)]
+        [InlineData( double.PositiveInfinity,  double.NegativeInfinity,  0.0,                     0.0)]
+        [InlineData( double.PositiveInfinity, -1.0,                      0.0,                     0.0)]
+        [InlineData( double.PositiveInfinity, -0.0,                      1.0,                     0.0)]
+        [InlineData( double.PositiveInfinity,  double.NaN,               double.NaN,              0.0)]
+        [InlineData( double.PositiveInfinity,  0.0,                      1.0,                     0.0)]
+        [InlineData( double.PositiveInfinity,  1.0,                      double.PositiveInfinity, 0.0)]
+        [InlineData( double.PositiveInfinity,  double.PositiveInfinity,  double.PositiveInfinity, 0.0)]
+        public static void Pow(double x, double y, double expectedResult, double allowedVariance)
+        {
+            AssertEqual(expectedResult, Math.Pow(x, y), allowedVariance);
+        }
+
+        [Fact]
+        public static void Round_Decimal()
+        {
+            Assert.Equal(0.0m, Math.Round(0.0m));
+            Assert.Equal(1.0m, Math.Round(1.4m));
+            Assert.Equal(2.0m, Math.Round(1.5m));
+            Assert.Equal(2e16m, Math.Round(2e16m));
+            Assert.Equal(0.0m, Math.Round(-0.0m));
+            Assert.Equal(-1.0m, Math.Round(-1.4m));
+            Assert.Equal(-2.0m, Math.Round(-1.5m));
+            Assert.Equal(-2e16m, Math.Round(-2e16m));
+        }
+
+        [Fact]
+        public static void Round_Decimal_Digits()
+        {
+            Assert.Equal(3.422m, Math.Round(3.42156m, 3, MidpointRounding.AwayFromZero));
+            Assert.Equal(-3.422m, Math.Round(-3.42156m, 3, MidpointRounding.AwayFromZero));
+            Assert.Equal(decimal.Zero, Math.Round(decimal.Zero, 3, MidpointRounding.AwayFromZero));
+        }
+
+        [Fact]
+        public static void Round_Double()
+        {
+            Assert.Equal(0.0, Math.Round(0.0));
+            Assert.Equal(1.0, Math.Round(1.4));
+            Assert.Equal(2.0, Math.Round(1.5));
+            Assert.Equal(2e16, Math.Round(2e16));
+            Assert.Equal(0.0, Math.Round(-0.0));
+            Assert.Equal(-1.0, Math.Round(-1.4));
+            Assert.Equal(-2.0, Math.Round(-1.5));
+            Assert.Equal(-2e16, Math.Round(-2e16));
+        }
+
+        [Fact]
+        public static void Round_Double_Digits()
+        {
+            Assert.Equal(3.422, Math.Round(3.42156, 3, MidpointRounding.AwayFromZero), 10);
+            Assert.Equal(-3.422, Math.Round(-3.42156, 3, MidpointRounding.AwayFromZero), 10);
+            Assert.Equal(0.0, Math.Round(0.0, 3, MidpointRounding.AwayFromZero));
+            Assert.Equal(double.NaN, Math.Round(double.NaN, 3, MidpointRounding.AwayFromZero));
+            Assert.Equal(double.PositiveInfinity, Math.Round(double.PositiveInfinity, 3, MidpointRounding.AwayFromZero));
+            Assert.Equal(double.NegativeInfinity, Math.Round(double.NegativeInfinity, 3, MidpointRounding.AwayFromZero));
         }
 
         [Fact]
@@ -584,7 +1169,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void Sign_Short()
+        public static void Sign_Int16()
         {
             Assert.Equal(0, Math.Sign((short)0));
             Assert.Equal(-1, Math.Sign((short)(-3)));
@@ -592,7 +1177,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void Sign_Int()
+        public static void Sign_Int32()
         {
             Assert.Equal(0, Math.Sign(0));
             Assert.Equal(-1, Math.Sign(-3));
@@ -600,7 +1185,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void Sign_Long()
+        public static void Sign_Int64()
         {
             Assert.Equal(0, Math.Sign(0));
             Assert.Equal(-1, Math.Sign(-3));
@@ -616,7 +1201,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void Sign_Float()
+        public static void Sign_Single()
         {
             Assert.Equal(0, Math.Sign(0.0f));
             Assert.Equal(0, Math.Sign(-0.0f));
@@ -625,6 +1210,203 @@ namespace System.Tests
             Assert.Equal(-1, Math.Sign(float.NegativeInfinity));
             Assert.Equal(1, Math.Sign(float.PositiveInfinity));
             Assert.Throws<ArithmeticException>(() => Math.Sign(float.NaN));
+        }
+
+        [Theory]
+        [InlineData( double.NegativeInfinity,  double.NaN,          0.0)]
+        [InlineData(-3.1415926535897932,      -0.0,                 CrossPlatformMachineEpsilon)]       // value: -(pi)
+        [InlineData(-2.7182818284590452,      -0.41078129050290870, CrossPlatformMachineEpsilon)]       // value: -(e)
+        [InlineData(-2.3025850929940457,      -0.74398033695749319, CrossPlatformMachineEpsilon)]       // value: -(ln(10))
+        [InlineData(-1.5707963267948966,      -1.0,                 CrossPlatformMachineEpsilon * 10)]  // value: -(pi / 2)
+        [InlineData(-1.4426950408889634,      -0.99180624439366372, CrossPlatformMachineEpsilon)]       // value: -(log2(e))
+        [InlineData(-1.4142135623730950,      -0.98776594599273553, CrossPlatformMachineEpsilon)]       // value: -(sqrt(2))
+        [InlineData(-1.1283791670955126,      -0.90371945743584630, CrossPlatformMachineEpsilon)]       // value: -(2 / sqrt(pi))
+        [InlineData(-1.0,                     -0.84147098480789651, CrossPlatformMachineEpsilon)]
+        [InlineData(-0.78539816339744831,     -0.70710678118654752, CrossPlatformMachineEpsilon)]       // value: -(pi / 4),        expected: -(1 / sqrt(2))
+        [InlineData(-0.70710678118654752,     -0.64963693908006244, CrossPlatformMachineEpsilon)]       // value: -(1 / sqrt(2))
+        [InlineData(-0.69314718055994531,     -0.63896127631363480, CrossPlatformMachineEpsilon)]       // value: -(ln(2))
+        [InlineData(-0.63661977236758134,     -0.59448076852482208, CrossPlatformMachineEpsilon)]       // value: -(2 / pi)
+        [InlineData(-0.43429448190325183,     -0.42077048331375735, CrossPlatformMachineEpsilon)]       // value: -(log10(e))
+        [InlineData(-0.31830988618379067,     -0.31296179620778659, CrossPlatformMachineEpsilon)]       // value: -(1 / pi)
+        [InlineData(-0.0,                     -0.0,                 0.0)]
+        [InlineData( double.NaN,               double.NaN,          0.0)]
+        [InlineData( 0.0,                      0.0,                 0.0)]
+        [InlineData( 0.31830988618379067,      0.31296179620778659, CrossPlatformMachineEpsilon)]       // value:  (1 / pi)
+        [InlineData( 0.43429448190325183,      0.42077048331375735, CrossPlatformMachineEpsilon)]       // value:  (log10(e))
+        [InlineData( 0.63661977236758134,      0.59448076852482208, CrossPlatformMachineEpsilon)]       // value:  (2 / pi)
+        [InlineData( 0.69314718055994531,      0.63896127631363480, CrossPlatformMachineEpsilon)]       // value:  (ln(2))
+        [InlineData( 0.70710678118654752,      0.64963693908006244, CrossPlatformMachineEpsilon)]       // value:  (1 / sqrt(2))
+        [InlineData( 0.78539816339744831,      0.70710678118654752, CrossPlatformMachineEpsilon)]       // value:  (pi / 4),        expected:  (1 / sqrt(2))
+        [InlineData( 1.0,                      0.84147098480789651, CrossPlatformMachineEpsilon)]
+        [InlineData( 1.1283791670955126,       0.90371945743584630, CrossPlatformMachineEpsilon)]       // value:  (2 / sqrt(pi))
+        [InlineData( 1.4142135623730950,       0.98776594599273553, CrossPlatformMachineEpsilon)]       // value:  (sqrt(2))
+        [InlineData( 1.4426950408889634,       0.99180624439366372, CrossPlatformMachineEpsilon)]       // value:  (log2(e))
+        [InlineData( 1.5707963267948966,       1.0,                 CrossPlatformMachineEpsilon * 10)]  // value:  (pi / 2)
+        [InlineData( 2.3025850929940457,       0.74398033695749319, CrossPlatformMachineEpsilon)]       // value:  (ln(10))
+        [InlineData( 2.7182818284590452,       0.41078129050290870, CrossPlatformMachineEpsilon)]       // value:  (e)
+        [InlineData( 3.1415926535897932,       0.0,                 CrossPlatformMachineEpsilon)]       // value:  (pi)
+        [InlineData( double.PositiveInfinity,  double.NaN,          0.0)]
+        public static void Sin(double value, double expectedResult, double allowedVariance)
+        {
+            AssertEqual(expectedResult, Math.Sin(value), allowedVariance);
+        }
+
+        [Theory]
+        [InlineData( double.NegativeInfinity,  double.NegativeInfinity, 0.0)]
+        [InlineData(-3.1415926535897932,      -11.548739357257748,      CrossPlatformMachineEpsilon * 100)]     // value: -(pi)
+        [InlineData(-2.7182818284590452,      -7.5441371028169758,      CrossPlatformMachineEpsilon * 10)]      // value: -(e)
+        [InlineData(-2.3025850929940457,      -4.95,                    CrossPlatformMachineEpsilon * 10)]      // value: -(ln(10))
+        [InlineData(-1.5707963267948966,      -2.3012989023072949,      CrossPlatformMachineEpsilon * 10)]      // value: -(pi / 2)
+        [InlineData(-1.4426950408889634,      -1.9978980091062796,      CrossPlatformMachineEpsilon * 10)]      // value: -(log2(e))
+        [InlineData(-1.4142135623730950,      -1.9350668221743567,      CrossPlatformMachineEpsilon * 10)]      // value: -(sqrt(2))
+        [InlineData(-1.1283791670955126,      -1.3835428792038633,      CrossPlatformMachineEpsilon * 10)]      // value: -(2 / sqrt(pi))
+        [InlineData(-1.0,                     -1.1752011936438015,      CrossPlatformMachineEpsilon * 10)]
+        [InlineData(-0.78539816339744831,     -0.86867096148600961,     CrossPlatformMachineEpsilon)]           // value: -(pi / 4)
+        [InlineData(-0.70710678118654752,     -0.76752314512611633,     CrossPlatformMachineEpsilon)]           // value: -(1 / sqrt(2))
+        [InlineData(-0.69314718055994531,     -0.75,                    CrossPlatformMachineEpsilon)]           // value: -(ln(2))
+        [InlineData(-0.63661977236758134,     -0.68050167815224332,     CrossPlatformMachineEpsilon)]           // value: -(2 / pi)
+        [InlineData(-0.43429448190325183,     -0.44807597941469025,     CrossPlatformMachineEpsilon)]           // value: -(log10(e))
+        [InlineData(-0.31830988618379067,     -0.32371243907207108,     CrossPlatformMachineEpsilon)]           // value: -(1 / pi)
+        [InlineData(-0.0,                     -0.0,                     0.0)]
+        [InlineData( double.NaN,               double.NaN,              0.0)]
+        [InlineData( 0.0,                      0.0,                     0.0)]
+        [InlineData( 0.31830988618379067,      0.32371243907207108,     CrossPlatformMachineEpsilon)]           // value:  (1 / pi)
+        [InlineData( 0.43429448190325183,      0.44807597941469025,     CrossPlatformMachineEpsilon)]           // value:  (log10(e))
+        [InlineData( 0.63661977236758134,      0.68050167815224332,     CrossPlatformMachineEpsilon)]           // value:  (2 / pi)
+        [InlineData( 0.69314718055994531,      0.75,                    CrossPlatformMachineEpsilon)]           // value:  (ln(2))
+        [InlineData( 0.70710678118654752,      0.76752314512611633,     CrossPlatformMachineEpsilon)]           // value:  (1 / sqrt(2))
+        [InlineData( 0.78539816339744831,      0.86867096148600961,     CrossPlatformMachineEpsilon)]           // value:  (pi / 4)
+        [InlineData( 1.0,                      1.1752011936438015,      CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 1.1283791670955126,       1.3835428792038633,      CrossPlatformMachineEpsilon * 10)]      // value:  (2 / sqrt(pi))
+        [InlineData( 1.4142135623730950,       1.9350668221743567,      CrossPlatformMachineEpsilon * 10)]      // value:  (sqrt(2))
+        [InlineData( 1.4426950408889634,       1.9978980091062796,      CrossPlatformMachineEpsilon * 10)]      // value:  (log2(e))
+        [InlineData( 1.5707963267948966,       2.3012989023072949,      CrossPlatformMachineEpsilon * 10)]      // value:  (pi / 2)
+        [InlineData( 2.3025850929940457,       4.95,                    CrossPlatformMachineEpsilon * 10)]      // value:  (ln(10))
+        [InlineData( 2.7182818284590452,       7.5441371028169758,      CrossPlatformMachineEpsilon * 10)]      // value:  (e)
+        [InlineData( 3.1415926535897932,       11.548739357257748,      CrossPlatformMachineEpsilon * 100)]     // value:  (pi)
+        [InlineData( double.PositiveInfinity,  double.PositiveInfinity, 0.0)]
+        public static void Sinh(double value, double expectedResult, double allowedVariance)
+        {
+            AssertEqual(expectedResult, Math.Sinh(value), allowedVariance);
+        }
+
+        [Theory]
+        [InlineData( double.NegativeInfinity,  double.NaN,             0.0)]
+        [InlineData(-3.1415926535897932,       double.NaN,             0.0)]                                 // value: (pi)
+        [InlineData(-2.7182818284590452,       double.NaN,             0.0)]                                 // value: (e)
+        [InlineData(-2.3025850929940457,       double.NaN,             0.0)]                                 // value: (ln(10))
+        [InlineData(-1.5707963267948966,       double.NaN,             0.0)]                                 // value: (pi / 2)
+        [InlineData(-1.4426950408889634,       double.NaN,             0.0)]                                 // value: (log2(e))
+        [InlineData(-1.4142135623730950,       double.NaN,             0.0)]                                 // value: (sqrt(2))
+        [InlineData(-1.1283791670955126,       double.NaN,             0.0)]                                 // value: (2 / sqrt(pi))
+        [InlineData(-1.0,                      double.NaN,             0.0)]
+        [InlineData(-0.78539816339744831,      double.NaN,             0.0)]                                 // value: (pi / 4)
+        [InlineData(-0.70710678118654752,      double.NaN,             0.0)]                                 // value: (1 / sqrt(2))
+        [InlineData(-0.69314718055994531,      double.NaN,             0.0)]                                 // value: (ln(2))
+        [InlineData(-0.63661977236758134,      double.NaN,             0.0)]                                 // value: (2 / pi)
+        [InlineData(-0.43429448190325183,      double.NaN,             0.0)]                                 // value: (log10(e))
+        [InlineData(-0.31830988618379067,      double.NaN,             0.0)]                                 // value: (1 / pi)
+        [InlineData(-0.0,                     -0.0,                    0.0)]
+        [InlineData( double.NaN,               double.NaN,             0.0)]
+        [InlineData( 0.0,                      0.0,                    0.0)]
+        [InlineData( 0.31830988618379067,      0.56418958354775629,    CrossPlatformMachineEpsilon)]        // value: (1 / pi)
+        [InlineData( 0.43429448190325183,      0.65901022898226081,    CrossPlatformMachineEpsilon)]        // value: (log10(e))
+        [InlineData( 0.63661977236758134,      0.79788456080286536,    CrossPlatformMachineEpsilon)]        // value: (2 / pi)
+        [InlineData( 0.69314718055994531,      0.83255461115769776,    CrossPlatformMachineEpsilon)]        // value: (ln(2))
+        [InlineData( 0.70710678118654752,      0.84089641525371454,    CrossPlatformMachineEpsilon)]        // value: (1 / sqrt(2))
+        [InlineData( 0.78539816339744831,      0.88622692545275801,    CrossPlatformMachineEpsilon)]        // value: (pi / 4)
+        [InlineData( 1.0,                      1.0,                    CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 1.1283791670955126,       1.0622519320271969,     CrossPlatformMachineEpsilon * 10)]   // value: (2 / sqrt(pi))
+        [InlineData( 1.4142135623730950,       1.1892071150027211,     CrossPlatformMachineEpsilon * 10)]   // value: (sqrt(2))
+        [InlineData( 1.4426950408889634,       1.2011224087864498,     CrossPlatformMachineEpsilon * 10)]   // value: (log2(e))
+        [InlineData( 1.5707963267948966,       1.2533141373155003,     CrossPlatformMachineEpsilon * 10)]   // value: (pi / 2)
+        [InlineData( 2.3025850929940457,       1.5174271293851464,     CrossPlatformMachineEpsilon * 10)]   // value: (ln(10))
+        [InlineData( 2.7182818284590452,       1.6487212707001281,     CrossPlatformMachineEpsilon * 10)]   // value: (e)
+        [InlineData( 3.1415926535897932,       1.7724538509055160,     CrossPlatformMachineEpsilon * 10)]   // value: (pi)
+        [InlineData( double.PositiveInfinity, double.PositiveInfinity, 0.0)]
+        public static void Sqrt(double value, double expectedResult, double allowedVariance)
+        {
+            AssertEqual(expectedResult, Math.Sqrt(value), allowedVariance);
+        }
+
+        [Theory]
+        [InlineData( double.NegativeInfinity,  double.NaN,              0.0)]
+        [InlineData(-3.1415926535897932,      -0.0,                     CrossPlatformMachineEpsilon)]       // value: -(pi)
+        [InlineData(-2.7182818284590452,       0.45054953406980750,     CrossPlatformMachineEpsilon)]       // value: -(e)
+        [InlineData(-2.3025850929940457,       1.1134071468135374,      CrossPlatformMachineEpsilon * 10)]  // value: -(ln(10))
+        [InlineData(-1.5707963267948966,       double.NegativeInfinity, 0.0, Skip = "https://github.com/dotnet/coreclr/issues/10276")]                               // value: -(pi / 2)
+        [InlineData(-1.5707963267948966,      -16331239353195370.0,     0.0)]                               // value: -(pi / 2)
+        [InlineData(-1.4426950408889634,      -7.7635756709721848,      CrossPlatformMachineEpsilon * 10)]  // value: -(log2(e))
+        [InlineData(-1.4142135623730950,      -6.3341191670421916,      CrossPlatformMachineEpsilon * 10)]  // value: -(sqrt(2))
+        [InlineData(-1.1283791670955126,      -2.1108768356626451,      CrossPlatformMachineEpsilon * 10)]  // value: -(2 / sqrt(pi))
+        [InlineData(-1.0,                     -1.5574077246549022,      CrossPlatformMachineEpsilon * 10)]
+        [InlineData(-0.78539816339744831,     -1.0,                     CrossPlatformMachineEpsilon * 10)]  // value: -(pi / 4)
+        [InlineData(-0.70710678118654752,     -0.85451043200960189,     CrossPlatformMachineEpsilon)]       // value: -(1 / sqrt(2))
+        [InlineData(-0.69314718055994531,     -0.83064087786078395,     CrossPlatformMachineEpsilon)]       // value: -(ln(2))
+        [InlineData(-0.63661977236758134,     -0.73930295048660405,     CrossPlatformMachineEpsilon)]       // value: -(2 / pi)
+        [InlineData(-0.43429448190325183,     -0.46382906716062964,     CrossPlatformMachineEpsilon)]       // value: -(log10(e))
+        [InlineData(-0.31830988618379067,     -0.32951473309607836,     CrossPlatformMachineEpsilon)]       // value: -(1 / pi)
+        [InlineData(-0.0,                     -0.0,                     0.0)]
+        [InlineData( double.NaN,               double.NaN,              0.0)]
+        [InlineData( 0.0,                      0.0,                     0.0)]
+        [InlineData( 0.31830988618379067,      0.32951473309607836,     CrossPlatformMachineEpsilon)]       // value:  (1 / pi)
+        [InlineData( 0.43429448190325183,      0.46382906716062964,     CrossPlatformMachineEpsilon)]       // value:  (log10(e))
+        [InlineData( 0.63661977236758134,      0.73930295048660405,     CrossPlatformMachineEpsilon)]       // value:  (2 / pi)
+        [InlineData( 0.69314718055994531,      0.83064087786078395,     CrossPlatformMachineEpsilon)]       // value:  (ln(2))
+        [InlineData( 0.70710678118654752,      0.85451043200960189,     CrossPlatformMachineEpsilon)]       // value:  (1 / sqrt(2))
+        [InlineData( 0.78539816339744831,      1.0,                     CrossPlatformMachineEpsilon * 10)]  // value:  (pi / 4)
+        [InlineData( 1.0,                      1.5574077246549022,      CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 1.1283791670955126,       2.1108768356626451,      CrossPlatformMachineEpsilon * 10)]  // value:  (2 / sqrt(pi))
+        [InlineData( 1.4142135623730950,       6.3341191670421916,      CrossPlatformMachineEpsilon * 10)]  // value:  (sqrt(2))
+        [InlineData( 1.4426950408889634,       7.7635756709721848,      CrossPlatformMachineEpsilon * 10)]  // value:  (log2(e))
+        [InlineData( 1.5707963267948966,       16331239353195370.0,     0.0)]                               // value:  (pi / 2)
+        [InlineData( 1.5707963267948966,       double.PositiveInfinity, 0.0, Skip = "https://github.com/dotnet/coreclr/issues/10276")]                               // value:  (pi / 2)
+        [InlineData( 2.3025850929940457,      -1.1134071468135374,      CrossPlatformMachineEpsilon * 10)]  // value:  (ln(10))
+        [InlineData( 2.7182818284590452,      -0.45054953406980750,     CrossPlatformMachineEpsilon)]       // value:  (e)
+        [InlineData( 3.1415926535897932,       0.0,                     CrossPlatformMachineEpsilon)]       // value:  (pi)
+        [InlineData( double.PositiveInfinity,  double.NaN,              0.0)]
+        public static void Tan(double value, double expectedResult, double allowedVariance)
+        {
+            AssertEqual(expectedResult, Math.Tan(value), allowedVariance);
+        }
+
+        [Theory]
+        [InlineData( double.NegativeInfinity, -1.0,                 CrossPlatformMachineEpsilon * 10)]
+        [InlineData(-3.1415926535897932,      -0.99627207622074994, CrossPlatformMachineEpsilon)]       // value: -(pi)
+        [InlineData(-2.7182818284590452,      -0.99132891580059984, CrossPlatformMachineEpsilon)]       // value: -(e)
+        [InlineData(-2.3025850929940457,      -0.98019801980198020, CrossPlatformMachineEpsilon)]       // value: -(ln(10))
+        [InlineData(-1.5707963267948966,      -0.91715233566727435, CrossPlatformMachineEpsilon)]       // value: -(pi / 2)
+        [InlineData(-1.4426950408889634,      -0.89423894585503855, CrossPlatformMachineEpsilon)]       // value: -(log2(e))
+        [InlineData(-1.4142135623730950,      -0.88838556158566054, CrossPlatformMachineEpsilon)]       // value: -(sqrt(2))
+        [InlineData(-1.1283791670955126,      -0.81046380599898809, CrossPlatformMachineEpsilon)]       // value: -(2 / sqrt(pi))
+        [InlineData(-1.0,                     -0.76159415595576489, CrossPlatformMachineEpsilon)]
+        [InlineData(-0.78539816339744831,     -0.65579420263267244, CrossPlatformMachineEpsilon)]       // value: -(pi / 4)
+        [InlineData(-0.70710678118654752,     -0.60885936501391381, CrossPlatformMachineEpsilon)]       // value: -(1 / sqrt(2))
+        [InlineData(-0.69314718055994531,     -0.6,                 CrossPlatformMachineEpsilon)]       // value: -(ln(2))
+        [InlineData(-0.63661977236758134,     -0.56259360033158334, CrossPlatformMachineEpsilon)]       // value: -(2 / pi)
+        [InlineData(-0.43429448190325183,     -0.40890401183401433, CrossPlatformMachineEpsilon)]       // value: -(log10(e))
+        [InlineData(-0.31830988618379067,     -0.30797791269089433, CrossPlatformMachineEpsilon)]       // value: -(1 / pi)
+        [InlineData(-0.0,                     -0.0,                 0.0)]
+        [InlineData( double.NaN,               double.NaN,          0.0)]
+        [InlineData( 0.0,                      0.0,                 0.0)]
+        [InlineData( 0.31830988618379067,      0.30797791269089433, CrossPlatformMachineEpsilon)]       // value:  (1 / pi)
+        [InlineData( 0.43429448190325183,      0.40890401183401433, CrossPlatformMachineEpsilon)]       // value:  (log10(e))
+        [InlineData( 0.63661977236758134,      0.56259360033158334, CrossPlatformMachineEpsilon)]       // value:  (2 / pi)
+        [InlineData( 0.69314718055994531,      0.6,                 CrossPlatformMachineEpsilon)]       // value:  (ln(2))
+        [InlineData( 0.70710678118654752,      0.60885936501391381, CrossPlatformMachineEpsilon)]       // value:  (1 / sqrt(2))
+        [InlineData( 0.78539816339744831,      0.65579420263267244, CrossPlatformMachineEpsilon)]       // value:  (pi / 4)
+        [InlineData( 1.0,                      0.76159415595576489, CrossPlatformMachineEpsilon)]
+        [InlineData( 1.1283791670955126,       0.81046380599898809, CrossPlatformMachineEpsilon)]       // value:  (2 / sqrt(pi))
+        [InlineData( 1.4142135623730950,       0.88838556158566054, CrossPlatformMachineEpsilon)]       // value:  (sqrt(2))
+        [InlineData( 1.4426950408889634,       0.89423894585503855, CrossPlatformMachineEpsilon)]       // value:  (log2(e))
+        [InlineData( 1.5707963267948966,       0.91715233566727435, CrossPlatformMachineEpsilon)]       // value:  (pi / 2)
+        [InlineData( 2.3025850929940457,       0.98019801980198020, CrossPlatformMachineEpsilon)]       // value:  (ln(10))
+        [InlineData( 2.7182818284590452,       0.99132891580059984, CrossPlatformMachineEpsilon)]       // value:  (e)
+        [InlineData( 3.1415926535897932,       0.99627207622074994, CrossPlatformMachineEpsilon)]       // value:  (pi)
+        [InlineData( double.PositiveInfinity,  1.0,                 CrossPlatformMachineEpsilon * 10)]
+        public static void Tanh(double value, double expectedResult, double allowedVariance)
+        {
+            AssertEqual(expectedResult, Math.Tanh(value), allowedVariance);
         }
 
         [Fact]

--- a/src/System.Runtime.Extensions/tests/System/Math.cs
+++ b/src/System.Runtime.Extensions/tests/System/Math.cs
@@ -51,11 +51,11 @@ namespace System.Tests
                     return;
                 }
 
-                throw new EqualException($"{"NaN",20}", $"{actual,20:G17}");
+                throw new EqualException(ToString(expected), ToString(actual));
             }
             else if (double.IsNaN(actual))
             {
-                throw new EqualException($"{expected,20:G17}", $"{"NaN",20}");
+                throw new EqualException(ToString(expected), ToString(actual));
             }
 
             if (double.IsNegativeInfinity(expected))
@@ -65,11 +65,11 @@ namespace System.Tests
                     return;
                 }
 
-                throw new EqualException($"{"-∞",20}", $"{actual,20:G17}");
+                throw new EqualException(ToString(expected), ToString(actual));
             }
             else if (double.IsNegativeInfinity(actual))
             {
-                throw new EqualException($"{expected,20:G17}", $"{"-∞",20}");
+                throw new EqualException(ToString(expected), ToString(actual));
             }
 
             if (double.IsPositiveInfinity(expected))
@@ -79,11 +79,11 @@ namespace System.Tests
                     return;
                 }
 
-                throw new EqualException($"{"+∞",20}", $"{actual,20:G17}");
+                throw new EqualException(ToString(expected), ToString(actual));
             }
             else if (double.IsPositiveInfinity(actual))
             {
-                throw new EqualException($"{expected,20:G17}", $"{"+∞",20}");
+                throw new EqualException(ToString(expected), ToString(actual));
             }
 
             if (IsNegativeZero(expected))
@@ -95,7 +95,7 @@ namespace System.Tests
 
                 if (IsPositiveZero(variance) || IsNegativeZero(variance))
                 {
-                    throw new EqualException($"{"-0.0",20}", $"{actual,20:G17}");
+                    throw new EqualException(ToString(expected), ToString(actual));
                 }
 
                 // When the variance is not ±0.0, then we are handling a case where
@@ -116,7 +116,7 @@ namespace System.Tests
 
                 if (IsPositiveZero(variance))
                 {
-                    throw new EqualException($"{"+0.0",20}", $"{actual,20:G17}");
+                    throw new EqualException(ToString(expected), ToString(actual));
                 }
 
                 // When the variance is not ±0.0, then we are handling a case where
@@ -132,7 +132,7 @@ namespace System.Tests
 
             if (delta > variance)
             {
-                throw new EqualException($"{expected,10:G9}", $"{actual,10:G9}");
+                throw new EqualException(ToString(expected), ToString(actual));
             }
         }
 
@@ -150,11 +150,11 @@ namespace System.Tests
                     return;
                 }
 
-                throw new EqualException($"{"NaN",10}", $"{actual,10:G9}");
+                throw new EqualException(ToString(expected), ToString(actual));
             }
             else if (float.IsNaN(actual))
             {
-                throw new EqualException($"{expected,10:G9}", $"{"NaN",10}");
+                throw new EqualException(ToString(expected), ToString(actual));
             }
 
             if (float.IsNegativeInfinity(expected))
@@ -164,11 +164,11 @@ namespace System.Tests
                     return;
                 }
 
-                throw new EqualException($"{"-∞",10}", $"{actual,10:G9}");
+                throw new EqualException(ToString(expected), ToString(actual));
             }
             else if (float.IsNegativeInfinity(actual))
             {
-                throw new EqualException($"{expected,10:G9}", $"{"-∞",10}");
+                throw new EqualException(ToString(expected), ToString(actual));
             }
 
             if (float.IsPositiveInfinity(expected))
@@ -178,11 +178,11 @@ namespace System.Tests
                     return;
                 }
 
-                throw new EqualException($"{"+∞",10}", $"{actual,10:G9}");
+                throw new EqualException(ToString(expected), ToString(actual));
             }
             else if (float.IsPositiveInfinity(actual))
             {
-                throw new EqualException($"{expected,10:G9}", $"{"+∞",10}");
+                throw new EqualException(ToString(expected), ToString(actual));
             }
 
             if (IsNegativeZero(expected))
@@ -194,7 +194,7 @@ namespace System.Tests
 
                 if (IsPositiveZero(variance) || IsNegativeZero(variance))
                 {
-                    throw new EqualException($"{"-0.0",10}", $"{actual,10:G9}");
+                    throw new EqualException(ToString(expected), ToString(actual));
                 }
 
                 // When the variance is not ±0.0, then we are handling a case where
@@ -215,7 +215,7 @@ namespace System.Tests
 
                 if (IsPositiveZero(variance))
                 {
-                    throw new EqualException($"{"+0.0",10}", $"{actual,10:G9}");
+                    throw new EqualException(ToString(expected), ToString(actual));
                 }
 
                 // When the variance is not ±0.0, then we are handling a case where
@@ -231,7 +231,7 @@ namespace System.Tests
 
             if (delta > variance)
             {
-                throw new EqualException($"{expected,10:G9}", $"{actual,10:G9}");
+                throw new EqualException(ToString(expected), ToString(actual));
             }
         }
 
@@ -253,6 +253,62 @@ namespace System.Tests
         private unsafe static bool IsPositiveZero(float value)
         {
             return (*(uint*)(&value)) == 0x00000000;
+        }
+
+        private static string ToString(double value)
+        {
+            if (double.IsNaN(value))
+            {
+                return "NaN".PadLeft(20);
+            }
+            else if (double.IsPositiveInfinity(value))
+            {
+                return "+∞".PadLeft(20);
+            }
+            else if (double.IsNegativeInfinity(value))
+            {
+                return "-∞".PadLeft(20);
+            }
+            else if (IsNegativeZero(value))
+            {
+                return "-0.0".PadLeft(20);
+            }
+            else if (IsPositiveZero(value))
+            {
+                return "+0.0".PadLeft(20);
+            }
+            else
+            {
+                return $"{value,20:G17}";
+            }
+        }
+
+        private static string ToString(float value)
+        {
+            if (double.IsNaN(value))
+            {
+                return "NaN".PadLeft(10);
+            }
+            else if (double.IsPositiveInfinity(value))
+            {
+                return "+∞".PadLeft(10);
+            }
+            else if (double.IsNegativeInfinity(value))
+            {
+                return "-∞".PadLeft(10);
+            }
+            else if (IsNegativeZero(value))
+            {
+                return "-0.0".PadLeft(10);
+            }
+            else if (IsPositiveZero(value))
+            {
+                return "+0.0".PadLeft(10);
+            }
+            else
+            {
+                return $"{value,10:G9}";
+            }
         }
 
         [Fact]

--- a/src/System.Runtime.Extensions/tests/System/Math.cs
+++ b/src/System.Runtime.Extensions/tests/System/Math.cs
@@ -1541,7 +1541,6 @@ namespace System.Tests
         [InlineData(-3.1415926535897932,      -0.0,                     CrossPlatformMachineEpsilon)]       // value: -(pi)
         [InlineData(-2.7182818284590452,       0.45054953406980750,     CrossPlatformMachineEpsilon)]       // value: -(e)
         [InlineData(-2.3025850929940457,       1.1134071468135374,      CrossPlatformMachineEpsilon * 10)]  // value: -(ln(10))
-        [InlineData(-1.5707963267948966,      -16331239353195370.0,     0.0)]                               // value: -(pi / 2)
         [InlineData(-1.4426950408889634,      -7.7635756709721848,      CrossPlatformMachineEpsilon * 10)]  // value: -(log2(e))
         [InlineData(-1.4142135623730950,      -6.3341191670421916,      CrossPlatformMachineEpsilon * 10)]  // value: -(sqrt(2))
         [InlineData(-1.1283791670955126,      -2.1108768356626451,      CrossPlatformMachineEpsilon * 10)]  // value: -(2 / sqrt(pi))
@@ -1565,12 +1564,29 @@ namespace System.Tests
         [InlineData( 1.1283791670955126,       2.1108768356626451,      CrossPlatformMachineEpsilon * 10)]  // value:  (2 / sqrt(pi))
         [InlineData( 1.4142135623730950,       6.3341191670421916,      CrossPlatformMachineEpsilon * 10)]  // value:  (sqrt(2))
         [InlineData( 1.4426950408889634,       7.7635756709721848,      CrossPlatformMachineEpsilon * 10)]  // value:  (log2(e))
-        [InlineData( 1.5707963267948966,       16331239353195370.0,     0.0)]                               // value:  (pi / 2)
         [InlineData( 2.3025850929940457,      -1.1134071468135374,      CrossPlatformMachineEpsilon * 10)]  // value:  (ln(10))
         [InlineData( 2.7182818284590452,      -0.45054953406980750,     CrossPlatformMachineEpsilon)]       // value:  (e)
         [InlineData( 3.1415926535897932,       0.0,                     CrossPlatformMachineEpsilon)]       // value:  (pi)
         [InlineData( double.PositiveInfinity,  double.NaN,              0.0)]
         public static void Tan(double value, double expectedResult, double allowedVariance)
+        {
+            AssertEqual(expectedResult, Math.Tan(value), allowedVariance);
+        }
+
+        [Theory]
+        [InlineData(-1.5707963267948966,      -16331239353195370.0,     0.0)]                               // value: -(pi / 2)
+        [InlineData( 1.5707963267948966,       16331239353195370.0,     0.0)]                               // value:  (pi / 2)
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public static void Tan_PiOver2(double value, double expectedResult, double allowedVariance)
+        {
+            AssertEqual(expectedResult, Math.Tan(value), allowedVariance);
+        }
+
+        [Theory]
+        [InlineData(-1.5707963267948966,      -16331778728383844.0,     0.0)]                               // value: -(pi / 2)
+        [InlineData( 1.5707963267948966,       16331778728383844.0,     0.0)]                               // value:  (pi / 2)
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+        public static void Tan_PiOver2_Legacy(double value, double expectedResult, double allowedVariance)
         {
             AssertEqual(expectedResult, Math.Tan(value), allowedVariance);
         }

--- a/src/System.Runtime.Extensions/tests/System/Math.cs
+++ b/src/System.Runtime.Extensions/tests/System/Math.cs
@@ -839,7 +839,7 @@ namespace System.Tests
         [InlineData(-0.63661977236758134,    -1.0,                     0.0)]    // value: -(2 / pi)
         [InlineData(-0.43429448190325183,    -1.0,                     0.0)]    // value: -(log10(e))
         [InlineData(-0.31830988618379067,    -1.0,                     0.0)]    // value: -(1 / pi)
-        [InlineData(-0.0,                    -0.0,                     0.0)]
+        [InlineData(-0.0,                    -0.0,                     0.0, Skip = "https://github.com/dotnet/coreclr/issues/10288")]
         [InlineData( double.NaN,              double.NaN,              0.0)]
         [InlineData( 0.0,                     0.0,                     0.0)]
         [InlineData( 0.31830988618379067,     0.0,                     0.0)]    // value:  (1 / pi)

--- a/src/System.Runtime.Extensions/tests/System/Math.cs
+++ b/src/System.Runtime.Extensions/tests/System/Math.cs
@@ -669,12 +669,12 @@ namespace System.Tests
         [InlineData(-1.4142135623730950,     -1.0,                     0.0)]    // value: -(sqrt(2))
         [InlineData(-1.1283791670955126,     -1.0,                     0.0)]    // value: -(2 / sqrt(pi))
         [InlineData(-1.0,                    -1.0,                     0.0)]
-        [InlineData(-0.78539816339744831,     0.0,                     0.0)]    // value: -(pi / 4)
-        [InlineData(-0.70710678118654752,     0.0,                     0.0)]    // value: -(1 / sqrt(2))
-        [InlineData(-0.69314718055994531,     0.0,                     0.0)]    // value: -(ln(2))
-        [InlineData(-0.63661977236758134,     0.0,                     0.0)]    // value: -(2 / pi)
-        [InlineData(-0.43429448190325183,     0.0,                     0.0)]    // value: -(log10(e))
-        [InlineData(-0.31830988618379067,     0.0,                     0.0)]    // value: -(1 / pi)
+        [InlineData(-0.78539816339744831,    -0.0,                     0.0, Skip = "https://github.com/dotnet/coreclr/issues/10287")]    // value: -(pi / 4)
+        [InlineData(-0.70710678118654752,    -0.0,                     0.0, Skip = "https://github.com/dotnet/coreclr/issues/10287")]    // value: -(1 / sqrt(2))
+        [InlineData(-0.69314718055994531,    -0.0,                     0.0, Skip = "https://github.com/dotnet/coreclr/issues/10287")]    // value: -(ln(2))
+        [InlineData(-0.63661977236758134,    -0.0,                     0.0, Skip = "https://github.com/dotnet/coreclr/issues/10287")]    // value: -(2 / pi)
+        [InlineData(-0.43429448190325183,    -0.0,                     0.0, Skip = "https://github.com/dotnet/coreclr/issues/10287")]    // value: -(log10(e))
+        [InlineData(-0.31830988618379067,    -0.0,                     0.0, Skip = "https://github.com/dotnet/coreclr/issues/10287")]    // value: -(1 / pi)
         [InlineData(-0.0,                    -0.0,                     0.0)]
         [InlineData( double.NaN,              double.NaN,              0.0)]
         [InlineData( 0.0,                     0.0,                     0.0)]

--- a/src/System.Runtime.Extensions/tests/System/Math.cs
+++ b/src/System.Runtime.Extensions/tests/System/Math.cs
@@ -533,15 +533,11 @@ namespace System.Tests
         }
 
         [Theory]
-        [InlineData( double.NegativeInfinity,  double.NegativeInfinity,  double.NaN,          0.0)]
-        [InlineData( double.NegativeInfinity,  double.NegativeInfinity, -2.3561944901923449,  CrossPlatformMachineEpsilon * 10, Skip = "https://github.com/dotnet/coreclr/issues/9806")]     // expected: -(3 * pi / 4)
         [InlineData( double.NegativeInfinity, -1.0,                     -1.5707963267948966,  CrossPlatformMachineEpsilon * 10)]    // expected: -(pi / 2)
         [InlineData( double.NegativeInfinity, -0.0,                     -1.5707963267948966,  CrossPlatformMachineEpsilon * 10)]    // expected: -(pi / 2)
         [InlineData( double.NegativeInfinity,  double.NaN,               double.NaN,          0.0)]
         [InlineData( double.NegativeInfinity,  0.0,                     -1.5707963267948966,  CrossPlatformMachineEpsilon * 10)]    // expected: -(pi / 2)
         [InlineData( double.NegativeInfinity,  1.0,                     -1.5707963267948966,  CrossPlatformMachineEpsilon * 10)]    // expected: -(pi / 2)
-        [InlineData( double.NegativeInfinity,  double.PositiveInfinity,  double.NaN,          0.0)]
-        [InlineData( double.NegativeInfinity,  double.PositiveInfinity, -0.78539816339744831, CrossPlatformMachineEpsilon, Skip = "https://github.com/dotnet/coreclr/issues/9806")]          // expected: -(pi / 4)
         [InlineData(-1.0,                     -1.0,                     -2.3561944901923449,  CrossPlatformMachineEpsilon * 10)]    // expected: -(3 * pi / 4)
         [InlineData(-1.0,                     -0.0,                     -1.5707963267948966,  CrossPlatformMachineEpsilon * 10)]    // expected: -(pi / 2)
         [InlineData(-1.0,                      double.NaN,               double.NaN,          0.0)]
@@ -623,16 +619,34 @@ namespace System.Tests
         [InlineData( 1.0,                      0.0,                      1.5707963267948966,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi / 2)
         [InlineData( 1.0,                      1.0,                      0.78539816339744831, CrossPlatformMachineEpsilon)]          // expected:  (pi / 4)
         [InlineData( 1.0,                      double.PositiveInfinity,  0.0,                 0.0)]
-        [InlineData( double.PositiveInfinity,  double.NegativeInfinity,  double.NaN,          0.0)]
-        [InlineData( double.PositiveInfinity,  double.NegativeInfinity,  2.3561944901923449,  CrossPlatformMachineEpsilon * 10, Skip = "https://github.com/dotnet/coreclr/issues/9806")]     // expected:  (3 * pi / 4)
         [InlineData( double.PositiveInfinity, -1.0,                      1.5707963267948966,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi / 2)
         [InlineData( double.PositiveInfinity, -0.0,                      1.5707963267948966,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi / 2)
         [InlineData( double.PositiveInfinity,  double.NaN,               double.NaN,          0.0)]
         [InlineData( double.PositiveInfinity,  0.0,                      1.5707963267948966,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi / 2)
         [InlineData( double.PositiveInfinity,  1.0,                      1.5707963267948966,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi / 2)
-        [InlineData( double.PositiveInfinity,  double.PositiveInfinity,  double.NaN,          0.0)]
-        [InlineData( double.PositiveInfinity,  double.PositiveInfinity,  0.78539816339744831, CrossPlatformMachineEpsilon, Skip = "https://github.com/dotnet/coreclr/issues/9806")]          // expected:  (pi / 4)
         public static void Atan2(double y, double x, double expectedResult, double allowedVariance)
+        {
+            AssertEqual(expectedResult, Math.Atan2(y, x), allowedVariance);
+        }
+
+        [Theory]
+        [InlineData( double.NegativeInfinity, double.NegativeInfinity, -2.3561944901923449,  CrossPlatformMachineEpsilon * 10)]    // expected: -(3 * pi / 4)
+        [InlineData( double.NegativeInfinity, double.PositiveInfinity, -0.78539816339744831, CrossPlatformMachineEpsilon)]         // expected: -(pi / 4)
+        [InlineData( double.PositiveInfinity, double.NegativeInfinity,  2.3561944901923449,  CrossPlatformMachineEpsilon * 10)]    // expected:  (3 * pi / 4)
+        [InlineData( double.PositiveInfinity, double.PositiveInfinity,  0.78539816339744831, CrossPlatformMachineEpsilon)]         // expected:  (pi / 4)
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public static void Atan2_IEEE(double y, double x, double expectedResult, double allowedVariance)
+        {
+            AssertEqual(expectedResult, Math.Atan2(y, x), allowedVariance);
+        }
+
+        [Theory]
+        [InlineData( double.NegativeInfinity, double.NegativeInfinity, double.NaN, 0.0)]
+        [InlineData( double.NegativeInfinity, double.PositiveInfinity, double.NaN, 0.0)]
+        [InlineData( double.PositiveInfinity, double.NegativeInfinity, double.NaN, 0.0)]
+        [InlineData( double.PositiveInfinity, double.PositiveInfinity, double.NaN, 0.0)]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+        public static void Atan2_IEEE_Legacy(double y, double x, double expectedResult, double allowedVariance)
         {
             AssertEqual(expectedResult, Math.Atan2(y, x), allowedVariance);
         }
@@ -1151,15 +1165,11 @@ namespace System.Tests
         [InlineData(-2.7182818284590452,       1.0,                     -2.7182818284590452,      CrossPlatformMachineEpsilon * 10)]        // x: -(e)  expected: (e)
         [InlineData(-2.7182818284590452,       1.5707963267948966,       double.NaN,              0.0)]                                     // x: -(e)  y:  (pi / 2)
         [InlineData(-2.7182818284590452,       double.PositiveInfinity,  double.PositiveInfinity, 0.0)]
-        [InlineData(-1.0,                      double.NegativeInfinity,  double.NaN,              0.0)]
-        [InlineData(-1.0,                      double.NegativeInfinity,  1.0,                     CrossPlatformMachineEpsilon * 10, Skip = "https://github.com/dotnet/coreclr/issues/9807")]
         [InlineData(-1.0,                     -1.0,                     -1.0,                     CrossPlatformMachineEpsilon * 10)]
         [InlineData(-1.0,                     -0.0,                      1.0,                     CrossPlatformMachineEpsilon * 10)]
         [InlineData(-1.0,                      double.NaN,               double.NaN,              0.0)]
         [InlineData(-1.0,                      0.0,                      1.0,                     CrossPlatformMachineEpsilon * 10)]
         [InlineData(-1.0,                      1.0,                     -1.0,                     CrossPlatformMachineEpsilon * 10)]
-        [InlineData(-1.0,                      double.PositiveInfinity,  double.NaN,              0.0)]
-        [InlineData(-1.0,                      double.PositiveInfinity,  1.0,                     CrossPlatformMachineEpsilon * 10, Skip = "https://github.com/dotnet/coreclr/issues/9807")]
         [InlineData(-0.0,                      double.NegativeInfinity,  double.PositiveInfinity, 0.0)]
         [InlineData(-0.0,                     -3.0,                      double.NegativeInfinity, 0.0)]
         [InlineData(-0.0,                     -2.0,                      double.PositiveInfinity, 0.0)]
@@ -1175,11 +1185,7 @@ namespace System.Tests
         [InlineData(-0.0,                      double.PositiveInfinity,  0.0,                     0.0)]
         [InlineData( double.NaN,               double.NegativeInfinity,  double.NaN,              0.0)]
         [InlineData( double.NaN,              -1.0,                      double.NaN,              0.0)]
-        [InlineData( double.NaN,              -0.0,                      double.NaN,              0.0)]
-        [InlineData( double.NaN,              -0.0,                      1.0,                     CrossPlatformMachineEpsilon * 10, Skip = "https://github.com/dotnet/coreclr/issues/9807")]
         [InlineData( double.NaN,               double.NaN,               double.NaN,              0.0)]
-        [InlineData( double.NaN,               0.0,                      double.NaN,              0.0)]
-        [InlineData( double.NaN,               0.0,                      1.0,                     CrossPlatformMachineEpsilon * 10, Skip = "https://github.com/dotnet/coreclr/issues/9807")]
         [InlineData( double.NaN,               1.0,                      double.NaN,              0.0)]
         [InlineData( double.NaN,               double.PositiveInfinity,  double.NaN,              0.0)]
         [InlineData( 0.0,                      double.NegativeInfinity,  double.PositiveInfinity, 0.0)]
@@ -1198,8 +1204,6 @@ namespace System.Tests
         [InlineData( 1.0,                      double.NegativeInfinity,  1.0,                     CrossPlatformMachineEpsilon * 10)]
         [InlineData( 1.0,                     -1.0,                      1.0,                     CrossPlatformMachineEpsilon * 10)]
         [InlineData( 1.0,                     -0.0,                      1.0,                     CrossPlatformMachineEpsilon * 10)]
-        [InlineData( 1.0,                      double.NaN,               double.NaN,              0.0)]
-        [InlineData( 1.0,                      double.NaN,               1.0,                     CrossPlatformMachineEpsilon * 10, Skip = "https://github.com/dotnet/coreclr/issues/9807")]
         [InlineData( 1.0,                      0.0,                      1.0,                     CrossPlatformMachineEpsilon * 10)]
         [InlineData( 1.0,                      1.0,                      1.0,                     CrossPlatformMachineEpsilon * 10)]
         [InlineData( 1.0,                      double.PositiveInfinity,  1.0,                     CrossPlatformMachineEpsilon * 10)]
@@ -1277,6 +1281,30 @@ namespace System.Tests
         [InlineData( double.PositiveInfinity,  1.0,                      double.PositiveInfinity, 0.0)]
         [InlineData( double.PositiveInfinity,  double.PositiveInfinity,  double.PositiveInfinity, 0.0)]
         public static void Pow(double x, double y, double expectedResult, double allowedVariance)
+        {
+            AssertEqual(expectedResult, Math.Pow(x, y), allowedVariance);
+        }
+
+        [Theory]
+        [InlineData(-1.0,         double.NegativeInfinity, 1.0, CrossPlatformMachineEpsilon * 10)]
+        [InlineData(-1.0,         double.PositiveInfinity, 1.0, CrossPlatformMachineEpsilon * 10)]
+        [InlineData( double.NaN, -0.0,                     1.0, CrossPlatformMachineEpsilon * 10)]
+        [InlineData( double.NaN,  0.0,                     1.0, CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 1.0,         double.NaN,              1.0, CrossPlatformMachineEpsilon * 10)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public static void Pow_IEEE(float x, float y, float expectedResult, float allowedVariance)
+        {
+            AssertEqual(expectedResult, Math.Pow(x, y), allowedVariance);
+        }
+
+        [Theory]
+        [InlineData(-1.0,         double.NegativeInfinity, double.NaN, 0.0)]
+        [InlineData(-1.0,         double.PositiveInfinity, double.NaN, 0.0)]
+        [InlineData( double.NaN, -0.0,                     double.NaN, 0.0)]
+        [InlineData( double.NaN,  0.0,                     double.NaN, 0.0)]
+        [InlineData( 1.0,         double.NaN,              double.NaN, 0.0)]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+        public static void Pow_IEEE_Legacy(float x, float y, float expectedResult, float allowedVariance)
         {
             AssertEqual(expectedResult, Math.Pow(x, y), allowedVariance);
         }
@@ -1513,7 +1541,6 @@ namespace System.Tests
         [InlineData(-3.1415926535897932,      -0.0,                     CrossPlatformMachineEpsilon)]       // value: -(pi)
         [InlineData(-2.7182818284590452,       0.45054953406980750,     CrossPlatformMachineEpsilon)]       // value: -(e)
         [InlineData(-2.3025850929940457,       1.1134071468135374,      CrossPlatformMachineEpsilon * 10)]  // value: -(ln(10))
-        [InlineData(-1.5707963267948966,       double.NegativeInfinity, 0.0, Skip = "https://github.com/dotnet/coreclr/issues/10276")]                               // value: -(pi / 2)
         [InlineData(-1.5707963267948966,      -16331239353195370.0,     0.0)]                               // value: -(pi / 2)
         [InlineData(-1.4426950408889634,      -7.7635756709721848,      CrossPlatformMachineEpsilon * 10)]  // value: -(log2(e))
         [InlineData(-1.4142135623730950,      -6.3341191670421916,      CrossPlatformMachineEpsilon * 10)]  // value: -(sqrt(2))
@@ -1539,7 +1566,6 @@ namespace System.Tests
         [InlineData( 1.4142135623730950,       6.3341191670421916,      CrossPlatformMachineEpsilon * 10)]  // value:  (sqrt(2))
         [InlineData( 1.4426950408889634,       7.7635756709721848,      CrossPlatformMachineEpsilon * 10)]  // value:  (log2(e))
         [InlineData( 1.5707963267948966,       16331239353195370.0,     0.0)]                               // value:  (pi / 2)
-        [InlineData( 1.5707963267948966,       double.PositiveInfinity, 0.0, Skip = "https://github.com/dotnet/coreclr/issues/10276")]                               // value:  (pi / 2)
         [InlineData( 2.3025850929940457,      -1.1134071468135374,      CrossPlatformMachineEpsilon * 10)]  // value:  (ln(10))
         [InlineData( 2.7182818284590452,      -0.45054953406980750,     CrossPlatformMachineEpsilon)]       // value:  (e)
         [InlineData( 3.1415926535897932,       0.0,                     CrossPlatformMachineEpsilon)]       // value:  (pi)

--- a/src/System.Runtime.Extensions/tests/System/MathF.netcoreapp.cs
+++ b/src/System.Runtime.Extensions/tests/System/MathF.netcoreapp.cs
@@ -1,9 +1,7 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Globalization;
 using Xunit;
 using Xunit.Sdk;
 
@@ -11,163 +9,563 @@ namespace System.Tests
 {
     public static partial class MathFTests
     {
-       // binary32 (float) has a machine epsilon of 2^-23 (approx. 1.19e-07). However, this is
-       // slightly too accurate when writing tests meant to run against math library implementations
-       // for various platforms. 2^-21 (approx. 4.76e-07) seems to be as accurate as we can get for
-       // our current set of platforms.
-       //
-       // The tests themselves will take `CrossPlatformMachineEpsilon` and adjust it according to the
-       // expected result so that the delta used for comparison will compare the most significant digits
-       // and ignore any digits that are outside the single precision range (6-9 digits).
-       //
-       // For example, a test with an expect result in the format of 0.xxxxxxxxx will use CrossPlatformMachineEpsilon
-       // for the variance, while an expected result in the format of 0.0xxxxxxxxx will use
-       // CrossPlatformMachineEpsilon / 10 and expected result in the format of x.xxxxxx will
-       // use CrossPlatformMachineEpsilon * 10.
+        // binary32 (float) has a machine epsilon of 2^-23 (approx. 1.19e-07). However, this
+        // is slightly too accurate when writing tests meant to run against libm implementations
+        // for various platforms. 2^-21 (approx. 4.76e-07) seems to be as accurate as we can get.
+        //
+        // The tests themselves will take CrossPlatformMachineEpsilon and adjust it according to the expected result
+        // so that the delta used for comparison will compare the most significant digits and ignore
+        // any digits that are outside the single precision range (6-9 digits).
+
+        // For example, a test with an expect result in the format of 0.xxxxxxxxx will use
+        // CrossPlatformMachineEpsilon for the variance, while an expected result in the format of 0.0xxxxxxxxx
+        // will use CrossPlatformMachineEpsilon / 10 and expected result in the format of x.xxxxxx will
+        // use CrossPlatformMachineEpsilon * 10.
         public const float CrossPlatformMachineEpsilon = 4.76837158e-07f;
 
-        /// <summary>
-        /// Verifies that two <see cref="float"/> values are equal, within the <paramref name="allowedVariance"/>.
-        /// </summary>
+        /// <summary>Verifies that two <see cref="float"/> values are equal, within the <paramref name="variance"/>.</summary>
         /// <param name="expected">The expected value</param>
         /// <param name="actual">The value to be compared against</param>
-        /// <param name="allowedVariance">The total variance allowed between the expected and actual results.</param>
+        /// <param name="variance">The total variance allowed between the expected and actual results.</param>
         /// <exception cref="EqualException">Thrown when the values are not equal</exception>
-        public static void AssertEqual(float expected, float actual, float allowedVariance)
+        public static void AssertEqual(float expected, float actual, float variance)
         {
-            // This is essentially equivalent to the Xunit.Assert.Equal(double, double, int) implementation
-            // available here: https://github.com/xunit/xunit/blob/2.1/src/xunit.assert/Asserts/EqualityAsserts.cs#L46
+            if (float.IsNaN(expected))
+            {
+                if (float.IsNaN(actual))
+                {
+                    return;
+                }
+
+                throw new EqualException($"{"NaN",10}", $"{actual,10:G9}");
+            }
+            else if (float.IsNaN(actual))
+            {
+                throw new EqualException($"{expected,10:G9}", $"{"NaN",10}");
+            }
+
+            if (float.IsNegativeInfinity(expected))
+            {
+                if (float.IsNegativeInfinity(actual))
+                {
+                    return;
+                }
+
+                throw new EqualException($"{"-∞",10}", $"{actual,10:G9}");
+            }
+            else if (float.IsNegativeInfinity(actual))
+            {
+                throw new EqualException($"{expected,10:G9}", $"{"-∞",10}");
+            }
+
+            if (float.IsPositiveInfinity(expected))
+            {
+                if (float.IsPositiveInfinity(actual))
+                {
+                    return;
+                }
+
+                throw new EqualException($"{"+∞",10}", $"{actual,10:G9}");
+            }
+            else if (float.IsPositiveInfinity(actual))
+            {
+                throw new EqualException($"{expected,10:G9}", $"{"+∞",10}");
+            }
+
+            if (IsNegativeZero(expected))
+            {
+                if (IsNegativeZero(actual))
+                {
+                    return;
+                }
+
+                if (IsPositiveZero(variance) || IsNegativeZero(variance))
+                {
+                    throw new EqualException($"{"-0.0",10}", $"{actual,10:G9}");
+                }
+
+                // When the variance is not ±0.0, then we are handling a case where
+                // the actual result is expected to not be exactly -0.0 on some platforms
+                // and we should fallback to checking if it is within the allowed variance instead.
+            }
+            else if (IsNegativeZero(actual))
+            {
+                // Do nothing, since the actual result could still be within the allowed variance
+            }
+
+            if (IsPositiveZero(expected))
+            {
+                if (IsPositiveZero(actual))
+                {
+                    return;
+                }
+
+                if (IsPositiveZero(variance))
+                {
+                    throw new EqualException($"{"+0.0",10}", $"{actual,10:G9}");
+                }
+
+                // When the variance is not ±0.0, then we are handling a case where
+                // the actual result is expected to not be exactly +0.0 on some platforms
+                // and we should fallback to checking if it is within the allowed variance instead.
+            }
+            else if (IsPositiveZero(actual))
+            {
+                // Do nothing, since the actual result could still be within the allowed variance
+            }
 
             var delta = MathF.Abs(actual - expected);
 
-            if (delta > allowedVariance)
+            if (delta > variance)
             {
                 throw new EqualException($"{expected,10:G9}", $"{actual,10:G9}");
             }
         }
 
-        [Fact]
-        public static void Abs()
+        private unsafe static bool IsNegativeZero(float value)
         {
-            Assert.Equal(MathF.PI, MathF.Abs(MathF.PI));
-            Assert.Equal(0.0f, MathF.Abs(0.0f));
-            Assert.Equal(MathF.PI, MathF.Abs(-MathF.PI));
-            Assert.Equal(float.NaN, MathF.Abs(float.NaN));
-            Assert.Equal(float.PositiveInfinity, MathF.Abs(float.PositiveInfinity));
-            Assert.Equal(float.PositiveInfinity, MathF.Abs(float.NegativeInfinity));
+            return (*(uint*)(&value)) == 0x80000000;
         }
 
-        [Fact]
-        public static void Acos()
+        private unsafe static bool IsPositiveZero(float value)
         {
-            Assert.Equal(0.0f, MathF.Acos(1.0f));
-            AssertEqual(MathF.PI / 2.0f, MathF.Acos(0.0f), CrossPlatformMachineEpsilon * 10);
-            AssertEqual(MathF.PI, MathF.Acos(-1.0f), CrossPlatformMachineEpsilon * 10);
-            Assert.Equal(float.NaN, MathF.Acos(float.NaN));
-            Assert.Equal(float.NaN, MathF.Acos(float.PositiveInfinity));
-            Assert.Equal(float.NaN, MathF.Acos(float.NegativeInfinity));
+            return (*(uint*)(&value)) == 0x00000000;
         }
 
-        [Fact]
-        public static void Asin()
+        [Theory]
+        [InlineData( float.NegativeInfinity, float.PositiveInfinity, 0.0f)]
+        [InlineData(-3.14159265f,            3.14159265f,            CrossPlatformMachineEpsilon * 10)]     // value: -(pi)             expected: (pi)
+        [InlineData(-2.71828183f,            2.71828183f,            CrossPlatformMachineEpsilon * 10)]     // value: -(e)              expected: (e)
+        [InlineData(-2.30258509f,            2.30258509f,            CrossPlatformMachineEpsilon * 10)]     // value: -(ln(10))         expected: (ln(10))
+        [InlineData(-1.57079633f,            1.57079633f,            CrossPlatformMachineEpsilon * 10)]     // value: -(pi / 2)         expected: (pi / 2)
+        [InlineData(-1.44269504f,            1.44269504f,            CrossPlatformMachineEpsilon * 10)]     // value: -(log2(e))        expected: (log2(e))
+        [InlineData(-1.41421356f,            1.41421356f,            CrossPlatformMachineEpsilon * 10)]     // value: -(sqrt(2))        expected: (sqrt(2))
+        [InlineData(-1.12837917f,            1.12837917f,            CrossPlatformMachineEpsilon * 10)]     // value: -(2 / sqrt(pi))   expected: (2 / sqrt(pi))
+        [InlineData(-1.0f,                   1.0f,                   CrossPlatformMachineEpsilon * 10)]
+        [InlineData(-0.785398163f,           0.785398163f,           CrossPlatformMachineEpsilon)]          // value: -(pi / 4)         expected: (pi / 4)
+        [InlineData(-0.707106781f,           0.707106781f,           CrossPlatformMachineEpsilon)]          // value: -(1 / sqrt(2))    expected: (1 / sqrt(2))
+        [InlineData(-0.693147181f,           0.693147181f,           CrossPlatformMachineEpsilon)]          // value: -(ln(2))          expected: (ln(2))
+        [InlineData(-0.636619772f,           0.636619772f,           CrossPlatformMachineEpsilon)]          // value: -(2 / pi)         expected: (2 / pi)
+        [InlineData(-0.434294482f,           0.434294482f,           CrossPlatformMachineEpsilon)]          // value: -(log10(e))       expected: (log10(e))
+        [InlineData(-0.318309886f,           0.318309886f,           CrossPlatformMachineEpsilon)]          // value: -(1 / pi)         expected: (1 / pi)
+        [InlineData(-0.0f,                   0.0f,                   0.0f)]
+        [InlineData( float.NaN,              float.NaN,              0.0f)]
+        [InlineData( 0.0f,                   0.0f,                   0.0f)]
+        [InlineData( 0.318309886f,           0.318309886f,           CrossPlatformMachineEpsilon)]          // value:  (1 / pi)         expected: (1 / pi)
+        [InlineData( 0.434294482f,           0.434294482f,           CrossPlatformMachineEpsilon)]          // value:  (log10(e))       expected: (log10(e))
+        [InlineData( 0.636619772f,           0.636619772f,           CrossPlatformMachineEpsilon)]          // value:  (2 / pi)         expected: (2 / pi)
+        [InlineData( 0.693147181f,           0.693147181f,           CrossPlatformMachineEpsilon)]          // value:  (ln(2))          expected: (ln(2))
+        [InlineData( 0.707106781f,           0.707106781f,           CrossPlatformMachineEpsilon)]          // value:  (1 / sqrt(2))    expected: (1 / sqrt(2))
+        [InlineData( 0.785398163f,           0.785398163f,           CrossPlatformMachineEpsilon)]          // value:  (pi / 4)         expected: (pi / 4)
+        [InlineData( 1.0f,                   1.0f,                   CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 1.12837917f,            1.12837917f,            CrossPlatformMachineEpsilon * 10)]     // value:  (2 / sqrt(pi))   expected: (2 / sqrt(pi))
+        [InlineData( 1.41421356f,            1.41421356f,            CrossPlatformMachineEpsilon * 10)]     // value:  (sqrt(2))        expected: (sqrt(2))
+        [InlineData( 1.44269504f,            1.44269504f,            CrossPlatformMachineEpsilon * 10)]     // value:  (log2(e))        expected: (log2(e))
+        [InlineData( 1.57079633f,            1.57079633f,            CrossPlatformMachineEpsilon * 10)]     // value:  (pi / 2)         expected: (pi / 2)
+        [InlineData( 2.30258509f,            2.30258509f,            CrossPlatformMachineEpsilon * 10)]     // value:  (ln(10))         expected: (ln(10))
+        [InlineData( 2.71828183f,            2.71828183f,            CrossPlatformMachineEpsilon * 10)]     // value:  (e)              expected: (e)
+        [InlineData( 3.14159265f,            3.14159265f,            CrossPlatformMachineEpsilon * 10)]     // value:  (pi)             expected: (pi)
+        [InlineData( float.PositiveInfinity, float.PositiveInfinity, 0.0f)]
+        public static void Abs(float value, float expectedResult, float allowedVariance)
         {
-            AssertEqual(MathF.PI / 2.0f, MathF.Asin(1.0f), CrossPlatformMachineEpsilon * 10);
-            Assert.Equal(0.0f, MathF.Asin(0.0f));
-            AssertEqual(-MathF.PI / 2.0f, MathF.Asin(-1.0f), CrossPlatformMachineEpsilon * 10);
-            Assert.Equal(float.NaN, MathF.Asin(float.NaN));
-            Assert.Equal(float.NaN, MathF.Asin(float.PositiveInfinity));
-            Assert.Equal(float.NaN, MathF.Asin(float.NegativeInfinity));
+            AssertEqual(expectedResult, MathF.Abs(value), allowedVariance);
         }
 
-        [Fact]
-        public static void Atan()
+        [Theory]
+        [InlineData( float.NegativeInfinity, float.NaN,    0.0f)]
+        [InlineData(-1.0f,                   3.14159265f,  CrossPlatformMachineEpsilon * 10)]   // expected:  (pi)
+        [InlineData(-0.911733915f,           2.71828183f,  CrossPlatformMachineEpsilon * 10)]   // expected:  (e)
+        [InlineData(-0.668201510f,           2.30258509f,  CrossPlatformMachineEpsilon * 10)]   // expected:  (ln(10))
+        [InlineData(-0.0f,                   1.57079633f,  CrossPlatformMachineEpsilon * 10)]   // expected:  (pi / 2)
+        [InlineData( float.NaN,              float.NaN,    0.0f)]
+        [InlineData( 0.0f,                   1.57079633f,  CrossPlatformMachineEpsilon * 10)]   // expected:  (pi / 2)
+        [InlineData( 0.127751218f,           1.44269504f,  CrossPlatformMachineEpsilon * 10)]   // expected:  (log2(e))
+        [InlineData( 0.155943695f,           1.41421356f,  CrossPlatformMachineEpsilon * 10)]   // expected:  (sqrt(2))
+        [InlineData( 0.428125148f,           1.12837917f,  CrossPlatformMachineEpsilon * 10)]   // expected:  (2 / sqrt(pi))
+        [InlineData( 0.540302306f,           1.0f,         CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 0.707106781f,           0.785398163f, CrossPlatformMachineEpsilon)]        // expected:  (pi / 4),         value:  (1 / sqrt(2))
+        [InlineData( 0.760244597f,           0.707106781f, CrossPlatformMachineEpsilon)]        // expected:  (1 / sqrt(2))
+        [InlineData( 0.769238901f,           0.693147181f, CrossPlatformMachineEpsilon)]        // expected:  (ln(2))
+        [InlineData( 0.804109828f,           0.636619772f, CrossPlatformMachineEpsilon)]        // expected:  (2 / pi)
+        [InlineData( 0.907167129f,           0.434294482f, CrossPlatformMachineEpsilon)]        // expected:  (log10(e))
+        [InlineData( 0.949765715f,           0.318309886f, CrossPlatformMachineEpsilon)]        // expected:  (1 / pi)
+        [InlineData( 1.0f,                   0.0f,         0.0f)]
+        [InlineData( float.PositiveInfinity, float.NaN,    0.0f)]
+        public static void Acos(float value, float expectedResult, float allowedVariance)
         {
-            AssertEqual(MathF.PI / 4.0f, MathF.Atan(1.0f), CrossPlatformMachineEpsilon);
-            Assert.Equal(0.0f, MathF.Atan(0.0f));
-            AssertEqual(-MathF.PI / 4.0f, MathF.Atan(-1.0f), CrossPlatformMachineEpsilon);
-            Assert.Equal(float.NaN, MathF.Atan(float.NaN));
-            AssertEqual(MathF.PI / 2.0f, MathF.Atan(float.PositiveInfinity), CrossPlatformMachineEpsilon * 10);
-            AssertEqual(-MathF.PI / 2.0f, MathF.Atan(float.NegativeInfinity), CrossPlatformMachineEpsilon * 10);
+            AssertEqual(expectedResult, MathF.Acos(value), allowedVariance);
         }
 
-        [ActiveIssue("https://github.com/dotnet/coreclr/issues/9806")]
-        [Fact]
-        public static void Atan2()
+        [Theory]
+        [InlineData( float.NegativeInfinity,  float.NaN,    0.0f)]
+        [InlineData(-1.0f,                   -1.57079633f,  CrossPlatformMachineEpsilon * 10)]  // expected: -(pi / 2)
+        [InlineData(-0.991806244f,           -1.44269504f,  CrossPlatformMachineEpsilon * 10)]  // expected: -(log2(e))
+        [InlineData(-0.987765946f,           -1.41421356f,  CrossPlatformMachineEpsilon * 10)]  // expected: -(sqrt(2))
+        [InlineData(-0.903719457f,           -1.12837917f,  CrossPlatformMachineEpsilon * 10)]  // expected: -(2 / sqrt(pi))
+        [InlineData(-0.841470985f,           -1.0f,         CrossPlatformMachineEpsilon * 10)]
+        [InlineData(-0.743980337f,           -0.839007561f, CrossPlatformMachineEpsilon)]       // expected: -(pi - ln(10))
+        [InlineData(-0.707106781f,           -0.785398163f, CrossPlatformMachineEpsilon)]       // expected: -(pi / 4),         value: (1 / sqrt(2))
+        [InlineData(-0.649636939f,           -0.707106781f, CrossPlatformMachineEpsilon)]       // expected: -(1 / sqrt(2))
+        [InlineData(-0.638961276f,           -0.693147181f, CrossPlatformMachineEpsilon)]       // expected: -(ln(2))
+        [InlineData(-0.594480769f,           -0.636619772f, CrossPlatformMachineEpsilon)]       // expected: -(2 / pi)
+        [InlineData(-0.420770483f,           -0.434294482f, CrossPlatformMachineEpsilon)]       // expected: -(log10(e))
+        [InlineData(-0.410781291f,           -0.423310825f, CrossPlatformMachineEpsilon)]       // expected: -(pi - e)
+        [InlineData(-0.312961796f,           -0.318309886f, CrossPlatformMachineEpsilon)]       // expected: -(1 / pi)
+        [InlineData(-0.0f,                   -0.0f,         0.0f)]
+        [InlineData( float.NaN,               float.NaN,    0.0f)]
+        [InlineData( 0.0f,                    0.0f,         0.0f)]
+        [InlineData( 0.312961796f,            0.318309886f, CrossPlatformMachineEpsilon)]       // expected:  (1 / pi)
+        [InlineData( 0.410781291f,            0.423310825f, CrossPlatformMachineEpsilon)]       // expected:  (pi - e)
+        [InlineData( 0.420770483f,            0.434294482f, CrossPlatformMachineEpsilon)]       // expected:  (log10(e))
+        [InlineData( 0.594480769f,            0.636619772f, CrossPlatformMachineEpsilon)]       // expected:  (2 / pi)
+        [InlineData( 0.638961276f,            0.693147181f, CrossPlatformMachineEpsilon)]       // expected:  (ln(2))
+        [InlineData( 0.649636939f,            0.707106781f, CrossPlatformMachineEpsilon)]       // expected:  (1 / sqrt(2))
+        [InlineData( 0.707106781f,            0.785398163f, CrossPlatformMachineEpsilon)]       // expected:  (pi / 4),         value: (1 / sqrt(2))
+        [InlineData( 0.743980337f,            0.839007561f, CrossPlatformMachineEpsilon)]       // expected:  (pi - ln(10))
+        [InlineData( 0.841470985f,            1.0f,         CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 0.903719457f,            1.12837917f,  CrossPlatformMachineEpsilon * 10)]  // expected:  (2 / sqrt(pi))
+        [InlineData( 0.987765946f,            1.41421356f,  CrossPlatformMachineEpsilon * 10)]  // expected:  (sqrt(2))
+        [InlineData( 0.991806244f,            1.44269504f,  CrossPlatformMachineEpsilon * 10)]  // expected:  (log2(e))
+        [InlineData( 1.0f,                    1.57079633f,  CrossPlatformMachineEpsilon * 10)]  // expected:  (pi / 2)
+        [InlineData( float.PositiveInfinity,  float.NaN,    0.0f)]
+        public static void Asin(float value, float expectedResult, float allowedVariance)
         {
-            AssertEqual(-MathF.PI, MathF.Atan2(-0.0f, -0.0f), CrossPlatformMachineEpsilon * 10);
-            Assert.Equal(-0.0f, MathF.Atan2(-0.0f, 0.0f));
-            AssertEqual(MathF.PI, MathF.Atan2(0.0f, -0.0f), CrossPlatformMachineEpsilon * 10);
-            Assert.Equal(0.0f, MathF.Atan2(0.0f, 0.0f));
-            AssertEqual(MathF.PI / 2.0f, MathF.Atan2(1.0f, 0.0f), CrossPlatformMachineEpsilon * 10);
-            AssertEqual(0.588002604f, MathF.Atan2(2.0f, 3.0f), CrossPlatformMachineEpsilon);
-            Assert.Equal(0.0f, MathF.Atan2(0.0f, 3.0f));
-            AssertEqual(-0.588002604f, MathF.Atan2(-2.0f, 3.0f), CrossPlatformMachineEpsilon);
-            Assert.Equal(float.NaN, MathF.Atan2(float.NaN, 1.0f));
-            Assert.Equal(float.NaN, MathF.Atan2(1.0f, float.NaN));
-            AssertEqual(MathF.PI / 2.0f, MathF.Atan2(float.PositiveInfinity, 1.0f), CrossPlatformMachineEpsilon * 10);
-            AssertEqual(-MathF.PI / 2.0f, MathF.Atan2(float.NegativeInfinity, 1.0f), CrossPlatformMachineEpsilon * 10);
-            Assert.Equal(0.0f, MathF.Atan2(1.0f, float.PositiveInfinity));
-            AssertEqual(MathF.PI, MathF.Atan2(1.0f, float.NegativeInfinity), CrossPlatformMachineEpsilon * 10);
-            Assert.Equal(float.NaN, MathF.Atan2(float.NegativeInfinity, float.NegativeInfinity));
-            Assert.Equal(float.NaN, MathF.Atan2(float.NegativeInfinity, float.PositiveInfinity));
-            Assert.Equal(float.NaN, MathF.Atan2(float.PositiveInfinity, float.NegativeInfinity));
-            Assert.Equal(float.NaN, MathF.Atan2(float.PositiveInfinity, float.PositiveInfinity));
+            AssertEqual(expectedResult, MathF.Asin(value), allowedVariance);
         }
 
-        [Fact]
-        public static void Ceiling()
+        [Theory]
+        [InlineData( float.NegativeInfinity, -1.57079633f,  CrossPlatformMachineEpsilon * 10)]  // expected: -(pi / 2)
+        [InlineData(-7.76357567f,            -1.44269504f,  CrossPlatformMachineEpsilon * 10)]  // expected: -(log2(e))
+        [InlineData(-6.33411917f,            -1.41421356f,  CrossPlatformMachineEpsilon * 10)]  // expected: -(sqrt(2))
+        [InlineData(-2.11087684f,            -1.12837917f,  CrossPlatformMachineEpsilon * 10)]  // expected: -(2 / sqrt(pi))
+        [InlineData(-1.55740772f,            -1.0f,         CrossPlatformMachineEpsilon * 10)]
+        [InlineData(-1.11340715f,            -0.839007561f, CrossPlatformMachineEpsilon)]       // expected: -(pi - ln(10))
+        [InlineData(-1.0f,                   -0.785398163f, CrossPlatformMachineEpsilon)]       // expected: -(pi / 4)
+        [InlineData(-0.854510432f,           -0.707106781f, CrossPlatformMachineEpsilon)]       // expected: -(1 / sqrt(2))
+        [InlineData(-0.830640878f,           -0.693147181f, CrossPlatformMachineEpsilon)]       // expected: -(ln(2))
+        [InlineData(-0.739302950f,           -0.636619772f, CrossPlatformMachineEpsilon)]       // expected: -(2 / pi)
+        [InlineData(-0.463829067f,           -0.434294482f, CrossPlatformMachineEpsilon)]       // expected: -(log10(e))
+        [InlineData(-0.450549534f,           -0.423310825f, CrossPlatformMachineEpsilon)]       // expected: -(pi - e)
+        [InlineData(-0.329514733f,           -0.318309886f, CrossPlatformMachineEpsilon)]       // expected: -(1 / pi)
+        [InlineData(-0.0f,                   -0.0f,         0.0f)]
+        [InlineData( float.NaN,               float.NaN,    0.0f)]
+        [InlineData( 0.0f,                    0.0f,         0.0f)]
+        [InlineData( 0.329514733f,            0.318309886f, CrossPlatformMachineEpsilon)]       // expected:  (1 / pi)
+        [InlineData( 0.450549534f,            0.423310825f, CrossPlatformMachineEpsilon)]       // expected:  (pi - e)
+        [InlineData( 0.463829067f,            0.434294482f, CrossPlatformMachineEpsilon)]       // expected:  (log10(e))
+        [InlineData( 0.739302950f,            0.636619772f, CrossPlatformMachineEpsilon)]       // expected:  (2 / pi)
+        [InlineData( 0.830640878f,            0.693147181f, CrossPlatformMachineEpsilon)]       // expected:  (ln(2))
+        [InlineData( 0.854510432f,            0.707106781f, CrossPlatformMachineEpsilon)]       // expected:  (1 / sqrt(2))
+        [InlineData( 1.0f,                    0.785398163f, CrossPlatformMachineEpsilon)]       // expected:  (pi / 4)
+        [InlineData( 1.11340715f,             0.839007561f, CrossPlatformMachineEpsilon)]       // expected:  (pi - ln(10))
+        [InlineData( 1.55740772f,             1.0f,         CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 2.11087684f,             1.12837917f,  CrossPlatformMachineEpsilon * 10)]  // expected:  (2 / sqrt(pi))
+        [InlineData( 6.33411917f,             1.41421356f,  CrossPlatformMachineEpsilon * 10)]  // expected:  (sqrt(2))
+        [InlineData( 7.76357567f,             1.44269504f,  CrossPlatformMachineEpsilon * 10)]  // expected:  (log2(e))
+        [InlineData( float.PositiveInfinity,  1.57079633f,  CrossPlatformMachineEpsilon * 10)]  // expected:  (pi / 2)
+        public static void Atan(float value, float expectedResult, float allowedVariance)
         {
-            Assert.Equal(2.0f, MathF.Ceiling(1.1f));
-            Assert.Equal(2.0f, MathF.Ceiling(1.9f));
-            Assert.Equal(-1.0f, MathF.Ceiling(-1.1f));
-            Assert.Equal(float.NaN, MathF.Ceiling(float.NaN));
-            Assert.Equal(float.PositiveInfinity, MathF.Ceiling(float.PositiveInfinity));
-            Assert.Equal(float.NegativeInfinity, MathF.Ceiling(float.NegativeInfinity));
+            AssertEqual(expectedResult, MathF.Atan(value), allowedVariance);
         }
 
-        [Fact]
-        public static void Cos()
+        [Theory]
+        [InlineData( float.NegativeInfinity,  float.NegativeInfinity,  float.NaN,    0.0f)]
+        [InlineData( float.NegativeInfinity,  float.NegativeInfinity, -2.35619449f,  CrossPlatformMachineEpsilon * 10, Skip = "https://github.com/dotnet/coreclr/issues/9806")]     // expected: -(3 * pi / 4)
+        [InlineData( float.NegativeInfinity, -1.0f,                   -1.57079633f,  CrossPlatformMachineEpsilon * 10)]     // expected: -(pi / 2)
+        [InlineData( float.NegativeInfinity, -0.0f,                   -1.57079633f,  CrossPlatformMachineEpsilon * 10)]     // expected: -(pi / 2)
+        [InlineData( float.NegativeInfinity,  float.NaN,               float.NaN,    0.0f)]
+        [InlineData( float.NegativeInfinity,  0.0f,                   -1.57079633f,  CrossPlatformMachineEpsilon * 10)]     // expected: -(pi / 2)
+        [InlineData( float.NegativeInfinity,  1.0f,                   -1.57079633f,  CrossPlatformMachineEpsilon * 10)]     // expected: -(pi / 2)
+        [InlineData( float.NegativeInfinity,  float.PositiveInfinity,  float.NaN,    0.0f)]
+        [InlineData( float.NegativeInfinity,  float.PositiveInfinity, -0.785398163f, CrossPlatformMachineEpsilon, Skip = "https://github.com/dotnet/coreclr/issues/9806")]          // expected: -(pi / 4)
+        [InlineData(-1.0f,                   -1.0f,                   -2.35619449f,  CrossPlatformMachineEpsilon * 10)]     // expected: -(3 * pi / 4)
+        [InlineData(-1.0f,                   -0.0f,                   -1.57079633f,  CrossPlatformMachineEpsilon * 10)]     // expected: -(pi / 2)
+        [InlineData(-1.0f,                    float.NaN,               float.NaN,    0.0f)]
+        [InlineData(-1.0f,                    0.0f,                   -1.57079633f,  CrossPlatformMachineEpsilon * 10)]     // expected: -(pi / 2)
+        [InlineData(-1.0f,                    1.0f,                   -0.785398163f, CrossPlatformMachineEpsilon)]          // expected: -(pi / 4)
+        [InlineData(-1.0f,                    float.PositiveInfinity, -0.0f,         0.0f)]
+        [InlineData(-0.991806244f,           -0.127751218f,           -1.69889761f,  CrossPlatformMachineEpsilon * 10)]     // expected: -(pi - log2(e))
+        [InlineData(-0.991806244f,            0.127751218f,           -1.44269504f,  CrossPlatformMachineEpsilon * 10)]     // expected: -(log2(e))
+        [InlineData(-0.987765946f,           -0.155943695f,           -1.72737909f,  CrossPlatformMachineEpsilon * 10)]     // expected: -(pi - sqrt(2))
+        [InlineData(-0.987765946f,            0.155943695f,           -1.41421356f,  CrossPlatformMachineEpsilon * 10)]     // expected: -(sqrt(2))
+        [InlineData(-0.903719457f,           -0.428125148f,           -2.01321349f,  CrossPlatformMachineEpsilon * 10)]     // expected: -(pi - (2 / sqrt(pi))
+        [InlineData(-0.903719457f,            0.428125148f,           -1.12837917f,  CrossPlatformMachineEpsilon * 10)]     // expected: -(2 / sqrt(pi)
+        [InlineData(-0.841470985f,           -0.540302306f,           -2.14159265f,  CrossPlatformMachineEpsilon * 10)]     // expected: -(pi - 1)
+        [InlineData(-0.841470985f,            0.540302306f,           -1.0f,         CrossPlatformMachineEpsilon * 10)]
+        [InlineData(-0.743980337f,           -0.668201510f,           -2.30258509f,  CrossPlatformMachineEpsilon * 10)]     // expected: -(ln(10))
+        [InlineData(-0.743980337f,            0.668201510f,           -0.839007561f, CrossPlatformMachineEpsilon)]          // expected: -(pi - ln(10))
+        [InlineData(-0.707106781f,           -0.707106781f,           -2.35619449f,  CrossPlatformMachineEpsilon * 10)]     // expected: -(3 * pi / 4),         y: -(1 / sqrt(2))   x: -(1 / sqrt(2))
+        [InlineData(-0.707106781f,            0.707106781f,           -0.785398163f, CrossPlatformMachineEpsilon)]          // expected: -(pi / 4),             y: -(1 / sqrt(2))   x:  (1 / sqrt(2))
+        [InlineData(-0.649636939f,           -0.760244597f,           -2.43448587f,  CrossPlatformMachineEpsilon * 10)]     // expected: -(pi - (1 / sqrt(2))
+        [InlineData(-0.649636939f,            0.760244597f,           -0.707106781f, CrossPlatformMachineEpsilon)]          // expected: -(1 / sqrt(2))
+        [InlineData(-0.638961276f,           -0.769238901f,           -2.44844547f,  CrossPlatformMachineEpsilon * 10)]     // expected: -(pi - ln(2))
+        [InlineData(-0.638961276f,            0.769238901f,           -0.693147181f, CrossPlatformMachineEpsilon)]          // expected: -(ln(2))
+        [InlineData(-0.594480769f,           -0.804109828f,           -2.50497288f,  CrossPlatformMachineEpsilon * 10)]     // expected: -(pi - (2 / pi))
+        [InlineData(-0.594480769f,            0.804109828f,           -0.636619772f, CrossPlatformMachineEpsilon)]          // expected: -(2 / pi)
+        [InlineData(-0.420770483f,           -0.907167129f,           -2.70729817f,  CrossPlatformMachineEpsilon * 10)]     // expected: -(pi - log10(e))
+        [InlineData(-0.420770483f,            0.907167129f,           -0.434294482f, CrossPlatformMachineEpsilon)]          // expected: -(log10(e))
+        [InlineData(-0.410781291f,           -0.911733915f,           -2.71828183f,  CrossPlatformMachineEpsilon * 10)]     // expected: -(e)
+        [InlineData(-0.410781291f,            0.911733915f,           -0.423310825f, CrossPlatformMachineEpsilon)]          // expected: -(pi - e)
+        [InlineData(-0.312961796f,           -0.949765715f,           -2.82328277f,  CrossPlatformMachineEpsilon * 10)]     // expected: -(pi - (1 / pi))
+        [InlineData(-0.312961796f,            0.949765715f,           -0.318309886f, CrossPlatformMachineEpsilon)]          // expected: -(1 / pi)
+        [InlineData(-0.0f,                    float.NegativeInfinity, -3.14159265f,  CrossPlatformMachineEpsilon * 10)]     // expected: -(pi)
+        [InlineData(-0.0f,                   -1.0f,                   -3.14159265f,  CrossPlatformMachineEpsilon * 10)]     // expected: -(pi)
+        [InlineData(-0.0f,                   -0.0f,                   -3.14159265f,  CrossPlatformMachineEpsilon * 10)]     // expected: -(pi)
+        [InlineData(-0.0f,                    float.NaN,               float.NaN,    0.0f)]
+        [InlineData(-0.0f,                    0.0f,                   -0.0f,         0.0f)]
+        [InlineData(-0.0f,                    1.0f,                   -0.0f,         0.0f)]
+        [InlineData(-0.0f,                    float.PositiveInfinity, -0.0f,         0.0f)]
+        [InlineData( float.NaN,               float.NegativeInfinity,  float.NaN,    0.0f)]
+        [InlineData( float.NaN,              -1.0f,                    float.NaN,    0.0f)]
+        [InlineData( float.NaN,              -0.0f,                    float.NaN,    0.0f)]
+        [InlineData( float.NaN,               float.NaN,               float.NaN,    0.0f)]
+        [InlineData( float.NaN,               0.0f,                    float.NaN,    0.0f)]
+        [InlineData( float.NaN,               1.0f,                    float.NaN,    0.0f)]
+        [InlineData( float.NaN,               float.PositiveInfinity,  float.NaN,    0.0f)]
+        [InlineData( 0.0f,                    float.NegativeInfinity,  3.14159265f,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi)
+        [InlineData( 0.0f,                   -1.0f,                    3.14159265f,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi)
+        [InlineData( 0.0f,                   -0.0f,                    3.14159265f,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi)
+        [InlineData( 0.0f,                    float.NaN,               float.NaN,    0.0f)]
+        [InlineData( 0.0f,                    0.0f,                    0.0f,         0.0f)]
+        [InlineData( 0.0f,                    1.0f,                    0.0f,         0.0f)]
+        [InlineData( 0.0f,                    float.PositiveInfinity,  0.0f,         0.0f)]
+        [InlineData( 0.312961796f,           -0.949765715f,            2.82328277f,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi - (1 / pi))
+        [InlineData( 0.312961796f,            0.949765715f,            0.318309886f, CrossPlatformMachineEpsilon)]          // expected:  (1 / pi)
+        [InlineData( 0.410781291f,           -0.911733915f,            2.71828183f,  CrossPlatformMachineEpsilon * 10)]     // expected:  (e)
+        [InlineData( 0.410781291f,            0.911733915f,            0.423310825f, CrossPlatformMachineEpsilon)]          // expected:  (pi - e)
+        [InlineData( 0.420770483f,           -0.907167129f,            2.70729817f,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi - log10(e))
+        [InlineData( 0.420770483f,            0.907167129f,            0.434294482f, CrossPlatformMachineEpsilon)]          // expected:  (log10(e))
+        [InlineData( 0.594480769f,           -0.804109828f,            2.50497288f,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi - (2 / pi))
+        [InlineData( 0.594480769f,            0.804109828f,            0.636619772f, CrossPlatformMachineEpsilon)]          // expected:  (2 / pi)
+        [InlineData( 0.638961276f,           -0.769238901f,            2.44844547f,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi - ln(2))
+        [InlineData( 0.638961276f,            0.769238901f,            0.693147181f, CrossPlatformMachineEpsilon)]          // expected:  (ln(2))
+        [InlineData( 0.649636939f,           -0.760244597f,            2.43448587f,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi - (1 / sqrt(2))
+        [InlineData( 0.649636939f,            0.760244597f,            0.707106781f, CrossPlatformMachineEpsilon)]          // expected:  (1 / sqrt(2))
+        [InlineData( 0.707106781f,           -0.707106781f,            2.35619449f,  CrossPlatformMachineEpsilon * 10)]     // expected:  (3 * pi / 4),         y:  (1 / sqrt(2))   x: -(1 / sqrt(2))
+        [InlineData( 0.707106781f,            0.707106781f,            0.785398163f, CrossPlatformMachineEpsilon)]          // expected:  (pi / 4),             y:  (1 / sqrt(2))   x:  (1 / sqrt(2))
+        [InlineData( 0.743980337f,           -0.668201510f,            2.30258509f,  CrossPlatformMachineEpsilon * 10)]     // expected:  (ln(10))
+        [InlineData( 0.743980337f,            0.668201510f,            0.839007561f, CrossPlatformMachineEpsilon)]          // expected:  (pi - ln(10))
+        [InlineData( 0.841470985f,           -0.540302306f,            2.14159265f,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi - 1)
+        [InlineData( 0.841470985f,            0.540302306f,            1.0f,         CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 0.903719457f,           -0.428125148f,            2.01321349f,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi - (2 / sqrt(pi))
+        [InlineData( 0.903719457f,            0.428125148f,            1.12837917f,  CrossPlatformMachineEpsilon * 10)]     // expected:  (2 / sqrt(pi))
+        [InlineData( 0.987765946f,           -0.155943695f,            1.72737909f,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi - sqrt(2))
+        [InlineData( 0.987765946f,            0.155943695f,            1.41421356f,  CrossPlatformMachineEpsilon * 10)]     // expected:  (sqrt(2))
+        [InlineData( 0.991806244f,           -0.127751218f,            1.69889761f,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi - log2(e))
+        [InlineData( 0.991806244f,            0.127751218f,            1.44269504f,  CrossPlatformMachineEpsilon * 10)]     // expected:  (log2(e))
+        [InlineData( 1.0f,                   -1.0f,                    2.35619449f,  CrossPlatformMachineEpsilon * 10)]     // expected:  (3 * pi / 4)
+        [InlineData( 1.0f,                   -0.0f,                    1.57079633f,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi / 2)
+        [InlineData( 1.0f,                    float.NaN,               float.NaN,    0.0f)]
+        [InlineData( 1.0f,                    0.0f,                    1.57079633f,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi / 2)
+        [InlineData( 1.0f,                    1.0f,                    0.785398163f, CrossPlatformMachineEpsilon)]          // expected:  (pi / 4)
+        [InlineData( 1.0f,                    float.PositiveInfinity,  0.0f,         0.0f)]
+        [InlineData( float.PositiveInfinity,  float.NegativeInfinity,  float.NaN,    0.0f)]
+        [InlineData( float.PositiveInfinity,  float.NegativeInfinity,  2.35619449f,  CrossPlatformMachineEpsilon * 10, Skip = "https://github.com/dotnet/coreclr/issues/9806")]     // expected:  (3 * pi / 4)
+        [InlineData( float.PositiveInfinity, -1.0f,                    1.57079633f,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi / 2)
+        [InlineData( float.PositiveInfinity, -0.0f,                    1.57079633f,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi / 2)
+        [InlineData( float.PositiveInfinity,  float.NaN,               float.NaN,    0.0f)]
+        [InlineData( float.PositiveInfinity,  0.0f,                    1.57079633f,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi / 2)
+        [InlineData( float.PositiveInfinity,  1.0f,                    1.57079633f,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi / 2)
+        [InlineData( float.PositiveInfinity,  float.PositiveInfinity,  float.NaN,    0.0f)]
+        [InlineData( float.PositiveInfinity,  float.PositiveInfinity,  0.785398163f, CrossPlatformMachineEpsilon, Skip = "https://github.com/dotnet/coreclr/issues/9806")]          // expected:  (pi / 4)
+        public static void Atan2(float y, float x, float expectedResult, float allowedVariance)
         {
-            AssertEqual(0.540302306f, MathF.Cos(1.0f), CrossPlatformMachineEpsilon);
-            Assert.Equal(1.0f, MathF.Cos(0.0f));
-            AssertEqual(0.540302306f, MathF.Cos(-1.0f), CrossPlatformMachineEpsilon);
-            Assert.Equal(float.NaN, MathF.Cos(float.NaN));
-            Assert.Equal(float.NaN, MathF.Cos(float.PositiveInfinity));
-            Assert.Equal(float.NaN, MathF.Cos(float.NegativeInfinity));
+            AssertEqual(expectedResult, MathF.Atan2(y, x), allowedVariance);
         }
 
-        [Fact]
-        public static void Cosh()
+        [Theory]
+        [InlineData(float.NegativeInfinity,  float.NegativeInfinity, 0.0f)]
+        [InlineData(-3.14159265f,           -3.0f,                   0.0f)]  // value: -(pi)
+        [InlineData(-2.71828183f,           -2.0f,                   0.0f)]  // value: -(e)
+        [InlineData(-2.30258509f,           -2.0f,                   0.0f)]  // value: -(ln(10))
+        [InlineData(-1.57079633f,           -1.0f,                   0.0f)]  // value: -(pi / 2)
+        [InlineData(-1.44269504f,           -1.0f,                   0.0f)]  // value: -(log2(e))
+        [InlineData(-1.41421356f,           -1.0f,                   0.0f)]  // value: -(sqrt(2))
+        [InlineData(-1.12837917f,           -1.0f,                   0.0f)]  // value: -(2 / sqrt(pi))
+        [InlineData(-1.0f,                  -1.0f,                   0.0f)]
+        [InlineData(-0.785398163f,           0.0f,                   0.0f)]  // value: -(pi / 4)
+        [InlineData(-0.707106781f,           0.0f,                   0.0f)]  // value: -(1 / sqrt(2))
+        [InlineData(-0.693147181f,           0.0f,                   0.0f)]  // value: -(ln(2))
+        [InlineData(-0.636619772f,           0.0f,                   0.0f)]  // value: -(2 / pi)
+        [InlineData(-0.434294482f,           0.0f,                   0.0f)]  // value: -(log10(e))
+        [InlineData(-0.318309886f,           0.0f,                   0.0f)]  // value: -(1 / pi)
+        [InlineData(-0.0f,                  -0.0f,                   0.0f)]
+        [InlineData( float.NaN,              float.NaN,              0.0f)]
+        [InlineData( 0.0f,                   0.0f,                   0.0f)]
+        [InlineData( 0.318309886f,           1.0f,                   0.0f)]  // value:  (1 / pi)
+        [InlineData( 0.434294482f,           1.0f,                   0.0f)]  // value:  (log10(e))
+        [InlineData( 0.636619772f,           1.0f,                   0.0f)]  // value:  (2 / pi)
+        [InlineData( 0.693147181f,           1.0f,                   0.0f)]  // value:  (ln(2))
+        [InlineData( 0.707106781f,           1.0f,                   0.0f)]  // value:  (1 / sqrt(2))
+        [InlineData( 0.785398163f,           1.0f,                   0.0f)]  // value:  (pi / 4)
+        [InlineData( 1.0f,                   1.0f,                   0.0f)]
+        [InlineData( 1.12837917f,            2.0f,                   0.0f)]  // value:  (2 / sqrt(pi))
+        [InlineData( 1.41421356f,            2.0f,                   0.0f)]  // value:  (sqrt(2))
+        [InlineData( 1.44269504f,            2.0f,                   0.0f)]  // value:  (log2(e))
+        [InlineData( 1.57079633f,            2.0f,                   0.0f)]  // value:  (pi / 2)
+        [InlineData( 2.30258509f,            3.0f,                   0.0f)]  // value:  (ln(10))
+        [InlineData( 2.71828183f,            3.0f,                   0.0f)]  // value:  (e)
+        [InlineData( 3.14159265f,            4.0f,                   0.0f)]  // value:  (pi)
+        [InlineData(float.PositiveInfinity,  float.PositiveInfinity, 0.0f)]
+        public static void Ceiling(float value, float expectedResult, float allowedVariance)
         {
-            AssertEqual(1.54308063f, MathF.Cosh(1.0f), CrossPlatformMachineEpsilon * 10);
-            Assert.Equal(1.0f, MathF.Cosh(0.0f));
-            AssertEqual(1.54308063f, MathF.Cosh(-1.0f), CrossPlatformMachineEpsilon * 10);
-            Assert.Equal(float.NaN, MathF.Cosh(float.NaN));
-            Assert.Equal(float.PositiveInfinity, MathF.Cosh(float.PositiveInfinity));
-            Assert.Equal(float.PositiveInfinity, MathF.Cosh(float.NegativeInfinity));
+            AssertEqual(expectedResult, MathF.Ceiling(value), allowedVariance);
         }
 
-        [Fact]
-        public static void Exp()
+        [Theory]
+        [InlineData( float.NegativeInfinity,  float.NaN,    0.0f)]
+        [InlineData(-3.14159265f,            -1.0f,         CrossPlatformMachineEpsilon * 10)]  // value: -(pi)
+        [InlineData(-2.71828183f,            -0.911733918f, CrossPlatformMachineEpsilon)]       // value: -(e)
+        [InlineData(-2.30258509f,            -0.668201510f, CrossPlatformMachineEpsilon)]       // value: -(ln(10))
+        [InlineData(-1.57079633f,             0.0f,         CrossPlatformMachineEpsilon)]       // value: -(pi / 2)
+        [InlineData(-1.44269504f,             0.127751218f, CrossPlatformMachineEpsilon)]       // value: -(log2(e))
+        [InlineData(-1.41421356f,             0.155943695f, CrossPlatformMachineEpsilon)]       // value: -(sqrt(2))
+        [InlineData(-1.12837917f,             0.428125148f, CrossPlatformMachineEpsilon)]       // value: -(2 / sqrt(pi))
+        [InlineData(-1.0f,                    0.540302306f, CrossPlatformMachineEpsilon)]
+        [InlineData(-0.785398163f,            0.707106781f, CrossPlatformMachineEpsilon)]       // value: -(pi / 4),        expected:  (1 / sqrt(2))
+        [InlineData(-0.707106781f,            0.760244597f, CrossPlatformMachineEpsilon)]       // value: -(1 / sqrt(2))
+        [InlineData(-0.693147181f,            0.769238901f, CrossPlatformMachineEpsilon)]       // value: -(ln(2))
+        [InlineData(-0.636619772f,            0.804109828f, CrossPlatformMachineEpsilon)]       // value: -(2 / pi)
+        [InlineData(-0.434294482f,            0.907167129f, CrossPlatformMachineEpsilon)]       // value: -(log10(e))
+        [InlineData(-0.318309886f,            0.949765715f, CrossPlatformMachineEpsilon)]       // value: -(1 / pi)
+        [InlineData(-0.0f,                    1.0f,         CrossPlatformMachineEpsilon * 10)]
+        [InlineData( float.NaN,               float.NaN,    0.0f)]
+        [InlineData( 0.0f,                    1.0f,         CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 0.318309886f,            0.949765715f, CrossPlatformMachineEpsilon)]       // value:  (1 / pi)
+        [InlineData( 0.434294482f,            0.907167129f, CrossPlatformMachineEpsilon)]       // value:  (log10(e))
+        [InlineData( 0.636619772f,            0.804109828f, CrossPlatformMachineEpsilon)]       // value:  (2 / pi)
+        [InlineData( 0.693147181f,            0.769238901f, CrossPlatformMachineEpsilon)]       // value:  (ln(2))
+        [InlineData( 0.707106781f,            0.760244597f, CrossPlatformMachineEpsilon)]       // value:  (1 / sqrt(2))
+        [InlineData( 0.785398163f,            0.707106781f, CrossPlatformMachineEpsilon)]       // value:  (pi / 4),        expected:  (1 / sqrt(2))
+        [InlineData( 1.0f,                    0.540302306f, CrossPlatformMachineEpsilon)]
+        [InlineData( 1.12837917f,             0.428125148f, CrossPlatformMachineEpsilon)]       // value:  (2 / sqrt(pi))
+        [InlineData( 1.41421356f,             0.155943695f, CrossPlatformMachineEpsilon)]       // value:  (sqrt(2))
+        [InlineData( 1.44269504f,             0.127751218f, CrossPlatformMachineEpsilon)]       // value:  (log2(e))
+        [InlineData( 1.57079633f,             0.0f,         CrossPlatformMachineEpsilon)]       // value:  (pi / 2)
+        [InlineData( 2.30258509f,            -0.668201510f, CrossPlatformMachineEpsilon)]       // value:  (ln(10))
+        [InlineData( 2.71828183f,            -0.911733918f, CrossPlatformMachineEpsilon)]       // value:  (e)
+        [InlineData( 3.14159265f,            -1.0f,         CrossPlatformMachineEpsilon * 10)]  // value:  (pi)
+        [InlineData( float.PositiveInfinity,  float.NaN,    0.0f)]
+        public static void Cos(float value, float expectedResult, float allowedVariance)
         {
-            AssertEqual(20.0855369f, MathF.Exp(3.0f), CrossPlatformMachineEpsilon * 100);
-            Assert.Equal(1.0f, MathF.Exp(0.0f));
-            Assert.Equal(MathF.E, MathF.Exp(1.0f));
-            AssertEqual(0.0497870684f, MathF.Exp(-3.0f), CrossPlatformMachineEpsilon / 10);
-            Assert.Equal(float.NaN, MathF.Exp(float.NaN));
-            Assert.Equal(float.PositiveInfinity, MathF.Exp(float.PositiveInfinity));
-            Assert.Equal(0.0f, MathF.Exp(float.NegativeInfinity));
+            AssertEqual(expectedResult, MathF.Cos(value), allowedVariance);
         }
 
-        [Fact]
-        public static void Floor()
+        [Theory]
+        [InlineData( float.NegativeInfinity, float.PositiveInfinity, 0.0f)]
+        [InlineData(-3.14159265f,            11.5919533f,            CrossPlatformMachineEpsilon * 100)]    // value:  (pi)
+        [InlineData(-2.71828183f,            7.61012514f,            CrossPlatformMachineEpsilon * 10)]     // value:  (e)
+        [InlineData(-2.30258509f,            5.05f,                  CrossPlatformMachineEpsilon * 10)]     // value:  (ln(10))
+        [InlineData(-1.57079633f,            2.50917848f,            CrossPlatformMachineEpsilon * 10)]     // value:  (pi / 2)
+        [InlineData(-1.44269504f,            2.23418810f,            CrossPlatformMachineEpsilon * 10)]     // value:  (log2(e))
+        [InlineData(-1.41421356f,            2.17818356f,            CrossPlatformMachineEpsilon * 10)]     // value:  (sqrt(2))
+        [InlineData(-1.12837917f,            1.70710014f,            CrossPlatformMachineEpsilon * 10)]     // value:  (2 / sqrt(pi))
+        [InlineData(-1.0f,                   1.54308063f,            CrossPlatformMachineEpsilon * 10)]
+        [InlineData(-0.785398163f,           1.32460909f,            CrossPlatformMachineEpsilon * 10)]     // value:  (pi / 4)
+        [InlineData(-0.707106781f,           1.26059184f,            CrossPlatformMachineEpsilon * 10)]     // value:  (1 / sqrt(2))
+        [InlineData(-0.693147181f,           1.25f,                  CrossPlatformMachineEpsilon * 10)]     // value:  (ln(2))
+        [InlineData(-0.636619772f,           1.20957949f,            CrossPlatformMachineEpsilon * 10)]     // value:  (2 / pi)
+        [InlineData(-0.434294482f,           1.09579746f,            CrossPlatformMachineEpsilon * 10)]     // value:  (log10(e))
+        [InlineData(-0.318309886f,           1.05108979f,            CrossPlatformMachineEpsilon * 10)]     // value:  (1 / pi)
+        [InlineData(-0.0f,                   1.0f,                   CrossPlatformMachineEpsilon * 10)]
+        [InlineData( float.NaN,              float.NaN,              0.0f)]
+        [InlineData( 0.0f,                   1.0f,                   CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 0.318309886f,           1.05108979f,            CrossPlatformMachineEpsilon * 10)]     // value:  (1 / pi)
+        [InlineData( 0.434294482f,           1.09579746f,            CrossPlatformMachineEpsilon * 10)]     // value:  (log10(e))
+        [InlineData( 0.636619772f,           1.20957949f,            CrossPlatformMachineEpsilon * 10)]     // value:  (2 / pi)
+        [InlineData( 0.693147181f,           1.25f,                  CrossPlatformMachineEpsilon * 10)]     // value:  (ln(2))
+        [InlineData( 0.707106781f,           1.26059184f,            CrossPlatformMachineEpsilon * 10)]     // value:  (1 / sqrt(2))
+        [InlineData( 0.785398163f,           1.32460909f,            CrossPlatformMachineEpsilon * 10)]     // value:  (pi / 4)
+        [InlineData( 1.0f,                   1.54308063f,            CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 1.12837917f,            1.70710014f,            CrossPlatformMachineEpsilon * 10)]     // value:  (2 / sqrt(pi))
+        [InlineData( 1.41421356f,            2.17818356f,            CrossPlatformMachineEpsilon * 10)]     // value:  (sqrt(2))
+        [InlineData( 1.44269504f,            2.23418810f,            CrossPlatformMachineEpsilon * 10)]     // value:  (log2(e))
+        [InlineData( 1.57079633f,            2.50917848f,            CrossPlatformMachineEpsilon * 10)]     // value:  (pi / 2)
+        [InlineData( 2.30258509f,            5.05f,                  CrossPlatformMachineEpsilon * 10)]     // value:  (ln(10))
+        [InlineData( 2.71828183f,            7.61012514f,            CrossPlatformMachineEpsilon * 10)]     // value:  (e)
+        [InlineData( 3.14159265f,            11.5919533f,            CrossPlatformMachineEpsilon * 100)]    // value:  (pi)
+        [InlineData( float.PositiveInfinity, float.PositiveInfinity, 0.0f)]
+        public static void Cosh(float value, float expectedResult, float allowedVariance)
         {
-            Assert.Equal(1.0f, MathF.Floor(1.1f));
-            Assert.Equal(1.0f, MathF.Floor(1.9f));
-            Assert.Equal(-2.0f, MathF.Floor(-1.1f));
-            Assert.Equal(float.NaN, MathF.Floor(float.NaN));
-            Assert.Equal(float.PositiveInfinity, MathF.Floor(float.PositiveInfinity));
-            Assert.Equal(float.NegativeInfinity, MathF.Floor(float.NegativeInfinity));
+            AssertEqual(expectedResult, MathF.Cosh(value), allowedVariance);
+        }
+
+        [Theory]
+        [InlineData( float.NegativeInfinity, 0.0f,                   CrossPlatformMachineEpsilon)]
+        [InlineData(-3.14159265f,            0.0432139183f,          CrossPlatformMachineEpsilon / 10)]     // value: -(pi)
+        [InlineData(-2.71828183f,            0.0659880358f,          CrossPlatformMachineEpsilon / 10)]     // value: -(e)
+        [InlineData(-2.30258509f,            0.1f,                   CrossPlatformMachineEpsilon)]          // value: -(ln(10))
+        [InlineData(-1.57079633f,            0.207879576f,           CrossPlatformMachineEpsilon)]          // value: -(pi / 2)
+        [InlineData(-1.44269504f,            0.236290088f,           CrossPlatformMachineEpsilon)]          // value: -(log2(e))
+        [InlineData(-1.41421356f,            0.243116734f,           CrossPlatformMachineEpsilon)]          // value: -(sqrt(2))
+        [InlineData(-1.12837917f,            0.323557264f,           CrossPlatformMachineEpsilon)]          // value: -(2 / sqrt(pi))
+        [InlineData(-1.0f,                   0.367879441f,           CrossPlatformMachineEpsilon)]
+        [InlineData(-0.785398163f,           0.455938128f,           CrossPlatformMachineEpsilon)]          // value: -(pi / 4)
+        [InlineData(-0.707106781f,           0.493068691f,           CrossPlatformMachineEpsilon)]          // value: -(1 / sqrt(2))
+        [InlineData(-0.693147181f,           0.5f,                   CrossPlatformMachineEpsilon)]          // value: -(ln(2))
+        [InlineData(-0.636619772f,           0.529077808f,           CrossPlatformMachineEpsilon)]          // value: -(2 / pi)
+        [InlineData(-0.434294482f,           0.647721485f,           CrossPlatformMachineEpsilon)]          // value: -(log10(e))
+        [InlineData(-0.318309886f,           0.727377349f,           CrossPlatformMachineEpsilon)]          // value: -(1 / pi)
+        [InlineData(-0.0f,                   1.0f,                   CrossPlatformMachineEpsilon * 10)]
+        [InlineData( float.NaN,              float.NaN,              0.0f)]
+        [InlineData( 0.0f,                   1.0f,                   CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 0.318309886f,           1.37480223f,            CrossPlatformMachineEpsilon * 10)]     // value:  (1 / pi)
+        [InlineData( 0.434294482f,           1.54387344f,            CrossPlatformMachineEpsilon * 10)]     // value:  (log10(e))
+        [InlineData( 0.636619772f,           1.89008116f,            CrossPlatformMachineEpsilon * 10)]     // value:  (2 / pi)
+        [InlineData( 0.693147181f,           2.0f,                   CrossPlatformMachineEpsilon * 10)]     // value:  (ln(2))
+        [InlineData( 0.707106781f,           2.02811498f,            CrossPlatformMachineEpsilon * 10)]     // value:  (1 / sqrt(2))
+        [InlineData( 0.785398163f,           2.19328005f,            CrossPlatformMachineEpsilon * 10)]     // value:  (pi / 4)
+        [InlineData( 1.0f,                   2.71828183f,            CrossPlatformMachineEpsilon * 10)]     //                          expected: (e)
+        [InlineData( 1.12837917f,            3.09064302f,            CrossPlatformMachineEpsilon * 10)]     // value:  (2 / sqrt(pi))
+        [InlineData( 1.41421356f,            4.11325038f,            CrossPlatformMachineEpsilon * 10)]     // value:  (sqrt(2))
+        [InlineData( 1.44269504f,            4.23208611f,            CrossPlatformMachineEpsilon * 10)]     // value:  (log2(e))
+        [InlineData( 1.57079633f,            4.81047738f,            CrossPlatformMachineEpsilon * 10)]     // value:  (pi / 2)
+        [InlineData( 2.30258509f,            10.0f,                  CrossPlatformMachineEpsilon * 100)]    // value:  (ln(10))
+        [InlineData( 2.71828183f,            15.1542622f,            CrossPlatformMachineEpsilon * 100)]    // value:  (e)
+        [InlineData( 3.14159265f,            23.1406926f,            CrossPlatformMachineEpsilon * 100)]    // value:  (pi)
+        [InlineData( float.PositiveInfinity, float.PositiveInfinity, 0.0f)]
+        public static void Exp(float value, float expectedResult, float allowedVariance)
+        {
+            AssertEqual(expectedResult, MathF.Exp(value), allowedVariance);
+        }
+
+        [Theory]
+        [InlineData(float.NegativeInfinity,  float.NegativeInfinity, 0.0f)]
+        [InlineData(-3.14159265f,           -4.0f,                   0.0f)]  // value: -(pi)
+        [InlineData(-2.71828183f,           -3.0f,                   0.0f)]  // value: -(e)
+        [InlineData(-2.30258509f,           -3.0f,                   0.0f)]  // value: -(ln(10))
+        [InlineData(-1.57079633f,           -2.0f,                   0.0f)]  // value: -(pi / 2)
+        [InlineData(-1.44269504f,           -2.0f,                   0.0f)]  // value: -(log2(e))
+        [InlineData(-1.41421356f,           -2.0f,                   0.0f)]  // value: -(sqrt(2))
+        [InlineData(-1.12837917f,           -2.0f,                   0.0f)]  // value: -(2 / sqrt(pi))
+        [InlineData(-1.0f,                  -1.0f,                   0.0f)]
+        [InlineData(-0.785398163f,          -1.0f,                   0.0f)]  // value: -(pi / 4)
+        [InlineData(-0.707106781f,          -1.0f,                   0.0f)]  // value: -(1 / sqrt(2))
+        [InlineData(-0.693147181f,          -1.0f,                   0.0f)]  // value: -(ln(2))
+        [InlineData(-0.636619772f,          -1.0f,                   0.0f)]  // value: -(2 / pi)
+        [InlineData(-0.434294482f,          -1.0f,                   0.0f)]  // value: -(log10(e))
+        [InlineData(-0.318309886f,          -1.0f,                   0.0f)]  // value: -(1 / pi)
+        [InlineData(-0.0f,                  -0.0f,                   0.0f)]
+        [InlineData( float.NaN,              float.NaN,              0.0f)]
+        [InlineData( 0.0f,                   0.0f,                   0.0f)]
+        [InlineData( 0.318309886f,           0.0f,                   0.0f)]  // value:  (1 / pi)
+        [InlineData( 0.434294482f,           0.0f,                   0.0f)]  // value:  (log10(e))
+        [InlineData( 0.636619772f,           0.0f,                   0.0f)]  // value:  (2 / pi)
+        [InlineData( 0.693147181f,           0.0f,                   0.0f)]  // value:  (ln(2))
+        [InlineData( 0.707106781f,           0.0f,                   0.0f)]  // value:  (1 / sqrt(2))
+        [InlineData( 0.785398163f,           0.0f,                   0.0f)]  // value:  (pi / 4)
+        [InlineData( 1.0f,                   1.0f,                   0.0f)]
+        [InlineData( 1.12837917f,            1.0f,                   0.0f)]  // value:  (2 / sqrt(pi))
+        [InlineData( 1.41421356f,            1.0f,                   0.0f)]  // value:  (sqrt(2))
+        [InlineData( 1.44269504f,            1.0f,                   0.0f)]  // value:  (log2(e))
+        [InlineData( 1.57079633f,            1.0f,                   0.0f)]  // value:  (pi / 2)
+        [InlineData( 2.30258509f,            2.0f,                   0.0f)]  // value:  (ln(10))
+        [InlineData( 2.71828183f,            2.0f,                   0.0f)]  // value:  (e)
+        [InlineData( 3.14159265f,            3.0f,                   0.0f)]  // value:  (pi)
+        [InlineData(float.PositiveInfinity,  float.PositiveInfinity, 0.0f)]
+        public static void Floor(float value, float expectedResult, float allowedVariance)
+        {
+            AssertEqual(expectedResult, MathF.Floor(value), allowedVariance);
         }
 
         [Fact]
@@ -185,15 +583,44 @@ namespace System.Tests
             AssertEqual(-1.4f, MathF.IEEERemainder(-17.8f, -4.1f), CrossPlatformMachineEpsilon * 10);
         }
 
-        [Fact]
-        public static void Log()
+        [Theory]
+        [InlineData( float.NegativeInfinity,  float.NaN,              0.0f)]
+        [InlineData(-0.0f,                    float.NegativeInfinity, 0.0f)]
+        [InlineData( float.NaN,               float.NaN,              0.0f)]
+        [InlineData( 0.0f,                    float.NegativeInfinity, 0.0f)]
+        [InlineData( 0.0432139183f,          -3.14159265f,            CrossPlatformMachineEpsilon * 10)]    // expected: -(pi)
+        [InlineData( 0.0659880358f,          -2.71828183f,            CrossPlatformMachineEpsilon * 10)]    // expected: -(e)
+        [InlineData( 0.1f,                   -2.30258509f,            CrossPlatformMachineEpsilon * 10)]    // expected: -(ln(10))
+        [InlineData( 0.207879576f,           -1.57079633f,            CrossPlatformMachineEpsilon * 10)]    // expected: -(pi / 2)
+        [InlineData( 0.236290088f,           -1.44269504f,            CrossPlatformMachineEpsilon * 10)]    // expected: -(log2(e))
+        [InlineData( 0.243116734f,           -1.41421356f,            CrossPlatformMachineEpsilon * 10)]    // expected: -(sqrt(2))
+        [InlineData( 0.323557264f,           -1.12837917f,            CrossPlatformMachineEpsilon * 10)]    // expected: -(2 / sqrt(pi))
+        [InlineData( 0.367879441f,           -1.0f,                   CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 0.455938128f,           -0.785398163f,           CrossPlatformMachineEpsilon)]         // expected: -(pi / 4)
+        [InlineData( 0.493068691f,           -0.707106781f,           CrossPlatformMachineEpsilon)]         // expected: -(1 / sqrt(2))
+        [InlineData( 0.5f,                   -0.693147181f,           CrossPlatformMachineEpsilon)]         // expected: -(ln(2))
+        [InlineData( 0.529077808f,           -0.636619772f,           CrossPlatformMachineEpsilon)]         // expected: -(2 / pi)
+        [InlineData( 0.647721485f,           -0.434294482f,           CrossPlatformMachineEpsilon)]         // expected: -(log10(e))
+        [InlineData( 0.727377349f,           -0.318309886f,           CrossPlatformMachineEpsilon)]         // expected: -(1 / pi)
+        [InlineData( 1.0f,                    0.0f,                   0.0f)]
+        [InlineData( 1.37480223f,             0.318309886f,           CrossPlatformMachineEpsilon)]         // expected:  (1 / pi)
+        [InlineData( 1.54387344f,             0.434294482f,           CrossPlatformMachineEpsilon)]         // expected:  (log10(e))
+        [InlineData( 1.89008116f,             0.636619772f,           CrossPlatformMachineEpsilon)]         // expected:  (2 / pi)
+        [InlineData( 2.0f,                    0.693147181f,           CrossPlatformMachineEpsilon)]         // expected:  (ln(2))
+        [InlineData( 2.02811498f,             0.707106781f,           CrossPlatformMachineEpsilon)]         // expected:  (1 / sqrt(2))
+        [InlineData( 2.19328005f,             0.785398163f,           CrossPlatformMachineEpsilon)]         // expected:  (pi / 4)
+        [InlineData( 2.71828183f,             1.0f,                   CrossPlatformMachineEpsilon * 10)]    //                              value: (e)
+        [InlineData( 3.09064302f,             1.12837917f,            CrossPlatformMachineEpsilon * 10)]    // expected:  (2 / sqrt(pi))
+        [InlineData( 4.11325038f,             1.41421356f,            CrossPlatformMachineEpsilon * 10)]    // expected:  (sqrt(2))
+        [InlineData( 4.23208611f,             1.44269504f,            CrossPlatformMachineEpsilon * 10)]    // expected:  (log2(e))
+        [InlineData( 4.81047738f,             1.57079633f,            CrossPlatformMachineEpsilon * 10)]    // expected:  (pi / 2)
+        [InlineData( 10.0f,                   2.30258509f,            CrossPlatformMachineEpsilon * 10)]    // expected:  (ln(10))
+        [InlineData( 15.1542622f,             2.71828183f,            CrossPlatformMachineEpsilon * 10)]    // expected:  (e)
+        [InlineData( 23.1406926f,             3.14159265f,            CrossPlatformMachineEpsilon * 10)]    // expected:  (pi)
+        [InlineData( float.PositiveInfinity,  float.PositiveInfinity, 0.0f)]
+        public static void Log(float value, float expectedResult, float allowedVariance)
         {
-            AssertEqual(1.09861229f, MathF.Log(3.0f), CrossPlatformMachineEpsilon * 10);
-            Assert.Equal(float.NegativeInfinity, MathF.Log(0.0f));
-            Assert.Equal(float.NaN, MathF.Log(-3.0f));
-            Assert.Equal(float.NaN, MathF.Log(float.NaN));
-            Assert.Equal(float.PositiveInfinity, MathF.Log(float.PositiveInfinity));
-            Assert.Equal(float.NaN, MathF.Log(float.NegativeInfinity));
+            AssertEqual(expectedResult, MathF.Log(value), allowedVariance);
         }
 
         [Fact]
@@ -208,15 +635,44 @@ namespace System.Tests
             Assert.Equal(float.NaN, MathF.Log(float.NegativeInfinity, 3.0f));
         }
 
-        [Fact]
-        public static void Log10()
+        [Theory]
+        [InlineData( float.NegativeInfinity,  float.NaN,              0.0f)]
+        [InlineData(-0.0f,                    float.NegativeInfinity, 0.0f)]
+        [InlineData( float.NaN,               float.NaN,              0.0f)]
+        [InlineData( 0.0f,                    float.NegativeInfinity, 0.0f)]
+        [InlineData( 0.000721784159f,        -3.14159265f,            CrossPlatformMachineEpsilon * 10)]    // expected: -(pi)
+        [InlineData( 0.00191301410f,         -2.71828183f,            CrossPlatformMachineEpsilon * 10)]    // expected: -(e)
+        [InlineData( 0.00498212830f,         -2.30258509f,            CrossPlatformMachineEpsilon * 10)]    // expected: -(ln(10))
+        [InlineData( 0.0268660410f,          -1.57079633f,            CrossPlatformMachineEpsilon * 10)]    // expected: -(pi / 2)
+        [InlineData( 0.0360831928f,          -1.44269504f,            CrossPlatformMachineEpsilon * 10)]    // expected: -(log2(e))
+        [InlineData( 0.0385288847f,          -1.41421356f,            CrossPlatformMachineEpsilon * 10)]    // expected: -(sqrt(2))
+        [InlineData( 0.0744082059f,          -1.12837917f,            CrossPlatformMachineEpsilon * 10)]    // expected: -(2 / sqrt(pi))
+        [InlineData( 0.1f,                   -1.0f,                   CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 0.163908636f,           -0.785398163f,           CrossPlatformMachineEpsilon)]         // expected: -(pi / 4)
+        [InlineData( 0.196287760f,           -0.707106781f,           CrossPlatformMachineEpsilon)]         // expected: -(1 / sqrt(2))
+        [InlineData( 0.202699566f,           -0.693147181f,           CrossPlatformMachineEpsilon)]         // expected: -(ln(2))
+        [InlineData( 0.230876765f,           -0.636619772f,           CrossPlatformMachineEpsilon)]         // expected: -(2 / pi)
+        [InlineData( 0.367879441f,           -0.434294482f,           CrossPlatformMachineEpsilon)]         // expected: -(log10(e))
+        [InlineData( 0.480496373f,           -0.318309886f,           CrossPlatformMachineEpsilon)]         // expected: -(1 / pi)
+        [InlineData( 1.0f,                    0.0f,                   0.0f)]
+        [InlineData( 2.08118116f,             0.318309886f,           CrossPlatformMachineEpsilon)]         // expected:  (1 / pi)
+        [InlineData( 2.71828183f,             0.434294482f,           CrossPlatformMachineEpsilon)]         // expected:  (log10(e))        value: (e)
+        [InlineData( 4.33131503f,             0.636619772f,           CrossPlatformMachineEpsilon)]         // expected:  (2 / pi)
+        [InlineData( 4.93340967f,             0.693147181f,           CrossPlatformMachineEpsilon)]         // expected:  (ln(2))
+        [InlineData( 5.09456117f,             0.707106781f,           CrossPlatformMachineEpsilon)]         // expected:  (1 / sqrt(2))
+        [InlineData( 6.10095980f,             0.785398163f,           CrossPlatformMachineEpsilon)]         // expected:  (pi / 4)
+        [InlineData( 10.0f,                   1.0f,                   CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 13.4393779f,             1.12837917f,            CrossPlatformMachineEpsilon * 10)]    // expected:  (2 / sqrt(pi))
+        [InlineData( 25.9545535f,             1.41421356f,            CrossPlatformMachineEpsilon * 10)]    // expected:  (sqrt(2))
+        [InlineData( 27.7137338f,             1.44269504f,            CrossPlatformMachineEpsilon * 10)]    // expected:  (log2(e))
+        [InlineData( 37.2217105f,             1.57079633f,            CrossPlatformMachineEpsilon * 10)]    // expected:  (pi / 2)
+        [InlineData( 200.717432f,             2.30258509f,            CrossPlatformMachineEpsilon * 10)]    // expected:  (ln(10))
+        [InlineData( 522.735300f,             2.71828183f,            CrossPlatformMachineEpsilon * 10)]    // expected:  (e)
+        [InlineData( 1385.45573f,             3.14159265f,            CrossPlatformMachineEpsilon * 10)]    // expected:  (pi)
+        [InlineData( float.PositiveInfinity,  float.PositiveInfinity, 0.0f)]
+        public static void Log10(float value, float expectedResult, float allowedVariance)
         {
-            AssertEqual(0.477121255f, MathF.Log10(3.0f), CrossPlatformMachineEpsilon);
-            Assert.Equal(float.NegativeInfinity, MathF.Log10(0.0f));
-            Assert.Equal(float.NaN, MathF.Log10(-3.0f));
-            Assert.Equal(float.NaN, MathF.Log10(float.NaN));
-            Assert.Equal(float.PositiveInfinity, MathF.Log10(float.PositiveInfinity));
-            Assert.Equal(float.NaN, MathF.Log10(float.NegativeInfinity));
+            AssertEqual(expectedResult, MathF.Log10(value), allowedVariance);
         }
 
         [Fact]
@@ -239,44 +695,164 @@ namespace System.Tests
             Assert.Equal(float.NaN, MathF.Min(float.NaN, float.NaN));
         }
 
-        [ActiveIssue("https://github.com/dotnet/coreclr/issues/9806")]
-        [Fact]
-        public static void Pow()
+        [Theory]
+        [InlineData( float.NegativeInfinity,  float.NegativeInfinity,  0.0f,                   0.0f)]
+        [InlineData( float.NegativeInfinity, -1.0f,                   -0.0f,                   0.0f)]
+        [InlineData( float.NegativeInfinity, -0.0f,                    1.0f,                   CrossPlatformMachineEpsilon * 10)]
+        [InlineData( float.NegativeInfinity,  float.NaN,               float.NaN,              0.0f)]
+        [InlineData( float.NegativeInfinity,  0.0f,                    1.0f,                   CrossPlatformMachineEpsilon * 10)]
+        [InlineData( float.NegativeInfinity,  1.0f,                    float.NegativeInfinity, 0.0f)]
+        [InlineData( float.NegativeInfinity,  float.PositiveInfinity,  float.PositiveInfinity, 0.0f)]
+        [InlineData(-10.0f,                   float.NegativeInfinity,  0.0f,                   0.0f)]
+        [InlineData(-10.0f,                  -1.57079633f,             float.NaN,              0.0f)]                                   //          y: -(pi / 2)
+        [InlineData(-10.0f,                  -1.0f,                   -0.1f,                   CrossPlatformMachineEpsilon)]
+        [InlineData(-10.0f,                  -0.785398163f,            float.NaN,              0.0f)]                                   //          y: -(pi / 4)
+        [InlineData(-10.0f,                  -0.0f,                    1.0f,                   CrossPlatformMachineEpsilon * 10)]
+        [InlineData(-10.0f,                   float.NaN,               float.NaN,              0.0f)]
+        [InlineData(-10.0f,                   0.0f,                    1.0f,                   CrossPlatformMachineEpsilon * 10)]
+        [InlineData(-10.0f,                   0.785398163f,            float.NaN,              0.0f)]                                   //          y:  (pi / 4)
+        [InlineData(-10.0f,                   1.0f,                   -10.0f,                  CrossPlatformMachineEpsilon * 100)]
+        [InlineData(-10.0f,                   1.57079633f,             float.NaN,              0.0f)]                                   //          y:  (pi / 2)
+        [InlineData(-10.0f,                   float.PositiveInfinity,  float.PositiveInfinity, 0.0f)]
+        [InlineData(-2.71828183f,             float.NegativeInfinity,  0.0f,                   0.0f)]                                   // x: -(e)
+        [InlineData(-2.71828183f,            -1.57079633f,             float.NaN,              0.0f)]                                   // x: -(e)  y: -(pi / 2)
+        [InlineData(-2.71828183f,            -1.0f,                   -0.367879441f,           CrossPlatformMachineEpsilon)]            // x: -(e)
+        [InlineData(-2.71828183f,            -0.785398163f,            float.NaN,              0.0f)]                                   // x: -(e)  y: -(pi / 4)
+        [InlineData(-2.71828183f,            -0.0f,                    1.0f,                   CrossPlatformMachineEpsilon * 10)]       // x: -(e)
+        [InlineData(-2.71828183f,             float.NaN,               float.NaN,              0.0f)]
+        [InlineData(-2.71828183f,             0.0f,                    1.0f,                   CrossPlatformMachineEpsilon * 10)]       // x: -(e)
+        [InlineData(-2.71828183f,             0.785398163f,            float.NaN,              0.0f)]                                   // x: -(e)  y:  (pi / 4)
+        [InlineData(-2.71828183f,             1.0f,                   -2.71828183f,            CrossPlatformMachineEpsilon * 10)]       // x: -(e)  expected: (e)
+        [InlineData(-2.71828183f,             1.57079633f,             float.NaN,              0.0f)]                                   // x: -(e)  y:  (pi / 2)
+        [InlineData(-2.71828183f,             float.PositiveInfinity,  float.PositiveInfinity, 0.0f)]
+        [InlineData(-1.0f,                    float.NegativeInfinity,  float.NaN,              0.0f)]
+        [InlineData(-1.0f,                    float.NegativeInfinity,  1.0f,                   CrossPlatformMachineEpsilon * 10, Skip = "https://github.com/dotnet/coreclr/issues/9807")]
+        [InlineData(-1.0f,                   -1.0f,                   -1.0f,                   CrossPlatformMachineEpsilon * 10)]
+        [InlineData(-1.0f,                   -0.0f,                    1.0f,                   CrossPlatformMachineEpsilon * 10)]
+        [InlineData(-1.0f,                    float.NaN,               float.NaN,              0.0f)]
+        [InlineData(-1.0f,                    0.0f,                    1.0f,                   CrossPlatformMachineEpsilon * 10)]
+        [InlineData(-1.0f,                    1.0f,                   -1.0f,                   CrossPlatformMachineEpsilon * 10)]
+        [InlineData(-1.0f,                    float.PositiveInfinity,  float.NaN,              0.0f)]
+        [InlineData(-1.0f,                    float.PositiveInfinity,  1.0f,                   CrossPlatformMachineEpsilon * 10, Skip = "https://github.com/dotnet/coreclr/issues/9807")]
+        [InlineData(-0.0f,                    float.NegativeInfinity,  float.PositiveInfinity, 0.0f)]
+        [InlineData(-0.0f,                   -3.0f,                    float.NegativeInfinity, 0.0f)]
+        [InlineData(-0.0f,                   -2.0f,                    float.PositiveInfinity, 0.0f)]
+        [InlineData(-0.0f,                   -1.57079633f,             float.PositiveInfinity, 0.0f)]                                   //          y: -(pi / 2)
+        [InlineData(-0.0f,                   -1.0f,                    float.NegativeInfinity, 0.0f)]
+        [InlineData(-0.0f,                   -0.0f,                    1.0f,                   CrossPlatformMachineEpsilon * 10)]
+        [InlineData(-0.0f,                    float.NaN,               float.NaN,              0.0f)]
+        [InlineData(-0.0f,                    0.0f,                    1.0f,                   CrossPlatformMachineEpsilon * 10)]
+        [InlineData(-0.0f,                    1.0f,                   -0.0f,                   0.0f)]
+        [InlineData(-0.0f,                    1.57079633f,             0.0f,                   0.0f)]                                   //          y: -(pi / 2)
+        [InlineData(-0.0f,                    2.0f,                    0.0f,                   0.0f)]
+        [InlineData(-0.0f,                    3.0f,                   -0.0f,                   0.0f)]
+        [InlineData(-0.0f,                    float.PositiveInfinity,  0.0f,                   0.0f)]
+        [InlineData( float.NaN,               float.NegativeInfinity,  float.NaN,              0.0f)]
+        [InlineData( float.NaN,              -1.0f,                    float.NaN,              0.0f)]
+        [InlineData( float.NaN,              -0.0f,                    float.NaN,              0.0f)]
+        [InlineData( float.NaN,              -0.0f,                    1.0f,                   CrossPlatformMachineEpsilon * 10, Skip = "https://github.com/dotnet/coreclr/issues/9807")]
+        [InlineData( float.NaN,               float.NaN,               float.NaN,              0.0f)]
+        [InlineData( float.NaN,               0.0f,                    float.NaN,              0.0f)]
+        [InlineData( float.NaN,               0.0f,                    1.0f,                   CrossPlatformMachineEpsilon * 10, Skip = "https://github.com/dotnet/coreclr/issues/9807")]
+        [InlineData( float.NaN,               1.0f,                    float.NaN,              0.0f)]
+        [InlineData( float.NaN,               float.PositiveInfinity,  float.NaN,              0.0f)]
+        [InlineData( 0.0f,                    float.NegativeInfinity,  float.PositiveInfinity, 0.0f)]
+        [InlineData( 0.0f,                   -3.0f,                    float.PositiveInfinity, 0.0f)]
+        [InlineData( 0.0f,                   -2.0f,                    float.PositiveInfinity, 0.0f)]
+        [InlineData( 0.0f,                   -1.57079633f,             float.PositiveInfinity, 0.0f)]                                   //          y: -(pi / 2)
+        [InlineData( 0.0f,                   -1.0f,                    float.PositiveInfinity, 0.0f)]
+        [InlineData( 0.0f,                   -0.0f,                    1.0f,                   CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 0.0f,                    float.NaN,               float.NaN,              0.0f)]
+        [InlineData( 0.0f,                    0.0f,                    1.0f,                   CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 0.0f,                    1.0f,                    0.0f,                   0.0f)]
+        [InlineData( 0.0f,                    1.57079633f,             0.0f,                   0.0f)]                                   //          y: -(pi / 2)
+        [InlineData( 0.0f,                    2.0f,                    0.0f,                   0.0f)]
+        [InlineData( 0.0f,                    3.0f,                    0.0f,                   0.0f)]
+        [InlineData( 0.0f,                    float.PositiveInfinity,  0.0f,                   0.0f)]
+        [InlineData( 1.0f,                    float.NegativeInfinity,  1.0f,                   CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 1.0f,                   -1.0f,                    1.0f,                   CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 1.0f,                   -0.0f,                    1.0f,                   CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 1.0f,                    float.NaN,               float.NaN,              0.0f)]
+        [InlineData( 1.0f,                    float.NaN,               1.0f,                   CrossPlatformMachineEpsilon * 10, Skip = "https://github.com/dotnet/coreclr/issues/9807")]
+        [InlineData( 1.0f,                    0.0f,                    1.0f,                   CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 1.0f,                    1.0f,                    1.0f,                   CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 1.0f,                    float.PositiveInfinity,  1.0f,                   CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 2.71828183f,             float.NegativeInfinity,  0.0f,                   0.0f)]
+        [InlineData( 2.71828183f,            -3.14159265f,             0.0432139183f,          CrossPlatformMachineEpsilon / 10)]       // x:  (e)  y: -(pi)
+        [InlineData( 2.71828183f,            -2.71828183f,             0.0659880358f,          CrossPlatformMachineEpsilon / 10)]       // x:  (e)  y: -(e)
+        [InlineData( 2.71828183f,            -2.30258509f,             0.1f,                   CrossPlatformMachineEpsilon)]            // x:  (e)  y: -(ln(10))
+        [InlineData( 2.71828183f,            -1.57079633f,             0.207879576f,           CrossPlatformMachineEpsilon)]            // x:  (e)  y: -(pi / 2)
+        [InlineData( 2.71828183f,            -1.44269504f,             0.236290088f,           CrossPlatformMachineEpsilon)]            // x:  (e)  y: -(log2(e))
+        [InlineData( 2.71828183f,            -1.41421356f,             0.243116734f,           CrossPlatformMachineEpsilon)]            // x:  (e)  y: -(sqrt(2))
+        [InlineData( 2.71828183f,            -1.12837917f,             0.323557264f,           CrossPlatformMachineEpsilon)]            // x:  (e)  y: -(2 / sqrt(pi))
+        [InlineData( 2.71828183f,            -1.0f,                    0.367879441f,           CrossPlatformMachineEpsilon)]            // x:  (e)
+        [InlineData( 2.71828183f,            -0.785398163f,            0.455938128f,           CrossPlatformMachineEpsilon)]            // x:  (e)  y: -(pi / 4)
+        [InlineData( 2.71828183f,            -0.707106781f,            0.493068691f,           CrossPlatformMachineEpsilon)]            // x:  (e)  y: -(1 / sqrt(2))
+        [InlineData( 2.71828183f,            -0.693147181f,            0.5f,                   CrossPlatformMachineEpsilon)]            // x:  (e)  y: -(ln(2))
+        [InlineData( 2.71828183f,            -0.636619772f,            0.529077808f,           CrossPlatformMachineEpsilon)]            // x:  (e)  y: -(2 / pi)
+        [InlineData( 2.71828183f,            -0.434294482f,            0.647721485f,           CrossPlatformMachineEpsilon)]            // x:  (e)  y: -(log10(e))
+        [InlineData( 2.71828183f,            -0.318309886f,            0.727377349f,           CrossPlatformMachineEpsilon)]            // x:  (e)  y: -(1 / pi)
+        [InlineData( 2.71828183f,            -0.0f,                    1.0f,                   CrossPlatformMachineEpsilon * 10)]       // x:  (e)
+        [InlineData( 2.71828183f,             float.NaN,               float.NaN,              0.0f)]
+        [InlineData( 2.71828183f,             0.0f,                    1.0f,                   CrossPlatformMachineEpsilon * 10)]       // x:  (e)
+        [InlineData( 2.71828183f,             0.318309886f,            1.37480223f,            CrossPlatformMachineEpsilon * 10)]       // x:  (e)  y:  (1 / pi)
+        [InlineData( 2.71828183f,             0.434294482f,            1.54387344f,            CrossPlatformMachineEpsilon * 10)]       // x:  (e)  y:  (log10(e))
+        [InlineData( 2.71828183f,             0.636619772f,            1.89008116f,            CrossPlatformMachineEpsilon * 10)]       // x:  (e)  y:  (2 / pi)
+        [InlineData( 2.71828183f,             0.693147181f,            2.0f,                   CrossPlatformMachineEpsilon * 10)]       // x:  (e)  y:  (ln(2))
+        [InlineData( 2.71828183f,             0.707106781f,            2.02811498f,            CrossPlatformMachineEpsilon * 10)]       // x:  (e)  y:  (1 / sqrt(2))
+        [InlineData( 2.71828183f,             0.785398163f,            2.19328005f,            CrossPlatformMachineEpsilon * 10)]       // x:  (e)  y:  (pi / 4)
+        [InlineData( 2.71828183f,             1.0f,                    2.71828183f,            CrossPlatformMachineEpsilon * 10)]       // x:  (e)                      expected: (e)
+        [InlineData( 2.71828183f,             1.12837917f,             3.09064302f,            CrossPlatformMachineEpsilon * 10)]       // x:  (e)  y:  (2 / sqrt(pi))
+        [InlineData( 2.71828183f,             1.41421356f,             4.11325038f,            CrossPlatformMachineEpsilon * 10)]       // x:  (e)  y:  (sqrt(2))
+        [InlineData( 2.71828183f,             1.44269504f,             4.23208611f,            CrossPlatformMachineEpsilon * 10)]       // x:  (e)  y:  (log2(e))
+        [InlineData( 2.71828183f,             1.57079633f,             4.81047738f,            CrossPlatformMachineEpsilon * 10)]       // x:  (e)  y:  (pi / 2)
+        [InlineData( 2.71828183f,             2.30258509f,             10.0f,                  CrossPlatformMachineEpsilon * 100)]      // x:  (e)  y:  (ln(10))
+        [InlineData( 2.71828183f,             2.71828183f,             15.1542622f,            CrossPlatformMachineEpsilon * 100)]      // x:  (e)  y:  (e)
+        [InlineData( 2.71828183f,             3.14159265f,             23.1406926f,            CrossPlatformMachineEpsilon * 100)]      // x:  (e)  y:  (pi)
+        [InlineData( 2.71828183f,             float.PositiveInfinity,  float.PositiveInfinity, 0.0f)]                                   // x:  (e)
+        [InlineData( 10.0f,                   float.NegativeInfinity,  0.0f,                   0.0f)]
+        [InlineData( 10.0f,                  -3.14159265f,             0.000721784159f,        CrossPlatformMachineEpsilon / 1000)]     //          y: -(pi)
+        [InlineData( 10.0f,                  -2.71828183f,             0.00191301410f,         CrossPlatformMachineEpsilon / 100)]      //          y: -(e)
+        [InlineData( 10.0f,                  -2.30258509f,             0.00498212830f,         CrossPlatformMachineEpsilon / 100)]      //          y: -(ln(10))
+        [InlineData( 10.0f,                  -1.57079633f,             0.0268660410f,          CrossPlatformMachineEpsilon / 10)]       //          y: -(pi / 2)
+        [InlineData( 10.0f,                  -1.44269504f,             0.0360831928f,          CrossPlatformMachineEpsilon / 10)]       //          y: -(log2(e))
+        [InlineData( 10.0f,                  -1.41421356f,             0.0385288847f,          CrossPlatformMachineEpsilon / 10)]       //          y: -(sqrt(2))
+        [InlineData( 10.0f,                  -1.12837917f,             0.0744082059f,          CrossPlatformMachineEpsilon / 10)]       //          y: -(2 / sqrt(pi))
+        [InlineData( 10.0f,                  -1.0f,                    0.1f,                   CrossPlatformMachineEpsilon)]
+        [InlineData( 10.0f,                  -0.785398163f,            0.163908636f,           CrossPlatformMachineEpsilon)]            //          y: -(pi / 4)
+        [InlineData( 10.0f,                  -0.707106781f,            0.196287760f,           CrossPlatformMachineEpsilon)]            //          y: -(1 / sqrt(2))
+        [InlineData( 10.0f,                  -0.693147181f,            0.202699566f,           CrossPlatformMachineEpsilon)]            //          y: -(ln(2))
+        [InlineData( 10.0f,                  -0.636619772f,            0.230876765f,           CrossPlatformMachineEpsilon)]            //          y: -(2 / pi)
+        [InlineData( 10.0f,                  -0.434294482f,            0.367879441f,           CrossPlatformMachineEpsilon)]            //          y: -(log10(e))
+        [InlineData( 10.0f,                  -0.318309886f,            0.480496373f,           CrossPlatformMachineEpsilon)]            //          y: -(1 / pi)
+        [InlineData( 10.0f,                  -0.0f,                    1.0f,                   CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 10.0f,                   float.NaN,               float.NaN,              0.0f)]
+        [InlineData( 10.0f,                   0.0f,                    1.0f,                   CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 10.0f,                   0.318309886f,            2.08118116f,            CrossPlatformMachineEpsilon * 10)]       //          y:  (1 / pi)
+        [InlineData( 10.0f,                   0.434294482f,            2.71828183f,            CrossPlatformMachineEpsilon * 10)]       //          y:  (log10(e))      expected: (e)
+        [InlineData( 10.0f,                   0.636619772f,            4.33131503f,            CrossPlatformMachineEpsilon * 10)]       //          y:  (2 / pi)
+        [InlineData( 10.0f,                   0.693147181f,            4.93340967f,            CrossPlatformMachineEpsilon * 10)]       //          y:  (ln(2))
+        [InlineData( 10.0f,                   0.707106781f,            5.09456117f,            CrossPlatformMachineEpsilon * 10)]       //          y:  (1 / sqrt(2))
+        [InlineData( 10.0f,                   0.785398163f,            6.10095980f,            CrossPlatformMachineEpsilon * 10)]       //          y:  (pi / 4)
+        [InlineData( 10.0f,                   1.0f,                    10.0f,                  CrossPlatformMachineEpsilon * 100)]
+        [InlineData( 10.0f,                   1.12837917f,             13.4393779f,            CrossPlatformMachineEpsilon * 100)]      //          y:  (2 / sqrt(pi))
+        [InlineData( 10.0f,                   1.41421356f,             25.9545535f,            CrossPlatformMachineEpsilon * 100)]      //          y:  (sqrt(2))
+        [InlineData( 10.0f,                   1.44269504f,             27.7137338f,            CrossPlatformMachineEpsilon * 100)]      //          y:  (log2(e))
+        [InlineData( 10.0f,                   1.57079633f,             37.2217105f,            CrossPlatformMachineEpsilon * 100)]      //          y:  (pi / 2)
+        [InlineData( 10.0f,                   2.30258509f,             200.717432f,            CrossPlatformMachineEpsilon * 1000)]     //          y:  (ln(10))
+        [InlineData( 10.0f,                   2.71828183f,             522.735300f,            CrossPlatformMachineEpsilon * 1000)]     //          y:  (e)
+        [InlineData( 10.0f,                   3.14159265f,             1385.45573f,            CrossPlatformMachineEpsilon * 10000)]    //          y:  (pi)
+        [InlineData( 10.0f,                   float.PositiveInfinity,  float.PositiveInfinity, 0.0f)]
+        [InlineData( float.PositiveInfinity,  float.NegativeInfinity,  0.0f,                   0.0f)]
+        [InlineData( float.PositiveInfinity, -1.0f,                    0.0f,                   0.0f)]
+        [InlineData( float.PositiveInfinity, -0.0f,                    1.0f,                   0.0f)]
+        [InlineData( float.PositiveInfinity,  float.NaN,               float.NaN,              0.0f)]
+        [InlineData( float.PositiveInfinity,  0.0f,                    1.0f,                   0.0f)]
+        [InlineData( float.PositiveInfinity,  1.0f,                    float.PositiveInfinity, 0.0f)]
+        [InlineData( float.PositiveInfinity,  float.PositiveInfinity,  float.PositiveInfinity, 0.0f)]
+        public static void Pow(float x, float y, float expectedResult, float allowedVariance)
         {
-            Assert.Equal(1.0f, MathF.Pow(0.0f, 0.0f));
-            Assert.Equal(1.0f, MathF.Pow(1.0f, 0.0f));
-            Assert.Equal(8.0f, MathF.Pow(2.0f, 3.0f));
-            Assert.Equal(0.0f, MathF.Pow(0.0f, 3.0f));
-            Assert.Equal(-8.0f, MathF.Pow(-2.0f, 3.0f));
-            Assert.Equal(float.NaN, MathF.Pow(float.NaN, 1.0f));
-            Assert.Equal(float.NaN, MathF.Pow(1.0f, float.NaN));
-            Assert.Equal(float.PositiveInfinity, MathF.Pow(float.PositiveInfinity, 1.0f));
-            Assert.Equal(float.NegativeInfinity, MathF.Pow(float.NegativeInfinity, 1.0f));
-            Assert.Equal(1.0f, MathF.Pow(1.0f, float.PositiveInfinity));
-            Assert.Equal(1.0f, MathF.Pow(1.0f, float.NegativeInfinity));
-            Assert.Equal(0.0f, MathF.Pow(0.0f, float.PositiveInfinity));
-            Assert.Equal(float.PositiveInfinity, MathF.Pow(0.0f, -1.0f));
-            Assert.Equal(float.PositiveInfinity, MathF.Pow(0.0f, float.NegativeInfinity));
-            Assert.Equal(float.NaN, MathF.Pow(-1.0f, float.PositiveInfinity));
-            Assert.Equal(float.NaN, MathF.Pow(-1.0f, float.NegativeInfinity));
-            Assert.Equal(float.PositiveInfinity, MathF.Pow(1.1f, float.PositiveInfinity));
-            Assert.Equal(0.0f, MathF.Pow(1.1f, float.NegativeInfinity));
-            Assert.Equal(float.PositiveInfinity, MathF.Pow(-1.1f, float.PositiveInfinity));
-            Assert.Equal(0.0f, MathF.Pow(-1.1f, float.NegativeInfinity));
-            Assert.Equal(0.0f, MathF.Pow(1.1f, float.NegativeInfinity));
-            Assert.Equal(float.NaN, MathF.Pow(float.NaN, 0.0f));
-            Assert.Equal(1.0f, MathF.Pow(0.0f, -0.0f));
-            Assert.Equal(0.0f, MathF.Pow(0.0f, 1.0f));
-            Assert.Equal(float.PositiveInfinity, MathF.Pow(-0.0f, float.NegativeInfinity));
-            Assert.Equal(float.NegativeInfinity, MathF.Pow(-0.0f, -1.0f));
-            Assert.Equal(1.0f, MathF.Pow(-0.0f, -0.0f));
-            Assert.Equal(1.0f, MathF.Pow(-0.0f, 0.0f));
-            Assert.Equal(-0.0f, MathF.Pow(-0.0f, 1.0f));
-            Assert.Equal(0.0f, MathF.Pow(-0.0f, float.PositiveInfinity));
-            Assert.Equal(0.0f, MathF.Pow(float.NegativeInfinity, float.NegativeInfinity));
-            Assert.Equal(float.PositiveInfinity, MathF.Pow(float.NegativeInfinity, float.PositiveInfinity));
-            Assert.Equal(0.0f, MathF.Pow(float.PositiveInfinity, float.NegativeInfinity));
-            Assert.Equal(float.PositiveInfinity, MathF.Pow(float.PositiveInfinity, float.PositiveInfinity));
+            AssertEqual(expectedResult, MathF.Pow(x, y), allowedVariance);
         }
 
         [Fact]
@@ -315,59 +891,201 @@ namespace System.Tests
             Assert.Throws<ArithmeticException>(() => MathF.Sign(float.NaN));
         }
 
-        [Fact]
-        public static void Sin()
+        [Theory]
+        [InlineData( float.NegativeInfinity,  float.NaN,    0.0f)]
+        [InlineData(-3.14159265f,            -0.0f,         CrossPlatformMachineEpsilon)]       // value: -(pi)
+        [InlineData(-2.71828183f,            -0.410781291f, CrossPlatformMachineEpsilon)]       // value: -(e)
+        [InlineData(-2.30258509f,            -0.743980337f, CrossPlatformMachineEpsilon)]       // value: -(ln(10))
+        [InlineData(-1.57079633f,            -1.0f,         CrossPlatformMachineEpsilon * 10)]  // value: -(pi / 2)
+        [InlineData(-1.44269504f,            -0.991806244f, CrossPlatformMachineEpsilon)]       // value: -(log2(e))
+        [InlineData(-1.41421356f,            -0.987765946f, CrossPlatformMachineEpsilon)]       // value: -(sqrt(2))
+        [InlineData(-1.12837917f,            -0.903719457f, CrossPlatformMachineEpsilon)]       // value: -(2 / sqrt(pi))
+        [InlineData(-1.0f,                   -0.841470985f, CrossPlatformMachineEpsilon)]
+        [InlineData(-0.785398163f,           -0.707106781f, CrossPlatformMachineEpsilon)]       // value: -(pi / 4),        expected: -(1 / sqrt(2))
+        [InlineData(-0.707106781f,           -0.649636939f, CrossPlatformMachineEpsilon)]       // value: -(1 / sqrt(2))
+        [InlineData(-0.693147181f,           -0.638961276f, CrossPlatformMachineEpsilon)]       // value: -(ln(2))
+        [InlineData(-0.636619772f,           -0.594480769f, CrossPlatformMachineEpsilon)]       // value: -(2 / pi)
+        [InlineData(-0.434294482f,           -0.420770483f, CrossPlatformMachineEpsilon)]       // value: -(log10(e))
+        [InlineData(-0.318309886f,           -0.312961796f, CrossPlatformMachineEpsilon)]       // value: -(1 / pi)
+        [InlineData(-0.0f,                   -0.0f,         0.0f)]
+        [InlineData( float.NaN,               float.NaN,    0.0f)]
+        [InlineData( 0.0f,                    0.0f,         0.0f)]
+        [InlineData( 0.318309886f,            0.312961796f, CrossPlatformMachineEpsilon)]       // value:  (1 / pi)
+        [InlineData( 0.434294482f,            0.420770483f, CrossPlatformMachineEpsilon)]       // value:  (log10(e))
+        [InlineData( 0.636619772f,            0.594480769f, CrossPlatformMachineEpsilon)]       // value:  (2 / pi)
+        [InlineData( 0.693147181f,            0.638961276f, CrossPlatformMachineEpsilon)]       // value:  (ln(2))
+        [InlineData( 0.707106781f,            0.649636939f, CrossPlatformMachineEpsilon)]       // value:  (1 / sqrt(2))
+        [InlineData( 0.785398163f,            0.707106781f, CrossPlatformMachineEpsilon)]       // value:  (pi / 4),        expected:  (1 / sqrt(2))
+        [InlineData( 1.0f,                    0.841470985f, CrossPlatformMachineEpsilon)]
+        [InlineData( 1.12837917f,             0.903719457f, CrossPlatformMachineEpsilon)]       // value:  (2 / sqrt(pi))
+        [InlineData( 1.41421356f,             0.987765946f, CrossPlatformMachineEpsilon)]       // value:  (sqrt(2))
+        [InlineData( 1.44269504f,             0.991806244f, CrossPlatformMachineEpsilon)]       // value:  (log2(e))
+        [InlineData( 1.57079633f,             1.0f,         CrossPlatformMachineEpsilon * 10)]  // value:  (pi / 2)
+        [InlineData( 2.30258509f,             0.743980337f, CrossPlatformMachineEpsilon)]       // value:  (ln(10))
+        [InlineData( 2.71828183f,             0.410781291f, CrossPlatformMachineEpsilon)]       // value:  (e)
+        [InlineData( 3.14159265f,             0.0f,         CrossPlatformMachineEpsilon)]       // value:  (pi)
+        [InlineData( float.PositiveInfinity,  float.NaN,    0.0f)]
+        public static void Sin(float value, float expectedResult, float allowedVariance)
         {
-            AssertEqual(0.841470985f, MathF.Sin(1.0f), CrossPlatformMachineEpsilon);
-            Assert.Equal(0.0f, MathF.Sin(0.0f));
-            AssertEqual(-0.841470985f, MathF.Sin(-1.0f), CrossPlatformMachineEpsilon);
-            Assert.Equal(float.NaN, MathF.Sin(float.NaN));
-            Assert.Equal(float.NaN, MathF.Sin(float.PositiveInfinity));
-            Assert.Equal(float.NaN, MathF.Sin(float.NegativeInfinity));
+            AssertEqual(expectedResult, MathF.Sin(value), allowedVariance);
         }
 
-        [Fact]
-        public static void Sinh()
+        [Theory]
+        [InlineData( float.NegativeInfinity,  float.NegativeInfinity, 0.0f)]
+        [InlineData(-3.14159265f,            -11.5487394f,            CrossPlatformMachineEpsilon * 100)]   // value: -(pi)
+        [InlineData(-2.71828183f,            -7.54413710f,            CrossPlatformMachineEpsilon * 10)]    // value: -(e)
+        [InlineData(-2.30258509f,            -4.95f,                  CrossPlatformMachineEpsilon * 10)]    // value: -(ln(10))
+        [InlineData(-1.57079633f,            -2.30129890f,            CrossPlatformMachineEpsilon * 10)]    // value: -(pi / 2)
+        [InlineData(-1.44269504f,            -1.99789801f,            CrossPlatformMachineEpsilon * 10)]    // value: -(log2(e))
+        [InlineData(-1.41421356f,            -1.93506682f,            CrossPlatformMachineEpsilon * 10)]    // value: -(sqrt(2))
+        [InlineData(-1.12837917f,            -1.38354288f,            CrossPlatformMachineEpsilon * 10)]    // value: -(2 / sqrt(pi))
+        [InlineData(-1.0f,                   -1.17520119f,            CrossPlatformMachineEpsilon * 10)]
+        [InlineData(-0.785398163f,           -0.868670961f,           CrossPlatformMachineEpsilon)]         // value: -(pi / 4)
+        [InlineData(-0.707106781f,           -0.767523145f,           CrossPlatformMachineEpsilon)]         // value: -(1 / sqrt(2))
+        [InlineData(-0.693147181f,           -0.75f,                  CrossPlatformMachineEpsilon)]         // value: -(ln(2))
+        [InlineData(-0.636619772f,           -0.680501678f,           CrossPlatformMachineEpsilon)]         // value: -(2 / pi)
+        [InlineData(-0.434294482f,           -0.448075979f,           CrossPlatformMachineEpsilon)]         // value: -(log10(e))
+        [InlineData(-0.318309886f,           -0.323712439f,           CrossPlatformMachineEpsilon)]         // value: -(1 / pi)
+        [InlineData(-0.0f,                   -0.0f,                   0.0f)]
+        [InlineData( float.NaN,               float.NaN,              0.0f)]
+        [InlineData( 0.0f,                    0.0f,                   0.0f)]
+        [InlineData( 0.318309886f,            0.323712439f,           CrossPlatformMachineEpsilon)]         // value:  (1 / pi)
+        [InlineData( 0.434294482f,            0.448075979f,           CrossPlatformMachineEpsilon)]         // value:  (log10(e))
+        [InlineData( 0.636619772f,            0.680501678f,           CrossPlatformMachineEpsilon)]         // value:  (2 / pi)
+        [InlineData( 0.693147181f,            0.75f,                  CrossPlatformMachineEpsilon)]         // value:  (ln(2))
+        [InlineData( 0.707106781f,            0.767523145f,           CrossPlatformMachineEpsilon)]         // value:  (1 / sqrt(2))
+        [InlineData( 0.785398163f,            0.868670961f,           CrossPlatformMachineEpsilon)]         // value:  (pi / 4)
+        [InlineData( 1.0f,                    1.17520119f,            CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 1.12837917f,             1.38354288f,            CrossPlatformMachineEpsilon * 10)]    // value:  (2 / sqrt(pi))
+        [InlineData( 1.41421356f,             1.93506682f,            CrossPlatformMachineEpsilon * 10)]    // value:  (sqrt(2))
+        [InlineData( 1.44269504f,             1.99789801f,            CrossPlatformMachineEpsilon * 10)]    // value:  (log2(e))
+        [InlineData( 1.57079633f,             2.30129890f,            CrossPlatformMachineEpsilon * 10)]    // value:  (pi / 2)
+        [InlineData( 2.30258509f,             4.95f,                  CrossPlatformMachineEpsilon * 10)]    // value:  (ln(10))
+        [InlineData( 2.71828183f,             7.54413710f,            CrossPlatformMachineEpsilon * 10)]    // value:  (e)
+        [InlineData( 3.14159265f,             11.5487394f,            CrossPlatformMachineEpsilon * 100)]   // value:  (pi)
+        [InlineData( float.PositiveInfinity,  float.PositiveInfinity, 0.0f)]
+        public static void Sinh(float value, float expectedResult, float allowedVariance)
         {
-            AssertEqual(1.17520119f, MathF.Sinh(1.0f), CrossPlatformMachineEpsilon * 10);
-            Assert.Equal(0.0f, MathF.Sinh(0.0f));
-            AssertEqual(-1.17520119f, MathF.Sinh(-1.0f), CrossPlatformMachineEpsilon * 10);
-            Assert.Equal(float.NaN, MathF.Sinh(float.NaN));
-            Assert.Equal(float.PositiveInfinity, MathF.Sinh(float.PositiveInfinity));
-            Assert.Equal(float.NegativeInfinity, MathF.Sinh(float.NegativeInfinity));
+            AssertEqual(expectedResult, MathF.Sinh(value), allowedVariance);
         }
 
-        [Fact]
-        public static void Sqrt()
+        [Theory]
+        [InlineData( float.NegativeInfinity,  float.NaN,              0.0f)]
+        [InlineData(-3.14159265f,             float.NaN,              0.0f)]                                 // value: (pi)
+        [InlineData(-2.71828183f,             float.NaN,              0.0f)]                                 // value: (e)
+        [InlineData(-2.30258509f,             float.NaN,              0.0f)]                                 // value: (ln(10))
+        [InlineData(-1.57079633f,             float.NaN,              0.0f)]                                 // value: (pi / 2)
+        [InlineData(-1.44269504f,             float.NaN,              0.0f)]                                 // value: (log2(e))
+        [InlineData(-1.41421356f,             float.NaN,              0.0f)]                                 // value: (sqrt(2))
+        [InlineData(-1.12837917f,             float.NaN,              0.0f)]                                 // value: (2 / sqrt(pi))
+        [InlineData(-1.0f,                    float.NaN,              0.0f)]
+        [InlineData(-0.785398163f,            float.NaN,              0.0f)]                                 // value: (pi / 4)
+        [InlineData(-0.707106781f,            float.NaN,              0.0f)]                                 // value: (1 / sqrt(2))
+        [InlineData(-0.693147181f,            float.NaN,              0.0f)]                                 // value: (ln(2))
+        [InlineData(-0.636619772f,            float.NaN,              0.0f)]                                 // value: (2 / pi)
+        [InlineData(-0.434294482f,            float.NaN,              0.0f)]                                 // value: (log10(e))
+        [InlineData(-0.318309886f,            float.NaN,              0.0f)]                                 // value: (1 / pi)
+        [InlineData(-0.0f,                   -0.0f,                   0.0f)]
+        [InlineData( float.NaN,               float.NaN,              0.0f)]
+        [InlineData( 0.0f,                    0.0f,                   0.0f)]
+        [InlineData( 0.318309886f,            0.564189584f,           CrossPlatformMachineEpsilon)]          // value: (1 / pi)
+        [InlineData( 0.434294482f,            0.659010229f,           CrossPlatformMachineEpsilon)]          // value: (log10(e))
+        [InlineData( 0.636619772f,            0.797884561f,           CrossPlatformMachineEpsilon)]          // value: (2 / pi)
+        [InlineData( 0.693147181f,            0.832554611f,           CrossPlatformMachineEpsilon)]          // value: (ln(2))
+        [InlineData( 0.707106781f,            0.840896415f,           CrossPlatformMachineEpsilon)]          // value: (1 / sqrt(2))
+        [InlineData( 0.785398163f,            0.886226925f,           CrossPlatformMachineEpsilon)]          // value: (pi / 4)
+        [InlineData( 1.0f,                    1.0f,                   CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 1.12837917f,             1.06225193f,            CrossPlatformMachineEpsilon * 10)]     // value: (2 / sqrt(pi))
+        [InlineData( 1.41421356f,             1.18920712f,            CrossPlatformMachineEpsilon * 10)]     // value: (sqrt(2))
+        [InlineData( 1.44269504f,             1.20112241f,            CrossPlatformMachineEpsilon * 10)]     // value: (log2(e))
+        [InlineData( 1.57079633f,             1.25331414f,            CrossPlatformMachineEpsilon * 10)]     // value: (pi / 2)
+        [InlineData( 2.30258509f,             1.51742713f,            CrossPlatformMachineEpsilon * 10)]     // value: (ln(10))
+        [InlineData( 2.71828183f,             1.64872127f,            CrossPlatformMachineEpsilon * 10)]     // value: (e)
+        [InlineData( 3.14159265f,             1.77245385F,            CrossPlatformMachineEpsilon * 10)]     // value: (pi)
+        [InlineData( float.PositiveInfinity,  float.PositiveInfinity, 0.0f)]
+        public static void Sqrt(float value, float expectedResult, float allowedVariance)
         {
-            AssertEqual(1.73205081f, MathF.Sqrt(3.0f), CrossPlatformMachineEpsilon * 10);
-            Assert.Equal(0.0f, MathF.Sqrt(0.0f));
-            Assert.Equal(float.NaN, MathF.Sqrt(-3.0f));
-            Assert.Equal(float.NaN, MathF.Sqrt(float.NaN));
-            Assert.Equal(float.PositiveInfinity, MathF.Sqrt(float.PositiveInfinity));
-            Assert.Equal(float.NaN, MathF.Sqrt(float.NegativeInfinity));
+            AssertEqual(expectedResult, MathF.Sqrt(value), allowedVariance);
         }
 
-        [Fact]
-        public static void Tan()
+        [Theory]
+        [InlineData( float.NegativeInfinity,  float.NaN,              0.0f)]
+        [InlineData(-3.14159265f,            -0.0f,                   CrossPlatformMachineEpsilon)]         // value: -(pi)
+        [InlineData(-2.71828183f,             0.450549534f,           CrossPlatformMachineEpsilon)]         // value: -(e)
+        [InlineData(-2.30258509f,             1.11340715f,            CrossPlatformMachineEpsilon * 10)]    // value: -(ln(10))
+        [InlineData(-1.57079633f,             float.NegativeInfinity, 0.0f, Skip = "https://github.com/dotnet/coreclr/issues/10276")]                                // value: -(pi / 2)
+        [InlineData(-1.57079633f,             22877332.0f,            0.0f)]                                // value: -(pi / 2)
+        [InlineData(-1.44269504f,            -7.76357567f,            CrossPlatformMachineEpsilon * 10)]    // value: -(log2(e))
+        [InlineData(-1.41421356f,            -6.33411917f,            CrossPlatformMachineEpsilon * 10)]    // value: -(sqrt(2))
+        [InlineData(-1.12837917f,            -2.11087684f,            CrossPlatformMachineEpsilon * 10)]    // value: -(2 / sqrt(pi))
+        [InlineData(-1.0f,                   -1.55740772f,            CrossPlatformMachineEpsilon * 10)]
+        [InlineData(-0.785398163f,           -1.0f,                   CrossPlatformMachineEpsilon * 10)]    // value: -(pi / 4)
+        [InlineData(-0.707106781f,           -0.854510432f,           CrossPlatformMachineEpsilon)]         // value: -(1 / sqrt(2))
+        [InlineData(-0.693147181f,           -0.830640878f,           CrossPlatformMachineEpsilon)]         // value: -(ln(2))
+        [InlineData(-0.636619772f,           -0.739302950f,           CrossPlatformMachineEpsilon)]         // value: -(2 / pi)
+        [InlineData(-0.434294482f,           -0.463829067f,           CrossPlatformMachineEpsilon)]         // value: -(log10(e))
+        [InlineData(-0.318309886f,           -0.329514733f,           CrossPlatformMachineEpsilon)]         // value: -(1 / pi)
+        [InlineData(-0.0f,                   -0.0f,                   0.0f)]
+        [InlineData( float.NaN,               float.NaN,              0.0f)]
+        [InlineData( 0.0f,                    0.0f,                   0.0f)]
+        [InlineData( 0.318309886f,            0.329514733f,           CrossPlatformMachineEpsilon)]         // value:  (1 / pi)
+        [InlineData( 0.434294482f,            0.463829067f,           CrossPlatformMachineEpsilon)]         // value:  (log10(e))
+        [InlineData( 0.636619772f,            0.739302950f,           CrossPlatformMachineEpsilon)]         // value:  (2 / pi)
+        [InlineData( 0.693147181f,            0.830640878f,           CrossPlatformMachineEpsilon)]         // value:  (ln(2))
+        [InlineData( 0.707106781f,            0.854510432f,           CrossPlatformMachineEpsilon)]         // value:  (1 / sqrt(2))
+        [InlineData( 0.785398163f,            1.0f,                   CrossPlatformMachineEpsilon * 10)]    // value:  (pi / 4)
+        [InlineData( 1.0f,                    1.55740772f,            CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 1.12837917f,             2.11087684f,            CrossPlatformMachineEpsilon * 10)]    // value:  (2 / sqrt(pi))
+        [InlineData( 1.41421356f,             6.33411917f,            CrossPlatformMachineEpsilon * 10)]    // value:  (sqrt(2))
+        [InlineData( 1.44269504f,             7.76357567f,            CrossPlatformMachineEpsilon * 10)]    // value:  (log2(e))
+        [InlineData( 1.57079633f,            -22877332.0f,            0.0f)]                                // value:  (pi / 2)
+        [InlineData( 1.57079633f,             float.PositiveInfinity, 0.0f, Skip = "https://github.com/dotnet/coreclr/issues/10276")]                                // value:  (pi / 2)
+        [InlineData( 2.30258509f,            -1.11340715f,            CrossPlatformMachineEpsilon * 10)]    // value:  (ln(10))
+        [InlineData( 2.71828183f,            -0.450549534f,           CrossPlatformMachineEpsilon)]         // value:  (e)
+        [InlineData( 3.14159265f,             0.0f,                   CrossPlatformMachineEpsilon)]         // value:  (pi)
+        [InlineData( float.PositiveInfinity,  float.NaN,              0.0f)]
+        public static void Tan(float value, float expectedResult, float allowedVariance)
         {
-            AssertEqual(1.55740772f, MathF.Tan(1.0f), CrossPlatformMachineEpsilon * 10);
-            Assert.Equal(0.0f, MathF.Tan(0.0f));
-            AssertEqual(-1.55740772f, MathF.Tan(-1.0f), CrossPlatformMachineEpsilon * 10);
-            Assert.Equal(float.NaN, MathF.Tan(float.NaN));
-            Assert.Equal(float.NaN, MathF.Tan(float.PositiveInfinity));
-            Assert.Equal(float.NaN, MathF.Tan(float.NegativeInfinity));
+            AssertEqual(expectedResult, MathF.Tan(value), allowedVariance);
         }
 
-        [Fact]
-        public static void Tanh()
+        [Theory]
+        [InlineData( float.NegativeInfinity, -1.0f,         CrossPlatformMachineEpsilon * 10)]
+        [InlineData(-3.14159265f,            -0.996272076f, CrossPlatformMachineEpsilon)]       // value: -(pi)
+        [InlineData(-2.71828183f,            -0.991328916f, CrossPlatformMachineEpsilon)]       // value: -(e)
+        [InlineData(-2.30258509f,            -0.980198020f, CrossPlatformMachineEpsilon)]       // value: -(ln(10))
+        [InlineData(-1.57079633f,            -0.917152336f, CrossPlatformMachineEpsilon)]       // value: -(pi / 2)
+        [InlineData(-1.44269504f,            -0.894238946f, CrossPlatformMachineEpsilon)]       // value: -(log2(e))
+        [InlineData(-1.41421356f,            -0.888385562f, CrossPlatformMachineEpsilon)]       // value: -(sqrt(2))
+        [InlineData(-1.12837917f,            -0.810463806f, CrossPlatformMachineEpsilon)]       // value: -(2 / sqrt(pi))
+        [InlineData(-1.0f,                   -0.761594156f, CrossPlatformMachineEpsilon)]
+        [InlineData(-0.785398163f,           -0.655794203f, CrossPlatformMachineEpsilon)]       // value: -(pi / 4)
+        [InlineData(-0.707106781f,           -0.608859365f, CrossPlatformMachineEpsilon)]       // value: -(1 / sqrt(2))
+        [InlineData(-0.693147181f,           -0.6f,         CrossPlatformMachineEpsilon)]       // value: -(ln(2))
+        [InlineData(-0.636619772f,           -0.562593600f, CrossPlatformMachineEpsilon)]       // value: -(2 / pi)
+        [InlineData(-0.434294482f,           -0.408904012f, CrossPlatformMachineEpsilon)]       // value: -(log10(e))
+        [InlineData(-0.318309886f,           -0.307977913f, CrossPlatformMachineEpsilon)]       // value: -(1 / pi)
+        [InlineData(-0.0f,                   -0.0f,         0.0f)]
+        [InlineData( float.NaN,               float.NaN,    0.0f)]
+        [InlineData( 0.0f,                    0.0f,         0.0f)]
+        [InlineData( 0.318309886f,            0.307977913f, CrossPlatformMachineEpsilon)]       // value:  (1 / pi)
+        [InlineData( 0.434294482f,            0.408904012f, CrossPlatformMachineEpsilon)]       // value:  (log10(e))
+        [InlineData( 0.636619772f,            0.562593600f, CrossPlatformMachineEpsilon)]       // value:  (2 / pi)
+        [InlineData( 0.693147181f,            0.6f,         CrossPlatformMachineEpsilon)]       // value:  (ln(2))
+        [InlineData( 0.707106781f,            0.608859365f, CrossPlatformMachineEpsilon)]       // value:  (1 / sqrt(2))
+        [InlineData( 0.785398163f,            0.655794203f, CrossPlatformMachineEpsilon)]       // value:  (pi / 4)
+        [InlineData( 1.0f,                    0.761594156f, CrossPlatformMachineEpsilon)]
+        [InlineData( 1.12837917f,             0.810463806f, CrossPlatformMachineEpsilon)]       // value:  (2 / sqrt(pi))
+        [InlineData( 1.41421356f,             0.888385562f, CrossPlatformMachineEpsilon)]       // value:  (sqrt(2))
+        [InlineData( 1.44269504f,             0.894238946f, CrossPlatformMachineEpsilon)]       // value:  (log2(e))
+        [InlineData( 1.57079633f,             0.917152336f, CrossPlatformMachineEpsilon)]       // value:  (pi / 2)
+        [InlineData( 2.30258509f,             0.980198020f, CrossPlatformMachineEpsilon)]       // value:  (ln(10))
+        [InlineData( 2.71828183f,             0.991328916f, CrossPlatformMachineEpsilon)]       // value:  (e)
+        [InlineData( 3.14159265f,             0.996272076f, CrossPlatformMachineEpsilon)]       // value:  (pi)
+        [InlineData( float.PositiveInfinity,  1.0f,         CrossPlatformMachineEpsilon * 10)]
+        public static void Tanh(float value, float expectedResult, float allowedVariance)
         {
-            AssertEqual(0.761594156f, MathF.Tanh(1.0f), CrossPlatformMachineEpsilon);
-            Assert.Equal(0.0f, MathF.Tanh(0.0f));
-            AssertEqual(-0.761594156f, MathF.Tanh(-1.0f), CrossPlatformMachineEpsilon);
-            Assert.Equal(float.NaN, MathF.Tanh(float.NaN));
-            Assert.Equal(1.0f, MathF.Tanh(float.PositiveInfinity));
-            Assert.Equal(-1.0f, MathF.Tanh(float.NegativeInfinity));
+            AssertEqual(expectedResult, MathF.Tanh(value), allowedVariance);
         }
 
         [Fact]

--- a/src/System.Runtime.Extensions/tests/System/MathF.netcoreapp.cs
+++ b/src/System.Runtime.Extensions/tests/System/MathF.netcoreapp.cs
@@ -425,12 +425,12 @@ namespace System.Tests
         [InlineData(-1.41421356f,           -1.0f,                   0.0f)]     // value: -(sqrt(2))
         [InlineData(-1.12837917f,           -1.0f,                   0.0f)]     // value: -(2 / sqrt(pi))
         [InlineData(-1.0f,                  -1.0f,                   0.0f)]
-        [InlineData(-0.785398163f,           0.0f,                   0.0f)]     // value: -(pi / 4)
-        [InlineData(-0.707106781f,           0.0f,                   0.0f)]     // value: -(1 / sqrt(2))
-        [InlineData(-0.693147181f,           0.0f,                   0.0f)]     // value: -(ln(2))
-        [InlineData(-0.636619772f,           0.0f,                   0.0f)]     // value: -(2 / pi)
-        [InlineData(-0.434294482f,           0.0f,                   0.0f)]     // value: -(log10(e))
-        [InlineData(-0.318309886f,           0.0f,                   0.0f)]     // value: -(1 / pi)
+        [InlineData(-0.785398163f,          -0.0f,                   0.0f, Skip = "https://github.com/dotnet/coreclr/issues/10287")]  // value: -(pi / 4)
+        [InlineData(-0.707106781f,          -0.0f,                   0.0f, Skip = "https://github.com/dotnet/coreclr/issues/10287")]  // value: -(1 / sqrt(2))
+        [InlineData(-0.693147181f,          -0.0f,                   0.0f, Skip = "https://github.com/dotnet/coreclr/issues/10287")]  // value: -(ln(2))
+        [InlineData(-0.636619772f,          -0.0f,                   0.0f, Skip = "https://github.com/dotnet/coreclr/issues/10287")]  // value: -(2 / pi)
+        [InlineData(-0.434294482f,          -0.0f,                   0.0f, Skip = "https://github.com/dotnet/coreclr/issues/10287")]  // value: -(log10(e))
+        [InlineData(-0.318309886f,          -0.0f,                   0.0f, Skip = "https://github.com/dotnet/coreclr/issues/10287")]  // value: -(1 / pi)
         [InlineData(-0.0f,                  -0.0f,                   0.0f)]
         [InlineData( float.NaN,              float.NaN,              0.0f)]
         [InlineData( 0.0f,                   0.0f,                   0.0f)]

--- a/src/System.Runtime.Extensions/tests/System/MathF.netcoreapp.cs
+++ b/src/System.Runtime.Extensions/tests/System/MathF.netcoreapp.cs
@@ -21,14 +21,14 @@ namespace System.Tests
         // CrossPlatformMachineEpsilon for the variance, while an expected result in the format of 0.0xxxxxxxxx
         // will use CrossPlatformMachineEpsilon / 10 and expected result in the format of x.xxxxxx will
         // use CrossPlatformMachineEpsilon * 10.
-        public const float CrossPlatformMachineEpsilon = 4.76837158e-07f;
+        private const float CrossPlatformMachineEpsilon = 4.76837158e-07f;
 
         /// <summary>Verifies that two <see cref="float"/> values are equal, within the <paramref name="variance"/>.</summary>
         /// <param name="expected">The expected value</param>
         /// <param name="actual">The value to be compared against</param>
         /// <param name="variance">The total variance allowed between the expected and actual results.</param>
         /// <exception cref="EqualException">Thrown when the values are not equal</exception>
-        public static void AssertEqual(float expected, float actual, float variance)
+        private static void AssertEqual(float expected, float actual, float variance)
         {
             if (float.IsNaN(expected))
             {

--- a/src/System.Runtime.Extensions/tests/System/MathF.netcoreapp.cs
+++ b/src/System.Runtime.Extensions/tests/System/MathF.netcoreapp.cs
@@ -297,15 +297,11 @@ namespace System.Tests
         }
 
         [Theory]
-        [InlineData( float.NegativeInfinity,  float.NegativeInfinity,  float.NaN,    0.0f)]
-        [InlineData( float.NegativeInfinity,  float.NegativeInfinity, -2.35619449f,  CrossPlatformMachineEpsilon * 10, Skip = "https://github.com/dotnet/coreclr/issues/9806")]     // expected: -(3 * pi / 4)
         [InlineData( float.NegativeInfinity, -1.0f,                   -1.57079633f,  CrossPlatformMachineEpsilon * 10)]     // expected: -(pi / 2)
         [InlineData( float.NegativeInfinity, -0.0f,                   -1.57079633f,  CrossPlatformMachineEpsilon * 10)]     // expected: -(pi / 2)
         [InlineData( float.NegativeInfinity,  float.NaN,               float.NaN,    0.0f)]
         [InlineData( float.NegativeInfinity,  0.0f,                   -1.57079633f,  CrossPlatformMachineEpsilon * 10)]     // expected: -(pi / 2)
         [InlineData( float.NegativeInfinity,  1.0f,                   -1.57079633f,  CrossPlatformMachineEpsilon * 10)]     // expected: -(pi / 2)
-        [InlineData( float.NegativeInfinity,  float.PositiveInfinity,  float.NaN,    0.0f)]
-        [InlineData( float.NegativeInfinity,  float.PositiveInfinity, -0.785398163f, CrossPlatformMachineEpsilon, Skip = "https://github.com/dotnet/coreclr/issues/9806")]          // expected: -(pi / 4)
         [InlineData(-1.0f,                   -1.0f,                   -2.35619449f,  CrossPlatformMachineEpsilon * 10)]     // expected: -(3 * pi / 4)
         [InlineData(-1.0f,                   -0.0f,                   -1.57079633f,  CrossPlatformMachineEpsilon * 10)]     // expected: -(pi / 2)
         [InlineData(-1.0f,                    float.NaN,               float.NaN,    0.0f)]
@@ -387,16 +383,34 @@ namespace System.Tests
         [InlineData( 1.0f,                    0.0f,                    1.57079633f,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi / 2)
         [InlineData( 1.0f,                    1.0f,                    0.785398163f, CrossPlatformMachineEpsilon)]          // expected:  (pi / 4)
         [InlineData( 1.0f,                    float.PositiveInfinity,  0.0f,         0.0f)]
-        [InlineData( float.PositiveInfinity,  float.NegativeInfinity,  float.NaN,    0.0f)]
-        [InlineData( float.PositiveInfinity,  float.NegativeInfinity,  2.35619449f,  CrossPlatformMachineEpsilon * 10, Skip = "https://github.com/dotnet/coreclr/issues/9806")]     // expected:  (3 * pi / 4)
         [InlineData( float.PositiveInfinity, -1.0f,                    1.57079633f,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi / 2)
         [InlineData( float.PositiveInfinity, -0.0f,                    1.57079633f,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi / 2)
         [InlineData( float.PositiveInfinity,  float.NaN,               float.NaN,    0.0f)]
         [InlineData( float.PositiveInfinity,  0.0f,                    1.57079633f,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi / 2)
         [InlineData( float.PositiveInfinity,  1.0f,                    1.57079633f,  CrossPlatformMachineEpsilon * 10)]     // expected:  (pi / 2)
-        [InlineData( float.PositiveInfinity,  float.PositiveInfinity,  float.NaN,    0.0f)]
-        [InlineData( float.PositiveInfinity,  float.PositiveInfinity,  0.785398163f, CrossPlatformMachineEpsilon, Skip = "https://github.com/dotnet/coreclr/issues/9806")]          // expected:  (pi / 4)
         public static void Atan2(float y, float x, float expectedResult, float allowedVariance)
+        {
+            AssertEqual(expectedResult, MathF.Atan2(y, x), allowedVariance);
+        }
+
+        [Theory]
+        [InlineData( float.NegativeInfinity, float.NegativeInfinity, -2.35619449f,  CrossPlatformMachineEpsilon * 10)]     // expected: -(3 * pi / 4)
+        [InlineData( float.NegativeInfinity, float.PositiveInfinity, -0.785398163f, CrossPlatformMachineEpsilon)]          // expected: -(pi / 4)
+        [InlineData( float.PositiveInfinity, float.NegativeInfinity,  2.35619449f,  CrossPlatformMachineEpsilon * 10)]     // expected:  (3 * pi / 4
+        [InlineData( float.PositiveInfinity, float.PositiveInfinity,  0.785398163f, CrossPlatformMachineEpsilon)]          // expected:  (pi / 4)
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public static void Atan2_IEEE(float y, float x, float expectedResult, float allowedVariance)
+        {
+            AssertEqual(expectedResult, MathF.Atan2(y, x), allowedVariance);
+        }
+
+        [Theory]
+        [InlineData( float.NegativeInfinity, float.NegativeInfinity,  float.NaN, 0.0f)]
+        [InlineData( float.NegativeInfinity, float.PositiveInfinity,  float.NaN, 0.0f)]
+        [InlineData( float.PositiveInfinity, float.NegativeInfinity,  float.NaN, 0.0f)]
+        [InlineData( float.PositiveInfinity, float.PositiveInfinity,  float.NaN, 0.0f)]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+        public static void Atan2_IEEE_Legacy(float y, float x, float expectedResult, float allowedVariance)
         {
             AssertEqual(expectedResult, MathF.Atan2(y, x), allowedVariance);
         }
@@ -753,15 +767,11 @@ namespace System.Tests
         [InlineData(-2.71828183f,             1.0f,                   -2.71828183f,            CrossPlatformMachineEpsilon * 10)]       // x: -(e)  expected: (e)
         [InlineData(-2.71828183f,             1.57079633f,             float.NaN,              0.0f)]                                   // x: -(e)  y:  (pi / 2)
         [InlineData(-2.71828183f,             float.PositiveInfinity,  float.PositiveInfinity, 0.0f)]
-        [InlineData(-1.0f,                    float.NegativeInfinity,  float.NaN,              0.0f)]
-        [InlineData(-1.0f,                    float.NegativeInfinity,  1.0f,                   CrossPlatformMachineEpsilon * 10, Skip = "https://github.com/dotnet/coreclr/issues/9807")]
         [InlineData(-1.0f,                   -1.0f,                   -1.0f,                   CrossPlatformMachineEpsilon * 10)]
         [InlineData(-1.0f,                   -0.0f,                    1.0f,                   CrossPlatformMachineEpsilon * 10)]
         [InlineData(-1.0f,                    float.NaN,               float.NaN,              0.0f)]
         [InlineData(-1.0f,                    0.0f,                    1.0f,                   CrossPlatformMachineEpsilon * 10)]
         [InlineData(-1.0f,                    1.0f,                   -1.0f,                   CrossPlatformMachineEpsilon * 10)]
-        [InlineData(-1.0f,                    float.PositiveInfinity,  float.NaN,              0.0f)]
-        [InlineData(-1.0f,                    float.PositiveInfinity,  1.0f,                   CrossPlatformMachineEpsilon * 10, Skip = "https://github.com/dotnet/coreclr/issues/9807")]
         [InlineData(-0.0f,                    float.NegativeInfinity,  float.PositiveInfinity, 0.0f)]
         [InlineData(-0.0f,                   -3.0f,                    float.NegativeInfinity, 0.0f)]
         [InlineData(-0.0f,                   -2.0f,                    float.PositiveInfinity, 0.0f)]
@@ -777,11 +787,7 @@ namespace System.Tests
         [InlineData(-0.0f,                    float.PositiveInfinity,  0.0f,                   0.0f)]
         [InlineData( float.NaN,               float.NegativeInfinity,  float.NaN,              0.0f)]
         [InlineData( float.NaN,              -1.0f,                    float.NaN,              0.0f)]
-        [InlineData( float.NaN,              -0.0f,                    float.NaN,              0.0f)]
-        [InlineData( float.NaN,              -0.0f,                    1.0f,                   CrossPlatformMachineEpsilon * 10, Skip = "https://github.com/dotnet/coreclr/issues/9807")]
         [InlineData( float.NaN,               float.NaN,               float.NaN,              0.0f)]
-        [InlineData( float.NaN,               0.0f,                    float.NaN,              0.0f)]
-        [InlineData( float.NaN,               0.0f,                    1.0f,                   CrossPlatformMachineEpsilon * 10, Skip = "https://github.com/dotnet/coreclr/issues/9807")]
         [InlineData( float.NaN,               1.0f,                    float.NaN,              0.0f)]
         [InlineData( float.NaN,               float.PositiveInfinity,  float.NaN,              0.0f)]
         [InlineData( 0.0f,                    float.NegativeInfinity,  float.PositiveInfinity, 0.0f)]
@@ -800,8 +806,6 @@ namespace System.Tests
         [InlineData( 1.0f,                    float.NegativeInfinity,  1.0f,                   CrossPlatformMachineEpsilon * 10)]
         [InlineData( 1.0f,                   -1.0f,                    1.0f,                   CrossPlatformMachineEpsilon * 10)]
         [InlineData( 1.0f,                   -0.0f,                    1.0f,                   CrossPlatformMachineEpsilon * 10)]
-        [InlineData( 1.0f,                    float.NaN,               float.NaN,              0.0f)]
-        [InlineData( 1.0f,                    float.NaN,               1.0f,                   CrossPlatformMachineEpsilon * 10, Skip = "https://github.com/dotnet/coreclr/issues/9807")]
         [InlineData( 1.0f,                    0.0f,                    1.0f,                   CrossPlatformMachineEpsilon * 10)]
         [InlineData( 1.0f,                    1.0f,                    1.0f,                   CrossPlatformMachineEpsilon * 10)]
         [InlineData( 1.0f,                    float.PositiveInfinity,  1.0f,                   CrossPlatformMachineEpsilon * 10)]
@@ -879,6 +883,30 @@ namespace System.Tests
         [InlineData( float.PositiveInfinity,  1.0f,                    float.PositiveInfinity, 0.0f)]
         [InlineData( float.PositiveInfinity,  float.PositiveInfinity,  float.PositiveInfinity, 0.0f)]
         public static void Pow(float x, float y, float expectedResult, float allowedVariance)
+        {
+            AssertEqual(expectedResult, MathF.Pow(x, y), allowedVariance);
+        }
+
+        [Theory]
+        [InlineData(-1.0f,       float.NegativeInfinity, 1.0f, CrossPlatformMachineEpsilon * 10)]
+        [InlineData(-1.0f,       float.PositiveInfinity, 1.0f, CrossPlatformMachineEpsilon * 10)]
+        [InlineData( float.NaN, -0.0f,                   1.0f, CrossPlatformMachineEpsilon * 10)]
+        [InlineData( float.NaN,  0.0f,                   1.0f, CrossPlatformMachineEpsilon * 10)]
+        [InlineData( 1.0f,       float.NaN,              1.0f, CrossPlatformMachineEpsilon * 10)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public static void Pow_IEEE(float x, float y, float expectedResult, float allowedVariance)
+        {
+            AssertEqual(expectedResult, MathF.Pow(x, y), allowedVariance);
+        }
+
+        [Theory]
+        [InlineData(-1.0f,      float.NegativeInfinity, float.NaN, 0.0f)]
+        [InlineData(-1.0f,      float.PositiveInfinity, float.NaN, 0.0f)]
+        [InlineData( float.NaN,-0.0f,                   float.NaN, 0.0f)]
+        [InlineData( float.NaN, 0.0f,                   float.NaN, 0.0f)]
+        [InlineData( 1.0f,      float.NaN,              float.NaN, 0.0f)]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+        public static void Pow_IEEE_Legacy(float x, float y, float expectedResult, float allowedVariance)
         {
             AssertEqual(expectedResult, MathF.Pow(x, y), allowedVariance);
         }
@@ -1041,7 +1069,6 @@ namespace System.Tests
         [InlineData(-3.14159265f,            -0.0f,                   CrossPlatformMachineEpsilon)]         // value: -(pi)
         [InlineData(-2.71828183f,             0.450549534f,           CrossPlatformMachineEpsilon)]         // value: -(e)
         [InlineData(-2.30258509f,             1.11340715f,            CrossPlatformMachineEpsilon * 10)]    // value: -(ln(10))
-        [InlineData(-1.57079633f,             float.NegativeInfinity, 0.0f, Skip = "https://github.com/dotnet/coreclr/issues/10276")]                                // value: -(pi / 2)
         [InlineData(-1.57079633f,             22877332.0f,            0.0f)]                                // value: -(pi / 2)
         [InlineData(-1.44269504f,            -7.76357567f,            CrossPlatformMachineEpsilon * 10)]    // value: -(log2(e))
         [InlineData(-1.41421356f,            -6.33411917f,            CrossPlatformMachineEpsilon * 10)]    // value: -(sqrt(2))
@@ -1067,7 +1094,6 @@ namespace System.Tests
         [InlineData( 1.41421356f,             6.33411917f,            CrossPlatformMachineEpsilon * 10)]    // value:  (sqrt(2))
         [InlineData( 1.44269504f,             7.76357567f,            CrossPlatformMachineEpsilon * 10)]    // value:  (log2(e))
         [InlineData( 1.57079633f,            -22877332.0f,            0.0f)]                                // value:  (pi / 2)
-        [InlineData( 1.57079633f,             float.PositiveInfinity, 0.0f, Skip = "https://github.com/dotnet/coreclr/issues/10276")]                                // value:  (pi / 2)
         [InlineData( 2.30258509f,            -1.11340715f,            CrossPlatformMachineEpsilon * 10)]    // value:  (ln(10))
         [InlineData( 2.71828183f,            -0.450549534f,           CrossPlatformMachineEpsilon)]         // value:  (e)
         [InlineData( 3.14159265f,             0.0f,                   CrossPlatformMachineEpsilon)]         // value:  (pi)

--- a/src/System.Runtime.Extensions/tests/System/MathF.netcoreapp.cs
+++ b/src/System.Runtime.Extensions/tests/System/MathF.netcoreapp.cs
@@ -37,11 +37,11 @@ namespace System.Tests
                     return;
                 }
 
-                throw new EqualException($"{"NaN",10}", $"{actual,10:G9}");
+                throw new EqualException(ToString(expected), ToString(actual));
             }
             else if (float.IsNaN(actual))
             {
-                throw new EqualException($"{expected,10:G9}", $"{"NaN",10}");
+                throw new EqualException(ToString(expected), ToString(actual));
             }
 
             if (float.IsNegativeInfinity(expected))
@@ -51,11 +51,11 @@ namespace System.Tests
                     return;
                 }
 
-                throw new EqualException($"{"-∞",10}", $"{actual,10:G9}");
+                throw new EqualException(ToString(expected), ToString(actual));
             }
             else if (float.IsNegativeInfinity(actual))
             {
-                throw new EqualException($"{expected,10:G9}", $"{"-∞",10}");
+                throw new EqualException(ToString(expected), ToString(actual));
             }
 
             if (float.IsPositiveInfinity(expected))
@@ -65,11 +65,11 @@ namespace System.Tests
                     return;
                 }
 
-                throw new EqualException($"{"+∞",10}", $"{actual,10:G9}");
+                throw new EqualException(ToString(expected), ToString(actual));
             }
             else if (float.IsPositiveInfinity(actual))
             {
-                throw new EqualException($"{expected,10:G9}", $"{"+∞",10}");
+                throw new EqualException(ToString(expected), ToString(actual));
             }
 
             if (IsNegativeZero(expected))
@@ -81,7 +81,7 @@ namespace System.Tests
 
                 if (IsPositiveZero(variance) || IsNegativeZero(variance))
                 {
-                    throw new EqualException($"{"-0.0",10}", $"{actual,10:G9}");
+                    throw new EqualException(ToString(expected), ToString(actual));
                 }
 
                 // When the variance is not ±0.0, then we are handling a case where
@@ -102,7 +102,7 @@ namespace System.Tests
 
                 if (IsPositiveZero(variance))
                 {
-                    throw new EqualException($"{"+0.0",10}", $"{actual,10:G9}");
+                    throw new EqualException(ToString(expected), ToString(actual));
                 }
 
                 // When the variance is not ±0.0, then we are handling a case where
@@ -114,11 +114,11 @@ namespace System.Tests
                 // Do nothing, since the actual result could still be within the allowed variance
             }
 
-            var delta = MathF.Abs(actual - expected);
+            var delta = Math.Abs(actual - expected);
 
             if (delta > variance)
             {
-                throw new EqualException($"{expected,10:G9}", $"{actual,10:G9}");
+                throw new EqualException(ToString(expected), ToString(actual));
             }
         }
 
@@ -130,6 +130,34 @@ namespace System.Tests
         private unsafe static bool IsPositiveZero(float value)
         {
             return (*(uint*)(&value)) == 0x00000000;
+        }
+
+        private static string ToString(float value)
+        {
+            if (double.IsNaN(value))
+            {
+                return "NaN".PadLeft(10);
+            }
+            else if (double.IsPositiveInfinity(value))
+            {
+                return "+∞".PadLeft(10);
+            }
+            else if (double.IsNegativeInfinity(value))
+            {
+                return "-∞".PadLeft(10);
+            }
+            else if (IsNegativeZero(value))
+            {
+                return "-0.0".PadLeft(10);
+            }
+            else if (IsPositiveZero(value))
+            {
+                return "+0.0".PadLeft(10);
+            }
+            else
+            {
+                return $"{value,10:G9}";
+            }
         }
 
         [Theory]
@@ -375,37 +403,37 @@ namespace System.Tests
 
         [Theory]
         [InlineData(float.NegativeInfinity,  float.NegativeInfinity, 0.0f)]
-        [InlineData(-3.14159265f,           -3.0f,                   0.0f)]  // value: -(pi)
-        [InlineData(-2.71828183f,           -2.0f,                   0.0f)]  // value: -(e)
-        [InlineData(-2.30258509f,           -2.0f,                   0.0f)]  // value: -(ln(10))
-        [InlineData(-1.57079633f,           -1.0f,                   0.0f)]  // value: -(pi / 2)
-        [InlineData(-1.44269504f,           -1.0f,                   0.0f)]  // value: -(log2(e))
-        [InlineData(-1.41421356f,           -1.0f,                   0.0f)]  // value: -(sqrt(2))
-        [InlineData(-1.12837917f,           -1.0f,                   0.0f)]  // value: -(2 / sqrt(pi))
+        [InlineData(-3.14159265f,           -3.0f,                   0.0f)]     // value: -(pi)
+        [InlineData(-2.71828183f,           -2.0f,                   0.0f)]     // value: -(e)
+        [InlineData(-2.30258509f,           -2.0f,                   0.0f)]     // value: -(ln(10))
+        [InlineData(-1.57079633f,           -1.0f,                   0.0f)]     // value: -(pi / 2)
+        [InlineData(-1.44269504f,           -1.0f,                   0.0f)]     // value: -(log2(e))
+        [InlineData(-1.41421356f,           -1.0f,                   0.0f)]     // value: -(sqrt(2))
+        [InlineData(-1.12837917f,           -1.0f,                   0.0f)]     // value: -(2 / sqrt(pi))
         [InlineData(-1.0f,                  -1.0f,                   0.0f)]
-        [InlineData(-0.785398163f,           0.0f,                   0.0f)]  // value: -(pi / 4)
-        [InlineData(-0.707106781f,           0.0f,                   0.0f)]  // value: -(1 / sqrt(2))
-        [InlineData(-0.693147181f,           0.0f,                   0.0f)]  // value: -(ln(2))
-        [InlineData(-0.636619772f,           0.0f,                   0.0f)]  // value: -(2 / pi)
-        [InlineData(-0.434294482f,           0.0f,                   0.0f)]  // value: -(log10(e))
-        [InlineData(-0.318309886f,           0.0f,                   0.0f)]  // value: -(1 / pi)
+        [InlineData(-0.785398163f,           0.0f,                   0.0f)]     // value: -(pi / 4)
+        [InlineData(-0.707106781f,           0.0f,                   0.0f)]     // value: -(1 / sqrt(2))
+        [InlineData(-0.693147181f,           0.0f,                   0.0f)]     // value: -(ln(2))
+        [InlineData(-0.636619772f,           0.0f,                   0.0f)]     // value: -(2 / pi)
+        [InlineData(-0.434294482f,           0.0f,                   0.0f)]     // value: -(log10(e))
+        [InlineData(-0.318309886f,           0.0f,                   0.0f)]     // value: -(1 / pi)
         [InlineData(-0.0f,                  -0.0f,                   0.0f)]
         [InlineData( float.NaN,              float.NaN,              0.0f)]
         [InlineData( 0.0f,                   0.0f,                   0.0f)]
-        [InlineData( 0.318309886f,           1.0f,                   0.0f)]  // value:  (1 / pi)
-        [InlineData( 0.434294482f,           1.0f,                   0.0f)]  // value:  (log10(e))
-        [InlineData( 0.636619772f,           1.0f,                   0.0f)]  // value:  (2 / pi)
-        [InlineData( 0.693147181f,           1.0f,                   0.0f)]  // value:  (ln(2))
-        [InlineData( 0.707106781f,           1.0f,                   0.0f)]  // value:  (1 / sqrt(2))
-        [InlineData( 0.785398163f,           1.0f,                   0.0f)]  // value:  (pi / 4)
+        [InlineData( 0.318309886f,           1.0f,                   0.0f)]     // value:  (1 / pi)
+        [InlineData( 0.434294482f,           1.0f,                   0.0f)]     // value:  (log10(e))
+        [InlineData( 0.636619772f,           1.0f,                   0.0f)]     // value:  (2 / pi)
+        [InlineData( 0.693147181f,           1.0f,                   0.0f)]     // value:  (ln(2))
+        [InlineData( 0.707106781f,           1.0f,                   0.0f)]     // value:  (1 / sqrt(2))
+        [InlineData( 0.785398163f,           1.0f,                   0.0f)]     // value:  (pi / 4)
         [InlineData( 1.0f,                   1.0f,                   0.0f)]
-        [InlineData( 1.12837917f,            2.0f,                   0.0f)]  // value:  (2 / sqrt(pi))
-        [InlineData( 1.41421356f,            2.0f,                   0.0f)]  // value:  (sqrt(2))
-        [InlineData( 1.44269504f,            2.0f,                   0.0f)]  // value:  (log2(e))
-        [InlineData( 1.57079633f,            2.0f,                   0.0f)]  // value:  (pi / 2)
-        [InlineData( 2.30258509f,            3.0f,                   0.0f)]  // value:  (ln(10))
-        [InlineData( 2.71828183f,            3.0f,                   0.0f)]  // value:  (e)
-        [InlineData( 3.14159265f,            4.0f,                   0.0f)]  // value:  (pi)
+        [InlineData( 1.12837917f,            2.0f,                   0.0f)]     // value:  (2 / sqrt(pi))
+        [InlineData( 1.41421356f,            2.0f,                   0.0f)]     // value:  (sqrt(2))
+        [InlineData( 1.44269504f,            2.0f,                   0.0f)]     // value:  (log2(e))
+        [InlineData( 1.57079633f,            2.0f,                   0.0f)]     // value:  (pi / 2)
+        [InlineData( 2.30258509f,            3.0f,                   0.0f)]     // value:  (ln(10))
+        [InlineData( 2.71828183f,            3.0f,                   0.0f)]     // value:  (e)
+        [InlineData( 3.14159265f,            4.0f,                   0.0f)]     // value:  (pi)
         [InlineData(float.PositiveInfinity,  float.PositiveInfinity, 0.0f)]
         public static void Ceiling(float value, float expectedResult, float allowedVariance)
         {

--- a/src/System.Runtime.Numerics/tests/ComplexTests.cs
+++ b/src/System.Runtime.Numerics/tests/ComplexTests.cs
@@ -892,11 +892,61 @@ namespace System.Numerics.Tests
             yield return new object[] { RandomPositiveDouble(), RandomNegativePhase() }; // Fourth quadrant
         }
 
-        [ActiveIssue("https://github.com/dotnet/coreclr/issues/9806")]
         [Theory]
         [MemberData(nameof(FromPolarCoordinates_TestData))]
         [MemberData(nameof(Invalid_2_TestData))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public static void FromPolarCoordinates(double magnitude, double phase)
+        {
+            Complex complex = Complex.FromPolarCoordinates(magnitude, phase);
+
+            // double.IsNaN(magnitude) is checked in the verification method.
+            if (double.IsNaN(phase) || double.IsInfinity(phase))
+            {
+                magnitude = double.NaN;
+                phase = double.NaN;
+            }
+            // Special check in Complex.Abs method
+            else if (double.IsInfinity(magnitude))
+            {
+                magnitude = double.PositiveInfinity;
+                phase = double.NaN;
+            }
+
+            if (double.IsInfinity(complex.Imaginary) && double.IsInfinity(complex.Real))
+            {
+                if (double.IsNegativeInfinity(complex.Imaginary))
+                {
+                    if (double.IsNegativeInfinity(complex.Real))
+                    {
+                        phase = -3 * Math.PI / 4;
+                    }
+                    else
+                    {
+                        phase = -Math.PI / 4;
+                    }
+                }
+                else if (double.IsNegativeInfinity(complex.Real))
+                {
+                    phase = 3 * Math.PI / 4;
+                }
+                else
+                {
+                    phase = Math.PI / 4;
+                }
+            }
+
+            VerifyMagnitudePhaseProperties(complex, magnitude, phase);
+
+            complex = new Complex(complex.Real, complex.Imaginary);
+            VerifyMagnitudePhaseProperties(complex, magnitude, phase);
+        }
+
+        [Theory]
+        [MemberData(nameof(FromPolarCoordinates_TestData))]
+        [MemberData(nameof(Invalid_2_TestData))]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+        public static void FromPolarCoordinates_Legacy(double magnitude, double phase)
         {
             Complex complex = Complex.FromPolarCoordinates(magnitude, phase);
 


### PR DESCRIPTION
This resolves https://github.com/dotnet/corefx/issues/12855

These tests are essentially the same as those that are implemented in C++ in the CoreCLR PAL layer: https://github.com/dotnet/coreclr/tree/master/src/pal/tests/palsuite/c_runtime

These tests cover ~~all~~ most of the interesting corner cases, except for subnormal values, and max/min domain inputs.