### PR TITLE
Avoid allocation in SocketAsyncEventArgs when buffer configuration changes

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
@@ -22,7 +22,7 @@ namespace System.Net.Sockets
             // No-op for *nix.
         }
 
-        private void FreeInternals(bool calledFromFinalizer)
+        private void FreeInternals()
         {
             // No-op for *nix.
         }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
@@ -402,7 +402,7 @@ namespace System.Net.Sockets
             }
 
             // OK to dispose now.
-            FreeInternals(false);
+            FreeInternals();
 
             // Don't bother finalizing later.
             GC.SuppressFinalize(this);
@@ -410,7 +410,10 @@ namespace System.Net.Sockets
 
         ~SocketAsyncEventArgs()
         {
-            FreeInternals(true);
+            if (!Environment.HasShutdownStarted)
+            {
+                FreeInternals();
+            }
         }
 
         // NOTE: Use a try/finally to make sure Complete is called when you're done


### PR DESCRIPTION
(1) Manage our own buffer pinning, instead of having the Overlapped infrastructure do this.  This allows us to not reallocate Overlapped when buffer configuration changes.
(2) Only reallocate _wsaBuffersArray when it needs to grow, otherwise reuse existing array.