### PR TITLE
Add Retries to FSW WaitFor* Tests

### DIFF
--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.WaitForChanged.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.WaitForChanged.cs
@@ -146,26 +146,19 @@ namespace System.IO.Tests
                         }
                     }
 
-                    if ((TaskStatus.RanToCompletion != t.Status) ||
-                        (changeType != t.Result.ChangeType) ||
-                        (null == t.Result.Name) ||
-                        (null != t.Result.OldName) ||
-                        (t.Result.TimedOut))
+                    try
                     {
-                        if (i == DefaultAttemptsForExpectedEvent)
-                        {
-                            Assert.Equal(TaskStatus.RanToCompletion, t.Status);
-                            Assert.Equal(changeType, t.Result.ChangeType);
-                            Assert.NotNull(t.Result.Name);
-                            Assert.Null(t.Result.OldName);
-                            Assert.False(t.Result.TimedOut);
-                        }
+                        Assert.Equal(TaskStatus.RanToCompletion, t.Status);
+                        Assert.Equal(changeType, t.Result.ChangeType);
+                        Assert.NotNull(t.Result.Name);
+                        Assert.Null(t.Result.OldName);
+                        Assert.False(t.Result.TimedOut);
                     }
-                    else
+                    catch when (i < DefaultAttemptsForExpectedEvent)
                     {
-                        // This test has passed, so no need to retry it.
-                        break;
+                        continue;
                     }
+                    return;
                 }
             }
         }
@@ -187,11 +180,8 @@ namespace System.IO.Tests
                         File.AppendAllText(name, "text");
                         Task.Delay(BetweenOperationsDelayMilliseconds).Wait();
                     }
-                    if ((TaskStatus.RanToCompletion != t.Status) ||
-                        (WatcherChangeTypes.Changed != t.Result.ChangeType) ||
-                        (null == t.Result.Name) ||
-                        (null != t.Result.OldName) ||
-                        (t.Result.TimedOut))
+
+                    try
                     {
                         if (i == DefaultAttemptsForExpectedEvent)
                         {
@@ -202,11 +192,11 @@ namespace System.IO.Tests
                             Assert.False(t.Result.TimedOut);
                         }
                     }
-                    else
+                    catch when (i < DefaultAttemptsForExpectedEvent)
                     {
-                        // This test has passed, so no need to retry it.
-                        break;
+                        continue;
                     }
+                    return;
                 }
             }
         }
@@ -233,10 +223,7 @@ namespace System.IO.Tests
                         Task.Delay(BetweenOperationsDelayMilliseconds).Wait();
                     }
 
-                    if ((TaskStatus.RanToCompletion != t.Status) ||
-                        (t.Result.ChangeType != WatcherChangeTypes.Created && t.Result.ChangeType != WatcherChangeTypes.Renamed) ||
-                        (null == t.Result.Name) ||
-                        (t.Result.TimedOut))
+                    try
                     {
                         if (i == DefaultAttemptsForExpectedEvent)
                         {
@@ -246,11 +233,11 @@ namespace System.IO.Tests
                             Assert.False(t.Result.TimedOut);
                         }
                     }
-                    else
+                    catch when (i < DefaultAttemptsForExpectedEvent)
                     {
-                        // This test has passed, so no need to retry it.
-                        break;
+                        continue;
                     }
+                    return;
                 }
             }
         }

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.WaitForChanged.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.WaitForChanged.cs
@@ -125,7 +125,6 @@ namespace System.IO.Tests
         }
 
         [Theory]
-        [OuterLoop("This test has a longer than average timeout and may fail intermittently")]
         [InlineData(WatcherChangeTypes.Created)]
         [InlineData(WatcherChangeTypes.Deleted)]
         public void CreatedDeleted_Success(WatcherChangeTypes changeType)
@@ -133,76 +132,126 @@ namespace System.IO.Tests
             using (var testDirectory = new TempDirectory(GetTestFilePath()))
             using (var fsw = new FileSystemWatcher(testDirectory.Path))
             {
-                Task<WaitForChangedResult> t = Task.Run(() => fsw.WaitForChanged(changeType, LongWaitTimeout));
-                while (!t.IsCompleted)
+                for (int i = 1; i <= DefaultAttemptsForExpectedEvent; i++)
                 {
-                    string path = Path.Combine(testDirectory.Path, Path.GetRandomFileName());
-                    File.WriteAllText(path, "text");
-                    Task.Delay(BetweenOperationsDelayMilliseconds).Wait();
-                    if ((changeType & WatcherChangeTypes.Deleted) != 0)
+                    Task<WaitForChangedResult> t = Task.Run(() => fsw.WaitForChanged(changeType, WaitForExpectedEventTimeout));
+                    while (!t.IsCompleted)
                     {
-                        File.Delete(path);
+                        string path = Path.Combine(testDirectory.Path, Path.GetRandomFileName());
+                        File.WriteAllText(path, "text");
+                        Task.Delay(BetweenOperationsDelayMilliseconds).Wait();
+                        if ((changeType & WatcherChangeTypes.Deleted) != 0)
+                        {
+                            File.Delete(path);
+                        }
+                    }
+
+                    if ((TaskStatus.RanToCompletion != t.Status) ||
+                        (changeType != t.Result.ChangeType) ||
+                        (null == t.Result.Name) ||
+                        (null != t.Result.OldName) ||
+                        (t.Result.TimedOut))
+                    {
+                        if (i == DefaultAttemptsForExpectedEvent)
+                        {
+                            Assert.Equal(TaskStatus.RanToCompletion, t.Status);
+                            Assert.Equal(changeType, t.Result.ChangeType);
+                            Assert.NotNull(t.Result.Name);
+                            Assert.Null(t.Result.OldName);
+                            Assert.False(t.Result.TimedOut);
+                        }
+                    }
+                    else
+                    {
+                        // This test has passed, so no need to retry it.
+                        break;
                     }
                 }
-
-                Assert.Equal(TaskStatus.RanToCompletion, t.Status);
-                Assert.Equal(changeType, t.Result.ChangeType);
-                Assert.NotNull(t.Result.Name);
-                Assert.Null(t.Result.OldName);
-                Assert.False(t.Result.TimedOut);
             }
         }
 
         [Fact]
-        [OuterLoop("This test has a longer than average timeout and may fail intermittently")]
         public void Changed_Success()
         {
             using (var testDirectory = new TempDirectory(GetTestFilePath()))
             using (var fsw = new FileSystemWatcher(testDirectory.Path))
             {
-                string name = Path.Combine(testDirectory.Path, Path.GetRandomFileName());
-                File.Create(name).Dispose();
-
-                Task<WaitForChangedResult> t = Task.Run(() => fsw.WaitForChanged(WatcherChangeTypes.Changed, LongWaitTimeout));
-                while (!t.IsCompleted)
+                for (int i = 1; i <= DefaultAttemptsForExpectedEvent; i++)
                 {
-                    File.AppendAllText(name, "text");
-                    Task.Delay(BetweenOperationsDelayMilliseconds).Wait();
-                }
+                    string name = Path.Combine(testDirectory.Path, Path.GetRandomFileName());
+                    File.Create(name).Dispose();
 
-                Assert.Equal(TaskStatus.RanToCompletion, t.Status);
-                Assert.Equal(WatcherChangeTypes.Changed, t.Result.ChangeType);
-                Assert.NotNull(t.Result.Name);
-                Assert.Null(t.Result.OldName);
-                Assert.False(t.Result.TimedOut);
+                    Task<WaitForChangedResult> t = Task.Run(() => fsw.WaitForChanged(WatcherChangeTypes.Changed, WaitForExpectedEventTimeout));
+                    while (!t.IsCompleted)
+                    {
+                        File.AppendAllText(name, "text");
+                        Task.Delay(BetweenOperationsDelayMilliseconds).Wait();
+                    }
+                    if ((TaskStatus.RanToCompletion != t.Status) ||
+                        (WatcherChangeTypes.Changed != t.Result.ChangeType) ||
+                        (null == t.Result.Name) ||
+                        (null != t.Result.OldName) ||
+                        (t.Result.TimedOut))
+                    {
+                        if (i == DefaultAttemptsForExpectedEvent)
+                        {
+                            Assert.Equal(TaskStatus.RanToCompletion, t.Status);
+                            Assert.Equal(WatcherChangeTypes.Changed, t.Result.ChangeType);
+                            Assert.NotNull(t.Result.Name);
+                            Assert.Null(t.Result.OldName);
+                            Assert.False(t.Result.TimedOut);
+                        }
+                    }
+                    else
+                    {
+                        // This test has passed, so no need to retry it.
+                        break;
+                    }
+                }
             }
         }
 
         [Fact]
-        [OuterLoop("This test has a longer than average timeout and may fail intermittently")]
         public void Renamed_Success()
         {
             using (var testDirectory = new TempDirectory(GetTestFilePath()))
             using (var fsw = new FileSystemWatcher(testDirectory.Path))
             {
-                Task<WaitForChangedResult> t = Task.Run(() =>
-                    fsw.WaitForChanged(WatcherChangeTypes.Renamed | WatcherChangeTypes.Created, LongWaitTimeout)); // on some OSes, the renamed might come through as Deleted/Created
-
-                string name = Path.Combine(testDirectory.Path, Path.GetRandomFileName());
-                File.Create(name).Dispose();
-
-                while (!t.IsCompleted)
+                for (int i = 1; i <= DefaultAttemptsForExpectedEvent; i++)
                 {
-                    string newName = Path.Combine(testDirectory.Path, Path.GetRandomFileName());
-                    File.Move(name, newName);
-                    name = newName;
-                    Task.Delay(BetweenOperationsDelayMilliseconds).Wait();
-                }
+                    Task<WaitForChangedResult> t = Task.Run(() =>
+                        fsw.WaitForChanged(WatcherChangeTypes.Renamed | WatcherChangeTypes.Created, WaitForExpectedEventTimeout)); // on some OSes, the renamed might come through as Deleted/Created
 
-                Assert.Equal(TaskStatus.RanToCompletion, t.Status);
-                Assert.True(t.Result.ChangeType == WatcherChangeTypes.Created || t.Result.ChangeType == WatcherChangeTypes.Renamed);
-                Assert.NotNull(t.Result.Name);
-                Assert.False(t.Result.TimedOut);
+                    string name = Path.Combine(testDirectory.Path, Path.GetRandomFileName());
+                    File.Create(name).Dispose();
+
+                    while (!t.IsCompleted)
+                    {
+                        string newName = Path.Combine(testDirectory.Path, Path.GetRandomFileName());
+                        File.Move(name, newName);
+                        name = newName;
+                        Task.Delay(BetweenOperationsDelayMilliseconds).Wait();
+                    }
+
+                    if ((TaskStatus.RanToCompletion != t.Status) ||
+                        (t.Result.ChangeType != WatcherChangeTypes.Created && t.Result.ChangeType != WatcherChangeTypes.Renamed) ||
+                        (null == t.Result.Name) ||
+                        (t.Result.TimedOut))
+                    {
+                        if (i == DefaultAttemptsForExpectedEvent)
+                        {
+                            Assert.Equal(TaskStatus.RanToCompletion, t.Status);
+                            Assert.True(t.Result.ChangeType == WatcherChangeTypes.Created || t.Result.ChangeType == WatcherChangeTypes.Renamed);
+                            Assert.NotNull(t.Result.Name);
+                            Assert.False(t.Result.TimedOut);
+                        }
+                    }
+                    else
+                    {
+                        // This test has passed, so no need to retry it.
+                        break;
+                    }
+                }
             }
         }
 

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.WaitForChanged.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.WaitForChanged.cs
@@ -183,14 +183,11 @@ namespace System.IO.Tests
 
                     try
                     {
-                        if (i == DefaultAttemptsForExpectedEvent)
-                        {
-                            Assert.Equal(TaskStatus.RanToCompletion, t.Status);
-                            Assert.Equal(WatcherChangeTypes.Changed, t.Result.ChangeType);
-                            Assert.NotNull(t.Result.Name);
-                            Assert.Null(t.Result.OldName);
-                            Assert.False(t.Result.TimedOut);
-                        }
+                        Assert.Equal(TaskStatus.RanToCompletion, t.Status);
+                        Assert.Equal(WatcherChangeTypes.Changed, t.Result.ChangeType);
+                        Assert.NotNull(t.Result.Name);
+                        Assert.Null(t.Result.OldName);
+                        Assert.False(t.Result.TimedOut);
                     }
                     catch when (i < DefaultAttemptsForExpectedEvent)
                     {
@@ -225,13 +222,10 @@ namespace System.IO.Tests
 
                     try
                     {
-                        if (i == DefaultAttemptsForExpectedEvent)
-                        {
-                            Assert.Equal(TaskStatus.RanToCompletion, t.Status);
-                            Assert.True(t.Result.ChangeType == WatcherChangeTypes.Created || t.Result.ChangeType == WatcherChangeTypes.Renamed);
-                            Assert.NotNull(t.Result.Name);
-                            Assert.False(t.Result.TimedOut);
-                        }
+                        Assert.Equal(TaskStatus.RanToCompletion, t.Status);
+                        Assert.True(t.Result.ChangeType == WatcherChangeTypes.Created || t.Result.ChangeType == WatcherChangeTypes.Renamed);
+                        Assert.NotNull(t.Result.Name);
+                        Assert.False(t.Result.TimedOut);
                     }
                     catch when (i < DefaultAttemptsForExpectedEvent)
                     {


### PR DESCRIPTION
These tests are intermittently failing on some platforms from events not being risen by the filesystem. It's causing a fair amount of churn, so I'm adding retries to them like we have for a lot of the other FSW tests that are susceptible to intermittent failures. Doing so also greatly reduces the runtime in the failure case, allowing us to move the tests back to innerloop.

resolves https://github.com/dotnet/corefx/issues/16857

cc: @JeremyKuhne @danmosemsft 