### PR TITLE
Separate non-Windows platform detection to its own file to fix ilc errors

### DIFF
--- a/src/Common/tests/System/PlatformDetection.Unix.cs
+++ b/src/Common/tests/System/PlatformDetection.Unix.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using Xunit;
+
+namespace System
+{
+    public static partial class PlatformDetection
+    {
+        public static Version OSXKernelVersion { get; } = GetOSXKernelVersion();
+
+        private static Version GetOSXKernelVersion()
+        {
+            if (IsOSX)
+            {
+                byte[] bytes = new byte[256];
+                IntPtr bytesLength = new IntPtr(bytes.Length);
+                Assert.Equal(0, sysctlbyname("kern.osrelease", bytes, ref bytesLength, null, IntPtr.Zero));
+                string versionString = Encoding.UTF8.GetString(bytes);
+                return Version.Parse(versionString);
+            }
+
+            return new Version(0, 0, 0);
+        }
+
+        [DllImport("libc", SetLastError = true)]
+        private static extern int sysctlbyname(string ctlName, byte[] oldp, ref IntPtr oldpLen, byte[] newp, IntPtr newpLen);
+    }
+}

--- a/src/Common/tests/System/PlatformDetection.cs
+++ b/src/Common/tests/System/PlatformDetection.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace System
 {
-    public static class PlatformDetection
+    public static partial class PlatformDetection
     {
         public static bool IsFullFramework => RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
 
@@ -151,8 +151,6 @@ namespace System
             return false;
         }
 
-        public static Version OSXKernelVersion { get; } = GetOSXKernelVersion();
-
         private static IdVersionPair ParseOsReleaseFile()
         {
             Debug.Assert(RuntimeInformation.IsOSPlatform(OSPlatform.Linux));
@@ -236,23 +234,6 @@ namespace System
 
             return -1;
         }
-
-        private static Version GetOSXKernelVersion()
-        {
-            if (IsOSX)
-            {
-                byte[] bytes = new byte[256];
-                IntPtr bytesLength = new IntPtr(bytes.Length);
-                Assert.Equal(0, sysctlbyname("kern.osrelease", bytes, ref bytesLength, null, IntPtr.Zero));
-                string versionString = Encoding.UTF8.GetString(bytes);
-                return Version.Parse(versionString);
-            }
-
-            return new Version(0, 0, 0);
-        }
-
-        [DllImport("libc", SetLastError = true)]
-        private static extern int sysctlbyname(string ctlName, byte[] oldp, ref IntPtr oldpLen, byte[] newp, IntPtr newpLen);
 
         [DllImport("ntdll.dll")]
         private static extern int RtlGetVersion(out RTL_OSVERSIONINFOEX lpVersionInformation);

--- a/src/System.Globalization/tests/Configurations.props
+++ b/src/System.Globalization/tests/Configurations.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       netstandard;
+      uap-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoData.cs
+++ b/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoData.cs
@@ -29,19 +29,23 @@ namespace System.Globalization.Tests
 
         public static string[] FrFRDayNames()
         {
+#if !uap
             if (PlatformDetection.IsOSX && PlatformDetection.OSXKernelVersion < new Version(16, 0))
             {
                 return new string[] { "Dimanche", "Lundi", "Mardi", "Mercredi", "Jeudi", "Vendredi", "Samedi" };
             }
+#endif
             return new string[] { "dimanche", "lundi", "mardi", "mercredi", "jeudi", "vendredi", "samedi" };
         }
 
         public static string[] FrFRAbbreviatedDayNames()
         {
+#if !uap
             if (PlatformDetection.IsOSX  && PlatformDetection.OSXKernelVersion < new Version(16, 0))
             {
                 return new string[] { "Dim.", "Lun.", "Mar.", "Mer.", "Jeu.", "Ven.", "Sam." };
             }
+#endif
             return new string[] { "dim.", "lun.", "mar.", "mer.", "jeu.", "ven.", "sam." };
         }
 

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoData.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoData.cs
@@ -9,8 +9,11 @@ namespace System.Globalization.Tests
         public static int[] UrINNumberGroupSizes()
         {
             if ((PlatformDetection.IsWindows && PlatformDetection.WindowsVersion >= 10)
+#if !uap
                 ||
-                (PlatformDetection.IsOSX && PlatformDetection.OSXKernelVersion >= new Version(15, 0)))
+                (PlatformDetection.IsOSX && PlatformDetection.OSXKernelVersion >= new Version(15, 0))
+#endif
+                )
             {
                 return new int[] { 3 };
             }

--- a/src/System.Globalization/tests/System.Globalization.Tests.csproj
+++ b/src/System.Globalization/tests/System.Globalization.Tests.csproj
@@ -125,7 +125,7 @@
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
       <Link>Common\System\PlatformDetection.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\PlatformDetection.Unix.cs" Condition="'$(TargetGroup)' != 'uap'">
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.Unix.cs" Condition="'$(TargetsWindows)' != 'true'">
       <Link>Common\System\PlatformDetection.Unix.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)\System\RandomDataGenerator.cs">

--- a/src/System.Globalization/tests/System.Globalization.Tests.csproj
+++ b/src/System.Globalization/tests/System.Globalization.Tests.csproj
@@ -3,6 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{9A8926D9-1D4C-4069-8965-A626F6CA8C29}</ProjectGuid>
+    <DefineConstants Condition="'$(TargetGroup)' == 'uap'">$(DefineConstants);uap</DefineConstants>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
@@ -123,6 +124,9 @@
     <!-- Helpers -->
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
       <Link>Common\System\PlatformDetection.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.Unix.cs" Condition="'$(TargetGroup)' != 'uap'">
+      <Link>Common\System\PlatformDetection.Unix.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)\System\RandomDataGenerator.cs">
       <Link>Common\System\RandomDataGenerator.cs</Link>


### PR DESCRIPTION
cc: @weshaggard @tarekgh 

This is required for the ilc uapaot test run since if we don't separate this code out, then a reference to libc.dll will be added to the test assembly which will crash the ilc compiled runner at test execution time.