### PR TITLE
Fix Sec.AccessControl CommonSecurityDescriptor bug.

### DIFF
--- a/src/Common/src/Interop/Windows/advapi32/Interop.ConvertSdToStringSd.cs
+++ b/src/Common/src/Interop/Windows/advapi32/Interop.ConvertSdToStringSd.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-        [DllImport(Interop.Libraries.Advapi32, EntryPoint = "ConvertStringSecurityDescriptorToSecurityDescriptorW",
+        [DllImport(Interop.Libraries.Advapi32, EntryPoint = "ConvertSecurityDescriptorToStringSecurityDescriptorW",
             CallingConvention = CallingConvention.Winapi, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
         internal static extern bool ConvertSdToStringSd(
             byte[] securityDescriptor,

--- a/src/System.Security.AccessControl/tests/CommonSecurityDescriptor/CommonSecurityDescriptor_CreateFromRawSecurityDescriptor.cs
+++ b/src/System.Security.AccessControl/tests/CommonSecurityDescriptor/CommonSecurityDescriptor_CreateFromRawSecurityDescriptor.cs
@@ -46,7 +46,6 @@ namespace System.Security.AccessControl.Tests
 
         [Theory]
         [MemberData(nameof(CommonSecurityDescriptor_CreateFromRawSecurityDescriptor_TestData))]
-        [ActiveIssue(16919)]
         public static void TestCreateFromRawSecurityDescriptor(bool isContainer, bool isDS, string rawSecurityDescriptorSddl, string verifierSddl)
         {
             RawSecurityDescriptor rawSecurityDescriptor = new RawSecurityDescriptor(rawSecurityDescriptorSddl);

--- a/src/System.Security.AccessControl/tests/CommonSecurityDescriptor/CommonSecurityDescriptor_CreateFromSddlForm.cs
+++ b/src/System.Security.AccessControl/tests/CommonSecurityDescriptor/CommonSecurityDescriptor_CreateFromSddlForm.cs
@@ -83,7 +83,6 @@ namespace System.Security.AccessControl.Tests
 
         [Theory]
         [MemberData(nameof(CommonSecurityDescriptor_CreateFromSddlForm_TestData))]
-        [ActiveIssue(16919)]
         public static void TestCreateFromSddlForm(bool isContainer, bool isDS, string sddl, string verifierSddl)
         {
             CommonSecurityDescriptor commonSecurityDescriptor = null;

--- a/src/System.Security.AccessControl/tests/CommonSecurityDescriptor/CommonSecurityDescriptor_GetSddlForm.cs
+++ b/src/System.Security.AccessControl/tests/CommonSecurityDescriptor/CommonSecurityDescriptor_GetSddlForm.cs
@@ -13,7 +13,7 @@ namespace System.Security.AccessControl.Tests
     {
        public static IEnumerable<object[]> CommonSecurityDescriptor_GetSddlForm_TestData()
        {
-           yield return new object[] { true, false, 20, "BA", "BG", "64:2:4096:BA:false:0", "0:1:4096:BO:false:0", false, false, false, false , null};
+           yield return new object[] { true, false, 20, "BA", "BG", "64:2:4096:BA:false:0", "0:1:4096:BO:false:0", false, false, false, false , "" };
            yield return new object[] { true, false, 20, "BA", "BG", "64:2:4096:BA:false:0", "0:1:4096:BO:false:0", false, false, false, true , "D:(D;;0x1000;;;BO)" };
            yield return new object[] { true, false, 20, "BA", "BG", "64:2:4096:BA:false:0", "0:1:4096:BO:false:0", false, false, true , false, "S:(AU;SA;0x1000;;;BA)" };
            yield return new object[] { true, false, 20, "BA", "BG", "64:2:4096:BA:false:0", "0:1:4096:BO:false:0", false, false, true , true , "D:(D;;0x1000;;;BO)S:(AU;SA;0x1000;;;BA)" };
@@ -29,7 +29,7 @@ namespace System.Security.AccessControl.Tests
            yield return new object[] { true, false, 20, "BA", "BG", "64:2:4096:BA:false:0", "0:1:4096:BO:false:0", true , true , false, true , "O:BAG:BGD:(D;;0x1000;;;BO)" };
            yield return new object[] { true, false, 20, "BA", "BG", "64:2:4096:BA:false:0", "0:1:4096:BO:false:0", true , true , true , false, "O:BAG:BGS:(AU;SA;0x1000;;;BA)" };
            yield return new object[] { true, false, 20, "BA", "BG", "64:2:4096:BA:false:0", "0:1:4096:BO:false:0", true , true , true , true , "O:BAG:BGD:(D;;0x1000;;;BO)S:(AU;SA;0x1000;;;BA)" };
-           yield return new object[] { true, false, 0 , null, null, null                  , null                 , true , true , true , true , null};
+           yield return new object[] { true, false, 0 , null, null, null                  , null                 , true , true , true , true , "" };
            yield return new object[] { true, false, 4 , "BA", "BG", "64:2:4096:BA:false:0", "0:1:4096:BO:false:0", true , true , true , true , "O:BAG:BGD:(D;;0x1000;;;BO)S:(AU;SA;0x1000;;;BA)" };
            yield return new object[] { true, false, 4 , "BA", "BG", null                  , "0:1:4096:BO:false:0", true , true , true , true , "O:BAG:BGD:(D;;0x1000;;;BO)" };
            yield return new object[] { true, false, 20, "BA", "BG", null                  , "0:1:4096:BO:false:0", true , true , true , true , "O:BAG:BGD:(D;;0x1000;;;BO)" };
@@ -42,7 +42,6 @@ namespace System.Security.AccessControl.Tests
 
         [Theory]
         [MemberData(nameof(CommonSecurityDescriptor_GetSddlForm_TestData))]
-        [ActiveIssue(16919)]
         public static void TestGetSddlForm(bool isContainer, bool isDS, int flags, string ownerStr, string groupStr, string saclStr, string daclStr, bool getOwner, bool getGroup, bool getSacl, bool getDacl, string expectedSddl)
         {
             CommonSecurityDescriptor commonSecurityDescriptor = null;
@@ -83,10 +82,7 @@ namespace System.Security.AccessControl.Tests
                 accControlSections |= AccessControlSections.Access;
 
             resultSddl = commonSecurityDescriptor.GetSddlForm(accControlSections);
-            if (expectedSddl == null || resultSddl == null)
-                Assert.True(expectedSddl == null && resultSddl == null);
-            else
-                Assert.True(String.Compare(expectedSddl, resultSddl, StringComparison.CurrentCultureIgnoreCase) == 0);
+            Assert.True(string.Compare(expectedSddl, resultSddl, StringComparison.CurrentCultureIgnoreCase) == 0);
         }
 
     }

--- a/src/System.Security.AccessControl/tests/CommonSecurityDescriptor/CommonSecurityDescriptor_PurgeAccessControl.cs
+++ b/src/System.Security.AccessControl/tests/CommonSecurityDescriptor/CommonSecurityDescriptor_PurgeAccessControl.cs
@@ -36,7 +36,6 @@ namespace System.Security.AccessControl.Tests
 
         [Theory]
         [MemberData(nameof(CommonSecurityDescriptor_PurgeAccessControl_TestData))]
-        [ActiveIssue(16919)]
         public static void TestPurgeAccessControl(bool isContainer, bool isDS, string sddl, string sidString, string verifierSddl)
         {
             CommonSecurityDescriptor commonSecurityDescriptor = null;

--- a/src/System.Security.AccessControl/tests/CommonSecurityDescriptor/CommonSecurityDescriptor_PurgeAudit.cs
+++ b/src/System.Security.AccessControl/tests/CommonSecurityDescriptor/CommonSecurityDescriptor_PurgeAudit.cs
@@ -37,7 +37,6 @@ namespace System.Security.AccessControl.Tests
 
         [Theory]
         [MemberData(nameof(CommonSecurityDescriptor_PurgeAudit_TestData))]
-        [ActiveIssue(16919)]
         public static void TestPurgeAudit(bool isContainer, bool isDS, string sddl, string sidString, string verifierSddl)
         {
             CommonSecurityDescriptor commonSecurityDescriptor = null;

--- a/src/System.Security.AccessControl/tests/CommonSecurityDescriptor/CommonSecurityDescriptor_SetDiscretionaryAclProtection.cs
+++ b/src/System.Security.AccessControl/tests/CommonSecurityDescriptor/CommonSecurityDescriptor_SetDiscretionaryAclProtection.cs
@@ -24,7 +24,6 @@ namespace System.Security.AccessControl.Tests
 
         [Theory]
         [MemberData(nameof(CommonSecurityDescriptor_SetDiscretionaryAclProtection_TestData))]
-        [ActiveIssue(16919)]
         public static void TestSetDiscretionaryAclProtection(bool isContainer, bool isDS, string sddl, bool isProtected, bool preserveInheritance, string verifierSddl)
         {
             CommonSecurityDescriptor commonSecurityDescriptor = null;

--- a/src/System.Security.AccessControl/tests/CommonSecurityDescriptor/CommonSecurityDescriptor_SetSystemAclProtection.cs
+++ b/src/System.Security.AccessControl/tests/CommonSecurityDescriptor/CommonSecurityDescriptor_SetSystemAclProtection.cs
@@ -50,7 +50,6 @@ namespace System.Security.AccessControl.Tests
 
         [Theory]
         [MemberData(nameof(CommonSecurityDescriptor_SetSystemAclProtection_TestData))]
-        [ActiveIssue(16919)]
         public static void TestSetSystemAclProtection(bool isContainer, bool isDS, string sddl, bool isProtected, bool preserveInheritance, string verifierSddl)
         {
             CommonSecurityDescriptor commonSecurityDescriptor = null;


### PR DESCRIPTION
When the source for System.Security.AccessControl was ported, one of the Interop functions was misnamed. This was causing the entire CommonSecurityDescriptor class to be broken, and since the tests weren't ported until later we weren't aware that it was broken. This Commit fixes the function call and re-enables the tests that assert the correct behavior (verified against desktop).

resolves https://github.com/dotnet/corefx/issues/16919

PTAL: @bartonjs 
FYI: @danmosemsft @joperezr @LordMike (fixes your https://github.com/DiscUtils/DiscUtils/issues/14)