### PR TITLE
Update localization resource string for etw tracing event source to reflect the System.Transctions.Local name change.

### DIFF
--- a/src/System.Transactions.Local/src/System/Transactions/TransactionsEtwProvider.cs
+++ b/src/System.Transactions.Local/src/System/Transactions/TransactionsEtwProvider.cs
@@ -73,7 +73,7 @@ namespace System.Transactions
     [EventSource(
         Name = "System.Transactions.TransactionsEventSource",
         Guid = "8ac2d80a-1f1a-431b-ace4-bff8824aef0b",
-        LocalizationResources = "FxResources.System.Transactions.SR")]
+        LocalizationResources = "FxResources.System.Transactions.Local.SR")]
     internal sealed class TransactionsEtwProvider : EventSource
     {
         /// <summary>


### PR DESCRIPTION
Need to update the resource string for System.Transactions.Local etw event provider.