### PR TITLE
Fix System.Console difference in behavior

### DIFF
--- a/src/System.Console/src/System/Console.cs
+++ b/src/System.Console/src/System/Console.cs
@@ -223,10 +223,6 @@ namespace System
             }
             set
             {
-                if (value <= 0)
-                {
-                    throw new ArgumentOutOfRangeException("width", value, SR.ArgumentOutOfRange_NeedPosNum);
-                }
                 ConsolePal.WindowWidth = value;
             }
         }
@@ -239,10 +235,6 @@ namespace System
             }
             set
             {
-                if (value <= 0)
-                {
-                    throw new ArgumentOutOfRangeException("height", value, SR.ArgumentOutOfRange_NeedPosNum);
-                }
                 ConsolePal.WindowHeight = value;
             }
         }

--- a/src/System.Console/tests/WindowAndCursorProps.cs
+++ b/src/System.Console/tests/WindowAndCursorProps.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Threading;
 using Xunit;
 using Xunit.NetCore.Extensions;
 
@@ -33,8 +34,16 @@ public class WindowAndCursorProps : RemoteExecutorTestBase
     [Fact]
     public static void WindowWidth_WindowHeight_InvalidSize()
     {
-        Assert.Throws<ArgumentOutOfRangeException>("width", () => Console.WindowWidth = 0);
-        Assert.Throws<ArgumentOutOfRangeException>("height", () => Console.WindowHeight = 0);
+        if (Console.IsOutputRedirected)
+        {
+            Assert.Throws<IOException>(() => Console.WindowWidth = 0);
+            Assert.Throws<IOException>(() => Console.WindowHeight = 0);
+        }
+        else
+        {
+            Assert.Throws<ArgumentOutOfRangeException>("width", () => Console.WindowWidth = 0);
+            Assert.Throws<ArgumentOutOfRangeException>("height", () => Console.WindowHeight = 0);
+        }
     }
 
     [Fact]

--- a/src/System.Console/tests/WindowAndCursorProps.cs
+++ b/src/System.Console/tests/WindowAndCursorProps.cs
@@ -6,7 +6,6 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
-using System.Threading;
 using Xunit;
 using Xunit.NetCore.Extensions;
 

--- a/src/System.Console/tests/WindowAndCursorProps.cs
+++ b/src/System.Console/tests/WindowAndCursorProps.cs
@@ -31,6 +31,7 @@ public class WindowAndCursorProps : RemoteExecutorTestBase
     }
 
     [Fact]
+    [PlatformSpecific(TestPlatforms.Windows)]  // Expected behavior specific to Windows
     public static void WindowWidth_WindowHeight_InvalidSize()
     {
         if (Console.IsOutputRedirected)


### PR DESCRIPTION
We were having a difference in behavior where in `Console.WindowWidth` and `Console.WindowHeight` setters in Core if the value was <= 0 we would throw an `ArgumentOutOfRangeException` no matter if the Console output is redirected. In desktop if the output is redirected and we try to change the Console Width/Height we would get a `System.IO.IOException` so this was causing a test to fail when the output was redirected e.g executing through MsBuild.

cc: @weshaggard @tarekgh @stephentoub @danmosemsft 