### PR TITLE
Fix erroneous XML doc in ImmutableArray

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray.cs
@@ -137,7 +137,7 @@ namespace System.Collections.Immutable
         }
 
         /// <summary>
-        /// Creates an empty <see cref="ImmutableArray{T}"/>.
+        /// Creates an <see cref="ImmutableArray{T}"/> with the specified elements.
         /// </summary>
         /// <typeparam name="T">The type of element stored in the array.</typeparam>
         /// <param name="items">The elements to store in the array.</param>


### PR DESCRIPTION
`ImmutableArray.Create(T[])` does not always create an empty immutable array. I noticed this in Visual Studio while using `ImmutableArray` in one of my own projects.

/cc @AArnott, @stephentoub 