### PR TITLE
Revert "remove references to System.Reflection.Emit.Xxx for UAP builds of System.Linq.Expressions"

### DIFF
--- a/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
+++ b/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
@@ -36,6 +36,9 @@
     <ProjectReference Include="..\..\System.ObjectModel\src\System.ObjectModel.csproj" />
     <ProjectReference Include="..\..\System.Reflection.Primitives\src\System.Reflection.Primitives.csproj" />
     <ProjectReference Include="..\..\System.Linq\src\System.Linq.csproj" />
+    <Reference Include="System.Reflection.Emit.ILGeneration" /> <!-- Have to add reference to ref because the contract is not fulfilled yet -->
+    <Reference Include="System.Reflection.Emit" /> <!-- Have to add reference to ref because the contract is not fulfilled yet -->
+    <Reference Include="System.Reflection.Emit.Lightweight" /> <!-- Have to add reference to ref because the contract is not fulfilled yet -->
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'uapaot'">
     <Reference Include="System.Collections" />

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -50,6 +50,9 @@
     <ReferenceFromRuntime Include="System.Runtime.InteropServices" />
     <ReferenceFromRuntime Include="System.Private.Interop" />
     <ReferenceFromRuntime Include="netstandard" />
+    <Reference Include="System.Reflection.Emit.ILGeneration" />
+    <Reference Include="System.Reflection.Emit" />
+    <Reference Include="System.Reflection.Emit.Lightweight" />
   </ItemGroup>
   <ItemGroup>
     <!-- Remove this when TypeBuilder extends TypeInfo. See https://github.com/dotnet/corefx/issues/14334 -->


### PR DESCRIPTION
Reverts dotnet/corefx#17252

This broke the uapaot vertical build.

cc: @danmosemsft @VSadov 