### PR TITLE
Fix NotImplementedExceptions related to sha256, sha384, sha512 in SignedXML

### DIFF
--- a/src/System.Security.Cryptography.Xml/src/System.Security.Cryptography.Xml.csproj
+++ b/src/System.Security.Cryptography.Xml/src/System.Security.Cryptography.Xml.csproj
@@ -83,7 +83,7 @@
     <Compile Include="System\Security\Cryptography\Xml\XmlDsigXsltTransform.cs" />
     <Compile Include="System\Security\Cryptography\Xml\XmlLicenseTransform.cs" />
     <Compile Include="System\Security\Cryptography\Xml\CryptoHelpers.cs" />
-    <Compile Include="System\Security\Cryptography\Xml\RSAPKCS1SignatureDescriptionBase.cs" />
+    <Compile Include="System\Security\Cryptography\Xml\RSAPKCS1SignatureDescription.cs" />
     <Compile Include="System\Security\Cryptography\Xml\RSAPKCS1SHA1SignatureDescription.cs" />
     <Compile Include="System\Security\Cryptography\Xml\RSAPKCS1SHA256SignatureDescription.cs" />
     <Compile Include="System\Security\Cryptography\Xml\RSAPKCS1SHA512SignatureDescription.cs" />

--- a/src/System.Security.Cryptography.Xml/src/System.Security.Cryptography.Xml.csproj
+++ b/src/System.Security.Cryptography.Xml/src/System.Security.Cryptography.Xml.csproj
@@ -83,7 +83,11 @@
     <Compile Include="System\Security\Cryptography\Xml\XmlDsigXsltTransform.cs" />
     <Compile Include="System\Security\Cryptography\Xml\XmlLicenseTransform.cs" />
     <Compile Include="System\Security\Cryptography\Xml\CryptoHelpers.cs" />
+    <Compile Include="System\Security\Cryptography\Xml\RSAPKCS1SignatureDescriptionBase.cs" />
     <Compile Include="System\Security\Cryptography\Xml\RSAPKCS1SHA1SignatureDescription.cs" />
+    <Compile Include="System\Security\Cryptography\Xml\RSAPKCS1SHA256SignatureDescription.cs" />
+    <Compile Include="System\Security\Cryptography\Xml\RSAPKCS1SHA512SignatureDescription.cs" />
+    <Compile Include="System\Security\Cryptography\Xml\RSAPKCS1SHA384SignatureDescription.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Collections" />

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CryptoHelpers.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CryptoHelpers.cs
@@ -60,17 +60,13 @@ namespace System.Security.Cryptography.Xml
                 case "http://www.w3.org/2000/09/xmldsig#rsa-sha1":
                     return new RSAPKCS1SHA1SignatureDescription();
                 case "System.Security.Cryptography.RSASignatureDescription":
-                    throw new NotImplementedException(name);
-                    //return new RSAPKCS1SHA1SignatureDescription();
+                    return new RSAPKCS1SHA1SignatureDescription();
                 case "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256":
-                    throw new NotImplementedException(name);
-                    //return new RSAPKCS1SHA256SignatureDescription();
+                    return new RSAPKCS1SHA256SignatureDescription();
                 case "http://www.w3.org/2001/04/xmldsig-more#rsa-sha384":
-                    throw new NotImplementedException(name);
-                    //return new RSAPKCS1SHA384SignatureDescription();
+                    return new RSAPKCS1SHA384SignatureDescription();
                 case "http://www.w3.org/2001/04/xmldsig-more#rsa-sha512":
-                    throw new NotImplementedException(name);
-                    //return new RSAPKCS1SHA512SignatureDescription();
+                    return new RSAPKCS1SHA512SignatureDescription();
 
                 // workarounds for issue https://github.com/dotnet/corefx/issues/16563
                 // remove attribute from this method when removing them

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/RSAPKCS1SHA1SignatureDescription.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/RSAPKCS1SHA1SignatureDescription.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace System.Security.Cryptography.Xml
 {
-    internal class RSAPKCS1SHA1SignatureDescription : RSAPKCS1SignatureDescriptionBase
+    internal class RSAPKCS1SHA1SignatureDescription : RSAPKCS1SignatureDescription
     {
         public RSAPKCS1SHA1SignatureDescription() : base("SHA1")
         {

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/RSAPKCS1SHA256SignatureDescription.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/RSAPKCS1SHA256SignatureDescription.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace System.Security.Cryptography.Xml
 {
-    internal class RSAPKCS1SHA256SignatureDescription : RSAPKCS1SignatureDescriptionBase
+    internal class RSAPKCS1SHA256SignatureDescription : RSAPKCS1SignatureDescription
     {
         public RSAPKCS1SHA256SignatureDescription() : base("SHA256")
         {

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/RSAPKCS1SHA256SignatureDescription.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/RSAPKCS1SHA256SignatureDescription.cs
@@ -10,16 +10,15 @@ using System.Threading.Tasks;
 
 namespace System.Security.Cryptography.Xml
 {
-    internal class RSAPKCS1SHA1SignatureDescription : RSAPKCS1SignatureDescriptionBase
+    internal class RSAPKCS1SHA256SignatureDescription : RSAPKCS1SignatureDescriptionBase
     {
-        public RSAPKCS1SHA1SignatureDescription() : base("SHA1")
+        public RSAPKCS1SHA256SignatureDescription() : base("SHA256")
         {
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA5350", Justification = "SHA1 needed for compat.")]
         public sealed override HashAlgorithm CreateDigest()
         {
-            return SHA1.Create();
+            return SHA256.Create();
         }
     }
 }

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/RSAPKCS1SHA384SignatureDescription.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/RSAPKCS1SHA384SignatureDescription.cs
@@ -10,16 +10,15 @@ using System.Threading.Tasks;
 
 namespace System.Security.Cryptography.Xml
 {
-    internal class RSAPKCS1SHA1SignatureDescription : RSAPKCS1SignatureDescriptionBase
+    internal class RSAPKCS1SHA384SignatureDescription : RSAPKCS1SignatureDescriptionBase
     {
-        public RSAPKCS1SHA1SignatureDescription() : base("SHA1")
+        public RSAPKCS1SHA384SignatureDescription() : base("SHA384")
         {
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA5350", Justification = "SHA1 needed for compat.")]
         public sealed override HashAlgorithm CreateDigest()
         {
-            return SHA1.Create();
+            return SHA384.Create();
         }
     }
 }

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/RSAPKCS1SHA384SignatureDescription.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/RSAPKCS1SHA384SignatureDescription.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace System.Security.Cryptography.Xml
 {
-    internal class RSAPKCS1SHA384SignatureDescription : RSAPKCS1SignatureDescriptionBase
+    internal class RSAPKCS1SHA384SignatureDescription : RSAPKCS1SignatureDescription
     {
         public RSAPKCS1SHA384SignatureDescription() : base("SHA384")
         {

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/RSAPKCS1SHA512SignatureDescription.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/RSAPKCS1SHA512SignatureDescription.cs
@@ -10,16 +10,15 @@ using System.Threading.Tasks;
 
 namespace System.Security.Cryptography.Xml
 {
-    internal class RSAPKCS1SHA1SignatureDescription : RSAPKCS1SignatureDescriptionBase
+    internal class RSAPKCS1SHA512SignatureDescription : RSAPKCS1SignatureDescriptionBase
     {
-        public RSAPKCS1SHA1SignatureDescription() : base("SHA1")
+        public RSAPKCS1SHA512SignatureDescription() : base("SHA512")
         {
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA5350", Justification = "SHA1 needed for compat.")]
         public sealed override HashAlgorithm CreateDigest()
         {
-            return SHA1.Create();
+            return SHA512.Create();
         }
     }
 }

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/RSAPKCS1SHA512SignatureDescription.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/RSAPKCS1SHA512SignatureDescription.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace System.Security.Cryptography.Xml
 {
-    internal class RSAPKCS1SHA512SignatureDescription : RSAPKCS1SignatureDescriptionBase
+    internal class RSAPKCS1SHA512SignatureDescription : RSAPKCS1SignatureDescription
     {
         public RSAPKCS1SHA512SignatureDescription() : base("SHA512")
         {

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/RSAPKCS1SignatureDescription.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/RSAPKCS1SignatureDescription.cs
@@ -10,9 +10,9 @@ using System.Threading.Tasks;
 
 namespace System.Security.Cryptography.Xml
 {
-    internal abstract class RSAPKCS1SignatureDescriptionBase : SignatureDescription
+    internal abstract class RSAPKCS1SignatureDescription : SignatureDescription
     {
-        public RSAPKCS1SignatureDescriptionBase(string hashAlgorithmName)
+        public RSAPKCS1SignatureDescription(string hashAlgorithmName)
         {
             KeyAlgorithm = typeof(System.Security.Cryptography.RSA).AssemblyQualifiedName;
             FormatterAlgorithm = typeof(System.Security.Cryptography.RSAPKCS1SignatureFormatter).AssemblyQualifiedName;

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/RSAPKCS1SignatureDescriptionBase.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/RSAPKCS1SignatureDescriptionBase.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System.Security.Cryptography.Xml
+{
+    internal abstract class RSAPKCS1SignatureDescriptionBase : SignatureDescription
+    {
+        public RSAPKCS1SignatureDescriptionBase(string hashAlgorithmName)
+        {
+            KeyAlgorithm = typeof(System.Security.Cryptography.RSA).AssemblyQualifiedName;
+            FormatterAlgorithm = typeof(System.Security.Cryptography.RSAPKCS1SignatureFormatter).AssemblyQualifiedName;
+            DeformatterAlgorithm = typeof(System.Security.Cryptography.RSAPKCS1SignatureDeformatter).AssemblyQualifiedName;
+            DigestAlgorithm = hashAlgorithmName;
+        }
+
+        public sealed override AsymmetricSignatureDeformatter CreateDeformatter(AsymmetricAlgorithm key)
+        {
+            var item = (AsymmetricSignatureDeformatter)CryptoHelpers.CreateFromName(DeformatterAlgorithm);
+            item.SetKey(key);
+            item.SetHashAlgorithm(DigestAlgorithm);
+            return item;
+        }
+
+        public sealed override AsymmetricSignatureFormatter CreateFormatter(AsymmetricAlgorithm key)
+        {
+            var item = (AsymmetricSignatureFormatter)CryptoHelpers.CreateFromName(FormatterAlgorithm);
+            item.SetKey(key);
+            item.SetHashAlgorithm(DigestAlgorithm);
+            return item;
+        }
+
+        public abstract override HashAlgorithm CreateDigest();
+    }
+}

--- a/src/System.Security.Cryptography.Xml/tests/Samples/SigningVerifyingWithCustomSignatureMethod.cs
+++ b/src/System.Security.Cryptography.Xml/tests/Samples/SigningVerifyingWithCustomSignatureMethod.cs
@@ -1,0 +1,76 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using Xunit;
+
+namespace System.Security.Cryptography.Xml.Tests
+{
+    // Based on implementation of MSDN samples:
+    // Signing: https://msdn.microsoft.com/en-us/library/ms229745(v=vs.110).aspx
+    // Verifying: https://msdn.microsoft.com/en-us/library/ms229745(v=vs.110).aspx
+    public class SigningAndVerifyingWithCustomSignatureMethod
+    {
+        const string ExampleXml = @"<?xml version=""1.0""?>
+<example>
+<test>some text node</test>
+</example>";
+
+        private static void SignXml(XmlDocument doc, RSA key, string signatureMethod, string digestMethod)
+        {
+            var signedXml = new SignedXml(doc)
+            {
+                SigningKey = key
+            };
+
+            signedXml.SignedInfo.SignatureMethod = signatureMethod;
+
+            var reference = new Reference();
+            reference.Uri = "";
+
+            reference.AddTransform(new XmlDsigEnvelopedSignatureTransform());
+            reference.DigestMethod = digestMethod;
+
+            signedXml.AddReference(reference);
+
+            signedXml.ComputeSignature();
+            XmlElement xmlDigitalSignature = signedXml.GetXml();
+            doc.DocumentElement.AppendChild(doc.ImportNode(xmlDigitalSignature, true));
+        }
+
+        private static bool VerifyXml(string signedXmlText, RSA key)
+        {
+            XmlDocument xmlDoc = new XmlDocument();
+            xmlDoc.PreserveWhitespace = true;
+            xmlDoc.LoadXml(signedXmlText);
+
+            SignedXml signedXml = new SignedXml(xmlDoc);
+            var signatureNode = (XmlElement)xmlDoc.GetElementsByTagName("Signature")[0];
+            signedXml.LoadXml(signatureNode);
+            return signedXml.CheckSignature(key);
+        }
+
+        [Theory]
+        [InlineData("http://www.w3.org/2001/04/xmldsig-more#rsa-sha256", "http://www.w3.org/2001/04/xmlenc#sha256")]
+        [InlineData("http://www.w3.org/2001/04/xmldsig-more#rsa-sha384", "http://www.w3.org/2001/04/xmldsig-more#sha384")]
+        [InlineData("http://www.w3.org/2001/04/xmldsig-more#rsa-sha512", "http://www.w3.org/2001/04/xmlenc#sha512")]
+        [InlineData("http://www.w3.org/2001/04/xmldsig-more#rsa-sha256", "http://www.w3.org/2001/04/xmlenc#sha512")]
+        public void SignedXmlHasVerifiableSignature(string signatureMethod, string digestMethod)
+        {
+            using (RSA key = RSA.Create())
+            {
+                var xmlDoc = new XmlDocument();
+                xmlDoc.PreserveWhitespace = true;
+                xmlDoc.LoadXml(ExampleXml);
+                SignXml(xmlDoc, key, signatureMethod, digestMethod);
+                Assert.True(VerifyXml(xmlDoc.OuterXml, key));
+            }
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Xml/tests/System.Security.Cryptography.Xml.Tests.csproj
+++ b/src/System.Security.Cryptography.Xml/tests/System.Security.Cryptography.Xml.Tests.csproj
@@ -26,6 +26,7 @@
     <Compile Include="ReferenceTest.cs" />
     <Compile Include="RSAKeyValueTest.cs" />
     <Compile Include="Samples\EncryptingDecryptingAsymmetric.cs" />
+    <Compile Include="Samples\SigningVerifyingWithCustomSignatureMethod.cs" />
     <Compile Include="Samples\SigningVerifying.cs" />
     <Compile Include="Samples\EncryptingDecryptingSymmetric.cs" />
     <Compile Include="SignatureTest.cs" />


### PR DESCRIPTION
Partially fixing https://github.com/dotnet/corefx/issues/16781 - I'm not sure if we do want to abandon some of those algorithms. List of items which is left:
- HMACRIPEMD160 - I think @morganbr has mentioned something about abandoning this
- DSASignatureDescription - we already do support it when used by URI but no by class name

@anthonylangsworth @tintoy @peterwurzinger @bartonjs @morganbr 