### PR TITLE
Only include symbols / src in transport packages, also fix pre-existing typo

### DIFF
--- a/Packaging.props
+++ b/Packaging.props
@@ -25,9 +25,6 @@
     <SkipGenerationCheck>true</SkipGenerationCheck>
     <!-- support check is broken until we reenable package harvesting -->
     <SkipSupportCheck>true</SkipSupportCheck>
-
-    <!-- Include symbols in package by default-->
-    <IncludeSymbolsInPackage Condition="'$(IncludeSymbolsInPackage)' == ''">true</IncludeSymbolsInPackage>
   </PropertyGroup>
 
   <Import Condition="Exists('pkg/baseline/baseline.props') AND '$(MSBuildProjectExtension)' == '.pkgproj'" Project="pkg/baseline/baseline.props" />

--- a/dir.props
+++ b/dir.props
@@ -186,8 +186,8 @@
     <NuGetRuntimeIdentifier Condition="'$(TargetGroup)' == 'netcore50'">win8</NuGetRuntimeIdentifier>
     <NuGetRuntimeIdentifier Condition="'$(TargetGroup)' == 'netcore50aot'">win8-aot</NuGetRuntimeIdentifier>
 
-    <!-- workaround Dev14 issue with nuget targets -->
-    <RuntimeIdentifier>$(NuGetRuntimeIdentifier)</RuntimeIdentifier>
+    <!-- workaround Dev14 issue with nuget targets, misspelling is intentional to align with Dev14 RTM targets -->
+    <RuntimeIndentifier>$(NuGetRuntimeIdentifier)</RuntimeIndentifier>
   </PropertyGroup>
 
   <!-- If there is a target group, try to find project.json and lockfile in a subfolder named as that target. -->

--- a/dir.props
+++ b/dir.props
@@ -187,7 +187,7 @@
     <NuGetRuntimeIdentifier Condition="'$(TargetGroup)' == 'netcore50aot'">win8-aot</NuGetRuntimeIdentifier>
 
     <!-- workaround Dev14 issue with nuget targets -->
-    <RuntimeIndentifier>$(NuGetRuntimeIdentifier)</RuntimeIndentifier>
+    <RuntimeIdentifier>$(NuGetRuntimeIdentifier)</RuntimeIdentifier>
   </PropertyGroup>
 
   <!-- If there is a target group, try to find project.json and lockfile in a subfolder named as that target. -->

--- a/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.pkgproj
+++ b/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.pkgproj
@@ -40,6 +40,9 @@
     <NETStandardLibraryPackage>NETStandard.Library2</NETStandardLibraryPackage>
     <NETStandardLibraryPackageVersion>2.0.0-beta-24709-0</NETStandardLibraryPackageVersion>
     <NETStandardVersion>2.0</NETStandardVersion>
+
+    <!-- Include symbols in package by default-->
+    <IncludeSymbolsInPackage Condition="'$(IncludeSymbolsInPackage)' == ''">true</IncludeSymbolsInPackage>
   </PropertyGroup>
 
   <Import Condition="'$(PackageTargetRuntime)' == ''" Project="$(RefBinDir)\*.props" />

--- a/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.pkgproj
+++ b/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.pkgproj
@@ -18,6 +18,9 @@
     <LibBinDir Condition="$(PackageTargetRuntime.EndsWith('-aot'))">$(UAPAOTPackageRuntimePath)</LibBinDir>
 
     <NETStandardVersion>2.0</NETStandardVersion>
+
+    <!-- Include symbols in package by default-->
+    <IncludeSymbolsInPackage Condition="'$(IncludeSymbolsInPackage)' == ''">true</IncludeSymbolsInPackage>
   </PropertyGroup>
 
   <Import Condition="'$(PackageTargetRuntime)' == ''" Project="$(RefBinDir)\*.props" />

--- a/pkg/Microsoft.Private.PackageBaseline/Microsoft.Private.PackageBaseline.pkgproj
+++ b/pkg/Microsoft.Private.PackageBaseline/Microsoft.Private.PackageBaseline.pkgproj
@@ -7,6 +7,9 @@
     <HarvestStablePackage>false</HarvestStablePackage>
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <PackageIndexFileName>packageIndex.json</PackageIndexFileName>
+
+    <!-- Include symbols in package by default-->
+    <IncludeSymbolsInPackage Condition="'$(IncludeSymbolsInPackage)' == ''">true</IncludeSymbolsInPackage>
   </PropertyGroup>
   
   <ItemGroup>

--- a/pkg/Microsoft.Private.PackageBaseline/Microsoft.Private.PackageBaseline.pkgproj
+++ b/pkg/Microsoft.Private.PackageBaseline/Microsoft.Private.PackageBaseline.pkgproj
@@ -7,9 +7,6 @@
     <HarvestStablePackage>false</HarvestStablePackage>
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <PackageIndexFileName>packageIndex.json</PackageIndexFileName>
-
-    <!-- Include symbols in package by default-->
-    <IncludeSymbolsInPackage Condition="'$(IncludeSymbolsInPackage)' == ''">true</IncludeSymbolsInPackage>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
https://github.com/dotnet/corefx/issues/17256

Only includes src / symbols in the transport packages.  Also, fixes a long-standing (unrelated) typo that I noticed in dir.props.

@ericstj @weshaggard 