### PR TITLE
Include desktop ref for System.Net.Http

### DIFF
--- a/buildvertical.targets
+++ b/buildvertical.targets
@@ -112,7 +112,7 @@
           Returns="$(PackageConfigurations)">
      <ItemGroup Condition="'$(PackageConfigurations)' == ''">
        <_buildConfigurations Include="$(BuildConfigurations)" />
-       <_excludeBuildConfigurations Include="@(_buildConfigurations)" Condition="'$(IsReferenceAssembly)' == 'true' AND ('%(Identity)' == 'netfx' OR $([System.String]::new('%(Identity)').StartsWith('net4')))"/>
+       <_excludeBuildConfigurations Include="@(_buildConfigurations)" Condition="'$(IsReferenceAssembly)' == 'true' AND ('%(Identity)' == 'netfx' OR $([System.String]::new('%(Identity)').StartsWith('net4'))) AND '$(IncludeDesktopRefInPackage)' != 'true'"/>
        <_packageConfigurations Include="@(_buildConfigurations)" Exclude="@(_excludeBuildConfigurations)" />
      </ItemGroup>
 

--- a/src/System.Net.Http/ref/System.Net.Http.csproj
+++ b/src/System.Net.Http/ref/System.Net.Http.csproj
@@ -3,6 +3,9 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{132BF813-FC40-4D39-8B6F-E55D7633F0ED}</ProjectGuid>
+    <!-- in most cases the desktop configuration of a contract is just for APICompat,
+         however in this case it is the actual ref we want to ship -->
+    <IncludeDesktopRefInPackage>true</IncludeDesktopRefInPackage>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46-Release|AnyCPU'" />


### PR DESCRIPTION
In most cases we don't include the desktop refs because those
configurations are merely present to pass to API Compat.

In the System.Net.Http case the ref is actually necessary since the
ref is a real ref and not a facade.

/cc @weshaggard 