### PR TITLE
Fix and clean up the Manual Tests for Sql

### DIFF
--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/Common/SystemDataInternals/TdsParserStateObjectHelper.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/Common/SystemDataInternals/TdsParserStateObjectHelper.cs
@@ -16,7 +16,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests.SystemDataInternals
         private static FieldInfo s_forceSyncOverAsyncAfterFirstPend = s_tdsParserStateObject.GetField("_forceSyncOverAsyncAfterFirstPend", BindingFlags.Static | BindingFlags.NonPublic);
         private static FieldInfo s_failAsyncPends = s_tdsParserStateObject.GetField("_failAsyncPends", BindingFlags.Static | BindingFlags.NonPublic);
         private static FieldInfo s_forcePendingReadsToWaitForUser = s_tdsParserStateObject.GetField("_forcePendingReadsToWaitForUser", BindingFlags.Static | BindingFlags.NonPublic);
-        private static FieldInfo s_tdsParserStateObjectSessionHandle = s_tdsParserStateObjectNative.GetField("_sessionHandle", BindingFlags.Instance | BindingFlags.NonPublic);
+        private static FieldInfo s_tdsParserStateObjectNativeSessionHandle = s_tdsParserStateObjectNative.GetField("_sessionHandle", BindingFlags.Instance | BindingFlags.NonPublic);
+        private static Type s_tdsParserStateObjectManaged = s_systemDotData.GetType("System.Data.SqlClient.SNI.TdsParserStateObjectManaged");
+        private static FieldInfo s_tdsParserStateObjectManagedSessionHandle = s_tdsParserStateObjectManaged.GetField("_sessionHandle", BindingFlags.Instance | BindingFlags.NonPublic);
 
         internal static bool ForceAllPends
         {
@@ -52,14 +54,14 @@ namespace System.Data.SqlClient.ManualTesting.Tests.SystemDataInternals
         {
             if (stateObject == null)
                 throw new ArgumentNullException("stateObject");
-            if (!s_tdsParserStateObject.IsInstanceOfType(stateObject))
+            if (!s_tdsParserStateObjectManaged.IsInstanceOfType(stateObject))
                 throw new ArgumentException("Object provided was not a DbConnectionInternal", "internalConnection");
         }
 
         internal static object GetSessionHandle(object stateObject)
         {
             VerifyObjectIsTdsParserStateObject(stateObject);
-            return s_tdsParserStateObjectSessionHandle.GetValue(stateObject);
+            return s_tdsParserStateObjectManagedSessionHandle.GetValue(stateObject);
         }
     }
 }

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/ExceptionTest/ExceptionTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/ExceptionTest/ExceptionTest.cs
@@ -21,19 +21,6 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         private const string warningInfoMessage = "Test of info messages";
         private const string orderIdQuery = "select orderid from orders where orderid < 10250";
 
-#if MANAGED_SNI
-        [CheckConnStrSetupFact]
-        public static void NonWindowsIntAuthFailureTest()
-        {
-            string connectionString = (new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr) { IntegratedSecurity = true }).ConnectionString;
-            Assert.Throws<NotSupportedException>(() => new SqlConnection(connectionString).Open());
-
-            // Should not receive any exception when using IntAuth=false
-            connectionString = (new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr) { IntegratedSecurity = false }).ConnectionString;
-            new SqlConnection(connectionString).Open();
-        }
-#endif
-
         [CheckConnStrSetupFact]
         public static void WarningTest()
         {


### PR DESCRIPTION
There are cleanup changes in here
1. Changed the reflect in Kill Connection to look for Managed SNI objects.
2. Deleted a test case which was expecting Integrated Auth to fail on Managed SNI.