### PR TITLE
Avoid allocation in TdsParse when reading multiple decimals without a call to writedecimal

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
@@ -5328,7 +5328,10 @@ namespace System.Data.SqlClient
             int i;
 
             if (null == bits)
+            {
                 bits = new int[4];
+                stateObj._decimalBits = bits;
+            }
             else
             {
                 for (i = 0; i < bits.Length; i++)


### PR DESCRIPTION
The TdsParserStateObject contais a array for _decimalBits that is supposed to be reused (See comment: // used alloc'd array if we have one already).
But it only gets assigned in TdsParser.WriteDecimal. So if we have a readonly workload we allocate the array every time we access a decimal.
Fix: assign the _decimalBits array in TryReadDecimalBits where it gets already checked.