### PR TITLE
Allow . as hostname in pipe names

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Net;
@@ -10,9 +9,7 @@ using System.Net.Security;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading.Tasks;
-using System;
-using System.Threading;
-using System.Collections;
+using System.IO;
 
 namespace System.Data.SqlClient.SNI
 {
@@ -575,7 +572,6 @@ namespace System.Data.SqlClient.SNI
 
         private const char CommaSeparator = ',';
         private const char BackSlashSeparator = '\\';
-        private const char ForwardSlashSeparator = '/';
         private const string DefaultHostName = "localhost";
         private const string DefaultSqlServerInstanceName = "mssqlserver";
         private const string PipeBeginning = @"\\";
@@ -817,7 +813,7 @@ namespace System.Data.SqlClient.SNI
                     for ( int i = 4; i < tokensByBackSlash.Length-1; i++)
                     {
                         pipeNameBuilder.Append(tokensByBackSlash[i]);
-                        pipeNameBuilder.Append(ForwardSlashSeparator);
+                        pipeNameBuilder.Append(Path.PathSeparator);
                     }
                     // Append the last part without a "/"
                     pipeNameBuilder.Append(tokensByBackSlash[tokensByBackSlash.Length - 1]);

--- a/src/System.Data.SqlClient/tests/FunctionalTests/ExceptionTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/ExceptionTest.cs
@@ -76,6 +76,26 @@ namespace System.Data.SqlClient.Tests
             }
         }
 
+        [Theory]
+        [InlineData(@"np:\\.\pipe\sqlbad\query")]
+        [InlineData(@"np:\\.\pipe\MSSQL$NonExistentInstance\sql\query")]
+        [InlineData(@"\\.\pipe\sqlbad\query")]
+        [InlineData(@"\\.\pipe\MSSQL$NonExistentInstance\sql\query")]
+        [InlineData(@"np:\\localhost\pipe\sqlbad\query")]
+        [InlineData(@"np:\\localhost\pipe\MSSQL$NonExistentInstance\sqlbad\query")]
+        [InlineData(@"\\localhost\pipe\sqlbad\query")]
+        [InlineData(@"\\localhost\pipe\MSSQL$NonExistentInstance\sqlbad\query")]
+        public void NamedPipeTest(string dataSource)
+        {
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder();
+            builder.DataSource = dataSource;
+            builder.ConnectTimeout = 1;
+            using(SqlConnection connection = new SqlConnection(builder.ConnectionString))
+            {
+                VerifyConnectionFailure<SqlException>(() => connection.Open(), "(provider: Named Pipes Provider, error: 11 - Timeout error)");
+            }
+        }
+
         private void GenerateConnectionException(string connectionString)
         {
             using (SqlConnection sqlConnection = new SqlConnection(connectionString))

--- a/src/System.Data.SqlClient/tests/FunctionalTests/ExceptionTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/ExceptionTest.cs
@@ -85,6 +85,7 @@ namespace System.Data.SqlClient.Tests
         [InlineData(@"np:\\localhost\pipe\MSSQL$NonExistentInstance\sqlbad\query")]
         [InlineData(@"\\localhost\pipe\sqlbad\query")]
         [InlineData(@"\\localhost\pipe\MSSQL$NonExistentInstance\sqlbad\query")]
+        [PlatformSpecific(TestPlatforms.Windows)] // Named pipes with the given input strings are not supported on Unix
         public void NamedPipeTest(string dataSource)
         {
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder();


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/17282

Since Uri cannot handle . as hostname, the changes include splitting the named pipe data source by \ and generating the hostname and pipename from the split parts. 

Apart from the tests added, I ran some tests with a SqlServer to see if the connectivity works. 

cc @corivera @geleems 