### PR TITLE
Remove SocketAsyncEventArgs._ptrNativeOverlapped

### DIFF
--- a/src/Common/src/Interop/Windows/Winsock/Interop.TransmitFile.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.TransmitFile.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 internal static partial class Interop
 {
@@ -16,7 +17,7 @@ internal static partial class Interop
             SafeHandle fileHandle,
             int numberOfBytesToWrite,
             int numberOfBytesPerSend,
-            SafeHandle overlapped,
+            NativeOverlapped* overlapped,
             TransmitFileBuffers* buffers,
             TransmitFileOptions flags);
 

--- a/src/Common/src/Interop/Windows/Winsock/Interop.WSAGetOverlappedResult.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.WSAGetOverlappedResult.cs
@@ -4,15 +4,16 @@
 
 using System.Runtime.InteropServices;
 using System.Net.Sockets;
+using System.Threading;
 
 internal static partial class Interop
 {
     internal static partial class Winsock
     {
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
-        internal static extern bool WSAGetOverlappedResult(
+        internal static unsafe extern bool WSAGetOverlappedResult(
             [In] SafeCloseSocket socketHandle,
-            [In] SafeHandle overlapped,
+            [In] NativeOverlapped* overlapped,
             [Out] out uint bytesTransferred,
             [In] bool wait,
             [Out] out SocketFlags socketFlags);

--- a/src/Common/src/Interop/Windows/Winsock/Interop.WSAIoctl.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.WSAIoctl.cs
@@ -34,17 +34,5 @@ internal static partial class Interop
             [Out] out int bytesTransferred,
             [In] IntPtr overlapped,
             [In] IntPtr completionRoutine);
-
-        [DllImport(Interop.Libraries.Ws2_32, SetLastError = true, EntryPoint = "WSAIoctl")]
-        internal static extern SocketError WSAIoctl_Blocking_Internal(
-            [In]  IntPtr socketHandle,
-            [In]  uint ioControlCode,
-            [In]  IntPtr inBuffer,
-            [In]  int inBufferSize,
-            [Out] IntPtr outBuffer,
-            [In]  int outBufferSize,
-            [Out] out int bytesTransferred,
-            [In]  SafeHandle overlapped,
-            [In]  IntPtr completionRoutine);
     }
 }

--- a/src/Common/src/Interop/Windows/Winsock/Interop.WSAIoctl.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.WSAIoctl.cs
@@ -32,7 +32,7 @@ internal static partial class Interop
             [Out] byte[] outBuffer,
             [In] int outBufferSize,
             [Out] out int bytesTransferred,
-            [In] SafeHandle overlapped,
+            [In] IntPtr overlapped,
             [In] IntPtr completionRoutine);
 
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true, EntryPoint = "WSAIoctl")]

--- a/src/Common/src/Interop/Windows/Winsock/Interop.WSARecv.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.WSARecv.cs
@@ -4,8 +4,9 @@
 
 using System;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using System.Threading;
 
 internal static partial class Interop
 {
@@ -18,7 +19,7 @@ internal static partial class Interop
             int bufferCount,
             out int bytesTransferred,
             ref SocketFlags socketFlags,
-            SafeNativeOverlapped overlapped,
+            NativeOverlapped* overlapped,
             IntPtr completionRoutine);
 
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
@@ -28,7 +29,7 @@ internal static partial class Interop
             int bufferCount,
             out int bytesTransferred,
             ref SocketFlags socketFlags,
-            SafeNativeOverlapped overlapped,
+            NativeOverlapped* overlapped,
             IntPtr completionRoutine);
 
         internal static unsafe SocketError WSARecv(
@@ -37,7 +38,7 @@ internal static partial class Interop
             int bufferCount,
             out int bytesTransferred,
             ref SocketFlags socketFlags,
-            SafeNativeOverlapped overlapped,
+            NativeOverlapped* overlapped,
             IntPtr completionRoutine)
         {
             // We intentionally do NOT copy this back after the function completes:
@@ -53,7 +54,7 @@ internal static partial class Interop
             int bufferCount,
             out int bytesTransferred,
             ref SocketFlags socketFlags,
-            SafeNativeOverlapped overlapped,
+            NativeOverlapped* overlapped,
             IntPtr completionRoutine)
         {
             Debug.Assert(buffers != null);
@@ -69,7 +70,7 @@ internal static partial class Interop
             int bufferCount,
             out int bytesTransferred,
             ref SocketFlags socketFlags,
-            SafeNativeOverlapped overlapped,
+            NativeOverlapped* overlapped,
             IntPtr completionRoutine)
         {
             Debug.Assert(buffers != null);

--- a/src/Common/src/Interop/Windows/Winsock/Interop.WSARecvFrom.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.WSARecvFrom.cs
@@ -4,8 +4,9 @@
 
 using System;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using System.Threading;
 
 internal static partial class Interop
 {
@@ -21,7 +22,7 @@ internal static partial class Interop
             ref SocketFlags socketFlags,
             IntPtr socketAddressPointer,
             IntPtr socketAddressSizePointer,
-            SafeNativeOverlapped overlapped,
+            NativeOverlapped* overlapped,
             IntPtr completionRoutine);
 
         internal static unsafe SocketError WSARecvFrom(
@@ -32,7 +33,7 @@ internal static partial class Interop
             ref SocketFlags socketFlags,
             IntPtr socketAddressPointer,
             IntPtr socketAddressSizePointer,
-            SafeNativeOverlapped overlapped,
+            NativeOverlapped* overlapped,
             IntPtr completionRoutine)
         {
             // We intentionally do NOT copy this back after the function completes:
@@ -50,7 +51,7 @@ internal static partial class Interop
             ref SocketFlags socketFlags,
             IntPtr socketAddressPointer,
             IntPtr socketAddressSizePointer,
-            SafeNativeOverlapped overlapped,
+            NativeOverlapped* overlapped,
             IntPtr completionRoutine)
         {
             Debug.Assert(buffers != null);

--- a/src/Common/src/Interop/Windows/Winsock/Interop.WSASend.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.WSASend.cs
@@ -4,8 +4,9 @@
 
 using System;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using System.Threading;
 
 internal static partial class Interop
 {
@@ -18,7 +19,7 @@ internal static partial class Interop
             int bufferCount,
             out int bytesTransferred,
             SocketFlags socketFlags,
-            SafeNativeOverlapped overlapped,
+            NativeOverlapped* overlapped,
             IntPtr completionRoutine);
 
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
@@ -28,7 +29,7 @@ internal static partial class Interop
             int bufferCount,
             out int bytesTransferred,
             SocketFlags socketFlags,
-            SafeNativeOverlapped overlapped,
+            NativeOverlapped* overlapped,
             IntPtr completionRoutine);
 
         internal static unsafe SocketError WSASend(
@@ -37,7 +38,7 @@ internal static partial class Interop
             int bufferCount,
             out int bytesTransferred,
             SocketFlags socketFlags,
-            SafeNativeOverlapped overlapped,
+            NativeOverlapped* overlapped,
             IntPtr completionRoutine)
         {
             // We intentionally do NOT copy this back after the function completes:
@@ -53,7 +54,7 @@ internal static partial class Interop
             int bufferCount,
             out int bytesTransferred,
             SocketFlags socketFlags,
-            SafeNativeOverlapped overlapped,
+            NativeOverlapped* overlapped,
             IntPtr completionRoutine)
         {
             Debug.Assert(buffers != null);
@@ -69,7 +70,7 @@ internal static partial class Interop
             int bufferCount,
             out int bytesTransferred,
             SocketFlags socketFlags,
-            SafeNativeOverlapped overlapped,
+            NativeOverlapped* overlapped,
             IntPtr completionRoutine)
         {
             Debug.Assert(buffers != null);

--- a/src/Common/src/Interop/Windows/Winsock/Interop.WSASendTo.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.WSASendTo.cs
@@ -4,8 +4,9 @@
 
 using System;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using System.Threading;
 
 internal static partial class Interop
 {
@@ -20,7 +21,7 @@ internal static partial class Interop
             SocketFlags socketFlags,
             IntPtr socketAddress,
             int socketAddressSize,
-            SafeNativeOverlapped overlapped,
+            NativeOverlapped* overlapped,
             IntPtr completionRoutine);
 
         internal static unsafe SocketError WSASendTo(
@@ -31,7 +32,7 @@ internal static partial class Interop
             SocketFlags socketFlags,
             IntPtr socketAddress,
             int socketAddressSize,
-            SafeNativeOverlapped overlapped,
+            NativeOverlapped* overlapped,
             IntPtr completionRoutine)
         {
             // We intentionally do NOT copy this back after the function completes:
@@ -49,7 +50,7 @@ internal static partial class Interop
             SocketFlags socketFlags,
             IntPtr socketAddress,
             int socketAddressSize,
-            SafeNativeOverlapped overlapped,
+            NativeOverlapped* overlapped,
             IntPtr completionRoutine)
         {
             Debug.Assert(buffers != null);

--- a/src/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
+++ b/src/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
@@ -223,9 +223,6 @@
     <Compile Include="$(CommonPath)\Interop\Windows\Winsock\Interop.WSASocketW.SafeCloseSocket.cs">
       <Link>Interop\Windows\Winsock\Interop.WSASocketW.SafeCloseSocket.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Winsock\SafeNativeOverlapped.cs">
-      <Link>Interop\Windows\Winsock\SafeNativeOverlapped.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Winsock\SafeOverlappedFree.cs">
       <Link>Interop\Windows\Winsock\SafeOverlappedFree.cs</Link>
     </Compile>

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.Windows.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.Windows.cs
@@ -251,7 +251,7 @@ namespace System.Net.NetworkInformation
                                 (int)IOControlCode.AddressListChange,
                                 null, 0, null, 0,
                                 out length,
-                                SafeNativeOverlapped.Zero, IntPtr.Zero);
+                                IntPtr.Zero, IntPtr.Zero);
 
                             if (errorCode != SocketError.Success)
                             {
@@ -290,7 +290,7 @@ namespace System.Net.NetworkInformation
                                 (int)IOControlCode.AddressListChange,
                                 null, 0, null, 0,
                                 out length,
-                                SafeNativeOverlapped.Zero, IntPtr.Zero);
+                                IntPtr.Zero, IntPtr.Zero);
 
                             if (errorCode != SocketError.Success)
                             {

--- a/src/System.Net.Sockets/src/System/Net/Sockets/DynamicWinsockMethods.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/DynamicWinsockMethods.cs
@@ -261,7 +261,7 @@ namespace System.Net.Sockets
         }
     }
 
-    internal delegate bool AcceptExDelegate(
+    internal unsafe delegate bool AcceptExDelegate(
                 SafeCloseSocket listenSocketHandle,
                 SafeCloseSocket acceptSocketHandle,
                 IntPtr buffer,
@@ -269,7 +269,7 @@ namespace System.Net.Sockets
                 int localAddressLength,
                 int remoteAddressLength,
                 out int bytesReceived,
-                SafeHandle overlapped);
+                NativeOverlapped* overlapped);
 
     internal delegate void GetAcceptExSockaddrsDelegate(
                 IntPtr buffer,
@@ -282,18 +282,18 @@ namespace System.Net.Sockets
                 out int remoteSocketAddressLength);
 
 
-    internal delegate bool ConnectExDelegate(
+    internal unsafe delegate bool ConnectExDelegate(
                 SafeCloseSocket socketHandle,
                 IntPtr socketAddress,
                 int socketAddressSize,
                 IntPtr buffer,
                 int dataLength,
                 out int bytesSent,
-                SafeHandle overlapped);
+                NativeOverlapped* overlapped);
 
-    internal delegate bool DisconnectExDelegate(
+    internal unsafe delegate bool DisconnectExDelegate(
                 SafeCloseSocket socketHandle, 
-                SafeHandle overlapped, 
+                NativeOverlapped* overlapped, 
                 int flags, 
                 int reserved);
 
@@ -303,11 +303,11 @@ namespace System.Net.Sockets
                 int flags, 
                 int reserved);
 
-    internal delegate SocketError WSARecvMsgDelegate(
+    internal unsafe delegate SocketError WSARecvMsgDelegate(
                 SafeCloseSocket socketHandle,
                 IntPtr msg,
                 out int bytesTransferred,
-                SafeHandle overlapped,
+                NativeOverlapped* overlapped,
                 IntPtr completionRoutine);
 
     internal delegate SocketError WSARecvMsgDelegateBlocking(
@@ -317,11 +317,11 @@ namespace System.Net.Sockets
                 IntPtr overlapped,
                 IntPtr completionRoutine);
 
-    internal delegate bool TransmitPacketsDelegate(
+    internal unsafe delegate bool TransmitPacketsDelegate(
                 SafeCloseSocket socketHandle,
                 IntPtr packetArray,
                 int elementCount,
                 int sendSize,
-                SafeNativeOverlapped overlapped,
+                NativeOverlapped* overlapped,
                 TransmitFileOptions flags);
 }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
@@ -25,14 +25,14 @@ namespace System.Net.Sockets
             }
         }
 
-        internal bool AcceptEx(SafeCloseSocket listenSocketHandle,
+        internal unsafe bool AcceptEx(SafeCloseSocket listenSocketHandle,
             SafeCloseSocket acceptSocketHandle,
             IntPtr buffer,
             int len,
             int localAddressLength,
             int remoteAddressLength,
             out int bytesReceived,
-            SafeHandle overlapped)
+            NativeOverlapped* overlapped)
         {
             EnsureDynamicWinsockMethods();
             AcceptExDelegate acceptEx = _dynamicWinsockMethods.GetDelegate<AcceptExDelegate>(listenSocketHandle);
@@ -69,7 +69,7 @@ namespace System.Net.Sockets
                 out remoteSocketAddressLength);
         }
 
-        internal bool DisconnectEx(SafeCloseSocket socketHandle, SafeHandle overlapped, int flags, int reserved)
+        internal unsafe bool DisconnectEx(SafeCloseSocket socketHandle, NativeOverlapped* overlapped, int flags, int reserved)
         {
             EnsureDynamicWinsockMethods();
             DisconnectExDelegate disconnectEx = _dynamicWinsockMethods.GetDelegate<DisconnectExDelegate>(socketHandle);
@@ -85,13 +85,13 @@ namespace System.Net.Sockets
             return disconnectEx_Blocking(socketHandle, overlapped, flags, reserved);
         }
 
-        internal bool ConnectEx(SafeCloseSocket socketHandle,
+        internal unsafe bool ConnectEx(SafeCloseSocket socketHandle,
             IntPtr socketAddress,
             int socketAddressSize,
             IntPtr buffer,
             int dataLength,
             out int bytesSent,
-            SafeHandle overlapped)
+            NativeOverlapped* overlapped)
         {
             EnsureDynamicWinsockMethods();
             ConnectExDelegate connectEx = _dynamicWinsockMethods.GetDelegate<ConnectExDelegate>(socketHandle);
@@ -99,7 +99,7 @@ namespace System.Net.Sockets
             return connectEx(socketHandle, socketAddress, socketAddressSize, buffer, dataLength, out bytesSent, overlapped);
         }
 
-        internal SocketError WSARecvMsg(SafeCloseSocket socketHandle, IntPtr msg, out int bytesTransferred, SafeHandle overlapped, IntPtr completionRoutine)
+        internal unsafe SocketError WSARecvMsg(SafeCloseSocket socketHandle, IntPtr msg, out int bytesTransferred, NativeOverlapped* overlapped, IntPtr completionRoutine)
         {
             EnsureDynamicWinsockMethods();
             WSARecvMsgDelegate recvMsg = _dynamicWinsockMethods.GetDelegate<WSARecvMsgDelegate>(socketHandle);
@@ -115,7 +115,7 @@ namespace System.Net.Sockets
             return recvMsg_Blocking(socketHandle, msg, out bytesTransferred, overlapped, completionRoutine);
         }
 
-        internal bool TransmitPackets(SafeCloseSocket socketHandle, IntPtr packetArray, int elementCount, int sendSize, SafeNativeOverlapped overlapped, TransmitFileOptions flags)
+        internal unsafe bool TransmitPackets(SafeCloseSocket socketHandle, IntPtr packetArray, int elementCount, int sendSize, NativeOverlapped* overlapped, TransmitFileOptions flags)
         {
             EnsureDynamicWinsockMethods();
             TransmitPacketsDelegate transmitPackets = _dynamicWinsockMethods.GetDelegate<TransmitPacketsDelegate>(socketHandle);

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
@@ -42,11 +42,6 @@ namespace System.Net.Sockets
             // No-op for *nix.
         }
 
-        private void InnerComplete()
-        {
-            // No-op for *nix.
-        }
-
         private void FinishOperationSync(SocketError socketError, int bytesTransferred, SocketFlags flags)
         {
             Debug.Assert(socketError != SocketError.IOPending);

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
@@ -377,8 +377,6 @@ namespace System.Net.Sockets
             // Mark as not in-use.
             _operating = Free;
 
-            InnerComplete();
-
             // Check for deferred Dispose().
             // The deferred Dispose is not guaranteed if Dispose is called while an operation is in progress. 
             // The _disposeCalled variable is not managed in a thread-safe manner on purpose for performance.


### PR DESCRIPTION
`SocketAsyncEventArgs` uses a `SafeNativeOverlapped` to represent the `NativeOverlapped*` it gets back from the `PreAllocatedOverlapped`.  This leads to several costs:
- Allocation/disposal of the `SafeNativeOverlapped`.  It used to be allocated/disposed for every operation, and that was fixed.  But it's still allocated/disposed every time the `SocketAsyncEventArgs` changes associated with a `Socket`, and that's problematic in a pooling situation, where a `SocketAsyncEventArgs` is taken from a pool, used for an operation, and then returned to the pool to be used subsequently by another operation, likely on a different socket.
- It adds a field to `SocketAsyncEventArgs`, as the `SafeNativeOverlapped` instance needs to be disposed of only when the operation completes.
- As with any `SafeHandle`, it adds AddRef/Release costs to each P/Invoke with which it's used.

But, it's unnecessary on `SocketAsyncEventArgs`.  The overlapped has a very controlled lifetime: it's created internally, it's passed to an internal async operation, and upon completion of that operation it's freed.  The benefits of the `SafeHandle` don't apply here:
- `SafeHandle`s help guaranteed cleanup via a finalizer, but we're not publishing this pointer and have knowledge of its complete lifetime.  The only place it would help is if we got an asynchronous exception (e.g. a thread abort) in a very unexpected place, and we don't need to be reliable against such things (nor would we be even if we added that).
- `SafeHandle`s help guarantee that the pointer won't be disposed of while still in use, but that's mainly relevant when handed out to multiple pieces of code, and in particular code we don't control... in this case, it's not handed out to any code other than that in this one file.

On my machine, this improves the throughput by ~13% in the example at https://github.com/dotnet/corefx/pull/17237#issuecomment-287613725 (which is stressing this case by changing the socket on every send/receive and doing very fast send/receives), and makes it allocation-free to change the Socket with which a SocketAsyncEventArgs is associated (whereas today there’s a 40byte SafeHandle allocation each time it changes).  With a small modification to that test to not change the buffer and instead set it once up front, this still has an ~8% throughput improvement, most of which is due to the reduction in SafeHandle marshaling and associated AddRef/Release costs.

cc: @geoffkizer, @davidsh, @cipop, @jkotas, @vancem