### PR TITLE
Creating special build configuration for uap for Microsoft.CSharp tests

### DIFF
--- a/src/Microsoft.CSharp/tests/CSharpArgumentInfoTests.cs
+++ b/src/Microsoft.CSharp/tests/CSharpArgumentInfoTests.cs
@@ -17,7 +17,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
 
         private static readonly string[] Names =
         {
-            "arg", "ARG", "Arg", "Argument name that isn’t a valid C♯ name 👿🤢",
+            "arg", "ARG", "Arg", 
+#if !uap
+            "Argument name that isn’t a valid C♯ name 👿🤢",
+#endif
             "horrid name with" + (char)0xD800 + "a half surrogate", "new", "break", null
         };
 

--- a/src/Microsoft.CSharp/tests/Configurations.props
+++ b/src/Microsoft.CSharp/tests/Configurations.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       netstandard;
+      uap-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj
+++ b/src/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj
@@ -3,9 +3,12 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{82B54697-0251-47A1-8546-FC507D0F3B08}</ProjectGuid>
+    <DefineConstants Condition="'$(TargetGroup)' == 'uap'">$(DefineConstants);uap</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
       <Link>Common\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>


### PR DESCRIPTION
Microsoft.CSharp.Tests has a Theory that uses some data with some invalid characters on it. This is causing that when we try to write the testResults.xml file, we try to AppContext.TryGetSwitch(string, boolean) which is not available in uapaot, causing the writing to the xml to crash. With these changes, we won't be testing that case for now in uapaot, so that we can produce valid testresults.xml files

cc: @weshaggard @danmosemsft 