### PR TITLE
Fix markdown headings to render correctly

### DIFF
--- a/Documentation/architecture/net-core-applications.md
+++ b/Documentation/architecture/net-core-applications.md
@@ -1,4 +1,4 @@
-﻿#.NET Core Applications
+﻿# .NET Core Applications
 
 NETCoreApp is the [target framework](https://docs.nuget.org/Create/TargetFrameworks) that represents .NET Core applications
 
@@ -11,7 +11,7 @@ Friendly name | .NET Core Application
 NuGet folder name | `netcoreapp1.0`
 NETStandard version supported | `netstandard1.6`
 
-##FAQ
+## FAQ
 **Q: What is a .NET Core application?**  
 **A:** A .NET Core application is an application that can run on any .NET Core runtime: CoreCLR (current), .NETNative (future). It can run on one of many .NET core platforms (Windows, OSX, Linux).  It relies on the host provided by the given runtime.  It's a composable framework built from the packages on which the application depends.  Its assembly loading policy permits newer versions of dependencies without any application configuration (eg: BindingRedirects are not required).
 

--- a/Documentation/building/unix-instructions.md
+++ b/Documentation/building/unix-instructions.md
@@ -1,6 +1,6 @@
 Building CoreFX on FreeBSD, Linux and OS X
 ==========================================
-##Building
+## Building
 
 1. Install the prerequisites ([Linux](#user-content-linux), [macOS](#user-content-macos))
 2. Clone the corefx repo `git clone https://github.com/dotnet/corefx.git`

--- a/Documentation/coding-guidelines/adding-api-guidelines.md
+++ b/Documentation/coding-guidelines/adding-api-guidelines.md
@@ -3,18 +3,18 @@ Recommended reading to better understand this document:
 | [Project-Guidelines](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/project-guidelines.md)
 | [Package-Projects](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/package-projects.md)
 
-#Add APIs
+# Add APIs
 - [Determining versions and targets](#determining-versions-and-targets)
 - [Making the changes in repo](#making-the-changes-in-repo)
 - [FAQ](#faq)
 
-##Determining versions and targets
+## Determining versions and targets
 
 1. [Determine what library](#determine-what-library) the API goes into.
 2. [Determine the target framework](#determine-target-framework) for the library that will contain the API.
 3. [Determine the version](#determine-library-version) for the library that will contain the API.
 
-###Determine what library
+### Determine what library
 - Propose a library for exposing it as part of the [API review process](http://aka.ms/apireview).
 - Keep in mind the API might be exposed in a reference assembly that
 doesn't match the identity of the implementation. There are many reasons for this but
@@ -22,7 +22,7 @@ the primary reason is to abstract the runtime assembly identities across
 different platforms while sharing a common API surface and allowing us to refactor
 the implementation without compat concerns in future releases.
 
-###Determine target framework
+### Determine target framework
 `<latest>` is the target framework version currently under development. Currently netcoreapp1.1 and netstandard1.7 (note netstandard1.7 is a placeholder for netstandard2.0).
 
 - If the library is [part of netstandard](#isnetstandard)
@@ -41,13 +41,13 @@ the implementation without compat concerns in future releases.
     `netstandard<latest>` it will have a target framework of `<framework><latest>`. Example `net<latest>` for desktop or `netcoreapp<latest>` for .NET Core.
 - It is not uncommon for a library to target the latest versions of multiple frameworks when adding new APIs (ex: https://github.com/dotnet/corefx/blob/master/src/System.Runtime/ref/System.Runtime.builds)
 
-###Determine library version
+### Determine library version
 - If targeting netstandard
   - Ensure minor version of the assembly is bumped since last stable package release
 - If targeting netcoreapp
   - No assembly version bump necessary
 
-##Making the changes in repo
+## Making the changes in repo
 
 **If changing the library version**
   - Update the `AssemblyVersion` property in `<Library>\dir.props` (ex: [System.Runtime\dir.props](https://github.com/dotnet/corefx/blob/master/src/System.Runtime/dir.props#L4)) to the version determined above.
@@ -95,7 +95,7 @@ the implementation without compat concerns in future releases.
   - Add new test code following [conventions](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/project-guidelines.md#code-file-naming-conventions) for new files to that are specific to the new target framework.
   - To run just the new test configuration run `msbuild <Library>.csproj /t:RebuildAndTest /p:TargetGroup=<TargetGroup>`
 
-##FAQ
+## FAQ
 _**<a name="isnetstandard">Is your API part of netstandard?</a>**_
 
 - For netstandard2.0 refer to https://github.com/dotnet/standard/tree/master/netstandard/ref, and if any Type is included in any of the *.cs files then it is part of netstandard.
@@ -133,7 +133,7 @@ If you are moving types down you need to version both contracts at the same time
 project references across the projects. You also need to be sure to leave type-forwards in the places
 where you removed types in order to maintain back-compat.
 
-###Potential clean-up work that can be done
+### Potential clean-up work that can be done
 - Remove old build configurations - The older build configurations will automatically be harvested from
 the last stable packages and thus can be removed.
 - Remove import statements - If not referencing any pre-netstandard stable packages the [imports of dotnet5.x](https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.Process/src/project.json#L28) are no longer needed and can be removed. We should also remove any dead target frameworks sections.

--- a/Documentation/coding-guidelines/netstandard20-corefx-infra.md
+++ b/Documentation/coding-guidelines/netstandard20-corefx-infra.md
@@ -1,5 +1,5 @@
-##dotnet/CoreFx
-###Libraries in NETStandard
+## dotnet/CoreFx
+### Libraries in NETStandard
 - ref
   - Default targetgroup should be NETCoreApp build
   - P2P references to other reference assembly CSProjs.
@@ -26,7 +26,7 @@
   - Use P2P references to pkgproj for things not in NETStandard.Library
   - Implementation is automatically injected by targets.
 
-###Libraries above NETStandard
+### Libraries above NETStandard
 - ref
   - Only required if component is inbox somewhere or has multiple implementations for same NETStandard version.
   - Build against NETStandard.Library package
@@ -45,7 +45,7 @@
   - Use P2P references for things not in NETStandard.Library
   - Implementation is automatically injected by targets.
 
-###NETStandard  compatibility facade
+### NETStandard  compatibility facade
 Provides compatibility between NETCore.App and libraries built against NETStandard.
 - ref
   - Should adapt supported NETStandard.dll to contract reference assemblies.
@@ -57,7 +57,7 @@ Provides compatibility between NETCore.App and libraries built against NETStanda
   - No individual package builds.
   - Should be included in NETCoreApp package as above
 
-###Desktop compatibility facades
+### Desktop compatibility facades
 - ref
   - Should adapt latest desktop surface to contract reference assemblies for anything that has type-overlap with desktop, including assemblies like Microsoft.Win32.Registry which are not in NETStandard.Library.
   - EG: `GenFacades -contracts:<desktopReferenceAssemblies> -seeds:<allNetCoreAppReferenceAssemblies>`
@@ -68,20 +68,20 @@ Provides compatibility between NETCore.App and libraries built against NETStanda
   - No individual package builds.
   - Should be included in NETCoreApp package as above
 
-###Native shims
+### Native shims
 - pkg
   - No individual package builds.
   - As with libraries in NETStandard the shims will be included in the runtime specific packages for NETCoreApp
 
-##Transition
+## Transition
 
-###End goal
+### End goal
 
 - CoreFx does not build any reference assemblies for NETStandard.
 - For every library in NETStandard.Library, the only configurations in CoreFx are framework-specific.  EG: NETCoreApp1.2, UAP10.1
 - For every library in NETCore.App but not in NETStandard.Library there must be a framework-specific configuration for NETCoreApp1.2.  Other configurations may exist to ship in a package, but those will not be built by folks building just NETCore.App.
 
-###Getting there (WIP)
+### Getting there (WIP)
 
 Folks still consume our current packages so we need to keep building those until we transition.
 

--- a/Documentation/coding-guidelines/package-projects.md
+++ b/Documentation/coding-guidelines/package-projects.md
@@ -271,7 +271,7 @@ Part of package build is to ensure that a package is applicable on all platforms
     </SupportedFramework>
     ```
 
-###Inbox assets
+### Inbox assets
 Some libraries are supported inbox on particular frameworks.  For these frameworks the package should not present any assets for (ref or lib) for that framework, but instead permit installation and provide no assets.  We do this in the package by using placeholders ref and lib folders for that framework.  In the package project one can use `InboxOnTargetFramework` items.  The following is an example from the System.Linq.Expressions package.
 ```
 <InboxOnTargetFramework Include="net45" />
@@ -292,7 +292,7 @@ If the library is also a "classic" reference assembly, not referenced by default
 
 Package validation will catch a case where we know a library is supported inbox but a package is using an asset from the package.  This data is driven by framework lists from previously-shipped targeting packs.  The error will appear as: *Framework net45 should support Microsoft.CSharp inbox but {explanation of problem}.  You may need to add <InboxOnTargetFramework Include="net45" /> to your project.*
 
-###External assets
+### External assets
 Runtime specific packages are used to break apart implementations into separate packages and enable "pay-for-play".  For example: don't download the Windows implementation if we're only building/deploying for linux.  In most cases we can completely separate implementations into separate packages such that they easily translate.  For example:
 ```
 runtimes/win/lib/dotnet5.4/System.Banana.dll
@@ -315,7 +315,7 @@ The fix for the error is to put a placeholder in the package that contains the a
 <ExternalOnTargetFramework Include="net46" />
 ```
 
-###Not supported
+### Not supported
 In rare cases a particular library might represent itself as targeting a specific portable moniker (eg: `dotnet5.4`) but it cannot be supported on a particular target framework that is included in that portable moniker for other reasons.  One example of this is System.Diagnostics.Process.  The surface area of this API is portable to dotnet5.4 and could technically run in UWP based on its managed dependencies.  The native API, however, is not supported in app container.  To prevent this package and packages which depend on from installing in UWP projects, only to fail at runtime, we can block the package from being installed.
 
 To do this we create a placeholder in the lib folder with the following syntax.  The resulting combination will be an applicable ref asset with no applicable lib and NuGet's compat check will fail.

--- a/Documentation/coding-guidelines/project-guidelines.md
+++ b/Documentation/coding-guidelines/project-guidelines.md
@@ -1,8 +1,8 @@
-#Build Project Guidelines
+# Build Project Guidelines
 In order to work in corefx repo you must first run build.cmd/sh from the root of the repo at least
 once before you can iterate and work on a given library project.
 
-##Behind the scenes with build.cmd/sh
+## Behind the scenes with build.cmd/sh
 
 - Setup tools (currently done in init-tools but will later be a boot-strap script in run.cmd/sh)
 - Restore external dependencies
@@ -18,17 +18,17 @@ once before you can iterate and work on a given library project.
  - Build src\sign.builds
 //**CONSIDER**: We should make this as part of the src.builds file instead of a separate .builds file.
 
-##Behind the scenes with build-test.cmd/sh
+## Behind the scenes with build-test.cmd/sh
 - build-test.cmd cannot be ran successfully until build.cmd has been ran at least once for a `BuildConfiguration`.
 - Build src\tests.builds which builds all applicable test projects. For test project information see [tests](#tests).
 - The build pass will happen twice. Once for the specific `$(BuildConfiguration)` and once for netstandard. That way we run both sets of applicable tests against for the given `$(BuildConfiguration)`.
 - TODO: Currently as part of src/post.builds we call CloudBuild.targets which sets up our test runs. This needs to be moved to be part of build-test.cmd now.
 
-##Behind the scenes with build-packages.cmd/sh
+## Behind the scenes with build-packages.cmd/sh
 - build-packages.cmd cannot be run successfully until build.cmd has been ran at least once for a BuildConfiguration.
 - Build src\packages.builds which will build only the packages it has the context to build which will generally be only the ones for the given `BuildConfiguration`. If a package requires assets from multiple `BuildConfigurations` it will require that all `BuildConfigurations` are built first.
 
-#Build Pivots
+# Build Pivots
 Below is a list of all the various options we pivot the project builds on:
 
 - **Target Frameworks:** NetFx (aka Desktop), netstandard (aka dotnet/Portable), NETCoreApp (aka .NET Core), UAP (aka UWP/Store/netcore50)
@@ -37,7 +37,7 @@ Below is a list of all the various options we pivot the project builds on:
 - **Flavor:** Debug, Release
 - **Architecture:** x86, x64, arm, arm64, AnyCPU
 
-##Individual build properties
+## Individual build properties
 The following are the properties associated with each build pivot
 
 - `$(TargetGroup) -> netstandard | netcoreapp | netcoreappcorert | netfx | uap | uapaot`
@@ -49,7 +49,7 @@ The following are the properties associated with each build pivot
 
 For more information on various targets see also [.NET Standard](https://github.com/dotnet/standard/blob/master/docs/versions.md)
 
-##Aggregate build properties
+## Aggregate build properties
 Each project will define a set of supported build configurations
 
 ```
@@ -88,7 +88,7 @@ All supported targets with unique windows/unix build for netcoreapp:
 <PropertyGroup>
 ```
 
-##Options for building
+## Options for building
 
 A full or individual project build is centered around BuildConfiguration and will be setup in one of the following ways:
 
@@ -101,20 +101,20 @@ On top of the `BuildConfiguration` we also have `RuntimeOS` which can be passed 
 
 Any of the mentioned properties can be set via `/p:<Property>=<Value>` at the command line. When building using our run tool or any of the wrapper scripts around it (i.e. build.cmd) a number of these properties have aliases which make them easier to pass (run build.cmd/sh -? for the aliases).
 
-##Selecting the correct build configuration
+## Selecting the correct build configuration
 When building an individual project the `BuildConfiguation` will be used to select the closest matching configuration listed in the projects `BuildConfigurations` property. The rules used to select the configuration will consider compatible target frameworks and OS fallbacks.
 
 TODO: Link to the target framework and OS fallbacks when they are available.
 Temporary versions are at https://github.com/dotnet/corefx/blob/dev/eng/src/Tools/GenerateProps/osgroups.props and https://github.com/dotnet/corefx/blob/dev/eng/src/Tools/GenerateProps/targetgroups.props
 
-##Supported full build configurations
+## Supported full build configurations
 - .NET Core latest on current OS (default) -> `netcoreapp-[RunningOS]`
 - .NET Core CoreRT -> `netcoreappcorert-[RunningOS]`
 - .NET Framework latest -> `netfx-Windows_NT`
 - UWP -> `uapaot-Windows_NT`
 - UAP F5 -> `uap-Windows_NT`
 
-##Project configurations for VS
+## Project configurations for VS
 For each unique configuration needed for a given library project a configuration property group should be added to the project so it can be selected and built in VS and also clearly identify the various configurations.<BR/>
 
 `<PropertyGroup Condition="'$(Configuration)|$(Platform)' == '$(OSGroup)-$(TargetGroup)-$(ConfigurationGroup)|$(Platform)'">`
@@ -144,7 +144,7 @@ Project configurations that are unique for a few different target frameworks and
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap101-Release|AnyCPU'" />
 ```
 
-##Updating Configurations
+## Updating Configurations
 
 We have a build task that you can run to automatically update all the projects with the above boilerplate as well as updating all the solution files for the libraries. Whenever you change the list of configurations for a project you can regenerate all these for the entire repo by running:
 
@@ -154,7 +154,7 @@ msbuild build.proj /t:UpdateVSConfigurations
 
 If you want to scope the geneneration you can either undo changes that you don't need or you can temporally limit the set of projects or directories by updating the item set in the UpdateVSConfigurations target in https://github.com/dotnet/corefx/blob/master/build.proj
 
-#Library project guidelines
+# Library project guidelines
 Library projects should use the following directory layout.
 
 ```
@@ -164,7 +164,7 @@ src\<Library Name>\pkg - Contains package projects for the library.
 src\<Library Name>\tests - Contains the test code for a library
 ```
 
-##ref
+## ref
 Reference assemblies are required for any library that has more than one implementation or uses a facade. A reference assembly is a surface-area-only assembly that represents the public API of the library. To generate a reference assembly source file you can use the [GenAPI tool](https://www.nuget.org/packages/Microsoft.DotNet.BuildTools.GenAPI). If a library is a pure portable library with a single implementation it need not use a reference assembly at all.
 
 In the ref directory for the library there should be at most **one** `.csproj` that contains the latest API for the reference assembly for the library. That project can contain multiple entries in its `BuildConfigurations` property.
@@ -180,32 +180,32 @@ There are two types of reference assembly projects:
  - Should contain `<Reference Include='netstandard'>`
  - Anything outside of netstandard should use a relative path `<ProjectReference>` to its dependencies it has. Those dependencies should only be libraries that are built against netstandard as well.
 
-###ref output
+### ref output
 The output for the ref project build will be a flat targeting pack folder in the following directory:
 
 `bin\ref\$(TargetGroup)`
 
 <BR/>//**CONSIDER**: Do we need a specific BuildConfiguration version of TargetGroup for this output path to ensure all projects output to same targeting path?
 
-##src
+## src
 In the src directory for a library there should be only **one** `.csproj` file that contains any information necessary to build the library in various configurations. All supported configurations should be listed in the `BuildConfigurations` property.
 
 All libraries should use `<Reference Include="..." />` for all their project references. That will cause them to be resolved against a targeting pack (i.e. `bin\ref\netcoreapp` or `\bin\ref\netstanard`) based on the project configuration. There should not be any direct project references to other libraries. The only exception to that rule right now is for partial facades which directly reference System.Private.CoreLib and thus need to directly reference other partial facades to avoid type conflicts.
 <BR>//**CONSIDER**: just using Reference and use a reference to System.Private.CoreLib as a trigger to turn the other References into a ProjectReference automatically. That will allow us to have consistency where all projects just use Reference.
 
-###src output
+### src output
 The output for the src product build will be a flat runtime folder into the following directory:
 
 `bin\runtime\$(BuildConfiguration)`
 
 Note: The `BuildConfiguration` is the global property and not the project configuration because we need all projects to output to the same runtime directory no matter which compatible configuration we select and build the project with.
 
-##pkg
+## pkg
 In the pkg directory for the library there should be only **one** `.pkgproj` for the primary package for the library. If the library has platform-specific implementations those should be split into platform specific projects in a subfolder for each platform. (see [Package projects](./package-projects.md))
 
 TODO: Outline changes needed for pkgprojs
 
-##tests
+## tests
 Similar to the src projects tests projects will define a `BuildConfigurations` property so they can list out the set of build configurations they support.
 
 Tests should not have any `<Reference>` or `<ProjectReference>` items in their project because they will automatically reference everything in the targeting pack based on the configuration they are building in. The only exception to this is a `<ProjectReference>` can be used to reference other test helper libraries or assets.
@@ -213,13 +213,13 @@ Tests should not have any `<Reference>` or `<ProjectReference>` items in their p
 In order to build and run a test project in a given configuration a root level build.cmd/sh must have been completed for that configuration first. Tests will run on the live built runtime at `bin\runtime\$(BuildConfiguration)`.
 TODO: We need update our test host so that it can run from the shared runtime directory as well as resolve assemblies from the test output directory.
 
-###tests output
+### tests output
 All test outputs should be under
 
 `bin\tests\$(MSBuildProjectName)\$(BuildConfiguration)` or
 `bin\tests\$(MSBuildProjectName)\netstandard`
 
-##Facades
+## Facades
 Facade are unique in that they don't have any code and instead are generated by finding a contract reference assembly with the matching identity and generating type forwards for all the types to where they live in the implementation assemblies (aka facade seeds). There are also partial facades which contain some type forwards as well as some code definitions. All the various build configurations should be contained in the one csproj file per library.
 
 TODO: Fill in more information about the required properties for creatng a facade project.

--- a/Documentation/project-docs/developer-guide.md
+++ b/Documentation/project-docs/developer-guide.md
@@ -30,7 +30,7 @@ For more information about the different options that each task has, use the arg
 build -?
 ```
 
-###Build
+### Build
 The CoreFX build has two logical components, the native build which produces the "shims" (which provide a stable interface between the OS and managed code) and
 the managed build which produces the MSIL code and nuget packages that make up CoreFX.
 
@@ -76,7 +76,7 @@ build -framework=netfx
 build -framework=uap
 ```
 
-###Build Native
+### Build Native
 The native build produces shims over libc, openssl, gssapi, libcurl and libz.
 The build system uses CMake (2.8.12 or higher) to generate Makefiles using clang (3.5 or higher).
 The build also uses git for generating some version information.
@@ -97,7 +97,7 @@ build-native -debug -buildArch=arm -- cross verbose
 
 For more information about extra parameters take a look at the scripts `build-native` under src/Native.
 
-###Build Managed
+### Build Managed
 Since the managed build uses the .NET Core CLI (which the build will download), managed components can only be built on a subset of distros.
 There are some additional prerequisites from the CLI which need to be installed. Both libicu and
 libunwind are used by CoreCLR to execute managed code, so they must be
@@ -117,7 +117,7 @@ build-managed -debug -buildArch=x64
 build-managed -debug -buildArch=x64 -os=Linux
 ```
 
-###Build And Run Tests
+### Build And Run Tests
 To build the tests and run them you can call the build-test script. The same parameters you pass to build should also be passed to build-tests script to ensure you are building and running the tests on the same configuration you have build the product on. However to run tests on the same machine you need to ensure the machine supports the configuration you are building.
 
 **Examples**

--- a/Documentation/project-docs/glossary.md
+++ b/Documentation/project-docs/glossary.md
@@ -103,13 +103,13 @@ A simple example of LINQ is
 var odds = source.Where(obj => obj.Id == 1).ToArray();
 ```
 
-####IQueryable&lt;T&gt; and Expressions
+#### IQueryable&lt;T&gt; and Expressions
 
 One of the big advantages of using LINQ over more common data processing patterns is that the function given to the LINQ function can be converted to an expression and then executed in some other form, like SQL or on another machine across the network. An expression is a in-memory representation of some logic to follow.
 
 For example, in the above sample `source` could actually be a database connection and the function call `Where(obj => obj.Id == 1)` would be conveted to a SQL WHERE clause: `WHERE ID = 1`, and then executed on the SQL server.
 
-####Parallel LINQ
+#### Parallel LINQ
 
 **Also referred to as**: PLINQ
 

--- a/pkg/Microsoft.NETCore.Platforms/readme.md
+++ b/pkg/Microsoft.NETCore.Platforms/readme.md
@@ -1,17 +1,17 @@
-#Runtime IDs
+# Runtime IDs
 The package `Microsoft.NETCore.Platforms` defines the runtime identifiers (RIDs) used by .NET packages to represent runtime-specific assets in NuGet packages.
 
-##What is a RID?
+## What is a RID?
 A RID is an opaque string that identifies a platform.  RIDs have relationships to other RIDs by "importing" the other RID.  In that way a RID is a directed graph of compatible RIDs.
 
-##How does NuGet use RIDs?
+## How does NuGet use RIDs?
 When NuGet is deciding which assets to use from a package and which packages to include NuGet will consider a RID if the project.json lists a RID in its `runtimes` section.
 
 - NuGet chooses the best RID-specific asset, where best is determined by a breadth first traversal of the RID graph.  Breadth ordering is document order.
 - NuGet considers RID-specific assets for two asset types: lib and native.
 - NuGet never considers RID-specific assets for compile.
 
-###Best RID
+### Best RID
 Consider the partial RID-graph:
 ```
         "any": {},
@@ -52,7 +52,7 @@ As such, best RID, when evaluating for win7-x64 would be:`win7-x64`, `win7`, `wi
 Similarly, when evaluating for `win-x64`: `win-x64`, `win`, `any`
 Note that `win7` comes before `win-x64` due to the import for `win7` appearing before the import for `win-x64` in document order.
 
-###RID-qualified assets are preferred
+### RID-qualified assets are preferred
 NuGet will always prefer a RID-qualified asset over a RID-less asset.  For example if a package contains
 ```
 lib/netcoreapp1.0/foo.dll
@@ -75,18 +75,18 @@ runtimes/win/lib/netstandard1.0/foo.dll
 ```
 When resolving for netstandard1.5/win7-x64 will select `lib/netstandard1.5/foo.dll` for the compile asset and `runtimes/win/lib/netstandard1.0/foo.dll` for the runtime asset.
 
-##Adding new RIDs
+## Adding new RIDs
 
-###Why do I need to add a new RID?
+### Why do I need to add a new RID?
 NuGet's extensibility mechanism for platform-specific assets requires a RID be defined for any platform that needs assets specific to that platform.  Unlike TFMs, which have a known relationship in NuGet (eg net4.5 is compatible with net4.0), RIDs are opaque strings which NuGet knows nothing about.  The definition and relationship of RIDs comes solely from the `runtime.json` files within the root of the packages referenced by the project.
 As such, whenever we want to put a new RID in a project.json in order to get assets specific for that RID we have to define the rid in some package.  Typically that package is `Microsoft.NETCore.Platforms` if the RID is "official".  If you'd like to prototype you can put the RID in any other package and so long as that package is referenced you can use that RID.
 
-###Do I really need to add a new RID?
+### Do I really need to add a new RID?
 If you're prototyping on a platform that is compatible with an existing platform then you can reuse the RID for that exsisting platform.  New RIDs are only needed when an asset needs to be different on a particular platform.
 
 `Microsoft.NETCore.Platforms` attempts to define all RIDs that packages may need, and as such will define RIDs for platforms that we don't actually cross compile for.  This is to support higher-level packages, 3rd party packages, that may need to cross-compile for that RID.
 
-###Naming convention
+### Naming convention
 We use the following convention in all newly-defined RIDs.  Some RIDs (win7-x64, win8-x64) predate this convention and don't follow it, but all new RIDs should follow it.
 `[os name].[version]-[architecture]-[additional qualifiers]`, for example `osx.10.10-x64` or `ubuntu.14.04-x64`
 - `[os name]` can contain any characters other than `.`
@@ -96,10 +96,10 @@ We use the following convention in all newly-defined RIDs.  Some RIDs (win7-x64,
 
 For all of these we strive to make them something that can be uniquely discoverable at runtime, so that a RID may be computed from an executing application.  As such these properties should be derivable from `/etc/os-release` or similar platform APIs / data.
 
-###Binary compatibility
+### Binary compatibility
 Binary compatibility is represented through imports.  If a platform is considered binary compatible with another version of the same platform, or a specific version of another platform, then it can import that platform.  This permits packages to reuse assets that were built for the imported platform on the compatible platform.  Binary compatibility here is a bit nebulous because inevietably different platforms will have observable differences that can cause compatibility problems.  For the purposes of RIDs we'll try to represent compatibility as versions of a platform that are explicitly advertised as being compatible with a previous version and/or another platform and don't have any known broad breaking changes.
 
-###Import convention
+### Import convention
 Imports should be used when the added RID is considered compatible with an existing RID.
 
 1. Architecture-specific RIDs should first import the architecture-less RID.  EG: `osx.10.11-x64` should first import `osx.10.11`.

--- a/src/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md
+++ b/src/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md
@@ -308,7 +308,7 @@ Id is passed to external dependencies and considered as [ParentId](#parentid) fo
 ### SetEndTime()
 `Activity SetEndTime(DateTime endTimeUtc)` - sets [Duration](#duration) as a difference between endTimeUtc and [StartTimeUtc](#starttimeutc).
 
-##DiagnosticSource
+## DiagnosticSource
 ### StartActivity
 `Activity StartActivity(Activity activity, object args)` - Starts the given activity and writes DiagnosticSource event message OperationName.Start with args payload.
 ### StopActivity

--- a/src/System.Reflection.Metadata/specs/PE-COFF.md
+++ b/src/System.Reflection.Metadata/specs/PE-COFF.md
@@ -1,4 +1,4 @@
-#PE/COFF Specification Addendum
+# PE/COFF Specification Addendum
 
 ## Deterministic PE/COFF File
 

--- a/src/System.Reflection.Metadata/specs/PortablePdb-Metadata.md
+++ b/src/System.Reflection.Metadata/specs/PortablePdb-Metadata.md
@@ -1,4 +1,4 @@
-#Portable PDB v1.0: Format Specification
+# Portable PDB v1.0: Format Specification
 
 ## Portable PDB
 The Portable PDB (Program Database) format describes an encoding of debugging information produced by compilers of Common Language Infrastructure (CLI) languages and consumed by debuggers and other tools. The format is based on the ECMA-335 Partition II metadata standard. It extends its schema while using the same physical table and stream layouts and encodings. The schema of the debugging metadata is complementary to the ECMA-335 metadata schema, therefore, the debugging metadata can (but doesn’t need to) be stored in the same metadata section of the PE/COFF file as the type system metadata.
@@ -133,7 +133,7 @@ _Sequence points blob_ has the following structure:
     Blob ::= header SequencePointRecord (SequencePointRecord | document-record)*
     SequencePointRecord ::= sequence-point-record | hidden-sequence-point-record
 
-#####header
+##### header
 | component        | value stored                  | integer representation |
 |:-----------------|:------------------------------|:-----------------------|
 | _LocalSignature_ | StandAloneSig table row id    | unsigned compressed    |
@@ -143,7 +143,7 @@ _LocalSignature_ stores the row id of the local signature of the method. This in
 
 _InitialDocument_ is only present if the _Document_ field of the _MethodDebugInformation_ table is nil (i.e. the method body spans multiple documents).
 
-#####sequence-point-record
+##### sequence-point-record
 | component      | value stored                                         | integer representation                      |
 |:---------------|:-----------------------------------------------------|:--------------------------------------------|
 | _δILOffset_    | _ILOffset_ if this is the first sequence point       | unsigned compressed                         |
@@ -156,7 +156,7 @@ _InitialDocument_ is only present if the _Document_ field of the _MethodDebugInf
 | _δStartColumn_ | _StartColumn_ if this is the first non-hidden sequence point | unsigned compressed |
 |                | _StartColumn_ - _PreviousNonHidden_._StartColumn_ otherwise  | signed compressed   |
 
-#####hidden-sequence-point-record
+##### hidden-sequence-point-record
 | component    | value stored                                           | integer representation          |
 |:-------------|:-------------------------------------------------------|:--------------------------------|
 | _δILOffset_  | _ILOffset_ if this is the first sequence point         | unsigned compressed             |
@@ -164,7 +164,7 @@ _InitialDocument_ is only present if the _Document_ field of the _MethodDebugInf
 | _ΔLine_      | 0                                                      | unsigned compressed             |
 | _ΔColumn_	   | 0                                                      | unsigned compressed             |
 
-#####document-record
+##### document-record
 | component    | value stored                       | integer representation         |
 |:-------------|:-----------------------------------|:-------------------------------|
 | _δILOffset_  | 0                                  | unsigned compressed            |


### PR DESCRIPTION
GitHub recently switched their rendering engine and now require a space between `#` and the actual heading. See https://github.github.com/gfm/#atx-headings