### PR TITLE
Remove System.Data.SqlClient and System.Text.Encoding.CodePages from shared fx.

### DIFF
--- a/src/System.Data.SqlClient/dir.props
+++ b/src/System.Data.SqlClient/dir.props
@@ -3,7 +3,5 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.1.2.0</AssemblyVersion>
-    <IsNETCoreApp>true</IsNETCoreApp>
-    <IsUAP>true</IsUAP>    
   </PropertyGroup>
 </Project>

--- a/src/System.Text.Encoding.CodePages/dir.props
+++ b/src/System.Text.Encoding.CodePages/dir.props
@@ -3,8 +3,5 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
-    <IsNETCoreApp>true</IsNETCoreApp>
-    <IsNETCoreAppRef>false</IsNETCoreAppRef>
-    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
System.Data.SqlClient doesn't need to be part of the shared framework in 2.0 as
it wasn't part of included in 1.X and it is no longer part of netstandard2.0.

System.Text.Encoding.CodePages was only needed by Roslyn which has been removed
and SqlClient which we are removing so we can now eliminate it from the shared
frameworks and make it as an opt-in only component as it was intended to be.

cc @ericstj @terrajobst @Petermarcu 

Contributes to https://github.com/dotnet/corefx/issues/16912