### PR TITLE
Adding tests for System.IO.Path.IsPathRooted that checks if invalid v…

### DIFF
--- a/src/System.Runtime.Extensions/tests/System/IO/PathTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/PathTests.cs
@@ -231,9 +231,9 @@ namespace System.IO.Tests
         // Testing invalid drive letters !(a-zA-Z)
         [PlatformSpecific(TestPlatforms.Windows)]
         [Theory]
-        [InlineData(@"@:\\foo")]    // 064 = @     065 = A
+        [InlineData(@"@:\foo")]    // 064 = @     065 = A
         [InlineData(@"[:\\")]       // 091 = [     090 = Z
-        [InlineData(@"`:\\foo")]    // 096 = `     097 = a
+        [InlineData(@"`:\foo")]    // 096 = `     097 = a
         [InlineData(@"{:\\")]       // 123 = {     122 = z
         public static void IsPathRooted_Windows_Invalid(string value)
         {

--- a/src/System.Runtime.Extensions/tests/System/IO/PathTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/PathTests.cs
@@ -227,6 +227,18 @@ namespace System.IO.Tests
             Assert.False(Path.IsPathRooted(uncPath));
             Assert.Equal(string.Empty, Path.GetPathRoot(uncPath));
         }
+        
+        // Testing invalid drive letters !(a-zA-Z)
+        [PlatformSpecific(TestPlatforms.Windows)]
+        [Theory]
+        [InlineData(@"@:\\foo")]    // 064 = @     065 = A
+        [InlineData(@"[:\\")]       // 091 = [     090 = Z
+        [InlineData(@"`:\\foo")]    // 096 = `     097 = a
+        [InlineData(@"{:\\")]       // 123 = {     122 = z
+        public static void IsPathRooted_Windows_Invalid(string value)
+        {
+            Assert.False(Path.IsPathRooted(value));
+        }
 
         [Fact]
         public static void GetRandomFileName()


### PR DESCRIPTION
…olume letters are indeed invalid

fixes https://github.com/dotnet/coreclr/issues/10297

Tests should work after coreclr merge is synced into corefx