### PR TITLE
Fix Http test regarding uri fragments and redirection

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -588,7 +588,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [OuterLoop] // TODO: Issue #11345
-        [ConditionalTheory(nameof(IsNotWindows7))] // TODO: Issue #16133
+        [ConditionalTheory(nameof(IsNotWindows7))] // Skip test on Win7 since WinHTTP has bugs w/ fragments.
         [InlineData("#origFragment", "", "#origFragment", false)]
         [InlineData("#origFragment", "", "#origFragment", true)]
         [InlineData("", "#redirFragment", "#redirFragment", false)]


### PR DESCRIPTION
No real test code change. But confirming that this test needs to be
skipped on Windows 7 due to a bug in WinHTTP with preserving fragments
in an uri during redirection. The WinHTTP bug was fixed in Windows 8.

Fixes #16272 .