### PR TITLE
Set the file version for the generate shims

### DIFF
--- a/src/shims/shims.proj
+++ b/src/shims/shims.proj
@@ -27,6 +27,7 @@
       <GenFacadesArgs>$(GenFacadesArgs) -seeds:"@(GenFacadesSeeds, ',')"</GenFacadesArgs>
       <GenFacadesArgs>$(GenFacadesArgs) -facadePath:"$(GenFacadesOutputPath)"</GenFacadesArgs>
       <GenFacadesArgs>$(GenFacadesArgs) -producePdb:false</GenFacadesArgs>
+      <GenFacadesArgs>$(GenFacadesArgs) -assemblyFileVersion:$(AssemblyFileVersion)</GenFacadesArgs>
       <!-- TODO: We should remove this flag once we have all the types for netstandard -->
       <GenFacadesArgs>$(GenFacadesArgs) -ignoreMissingTypes</GenFacadesArgs>
     </PropertyGroup>


### PR DESCRIPTION
@marksmeltzer pointed out we had incorrect file versions for some files which where are generate shims (https://github.com/dotnet/corefx/issues/17301#issuecomment-287928222) this fixes that issue.

Thanks @marksmeltzer for calling this to our attention.

cc @ericstj 