### PR TITLE
Skip NetEventSource logging tests on .NET Framework

### DIFF
--- a/src/System.Net.NameResolution/tests/FunctionalTests/LoggingTest.cs
+++ b/src/System.Net.NameResolution/tests/FunctionalTests/LoggingTest.cs
@@ -11,6 +11,7 @@ namespace System.Net.NameResolution.Tests
     public static class LoggingTest
     {
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core")]
         public static void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(Dns).GetTypeInfo().Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);

--- a/src/System.Net.Primitives/tests/FunctionalTests/LoggingTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/LoggingTest.cs
@@ -12,6 +12,7 @@ namespace System.Net.Primitives.Functional.Tests
     public class LoggingTest : RemoteExecutorTestBase
     {
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core")]
         public void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(IPAddress).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);
@@ -24,6 +25,7 @@ namespace System.Net.Primitives.Functional.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core")]
         public void EventSource_EventsRaisedAsExpected()
         {
             RemoteInvoke(() =>


### PR DESCRIPTION
The 'NetEventSource' logging only works on .NET Core libraries. So, we
need to skip these tests when running on full .NET Framework.

Fixes #14989