### PR TITLE
Skip more NetEventSource logging tests on .NET Framework

### DIFF
--- a/src/System.Net.Mail/tests/Functional/LoggingTest.cs
+++ b/src/System.Net.Mail/tests/Functional/LoggingTest.cs
@@ -12,6 +12,7 @@ namespace System.Net.Mail.Tests
     public class LoggingTest : RemoteExecutorTestBase
     {
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core")]
         public void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(SmtpClient).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);
@@ -24,6 +25,7 @@ namespace System.Net.Mail.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core")]
         public void EventSource_EventsRaisedAsExpected()
         {
             RemoteInvoke(() =>

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/LoggingTest.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/LoggingTest.cs
@@ -10,6 +10,7 @@ namespace System.Net.NetworkInformation.Tests
     public class LoggingTest
     {
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core")]
         public void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(NetworkChange).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);

--- a/src/System.Net.Ping/tests/FunctionalTests/LoggingTest.cs
+++ b/src/System.Net.Ping/tests/FunctionalTests/LoggingTest.cs
@@ -10,6 +10,7 @@ namespace System.Net.NetworkInformation.Tests
     public class LoggingTest
     {
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core")]
         public void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(Ping).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);

--- a/src/System.Net.Requests/tests/LoggingTest.cs
+++ b/src/System.Net.Requests/tests/LoggingTest.cs
@@ -10,6 +10,7 @@ namespace System.Net.Tests
     public class LoggingTest
     {
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core")]
         public void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(WebRequest).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);

--- a/src/System.Net.Security/tests/FunctionalTests/LoggingTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/LoggingTest.cs
@@ -12,6 +12,7 @@ namespace System.Net.Security.Tests
     public class LoggingTest : RemoteExecutorTestBase
     {
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core")]
         public void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(SslStream).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);
@@ -24,6 +25,7 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core")]
         [ActiveIssue(16516, TestPlatforms.Windows)]
         public void EventSource_EventsRaisedAsExpected()
         {

--- a/src/System.Net.Sockets/tests/FunctionalTests/LoggingTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/LoggingTest.cs
@@ -13,6 +13,7 @@ namespace System.Net.Sockets.Tests
     public class LoggingTest : RemoteExecutorTestBase
     {
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core")]
         public static void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(Socket).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);
@@ -26,6 +27,7 @@ namespace System.Net.Sockets.Tests
 
         [OuterLoop]
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core")]
         public void EventSource_EventsRaisedAsExpected()
         {
             RemoteInvoke(() =>

--- a/src/System.Net.WebHeaderCollection/tests/LoggingTest.cs
+++ b/src/System.Net.WebHeaderCollection/tests/LoggingTest.cs
@@ -10,6 +10,7 @@ namespace System.Net.Tests
     public class LoggingTest
     {
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core")]
         public void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(WebHeaderCollection).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);

--- a/src/System.Net.WebSockets.Client/tests/LoggingTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/LoggingTest.cs
@@ -11,6 +11,7 @@ namespace System.Net.WebSockets.Tests
     public class LoggingTest
     {
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core")]
         public void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(ClientWebSocket).GetTypeInfo().Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);


### PR DESCRIPTION
Similar to PR #17348.

The 'NetEventSource' logging only works on .NET Core libraries. So, we
need to skip these tests when running on full .NET Framework.