### PR TITLE
Fix Pipes AccessControl behavior to match Desktop

### DIFF
--- a/src/System.IO.Pipes.AccessControl/src/Resources/Strings.resx
+++ b/src/System.IO.Pipes.AccessControl/src/Resources/Strings.resx
@@ -67,4 +67,7 @@
   <data name="InvalidOperation_PipeNotYetConnected" xml:space="preserve">
     <value>Pipe is not connected.</value>
   </data>
+  <data name="IO_IO_PipeBroken" xml:space="preserve">
+    <value>Pipe is broken.</value>
+  </data>
 </root>

--- a/src/System.IO.Pipes.AccessControl/src/System/IO/PipesAclExtensions.cs
+++ b/src/System.IO.Pipes.AccessControl/src/System/IO/PipesAclExtensions.cs
@@ -12,28 +12,31 @@ namespace System.IO.Pipes
         [System.Security.SecurityCritical]
         public static PipeSecurity GetAccessControl(this PipeStream stream)
         {
-            // PipeState can not be Closed and the Handle can not be null or closed
-            var handle = stream.SafePipeHandle; // A non-null, open handle implies a non-closed PipeState.
+            // Checks that State != WaitingToConnect and State != Closed
+            var handle = stream.SafePipeHandle;
+
+            // PipeState must be Disconnected, Connected, or Broken
             return new PipeSecurity(handle, AccessControlSections.Access | AccessControlSections.Owner | AccessControlSections.Group);
         }
 
         [System.Security.SecurityCritical]
         public static void SetAccessControl(this PipeStream stream, PipeSecurity pipeSecurity)
         {
-            // PipeState can not be Closed and the Handle can not be null or closed
             if (pipeSecurity == null)
             {
                 throw new ArgumentNullException(nameof(pipeSecurity));
             }
 
-            var handle = stream.SafePipeHandle; // A non-null, open handle implies a non-closed PipeState.
+            // Checks that State != WaitingToConnect and State != Closed
+            var handle = stream.SafePipeHandle;
 
-            // NamedPipeClientStream: PipeState can not be WaitingToConnect or Broken. WaitingToConnect is covered by the SafePipeHandle check.
-            if (stream is NamedPipeClientStream && !stream.IsConnected) // Pipe could also be WaitingToConnect, Broken, Disconnected, or Closed.
+            // Checks that State != Broken
+            if (stream is NamedPipeClientStream && !stream.IsConnected)
             {
-                throw new InvalidOperationException(SR.InvalidOperation_PipeNotYetConnected);
+                throw new IOException(SR.IO_IO_PipeBroken);
             }
 
+            // PipeState must be either Disconected or Connected
             pipeSecurity.Persist(handle);
         }
     }

--- a/src/System.IO.Pipes.AccessControl/tests/NamedPipeTests/NamedPipeTest.AclExtensions.cs
+++ b/src/System.IO.Pipes.AccessControl/tests/NamedPipeTests/NamedPipeTest.AclExtensions.cs
@@ -28,23 +28,98 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
-        public void GetAccessControl_NamedPipe_BeforeWaitingToConnect()
+        public void SetAccessControl_NamedPipeStream()
         {
             string pipeName = GetUniquePipeName();
             var server = new NamedPipeServerStream(pipeName, PipeDirection.Out, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
             var client = new NamedPipeClientStream(".", pipeName, PipeDirection.In, PipeOptions.Asynchronous);
 
+            Task clientConnect = client.ConnectAsync();
+            server.WaitForConnection();
+            clientConnect.Wait();
+
+            Assert.NotNull(server.GetAccessControl());
+            server.SetAccessControl(new PipeSecurity());
+            Assert.NotNull(client.GetAccessControl());
+            client.SetAccessControl(new PipeSecurity());
+        }
+
+        [Fact]
+        public void SetAccessControl_NamedPipeStream_BeforeWaitingToConnect()
+        {
+            string pipeName = GetUniquePipeName();
+            var server = new NamedPipeServerStream(pipeName, PipeDirection.Out, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
+            var client = new NamedPipeClientStream(".", pipeName, PipeDirection.In, PipeOptions.Asynchronous);
+
+            // ServerStream.State = WaitingToConnect, ClientStream.State = WaitingToConnect
             Assert.NotNull(server.GetAccessControl());
             server.SetAccessControl(new PipeSecurity());
             Assert.Throws<InvalidOperationException>(() => client.GetAccessControl());
             Assert.Throws<InvalidOperationException>(() => client.SetAccessControl(new PipeSecurity()));
         }
 
-        /// <summary>
-        /// Tests that SetAccessControl on a Broken NamedPipeClientStream throws an Exception.
-        /// </summary>
         [Fact]
-        public void GetAccessControl_NamedPipeClientStream_Broken()
+        public void SetAccessControl_NamedPipeStream_ClientDisposed()
+        {
+            string pipeName = GetUniquePipeName();
+            var server = new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
+            var client = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
+
+            Task clientConnect = client.ConnectAsync();
+            server.WaitForConnection();
+            clientConnect.Wait();
+
+            // ServerStream.State = Broken, ClientStream.State = Closed
+            client.Dispose();
+            Assert.Throws<IOException>(() => server.Write(new byte[] { 0 }, 0, 1)); // Sets the servers PipeState to Broken
+            Assert.NotNull(server.GetAccessControl());
+            server.SetAccessControl(new PipeSecurity());
+            Assert.Throws<ObjectDisposedException>(() => client.GetAccessControl());
+            Assert.Throws<ObjectDisposedException>(() => client.SetAccessControl(new PipeSecurity()));
+        }
+
+        [Fact]
+        public void SetAccessControl_NamedPipeStream_ClientHandleClosed()
+        {
+            string pipeName = GetUniquePipeName();
+            var server = new NamedPipeServerStream(pipeName, PipeDirection.Out, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
+            var client = new NamedPipeClientStream(".", pipeName, PipeDirection.In, PipeOptions.Asynchronous);
+
+            Task clientConnect = client.ConnectAsync();
+            server.WaitForConnection();
+            clientConnect.Wait();
+
+            // ServerStream.State = Broken, ClientStream.State = Closed
+            client.SafePipeHandle.Close();
+            Assert.Throws<IOException>(() => server.Write(new byte[] { 0 }, 0, 1));
+            Assert.NotNull(server.GetAccessControl());
+            server.SetAccessControl(new PipeSecurity());
+            Assert.Throws<ObjectDisposedException>(() => client.GetAccessControl());
+            Assert.Throws<ObjectDisposedException>(() => client.SetAccessControl(new PipeSecurity()));
+        }
+
+        [Fact]
+        public void SetAccessControl_NamedPipeStream_ServerDisconnected()
+        {
+            string pipeName = GetUniquePipeName();
+            var server = new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
+            var client = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
+
+            Task clientConnect = client.ConnectAsync();
+            server.WaitForConnection();
+            clientConnect.Wait();
+            
+            // ServerStream.State = Disconnected, ClientStream.State = Broken
+            server.Disconnect();
+            Assert.Throws<IOException>(() => client.Write(new byte[] { 0 }, 0, 1));
+            Assert.NotNull(server.GetAccessControl());
+            server.SetAccessControl(new PipeSecurity());
+            Assert.Throws<InvalidOperationException>(() => client.GetAccessControl());
+            Assert.Throws<IOException>(() => client.SetAccessControl(new PipeSecurity()));
+        }
+
+        [Fact]
+        public void SetAccessControl_NamedPipeStream_ServerDisposed()
         {
             string pipeName = GetUniquePipeName();
             var server = new NamedPipeServerStream(pipeName, PipeDirection.In, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
@@ -54,38 +129,33 @@ namespace System.IO.Pipes.Tests
             server.WaitForConnection();
             clientConnect.Wait();
 
-            Assert.NotNull(server.GetAccessControl());
-            server.SetAccessControl(new PipeSecurity());
-            Assert.NotNull(client.GetAccessControl());
-            client.SetAccessControl(new PipeSecurity());
-
+            // ServerStream.State = Closed, ClientStream.State = Broken
             server.Dispose();
-            Assert.Throws<IOException>(() => client.Write(new byte[] { 0 }, 0, 1)); // Sets the clients PipeState to Broken
-            Assert.Throws<InvalidOperationException>(() => client.SetAccessControl(new PipeSecurity()));
+            Assert.Throws<IOException>(() => client.Write(new byte[] { 0 }, 0, 1));
+            Assert.Throws<ObjectDisposedException>(() => server.GetAccessControl());
+            Assert.Throws<ObjectDisposedException>(() => server.SetAccessControl(new PipeSecurity()));
+            Assert.NotNull(client.GetAccessControl());
+            Assert.Throws<IOException>(() => client.SetAccessControl(new PipeSecurity()));
         }
 
-        /// <summary>
-        /// Tests that SetAccessControl on a Broken NamedPipeServerStream succeeds
-        /// </summary>
         [Fact]
-        public void GetAccessControl_NamedPipeServerStream_Broken()
+        public void SetAccessControl_NamedPipeStream_ServerHandleClosed()
         {
             string pipeName = GetUniquePipeName();
-            var server = new NamedPipeServerStream(pipeName, PipeDirection.Out, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
-            var client = new NamedPipeClientStream(".", pipeName, PipeDirection.In, PipeOptions.Asynchronous);
+            var server = new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
+            var client = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
 
             Task clientConnect = client.ConnectAsync();
             server.WaitForConnection();
             clientConnect.Wait();
 
-            Assert.NotNull(server.GetAccessControl());
-            server.SetAccessControl(new PipeSecurity());
+            // ServerStream.State = Closed, ClientStream.State = Broken
+            server.SafePipeHandle.Close();
+            Assert.Throws<IOException>(() => client.Write(new byte[] { 0 }, 0, 1));
+            Assert.Throws<ObjectDisposedException>(() => server.GetAccessControl());
+            Assert.Throws<ObjectDisposedException>(() => server.SetAccessControl(new PipeSecurity()));
             Assert.NotNull(client.GetAccessControl());
-            client.SetAccessControl(new PipeSecurity());
-
-            client.Dispose();
-            Assert.Throws<IOException>(() => server.Write(new byte[] { 0 }, 0, 1)); // Sets the servers PipeState to Broken
-            server.SetAccessControl(new PipeSecurity());
+            Assert.Throws<IOException>(() => client.SetAccessControl(new PipeSecurity()));
         }
     }
 }

--- a/src/System.Security.AccessControl/src/Resources/Strings.resx
+++ b/src/System.Security.AccessControl/src/Resources/Strings.resx
@@ -181,6 +181,9 @@
   <data name="InvalidOperation_OnlyValidForDS" xml:space="preserve">
     <value>Adding ACEs with Object Flags and Object GUIDs is only valid for directory-object ACLs.</value>
   </data>
+  <data name="InvalidOperation_DisconnectedPipe" xml:space="preserve">
+    <value>The pipe has been disconnected.</value>
+  </data>
   <data name="NotSupported_SetMethod" xml:space="preserve">
     <value>The 'set' method is not supported on this property.</value>
   </data>

--- a/src/System.Security.AccessControl/src/System/Security/AccessControl/NativeObjectSecurity.cs
+++ b/src/System.Security.AccessControl/src/System/Security/AccessControl/NativeObjectSecurity.cs
@@ -152,6 +152,10 @@ nameof(name));
                     {
                         exception = new NotSupportedException(SR.AccessControl_NoAssociatedSecurity);
                     }
+                    else if (error == Interop.Errors.ERROR_PIPE_NOT_CONNECTED)
+                    {
+                        exception = new InvalidOperationException(SR.InvalidOperation_DisconnectedPipe);
+                    }
                     else
                     {
                         Debug.Assert(false, string.Format(CultureInfo.InvariantCulture, "Win32GetSecurityInfo() failed with unexpected error code {0}", error));


### PR DESCRIPTION
There are two discrepancies in System.IO.Pipes.AccessControl behavior between netfx/netcoreapp that this resolves:
- SetAccessControl on a broken NamedPipeClientStream should throw an IOException (before this was throwing an InvalidOperationException)
- GetAccessControl on a NamedPipeClientStream for which the paired NamedPipeServerStream has been disconnected should throw an InvalidOperationException (before this was hitting a Debug statement in Debug or an InvalidOperationException in Release).

This PR also expands the Pipes.AccessControl tests to cover the above scenarios as well as several others that we weren't testing.

replaces https://github.com/dotnet/corefx/pull/17251
resolves #10899
resolves #12761