### PR TITLE
Adding Span IndexOfAny APIs that take 2 and 3 bytes

### DIFF
--- a/src/System.Memory/ref/System.Memory.cs
+++ b/src/System.Memory/ref/System.Memory.cs
@@ -99,8 +99,10 @@ namespace System
 
         public static int IndexOfAny(this Span<byte> span, byte value0, byte value1) { throw null; }
         public static int IndexOfAny(this Span<byte> span, byte value0, byte value1, byte value2) { throw null; }
+        public static int IndexOfAny(this Span<byte> span, ReadOnlySpan<byte> values) { throw null; }
         public static int IndexOfAny(this ReadOnlySpan<byte> span, byte value0, byte value1) { throw null; }
         public static int IndexOfAny(this ReadOnlySpan<byte> span, byte value0, byte value1, byte value2) { throw null; }
+        public static int IndexOfAny(this ReadOnlySpan<byte> span, ReadOnlySpan<byte> values) { throw null; }
 
         public static bool SequenceEqual<T>(this Span<T> first, ReadOnlySpan<T> second) where T:struct, IEquatable<T> { throw null; }
         public static bool SequenceEqual(this Span<byte> first, ReadOnlySpan<byte> second) { throw null; }

--- a/src/System.Memory/ref/System.Memory.cs
+++ b/src/System.Memory/ref/System.Memory.cs
@@ -97,6 +97,11 @@ namespace System
         public static int IndexOf<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> value) where T : struct, IEquatable<T> { throw null; }
         public static int IndexOf(this ReadOnlySpan<byte> span, ReadOnlySpan<byte> value) { throw null; }
 
+        public static int IndexOf(this Span<byte> span, byte value0, byte value1) { throw null; }
+        public static int IndexOf(this Span<byte> span, byte value0, byte value1, byte value2) { throw null; }
+        public static int IndexOf(this ReadOnlySpan<byte> span, byte value0, byte value1) { throw null; }
+        public static int IndexOf(this ReadOnlySpan<byte> span, byte value0, byte value1, byte value2) { throw null; }
+
         public static bool SequenceEqual<T>(this Span<T> first, ReadOnlySpan<T> second) where T:struct, IEquatable<T> { throw null; }
         public static bool SequenceEqual(this Span<byte> first, ReadOnlySpan<byte> second) { throw null; }
 

--- a/src/System.Memory/ref/System.Memory.cs
+++ b/src/System.Memory/ref/System.Memory.cs
@@ -97,10 +97,10 @@ namespace System
         public static int IndexOf<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> value) where T : struct, IEquatable<T> { throw null; }
         public static int IndexOf(this ReadOnlySpan<byte> span, ReadOnlySpan<byte> value) { throw null; }
 
-        public static int IndexOf(this Span<byte> span, byte value0, byte value1) { throw null; }
-        public static int IndexOf(this Span<byte> span, byte value0, byte value1, byte value2) { throw null; }
-        public static int IndexOf(this ReadOnlySpan<byte> span, byte value0, byte value1) { throw null; }
-        public static int IndexOf(this ReadOnlySpan<byte> span, byte value0, byte value1, byte value2) { throw null; }
+        public static int IndexOfAny(this Span<byte> span, byte value0, byte value1) { throw null; }
+        public static int IndexOfAny(this Span<byte> span, byte value0, byte value1, byte value2) { throw null; }
+        public static int IndexOfAny(this ReadOnlySpan<byte> span, byte value0, byte value1) { throw null; }
+        public static int IndexOfAny(this ReadOnlySpan<byte> span, byte value0, byte value1, byte value2) { throw null; }
 
         public static bool SequenceEqual<T>(this Span<T> first, ReadOnlySpan<T> second) where T:struct, IEquatable<T> { throw null; }
         public static bool SequenceEqual(this Span<byte> first, ReadOnlySpan<byte> second) { throw null; }

--- a/src/System.Memory/src/System/SpanExtensions.cs
+++ b/src/System.Memory/src/System/SpanExtensions.cs
@@ -152,6 +152,17 @@ namespace System
         }
 
         /// <summary>
+        /// Searches for the first index of any of the specified values similar to calling IndexOf several times with the logical OR operator. If not found, returns -1. 
+        /// </summary>
+        /// <param name="span">The span to search.</param>
+        /// <param name="values">The set of values to search for.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int IndexOfAny(this Span<byte> span, ReadOnlySpan<byte> values)
+        {
+            return SpanHelpers.IndexOfAny(ref span.DangerousGetPinnableReference(), span.Length, ref values.DangerousGetPinnableReference(), values.Length);
+        }
+
+        /// <summary>
         /// Searches for the first index of any of the specified values similar to calling IndexOf several times with the logical OR operator. If not found, returns -1.
         /// </summary>
         /// <param name="span">The span to search.</param>
@@ -174,6 +185,17 @@ namespace System
         public static int IndexOfAny(this ReadOnlySpan<byte> span, byte value0, byte value1, byte value2)
         {
             return SpanHelpers.IndexOfAny(ref span.DangerousGetPinnableReference(), value0, value1, value2, span.Length);
+        }
+
+        /// <summary>
+        /// Searches for the first index of any of the specified values similar to calling IndexOf several times with the logical OR operator. If not found, returns -1. 
+        /// </summary>
+        /// <param name="span">The span to search.</param>
+        /// <param name="values">The set of values to search for.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int IndexOfAny(this ReadOnlySpan<byte> span, ReadOnlySpan<byte> values)
+        {
+            return SpanHelpers.IndexOfAny(ref span.DangerousGetPinnableReference(), span.Length, ref values.DangerousGetPinnableReference(), values.Length);
         }
 
         /// <summary>

--- a/src/System.Memory/src/System/SpanExtensions.cs
+++ b/src/System.Memory/src/System/SpanExtensions.cs
@@ -126,6 +126,58 @@ namespace System
         }
 
         /// <summary>
+        /// Searches for the specified values and returns the index of the first occurrence where all of them appear in sequence. If not found, returns -1. 
+        /// </summary>
+        /// <param name="span">The span to search.</param>
+        /// <param name="value0">The first value to search for.</param>
+        /// <param name="value1">The value to search for at the index right after the one where the first one is found.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int IndexOf(this Span<byte> span, byte value0, byte value1)
+        {
+            return SpanHelpers.IndexOf(ref span.DangerousGetPinnableReference(), value0, value1, span.Length);
+        }
+
+        /// <summary>
+        /// Searches for the specified values and returns the index of the first occurrence where all of them appear in sequence. If not found, returns -1. 
+        /// </summary>
+        /// <param name="span">The span to search.</param>
+        /// <param name="value0">The first value to search for.</param>
+        /// <param name="value1">The value to search for at the index right after the one where the first one is found.</param>
+        /// <param name="value2">The value to search for at the index right after the one where the second one is found.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int IndexOf(this Span<byte> span, byte value0, byte value1, byte value2)
+        {
+            return -1;
+            //return SpanHelpers.IndexOf(ref span.DangerousGetPinnableReference(), value0, value1, value2, span.Length);
+        }
+
+        /// <summary>
+        /// Searches for the specified values and returns the index of the first occurrence where all of them appear in sequence. If not found, returns -1. 
+        /// </summary>
+        /// <param name="span">The span to search.</param>
+        /// <param name="value0">The first value to search for.</param>
+        /// <param name="value1">The value to search for at the index right after the one where the first one is found.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int IndexOf(this ReadOnlySpan<byte> span, byte value0, byte value1)
+        {
+            return SpanHelpers.IndexOf(ref span.DangerousGetPinnableReference(), value0, value1, span.Length);
+        }
+
+        /// <summary>
+        /// Searches for the specified values and returns the index of the first occurrence where all of them appear in sequence. If not found, returns -1. 
+        /// </summary>
+        /// <param name="span">The span to search.</param>
+        /// <param name="value0">The first value to search for.</param>
+        /// <param name="value1">The value to search for at the index right after the one where the first one is found.</param>
+        /// <param name="value2">The value to search for at the index right after the one where the second one is found.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int IndexOf(this ReadOnlySpan<byte> span, byte value0, byte value1, byte value2)
+        {
+            return -1;
+            //return SpanHelpers.IndexOf(ref span.DangerousGetPinnableReference(), value0, value1, value2, span.Length);
+        }
+
+        /// <summary>
         /// Determines whether two sequences are equal by comparing the elements using IEquatable&lt;T&gt;.Equals(T). 
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/System.Memory/src/System/SpanExtensions.cs
+++ b/src/System.Memory/src/System/SpanExtensions.cs
@@ -147,8 +147,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int IndexOf(this Span<byte> span, byte value0, byte value1, byte value2)
         {
-            return -1;
-            //return SpanHelpers.IndexOf(ref span.DangerousGetPinnableReference(), value0, value1, value2, span.Length);
+            return SpanHelpers.IndexOf(ref span.DangerousGetPinnableReference(), value0, value1, value2, span.Length);
         }
 
         /// <summary>
@@ -173,8 +172,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int IndexOf(this ReadOnlySpan<byte> span, byte value0, byte value1, byte value2)
         {
-            return -1;
-            //return SpanHelpers.IndexOf(ref span.DangerousGetPinnableReference(), value0, value1, value2, span.Length);
+            return SpanHelpers.IndexOf(ref span.DangerousGetPinnableReference(), value0, value1, value2, span.Length);
         }
 
         /// <summary>

--- a/src/System.Memory/src/System/SpanExtensions.cs
+++ b/src/System.Memory/src/System/SpanExtensions.cs
@@ -125,54 +125,55 @@ namespace System
             return SpanHelpers.IndexOf(ref span.DangerousGetPinnableReference(), span.Length, ref value.DangerousGetPinnableReference(), value.Length);
         }
 
+
         /// <summary>
-        /// Searches for the specified values and returns the index of the first occurrence where all of them appear in sequence. If not found, returns -1. 
+        /// Searches for the first index of any of the specified values similar to calling IndexOf several times with the logical OR operator. If not found, returns -1.
         /// </summary>
         /// <param name="span">The span to search.</param>
-        /// <param name="value0">The first value to search for.</param>
-        /// <param name="value1">The value to search for at the index right after the one where the first one is found.</param>
+        /// <param name="value0">One of the values to search for.</param>
+        /// <param name="value1">One of the values to search for.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int IndexOf(this Span<byte> span, byte value0, byte value1)
+        public static int IndexOfAny(this Span<byte> span, byte value0, byte value1)
         {
-            return SpanHelpers.IndexOf(ref span.DangerousGetPinnableReference(), value0, value1, span.Length);
+            return SpanHelpers.IndexOfAny(ref span.DangerousGetPinnableReference(), value0, value1, span.Length);
         }
 
         /// <summary>
-        /// Searches for the specified values and returns the index of the first occurrence where all of them appear in sequence. If not found, returns -1. 
+        /// Searches for the first index of any of the specified values similar to calling IndexOf several times with the logical OR operator. If not found, returns -1.
         /// </summary>
         /// <param name="span">The span to search.</param>
-        /// <param name="value0">The first value to search for.</param>
-        /// <param name="value1">The value to search for at the index right after the one where the first one is found.</param>
-        /// <param name="value2">The value to search for at the index right after the one where the second one is found.</param>
+        /// <param name="value0">One of the values to search for.</param>
+        /// <param name="value1">One of the values to search for.</param>
+        /// <param name="value2">One of the values to search for.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int IndexOf(this Span<byte> span, byte value0, byte value1, byte value2)
+        public static int IndexOfAny(this Span<byte> span, byte value0, byte value1, byte value2)
         {
-            return SpanHelpers.IndexOf(ref span.DangerousGetPinnableReference(), value0, value1, value2, span.Length);
+            return SpanHelpers.IndexOfAny(ref span.DangerousGetPinnableReference(), value0, value1, value2, span.Length);
         }
 
         /// <summary>
-        /// Searches for the specified values and returns the index of the first occurrence where all of them appear in sequence. If not found, returns -1. 
+        /// Searches for the first index of any of the specified values similar to calling IndexOf several times with the logical OR operator. If not found, returns -1.
         /// </summary>
         /// <param name="span">The span to search.</param>
-        /// <param name="value0">The first value to search for.</param>
-        /// <param name="value1">The value to search for at the index right after the one where the first one is found.</param>
+        /// <param name="value0">One of the values to search for.</param>
+        /// <param name="value1">One of the values to search for.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int IndexOf(this ReadOnlySpan<byte> span, byte value0, byte value1)
+        public static int IndexOfAny(this ReadOnlySpan<byte> span, byte value0, byte value1)
         {
-            return SpanHelpers.IndexOf(ref span.DangerousGetPinnableReference(), value0, value1, span.Length);
+            return SpanHelpers.IndexOfAny(ref span.DangerousGetPinnableReference(), value0, value1, span.Length);
         }
 
         /// <summary>
-        /// Searches for the specified values and returns the index of the first occurrence where all of them appear in sequence. If not found, returns -1. 
+        /// Searches for the first index of any of the specified values similar to calling IndexOf several times with the logical OR operator. If not found, returns -1. 
         /// </summary>
         /// <param name="span">The span to search.</param>
-        /// <param name="value0">The first value to search for.</param>
-        /// <param name="value1">The value to search for at the index right after the one where the first one is found.</param>
-        /// <param name="value2">The value to search for at the index right after the one where the second one is found.</param>
+        /// <param name="value0">One of the values to search for.</param>
+        /// <param name="value1">One of the values to search for.</param>
+        /// <param name="value2">One of the values to search for.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int IndexOf(this ReadOnlySpan<byte> span, byte value0, byte value1, byte value2)
+        public static int IndexOfAny(this ReadOnlySpan<byte> span, byte value0, byte value1, byte value2)
         {
-            return SpanHelpers.IndexOf(ref span.DangerousGetPinnableReference(), value0, value1, value2, span.Length);
+            return SpanHelpers.IndexOfAny(ref span.DangerousGetPinnableReference(), value0, value1, value2, span.Length);
         }
 
         /// <summary>

--- a/src/System.Memory/src/System/SpanHelpers.byte.cs
+++ b/src/System.Memory/src/System/SpanHelpers.byte.cs
@@ -210,7 +210,7 @@ namespace System
                 unchecked
                 {
                     int unaligned = (int)(byte*)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
-                    nLength = (IntPtr)(uint)unaligned;
+                    nLength = (IntPtr)(uint)((Vector<byte>.Count - unaligned) & (Vector<byte>.Count - 1));
                 }
             }
             SequentialScan:
@@ -285,7 +285,7 @@ namespace System
                 {
                     goto NotFound;
                 }
-                nLength = (IntPtr)(uint)(length - Vector<byte>.Count);
+                nLength = (IntPtr)(uint)((length - (uint)index) & ~(Vector<byte>.Count - 1));
                 // Get comparision Vector
                 Vector<byte> values0 = GetVector(value0);
                 Vector<byte> values1 = GetVector(value1);
@@ -359,7 +359,7 @@ namespace System
                 unchecked
                 {
                     int unaligned = (int)(byte*)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
-                    nLength = (IntPtr)(uint)unaligned;
+                    nLength = (IntPtr)(uint)((Vector<byte>.Count - unaligned) & (Vector<byte>.Count - 1));
                 }
             }
             SequentialScan:
@@ -434,7 +434,7 @@ namespace System
                 {
                     goto NotFound;
                 }
-                nLength = (IntPtr)(uint)(length - Vector<byte>.Count);
+                nLength = (IntPtr)(uint)((length - (uint)index) & ~(Vector<byte>.Count - 1));
                 // Get comparision Vector
                 Vector<byte> values0 = GetVector(value0);
                 Vector<byte> values1 = GetVector(value1);

--- a/src/System.Memory/src/System/SpanHelpers.byte.cs
+++ b/src/System.Memory/src/System/SpanHelpers.byte.cs
@@ -48,6 +48,26 @@ namespace System
             return -1;
         }
 
+        public static int IndexOfAny(ref byte searchSpace, int searchSpaceLength, ref byte value, int valueLength)
+        {
+            Debug.Assert(searchSpaceLength >= 0);
+            Debug.Assert(valueLength >= 0);
+
+            if (valueLength == 0)
+                return 0;  // A zero-length sequence is always treated as "found" at the start of the search space.
+
+            int index = -1;
+            for (int i = 0; i < valueLength; i++)
+            {
+                var tempIndex = IndexOf(ref searchSpace, Unsafe.Add(ref value, i), searchSpaceLength);
+                if (tempIndex != -1)
+                {
+                    index = (index == -1 || index > tempIndex) ? tempIndex : index;
+                }
+            }
+            return index;
+        }
+
         public static unsafe int IndexOf(ref byte searchSpace, byte value, int length)
         {
             Debug.Assert(length >= 0);

--- a/src/System.Memory/src/System/SpanHelpers.byte.cs
+++ b/src/System.Memory/src/System/SpanHelpers.byte.cs
@@ -273,8 +273,8 @@ namespace System
                 {
                     var vData = Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index));
                     var vMatches = Vector.BitwiseOr(
-                        Vector.Equals(vData, values0),
-                        Vector.Equals(vData, values1));
+                                    Vector.Equals(vData, values0),
+                                    Vector.Equals(vData, values1));
 
                     if (!vMatches.Equals(Vector<byte>.Zero))
                     {
@@ -283,10 +283,10 @@ namespace System
                         break;
                     }
                     index += Vector<byte>.Count;
-                } while ((byte*) nLength > (byte*) index);
+                } while ((byte*)nLength > (byte*)index);
 
                 // Found match? Perform secondary search outside out of loop, so above loop body is small
-                if ((byte*) nLength > (byte*) index)
+                if ((byte*)nLength > (byte*)index)
                 {
                     // Find offset of first match
                     index += LocateFirstFoundByte(values0);
@@ -424,10 +424,10 @@ namespace System
                     var vData = Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index));
 
                     var vMatches = Vector.BitwiseOr(
-                        Vector.BitwiseAnd(
-                            Vector.Equals(vData, values0),
-                            Vector.Equals(vData, values1)),
-                        Vector.Equals(vData, values2));
+                                    Vector.BitwiseAnd(
+                                        Vector.Equals(vData, values0),
+                                        Vector.Equals(vData, values1)),
+                                    Vector.Equals(vData, values2));
 
                     if (!vMatches.Equals(Vector<byte>.Zero))
                     {

--- a/src/System.Memory/src/System/SpanHelpers.byte.cs
+++ b/src/System.Memory/src/System/SpanHelpers.byte.cs
@@ -176,7 +176,7 @@ namespace System
             return (int)(byte*)(index + 7);
         }
 
-        public static unsafe int IndexOf(ref byte searchSpace, byte value0, byte value1, int length)
+        public static unsafe int IndexOfAny(ref byte searchSpace, byte value0, byte value1, int length)
         {
             Debug.Assert(length >= 0);
 
@@ -195,51 +195,65 @@ namespace System
             }
             SequentialScan:
 #endif
-            while ((byte*)nLength >= (byte*)9)
+            uint lookUp;
+            while ((byte*)nLength >= (byte*)8)
             {
                 nLength -= 8;
 
-                if (uValue0 == Unsafe.Add(ref searchSpace, index) && uValue1 == Unsafe.Add(ref searchSpace, index + 1))
+                lookUp = Unsafe.Add(ref searchSpace, index);
+                if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found;
-                if (uValue0 == Unsafe.Add(ref searchSpace, index + 1) && uValue1 == Unsafe.Add(ref searchSpace, index + 2))
+                lookUp = Unsafe.Add(ref searchSpace, index + 1);
+                if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found1;
-                if (uValue0 == Unsafe.Add(ref searchSpace, index + 2) && uValue1 == Unsafe.Add(ref searchSpace, index + 3))
+                lookUp = Unsafe.Add(ref searchSpace, index + 2);
+                if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found2;
-                if (uValue0 == Unsafe.Add(ref searchSpace, index + 3) && uValue1 == Unsafe.Add(ref searchSpace, index + 4))
+                lookUp = Unsafe.Add(ref searchSpace, index + 3);
+                if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found3;
-                if (uValue0 == Unsafe.Add(ref searchSpace, index + 4) && uValue1 == Unsafe.Add(ref searchSpace, index + 5))
+                lookUp = Unsafe.Add(ref searchSpace, index + 4);
+                if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found4;
-                if (uValue0 == Unsafe.Add(ref searchSpace, index + 5) && uValue1 == Unsafe.Add(ref searchSpace, index + 6))
+                lookUp = Unsafe.Add(ref searchSpace, index + 5);
+                if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found5;
-                if (uValue0 == Unsafe.Add(ref searchSpace, index + 6) && uValue1 == Unsafe.Add(ref searchSpace, index + 7))
+                lookUp = Unsafe.Add(ref searchSpace, index + 6);
+                if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found6;
-                if (uValue0 == Unsafe.Add(ref searchSpace, index + 7) && uValue1 == Unsafe.Add(ref searchSpace, index + 8))
+                lookUp = Unsafe.Add(ref searchSpace, index + 7);
+                if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found7;
 
                 index += 8;
             }
 
-            if ((byte*)nLength >= (byte*)5)
+            if ((byte*)nLength >= (byte*)4)
             {
                 nLength -= 4;
 
-                if (uValue0 == Unsafe.Add(ref searchSpace, index) && uValue1 == Unsafe.Add(ref searchSpace, index + 1))
+                lookUp = Unsafe.Add(ref searchSpace, index);
+                if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found;
-                if (uValue0 == Unsafe.Add(ref searchSpace, index + 1) && uValue1 == Unsafe.Add(ref searchSpace, index + 2))
+                lookUp = Unsafe.Add(ref searchSpace, index + 1);
+                if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found1;
-                if (uValue0 == Unsafe.Add(ref searchSpace, index + 2) && uValue1 == Unsafe.Add(ref searchSpace, index + 3))
+                lookUp = Unsafe.Add(ref searchSpace, index + 2);
+                if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found2;
-                if (uValue0 == Unsafe.Add(ref searchSpace, index + 3) && uValue1 == Unsafe.Add(ref searchSpace, index + 4))
+                lookUp = Unsafe.Add(ref searchSpace, index + 3);
+                if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found3;
 
                 index += 4;
             }
 
-            while ((byte*)nLength >= (byte*)2)
+            while ((byte*)nLength > (byte*)0)
             {
                 nLength -= 1;
 
-                if (uValue0 == Unsafe.Add(ref searchSpace, index) && uValue1 == Unsafe.Add(ref searchSpace, index + 1))
+                lookUp = Unsafe.Add(ref searchSpace, index);
+                if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found;
 
                 index += 1;
@@ -257,11 +271,10 @@ namespace System
                 Vector<byte> values1 = GetVector(value1);
                 do
                 {
-                    var vData0 = Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index));
-                    var vData1 = Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index + 1));
-                    var vMatches = Vector.BitwiseAnd(
-                        Vector.Equals(vData0, values0),
-                        Vector.Equals(vData1, values1));
+                    var vData = Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index));
+                    var vMatches = Vector.BitwiseOr(
+                        Vector.Equals(vData, values0),
+                        Vector.Equals(vData, values1));
 
                     if (!vMatches.Equals(Vector<byte>.Zero))
                     {
@@ -311,7 +324,7 @@ namespace System
             return (int)(byte*)(index + 7);
         }
 
-        public static unsafe int IndexOf(ref byte searchSpace, byte value0, byte value1, byte value2, int length)
+        public static unsafe int IndexOfAny(ref byte searchSpace, byte value0, byte value1, byte value2, int length)
         {
             Debug.Assert(length >= 0);
 
@@ -331,77 +344,65 @@ namespace System
             }
             SequentialScan:
 #endif
-            while ((byte*)nLength >= (byte*)10)
+            uint lookUp;
+            while ((byte*)nLength >= (byte*)8)
             {
                 nLength -= 8;
 
-                if (uValue0 == Unsafe.Add(ref searchSpace, index) && 
-                    uValue1 == Unsafe.Add(ref searchSpace, index + 1) &&
-                    uValue2 == Unsafe.Add(ref searchSpace, index + 2))
+                lookUp = Unsafe.Add(ref searchSpace, index);
+                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found;
-                if (uValue0 == Unsafe.Add(ref searchSpace, index + 1) && 
-                    uValue1 == Unsafe.Add(ref searchSpace, index + 2) &&
-                    uValue2 == Unsafe.Add(ref searchSpace, index + 3))
+                lookUp = Unsafe.Add(ref searchSpace, index + 1);
+                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found1;
-                if (uValue0 == Unsafe.Add(ref searchSpace, index + 2) && 
-                    uValue1 == Unsafe.Add(ref searchSpace, index + 3) &&
-                    uValue2 == Unsafe.Add(ref searchSpace, index + 4))
+                lookUp = Unsafe.Add(ref searchSpace, index + 2);
+                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found2;
-                if (uValue0 == Unsafe.Add(ref searchSpace, index + 3) && 
-                    uValue1 == Unsafe.Add(ref searchSpace, index + 4) &&
-                    uValue2 == Unsafe.Add(ref searchSpace, index + 5))
+                lookUp = Unsafe.Add(ref searchSpace, index + 3);
+                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found3;
-                if (uValue0 == Unsafe.Add(ref searchSpace, index + 4) && 
-                    uValue1 == Unsafe.Add(ref searchSpace, index + 5) &&
-                    uValue2 == Unsafe.Add(ref searchSpace, index + 6))
+                lookUp = Unsafe.Add(ref searchSpace, index + 4);
+                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found4;
-                if (uValue0 == Unsafe.Add(ref searchSpace, index + 5) && 
-                    uValue1 == Unsafe.Add(ref searchSpace, index + 6) &&
-                    uValue2 == Unsafe.Add(ref searchSpace, index + 7))
+                lookUp = Unsafe.Add(ref searchSpace, index + 5);
+                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found5;
-                if (uValue0 == Unsafe.Add(ref searchSpace, index + 6) && 
-                    uValue1 == Unsafe.Add(ref searchSpace, index + 7) &&
-                    uValue2 == Unsafe.Add(ref searchSpace, index + 8))
+                lookUp = Unsafe.Add(ref searchSpace, index + 6);
+                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found6;
-                if (uValue0 == Unsafe.Add(ref searchSpace, index + 7) && 
-                    uValue1 == Unsafe.Add(ref searchSpace, index + 8) &&
-                    uValue2 == Unsafe.Add(ref searchSpace, index + 9))
+                lookUp = Unsafe.Add(ref searchSpace, index + 7);
+                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found7;
 
                 index += 8;
             }
 
-            if ((byte*)nLength >= (byte*)6)
+            if ((byte*)nLength >= (byte*)4)
             {
                 nLength -= 4;
 
-                if (uValue0 == Unsafe.Add(ref searchSpace, index) && 
-                    uValue1 == Unsafe.Add(ref searchSpace, index + 1) &&
-                    uValue2 == Unsafe.Add(ref searchSpace, index + 2))
+                lookUp = Unsafe.Add(ref searchSpace, index);
+                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found;
-                if (uValue0 == Unsafe.Add(ref searchSpace, index + 1) && 
-                    uValue1 == Unsafe.Add(ref searchSpace, index + 2) &&
-                    uValue2 == Unsafe.Add(ref searchSpace, index + 3))
+                lookUp = Unsafe.Add(ref searchSpace, index + 1);
+                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found1;
-                if (uValue0 == Unsafe.Add(ref searchSpace, index + 2) && 
-                    uValue1 == Unsafe.Add(ref searchSpace, index + 3) &&
-                    uValue2 == Unsafe.Add(ref searchSpace, index + 4))
+                lookUp = Unsafe.Add(ref searchSpace, index + 2);
+                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found2;
-                if (uValue0 == Unsafe.Add(ref searchSpace, index + 3) && 
-                    uValue1 == Unsafe.Add(ref searchSpace, index + 4) &&
-                    uValue2 == Unsafe.Add(ref searchSpace, index + 5))
+                lookUp = Unsafe.Add(ref searchSpace, index + 3);
+                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found3;
 
                 index += 4;
             }
 
-            while ((byte*)nLength >= (byte*)3)
+            while ((byte*)nLength > (byte*)0)
             {
                 nLength -= 1;
 
-                if (uValue0 == Unsafe.Add(ref searchSpace, index) && 
-                    uValue1 == Unsafe.Add(ref searchSpace, index + 1) &&
-                    uValue2 == Unsafe.Add(ref searchSpace, index + 2))
+                lookUp = Unsafe.Add(ref searchSpace, index);
+                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found;
 
                 index += 1;
@@ -420,15 +421,13 @@ namespace System
                 Vector<byte> values2 = GetVector(value2);
                 do
                 {
-                    var vData0 = Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index));
-                    var vData1 = Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index + 1));
-                    var vData2 = Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index + 2));
+                    var vData = Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index));
 
-                    var vMatches = Vector.BitwiseAnd(
+                    var vMatches = Vector.BitwiseOr(
                         Vector.BitwiseAnd(
-                            Vector.Equals(vData0, values0),
-                            Vector.Equals(vData1, values1)),
-                        Vector.Equals(vData2, values2));
+                            Vector.Equals(vData, values0),
+                            Vector.Equals(vData, values1)),
+                        Vector.Equals(vData, values2));
 
                     if (!vMatches.Equals(Vector<byte>.Zero))
                     {

--- a/src/System.Memory/src/System/SpanHelpers.byte.cs
+++ b/src/System.Memory/src/System/SpanHelpers.byte.cs
@@ -195,7 +195,7 @@ namespace System
             }
             SequentialScan:
 #endif
-            while ((byte*)nLength >= (byte*)8)
+            while ((byte*)nLength >= (byte*)9)
             {
                 nLength -= 8;
 
@@ -219,7 +219,7 @@ namespace System
                 index += 8;
             }
 
-            if ((byte*)nLength >= (byte*)4)
+            if ((byte*)nLength >= (byte*)5)
             {
                 nLength -= 4;
 
@@ -235,7 +235,7 @@ namespace System
                 index += 4;
             }
 
-            while ((byte*)nLength > (byte*)1)
+            while ((byte*)nLength >= (byte*)2)
             {
                 nLength -= 1;
 
@@ -282,6 +282,173 @@ namespace System
                 }
 
                 if ((int)(byte*)index <= length - 1)
+                {
+                    unchecked
+                    {
+                        nLength = (IntPtr)(length - (int)(byte*)index);
+                    }
+                    goto SequentialScan;
+                }
+            }
+            NotFound: // Workaround for https://github.com/dotnet/coreclr/issues/9692
+#endif
+            return -1;
+            Found: // Workaround for https://github.com/dotnet/coreclr/issues/9692
+            return (int)(byte*)index;
+            Found1:
+            return (int)(byte*)(index + 1);
+            Found2:
+            return (int)(byte*)(index + 2);
+            Found3:
+            return (int)(byte*)(index + 3);
+            Found4:
+            return (int)(byte*)(index + 4);
+            Found5:
+            return (int)(byte*)(index + 5);
+            Found6:
+            return (int)(byte*)(index + 6);
+            Found7:
+            return (int)(byte*)(index + 7);
+        }
+
+        public static unsafe int IndexOf(ref byte searchSpace, byte value0, byte value1, byte value2, int length)
+        {
+            Debug.Assert(length >= 0);
+
+            uint uValue0 = value0; // Use uint for comparisions to avoid unnecessary 8->32 extensions
+            uint uValue1 = value1; // Use uint for comparisions to avoid unnecessary 8->32 extensions
+            uint uValue2 = value2; // Use uint for comparisions to avoid unnecessary 8->32 extensions
+            IntPtr index = (IntPtr)0; // Use UIntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
+            IntPtr nLength = (IntPtr)(uint)length;
+#if !netstandard10
+            if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
+            {
+                unchecked
+                {
+                    int unaligned = (int)(byte*)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
+                    nLength = (IntPtr)(uint)unaligned;
+                }
+            }
+            SequentialScan:
+#endif
+            while ((byte*)nLength >= (byte*)10)
+            {
+                nLength -= 8;
+
+                if (uValue0 == Unsafe.Add(ref searchSpace, index) && 
+                    uValue1 == Unsafe.Add(ref searchSpace, index + 1) &&
+                    uValue2 == Unsafe.Add(ref searchSpace, index + 2))
+                    goto Found;
+                if (uValue0 == Unsafe.Add(ref searchSpace, index + 1) && 
+                    uValue1 == Unsafe.Add(ref searchSpace, index + 2) &&
+                    uValue2 == Unsafe.Add(ref searchSpace, index + 3))
+                    goto Found1;
+                if (uValue0 == Unsafe.Add(ref searchSpace, index + 2) && 
+                    uValue1 == Unsafe.Add(ref searchSpace, index + 3) &&
+                    uValue2 == Unsafe.Add(ref searchSpace, index + 4))
+                    goto Found2;
+                if (uValue0 == Unsafe.Add(ref searchSpace, index + 3) && 
+                    uValue1 == Unsafe.Add(ref searchSpace, index + 4) &&
+                    uValue2 == Unsafe.Add(ref searchSpace, index + 5))
+                    goto Found3;
+                if (uValue0 == Unsafe.Add(ref searchSpace, index + 4) && 
+                    uValue1 == Unsafe.Add(ref searchSpace, index + 5) &&
+                    uValue2 == Unsafe.Add(ref searchSpace, index + 6))
+                    goto Found4;
+                if (uValue0 == Unsafe.Add(ref searchSpace, index + 5) && 
+                    uValue1 == Unsafe.Add(ref searchSpace, index + 6) &&
+                    uValue2 == Unsafe.Add(ref searchSpace, index + 7))
+                    goto Found5;
+                if (uValue0 == Unsafe.Add(ref searchSpace, index + 6) && 
+                    uValue1 == Unsafe.Add(ref searchSpace, index + 7) &&
+                    uValue2 == Unsafe.Add(ref searchSpace, index + 8))
+                    goto Found6;
+                if (uValue0 == Unsafe.Add(ref searchSpace, index + 7) && 
+                    uValue1 == Unsafe.Add(ref searchSpace, index + 8) &&
+                    uValue2 == Unsafe.Add(ref searchSpace, index + 9))
+                    goto Found7;
+
+                index += 8;
+            }
+
+            if ((byte*)nLength >= (byte*)6)
+            {
+                nLength -= 4;
+
+                if (uValue0 == Unsafe.Add(ref searchSpace, index) && 
+                    uValue1 == Unsafe.Add(ref searchSpace, index + 1) &&
+                    uValue2 == Unsafe.Add(ref searchSpace, index + 2))
+                    goto Found;
+                if (uValue0 == Unsafe.Add(ref searchSpace, index + 1) && 
+                    uValue1 == Unsafe.Add(ref searchSpace, index + 2) &&
+                    uValue2 == Unsafe.Add(ref searchSpace, index + 3))
+                    goto Found1;
+                if (uValue0 == Unsafe.Add(ref searchSpace, index + 2) && 
+                    uValue1 == Unsafe.Add(ref searchSpace, index + 3) &&
+                    uValue2 == Unsafe.Add(ref searchSpace, index + 4))
+                    goto Found2;
+                if (uValue0 == Unsafe.Add(ref searchSpace, index + 3) && 
+                    uValue1 == Unsafe.Add(ref searchSpace, index + 4) &&
+                    uValue2 == Unsafe.Add(ref searchSpace, index + 5))
+                    goto Found3;
+
+                index += 4;
+            }
+
+            while ((byte*)nLength >= (byte*)3)
+            {
+                nLength -= 1;
+
+                if (uValue0 == Unsafe.Add(ref searchSpace, index) && 
+                    uValue1 == Unsafe.Add(ref searchSpace, index + 1) &&
+                    uValue2 == Unsafe.Add(ref searchSpace, index + 2))
+                    goto Found;
+
+                index += 1;
+            }
+#if !netstandard10
+            if (Vector.IsHardwareAccelerated)
+            {
+                if ((int)(byte*)index >= length - 2)
+                {
+                    goto NotFound;
+                }
+                nLength = (IntPtr)(uint)(length - Vector<byte>.Count);
+                // Get comparision Vector
+                Vector<byte> values0 = GetVector(value0);
+                Vector<byte> values1 = GetVector(value1);
+                Vector<byte> values2 = GetVector(value2);
+                do
+                {
+                    var vData0 = Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index));
+                    var vData1 = Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index + 1));
+                    var vData2 = Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index + 2));
+
+                    var vMatches = Vector.BitwiseAnd(
+                        Vector.BitwiseAnd(
+                            Vector.Equals(vData0, values0),
+                            Vector.Equals(vData1, values1)),
+                        Vector.Equals(vData2, values2));
+
+                    if (!vMatches.Equals(Vector<byte>.Zero))
+                    {
+                        // Found match, reuse Vector values0 to keep register pressure low
+                        values0 = vMatches;
+                        break;
+                    }
+                    index += Vector<byte>.Count;
+                } while ((byte*)nLength > (byte*)index);
+
+                // Found match? Perform secondary search outside out of loop, so above loop body is small
+                if ((byte*)nLength > (byte*)index)
+                {
+                    // Find offset of first match
+                    index += LocateFirstFoundByte(values0);
+                    // goto rather than inline return to keep function smaller
+                    goto Found;
+                }
+
+                if ((int)(byte*)index <= length - 2)
                 {
                     unchecked
                     {

--- a/src/System.Memory/tests/ReadOnlySpan/IndexOf.byte.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/IndexOf.byte.cs
@@ -350,5 +350,196 @@ namespace System.SpanTests
                 Assert.Equal(-1, index);
             }
         }
+
+        [Fact]
+        public static void ZeroLengthIndexOfMany_Byte()
+        {
+            ReadOnlySpan<byte> sp = new ReadOnlySpan<byte>(Array.Empty<byte>());
+            var values = new ReadOnlySpan<byte>(new byte[] { 0, 0, 0, 0 });
+            int idx = sp.IndexOfAny(values);
+            Assert.Equal(-1, idx);
+
+            values = new ReadOnlySpan<byte>(new byte[] { });
+            idx = sp.IndexOfAny(values);
+            Assert.Equal(0, idx);
+        }
+
+        [Fact]
+        public static void DefaultFilledIndexOfMany_Byte()
+        {
+            for (int length = 0; length < byte.MaxValue; length++)
+            {
+                byte[] a = new byte[length];
+                ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
+
+                var values = new ReadOnlySpan<byte>(new byte[] { default(byte), 99, 98, 0 });
+
+                for (int i = 0; i < length; i++)
+                {
+                    int idx = span.IndexOfAny(values);
+                    Assert.Equal(0, idx);
+                }
+            }
+        }
+
+        [Fact]
+        public static void TestMatchMany_Byte()
+        {
+            for (int length = 0; length < byte.MaxValue; length++)
+            {
+                byte[] a = new byte[length];
+                for (int i = 0; i < length; i++)
+                {
+                    a[i] = (byte)(i + 1);
+                }
+                ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
+
+                for (int targetIndex = 0; targetIndex < length; targetIndex++)
+                {
+                    var values = new ReadOnlySpan<byte>(new byte[] { a[targetIndex], 0, 0, 0 });
+                    int idx = span.IndexOfAny(values);
+                    Assert.Equal(targetIndex, idx);
+                }
+
+                for (int targetIndex = 0; targetIndex < length - 3; targetIndex++)
+                {
+                    var values = new ReadOnlySpan<byte>(new byte[] { a[targetIndex], a[targetIndex + 1], a[targetIndex + 2], a[targetIndex + 3] });
+                    int idx = span.IndexOfAny(values);
+                    Assert.Equal(targetIndex, idx);
+                }
+
+                for (int targetIndex = 0; targetIndex < length - 3; targetIndex++)
+                {
+                    var values = new ReadOnlySpan<byte>(new byte[] { 0, 0, 0, a[targetIndex + 3] });
+                    int idx = span.IndexOfAny(values);
+                    Assert.Equal(targetIndex + 3, idx);
+                }
+            }
+        }
+
+        [Fact]
+        public static void TestMatchValuesLargerMany_Byte()
+        {
+            var rnd = new Random(42);
+            for (int length = 2; length < byte.MaxValue; length++)
+            {
+                byte[] a = new byte[length];
+                int expectedIndex = length / 2;
+                for (int i = 0; i < length; i++)
+                {
+                    if (i == expectedIndex)
+                    {
+                        continue;
+                    }
+                    a[i] = 255;
+                }
+                ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
+
+                byte[] targets = new byte[length * 2];
+                for (int i = 0; i < targets.Length; i++)
+                {
+                    if (i == length + 1)
+                    {
+                        continue;
+                    }
+                    targets[i] = (byte)rnd.Next(1, 255);
+                }
+
+                var values = new ReadOnlySpan<byte>(targets);
+                int idx = span.IndexOfAny(values);
+                Assert.Equal(expectedIndex, idx);
+            }
+        }
+
+        [Fact]
+        public static void TestNoMatchMany_Byte()
+        {
+            var rnd = new Random(42);
+            for (int length = 1; length < byte.MaxValue; length++)
+            {
+                byte[] a = new byte[length];
+                byte[] targets = new byte[length];
+                for (int i = 0; i < targets.Length; i++)
+                {
+                    targets[i] = (byte)rnd.Next(1, 256);
+                }
+                ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
+                var values = new ReadOnlySpan<byte>(targets);
+
+                int idx = span.IndexOfAny(values);
+                Assert.Equal(-1, idx);
+            }
+        }
+
+        [Fact]
+        public static void TestNoMatchValuesLargerMany_Byte()
+        {
+            var rnd = new Random(42);
+            for (int length = 1; length < byte.MaxValue; length++)
+            {
+                byte[] a = new byte[length];
+                byte[] targets = new byte[length * 2];
+                for (int i = 0; i < targets.Length; i++)
+                {
+                    targets[i] = (byte)rnd.Next(1, 256);
+                }
+                ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
+                var values = new ReadOnlySpan<byte>(targets);
+
+                int idx = span.IndexOfAny(values);
+                Assert.Equal(-1, idx);
+            }
+        }
+
+        [Fact]
+        public static void TestMultipleMatchMany_Byte()
+        {
+            for (int length = 5; length < byte.MaxValue; length++)
+            {
+                byte[] a = new byte[length];
+                for (int i = 0; i < length; i++)
+                {
+                    byte val = (byte)(i + 1);
+                    a[i] = val == 200 ? (byte)201 : val;
+                }
+
+                a[length - 1] = 200;
+                a[length - 2] = 200;
+                a[length - 3] = 200;
+                a[length - 4] = 200;
+                a[length - 5] = 200;
+
+                ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
+                var values = new ReadOnlySpan<byte>(new byte[] { 200, 200, 200, 200, 200, 200, 200, 200, 200 });
+                int idx = span.IndexOfAny(values);
+                Assert.Equal(length - 5, idx);
+            }
+        }
+
+        [Fact]
+        public static void MakeSureNoChecksGoOutOfRangeMany_Byte()
+        {
+            for (int length = 1; length < byte.MaxValue; length++)
+            {
+                byte[] a = new byte[length + 2];
+                a[0] = 99;
+                a[length + 1] = 98;
+                ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a, 1, length - 1);
+                var values = new ReadOnlySpan<byte>(new byte[] { 99, 98, 99, 98, 99, 98 });
+                int index = span.IndexOfAny(values);
+                Assert.Equal(-1, index);
+            }
+
+            for (int length = 1; length < byte.MaxValue; length++)
+            {
+                byte[] a = new byte[length + 2];
+                a[0] = 99;
+                a[length + 1] = 99;
+                ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a, 1, length - 1);
+                var values = new ReadOnlySpan<byte>(new byte[] { 99, 99, 99, 99, 99, 99 });
+                int index = span.IndexOfAny(values);
+                Assert.Equal(-1, index);
+            }
+        }
     }
 }

--- a/src/System.Memory/tests/ReadOnlySpan/IndexOf.byte.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/IndexOf.byte.cs
@@ -75,8 +75,32 @@ namespace System.SpanTests
         public static void ZeroLengthIndexOfTwo_Byte()
         {
             ReadOnlySpan<byte> sp = new ReadOnlySpan<byte>(Array.Empty<byte>());
-            int idx = sp.IndexOf(0, 0);
+            int idx = sp.IndexOfAny(0, 0);
             Assert.Equal(-1, idx);
+        }
+
+        [Fact]
+        public static void DefaultFilledIndexOfTwo_Byte()
+        {
+            Random rnd = new Random(42);
+
+            for (int length = 0; length < 32; length++)
+            {
+                byte[] a = new byte[length];
+                ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
+
+                byte[] targets = { default(byte), 99 };
+
+                for (int i = 0; i < length; i++)
+                {
+                    int index;
+                    index = rnd.Next(0, 2) == 0 ? 0 : 1;
+                    byte target0 = targets[index];
+                    byte target1 = targets[(index + 1) % 2];
+                    int idx = span.IndexOfAny(target0, target1);
+                    Assert.Equal(0, idx);
+                }
+            }
         }
 
         [Fact]
@@ -94,9 +118,25 @@ namespace System.SpanTests
                 for (int targetIndex = 0; targetIndex < length - 1; targetIndex++)
                 {
                     byte target0 = a[targetIndex];
-                    byte target1 = a[targetIndex + 1];
-                    int idx = span.IndexOf(target0, target1);
+                    byte target1 = 99;
+                    int idx = span.IndexOfAny(target0, target1);
                     Assert.Equal(targetIndex, idx);
+                }
+
+                for (int targetIndex = 0; targetIndex < length - 1; targetIndex++)
+                {
+                    byte target0 = a[targetIndex];
+                    byte target1 = a[targetIndex + 1];
+                    int idx = span.IndexOfAny(target0, target1);
+                    Assert.Equal(targetIndex, idx);
+                }
+
+                for (int targetIndex = 0; targetIndex < length - 1; targetIndex++)
+                {
+                    byte target0 = 99;
+                    byte target1 = a[targetIndex + 1];
+                    int idx = span.IndexOfAny(target0, target1);
+                    Assert.Equal(targetIndex + 1, idx);
                 }
             }
         }
@@ -115,9 +155,9 @@ namespace System.SpanTests
 
                 for (int targetIndex = 0; targetIndex < length - 1; targetIndex++)
                 {
-                    byte target0 = a[targetIndex];
-                    byte target1 = (byte)(a[targetIndex + 1] + 1);
-                    int idx = span.IndexOf(target0, target1);
+                    byte target0 = 98;
+                    byte target1 = 99;
+                    int idx = span.IndexOfAny(target0, target1);
                     Assert.Equal(-1, idx);
                 }
             }
@@ -139,7 +179,7 @@ namespace System.SpanTests
                 a[length - 3] = 200;
 
                 ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
-                int idx = span.IndexOf(200, 200);
+                int idx = span.IndexOfAny(200, 200);
                 Assert.Equal(length - 3, idx);
             }
         }
@@ -147,40 +187,23 @@ namespace System.SpanTests
         [Fact]
         public static void MakeSureNoChecksGoOutOfRangeTwo_Byte()
         {
-            for (int length = 0; length < 100; length++)
+            for (int length = 1; length < 100; length++)
             {
-                byte[] a = new byte[length + 3];
+                byte[] a = new byte[length + 2];
                 a[0] = 99;
-                a[1] = 98;
-                a[length + 1] = 99;
-                a[length + 2] = 98;
-                ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a, 1, length);
-                int index = span.IndexOf(99, 98);
+                a[length + 1] = 98;
+                ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a, 1, length - 1);
+                int index = span.IndexOfAny(99, 98);
                 Assert.Equal(-1, index);
             }
 
-            for (int length = 0; length < 100; length++)
+            for (int length = 1; length < 100; length++)
             {
-                byte[] a = new byte[length + 3];
+                byte[] a = new byte[length + 2];
                 a[0] = 99;
-                a[1] = 99;
                 a[length + 1] = 99;
-                a[length + 2] = 99;
-                ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a, 1, length);
-                int index = span.IndexOf(99, 99);
-                Assert.Equal(-1, index);
-            }
-
-            for (int length = 0; length < 100; length++)
-            {
-                byte[] a = new byte[length + 3];
-                a[0] = 99;
-                a[1] = 99;
-                a[length] = 99;
-                a[length + 1] = 99;
-                a[length + 2] = 99;
-                ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a, 1, length);
-                int index = span.IndexOf(99, 98);
+                ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a, 1, length - 1);
+                int index = span.IndexOfAny(99, 99);
                 Assert.Equal(-1, index);
             }
         }
@@ -189,8 +212,33 @@ namespace System.SpanTests
         public static void ZeroLengthIndexOfThree_Byte()
         {
             ReadOnlySpan<byte> sp = new ReadOnlySpan<byte>(Array.Empty<byte>());
-            int idx = sp.IndexOf(0, 0, 0);
+            int idx = sp.IndexOfAny(0, 0, 0);
             Assert.Equal(-1, idx);
+        }
+
+        [Fact]
+        public static void DefaultFilledIndexOfThree_Byte()
+        {
+            Random rnd = new Random(42);
+
+            for (int length = 0; length < 32; length++)
+            {
+                byte[] a = new byte[length];
+                ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
+
+                byte[] targets = { default(byte), 99, 98 };
+
+                for (int i = 0; i < length; i++)
+                {
+                    int index;
+                    index = rnd.Next(0, 3);
+                    byte target0 = targets[index];
+                    byte target1 = targets[(index + 1) % 2];
+                    byte traget2 = targets[(index + 1) % 3];
+                    int idx = span.IndexOfAny(target0, target1, traget2);
+                    Assert.Equal(0, idx);
+                }
+            }
         }
 
         [Fact]
@@ -208,10 +256,28 @@ namespace System.SpanTests
                 for (int targetIndex = 0; targetIndex < length - 2; targetIndex++)
                 {
                     byte target0 = a[targetIndex];
+                    byte target1 = 99;
+                    byte target2 = 99;
+                    int idx = span.IndexOfAny(target0, target1, target2);
+                    Assert.Equal(targetIndex, idx);
+                }
+
+                for (int targetIndex = 0; targetIndex < length - 2; targetIndex++)
+                {
+                    byte target0 = a[targetIndex];
                     byte target1 = a[targetIndex + 1];
                     byte target2 = a[targetIndex + 2];
-                    int idx = span.IndexOf(target0, target1, target2);
+                    int idx = span.IndexOfAny(target0, target1, target2);
                     Assert.Equal(targetIndex, idx);
+                }
+
+                for (int targetIndex = 0; targetIndex < length - 2; targetIndex++)
+                {
+                    byte target0 = 99;
+                    byte target1 = 99;
+                    byte target2 = a[targetIndex + 2];
+                    int idx = span.IndexOfAny(target0, target1, target2);
+                    Assert.Equal(targetIndex + 2, idx);
                 }
             }
         }
@@ -228,12 +294,12 @@ namespace System.SpanTests
                 }
                 ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
 
-                for (int targetIndex = 0; targetIndex < length - 2; targetIndex++)
+                for (int targetIndex = 0; targetIndex < length - 1; targetIndex++)
                 {
-                    byte target0 = a[targetIndex];
-                    byte target1 = (byte)(a[targetIndex + 1] + 1);
-                    byte target2 = a[targetIndex + 2];
-                    int idx = span.IndexOf(target0, target1, target2);
+                    byte target0 = 98;
+                    byte target1 = 99;
+                    byte target2 = 100;
+                    int idx = span.IndexOfAny(target0, target1, target2);
                     Assert.Equal(-1, idx);
                 }
             }
@@ -256,7 +322,7 @@ namespace System.SpanTests
                 a[length - 4] = 200;
 
                 ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
-                int idx = span.IndexOf(200, 200, 200);
+                int idx = span.IndexOfAny(200, 200, 200);
                 Assert.Equal(length - 4, idx);
             }
         }
@@ -264,47 +330,23 @@ namespace System.SpanTests
         [Fact]
         public static void MakeSureNoChecksGoOutOfRangeThree_Byte()
         {
-            for (int length = 4; length < 5; length++)
+            for (int length = 1; length < 100; length++)
             {
-                byte[] a = new byte[length + 4];
+                byte[] a = new byte[length + 2];
                 a[0] = 99;
-                a[1] = 99;
-                a[2] = 98;
-                a[length] = 99;
-                a[length + 1] = 99;
-                a[length + 2] = 98;
-                a[length + 3] = 98;
-                ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a, 1, length);
-                int index = span.IndexOf(99, 99, 98);
+                a[length + 1] = 98;
+                ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a, 1, length - 1);
+                int index = span.IndexOfAny(99, 98, 99);
                 Assert.Equal(-1, index);
             }
 
-            for (int length = 0; length < 100; length++)
+            for (int length = 1; length < 100; length++)
             {
-                byte[] a = new byte[length + 4];
+                byte[] a = new byte[length + 2];
                 a[0] = 99;
-                a[1] = 99;
-                a[2] = 99;
                 a[length + 1] = 99;
-                a[length + 2] = 99;
-                a[length + 3] = 99;
-                ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a, 1, length);
-                int index = span.IndexOf(99, 99, 99);
-                Assert.Equal(-1, index);
-            }
-
-            for (int length = 0; length < 100; length++)
-            {
-                byte[] a = new byte[length + 4];
-                a[0] = 99;
-                a[1] = 99;
-                a[2] = 99;
-                a[length] = 99;
-                a[length + 1] = 99;
-                a[length + 2] = 99;
-                a[length + 3] = 99;
-                ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a, 1, length);
-                int index = span.IndexOf(99, 99, 98);
+                ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a, 1, length - 1);
+                int index = span.IndexOfAny(99, 99, 99);
                 Assert.Equal(-1, index);
             }
         }

--- a/src/System.Memory/tests/ReadOnlySpan/IndexOf.byte.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/IndexOf.byte.cs
@@ -70,5 +70,106 @@ namespace System.SpanTests
                 Assert.Equal(-1, index);
             }
         }
+
+        [Fact]
+        public static void ZeroLengthIndexOfTwo_Byte()
+        {
+            ReadOnlySpan<byte> sp = new ReadOnlySpan<byte>(Array.Empty<byte>());
+            int idx = sp.IndexOf(0, 0);
+            Assert.Equal(-1, idx);
+        }
+
+        [Fact]
+        public static void TestMatchTwo_Byte()
+        {
+            for (int length = 0; length < 32; length++)
+            {
+                byte[] a = new byte[length];
+                for (int i = 0; i < length; i++)
+                {
+                    a[i] = (byte)(i + 1);
+                }
+                ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
+
+                for (int targetIndex = 0; targetIndex < length - 1; targetIndex++)
+                {
+                    byte target0 = a[targetIndex];
+                    byte target1 = a[targetIndex + 1];
+                    int idx = span.IndexOf(target0, target1);
+                    Assert.Equal(targetIndex, idx);
+                }
+            }
+        }
+
+        [Fact]
+        public static void TestNoMatchTwo_Byte()
+        {
+            for (int length = 0; length < 32; length++)
+            {
+                byte[] a = new byte[length];
+                for (int i = 0; i < length; i++)
+                {
+                    a[i] = (byte)(i + 1);
+                }
+                ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
+
+                for (int targetIndex = 0; targetIndex < length - 1; targetIndex++)
+                {
+                    byte target0 = a[targetIndex];
+                    byte target1 = (byte)(a[targetIndex + 1] + 1);
+                    int idx = span.IndexOf(target0, target1);
+                    Assert.Equal(-1, idx);
+                }
+            }
+        }
+
+        [Fact]
+        public static void TestMultipleMatchTwo_Byte()
+        {
+            for (int length = 3; length < 32; length++)
+            {
+                byte[] a = new byte[length];
+                for (int i = 0; i < length; i++)
+                {
+                    a[i] = (byte)(i + 1);
+                }
+
+                a[length - 1] = 200;
+                a[length - 2] = 200;
+                a[length - 3] = 200;
+
+                ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
+                int idx = span.IndexOf(200, 200);
+                Assert.Equal(length - 3, idx);
+            }
+        }
+
+        [Fact]
+        public static void MakeSureNoChecksGoOutOfRangeTwo_Byte()
+        {
+            for (int length = 0; length < 100; length++)
+            {
+                byte[] a = new byte[length + 3];
+                a[0] = 99;
+                a[1] = 98;
+                a[length + 1] = 99;
+                a[length + 2] = 98;
+                ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a, 1, length);
+                int index = span.IndexOf(99, 98);
+                Assert.Equal(-1, index);
+            }
+
+            for (int length = 0; length < 100; length++)
+            {
+                byte[] a = new byte[length + 3];
+                a[0] = 99;
+                a[1] = 99;
+                a[length + 1] = 99;
+                a[length + 2] = 99;
+                ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a, 1, length);
+                int index = span.IndexOf(99, 99);
+                Assert.Equal(-1, index);
+            }
+        }
     }
 }

--- a/src/System.Memory/tests/ReadOnlySpan/IndexOf.byte.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/IndexOf.byte.cs
@@ -170,6 +170,143 @@ namespace System.SpanTests
                 int index = span.IndexOf(99, 99);
                 Assert.Equal(-1, index);
             }
+
+            for (int length = 0; length < 100; length++)
+            {
+                byte[] a = new byte[length + 3];
+                a[0] = 99;
+                a[1] = 99;
+                a[length] = 99;
+                a[length + 1] = 99;
+                a[length + 2] = 99;
+                ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a, 1, length);
+                int index = span.IndexOf(99, 98);
+                Assert.Equal(-1, index);
+            }
+        }
+
+        [Fact]
+        public static void ZeroLengthIndexOfThree_Byte()
+        {
+            ReadOnlySpan<byte> sp = new ReadOnlySpan<byte>(Array.Empty<byte>());
+            int idx = sp.IndexOf(0, 0, 0);
+            Assert.Equal(-1, idx);
+        }
+
+        [Fact]
+        public static void TestMatchThree_Byte()
+        {
+            for (int length = 0; length < 32; length++)
+            {
+                byte[] a = new byte[length];
+                for (int i = 0; i < length; i++)
+                {
+                    a[i] = (byte)(i + 1);
+                }
+                ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
+
+                for (int targetIndex = 0; targetIndex < length - 2; targetIndex++)
+                {
+                    byte target0 = a[targetIndex];
+                    byte target1 = a[targetIndex + 1];
+                    byte target2 = a[targetIndex + 2];
+                    int idx = span.IndexOf(target0, target1, target2);
+                    Assert.Equal(targetIndex, idx);
+                }
+            }
+        }
+
+        [Fact]
+        public static void TestNoMatchThree_Byte()
+        {
+            for (int length = 0; length < 32; length++)
+            {
+                byte[] a = new byte[length];
+                for (int i = 0; i < length; i++)
+                {
+                    a[i] = (byte)(i + 1);
+                }
+                ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
+
+                for (int targetIndex = 0; targetIndex < length - 2; targetIndex++)
+                {
+                    byte target0 = a[targetIndex];
+                    byte target1 = (byte)(a[targetIndex + 1] + 1);
+                    byte target2 = a[targetIndex + 2];
+                    int idx = span.IndexOf(target0, target1, target2);
+                    Assert.Equal(-1, idx);
+                }
+            }
+        }
+
+        [Fact]
+        public static void TestMultipleMatchThree_Byte()
+        {
+            for (int length = 4; length < 32; length++)
+            {
+                byte[] a = new byte[length];
+                for (int i = 0; i < length; i++)
+                {
+                    a[i] = (byte)(i + 1);
+                }
+
+                a[length - 1] = 200;
+                a[length - 2] = 200;
+                a[length - 3] = 200;
+                a[length - 4] = 200;
+
+                ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
+                int idx = span.IndexOf(200, 200, 200);
+                Assert.Equal(length - 4, idx);
+            }
+        }
+
+        [Fact]
+        public static void MakeSureNoChecksGoOutOfRangeThree_Byte()
+        {
+            for (int length = 4; length < 5; length++)
+            {
+                byte[] a = new byte[length + 4];
+                a[0] = 99;
+                a[1] = 99;
+                a[2] = 98;
+                a[length] = 99;
+                a[length + 1] = 99;
+                a[length + 2] = 98;
+                a[length + 3] = 98;
+                ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a, 1, length);
+                int index = span.IndexOf(99, 99, 98);
+                Assert.Equal(-1, index);
+            }
+
+            for (int length = 0; length < 100; length++)
+            {
+                byte[] a = new byte[length + 4];
+                a[0] = 99;
+                a[1] = 99;
+                a[2] = 99;
+                a[length + 1] = 99;
+                a[length + 2] = 99;
+                a[length + 3] = 99;
+                ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a, 1, length);
+                int index = span.IndexOf(99, 99, 99);
+                Assert.Equal(-1, index);
+            }
+
+            for (int length = 0; length < 100; length++)
+            {
+                byte[] a = new byte[length + 4];
+                a[0] = 99;
+                a[1] = 99;
+                a[2] = 99;
+                a[length] = 99;
+                a[length + 1] = 99;
+                a[length + 2] = 99;
+                a[length + 3] = 99;
+                ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a, 1, length);
+                int index = span.IndexOf(99, 99, 98);
+                Assert.Equal(-1, index);
+            }
         }
     }
 }

--- a/src/System.Memory/tests/Span/IndexOf.byte.cs
+++ b/src/System.Memory/tests/Span/IndexOf.byte.cs
@@ -350,5 +350,196 @@ namespace System.SpanTests
                 Assert.Equal(-1, index);
             }
         }
+
+        [Fact]
+        public static void ZeroLengthIndexOfMany_Byte()
+        {
+            Span<byte> sp = new Span<byte>(Array.Empty<byte>());
+            var values = new ReadOnlySpan<byte>(new byte[] {0, 0, 0, 0});
+            int idx = sp.IndexOfAny(values);
+            Assert.Equal(-1, idx);
+
+            values = new ReadOnlySpan<byte>(new byte[] {});
+            idx = sp.IndexOfAny(values);
+            Assert.Equal(0, idx);
+        }
+
+        [Fact]
+        public static void DefaultFilledIndexOfMany_Byte()
+        {
+            for (int length = 0; length < byte.MaxValue; length++)
+            {
+                byte[] a = new byte[length];
+                Span<byte> span = new Span<byte>(a);
+
+                var values = new ReadOnlySpan<byte>(new byte[] { default(byte), 99, 98, 0 });
+
+                for (int i = 0; i < length; i++)
+                {
+                    int idx = span.IndexOfAny(values);
+                    Assert.Equal(0, idx);
+                }
+            }
+        }
+
+        [Fact]
+        public static void TestMatchMany_Byte()
+        {
+            for (int length = 0; length < byte.MaxValue; length++)
+            {
+                byte[] a = new byte[length];
+                for (int i = 0; i < length; i++)
+                {
+                    a[i] = (byte)(i + 1);
+                }
+                Span<byte> span = new Span<byte>(a);
+
+                for (int targetIndex = 0; targetIndex < length; targetIndex++)
+                {
+                    var values = new ReadOnlySpan<byte>(new byte[] { a[targetIndex], 0, 0, 0 });
+                    int idx = span.IndexOfAny(values);
+                    Assert.Equal(targetIndex, idx);
+                }
+
+                for (int targetIndex = 0; targetIndex < length - 3; targetIndex++)
+                {
+                    var values = new ReadOnlySpan<byte>(new byte[] { a[targetIndex], a[targetIndex + 1], a[targetIndex + 2], a[targetIndex + 3] });
+                    int idx = span.IndexOfAny(values);
+                    Assert.Equal(targetIndex, idx);
+                }
+
+                for (int targetIndex = 0; targetIndex < length - 3; targetIndex++)
+                {
+                    var values = new ReadOnlySpan<byte>(new byte[] { 0, 0, 0, a[targetIndex + 3] });
+                    int idx = span.IndexOfAny(values);
+                    Assert.Equal(targetIndex + 3, idx);
+                }
+            }
+        }
+
+        [Fact]
+        public static void TestMatchValuesLargerMany_Byte()
+        {
+            var rnd = new Random(42);
+            for (int length = 2; length < byte.MaxValue; length++)
+            {
+                byte[] a = new byte[length];
+                int expectedIndex = length/2;
+                for (int i = 0; i < length; i++)
+                {
+                    if (i == expectedIndex)
+                    {
+                        continue;
+                    }
+                    a[i] = 255;
+                }
+                Span<byte> span = new Span<byte>(a);
+
+                byte[] targets = new byte[length*2];
+                for (int i = 0; i < targets.Length; i++)
+                {
+                    if (i == length + 1)
+                    {
+                        continue;
+                    }
+                    targets[i] = (byte)rnd.Next(1, 255);
+                }
+
+                var values = new ReadOnlySpan<byte>(targets);
+                int idx = span.IndexOfAny(values);
+                Assert.Equal(expectedIndex, idx);
+            }
+        }
+
+        [Fact]
+        public static void TestNoMatchMany_Byte()
+        {
+            var rnd = new Random(42);
+            for (int length = 1; length < byte.MaxValue; length++)
+            {
+                byte[] a = new byte[length];
+                byte[] targets = new byte[length];
+                for (int i = 0; i < targets.Length; i++)
+                {
+                    targets[i] = (byte) rnd.Next(1, 256);
+                }
+                Span<byte> span = new Span<byte>(a);
+                var values = new ReadOnlySpan<byte>(targets);
+
+                int idx = span.IndexOfAny(values);
+                Assert.Equal(-1, idx);
+            }
+        }
+
+        [Fact]
+        public static void TestNoMatchValuesLargerMany_Byte()
+        {
+            var rnd = new Random(42);
+            for (int length = 1; length < byte.MaxValue; length++)
+            {
+                byte[] a = new byte[length];
+                byte[] targets = new byte[length*2];
+                for (int i = 0; i < targets.Length; i++)
+                {
+                    targets[i] = (byte)rnd.Next(1, 256);
+                }
+                Span<byte> span = new Span<byte>(a);
+                var values = new ReadOnlySpan<byte>(targets);
+
+                int idx = span.IndexOfAny(values);
+                Assert.Equal(-1, idx);
+            }
+        }
+
+        [Fact]
+        public static void TestMultipleMatchMany_Byte()
+        {
+            for (int length = 5; length < byte.MaxValue; length++)
+            {
+                byte[] a = new byte[length];
+                for (int i = 0; i < length; i++)
+                {
+                    byte val = (byte)(i + 1);
+                    a[i] = val == 200 ? (byte)201 : val;
+                }
+
+                a[length - 1] = 200;
+                a[length - 2] = 200;
+                a[length - 3] = 200;
+                a[length - 4] = 200;
+                a[length - 5] = 200;
+
+                Span<byte> span = new Span<byte>(a);
+                var values = new ReadOnlySpan<byte>(new byte[] { 200, 200, 200, 200, 200, 200, 200, 200, 200 });
+                int idx = span.IndexOfAny(values);
+                Assert.Equal(length - 5, idx);
+            }
+        }
+
+        [Fact]
+        public static void MakeSureNoChecksGoOutOfRangeMany_Byte()
+        {
+            for (int length = 1; length < byte.MaxValue; length++)
+            {
+                byte[] a = new byte[length + 2];
+                a[0] = 99;
+                a[length + 1] = 98;
+                Span<byte> span = new Span<byte>(a, 1, length - 1);
+                var values = new ReadOnlySpan<byte>(new byte[] { 99, 98, 99, 98, 99, 98 });
+                int index = span.IndexOfAny(values);
+                Assert.Equal(-1, index);
+            }
+
+            for (int length = 1; length < byte.MaxValue; length++)
+            {
+                byte[] a = new byte[length + 2];
+                a[0] = 99;
+                a[length + 1] = 99;
+                Span<byte> span = new Span<byte>(a, 1, length - 1);
+                var values = new ReadOnlySpan<byte>(new byte[] { 99, 99, 99, 99, 99, 99 });
+                int index = span.IndexOfAny(values);
+                Assert.Equal(-1, index);
+            }
+        }
     }
 }

--- a/src/System.Memory/tests/Span/IndexOf.byte.cs
+++ b/src/System.Memory/tests/Span/IndexOf.byte.cs
@@ -70,5 +70,106 @@ namespace System.SpanTests
                 Assert.Equal(-1, index);
             }
         }
+
+        [Fact]
+        public static void ZeroLengthIndexOfTwo_Byte()
+        {
+            Span<byte> sp = new Span<byte>(Array.Empty<byte>());
+            int idx = sp.IndexOf(0, 0);
+            Assert.Equal(-1, idx);
+        }
+
+        [Fact]
+        public static void TestMatchTwo_Byte()
+        {
+            for (int length = 0; length < 32; length++)
+            {
+                byte[] a = new byte[length];
+                for (int i = 0; i < length; i++)
+                {
+                    a[i] = (byte)(i + 1);
+                }
+                Span<byte> span = new Span<byte>(a);
+
+                for (int targetIndex = 0; targetIndex < length - 1; targetIndex++)
+                {
+                    byte target0 = a[targetIndex];
+                    byte target1 = a[targetIndex + 1];
+                    int idx = span.IndexOf(target0, target1);
+                    Assert.Equal(targetIndex, idx);
+                }
+            }
+        }
+
+        [Fact]
+        public static void TestNoMatchTwo_Byte()
+        {
+            for (int length = 0; length < 32; length++)
+            {
+                byte[] a = new byte[length];
+                for (int i = 0; i < length; i++)
+                {
+                    a[i] = (byte)(i + 1);
+                }
+                Span<byte> span = new Span<byte>(a);
+
+                for (int targetIndex = 0; targetIndex < length - 1; targetIndex++)
+                {
+                    byte target0 = a[targetIndex];
+                    byte target1 = (byte)(a[targetIndex + 1] + 1);
+                    int idx = span.IndexOf(target0, target1);
+                    Assert.Equal(-1, idx);
+                }
+            }
+        }
+
+        [Fact]
+        public static void TestMultipleMatchTwo_Byte()
+        {
+            for (int length = 3; length < 32; length++)
+            {
+                byte[] a = new byte[length];
+                for (int i = 0; i < length; i++)
+                {
+                    a[i] = (byte)(i + 1);
+                }
+
+                a[length - 1] = 200;
+                a[length - 2] = 200;
+                a[length - 3] = 200;
+
+                Span<byte> span = new Span<byte>(a);
+                int idx = span.IndexOf(200, 200);
+                Assert.Equal(length - 3, idx);
+            }
+        }
+
+        [Fact]
+        public static void MakeSureNoChecksGoOutOfRangeTwo_Byte()
+        {
+            for (int length = 0; length < 100; length++)
+            {
+                byte[] a = new byte[length + 3];
+                a[0] = 99;
+                a[1] = 98;
+                a[length + 1] = 99;
+                a[length + 2] = 98;
+                Span<byte> span = new Span<byte>(a, 1, length);
+                int index = span.IndexOf(99, 98);
+                Assert.Equal(-1, index);
+            }
+
+            for (int length = 0; length < 100; length++)
+            {
+                byte[] a = new byte[length + 3];
+                a[0] = 99;
+                a[1] = 99;
+                a[length + 1] = 99;
+                a[length + 2] = 99;
+                Span<byte> span = new Span<byte>(a, 1, length);
+                int index = span.IndexOf(99, 99);
+                Assert.Equal(-1, index);
+            }
+        }
     }
 }

--- a/src/System.Memory/tests/Span/IndexOf.byte.cs
+++ b/src/System.Memory/tests/Span/IndexOf.byte.cs
@@ -75,8 +75,32 @@ namespace System.SpanTests
         public static void ZeroLengthIndexOfTwo_Byte()
         {
             Span<byte> sp = new Span<byte>(Array.Empty<byte>());
-            int idx = sp.IndexOf(0, 0);
+            int idx = sp.IndexOfAny(0, 0);
             Assert.Equal(-1, idx);
+        }
+
+        [Fact]
+        public static void DefaultFilledIndexOfTwo_Byte()
+        {
+            Random rnd = new Random(42);
+
+            for (int length = 0; length < 32; length++)
+            {
+                byte[] a = new byte[length];
+                Span<byte> span = new Span<byte>(a);
+
+                byte[] targets = { default(byte), 99 };
+
+                for (int i = 0; i < length; i++)
+                {
+                    int index;
+                    index = rnd.Next(0, 2) == 0 ? 0 : 1;
+                    byte target0 = targets[index];
+                    byte target1 = targets[(index + 1) % 2];
+                    int idx = span.IndexOfAny(target0, target1);
+                    Assert.Equal(0, idx);
+                }
+            }
         }
 
         [Fact]
@@ -94,9 +118,25 @@ namespace System.SpanTests
                 for (int targetIndex = 0; targetIndex < length - 1; targetIndex++)
                 {
                     byte target0 = a[targetIndex];
-                    byte target1 = a[targetIndex + 1];
-                    int idx = span.IndexOf(target0, target1);
+                    byte target1 = 99;
+                    int idx = span.IndexOfAny(target0, target1);
                     Assert.Equal(targetIndex, idx);
+                }
+
+                for (int targetIndex = 0; targetIndex < length - 1; targetIndex++)
+                {
+                    byte target0 = a[targetIndex];
+                    byte target1 = a[targetIndex + 1];
+                    int idx = span.IndexOfAny(target0, target1);
+                    Assert.Equal(targetIndex, idx);
+                }
+
+                for (int targetIndex = 0; targetIndex < length - 1; targetIndex++)
+                {
+                    byte target0 = 99;
+                    byte target1 = a[targetIndex + 1];
+                    int idx = span.IndexOfAny(target0, target1);
+                    Assert.Equal(targetIndex + 1, idx);
                 }
             }
         }
@@ -115,9 +155,9 @@ namespace System.SpanTests
 
                 for (int targetIndex = 0; targetIndex < length - 1; targetIndex++)
                 {
-                    byte target0 = a[targetIndex];
-                    byte target1 = (byte)(a[targetIndex + 1] + 1);
-                    int idx = span.IndexOf(target0, target1);
+                    byte target0 = 98;
+                    byte target1 = 99;
+                    int idx = span.IndexOfAny(target0, target1);
                     Assert.Equal(-1, idx);
                 }
             }
@@ -139,7 +179,7 @@ namespace System.SpanTests
                 a[length - 3] = 200;
 
                 Span<byte> span = new Span<byte>(a);
-                int idx = span.IndexOf(200, 200);
+                int idx = span.IndexOfAny(200, 200);
                 Assert.Equal(length - 3, idx);
             }
         }
@@ -147,50 +187,58 @@ namespace System.SpanTests
         [Fact]
         public static void MakeSureNoChecksGoOutOfRangeTwo_Byte()
         {
-            for (int length = 0; length < 100; length++)
+            for (int length = 1; length < 100; length++)
             {
-                byte[] a = new byte[length + 3];
+                byte[] a = new byte[length + 2];
                 a[0] = 99;
-                a[1] = 98;
-                a[length + 1] = 99;
-                a[length + 2] = 98;
-                Span<byte> span = new Span<byte>(a, 1, length);
-                int index = span.IndexOf(99, 98);
+                a[length + 1] = 98;
+                Span<byte> span = new Span<byte>(a, 1, length - 1);
+                int index = span.IndexOfAny(99, 98);
                 Assert.Equal(-1, index);
             }
 
-            for (int length = 0; length < 100; length++)
+            for (int length = 1; length < 100; length++)
             {
-                byte[] a = new byte[length + 3];
+                byte[] a = new byte[length + 2];
                 a[0] = 99;
-                a[1] = 99;
                 a[length + 1] = 99;
-                a[length + 2] = 99;
-                Span<byte> span = new Span<byte>(a, 1, length);
-                int index = span.IndexOf(99, 99);
-                Assert.Equal(-1, index);
-            }
-
-            for (int length = 0; length < 100; length++)
-            {
-                byte[] a = new byte[length + 3];
-                a[0] = 99;
-                a[1] = 99;
-                a[length] = 99;
-                a[length + 1] = 99;
-                a[length + 2] = 99;
-                Span<byte> span = new Span<byte>(a, 1, length);
-                int index = span.IndexOf(99, 98);
+                Span<byte> span = new Span<byte>(a, 1, length - 1);
+                int index = span.IndexOfAny(99, 99);
                 Assert.Equal(-1, index);
             }
         }
-        
+
         [Fact]
         public static void ZeroLengthIndexOfThree_Byte()
         {
             Span<byte> sp = new Span<byte>(Array.Empty<byte>());
-            int idx = sp.IndexOf(0, 0, 0);
+            int idx = sp.IndexOfAny(0, 0, 0);
             Assert.Equal(-1, idx);
+        }
+
+        [Fact]
+        public static void DefaultFilledIndexOfThree_Byte()
+        {
+            Random rnd = new Random(42);
+
+            for (int length = 0; length < 32; length++)
+            {
+                byte[] a = new byte[length];
+                Span<byte> span = new Span<byte>(a);
+
+                byte[] targets = { default(byte), 99, 98 };
+
+                for (int i = 0; i < length; i++)
+                {
+                    int index;
+                    index = rnd.Next(0, 3);
+                    byte target0 = targets[index];
+                    byte target1 = targets[(index + 1) % 2];
+                    byte traget2 = targets[(index + 1) % 3];
+                    int idx = span.IndexOfAny(target0, target1, traget2);
+                    Assert.Equal(0, idx);
+                }
+            }
         }
 
         [Fact]
@@ -208,10 +256,28 @@ namespace System.SpanTests
                 for (int targetIndex = 0; targetIndex < length - 2; targetIndex++)
                 {
                     byte target0 = a[targetIndex];
+                    byte target1 = 99;
+                    byte target2 = 99;
+                    int idx = span.IndexOfAny(target0, target1, target2);
+                    Assert.Equal(targetIndex, idx);
+                }
+
+                for (int targetIndex = 0; targetIndex < length - 2; targetIndex++)
+                {
+                    byte target0 = a[targetIndex];
                     byte target1 = a[targetIndex + 1];
                     byte target2 = a[targetIndex + 2];
-                    int idx = span.IndexOf(target0, target1, target2);
+                    int idx = span.IndexOfAny(target0, target1, target2);
                     Assert.Equal(targetIndex, idx);
+                }
+
+                for (int targetIndex = 0; targetIndex < length - 2; targetIndex++)
+                {
+                    byte target0 = 99;
+                    byte target1 = 99;
+                    byte target2 = a[targetIndex + 2];
+                    int idx = span.IndexOfAny(target0, target1, target2);
+                    Assert.Equal(targetIndex + 2, idx);
                 }
             }
         }
@@ -228,12 +294,12 @@ namespace System.SpanTests
                 }
                 Span<byte> span = new Span<byte>(a);
 
-                for (int targetIndex = 0; targetIndex < length - 2; targetIndex++)
+                for (int targetIndex = 0; targetIndex < length - 1; targetIndex++)
                 {
-                    byte target0 = a[targetIndex];
-                    byte target1 = (byte)(a[targetIndex + 1] + 1);
-                    byte target2 = a[targetIndex + 2];
-                    int idx = span.IndexOf(target0, target1, target2);
+                    byte target0 = 98;
+                    byte target1 = 99;
+                    byte target2 = 100;
+                    int idx = span.IndexOfAny(target0, target1, target2);
                     Assert.Equal(-1, idx);
                 }
             }
@@ -249,14 +315,14 @@ namespace System.SpanTests
                 {
                     a[i] = (byte)(i + 1);
                 }
-                
+
                 a[length - 1] = 200;
                 a[length - 2] = 200;
                 a[length - 3] = 200;
                 a[length - 4] = 200;
 
                 Span<byte> span = new Span<byte>(a);
-                int idx = span.IndexOf(200, 200, 200);
+                int idx = span.IndexOfAny(200, 200, 200);
                 Assert.Equal(length - 4, idx);
             }
         }
@@ -264,47 +330,23 @@ namespace System.SpanTests
         [Fact]
         public static void MakeSureNoChecksGoOutOfRangeThree_Byte()
         {
-            for (int length = 4; length < 5; length++)
+            for (int length = 1; length < 100; length++)
             {
-                byte[] a = new byte[length + 4];
+                byte[] a = new byte[length + 2];
                 a[0] = 99;
-                a[1] = 99;
-                a[2] = 98;
-                a[length] = 99;
-                a[length + 1] = 99;
-                a[length + 2] = 98;
-                a[length + 3] = 98;
-                Span<byte> span = new Span<byte>(a, 1, length);
-                int index = span.IndexOf(99, 99, 98);
+                a[length + 1] = 98;
+                Span<byte> span = new Span<byte>(a, 1, length - 1);
+                int index = span.IndexOfAny(99, 98, 99);
                 Assert.Equal(-1, index);
             }
 
-            for (int length = 0; length < 100; length++)
+            for (int length = 1; length < 100; length++)
             {
-                byte[] a = new byte[length + 4];
+                byte[] a = new byte[length + 2];
                 a[0] = 99;
-                a[1] = 99;
-                a[2] = 99;
                 a[length + 1] = 99;
-                a[length + 2] = 99;
-                a[length + 3] = 99;
-                Span<byte> span = new Span<byte>(a, 1, length);
-                int index = span.IndexOf(99, 99, 99);
-                Assert.Equal(-1, index);
-            }
-
-            for (int length = 0; length < 100; length++)
-            {
-                byte[] a = new byte[length + 4];
-                a[0] = 99;
-                a[1] = 99;
-                a[2] = 99;
-                a[length] = 99;
-                a[length + 1] = 99;
-                a[length + 2] = 99;
-                a[length + 3] = 99;
-                Span<byte> span = new Span<byte>(a, 1, length);
-                int index = span.IndexOf(99, 99, 98);
+                Span<byte> span = new Span<byte>(a, 1, length - 1);
+                int index = span.IndexOfAny(99, 99, 99);
                 Assert.Equal(-1, index);
             }
         }

--- a/src/System.Memory/tests/Span/IndexOf.byte.cs
+++ b/src/System.Memory/tests/Span/IndexOf.byte.cs
@@ -170,6 +170,143 @@ namespace System.SpanTests
                 int index = span.IndexOf(99, 99);
                 Assert.Equal(-1, index);
             }
+
+            for (int length = 0; length < 100; length++)
+            {
+                byte[] a = new byte[length + 3];
+                a[0] = 99;
+                a[1] = 99;
+                a[length] = 99;
+                a[length + 1] = 99;
+                a[length + 2] = 99;
+                Span<byte> span = new Span<byte>(a, 1, length);
+                int index = span.IndexOf(99, 98);
+                Assert.Equal(-1, index);
+            }
+        }
+        
+        [Fact]
+        public static void ZeroLengthIndexOfThree_Byte()
+        {
+            Span<byte> sp = new Span<byte>(Array.Empty<byte>());
+            int idx = sp.IndexOf(0, 0, 0);
+            Assert.Equal(-1, idx);
+        }
+
+        [Fact]
+        public static void TestMatchThree_Byte()
+        {
+            for (int length = 0; length < 32; length++)
+            {
+                byte[] a = new byte[length];
+                for (int i = 0; i < length; i++)
+                {
+                    a[i] = (byte)(i + 1);
+                }
+                Span<byte> span = new Span<byte>(a);
+
+                for (int targetIndex = 0; targetIndex < length - 2; targetIndex++)
+                {
+                    byte target0 = a[targetIndex];
+                    byte target1 = a[targetIndex + 1];
+                    byte target2 = a[targetIndex + 2];
+                    int idx = span.IndexOf(target0, target1, target2);
+                    Assert.Equal(targetIndex, idx);
+                }
+            }
+        }
+
+        [Fact]
+        public static void TestNoMatchThree_Byte()
+        {
+            for (int length = 0; length < 32; length++)
+            {
+                byte[] a = new byte[length];
+                for (int i = 0; i < length; i++)
+                {
+                    a[i] = (byte)(i + 1);
+                }
+                Span<byte> span = new Span<byte>(a);
+
+                for (int targetIndex = 0; targetIndex < length - 2; targetIndex++)
+                {
+                    byte target0 = a[targetIndex];
+                    byte target1 = (byte)(a[targetIndex + 1] + 1);
+                    byte target2 = a[targetIndex + 2];
+                    int idx = span.IndexOf(target0, target1, target2);
+                    Assert.Equal(-1, idx);
+                }
+            }
+        }
+
+        [Fact]
+        public static void TestMultipleMatchThree_Byte()
+        {
+            for (int length = 4; length < 32; length++)
+            {
+                byte[] a = new byte[length];
+                for (int i = 0; i < length; i++)
+                {
+                    a[i] = (byte)(i + 1);
+                }
+                
+                a[length - 1] = 200;
+                a[length - 2] = 200;
+                a[length - 3] = 200;
+                a[length - 4] = 200;
+
+                Span<byte> span = new Span<byte>(a);
+                int idx = span.IndexOf(200, 200, 200);
+                Assert.Equal(length - 4, idx);
+            }
+        }
+
+        [Fact]
+        public static void MakeSureNoChecksGoOutOfRangeThree_Byte()
+        {
+            for (int length = 4; length < 5; length++)
+            {
+                byte[] a = new byte[length + 4];
+                a[0] = 99;
+                a[1] = 99;
+                a[2] = 98;
+                a[length] = 99;
+                a[length + 1] = 99;
+                a[length + 2] = 98;
+                a[length + 3] = 98;
+                Span<byte> span = new Span<byte>(a, 1, length);
+                int index = span.IndexOf(99, 99, 98);
+                Assert.Equal(-1, index);
+            }
+
+            for (int length = 0; length < 100; length++)
+            {
+                byte[] a = new byte[length + 4];
+                a[0] = 99;
+                a[1] = 99;
+                a[2] = 99;
+                a[length + 1] = 99;
+                a[length + 2] = 99;
+                a[length + 3] = 99;
+                Span<byte> span = new Span<byte>(a, 1, length);
+                int index = span.IndexOf(99, 99, 99);
+                Assert.Equal(-1, index);
+            }
+
+            for (int length = 0; length < 100; length++)
+            {
+                byte[] a = new byte[length + 4];
+                a[0] = 99;
+                a[1] = 99;
+                a[2] = 99;
+                a[length] = 99;
+                a[length + 1] = 99;
+                a[length + 2] = 99;
+                a[length + 3] = 99;
+                Span<byte> span = new Span<byte>(a, 1, length);
+                int index = span.IndexOf(99, 99, 98);
+                Assert.Equal(-1, index);
+            }
         }
     }
 }


### PR DESCRIPTION
From:
https://github.com/dotnet/corefxlab/pull/1348#issuecomment-287998752

Part of https://github.com/dotnet/corefxlab/issues/1314 / https://github.com/dotnet/corefxlab/issues/1293

Adding:
```C#
    public static int IndexOfAny(this Span<byte> span, byte value0, byte value1)
    public static int IndexOfAny(this Span<byte> span, byte value0, byte value1, byte value2)
    public static int IndexOfAny(this Span<byte> span, ReadOnlySpan<byte> values)
    public static int IndexOfAny(this ReadOnlySpan<byte> span, byte value0, byte value1)
    public static int IndexOfAny(this ReadOnlySpan<byte> span, byte value0, byte value1, byte value2)
    public static int IndexOfAny(this ReadOnlySpan<byte> span, ReadOnlySpan<byte> values)
```
Edit: IndexOf => IndexOfAny

cc @KrzysztofCwalina, @davidfowl 