### PR TITLE
Force shim assembly references to 0.0.0.0

### DIFF
--- a/src/shims/shims.proj
+++ b/src/shims/shims.proj
@@ -28,6 +28,7 @@
       <GenFacadesArgs>$(GenFacadesArgs) -facadePath:"$(GenFacadesOutputPath)"</GenFacadesArgs>
       <GenFacadesArgs>$(GenFacadesArgs) -producePdb:false</GenFacadesArgs>
       <GenFacadesArgs>$(GenFacadesArgs) -assemblyFileVersion:$(AssemblyFileVersion)</GenFacadesArgs>
+      <GenFacadesArgs>$(GenFacadesArgs) -forceZeroVersionSeeds</GenFacadesArgs>
       <!-- TODO: We should remove this flag once we have all the types for netstandard -->
       <GenFacadesArgs>$(GenFacadesArgs) -ignoreMissingTypes</GenFacadesArgs>
     </PropertyGroup>


### PR DESCRIPTION
The shims will end up being pulled into assembly closures where sometimes
they will have a higher version of a dependency then what is actually needed.
This causes msbuild (RAR) to output warnings which are just noise. For shims
we really don't need the refenced to match exact versions so we can always force
them to be the lowest version 0.0.0.0 and they will unify up to what is on
the platform.

cc @ericstj 

I did some ad-hoc testing of this and verified that msbuild (RAR) no longer warns after this change it does AutoUnify and if that isn't enabled will cause a bunch of conflict warnings, but that is larger then just the shims. 