### PR TITLE
Named Multiply and Divide methods on TimeSpan

### DIFF
--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -2192,6 +2192,8 @@ namespace System
         public static int Compare(System.TimeSpan t1, System.TimeSpan t2) { throw null; }
         public int CompareTo(object value) { throw null; }
         public int CompareTo(System.TimeSpan value) { throw null; }
+        public System.TimeSpan Divide(double divisor) { throw null; }
+        public double Divide(System.TimeSpan ts) { throw null; }
         public System.TimeSpan Duration() { throw null; }
         public override bool Equals(object value) { throw null; }
         public bool Equals(System.TimeSpan obj) { throw null; }
@@ -2203,6 +2205,7 @@ namespace System
         public static System.TimeSpan FromSeconds(double value) { throw null; }
         public static System.TimeSpan FromTicks(long value) { throw null; }
         public override int GetHashCode() { throw null; }
+        public System.TimeSpan Multiply(double factor) { throw null; }
         public System.TimeSpan Negate() { throw null; }
         public static System.TimeSpan operator +(System.TimeSpan t1, System.TimeSpan t2) { throw null; }
         public static double operator /(System.TimeSpan t1, System.TimeSpan t2) { throw null; }

--- a/src/System.Runtime/tests/System/TimeSpanTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/TimeSpanTests.netcoreapp.cs
@@ -66,5 +66,48 @@ namespace System.Tests
         {
             Assert.Throws<ArgumentException>("divisor", () => TimeSpan.FromDays(1) / double.NaN);
         }
+
+        [Theory, MemberData(nameof(MultiplicationTestData))]
+        public static void NamedMultiplication(TimeSpan timeSpan, double factor, TimeSpan expected)
+        {
+            Assert.Equal(expected, timeSpan.Multiply(factor));
+        }
+
+        [Fact]
+        public static void NamedOverflowingMultiplication()
+        {
+            Assert.Throws<OverflowException>(() => TimeSpan.MaxValue.Multiply(1.000000001));
+        }
+
+        [Fact]
+        public static void NamedNaNMultiplication()
+        {
+            Assert.Throws<ArgumentException>("factor", () => TimeSpan.FromDays(1).Multiply(double.NaN));
+        }
+
+        [Theory, MemberData(nameof(MultiplicationTestData))]
+        public static void NamedDivision(TimeSpan timeSpan, double factor, TimeSpan expected)
+        {
+            Assert.Equal(factor, expected.Divide(timeSpan), 14);
+            double divisor = 1.0 / factor;
+            Assert.Equal(expected, timeSpan.Divide(divisor));
+        }
+
+        [Fact]
+        public static void NamedDivideByZero()
+        {
+            Assert.Throws<OverflowException>(() => TimeSpan.FromDays(1).Divide(0));
+            Assert.Throws<OverflowException>(() => TimeSpan.FromDays(-1).Divide(0));
+            Assert.Throws<OverflowException>(() => TimeSpan.Zero.Divide(0));
+            Assert.Equal(double.PositiveInfinity, TimeSpan.FromDays(1).Divide(TimeSpan.Zero));
+            Assert.Equal(double.NegativeInfinity, TimeSpan.FromDays(-1).Divide(TimeSpan.Zero));
+            Assert.True(double.IsNaN(TimeSpan.Zero.Divide(TimeSpan.Zero)));
+        }
+
+        [Fact]
+        public static void NamedNaNDivision()
+        {
+            Assert.Throws<ArgumentException>("divisor", () => TimeSpan.FromDays(1).Divide(double.NaN));
+        }
     }
 }


### PR DESCRIPTION
Update refs and add tests.

Closes #16476

Won't pass CI until dotnet/coreclr#10366 and dotnet/corert#3052 are in.