### PR TITLE
Fix the separator for NamedPipe

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
@@ -820,7 +820,7 @@ namespace System.Data.SqlClient.SNI
                     for ( int i = 4; i < tokensByBackSlash.Length-1; i++)
                     {
                         pipeNameBuilder.Append(tokensByBackSlash[i]);
-                        pipeNameBuilder.Append(Path.PathSeparator);
+                        pipeNameBuilder.Append(Path.DirectorySeparatorChar);
                     }
                     // Append the last part without a "/"
                     pipeNameBuilder.Append(tokensByBackSlash[tokensByBackSlash.Length - 1]);


### PR DESCRIPTION
The separator in the Named Pipes should be Path.DirectorySeparatorChar and no PathSeparator. 
Caught while running Manual Tests for various Named Pipes combinations.