### PR TITLE
Clear cached display name in validation context when member name is set

### DIFF
--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationContext.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationContext.cs
@@ -174,8 +174,15 @@ namespace System.ComponentModel.DataAnnotations
         /// </value>
         public string MemberName
         {
-            get { return _memberName; }
-            set { _memberName = value; }
+            get
+            {
+                return _memberName;
+            }
+            set
+            {
+                _memberName = value;
+                _displayName = null;
+            }
         }
 
         /// <summary>

--- a/src/System.ComponentModel.Annotations/tests/ValidationContextTests.cs
+++ b/src/System.ComponentModel.Annotations/tests/ValidationContextTests.cs
@@ -139,6 +139,17 @@ namespace System.ComponentModel.DataAnnotations.Tests
             validationContext.DisplayName = "OverriddenDisplayName";
             Assert.Equal("OverriddenDisplayName", validationContext.DisplayName);
         }
+
+        [Fact]
+        public static void Setting_MemberName_resets_DisplayName()
+        {
+            var testDataAnnotationsDerived = new TestClass();
+            var validationContext = new ValidationContext(testDataAnnotationsDerived);
+            validationContext.MemberName = "DisplayNameMember";
+            Assert.Equal("DisplayNameMemberDisplayName", validationContext.DisplayName);
+            validationContext.MemberName = "ExistingMember";
+            Assert.Equal("ExistingMember", validationContext.DisplayName);
+        }
     }
 
     public class TestClass


### PR DESCRIPTION
Fixes #11044