### PR TITLE
Enable additional linux portable platforms

### DIFF
--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -85,7 +85,7 @@
             "PB_DockerTag": "rhel7_prereqs_2",
             "PB_BuildArguments": "-buildArch=x64 -Release -portableLinux",
             "PB_SyncArguments": "-p -portableLinux -- /p:ArchGroup=x64",
-            "PB_TargetQueue": "Redhat.72.Amd64+Debian.82.Amd64"
+            "PB_TargetQueue": "Redhat.72.Amd64+Debian.82.Amd64+Ubuntu1404.Amd64+Ubuntu1604.Amd64+Ubuntu.1610.Amd64+suse.421.amd64"
           },
           "ReportingParameters": {
             "OperatingSystem": "RedHat 7",
@@ -469,7 +469,7 @@
             "PB_DockerTag": "rhel7_prereqs_2",
             "PB_BuildArguments": "-buildArch=x64 -Debug -portableLinux",
             "PB_SyncArguments": "-p -portableLinux -- /p:ArchGroup=x64",
-            "PB_TargetQueue": "Redhat.72.Amd64+Debian.82.Amd64"
+            "PB_TargetQueue": "Redhat.72.Amd64+Debian.82.Amd64+Ubuntu1404.Amd64+Ubuntu1604.Amd64+Ubuntu.1610.Amd64+suse.421.amd64"
           },
           "ReportingParameters": {
             "OperatingSystem": "RedHat 7",


### PR DESCRIPTION
Enables portable linux runs on official builds for
Ubuntu 14.04
Ubuntu 16.04
Ubuntu 16.10
openSuSE 42.1