### PR TITLE
Improve CI: disable socket tests on Linux that have may have port collisions

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
@@ -1477,7 +1477,7 @@ namespace System.Net.Sockets.Tests
 
         [Fact]
         // Binds to a specific port on 'connectTo' which on Unix may already be in use
-        // Also expected behavior is different on OSX and Linux (see ReceiveFromV4BoundToSpecificV6_NotReceived_Linux)
+        // Also expected behavior is different on OSX and Linux (ArgumentException instead of SocketException)
         [PlatformSpecific(TestPlatforms.Windows)]
         public void ReceiveFromV4BoundToSpecificV6_NotReceived()
         {
@@ -1486,27 +1486,6 @@ namespace System.Net.Sockets.Tests
                 ReceiveFrom_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback);
             });
         }
-
-        // Binds to a specific port on 'connectTo' which on Unix may already be in use
-        // Test preserved if we change these tests to run in series (instead of parallel) to avoid port collision
-#if false
-        // NOTE: on Linux, the OS IP stack changes a dual-mode socket back to a
-        //       normal IPv6 socket once the socket is bound to an IPv6-specific
-        //       address. As a result, the argument validation checks in
-        //       ReceiveFrom that check that the supplied endpoint is compatible
-        //       with the socket's address family fail. We've decided that this is
-        //       an acceptable difference due to the extra state that would otherwise
-        //       be necessary to emulate the Winsock behavior.
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/982
-        [PlatformSpecific(TestPlatforms.Linux)]  // Read the comment above
-        public void ReceiveFromV4BoundToSpecificV6_NotReceived_Linux()
-        {
-            Assert.Throws<ArgumentException>(() =>
-            {
-                ReceiveFrom_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback);
-            });
-        }
-#endif
 
         [Fact]
         // Binds to a specific port on 'connectTo' which on Unix may already be in use
@@ -1629,7 +1608,7 @@ namespace System.Net.Sockets.Tests
 
         [Fact]
         // Binds to a specific port on 'connectTo' which on Unix may already be in use
-        // Also expected behavior is different on OSX and Linux (see BeginReceiveFromV4BoundToSpecificV6_NotReceived_Linux)
+        // Also expected behavior is different on OSX and Linux (ArgumentException instead of TimeoutException)
         [PlatformSpecific(TestPlatforms.Windows)]
         public void BeginReceiveFromV4BoundToSpecificV6_NotReceived()
         {
@@ -1638,27 +1617,6 @@ namespace System.Net.Sockets.Tests
                 BeginReceiveFrom_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, expectedToTimeout: true);
             });
         }
-
-        // Binds to a specific port on 'connectTo' which on Unix may already be in use
-        // Test preserved if we change these tests to run in series (instead of parallel) to avoid port collision
-#if false
-        // NOTE: on Linux, the OS IP stack changes a dual-mode socket back to a
-        //       normal IPv6 socket once the socket is bound to an IPv6-specific
-        //       address. As a result, the argument validation checks in
-        //       ReceiveFrom that check that the supplied endpoint is compatible
-        //       with the socket's address family fail. We've decided that this is
-        //       an acceptable difference due to the extra state that would otherwise
-        //       be necessary to emulate the Winsock behavior.
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/982
-        [PlatformSpecific(TestPlatforms.Linux)]  // Read the comment above
-        public void BeginReceiveFromV4BoundToSpecificV6_NotReceived_Linux()
-        {
-            Assert.Throws<ArgumentException>(() =>
-            {
-                BeginReceiveFrom_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, expectedToTimeout: true);
-            });
-        }
-#endif
 
         [Fact]
         // Binds to a specific port on 'connectTo' which on Unix may already be in use

--- a/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
@@ -1464,7 +1464,9 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(~TestPlatforms.OSX)]  // ReceiveFrom not supported on OSX
+        // Binds to a specific port on 'connectTo' which on Unix may already be in use
+        // Also ReceiveFrom not supported on OSX
+        [PlatformSpecific(TestPlatforms.Windows)]
         public void ReceiveFromV6BoundToSpecificV4_NotReceived()
         {
             Assert.Throws<SocketException>(() =>
@@ -1474,7 +1476,9 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(~(TestPlatforms.Linux | TestPlatforms.OSX))]  // Expected behavior is different on OSX and Linux
+        // Binds to a specific port on 'connectTo' which on Unix may already be in use
+        // Also expected behavior is different on OSX and Linux (see ReceiveFromV4BoundToSpecificV6_NotReceived_Linux)
+        [PlatformSpecific(TestPlatforms.Windows)]
         public void ReceiveFromV4BoundToSpecificV6_NotReceived()
         {
             Assert.Throws<SocketException>(() =>
@@ -1483,6 +1487,9 @@ namespace System.Net.Sockets.Tests
             });
         }
 
+        // Binds to a specific port on 'connectTo' which on Unix may already be in use
+        // Test preserved if we change these tests to run in series (instead of parallel) to avoid port collision
+#if false
         // NOTE: on Linux, the OS IP stack changes a dual-mode socket back to a
         //       normal IPv6 socket once the socket is bound to an IPv6-specific
         //       address. As a result, the argument validation checks in
@@ -1499,9 +1506,12 @@ namespace System.Net.Sockets.Tests
                 ReceiveFrom_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback);
             });
         }
+#endif
 
         [Fact]
-        [PlatformSpecific(~TestPlatforms.OSX)]  // ReceiveFrom not supported on OSX
+        // Binds to a specific port on 'connectTo' which on Unix may already be in use
+        // Also ReceiveFrom not supported on OSX
+        [PlatformSpecific(TestPlatforms.Windows)]
         public void ReceiveFromV6BoundToAnyV4_NotReceived()
         {
             Assert.Throws<SocketException>(() =>
@@ -1606,7 +1616,9 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(~TestPlatforms.OSX)]  // BeginReceiveFrom not supported on OSX
+        // Binds to a specific port on 'connectTo' which on Unix may already be in use
+        // Also BeginReceiveFrom not supported on OSX
+        [PlatformSpecific(TestPlatforms.Windows)]
         public void BeginReceiveFromV6BoundToSpecificV4_NotReceived()
         {
             Assert.Throws<TimeoutException>(() =>
@@ -1616,7 +1628,9 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(~(TestPlatforms.Linux | TestPlatforms.OSX))]  // Expected behavior is different on OSX and Linux
+        // Binds to a specific port on 'connectTo' which on Unix may already be in use
+        // Also expected behavior is different on OSX and Linux (see BeginReceiveFromV4BoundToSpecificV6_NotReceived_Linux)
+        [PlatformSpecific(TestPlatforms.Windows)]
         public void BeginReceiveFromV4BoundToSpecificV6_NotReceived()
         {
             Assert.Throws<TimeoutException>(() =>
@@ -1625,6 +1639,9 @@ namespace System.Net.Sockets.Tests
             });
         }
 
+        // Binds to a specific port on 'connectTo' which on Unix may already be in use
+        // Test preserved if we change these tests to run in series (instead of parallel) to avoid port collision
+#if false
         // NOTE: on Linux, the OS IP stack changes a dual-mode socket back to a
         //       normal IPv6 socket once the socket is bound to an IPv6-specific
         //       address. As a result, the argument validation checks in
@@ -1641,9 +1658,12 @@ namespace System.Net.Sockets.Tests
                 BeginReceiveFrom_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, expectedToTimeout: true);
             });
         }
+#endif
 
         [Fact]
-        [PlatformSpecific(~TestPlatforms.OSX)]  // BeginReceiveFrom not supported on OSX
+        // Binds to a specific port on 'connectTo' which on Unix may already be in use
+        // Also BeginReceiveFrom not supported on OSX
+        [PlatformSpecific(TestPlatforms.Windows)]
         public void BeginReceiveFromV6BoundToAnyV4_NotReceived()
         {
             Assert.Throws<TimeoutException>(() =>


### PR DESCRIPTION
Similar to PR https://github.com/dotnet/corefx/pull/16548, this disables tests on Unix that may have IPV4+IPV6 port collisions with tests that run simultaneously.

Addresses https://github.com/dotnet/corefx/issues/13967 (CI failure in System.Net.Sockets.Tests.DualModeConnectionlessReceiveFrom.ReceiveFromV6BoundToAnyV4_NotReceived)

FWIW I have a POSIX C test that shows that such port collisions are possible under Linux - i.e. that it is possible to ask for two 'unused' ports (one IPV4, one IPV6) and then receive the two ports but which happen to have the same port #.

cc @CIPop, @davidsh