### PR TITLE
Add property to disable xunit appdomain execution from particular tests projects

### DIFF
--- a/Tools-Override/tests.targets
+++ b/Tools-Override/tests.targets
@@ -47,7 +47,8 @@
   <PropertyGroup>
     <XunitResultsFileName>testResults.xml</XunitResultsFileName>
 
-    <XunitOptions Condition="'$(BuildingNETFxVertical)' == 'true'">$(XunitOptions) -noshadow -noappdomain </XunitOptions>
+    <XunitOptions Condition="'$(BuildingNETFxVertical)' == 'true'">$(XunitOptions) -noshadow</XunitOptions>
+    <XunitOptions Condition="'$(BuildingNETFxVertical)' == 'true' and '$(XunitDisableAppDomain)' == 'true'">$(XunitOptions) -noappdomain </XunitOptions>
     <XunitOptions>$(XunitOptions) -xml $(XunitResultsFileName)</XunitOptions>
 
     <XunitOptions Condition="'$(Performance)'!='true'">$(XunitOptions) -notrait Benchmark=true</XunitOptions>

--- a/Tools-Override/tests.targets
+++ b/Tools-Override/tests.targets
@@ -48,7 +48,7 @@
     <XunitResultsFileName>testResults.xml</XunitResultsFileName>
 
     <XunitOptions Condition="'$(BuildingNETFxVertical)' == 'true'">$(XunitOptions) -noshadow</XunitOptions>
-    <XunitOptions Condition="'$(BuildingNETFxVertical)' == 'true' and '$(XunitDisableAppDomain)' == 'true'">$(XunitOptions) -noappdomain </XunitOptions>
+    <XunitOptions Condition="'$(BuildingNETFxVertical)' == 'true' and '$(XUnitNoAppdomain)' == 'true'">$(XunitOptions) -noappdomain </XunitOptions>
     <XunitOptions>$(XunitOptions) -xml $(XunitResultsFileName)</XunitOptions>
 
     <XunitOptions Condition="'$(Performance)'!='true'">$(XunitOptions) -notrait Benchmark=true</XunitOptions>

--- a/src/System.ComponentModel.EventBasedAsync/tests/System.ComponentModel.EventBasedAsync.Tests.csproj
+++ b/src/System.ComponentModel.EventBasedAsync/tests/System.ComponentModel.EventBasedAsync.Tests.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <!-- this tests run in multiple AppDomains in full framework, so if an Assert fails we would get a Serialization exception instead of the real failure.
     adding this xunit so it runs in one AppDomain -->
-    <XunitOptions Condition="'$(TestTFM)'=='net46'">$(XunitOptions) -noappdomain </XunitOptions>
+    <XunitDisableAppDomain>true</XunitDisableAppDomain>
     <ProjectGuid>{59E9B218-81D0-4A80-A4B7-66C716136D82}</ProjectGuid>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/src/System.ComponentModel.EventBasedAsync/tests/System.ComponentModel.EventBasedAsync.Tests.csproj
+++ b/src/System.ComponentModel.EventBasedAsync/tests/System.ComponentModel.EventBasedAsync.Tests.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <!-- this tests run in multiple AppDomains in full framework, so if an Assert fails we would get a Serialization exception instead of the real failure.
     adding this xunit so it runs in one AppDomain -->
-    <XunitDisableAppDomain>true</XunitDisableAppDomain>
+    <XUnitNoAppdomain>true</XUnitNoAppdomain>
     <ProjectGuid>{59E9B218-81D0-4A80-A4B7-66C716136D82}</ProjectGuid>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->


### PR DESCRIPTION
Fixes #17365 

We where passing the -noappdomain option by default when running tests on Desktop. This was causing some tests that use `ITestOutputHelper` to throw xunit exceptions (seems like an xunit issue). Now we will not pass the -noappdomain argument by default.

With this change we would provide a way to pass the -noappdomain option to the runner from the csproj itself by setting property `<XunitDisableAppDomain>` to true. 

I enabled this property already on `System.ComponentModel.EventBasedAsync` which we already had an issue related to a test failure that due to multiple app domains xunit was causing a `SerializationException` (#13418) which made it hard to debug the test failure.

cc: @tarekgh @davidsh @weshaggard @stephentoub 