### PR TITLE
Refactoring logic for building server spn

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNICommon.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNICommon.cs
@@ -70,6 +70,7 @@ namespace System.Data.SqlClient.SNI
         internal const int HandshakeFailureError = 31;
         internal const int InternalExceptionError = 35;
         internal const int ConnOpenFailedError = 40;
+        internal const int ErrorSpnLookup = 44;
         internal const int LocalDBErrorCode = 50;
         internal const int MultiSubnetFailoverWithMoreThan64IPs = 47;
         internal const int MultiSubnetFailoverWithInstanceSpecified = 48;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
@@ -316,18 +316,11 @@ namespace System.Data.SqlClient.SNI
 
                 try
                 {
-                    if (connPort >= 0)
-                    {
-                        spnBuffer = GetSqlServerSPN(hostName, connPort);
-                    }
-                    else
-                    {
-                        spnBuffer = GetSqlServerSPN(hostName, connInstanceName);
-                    }
+                    spnBuffer = GetSqlServerSPN(hostName, (connPort >= 0 ? connPort.ToString() : connInstanceName));
                 }
                 catch (Exception e)
                 {
-                    SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.TCP_PROV, SNICommon.InvalidConnStringError, e);
+                    SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.INVALID_PROV, SNICommon.ErrorSpnLookup, e);
                     return null;
                 }
             }
@@ -353,7 +346,7 @@ namespace System.Data.SqlClient.SNI
             return sniHandle;
         }
 
-        private static byte[] GetSqlServerSPN(string hostNameOrAddress, string instanceName = null)
+        private static byte[] GetSqlServerSPN(string hostNameOrAddress, string instanceName)
         {
             Debug.Assert(!string.IsNullOrWhiteSpace(hostNameOrAddress));
             IPHostEntry hostEntry = Dns.GetHostEntry(hostNameOrAddress);
@@ -364,12 +357,6 @@ namespace System.Data.SqlClient.SNI
             }
             string serverSpn = SqlServerSpnHeader + "/" + fullyQualifiedDomainName + ":" + instanceName;
             return Encoding.UTF8.GetBytes(serverSpn);
-        }
-
-        private static byte[] GetSqlServerSPN(string hostNameOrAddress, int port)
-        {
-            Debug.Assert(!string.IsNullOrWhiteSpace(hostNameOrAddress) && port >= 0 && port <= 65535);
-            return GetSqlServerSPN(hostNameOrAddress, port.ToString());
         }
 
         /// <summary>

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
@@ -308,19 +308,42 @@ namespace System.Data.SqlClient.SNI
                 return null;
             }
 
-            SNIHandle sniHandle = null;
+            if (isIntegratedSecurity)
+            {
+                string hostName = details.ServerName;
+                int connPort = details.Port;
+                string connInstanceName = details.InstanceName;
 
+                try
+                {
+                    if (connPort >= 0)
+                    {
+                        spnBuffer = GetSqlServerSPN(hostName, connPort);
+                    }
+                    else
+                    {
+                        spnBuffer = GetSqlServerSPN(hostName, connInstanceName);
+                    }
+                }
+                catch (Exception e)
+                {
+                    SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.TCP_PROV, SNICommon.InvalidConnStringError, e);
+                    return null;
+                }
+            }
+
+            SNIHandle sniHandle = null;
             switch (details.ConnectionProtocol)
             {
                 case DataSource.Protocol.TCP:
-                    sniHandle = CreateTcpHandle(details, timerExpire, callbackObject, parallel, ref spnBuffer, isIntegratedSecurity);
+                    sniHandle = CreateTcpHandle(details, timerExpire, callbackObject, parallel);
                     break;
                 case DataSource.Protocol.NP:
                     sniHandle = CreateNpHandle(details, timerExpire, callbackObject, parallel);
                     break;
                 case DataSource.Protocol.None:
                     // default to using tcp if no protocol is provided
-                    sniHandle = CreateTcpHandle(details, timerExpire, callbackObject, parallel, ref spnBuffer, isIntegratedSecurity);
+                    sniHandle = CreateTcpHandle(details, timerExpire, callbackObject, parallel);
                     break;
                 default:
                     Debug.Fail($"Unexpected connection protocol: {details.ConnectionProtocol}");
@@ -330,16 +353,23 @@ namespace System.Data.SqlClient.SNI
             return sniHandle;
         }
 
-        private static byte[] MakeMsSqlServerSPN(string fullyQualifiedDomainName, int port = DefaultSqlServerPort)
+        private static byte[] GetSqlServerSPN(string hostNameOrAddress, string instanceName = null)
         {
-            string serverSpn = SqlServerSpnHeader + "/" + fullyQualifiedDomainName + ":" + port;
+            Debug.Assert(!string.IsNullOrWhiteSpace(hostNameOrAddress));
+            IPHostEntry hostEntry = Dns.GetHostEntry(hostNameOrAddress);
+            string fullyQualifiedDomainName = hostEntry.HostName;
+            if (string.IsNullOrWhiteSpace(instanceName))
+            {
+                instanceName = DefaultSqlServerPort.ToString();
+            }
+            string serverSpn = SqlServerSpnHeader + "/" + fullyQualifiedDomainName + ":" + instanceName;
             return Encoding.UTF8.GetBytes(serverSpn);
         }
 
-        private static string GetFullyQualifiedDomainName(string hostNameOrAddress)
+        private static byte[] GetSqlServerSPN(string hostNameOrAddress, int port)
         {
-            IPHostEntry hostEntry = Dns.GetHostEntry(hostNameOrAddress);
-            return hostEntry.HostName;
+            Debug.Assert(!string.IsNullOrWhiteSpace(hostNameOrAddress) && port >= 0 && port <= 65535);
+            return GetSqlServerSPN(hostNameOrAddress, port.ToString());
         }
 
         /// <summary>
@@ -350,7 +380,7 @@ namespace System.Data.SqlClient.SNI
         /// <param name="callbackObject">Asynchronous I/O callback object</param>
         /// <param name="parallel">Should MultiSubnetFailover be used</param>
         /// <returns>SNITCPHandle</returns>
-        private SNITCPHandle CreateTcpHandle(DataSource details, long timerExpire, object callbackObject, bool parallel, ref byte[] spnBuffer, bool isIntegratedSecurity)
+        private SNITCPHandle CreateTcpHandle(DataSource details, long timerExpire, object callbackObject, bool parallel)
         {
             // TCP Format: 
             // tcp:<host name>\<instance name>
@@ -373,22 +403,8 @@ namespace System.Data.SqlClient.SNI
                 }
             }
 
-            if (hostName != null && port > 0 && isIntegratedSecurity)
-            {
-                try
-                {
-                    hostName = GetFullyQualifiedDomainName(hostName);
-                    spnBuffer = MakeMsSqlServerSPN(hostName, port);
-                }
-                catch (Exception e)
-                {
-                    SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.TCP_PROV, SNICommon.InvalidConnStringError, e);
-                    return null;
-                }
-            }
-
             return (hostName != null && port > 0) ?
-                 new SNITCPHandle(hostName, port, timerExpire, callbackObject, parallel) : null;
+                new SNITCPHandle(hostName, port, timerExpire, callbackObject, parallel) : null;
         }
 
         /// <summary>


### PR DESCRIPTION
The logic for building server spn was factored out from CreateTcpHandle for supporting Named Pipe.