### PR TITLE
Add more robust cleanup to linux build defs

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux-Crossbuild.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux-Crossbuild.json
@@ -216,9 +216,9 @@
     },
     {
       "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Delete files from $(PB_DockerCopyDest)",
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove old docker build logs",
       "timeoutInMinutes": 0,
       "task": {
         "id": "b7e8b412-0437-4065-9371-edc5881de25b",
@@ -250,26 +250,8 @@
     },
     {
       "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Run docker",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "docker",
-        "arguments": "stop $(PB_DockerContainerName)",
-        "workingFolder": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
+      "continueOnError": true,
+      "alwaysRun": true,
       "displayName": "Remove container",
       "timeoutInMinutes": 0,
       "task": {
@@ -279,7 +261,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "rm $(PB_DockerContainerName)",
+        "arguments": "rm -f $(PB_DockerContainerName)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -297,10 +279,46 @@
       },
       "inputs": {
         "CopyRoot": "$(PB_DockerCopyDest)/corefx",
-        "Contents": "**/*.log",
+        "Contents": "*.log",
         "ArtifactName": "BuildLogs",
         "ArtifactType": "Container",
         "TargetPath": "\\\\my\\share\\$(Build.DefinitionName)\\$(Build.BuildNumber)"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Cleanup Docker",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "$(Build.SourcesDirectory)/corefx/Tools/scripts/docker/cleanup-docker.sh",
+        "arguments": "",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Cleanup VSTS Agent",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "$(Build.SourcesDirectory)/corefx/Tools/msbuild.sh",
+        "arguments": "/p:AgentDirectory=$(Agent.HomeDirectory) /p:DoClean=$(PB_CleanAgent)",
+        "workingFolder": "$(Build.SourcesDirectory)/corefx/Tools/scripts/vstsagent/",
+        "failOnStandardError": "false"
       }
     }
   ],
@@ -353,7 +371,7 @@
       "value": "/root/corefx"
     },
     "PB_DockerContainerName": {
-      "value": "$(Build.BuildId)"
+      "value": "corefx-cross-$(Build.BuildId)"
     },
     "PB_DockerImageName": {
       "value": "$(PB_DockerRepository):$(PB_DockerTag)"
@@ -400,6 +418,9 @@
     },
     "portableLinux": {
       "value": ""
+    },
+    "PB_CleanAgent": {
+      "value": "true"
     }
   },
   "demands": [

--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux-Crossbuild.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux-Crossbuild.json
@@ -316,7 +316,7 @@
       },
       "inputs": {
         "filename": "$(Build.SourcesDirectory)/corefx/Tools/msbuild.sh",
-        "arguments": "/p:AgentDirectory=$(Agent.HomeDirectory) /p:DoClean=$(PB_CleanAgent)",
+        "arguments": "cleanupagent.proj /p:AgentDirectory=$(Agent.HomeDirectory) /p:DoClean=$(PB_CleanAgent)",
         "workingFolder": "$(Build.SourcesDirectory)/corefx/Tools/scripts/vstsagent/",
         "failOnStandardError": "false"
       }

--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
@@ -352,7 +352,7 @@
       },
       "inputs": {
         "filename": "$(Build.SourcesDirectory)/corefx/Tools/msbuild.sh",
-        "arguments": "/p:AgentDirectory=$(Agent.HomeDirectory) /p:DoClean=$(PB_CleanAgent)",
+        "arguments": "cleanupagent.proj /p:AgentDirectory=$(Agent.HomeDirectory) /p:DoClean=$(PB_CleanAgent)",
         "workingFolder": "$(Build.SourcesDirectory)/corefx/Tools/scripts/vstsagent/",
         "failOnStandardError": "false"
       }

--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
@@ -252,8 +252,8 @@
     },
     {
       "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
+      "continueOnError": true,
+      "alwaysRun": true,
       "displayName": "Remove old docker build logs",
       "timeoutInMinutes": 0,
       "task": {
@@ -286,26 +286,8 @@
     },
     {
       "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Stop detached docker container",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "docker",
-        "arguments": "stop $(PB_DockerContainerName)",
-        "workingFolder": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
+      "continueOnError": true,
+      "alwaysRun": true,
       "displayName": "Remove container",
       "timeoutInMinutes": 0,
       "task": {
@@ -315,14 +297,14 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "rm $(PB_DockerContainerName)",
+        "arguments": "rm -f $(PB_DockerContainerName)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
     },
     {
       "enabled": true,
-      "continueOnError": false,
+      "continueOnError": true,
       "alwaysRun": true,
       "displayName": "Copy Publish Artifact: BuildLogs",
       "timeoutInMinutes": 0,
@@ -337,6 +319,42 @@
         "ArtifactName": "BuildLogs",
         "ArtifactType": "Container",
         "TargetPath": "\\\\my\\share\\$(Build.DefinitionName)\\$(Build.BuildNumber)"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Cleanup Docker",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "$(Build.SourcesDirectory)/corefx/Tools/scripts/docker/cleanup-docker.sh",
+        "arguments": "",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Cleanup VSTS Agent",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "$(Build.SourcesDirectory)/corefx/Tools/msbuild.sh",
+        "arguments": "/p:AgentDirectory=$(Agent.HomeDirectory) /p:DoClean=$(PB_CleanAgent)",
+        "workingFolder": "$(Build.SourcesDirectory)/corefx/Tools/scripts/vstsagent/",
+        "failOnStandardError": "false"
       }
     }
   ],
@@ -383,7 +401,7 @@
       "value": "/root/corefx"
     },
     "PB_DockerContainerName": {
-      "value": "$(Build.BuildId)"
+      "value": "corefx-$(Build.BuildId)"
     },
     "PB_DockerImageName": {
       "value": "$(PB_DockerRepository):$(PB_DockerTag)"
@@ -440,12 +458,15 @@
       "allowOverride": true
     },
     "PB_BuildTestsArguments": {
-      "value": "-BuildArch=x64 -Debug -SkipTests",
+      "value": "-BuildArch=x64 -Release -SkipTests",
       "allowOverride": true
     },
     "PB_CreateHelixArguments": {
       "value": "/t:CloudBuild /p:ArchGroup=x64 /p:ConfigurationGroup=Debug /p:\"EnableCloudTest=true /p:\"TestProduct=corefx  /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Linux\" /p:FilterToOSGroup=Linux",
       "allowOverride": true
+    },
+    "PB_CleanAgent": {
+      "value": "true"
     }
   },
   "demands": [


### PR DESCRIPTION
- Changed all cleanup steps and steps that publish the build logs to always run and continue on error.
- Added step to cleanup docker at the end
- Added step to cleanup VSTS agent at the end
- Changed PB_DockerContainerName value so that it is a little easier to know what product is not cleaning up containers.
- Consolidated the Stop Container and Remove Container build steps.
- Changed the default value of PB_BuildTestsArguments so that it matches the configuration used in the PB_BuildArguments.  This makes it nicer if you are testing build definitions by manually queuing them.