### PR TITLE
Add signing marker files for shims

### DIFF
--- a/src/shims/shims.proj
+++ b/src/shims/shims.proj
@@ -44,6 +44,12 @@
 
     <Exec Command="$(GenFacadesCmd) -contracts:&quot;@(NETStandardContracts)&quot; @&quot;$(GenFacadesResponseFile)&quot;" WorkingDirectory="$(ToolRuntimePath)" />
 
+    <WriteSigningRequired
+        Condition="'$(SkipSigning)' != 'true' and '$(SignType)' != 'oss'"
+        AuthenticodeSig="Microsoft"
+        StrongNameSig="StrongName"
+        MarkerFile="$(GenFacadesOutputPath)%(GenFacadesContracts.Filename)%(GenFacadesContracts.Extension).requires_signing" />
+
     <Touch Files="$(GenFacadesSemaphoreFile)" AlwaysCreate="true" />
   </Target>
 

--- a/src/sign.builds
+++ b/src/sign.builds
@@ -4,17 +4,13 @@
   <Import Project="dir.props" />
   <Import Project="..\dir.targets" />
 
-  <PropertyGroup>
-    <OutDir>$(BinDir)</OutDir>
-  </PropertyGroup>
-
   <UsingTask AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" TaskName="ReadSigningRequired" />
 
   <ItemGroup>
     <WindowsNativeLocation Include="$(NativeBinDir)\clrcompression.dll" />
     <WindowsNativeLocation Include="$(NativeBinDir)_aot\clrcompression.dll" />
   </ItemGroup>
-  
+
   <Target Name="GenerateSignForWindowsNative">
     <WriteSigningRequired AuthenticodeSig="$(AuthenticodeSig)"
                           MarkerFile="%(WindowsNativeLocation.Identity).requires_signing" />
@@ -25,7 +21,8 @@
           DependsOnTargets="GenerateSignForWindowsNative">
     <!-- read all of the marker files and populate the FilesToSign item group -->
     <ItemGroup>
-      <SignMarkerFile Include="$(OutDir)**\*.requires_signing" />
+      <!-- Note: this also looks for things under bin\obj which require signing like the shims -->
+      <SignMarkerFile Include="$(BinDir)**\*.requires_signing" />
     </ItemGroup>
     <ReadSigningRequired MarkerFiles="@(SignMarkerFile)">
       <Output TaskParameter="SigningMetadata" ItemName="FilesToSign" />


### PR DESCRIPTION
This change adds the signing marker files for the generated shims
so that we sign the binaries.

cc @chcosta

@dagood do you know if we still have a tracking issue to verify signing before uploading packages? We seem to have a blind spot here. 