### PR TITLE
Fix System.Runtime.Extensions tests on uapaot

### DIFF
--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <ProjectGuid>{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DefineConstants Condition="'$(TargetsUnix)' == 'true'" >$(DefineConstants);Unix</DefineConstants>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />
@@ -79,7 +80,7 @@
     <Compile Include="System\Progress.cs" />
     <Compile Include="System\Random.cs" />
     <Compile Include="System\StringComparer.cs" />
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetNodeName.cs">
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetNodeName.cs" Condition="'$(TargetsUnix)' == 'true'">
       <Link>Common\Interop\Unix\System.Native\Interop.GetNodeName.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">

--- a/src/System.Runtime.Extensions/tests/System/Environment.GetEnvironmentVariable.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.GetEnvironmentVariable.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace System.Tests
 {
-    public class GetEnvironmentVariable
+    public partial class GetEnvironmentVariable
     {
         [Fact]
         public void InvalidArguments_ThrowsExceptions()
@@ -268,19 +268,23 @@ namespace System.Tests
         private static void SetEnvironmentVariableWithPInvoke(string name, string value)
         {
             bool success =
-                RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
-                    SetEnvironmentVariable(name, value) :
+#if !Unix
+                    SetEnvironmentVariable(name, value);
+#else
                     (value != null ? setenv(name, value, 1) : unsetenv(name)) == 0;
+#endif
             Assert.True(success);
         }
 
-        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        [DllImport("kernel32.dll", EntryPoint = "SetEnvironmentVariableW" , CharSet = CharSet.Unicode, SetLastError = true)]
         private static extern bool SetEnvironmentVariable(string lpName, string lpValue);
 
+#if Unix
         [DllImport("libc")]
         private static extern int setenv(string name, string value, int overwrite);
 
         [DllImport("libc")]
         private static extern int unsetenv(string name);
+#endif
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/Environment.MachineName.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.MachineName.cs
@@ -18,16 +18,13 @@ namespace System.Tests
 
         internal static string GetComputerName()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
+#if !Unix
                 return Environment.GetEnvironmentVariable("COMPUTERNAME");
-            }
-            else
-            {
+#else
                 string temp = Interop.Sys.GetNodeName();
                 int index = temp.IndexOf('.');
                 return index < 0 ? temp : temp.Substring(0, index);
-            }
+#endif
         }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/Environment.ProcessorCount.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.ProcessorCount.cs
@@ -26,6 +26,7 @@ namespace System.Tests
             Assert.Equal(expected, actual);
         }
 
+#if Unix
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // Uses P/Invokes to get processor information
         [Fact]
         public void Unix_ProcessorCountTest()
@@ -47,6 +48,7 @@ namespace System.Tests
 
         [DllImport("libc")]
         private static extern long sysconf(int name);
+#endif
 
         [DllImport("kernel32.dll", SetLastError = true)]
         internal static extern void GetSystemInfo(ref SYSTEM_INFO lpSystemInfo);

--- a/src/System.Runtime.Extensions/tests/System/IO/PathTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/PathTests.cs
@@ -697,7 +697,7 @@ namespace System.IO.Tests
         }
 
         // Windows-only P/Invoke to create 8.3 short names from long names
-        [DllImport("kernel32.dll", CharSet = CharSet.Ansi)]
+        [DllImport("kernel32.dll", EntryPoint = "GetShortPathNameW" ,CharSet = CharSet.Unicode)]
         private static extern uint GetShortPathName(string lpszLongPath, StringBuilder lpszShortPath, int cchBuffer);
     }
 }


### PR DESCRIPTION
FYI: @JeremyKuhne @danmosemsft 

These are the required changes in order to succesfully run ilc S.R.Extensions tests. 
Initial results of them are:
```
System.Runtime.Extensions.Tests  Total: 1317, Errors: 0, Failed: 172, Skipped: 1, Time: 7.761s
```