### PR TITLE
Add missing resource string

### DIFF
--- a/src/System.Runtime.WindowsRuntime/src/Resources/Strings.resx
+++ b/src/System.Runtime.WindowsRuntime/src/Resources/Strings.resx
@@ -112,6 +112,9 @@
   <data name="ArgumentOutOfRange_InvalidInputStreamOptionsEnumValue" xml:space="preserve">
     <value>The specified value is not a valid member of the InputStreamOptions enumeration.</value>
   </data>
+  <data name="ArgumentOutOfRange_NeedNonNegNum" xml:space="preserve">
+    <value>Non-negative number required.</value>
+  </data>
   <data name="ArgumentOutOfRange_WinRtAdapterBufferSizeMayNotBeNegative" xml:space="preserve">
     <value>The buffer size for a Windows Runtime stream adapter may not be negative. Use a positive buffer size or 0 to disable buffering.</value>
   </data>


### PR DESCRIPTION
Today this is working because S.R.WindowsRuntime has internals visible to
CoreLib and CoreLib defines this resource in an SR class. In newer
CoreCLR's that's not happening. If you try to update to consume a newer
CoreCLR you run into an issue.