### PR TITLE
Rewrite Socket.AcceptAsync Task-based method on SocketAsyncEventArgs

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
@@ -197,12 +197,9 @@ namespace System.Net.Sockets
             {
                 acceptSocket = new Socket(_addressFamily, _socketType, _protocolType);
             }
-            else
+            else if (acceptSocket._rightEndPoint != null && (!checkDisconnected || !acceptSocket._isDisconnected))
             {
-                if (acceptSocket._rightEndPoint != null && (!checkDisconnected || !acceptSocket._isDisconnected))
-                {
-                    throw new InvalidOperationException(SR.Format(SR.net_sockets_namedmustnotbebound, propertyName));
-                }
+                throw new InvalidOperationException(SR.Format(SR.net_sockets_namedmustnotbebound, propertyName));
             }
 
             handle = acceptSocket._handle;

--- a/src/System.Net.Sockets/tests/FunctionalTests/AcceptAsync.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/AcceptAsync.cs
@@ -249,7 +249,11 @@ namespace System.Net.Sockets.Tests
                 }
                 else
                 {
-                    Assert.Throws<InvalidOperationException>(() => listener.AcceptAsync(server).GetAwaiter().GetResult());
+                    if (listener.AcceptAsync(saea))
+                    {
+                        are.WaitOne();
+                    }
+                    Assert.Equal(SocketError.InvalidArgument, saea.SocketError);
                 }
             }
         }


### PR DESCRIPTION
It's currently implemented on top of the APM implementation; this changes it to be implemented on top of the SocketAsyncEventArgs implementation.  Doing so saves ~400 bytes and ~6 allocations per accept, so it almost breaks even on first accept, and after that it's a win.  Also provides a small throughput improvement.

cc: @geoffkizer, @davidsh, @cipop