### PR TITLE
Remove Assert.True(weakSwitch.IsAlive); from PruneTest() in SwitchClassTests.cs under System.Diagnostics.TraceSourceTests 

### DIFF
--- a/src/System.Diagnostics.TraceSource/tests/SwitchClassTests.cs
+++ b/src/System.Diagnostics.TraceSource/tests/SwitchClassTests.cs
@@ -48,7 +48,6 @@ namespace System.Diagnostics.TraceSourceTests
         {
             var strongSwitch = new TestSwitch();
             var weakSwitch = PruneMakeRef();
-            Assert.True(weakSwitch.IsAlive);
             GC.Collect(2);
             Trace.Refresh();
             Assert.False(weakSwitch.IsAlive);


### PR DESCRIPTION
Remove Assert.True(weakSwitch.IsAlive); from PruneTest() in SwitchClassTests.cs under System.Diagnostics.TraceSourceTests

File: src\System.Diagnostics.TraceSource\tests\SwitchClassTests.cs
 Method: PruneTest()

Fix #17300