### PR TITLE
Update Compression.Tests to not to write to current directory

### DIFF
--- a/src/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
@@ -220,7 +220,7 @@ namespace System.IO.Compression.Tests
         {
             string zipname = strange("largetrailingwhitespacedeflation.zip");
             string entryname = "A/B/C/D";
-            using (FileStream stream = File.Open(zipname, FileMode.Open, FileAccess.ReadWrite))
+            using (FileStream stream = File.Open(zipname, FileMode.Open, FileAccess.Read))
             using (ZipArchive archive = new ZipArchive(stream, ZipArchiveMode.Read))
             {
                 ZipArchiveEntry entry = archive.GetEntry(entryname);


### PR DESCRIPTION
There is no need for ReadWrite file access, only Read is enough because we do not write to this file, all operations are executed in the MemoryStream.

Fix #17072