### PR TITLE
Fix 'use of unassigned local variable' error if compiles for mono (System.Data)

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
@@ -1592,7 +1592,7 @@ namespace System.Data.SqlClient
 
         new public Task<SqlDataReader> ExecuteReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
         {
-            Guid operationId;
+            Guid operationId = default(Guid);
             if (!_parentOperationStarted)
                 operationId = _diagnosticListener.WriteCommandBefore(this);
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
@@ -463,8 +463,8 @@ namespace System.Data.SqlClient
         override public void Close()
         {
             ConnectionState previousState = State;
-            Guid operationId;
-            Guid clientConnectionId;
+            Guid operationId = default(Guid);
+            Guid clientConnectionId = default(Guid);
 
             // during the call to Dispose() there is a redundant call to 
             // Close(). because of this, the second time Close() is invoked the 


### PR DESCRIPTION
```
Guid id; //is not assigned
string str = id.ToString();
```
this code works fine for **.net core** because it compiles against the ref assemblies where `Guid` structure is empty (no fields) but when we try to use these files in mono - we have 'use of unassigned local variable operationId' compilation errors. There are only three such places in System.Data.Common and System.Data.SqlClient.

cc: @marek-safar 