### PR TITLE
Fix incremental restore of external

### DIFF
--- a/Tools-Override/packageresolve.targets
+++ b/Tools-Override/packageresolve.targets
@@ -33,6 +33,9 @@
     </IsRestoreRequired>
 
     <Exec Condition="Exists('$(ProjectJson)') AND '$(RestoreRequired)' == 'true'" Command="$(DnuRestoreCommand) &quot;$(ProjectJson)&quot;" StandardOutputImportance="Low" CustomErrorRegularExpression="^Unable to locate .*" />
+    
+    <!-- if lock file exists be sure to update timestamp otherwise we could get in a state of aways calling restore but the lock file not being updated -->
+    <Touch Condition="Exists('$(ProjectLockJson)') AND '$(RestoreRequired)' == 'true'" Files="$(ProjectLockJson)" />
   </Target>
 
   <ItemGroup Condition="'$(ResolvePackages)'=='true' or '$(PrereleaseResolveNuGetPackages)'=='true'">

--- a/external/dir.targets
+++ b/external/dir.targets
@@ -26,9 +26,6 @@
       Lines="$([System.IO.File]::ReadAllText('$(ProjectJsonTemplate)').Replace('{RID}', $(NuGetRuntimeIdentifier)).Replace('{TFM}', $(NuGetTargetMoniker)).Replace('{PackageId}', $(TargetingPackNugetPackageId)))"
       Overwrite="true"
                       />
-
-    <!-- if lock file exists be sure to update timestamp otherwise we could get in a state of aways calling restore but the lock file not being updated -->
-    <Touch Condition="Exists('$(ProjectLockJson)')" Files="$(ProjectLockJson)" />
   </Target>
 
   <!-- Override build and GetTargetPath to return all items deployed -->


### PR DESCRIPTION
We were always updating the lock file timestamp which caused restore to
be skipped after the first time it was run unless we got lucky and the 
timestamps were equal.

/cc @weshaggard 