### PR TITLE
Change the behavior of ReceiveAsync cancellation to throw OperationCanceledException

### DIFF
--- a/src/Common/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/Common/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -732,8 +732,9 @@ namespace System.Net.WebSockets
             }
             catch (Exception exc)
             {
-                if (_state == WebSocketState.Aborted) {
-                    throw new OperationCanceledException("Aborted");
+                if (_state == WebSocketState.Aborted)
+                {
+                    throw new OperationCanceledException(nameof(WebSocketState.Aborted), exc);
                 }
                 throw new WebSocketException(WebSocketError.ConnectionClosedPrematurely, exc);
             }

--- a/src/Common/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/Common/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -732,9 +732,10 @@ namespace System.Net.WebSockets
             }
             catch (Exception exc)
             {
-                throw _state == WebSocketState.Aborted ?
-                    new OperationCanceledException("Aborted") :
-                    new WebSocketException(WebSocketError.ConnectionClosedPrematurely, exc);
+                if (_state == WebSocketState.Aborted) {
+                    throw new OperationCanceledException("Aborted");
+                }
+                throw new WebSocketException(WebSocketError.ConnectionClosedPrematurely, exc);
             }
             finally
             {

--- a/src/Common/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/Common/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -733,7 +733,7 @@ namespace System.Net.WebSockets
             catch (Exception exc)
             {
                 throw _state == WebSocketState.Aborted ?
-                    new WebSocketException(WebSocketError.InvalidState, SR.Format(SR.net_WebSockets_InvalidState_ClosedOrAborted, "System.Net.WebSockets.InternalClientWebSocket", "Aborted"), exc) :
+                    new OperationCanceledException("Aborted") :
                     new WebSocketException(WebSocketError.ConnectionClosedPrematurely, exc);
             }
             finally

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinHttpWebSocket.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinHttpWebSocket.cs
@@ -795,9 +795,7 @@ namespace System.Net.WebSockets
 
             if (_operation.TcsReceive != null)
             {
-                var exception = new OperationCanceledException("Aborted");
-
-                _operation.TcsReceive.TrySetException(exception);
+                _operation.TcsReceive.TrySetCanceled();
             }
 
             if (_operation.TcsSend != null)

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinHttpWebSocket.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinHttpWebSocket.cs
@@ -795,12 +795,7 @@ namespace System.Net.WebSockets
 
             if (_operation.TcsReceive != null)
             {
-                var exception = new WebSocketException(
-                    WebSocketError.InvalidState,
-                    SR.Format(
-                        SR.net_WebSockets_InvalidState_ClosedOrAborted,
-                        "System.Net.WebSockets.InternalClientWebSocket",
-                        "Aborted"));
+                var exception = new OperationCanceledException("Aborted");
 
                 _operation.TcsReceive.TrySetException(exception);
             }

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinHttpWebSocketCallback.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinHttpWebSocketCallback.cs
@@ -315,18 +315,16 @@ namespace System.Net.WebSockets
 
             if (asyncResult.AsyncResult.dwError == Interop.WinHttp.ERROR_WINHTTP_OPERATION_CANCELLED)
             {
-                var exception = new OperationCanceledException("Aborted");
-
                 state.UpdateState(WebSocketState.Aborted);
 
                 if (state.TcsReceive != null)
                 {
-                    state.TcsReceive.TrySetException(exception);
+                    state.TcsReceive.TrySetCanceled();
                 }
 
                 if (state.TcsSend != null)
                 {
-                    state.TcsSend.TrySetException(exception);
+                    state.TcsSend.TrySetCanceled();
                 }
 
                 return;

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinHttpWebSocketCallback.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinHttpWebSocketCallback.cs
@@ -315,13 +315,7 @@ namespace System.Net.WebSockets
 
             if (asyncResult.AsyncResult.dwError == Interop.WinHttp.ERROR_WINHTTP_OPERATION_CANCELLED)
             {
-                var exception = new WebSocketException(
-                    WebSocketError.InvalidState,
-                    SR.Format(
-                        SR.net_WebSockets_InvalidState_ClosedOrAborted,
-                        "System.Net.WebSockets.InternalClientWebSocket",
-                        "Aborted"),
-                    innerException);
+                var exception = new OperationCanceledException("Aborted");
 
                 state.UpdateState(WebSocketState.Aborted);
 

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinRTWebSocket.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinRTWebSocket.cs
@@ -154,7 +154,13 @@ namespace System.Net.WebSockets
 
             if (_webSocketReceiveResultTcs != null)
             {
-                var exception = new OperationCanceledException("Aborted");
+                var exception = new WebSocketException(
+                    WebSocketError.InvalidState,
+                    SR.Format(
+                        SR.net_WebSockets_InvalidState_ClosedOrAborted,
+                        "System.Net.WebSockets.InternalClientWebSocket",
+                        "Aborted"));
+
                 _webSocketReceiveResultTcs.TrySetException(exception);
             }
 

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinRTWebSocket.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinRTWebSocket.cs
@@ -154,13 +154,7 @@ namespace System.Net.WebSockets
 
             if (_webSocketReceiveResultTcs != null)
             {
-                var exception = new WebSocketException(
-                    WebSocketError.InvalidState,
-                    SR.Format(
-                        SR.net_WebSockets_InvalidState_ClosedOrAborted,
-                        "System.Net.WebSockets.InternalClientWebSocket",
-                        "Aborted"));
-
+                var exception = new OperationCanceledException("Aborted");
                 _webSocketReceiveResultTcs.TrySetException(exception);
             }
 

--- a/src/System.Net.WebSockets.Client/tests/CancelTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/CancelTest.cs
@@ -118,7 +118,7 @@ namespace System.Net.WebSockets.Client.Tests
             }, server);
         }
         
-        [OuterLoop]
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task ReceiveAsync_CancelThenReceive_ThrowsOperationCanceledException(Uri server)
         {
@@ -134,7 +134,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
         
-        [OuterLoop]
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task ReceiveAsync_ReceiveThenCancel_ThrowsOperationCanceledException(Uri server)
         {
@@ -150,7 +150,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
         
-        [OuterLoop]
+        [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task ReceiveAsync_AfterCancellationDoReceiveAsync_ThrowsWebSocketException(Uri server)
         {

--- a/src/System.Net.WebSockets.Client/tests/CancelTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/CancelTest.cs
@@ -117,23 +117,52 @@ namespace System.Net.WebSockets.Client.Tests
                 await cws.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "CancelShutdown", cts.Token);
             }, server);
         }
-
-        [OuterLoop] // TODO: Issue #11345
+        
+        [OuterLoop]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
-        public async Task ReceiveAsync_CancelAndReceive_ThrowsWebSocketExceptionWithMessage(Uri server)
+        public async Task ReceiveAsync_CancelThenReceive_ThrowsOperationCanceledException(Uri server)
         {
             using (ClientWebSocket cws = await WebSocketHelper.GetConnectedWebSocket(server, TimeOutMilliseconds, _output))
             {
                 var recvBuffer = new byte[100];
                 var segment = new ArraySegment<byte>(recvBuffer);
-
                 var cts = new CancellationTokenSource();
-                // OperationCancelledException is thrown only if the token is canceled before calling ReceiveAsync
-                // Once it returns (with a Task<>), any cancellation that occurs is treated as a WebSocketException
+
+                cts.Cancel();
+                Task receive = cws.ReceiveAsync(segment, cts.Token);
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => receive);
+            }
+        }
+        
+        [OuterLoop]
+        [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
+        public async Task ReceiveAsync_ReceiveThenCancel_ThrowsOperationCanceledException(Uri server)
+        {
+            using (ClientWebSocket cws = await WebSocketHelper.GetConnectedWebSocket(server, TimeOutMilliseconds, _output))
+            {
+                var recvBuffer = new byte[100];
+                var segment = new ArraySegment<byte>(recvBuffer);
+                var cts = new CancellationTokenSource();
+
+                Task receive = cws.ReceiveAsync(segment, cts.Token);
+                cts.Cancel();
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => receive);
+            }
+        }
+        
+        [OuterLoop]
+        [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
+        public async Task ReceiveAsync_AfterCancellationDoReceiveAsync_ThrowsWebSocketException(Uri server)
+        {
+            using (ClientWebSocket cws = await WebSocketHelper.GetConnectedWebSocket(server, TimeOutMilliseconds, _output))
+            {
+                var recvBuffer = new byte[100];
+                var segment = new ArraySegment<byte>(recvBuffer);
+                var cts = new CancellationTokenSource();
+                
                 Task recieve = cws.ReceiveAsync(segment, cts.Token);
                 cts.Cancel();
-                WebSocketException wse = await Assert.ThrowsAnyAsync<WebSocketException>(() => recieve);
-
+                
                 WebSocketException ex = await Assert.ThrowsAsync<WebSocketException>(() =>
                     cws.ReceiveAsync(segment, CancellationToken.None));
                 Assert.Equal(

--- a/src/System.Net.WebSockets.Client/tests/CloseTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/CloseTest.cs
@@ -314,7 +314,7 @@ namespace System.Net.WebSockets.Client.Tests
                     await t;
                     Assert.Equal(WebSocketState.Closed, cws.State);
                 }
-                catch (WebSocketException)
+                catch (OperationCanceledException)
                 {
                     Assert.Equal(WebSocketState.Aborted, cws.State);
                 }

--- a/src/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
@@ -191,6 +191,10 @@ namespace System.Net.WebSockets.Client.Tests
                                 (errCode == WebSocketError.InvalidState) || (errCode == WebSocketError.Success),
                                 "WebSocketErrorCode");
                         }
+                        else if (ex is OperationCanceledException)
+                        {
+                            Assert.Equal(WebSocketState.Aborted, cws.State);
+                        }
                         else
                         {
                             Assert.True(false, "Unexpected exception: " + ex.Message);


### PR DESCRIPTION
Change the ClientWebSocket's behavior to throw OperationCanceledException, when cancellation happens during the execution of ReceiveAsync(new ArraySegment(Buffer), Ct).

Fix #5200 