### PR TITLE
Disable System.Thread outerloop test in desktop

### DIFF
--- a/src/System.Threading/tests/ReaderWriterLockSlimTests.cs
+++ b/src/System.Threading/tests/ReaderWriterLockSlimTests.cs
@@ -383,7 +383,7 @@ namespace System.Threading.Tests
 
         [Fact]
         [OuterLoop]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17443")] // Hangs in desktop
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #3364 and #5839")] // Hangs in desktop
         public static void ReleaseReadersWhenWaitingWriterTimesOut()
         {
             using (var rwls = new ReaderWriterLockSlim())

--- a/src/System.Threading/tests/ReaderWriterLockSlimTests.cs
+++ b/src/System.Threading/tests/ReaderWriterLockSlimTests.cs
@@ -383,7 +383,7 @@ namespace System.Threading.Tests
 
         [Fact]
         [OuterLoop]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17443")] // Hangs in desktop
         public static void ReleaseReadersWhenWaitingWriterTimesOut()
         {
             using (var rwls = new ReaderWriterLockSlim())

--- a/src/System.Threading/tests/ReaderWriterLockSlimTests.cs
+++ b/src/System.Threading/tests/ReaderWriterLockSlimTests.cs
@@ -383,6 +383,7 @@ namespace System.Threading.Tests
 
         [Fact]
         [OuterLoop]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public static void ReleaseReadersWhenWaitingWriterTimesOut()
         {
             using (var rwls = new ReaderWriterLockSlim())


### PR DESCRIPTION
This test hangs in desktop when running Outerloop.

See: #17443 

cc: @tarekgh @alexperovich @danmosemsft 