### PR TITLE
Fix TypeScope.GetEnumeratorElementType.

### DIFF
--- a/src/System.Private.Xml/src/Resources/System.Private.Xml.rd.xml
+++ b/src/System.Private.Xml/src/Resources/System.Private.Xml.rd.xml
@@ -7,5 +7,13 @@
         <Type Name="XmlQualifiedName" DataContractSerializer="Excluded" DataContractJsonSerializer="Excluded"/>
       </Namespace>
     </Assembly>
+    <Namespace Name="System.Collections">
+      <Type  Name="IEnumerable" Dynamic="Required All" />
+      <Type  Name="IEnumerator" Dynamic="Required All" />
+    </Namespace>
+    <Namespace Name="System.Collections.Generic">
+      <Type  Name="IEnumerable`1" Dynamic="Required All" />
+      <Type  Name="IEnumerator`1" Dynamic="Required All" />
+    </Namespace>
   </Library>
 </Directives>

--- a/src/System.Private.Xml/src/Resources/System.Private.Xml.rd.xml
+++ b/src/System.Private.Xml/src/Resources/System.Private.Xml.rd.xml
@@ -15,5 +15,8 @@
       <Type  Name="IEnumerable`1" Dynamic="Required All" />
       <Type  Name="IEnumerator`1" Dynamic="Required All" />
     </Namespace>
+    <Namespace Name="System">
+      <Type  Name="DBNull" Dynamic="Required All" />
+    </Namespace>
   </Library>
 </Directives>


### PR DESCRIPTION
[`System.Xml.Serialization.TypeScope.GetEnumeratorElementType`](https://github.com/dotnet/corefx/blob/master/src/System.Private.Xml/src/System/Xml/Serialization/Types.cs#L1292) is failing on uapaot as it does reflection on IEnumerable types but the metadata info for IEnumerable was reduced by UWP toolchain. 5 XmlSerializer tests failed on uapaot due to the issue. 

The fix is to modify System.Private.Xml's embedded rd.xml to keep the required metadata.

Fixed #17447 