### PR TITLE
Move Cryptography netcoreapp specific tests to netcoreapp files

### DIFF
--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/EC/CurveDef.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/EC/CurveDef.cs
@@ -6,6 +6,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
 {
     public class CurveDef
     {
+#if netcoreapp
         public CurveDef() { }
         public ECCurve Curve;
         public ECCurve.ECCurveType CurveType;
@@ -36,5 +37,6 @@ namespace System.Security.Cryptography.EcDsa.Tests
 
             return false;
         }
+#endif
     }
 }

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaFactory.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaFactory.cs
@@ -8,7 +8,9 @@ namespace System.Security.Cryptography.EcDsa.Tests
     {
         ECDsa Create();
         ECDsa Create(int keySize);
+#if netcoreapp
         ECDsa Create(ECCurve curve);
+#endif
         bool IsCurveValid(Oid oid);
         bool ExplicitCurvesSupported { get; }
     }
@@ -25,10 +27,12 @@ namespace System.Security.Cryptography.EcDsa.Tests
             return s_provider.Create(keySize);
         }
 
+#if netcoreapp
         public static ECDsa Create(ECCurve curve)
         {
             return s_provider.Create(curve);
         }
+#endif
 
         public static bool IsCurveValid(Oid oid)
         {

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaImportExport.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaImportExport.cs
@@ -9,6 +9,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
 {
     public class ECDsaImportExportTests : ECDsaTestsBase
     {
+#if netcoreapp
         [Theory]
         [MemberData(nameof(TestCurvesFull))]
         public static void TestNamedCurves(CurveDef curveDef)
@@ -288,5 +289,6 @@ namespace System.Security.Cryptography.EcDsa.Tests
             ECParameters paramSecondExport = ec.ExportExplicitParameters(curveDef.IncludePrivate);
             AssertEqual(parameters, paramSecondExport);
         }
+#endif
     }
 }

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTestData.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTestData.cs
@@ -20,6 +20,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
             ("a232cec7be26319e53db0d48470232d37793b06b99e8ed82fac1996b3d1596449087769927d64af657cce62d853c4cf7ff4c"
            + "d069eda230d1c524d225756ffbaf").HexToByteArray();
 
+#if netcoreapp
         internal static ECCurve GetNistP256ExplicitCurve()
         {
             // SEC2-Ver-1.0, 2.7.2
@@ -146,5 +147,6 @@ namespace System.Security.Cryptography.EcDsa.Tests
 
             return p;
         }
+#endif // netcoreapp
     }
 }

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTests.NistValidation.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTests.NistValidation.cs
@@ -18,7 +18,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
         // FIPS 186-4 ECDSA test vectors
         // 186-3ecdsatestvectors.zip
         // SigGen.txt
-
+#if netcoreapp
         [Fact]
         public static void ValidateNistP256Sha256()
         {
@@ -291,5 +291,6 @@ namespace System.Security.Cryptography.EcDsa.Tests
                 }
             }
         }
+#endif // netcoreapp
     }
 }

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTests.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTests.cs
@@ -12,6 +12,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
 {
     public partial class ECDsaTests : ECDsaTestsBase
     {
+#if netcoreapp
         [Fact]
         public void KeySizeProp()
         {
@@ -221,6 +222,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
                 Verify256(ecdsa, false); // will not match because of randomness
             }
         }
+#endif // netcoreapp
 
         [Theory, MemberData(nameof(AllImplementations))]
         public void SignDataByteArray_NullData_ThrowsArgumentNullException(ECDsa ecdsa)

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTestsBase.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTestsBase.cs
@@ -14,6 +14,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
     /// </summary>
     public abstract class ECDsaTestsBase
     {
+#if netcoreapp
         internal const string ECDSA_P224_OID_VALUE = "1.3.132.0.33"; // Also called nistP224 or secP224r1
         internal const string ECDSA_P256_OID_VALUE = "1.2.840.10045.3.1.7"; // Also called nistP256, secP256r1 or prime256v1(OpenSsl)
         internal const string ECDSA_P384_OID_VALUE = "1.3.132.0.34"; // Also called nistP384 or secP384r1
@@ -247,6 +248,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
                 return ECDsaFactory.ExplicitCurvesSupported;
             }
         }
+#endif // netcoreapp
     }
 
     internal static class EcDsaTestExtensions

--- a/src/System.Security.Cryptography.Algorithms/tests/DefaultECDsaProvider.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/DefaultECDsaProvider.cs
@@ -20,10 +20,12 @@ namespace System.Security.Cryptography.EcDsa.Tests
             return ec;
         }
 
+#if netcoreapp
         public ECDsa Create(ECCurve curve)
         {
             return ECDsa.Create(curve);
         }
+#endif
 
         public bool IsCurveValid(Oid oid)
         {

--- a/src/System.Security.Cryptography.Cng/tests/ECDsaCngImportExportTests.cs
+++ b/src/System.Security.Cryptography.Cng/tests/ECDsaCngImportExportTests.cs
@@ -46,6 +46,7 @@ namespace System.Security.Cryptography.Cng.Tests
             }
         }
 
+#if netcoreapp
         [ConditionalTheory(nameof(ECExplicitCurvesSupported)), MemberData(nameof(TestCurves))]
         public static void TestHashRoundTrip(CurveDef curveDef)
         {
@@ -68,5 +69,6 @@ namespace System.Security.Cryptography.Cng.Tests
                 Assert.Equal(0xFF, param2.Curve.Seed[0]);
             }
         }
+#endif // netcoreapp
     }
 }

--- a/src/System.Security.Cryptography.Cng/tests/ECDsaCngTests.cs
+++ b/src/System.Security.Cryptography.Cng/tests/ECDsaCngTests.cs
@@ -12,14 +12,6 @@ namespace System.Security.Cryptography.Cng.Tests
     public class ECDsaCngTests : ECDsaTestsBase
     {
         [Fact]
-        public static void TestPositive256WithBlob()
-        {
-            CngKey key = TestData.s_ECDsa256Key;
-            ECDsaCng e = new ECDsaCng(key);
-            Verify256(e, true);
-        }
-
-        [Fact]
         public static void TestNegativeVerify256()
         {
             CngKey key = TestData.s_ECDsa256Key;
@@ -123,18 +115,6 @@ namespace System.Security.Cryptography.Cng.Tests
             }
         }
 
-        [Theory, MemberData(nameof(TestCurves))]
-        public static void TestKeyPropertyFromNamedCurve(CurveDef curveDef)
-        {
-            ECDsaCng e = new ECDsaCng(curveDef.Curve);
-            CngKey key1 = e.Key;
-            VerifyKey(key1);
-            e.Exercise();
-
-            CngKey key2 = e.Key;
-            Assert.Same(key1, key2);
-        }
-
         [Fact]
         public static void TestCreateKeyFromCngAlgorithmNistP256()
         {
@@ -167,6 +147,27 @@ namespace System.Security.Cryptography.Cng.Tests
                 Assert.Equal(256, key1.KeySize);
                 VerifyKey(key1);
             }
+        }
+
+#if netcoreapp
+        [Fact]
+        public static void TestPositive256WithBlob()
+        {
+            CngKey key = TestData.s_ECDsa256Key;
+            ECDsaCng e = new ECDsaCng(key);
+            Verify256(e, true);
+        }
+
+        [Theory, MemberData(nameof(TestCurves))]
+        public static void TestKeyPropertyFromNamedCurve(CurveDef curveDef)
+        {
+            ECDsaCng e = new ECDsaCng(curveDef.Curve);
+            CngKey key1 = e.Key;
+            VerifyKey(key1);
+            e.Exercise();
+
+            CngKey key2 = e.Key;
+            Assert.Same(key1, key2);
         }
 
         [Fact]
@@ -203,6 +204,7 @@ namespace System.Security.Cryptography.Cng.Tests
                 Assert.Equal(algorithm, cng.Key.Algorithm);
             }
         }
+#endif // netcoreapp
 
         public static IEnumerable<object[]> SpecialNistKeys
         {

--- a/src/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
+++ b/src/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <ProjectGuid>{E1DAF7B9-BECB-4D25-AABB-C9E0BC73C690}</ProjectGuid>
     <UnsupportedPlatforms>Windows_NT</UnsupportedPlatforms>
+    <DefineConstants Condition="'$(TargetGroup)' == 'netcoreapp'">$(DefineConstants);netcoreapp</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Release|AnyCPU'" />


### PR DESCRIPTION
There are some tests that use types like `ECCurve` which is available until .NET 4.7 and it was causing a runtime exception when trying to run them on Desktop.

I moved those tests to be only included when running in netcoreapp.

cc: @bartonjs @danmosemsft @weshaggard @tarekgh 