### PR TITLE
Adding span tests to improve coverage

### DIFF
--- a/src/System.Memory/tests/ReadOnlySpan/CopyTo.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/CopyTo.cs
@@ -21,6 +21,32 @@ namespace System.SpanTests
         }
 
         [Fact]
+        public static void TryCopyToArraySegmentImplicit()
+        {
+            int[] src = { 1, 2, 3 };
+            int[] dst = { 5, 99, 100, 101, 10 };
+            var segment = new ArraySegment<int>(dst, 1, 3);
+
+            ReadOnlySpan<int> srcSpan = new ReadOnlySpan<int>(src);
+            bool success = srcSpan.TryCopyTo(segment);
+            Assert.True(success);
+            Assert.Equal<int>(src, segment);
+        }
+
+        [Fact]
+        public static void TryCopyToEmpty()
+        {
+            int[] src = { };
+            int[] dst = { 99, 100, 101 };
+
+            ReadOnlySpan<int> srcSpan = new ReadOnlySpan<int>(src);
+            bool success = srcSpan.TryCopyTo(dst);
+            Assert.True(success);
+            int[] expected = { 99, 100, 101 };
+            Assert.Equal<int>(expected, dst);
+        }
+
+        [Fact]
         public static void TryCopyToLonger()
         {
             int[] src = { 1, 2, 3 };

--- a/src/System.Memory/tests/ReadOnlySpan/Equality.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/Equality.cs
@@ -89,5 +89,16 @@ namespace System.SpanTests
             Assert.False(left == right);
             Assert.False(!(left != right));
         }
+
+        [Fact]
+        public static void CannotCallEqualsOnSpan()
+        {
+            ReadOnlySpan<int> left = new ReadOnlySpan<int>(new int[0]);
+            ReadOnlySpan<int> right = new ReadOnlySpan<int>(new int[0]);
+
+#pragma warning disable 0618
+            Assert.Throws<NotSupportedException>(() => left.Equals(right));
+#pragma warning restore 0618
+        }
     }
 }

--- a/src/System.Memory/tests/ReadOnlySpan/Equality.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/Equality.cs
@@ -94,11 +94,17 @@ namespace System.SpanTests
         public static void CannotCallEqualsOnSpan()
         {
             ReadOnlySpan<int> left = new ReadOnlySpan<int>(new int[0]);
-            ReadOnlySpan<int> right = new ReadOnlySpan<int>(new int[0]);
-
+            try
+            {
 #pragma warning disable 0618
-            Assert.Throws<NotSupportedException>(() => left.Equals(right));
+                bool result = left.Equals(new object());
 #pragma warning restore 0618
+                Assert.True(false);
+            }
+            catch (Exception ex)
+            {
+                Assert.True(ex is NotSupportedException);
+            }
         }
     }
 }

--- a/src/System.Memory/tests/ReadOnlySpan/GetHashCode.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/GetHashCode.cs
@@ -13,9 +13,17 @@ namespace System.SpanTests
         {
             ReadOnlySpan<int> span = new ReadOnlySpan<int>(new int[0]);
 
+            try
+            {
 #pragma warning disable 0618
-            Assert.Throws<NotSupportedException>(() => span.GetHashCode());
+                int result = span.GetHashCode();
 #pragma warning restore 0618
+                Assert.True(false);
+            }
+            catch (Exception ex)
+            {
+                Assert.True(ex is NotSupportedException);
+            }
         }
     }
 }

--- a/src/System.Memory/tests/ReadOnlySpan/GetHashCode.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/GetHashCode.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.SpanTests
+{
+    public static partial class ReadOnlySpanTests
+    {
+        [Fact]
+        public static void CannotCallGetHashCodeOnSpan()
+        {
+            ReadOnlySpan<int> span = new ReadOnlySpan<int>(new int[0]);
+
+#pragma warning disable 0618
+            Assert.Throws<NotSupportedException>(() => span.GetHashCode());
+#pragma warning restore 0618
+        }
+    }
+}

--- a/src/System.Memory/tests/ReadOnlySpan/IndexOf.byte.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/IndexOf.byte.cs
@@ -17,9 +17,26 @@ namespace System.SpanTests
         }
 
         [Fact]
+        public static void DefaultFilledIndexOf_Byte()
+        {
+            for (int length = 0; length <= byte.MaxValue; length++)
+            {
+                byte[] a = new byte[length];
+                ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
+
+                for (int i = 0; i < length; i++)
+                {
+                    byte target0 = default(byte);
+                    int idx = span.IndexOf(target0);
+                    Assert.Equal(0, idx);
+                }
+            }
+        }
+
+        [Fact]
         public static void TestMatch_Byte()
         {
-            for (int length = 0; length < 32; length++)
+            for (int length = 0; length < byte.MaxValue; length++)
             {
                 byte[] a = new byte[length];
                 for (int i = 0; i < length; i++)
@@ -38,14 +55,38 @@ namespace System.SpanTests
         }
 
         [Fact]
+        public static void TestNoMatch_Byte()
+        {
+            var rnd = new Random(42);
+            for (int length = 0; length <= byte.MaxValue; length++)
+            {
+                byte[] a = new byte[length];
+                byte target = (byte)rnd.Next(0, 256);
+                for (int i = 0; i < length; i++)
+                {
+                    byte val = (byte)(i + 1);
+                    a[i] = val == target ? (byte)(target + 1) : val;
+                }
+                Span<byte> span = new Span<byte>(a);
+                if (length % 16 == 0 || length == 39)
+                {
+                    rnd = new Random(42);
+                }
+                int idx = span.IndexOf(target);
+                Assert.Equal(-1, idx);
+            }
+        }
+
+        [Fact]
         public static void TestMultipleMatch_Byte()
         {
-            for (int length = 2; length < 32; length++)
+            for (int length = 2; length < byte.MaxValue; length++)
             {
                 byte[] a = new byte[length];
                 for (int i = 0; i < length; i++)
                 {
-                    a[i] = (byte)(i + 1);
+                    byte val = (byte)(i + 1);
+                    a[i] = val == 200 ? (byte)201 : val;
                 }
 
                 a[length - 1] = 200;
@@ -60,7 +101,7 @@ namespace System.SpanTests
         [Fact]
         public static void MakeSureNoChecksGoOutOfRange_Byte()
         {
-            for (int length = 0; length < 100; length++)
+            for (int length = 0; length < byte.MaxValue; length++)
             {
                 byte[] a = new byte[length + 2];
                 a[0] = 99;

--- a/src/System.Memory/tests/ReadOnlySpan/IndexOf.byte.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/IndexOf.byte.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Numerics;
 using Xunit;
 
 namespace System.SpanTests
@@ -67,13 +68,46 @@ namespace System.SpanTests
                     byte val = (byte)(i + 1);
                     a[i] = val == target ? (byte)(target + 1) : val;
                 }
-                Span<byte> span = new Span<byte>(a);
-                if (length % 16 == 0 || length == 39)
-                {
-                    rnd = new Random(42);
-                }
+                ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
+
                 int idx = span.IndexOf(target);
                 Assert.Equal(-1, idx);
+            }
+        }
+
+        [Fact]
+        public static void TestAllignmentNoMatch_Byte()
+        {
+            byte[] array = new byte[4 * Vector<byte>.Count];
+            for (var i = 0; i < Vector<byte>.Count; i++)
+            {
+                var span = new ReadOnlySpan<byte>(array, i, 3 * Vector<byte>.Count);
+                int idx = span.IndexOf((byte)'1');
+                Assert.Equal(-1, idx);
+
+                span = new ReadOnlySpan<byte>(array, i, 3 * Vector<byte>.Count - 3);
+                idx = span.IndexOf((byte)'1');
+                Assert.Equal(-1, idx);
+            }
+        }
+
+        [Fact]
+        public static void TestAllignmentMatch_Byte()
+        {
+            byte[] array = new byte[4 * Vector<byte>.Count];
+            for (int i = 0; i < array.Length; i++)
+            {
+                array[i] = 5;
+            }
+            for (var i = 0; i < Vector<byte>.Count; i++)
+            {
+                var span = new ReadOnlySpan<byte>(array, i, 3 * Vector<byte>.Count);
+                int idx = span.IndexOf(5);
+                Assert.Equal(0, idx);
+
+                span = new ReadOnlySpan<byte>(array, i, 3 * Vector<byte>.Count - 3);
+                idx = span.IndexOf(5);
+                Assert.Equal(0, idx);
             }
         }
 

--- a/src/System.Memory/tests/ReadOnlySpan/SequenceEqual.byte.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/SequenceEqual.byte.cs
@@ -29,6 +29,27 @@ namespace System.SpanTests
         }
 
         [Fact]
+        public static void SequenceEqualArrayImplicit_Byte()
+        {
+            byte[] a = { 4, 5, 6 };
+            ReadOnlySpan<byte> first = new ReadOnlySpan<byte>(a, 0, 3);
+            bool b = first.SequenceEqual(a);
+            Assert.True(b);
+        }
+
+        [Fact]
+        public static void SequenceEqualArraySegmentImplicit_Byte()
+        {
+            byte[] src = { 1, 2, 3 };
+            byte[] dst = { 5, 1, 2, 3, 10 };
+            var segment = new ArraySegment<byte>(dst, 1, 3);
+
+            ReadOnlySpan<byte> first = new ReadOnlySpan<byte>(src, 0, 3);
+            bool b = first.SequenceEqual(segment);
+            Assert.True(b);
+        }
+
+        [Fact]
         public static void LengthMismatchSequenceEqual_Byte()
         {
             byte[] a = { 4, 5, 6 };

--- a/src/System.Memory/tests/Span/Clear.cs
+++ b/src/System.Memory/tests/Span/Clear.cs
@@ -150,6 +150,21 @@ namespace System.SpanTests
         }
 
         [Fact]
+        public static void ClearValueTypeWithoutReferencesPointerSizeLonger()
+        {
+            long[] actual = new long[15];
+            for (int i = 0; i < actual.Length; i++)
+            {
+                actual[i] = i + 1;
+            }
+            long[] expected = new long[actual.Length];
+
+            var span = new Span<long>(actual);
+            span.Clear();
+            Assert.Equal<long>(expected, actual);
+        }
+
+        [Fact]
         public static void ClearReferenceType()
         {
             string[] actual = { "a", "b", "c" };
@@ -176,6 +191,17 @@ namespace System.SpanTests
         }
 
         [Fact]
+        public static void ClearEnumType()
+        {
+            TestEnum[] actual = {TestEnum.e0, TestEnum.e1, TestEnum.e2};
+            TestEnum[] expected = {default(TestEnum), default(TestEnum), default(TestEnum) };
+
+            var span = new Span<TestEnum>(actual);
+            span.Clear();
+            Assert.Equal<TestEnum>(expected, actual);
+        }
+
+        [Fact]
         public static void ClearValueTypeWithReferences()
         {
             TestValueTypeWithReference[] actual = {
@@ -194,7 +220,7 @@ namespace System.SpanTests
 
         [ActiveIssue(16492)]
         [OuterLoop]
-        [Fact]
+        //[Fact]
         public unsafe static void ClearLongerThanUintMaxValueBytes()
         {
             if (sizeof(IntPtr) == sizeof(long))
@@ -241,7 +267,7 @@ namespace System.SpanTests
 
         [ActiveIssue(16492)]
         [OuterLoop]
-        [Fact]
+        //[Fact]
         public unsafe static void ClearNativeLongerThanUintMaxValueBytes()
         {
             if (sizeof(IntPtr) == sizeof(long))

--- a/src/System.Memory/tests/Span/Clear.cs
+++ b/src/System.Memory/tests/Span/Clear.cs
@@ -150,7 +150,7 @@ namespace System.SpanTests
         }
 
         [Fact]
-        public static void ClearValueTypeWithoutReferencesPointerSizeLonger()
+        public static void ClearValueTypeWithoutReferencesPointerSize()
         {
             long[] actual = new long[15];
             for (int i = 0; i < actual.Length; i++)
@@ -220,7 +220,7 @@ namespace System.SpanTests
 
         [ActiveIssue(16492)]
         [OuterLoop]
-        //[Fact]
+        [Fact]
         public unsafe static void ClearLongerThanUintMaxValueBytes()
         {
             if (sizeof(IntPtr) == sizeof(long))
@@ -267,7 +267,7 @@ namespace System.SpanTests
 
         [ActiveIssue(16492)]
         [OuterLoop]
-        //[Fact]
+        [Fact]
         public unsafe static void ClearNativeLongerThanUintMaxValueBytes()
         {
             if (sizeof(IntPtr) == sizeof(long))

--- a/src/System.Memory/tests/Span/CopyTo.cs
+++ b/src/System.Memory/tests/Span/CopyTo.cs
@@ -21,6 +21,32 @@ namespace System.SpanTests
         }
 
         [Fact]
+        public static void TryCopyToArraySegmentImplicit()
+        {
+            int[] src = { 1, 2, 3 };
+            int[] dst = { 5, 99, 100, 101, 10 };
+            var segment = new ArraySegment<int>(dst, 1, 3);
+
+            Span<int> srcSpan = new Span<int>(src);
+            bool success = srcSpan.TryCopyTo(segment);
+            Assert.True(success);
+            Assert.Equal<int>(src, segment);
+        }
+
+        [Fact]
+        public static void TryCopyToEmpty()
+        {
+            int[] src = {};
+            int[] dst = { 99, 100, 101 };
+
+            Span<int> srcSpan = new Span<int>(src);
+            bool success = srcSpan.TryCopyTo(dst);
+            Assert.True(success);
+            int[] expected = { 99, 100, 101 };
+            Assert.Equal<int>(expected, dst);
+        }
+
+        [Fact]
         public static void TryCopyToLonger()
         {
             int[] src = { 1, 2, 3 };

--- a/src/System.Memory/tests/Span/Equality.cs
+++ b/src/System.Memory/tests/Span/Equality.cs
@@ -89,5 +89,16 @@ namespace System.SpanTests
             Assert.False(left == right);
             Assert.False(!(left != right));
         }
+
+        [Fact]
+        public static void CannotCallEqualsOnSpan()
+        {
+            Span<int> left = new Span<int>(new int[0]);
+            Span<int> right = new Span<int>(new int[0]);
+
+#pragma warning disable 0618
+            Assert.Throws<NotSupportedException>(() => left.Equals(right));
+#pragma warning restore 0618
+        }
     }
 }

--- a/src/System.Memory/tests/Span/Equality.cs
+++ b/src/System.Memory/tests/Span/Equality.cs
@@ -94,11 +94,18 @@ namespace System.SpanTests
         public static void CannotCallEqualsOnSpan()
         {
             Span<int> left = new Span<int>(new int[0]);
-            Span<int> right = new Span<int>(new int[0]);
 
+            try
+            {
 #pragma warning disable 0618
-            Assert.Throws<NotSupportedException>(() => left.Equals(right));
+                bool result = left.Equals(new object());
 #pragma warning restore 0618
+                Assert.True(false);
+            }
+            catch (Exception ex)
+            {
+                Assert.True(ex is NotSupportedException);
+            }
         }
     }
 }

--- a/src/System.Memory/tests/Span/GetHashCode.cs
+++ b/src/System.Memory/tests/Span/GetHashCode.cs
@@ -13,9 +13,17 @@ namespace System.SpanTests
         {
             Span<int> span = new Span<int>(new int[0]);
 
+            try
+            {
 #pragma warning disable 0618
-            Assert.Throws<NotSupportedException>(() => span.GetHashCode());
+                int result = span.GetHashCode();
 #pragma warning restore 0618
+                Assert.True(false);
+            }
+            catch (Exception ex)
+            {
+                Assert.True(ex is NotSupportedException);
+            }
         }
     }
 }

--- a/src/System.Memory/tests/Span/GetHashCode.cs
+++ b/src/System.Memory/tests/Span/GetHashCode.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.SpanTests
+{
+    public static partial class SpanTests
+    {
+        [Fact]
+        public static void CannotCallGetHashCodeOnSpan()
+        {
+            Span<int> span = new Span<int>(new int[0]);
+
+#pragma warning disable 0618
+            Assert.Throws<NotSupportedException>(() => span.GetHashCode());
+#pragma warning restore 0618
+        }
+    }
+}

--- a/src/System.Memory/tests/Span/IndexOf.byte.cs
+++ b/src/System.Memory/tests/Span/IndexOf.byte.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Numerics;
 using Xunit;
 
 namespace System.SpanTests
@@ -71,6 +72,42 @@ namespace System.SpanTests
                 
                 int idx = span.IndexOf(target);
                 Assert.Equal(-1, idx);
+            }
+        }
+
+        [Fact]
+        public static void TestAllignmentNoMatch_Byte()
+        {
+            byte[] array = new byte[4 * Vector<byte>.Count];
+            for (var i = 0; i < Vector<byte>.Count; i++)
+            {
+                var span = new Span<byte>(array, i, 3 * Vector<byte>.Count);
+                int idx = span.IndexOf((byte)'1');
+                Assert.Equal(-1, idx);
+
+                span = new Span<byte>(array, i, 3 * Vector<byte>.Count - 3);
+                idx = span.IndexOf((byte)'1');
+                Assert.Equal(-1, idx);
+            }
+        }
+
+        [Fact]
+        public static void TestAllignmentMatch_Byte()
+        {
+            byte[] array = new byte[4 * Vector<byte>.Count];
+            for (int i = 0; i < array.Length; i++)
+            {
+                array[i] = 5;
+            }
+            for (var i = 0; i < Vector<byte>.Count; i++)
+            {
+                var span = new Span<byte>(array, i, 3 * Vector<byte>.Count);
+                int idx = span.IndexOf(5);
+                Assert.Equal(0, idx);
+
+                span = new Span<byte>(array, i, 3 * Vector<byte>.Count - 3);
+                idx = span.IndexOf(5);
+                Assert.Equal(0, idx);
             }
         }
 

--- a/src/System.Memory/tests/Span/IndexOf.byte.cs
+++ b/src/System.Memory/tests/Span/IndexOf.byte.cs
@@ -17,9 +17,26 @@ namespace System.SpanTests
         }
 
         [Fact]
+        public static void DefaultFilledIndexOf_Byte()
+        {
+            for (int length = 0; length <= byte.MaxValue; length++)
+            {
+                byte[] a = new byte[length];
+                Span<byte> span = new Span<byte>(a);
+
+                for (int i = 0; i < length; i++)
+                {
+                    byte target0 = default(byte);
+                    int idx = span.IndexOf(target0);
+                    Assert.Equal(0, idx);
+                }
+            }
+        }
+
+        [Fact]
         public static void TestMatch_Byte()
         {
-            for (int length = 0; length < 32; length++)
+            for (int length = 0; length <= byte.MaxValue; length++)
             {
                 byte[] a = new byte[length];
                 for (int i = 0; i < length; i++)
@@ -38,14 +55,35 @@ namespace System.SpanTests
         }
 
         [Fact]
+        public static void TestNoMatch_Byte()
+        {
+            var rnd = new Random(42);
+            for (int length = 0; length <= byte.MaxValue; length++)
+            {
+                byte[] a = new byte[length];
+                byte target = (byte)rnd.Next(0, 256);
+                for (int i = 0; i < length; i++)
+                {
+                    byte val = (byte)(i + 1);
+                    a[i] = val == target ? (byte)(target + 1) : val;
+                }
+                Span<byte> span = new Span<byte>(a);
+                
+                int idx = span.IndexOf(target);
+                Assert.Equal(-1, idx);
+            }
+        }
+
+        [Fact]
         public static void TestMultipleMatch_Byte()
         {
-            for (int length = 2; length < 32; length++)
+            for (int length = 2; length <= byte.MaxValue; length++)
             {
                 byte[] a = new byte[length];
                 for (int i = 0; i < length; i++)
                 {
-                    a[i] = (byte)(i + 1);
+                    byte val = (byte)(i + 1);
+                    a[i] = val == 200 ? (byte)201 : val;
                 }
 
                 a[length - 1] = 200;
@@ -60,7 +98,7 @@ namespace System.SpanTests
         [Fact]
         public static void MakeSureNoChecksGoOutOfRange_Byte()
         {
-            for (int length = 0; length < 100; length++)
+            for (int length = 0; length <= byte.MaxValue; length++)
             {
                 byte[] a = new byte[length + 2];
                 a[0] = 99;

--- a/src/System.Memory/tests/Span/SequenceEqual.byte.cs
+++ b/src/System.Memory/tests/Span/SequenceEqual.byte.cs
@@ -29,6 +29,27 @@ namespace System.SpanTests
         }
 
         [Fact]
+        public static void SequenceEqualArrayImplicit_Byte()
+        {
+            byte[] a = { 4, 5, 6 };
+            Span<byte> first = new Span<byte>(a, 0, 3);
+            bool b = first.SequenceEqual(a);
+            Assert.True(b);
+        }
+
+        [Fact]
+        public static void SequenceEqualArraySegmentImplicit_Byte()
+        {
+            byte[] src = { 1, 2, 3 };
+            byte[] dst = { 5, 1, 2, 3, 10 };
+            var segment = new ArraySegment<byte>(dst, 1, 3);
+
+            Span<byte> first = new Span<byte>(src, 0, 3);
+            bool b = first.SequenceEqual(segment);
+            Assert.True(b);
+        }
+
+        [Fact]
         public static void LengthMismatchSequenceEqual_Byte()
         {
             byte[] a = { 4, 5, 6 };

--- a/src/System.Memory/tests/Span/TestHelpers.cs
+++ b/src/System.Memory/tests/Span/TestHelpers.cs
@@ -81,6 +81,15 @@ namespace System.SpanTests
             public int I;
             public string S;
         }
+
+        private enum TestEnum
+        {
+            e0,
+            e1,
+            e2,
+            e3,
+            e4,
+        }
     }
 }
 

--- a/src/System.Memory/tests/System.Memory.Tests.csproj
+++ b/src/System.Memory/tests/System.Memory.Tests.csproj
@@ -24,6 +24,7 @@
     <Compile Include="Span\Empty.cs" />
     <Compile Include="Span\Equality.cs" />
     <Compile Include="Span\GcReporting.cs" />
+    <Compile Include="Span\GetHashCode.cs" />
     <Compile Include="Span\IndexOf.T.cs" />
     <Compile Include="Span\IndexOf.byte.cs" />
     <Compile Include="Span\IndexOf.char.cs" />
@@ -52,6 +53,7 @@
     <Compile Include="ReadOnlySpan\DangerousGetPinnableReference.cs" />
     <Compile Include="ReadOnlySpan\Empty.cs" />
     <Compile Include="ReadOnlySpan\Equality.cs" />
+    <Compile Include="ReadOnlySpan\GetHashCode.cs" />
     <Compile Include="ReadOnlySpan\IndexOf.T.cs" />
     <Compile Include="ReadOnlySpan\IndexOf.byte.cs" />
     <Compile Include="ReadOnlySpan\IndexOf.char.cs" />


### PR DESCRIPTION
Fixes #17078 

Adding tests for:
- Implicit operators
- Obsolete methods
- Clear EnumType and Clear ValueType Without References Pointer Size
- Copy empty source
- Fill native memory
- Fill ValueType Without References for larger arrays
- Test IndexOf for larger arrays

Gets us much closer to 100% test coverage (for slow span at least), esp if you include outer-loop and 32-bit tests.