### PR TITLE
Performance improvement for ProcessManager.Windows.IsProcessRunning

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
@@ -27,19 +27,21 @@ namespace System.Diagnostics
         /// <returns>true if the process is running; otherwise, false.</returns>
         public static bool IsProcessRunning(int processId, string machineName)
         {
-            //Performance optimization for the local machine: 
-            //First try to OpenProcess by id, if valid handle is returned, the process is definitely running
-            //Otherwise enumerate all processes and compare ids
+            // Performance optimization for the local machine: 
+            // First try to OpenProcess by id, if valid handle is returned, the process is definitely running
+            // Otherwise enumerate all processes and compare ids
             if (!IsRemoteMachine(machineName))
             {
-                SafeProcessHandle processHandle = Interop.Kernel32.OpenProcess(Interop.Advapi32.ProcessOptions.PROCESS_QUERY_INFORMATION, false, processId);
-                if (!processHandle.IsInvalid)
+                using (SafeProcessHandle processHandle = Interop.Kernel32.OpenProcess(Interop.Advapi32.ProcessOptions.PROCESS_QUERY_INFORMATION, false, processId))
                 {
-                    return true;
+                    if (!processHandle.IsInvalid)
+                    {
+                        return true;
+                    }
                 }
             }
 
-            return IsProcessRunning(processId, GetProcessIds(machineName));
+            return Array.IndexOf(GetProcessIds(machineName), processId) >= 0;
         }
 
         /// <summary>Gets the ProcessInfo for the specified process ID on the specified machine.</summary>
@@ -178,11 +180,6 @@ namespace System.Diagnostics
                     tokenHandle.Dispose();
                 }
             }
-        }
-
-        private static bool IsProcessRunning(int processId, int[] processIds)
-        {
-            return Array.IndexOf(processIds, processId) >= 0;
         }
 
         public static SafeProcessHandle OpenProcess(int processId, int access, bool throwIfExited)

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
@@ -18,7 +18,7 @@ namespace System.Diagnostics
         /// <returns>true if the process is running; otherwise, false.</returns>
         public static bool IsProcessRunning(int processId)
         {
-            return IsProcessRunning(processId, GetProcessIds());
+            return IsProcessRunning(processId, ".");
         }
 
         /// <summary>Gets whether the process with the specified ID on the specified machine is currently running.</summary>
@@ -27,6 +27,18 @@ namespace System.Diagnostics
         /// <returns>true if the process is running; otherwise, false.</returns>
         public static bool IsProcessRunning(int processId, string machineName)
         {
+            //Performance optimization for the local machine: 
+            //First try to OpenProcess by id, if valid handle is returned, the process is definitely running
+            //Otherwise enumerate all processes and compare ids
+            if (!IsRemoteMachine(machineName))
+            {
+                SafeProcessHandle processHandle = Interop.Kernel32.OpenProcess(Interop.Advapi32.ProcessOptions.PROCESS_QUERY_INFORMATION, false, processId);
+                if (!processHandle.IsInvalid)
+                {
+                    return true;
+                }
+            }
+
             return IsProcessRunning(processId, GetProcessIds(machineName));
         }
 


### PR DESCRIPTION
Performance optimization for the local machine:
First try to OpenProcess by id, if valid handle is returned, the process is definitely running.
Otherwise enumerate all processes and compare ids (the logic we had before)

Fix #17382

Benchmarks before:
```
              Method |      Mean |    StdDev |
-------------------- |---------- |---------- |
      GetProcessById | 3.5353 ms | 0.0693 ms |
   GetProcessesEqual | 3.1075 ms | 0.0720 ms |
GetProcessesNotEqual | 3.1015 ms | 0.0416 ms |
```
After:
```
              Method |      Mean |    StdDev |
-------------------- |---------- |---------- |
      GetProcessById | 1.4213 ms | 0.0581 ms |
   GetProcessesEqual | 3.1123 ms | 0.0615 ms |
GetProcessesNotEqual | 3.0089 ms | 0.0532 ms |
```

Test program:
```csharp
using System.Diagnostics;
using System.Linq;
using System.Reflection;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

namespace GetProcessByIdBenchmark
{
    public class Program
    {
        private static int CurrentProcessId = Process.GetCurrentProcess().Id;
		
        [Benchmark]
        public void GetProcessById()
        {
            Process.GetProcessById(CurrentProcessId);
        }

        [Benchmark]
        public void GetProcessesEqual()
        {
            Process.GetProcesses().FirstOrDefault(a => a.Id == CurrentProcessId);
        }

        [Benchmark]
        public void GetProcessesNotEqual()
        {
            Process.GetProcesses().FirstOrDefault(a => a.Id != CurrentProcessId);
        }

        static void Main(string[] args)
        {
            BenchmarkSwitcher.FromAssembly(typeof(Program).GetTypeInfo().Assembly).Run(args);
        }
    }
}
```