### PR TITLE
Fix FIPS 186-3 DSACng signature with H < sizeof(Q)

### DIFF
--- a/src/Common/src/System/Security/Cryptography/DSACng.SignVerify.cs
+++ b/src/Common/src/System/Security/Cryptography/DSACng.SignVerify.cs
@@ -60,18 +60,18 @@ namespace System.Security.Cryptography
 
                 // FIPS 186-3 has this to say about hash output length vs Q (section 4.2):
                 //
-                // It is recommended that the security strength of the (L, N) pair
-                // and the security strength of the hash function used for the generation
-                // of digital signatures be the same unless an agreement has been made
-                // between participating entities to use a stronger hash function.
-                // When the length of the output of the hash function is greater than
-                // N (i.e., the bit length of q), then the leftmost N bits of the hash
-                // function output block **shall** be used in any calculation using the hash
-                // function output during the generation or verification of a digital
-                // signature. A hash function that provides a lower security strength
-                // than the (L, N) pair ordinarily **should not** be used, since this would
-                // reduce the security strength of the digital signature process to a
-                // level no greater than that provided by the hash function.
+                //    "It is recommended that the security strength of the (L, N) pair
+                //     and the security strength of the hash function used for the generation
+                //     of digital signatures be the same unless an agreement has been made
+                //     between participating entities to use a stronger hash function.
+                //     When the length of the output of the hash function is greater than
+                //     N (i.e., the bit length of q), then the leftmost N bits of the hash
+                //     function output block **shall** be used in any calculation using the hash
+                //     function output during the generation or verification of a digital
+                //     signature. A hash function that provides a lower security strength
+                //     than the (L, N) pair ordinarily **should not** be used, since this would
+                //     reduce the security strength of the digital signature process to a
+                //     level no greater than that provided by the hash function."
                 // (Emphasis in original)
                 //
                 // Windows CNG requires that the hash output and q match, but we can better

--- a/src/Common/src/System/Security/Cryptography/DSACng.SignVerify.cs
+++ b/src/Common/src/System/Security/Cryptography/DSACng.SignVerify.cs
@@ -58,29 +58,13 @@ namespace System.Security.Cryptography
 
                 int qLength = ComputeQLength();
 
-                // FIPS 186-3 has this to say about hash output length vs Q (section 4.2):
-                //
-                //    "It is recommended that the security strength of the (L, N) pair
-                //     and the security strength of the hash function used for the generation
-                //     of digital signatures be the same unless an agreement has been made
-                //     between participating entities to use a stronger hash function.
-                //     When the length of the output of the hash function is greater than
-                //     N (i.e., the bit length of q), then the leftmost N bits of the hash
-                //     function output block **shall** be used in any calculation using the hash
-                //     function output during the generation or verification of a digital
-                //     signature. A hash function that provides a lower security strength
-                //     than the (L, N) pair ordinarily **should not** be used, since this would
-                //     reduce the security strength of the digital signature process to a
-                //     level no greater than that provided by the hash function."
-                // (Emphasis in original)
-                //
-                // Windows CNG requires that the hash output and q match, but we can better
+                // Windows CNG requires that the hash output and q match sizes, but we can better
                 // interoperate with other FIPS 186-3 implementations if we perform truncation
                 // here, before sending it to CNG. Since this is a scenario presented in the
                 // CAVP reference test suite, we can confirm our implementation.
                 //
-                // If, on the other hand, Q is too big, we need to left-pad the hash with zeroes,
-                // since it gets treated as a big-endian number. Since this is also a scenario
+                // If, on the other hand, Q is too big, we need to left-pad the hash with zeroes
+                // (since it gets treated as a big-endian number). Since this is also a scenario
                 // presented in the CAVP reference test suite, we can confirm our implementation.
 
                 if (qLength == hash.Length)

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignVerify.NistValidation.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignVerify.NistValidation.cs
@@ -363,6 +363,63 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
+        public static void Fips186_3_L2048_N256_SHA1_1()
+        {
+            // http://csrc.nist.gov/groups/STM/cavp/documents/dss/186-3dsatestvectors.zip
+            // SigGen.txt
+            // [mod = L=2048, N=256, SHA-1, first case
+            const string p =
+                "c1a59d215573949e0b20a974c2edf2e3137ff2463062f75f1d13df12aba1076b" +
+                "b2d013402b60af6c187fb0fa362167c976c2617c726f9077f09e18c11b60f650" +
+                "08825bd6c02a1f57d3eb0ad41cd547de43d87f2525f971d42b306506e7ca03be" +
+                "63b35f4ada172d0a06924440a14250d7822ac2d5aeafed4619e79d4158a7d5eb" +
+                "2d9f023db181a8f094b2c6cb87cb8535416ac19813f07144660c557745f44a01" +
+                "c6b1029092c129b0d27183e82c5a21a80177ee7476eb95c466fb472bd3d2dc28" +
+                "6ce25847e93cbfa9ad39cc57035d0c7b64b926a9c7f5a7b2bc5abcbfbdc0b0e3" +
+                "fede3c1e02c44afc8aefc7957da07a0e5fd12339db8667616f62286df80d58ab";
+
+            const string q =
+                "8000000000000000000000001bd62c65e8b87c89797f8f0cbfa55e4a6810e2c7";
+
+            const string g =
+                "aea5878740f1424d3c6ea9c6b4799615d2749298a17e26207f76cef340ddd390" +
+                "e1b1ad6b6c0010ad015a103342ddd452cac024b36e42d9b8ed52fafae7a1d3ce" +
+                "9e4b21f910d1356eb163a3e5a8184c781bf14492afa2e4b0a56d8884fd01a628" +
+                "b9662739c42e5c5795ade2f5f27e6de1d963917ce8806fc40d021cd87aa3aa3a" +
+                "9e4f0c2c4c45d2959b2578b2fb1a2229c37e181059b9d5e7b7862fa82e2377a4" +
+                "9ed0f9dca820a5814079dd6610714efaf8b0cc683d8e72e4c884e6f9d4946b3e" +
+                "8d4cbb92adbbe7d4c47cc30be7f8c37ca81883a1aac6860059ff4640a29ccae7" +
+                "3de20b12e63b00a88b2ee9ba94b75eb40a656e15d9ec83731c85d0effcb9ef9f";
+
+            const string msg =
+                "de3605dbefde353cbe05e0d6098647b6d041460dfd4c000312be1afe7551fd3b" +
+                "93fed76a9763c34e004564b8f7dcacbd99e85030632c94e9b0a032046523b7aa" +
+                "cdf934a2dbbdcfceefe66b4e3d1cb29e994ff3a4648a8edd9d58ed71f12399d9" +
+                "0624789c4e0eebb0fbd5080f7d730f875a1f290749334cb405e9fd2ae1b4ed65";
+
+            const string x =
+                "5a42e77248358f06ae980a2c64f6a22bea2bf7b4fc0015745053c432b7132a67";
+
+            const string y =
+                "880e17c4ae8141750609d8251c0bbd7acf6d0b460ed3688e9a5f990e6c4b5b00" +
+                "875da750e0228a04102a35f57e74b8d2f9b6950f0d1db8d302c5c90a5b8786a8" +
+                "2c68ff5b17a57a758496c5f8053e4484a253d9942204d9a1109f4bd2a3ec311a" +
+                "60cf69c685b586d986f565d33dbf5aab7091e31aa4102c4f4b53fbf872d70015" +
+                "6465b6c075e7f778471a23502dc0fee41b271c837a1c26691699f3550d060a33" +
+                "1099f64837cddec69caebf51bf4ec9f36f2a220fe773cb4d3c02d0446ddd4613" +
+                "3532ef1c3c69d432e303502bd05a75279a7809a742ac4a7872b07f1908654049" +
+                "419350e37a95f2ef33361d8d8736d4083dc14c0bb972e14d4c7b97f3ddfccaef";
+
+            const string r =
+                "363e01c564f380a27d7d23b207af3f961d48fc0995487f60052775d724ab3d10";
+
+            const string s =
+                "4916d91b2927294e429d537c06dd2463d1845018cca2873e90a6c837b445fdde";
+
+            Validate(p, q, g, x, y, msg, r, s, HashAlgorithmName.SHA1);
+        }
+
+        [ConditionalFact(nameof(SupportsFips186_3))]
         public static void Fips186_3_L2048_N256_SHA384_3()
         {
             // http://csrc.nist.gov/groups/STM/cavp/documents/dss/186-3dsatestvectors.zip

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignVerify.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignVerify.cs
@@ -169,6 +169,45 @@ namespace System.Security.Cryptography.Dsa.Tests
             }
         }
 
+        [ConditionalFact(nameof(SupportsFips186_3))]
+        public static void Sign2048WithSha1()
+        {
+            byte[] data = { 1, 2, 3, 4 };
+
+            using (DSA dsa = DSAFactory.Create())
+            {
+                dsa.ImportParameters(DSATestData.GetDSA2048Params());
+
+                byte[] signature = dsa.SignData(data, HashAlgorithmName.SHA1);
+
+                Assert.True(dsa.VerifyData(data, signature, HashAlgorithmName.SHA1));
+            }
+        }
+
+        [ConditionalFact(nameof(SupportsFips186_3))]
+        public static void Verify2048WithSha1()
+        {
+            byte[] data = { 1, 2, 3, 4 };
+
+            byte[] signature = (
+                "28DC05B452C8FC0E0BFE9DA067D11147D31B1F3C63E5CF95046A812417C64844868D04D3A1D23" +
+                "13E5DD07DE757B3A836E70A1C85DDC90CB62DE2E44746C760F2").HexToByteArray();
+
+            using (DSA dsa = DSAFactory.Create())
+            {
+                dsa.ImportParameters(DSATestData.GetDSA2048Params());
+
+                Assert.True(dsa.VerifyData(data, signature, HashAlgorithmName.SHA1), "Untampered data verifies");
+
+                data[0] ^= 0xFF;
+                Assert.False(dsa.VerifyData(data, signature, HashAlgorithmName.SHA1), "Tampered data verifies");
+
+                data[0] ^= 0xFF;
+                signature[signature.Length - 1] ^= 0xFF;
+                Assert.False(dsa.VerifyData(data, signature, HashAlgorithmName.SHA1), "Tampered signature verifies");
+            }
+        }
+
         private static void SignAndVerify(byte[] data, string hashAlgorithmName, DSAParameters dsaParameters, int expectedSignatureLength)
         {
             using (DSA dsa = DSAFactory.Create())


### PR DESCRIPTION
Add signing tests and stable verification tests for the scenario where a short
hash is chosen; as well as a whole lot of justification commenting.

Fixes #17305.