### PR TITLE
Stop using TaskCreationOptions.PreferFairness in Parallel.For/ForEach/Invoke

### DIFF
--- a/src/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/TaskReplicator.cs
+++ b/src/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/TaskReplicator.cs
@@ -79,7 +79,7 @@ namespace System.Threading.Tasks
 
                     if (userActionYieldedBeforeCompletion)
                     {
-                        _pendingTask = new Task(s => ((Replica)s).Execute(), this, CancellationToken.None, TaskCreationOptions.PreferFairness);
+                        _pendingTask = new Task(s => ((Replica)s).Execute(), this, CancellationToken.None, TaskCreationOptions.None);
                         _pendingTask.Start(_replicator._scheduler);
                     }
                     else


### PR DESCRIPTION
The Parallel.For/ForEach/Invoke implementation in desktop uses a task-replicating functionality built into Task.  This mechanism was a hold-over from pre-release TPL and was never exposed, nor was it particularly desirable for a situation other than Parallel, and has since been removed.  To implement Parallel for corefx, then, a separate replication mechanism was implemented on top of Tasks rather than as part of its implementation, and in doing so it seems a small bug snuck in.

Parallel loops expand across the target scheduler by having creating a single task that participates in the body of the loop; when that task is executed, it creates a "replica" of itself that's scheduled before invoking the actual body of the task.  If another thread becomes available to help, it'll pick up that replica and execute it, which will in turn create a replica of itself.  And so on.

The problem is that the corefx version is creating that replica with TaskCreationOptions.PreferFairness.  The goal of these replicas is that they're only handled when there are threads available to participate in the loop, and other available work should be preferred.  So, for example, if a parallel loop is used in the processing of a web request, we want the server/pool to prioritize handling of new incoming requests over having all threads participate in the loop for a single request, and only have threads help out the loop if they're not busy doing anything else.  By specifying PreferFairness, Parallel in corefx is putting its tasks into the global thread pool queue, prioritized in a FIFO manner with all other tasks coming into the global queue, and prioritized ahead of other tasks created by the body of the loop itself.  Note that the desktop implementation doesn't use PreferFairness.

The fix is simply to change PreferFairness to None when creating the replicas.

In the repro in #12217, the presence of PreferFairness caused the replicas to be prioritized over the ContinueWith tasks created in the body of the parallel loop.  That in turn caused replicas to be executed instead of the continuations, which resulted in queue length growing, which resulted in the pool introducing more threads, which in turn made GC/allocation slower (more threads doing almost pure allocation in a loop), which fed into a cycle of more threads being created, more replicas getting prioritized over continuations, etc.  Before the change, if I ran the repro in a loop, thread count would increase fairly consistently and execution time of each iteration would grow significantly over the last; after the change, things stabilize quickly.

Fixes #12217 
cc: @cipop, @kouvel