### PR TITLE
Disable assembly-level parallelization of the System.Runtime.Numerics tests

### DIFF
--- a/src/System.Runtime.Numerics/tests/System.Runtime.Numerics.Tests.csproj
+++ b/src/System.Runtime.Numerics/tests/System.Runtime.Numerics.Tests.csproj
@@ -56,6 +56,7 @@
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
       <Link>Common\System\PlatformDetection.cs</Link>
     </Compile>
+    <Compile Include="XunitAssemblyTestCollection.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime.Numerics/tests/XunitAssemblyTestCollection.cs
+++ b/src/System.Runtime.Numerics/tests/XunitAssemblyTestCollection.cs
@@ -1,0 +1,6 @@
+﻿using Xunit;
+
+// The MyBigIntImp class contains public static shared state. This means it is not safe to run tests
+// which modify that state in parallel. In order to run these tests in parallel, we need to fix that.
+// See issue: https://github.com/dotnet/corefx/issues/17499
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/15395.

This will cause the tests to be slightly slower, so I'll look into fixing the public state as well.