### PR TITLE
Skip SendBufferSize=0 test on OSX.

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -680,8 +680,8 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [ActiveIssue(16716, TestPlatforms.OSX)] // SendBufferSize = 0 throws
         [Fact]
+        [PlatformSpecific(~TestPlatforms.OSX)] // SendBufferSize = 0 not supported on OSX.
         public async Task SendRecv_NoBuffering_Success()
         {
             if (!SupportsNonBlocking) return;

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -681,7 +681,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(~TestPlatforms.OSX)] // SendBufferSize = 0 not supported on OSX.
+        [PlatformSpecific(~TestPlatforms.OSX)] // SendBufferSize, ReceiveBufferSize = 0 not supported on OSX.
         public async Task SendRecv_NoBuffering_Success()
         {
             if (!SupportsNonBlocking) return;


### PR DESCRIPTION
cc @stephentoub @geoffkizer 

UPDATE:
contributes to #16716 