### PR TITLE
Fix clrcompression binplacing for tests

### DIFF
--- a/src/Native/build-native.cmd
+++ b/src/Native/build-native.cmd
@@ -110,7 +110,15 @@ if %__IntermediatesDir% == "" (
 set "__CMakeBinDir=%__CMakeBinDir:\=/%"
 set "__IntermediatesDir=%__IntermediatesDir:\=/%"
 set "__RuntimePath=%__binDir%\runtime\%__TargetGroup%-Windows_NT-%CMAKE_BUILD_TYPE%-%__BuildArch%\"
-set "__TestSharedFrameworkPath=%__binDir%\testhost\%__TargetGroup%-Windows_NT-%CMAKE_BUILD_TYPE%-%__BuildArch%\shared\Microsoft.NETCore.App\9.9.9\"
+if "%__TargetGroup%" == "uapaot" (
+    set "__TestSharedFrameworkPath=%__binDir%\testhost\ILCInputFolder\"
+) else (
+    if "%__TargetGroup%" == "uap" (
+        set "__TestSharedFrameworkPath=%__binDir%\testhost\UAPLayout\"
+    ) else (
+        set "__TestSharedFrameworkPath=%__binDir%\testhost\%__TargetGroup%-Windows_NT-%CMAKE_BUILD_TYPE%-%__BuildArch%\shared\Microsoft.NETCore.App\9.9.9\"
+    )
+)
 
 :: Check that the intermediate directory exists so we can place our cmake build tree there
 if exist "%__IntermediatesDir%" rd /s /q "%__IntermediatesDir%"


### PR DESCRIPTION
cc: @weshaggard @AlexGhiondea 

To be clear, I don't like at all the way we do this today but I don't know of a better way given that we use CMake as opposed to msbuild to build our native bits so we can't really use our binplacing logic as we do everywhere else. This changes will make it so that clrcompression gets binplaced to the right path for the testhost.