### PR TITLE
Adding more Span Tests for CopyTo and Clear

### DIFF
--- a/src/System.Memory/tests/ReadOnlySpan/CopyTo.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/CopyTo.cs
@@ -21,6 +21,18 @@ namespace System.SpanTests
         }
 
         [Fact]
+        public static void TryCopyToSingle()
+        {
+            int[] src = { 1 };
+            int[] dst = { 99 };
+
+            ReadOnlySpan<int> srcSpan = new ReadOnlySpan<int>(src);
+            bool success = srcSpan.TryCopyTo(dst);
+            Assert.True(success);
+            Assert.Equal<int>(src, dst);
+        }
+
+        [Fact]
         public static void TryCopyToArraySegmentImplicit()
         {
             int[] src = { 1, 2, 3 };

--- a/src/System.Memory/tests/Span/Clear.cs
+++ b/src/System.Memory/tests/Span/Clear.cs
@@ -17,6 +17,13 @@ namespace System.SpanTests
         }
 
         [Fact]
+        public static void ClearEmptyWithReference()
+        {
+            var span = Span<string>.Empty;
+            span.Clear();
+        }
+
+        [Fact]
         public static void ClearByteLonger()
         {
             const byte initial = 5;

--- a/src/System.Memory/tests/Span/CopyTo.cs
+++ b/src/System.Memory/tests/Span/CopyTo.cs
@@ -21,6 +21,18 @@ namespace System.SpanTests
         }
 
         [Fact]
+        public static void TryCopyToSingle()
+        {
+            int[] src = { 1 };
+            int[] dst = { 99 };
+
+            Span<int> srcSpan = new Span<int>(src);
+            bool success = srcSpan.TryCopyTo(dst);
+            Assert.True(success);
+            Assert.Equal<int>(src, dst);
+        }
+
+        [Fact]
         public static void TryCopyToArraySegmentImplicit()
         {
             int[] src = { 1, 2, 3 };


### PR DESCRIPTION
Addresses #17078 
Part of https://github.com/dotnet/corefxlab/issues/1314

cc @shiftylogic 

Improves test coverage for System.Private.Corelib (SpanHelper)
