### PR TITLE
Typo in NetworkInterface.Speed range tests adjusted for Wi-Fi Direct Virtual Adapters PR

### DIFF
--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
@@ -43,7 +43,7 @@ namespace System.Net.NetworkInformation.Tests
 
                 // Validate NIC speed overflow.
                 // We've found that certain WiFi adapters will return speed of -1 when not connected.
-                // We've found that Wi-Fi Direct Virutal Adapters return speed of -1 even when up.
+                // We've found that Wi-Fi Direct Virtual Adapters return speed of -1 even when up.
                 Assert.InRange(nic.Speed, -1, long.MaxValue);
 
                 _log.WriteLine("SupportsMulticast: " + nic.SupportsMulticast);


### PR DESCRIPTION
Just a typo :(

https://github.com/dotnet/corefx/pull/17516