### PR TITLE
Remove shared state from MyBigInt

### DIFF
--- a/src/System.Runtime.Numerics/tests/BigInteger/MyBigInt.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/MyBigInt.cs
@@ -9,8 +9,6 @@ namespace System.Numerics.Tests
 {
     public static class MyBigIntImp
     {
-        public static BigInteger outParam = 0;
-
         public static BigInteger DoUnaryOperatorMine(BigInteger num1, string op)
         {
             List<byte> bytes1 = new List<byte>(num1.ToByteArray());
@@ -92,6 +90,13 @@ namespace System.Numerics.Tests
 
         public static BigInteger DoBinaryOperatorMine(BigInteger num1, BigInteger num2, string op)
         {
+            BigInteger num3;
+
+            return DoBinaryOperatorMine(num1, num2, op, out num3);
+        }
+
+        public static BigInteger DoBinaryOperatorMine(BigInteger num1, BigInteger num2, string op, out BigInteger num3)
+        {
             List<byte> bytes1 = new List<byte>(num1.ToByteArray());
             List<byte> bytes2 = new List<byte>(num2.ToByteArray());
 
@@ -123,7 +128,7 @@ namespace System.Numerics.Tests
                     BigInteger ret = new BigInteger(Divide(bytes1, bytes2).ToArray());
                     bytes1 = new List<byte>(num1.ToByteArray());
                     bytes2 = new List<byte>(num2.ToByteArray());
-                    outParam = new BigInteger(Remainder(bytes1, bytes2).ToArray());
+                    num3 = new BigInteger(Remainder(bytes1, bytes2).ToArray());
                     return ret;
                 case "bRemainder":
                 case "b%":

--- a/src/System.Runtime.Numerics/tests/BigInteger/stackcalculator.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/stackcalculator.cs
@@ -65,11 +65,11 @@ namespace System.Numerics.Tests
 
                 snnum1 = snCalc.Pop();
                 snnum2 = snCalc.Pop();
-                snCalc.Push(DoBinaryOperatorSN(snnum1, snnum2, op));
+                snCalc.Push(DoBinaryOperatorSN(snnum1, snnum2, op, out _snOut));
 
                 mynum1 = myCalc.Pop();
                 mynum2 = myCalc.Pop();
-                myCalc.Push(MyBigIntImp.DoBinaryOperatorMine(mynum1, mynum2, op));
+                myCalc.Push(MyBigIntImp.DoBinaryOperatorMine(mynum1, mynum2, op, out _myOut));
 
                 ret = true;
             }
@@ -176,6 +176,13 @@ namespace System.Numerics.Tests
 
         private BigInteger DoBinaryOperatorSN(BigInteger num1, BigInteger num2, string op)
         {
+            BigInteger num3;
+
+            return DoBinaryOperatorSN(num1, num2, op, out num3);
+        }
+
+        private BigInteger DoBinaryOperatorSN(BigInteger num1, BigInteger num2, string op, out BigInteger num3)
+        {
             switch (op)
             {
                 case "bMin":
@@ -210,10 +217,7 @@ namespace System.Numerics.Tests
                     int arg2 = (int)num2;
                     return BigInteger.Pow(num1, arg2);
                 case "bDivRem":
-                    BigInteger num3;
-                    BigInteger ret = BigInteger.DivRem(num1, num2, out num3);
-                    SetSNOutCheck(num3);
-                    return ret;
+                    return BigInteger.DivRem(num1, num2, out num3);
                 case "bRemainder":
                     return BigInteger.Remainder(num1, num2);
                 case "bDivide":
@@ -239,18 +243,13 @@ namespace System.Numerics.Tests
                     throw new ArgumentException(String.Format("Invalid operation found: {0}", op));
             }
         }
-        
-        private void SetSNOutCheck(BigInteger value)
-        {
-            _snOut = value;
-        }
 
         public void VerifyOutParameter()
         {
-            Assert.Equal(_snOut, MyBigIntImp.outParam);
+            Assert.Equal(_snOut, _myOut);
 
             _snOut = 0;
-            MyBigIntImp.outParam = 0;
+            _myOut = 0;
         }
 
         private static String Print(byte[] bytes)

--- a/src/System.Runtime.Numerics/tests/System.Runtime.Numerics.Tests.csproj
+++ b/src/System.Runtime.Numerics/tests/System.Runtime.Numerics.Tests.csproj
@@ -56,7 +56,6 @@
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
       <Link>Common\System\PlatformDetection.cs</Link>
     </Compile>
-    <Compile Include="XunitAssemblyTestCollection.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime.Numerics/tests/XunitAssemblyTestCollection.cs
+++ b/src/System.Runtime.Numerics/tests/XunitAssemblyTestCollection.cs
@@ -1,6 +1,0 @@
-﻿using Xunit;
-
-// The MyBigIntImp class contains public static shared state. This means it is not safe to run tests
-// which modify that state in parallel. In order to run these tests in parallel, we need to fix that.
-// See issue: https://github.com/dotnet/corefx/issues/17499
-[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]


### PR DESCRIPTION
Having shared state is no good idea for running unit tests in parallel. Because of sporadic issues parallelization has been disabled. Without that state, we're able to run these tests in parallel again.

Fixes #17499