### PR TITLE
Remove some unreachable branches from S.L.Expressions

### DIFF
--- a/src/System.Linq.Expressions/src/Resources/Strings.resx
+++ b/src/System.Linq.Expressions/src/Resources/Strings.resx
@@ -355,9 +355,6 @@
   <data name="TypeNotIEnumerable" xml:space="preserve">
     <value>Type '{0}' is not IEnumerable</value>
   </data>
-  <data name="UnexpectedCoalesceOperator" xml:space="preserve">
-    <value>Unexpected coalesce operator.</value>
-  </data>
   <data name="InvalidCast" xml:space="preserve">
     <value>Cannot cast from type '{0}' to type '{1}</value>
   </data>

--- a/src/System.Linq.Expressions/src/Resources/Strings.resx
+++ b/src/System.Linq.Expressions/src/Resources/Strings.resx
@@ -367,9 +367,6 @@
   <data name="UnhandledBindingType" xml:space="preserve">
     <value>Unhandled Binding Type: {0}</value>
   </data>
-  <data name="UnhandledConvert" xml:space="preserve">
-    <value>Unhandled convert: {0}</value>
-  </data>
   <data name="UnhandledUnary" xml:space="preserve">
     <value>Unhandled unary: {0}</value>
   </data>

--- a/src/System.Linq.Expressions/src/Resources/Strings.resx
+++ b/src/System.Linq.Expressions/src/Resources/Strings.resx
@@ -526,9 +526,6 @@
   <data name="IncorrectNumberOfConstructorArguments" xml:space="preserve">
     <value>Incorrect number of arguments for constructor</value>
   </data>
-  <data name="OperatorNotImplementedForType" xml:space="preserve">
-    <value>The operator '{0}' is not implemented for type '{1}'</value>
-  </data>
   <data name="NonStaticConstructorRequired" xml:space="preserve">
     <value>The constructor should not be static</value>
   </data>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -754,7 +754,7 @@ namespace System.Linq.Expressions.Compiler
                         case TypeCode.UInt64: method = Decimal_op_Implicit_UInt64; break;
                         case TypeCode.Char:   method = Decimal_op_Implicit_Char;   break;
                         default:
-                            throw Error.UnhandledConvert(typeTo);
+                            throw ContractUtils.Unreachable;
                     }
 
                     il.Emit(OpCodes.Call, method);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -636,10 +636,7 @@ namespace System.Linq.Expressions.Compiler
                 return;
             }
 
-            if (typeFrom == typeof(void) || typeTo == typeof(void))
-            {
-                throw ContractUtils.Unreachable;
-            }
+            Debug.Assert(typeFrom != typeof(void) && typeTo != typeof(void));
 
             bool isTypeFromNullable = typeFrom.IsNullableType();
             bool isTypeToNullable = typeTo.IsNullableType();

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
@@ -165,10 +165,8 @@ namespace System.Linq.Expressions.Compiler
                 EmitUnliftedEquality(op, leftType);
                 return;
             }
-            if (!leftType.IsPrimitive)
-            {
-                throw Error.OperatorNotImplementedForType(op, leftType);
-            }
+
+            Debug.Assert(leftType.IsPrimitive);
 
             switch (op)
             {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
@@ -276,7 +276,7 @@ namespace System.Linq.Expressions.Compiler
                     // Guaranteed to fit within result type: no conversion
                     return;
                 default:
-                    throw Error.UnhandledBinary(op, nameof(op));
+                    throw ContractUtils.Unreachable;
             }
 
             EmitConvertArithmeticResult(op, leftType);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
@@ -137,9 +137,10 @@ namespace System.Linq.Expressions.Compiler
 
         private void EmitBinaryOperator(ExpressionType op, Type leftType, Type rightType, Type resultType, bool liftedToNull)
         {
+            Debug.Assert(op != ExpressionType.Coalesce);
+
             bool leftIsNullable = leftType.IsNullableType();
             bool rightIsNullable = rightType.IsNullableType();
-
             switch (op)
             {
                 case ExpressionType.ArrayIndex:
@@ -149,8 +150,6 @@ namespace System.Linq.Expressions.Compiler
                     }
                     EmitGetArrayElement(leftType);
                     return;
-                case ExpressionType.Coalesce:
-                    throw Error.UnexpectedCoalesceOperator();
             }
 
             if (leftIsNullable || rightIsNullable)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
@@ -328,10 +328,7 @@ namespace System.Linq.Expressions.Compiler
         private void EmitUnliftedEquality(ExpressionType op, Type type)
         {
             Debug.Assert(op == ExpressionType.Equal || op == ExpressionType.NotEqual);
-            if (!type.IsPrimitive && type.IsValueType && !type.IsEnum)
-            {
-                throw Error.OperatorNotImplementedForType(op, type);
-            }
+            Debug.Assert(type.IsPrimitive || !type.IsValueType || type.IsEnum);
             _ilg.Emit(OpCodes.Ceq);
             if (op == ExpressionType.NotEqual)
             {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
@@ -138,21 +138,12 @@ namespace System.Linq.Expressions.Compiler
         private void EmitBinaryOperator(ExpressionType op, Type leftType, Type rightType, Type resultType, bool liftedToNull)
         {
             Debug.Assert(op != ExpressionType.Coalesce);
-
-            bool leftIsNullable = leftType.IsNullableType();
-            bool rightIsNullable = rightType.IsNullableType();
-            switch (op)
+            if (op == ExpressionType.ArrayIndex)
             {
-                case ExpressionType.ArrayIndex:
-                    if (rightType != typeof(int))
-                    {
-                        throw ContractUtils.Unreachable;
-                    }
-                    EmitGetArrayElement(leftType);
-                    return;
+                Debug.Assert(rightType == typeof(int));
+                EmitGetArrayElement(leftType);
             }
-
-            if (leftIsNullable || rightIsNullable)
+            else if (leftType.IsNullableType() || rightType.IsNullableType())
             {
                 EmitLiftedBinaryOp(op, leftType, rightType, resultType, liftedToNull);
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
@@ -265,18 +265,12 @@ namespace System.Linq.Expressions.Compiler
                     // Not an arithmetic operation: no conversion
                     return;
                 case ExpressionType.LeftShift:
-                    if (rightType != typeof(int))
-                    {
-                        throw ContractUtils.Unreachable;
-                    }
+                    Debug.Assert(rightType == typeof(int));
                     EmitShiftMask(leftType);
                     _ilg.Emit(OpCodes.Shl);
                     break;
                 case ExpressionType.RightShift:
-                    if (rightType != typeof(int))
-                    {
-                        throw ContractUtils.Unreachable;
-                    }
+                    Debug.Assert(rightType == typeof(int));
                     EmitShiftMask(leftType);
                     _ilg.Emit(leftType.IsUnsigned() ? OpCodes.Shr_Un : OpCodes.Shr);
                     // Guaranteed to fit within result type: no conversion

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
@@ -751,7 +751,7 @@ namespace System.Linq.Expressions.Compiler
                     EmitVariableAssignment(node, emitAs);
                     return;
                 default:
-                    throw Error.InvalidLvalue(node.Left.NodeType);
+                    throw ContractUtils.Unreachable;
             }
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
@@ -965,22 +965,14 @@ namespace System.Linq.Expressions.Compiler
         private void EmitMemberAssignment(MemberAssignment binding, Type objectType)
         {
             EmitExpression(binding.Expression);
-            FieldInfo fi = binding.Member as FieldInfo;
-            if (fi != null)
+            if (binding.Member is FieldInfo fi)
             {
                 _ilg.Emit(OpCodes.Stfld, fi);
             }
             else
             {
-                PropertyInfo pi = binding.Member as PropertyInfo;
-                if (pi != null)
-                {
-                    EmitCall(objectType, pi.GetSetMethod(nonPublic: true));
-                }
-                else
-                {
-                    throw Error.UnhandledBinding();
-                }
+                Debug.Assert(binding.Member is PropertyInfo);
+                EmitCall(objectType, (binding.Member as PropertyInfo).GetSetMethod(nonPublic: true));
             }
         }
 
@@ -1117,11 +1109,8 @@ namespace System.Linq.Expressions.Compiler
 
         private static Type GetMemberType(MemberInfo member)
         {
-            FieldInfo fi = member as FieldInfo;
-            if (fi != null) return fi.FieldType;
-            PropertyInfo pi = member as PropertyInfo;
-            if (pi != null) return pi.PropertyType;
-            throw Error.MemberNotFieldOrProperty(member, nameof(member));
+            Debug.Assert(member is FieldInfo || member is PropertyInfo);
+            return member is FieldInfo fi ? fi.FieldType : (member as PropertyInfo).PropertyType;
         }
 
         #endregion

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Logical.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Logical.cs
@@ -94,17 +94,17 @@ namespace System.Linq.Expressions.Compiler
             {
                 EmitNullableCoalesce(b);
             }
-            else if (b.Left.Type.IsValueType)
-            {
-                throw Error.CoalesceUsedOnNonNullType();
-            }
-            else if (b.Conversion != null)
-            {
-                EmitLambdaReferenceCoalesce(b);
-            }
             else
             {
-                EmitReferenceCoalesceWithoutConversion(b);
+                Debug.Assert(!b.Left.Type.IsValueType);
+                if (b.Conversion != null)
+                {
+                    EmitLambdaReferenceCoalesce(b);
+                }
+                else
+                {
+                    EmitReferenceCoalesceWithoutConversion(b);
+                }
             }
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
@@ -1270,16 +1270,6 @@ namespace System.Linq.Expressions
             return new NotSupportedException();
         }
 
-#if FEATURE_COMPILE
-        /// <summary>
-        /// NotImplementedException with message like "The operator '{0}' is not implemented for type '{1}'"
-        /// </summary>
-        internal static Exception OperatorNotImplementedForType(object p0, object p1)
-        {
-            return NotImplemented.ByDesignWithMessage(Strings.OperatorNotImplementedForType(p0, p1));
-        }
-#endif
-
         /// <summary>
         /// ArgumentException with message like "The constructor should not be static"
         /// </summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
@@ -930,13 +930,7 @@ namespace System.Linq.Expressions
         {
             return new ArgumentException(Strings.TypeNotIEnumerable(p0), paramName);
         }
-        /// <summary>
-        /// InvalidOperationException with message like "Unexpected coalesce operator."
-        /// </summary>
-        internal static Exception UnexpectedCoalesceOperator()
-        {
-            return new InvalidOperationException(Strings.UnexpectedCoalesceOperator);
-        }
+
         /// <summary>
         /// InvalidOperationException with message like "Cannot cast from type '{0}' to type '{1}"
         /// </summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
@@ -959,13 +959,7 @@ namespace System.Linq.Expressions
         {
             return new ArgumentException(Strings.UnhandledBindingType(p0));
         }
-        /// <summary>
-        /// ArgumentException with message like "Unhandled convert: {0}"
-        /// </summary>
-        internal static Exception UnhandledConvert(object p0)
-        {
-            return new ArgumentException(Strings.UnhandledConvert(p0));
-        }
+
         /// <summary>
         /// ArgumentException with message like "Unhandled unary: {0}"
         /// </summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
@@ -803,13 +803,6 @@ namespace System.Linq.Expressions
         internal static string PdbGeneratorNeedsExpressionCompiler => SR.PdbGeneratorNeedsExpressionCompiler;
 #endif
 
-#if FEATURE_COMPILE
-        /// <summary>
-        /// A string like "The operator '{0}' is not implemented for type '{1}'"
-        /// </summary>
-        internal static string OperatorNotImplementedForType(object p0, object p1) => SR.Format(SR.OperatorNotImplementedForType, p0, p1);
-#endif
-
         /// <summary>
         /// A string like "The constructor should not be static"
         /// </summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
@@ -595,11 +595,6 @@ namespace System.Linq.Expressions
         internal static string UnhandledBindingType(object p0) => SR.Format(SR.UnhandledBindingType, p0);
 
         /// <summary>
-        /// A string like "Unhandled convert: {0}"
-        /// </summary>
-        internal static string UnhandledConvert(object p0) => SR.Format(SR.UnhandledConvert, p0);
-
-        /// <summary>
         /// A string like "Unhandled unary: {0}"
         /// </summary>
         internal static string UnhandledUnary(object p0) => SR.Format(SR.UnhandledUnary, p0);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
@@ -575,11 +575,6 @@ namespace System.Linq.Expressions
         internal static string TypeNotIEnumerable(object p0) => SR.Format(SR.TypeNotIEnumerable, p0);
 
         /// <summary>
-        /// A string like "Unexpected coalesce operator."
-        /// </summary>
-        internal static string UnexpectedCoalesceOperator => SR.UnexpectedCoalesceOperator;
-
-        /// <summary>
         /// A string like "Cannot cast from type '{0}' to type '{1}"
         /// </summary>
         internal static string InvalidCast(object p0, object p1) => SR.Format(SR.InvalidCast, p0, p1);


### PR DESCRIPTION
Or if the branch is an unreachable default case, throw `Unreachable` rather than any other exception.

All cases where rules in the expression factories make paths in the compiler impossible.