### PR TITLE
Add test for HttpClient handling of trailer headers

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
@@ -921,6 +921,17 @@ namespace System.Net.Http
                             return 0;
                         }
 
+                        // Make sure we've not yet published the response. This could happen with trailer headers,
+                        // in which case we just ignore them (we don't want to add them to the response headers at
+                        // this point, as it'd contribute to a race condition, both in terms of headers appearing
+                        // "randomly" and in terms of accessing a non-thread-safe data structure from this thread
+                        // while the consumer might be accessing / mutating it elsewhere.)
+                        if (easy.Task.IsCompleted)
+                        {
+                            CurlHandler.EventSourceTrace("Response already published. Ignoring headers.", easy: easy);
+                            return size;
+                        }
+
                         CurlResponseMessage response = easy._responseMessage;
                         CurlResponseHeaderReader reader = new CurlResponseHeaderReader(buffer, size);
 


### PR DESCRIPTION
Contributes to https://github.com/dotnet/corefx/issues/17174

Adding a test for trailers.  This fails right now on unix due to a libcurl bug: https://github.com/curl/curl/issues/1354.  A fix is in the works for that, and I confirmed that building a libcurl with that fix and using it allows these tests of HttpClient to pass.

cc: @Priya91, @Drawaes