### PR TITLE
Remove ExpressionNotSupportedForType error from S.L.Expressions

### DIFF
--- a/src/System.Linq.Expressions/src/Resources/Strings.resx
+++ b/src/System.Linq.Expressions/src/Resources/Strings.resx
@@ -307,9 +307,6 @@
   <data name="NotAMemberOfAnyType" xml:space="preserve">
     <value>'{0}' is not a member of any type</value>
   </data>
-  <data name="ExpressionNotSupportedForType" xml:space="preserve">
-    <value>The expression '{0}' is not supported for type '{1}'</value>
-  </data>
   <data name="UnsupportedExpressionType" xml:space="preserve">
     <value>The expression type '{0}' is not supported</value>
   </data>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
@@ -837,14 +837,6 @@ namespace System.Linq.Expressions
         }
 
         /// <summary>
-        /// PlatformNotSupportedException with message like "The instruction '{0}' is not supported for type '{1}'"
-        /// </summary>
-        internal static Exception ExpressionNotSupportedForType(object p0, object p1)
-        {
-            return new PlatformNotSupportedException(Strings.ExpressionNotSupportedForType(p0, p1));
-        }
-
-        /// <summary>
         /// ArgumentException with message like "ParameterExpression of type '{0}' cannot be used for delegate parameter of type '{1}'"
         /// </summary>
         internal static Exception ParameterExpressionNotValidAsDelegate(object p0, object p1)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/AndInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/AndInstruction.cs
@@ -188,7 +188,7 @@ namespace System.Linq.Expressions.Interpreter
                 case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new AndUInt64());
                 case TypeCode.Boolean: return s_Boolean ?? (s_Boolean = new AndBoolean());
                 default:
-                    throw Error.ExpressionNotSupportedForType("And", type);
+                    throw ContractUtils.Unreachable;
             }
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DecrementInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DecrementInstruction.cs
@@ -168,7 +168,7 @@ namespace System.Linq.Expressions.Interpreter
                 case TypeCode.Single: return s_Single ?? (s_Single = new DecrementSingle());
                 case TypeCode.Double: return s_Double ?? (s_Double = new DecrementDouble());
                 default:
-                    throw Error.ExpressionNotSupportedForType("Decrement", type);
+                    throw ContractUtils.Unreachable;
             }
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DivInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DivInstruction.cs
@@ -184,7 +184,7 @@ namespace System.Linq.Expressions.Interpreter
                 case TypeCode.Single: return s_Single ?? (s_Single = new DivSingle());
                 case TypeCode.Double: return s_Double ?? (s_Double = new DivDouble());
                 default:
-                    throw Error.ExpressionNotSupportedForType("Div", type);
+                    throw ContractUtils.Unreachable;
             }
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ExclusiveOrInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ExclusiveOrInstruction.cs
@@ -176,7 +176,7 @@ namespace System.Linq.Expressions.Interpreter
                 case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new ExclusiveOrUInt64());
                 case TypeCode.Boolean: return s_Boolean ?? (s_Boolean = new ExclusiveOrBoolean());
                 default:
-                    throw Error.ExpressionNotSupportedForType("ExclusiveOr", type);
+                    throw ContractUtils.Unreachable;
             }
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/GreaterThanInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/GreaterThanInstruction.cs
@@ -295,7 +295,7 @@ namespace System.Linq.Expressions.Interpreter
                     case TypeCode.Single: return s_liftedToNullSingle ?? (s_liftedToNullSingle = new GreaterThanSingle(null));
                     case TypeCode.Double: return s_liftedToNullDouble ?? (s_liftedToNullDouble = new GreaterThanDouble(null));
                     default:
-                        throw Error.ExpressionNotSupportedForType("GreaterThan", type);
+                        throw ContractUtils.Unreachable;
                 }
             }
             else
@@ -314,7 +314,7 @@ namespace System.Linq.Expressions.Interpreter
                     case TypeCode.Single: return s_Single ?? (s_Single = new GreaterThanSingle(Utils.BoxedFalse));
                     case TypeCode.Double: return s_Double ?? (s_Double = new GreaterThanDouble(Utils.BoxedFalse));
                     default:
-                        throw Error.ExpressionNotSupportedForType("GreaterThan", type);
+                        throw ContractUtils.Unreachable;
                 }
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/GreaterThanOrEqualInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/GreaterThanOrEqualInstruction.cs
@@ -295,7 +295,7 @@ namespace System.Linq.Expressions.Interpreter
                     case TypeCode.Single: return s_liftedToNullSingle ?? (s_liftedToNullSingle = new GreaterThanOrEqualSingle(null));
                     case TypeCode.Double: return s_liftedToNullDouble ?? (s_liftedToNullDouble = new GreaterThanOrEqualDouble(null));
                     default:
-                        throw Error.ExpressionNotSupportedForType("GreaterThanOrEqual", type);
+                        throw ContractUtils.Unreachable;
                 }
             }
             else
@@ -314,7 +314,7 @@ namespace System.Linq.Expressions.Interpreter
                     case TypeCode.Single: return s_Single ?? (s_Single = new GreaterThanOrEqualSingle(Utils.BoxedFalse));
                     case TypeCode.Double: return s_Double ?? (s_Double = new GreaterThanOrEqualDouble(Utils.BoxedFalse));
                     default:
-                        throw Error.ExpressionNotSupportedForType("GreaterThanOrEqual", type);
+                        throw ContractUtils.Unreachable;
                 }
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/IncrementInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/IncrementInstruction.cs
@@ -168,7 +168,7 @@ namespace System.Linq.Expressions.Interpreter
                 case TypeCode.Single: return s_Single ?? (s_Single = new IncrementSingle());
                 case TypeCode.Double: return s_Double ?? (s_Double = new IncrementDouble());
                 default:
-                    throw Error.ExpressionNotSupportedForType("Increment", type);
+                    throw ContractUtils.Unreachable;
             }
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LeftShiftInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LeftShiftInstruction.cs
@@ -175,7 +175,7 @@ namespace System.Linq.Expressions.Interpreter
                 case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new LeftShiftUInt32());
                 case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new LeftShiftUInt64());
                 default:
-                    throw Error.ExpressionNotSupportedForType("LeftShift", type);
+                    throw ContractUtils.Unreachable;
             }
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LessThanInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LessThanInstruction.cs
@@ -294,7 +294,7 @@ namespace System.Linq.Expressions.Interpreter
                     case TypeCode.Single: return s_liftedToNullSingle ?? (s_liftedToNullSingle = new LessThanSingle(null));
                     case TypeCode.Double: return s_liftedToNullDouble ?? (s_liftedToNullDouble = new LessThanDouble(null));
                     default:
-                        throw Error.ExpressionNotSupportedForType("LessThan", type);
+                        throw ContractUtils.Unreachable;
                 }
             }
             else
@@ -313,7 +313,7 @@ namespace System.Linq.Expressions.Interpreter
                     case TypeCode.Single: return s_Single ?? (s_Single = new LessThanSingle(Utils.BoxedFalse));
                     case TypeCode.Double: return s_Double ?? (s_Double = new LessThanDouble(Utils.BoxedFalse));
                     default:
-                        throw Error.ExpressionNotSupportedForType("LessThan", type);
+                        throw ContractUtils.Unreachable;
                 }
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LessThanOrEqualInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LessThanOrEqualInstruction.cs
@@ -295,7 +295,7 @@ namespace System.Linq.Expressions.Interpreter
                     case TypeCode.Single: return s_liftedToNullSingle ?? (s_liftedToNullSingle = new LessThanOrEqualSingle(null));
                     case TypeCode.Double: return s_liftedToNullDouble ?? (s_liftedToNullDouble = new LessThanOrEqualDouble(null));
                     default:
-                        throw Error.ExpressionNotSupportedForType("LessThanOrEqual", type);
+                        throw ContractUtils.Unreachable;
                 }
             }
             else
@@ -314,7 +314,7 @@ namespace System.Linq.Expressions.Interpreter
                     case TypeCode.Single: return s_Single ?? (s_Single = new LessThanOrEqualSingle(Utils.BoxedFalse));
                     case TypeCode.Double: return s_Double ?? (s_Double = new LessThanOrEqualDouble(Utils.BoxedFalse));
                     default:
-                        throw Error.ExpressionNotSupportedForType("LessThanOrEqual", type);
+                        throw ContractUtils.Unreachable;
                 }
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ModuloInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ModuloInstruction.cs
@@ -184,7 +184,7 @@ namespace System.Linq.Expressions.Interpreter
                 case TypeCode.Single: return s_Single ?? (s_Single = new ModuloSingle());
                 case TypeCode.Double: return s_Double ?? (s_Double = new ModuloDouble());
                 default:
-                    throw Error.ExpressionNotSupportedForType("Modulo", type);
+                    throw ContractUtils.Unreachable;
             }
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NegateInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NegateInstruction.cs
@@ -114,7 +114,7 @@ namespace System.Linq.Expressions.Interpreter
                 case TypeCode.Single: return s_Single ?? (s_Single = new NegateSingle());
                 case TypeCode.Double: return s_Double ?? (s_Double = new NegateDouble());
                 default:
-                    throw Error.ExpressionNotSupportedForType("Negate", type);
+                    throw ContractUtils.Unreachable;
             }
         }
     }
@@ -225,7 +225,7 @@ namespace System.Linq.Expressions.Interpreter
                 case TypeCode.Single: return s_Single ?? (s_Single = new NegateCheckedSingle());
                 case TypeCode.Double: return s_Double ?? (s_Double = new NegateCheckedDouble());
                 default:
-                    throw Error.ExpressionNotSupportedForType("NegateChecked", type);
+                    throw ContractUtils.Unreachable;
             }
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotInstruction.cs
@@ -183,7 +183,7 @@ namespace System.Linq.Expressions.Interpreter
                 case TypeCode.Byte: return s_Byte ?? (s_Byte = new NotByte());
                 case TypeCode.SByte: return s_SByte ?? (s_SByte = new NotSByte());
                 default:
-                    throw Error.ExpressionNotSupportedForType("Not", type);
+                    throw ContractUtils.Unreachable;
             }
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/OrInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/OrInstruction.cs
@@ -190,7 +190,7 @@ namespace System.Linq.Expressions.Interpreter
                 case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new OrUInt64());
                 case TypeCode.Boolean: return s_Boolean ?? (s_Boolean = new OrBoolean());
                 default:
-                    throw Error.ExpressionNotSupportedForType("Or", type);
+                    throw ContractUtils.Unreachable;
             }
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/RightShiftInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/RightShiftInstruction.cs
@@ -175,7 +175,7 @@ namespace System.Linq.Expressions.Interpreter
                 case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new RightShiftUInt32());
                 case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new RightShiftUInt64());
                 default:
-                    throw Error.ExpressionNotSupportedForType("RightShift", type);
+                    throw ContractUtils.Unreachable;
             }
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
@@ -510,11 +510,6 @@ namespace System.Linq.Expressions
         internal static string NotAMemberOfAnyType(object p0) => SR.Format(SR.NotAMemberOfAnyType, p0);
 
         /// <summary>
-        /// A string like "The expression '{0}' is not supported for type '{1}'"
-        /// </summary>
-        internal static string ExpressionNotSupportedForType(object p0, object p1) => SR.Format(SR.ExpressionNotSupportedForType, p0, p1);
-
-        /// <summary>
         /// A string like "ParameterExpression of type '{0}' cannot be used for delegate parameter of type '{1}'"
         /// </summary>
         internal static string ParameterExpressionNotValidAsDelegate(object p0, object p1) => SR.Format(SR.ParameterExpressionNotValidAsDelegate, p0, p1);


### PR DESCRIPTION
Every callsite is demonstrably unreachable. Use `ContractUtils.Unreachable` instead.