### PR TITLE
Remove redundant overrides in S.L.Expression instructions.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ArrayOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ArrayOperations.cs
@@ -119,7 +119,6 @@ namespace System.Linq.Expressions.Interpreter
         private SetArrayItemInstruction() { }
 
         public override int ConsumedStack => 3;
-        public override int ProducedStack => 0;
         public override string InstructionName => "SetArrayItem";
 
         public override int Run(InterpretedFrame frame)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
@@ -259,8 +259,6 @@ namespace System.Linq.Expressions.Interpreter
 
         public override int ConsumedStack => ArgumentCount;
 
-        public override string ToString() => "Call()";
-
         #endregion
 
         /// <summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
@@ -257,13 +257,11 @@ namespace System.Linq.Expressions.Interpreter
         private readonly bool _hasValue;
         private readonly bool _labelTargetGetsValue;
 
-        // The values should technically be Consumed = 1, Produced = 1 for gotos that target a label whose continuation depth
+        // Should technically return 1 for ConsumedContinuations and ProducedContinuations for gotos that target a label whose continuation depth
         // is different from the current continuation depth. This is because we will consume one continuation from the _continuations
         // and at meantime produce a new _pendingContinuation. However, in case of forward gotos, we don't not know that is the
         // case until the label is emitted. By then the consumed and produced stack information is useless.
         // The important thing here is that the stack balance is 0.
-        public override int ConsumedContinuations => 0;
-        public override int ProducedContinuations => 0;
 
         public override int ConsumedStack => _hasValue ? 1 : 0;
         public override int ProducedStack => _hasResult ? 1 : 0;
@@ -646,7 +644,6 @@ namespace System.Linq.Expressions.Interpreter
 
         public override string InstructionName => "EnterExceptionFilter";
 
-        public override int ConsumedStack => 0;
 
         // The exception is pushed onto the stack in the filter runner.
         public override int ProducedStack => 1;
@@ -666,8 +663,6 @@ namespace System.Linq.Expressions.Interpreter
 
         // The exception and the boolean result are popped from the stack in the filter runner.
         public override int ConsumedStack => 2;
-
-        public override int ProducedStack => 0;
 
         [ExcludeFromCodeCoverage] // Known to be a no-op, this instruction is skipped on execution.
         public override int Run(InterpretedFrame frame) => 1;
@@ -805,7 +800,6 @@ namespace System.Linq.Expressions.Interpreter
 
         public override string InstructionName => "IntSwitch";
         public override int ConsumedStack => 1;
-        public override int ProducedStack => 0;
 
         public override int Run(InterpretedFrame frame)
         {
@@ -829,7 +823,6 @@ namespace System.Linq.Expressions.Interpreter
 
         public override string InstructionName => "StringSwitch";
         public override int ConsumedStack => 1;
-        public override int ProducedStack => 0;
 
         public override int Run(InterpretedFrame frame)
         {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/EqualInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/EqualInstruction.cs
@@ -555,7 +555,5 @@ namespace System.Linq.Expressions.Interpreter
                 }
             }
         }
-
-        public override string ToString() => "Equal()";
     }
 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/FieldOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/FieldOperations.cs
@@ -69,7 +69,6 @@ namespace System.Linq.Expressions.Interpreter
 
         public override string InstructionName => "StoreField";
         public override int ConsumedStack => 2;
-        public override int ProducedStack => 0;
 
         public override int Run(InterpretedFrame frame)
         {
@@ -91,8 +90,8 @@ namespace System.Linq.Expressions.Interpreter
         }
 
         public override string InstructionName => "StoreStaticField";
+
         public override int ConsumedStack => 1;
-        public override int ProducedStack => 0;
 
         public override int Run(InterpretedFrame frame)
         {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/GreaterThanInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/GreaterThanInstruction.cs
@@ -318,7 +318,5 @@ namespace System.Linq.Expressions.Interpreter
                 }
             }
         }
-
-        public override string ToString() => "GreaterThan()";
     }
 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/GreaterThanOrEqualInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/GreaterThanOrEqualInstruction.cs
@@ -318,7 +318,5 @@ namespace System.Linq.Expressions.Interpreter
                 }
             }
         }
-
-        public override string ToString() => "GreaterThanOrEqual()";
     }
 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalAccess.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalAccess.cs
@@ -186,7 +186,6 @@ namespace System.Linq.Expressions.Interpreter
         }
 
         public override int ConsumedStack => 1;
-        public override int ProducedStack => 0;
         public override string InstructionName => "StoreLocalBox";
 
         public override int Run(InterpretedFrame frame)
@@ -464,8 +463,6 @@ namespace System.Linq.Expressions.Interpreter
             frame.Push(RuntimeVariables.Create(ret));
             return 1;
         }
-
-        public override string ToString() => "GetRuntimeVariables()";
     }
 
     #endregion

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/StackOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/StackOperations.cs
@@ -68,8 +68,6 @@ namespace System.Linq.Expressions.Interpreter
             frame.Pop();
             return 1;
         }
-
-        public override string ToString() => "Pop()";
     }
 
     internal sealed class DupInstruction : Instruction
@@ -78,8 +76,8 @@ namespace System.Linq.Expressions.Interpreter
 
         private DupInstruction() { }
 
-        public override int ConsumedStack => 0;
         public override int ProducedStack => 1;
+
         public override string InstructionName => "Dup";
 
         public override int Run(InterpretedFrame frame)
@@ -87,7 +85,5 @@ namespace System.Linq.Expressions.Interpreter
             frame.Dup();
             return 1;
         }
-
-        public override string ToString() => "Dup()";
     }
 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
@@ -468,8 +468,8 @@ namespace System.Linq.Expressions.Interpreter
             _hoistedVariables = hoistedVariables;
         }
 
-        public override int ConsumedStack => 0;
         public override int ProducedStack => 1;
+
         public override string InstructionName => "Quote";
 
         public override int Run(InterpretedFrame frame)


### PR DESCRIPTION
Either completely duplicates what the base class does or add a tiny micro-opt **and** are only used in debug situations and hence that micro-opt is particularly hard to justify