### PR TITLE
Fix Http Unit tests for NETFX build

### DIFF
--- a/src/System.Net.Http/tests/UnitTests/Configurations.props
+++ b/src/System.Net.Http/tests/UnitTests/Configurations.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       netcoreapp;
+      netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -5,6 +5,8 @@
     <ProjectGuid>{5F9C3C9F-652E-461E-B2D6-85D264F5A733}</ProjectGuid>
     <StringResourcesPath>../../src/Resources/Strings.resx</StringResourcesPath>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn Condition="'$(TargetGroup)' == 'netfx'">$(NoWarn);0436</NoWarn>
+    <DefineConstants Condition="'$(TargetGroup)' == 'netfx'">$(DefineConstants);NET46</DefineConstants>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <!-- Do not reference these assemblies from the TargetingPack since we are building part of the source code for tests. -->


### PR DESCRIPTION
Change the CSPROJ so that Http Unit tests now build and run successfully.

i.e.:

>Msbuild /t:rebuildandtest /p:TargetGroup=netfx

now works in the src/System.Net.Http/tests/UnitTests folder