### PR TITLE
Further reduce peak memory usage in the System.Runtime.Numerics tests

### DIFF
--- a/src/System.Runtime.Numerics/tests/BigInteger/cast_from.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/cast_from.cs
@@ -724,7 +724,7 @@ namespace System.Numerics.Tests
 
                 for (int j = 0; j < bigShiftLoopLimit; j++)
                 {
-                    temp = temp << (int.MaxValue / 2);
+                    temp = temp << (int.MaxValue / 10);
                     VerifyDoubleExplicitCastFromBigInteger(Double.PositiveInfinity, temp);
                     VerifyDoubleExplicitCastFromBigInteger(Double.NegativeInfinity, -temp);
                 }


### PR DESCRIPTION
This lowers the memory usage of the test case even further, down to about 900 MB on my machine (down from ~3.5GB). Note that this is still producing extremely large numbers; we left-shift an integer about 200,000,000 times.