### PR TITLE
Adding ObsoleteAttribute to SSL for ServicePointManager

### DIFF
--- a/src/System.Net.ServicePoint/ref/System.Net.ServicePoint.cs
+++ b/src/System.Net.ServicePoint/ref/System.Net.ServicePoint.cs
@@ -56,6 +56,7 @@ namespace System.Net
     {
         SystemDefault = 0,
 #pragma warning disable CS0618
+        [Obsolete("This value has been deprecated.  It is no longer supported. http://go.microsoft.com/fwlink/?linkid=14202")]
         Ssl3 = System.Security.Authentication.SslProtocols.Ssl3,
 #pragma warning restore CS0618
         Tls = System.Security.Authentication.SslProtocols.Tls,

--- a/src/System.Net.ServicePoint/tests/ServicePointManagerTest.cs
+++ b/src/System.Net.ServicePoint/tests/ServicePointManagerTest.cs
@@ -157,8 +157,10 @@ namespace System.Net.Tests
             const int ssl2Server = 0x00000004;
 
             SecurityProtocolType ssl2 = (SecurityProtocolType)(ssl2Client | ssl2Server);
+#pragma warning disable 0618 // Ssl2, Ssl3 are deprecated.
             Assert.Throws<NotSupportedException>(() => ServicePointManager.SecurityProtocol = SecurityProtocolType.Ssl3);
             Assert.Throws<NotSupportedException>(() => ServicePointManager.SecurityProtocol = SecurityProtocolType.Ssl3 | ssl2);
+#pragma warning restore
             Assert.Throws<NotSupportedException>(() => ServicePointManager.SecurityProtocol = ssl2);
             Assert.Throws<ArgumentNullException>("uriString", () => ServicePointManager.FindServicePoint((string)null, null));
             Assert.Throws<ArgumentOutOfRangeException>("value", () => ServicePointManager.MaxServicePoints = -1);


### PR DESCRIPTION
Adding ObsoleteAttribute to SSL for ServicePointManager's SecurityProtocolType.

Fixes #13922