### PR TITLE
Add "mono" configuration

### DIFF
--- a/Tools-Override/ApiCompat.targets
+++ b/Tools-Override/ApiCompat.targets
@@ -3,16 +3,17 @@
   <UsingTask TaskName="LocatePreviousContract" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
 
   <PropertyGroup>
-    <ApiCompatBaseline Condition="!Exists('$(ApiCompatBaseline)')">$(MSBuildProjectDirectory)\ApiCompatBaseline.$(TargetGroup).txt</ApiCompatBaseline>
-    <ApiCompatBaseline Condition="!Exists('$(ApiCompatBaseline)')">$(MSBuildProjectDirectory)\ApiCompatBaseline.txt</ApiCompatBaseline>
+    <RunApiCompat Condition="'$(RunApiCompat)'==''">false</RunApiCompat>
   </PropertyGroup>
 
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(RunApiCompat)' == 'true'">
+    <ApiCompatBaseline Condition="!Exists('$(ApiCompatBaseline)')">$(MSBuildProjectDirectory)\ApiCompatBaseline.$(TargetGroup).txt</ApiCompatBaseline>
+    <ApiCompatBaseline Condition="!Exists('$(ApiCompatBaseline)')">$(MSBuildProjectDirectory)\ApiCompatBaseline.txt</ApiCompatBaseline>
+
     <RunApiCompatForSrc Condition="$(MSBuildProjectDirectory.EndsWith('src'))">true</RunApiCompatForSrc>
     <!-- TODO: Disable the version over version ref compat checks for now because
     we don't have a great way to get the previous version -->
     <RunApiCompatForRef Condition="$(MSBuildProjectDirectory.EndsWith('ref'))">false</RunApiCompatForRef>
-    <RunApiCompat Condition="'$(RunApiCompat)'==''">false</RunApiCompat>
 
     <ResolveMatchingContract Condition="'$(RunApiCompatForSrc)'=='true'">true</ResolveMatchingContract>
     <TargetsTriggeredByCompilation Condition="'$(RunApiCompatForSrc)'=='true'">$(TargetsTriggeredByCompilation);ValidateApiCompatForSrc</TargetsTriggeredByCompilation>

--- a/buildvertical.targets
+++ b/buildvertical.targets
@@ -113,6 +113,7 @@
      <ItemGroup Condition="'$(PackageConfigurations)' == ''">
        <_buildConfigurations Include="$(BuildConfigurations)" />
        <_excludeBuildConfigurations Include="@(_buildConfigurations)" Condition="'$(IsReferenceAssembly)' == 'true' AND ('%(Identity)' == 'netfx' OR $([System.String]::new('%(Identity)').StartsWith('net4'))) AND '$(IncludeDesktopRefInPackage)' != 'true'"/>
+       <_excludeBuildConfigurations Include="mono" />
        <_packageConfigurations Include="@(_buildConfigurations)" Exclude="@(_excludeBuildConfigurations)" />
      </ItemGroup>
 

--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
     "TargetGroup": {
       "description": "Sets the target framework for the BuildConfiguration you want to build.",
       "valueType": "property",
-      "values": ["netcoreapp", "netstandard", "netfx", "uap"],
+      "values": ["netcoreapp", "netstandard", "netfx", "uap", "mono"],
       "defaultValue": "netcoreapp"
     },
     "OSGroup": {

--- a/external/runtime/Configurations.props
+++ b/external/runtime/Configurations.props
@@ -6,6 +6,7 @@
       netcoreapp-Unix;
       uap;
       uapaot;
+      mono;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/Tools/GenerateProps/targetgroups.props
+++ b/src/Tools/GenerateProps/targetgroups.props
@@ -184,5 +184,8 @@
       <!-- this targetgroup is not considered compatible with any other targetgroup so it should only
            build when specified directly or BuildAllConfigurations is set to True.  -->
     </TargetGroups>
+    <TargetGroups Include="mono">
+      <NuGetTargetMoniker>.NETFramework,Version=v4.6.3</NuGetTargetMoniker>
+    </TargetGroups>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This configuration will ease the integration of corefx sources into mono. The plan, discussed with @weshaggard, is to have this configuration where we compile all sources used by https://github.com/mono/mono/ in a "one assembly for all platforms" manner.