### PR TITLE
Fix native error handling on Linux during host name resolution

### DIFF
--- a/src/Native/Unix/System.Native/pal_networking.cpp
+++ b/src/Native/Unix/System.Native/pal_networking.cpp
@@ -570,14 +570,10 @@ static int GetHostByNameHelper(const uint8_t* hostname, hostent** entry)
         hostent* result = reinterpret_cast<hostent*>(buffer);
         char* scratch = reinterpret_cast<char*>(&buffer[sizeof(hostent)]);
 
-        int getHostErrno;
+        int getHostErrno = 0;
         int err = gethostbyname_r(reinterpret_cast<const char*>(hostname), result, scratch, scratchLen, entry, &getHostErrno);
         switch (err)
         {
-            case 0:
-                *entry = result;
-                return 0;
-
             case ERANGE:
                 free(buffer);
                 size_t tmpScratchLen;
@@ -588,6 +584,14 @@ static int GetHostByNameHelper(const uint8_t* hostname, hostent** entry)
                 }
                 scratchLen = tmpScratchLen;
                 break;
+
+            case 0:
+                if (!getHostErrno)
+                {
+                    *entry = result;
+                    return 0;
+                }
+                // Error; fall through
 
             default:
                 free(buffer);
@@ -649,14 +653,10 @@ static int GetHostByAddrHelper(const uint8_t* addr, const socklen_t addrLen, int
         hostent* result = reinterpret_cast<hostent*>(buffer);
         char* scratch = reinterpret_cast<char*>(&buffer[sizeof(hostent)]);
 
-        int getHostErrno;
+        int getHostErrno = 0;
         int err = gethostbyaddr_r(addr, addrLen, type, result, scratch, scratchLen, entry, &getHostErrno);
         switch (err)
         {
-            case 0:
-                *entry = result;
-                return 0;
-
             case ERANGE:
                 free(buffer);
                 size_t tmpScratchLen;
@@ -667,6 +667,14 @@ static int GetHostByAddrHelper(const uint8_t* addr, const socklen_t addrLen, int
                 }
                 scratchLen = tmpScratchLen;
                 break;
+
+            case 0:
+                if (!getHostErrno)
+                {
+                    *entry = result;
+                    return 0;
+                }
+                // Error; fall through
 
             default:
                 free(buffer);

--- a/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
+++ b/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
@@ -33,14 +33,14 @@ namespace System.Net.NameResolution.PalTests
         }
 
         public static object[][] InvalidHostNames = new object[][] {
-            new object[] { "fkdsfsjfsrH:" },
+            new object[] { ":" },
             new object[] { "..." }
         };
 
         [Theory, MemberData(nameof(InvalidHostNames))]
-        public void GetHostByName_Invalid_HostName(string hostName)
+        public void GetHostByName_InvalidHostName_Throws(string hostName)
         {
-            Assert.Throws<SocketException>(() => NameResolutionPal.GetHostByName(hostName));
+            Assert.ThrowsAny<SocketException>(() => NameResolutionPal.GetHostByName(hostName));
         }
 
         [Fact]

--- a/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
+++ b/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
@@ -32,6 +32,17 @@ namespace System.Net.NameResolution.PalTests
             Assert.NotNull(hostEntry.Aliases);
         }
 
+        public static object[][] InvalidHostNames = new object[][] {
+            new object[] { "fkdsfsjfsrH:" },
+            new object[] { "..." }
+        };
+
+        [Theory, MemberData(nameof(InvalidHostNames))]
+        public void GetHostByName_Invalid_HostName(string hostName)
+        {
+            Assert.Throws<SocketException>(() => NameResolutionPal.GetHostByName(hostName));
+        }
+
         [Fact]
         public void GetHostByName_HostName()
         {


### PR DESCRIPTION
This fixes native error handling when calling the POSIX method gethostbyaddr_r, preventing seg faults and other issues. This was found when attempting to debug issue https://github.com/dotnet/corefx/issues/17177.

A POSIX test on Ubuntu shows that gethostbyaddr_r can return 0 (success) even for host names that are not resolved. A similar test was added in this PR that seg faults on Ubuntu (the one with host name of "fkdsfsjfsrH:") before the fix here.

The return value for gethostbyaddr_r appears to be primarily designed for retry logic, not for all errors. Instead the last argument should be checked. The Ubuntu man pages are not complete\correct here.

Also changed gethostbyname_r since it follows the same pattern.

cc @CIPop @davidsh