### PR TITLE
Remove some if !uap's

### DIFF
--- a/src/Common/src/System/Security/Cryptography/ECDsaCng.cs
+++ b/src/Common/src/System/Security/Cryptography/ECDsaCng.cs
@@ -13,7 +13,6 @@ namespace System.Security.Cryptography
 #endif
         public sealed partial class ECDsaCng : ECDsa
         {
-#if !uap
             /// <summary>
             /// Create an ECDsaCng algorithm with a named curve.
             /// </summary>
@@ -29,7 +28,6 @@ namespace System.Security.Cryptography
                 // Named curves generate the key immediately
                 GenerateKey(curve);
             }
-#endif
 
             /// <summary>
             ///     Create an ECDsaCng algorithm with a random 521 bit key pair.

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDsaCng.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDsaCng.cs
@@ -19,7 +19,6 @@ namespace System.Security.Cryptography
             return new ECDsaImplementation.ECDsaCng();
         }
 
-#if !uap
         /// <summary>
         /// Creates an instance of the platform specific implementation of the cref="ECDsa" algorithm.
         /// </summary>
@@ -30,7 +29,6 @@ namespace System.Security.Cryptography
         {
             return new ECDsaImplementation.ECDsaCng(curve);
         }
-#endif // uap
 
         /// <summary>
         /// Creates an instance of the platform specific implementation of the cref="ECDsa" algorithm.

--- a/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/CngAlgorithmCore.cs
+++ b/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/CngAlgorithmCore.cs
@@ -71,7 +71,6 @@ namespace Internal.Cryptography
             return _lazyKey;
         }
 
-#if !uap
         public CngKey GetOrGenerateKey(ECCurve? curve)
         {
             if (_lazyKey != null)
@@ -125,7 +124,6 @@ namespace Internal.Cryptography
 
             return _lazyKey;
         }
-#endif // !uap
 
         public void SetKey(CngKey key)
         {

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.EC.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.EC.cs
@@ -37,12 +37,10 @@ namespace System.Security.Cryptography
 
         internal string GetCurveName()
         {
-#if !uap
             if (IsECNamedCurve())
             {
                 return _keyHandle.GetPropertyAsString(KeyPropertyName.ECCCurveName, CngPropertyOptions.None);
             }
-#endif // !uap
 
             // Use hard-coded values (for use with pre-Win10 APIs)
             return GetECSpecificCurveName(); 
@@ -74,7 +72,6 @@ namespace System.Security.Cryptography
             throw new PlatformNotSupportedException(string.Format(SR.Cryptography_CurveNotSupported, algorithm));
         }
 
-#if !uap
         /// <summary>
         ///     Return a CngProperty representing a named curve.
         /// </summary>
@@ -88,7 +85,6 @@ namespace System.Security.Cryptography
                 return new CngProperty(KeyPropertyName.ECCCurveName, curveNameBytes, CngPropertyOptions.None);
             }
         }
-#endif // !uap
 
         /// <summary>
         /// Map a curve name to algorithm. This enables curves that worked pre-Win10

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.Import.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.Import.cs
@@ -59,9 +59,7 @@ namespace System.Security.Cryptography
             }
             else
             {
-#if !uap
                 keyHandle = ECCng.ImportKeyBlob(format.Format, keyBlob, curveName, providerHandle);
-#endif // !uap
             }
 
             CngKey key = new CngKey(providerHandle, keyHandle);

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/ECDsaCng.Key.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/ECDsaCng.Key.cs
@@ -39,7 +39,6 @@ namespace System.Security.Cryptography
             }
         }
 
-#if !uap
         public override void GenerateKey(ECCurve curve)
         {
             curve.Validate();
@@ -82,7 +81,6 @@ namespace System.Security.Cryptography
                 throw new PlatformNotSupportedException(string.Format(SR.Cryptography_CurveNotSupported, curve.CurveType.ToString()));
             }
         }
-#endif // !uap
 
         private CngKey GetKey()
         {
@@ -90,10 +88,8 @@ namespace System.Security.Cryptography
 
             if (_core.IsKeyGeneratedNamedCurve())
             {
-#if !uap
                 // Curve was previously created, so use that
                 key = _core.GetOrGenerateKey(null);
-#endif // !uap
             }
             else
             {

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/ECDsaCng.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/ECDsaCng.cs
@@ -57,34 +57,22 @@ namespace System.Security.Cryptography
 
         private void ImportFullKeyBlob(byte[] ecfullKeyBlob, bool includePrivateParameters)
         {
-#if !uap
             Key = ECCng.ImportFullKeyBlob(ecfullKeyBlob, includePrivateParameters);
-#endif // !uap
         }
 
         private void ImportKeyBlob(byte[] ecfullKeyBlob, string curveName, bool includePrivateParameters)
         {
-#if !uap
             Key = ECCng.ImportKeyBlob(ecfullKeyBlob, curveName, includePrivateParameters);
-#endif // !uap
         }
 
         private byte[] ExportKeyBlob(bool includePrivateParameters)
         {
-#if uap
-            return null;
-#else
             return ECCng.ExportKeyBlob(Key, includePrivateParameters);
-#endif // uap
         }
 
         private byte[] ExportFullKeyBlob(bool includePrivateParameters)
         {
-#if uap
-            return null;
-#else
             return ECCng.ExportFullKeyBlob(Key, includePrivateParameters);
-#endif // uap
         }
     }
 }

--- a/src/shims/ApiCompatBaseline.uap.netstandard20.txt
+++ b/src/shims/ApiCompatBaseline.uap.netstandard20.txt
@@ -9,8 +9,6 @@ MembersMustExist : Member 'System.Net.CookieCollection.Item.get(System.String)' 
 MembersMustExist : Member 'System.Net.CookieContainer.Add(System.Net.Cookie)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Net.CookieContainer.Add(System.Uri, System.Net.Cookie)' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Net.CookieException' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Security.Cryptography.ECDsa.Create(System.Security.Cryptography.ECCurve)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Security.Cryptography.ECDsaCng..ctor(System.Security.Cryptography.ECCurve)' does not exist in the implementation but it does exist in the contract.
 Compat issues with assembly System:
 TypesMustExist : Type 'System.Net.Cookie' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Net.CookieCollection.Add(System.Net.Cookie)' does not exist in the implementation but it does exist in the contract.
@@ -20,9 +18,6 @@ MembersMustExist : Member 'System.Net.CookieCollection.Item.get(System.String)' 
 MembersMustExist : Member 'System.Net.CookieContainer.Add(System.Net.Cookie)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Net.CookieContainer.Add(System.Uri, System.Net.Cookie)' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Net.CookieException' does not exist in the implementation but it does exist in the contract.
-Compat issues with assembly System.Core:
-MembersMustExist : Member 'System.Security.Cryptography.ECDsa.Create(System.Security.Cryptography.ECCurve)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Security.Cryptography.ECDsaCng..ctor(System.Security.Cryptography.ECCurve)' does not exist in the implementation but it does exist in the contract.
 Compat issues with assembly System.IO.FileSystem.AccessControl:
 TypesMustExist : Type 'System.IO.FileSystemAclExtensions' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Security.AccessControl.DirectoryObjectSecurity' does not exist in the implementation but it does exist in the contract.
@@ -41,8 +36,4 @@ MembersMustExist : Member 'System.Net.CookieCollection.Item.get(System.String)' 
 MembersMustExist : Member 'System.Net.CookieContainer.Add(System.Net.Cookie)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Net.CookieContainer.Add(System.Uri, System.Net.Cookie)' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Net.CookieException' does not exist in the implementation but it does exist in the contract.
-Compat issues with assembly System.Security.Cryptography.Algorithms:
-MembersMustExist : Member 'System.Security.Cryptography.ECDsa.Create(System.Security.Cryptography.ECCurve)' does not exist in the implementation but it does exist in the contract.
-Compat issues with assembly System.Security.Cryptography.Cng:
-MembersMustExist : Member 'System.Security.Cryptography.ECDsaCng..ctor(System.Security.Cryptography.ECCurve)' does not exist in the implementation but it does exist in the contract.
-Total Issues: 38
+Total Issues: 32


### PR DESCRIPTION
Remove some #if !uap's in S.S.Crypto to bring back some API to uap.

@bartonjs I do not know why these were originally if'defed long ago, but the build succeeds. do you know why? is it ok to submit this?