### PR TITLE
Increase stack size for CompileDeepTree_NoStackOverflowFast

### DIFF
--- a/src/System.Linq.Expressions/tests/CompilerTests.cs
+++ b/src/System.Linq.Expressions/tests/CompilerTests.cs
@@ -38,11 +38,11 @@ namespace System.Linq.Expressions.Tests
                 e = Expression.Add(e, Expression.Constant(1));
 
             Func<int> f = null;
-            // Request a stack size of 64K to get very small stack.
+            // Request a stack size of 128KiB to get very small stack.
             // This reduces the size of tree needed to risk a stack overflow.
             // This though will only risk overflow once, so the outerloop test
             // above is still needed.
-            Thread t = new Thread(() => f = Expression.Lambda<Func<int>>(e).Compile(useInterpreter), 65536);
+            Thread t = new Thread(() => f = Expression.Lambda<Func<int>>(e).Compile(useInterpreter), 128 * 1024);
             t.Start();
             t.Join();
 


### PR DESCRIPTION
Should allow it to run with checked coreclr builds, but still test the stack-overflow guards without running for a long time.

Fixes #17550

cc @RussKeldorph