### PR TITLE
Re-authoring the UAP package to make sure we have the right set of assemblies

### DIFF
--- a/src/System.IO.IsolatedStorage/src/System.IO.IsolatedStorage.csproj
+++ b/src/System.IO.IsolatedStorage/src/System.IO.IsolatedStorage.csproj
@@ -34,7 +34,7 @@
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.Diagnostics.Tools" />
     <Reference Include="System.IO.FileSystem" />
-    <Reference Include="System.IO.FileSystem.AccessControl" />
+    <Reference Include="System.IO.FileSystem.AccessControl" Condition="'$(TargetGroup)' != 'uap'" />
     <Reference Include="System.Linq" />
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />

--- a/src/System.Text.Encoding.CodePages/dir.props
+++ b/src/System.Text.Encoding.CodePages/dir.props
@@ -3,5 +3,6 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/shims/dir.props
+++ b/src/shims/dir.props
@@ -15,14 +15,18 @@
     <NetFxReference Include="System" />
     <NetFxReference Include="System.Core" />
     <NetFxReference Include="System.ComponentModel.Composition" />
+    <NetFxReference Include="System.ComponentModel.DataAnnotations" />
     <NetFxReference Include="System.Data" />
     <NetFxReference Include="System.Drawing" />
     <NetFxReference Include="System.IO.Compression.FileSystem" />
+    <NetFxReference Include="System.Net" />
     <NetFxReference Include="System.Numerics" />
     <NetFxReference Include="System.Runtime.Serialization" />
     <NetFxReference Include="System.Transactions" />
+    <NetFxReference Include="System.Windows" />
     <NetFxReference Include="System.Web" />
     <NetFxReference Include="System.Xml" />
+    <NetFxReference Include="System.Xml.Serialization" />
     <NetFxReference Include="System.Xml.Linq" />
   </ItemGroup>
 


### PR DESCRIPTION
cc: @weshaggard @ericstj 

FYI: @tijoytom 

Fixes to the UAP package so that we have the right set of assemblies for ref and lib required to actually consume the package.