### PR TITLE
Disallow FileMode.Truncate in MMF.CreateFromFile

### DIFF
--- a/src/System.IO.MemoryMappedFiles/src/Resources/Strings.resx
+++ b/src/System.IO.MemoryMappedFiles/src/Resources/Strings.resx
@@ -109,6 +109,9 @@
   <data name="Argument_NewMMFAppendModeNotAllowed" xml:space="preserve">
     <value>FileMode.Append is not permitted when creating new memory mapped files. Instead, use MemoryMappedFileView to ensure write-only access within a specified region.</value>
   </data>
+  <data name="Argument_NewMMFTruncateModeNotAllowed" xml:space="preserve">
+    <value>FileMode.Truncate is not permitted when creating new memory mapped files.</value>
+  </data>
   <data name="ArgumentNull_MapName" xml:space="preserve">
     <value>Map name cannot be null.</value>
   </data>

--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.cs
@@ -141,6 +141,10 @@ namespace System.IO.MemoryMappedFiles
             {
                 throw new ArgumentException(SR.Argument_NewMMFAppendModeNotAllowed, nameof(mode));
             }
+            if (mode == FileMode.Truncate)
+            {
+                throw new ArgumentException(SR.Argument_NewMMFTruncateModeNotAllowed, nameof(mode));
+            }
             if (access == MemoryMappedFileAccess.Write)
             {
                 throw new ArgumentException(SR.Argument_NewMMFWriteAccessNotAllowed, nameof(access));

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
@@ -368,21 +368,19 @@ namespace System.IO.MemoryMappedFiles.Tests
         [InlineData(10000)]
         public void ValidArgumentCombinationsWithPath_ModeCreate(long capacity)
         {
-            string mapName = CreateUniqueMapName();
-
             using (TempFile file = new TempFile(GetTestFilePath(), capacity))
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(file.Path, FileMode.Create, mapName, capacity))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(file.Path, FileMode.Create, null, capacity))
             {
                 ValidateMemoryMappedFile(mmf, capacity);
             }
 
             using (TempFile file = new TempFile(GetTestFilePath(), capacity))
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(file.Path, FileMode.Create, mapName, capacity, MemoryMappedFileAccess.ReadWrite))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(file.Path, FileMode.Create, null, capacity, MemoryMappedFileAccess.ReadWrite))
             {
                 ValidateMemoryMappedFile(mmf, capacity, MemoryMappedFileAccess.ReadWrite);
             }
 
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(GetTestFilePath(), FileMode.Create, mapName, capacity))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(GetTestFilePath(), FileMode.Create, null, capacity))
             {
                 ValidateMemoryMappedFile(mmf, capacity);
             }

--- a/src/System.IO.MemoryMappedFiles/tests/System.IO.MemoryMappedFiles.Tests.csproj
+++ b/src/System.IO.MemoryMappedFiles/tests/System.IO.MemoryMappedFiles.Tests.csproj
@@ -30,6 +30,9 @@
     <Compile Include="$(CommonTestPath)\System\IO\FileCleanupTestBase.cs">
       <Link>Common\System\IO\FileCleanupTestBase.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\AssertExtensions.cs">
+      <Link>Common\System\AssertExtensions.cs</Link>
+    </Compile>
     <Compile Include="XunitAssemblyAttributes.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Using CreateFromFile on netfx with FileMode.Truncate always results in an ArgumentException whereas in netcoreapp we allow it. It seems like a sort of unintended consequence of the removal of the reliance on the FileSystremRights FileStream constructor. The ArgumentException from FileMode.Truncate was coming from that constructor where it asserts that FileMode.Truncate requires FileSystemRights.Write, but we were only passing FileSystemRights.WriteData.

I'm fixing netcore to have the same behavior as netfx, except that the ArgumentException message will be more helpful and it will also have a parameterName. Tests are also updated.

found while investigating https://github.com/dotnet/corefx/issues/10895

@stephentoub 
