### PR TITLE
Make Activity Class never thow exceptions to any callers

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -207,11 +207,17 @@ namespace System.Diagnostics
         public Activity SetParentId(string parentId)
         {
             if (Parent != null)
+            {
                 NotifyError(new InvalidOperationException($"Trying to set {nameof(ParentId)} on activity which has {nameof(Parent)}"));
+            }
             else if (ParentId != null)
+            {
                 NotifyError(new InvalidOperationException($"{nameof(ParentId)} is already set"));
+            }
             else if (string.IsNullOrEmpty(parentId))
+            {
                 NotifyError(new ArgumentException($"{nameof(parentId)} must not be null or empty"));
+            }
             else
             {
                 ParentId = parentId;
@@ -227,7 +233,9 @@ namespace System.Diagnostics
         public Activity SetStartTime(DateTime startTimeUtc)
         {
             if (startTimeUtc.Kind != DateTimeKind.Utc)
+            {
                 NotifyError(new InvalidOperationException($"{nameof(startTimeUtc)} is not UTC"));
+            }
             else
             {
                 StartTimeUtc = startTimeUtc;
@@ -244,7 +252,9 @@ namespace System.Diagnostics
         public Activity SetEndTime(DateTime endTimeUtc)
         {
             if (endTimeUtc.Kind != DateTimeKind.Utc)
+            {
                 NotifyError(new InvalidOperationException($"{nameof(endTimeUtc)} is not UTC"));
+            }
             else
             {
                 Duration = endTimeUtc - StartTimeUtc;
@@ -276,7 +286,9 @@ namespace System.Diagnostics
         public Activity Start()
         {
             if (Id != null)
+            {
                 NotifyError(new InvalidOperationException("Trying to start an Activity that was already started"));
+            }
             else
             {
                 if (ParentId == null)
@@ -325,7 +337,7 @@ namespace System.Diagnostics
         }
 
         #region private 
-        private void NotifyError(Exception exception)
+        private static void NotifyError(Exception exception)
         {
             // Throw and catch the exception.  This lets it be seen by the debugger
             // ETW, and other monitoring tools.   However we immediately swallow the

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -347,7 +347,7 @@ namespace System.Diagnostics
             {
                 throw exception;
             }
-            catch (Exception) { }
+            catch { }
         }
 
         private string GenerateId()

--- a/src/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
@@ -66,17 +66,28 @@ namespace System.Diagnostics.Tests
         public void SetParentId()
         {
             var parent = new Activity("parent");
-            Assert.Throws<ArgumentException>(() => parent.SetParentId(null));
-            Assert.Throws<ArgumentException>(() => parent.SetParentId(""));
+            parent.SetParentId(null);  // Error does nothing
+            Assert.Null(parent.ParentId);
+
+            parent.SetParentId("");  // Error does nothing
+            Assert.Null(parent.ParentId);
+
             parent.SetParentId("1");
-            Assert.Equal("1", parent.ParentId);
-            Assert.Throws<InvalidOperationException>(() => parent.SetParentId("2"));
+            Assert.Equal(parent.ParentId, "1");
+
+            parent.SetParentId("2"); // Error does nothing
+            Assert.Equal(parent.ParentId, "1");
 
             Assert.Equal(parent.ParentId, parent.RootId);
             parent.Start();
+
+
             var child = new Activity("child");
             child.Start();
-            Assert.Throws<InvalidOperationException>(() => child.SetParentId("3"));
+
+            Assert.Equal(child.ParentId, parent.Id);
+            child.SetParentId("3");  // Error does nothing;
+            Assert.Equal(child.ParentId, parent.Id);
         }
 
         /// <summary>
@@ -243,15 +254,23 @@ namespace System.Diagnostics.Tests
         public void StartStopWithTimestamp()
         {
             var activity = new Activity("activity");
-            Assert.Throws<InvalidOperationException>(() => activity.SetStartTime(DateTime.Now));
+            Assert.Equal(activity.StartTimeUtc, default(DateTime));
 
-            var startTime = DateTime.UtcNow.AddSeconds(-1);
+            activity.SetStartTime(DateTime.Now);    // Error Does nothing because it is not UTC
+            Assert.Equal(activity.StartTimeUtc, default(DateTime));
+
+            var startTime = DateTime.UtcNow.AddSeconds(-1); // A valid time in the past that we want to be our offical start time.  
             activity.SetStartTime(startTime);
 
             activity.Start();
-            Assert.Equal(startTime, activity.StartTimeUtc);
+            Assert.Equal(startTime, activity.StartTimeUtc); // we use our offical start time not the time now.  
+            Assert.Equal(activity.Duration, TimeSpan.Zero);
 
-            Assert.Throws<InvalidOperationException>(() => activity.SetEndTime(DateTime.Now));
+            Thread.Sleep(35);
+
+            activity.SetEndTime(DateTime.Now);      // Error does nothing because it is not UTC    
+            Assert.Equal(activity.Duration, TimeSpan.Zero);
+
             var stopTime = DateTime.UtcNow;
             activity.SetEndTime(stopTime);
             Assert.Equal(stopTime - startTime, activity.Duration);
@@ -335,7 +354,10 @@ namespace System.Diagnostics.Tests
         {
             var activity = new Activity("activity");
             activity.Start();
-            Assert.Throws<InvalidOperationException>(() => activity.Start());
+            var id = activity.Id;
+
+            activity.Start();       // Error already started.  Does nothing.  
+            Assert.Equal(id, activity.Id);
         }
 
         /// <summary>
@@ -344,7 +366,9 @@ namespace System.Diagnostics.Tests
         [Fact]
         public void StopNotStarted()
         {
-            Assert.Throws<InvalidOperationException>(() => new Activity("activity").Stop());
+            var activity = new Activity("activity");
+            activity.Stop();        // Error Does Nothing
+            Assert.Equal(activity.Duration, TimeSpan.Zero);
         }
 
         /// <summary>

--- a/src/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
@@ -73,21 +73,20 @@ namespace System.Diagnostics.Tests
             Assert.Null(parent.ParentId);
 
             parent.SetParentId("1");
-            Assert.Equal(parent.ParentId, "1");
+            Assert.Equal("1", parent.ParentId);
 
             parent.SetParentId("2"); // Error does nothing
-            Assert.Equal(parent.ParentId, "1");
+            Assert.Equal("1", parent.ParentId);
 
             Assert.Equal(parent.ParentId, parent.RootId);
             parent.Start();
 
-
             var child = new Activity("child");
             child.Start();
 
-            Assert.Equal(child.ParentId, parent.Id);
+            Assert.Equal(parent.Id, child.ParentId);
             child.SetParentId("3");  // Error does nothing;
-            Assert.Equal(child.ParentId, parent.Id);
+            Assert.Equal(parent.Id, child.ParentId);
         }
 
         /// <summary>
@@ -254,22 +253,22 @@ namespace System.Diagnostics.Tests
         public void StartStopWithTimestamp()
         {
             var activity = new Activity("activity");
-            Assert.Equal(activity.StartTimeUtc, default(DateTime));
+            Assert.Equal(default(DateTime), activity.StartTimeUtc);
 
             activity.SetStartTime(DateTime.Now);    // Error Does nothing because it is not UTC
-            Assert.Equal(activity.StartTimeUtc, default(DateTime));
+            Assert.Equal(default(DateTime), activity.StartTimeUtc);
 
             var startTime = DateTime.UtcNow.AddSeconds(-1); // A valid time in the past that we want to be our offical start time.  
             activity.SetStartTime(startTime);
 
             activity.Start();
             Assert.Equal(startTime, activity.StartTimeUtc); // we use our offical start time not the time now.  
-            Assert.Equal(activity.Duration, TimeSpan.Zero);
+            Assert.Equal(TimeSpan.Zero, activity.Duration);
 
             Thread.Sleep(35);
 
             activity.SetEndTime(DateTime.Now);      // Error does nothing because it is not UTC    
-            Assert.Equal(activity.Duration, TimeSpan.Zero);
+            Assert.Equal(TimeSpan.Zero, activity.Duration);
 
             var stopTime = DateTime.UtcNow;
             activity.SetEndTime(stopTime);
@@ -368,7 +367,7 @@ namespace System.Diagnostics.Tests
         {
             var activity = new Activity("activity");
             activity.Stop();        // Error Does Nothing
-            Assert.Equal(activity.Duration, TimeSpan.Zero);
+            Assert.Equal(TimeSpan.Zero, activity.Duration);
         }
 
         /// <summary>


### PR DESCRIPTION
Instead it throws and immeidately catches the exceptions.   That way callers don't need to bother.
We throw and catch so the exception show up in debuggers and monitors.