### PR TITLE
Remove usage of UAPToolsFolder property

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
@@ -141,7 +141,7 @@
       },
       "inputs": {
         "filename": "$(Build.SourcesDirectory)\\corefx\\build.cmd",
-        "arguments": "$(PB_BuildArguments) $(PB_PipelineBuildMSBuildArguments) /p:\"UAPToolsFolder=$(PB_UAPToolsFolder)\"",
+        "arguments": "$(PB_BuildArguments) $(PB_PipelineBuildMSBuildArguments)",
         "workingFolder": "corefx",
         "failOnStandardError": "false"
       }
@@ -497,10 +497,6 @@
     "PB_PipelineBuildMSBuildArguments": {
       "value": "",
       "allowOverride": true
-    },
-    "PB_UAPToolsFolder": {
-      "value": null,
-      "isSecret": true
     }
   },
   "demands": [


### PR DESCRIPTION
Remove UAPToolsFolder property being passed in, which allows this to default to the generated version (defaults to path inside the packages folder)
@chcosta , @AlexGhiondea 