### PR TITLE
Adding updates to packages to update SqlClient in the 1.1.x release

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -954,7 +954,8 @@
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.1.0",
         "4.1.0.0": "4.1.0",
-        "4.1.1.0": "4.3.0"
+        "4.1.1.0": "4.3.0",
+        "4.1.1.1": "4.3.1"
       }
     },
     "System.Diagnostics.Contracts": {

--- a/src/System.Data.SqlClient/dir.props
+++ b/src/System.Data.SqlClient/dir.props
@@ -2,6 +2,7 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.1.1.1</AssemblyVersion>
+    <PackageVersion>4.3.1</PackageVersion>
   </PropertyGroup>
 </Project>
 

--- a/src/System.Data.SqlClient/dir.props
+++ b/src/System.Data.SqlClient/dir.props
@@ -1,7 +1,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.1.1</AssemblyVersion>
   </PropertyGroup>
 </Project>
 

--- a/src/System.Data.SqlClient/pkg/System.Data.SqlClient.pkgproj
+++ b/src/System.Data.SqlClient/pkg/System.Data.SqlClient.pkgproj
@@ -18,5 +18,12 @@
     <InboxOnTargetFramework Include="xamarintvos10" />
     <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
+  <!-- Added in release/1.1.0 to suppress package validation. In master this is controlled by Packaging.props -->
+  <ItemGroup>
+    <ValidatePackageSuppression Include="SuppressNETStandardInference">
+      <!-- desktop assemblies must version past NETStandard refs -->
+      <Value>.NETFramework,Version=v4.6;.NETFramework,Version=v4.6.1;.NETFramework,Version=v4.6.2;.NETFramework,Version=v4.6.3</Value>
+    </ValidatePackageSuppression>
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -25,6 +25,9 @@
     <Project Include="..\pkg\Microsoft.Private.PackageBaseline\Microsoft.Private.PackageBaseline.builds">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
+    <Project Include="System.Data.SqlClient\pkg\System.Data.SqlClient.builds">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
     <Project Include="System.Diagnostics.DiagnosticSource\pkg\System.Diagnostics.DiagnosticSource.builds">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>       


### PR DESCRIPTION
The changes enable the build of the service release for System.Data.SqlClient for release/1.1.0 branch of .Net Core. 

Verified locally by `build.cmd` at the root of the clone. 
Following is a structure of what was produced

```
F:\NETCORE\COREFX\BIN\PACKAGES\DEBUG
|   Microsoft.Private.PackageBaseline.1.0.1-servicing-25127-0.nupkg
|   System.Data.SqlClient.4.3.1-servicing-25127-0.nupkg
|   System.Diagnostics.DiagnosticSource.4.3.1-servicing-25127-0.nupkg
|   System.Net.Http.4.3.2-servicing-25127-0.nupkg
|   System.ValueTuple.4.3.1-servicing-25127-0.nupkg
|
+---reports
|       Microsoft.Private.PackageBaseline.json
|       System.Data.SqlClient.json
|       System.Diagnostics.DiagnosticSource.json
|       System.Net.Http.json
|       System.ValueTuple.json
|
+---specs
|       Microsoft.Private.PackageBaseline.nuspec
|       Microsoft.Private.PackageBaseline.nuspec.pkgpath
|       System.Data.SqlClient.nuspec
|       System.Data.SqlClient.nuspec.pkgpath
|       System.Diagnostics.DiagnosticSource.nuspec
|       System.Diagnostics.DiagnosticSource.nuspec.pkgpath
|       System.Net.Http.nuspec
|       System.Net.Http.nuspec.pkgpath
|       System.ValueTuple.nuspec
|       System.ValueTuple.nuspec.pkgpath
|
\---symbols
        System.Data.SqlClient.4.3.1-servicing-25127-0.symbols.nupkg
        System.Diagnostics.DiagnosticSource.4.3.1-servicing-25127-0.symbols.nupkg
        System.Net.Http.4.3.2-servicing-25127-0.symbols.nupkg
        System.ValueTuple.4.3.1-servicing-25127-0.symbols.nupkg
```

There is a System.Data.SqlClient.4.3.1-servicing-25127-0.nupkg package with the updated package version. 
Verified that the runtime DLL has the required changes that were meant to go into service release.