### PR TITLE
Added Dutch Titlecasing Tests

### DIFF
--- a/src/System.Globalization/tests/TextInfo/TextInfoTests.netstandard.cs
+++ b/src/System.Globalization/tests/TextInfo/TextInfoTests.netstandard.cs
@@ -71,6 +71,7 @@ namespace System.Globalization.Tests
                 Assert.Equal("IJ IJ IJ IJ", ti.ToTitleCase("ij iJ Ij IJ"));
                 Assert.Equal("IJzeren Eigenschappen", ti.ToTitleCase("ijzeren eigenschappen"));
                 Assert.Equal("Lake IJssel", ti.ToTitleCase("lake iJssel"));
+                Assert.Equal("Boba N' IJango Fett PEW PEW", ti.ToTitleCase("Boba n' Ijango fett PEW PEW"));
             }
         }
     }

--- a/src/System.Globalization/tests/TextInfo/TextInfoTests.netstandard.cs
+++ b/src/System.Globalization/tests/TextInfo/TextInfoTests.netstandard.cs
@@ -64,6 +64,9 @@ namespace System.Globalization.Tests
         public static IEnumerable<object[]> DutchTitleCaseInfo_TestData()
         {
             yield return new object[] { "nl-NL", "IJ IJ IJ IJ", "ij iJ Ij IJ" };
+            yield return new object[] { "nl-be", "IJzeren Eigenschappen", "ijzeren eigenschappen" };
+            yield return new object[] { "NL-NL", "Lake IJssel", "lake iJssel" };
+            yield return new object[] { "NL-BE", "Boba N' IJango Fett PEW PEW", "Boba n' Ijango fett PEW PEW" };
             yield return new object[] { "en-us", "Ijill And Ijack", "ijill and ijack" };
             yield return new object[] { "de-DE", "Ij Ij IJ Ij", "ij ij IJ ij" };
             yield return new object[] { "he-il", "Ijon't Know What Will Happen.", "Ijon't know what Will happen." };

--- a/src/System.Globalization/tests/TextInfo/TextInfoTests.netstandard.cs
+++ b/src/System.Globalization/tests/TextInfo/TextInfoTests.netstandard.cs
@@ -61,18 +61,20 @@ namespace System.Globalization.Tests
             Assert.Throws<ArgumentNullException>("str", () => ti.ToTitleCase(null));
         }
 
-        [Fact]
-        public void ToTitleCaseDutchTest()
+        public static IEnumerable<object[]> DutchTitleCaseInfo_TestData()
         {
-            string[] dutchCultureInfos = new string[] { "nl-BE", "nl-NL" };
-            foreach (string cultureInfo in dutchCultureInfos)
-            {
-                TextInfo ti = CultureInfo.GetCultureInfo(cultureInfo).TextInfo;
-                Assert.Equal("IJ IJ IJ IJ", ti.ToTitleCase("ij iJ Ij IJ"));
-                Assert.Equal("IJzeren Eigenschappen", ti.ToTitleCase("ijzeren eigenschappen"));
-                Assert.Equal("Lake IJssel", ti.ToTitleCase("lake iJssel"));
-                Assert.Equal("Boba N' IJango Fett PEW PEW", ti.ToTitleCase("Boba n' Ijango fett PEW PEW"));
-            }
+            yield return new object[] { "nl-NL", "IJ IJ IJ IJ", "ij iJ Ij IJ" };
+            yield return new object[] { "en-us", "Ijill And Ijack", "ijill and ijack" };
+            yield return new object[] { "de-DE", "Ij Ij IJ Ij", "ij ij IJ ij" };
+            yield return new object[] { "he-il", "Ijon't Know What Will Happen.", "Ijon't know what Will happen." };
+        }
+
+        [Theory]
+        [MemberData(nameof(DutchTitleCaseInfo_TestData))]
+        public void ToTitleCaseDutchTest(string cultureName, string expected, string actual)
+        {
+            TextInfo ti = CultureInfo.GetCultureInfo(cultureName).TextInfo;
+            Assert.Equal(expected, ti.ToTitleCase(actual));
         }
     }
 }

--- a/src/System.Globalization/tests/TextInfo/TextInfoTests.netstandard.cs
+++ b/src/System.Globalization/tests/TextInfo/TextInfoTests.netstandard.cs
@@ -60,5 +60,18 @@ namespace System.Globalization.Tests
 
             Assert.Throws<ArgumentNullException>("str", () => ti.ToTitleCase(null));
         }
+
+        [Fact]
+        public void ToTitleCaseDutchTest()
+        {
+            string[] dutchCultureInfos = new string[] { "nl-BE", "nl-NL" };
+            foreach (string cultureInfo in dutchCultureInfos)
+            {
+                TextInfo ti = CultureInfo.GetCultureInfo(cultureInfo).TextInfo;
+                Assert.Equal("IJ IJ IJ IJ", ti.ToTitleCase("ij iJ Ij IJ"));
+                Assert.Equal("IJzeren Eigenschappen", ti.ToTitleCase("ijzeren eigenschappen"));
+                Assert.Equal("Lake IJssel", ti.ToTitleCase("lake iJssel"));
+            }
+        }
     }
 }

--- a/src/System.Globalization/tests/TextInfo/TextInfoTests.netstandard.cs
+++ b/src/System.Globalization/tests/TextInfo/TextInfoTests.netstandard.cs
@@ -74,6 +74,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(DutchTitleCaseInfo_TestData))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Desktop Framework hasn't received the fix for dotnet/corefx#16770 yet.")]
         public void ToTitleCaseDutchTest(string cultureName, string expected, string actual)
         {
             TextInfo ti = CultureInfo.GetCultureInfo(cultureName).TextInfo;


### PR DESCRIPTION

Related to:

- Issue:  [dotnet/corefx#16770](https://github.com/dotnet/corefx/issues/16770)
- Pull Request:  [dotnet/corefx#10195](https://github.com/dotnet/coreclr/pull/10195)

Added a series of tests to check the validity of recent changes to resolve a bug within the Titlecasing functionality for strings that began with "IJ" in Dutch cultures. 

CC: @tarekgh 
 