### PR TITLE
[WIP] Publish packages for netcoreapp remote testing

### DIFF
--- a/dir.targets
+++ b/dir.targets
@@ -57,7 +57,6 @@
     </BinPlaceConfiguration>
 
     <BinPlaceConfiguration Condition="'$(IsNETCoreApp)' == 'true' AND '$(IsTestProject)' == 'true' AND '$(BinPlaceNETCoreAppTests)' == 'true'" Include="netcoreapp-$(_bc_OSGroup)">
-      <PackageFileRuntimePath>$(NETCoreAppPackageRuntimePath)\..\tests</PackageFileRuntimePath>
       <RuntimePath>$(NETCoreAppPackageRuntimePath)\..\tests</RuntimePath>
     </BinPlaceConfiguration>
 

--- a/dir.targets
+++ b/dir.targets
@@ -43,6 +43,7 @@
     <!-- if building desktop facade, we don't bin place the refs -->
     <BinPlaceRef Condition="'$(BinPlaceRef)' == '' And '$(BuildingDesktopFacade)' != 'true' And ('$(IsReferenceAssembly)' == 'true' OR '$(IsRuntimeAndReferenceAssembly)' == 'true')">true</BinPlaceRef>
     <BinPlaceRuntime Condition="'$(BinPlaceRuntime)' == '' And ('$(IsRuntimeAssembly)' == 'true' OR '$(IsRuntimeAndReferenceAssembly)' == 'true')">true</BinPlaceRuntime>
+    <BinPlaceRuntime Condition="'$(BinPlaceRuntime)' == '' And ('$(IsNETCoreApp)' == 'true' AND '$(IsTestProject)' == 'true' AND '$(BinPlaceNETCoreAppTests)' == 'true')">true</BinPlaceRuntime>
 
     <!-- if building desktop facade and bin placing the runtime, then we need to bin place the refs too -->
     <BinPlaceRef Condition="'$(BuildingDesktopFacade)' == 'true' And '$(BinPlaceRuntime)' == 'true'">true</BinPlaceRef>
@@ -55,8 +56,13 @@
       <RuntimePath>$(RuntimePath)</RuntimePath>
     </BinPlaceConfiguration>
 
+    <BinPlaceConfiguration Condition="'$(IsNETCoreApp)' == 'true' AND '$(IsTestProject)' == 'true' AND '$(BinPlaceNETCoreAppTests)' == 'true'" Include="netcoreapp-$(_bc_OSGroup)">
+      <PackageFileRuntimePath>$(NETCoreAppPackageRuntimePath)\..\tests</PackageFileRuntimePath>
+      <RuntimePath>$(NETCoreAppPackageRuntimePath)\..\tests</RuntimePath>
+    </BinPlaceConfiguration>
+
     <!-- binplace to directories for packages -->
-    <BinPlaceConfiguration Condition="'$(IsNETCoreApp)' == 'true' AND '$(BuildingNETCoreAppVertical)' == 'true'" Include="netcoreapp-$(_bc_OSGroup)">
+    <BinPlaceConfiguration Condition="'$(IsNETCoreApp)' == 'true' AND '$(IsTestProject)' != 'true' AND '$(BuildingNETCoreAppVertical)' == 'true'" Include="netcoreapp-$(_bc_OSGroup)">
       <PackageFileRefPath Condition="'$(IsNETCoreAppRef)' == 'true'">$(NETCoreAppPackageRefPath)</PackageFileRefPath>
       <PackageFileRuntimePath>$(NETCoreAppPackageRuntimePath)</PackageFileRuntimePath>
       <RuntimePath Condition="'$(BinPlaceNETCoreAppPackage)' == 'true'">$(NETCoreAppPackageRuntimePath)\..\runtime</RuntimePath>

--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -6,7 +6,8 @@
          This RID value doesn't really matter, since the assets we are copying are not RID specific, so defaulting to Windows here
     -->
     <NugetRuntimeIdentifier>win7-x64</NugetRuntimeIdentifier>
-    <OutputPath>$(RuntimePath)</OutputPath>
+    <OutputPath Condition="'$(BinPlaceNETCoreAppTestDependencies)' == 'true'">$(NETCoreAppPackageRuntimePath)\..\dependencies</OutputPath>
+    <OutputPath Condition="'$(OutputPath)' == ''">$(RuntimePath)</OutputPath>
     <XUnitRunnerPackageId Condition="'$(TargetGroup)' != 'netfx'">xunit.console.netcore</XUnitRunnerPackageId>
     <XUnitRunnerPackageId Condition="'$(TargetGroup)' == 'netfx'">xunit.runner.console</XUnitRunnerPackageId>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == 'uapaot'">.NETStandard,Version=v2.0</NuGetTargetMoniker>

--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -6,8 +6,8 @@
          This RID value doesn't really matter, since the assets we are copying are not RID specific, so defaulting to Windows here
     -->
     <NugetRuntimeIdentifier>win7-x64</NugetRuntimeIdentifier>
+    <OutputPath>$(RuntimePath)</OutputPath>
     <OutputPath Condition="'$(BinPlaceNETCoreAppTestDependencies)' == 'true'">$(NETCoreAppPackageRuntimePath)\..\dependencies</OutputPath>
-    <OutputPath Condition="'$(OutputPath)' == ''">$(RuntimePath)</OutputPath>
     <XUnitRunnerPackageId Condition="'$(TargetGroup)' != 'netfx'">xunit.console.netcore</XUnitRunnerPackageId>
     <XUnitRunnerPackageId Condition="'$(TargetGroup)' == 'netfx'">xunit.runner.console</XUnitRunnerPackageId>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == 'uapaot'">.NETStandard,Version=v2.0</NuGetTargetMoniker>


### PR DESCRIPTION
This commit introduces two additional flags to publish remote testing packages:
 - BinPlaceNETCoreAppTests
 - BinPlaceNETCoreAppTestDependencies

These options allow us to collect all the stubs for netcoreapp unittest from the following directories:
 - bin\pkg\netcoreapp\tests (for tests)
 - bin\pkg\netcoreapp\dependencies (for xunit framework)