### PR TITLE
Avoid NullReferenceException in WinHttpWebSocketState.Dispose

### DIFF
--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinHttpWebSocketState.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinHttpWebSocketState.cs
@@ -264,17 +264,9 @@ namespace System.Net.WebSockets
         #region IDisposable Support
         private void Dispose(bool disposing)
         {
-            if (_webSocketHandle != null)
-            {
-                _webSocketHandle.Dispose();
-                // Will be set to null in the callback.
-            }
-
-            if (_requestHandle != null)
-            {
-                _requestHandle.Dispose();
-                // Will be set to null in the callback.
-            }
+            // These will be set to null in the callback.
+            _webSocketHandle?.Dispose();
+            _requestHandle?.Dispose();
 
             Interop.WinHttp.SafeWinHttpHandle.DisposeAndClearHandle(ref _connectionHandle);
             Interop.WinHttp.SafeWinHttpHandle.DisposeAndClearHandle(ref _sessionHandle);


### PR DESCRIPTION
Per issue https://github.com/dotnet/corefx/issues/16419 avoid referencing null _requestHandle field in WinHttpWebSocketState.Dispose.

The test Abort_CloseAndAbort_Success may cause a race condition with _requestHandle and raise a NullReferenceException. The test does a CloseAsync followed by an Abort. Depending on timing, the Abort may come after or during the WinHttp callback triggered by the CloseAsync.
```c#
Task t = cws.CloseAsync(WebSocketCloseStatus.NormalClosure, "AbortClose", ctsDefault.Token);
cws.Abort();
await t;
```

cc @CIPop @davidsh 