### PR TITLE
Revert MMF.CreateFromFile FileShare to None

### DIFF
--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.cs
@@ -147,7 +147,7 @@ namespace System.IO.MemoryMappedFiles
             }
 
             bool existed = File.Exists(path);
-            FileStream fileStream = new FileStream(path, mode, GetFileAccess(access), FileShare.Read, 0x1000, FileOptions.None);
+            FileStream fileStream = new FileStream(path, mode, GetFileAccess(access), FileShare.None, 0x1000, FileOptions.None);
 
             if (capacity == 0 && fileStream.Length == 0)
             {

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
@@ -573,15 +573,16 @@ namespace System.IO.MemoryMappedFiles.Tests
         }
 
         /// <summary>
-        /// Test exceptional behavior when trying to create a map for a read-write file that's currently in use.
+        /// Test exceptional behavior when trying to create a map for a  file that's currently in use.
         /// </summary>
-        [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)] // FileShare is limited on Unix, with None == exclusive, everything else == concurrent
-        public void FileInUse_CreateFromFile_FailsWithExistingReadWriteFile()
+        [Theory]
+        [InlineData(FileShare.Read)]
+        [InlineData(FileShare.None)]
+        public void FileInUse_CreateFromFile_FailsWithExistingReadWriteFile(FileShare share)
         {
             // Already opened with a FileStream
             using (TempFile file = new TempFile(GetTestFilePath(), 4096))
-            using (FileStream fs = File.Open(file.Path, FileMode.Open))
+            using (FileStream fs = File.Open(file.Path, FileMode.Open, FileAccess.ReadWrite, share))
             {
                 Assert.Throws<IOException>(() => MemoryMappedFile.CreateFromFile(file.Path));
             }
@@ -591,7 +592,6 @@ namespace System.IO.MemoryMappedFiles.Tests
         /// Test exceptional behavior when trying to create a map for a non-shared file that's currently in use.
         /// </summary>
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)] // FileShare is limited on Unix, with None == exclusive, everything else == concurrent
         public void FileInUse_CreateFromFile_FailsWithExistingReadWriteMap()
         {
             // Already opened with another read-write map
@@ -599,37 +599,6 @@ namespace System.IO.MemoryMappedFiles.Tests
             using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(file.Path))
             {
                 Assert.Throws<IOException>(() => MemoryMappedFile.CreateFromFile(file.Path));
-            }
-        }
-
-        /// <summary>
-        /// Test exceptional behavior when trying to create a map for a non-shared file that's currently in use.
-        /// </summary>
-        [Fact]
-        public void FileInUse_CreateFromFile_FailsWithExistingNoShareFile()
-        {
-            // Already opened with a FileStream
-            using (TempFile file = new TempFile(GetTestFilePath(), 4096))
-            using (FileStream fs = File.Open(file.Path, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
-            {
-                Assert.Throws<IOException>(() => MemoryMappedFile.CreateFromFile(file.Path));
-            }
-        }
-
-        /// <summary>
-        /// Test to validate we can create multiple concurrent read-only maps from the same file path.
-        /// </summary>
-        [Fact]
-        public void FileInUse_CreateFromFile_SucceedsWithReadOnly()
-        {
-            const int Capacity = 4096;
-            using (TempFile file = new TempFile(GetTestFilePath(), Capacity))
-            using (MemoryMappedFile mmf1 = MemoryMappedFile.CreateFromFile(file.Path, FileMode.Open, null, Capacity, MemoryMappedFileAccess.Read))
-            using (MemoryMappedFile mmf2 = MemoryMappedFile.CreateFromFile(file.Path, FileMode.Open, null, Capacity, MemoryMappedFileAccess.Read))
-            using (MemoryMappedViewAccessor acc1 = mmf1.CreateViewAccessor(0, Capacity, MemoryMappedFileAccess.Read))
-            using (MemoryMappedViewAccessor acc2 = mmf2.CreateViewAccessor(0, Capacity, MemoryMappedFileAccess.Read))
-            {
-                Assert.Equal(acc1.Capacity, acc2.Capacity);
             }
         }
 


### PR DESCRIPTION
Reverting a purposeful change to the behavior of CreateFromFile for compat purposes. On netfx, we use FileShare.None for CreateFromFile calls, but on netcoreapp we use FileShare.Read. This means we won't be throwing exceptions for netcoreapp in a lot of cases where we would be in netfx.

Reverts #6152

@stephentoub