### PR TITLE
Expose deconstruct api and add tests

### DIFF
--- a/src/Common/tests/System/Collections/IDictionary.Generic.Tests.cs
+++ b/src/Common/tests/System/Collections/IDictionary.Generic.Tests.cs
@@ -12,7 +12,7 @@ namespace System.Collections.Tests
     /// Contains tests that ensure the correctness of any class that implements the generic
     /// IDictionary interface
     /// </summary>
-    public abstract class IDictionary_Generic_Tests<TKey, TValue> : ICollection_Generic_Tests<KeyValuePair<TKey, TValue>>
+    public abstract partial class IDictionary_Generic_Tests<TKey, TValue> : ICollection_Generic_Tests<KeyValuePair<TKey, TValue>>
     {
         #region IDictionary<TKey, TValue> Helper Methods
 

--- a/src/Common/tests/System/Collections/IDictionary.Generic.Tests.netcoreapp.cs
+++ b/src/Common/tests/System/Collections/IDictionary.Generic.Tests.netcoreapp.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Collections.Tests
+{
+    /// <summary>
+    /// Contains tests that ensure the correctness of any class that implements the generic
+    /// IDictionary interface
+    /// </summary>
+    public abstract partial class IDictionary_Generic_Tests<TKey, TValue> : ICollection_Generic_Tests<KeyValuePair<TKey, TValue>>
+    {
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void KeyValuePair_Deconstruct(int size)
+        {
+            IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(size);
+            Assert.All(dictionary, (entry) => {
+                TKey key;
+                TValue value;
+                entry.Deconstruct(out key, out value);
+                Assert.Equal(entry.Key, key);
+                Assert.Equal(entry.Value, value);
+
+                key = default(TKey);
+                value = default(TValue);
+                (key, value) = entry;
+                Assert.Equal(entry.Key, key);
+                Assert.Equal(entry.Value, value);
+            });
+        }
+    }
+}

--- a/src/Common/tests/System/Collections/IDictionary.NonGeneric.Tests.cs
+++ b/src/Common/tests/System/Collections/IDictionary.NonGeneric.Tests.cs
@@ -12,7 +12,7 @@ namespace System.Collections.Tests
     /// Contains tests that ensure the correctness of any class that implements the nongeneric
     /// IDictionary interface
     /// </summary>
-    public abstract class IDictionary_NonGeneric_Tests : ICollection_NonGeneric_Tests
+    public abstract partial class IDictionary_NonGeneric_Tests : ICollection_NonGeneric_Tests
     {
         #region IDictionary Helper Methods
 

--- a/src/Common/tests/System/Collections/IDictionary.NonGeneric.Tests.netcoreapp.cs
+++ b/src/Common/tests/System/Collections/IDictionary.NonGeneric.Tests.netcoreapp.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Collections.Tests
+{
+    /// <summary>
+    /// Contains tests that ensure the correctness of any class that implements the nongeneric
+    /// IDictionary interface
+    /// </summary>
+    public abstract partial class IDictionary_NonGeneric_Tests : ICollection_NonGeneric_Tests
+    {
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void DictionaryEntry_Deconstruct(int size)
+        {
+            IDictionary dictionary = NonGenericIDictionaryFactory(size);
+
+            // Assert.All is only supported for generic collections.
+            foreach (DictionaryEntry entry in dictionary)
+            {
+                object key;
+                object value;
+                entry.Deconstruct(out key, out value);
+                Assert.Equal(key, entry.Key);
+                Assert.Equal(value, entry.Value);
+
+                key = null;
+                value = null;
+                (key, value) = entry;
+                Assert.Equal(key, entry.Key);
+                Assert.Equal(value, entry.Value);
+            }
+        }
+    }
+}

--- a/src/System.Collections/tests/System.Collections.Tests.csproj
+++ b/src/System.Collections/tests/System.Collections.Tests.csproj
@@ -26,8 +26,14 @@
     <Compile Include="$(CommonTestPath)\System\Collections\IDictionary.NonGeneric.Tests.cs">
       <Link>Common\System\Collections\IDictionary.NonGeneric.Tests.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Collections\IDictionary.NonGeneric.Tests.netcoreapp.cs" Condition="'$(TargetGroup)' == 'netcoreapp'">
+      <Link>Common\System\Collections\IDictionary.NonGeneric.Tests.netcoreapp.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Collections\IDictionary.Generic.Tests.cs">
       <Link>Common\System\Collections\IDictionary.Generic.Tests.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Collections\IDictionary.Generic.Tests.netcoreapp.cs" Condition="'$(TargetGroup)' == 'netcoreapp'">
+      <Link>Common\System\Collections\IDictionary.Generic.Tests.netcoreapp.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.NonGeneric.Tests.cs">
       <Link>Common\System\Collections\IEnumerable.NonGeneric.Tests.cs</Link>

--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -3648,6 +3648,8 @@ namespace System.Collections
     public partial struct DictionaryEntry
     {
         public DictionaryEntry(object key, object value) { throw null; }
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public void Deconstruct(out object key, out object value) { throw null; }
         public object Key { get { throw null; } set { } }
         public object Value { get { throw null; } set { } }
     }
@@ -3810,6 +3812,8 @@ namespace System.Collections.Generic
     public partial struct KeyValuePair<TKey, TValue>
     {
         public KeyValuePair(TKey key, TValue value) { throw null; }
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public void Deconstruct(out TKey key, out TValue value) { throw null; }
         public TKey Key { get { throw null; } }
         public TValue Value { get { throw null; } }
         public override string ToString() { throw null; }


### PR DESCRIPTION
This is a pick up of the abandoned PR: #14621

The implementation went into corert and coreclr but the APIs where never exposed in the contract nor tests where added. 
Fixes: #13746

cc: @ianhays @stephentoub @danmosemsft 