### PR TITLE
Revert "Clear cached display name in validation context when member name is set"

### DIFF
--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationContext.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationContext.cs
@@ -174,15 +174,8 @@ namespace System.ComponentModel.DataAnnotations
         /// </value>
         public string MemberName
         {
-            get
-            {
-                return _memberName;
-            }
-            set
-            {
-                _memberName = value;
-                _displayName = null;
-            }
+            get { return _memberName; }
+            set { _memberName = value; }
         }
 
         /// <summary>

--- a/src/System.ComponentModel.Annotations/tests/ValidationContextTests.cs
+++ b/src/System.ComponentModel.Annotations/tests/ValidationContextTests.cs
@@ -139,17 +139,6 @@ namespace System.ComponentModel.DataAnnotations.Tests
             validationContext.DisplayName = "OverriddenDisplayName";
             Assert.Equal("OverriddenDisplayName", validationContext.DisplayName);
         }
-
-        [Fact]
-        public static void Setting_MemberName_resets_DisplayName()
-        {
-            var testDataAnnotationsDerived = new TestClass();
-            var validationContext = new ValidationContext(testDataAnnotationsDerived);
-            validationContext.MemberName = "DisplayNameMember";
-            Assert.Equal("DisplayNameMemberDisplayName", validationContext.DisplayName);
-            validationContext.MemberName = "ExistingMember";
-            Assert.Equal("ExistingMember", validationContext.DisplayName);
-        }
     }
 
     public class TestClass


### PR DESCRIPTION
Reverts dotnet/corefx#17380 per https://github.com/dotnet/corefx/issues/11044#issuecomment-290167071

cc: @lajones, @tuespetre, @ajcvickers