### PR TITLE
SerialPort: Don't allow unhandled exceptions out of Background thread

### DIFF
--- a/src/System.IO.Ports/src/System/IO/Ports/SerialStream.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/SerialStream.cs
@@ -1698,8 +1698,15 @@ namespace System.IO.Ports
                 {
                     WaitForCommEvent();
                 }
-                catch(Exception ex)
+                catch (ObjectDisposedException)
                 {
+                    // These can happen in some messy tear-down situations (e.g. unexpected USB unplug)
+                    // See GH issue #17661
+                }
+                catch (Exception ex)
+                {
+                    // We don't know of any reason why this should happen, but we still
+                    // don't want process termination
                     Debug.Fail("Unhandled exception thrown from WaitForCommEvent", ex.ToString());
                 }
             }

--- a/src/System.IO.Ports/src/System/IO/Ports/SerialStream.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/SerialStream.cs
@@ -1692,10 +1692,9 @@ namespace System.IO.Ports
                 {
                     WaitForCommEvent();
                 }
-                catch
+                catch(Exception ex)
                 {
-                    //TODO What is the correct behaviour for discarding exceptions
-                    // in this situation?  Should we log them in any way?
+                    Debug.Fail("Unhandled exception thrown from WaitForCommEvent", ex.ToString());
                 }
             }
 

--- a/src/System.IO.Ports/src/System/IO/Ports/SerialStream.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/SerialStream.cs
@@ -714,10 +714,13 @@ namespace System.IO.Ports
 
                 // prep. for starting event cycle.
                 _eventRunner = new EventLoopRunner(this);
+
+                // We should consider migrating to a Task here rather than simple background Thread
+                // This would let any exceptions be marshalled back to the owner of the SerialPort
+                // Some discussion in GH issue #17666
                 Thread eventLoopThread = new Thread(_eventRunner.SafelyWaitForCommEvent);
                 eventLoopThread.IsBackground = true;
                 eventLoopThread.Start();
-
             }
             catch
             {
@@ -1685,6 +1688,9 @@ namespace System.IO.Ports
             /// Call WaitForCommEvent (which is a thread function for a background thread)
             /// within an exception handler, so that unhandled exceptions in WaitForCommEvent
             /// don't cause process termination
+            /// Ultimately it would be good to migrate to a Task here rather than simple background Thread
+            /// This would let any exceptions be marshalled back to the owner of the SerialPort
+            /// Some discussion in GH issue #17666
             /// </summary>
             internal void SafelyWaitForCommEvent()
             {


### PR DESCRIPTION
Fixes #17661