### PR TITLE
Add serialization test for CookieContainer

### DIFF
--- a/src/System.Net.Primitives/tests/FunctionalTests/SerializationTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/SerializationTest.cs
@@ -20,9 +20,21 @@ namespace System.Net.Primitives.Functional.Tests
 
         [Theory]
         [MemberData(nameof(SerializeDeserialize_Roundtrip_MemberData))]
-        public static void SerializeDeserialize_Roundtrip(object obj)
+        public static void SerializeDeserialize_Roundtrip_EqualObjects(object obj)
         {
             Assert.Equal(obj, BinaryFormatterHelpers.Clone(obj));
+        }
+
+        [Fact]
+        public static void SerializeDeserialize_CookieContainerRoundtrip_EqualValues()
+        {
+            CookieContainer cookies1 = new CookieContainer();
+            CookieContainer cookies2 = BinaryFormatterHelpers.Clone(cookies1);
+
+            Assert.Equal(cookies1.Capacity, cookies2.Capacity);
+            Assert.Equal(cookies1.Count, cookies2.Count);
+            Assert.Equal(cookies1.MaxCookieSize, cookies2.MaxCookieSize);
+            Assert.Equal(cookies2.PerDomainCapacity, cookies2.PerDomainCapacity);
         }
     }
 }

--- a/src/System.Net.Primitives/tests/FunctionalTests/SerializationTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/SerializationTest.cs
@@ -34,7 +34,7 @@ namespace System.Net.Primitives.Functional.Tests
             Assert.Equal(cookies1.Capacity, cookies2.Capacity);
             Assert.Equal(cookies1.Count, cookies2.Count);
             Assert.Equal(cookies1.MaxCookieSize, cookies2.MaxCookieSize);
-            Assert.Equal(cookies2.PerDomainCapacity, cookies2.PerDomainCapacity);
+            Assert.Equal(cookies1.PerDomainCapacity, cookies2.PerDomainCapacity);
         }
     }
 }


### PR DESCRIPTION
.NET Core 2.0 now supports full binary serialization. `CookieContainer`
was already marked Serializable. Adding a test to verify that.

Note: a separate test method was added since CookieContainer doesn't
override `Equals`.

Fixes #9184