### PR TITLE
Make Activity Serializable on NET 4.5

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.Current.net45.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.Current.net45.cs
@@ -8,6 +8,7 @@ using System.Threading;
 
 namespace System.Diagnostics
 {
+    [Serializable]
     public partial class Activity
     {
         /// <summary>

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.Current.net45.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.Current.net45.cs
@@ -4,7 +4,6 @@
 
 using System.Runtime.Remoting.Messaging;
 using System.Security;
-using System.Threading;
 
 namespace System.Diagnostics
 {
@@ -35,7 +34,13 @@ namespace System.Diagnostics
         }
 
 #region private
-        private static readonly string FieldKey = $"{typeof(Activity).FullName}.Value.{AppDomain.CurrentDomain.Id}";
+        
+        [Serializable]
+        private partial class KeyValueListNode
+        {
+        }
+
+        private static readonly string FieldKey = $"{typeof(Activity).FullName}";
 #endregion
     }
 }

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -420,10 +420,11 @@ namespace System.Diagnostics
 
         private const int RequestIdMaxLength = 1024;
         private const char RootIdPrefix = '|';
+
         /// <summary>
         /// Having our own key-value linked list allows us to be more efficient  
         /// </summary>
-        private class KeyValueListNode
+        private partial class KeyValueListNode
         {
             public KeyValuePair<string, string> keyValue;
             public KeyValueListNode Next;


### PR DESCRIPTION
In order to store Activity in LogicalCallContext, Activity [must be](https://msdn.microsoft.com/en-us/library/system.runtime.remoting.messaging.callcontext.logicalsetdata(v=vs.110).aspx) serializable 

It only affect the cross app-domain communication, which is not the case for Activity, however causes some implicit problems with MsTest