### PR TITLE
Increased code coverage for EncryptedXml from 62% to 91.8%

### DIFF
--- a/src/System.Security.Cryptography.Xml/tests/EncryptedXmlTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/EncryptedXmlTest.cs
@@ -24,6 +24,29 @@ namespace System.Security.Cryptography.Xml.Tests
 {
     public class EncryptedXmlTest
     {
+        private class NotSupportedSymmetricAlgorithm : SymmetricAlgorithm
+        {
+            public override ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[] rgbIV)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void GenerateIV()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void GenerateKey()
+            {
+                throw new NotImplementedException();
+            }
+        }
+
         [Fact]
         public void Constructor_Default()
         {
@@ -152,7 +175,6 @@ namespace System.Security.Cryptography.Xml.Tests
                         dr.Uri = "_0";
                         ekey.AddReference(dr);
                         edata.KeyInfo.AddClause(new KeyInfoEncryptedKey(ekey));
-                        edata.KeyInfo = new KeyInfo();
                         ekey.KeyInfo.AddClause(new RSAKeyValue(RSA.Create()));
                         edata.CipherData.CipherValue = encrypted;
                         EncryptedXml.ReplaceElement(doc.DocumentElement, edata, false);
@@ -183,6 +205,166 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        public void Encrypt_DecryptDocument_AES()
+        {
+            XmlDocument doc = new XmlDocument();
+            doc.PreserveWhitespace = true;
+            string xml = "<root>  <child>sample</child>   </root>";
+            doc.LoadXml(xml);
+
+            using (Aes aes = Aes.Create())
+            {
+                EncryptedXml exml = new EncryptedXml();
+                exml.AddKeyNameMapping("aes", aes);
+                EncryptedData ed = exml.Encrypt(doc.DocumentElement, "aes");
+
+                doc.LoadXml(ed.GetXml().OuterXml);
+                EncryptedXml exmlDecryptor = new EncryptedXml(doc);
+                exmlDecryptor.AddKeyNameMapping("aes", aes);
+                exmlDecryptor.DecryptDocument();
+
+                Assert.Equal(xml, doc.OuterXml);
+            }
+        }
+
+        [Fact]
+        public void Encrypt_X509()
+        {
+            XmlDocument doc = new XmlDocument();
+            doc.PreserveWhitespace = true;
+            string xml = "<root>  <child>sample</child>   </root>";
+            doc.LoadXml(xml);
+
+            using (X509Certificate2 certificate = TestHelpers.GetSampleX509Certificate())
+            {
+                EncryptedXml exml = new EncryptedXml();
+                EncryptedData ed = exml.Encrypt(doc.DocumentElement, certificate);
+
+                Assert.NotNull(ed);
+
+                doc.LoadXml(ed.GetXml().OuterXml);
+                XmlNamespaceManager nm = new XmlNamespaceManager(doc.NameTable);
+                nm.AddNamespace("enc", EncryptedXml.XmlEncNamespaceUrl);
+
+                Assert.NotNull(doc.SelectSingleNode("//enc:EncryptedKey", nm));
+            }
+        }
+
+        [Fact]
+        public void Encrypt_X509_XmlNull()
+        {
+            using (X509Certificate2 certificate = TestHelpers.GetSampleX509Certificate())
+            {
+                EncryptedXml exml = new EncryptedXml();
+                Assert.Throws<ArgumentNullException>(() => exml.Encrypt(null, certificate));
+            }
+        }
+
+        [Fact]
+        public void Encrypt_X509_CertificateNull()
+        {
+            XmlDocument doc = new XmlDocument();
+            doc.LoadXml("<root />");
+            EncryptedXml exml = new EncryptedXml();
+            X509Certificate2 certificate = null;
+            Assert.Throws<ArgumentNullException>(() => exml.Encrypt(doc.DocumentElement, certificate));
+        }
+
+        [Fact]
+        public void Encrypt_XmlNull()
+        {
+            EncryptedXml exml = new EncryptedXml();
+            Assert.Throws<ArgumentNullException>(() => exml.Encrypt(null, "aes"));
+        }
+
+        [Fact]
+        public void Encrypt_KeyNameNull()
+        {
+            XmlDocument doc = new XmlDocument();
+            doc.LoadXml("<root />");
+            EncryptedXml exml = new EncryptedXml();
+            string keyName = null;
+            Assert.Throws<ArgumentNullException>(() => exml.Encrypt(doc.DocumentElement, keyName));
+        }
+
+        [Fact]
+        public void Encrypt_MissingKey()
+        {
+            XmlDocument doc = new XmlDocument();
+            doc.LoadXml("<root />");
+            EncryptedXml exml = new EncryptedXml();
+            Assert.Throws<CryptographicException>(() => exml.Encrypt(doc.DocumentElement, "aes"));
+        }
+
+        [Fact]
+        public void Encrypt_RSA()
+        {
+            using (RSA rsa = RSA.Create())
+            {
+                CheckEncryptionMethod(rsa, EncryptedXml.XmlEncRSA15Url);
+            }
+        }
+
+        [Fact]
+        public void Encrypt_TripleDES()
+        {
+            using (TripleDES tripleDes = TripleDES.Create())
+            {
+                CheckEncryptionMethod(tripleDes, EncryptedXml.XmlEncTripleDESKeyWrapUrl);
+            }
+        }
+
+        [Fact]
+        public void Encrypt_AES128()
+        {
+            using (Aes aes = Aes.Create())
+            {
+                aes.KeySize = 128;
+                CheckEncryptionMethod(aes, EncryptedXml.XmlEncAES128KeyWrapUrl);
+            }
+        }
+
+        [Fact]
+        public void Encrypt_AES192()
+        {
+            using (Aes aes = Aes.Create())
+            {
+                aes.KeySize = 192;
+                CheckEncryptionMethod(aes, EncryptedXml.XmlEncAES192KeyWrapUrl);
+            }
+        }
+
+        [Fact]
+        public void Encrypt_NotSupportedAlgorithm()
+        {
+            Assert.Throws<CryptographicException>(() => CheckEncryptionMethod(new NotSupportedSymmetricAlgorithm(), EncryptedXml.XmlEncAES192KeyWrapUrl));
+        }
+
+        [Fact]
+        public void AddKeyNameMapping_KeyNameNull()
+        {
+            EncryptedXml exml = new EncryptedXml();
+            using (Aes aes = Aes.Create())
+            {
+                Assert.Throws<ArgumentNullException>(() => exml.AddKeyNameMapping(null, aes));
+            }
+        }
+
+        [Fact]
+        public void AddKeyNameMapping_KeyObjectNull()
+        {
+            EncryptedXml exml = new EncryptedXml();
+            Assert.Throws<ArgumentNullException>(() => exml.AddKeyNameMapping("no_object", null));
+        }
+
+        [Fact]
+        public void AddKeyNameMapping_KeyObjectWrongType()
+        {
+            EncryptedXml exml = new EncryptedXml();
+            Assert.Throws<CryptographicException>(() => exml.AddKeyNameMapping("string", ""));
+        }
+
+        [Fact]
         public void ReplaceData_XmlElementNull()
         {
             EncryptedXml ex = new EncryptedXml();
@@ -194,6 +376,7 @@ namespace System.Security.Cryptography.Xml.Tests
         {
             EncryptedXml ex = new EncryptedXml();
             XmlDocument doc = new XmlDocument();
+            doc.LoadXml("<root />");
             Assert.Throws<ArgumentNullException>(() => ex.ReplaceData(doc.DocumentElement, null));
         }
 
@@ -207,7 +390,20 @@ namespace System.Security.Cryptography.Xml.Tests
         public void ReplaceElement_EncryptedDataNull()
         {
             XmlDocument doc = new XmlDocument();
+            doc.LoadXml("<root />");
             Assert.Throws<ArgumentNullException>(() => EncryptedXml.ReplaceElement(doc.DocumentElement, null, false));
+        }
+
+        [Fact]
+        public void ReplaceElement_ContentTrue()
+        {
+            XmlDocument doc = new XmlDocument();
+            doc.LoadXml("<root />");
+            EncryptedData edata = new EncryptedData();
+            edata.CipherData.CipherValue = new byte[16];
+            EncryptedXml.ReplaceElement(doc.DocumentElement, edata, true);
+            Assert.Equal("root", doc.DocumentElement.Name);
+            Assert.Equal("EncryptedData", doc.DocumentElement.FirstChild.Name);
         }
 
         [Fact]
@@ -232,10 +428,65 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        public void GetDecryptionKey_NoEncryptionMethod()
+        {
+            EncryptedData edata = new EncryptedData();
+            edata.KeyInfo = new KeyInfo();
+            edata.KeyInfo.AddClause(new KeyInfoEncryptedKey(new EncryptedKey()));
+            EncryptedXml exml = new EncryptedXml();
+            Assert.Throws<CryptographicException>(() => exml.GetDecryptionKey(edata, null));
+        }
+
+        [Fact]
         public void GetDecryptionKey_StringNull()
         {
             EncryptedXml ex = new EncryptedXml();
             Assert.Null(ex.GetDecryptionKey(new EncryptedData(), null));
+        }
+
+        [Fact]
+        public void GetDecryptionKey_KeyInfoName()
+        {
+            using (Aes aes = Aes.Create())
+            {
+                EncryptedData edata = new EncryptedData();
+                edata.KeyInfo = new KeyInfo();
+                edata.KeyInfo.AddClause(new KeyInfoName("aes"));
+
+                EncryptedXml exml = new EncryptedXml();
+                exml.AddKeyNameMapping("aes", aes);
+                SymmetricAlgorithm decryptedAlg = exml.GetDecryptionKey(edata, null);
+
+                Assert.Equal(aes.Key, decryptedAlg.Key);
+            }
+        }
+
+        [Fact]
+        public void GetDecryptionKey_CarriedKeyName()
+        {
+            using (Aes aes = Aes.Create())
+            {
+                EncryptedData edata = new EncryptedData();
+                edata.KeyInfo = new KeyInfo();
+                edata.KeyInfo.AddClause(new KeyInfoName("aes"));
+
+                EncryptedKey ekey = new EncryptedKey();
+                byte[] encKeyBytes = EncryptedXml.EncryptKey(aes.Key, aes);
+                ekey.CipherData = new CipherData(encKeyBytes);
+                ekey.EncryptionMethod = new EncryptionMethod(EncryptedXml.XmlEncAES256Url);
+                ekey.CarriedKeyName = "aes";
+                ekey.KeyInfo = new KeyInfo();
+                ekey.KeyInfo.AddClause(new KeyInfoName("another_aes"));
+
+                XmlDocument doc = new XmlDocument();
+                doc.LoadXml(ekey.GetXml().OuterXml);
+
+                EncryptedXml exml = new EncryptedXml(doc);
+                exml.AddKeyNameMapping("another_aes", aes);
+                SymmetricAlgorithm decryptedAlg = exml.GetDecryptionKey(edata, EncryptedXml.XmlEncAES256Url);
+
+                Assert.Equal(aes.Key, decryptedAlg.Key);
+            }
         }
 
         [Fact]
@@ -265,9 +516,30 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        public void GetDecryptionIV_InvalidAlgorithmUri()
+        {
+            EncryptedXml ex = new EncryptedXml();
+            EncryptedData encryptedData = new EncryptedData();
+            encryptedData.CipherData = new CipherData(new byte[16]);
+            Assert.Throws<CryptographicException>(() => ex.GetDecryptionIV(encryptedData, "invalid"));
+        }
+
+        [Fact]
+        public void GetDecryptionIV_TripleDesUri()
+        {
+            EncryptedXml ex = new EncryptedXml();
+            EncryptedData encryptedData = new EncryptedData();
+            encryptedData.CipherData = new CipherData(new byte[16]);
+            Assert.Equal(8, ex.GetDecryptionIV(encryptedData, EncryptedXml.XmlEncTripleDESUrl).Length);
+        }
+
+        [Fact]
         public void DecryptKey_KeyNull()
         {
-            Assert.Throws<ArgumentNullException>(() => EncryptedXml.DecryptKey(null, Rijndael.Create()));
+            using (Aes aes = Aes.Create())
+            {
+                Assert.Throws<ArgumentNullException>(() => EncryptedXml.DecryptKey(null, aes));
+            }
         }
 
         [Fact]
@@ -279,7 +551,10 @@ namespace System.Security.Cryptography.Xml.Tests
         [Fact]
         public void EncryptKey_KeyNull()
         {
-            Assert.Throws<ArgumentNullException>(() => EncryptedXml.EncryptKey(null, Rijndael.Create()));
+            using (Aes aes = Aes.Create())
+            {
+                Assert.Throws<ArgumentNullException>(() => EncryptedXml.EncryptKey(null, aes));
+            }
         }
 
         [Fact]
@@ -289,10 +564,46 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        public void EncryptKey_WrongSymmetricAlgorithm()
+        {
+            Assert.Throws<CryptographicException>(() => EncryptedXml.EncryptKey(new byte[16], new NotSupportedSymmetricAlgorithm()));
+        }
+
+        [Fact]
+        public void EncryptKey_RSA_KeyDataNull()
+        {
+            using (RSA rsa = RSA.Create())
+            {
+                Assert.Throws<ArgumentNullException>(() => EncryptedXml.EncryptKey(null, rsa, false));
+            }
+        }
+
+        [Fact]
+        public void EncryptKey_RSA_RSANull()
+        {
+            Assert.Throws<ArgumentNullException>(() => EncryptedXml.EncryptKey(new byte[16], null, false));
+        }
+
+        [Fact]
+        public void EncryptKey_RSA_UseOAEP()
+        {
+            byte[] data = Encoding.ASCII.GetBytes("12345678");
+            using (RSA rsa = RSA.Create())
+            {
+                byte[] encryptedData = EncryptedXml.EncryptKey(data, rsa, true);
+                byte[] decryptedData = EncryptedXml.DecryptKey(encryptedData, rsa, true);
+                Assert.Equal(data, decryptedData);
+            }
+        }
+
+        [Fact]
         public void DecryptData_EncryptedDataNull()
         {
             EncryptedXml ex = new EncryptedXml();
-            Assert.Throws<ArgumentNullException>(() => ex.DecryptData(null, Aes.Create()));
+            using (Aes aes = Aes.Create())
+            {
+                Assert.Throws<ArgumentNullException>(() => ex.DecryptData(null, aes));
+            }
         }
 
         [Fact]
@@ -303,10 +614,74 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        public void DecryptData_CipherReference_InvalidUri()
+        {
+            XmlDocument doc = new XmlDocument();
+            doc.PreserveWhitespace = true;
+            string xml = "<root>  <child>sample</child>   </root>";
+            doc.LoadXml(xml);
+
+            using (Aes aes = Aes.Create())
+            {
+                EncryptedXml exml = new EncryptedXml();
+                exml.AddKeyNameMapping("aes", aes);
+                EncryptedData ed = exml.Encrypt(doc.DocumentElement, "aes");
+                ed.CipherData = new CipherData();
+                ed.CipherData.CipherReference = new CipherReference("invaliduri");
+
+                Assert.Throws<CryptographicException>(() => exml.DecryptData(ed, aes));
+            }
+        }
+
+        [Fact]
+        public void DecryptData_CipherReference_IdUri()
+        {
+            XmlDocument doc = new XmlDocument();
+            doc.PreserveWhitespace = true;
+            string xml = "<root>  <child>sample</child>   </root>";
+            doc.LoadXml(xml);
+
+            using (Aes aes = Aes.Create())
+            {
+                EncryptedXml exml = new EncryptedXml(doc);
+                string cipherValue = Convert.ToBase64String(exml.EncryptData(Encoding.UTF8.GetBytes(xml), aes));
+
+                EncryptedData ed = new EncryptedData();
+                ed.Type = EncryptedXml.XmlEncElementUrl;
+                ed.EncryptionMethod = new EncryptionMethod(EncryptedXml.XmlEncAES256Url);
+                ed.CipherData = new CipherData();
+                // Create CipherReference: first extract node value, then convert from base64 using Transforms
+                ed.CipherData.CipherReference = new CipherReference("#ID_0");
+                string xslt = "<xsl:stylesheet version=\"1.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\"><xsl:template match = \"/\"><xsl:value-of select=\".\" /></xsl:template></xsl:stylesheet>";
+                XmlDsigXsltTransform xsltTransform = new XmlDsigXsltTransform();
+                XmlDocument xsltDoc = new XmlDocument();
+                xsltDoc.LoadXml(xslt);
+                xsltTransform.LoadInnerXml(xsltDoc.ChildNodes);
+                ed.CipherData.CipherReference.AddTransform(xsltTransform);
+                ed.CipherData.CipherReference.AddTransform(new XmlDsigBase64Transform());
+
+                // Create a document with EncryptedData and node with the actual cipher data (with the ID)
+                doc.LoadXml("<root></root>");
+                XmlNode encryptedDataNode = doc.ImportNode(ed.GetXml(), true);
+                doc.DocumentElement.AppendChild(encryptedDataNode);
+                XmlElement cipherDataByReference = doc.CreateElement("CipherData");
+                cipherDataByReference.SetAttribute("ID", "ID_0");
+                cipherDataByReference.InnerText = cipherValue;
+                doc.DocumentElement.AppendChild(cipherDataByReference);
+
+                string decryptedXmlString = Encoding.UTF8.GetString(exml.DecryptData(ed, aes));
+                Assert.Equal(xml, decryptedXmlString);
+            }
+        }
+
+        [Fact]
         public void EncryptData_DataNull()
         {
             EncryptedXml ex = new EncryptedXml();
-            Assert.Throws<ArgumentNullException>(() => ex.EncryptData(null, Aes.Create()));
+            using (Aes aes = Aes.Create())
+            {
+                Assert.Throws<ArgumentNullException>(() => ex.EncryptData(null, aes));
+            }
         }
 
         [Fact]
@@ -317,10 +692,22 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
-        public void EncryptData_XmlElementNull()
+        public void EncryptData_Xml_SymmetricAlgorithmNull()
+        {
+            XmlDocument doc = new XmlDocument();
+            doc.LoadXml("<root />");
+            EncryptedXml ex = new EncryptedXml();
+            Assert.Throws<ArgumentNullException>(() => ex.EncryptData(doc.DocumentElement, null, true));
+        }
+
+        [Fact]
+        public void EncryptData_Xml_XmlElementNull()
         {
             EncryptedXml ex = new EncryptedXml();
-            Assert.Throws<ArgumentNullException>(() => ex.EncryptData(null, Aes.Create(), true));
+            using (Aes aes = Aes.Create())
+            {
+                Assert.Throws<ArgumentNullException>(() => ex.EncryptData(null, aes, true));
+            }
         }
 
         [Fact]
@@ -328,6 +715,96 @@ namespace System.Security.Cryptography.Xml.Tests
         {
             EncryptedXml ex = new EncryptedXml();
             Assert.Throws<ArgumentNullException>(() => ex.DecryptEncryptedKey(null));
+        }
+
+        [Fact]
+        public void DecryptEncryptedKey_Empty()
+        {
+            EncryptedXml ex = new EncryptedXml();
+            EncryptedKey ek = new EncryptedKey();
+            Assert.Null(ex.DecryptEncryptedKey(ek));
+        }
+
+        [Fact]
+        public void DecryptEncryptedKey_KeyInfoRetrievalMethod()
+        {
+            XmlDocument doc = new XmlDocument();
+            doc.PreserveWhitespace = true;
+            string xml = "<root>  <child>sample</child>   </root>";
+            doc.LoadXml(xml);
+
+            using (Aes aes = Aes.Create())
+            {
+                EncryptedXml exml = new EncryptedXml(doc);
+                exml.AddKeyNameMapping("aes", aes);
+
+                EncryptedKey ekey = new EncryptedKey();
+                byte[] encKeyBytes = EncryptedXml.EncryptKey(aes.Key, aes);
+                ekey.CipherData = new CipherData(encKeyBytes);
+                ekey.EncryptionMethod = new EncryptionMethod(EncryptedXml.XmlEncAES256Url);
+                ekey.Id = "Key_ID";
+                ekey.KeyInfo = new KeyInfo();
+                ekey.KeyInfo.AddClause(new KeyInfoName("aes"));
+
+                doc.LoadXml(ekey.GetXml().OuterXml);
+
+                EncryptedKey ekeyRetrieval = new EncryptedKey();
+                KeyInfo keyInfoRetrieval = new KeyInfo();
+                keyInfoRetrieval.AddClause(new KeyInfoRetrievalMethod("#Key_ID"));
+                ekeyRetrieval.KeyInfo = keyInfoRetrieval;
+
+                byte[] decryptedKey = exml.DecryptEncryptedKey(ekeyRetrieval);
+                Assert.Equal(aes.Key, decryptedKey);
+
+                EncryptedData eData = new EncryptedData();
+                eData.EncryptionMethod = new EncryptionMethod(EncryptedXml.XmlEncAES256Url);
+                eData.KeyInfo = keyInfoRetrieval;
+                SymmetricAlgorithm decryptedAlg = exml.GetDecryptionKey(eData, null);
+                Assert.Equal(aes.Key, decryptedAlg.Key);
+            }
+        }
+
+        [Fact]
+        public void DecryptEncryptedKey_KeyInfoEncryptedKey()
+        {
+            XmlDocument doc = new XmlDocument();
+            doc.PreserveWhitespace = true;
+            string xml = "<root>  <child>sample</child>   </root>";
+            doc.LoadXml(xml);
+
+            using (Aes aes = Aes.Create())
+            {
+                EncryptedXml exml = new EncryptedXml(doc);
+                exml.AddKeyNameMapping("aes", aes);
+
+                EncryptedKey ekey = new EncryptedKey();
+                byte[] encKeyBytes = EncryptedXml.EncryptKey(aes.Key, aes);
+                ekey.CipherData = new CipherData(encKeyBytes);
+                ekey.EncryptionMethod = new EncryptionMethod(EncryptedXml.XmlEncAES256Url);
+                ekey.Id = "Key_ID";
+                ekey.KeyInfo = new KeyInfo();
+                ekey.KeyInfo.AddClause(new KeyInfoName("aes"));
+
+                KeyInfo topLevelKeyInfo = new KeyInfo();
+                topLevelKeyInfo.AddClause(new KeyInfoEncryptedKey(ekey));
+
+                EncryptedKey ekeyTopLevel = new EncryptedKey();
+                byte[] encTopKeyBytes = EncryptedXml.EncryptKey(aes.Key, aes);
+                ekeyTopLevel.CipherData = new CipherData(encTopKeyBytes);
+                ekeyTopLevel.EncryptionMethod = new EncryptionMethod(EncryptedXml.XmlEncAES256Url);
+                ekeyTopLevel.KeyInfo = topLevelKeyInfo;
+
+                doc.LoadXml(ekeyTopLevel.GetXml().OuterXml);
+
+                byte[] decryptedKey = exml.DecryptEncryptedKey(ekeyTopLevel);
+                Assert.Equal(aes.Key, decryptedKey);
+
+                EncryptedData eData = new EncryptedData();
+                eData.EncryptionMethod = new EncryptionMethod(EncryptedXml.XmlEncAES256Url);
+                eData.KeyInfo = topLevelKeyInfo;
+                SymmetricAlgorithm decryptedAlg = exml.GetDecryptionKey(eData, null);
+                Assert.Equal(aes.Key, decryptedAlg.Key);
+            }
         }
 
         [Fact]
@@ -366,7 +843,7 @@ namespace System.Security.Cryptography.Xml.Tests
                 byte[] key = Encoding.ASCII.GetBytes("12345678");
 
                 byte[] encryptedKey = EncryptedXml.EncryptKey(key, aes);
-                
+
                 Assert.NotNull(encryptedKey);
                 Assert.Equal(key, EncryptedXml.DecryptKey(encryptedKey, aes));
             }
@@ -447,6 +924,46 @@ namespace System.Security.Cryptography.Xml.Tests
             }
         }
 
+        [Fact]
+        public void DecryptKey_NotSupportedAlgorithm()
+        {
+            Assert.Throws<CryptographicException>(() => EncryptedXml.DecryptKey(new byte[16], new NotSupportedSymmetricAlgorithm()));
+        }
+
+        [Fact]
+        public void DecryptKey_RSA_KeyDataNull()
+        {
+            using (RSA rsa = RSA.Create())
+            {
+                Assert.Throws<ArgumentNullException>(() => EncryptedXml.DecryptKey(null, rsa, false));
+            }
+        }
+
+        [Fact]
+        public void DecryptKey_RSA_RSANull()
+        {
+            Assert.Throws<ArgumentNullException>(() => EncryptedXml.DecryptKey(new byte[16], null, false));
+        }
+
+        [Fact]
+        public void Properties()
+        {
+            EncryptedXml exml = new EncryptedXml();
+            exml.XmlDSigSearchDepth = 10;
+            exml.Resolver = null;
+            exml.Padding = PaddingMode.None;
+            exml.Mode = CipherMode.CBC;
+            exml.Encoding = Encoding.ASCII;
+            exml.Recipient = "Recipient";
+
+            Assert.Equal(10, exml.XmlDSigSearchDepth);
+            Assert.Null(exml.Resolver);
+            Assert.Equal(PaddingMode.None, exml.Padding);
+            Assert.Equal(CipherMode.CBC, exml.Mode);
+            Assert.Equal(Encoding.ASCII, exml.Encoding);
+            Assert.Equal("Recipient", exml.Recipient);
+        }
+
         private Stream LoadResourceStream(string resourceName)
         {
             return Assembly.GetCallingAssembly().GetManifestResourceStream(resourceName);
@@ -461,6 +978,23 @@ namespace System.Security.Cryptography.Xml.Tests
                 stream.Read(buffer, 0, (int)length);
                 return buffer;
             }
+        }
+
+        private void CheckEncryptionMethod(object algorithm, string uri)
+        {
+            XmlDocument doc = new XmlDocument();
+            doc.LoadXml("<root />");
+            EncryptedXml exml = new EncryptedXml();
+            exml.AddKeyNameMapping("key", algorithm);
+
+            EncryptedData edata = exml.Encrypt(doc.DocumentElement, "key");
+            IEnumerator keyInfoEnum = edata.KeyInfo.GetEnumerator();
+            keyInfoEnum.MoveNext();
+            KeyInfoEncryptedKey kiEncKey = keyInfoEnum.Current as KeyInfoEncryptedKey;
+
+            Assert.NotNull(edata);
+            Assert.Equal(uri, kiEncKey.EncryptedKey.EncryptionMethod.KeyAlgorithm);
+            Assert.NotNull(edata.CipherData.CipherValue);
         }
     }
 }

--- a/src/System.Security.Cryptography.Xml/tests/EncryptedXmlTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/EncryptedXmlTest.cs
@@ -247,6 +247,7 @@ namespace System.Security.Cryptography.Xml.Tests
                 nm.AddNamespace("enc", EncryptedXml.XmlEncNamespaceUrl);
 
                 Assert.NotNull(doc.SelectSingleNode("//enc:EncryptedKey", nm));
+                Assert.DoesNotContain("sample", doc.OuterXml);
             }
         }
 


### PR DESCRIPTION
Added tests for System.Security.Cryptography.Xml.EncryptedXml.
Overall code coverage for System.Security.Cryptography.Xml increased from 64.4% to 68.2%

Part of #16829