### PR TITLE
Remove spurious HashSet<T>.Contains from Microsoft.CSharp

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
@@ -885,7 +885,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         }
                         return false;
                     }
-                    if (names.Contains(name))
+
+                    if (!names.Add(name))
                     {
                         if (_pDuplicateSpecifiedName == null)
                         {
@@ -893,7 +894,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         }
                         return false;
                     }
-                    names.Add(name);
                 }
                 return true;
             }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
@@ -1974,17 +1974,16 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                 foreach (CType pCurrent in _pLowerBounds[iParam])
                 {
-                    if (!typeSet.Contains(pCurrent))
+                    if (typeSet.Add(pCurrent))
                     {
-                        typeSet.Add(pCurrent);
                         initialCandidates.Add(pCurrent);
                     }
                 }
+
                 foreach (CType pCurrent in _pUpperBounds[iParam])
                 {
-                    if (!typeSet.Contains(pCurrent))
+                    if (typeSet.Add(pCurrent))
                     {
-                        typeSet.Add(pCurrent);
                         initialCandidates.Add(pCurrent);
                     }
                 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
@@ -2047,11 +2047,10 @@ namespace Microsoft.CSharp.RuntimeBinder
                 type = type.GetGenericTypeDefinition();
             }
 
-            if (_typesWithConversionsLoaded.Contains(type))
+            if (!_typesWithConversionsLoaded.Add(type))
             {
                 return;
             }
-            _typesWithConversionsLoaded.Add(type);
 
             // Always make the aggregate for the type, regardless of whether or not
             // there are any conversions.


### PR DESCRIPTION
Testing `Contains()` prior to calling `Add()` is wasteful; just examine the result of calling `Add()`.