### PR TITLE
Fix signing of shims by passing the right strongname

### DIFF
--- a/src/shims/dir.props
+++ b/src/shims/dir.props
@@ -15,7 +15,9 @@
     <NetFxReference Include="System" />
     <NetFxReference Include="System.Core" />
     <NetFxReference Include="System.ComponentModel.Composition" />
-    <NetFxReference Include="System.ComponentModel.DataAnnotations" />
+    <NetFxReference Include="System.ComponentModel.DataAnnotations">
+      <StrongNameSig>MSSharedLib</StrongNameSig>
+    </NetFxReference> 
     <NetFxReference Include="System.Data" />
     <NetFxReference Include="System.Drawing" />
     <NetFxReference Include="System.IO.Compression.FileSystem" />

--- a/src/shims/shims.proj
+++ b/src/shims/shims.proj
@@ -4,7 +4,10 @@
 
   <Target Name="GetGenFacadesInputs">
     <ItemGroup>
-      <NetFxContracts Include="@(NetFxReference->'$(NetFxRefPath)%(Identity).dll')" />
+      <NetFxContracts Include="@(NetFxReference->'$(NetFxRefPath)%(Identity).dll')">
+        <StrongNameSig Condition="'%(NetfxReference.StrongNameSig)' == ''">StrongName</StrongNameSig>
+        <StrongNameSig Condition="'%(NetfxReference.StrongNameSig)' != ''">%(NetfxReference.StrongNameSig)</StrongNameSig>
+      </NetFxContracts>
       <NETStandardContracts Include="$(NetStandardRefPath)netstandard.dll" />
       <GenFacadesContracts Include="@(NetFxContracts);@(NETStandardContracts)" />
       <GenFacadesSeeds Include="$(RefPath)*.dll" Exclude="$(RefPath)System.Private.CoreLib.dll" />
@@ -47,7 +50,7 @@
     <WriteSigningRequired
         Condition="'$(SkipSigning)' != 'true' and '$(SignType)' != 'oss'"
         AuthenticodeSig="Microsoft"
-        StrongNameSig="StrongName"
+        StrongNameSig="%(NetFxContracts.StrongNameSig)"
         MarkerFile="$(GenFacadesOutputPath)%(NetFxContracts.Filename)%(NetFxContracts.Extension).requires_signing" />
 
     <!--

--- a/src/sign.builds
+++ b/src/sign.builds
@@ -32,12 +32,14 @@
     <ReadSigningRequired MarkerFiles="@(SignMarkerFile)">
       <Output TaskParameter="SigningMetadata" ItemName="FilesToSign" />
     </ReadSigningRequired>
+    <Message Text="Attempting to sign %(FilesToSign.Identity) with authenticode %(FilesToSign.Authenticode) and strongname %(FilesToSign.StrongName)" />
   </Target>
 
   <Target Name="Build"
           Condition="'$(SkipSigning)' != 'true' and '$(SignType)' != 'oss'"
           DependsOnTargets="GetFilesToSignItems">
-    <CallTarget Targets="SignFiles" />
+    <!--ToDo: Remove ContinueOnError once we verify that signing is succeeding-->
+    <CallTarget Targets="SignFiles" ContinueOnError="true" />
     <!-- now that the files have been signed delete the marker files -->
     <Delete Files="@(SignMarkerFile)" />
   </Target>


### PR DESCRIPTION
cc: @weshaggard @Petermarcu 

- Fixing signing of System.ComponentModel.DataAnnotations shim by passing in the right strongNameSig.
- Not fail the official build if signing fails (temporary to unblock build in case fix doesn't work)
- Added some logging for signing.
