### PR TITLE
Get IO.FileSystem tests running on NetFX

### DIFF
--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -222,7 +222,8 @@ namespace System.IO.Tests
 
         [Theory, MemberData(nameof(PathsWithInvalidColons))]
         [PlatformSpecific(TestPlatforms.Windows)]  // invalid colons throws ArgumentException
-        public void PathWithInvalidColons_ThrowsArgumentException(string invalidPath)
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Versions of netfx older than 4.6.2 throw an ArgumentException instead of NotSupportedException. Until all of our machines run netfx against the actual latest version, these will fail.")]
+        public void PathWithInvalidColons_ThrowsNotSupportedException(string invalidPath)
         {
             Assert.Throws<NotSupportedException>(() => Create(invalidPath));
         }

--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
@@ -4,6 +4,7 @@
 
 using System.Runtime.InteropServices;
 using Xunit;
+using System.Linq;
 
 namespace System.IO.Tests
 {
@@ -251,6 +252,9 @@ namespace System.IO.Tests
             Assert.Throws<ArgumentException>(() => GetEntries(TestDirectory, @".." + Path.DirectorySeparatorChar));
         }
 
+        private static char[] OldWildcards = new char[] { '*', '?' };
+        private static char[] NewWildcards = new char[] { '<', '>', '\"' };
+
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]  // Windows-invalid search patterns throw
         public void WindowsSearchPatternInvalid()
@@ -258,7 +262,7 @@ namespace System.IO.Tests
             Assert.Throws<ArgumentException>(() => GetEntries(TestDirectory, "\0"));
             Assert.Throws<ArgumentException>(() => GetEntries(TestDirectory, "|"));
 
-            Assert.All(Path.GetInvalidFileNameChars(), invalidChar =>
+            Assert.All(Path.GetInvalidFileNameChars().Except(OldWildcards).Except(NewWildcards), invalidChar =>
             {
                 switch (invalidChar)
                 {
@@ -282,18 +286,40 @@ namespace System.IO.Tests
                             GetEntries(Directory.GetCurrentDirectory(), string.Format("te{0}st", invalidChar.ToString()));
                         }
                         break;
-                    // Wildcard chars
-                    case '*':
-                    case '?':
-                    case '<':
-                    case '>':
-                    case '\"':
-                        GetEntries(Directory.GetCurrentDirectory(), string.Format("te{0}st", invalidChar.ToString()));
-                        break;
                     default:
                         Assert.Throws<ArgumentException>(() => GetEntries(Directory.GetCurrentDirectory(), string.Format("te{0}st", invalidChar.ToString())));
                         break;
                 }
+            });
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]  // Windows-invalid search patterns throw
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "")]
+        public void WindowsSearchPatternInvalid_Wildcards_netcoreapp()
+        {
+            Assert.All(OldWildcards, invalidChar =>
+            {
+                GetEntries(Directory.GetCurrentDirectory(), string.Format("te{0}st", invalidChar.ToString()));
+            });
+            Assert.All(NewWildcards, invalidChar =>
+            {
+                GetEntries(Directory.GetCurrentDirectory(), string.Format("te{0}st", invalidChar.ToString()));
+            });
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]  // Windows-invalid search patterns throw
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "")]
+        public void WindowsSearchPatternInvalid_Wildcards_netfx()
+        {
+            Assert.All(OldWildcards, invalidChar =>
+            {
+                GetEntries(Directory.GetCurrentDirectory(), string.Format("te{0}st", invalidChar.ToString()));
+            });
+            Assert.All(NewWildcards, invalidChar =>
+            {
+                Assert.Throws<ArgumentException>(() => GetEntries(Directory.GetCurrentDirectory(), string.Format("te{0}st", invalidChar.ToString())));
             });
         }
 

--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
@@ -310,7 +310,7 @@ namespace System.IO.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]  // Windows-invalid search patterns throw
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "In netcoreapp we made three new characters be treated as valid wildcards instead of invalid characters. NetFX still treats them as InvalidChars.")]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "In netcoreapp we made three new characters be treated as valid wildcards instead of invalid characters. NetFX still treats them as InvalidChars.")]
         public void WindowsSearchPatternInvalid_Wildcards_netfx()
         {
             Assert.All(OldWildcards, invalidChar =>

--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
@@ -295,7 +295,7 @@ namespace System.IO.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]  // Windows-invalid search patterns throw
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "In netcoreapp we made three new characters be treated as valid wildcards instead of invalid characters. NetFX still treats them as InvalidChars.")]
         public void WindowsSearchPatternInvalid_Wildcards_netcoreapp()
         {
             Assert.All(OldWildcards, invalidChar =>
@@ -310,7 +310,7 @@ namespace System.IO.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]  // Windows-invalid search patterns throw
-        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "In netcoreapp we made three new characters be treated as valid wildcards instead of invalid characters. NetFX still treats them as InvalidChars.")]
         public void WindowsSearchPatternInvalid_Wildcards_netfx()
         {
             Assert.All(OldWildcards, invalidChar =>

--- a/src/System.IO.FileSystem/tests/File/Move.cs
+++ b/src/System.IO.FileSystem/tests/File/Move.cs
@@ -199,6 +199,7 @@ namespace System.IO.Tests
 
         [Theory MemberData(nameof(PathsWithInvalidColons))]
         [PlatformSpecific(TestPlatforms.Windows)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Versions of netfx older than 4.6.2 throw an ArgumentException instead of NotSupportedException. Until all of our machines run netfx against the actual latest version, these will fail.")]
         public void WindowsPathWithIllegalColons(string invalidPath)
         {
             FileInfo testFile = new FileInfo(GetTestFilePath());

--- a/src/System.IO.FileSystem/tests/FileStream/CopyToAsync.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/CopyToAsync.cs
@@ -27,11 +27,6 @@ namespace System.IO.Tests
                 fs.Dispose();
                 Assert.Throws<ObjectDisposedException>(() => { fs.CopyToAsync(new MemoryStream()); });
             }
-            using (FileStream fs = new FileStream(GetTestFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.None, 0x100, useAsync))
-            {
-                fs.SafeFileHandle.Dispose();
-                Assert.Throws<ObjectDisposedException>(() => { fs.CopyToAsync(new MemoryStream()); });
-            }
             using (FileStream fs = new FileStream(GetTestFilePath(), FileMode.Create, FileAccess.Write))
             {
                 Assert.Throws<NotSupportedException>(() => { fs.CopyToAsync(new MemoryStream()); });
@@ -41,6 +36,53 @@ namespace System.IO.Tests
             {
                 dst.Dispose();
                 Assert.Throws<ObjectDisposedException>(() => { src.CopyToAsync(dst); });
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "This fails on netcoreapp because the Stream CopyToAsync calls Length which checks the validity of the underlying handle. On NetFX the operation no-ops for no input or delays failure to execution for input. See /dotnet/coreclr/pull/4540.")]
+        public void DisposeHandleThenUseFileStream_CopyToAsync(bool useAsync)
+        {
+            using (FileStream fs = new FileStream(GetTestFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.None, 0x100, useAsync))
+            {
+                fs.SafeFileHandle.Dispose();
+                Assert.Throws<ObjectDisposedException>(() => { fs.CopyToAsync(new MemoryStream()); });
+            }
+
+            using (FileStream fs = new FileStream(GetTestFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.None, 0x100, useAsync))
+            {
+                fs.Write(TestBuffer, 0, TestBuffer.Length);
+                fs.SafeFileHandle.Dispose();
+                Assert.Throws<ObjectDisposedException>(() => { fs.CopyToAsync(new MemoryStream()).Wait(); });
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "This fails on netcoreapp because the Stream CopyToAsync calls Length which checks the validity of the underlying handle. On NetFX the operation no-ops for no input or delays failure to execution for input. See /dotnet/coreclr/pull/4540.")]
+        public void DisposeHandleThenUseFileStream_CopyToAsync_netfx(bool useAsync)
+        {
+            using (FileStream fs = new FileStream(GetTestFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.None, 0x100, useAsync))
+            {
+                fs.SafeFileHandle.Dispose();
+                fs.CopyToAsync(new MemoryStream());
+            }
+
+            using (FileStream fs = new FileStream(GetTestFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.None, 0x100, useAsync))
+            {
+                fs.Write(TestBuffer, 0, TestBuffer.Length);
+                fs.SafeFileHandle.Dispose();
+                try
+                {
+                    fs.CopyToAsync(new MemoryStream()).Wait();
+                }
+                catch (AggregateException e)
+                {
+                    Assert.Equal(typeof(ObjectDisposedException), e.InnerException.GetType());
+                }
             }
         }
 

--- a/src/System.IO.FileSystem/tests/FileStream/CopyToAsync.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/CopyToAsync.cs
@@ -42,7 +42,7 @@ namespace System.IO.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "This fails on netcoreapp because the Stream CopyToAsync calls Length which checks the validity of the underlying handle. On NetFX the operation no-ops for no input or delays failure to execution for input. See /dotnet/coreclr/pull/4540.")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "The Stream CopyToAsync fails on netcoreapp because it calls Length which checks the validity of the underlying handle. On NetFX the operation no-ops for no input or delays failure to execution for input. See /dotnet/coreclr/pull/4540.")]
         public void DisposeHandleThenUseFileStream_CopyToAsync(bool useAsync)
         {
             using (FileStream fs = new FileStream(GetTestFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.None, 0x100, useAsync))
@@ -62,7 +62,7 @@ namespace System.IO.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "This fails on netcoreapp because the Stream CopyToAsync calls Length which checks the validity of the underlying handle. On NetFX the operation no-ops for no input or delays failure to execution for input. See /dotnet/coreclr/pull/4540.")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "The Stream CopyToAsync fails on netcoreapp because it calls Length which checks the validity of the underlying handle. On NetFX the operation no-ops for no input or delays failure to execution for input. See /dotnet/coreclr/pull/4540.")]
         public void DisposeHandleThenUseFileStream_CopyToAsync_netfx(bool useAsync)
         {
             using (FileStream fs = new FileStream(GetTestFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.None, 0x100, useAsync))

--- a/src/System.IO.FileSystem/tests/FileStream/CopyToAsync.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/CopyToAsync.cs
@@ -62,7 +62,7 @@ namespace System.IO.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "The Stream CopyToAsync fails on netcoreapp because it calls Length which checks the validity of the underlying handle. On NetFX the operation no-ops for no input or delays failure to execution for input. See /dotnet/coreclr/pull/4540.")]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "The Stream CopyToAsync fails on netcoreapp because it calls Length which checks the validity of the underlying handle. On NetFX the operation no-ops for no input or delays failure to execution for input. See /dotnet/coreclr/pull/4540.")]
         public void DisposeHandleThenUseFileStream_CopyToAsync_netfx(bool useAsync)
         {
             using (FileStream fs = new FileStream(GetTestFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.None, 0x100, useAsync))

--- a/src/System.IO.FileSystem/tests/FileStream/IsAsync.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/IsAsync.cs
@@ -40,6 +40,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetFX defaults useAsync to false for the SafeFileHandle/FileAccess constructor which leads to an ArgumentException for an async handle. In netcoreapp this constructor was fixed to check the async status of the handle and use that for the useAsync value.")]
         public void AsyncDiscoveredFromHandle()
         {
             using (FileStream fs = new FileStream(GetTestFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.Read, 4096, true))

--- a/src/System.IO.FileSystem/tests/FileStream/ReadAsync.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ReadAsync.cs
@@ -226,6 +226,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "In netcoreapp we modified ReadAsync/WriteAsync to complete synchronously here, but that change was not backported to netfx.")]
         public async Task ReadAsyncBufferedCompletesSynchronously()
         {
             string fileName = GetTestFilePath();

--- a/src/System.IO.FileSystem/tests/FileStream/SafeFileHandle.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/SafeFileHandle.cs
@@ -59,10 +59,20 @@ namespace System.IO.Tests
             }
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task ThrowWhenHandlePositionIsChanged(bool useAsync)
+        [Fact]
+        public async Task ThrowWhenHandlePositionIsChanged_sync()
+        {
+            await ThrowWhenHandlePositionIsChanged(useAsync: false);
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetFX doesn't allow concurrent FileStream access when using overlapped IO.")]
+        public async Task ThrowWhenHandlePositionIsChanged_async()
+        {
+            await ThrowWhenHandlePositionIsChanged(useAsync: true);
+        }
+
+        private async Task ThrowWhenHandlePositionIsChanged(bool useAsync)
         {
             string fileName = GetTestFilePath();
 

--- a/src/System.IO.FileSystem/tests/FileStream/Seek.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/Seek.cs
@@ -15,7 +15,7 @@ namespace System.IO.Tests
         {
             using (FileStream fs = new FileStream(GetTestFilePath(), FileMode.Create))
             {
-                Assert.Throws<ArgumentException>("origin", () => fs.Seek(0, ~SeekOrigin.Begin));
+                AssertExtensions.Throws<ArgumentException>("origin", null, () => fs.Seek(0, ~SeekOrigin.Begin));
             }
         }
 
@@ -48,7 +48,7 @@ namespace System.IO.Tests
                 // no fast path
                 Assert.Throws<ObjectDisposedException>(() => fs.Seek(fs.Position, SeekOrigin.Begin));
                 // parameter checking happens first
-                Assert.Throws<ArgumentException>("origin", () => fs.Seek(0, ~SeekOrigin.Begin));
+                AssertExtensions.Throws<ArgumentException>("origin", null, () => fs.Seek(0, ~SeekOrigin.Begin));
             }
         }
 
@@ -61,7 +61,7 @@ namespace System.IO.Tests
                 // no fast path
                 Assert.Throws<NotSupportedException>(() => fs.Seek(fs.Position, SeekOrigin.Begin));
                 // parameter checking happens first
-                Assert.Throws<ArgumentException>("origin", () => fs.Seek(0, ~SeekOrigin.Begin));
+                AssertExtensions.Throws<ArgumentException>("origin", null, () => fs.Seek(0, ~SeekOrigin.Begin));
                 // dispose checking happens first
                 fs.Dispose();
                 Assert.Throws<ObjectDisposedException>(() => fs.Seek(fs.Position, SeekOrigin.Begin));

--- a/src/System.IO.FileSystem/tests/FileStream/SetLength.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/SetLength.cs
@@ -65,7 +65,7 @@ namespace System.IO.Tests
                 // no fast path
                 Assert.Throws<NotSupportedException>(() => fs.Seek(fs.Position, SeekOrigin.Begin));
                 // parameter checking happens first
-                Assert.Throws<ArgumentException>("origin", () => fs.Seek(0, ~SeekOrigin.Begin));
+                AssertExtensions.Throws<ArgumentException>("origin", null, () => fs.Seek(0, ~SeekOrigin.Begin));
                 // dispose checking happens first
                 fs.Dispose();
                 Assert.Throws<ObjectDisposedException>(() => fs.Seek(fs.Position, SeekOrigin.Begin));

--- a/src/System.IO.FileSystem/tests/FileStream/WriteAsync.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/WriteAsync.cs
@@ -207,6 +207,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "In netcoreapp we modified ReadAsync/WriteAsync to complete synchronously here, but that change was not backported to netfx.")]
         public void WriteAsyncBufferedCompletesSynchronously()
         {
             using (FileStream fs = new FileStream(

--- a/src/System.IO.FileSystem/tests/FileStream/ctor_sfh_fa.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ctor_sfh_fa.cs
@@ -134,6 +134,7 @@ namespace System.IO.Tests
     public class DerivedFileStream_ctor_sfh_fa : FileSystemTest
     {
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "The NetFX FileStream Handle constructor calls the virtual Can*. This has been fixed in netcoreapp to instead directly check for write/read FileAccess.")]
         public void VirtualCanReadWrite_ShouldNotBeCalledDuringCtor()
         {
             using (var fs = File.Create(GetTestFilePath()))

--- a/src/System.IO.FileSystem/tests/FileStream/ctor_sfh_fa_buffer_async.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ctor_sfh_fa_buffer_async.cs
@@ -22,6 +22,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetFX doesn't allow concurrent FileStream access when using overlapped IO.")]
         public void MatchedAsync()
         {
             using (FileStream fs = new FileStream(GetTestFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite | FileShare.Delete, 4096, true))

--- a/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm.cs
@@ -167,7 +167,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public void FileModeAppend()
+        public virtual void FileModeAppend()
         {
             using (FileStream fs = CreateFileStream(GetTestFilePath(), FileMode.Append))
             {
@@ -177,7 +177,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public void FileModeAppendExisting()
+        public virtual void FileModeAppendExisting()
         {
             string fileName = GetTestFilePath();
             using (FileStream fs = CreateFileStream(fileName, FileMode.Create))

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -163,6 +163,9 @@
     <Compile Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorTestBase.cs">
       <Link>Common\System\Diagnostics\RemoteExecutorTestBase.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\AssertExtensions.cs">
+      <Link>Common\System\AssertExtensions.cs</Link>
+    </Compile>
     <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
       <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
       <Name>RemoteExecutorConsoleApp</Name>


### PR DESCRIPTION
There were a high number of failing FileSystem tests for NetFX. This PR modifies the tests to run on NetFX without failures and adds comments for the reasons for the tests that had to be disabled.

resolves https://github.com/dotnet/corefx/issues/14987
resolves https://github.com/dotnet/corefx/issues/17659

cc: @stephentoub @JeremyKuhne @safern 