### PR TITLE
Update exception thrown in Prelogin handshake processing due to invalid size in TDS header

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
@@ -676,9 +676,9 @@ namespace System.Data.SqlClient
 
             if (!_physicalStateObj.TryProcessHeader()) { throw SQL.SynchronousCallMayNotPend(); }
 
-            if (_physicalStateObj._inBytesPacket > TdsEnums.MAX_PACKET_SIZE || _physicalStateObj._inBytesPacket < 0)
+            if (_physicalStateObj._inBytesPacket > TdsEnums.MAX_PACKET_SIZE || _physicalStateObj._inBytesPacket <= 0)
             {
-                throw SQL.InvalidPacketSize();
+                throw SQL.ParsingError();
             }
             byte[] payload = new byte[_physicalStateObj._inBytesPacket];
 


### PR DESCRIPTION
Changing error to SQL.ParsingError to match similar error case in TdsParserStateObject.TryProcessHeader