### PR TITLE
Fix NumberFormatInfoNumberGroupSizes test for certain OS

### DIFF
--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoData.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoData.cs
@@ -9,13 +9,12 @@ namespace System.Globalization.Tests
         public static int[] UrINNumberGroupSizes()
         {
             if (
-                ((PlatformDetection.IsWindows && PlatformDetection.WindowsVersion >= 10)
+                (PlatformDetection.IsWindows && PlatformDetection.WindowsVersion >= 10)
 #if !uap
                 ||
                 (PlatformDetection.IsOSX && PlatformDetection.OSXKernelVersion >= new Version(15, 0))
 #endif
-                ) &&
-                (!PlatformDetection.IsUbuntu1510 && !PlatformDetection.IsUbuntu1604 && !PlatformDetection.IsUbuntu1610)
+                || PlatformDetection.IsUbuntu1510 || PlatformDetection.IsUbuntu1604 || PlatformDetection.IsUbuntu1610 || PlatformDetection.IsFedora
                )
             {
                 return new int[] { 3 };

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoNumberGroupSizes.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoNumberGroupSizes.cs
@@ -13,7 +13,12 @@ namespace System.Globalization.Tests
         {
             yield return new object[] { NumberFormatInfo.InvariantInfo, new int[] { 3 } };
             yield return new object[] { new CultureInfo("en-US").NumberFormat, new int[] { 3 } };
-            yield return new object[] { new CultureInfo("ur-IN").NumberFormat, NumberFormatInfoData.UrINNumberGroupSizes() };
+
+            // Culture does not exist on Windows 7
+            if (!PlatformDetection.IsWindows7)
+            {
+                yield return new object[] { new CultureInfo("ur-IN").NumberFormat, NumberFormatInfoData.UrINNumberGroupSizes() };
+            }
         }
 
         [Theory]


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/17713

On Windows 7 the culture is not found. I thought it was excluded because the expected result was different. Reverting the condition back to how it was.

@tarekgh 