### PR TITLE
Add tests for FormatterServices.GetUninitializedObject

### DIFF
--- a/src/Common/tests/System/NonRuntimeType.cs
+++ b/src/Common/tests/System/NonRuntimeType.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.Reflection;
+
+namespace System
+{
+    public class NonRuntimeType : Type
+    {
+        public override Assembly Assembly => null;
+        public override string AssemblyQualifiedName => null;
+        public override Type BaseType => null;
+        public override string FullName => null;
+        public override Guid GUID => Guid.Empty;
+        public override Module Module => null;
+        public override string Namespace => null;
+        public override Type UnderlyingSystemType => null;
+        public override string Name => null;
+        public override ConstructorInfo[] GetConstructors(BindingFlags bindingAttr) => null;
+        public override object[] GetCustomAttributes(bool inherit) => null;
+        public override object[] GetCustomAttributes(Type attributeType, bool inherit) => null;
+        public override Type GetElementType() => null;
+        public override EventInfo GetEvent(string name, BindingFlags bindingAttr) => null;
+        public override EventInfo[] GetEvents(BindingFlags bindingAttr) => null;
+        public override FieldInfo GetField(string name, BindingFlags bindingAttr) => null;
+        public override FieldInfo[] GetFields(BindingFlags bindingAttr) => null;
+        public override Type GetInterface(string name, bool ignoreCase) => null;
+        public override Type[] GetInterfaces() => null;
+        public override MemberInfo[] GetMembers(BindingFlags bindingAttr) => null;
+        public override MethodInfo[] GetMethods(BindingFlags bindingAttr) => null;
+        public override Type GetNestedType(string name, BindingFlags bindingAttr) => null;
+        public override Type[] GetNestedTypes(BindingFlags bindingAttr) => null;
+        public override PropertyInfo[] GetProperties(BindingFlags bindingAttr) => null;
+        public override object InvokeMember(string name, BindingFlags invokeAttr, Binder binder, object target, object[] args, ParameterModifier[] modifiers, CultureInfo culture, string[] namedParameters) => null;
+        public override bool IsDefined(Type attributeType, bool inherit) => false;
+        protected override TypeAttributes GetAttributeFlagsImpl() => TypeAttributes.NotPublic;
+        protected override ConstructorInfo GetConstructorImpl(BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers) => null;
+        protected override MethodInfo GetMethodImpl(string name, BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers) => null;
+        protected override PropertyInfo GetPropertyImpl(string name, BindingFlags bindingAttr, Binder binder, Type returnType, Type[] types, ParameterModifier[] modifiers) => null;
+        protected override bool HasElementTypeImpl() => false;
+        protected override bool IsArrayImpl() => false;
+        protected override bool IsByRefImpl() => false;
+        protected override bool IsCOMObjectImpl() => false;
+        protected override bool IsPointerImpl() => false;
+        protected override bool IsPrimitiveImpl() => false;
+    }
+}

--- a/src/System.Runtime.Serialization.Formatters/tests/Configurations.props
+++ b/src/System.Runtime.Serialization.Formatters/tests/Configurations.props
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <!-- Needs netfx configuration per bug (dotnet/corefx #17575) so tests are actively running in desktop -->
     <BuildConfigurations>
-      netcoreapp;
       netstandard;
       netfx;
     </BuildConfigurations>

--- a/src/System.Runtime.Serialization.Formatters/tests/Configurations.props
+++ b/src/System.Runtime.Serialization.Formatters/tests/Configurations.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <!-- Needs netfx configuration per bug (dotnet/corefx #17575) so tests are actively running in desktop -->
     <BuildConfigurations>
+      netcoreapp;
       netstandard;
       netfx;
     </BuildConfigurations>

--- a/src/System.Runtime.Serialization.Formatters/tests/FormatterServicesTests.Windows.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/FormatterServicesTests.Windows.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace System.Runtime.Serialization.Formatters.Tests
+{
+    public partial class FormatterServicesTests
+    {
+        [Fact]
+        public void GetUninitializedObject_COMObject_ThrowsNotSupportedException()
+        {
+            Type comObjectType = typeof(COMObject);
+            Assert.True(comObjectType.IsCOMObject);
+
+            Assert.Throws<NotSupportedException>(() => FormatterServices.GetUninitializedObject(typeof(COMObject)));
+            Assert.Throws<NotSupportedException>(() => FormatterServices.GetSafeUninitializedObject(typeof(COMObject)));
+        }
+
+        [ComImport]
+        [Guid("00000000-0000-0000-0000-000000000000")]
+        public class COMObject { }
+    }
+}

--- a/src/System.Runtime.Serialization.Formatters/tests/FormatterServicesTests.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/FormatterServicesTests.cs
@@ -2,7 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using System.Globalization;
 using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.Runtime.Serialization.Formatters.Tests
@@ -29,21 +34,260 @@ namespace System.Runtime.Serialization.Formatters.Tests
         }
 
         [Fact]
-        public void GetUninitializedObject_InvalidArguments_ThrowsException()
+        public void GetUninitializedObject_NullType_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>("type", () => FormatterServices.GetUninitializedObject(null));
             Assert.Throws<ArgumentNullException>("type", () => FormatterServices.GetSafeUninitializedObject(null));
         }
 
+#if netcoreapp
         [Fact]
-        public void GetUninitializedObject_DoesNotRunConstructor()
+        public void GetUninitializedObject_NonRuntimeType_ThrowsSerializationException()
         {
-            Assert.Equal(42, new ObjectWithDefaultCtor().Value);
-            Assert.Equal(0, ((ObjectWithDefaultCtor)FormatterServices.GetUninitializedObject(typeof(ObjectWithDefaultCtor))).Value);
-            Assert.Equal(0, ((ObjectWithDefaultCtor)FormatterServices.GetSafeUninitializedObject(typeof(ObjectWithDefaultCtor))).Value);
+            AssemblyName assemblyName = new AssemblyName("AssemblyName");
+            AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+            ModuleBuilder mboduleBuilder = assemblyBuilder.DefineDynamicModule(assemblyName.Name);
+
+            TypeBuilder typeBuilder = mboduleBuilder.DefineType("TestType", TypeAttributes.Public);
+
+            GenericTypeParameterBuilder[] typeParams = typeBuilder.DefineGenericParameters("T");
+            Type nonRuntimeType = typeParams[0].UnderlyingSystemType;
+
+            Assert.Throws<SerializationException>(() => FormatterServices.GetUninitializedObject(nonRuntimeType));
+            Assert.Throws<SerializationException>(() => FormatterServices.GetSafeUninitializedObject(nonRuntimeType));
+        }
+#endif
+
+        public static IEnumerable<object[]> GetUninitializedObject_NotSupportedType_TestData()
+        {
+            yield return new object[] { typeof(int[]) };
+            yield return new object[] { typeof(int[,]) };
+            yield return new object[] { typeof(int).MakePointerType() };
+            yield return new object[] { typeof(int).MakeByRefType() };
         }
 
-        private class ObjectWithDefaultCtor
+        [Theory]
+        [MemberData(nameof(GetUninitializedObject_NotSupportedType_TestData))]
+        public void GetUninitializedObject_NotSupportedType_ThrowsArgumentException(Type type)
+        {
+            Assert.Throws<ArgumentException>(null, () => FormatterServices.GetUninitializedObject(type));
+            Assert.Throws<ArgumentException>(null, () => FormatterServices.GetSafeUninitializedObject(type));
+        }
+
+        [Theory]
+        [InlineData(typeof(AbstractClass))]
+        [InlineData(typeof(StaticClass))]
+        [InlineData(typeof(Interface))]
+        [InlineData(typeof(Array))]
+        public void GetUninitializedObject_AbstractClass_ThrowsMemberAccessException(Type type)
+        {
+            Assert.Throws<MemberAccessException>(() => FormatterServices.GetUninitializedObject(type));
+            Assert.Throws<MemberAccessException>(() => FormatterServices.GetSafeUninitializedObject(type));
+        }
+
+        private abstract class AbstractClass { }
+        private static class StaticClass { }
+        private interface Interface { }
+
+        public static IEnumerable<object[]> GetUninitializedObject_OpenGenericClass_TestData()
+        {
+            yield return new object[] { typeof(GenericClass<>) };
+            yield return new object[] { typeof(GenericClass<>).MakeGenericType(typeof(GenericClass<>)) };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetUninitializedObject_OpenGenericClass_TestData))]
+        public void GetUninitializedObject_OpenGenericClass_ThrowsMemberAccessException(Type type)
+        {
+            Assert.Throws<MemberAccessException>(() => FormatterServices.GetUninitializedObject(type));
+            Assert.Throws<MemberAccessException>(() => FormatterServices.GetSafeUninitializedObject(type));
+        }
+
+        public interface IGenericClass
+        {
+            int Value { get; set; }
+        }
+
+        public class GenericClass<T> : IGenericClass
+        {
+            public int Value { get; set; }
+        }
+
+        public static IEnumerable<object[]> GetUninitializedObject_ByRefLikeType_TestData()
+        {
+            yield return new object[] { typeof(ArgIterator) };
+            yield return new object[] { typeof(RuntimeArgumentHandle) };
+            yield return new object[] { typeof(TypedReference) };
+
+            yield return new object[] { typeof(Span<int>) };
+            yield return new object[] { typeof(ReadOnlySpan<int>) };
+        }
+
+        public static IEnumerable<object[]> GetUninitializedObject_ByRefLikeType_NetCore_TestData()
+        {
+            yield return new object[] { Type.GetType("System.ByReference`1[System.Int32]") };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetUninitializedObject_ByRefLikeType_TestData))]
+        [MemberData(nameof(GetUninitializedObject_ByRefLikeType_NetCore_TestData))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "The full .NET framework supports GetUninitializedObject for by ref like types")]
+        public void GetUninitializedObject_ByRefLikeType_NetCore_ThrowsNotSupportedException(Type type)
+        {
+            Assert.Throws<NotSupportedException>(() => FormatterServices.GetUninitializedObject(type));
+            Assert.Throws<NotSupportedException>(() => FormatterServices.GetSafeUninitializedObject(type));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetUninitializedObject_ByRefLikeType_TestData))]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "The coreclr doesn't support GetUninitializedObject for by ref like types")]
+        public void GetUninitializedObject_ByRefLikeType_Netfx_ThrowsNotSupportedException(Type type)
+        {
+            Assert.NotNull(FormatterServices.GetUninitializedObject(type));
+            Assert.NotNull(FormatterServices.GetSafeUninitializedObject(type));
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "The full .NET framework supports GetUninitializedObject for shared generic instances")]
+        public void GetUniniitalizedObject_SharedGenericInstance_NetCore_ThrowsNotSupportedException()
+        {
+            Type canonType = Type.GetType("System.__Canon");
+            Assert.NotNull(canonType);
+            Type sharedGenericInstance = typeof(GenericClass<>).MakeGenericType(canonType);
+            Assert.Throws<NotSupportedException>(() => FormatterServices.GetUninitializedObject(sharedGenericInstance));
+            Assert.Throws<NotSupportedException>(() => FormatterServices.GetSafeUninitializedObject(sharedGenericInstance));
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "The coreclr doesn't support GetUninitializedObject for shared generic instances")]
+        public void GetUniniitalizedObject_SharedGenericInstance_Netfx_InitializesValue()
+        {
+            Type canonType = Type.GetType("System.__Canon");
+            Assert.NotNull(canonType);
+            Type sharedGenericInstance = typeof(GenericClass<>).MakeGenericType(canonType);
+            Assert.Throws<NotSupportedException>(() => FormatterServices.GetUninitializedObject(sharedGenericInstance));
+            Assert.Equal(0, ((IGenericClass)FormatterServices.GetSafeUninitializedObject(sharedGenericInstance)).Value);
+        }
+
+        [Fact]
+        public void GetUninitializedObject_NullableType_InitializesValue()
+        {
+            int? nullableUnsafe = (int?)FormatterServices.GetUninitializedObject(typeof(int?));
+            Assert.True(nullableUnsafe.HasValue);
+            Assert.Equal(0, nullableUnsafe.Value);
+
+            int? nullableSafe = (int?)FormatterServices.GetSafeUninitializedObject(typeof(int?));
+            Assert.True(nullableSafe.HasValue);
+            Assert.Equal(0, nullableSafe.Value);
+        }
+
+        [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "The full .NET framework doesn't support GetUninitializedObject for COM objects")]
+        public void GetUninitializedObject_ContextBoundObjectSubclass_NetCore_InitializesValue()
+        {
+            Assert.Equal(0, ((COMObject)FormatterServices.GetUninitializedObject(typeof(COMObject))).Value);
+            Assert.Equal(0, ((COMObject)FormatterServices.GetSafeUninitializedObject(typeof(COMObject))).Value);
+        }
+
+        [Theory]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "The coreclr supports GetUninitializedObject for COM objects")]
+        public void GetUninitializedObject_ContextBoundObjectSubclass_Netfx_ThrowsNotSupportedException()
+        {
+            Assert.Throws<NotSupportedException>(() => FormatterServices.GetUninitializedObject(typeof(COMObject)));
+            Assert.Throws<NotSupportedException>(() => FormatterServices.GetSafeUninitializedObject(typeof(COMObject)));
+        }
+
+        public class COMObject : ContextBoundObject
+        {
+            public int Value { get; set; }
+        }
+
+        [Fact]
+        public void GetUninitializedObject_TypeHasDefaultConstructor_DoesNotRunConstructor()
+        {
+            Assert.Equal(42, new ObjectWithDefaultConstructor().Value);
+            Assert.Equal(0, ((ObjectWithDefaultConstructor)FormatterServices.GetUninitializedObject(typeof(ObjectWithDefaultConstructor))).Value);
+            Assert.Equal(0, ((ObjectWithDefaultConstructor)FormatterServices.GetSafeUninitializedObject(typeof(ObjectWithDefaultConstructor))).Value);
+        }
+
+        private class ObjectWithDefaultConstructor
+        {
+            public ObjectWithDefaultConstructor()
+            {
+                Value = 42;
+            }
+
+            public int Value;
+        }
+
+        [Fact]
+        public void GetUninitializedObject_StaticConstructor_CallsStaticConstructor()
+        {
+            Assert.Equal(2, ((ObjectWithStaticConstructor)FormatterServices.GetUninitializedObject(typeof(ObjectWithStaticConstructor))).GetValue());
+        }
+
+        private class ObjectWithStaticConstructor
+        {
+            private static int s_value = 1;
+
+            static ObjectWithStaticConstructor()
+            {
+                s_value = 2;
+            }
+
+            public int GetValue() => s_value;
+        }
+
+        [Fact]
+        public void GetUninitializedObject_StaticField_InitializesStaticFields()
+        {
+            Assert.Equal(1, ((ObjectWithStaticField)FormatterServices.GetUninitializedObject(typeof(ObjectWithStaticField))).GetValue());
+        }
+
+        private class ObjectWithStaticField
+        {
+            private static int s_value = 1;
+
+            public int GetValue() => s_value;
+        }
+
+        [Fact]
+        public void GetUninitializedObject_StaticConstructorThrows_ThrowsTypeInitializationException()
+        {
+            TypeInitializationException ex = Assert.Throws<TypeInitializationException>(() => FormatterServices.GetUninitializedObject(typeof(StaticConstructorThrows)));
+            Assert.IsType<DivideByZeroException>(ex.InnerException);
+        }
+
+        private class StaticConstructorThrows
+        {
+            static StaticConstructorThrows()
+            {
+                throw new DivideByZeroException();
+            }
+        }
+
+        [Fact]
+        public void GetUninitializedObject_ClassFieldWithDefaultValue_DefaultValueIgnored()
+        {
+            Assert.Equal(42, new ObjectWithStructDefaultField().Value);
+            Assert.Null(((ObjectWithClassDefaultField)FormatterServices.GetUninitializedObject(typeof(ObjectWithClassDefaultField))).Value);
+            Assert.Null(((ObjectWithClassDefaultField)FormatterServices.GetSafeUninitializedObject(typeof(ObjectWithClassDefaultField))).Value);
+        }
+
+        private class ObjectWithClassDefaultField
+        {
+            public string Value = "abc";
+        }
+
+        [Fact]
+        public void GetUninitializedObject_StructFieldWithDefaultValue_DefaultValueIgnored()
+        {
+            Assert.Equal(42, new ObjectWithStructDefaultField().Value);
+            Assert.Equal(0, ((ObjectWithStructDefaultField)FormatterServices.GetUninitializedObject(typeof(ObjectWithStructDefaultField))).Value);
+            Assert.Equal(0, ((ObjectWithStructDefaultField)FormatterServices.GetSafeUninitializedObject(typeof(ObjectWithStructDefaultField))).Value);
+        }
+
+        private class ObjectWithStructDefaultField
         {
             public int Value = 42;
         }

--- a/src/System.Runtime.Serialization.Formatters/tests/FormatterServicesTests.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/FormatterServicesTests.cs
@@ -114,11 +114,13 @@ namespace System.Runtime.Serialization.Formatters.Tests
             yield return new object[] { typeof(StructWithSpanField) };
         }
 
+#pragma warning disable 0169 // The private field 'class member' is never used
         private struct StructWithSpanField
         {
             Span<byte> _bytes;
             int _position;
         }
+#pragma warning restore 0169
 
         [Theory]
         [MemberData(nameof(GetUninitializedObject_ByRefLikeType_NetCore_TestData))]

--- a/src/System.Runtime.Serialization.Formatters/tests/FormatterServicesTests.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/FormatterServicesTests.cs
@@ -50,6 +50,7 @@ namespace System.Runtime.Serialization.Formatters.Tests
             yield return new object[] { typeof(int[,]) };
             yield return new object[] { typeof(int).MakePointerType() };
             yield return new object[] { typeof(int).MakeByRefType() };
+            yield return new object[] { typeof(GenericClass<>).GetTypeInfo().GenericTypeParameters[0] };
         }
 
         [Theory]

--- a/src/System.Runtime.Serialization.Formatters/tests/FormatterServicesTests.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/FormatterServicesTests.cs
@@ -104,21 +104,28 @@ namespace System.Runtime.Serialization.Formatters.Tests
             yield return new object[] { typeof(ArgIterator) };
             yield return new object[] { typeof(RuntimeArgumentHandle) };
             yield return new object[] { typeof(TypedReference) };
-
-            yield return new object[] { typeof(Span<int>) };
-            yield return new object[] { typeof(ReadOnlySpan<int>) };
         }
 
         public static IEnumerable<object[]> GetUninitializedObject_ByRefLikeType_NetCore_TestData()
         {
+            yield return new object[] { typeof(Span<int>) };
+            yield return new object[] { typeof(ReadOnlySpan<int>) };
             yield return new object[] { Type.GetType("System.ByReference`1[System.Int32]") };
         }
 
         [Theory]
-        [MemberData(nameof(GetUninitializedObject_ByRefLikeType_TestData))]
         [MemberData(nameof(GetUninitializedObject_ByRefLikeType_NetCore_TestData))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "The full .NET framework supports GetUninitializedObject for by ref like types")]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.Netcoreapp, "Some runtimes don't support or recognise Span<T>, ReadOnlySpan<T> or ByReference<T> as ref types.")]
         public void GetUninitializedObject_ByRefLikeType_NetCore_ThrowsNotSupportedException(Type type)
+        {
+            Assert.Throws<NotSupportedException>(() => FormatterServices.GetUninitializedObject(type));
+            Assert.Throws<NotSupportedException>(() => FormatterServices.GetSafeUninitializedObject(type));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetUninitializedObject_ByRefLikeType_TestData))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "The full .NET framework supports GetUninitializedObject for by ref like types")]
+        public void GetUninitializedObject_ByRefLikeType_NonNetfx_ThrowsNotSupportedException(Type type)
         {
             Assert.Throws<NotSupportedException>(() => FormatterServices.GetUninitializedObject(type));
             Assert.Throws<NotSupportedException>(() => FormatterServices.GetSafeUninitializedObject(type));

--- a/src/System.Runtime.Serialization.Formatters/tests/FormatterServicesTests.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/FormatterServicesTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace System.Runtime.Serialization.Formatters.Tests
 {
-    public class FormatterServicesTests
+    public partial class FormatterServicesTests
     {
         [Fact]
         public void CheckTypeSecurity_Nop()
@@ -173,20 +173,6 @@ namespace System.Runtime.Serialization.Formatters.Tests
             Assert.True(nullableSafe.HasValue);
             Assert.Equal(0, nullableSafe.Value);
         }
-
-        [Fact]
-        public void GetUninitializedObject_COMObject_ThrowsNotSupportedException()
-        {
-            Type comObjectType = typeof(COMObject);
-            Assert.True(comObjectType.IsCOMObject);
-
-            Assert.Throws<NotSupportedException>(() => FormatterServices.GetUninitializedObject(typeof(COMObject)));
-            Assert.Throws<NotSupportedException>(() => FormatterServices.GetSafeUninitializedObject(typeof(COMObject)));
-        }
-
-        [ComImport]
-        [Guid("00000000-0000-0000-0000-000000000000")]
-        public class COMObject { }
 
         [Theory]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "The full .NET framework doesn't support GetUninitializedObject for subclasses of ContextBoundObject")]

--- a/src/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
+++ b/src/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
@@ -4,7 +4,10 @@
   <PropertyGroup>
     <ProjectGuid>{13CE5E71-D373-4EA6-B3CB-166FF089A42A}</ProjectGuid>
     <SkipIncludeNewtonsoftJson>true</SkipIncludeNewtonsoftJson>
+    <DefineConstants Condition="'$(TargetGroup)'=='netcoreapp'">$(DefineConstants);netcoreapp</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />

--- a/src/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
+++ b/src/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
@@ -4,10 +4,7 @@
   <PropertyGroup>
     <ProjectGuid>{13CE5E71-D373-4EA6-B3CB-166FF089A42A}</ProjectGuid>
     <SkipIncludeNewtonsoftJson>true</SkipIncludeNewtonsoftJson>
-    <DefineConstants Condition="'$(TargetGroup)'=='netcoreapp'">$(DefineConstants);netcoreapp</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
@@ -22,6 +19,9 @@
     <Compile Include="SerializationInfoTests.cs" />
     <Compile Include="SerializationTypes.cs" />
     <Compile Include="SurrogateSelectorTests.cs" />
+    <Compile Include="$(CommonTestPath)\System\NonRuntimeType.cs">
+      <Link>Common\System\NonRuntimeType.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorTestBase.cs">
       <Link>Common\System\Diagnostics\RemoteExecutorTestBase.cs</Link>
     </Compile>

--- a/src/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
+++ b/src/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
@@ -14,6 +14,7 @@
     <Compile Include="OptionalFieldAttributeTests.cs" />
     <Compile Include="FormatterConverterTests.cs" />
     <Compile Include="FormatterServicesTests.cs" />
+    <Compile Include="FormatterServicesTests.Windows.cs" Condition="'$(TargetsWindows)' == 'true'" />
     <Compile Include="FormatterTests.cs" />
     <Compile Include="SerializationBinderTests.cs" />
     <Compile Include="SerializationInfoTests.cs" />


### PR DESCRIPTION
- non runtime types
- array, pointer, ref types
- abstract/interface types
- open generic types
- byref like types
- shared generic instantiations
- COM objects
- nullable types
- default constructor
- static constructor (non beforefieldinit)
- static field (beforefieldinit)
- static constructor throwing

Fixes #16995