### PR TITLE
Fix System.Runtime.Tests netfx compilation

### DIFF
--- a/src/System.Runtime/tests/System/ActivatorTests.cs
+++ b/src/System.Runtime/tests/System/ActivatorTests.cs
@@ -66,7 +66,8 @@ namespace System.Tests
         [Fact]
         public static void CreateInstance_Invalid()
         {
-            Assert.Throws<ArgumentNullException>("type", () => Activator.CreateInstance(null)); // Type is null
+            Type nullType = null;
+            Assert.Throws<ArgumentNullException>("type", () => Activator.CreateInstance(nullType)); // Type is null
             Assert.Throws<ArgumentNullException>("type", () => Activator.CreateInstance(null, new object[0])); // Type is null
 
             Assert.Throws<AmbiguousMatchException>(() => Activator.CreateInstance(typeof(Choice1), new object[] { null }));

--- a/src/System.Runtime/tests/System/DateTimeOffsetTests.cs
+++ b/src/System.Runtime/tests/System/DateTimeOffsetTests.cs
@@ -958,7 +958,7 @@ namespace System.Tests
             Assert.Throws<ArgumentException>("styles", () => DateTimeOffset.Parse("06/08/1990", null, style));
             Assert.Throws<ArgumentException>("styles", () => DateTimeOffset.ParseExact("06/08/1990", "Y", null, style));
 
-            DateTimeOffset dateTimeOffset;
+            DateTimeOffset dateTimeOffset = default(DateTimeOffset);
             Assert.Throws<ArgumentException>("styles", () => DateTimeOffset.TryParse("06/08/1990", null, style, out dateTimeOffset));
             Assert.Equal(default(DateTimeOffset), dateTimeOffset);
 


### PR DESCRIPTION
- An ambiguity error for single parameter `null`
- Use of uninitialized variable error