### PR TITLE
Fix Enum.Format tests for recent coreclr fixes to align with netfx behaviour

### DIFF
--- a/src/System.Runtime/tests/System/EnumTests.cs
+++ b/src/System.Runtime/tests/System/EnumTests.cs
@@ -322,7 +322,7 @@ namespace System.Tests
             }
             else
             {
-                Format(enumType, value, "G", expected);
+                Format(enumType, value, "G", expected ?? value.ToString());
             }
         }
 


### PR DESCRIPTION
See https://github.com/dotnet/coreclr/pull/10610

@benaadams @jkotas if we pull this in when updating the coreclr packages, then the tests will pass, assuming we now align with the netfx behaviour
