### PR TITLE
Removing ContinueOnError now that we know the signing problem is fixed.

### DIFF
--- a/src/sign.builds
+++ b/src/sign.builds
@@ -32,14 +32,13 @@
     <ReadSigningRequired MarkerFiles="@(SignMarkerFile)">
       <Output TaskParameter="SigningMetadata" ItemName="FilesToSign" />
     </ReadSigningRequired>
-    <Message Text="Attempting to sign %(FilesToSign.Identity) with authenticode %(FilesToSign.Authenticode) and strongname %(FilesToSign.StrongName)" />
+    <Message Importance="High" Text="Attempting to sign %(FilesToSign.Identity) with authenticode %(FilesToSign.Authenticode) and strongname %(FilesToSign.StrongName)" />
   </Target>
 
   <Target Name="Build"
           Condition="'$(SkipSigning)' != 'true' and '$(SignType)' != 'oss'"
           DependsOnTargets="GetFilesToSignItems">
-    <!--ToDo: Remove ContinueOnError once we verify that signing is succeeding-->
-    <CallTarget Targets="SignFiles" ContinueOnError="true" />
+    <CallTarget Targets="SignFiles" />
     <!-- now that the files have been signed delete the marker files -->
     <Delete Files="@(SignMarkerFile)" />
   </Target>


### PR DESCRIPTION
cc: @weshaggard 

Also increasing the Importance of the signing task so that we can see them on minimal logs.