### PR TITLE
Fix LinuxCross Portable Build

### DIFF
--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -159,7 +159,8 @@
           "Name": "DotNet-CoreFx-Trusted-Linux-Crossbuild",
           "Parameters": {
             "PB_DockerTag": "ubuntu1404_cross_prereqs_v2",
-            "PB_BuildArguments": "-buildArch=arm -portable",
+            "PB_Architecture": "arm",
+            "PB_BuildArguments": "-portable",
             "PB_SyncArguments": "-p -portable -- /p:ArchGroup=arm",
           },
           "ReportingParameters": {

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -159,7 +159,7 @@
           "Name": "DotNet-CoreFx-Trusted-Linux-Crossbuild",
           "Parameters": {
             "PB_DockerTag": "ubuntu1404_cross_prereqs_v2",
-            "PB_BuildArguments": "-buildArch=arm -Release -portable",
+            "PB_BuildArguments": "-buildArch=arm -portable",
             "PB_SyncArguments": "-p -portable -- /p:ArchGroup=arm",
           },
           "ReportingParameters": {


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build?_a=summary&buildId=649339

@weshaggard PTAL. Can you also help me understand why this is unique to Portable CrossBuild I introduced and not Linux-x64 Portable build though the definition structure is the same?