### PR TITLE
Adding back AsSpan for fast span

### DIFF
--- a/src/System.Memory/src/System/SpanExtensions.Fast.cs
+++ b/src/System.Memory/src/System/SpanExtensions.Fast.cs
@@ -45,10 +45,7 @@ namespace System
         /// </summary>
         /// <param name="text">The target string.</param>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="text"/> is null.</exception>
-        public static ReadOnlySpan<char> AsSpan(this string text)
-        {
-            throw new NotImplementedException();
-        }
+        public static ReadOnlySpan<char> AsSpan(this string text) => Span.AsSpan(text);
 
         /// <summary>
         /// Casts a Span of one primitive type <typeparamref name="TFrom"/> to another primitive type <typeparamref name="TTo"/>.


### PR DESCRIPTION
Once we consume a new coreclr package (after this PR: https://github.com/dotnet/coreclr/pull/10544), this should go green.

