### PR TITLE
Fixing UAP package RIDS

### DIFF
--- a/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.props
+++ b/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.props
@@ -11,8 +11,7 @@
     <When Condition="'$(PackageRID)' != ''" />
     <When Condition="'$(_runtimeOSFamily)' == 'win'">
       <PropertyGroup>
-        <PackageRID Condition="'$(ArchGroup)' == 'x86' OR '$(ArchGroup)' == 'x64'">win7-$(ArchGroup)$(_aotSuffix)</PackageRID>
-        <PackageRID Condition="'$(ArchGroup)' == 'arm'">win8-$(ArchGroup)$(_aotSuffix)</PackageRID>
+        <PackageRID>win10-$(ArchGroup)$(_aotSuffix)</PackageRID>
       </PropertyGroup>
     </When>
     <Otherwise>


### PR DESCRIPTION
cc: @ericstj 
FYI: @tijoytom 

Fixing UAP package rids so that they are all win10.