### PR TITLE
For auto-update, find project.jsons relative to dependencies.props

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -185,9 +185,9 @@
     </DependencyBuildInfo>
 
     <!-- project.json files to update -->
-    <ProjectJsonFiles Include="external\**\project.json" />
-    <ProjectJsonFiles Include="external\**\optional.json" />
-    <ProjectJsonFiles Include="external\**\project.json.template" />
+    <ProjectJsonFiles Include="$(MSBuildThisFileDirectory)external\**\project.json" />
+    <ProjectJsonFiles Include="$(MSBuildThisFileDirectory)external\**\optional.json" />
+    <ProjectJsonFiles Include="$(MSBuildThisFileDirectory)external\**\project.json.template" />
 
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Using `dependencies.props`'s directory allows outside projects to use this file. For example, BfS could use `ProjectJsonFiles` to do upgrades. @ellismg 