### PR TITLE
Remove remaining references to Fedora 23

### DIFF
--- a/init-tools.sh
+++ b/init-tools.sh
@@ -43,10 +43,6 @@ get_current_linux_name() {
         echo "alpine"
         return 0
     elif [ "$(cat /etc/*-release | grep -cim1 fedora)" -eq 1 ]; then
-        if [ "$(cat /etc/*-release | grep -cim1 23)" -eq 1 ]; then
-            echo "fedora.23"
-            return 0
-        fi
         if [ "$(cat /etc/*-release | grep -cim1 24)" -eq 1 ]; then
             echo "fedora.24"
             return 0

--- a/perf.groovy
+++ b/perf.groovy
@@ -15,7 +15,6 @@ def projectFolder = Utilities.getFolderName(project) + '/' + Utilities.getFolder
 def osGroupMap = ['Ubuntu14.04':'Linux',
                   'Ubuntu16.04':'Linux',
                   'Debian8.4':'Linux',
-                  'Fedora23':'Linux',
                   'OSX':'OSX',
                   'Windows_NT':'Windows_NT',
                   'CentOS7.1': 'Linux',
@@ -27,7 +26,6 @@ def osGroupMap = ['Ubuntu14.04':'Linux',
 def targetNugetRuntimeMap = ['OSX' : 'osx.10.10-x64',
                              'Ubuntu14.04' : 'ubuntu.14.04-x64',
                              'Ubuntu16.04' : 'ubuntu.16.04-x64',
-                             'Fedora23' : 'fedora.23-x64',
                              'Debian8.4' : 'debian.8-x64',
                              'CentOS7.1' : 'centos.7-x64',
                              'OpenSUSE13.2' : 'opensuse.13.2-x64',
@@ -43,7 +41,6 @@ def osShortName = ['Windows 10': 'win10',
                    'CentOS7.1' : 'centos7.1',
                    'Debian8.4' : 'debian8.4',
                    'OpenSUSE13.2' : 'opensuse13.2',
-                   'Fedora23' : 'fedora23',
                    'RHEL7.2' : 'rhel7.2']
 
 

--- a/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -519,13 +519,6 @@
             "#import": [ "fedora", "linux-x64" ]
         },
 
-        "fedora.23": {
-            "#import": [ "fedora" ]
-        },
-        "fedora.23-x64": {
-            "#import": [ "fedora.23", "fedora-x64" ]
-        },
-
         "fedora.24": {
             "#import": [ "fedora" ]
         },
@@ -922,18 +915,11 @@
             "#import": [ "fedora-corert", "linux-x64-corert", "fedora-x64" ]
         },
 
-        "fedora.23-corert": {
-            "#import": [ "fedora-corert", "fedora.23" ]
-        },
-        "fedora.23-x64-corert": {
-            "#import": [ "fedora.23-corert", "fedora-x64-corert", "fedora.23-x64" ]
-        },
-
         "fedora.24-corert": {
-            "#import": [ "fedora.23-corert", "fedora.24" ]
+            "#import": [ "fedora.24" ]
         },
         "fedora.24-x64-corert": {
-            "#import": [ "fedora.24-corert", "fedora.23-x64-corert", "fedora.24-x64" ]
+            "#import": [ "fedora.24-corert", "fedora.24-x64" ]
         },
 
         "opensuse-corert": {

--- a/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -519,6 +519,13 @@
             "#import": [ "fedora", "linux-x64" ]
         },
 
+        "fedora.23": {
+            "#import": [ "fedora" ]
+        },
+        "fedora.23-x64": {
+            "#import": [ "fedora.23", "fedora-x64" ]
+        },
+
         "fedora.24": {
             "#import": [ "fedora" ]
         },
@@ -915,11 +922,18 @@
             "#import": [ "fedora-corert", "linux-x64-corert", "fedora-x64" ]
         },
 
+        "fedora.23-corert": {
+            "#import": [ "fedora-corert", "fedora.23" ]
+        },
+        "fedora.23-x64-corert": {
+            "#import": [ "fedora.23-corert", "fedora-x64-corert", "fedora.23-x64" ]
+        },
+
         "fedora.24-corert": {
-            "#import": [ "fedora.24" ]
+            "#import": [ "fedora.23-corert", "fedora.24" ]
         },
         "fedora.24-x64-corert": {
-            "#import": [ "fedora.24-corert", "fedora.24-x64" ]
+            "#import": [ "fedora.24-corert", "fedora.23-x64-corert", "fedora.24-x64" ]
         },
 
         "opensuse-corert": {

--- a/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.props
+++ b/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.props
@@ -42,7 +42,6 @@
       <Platform>armel</Platform>
     </OfficialBuildRID>
     <OfficialBuildRID Include="debian.8-x64" />
-    <OfficialBuildRID Include="fedora.23-x64" />
     <OfficialBuildRID Include="fedora.24-x64" />
     <OfficialBuildRID Include="linux-x64" />
     <OfficialBuildRID Include="opensuse.13.2-x64" />

--- a/src/Native/pkg/dir.props
+++ b/src/Native/pkg/dir.props
@@ -9,7 +9,6 @@
     <WinNativePath Condition="'$(WinNativePath)' == ''">$(BinDir)Windows_NT.$(PackagePlatform).$(ConfigurationGroup)\native\</WinNativePath>
     <RHELNativePath Condition="'$(RHELNativePath)' == ''">$(LinuxNativePath)</RHELNativePath>
     <DebianNativePath Condition="'$(DebianNativePath)' == ''">$(LinuxNativePath)</DebianNativePath>
-    <Fedora23NativePath Condition="'$(Fedora23NativePath)' == ''">$(LinuxNativePath)</Fedora23NativePath>
     <Fedora24NativePath Condition="'$(Fedora24NativePath)' == ''">$(LinuxNativePath)</Fedora24NativePath>
     <OSXNativePath Condition="'$(OSXNativePath)' == ''">$(BinDir)OSX.$(PackagePlatform).$(ConfigurationGroup)\native\</OSXNativePath>
     <OpenSuse132NativePath Condition="'$(OpenSuse132NativePath)' == ''">$(LinuxNativePath)</OpenSuse132NativePath>

--- a/src/System.Security.Cryptography.X509Certificates/tests/X509FilesystemTests.Unix.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X509FilesystemTests.Unix.cs
@@ -15,7 +15,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
     [Collection("X509Filesystem")]
     public static class X509FilesystemTests
     {
-        // #9293: Our Fedora23 and Ubuntu1610 CI machines use NTFS for "tmphome", which causes our filesystem permissions checks to fail.
+        // #9293: Our Fedora and Ubuntu1610 CI machines use NTFS for "tmphome", which causes our filesystem permissions checks to fail.
         private static bool IsReliableInCI { get; } = ChainTests.IsReliableInCI;
 
         [ActiveIssue(12833, TestPlatforms.AnyUnix)]


### PR DESCRIPTION
I am not familiar with what the .json files do, so I'm only speculating what the correct change is here. As far as I know, the references aren't breaking anything. Please advise.

@gkhanna79 @weshaggard @dagood 

Pointed out in https://github.com/dotnet/core-setup/pull/1912