### PR TITLE
Include error number in asserts out of pal_networking.cpp

### DIFF
--- a/src/Native/Unix/Common/pal_utilities.h
+++ b/src/Native/Unix/Common/pal_utilities.h
@@ -17,16 +17,16 @@
 #include <unistd.h>
 
 #ifdef DEBUG
-#define assert_msg(cond, msg, errno) do \
+#define assert_msg(cond, msg, err) do \
 { \
   if(!(cond)) \
   { \
-    fprintf(stderr, "%s (%d): error %d: %s. (%s)\n", __FILE__, __LINE__, errno, msg, strerror(errno)); \
+    fprintf(stderr, "%s (%d): error %d: %s. (if an error, it may be %s)\n", __FILE__, __LINE__, err, msg, strerror(err)); \
     assert(cond && "assert_msg failed"); \
   } \
 } while(0)
 #else // DEBUG
-#define assert_msg(cond, msg, errno)
+#define assert_msg(cond, msg, err)
 #endif // DEBUG
 
 /**

--- a/src/Native/Unix/Common/pal_utilities.h
+++ b/src/Native/Unix/Common/pal_utilities.h
@@ -21,16 +21,16 @@
 { \
   if(!(cond)) \
   { \
-    fprintf(stderr, "%s (%d): error %d: %s. %s\n", __FILE__, __LINE__, err, msg, strerror(err)); \
-    assert(cond && "assert_err failed"); \
+    fprintf(stderr, "%s (%d): error %d: %s. %s (%s failed)\n", __FILE__, __LINE__, err, msg, strerror(err), #cond); \
+    assert(false && "assert_err failed"); \
   } \
 } while(0)
 #define assert_msg(cond, msg, val) do \
 { \
   if(!(cond)) \
   { \
-    fprintf(stderr, "%s (%d): error %d: %s\n", __FILE__, __LINE__, val, msg); \
-    assert(cond && "assert_msg failed"); \
+    fprintf(stderr, "%s (%d): error %d: %s (%s failed)\n", __FILE__, __LINE__, val, msg, #cond); \
+    assert(false && "assert_msg failed"); \
   } \
 } while(0)
 #else // DEBUG

--- a/src/Native/Unix/Common/pal_utilities.h
+++ b/src/Native/Unix/Common/pal_utilities.h
@@ -22,7 +22,7 @@
   if(!(cond)) \
   { \
     fprintf(stderr, "%s (%d): error %d: %s. %s\n", __FILE__, __LINE__, err, msg, strerror(err)); \
-    assert(cond && "assert_msg failed"); \
+    assert(cond && "assert_err failed"); \
   } \
 } while(0)
 #define assert_msg(cond, msg, val) do \

--- a/src/Native/Unix/Common/pal_utilities.h
+++ b/src/Native/Unix/Common/pal_utilities.h
@@ -17,16 +17,25 @@
 #include <unistd.h>
 
 #ifdef DEBUG
-#define assert_msg(cond, msg, err) do \
+#define assert_err(cond, msg, err) do \
 { \
   if(!(cond)) \
   { \
-    fprintf(stderr, "%s (%d): error %d: %s. (if an error, it may be %s)\n", __FILE__, __LINE__, err, msg, strerror(err)); \
+    fprintf(stderr, "%s (%d): error %d: %s. %s\n", __FILE__, __LINE__, err, msg, strerror(err)); \
+    assert(cond && "assert_msg failed"); \
+  } \
+} while(0)
+#define assert_msg(cond, msg, val) do \
+{ \
+  if(!(cond)) \
+  { \
+    fprintf(stderr, "%s (%d): error %d: %s\n", __FILE__, __LINE__, val, msg); \
     assert(cond && "assert_msg failed"); \
   } \
 } while(0)
 #else // DEBUG
-#define assert_msg(cond, msg, err)
+#define assert_err(cond, msg, err)
+#define assert_msg(cond, msg, val)
 #endif // DEBUG
 
 /**

--- a/src/Native/Unix/Common/pal_utilities.h
+++ b/src/Native/Unix/Common/pal_utilities.h
@@ -16,6 +16,19 @@
 #include <type_traits>
 #include <unistd.h>
 
+#ifdef DEBUG
+#define assert_msg(cond, msg, errno) do \
+{ \
+  if(!(cond)) \
+  { \
+    fprintf(stderr, "%s (%d): error %d: %s. (%s)\n", __FILE__, __LINE__, errno, msg, strerror(errno)); \
+    assert(cond && "assert_msg failed"); \
+  } \
+} while(0)
+#else // DEBUG
+#define assert_msg(cond, msg, errno)
+#endif // DEBUG
+
 /**
  * ResultOf<T> is shorthand for typename std::result_of<T>::type.
  * Equivalent to C++14 std::result_of_t.

--- a/src/Native/Unix/System.Native/pal_console.cpp
+++ b/src/Native/Unix/System.Native/pal_console.cpp
@@ -374,7 +374,7 @@ void* SignalHandlerLoop(void* arg)
             return nullptr;
         }
 
-        assert_msg(signalCode == SIGQUIT || signalCode == SIGINT, "invalid signalCode", (int)signalCode);
+        assert_msg(signalCode == SIGQUIT || signalCode == SIGINT, "invalid signalCode", static_cast<int>(signalCode));
 
         // We're now handling SIGQUIT and SIGINT. Invoke the callback, if we have one.
         CtrlCallback callback = g_ctrlCallback;

--- a/src/Native/Unix/System.Native/pal_console.cpp
+++ b/src/Native/Unix/System.Native/pal_console.cpp
@@ -374,7 +374,7 @@ void* SignalHandlerLoop(void* arg)
             return nullptr;
         }
 
-        assert(signalCode == SIGQUIT || signalCode == SIGINT);
+        assert_msg(signalCode == SIGQUIT || signalCode == SIGINT, "invalid signalCode", (int)signalCode);
 
         // We're now handling SIGQUIT and SIGINT. Invoke the callback, if we have one.
         CtrlCallback callback = g_ctrlCallback;

--- a/src/Native/Unix/System.Native/pal_errno.cpp
+++ b/src/Native/Unix/System.Native/pal_errno.cpp
@@ -385,7 +385,7 @@ extern "C" int32_t SystemNative_ConvertErrorPalToPlatform(Error error)
     // note that there is probably a corresponding missing case in the
     // other direction above, but the compiler can't warn in that case
     // because the platform values are not part of an enum.
-    assert_msg(false, "Unknown error code", (int)error);
+    assert_msg(false, "Unknown error code", static_cast<int>(error));
     return -1;
 }
 

--- a/src/Native/Unix/System.Native/pal_errno.cpp
+++ b/src/Native/Unix/System.Native/pal_errno.cpp
@@ -385,7 +385,7 @@ extern "C" int32_t SystemNative_ConvertErrorPalToPlatform(Error error)
     // note that there is probably a corresponding missing case in the
     // other direction above, but the compiler can't warn in that case
     // because the platform values are not part of an enum.
-    assert(false && "Unknown error code");
+    assert_msg(false, "Unknown error code", (int)error);
     return -1;
 }
 
@@ -424,7 +424,7 @@ extern "C" const char* SystemNative_StrErrorR(int32_t platformErrno, char* buffe
     // The only other valid error codes are 0 for success or EINVAL for
     // an unknown error, but in the latter case a reasonable string (e.g
     // "Unknown error: 0x123") is returned.
-    assert(error == 0 || error == EINVAL);
+    assert_msg(error == 0 || error == EINVAL, "invalid error", error);
     return buffer;
 #endif
 }

--- a/src/Native/Unix/System.Native/pal_errno.cpp
+++ b/src/Native/Unix/System.Native/pal_errno.cpp
@@ -385,7 +385,7 @@ extern "C" int32_t SystemNative_ConvertErrorPalToPlatform(Error error)
     // note that there is probably a corresponding missing case in the
     // other direction above, but the compiler can't warn in that case
     // because the platform values are not part of an enum.
-    assert_msg(false, "Unknown error code", static_cast<int>(error));
+    assert_err(false, "Unknown error code", static_cast<int>(error));
     return -1;
 }
 
@@ -424,7 +424,7 @@ extern "C" const char* SystemNative_StrErrorR(int32_t platformErrno, char* buffe
     // The only other valid error codes are 0 for success or EINVAL for
     // an unknown error, but in the latter case a reasonable string (e.g
     // "Unknown error: 0x123") is returned.
-    assert_msg(error == 0 || error == EINVAL, "invalid error", error);
+    assert_err(error == 0 || error == EINVAL, "invalid error", error);
     return buffer;
 #endif
 }

--- a/src/Native/Unix/System.Native/pal_io.cpp
+++ b/src/Native/Unix/System.Native/pal_io.cpp
@@ -213,13 +213,13 @@ static int32_t ConvertOpenFlags(int32_t flags)
             ret = O_WRONLY;
             break;
         default:
-            assert_msg(false, "Unknown Open access mode", (int)flags);
+            assert_msg(false, "Unknown Open access mode", static_cast<int>(flags));
             return -1;
     }
 
     if (flags & ~(PAL_O_ACCESS_MODE_MASK | PAL_O_CLOEXEC | PAL_O_CREAT | PAL_O_EXCL | PAL_O_TRUNC | PAL_O_SYNC))
     {
-        assert_msg(false, "Unknown Open flag", (int)flags);
+        assert_msg(false, "Unknown Open flag", static_cast<int>(flags));
         return -1;
     }
 
@@ -417,7 +417,7 @@ extern "C" int32_t SystemNative_Pipe(int32_t pipeFds[2], int32_t flags)
             flags = O_CLOEXEC;
             break;
         default:
-            assert_msg(false, "Unknown pipe flag", (int)flags);
+            assert_msg(false, "Unknown pipe flag", static_cast<int>(flags));
             errno = EINVAL;
             return -1;
     }
@@ -642,7 +642,7 @@ static int32_t ConvertMMapProtection(int32_t protection)
 
     if (protection & ~(PAL_PROT_READ | PAL_PROT_WRITE | PAL_PROT_EXEC))
     {
-        assert_msg(false, "Unknown protection", (int)protection)
+        assert_msg(false, "Unknown protection", static_cast<int>(protection));
         return -1;
     }
 
@@ -662,7 +662,7 @@ static int32_t ConvertMMapFlags(int32_t flags)
 {
     if (flags & ~(PAL_MAP_SHARED | PAL_MAP_PRIVATE | PAL_MAP_ANONYMOUS))
     {
-        assert_msg(false, "Unknown MMap flag", (int)flags)
+        assert_msg(false, "Unknown MMap flag", static_cast<int>(flags));
         return -1;
     }
 
@@ -682,7 +682,7 @@ static int32_t ConvertMSyncFlags(int32_t flags)
 {
     if (flags & ~(PAL_MS_SYNC | PAL_MS_ASYNC | PAL_MS_INVALIDATE))
     {
-        assert_msg(false, "Unknown MSync flag", (int)flags)
+        assert_msg(false, "Unknown MSync flag", static_cast<int>(flags));
         return -1;
     }
 
@@ -774,7 +774,7 @@ extern "C" int32_t SystemNative_MAdvise(void* address, uint64_t length, MemoryAd
 #endif
     }
 
-    assert_msg(false, "Unknown MemoryAdvice", (int)advice);
+    assert_msg(false, "Unknown MemoryAdvice", static_cast<int>(advice));
     errno = EINVAL;
     return -1;
 }
@@ -849,7 +849,7 @@ extern "C" int64_t SystemNative_SysConf(SysConfName name)
             return sysconf(_SC_NPROCESSORS_ONLN);
     }
 
-    assert_msg(false, "Unknown SysConf name", (int)name)
+    assert_msg(false, "Unknown SysConf name", static_cast<int>(name));
     errno = EINVAL;
     return -1;
 }

--- a/src/Native/Unix/System.Native/pal_io.cpp
+++ b/src/Native/Unix/System.Native/pal_io.cpp
@@ -213,13 +213,13 @@ static int32_t ConvertOpenFlags(int32_t flags)
             ret = O_WRONLY;
             break;
         default:
-            assert(false && "Unknown Open access mode.");
+            assert_msg(false, "Unknown Open access mode", (int)flags);
             return -1;
     }
 
     if (flags & ~(PAL_O_ACCESS_MODE_MASK | PAL_O_CLOEXEC | PAL_O_CREAT | PAL_O_EXCL | PAL_O_TRUNC | PAL_O_SYNC))
     {
-        assert(false && "Unknown Open flag.");
+        assert_msg(false, "Unknown Open flag", (int)flags);
         return -1;
     }
 
@@ -384,7 +384,7 @@ extern "C" int32_t SystemNative_ReadDirR(DIR* dir, void* buffer, int32_t bufferS
         //  kernel set errno -> failure
         if (errno != 0)
         {
-            assert(errno == EBADF); // Invalid directory stream descriptor dir.
+            assert_msg(errno == EBADF, "Invalid directory stream descriptor dir", errno);
             return errno;
         }
         return -1;
@@ -417,7 +417,7 @@ extern "C" int32_t SystemNative_Pipe(int32_t pipeFds[2], int32_t flags)
             flags = O_CLOEXEC;
             break;
         default:
-            assert(false && "Unknown flag.");
+            assert_msg(false, "Unknown pipe flag", (int)flags);
             errno = EINVAL;
             return -1;
     }
@@ -642,7 +642,7 @@ static int32_t ConvertMMapProtection(int32_t protection)
 
     if (protection & ~(PAL_PROT_READ | PAL_PROT_WRITE | PAL_PROT_EXEC))
     {
-        assert(false && "Unknown protection.");
+        assert_msg(false, "Unknown protection", (int)protection)
         return -1;
     }
 
@@ -662,7 +662,7 @@ static int32_t ConvertMMapFlags(int32_t flags)
 {
     if (flags & ~(PAL_MAP_SHARED | PAL_MAP_PRIVATE | PAL_MAP_ANONYMOUS))
     {
-        assert(false && "Unknown MMap flag.");
+        assert_msg(false, "Unknown MMap flag", (int)flags)
         return -1;
     }
 
@@ -682,7 +682,7 @@ static int32_t ConvertMSyncFlags(int32_t flags)
 {
     if (flags & ~(PAL_MS_SYNC | PAL_MS_ASYNC | PAL_MS_INVALIDATE))
     {
-        assert(false && "Unknown MSync flag.");
+        assert_msg(false, "Unknown MSync flag", (int)flags)
         return -1;
     }
 
@@ -774,7 +774,7 @@ extern "C" int32_t SystemNative_MAdvise(void* address, uint64_t length, MemoryAd
 #endif
     }
 
-    assert(false && "Unknown MemoryAdvice");
+    assert_msg(false, "Unknown MemoryAdvice", (int)advice);
     errno = EINVAL;
     return -1;
 }
@@ -849,7 +849,7 @@ extern "C" int64_t SystemNative_SysConf(SysConfName name)
             return sysconf(_SC_NPROCESSORS_ONLN);
     }
 
-    assert(false && "Unknown SysConfName");
+    assert_msg(false, "Unknown SysConf name", (int)name)
     errno = EINVAL;
     return -1;
 }

--- a/src/Native/Unix/System.Native/pal_io.cpp
+++ b/src/Native/Unix/System.Native/pal_io.cpp
@@ -200,7 +200,6 @@ extern "C" int32_t SystemNative_LStat(const char* path, FileStatus* output)
 
 static int32_t ConvertOpenFlags(int32_t flags)
 {
-            assert_msg(false, "Unknown Open flag", static_cast<int>(flags));
     int32_t ret;
     switch (flags & PAL_O_ACCESS_MODE_MASK)
     {

--- a/src/Native/Unix/System.Native/pal_io.cpp
+++ b/src/Native/Unix/System.Native/pal_io.cpp
@@ -200,6 +200,7 @@ extern "C" int32_t SystemNative_LStat(const char* path, FileStatus* output)
 
 static int32_t ConvertOpenFlags(int32_t flags)
 {
+            assert_msg(false, "Unknown Open flag", static_cast<int>(flags));
     int32_t ret;
     switch (flags & PAL_O_ACCESS_MODE_MASK)
     {
@@ -384,7 +385,7 @@ extern "C" int32_t SystemNative_ReadDirR(DIR* dir, void* buffer, int32_t bufferS
         //  kernel set errno -> failure
         if (errno != 0)
         {
-            assert_msg(errno == EBADF, "Invalid directory stream descriptor dir", errno);
+            assert_err(errno == EBADF, "Invalid directory stream descriptor dir", errno);
             return errno;
         }
         return -1;

--- a/src/Native/Unix/System.Native/pal_networking.cpp
+++ b/src/Native/Unix/System.Native/pal_networking.cpp
@@ -231,7 +231,7 @@ static int32_t ConvertGetAddrInfoAndGetNameInfoErrorsToPal(int32_t error)
             return PAL_EAI_NONAME;
     }
 
-    assert_msg(false, "Unknown AddrInfo error flag", error);
+    assert_err(false, "Unknown AddrInfo error flag", error);
     return -1;
 }
 
@@ -411,7 +411,7 @@ static int ConvertGetHostErrorPlatformToPal(int error)
             return PAL_NO_DATA;
 
         default:
-            assert_msg(false, "Unknown gethostbyname/gethostbyaddr error code", error);
+            assert_err(false, "Unknown gethostbyname/gethostbyaddr error code", error);
             return PAL_HOST_NOT_FOUND;
     }
 }

--- a/src/Native/Unix/System.Native/pal_networking.cpp
+++ b/src/Native/Unix/System.Native/pal_networking.cpp
@@ -2558,7 +2558,7 @@ static SocketEvents GetSocketEvents(int16_t filter, uint16_t flags)
             break;
 
         default:
-            assert(false && "unexpected kqueue filter type");
+            assert_msg(false, "unexpected kqueue filter type", (int)filter);
             return PAL_SA_NONE;
     }
 

--- a/src/Native/Unix/System.Native/pal_networking.cpp
+++ b/src/Native/Unix/System.Native/pal_networking.cpp
@@ -231,7 +231,7 @@ static int32_t ConvertGetAddrInfoAndGetNameInfoErrorsToPal(int32_t error)
             return PAL_EAI_NONAME;
     }
 
-    assert(false && "Unknown AddrInfo error flag");
+    assert_msg(false, "Unknown AddrInfo error flag", error);
     return -1;
 }
 
@@ -411,7 +411,7 @@ static int ConvertGetHostErrorPlatformToPal(int error)
             return PAL_NO_DATA;
 
         default:
-            assert(false && "Unknown gethostbyname/gethostbyaddr error code");
+            assert_msg(false, "Unknown gethostbyname/gethostbyaddr error code", error);
             return PAL_HOST_NOT_FOUND;
     }
 }

--- a/src/Native/Unix/System.Native/pal_networking.cpp
+++ b/src/Native/Unix/System.Native/pal_networking.cpp
@@ -2558,7 +2558,7 @@ static SocketEvents GetSocketEvents(int16_t filter, uint16_t flags)
             break;
 
         default:
-            assert_msg(false, "unexpected kqueue filter type", (int)filter);
+            assert_msg(false, "unexpected kqueue filter type", static_cast<int>(filter));
             return PAL_SA_NONE;
     }
 

--- a/src/Native/Unix/System.Native/pal_process.cpp
+++ b/src/Native/Unix/System.Native/pal_process.cpp
@@ -285,7 +285,7 @@ static int32_t ConvertRLimitResourcesPalToPlatform(RLimitResources value)
             return RLIMIT_NOFILE;
     }
 
-    assert(false && "Unknown RLIMIT value");
+    assert_msg(false, "Unknown RLIMIT value", (int)value);
     return -1;
 }
 
@@ -438,7 +438,7 @@ extern "C" int64_t SystemNative_PathConf(const char* path, PathConfName name)
 
     if (confValue == -1)
     {
-        assert(false && "Unknown PathConfName");
+        assert_msg(false, "Unknown PathConfName", (int)name);
         errno = EINVAL;
         return -1;
     }

--- a/src/Native/Unix/System.Native/pal_process.cpp
+++ b/src/Native/Unix/System.Native/pal_process.cpp
@@ -285,7 +285,7 @@ static int32_t ConvertRLimitResourcesPalToPlatform(RLimitResources value)
             return RLIMIT_NOFILE;
     }
 
-    assert_msg(false, "Unknown RLIMIT value", (int)value);
+    assert_msg(false, "Unknown RLIMIT value", static_cast<int>(value));
     return -1;
 }
 
@@ -438,7 +438,7 @@ extern "C" int64_t SystemNative_PathConf(const char* path, PathConfName name)
 
     if (confValue == -1)
     {
-        assert_msg(false, "Unknown PathConfName", (int)name);
+        assert_msg(false, "Unknown PathConfName", static_cast<int>(name));
         errno = EINVAL;
         return -1;
     }


### PR DESCRIPTION
Contributes to https://github.com/dotnet/corefx/issues/17749

Note: this does not emit output in retail. In the cases here, it was failing in debug though.