### PR TITLE
baseline missing timezone info "Z"

### DIFF
--- a/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -1885,7 +1885,7 @@ string.Format(@"<?xml version=""1.0"" encoding=""utf-8""?>
 <DerivedClassWithSameProperty2 xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">
   <StringProperty>TestString</StringProperty>
   <IntProperty>5</IntProperty>
-  <DateTimeProperty>0001-01-01T00:00:00.00001</DateTimeProperty>
+  <DateTimeProperty>0001-01-01T00:00:00.00001Z</DateTimeProperty>
   <ListProperty>
     <string>one</string>
     <string>two</string>

--- a/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -1874,7 +1874,6 @@ string.Format(@"<?xml version=""1.0"" encoding=""utf-8""?>
     }
 
     [Fact]
-    [ActiveIssue(16752)] //fails when using CodeGen as well
     public static void Xml_BaseClassAndDerivedClass2WithSameProperty()
     {
         var value = new DerivedClassWithSameProperty2() { DateTimeProperty = new DateTime(100, DateTimeKind.Utc), IntProperty = 5, StringProperty = "TestString", ListProperty = new List<string>() };


### PR DESCRIPTION
@zhenlan @shmao  @huanwu 
The case fail when use VS run system.private.xml solution, because the case use parameter DateTimeKind.Utc when instantiate DateTime(), after serialization, it will contain time zone info Z.
The fix: add timezone info "Z" into baseline string.