### PR TITLE
Switch BitArray to using uint internally

### DIFF
--- a/src/System.Collections/System.Collections.sln
+++ b/src/System.Collections/System.Collections.sln
@@ -35,10 +35,10 @@ Global
 		{F5EB9630-AD29-4880-963F-F2D39C684D8A}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
 		{F5EB9630-AD29-4880-963F-F2D39C684D8A}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
 		{F5EB9630-AD29-4880-963F-F2D39C684D8A}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
-		{16568C86-E97E-42C6-B683-65A1B5AF2EC8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{16568C86-E97E-42C6-B683-65A1B5AF2EC8}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{16568C86-E97E-42C6-B683-65A1B5AF2EC8}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{16568C86-E97E-42C6-B683-65A1B5AF2EC8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{16568C86-E97E-42C6-B683-65A1B5AF2EC8}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
+		{16568C86-E97E-42C6-B683-65A1B5AF2EC8}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
+		{16568C86-E97E-42C6-B683-65A1B5AF2EC8}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
+		{16568C86-E97E-42C6-B683-65A1B5AF2EC8}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
 		{D5FF747F-7A0B-9003-885A-FE9A63E755E5}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
 		{D5FF747F-7A0B-9003-885A-FE9A63E755E5}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
 		{D5FF747F-7A0B-9003-885A-FE9A63E755E5}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU

--- a/src/System.Collections/tests/Performance/Perf.BitArray.cs
+++ b/src/System.Collections/tests/Performance/Perf.BitArray.cs
@@ -1,0 +1,224 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Xunit.Performance;
+using Xunit;
+
+namespace System.Collections.Tests
+{
+    public static partial class Perf_BitArray
+    {
+        private readonly static Random _random = new Random(837322);
+
+        private static int[] CreateIntArray(int size)
+        {
+            if (size == 0)
+            {
+                return new int[] { /* Deliberately Empty */ };
+            }
+
+            byte[] original = CreateByteArray(size);
+            int[] data = new int[(original.Length - 3) / 4 + 1];
+            for (int i = 0; i < data.Length; i++)
+            {
+                int orig = i * 4;
+                data[i] = (original[orig + 0] << 0) | (original[orig + 1] << 8) | (original[orig + 2] << 16) | (original[orig + 3] << 24);
+            }
+
+            return data;
+        }
+
+        private static byte[] CreateByteArray(int size)
+        {
+            if (size == 0)
+            {
+                return new byte[] { /* Deliberately Empty */ };
+            }
+
+            byte[] data = new byte[size / 8];
+            _random.NextBytes(data);
+            return data;
+        }
+
+        [Benchmark]
+        [InlineData(0)]
+        [InlineData(1024)]
+        [InlineData(4096)]
+        [InlineData(16384)]
+        public static void ctor_intarray(int size)
+        {
+            int[] source = CreateIntArray(size);
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i <= 20000; i++)
+                    {
+                        new BitArray(source);
+                    }
+        }
+
+        [Benchmark]
+        [InlineData(0)]
+        [InlineData(1024)]
+        [InlineData(4096)]
+        [InlineData(16384)]
+        public static void ctor_bytearray(int size)
+        {
+            byte[] source = CreateByteArray(size);
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i <= 20000; i++)
+                    {
+                        new BitArray(source);
+                    }
+        }
+
+        [Benchmark]
+        [InlineData(0)]
+        [InlineData(1024)]
+        [InlineData(4096)]
+        [InlineData(16384)]
+        public static void CopyTo_intarray(int size)
+        {
+            BitArray source = new BitArray(CreateIntArray(size));
+            int[] destination = new int[size];
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i <= 20000; i++)
+                    {
+                        ((ICollection)source).CopyTo(destination, 0);
+                    }
+        }
+
+        [Benchmark]
+        [InlineData(0)]
+        [InlineData(1024)]
+        [InlineData(4096)]
+        [InlineData(16384)]
+        public static void CopyTo_bytearray(int size)
+        {
+            BitArray source = new BitArray(CreateByteArray(size));
+            byte[] destination = new byte[size];
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i <= 20000; i++)
+                    {
+                        ((ICollection)source).CopyTo(destination, 0);
+                    }
+        }
+
+        [Benchmark]
+        [InlineData(1024)]
+        [InlineData(4096)]
+        [InlineData(16384)]
+        public static void Get(int size)
+        {
+            BitArray source = new BitArray(CreateByteArray(size));
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i <= 20000; i++)
+                    {
+                        bool a = source[_random.Next(size)];
+                    }
+        }
+
+        [Benchmark]
+        [InlineData(1024)]
+        [InlineData(4096)]
+        [InlineData(16384)]
+        public static void Set(int size)
+        {
+            BitArray source = new BitArray(CreateByteArray(size));
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i <= 20000; i++)
+                    {
+                        source[_random.Next(size)] = (_random.Next(1) == 0);
+                    }
+        }
+
+        [Benchmark]
+        [InlineData(0)]
+        [InlineData(1024)]
+        [InlineData(4096)]
+        [InlineData(16384)]
+        public static void Not(int size)
+        {
+            BitArray source = new BitArray(CreateByteArray(size));
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i <= 20000; i++)
+                    {
+                        source = source.Not();
+                    }
+        }
+
+        [Benchmark]
+        [InlineData(0)]
+        [InlineData(1024)]
+        [InlineData(4096)]
+        [InlineData(16384)]
+        public static void And(int size)
+        {
+            BitArray source = new BitArray(CreateByteArray(size));
+            BitArray other = new BitArray(CreateByteArray(size));
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i <= 20000; i++)
+                    {
+                        BitArray result = source.And(other);
+                    }
+        }
+
+        [Benchmark]
+        [InlineData(0)]
+        [InlineData(1024)]
+        [InlineData(4096)]
+        [InlineData(16384)]
+        public static void Or(int size)
+        {
+            BitArray source = new BitArray(CreateByteArray(size));
+            BitArray other = new BitArray(CreateByteArray(size));
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i <= 20000; i++)
+                    {
+                        BitArray result = source.Or(other);
+                    }
+        }
+
+        [Benchmark]
+        [InlineData(0)]
+        [InlineData(1024)]
+        [InlineData(4096)]
+        [InlineData(16384)]
+        public static void Length(int size)
+        {
+            BitArray source = new BitArray(CreateByteArray(size));
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i <= 20000; i++)
+                    {
+                        BitArray copy = (BitArray)source.Clone();
+                        copy.Length = (source.Length / 2);
+                    }
+        }
+
+        [Benchmark]
+        [InlineData(0)]
+        [InlineData(1024)]
+        [InlineData(4096)]
+        [InlineData(16384)]
+        public static void Xor(int size)
+        {
+            BitArray source = new BitArray(CreateByteArray(size));
+            BitArray other = new BitArray(CreateByteArray(size));
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i <= 20000; i++)
+                    {
+                        BitArray result = source.Xor(other);
+                    }
+        }
+    }
+}

--- a/src/System.Collections/tests/Performance/Perf.BitArray.netcoreapp.cs
+++ b/src/System.Collections/tests/Performance/Perf.BitArray.netcoreapp.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Xunit.Performance;
+using Xunit;
+
+namespace System.Collections.Tests
+{
+    public static partial class Perf_BitArray
+    {
+        [Benchmark]
+        [InlineData(0)]
+        [InlineData(1024)]
+        [InlineData(4096)]
+        [InlineData(16384)]
+        public static void LeftShift(int size)
+        {
+            BitArray source = new BitArray(CreateByteArray(size));
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i <= 20000; i++)
+                    {
+                        BitArray copy = (BitArray)source.Clone();
+                        BitArray result = copy.LeftShift(size / 2);
+                    }
+        }
+
+        [Benchmark]
+        [InlineData(0)]
+        [InlineData(1024)]
+        [InlineData(4096)]
+        [InlineData(16384)]
+        public static void RightShift(int size)
+        {
+            BitArray source = new BitArray(CreateByteArray(size));
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i <= 20000; i++)
+                    {
+                        BitArray copy = (BitArray)source.Clone();
+                        BitArray result = copy.RightShift(size / 2);
+                    }
+        }
+    }
+}

--- a/src/System.Collections/tests/Performance/System.Collections.Performance.Tests.csproj
+++ b/src/System.Collections/tests/Performance/System.Collections.Performance.Tests.csproj
@@ -12,6 +12,8 @@
     <Compile Include="$(CommonTestPath)\System\Collections\DictionaryExtensions.cs">
       <Link>Common\System\Collections\DictionaryExtensions.cs</Link>
     </Compile>
+    <Compile Include="Perf.BitArray.cs" />
+    <Compile Include="Perf.BitArray.netcoreapp.cs" />
     <Compile Include="Perf.Dictionary.cs" />
     <Compile Include="Perf.HashSet.cs" />
     <Compile Include="Perf.List.cs" />

--- a/src/System.Collections/tests/Performance/System.Collections.Performance.Tests.csproj
+++ b/src/System.Collections/tests/Performance/System.Collections.Performance.Tests.csproj
@@ -6,14 +6,16 @@
     <ProjectGuid>{16568C86-E97E-42C6-B683-65A1B5AF2EC8}</ProjectGuid>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="$(CommonTestPath)\System\Collections\DictionaryExtensions.cs">
       <Link>Common\System\Collections\DictionaryExtensions.cs</Link>
     </Compile>
     <Compile Include="Perf.BitArray.cs" />
-    <Compile Include="Perf.BitArray.netcoreapp.cs" />
+    <Compile Include="Perf.BitArray.netcoreapp.cs" Condition="'$(TargetGroup)'=='netcoreapp'" />
     <Compile Include="Perf.Dictionary.cs" />
     <Compile Include="Perf.HashSet.cs" />
     <Compile Include="Perf.List.cs" />


### PR DESCRIPTION
Updates `BitArray` to use uint internally.  This primarily means that the right/left shift no longer have to cast to uint during the operation to protect against the arithmetic nature of the operation (since when backed by an int, if the top bit of the int was set it would shift set bits down).

As part of this effort, added performance tests for `BitArray` first to observe those effects, and removed (as many as possible) magic numbers present in the class.  Full results are [here](https://1drv.ms/x/s!AgmkmomTldiairQDM67k2hWAOPB7dA), but a quick summary:

Operation | Size  | Average Elapsed - original | Standard Deviation - original | Average Elapsed - uint/blitting | Standard Deviation - uint/blitting | Error | % Difference elapsed
--|--|--|--|--|--|--|--
And | 0 | 0.554 | 0.189 | 0.541 | 0.389 | 0.34 | -2.439
And | 1024 | 4.45 | 2.16 | 3.955 | 0.488 | 2.104 | -12.511
And | 4096 | 13.616 | 2.278 | 14.141 | 2.92 | 1.827 | 3.71
And | 16384 | 49.244 | 3.03 | 50.765 | 1.966 | 2.306 | 2.995
CopyTo_bytearray | 0 | 1.277 | 0.171 | 1.612 | 0.304 | 0.251 | 20.777
CopyTo_bytearray | 1024 | 15.61 | 1.052 | 1.89 | 0.355 | 0.99 | -725.839
CopyTo_bytearray | 4096 | 64.14 | 6.996 | 2.093 | 0.344 | 6.988 | -2964.492
CopyTo_bytearray | 16384 | 229.413 | 7.645 | 2.607 | 0.479 | 7.63 | -8700.778
CopyTo_intarray | 0 | 1.169 | 0.188 | 0.986 | 0.2 | 0.068 | -18.477
CopyTo_intarray | 1024 | 1.356 | 0.266 | 1.24 | 0.238 | 0.119 | -9.36
CopyTo_intarray | 4096 | 1.633 | 0.319 | 1.45 | 0.222 | 0.229 | -12.642
CopyTo_intarray | 16384 | 1.905 | 0.172 | 1.88 | 0.25 | 0.181 | -1.365
ctor_bytearray | 0 | 0.789 | 0.128 | 0.86 | 0.18 | 0.127 | 8.246
ctor_bytearray | 1024 | 5.666 | 0.762 | 1.414 | 0.264 | 0.715 | -300.725
ctor_bytearray | 4096 | 20.241 | 3.907 | 2.611 | 0.458 | 3.88 | -675.212
ctor_bytearray | 16384 | 72.49 | 6.846 | 7.196 | 1.024 | 6.769 | -907.426
ctor_intarray | 0 | 0.846 | 0.19 | 0.746 | 0.175 | 0.074 | -13.439
ctor_intarray | 1024 | 1.259 | 0.279 | 1.236 | 0.24 | 0.142 | -1.845
ctor_intarray | 4096 | 2.243 | 0.328 | 2.388 | 0.43 | 0.278 | 6.07
ctor_intarray | 16384 | 6.081 | 1.07 | 6.928 | 0.92 | 0.546 | 12.221
Get | 1024 | 0.738 | 0.192 | 0.683 | 0.116 | 0.153 | -8.149
Get | 4096 | 0.668 | 0.105 | 0.696 | 0.126 | 0.07 | 3.935
Get | 16384 | 0.651 | 0.112 | 0.696 | 0.125 | 0.056 | 6.511
LeftShift | 0 | 1.276 | 0.226 | 1.437 | 0.386 | 0.313 | 11.215
LeftShift | 1024 | 2.927 | 0.533 | 3.229 | 0.491 | 0.207 | 9.342
LeftShift | 4096 | 4.16 | 0.614 | 5.035 | 0.716 | 0.368 | 17.393
LeftShift | 16384 | 7.953 | 0.814 | 9.977 | 1.067 | 0.69 | 20.282
Length | 0 | 1.688 | 0.259 | 1.638 | 0.298 | 0.147 | -3.059
Length | 1024 | 2.197 | 0.509 | 2.378 | 0.432 | 0.269 | 7.607
Length | 4096 | 3.782 | 0.534 | 3.721 | 0.59 | 0.251 | -1.631
Length | 16384 | 8.41 | 1.025 | 8.269 | 0.951 | 0.382 | -1.713
Not | 0 | 0.376 | 0.074 | 0.388 | 0.081 | 0.033 | 3.066
Not | 1024 | 3.516 | 0.497 | 3.677 | 0.411 | 0.279 | 4.363
Not | 4096 | 11.85 | 1.166 | 12.44 | 0.991 | 0.614 | 4.743
Not | 16384 | 44.641 | 3.297 | 47.095 | 1.403 | 2.984 | 5.21
Or | 0 | 0.489 | 0.09 | 0.475 | 0.101 | 0.046 | -2.995
Or | 1024 | 4.079 | 0.849 | 3.963 | 0.492 | 0.692 | -2.919
Or | 4096 | 13.011 | 2.534 | 13.439 | 0.964 | 2.343 | 3.178
Or | 16384 | 50.897 | 5.505 | 51.512 | 2.261 | 5.019 | 1.193
RightShift | 0 | 1.442 | 0.21 | 1.43 | 0.525 | 0.481 | -0.81
RightShift | 1024 | 3.24 | 0.46 | 3.504 | 0.525 | 0.253 | 7.538
RightShift | 4096 | 5.083 | 0.944 | 5.262 | 0.642 | 0.692 | 3.391
RightShift | 16384 | 8.854 | 1.131 | 10.161 | 1.029 | 0.469 | 12.86
Set | 1024 | 0.862 | 0.115 | 0.985 | 0.155 | 0.104 | 12.486
Set | 4096 | 0.857 | 0.108 | 0.973 | 0.149 | 0.103 | 11.999
Set | 16384 | 0.896 | 0.145 | 0.975 | 0.146 | 0.017 | 8.088
Xor | 0 | 0.42 | 0.057 | 0.479 | 0.103 | 0.086 | 12.253
Xor | 1024 | 3.453 | 0.317 | 3.94 | 0.469 | 0.346 | 12.356
Xor | 4096 | 12.378 | 1.507 | 13.351 | 1.299 | 0.764 | 7.286
Xor | 16384 | 44.231 | 0.937 | 50.957 | 1.791 | 1.526 | 13.199



To speed up the array-based constructors and `CopytTo` (especially, admittedly, after the switch to uint....), added in-out blitting/splatting.  For byte arrays this really only works on little-endian based architectures, so we have to fall back on other methods at that point.