### PR TITLE
Mark SortedSet test failure by design

### DIFF
--- a/src/Common/tests/System/Collections/ISet.Generic.Tests.cs
+++ b/src/Common/tests/System/Collections/ISet.Generic.Tests.cs
@@ -419,7 +419,7 @@ namespace System.Collections.Tests
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #16796")] //Throws InvalidOperationException
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework throws InvalidOperationException")]
         public void ISet_Generic_IntersectWith_Itself(int setLength)
         {
             ISet<T> set = GenericISetFactory(setLength);


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/16796

Change was introduced in https://github.com/dotnet/corefx/pull/16758 and was apparently deemed an acceptable breaking change so there's no need to track it as an issue.

@safern @tarekgh @stephentoub 