### PR TITLE
Disable parts of MemoryMappedFile tests for desktop

### DIFF
--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
@@ -549,10 +549,14 @@ namespace System.IO.MemoryMappedFiles.Tests
         public void FileDoesNotExist(FileMode mode)
         {
             Assert.Throws<FileNotFoundException>(() => MemoryMappedFile.CreateFromFile(GetTestFilePath()));
-            Assert.Throws<FileNotFoundException>(() => MemoryMappedFile.CreateFromFile(GetTestFilePath(), mode));
-            Assert.Throws<FileNotFoundException>(() => MemoryMappedFile.CreateFromFile(GetTestFilePath(), mode, null));
-            Assert.Throws<FileNotFoundException>(() => MemoryMappedFile.CreateFromFile(GetTestFilePath(), mode, null, 4096));
-            Assert.Throws<FileNotFoundException>(() => MemoryMappedFile.CreateFromFile(GetTestFilePath(), mode, null, 4096, MemoryMappedFileAccess.ReadWrite));
+
+            if (!(PlatformDetection.IsFullFramework && mode == FileMode.Truncate)) // Bug in .NET Framework blocked CreateFromFile with Truncate
+            {
+                Assert.Throws<FileNotFoundException>(() => MemoryMappedFile.CreateFromFile(GetTestFilePath(), mode));
+                Assert.Throws<FileNotFoundException>(() => MemoryMappedFile.CreateFromFile(GetTestFilePath(), mode, null));
+                Assert.Throws<FileNotFoundException>(() => MemoryMappedFile.CreateFromFile(GetTestFilePath(), mode, null, 4096));
+                Assert.Throws<FileNotFoundException>(() => MemoryMappedFile.CreateFromFile(GetTestFilePath(), mode, null, 4096, MemoryMappedFileAccess.ReadWrite));
+            }
         }
 
         /// <summary>

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
@@ -361,6 +361,11 @@ namespace System.IO.MemoryMappedFiles.Tests
         public void ValidArgumentCombinationsWithPath_ModesCreateOrTruncate(
             FileMode mode, string mapName, long capacity, MemoryMappedFileAccess access)
         {
+            if (PlatformDetection.IsFullFramework && mode == FileMode.Truncate)
+            {
+                return; // Bug in .NET Framework blocked CreateFromFile with Truncate
+            }
+
             // For FileMode.Create/Truncate, try existing files.  Only the overloads that take a capacity are valid because
             // both of these modes will cause the input file to be made empty, and an empty file doesn't work with the default capacity.
 

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
@@ -620,6 +620,7 @@ namespace System.IO.MemoryMappedFiles.Tests
         /// Test to validate we can create multiple concurrent read-only maps from the same file path.
         /// </summary>
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Framework fails with IOException: behavior changed in e3e764f2")]
         public void FileInUse_CreateFromFile_SucceedsWithReadOnly()
         {
             const int Capacity = 4096;

--- a/src/System.IO.MemoryMappedFiles/tests/System.IO.MemoryMappedFiles.Tests.csproj
+++ b/src/System.IO.MemoryMappedFiles/tests/System.IO.MemoryMappedFiles.Tests.csproj
@@ -30,6 +30,9 @@
     <Compile Include="$(CommonTestPath)\System\IO\FileCleanupTestBase.cs">
       <Link>Common\System\IO\FileCleanupTestBase.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>Common\System\PlatformDetection.cs</Link>
+    </Compile>
     <Compile Include="XunitAssemblyAttributes.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Fix https://github.com/dotnet/corefx/issues/17725 by disabling for desktop.

This was an intentional improvement made in https://github.com/dotnet/corefx/commit/e3e764f22db3e2f6f1fb9f0b78d291caea52d3d9 by @stephentoub .