### PR TITLE
Accommodate changed event source name

### DIFF
--- a/src/System.Threading.Tasks.Parallel/tests/EtwTests.cs
+++ b/src/System.Threading.Tasks.Parallel/tests/EtwTests.cs
@@ -15,7 +15,8 @@ namespace System.Threading.Tasks.Tests
         [Fact]
         public static void TestEtw()
         {
-            using (var listener = new TestEventListener("System.Threading.Tasks.Parallel.EventSource", EventLevel.Verbose))
+            var eventSourceName = PlatformDetection.IsFullFramework ? "System.Threading.Tasks.TplEventSource" : "System.Threading.Tasks.Parallel.EventSource";
+            using (var listener = new TestEventListener(eventSourceName, EventLevel.Verbose))
             {
                 var events = new ConcurrentQueue<int>();
                 listener.RunWithCallback(ev => events.Enqueue(ev.EventId), () => {

--- a/src/System.Threading.Tasks.Parallel/tests/System.Threading.Tasks.Parallel.Tests.csproj
+++ b/src/System.Threading.Tasks.Parallel/tests/System.Threading.Tasks.Parallel.Tests.csproj
@@ -14,6 +14,9 @@
     <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs">
       <Link>Common\System\Diagnostics\Tracing\TestEventListener.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>Common\System\PlatformDetection.cs</Link>
+    </Compile>
     <Compile Include="BreakTests.cs" />
     <Compile Include="EtwTests.cs" />
     <Compile Include="ParallelFor.cs" />


### PR DESCRIPTION
Fix https://github.com/dotnet/corefx/issues/17727

The code to fire the event is the same
https://referencesource.microsoft.com/#mscorlib/system/threading/Tasks/TPLETWProvider.cs,253
however the provider name is `[EventSource(Name = "System.Threading.Tasks.Parallel.EventSource")]` but was
```
    [EventSource(
        Name = "System.Threading.Tasks.TplEventSource",
        Guid = "2e5dba47-a3d2-4d16-8ee0-6671ffdcd7b5", 
        LocalizationResources = "mscorlib")]
```

This has been the case since 2015 so I assume @vancem this is fine and not going to break tools like VS or we would have already noticed.

@alexperovich @safern @stephentoub 