### PR TITLE
Fix Type tests using netfx

### DIFF
--- a/src/System.Runtime/tests/System/TypeTests.cs
+++ b/src/System.Runtime/tests/System/TypeTests.cs
@@ -304,26 +304,11 @@ namespace System.Tests
             public string Value = "The Value property.";
         }
 
-        static string sourceTestAssemblyPath = Path.Combine(Environment.CurrentDirectory, "TestLoadAssembly.dll");
-        static string destTestAssemblyPath = Path.Combine(Environment.CurrentDirectory, "TestLoadAssembly", "TestLoadAssembly.dll");
+        static string s_testAssemblyPath = Path.Combine(Environment.CurrentDirectory, "TestLoadAssembly.dll");
         static string testtype = "System.Collections.Generic.Dictionary`2[[Program, Foo], [Program, Foo]]";
-        static TypeTestsExtended()
-        {
-            // Move TestLoadAssembly.dll to subfolder TestLoadAssembly
-            try
-            {
-                Directory.CreateDirectory(Path.GetDirectoryName(destTestAssemblyPath));
-                File.Move(sourceTestAssemblyPath, destTestAssemblyPath);
-            }
-            catch (System.Exception) { }
-            finally
-            {
-                File.Delete(sourceTestAssemblyPath);
-            }
-        }
 
         private static Func<AssemblyName, Assembly> assemblyloader = (aName) => aName.Name == "TestLoadAssembly" ?
-                           Assembly.LoadFrom(@".\TestLoadAssembly\TestLoadAssembly.dll") :
+                           Assembly.LoadFrom(@".\TestLoadAssembly.dll") :
                            null;
         private static Func<Assembly, String, Boolean, Type> typeloader = (assem, name, ignore) => assem == null ?
                              Type.GetType(name, false, ignore) :
@@ -337,7 +322,7 @@ namespace System.Tests
                    string test1 = testtype;
                    Type t1 = Type.GetType(test1,
                              (aName) => aName.Name == "Foo" ?
-                                   Assembly.LoadFrom(destTestAssemblyPath) : null,
+                                   Assembly.LoadFrom(s_testAssemblyPath) : null,
                              typeloader,
                              true
                      );
@@ -365,7 +350,7 @@ namespace System.Tests
                    Assert.Throws<System.IO.FileNotFoundException>(() =>
                    Type.GetType(test1,
                      (aName) => aName.Name == "Foo" ?
-                         Assembly.LoadFrom(@".\TestLoadAssembly.dll") : null,
+                         Assembly.LoadFrom(@".\NoSuchTestLoadAssembly.dll") : null,
                      typeloader,
                      true
                   ));


### PR DESCRIPTION
The following test failures occur running `msbuild /T:BuildAndTest /P:TargetGroup=netfx`

```
      System.Tests.TypeTestsExtended.GetTypeByName [FAIL]
        System.TypeInitializationException : The type initializer for 'System.Tests.TypeTestsExtended' threw an excepti
  on.
        ---- System.UnauthorizedAccessException : Access to the path 'C:\Users\hughb\Documents\GitHub\corefx\bin\AnyOS.
  AnyCPU.Debug\System.Runtime.Tests\netstandard\TestLoadAssembly.dll' is denied.
        Stack Trace:
             at System.Tests.TypeTestsExtended.GetTypeByName()
          ----- Inner Stack Trace -----
             at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
             at System.IO.File.InternalDelete(String path, Boolean checkHost)
          C:\Users\hughb\Documents\GitHub\corefx\src\System.Runtime\tests\System\TypeTests.cs(321,0): at System.Tests.T
  ypeTestsExtended..cctor()
      System.Tests.TypeTestsExtended.GetTypeByNameTypeloadFailure [FAIL]
        System.TypeInitializationException : The type initializer for 'System.Tests.TypeTestsExtended' threw an excepti
  on.
        ---- System.UnauthorizedAccessException : Access to the path 'C:\Users\hughb\Documents\GitHub\corefx\bin\AnyOS.
  AnyCPU.Debug\System.Runtime.Tests\netstandard\TestLoadAssembly.dll' is denied.
        Stack Trace:
             at System.Tests.TypeTestsExtended.GetTypeByNameTypeloadFailure()
          ----- Inner Stack Trace -----
             at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
             at System.IO.File.InternalDelete(String path, Boolean checkHost)
          C:\Users\hughb\Documents\GitHub\corefx\src\System.Runtime\tests\System\TypeTests.cs(321,0): at System.Tests.T
  ypeTestsExtended..cctor()
      System.Tests.TypeTestsExtended.GetTypeByNameCaseSensitiveTypeloadFailure [FAIL]
        System.TypeInitializationException : The type initializer for 'System.Tests.TypeTestsExtended' threw an excepti
  on.
        ---- System.UnauthorizedAccessException : Access to the path 'C:\Users\hughb\Documents\GitHub\corefx\bin\AnyOS.
  AnyCPU.Debug\System.Runtime.Tests\netstandard\TestLoadAssembly.dll' is denied.
        Stack Trace:
             at System.Tests.TypeTestsExtended.GetTypeByNameCaseSensitiveTypeloadFailure()
          ----- Inner Stack Trace -----
             at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
             at System.IO.File.InternalDelete(String path, Boolean checkHost)
          C:\Users\hughb\Documents\GitHub\corefx\src\System.Runtime\tests\System\TypeTests.cs(321,0): at System.Tests.T
  ypeTestsExtended..cctor()
```

Looking into this, I noticed that if I disabled two of the three failing tests, no exception was thrown and the non-disabled test that was previously failing would pass.

This suggested that this is a test issue - that the tests are running parallel to each other and this causes failures.

After investigation, it seemed that this is caused by trying to delete a file at the same time that it is being moved. This caused a race condition - but I'm not sure why it only occurs on desktop.

The fix is to avoid moving and deleting sources. Instead, we can just refer to the original assembly instead of the new destination assembly.

This also requires modifying the tests that expect a FileNotFoundException trying to access the original assembly - this is because we previously deleted it. This is not a problem, as we can modify the test data, and it has exactly the same meaning - trying to load an assembly that doesn't exist.

Contributes to #17723

@rakhu @danmoesemsft