### PR TITLE
Fix MaxResponseHeadersLengthSemantics

### DIFF
--- a/src/Common/src/System/Net/Http/HttpHandlerDefaults.cs
+++ b/src/Common/src/System/Net/Http/HttpHandlerDefaults.cs
@@ -11,7 +11,7 @@ namespace System.Net.Http
     {
         public const int DefaultMaxAutomaticRedirections = 50;
         public const int DefaultMaxConnectionsPerServer = int.MaxValue;
-        public const int DefaultMaxResponseHeaderLength = 64 * 1024;
+        public const int DefaultMaxResponseHeadersLength = 64; // Units in K (1024) bytes.
         public const DecompressionMethods DefaultAutomaticDecompression = DecompressionMethods.None;
         public const bool DefaultAutomaticRedirection = true;
         public const bool DefaultUseCookies = true;

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -87,7 +87,7 @@ namespace System.Net.Http
         private TimeSpan _sendTimeout = TimeSpan.FromSeconds(30);
         private TimeSpan _receiveHeadersTimeout = TimeSpan.FromSeconds(30);
         private TimeSpan _receiveDataTimeout = TimeSpan.FromSeconds(30);
-        private int _maxResponseHeadersLength = 64 * 1024;
+        private int _maxResponseHeadersLength = HttpHandlerDefaults.DefaultMaxResponseHeadersLength;
         private int _maxResponseDrainSize = 64 * 1024;
         private IDictionary<String, Object> _properties; // Only create dictionary when required.
         private volatile bool _operationStarted;
@@ -1173,7 +1173,7 @@ namespace System.Net.Http
 
         private void SetRequestHandleBufferingOptions(SafeWinHttpHandle requestHandle)
         {
-            uint optionData = (uint)_maxResponseHeadersLength;
+            uint optionData = (uint)(_maxResponseHeadersLength * 1024);
             SetWinHttpOption(requestHandle, Interop.WinHttp.WINHTTP_OPTION_MAX_RESPONSE_HEADER_SIZE, ref optionData);
             optionData = (uint)_maxResponseDrainSize;
             SetWinHttpOption(requestHandle, Interop.WinHttp.WINHTTP_OPTION_MAX_RESPONSE_DRAIN_SIZE, ref optionData);

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpHandlerTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpHandlerTest.cs
@@ -59,7 +59,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             Assert.Equal(TimeSpan.FromSeconds(30), handler.SendTimeout);
             Assert.Equal(TimeSpan.FromSeconds(30), handler.ReceiveHeadersTimeout);
             Assert.Equal(TimeSpan.FromSeconds(30), handler.ReceiveDataTimeout);
-            Assert.Equal(64 * 1024, handler.MaxResponseHeadersLength);
+            Assert.Equal(64, handler.MaxResponseHeadersLength);
             Assert.Equal(64 * 1024, handler.MaxResponseDrainSize);
             Assert.NotNull(handler.Properties);
         }

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
@@ -937,7 +937,7 @@ namespace System.Net.Http
 
                         // Validate that we haven't received too much header data.
                         ulong headerBytesReceived = response._headerBytesReceived + size;
-                        if (headerBytesReceived > (ulong)easy._handler.MaxResponseHeadersLength)
+                        if (headerBytesReceived > (ulong)(easy._handler.MaxResponseHeadersLength * 1024))
                         {
                             throw new HttpRequestException(
                                 SR.Format(SR.net_http_response_headers_exceeded_length, easy._handler.MaxResponseHeadersLength));

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
@@ -936,6 +936,7 @@ namespace System.Net.Http
                         CurlResponseHeaderReader reader = new CurlResponseHeaderReader(buffer, size);
 
                         // Validate that we haven't received too much header data.
+                        // MaxResponseHeadersLength property is in units in K (1024) bytes.
                         ulong headerBytesReceived = response._headerBytesReceived + size;
                         if (headerBytesReceived > (ulong)(easy._handler.MaxResponseHeadersLength * 1024))
                         {

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -144,7 +144,7 @@ namespace System.Net.Http
         private bool _automaticRedirection = HttpHandlerDefaults.DefaultAutomaticRedirection;
         private int _maxAutomaticRedirections = HttpHandlerDefaults.DefaultMaxAutomaticRedirections;
         private int _maxConnectionsPerServer = HttpHandlerDefaults.DefaultMaxConnectionsPerServer;
-        private int _maxResponseHeadersLength = HttpHandlerDefaults.DefaultMaxResponseHeaderLength;
+        private int _maxResponseHeadersLength = HttpHandlerDefaults.DefaultMaxResponseHeadersLength;
         private ClientCertificateOption _clientCertificateOption = HttpHandlerDefaults.DefaultClientCertificateOption;
         private X509Certificate2Collection _clientCertificates;
         private Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> _serverCertificateValidationCallback;

--- a/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -39,7 +39,7 @@ namespace System.Net
 
         private Task<HttpResponseMessage> _sendRequestTask;
 
-        private static int _defaultMaxResponseHeaderLength = HttpHandlerDefaults.DefaultMaxResponseHeaderLength;
+        private static int _defaultMaxResponseHeadersLength = HttpHandlerDefaults.DefaultMaxResponseHeadersLength;
 
         private int _beginGetRequestStreamCalled = 0;
         private int _beginGetResponseCalled = 0;
@@ -47,7 +47,7 @@ namespace System.Net
         private int _endGetResponseCalled = 0;
                 
         private int _maximumAllowedRedirections = HttpHandlerDefaults.DefaultMaxAutomaticRedirections;
-        private int _maximumResponseHeaderLen = _defaultMaxResponseHeaderLength;
+        private int _maximumResponseHeadersLen = _defaultMaxResponseHeadersLength;
         private ServicePoint _servicePoint;
         private int _timeout = WebRequest.DefaultTimeoutMilliseconds;
         private HttpContinueDelegate _continueDelegate;
@@ -150,11 +150,11 @@ namespace System.Net
         {
             get
             {
-                return _maximumResponseHeaderLen;
+                return _maximumResponseHeadersLen;
             }
             set
             {
-                _maximumResponseHeaderLen = value;
+                _maximumResponseHeadersLen = value;
             }
         }
                 
@@ -621,11 +621,11 @@ namespace System.Net
         {
             get
             {
-                return _defaultMaxResponseHeaderLength;
+                return _defaultMaxResponseHeadersLength;
             }
             set
             {
-                _defaultMaxResponseHeaderLength = value;
+                _defaultMaxResponseHeadersLength = value;
             }
         }
 

--- a/src/System.Net.Requests/tests/HttpWebRequestHeaderTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestHeaderTest.cs
@@ -30,7 +30,7 @@ namespace System.Net.Tests
             Assert.NotNull(HttpWebRequest.DefaultCachePolicy);
             Assert.Null(request.CookieContainer);
             Assert.Equal(0, HttpWebRequest.DefaultMaximumErrorResponseLength); // NetFX behavior difference (64 on NetFX).
-            Assert.Equal(65536, HttpWebRequest.DefaultMaximumResponseHeadersLength); // NetFX behavior difference (64 on NetFX).
+            Assert.Equal(64, HttpWebRequest.DefaultMaximumResponseHeadersLength);
             Assert.Null(request.CookieContainer);
             Assert.True(request.AllowWriteStreamBuffering);
             Assert.NotNull(request.ClientCertificates);


### PR DESCRIPTION
The new HttpClientHandler.MaxResponseHeadersLength property is defined differently from the similarly
named WebRequestHandler and HttpWebRequest properties. The units are supposed to be in Kilobytes
(1024 bytes). This problem was discovered while doing .NET Core vs. .NET Framework compat testing.

Fix the semantics to match the existing WebRequestHandler and HttpWebRequest properties. Adjust tests.

Contributes to #17691