### PR TITLE
Add missing error code NO_ADDRESS

### DIFF
--- a/src/Native/Unix/System.Native/pal_networking.cpp
+++ b/src/Native/Unix/System.Native/pal_networking.cpp
@@ -410,6 +410,9 @@ static int ConvertGetHostErrorPlatformToPal(int error)
         case NO_DATA:
             return PAL_NO_DATA;
 
+        case NO_ADDRESS:
+            return PAL_NO_ADDRESS;
+
         default:
             assert_err(false, "Unknown gethostbyname/gethostbyaddr error code", error);
             return PAL_HOST_NOT_FOUND;


### PR DESCRIPTION
Fix https://github.com/dotnet/corefx/issues/17749

According to https://linux.die.net/man/3/gethostbyname and https://linux.die.net/man/3/gethostbyaddr this error code can be returned, and we weren't handling it.

Note      PAL_NO_ADDRESS = PAL_NO_DATA,

I didn't trace through the managed code to see what we do with PAL_NO_DATA, clearly it should be handled already.

@Priya91 @steveharter 