### PR TITLE
Fix PNSE with HttpClientHandler.MaxAutomaticRedirections property

### DIFF
--- a/src/System.Net.Http/src/netcore50/System/Net/HttpClientHandler.cs
+++ b/src/System.Net.Http/src/netcore50/System/Net/HttpClientHandler.cs
@@ -284,11 +284,14 @@ namespace System.Net.Http
             get { return 10; }
             set
             {
+                /*
+                 * https://github.com/dotnet/corefx/issues/17812
                 if (value != MaxAutomaticRedirections)
                 {
                     throw new PlatformNotSupportedException(String.Format(CultureInfo.InvariantCulture,
                         SR.net_http_value_not_supported, value, nameof(MaxAutomaticRedirections)));
                 }
+                */
                 CheckDisposedOrStarted();
             }
         }


### PR DESCRIPTION
This's a temporary fix for issue
https://github.com/dotnet/corefx/issues/17812
to get us unblocked for ns2.0 UWP app-compact.