### PR TITLE
Add ILLink to the build

### DIFF
--- a/Tools-Override/FrameworkTargeting.targets
+++ b/Tools-Override/FrameworkTargeting.targets
@@ -222,17 +222,24 @@
   </PropertyGroup>
 
   <Target Name="BinPlace"
-          DependsOnTargets="GetBinPlaceDirs;BinPlaceFiles;BinPlaceProps"
+          DependsOnTargets="GetBinPlaceConfiguration;BinPlaceFiles;BinPlaceProps"
           AfterTargets="CopyFilesToOutputDirectory"
           Condition="'$(EnableBinPlacing)' == 'true'" />
 
   <Target Name="BinPlaceFiles"
           Condition="'@(BinPlaceDir)' != ''"
-          DependsOnTargets="GetBinPlaceItems" >
+          DependsOnTargets="GetBinPlaceItems"
+          Inputs="@(BinPlaceDir);%(BinPlaceDir.ItemName)"
+          Outputs="unused" >
+
+    <PropertyGroup>
+      <_BinPlaceItemName>%(BinPlaceDir.ItemName)</_BinPlaceItemName>
+      <_BinPlaceItemName Condition="'$(_BinPlaceItemName)' == ''">BinPlaceItem</_BinPlaceItemName>
+    </PropertyGroup>
 
     <Message Importance="low" Text="BinPlaceDir: @(BinPlaceDir)" />
 
-    <Copy SourceFiles="@(BinPlaceItem)"
+    <Copy SourceFiles="@($(_BinPlaceItemName))"
           DestinationFolder="%(BinPlaceDir.Identity)" 
           SkipUnchangedFiles="true"
           OverwriteReadOnlyFiles="true"
@@ -284,7 +291,7 @@
   </Target>
 
   <UsingTask TaskName="FindBestConfigurations" AssemblyFile="$(CoreFxToolsTaskDir)CoreFx.Tools.dll"/>
-  <Target Name="GetBinPlaceDirs" DependsOnTargets="GetBuildConfigurations">
+  <Target Name="GetBinPlaceConfiguration" DependsOnTargets="GetBuildConfigurations">
     <!-- find which, if any, build configuration of this project is best
          for each binplace configuration -->
     <FindBestConfigurations Properties="@(Property)"
@@ -297,12 +304,25 @@
     <ItemGroup>
       <_currentBinPlaceConfigurations Include="@(_bestBinlaceConfigurations)" Condition="'%(Identity)' == '$(Configuration)' OR '%(Identity)-$(ConfigurationGroup)' == '$(Configuration)'" />
 
-      <BinPlaceDir Condition="'$(BinPlaceRuntime)' == 'true'" Include="%(_currentBinPlaceConfigurations.RuntimePath)" />
-      <BinPlaceDir Condition="'$(BinPlaceRef)' == 'true'" Include="%(_currentBinPlaceConfigurations.RefPath)" />
+      <BinPlaceDir Condition="'$(BinPlaceRuntime)' == 'true'" Include="@(_currentBinPlaceConfigurations->'%(RuntimePath)')" />
+      <BinPlaceDir Condition="'$(BinPlaceRef)' == 'true'" Include="@(_currentBinPlaceConfigurations->'%(RefPath)')" />
 
       <PackageFileDir Condition="'$(BinPlaceRuntime)' == 'true'" Include="%(_currentBinPlaceConfigurations.PackageFileRuntimePath)" />
       <PackageFileDir Condition="'$(BinPlaceRef)' == 'true'" Include="%(_currentBinPlaceConfigurations.PackageFileRefPath)" />
+
+      <!-- permit BinplaceConfigurations to define SetProperties metadata, 
+           set those properties when BinplaceConfiguration is active -->
+      <_binplacePropertyTuples Include="%(_currentBinPlaceConfigurations.SetProperties)" />
+
+      <_binplaceSetProperty Condition="'%(_binplacePropertyTuples.Identity)' != ''" 
+                            Include="$([System.String]::new('%(_binplacePropertyTuples.Identity)').Split('=')[0])">
+        <Value>$([System.String]::new('%(_binplacePropertyTuples.Identity)').Split('=')[1])</Value>
+      </_binplaceSetProperty>
     </ItemGroup>
+
+    <CreateProperty Value="%(_binplaceSetProperty.Value)" Condition="'@(_binplaceSetProperty)' != ''" >
+      <Output TaskParameter="Value" PropertyName="%(_binplaceSetProperty.Identity)" />
+    </CreateProperty>
   </Target>
 
   <!-- Incremental clean only cleans paths under Intermediate or OutDir, handle additional paths -->

--- a/dir.targets
+++ b/dir.targets
@@ -60,6 +60,8 @@
       <PackageFileRefPath Condition="'$(IsNETCoreAppRef)' == 'true'">$(NETCoreAppPackageRefPath)</PackageFileRefPath>
       <PackageFileRuntimePath>$(NETCoreAppPackageRuntimePath)</PackageFileRuntimePath>
       <RuntimePath Condition="'$(BinPlaceNETCoreAppPackage)' == 'true'">$(NETCoreAppPackageRuntimePath)\..\runtime</RuntimePath>
+      <!-- enable trimming for any project that's part of the shared framework -->
+      <SetProperties Condition="'$(IsRuntimeAssembly)' == 'true'">ILLinkTrimAssembly=true</SetProperties>
     </BinPlaceConfiguration>
     <BinPlaceConfiguration Condition="'$(IsUAP)' == 'true' AND '$(BuildingUAPVertical)' == 'true'" Include="uap-$(_bc_OSGroup)">
       <PackageFileRefPath Condition="'$(IsUAPRef)'=='true'">$(UAPPackageRefPath)</PackageFileRefPath>
@@ -107,6 +109,7 @@
   <Import Condition="Exists('$(MSBuildThisFileDirectory)..\open.targets')" Project="$(MSBuildThisFileDirectory)..\open.targets" />
 
   <Import Project="$(MSBuildThisFileDirectory)referenceFromRuntime.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)illink.targets" />
 
   <PropertyGroup>
     <!-- We don't use any of MSBuild's resolution logic for resolving the framework, so just set these two properties to any folder that exists to skip

--- a/dir.targets
+++ b/dir.targets
@@ -60,8 +60,8 @@
       <PackageFileRefPath Condition="'$(IsNETCoreAppRef)' == 'true'">$(NETCoreAppPackageRefPath)</PackageFileRefPath>
       <PackageFileRuntimePath>$(NETCoreAppPackageRuntimePath)</PackageFileRuntimePath>
       <RuntimePath Condition="'$(BinPlaceNETCoreAppPackage)' == 'true'">$(NETCoreAppPackageRuntimePath)\..\runtime</RuntimePath>
-      <!-- enable trimming for any project that's part of the shared framework -->
-      <SetProperties Condition="'$(IsRuntimeAssembly)' == 'true'">ILLinkTrimAssembly=true</SetProperties>
+      <!-- enable trimming for any runtime project that's part of the shared framework and hasn't already set ILLinkTrimAssembly -->
+      <SetProperties Condition="'$(BinPlaceRuntime)' == 'true' AND '$(ILLinkTrimAssembly)' == ''">ILLinkTrimAssembly=true</SetProperties>
     </BinPlaceConfiguration>
     <BinPlaceConfiguration Condition="'$(IsUAP)' == 'true' AND '$(BuildingUAPVertical)' == 'true'" Include="uap-$(_bc_OSGroup)">
       <PackageFileRefPath Condition="'$(IsUAPRef)'=='true'">$(UAPPackageRefPath)</PackageFileRefPath>

--- a/external/ILLink/ILLink.depproj
+++ b/external/ILLink/ILLink.depproj
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <NuGetTargetMoniker>.NETCoreApp,Version=v1.1</NuGetTargetMoniker>
+    <OutputPath>$(ToolsDir)ILLink</OutputPath>
+    <IsRuntimeAssembly>false</IsRuntimeAssembly>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <Target Name="IncludeAllFiles"
+          AfterTargets="ResolveNuGetPackages">
+    <ItemGroup>
+      <ReferenceCopyLocalPaths Include="%(ReferenceCopyLocalPaths.RootDir)%(ReferenceCopyLocalPaths.Directory)\*.*" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/external/ILLink/project.json.template
+++ b/external/ILLink/project.json.template
@@ -1,0 +1,14 @@
+{
+  "dependencies": {
+    "Microsoft.NETCore.ILLink": {
+      "version": "0.1.8-preview",
+      "exclude": "compile"
+    }
+  },
+  "frameworks": {
+    "netcoreapp1.1": { }
+  },
+  "runtimes": {
+    "{RID}": {}
+  }
+}

--- a/external/dir.proj
+++ b/external/dir.proj
@@ -15,6 +15,7 @@
     <Project Include="portable\portable.depproj" />
     <Project Include="uapaotredist/uapaotredist.depproj" />
     <Project Include="ilasm/ilasm.depproj" />
+    <Project Condition="'$(ILLinkTrimAssembly)' != 'false'" Include="ILLink/ILLink.depproj" />
   </ItemGroup>
 
   <Import Project="../dir.traversal.targets" />

--- a/illink.targets
+++ b/illink.targets
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <TargetsTriggeredByCompilation>
+      $(TargetsTriggeredByCompilation);
+      _SetILLinkTrimAssembly;
+      ILLinkTrimAssembly
+    </TargetsTriggeredByCompilation>
+  </PropertyGroup>
+
+  <!-- Inputs and outputs of ILLinkTrimAssembly -->
+  <PropertyGroup>
+    <ILLinkToolPath Condition="'$(ILLinkToolPath)' == ''">$(ToolsDir)ILLink/illink.dll</ILLinkToolPath>
+    <ILLinkTrimAssemblyPath>$(IntermediateOutputPath)$(TargetName)$(TargetExt)</ILLinkTrimAssemblyPath>
+    <ILLinkTrimAssemblySymbols>$(IntermediateOutputPath)$(TargetName).pdb</ILLinkTrimAssemblySymbols>
+    <ILLinkTrimInputPath>$(IntermediateOutputPath)PreTrim/</ILLinkTrimInputPath>
+    <ILLinkTrimInputAssembly>$(ILLinkTrimInputPath)$(TargetName)$(TargetExt)</ILLinkTrimInputAssembly>
+    <ILLinkTrimInputSymbols>$(ILLinkTrimInputPath)$(TargetName).pdb</ILLinkTrimInputSymbols>
+    <ILLinkTrimOutputPath>$(IntermediateOutputPath)</ILLinkTrimOutputPath>
+
+    <ILLinkTrimXml Condition="'$(ILLinkTrimXml)' == '' AND Exists('$(MSBuildProjectDirectory)/ILLinkTrim.xml')">$(MSBuildProjectDirectory)/ILLinkTrim.xml</ILLinkTrimXml>
+
+    <!-- if building a PDB, tell illink to rewrite the symbols file -->
+    <ILLinkRewritePDBs Condition="'$(ILLinkRewritePDBs)' == '' AND '$(DebugSymbols)' != 'false'">true</ILLinkRewritePDBs>
+  </PropertyGroup>
+
+  <!-- Custom binplacing for pre/post-trimming and reports that is useful for analysis 
+       Must be enabled by setting BinPlaceILLinkTrimAssembly=true
+  --> 
+  <ItemGroup Condition="'$(BinPlaceILLinkTrimAssembly)' == 'true'">
+    <BinPlaceConfiguration Include="$(BuildConfiguration)">
+      <RuntimePath>$(BinDir)ILLinkTrimAssembly/$(BuildConfiguration)/trimmed</RuntimePath>
+      <ItemName>TrimmedItem</ItemName>
+    </BinPlaceConfiguration>
+    <BinPlaceConfiguration Include="$(BuildConfiguration)">
+      <RuntimePath>$(BinDir)ILLinkTrimAssembly/$(BuildConfiguration)/reports</RuntimePath>
+      <ItemName>TrimmingReport</ItemName>
+    </BinPlaceConfiguration>
+    <BinPlaceConfiguration Include="$(BuildConfiguration)">
+      <RuntimePath>$(BinDir)ILLinkTrimAssembly/$(BuildConfiguration)/pretrimmed</RuntimePath>
+      <ItemName>PreTrimmedItem</ItemName>
+    </BinPlaceConfiguration>
+  </ItemGroup>
+
+  <Target Name="_SetILLinkTrimAssembly" 
+          Condition="'$(ILLinkTrimAssembly)' == ''"
+          DependsOnTargets="GetBinPlaceConfiguration">
+    <PropertyGroup>
+      <!-- Currently ILLink cannot handle type projections from Windows.winmd, disable if the project references it -->
+      <ILLinkTrimAssembly Condition="'%(ReferencePath.FileName)%(ReferencePath.Extension)' == 'Windows.winmd'">false</ILLinkTrimAssembly>
+    </PropertyGroup>
+  </Target>
+
+  <!-- ILLinkTrimAssembly
+       Examines the "input assembly" for IL that is unreachable from public API and trims that,
+       rewriting the assembly to an "output assembly"
+  -->
+  <Target Name="ILLinkTrimAssembly" Condition="'$(ILLinkTrimAssembly)' == 'true'" DependsOnTargets="EnsureBuildToolsRuntime">
+    <ItemGroup>
+      <!-- currently only directories are supported by ILLink. -->
+      <_ILLinkReferenceDirectory Include="%(ReferencePath.RootDir)%(ReferencePath.Directory)" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <!-- Root public entry points in this assembly.
+           Currently this must be passed as name and directory.
+           Directory of this assembly *must* occur before directory of references. -->
+      <ILLinkArgs>$(ILLinkArgs) -r $(TargetName)</ILLinkArgs>
+      <ILLinkArgs>$(ILLinkArgs) -d $(ILLinkTrimInputPath)</ILLinkArgs>
+      <!-- directories to examine for assembly dependencies -->
+      <ILLinkArgs>$(ILLinkArgs) @(_ILLinkReferenceDirectory->'-d %(Identity)', ' ')</ILLinkArgs>
+      <!-- don't trim anything that's defined in core assemblies -->
+      <ILLinkArgs>$(ILLinkArgs) -c skip</ILLinkArgs>
+      <ILLinkArgs>$(ILLinkArgs) -p skip netstandard</ILLinkArgs>
+      <!-- keep type-forward assemblies (facades) -->
+      <ILLinkArgs>$(ILLinkArgs) -t</ILLinkArgs>
+      <ILLinkArgs>$(ILLinkArgs) -out $(ILLinkTrimOutputPath)</ILLinkArgs>
+      <ILLinkArgs Condition="'$(ILLinkTrimXml)' != ''">$(ILLinkArgs) -x $(ILLinkTrimXml)</ILLinkArgs>
+      <ILLinkArgs Condition="'$(ILLinkRewritePDBs)' == 'true' AND Exists('$(ILLinkTrimAssemblySymbols)')">$(ILLinkArgs) -b true</ILLinkArgs>
+    </PropertyGroup>
+
+    <MakeDir Directories="$(ILLinkTrimInputPath)" />
+
+    <!-- Move the assembly into a subdirectory for ILLink -->
+    <Move SourceFiles="$(ILLinkTrimAssemblyPath)"
+          DestinationFolder="$(ILLinkTrimInputPath)"
+    />
+
+    <!-- Move the PDB into a subdirectory for ILLink if we are rewriting PDBs -->
+    <Move SourceFiles="$(ILLinkTrimAssemblySymbols)"
+          DestinationFolder="$(ILLinkTrimInputPath)"
+          Condition="'$(ILLinkRewritePDBs)' == 'true' AND Exists('$(ILLinkTrimAssemblySymbols)')"
+    />
+
+    <PropertyGroup>
+      <ILLinkCmd>$(OverrideToolHost) "$(ILLinkToolPath)"</ILLinkCmd>
+    </PropertyGroup>
+
+    <Exec Command="$(ILLinkCmd) $(ILLinkArgs)" />
+  </Target>
+
+  <!-- ILLink reporting.
+       Only enabled when developer specifies a path to the AsmDiff tool with property AsmDiffCmd.
+       EG: AsmDiffCmd=d:\tools\asmdiff\asmdiff.exe
+       This is necessary until the AsmDiff tool is ported to .NET Core. -->
+  <Target Name="_CreateILLinkTrimAssemblyReports"
+          AfterTargets="ILLinkTrimAssembly"
+          Condition="'$(AsmDiffCmd)' != ''">
+    <PropertyGroup>
+      <AsmDiffArgs>$(AsmDiffArgs) $(ILLinkTrimInputAssembly)</AsmDiffArgs>
+      <AsmDiffArgs>$(AsmDiffArgs) $(ILLinkTrimAssemblyPath)</AsmDiffArgs>
+      <AsmDiffArgs>$(AsmDiffArgs) -includePrivateApis -includeInternalApis -alwaysDiffMembers -diffAttributes</AsmDiffArgs>
+
+      <AsmDiffReport>$(IntermediateOutputPath)$(TargetName).diff.html</AsmDiffReport>
+      <AsmDiffReportArgs>$(AsmDiffArgs) -out:$(AsmDiffReport)</AsmDiffReportArgs>
+      <AsmDiffReportArgs>$(AsmDiffReportArgs) -unchanged -changed -added -removed</AsmDiffReportArgs>
+
+      <AsmDiffList>$(IntermediateOutputPath)$(TargetName).diff.csv</AsmDiffList>
+      <AsmDiffListArgs>$(AsmDiffArgs) -out:$(AsmDiffList)</AsmDiffListArgs>
+      <AsmDiffListArgs>$(AsmDiffListArgs) -unchanged -changed -added -removed </AsmDiffListArgs>
+      <AsmDiffListArgs>$(AsmDiffListArgs) -diffWriter:CSV</AsmDiffListArgs>
+    </PropertyGroup>
+
+    <Exec Command="$(AsmDiffCmd) $(AsmDiffReportArgs)" />
+    <Message Text="Assembly trimming diff: $(AsmDiffReport)" />
+    <Exec Command="$(AsmDiffCmd) $(AsmDiffListArgs)" />
+    <Message Text="Assembly trimming report: $(AsmDiffList)" />
+  </Target>
+  
+  <!-- Similar to _CheckForCompileOutputs and runs in the same places, 
+       always set these even if compile didn't run. -->
+  <Target Name="_CheckForILLinkTrimAssemblyOutputs" 
+          BeforeTargets="CopyFilesToOutputDirectory;_CleanGetCurrentAndPriorFileWrites"
+          Condition="'$(ILLinkTrimAssembly)' == 'true'">
+    <ItemGroup>
+      <PreTrimmedItem Condition="Exists('$(ILLinkTrimInputAssembly)')" Include="$(ILLinkTrimInputAssembly)" />
+      <PreTrimmedItem Condition="'$(ILLinkRewritePDBs)' == 'true' AND Exists('$(ILLinkTrimInputSymbols)')" Include="$(ILLinkTrimInputSymbols)" />
+      <FileWrites Include="@(PreTrimmedItem)" />
+
+      <TrimmedItem Condition="Exists('$(ILLinkTrimAssemblyPath)')" Include="$(ILLinkTrimAssemblyPath)" />
+      <TrimmedItem Condition="'$(ILLinkRewritePDBs)' == 'true' AND Exists('$(ILLinkTrimAssemblySymbols)')" Include="$(ILLinkTrimAssemblySymbols)" />
+
+      <TrimmingReport Condition="Exists('$(AsmDiffReport)')" Include="$(AsmDiffReport)" />
+      <TrimmingReport Condition="Exists('$(AsmDiffList)')" Include="$(AsmDiffList)" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/System.Diagnostics.DiagnosticSource/src/ILLinkTrim.xml
+++ b/src/System.Diagnostics.DiagnosticSource/src/ILLinkTrim.xml
@@ -1,0 +1,13 @@
+<linker>
+  <assembly fullname="System.Diagnostics.DiagnosticSource">
+    <type fullname="System.Diagnostics.DiagnosticSourceEventSource">
+      <!-- DiagnosticSourceEventSource calls these methods through reflection based on strings passed from user code -->
+      <method name="Activity1Start" />
+      <method name="Activity1Stop" />
+      <method name="Activity2Start" />
+      <method name="Activity2Stop" />
+      <method name="RecursiveActivity1Start" />
+      <method name="RecursiveActivity1Stop" />
+    </type>
+  </assembly>
+</linker>

--- a/src/System.Linq.Expressions/src/ILLinkTrim.xml
+++ b/src/System.Linq.Expressions/src/ILLinkTrim.xml
@@ -1,0 +1,8 @@
+<linker>
+  <assembly fullname="System.Linq.Expressions">
+    <type fullname="System.Linq.Expressions.Interpreter.LightLambda">
+      <!-- required by debugger -->
+      <method name="get_DebugView" />
+    </type>
+  </assembly>
+</linker>

--- a/src/System.Linq/src/ILLinkTrim.xml
+++ b/src/System.Linq/src/ILLinkTrim.xml
@@ -1,0 +1,8 @@
+<linker>
+  <assembly fullname="System.Linq">
+    <!-- required by debugger, see comment in System/Linq/DebugView.cs -->
+    <type fullname="System.Linq.SystemCore_EnumerableDebugView" />
+    <type fullname="System.Linq.SystemCore_EnumerableDebugView`1" />
+    <type fullname="System.Linq.SystemCore_EnumerableDebugViewEmptyException" />
+  </assembly>
+</linker>

--- a/src/System.Net.Http/src/ILLinkTrim.xml
+++ b/src/System.Net.Http/src/ILLinkTrim.xml
@@ -1,0 +1,6 @@
+<linker>
+  <assembly fullname="System.Net.Http">
+    <!-- Anonymous types are used with DiagnosticSource logging and subscribers reflect over those, calling their public getters. -->
+    <type fullname="*f__AnonymousType*" />
+  </assembly>
+</linker>

--- a/src/System.Net.NetworkInformation/src/ILLinkTrim.xml
+++ b/src/System.Net.NetworkInformation/src/ILLinkTrim.xml
@@ -1,0 +1,6 @@
+<linker>
+  <assembly fullname="System.Net.NetworkInformation">
+    <!-- NetEventSource isn't used by this assembly but tests check for its presence -->
+    <type fullname="System.Net.NetEventSource" />
+  </assembly>
+</linker>

--- a/src/System.Net.Ping/src/ILLinkTrim.xml
+++ b/src/System.Net.Ping/src/ILLinkTrim.xml
@@ -1,0 +1,6 @@
+<linker>
+  <assembly fullname="System.Net.Ping">
+    <!-- NetEventSource isn't used by this assembly but tests check for its presence -->
+    <type fullname="System.Net.NetEventSource" />
+  </assembly>
+</linker>

--- a/src/System.Net.Security/src/ILLinkTrim.xml
+++ b/src/System.Net.Security/src/ILLinkTrim.xml
@@ -1,0 +1,12 @@
+<linker>
+  <assembly fullname="System.Net.Security">
+    <type fullname="System.Net.NTAuthentication">
+      <!-- Called through reflection by System.Net.Mail tests -->
+      <method name="GetOutgoingBlob" />
+      <method name="MakeSignature" />
+      <method name="VerifySignature" />
+    </type>
+    <!-- required by tests -->
+    <type fullname="System.Net.NetEventSource" />
+  </assembly>
+</linker>

--- a/src/System.Private.DataContractSerialization/src/ILLinkTrim.xml
+++ b/src/System.Private.DataContractSerialization/src/ILLinkTrim.xml
@@ -1,0 +1,8 @@
+<linker>
+  <assembly fullname="System.Private.DataContractSerialization">
+    <type fullname="System.Runtime.Serialization.DataContractSerializer">
+      <!-- called through reflection by tests -->
+      <method name="set_Option" />
+    </type>
+  </assembly>
+</linker>

--- a/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.ilproj
+++ b/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.ilproj
@@ -16,8 +16,5 @@
     <Compile Include="System.Runtime.CompilerServices.Unsafe.il" />
     <Reference Include="System.Runtime" />
   </ItemGroup>
-  <Target Name="RunAfterCoreCompile" AfterTargets="CoreCompile">
-    <CallTarget Targets="$(TargetsTriggeredByCompilation)" Condition="'$(TargetsTriggeredByCompilation)' != ''" />
-  </Target>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/Tools/dir.targets
+++ b/src/Tools/dir.targets
@@ -1,0 +1,6 @@
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\dir.targets" />
+
+  <!-- this depends on the tasks and targets that we're building -->
+  <Target Name="GetBinPlaceConfiguration" />
+</Project>


### PR DESCRIPTION
This adds ILLink (a .NET Core build of the mono linker) to the build
tools and uses it to trim non-public unreachable IL and metadata from
our assemblies.

This is enabled by default for any assembly that is part of NETCore.App.

This can be disabled by setting ILLinkTrimAssembly=false.

In some cases ILLink may trim too much, for example a runtime
dependency via reflection on private or internal API.
If we cannot update ILLink to understand this dependency via heuristic
then we can manually "root" the private or internal API.
This is done by adding an XML file next to the project with the name
ILLinkTrim.xml that follows the format documented here:
https://github.com/mono/linker/blob/master/linker/README

Replaces https://github.com/dotnet/corefx/pull/17632

/cc @erozenfeld @sbomer @weshaggard 