### PR TITLE
Fix registry enumeration.

### DIFF
--- a/src/Common/src/Interop/Windows/advapi32/Interop.RegEnumKeyEx.cs
+++ b/src/Common/src/Interop/Windows/advapi32/Interop.RegEnumKeyEx.cs
@@ -15,7 +15,7 @@ internal partial class Interop
         internal static extern unsafe int RegEnumKeyEx(
             SafeRegistryHandle hKey,
             int dwIndex,
-            char* lpName,
+            char[] lpName,
             ref int lpcbName,
             int[] lpReserved,
             [Out]StringBuilder lpClass,

--- a/src/Common/src/Interop/Windows/advapi32/Interop.RegEnumValue.cs
+++ b/src/Common/src/Interop/Windows/advapi32/Interop.RegEnumValue.cs
@@ -14,7 +14,7 @@ internal partial class Interop
         internal static extern unsafe int RegEnumValue(
             SafeRegistryHandle hKey,
             int dwIndex,
-            char* lpValueName,
+            char[] lpValueName,
             ref int lpcbValueName,
             IntPtr lpReserved_MustBeZero,
             int[] lpType,

--- a/src/Microsoft.Win32.Registry/src/Microsoft.Win32.Registry.csproj
+++ b/src/Microsoft.Win32.Registry/src/Microsoft.Win32.Registry.csproj
@@ -105,6 +105,8 @@
     <Reference Include="mscorlib" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="System.Buffers" />
+    <Reference Include="System.Collections" />
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.Diagnostics.Tools" />
     <Reference Include="System.Resources.ResourceManager" />

--- a/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKey.Windows.cs
+++ b/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKey.Windows.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Security.AccessControl;
+using System.Buffers;
 
 /*
   Note on transaction support:
@@ -395,34 +396,45 @@ namespace Microsoft.Win32
 
         private unsafe string[] InternalGetSubKeyNamesCore(int subkeys)
         {
-            string[] names = new string[subkeys];
-            char[] name = new char[MaxKeyLength + 1];
+            List<string> names = new List<string>(subkeys);
+            char[] name = ArrayPool<char>.Shared.Rent(MaxKeyLength + 1);
 
-            int namelen;
-
-            fixed (char* namePtr = &name[0])
+            try
             {
-                for (int i = 0; i < subkeys; i++)
-                {
-                    namelen = name.Length; // Don't remove this. The API's doesn't work if this is not properly initialized.
-                    int ret = Interop.Advapi32.RegEnumKeyEx(_hkey,
-                        i,
-                        namePtr,
-                        ref namelen,
-                        null,
-                        null,
-                        null,
-                        null);
-                    if (ret != 0)
-                    {
-                        Win32Error(ret, null);
-                    }
+                int index = 0;
+                int result;
+                int nameLength = name.Length;
 
-                    names[i] = new string(namePtr);
+                while ((result = Interop.Advapi32.RegEnumKeyEx(
+                    _hkey,
+                    index,
+                    name,
+                    ref nameLength,
+                    null,
+                    null,
+                    null,
+                    null)) != Interop.Errors.ERROR_NO_MORE_ITEMS)
+                {
+                    switch (result)
+                    {
+                        case Interop.Errors.ERROR_SUCCESS:
+                            names.Add(new string(name, 0, nameLength));
+                            nameLength = name.Length;
+                            index++;
+                            break;
+                        default:
+                            // Throw the error
+                            Win32Error(result, null);
+                            break;
+                    }
                 }
             }
+            finally
+            {
+                ArrayPool<char>.Shared.Return(name);
+            }
 
-            return names;
+            return names.ToArray();
         }
 
         private int InternalValueCountCore()
@@ -453,37 +465,73 @@ namespace Microsoft.Win32
         /// <returns>All value names.</returns>
         private unsafe string[] GetValueNamesCore(int values)
         {
-            string[] names = new string[values];
-            char[] name = new char[MaxValueLength + 1];
-            int namelen;
+            List<string> names = new List<string>(values);
 
-            fixed (char* namePtr = &name[0])
+            // Names in the registry aren't usually very long, although they can go to as large
+            // as 16383 characters (MaxValueLength).
+            //
+            // Every call to RegEnumValue will allocate another buffer to get the data from
+            // NtEnumerateValueKey before copying it back out to our passed in buffer. This can
+            // add up quickly- we'll try to keep the memory pressure low and grow the buffer
+            // only if needed.
+
+            char[] name = ArrayPool<char>.Shared.Rent(100);
+
+            try
             {
-                for (int i = 0; i < values; i++)
+                int index = 0;
+                int result;
+                int nameLength = name.Length;
+
+                while ((result = Interop.Advapi32.RegEnumValue(
+                    _hkey,
+                    index,
+                    name,
+                    ref nameLength,
+                    IntPtr.Zero,
+                    null,
+                    null,
+                    null)) != Interop.Errors.ERROR_NO_MORE_ITEMS)
                 {
-                    namelen = name.Length;
-
-                    int ret = Interop.Advapi32.RegEnumValue(_hkey,
-                        i,
-                        namePtr,
-                        ref namelen,
-                        IntPtr.Zero,
-                        null,
-                        null,
-                        null);
-
-                    if (ret != 0)
+                    switch (result)
                     {
-                        // ignore ERROR_MORE_DATA if we're querying HKEY_PERFORMANCE_DATA
-                        if (!(IsPerfDataKey() && ret == Interop.Errors.ERROR_MORE_DATA))
-                            Win32Error(ret, null);
+                        // The size is only ever reported back correctly in the case
+                        // of ERROR_SUCCESS. It will almost always be changed, however.
+                        case Interop.Errors.ERROR_SUCCESS:
+                            names.Add(new string(name, 0, nameLength));
+                            index++;
+                            break;
+                        case Interop.Errors.ERROR_MORE_DATA:
+                            if (IsPerfDataKey())
+                            {
+                                // Enumerating the values for Perf keys always returns ERROR_MORE_DATA.
+                                names.Add(new string(name));
+                                index++;
+                                break;
+                            }
+                            else
+                            {
+                                nameLength = name.Length;
+                                ArrayPool<char>.Shared.Return(name);
+                                name = ArrayPool<char>.Shared.Rent(nameLength + 100);
+                                break;
+                            }
+                        default:
+                            // Throw the error
+                            Win32Error(result, null);
+                            break;
                     }
 
-                    names[i] = new string(namePtr);
+                    // Always set the name length back to the buffer size
+                    nameLength = name.Length;
                 }
             }
+            finally
+            {
+                ArrayPool<char>.Shared.Return(name);
+            }
 
-            return names;
+            return names.ToArray();
         }
 
         private object InternalGetValueCore(string name, object defaultValue, bool doNotExpand)
@@ -505,15 +553,15 @@ namespace Microsoft.Win32
                     byte[] blob = new byte[size];
                     while (Interop.Errors.ERROR_MORE_DATA == (r = Interop.Advapi32.RegQueryValueEx(_hkey, name, null, ref type, blob, ref sizeInput)))
                     {
-                        if (size == Int32.MaxValue)
+                        if (size == int.MaxValue)
                         {
                             // ERROR_MORE_DATA was returned however we cannot increase the buffer size beyond Int32.MaxValue
                             Win32Error(r, name);
                         }
-                        else if (size > (Int32.MaxValue / 2))
+                        else if (size > (int.MaxValue / 2))
                         {
                             // at this point in the loop "size * 2" would cause an overflow
-                            size = Int32.MaxValue;
+                            size = int.MaxValue;
                         }
                         else
                         {

--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_GetValueNames.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_GetValueNames.cs
@@ -62,7 +62,8 @@ namespace Microsoft.Win32.RegistryTests
         public static void TestGetValueNamesForPerformanceData()
         {
             var rk = Registry.PerformanceData;
-            int iNumValue = rk.GetValueNames().Length;
+            string[] names = rk.GetValueNames();
+            Assert.Equal(new string[] { "Global", "Costly" }, names);
         }
     }
 }


### PR DESCRIPTION
Key data (values and subkeys) can change while we're in the midst of enumerating. This is causing intermittent failures in tests as ERROR_NO_MORE_ITEMS surfaces as an exception as we try and iterate past removed data.

In addition, allocating 32K to get value names causes 32K * number of items to get natively allocated on the heap.  While these allocs are returned on each iteration it could potentially cause significant grief for large keys and concurrent heap allocations. Above and beyond this, allocating 64K for what are typically < 20 character names is a bit crazy, and as such we'll optimize for the common case.

Related to #17037, #16961- **however** this doesn't directly fix those as there is another copy of the registry code in System.Private.Corelib that those issues are actually using. I'll be following up shortly with the SPCL fix.