### PR TITLE
Fix DataContractSerializer ReflectionOnly tests

### DIFF
--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -23,16 +23,6 @@ using Xunit;
 
 public static partial class DataContractSerializerTests
 {
-#if ReflectionOnly
-    private static readonly string SerializationOptionSetterName = "set_Option";
-
-    static DataContractSerializerTests()
-    {
-        var method = typeof(DataContractSerializer).GetMethod(SerializationOptionSetterName, BindingFlags.NonPublic | BindingFlags.Static);
-        Assert.True(method != null, $"No method named {SerializationOptionSetterName}");
-        method.Invoke(null, new object[] { 1 });
-    }
-#endif
     [Fact]
     public static void DCS_DateTimeOffsetAsRoot()
     {

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.netcoreapp.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.netcoreapp.cs
@@ -4,6 +4,7 @@
 
 using SerializationTypes;
 using System.IO;
+using System.Reflection;
 using System.Runtime.Serialization;
 using Xunit;
 

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.netcoreapp.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.netcoreapp.cs
@@ -9,6 +9,17 @@ using Xunit;
 
 public static partial class DataContractSerializerTests
 {
+#if ReflectionOnly
+    private static readonly string SerializationOptionSetterName = "set_Option";
+
+    static DataContractSerializerTests()
+    {
+        var method = typeof(DataContractSerializer).GetMethod(SerializationOptionSetterName, BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.True(method != null, $"No method named {SerializationOptionSetterName}");
+        method.Invoke(null, new object[] { 1 });
+    }
+#endif
+
 	[Fact]
     public static void DCS_MyPersonSurrogate()
     {


### PR DESCRIPTION
The DataContractSerializer tests when in ReflectionOnly mode try to get `DataContractSerializer.Option` setter method through reflection which is not available in Desktop so when trying to run this tests in netfx we would get failures.

Fixes: https://github.com/dotnet/corefx/issues/17774

cc: @danmosemsft 