### PR TITLE
Change command cancellation to use a specific cancellationOwner field, rather than the more generic Owner field

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlBulkCopy.cs
@@ -2802,6 +2802,7 @@ namespace System.Data.SqlClient
                 {
                     _stateObj = _parser.GetSession(this);
                     _stateObj._bulkCopyOpperationInProgress = true;
+                    _stateObj.StartSession(this);
                 }
                 finally
                 {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
@@ -2422,6 +2422,7 @@ namespace System.Data.SqlClient
             }
 
             TdsParserStateObject stateObj = parser.GetSession(this);
+            stateObj.StartSession(this);
 
             _stateObj = stateObj;
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDataReader.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDataReader.cs
@@ -2,10 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
-
-//------------------------------------------------------------------------------
-
 using System.Collections;
 using System.Collections.ObjectModel;
 using System.Data.Common;
@@ -406,7 +402,7 @@ namespace System.Data.SqlClient
             TdsParserStateObject stateObj = _stateObj;
             if (null != stateObj)
             {
-                stateObj.Cancel(this);
+                stateObj.Cancel(command);
             }
         }
 

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/CommandCancelTest/CommandCancelTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/CommandCancelTest/CommandCancelTest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace System.Data.SqlClient.ManualTesting.Tests
@@ -13,9 +14,89 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         private static readonly string s_connStr = (new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr) { PacketSize = 512 }).ConnectionString;
 
         [CheckConnStrSetupFact]
+        public static void PlainCancelTest()
+        {
+            PlainCancel(s_connStr);
+        }
+
+        [CheckConnStrSetupFact]
+        public static void PlainMARSCancelTest()
+        {
+            PlainCancel((new SqlConnectionStringBuilder(s_connStr) { MultipleActiveResultSets = true }).ConnectionString);
+        }
+
+        [CheckConnStrSetupFact]
+        public static void PlainCancelTestAsync()
+        {
+            PlainCancelAsync(s_connStr);
+        }
+
+        [CheckConnStrSetupFact]
+        public static void PlainMARSCancelTestAsync()
+        {
+            PlainCancelAsync((new SqlConnectionStringBuilder(s_connStr) { MultipleActiveResultSets = true }).ConnectionString);
+        }
+
+        private static void PlainCancel(string connString)
+        {
+            using (SqlConnection conn = new SqlConnection(connString))
+            using (SqlCommand cmd = new SqlCommand("select * from dbo.Orders; waitfor delay '00:00:10'; select * from dbo.Orders", conn))
+            {
+                conn.Open();
+                using (SqlDataReader reader = cmd.ExecuteReader())
+                {
+                    cmd.Cancel();
+                    DataTestUtility.AssertThrowsWrapper<SqlException>(
+                        () =>
+                        {
+                            do
+                            {
+                                while (reader.Read())
+                                {
+                                }
+                            }
+                            while (reader.NextResult());
+                        },
+                        "A severe error occurred on the current command.  The results, if any, should be discarded.");
+                }
+            }
+        }
+
+        private static void PlainCancelAsync(string connString)
+        {
+            using (SqlConnection conn = new SqlConnection(connString))
+            using (SqlCommand cmd = new SqlCommand("select * from dbo.Orders; waitfor delay '00:00:10'; select * from dbo.Orders", conn))
+            {
+                conn.Open();
+                Task<SqlDataReader> readerTask = cmd.ExecuteReaderAsync();
+                DataTestUtility.AssertThrowsWrapper<SqlException>(
+                    () =>
+                    {
+                        readerTask.Wait(2000);
+                        SqlDataReader reader = readerTask.Result;
+                        cmd.Cancel();
+                        do
+                        {
+                            while (reader.Read())
+                            {
+                            }
+                        }
+                        while (reader.NextResult());
+                    },
+                    "A severe error occurred on the current command.  The results, if any, should be discarded.");
+            }
+        }
+
+        [CheckConnStrSetupFact]
         public static void MultiThreadedCancel_NonAsync()
         {
             MultiThreadedCancel(s_connStr, false);
+        }
+
+        [CheckConnStrSetupFact]
+        public static void MultiThreadedCancel_Async()
+        {
+            MultiThreadedCancel(s_connStr, true);
         }
 
         [CheckConnStrSetupFact]
@@ -74,7 +155,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        //InvalidOperationException from conenction.Dispose if that connection has prepared command cancelled during reading of data
+        //InvalidOperationException from connection.Dispose if that connection has prepared command cancelled during reading of data
         private static void CancelAndDisposePreparedCommand(string constr)
         {
             int expectedValue = 1;
@@ -83,8 +164,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                 try
                 {
                     // Generate a query with a large number of results.
-                    using (var command = new SqlCommand("select @P from sysobjects a cross join sysobjects b cross join sysobjects c cross join sysobjects d cross join sysobjects e cross join sysobjects f"
-                        , connection))
+                    using (var command = new SqlCommand("select @P from sysobjects a cross join sysobjects b cross join sysobjects c cross join sysobjects d cross join sysobjects e cross join sysobjects f", connection))
                     {
                         command.Parameters.Add(new SqlParameter("@P", SqlDbType.Int) { Value = expectedValue });
                         connection.Open();
@@ -110,7 +190,6 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                 }
             }
         }
-
 
         private static void VerifyConnection(SqlCommand cmd)
         {


### PR DESCRIPTION
This change brings SqlClient cancellation in line with Framework. Currently, we use the Owner field in TdsParserStateObject to check the Cancel() caller, but overloading the Owner field with BulkCopy introduced some issues with the TdsParserStateObject not being disposed, since it was setting the Owner field to manage cancellation. This change introduces the "StartSession" behavior from framework, and uses a specific cancellationOwner field. (This field in Framework is represented as an int though, since it's an objectID also used with BID tracing.)