### PR TITLE
[Port to 1.1.x] Fix the P/Invoke target for System.Security.Cryptography.Algorithms.Tests

### DIFF
--- a/src/System.Security.Cryptography.Algorithms/tests/DefaultECDsaProvider.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/DefaultECDsaProvider.cs
@@ -92,19 +92,16 @@ namespace System.Security.Cryptography.EcDsa.Tests
         private static readonly IECDsaProvider s_provider = new ECDsaProvider();
     }
 
-    internal static partial class Interop
-    {
-        private static partial class Libraries
-        {
-            internal const string CryptoNative = "System.Security.Cryptography.Native";
-        }
-        internal static partial class Crypto
-        {
-            [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcKeyCreateByOid")]
-            internal static extern IntPtr EcKeyCreateByOid(string oid);
+}
 
-            [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcKeyDestroy")]
-            internal static extern void EcKeyDestroy(IntPtr r);
-        }
+internal static partial class Interop
+{
+    internal static partial class Crypto
+    {
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcKeyCreateByOid")]
+        internal static extern System.IntPtr EcKeyCreateByOid(string oid);
+
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcKeyDestroy")]
+        internal static extern void EcKeyDestroy(System.IntPtr r);
     }
 }

--- a/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
+++ b/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
@@ -123,6 +123,9 @@
     <Compile Include="Sha512Tests.cs" />
     <Compile Include="TripleDesProvider.cs" />
     <Compile Include="TripleDesTests.cs" />
+    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+      <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\ByteUtils.cs">
       <Link>CommonTest\System\Security\Cryptography\ByteUtils.cs</Link>
     </Compile>


### PR DESCRIPTION
The crypto shim got renamed, but a capabilities probe in the S.S.C.Algorithms
test library didn't get the memo.  This didn't matter much because the old shim
name is still produced for compatibility, but it got highlighted in a test with
packages change.

This change removes the duplicate definition of the library name, and includes
the Unix library names list, but leaves the individual targeted methods in place.

Fixes #16047, by cherry-picking the commit from #13123.