### PR TITLE
Move System.Net.Cookie to System.Net namespace

### DIFF
--- a/src/System.Net.Primitives/src/System/Net/Cookie.cs
+++ b/src/System.Net.Primitives/src/System/Net/Cookie.cs
@@ -8,19 +8,7 @@ using System.Globalization;
 using System.IO;
 using System.Text;
 
-// The uap #define is used in some source files to indicate we are compiling classes
-// directly into the UWP System.Net.Http.dll implementation assembly in order to use internal class
-// methods. Internal methods are needed in order to map cookie response headers from the WinRT Windows.Web.Http APIs.
-// Windows.Web.Http is used underneath the System.Net.Http classes on .NET Native. Having other similarly
-// named classes would normally conflict with the public System.Net namespace classes.
-// So, we need to move the classes to a different namespace. Those classes are never
-// exposed up to user code so there isn't a problem.  In the future, we might expose some of the internal methods
-// as new public APIs and then we can remove this duplicate source code inclusion in the binaries.
-#if uap
-namespace System.Net.Internal
-#else
 namespace System.Net
-#endif
 {
     internal enum CookieVariant
     {

--- a/src/System.Net.Primitives/src/System/Net/CookieCollection.cs
+++ b/src/System.Net.Primitives/src/System/Net/CookieCollection.cs
@@ -4,9 +4,6 @@
 
 using System.Collections;
 using System.Collections.Generic;
-#if uap
-using System.Net.Internal;
-#endif
 
 namespace System.Net
 {

--- a/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
+++ b/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
@@ -7,9 +7,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Net.NetworkInformation;
 using System.Text;
-#if uap
-using System.Net.Internal;
-#endif
 
 // Relevant cookie specs:
 //

--- a/src/System.Net.Primitives/src/System/Net/CookieException.cs
+++ b/src/System.Net.Primitives/src/System/Net/CookieException.cs
@@ -4,19 +4,7 @@
 
 using System.Runtime.Serialization;
 
-// The uap #define is used in some source files to indicate we are compiling classes
-// directly into the UWP System.Net.Http.dll implementation assembly in order to use internal class
-// methods. Internal methods are needed in order to map cookie response headers from the WinRT Windows.Web.Http APIs.
-// Windows.Web.Http is used underneath the System.Net.Http classes on .NET Native. Having other similarly
-// named classes would normally conflict with the public System.Net namespace classes.
-// So, we need to move the classes to a different namespace. Those classes are never
-// exposed up to user code so there isn't a problem.  In the future, we might expose some of the internal methods
-// as new public APIs and then we can remove this duplicate source code inclusion in the binaries.
-#if uap
-namespace System.Net.Internal
-#else
 namespace System.Net
-#endif
 {
     [Serializable]
     public class CookieException : FormatException, ISerializable


### PR DESCRIPTION
Move  Cookie to System.Net namespace for UAP since cookie is in ns2.0 
public System.Net contract.