### PR TITLE
Update VerifyNETStandard target to use live netstandard package

### DIFF
--- a/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.pkgproj
+++ b/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.pkgproj
@@ -27,7 +27,7 @@
 
   <PropertyGroup>
     <IsLineupPackage Condition="'$(PackageTargetRuntime)' == ''">true</IsLineupPackage>
-    <PreventImplementationReference Condition="'$(PackageTargetRuntime)' != ''">true</PreventImplementationReference>     
+    <PreventImplementationReference Condition="'$(PackageTargetRuntime)' != ''">true</PreventImplementationReference>
     <TargetFrameworkName>netcoreapp</TargetFrameworkName>
     <TargetFrameworkVersion>2.0</TargetFrameworkVersion>
     <TargetFramework>$(TargetFrameworkName)$(TargetFrameworkVersion)</TargetFramework>
@@ -37,8 +37,6 @@
     <RefBinDir>$(NETCoreAppPackageRefPath)</RefBinDir>
     <LibBinDir>$(NETCoreAppPackageRuntimePath)</LibBinDir>
 
-    <NETStandardLibraryPackage>NETStandard.Library2</NETStandardLibraryPackage>
-    <NETStandardLibraryPackageVersion>2.0.0-beta-24709-0</NETStandardLibraryPackageVersion>
     <NETStandardVersion>2.0</NETStandardVersion>
 
     <!-- Include symbols in package by default-->
@@ -112,13 +110,15 @@
 
   <Target Name="VerifyNETStandard" AfterTargets="Build">
     <ItemGroup>
-      <_NETStandardFile Include="$(PackagesDir)$(NETStandardLibraryPackage)\$(NETStandardLibraryPackageVersion)\ref\netstandard$(NETStandardVersion)\*.dll" />
+      <_NETStandardFile Include="$(PackagesDir)$(NETStandardPackageId)\$(NETStandardPackageVersion)\build\netstandard$(NETStandardVersion)\ref\*.dll" />
+      <!-- force a missing file there are no files found in the package -->
+      <_NETStandardFile Include="$(PackagesDir)$(NETStandardPackageId)\$(NETStandardPackageVersion)\build\netstandard$(NETStandardVersion)\ref\MISSING_REF_BUILD" Condition="'@(_NETStandardFile)' == ''" />
       <_NETStandardMissingFile Include="@(_NETStandardFile->'%(FileName)')" Exclude="@(File->'%(FileName)')" />
       <_NETStandardMissingFileError Include="@(_NETStandardMissingFile)" Exclude="@(SuppressNETStandardMissingFile)" />
       <_NETStandardSuppressedMissingFile Include="@(_NETStandardMissingFile)" Exclude="@(_NETStandardMissingFileError)" />
     </ItemGroup>
-    <Message Condition="'@(_NETStandardSuppressedMissingFile)' != ''" Text="Files'@(_NETStandardSuppressedMissingFile)' are part of '$(NETStandardLibraryPackage)' but missing from this package.  This error has been suppressed." />
-    <Error Condition="'@(_NETStandardMissingFileError)' != ''" Text="Files '@(_NETStandardMissingFileError)' are part of '$(NETStandardLibraryPackage)' but missing from this package." />
+    <Message Condition="'@(_NETStandardSuppressedMissingFile)' != ''" Text="Files'@(_NETStandardSuppressedMissingFile)' are part of '$(NETStandardPackageId)' but missing from this package.  This error has been suppressed." />
+    <Error Condition="'@(_NETStandardMissingFileError)' != ''" Text="Files '@(_NETStandardMissingFileError)' are part of '$(NETStandardPackageId)' but missing from this package." />
   </Target>
 
   <Target Name="GetSymbolPackageFiles" BeforeTargets="GetPackageFiles">

--- a/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.pkgproj
+++ b/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.pkgproj
@@ -96,7 +96,9 @@
 
   <Target Name="VerifyNETStandard" AfterTargets="Build">
     <ItemGroup>
-      <_NETStandardFile Include="$(PackagesDir)$(NETStandardPackageId)\$(NETStandardPackageVersion)\ref\netstandard$(NETStandardVersion)\*.dll" />
+      <_NETStandardFile Include="$(PackagesDir)$(NETStandardPackageId)\$(NETStandardPackageVersion)\build\netstandard$(NETStandardVersion)\ref\*.dll" />
+      <!-- force a missing file there are no files found in the package -->
+      <_NETStandardFile Include="$(PackagesDir)$(NETStandardPackageId)\$(NETStandardPackageVersion)\build\netstandard$(NETStandardVersion)\ref\MISSING_REF_BUILD" Condition="'@(_NETStandardFile)' == ''" />
       <_NETStandardMissingFile Include="@(_NETStandardFile->'%(FileName)')" Exclude="@(File->'%(FileName)')" />
       <_NETStandardMissingFileError Include="@(_NETStandardMissingFile)" Exclude="@(SuppressNETStandardMissingFile)" />
       <_NETStandardSuppressedMissingFile Include="@(_NETStandardMissingFile)" Exclude="@(_NETStandardMissingFileError)" />

--- a/src/System.Resources.Reader/dir.props
+++ b/src/System.Resources.Reader/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.SecureString/dir.props
+++ b/src/System.Security.SecureString/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.ValueTuple/dir.props
+++ b/src/System.ValueTuple/dir.props
@@ -3,5 +3,7 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.2.0</AssemblyVersion>
+    <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/shims/dir.props
+++ b/src/shims/dir.props
@@ -17,13 +17,16 @@
     <NetFxReference Include="System.ComponentModel.Composition" />
     <NetFxReference Include="System.ComponentModel.DataAnnotations">
       <StrongNameSig>MSSharedLib</StrongNameSig>
-    </NetFxReference> 
+    </NetFxReference>
     <NetFxReference Include="System.Data" />
     <NetFxReference Include="System.Drawing" />
     <NetFxReference Include="System.IO.Compression.FileSystem" />
     <NetFxReference Include="System.Net" />
     <NetFxReference Include="System.Numerics" />
     <NetFxReference Include="System.Runtime.Serialization" />
+    <NetFxReference Include="System.ServiceModel.Web">
+      <StrongNameSig>MSSharedLib</StrongNameSig>
+    </NetFxReference>
     <NetFxReference Include="System.Transactions" />
     <NetFxReference Include="System.Windows" />
     <NetFxReference Include="System.Web" />


### PR DESCRIPTION
We never updated the VerifyNETStandard target in our pkg package
when we started automatically consuming the NETStandard.Library package
so this change fixes it to use the same package as we are consuming
elsewhere in corefx.

Also adds System.ServiceModel.Web shim to the set of shims we support

PTAL @ericstj 