### PR TITLE
FIx System.Net.Requests tests for Desktop

### DIFF
--- a/src/System.Net.Requests/tests/HttpWebRequestHeaderTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestHeaderTest.cs
@@ -29,12 +29,22 @@ namespace System.Net.Tests
             Assert.False(request.HaveResponse);
             Assert.NotNull(HttpWebRequest.DefaultCachePolicy);
             Assert.Null(request.CookieContainer);
-            Assert.Equal(0, HttpWebRequest.DefaultMaximumErrorResponseLength); // NetFX behavior difference (64 on NetFX).
             Assert.Equal(64, HttpWebRequest.DefaultMaximumResponseHeadersLength);
             Assert.Null(request.CookieContainer);
             Assert.True(request.AllowWriteStreamBuffering);
             Assert.NotNull(request.ClientCertificates);
-            Assert.Throws<NotImplementedException>(() => request.ConnectionGroupName); //NetFX behavior difference.
+
+            // TODO: Issue #17842
+            if (!PlatformDetection.IsFullFramework)
+            {
+                Assert.Equal(0, HttpWebRequest.DefaultMaximumErrorResponseLength);
+                Assert.Throws<NotImplementedException>(() => request.ConnectionGroupName);
+            }
+            else
+            {
+                Assert.Equal(64, HttpWebRequest.DefaultMaximumErrorResponseLength);
+                Assert.Null(request.ConnectionGroupName);
+            }
         }
 
         [OuterLoop]
@@ -73,12 +83,13 @@ namespace System.Net.Tests
             Assert.Equal(request.CookieContainer.GetCookies(remoteServer).Count, 2);
         }
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17842")] // Difference in behavior
         [OuterLoop]
         [Theory, MemberData(nameof(EchoServers))]
         public void HttpWebRequest_ServicePoint_Throws(Uri remoteServer)
         {
             HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
-            Assert.Throws<PlatformNotSupportedException>(() => request.ServicePoint); // NetFX Behavior difference.
+            Assert.Throws<PlatformNotSupportedException>(() => request.ServicePoint);
         }
 
         [OuterLoop]

--- a/src/System.Net.Requests/tests/HttpWebResponseHeaderTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebResponseHeaderTest.cs
@@ -75,6 +75,7 @@ namespace System.Net.Tests
             });
         }
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17842")] // Difference in behavior
         [OuterLoop]
         [Fact]
         public async Task HttpWebResponse_Close_Success()


### PR DESCRIPTION
Adjust tests to run clean against Desktop.

Contributes to #17842