### PR TITLE
Add enhanced overloads for RSA and DSA.Create

### DIFF
--- a/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
+++ b/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
@@ -99,7 +99,9 @@ namespace System.Security.Cryptography
     {
         protected DSA() { }
         public static new System.Security.Cryptography.DSA Create() { throw null; }
+        public static System.Security.Cryptography.DSA Create(int keySizeInBits) { throw null; }
         public static new System.Security.Cryptography.DSA Create(string algName) { throw null; }
+        public static System.Security.Cryptography.DSA Create(System.Security.Cryptography.DSAParameters parameters) { throw null; }
         public abstract byte[] CreateSignature(byte[] rgbHash);
         public abstract System.Security.Cryptography.DSAParameters ExportParameters(bool includePrivateParameters);
         public override void FromXmlString(string xmlString) { }
@@ -395,7 +397,9 @@ namespace System.Security.Cryptography
         public override string KeyExchangeAlgorithm { get { throw null; } }
         public override string SignatureAlgorithm { get { throw null; } }
         public static new System.Security.Cryptography.RSA Create() { throw null; }
+        public static System.Security.Cryptography.RSA Create(int keySizeInBits) { throw null; }
         public static new System.Security.Cryptography.RSA Create(string algName) { throw null; }
+        public static System.Security.Cryptography.RSA Create(System.Security.Cryptography.RSAParameters parameters) { throw null; }
         public virtual byte[] Decrypt(byte[] data, System.Security.Cryptography.RSAEncryptionPadding padding) { throw null; }
         public virtual byte[] DecryptValue(byte[] rgb) { throw null; }
         public virtual byte[] Encrypt(byte[] data, System.Security.Cryptography.RSAEncryptionPadding padding) { throw null; }

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/DSA.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/DSA.cs
@@ -19,6 +19,38 @@ namespace System.Security.Cryptography
             return (DSA)CryptoConfig.CreateFromName(algName);
         }
 
+        public static DSA Create(int keySizeInBits)
+        {
+            DSA dsa = Create();
+
+            try
+            {
+                dsa.KeySize = keySizeInBits;
+                return dsa;
+            }
+            catch
+            {
+                dsa.Dispose();
+                throw;
+            }
+        }
+
+        public static DSA Create(DSAParameters parameters)
+        {
+            DSA dsa = Create();
+
+            try
+            {
+                dsa.ImportParameters(parameters);
+                return dsa;
+            }
+            catch
+            {
+                dsa.Dispose();
+                throw;
+            }
+        }
+
         // DSA does not encode the algorithm identifier into the signature blob, therefore CreateSignature and
         // VerifySignature do not need the HashAlgorithmName value, only SignData and VerifyData do.
         abstract public byte[] CreateSignature(byte[] rgbHash);

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSA.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSA.cs
@@ -15,6 +15,38 @@ namespace System.Security.Cryptography
             return (RSA)CryptoConfig.CreateFromName(algName);
         }
 
+        public static RSA Create(int keySizeInBits)
+        {
+            RSA rsa = Create();
+
+            try
+            {
+                rsa.KeySize = keySizeInBits;
+                return rsa;
+            }
+            catch
+            {
+                rsa.Dispose();
+                throw;
+            }
+        }
+
+        public static RSA Create(RSAParameters parameters)
+        {
+            RSA rsa = Create();
+
+            try
+            {
+                rsa.ImportParameters(parameters);
+                return rsa;
+            }
+            catch
+            {
+                rsa.Dispose();
+                throw;
+            }
+        }
+
         public abstract RSAParameters ExportParameters(bool includePrivateParameters);
         public abstract void ImportParameters(RSAParameters parameters);
         public virtual byte[] Encrypt(byte[] data, RSAEncryptionPadding padding) { throw DerivedClassMustOverride(); }

--- a/src/System.Security.Cryptography.Algorithms/tests/DSACreateTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/DSACreateTests.cs
@@ -1,0 +1,94 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography.Dsa.Tests;
+using Xunit;
+
+namespace System.Security.Cryptography.Algorithms.Tests
+{
+    public static class DSACreateTests
+    {
+        public static bool SupportsKeyGeneration => DSAFactory.SupportsKeyGeneration;
+        public static bool SupportsFips186_3 => DSAFactory.SupportsFips186_3;
+
+        [ConditionalTheory(nameof(SupportsKeyGeneration))]
+        [InlineData(512)]
+        [InlineData(960)]
+        [InlineData(1024)]
+        public static void CreateWithKeysize(int keySizeInBits)
+        {
+            using (DSA dsa = DSA.Create(keySizeInBits))
+            {
+                Assert.Equal(keySizeInBits, dsa.KeySize);
+
+                DSAParameters parameters = dsa.ExportParameters(false);
+                Assert.Equal(keySizeInBits, parameters.Y.Length << 3);
+                Assert.Equal(keySizeInBits, dsa.KeySize);
+            }
+        }
+
+        [ConditionalTheory(nameof(SupportsKeyGeneration), nameof(SupportsFips186_3))]
+        [InlineData(1088)]
+        public static void CreateWithKeysize_BigKeys(int keySizeInBits)
+        {
+            using (DSA dsa = DSA.Create(keySizeInBits))
+            {
+                Assert.Equal(keySizeInBits, dsa.KeySize);
+
+                DSAParameters parameters = dsa.ExportParameters(false);
+                Assert.Equal(keySizeInBits, parameters.Y.Length << 3);
+                Assert.Equal(keySizeInBits, dsa.KeySize);
+            }
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(1023)]
+        public static void CreateWithKeysize_InvalidKeySize(int keySizeInBits)
+        {
+            Assert.Throws<CryptographicException>(() => DSA.Create(keySizeInBits));
+        }
+
+        [Fact]
+        public static void CreateWithParameters_512()
+        {
+            CreateWithParameters(DSATestData.Dsa512Parameters);
+        }
+
+        [Fact]
+        public static void CreateWithParameters_1024()
+        {
+            CreateWithParameters(DSATestData.GetDSA1024Params());
+        }
+
+        [ConditionalFact(nameof(SupportsFips186_3))]
+        public static void CreateWithParameters_2048()
+        {
+            CreateWithParameters(DSATestData.GetDSA2048Params());
+        }
+
+        private static void CreateWithParameters(DSAParameters parameters)
+        {
+            DSAParameters exportedPrivate;
+
+            using (DSA dsa = DSA.Create(parameters))
+            {
+                exportedPrivate = dsa.ExportParameters(true);
+            }
+
+            DSAImportExport.AssertKeyEquals(ref parameters, ref exportedPrivate);
+        }
+
+        [Fact]
+        public static void CreateWithInvalidParameters()
+        {
+            DSAParameters parameters = DSATestData.GetDSA1024Params();
+            parameters.X = null;
+            parameters.Y = null;
+
+            Assert.Throws<ArgumentException>(() => DSA.Create(parameters));
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/tests/DefaultDSAProvider.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/DefaultDSAProvider.cs
@@ -13,9 +13,13 @@ namespace System.Security.Cryptography.Dsa.Tests
 
         public DSA Create(int keySize)
         {
+#if netcoreapp
+            return DSA.Create(keySize);
+#else
             DSA dsa = Create();
             dsa.KeySize = keySize;
             return dsa;
+#endif
         }
 
         public bool SupportsFips186_3

--- a/src/System.Security.Cryptography.Algorithms/tests/DefaultRSAProvider.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/DefaultRSAProvider.cs
@@ -17,9 +17,13 @@ namespace System.Security.Cryptography.Rsa.Tests
 
         public RSA Create(int keySize)
         {
+#if netcoreapp
+            return RSA.Create(keySize);
+#else
             RSA rsa = Create();
             rsa.KeySize = keySize;
             return rsa;
+#endif
         }
 
         public bool Supports384PrivateKey

--- a/src/System.Security.Cryptography.Algorithms/tests/RSACreateTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/RSACreateTests.cs
@@ -1,0 +1,81 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography.Rsa.Tests;
+using Xunit;
+
+namespace System.Security.Cryptography.Algorithms.Tests
+{
+    public static class RSACreateTests
+    {
+        // macOS has the highest smallest key value, 1024.
+        // Windows CNG has the highest step size, 64.
+        // This needs to take both into account.
+        [Theory]
+        [InlineData(1024)]
+        [InlineData(1088)]
+        [InlineData(1152)]
+        [InlineData(2048)]
+        public static void CreateWithKeysize(int keySizeInBits)
+        {
+            using (RSA rsa = RSA.Create(keySizeInBits))
+            {
+                Assert.Equal(keySizeInBits, rsa.KeySize);
+
+                RSAParameters parameters = rsa.ExportParameters(false);
+                Assert.Equal(keySizeInBits, parameters.Modulus.Length << 3);
+                Assert.Equal(keySizeInBits, rsa.KeySize);
+            }
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(1023)]
+        [InlineData(1025)]
+        public static void CreateWithKeysize_InvalidKeySize(int keySizeInBits)
+        {
+            Assert.Throws<CryptographicException>(() => RSA.Create(keySizeInBits));
+        }
+
+        [Fact]
+        public static void CreateWithParameters_1032()
+        {
+            CreateWithParameters(TestData.RSA1032Parameters);
+        }
+
+        [Fact]
+        public static void CreateWithParameters_UnusualExponent()
+        {
+            CreateWithParameters(TestData.UnusualExponentParameters);
+        }
+
+        [Fact]
+        public static void CreateWithParameters_2048()
+        {
+            CreateWithParameters(TestData.RSA2048Params);
+        }
+
+        private static void CreateWithParameters(RSAParameters parameters)
+        {
+            RSAParameters exportedPrivate;
+
+            using (RSA rsa = RSA.Create(parameters))
+            {
+                exportedPrivate = rsa.ExportParameters(true);
+            }
+
+            ImportExport.AssertKeyEquals(ref parameters, ref exportedPrivate);
+        }
+
+        [Fact]
+        public static void CreateWithInvalidParameters()
+        {
+            RSAParameters parameters = TestData.RSA1032Parameters;
+            parameters.Exponent = null;
+
+            Assert.Throws<CryptographicException>(() => RSA.Create(parameters));
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
+++ b/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
@@ -140,6 +140,7 @@
     <Compile Include="DefaultDSAProvider.cs" />
     <Compile Include="DESProvider.cs" />
     <Compile Include="DESTests.cs" />
+    <Compile Include="DSACreateTests.cs" />
     <Compile Include="DSASignatureFormatterTests.cs" />
     <Compile Include="ECDiffieHellmanPublicKeyTests.cs" />
     <Compile Include="PaddingModeTests.cs" />
@@ -147,6 +148,7 @@
     <Compile Include="RC2Provider.cs" />
     <Compile Include="RC2Tests.cs" />
     <Compile Include="RijndaelTests.cs" />
+    <Compile Include="RSACreateTests.cs" />
     <Compile Include="RSAKeyExchangeFormatterTests.cs" />
     <Compile Include="RSASignatureFormatterTests.cs" />
     <Compile Include="Sha1ManagedTests.cs" />


### PR DESCRIPTION
During the design of the ECC import/export feature we concluded that
better overloads for the asymmetric algorithms' Create methods should
exist which allow the user to specify the generation space (an ECCurve for ECC,
a keysize for RSA and DSA) or to specify key parameters for importing.

These methods are currently pure convenience, but in the future they could
end up using the arguments to change a preferred back-end provider;
for example, on netfx RSA.Create(RSAParameters) could prefer RSACng when the Exponent is
larger than 4 bytes, since RSACryptoServiceProvider cannot process those keys.

Fixes #8688, completes #8487 (for corefx)
ECDsa: Done in .NET Core (1.0)
RSA: Done in .NET Core (2.0, this change)
DSA: Done in .NET Core (2.0, this change)
ECDiffieHellman: Not yet available in corefx.