### PR TITLE
update baselines

### DIFF
--- a/src/shims/ApiCompatBaseline.netcoreapp.netstandard20.txt
+++ b/src/shims/ApiCompatBaseline.netcoreapp.netstandard20.txt
@@ -1,1 +1,15 @@
-Total Issues: 0
+DEFAULT_APPNAME Error: 0 : Failed to find or load matching assembly 'System.ServiceModel.Web'.
+Compat issues with assembly netstandard:
+TypesMustExist : Type 'System.Security.Cryptography.SHA256CryptoServiceProvider' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.SHA384CryptoServiceProvider' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.SHA512CryptoServiceProvider' does not exist in the implementation but it does exist in the contract.
+Compat issues with assembly System.Core:
+TypesMustExist : Type 'System.Security.Cryptography.SHA256CryptoServiceProvider' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.SHA384CryptoServiceProvider' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.SHA512CryptoServiceProvider' does not exist in the implementation but it does exist in the contract.
+Compat issues with assembly System.ServiceModel.Web:
+TypesMustExist : Type 'System.Runtime.Serialization.Json.DataContractJsonSerializer' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.Json.IXmlJsonReaderInitializer' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.Json.IXmlJsonWriterInitializer' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Runtime.Serialization.Json.JsonReaderWriterFactory' does not exist in the implementation but it does exist in the contract.
+Total Issues: 10

--- a/src/shims/ApiCompatBaseline.netcoreapp.netstandard20Only.txt
+++ b/src/shims/ApiCompatBaseline.netcoreapp.netstandard20Only.txt
@@ -1,2 +1,6 @@
 DEFAULT_APPNAME Error: 0 : Unable to resolve assembly 'Assembly(Name=System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)' referenced by the implementation assembly 'Microsoft.Cci.DummyModule'.
-Total Issues: 0
+Compat issues with assembly netstandard:
+TypesMustExist : Type 'System.Security.Cryptography.SHA256CryptoServiceProvider' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.SHA384CryptoServiceProvider' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.Cryptography.SHA512CryptoServiceProvider' does not exist in the implementation but it does exist in the contract.
+Total Issues: 3


### PR DESCRIPTION
SHA* are due to being added to standard.

@joperezr can you figure out the System.Runtime.Serialization ones? I can't. They ARE present in `C:\git\corefx\bin\ref\netcoreapp\System.Runtime.Serialization.Json.dll`

I guess it's because of `+DEFAULT_APPNAME Error: 0 : Failed to find or load matching assembly 'System.ServiceModel.Web'.` S.SM.Web is on the "left side" at `C:\git\corefx\bin\ref\netstandard\System.ServiceModel.Web.dll` and it type forwards to `C:\git\corefx\bin\ref\netstandard\netstandard.dll`. I'm not sure why it can't find it.

@CIPop 
https://github.com/dotnet/corefx/issues/17390#issuecomment-291359059