### PR TITLE
Fix export of odd-byte-length RSA keys on macOS

### DIFF
--- a/src/Common/src/System/Security/Cryptography/RSASecurityTransforms.cs
+++ b/src/Common/src/System/Security/Cryptography/RSASecurityTransforms.cs
@@ -470,7 +470,8 @@ namespace System.Security.Cryptography
             parameters.Exponent = KeyBlobHelpers.TrimPaddingByte(privateKey.ReadIntegerBytes());
 
             int modulusLen = parameters.Modulus.Length;
-            int halfModulus = modulusLen / 2;
+            // Add one so that odd byte-length values (RSA 1032) get padded correctly.
+            int halfModulus = (modulusLen + 1) / 2;
 
             parameters.D = KeyBlobHelpers.PadOrTrim(privateKey.ReadIntegerBytes(), modulusLen);
             parameters.P = KeyBlobHelpers.PadOrTrim(privateKey.ReadIntegerBytes(), halfModulus);

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
@@ -121,6 +121,27 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        public static void ImportExport1032()
+        {
+            RSAParameters imported = TestData.RSA1032Parameters;
+            RSAParameters exported;
+            RSAParameters exportedPublic;
+
+            using (RSA rsa = RSAFactory.Create())
+            {
+                rsa.ImportParameters(imported);
+                exported = rsa.ExportParameters(true);
+                exportedPublic = rsa.ExportParameters(false);
+            }
+
+            AssertKeyEquals(ref imported, ref exported);
+
+            Assert.Equal(exportedPublic.Modulus, imported.Modulus);
+            Assert.Equal(exportedPublic.Exponent, imported.Exponent);
+            Assert.Null(exportedPublic.D);
+        }
+
+        [Fact]
         public static void ImportReset()
         {
             using (RSA rsa = RSAFactory.Create())


### PR DESCRIPTION
RSA 1032 has a 129 byte modulus, which means the halfModulus values are
64.5 byte values (64 bytes and a nybble).  Round up the division so that the
extra nybble has a place to go.

Fixes the bug discovered by #17851