### PR TITLE
Don't set CustomErrorMessageSet to true for default constructions of ValidationAttributes

### DIFF
--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationAttribute.cs
@@ -84,7 +84,6 @@ namespace System.ComponentModel.DataAnnotations
             {
                 _defaultErrorMessage = value;
                 _errorMessageResourceAccessor = null;
-                CustomErrorMessageSet = true;
             }
         }
 

--- a/src/System.ComponentModel.Annotations/tests/EmailAddressAttributeTests.cs
+++ b/src/System.ComponentModel.Annotations/tests/EmailAddressAttributeTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Reflection;
 using Xunit;
 
 namespace System.ComponentModel.DataAnnotations.Tests
@@ -43,6 +44,18 @@ namespace System.ComponentModel.DataAnnotations.Tests
             var attribute = new EmailAddressAttribute();
             Assert.Equal(DataType.EmailAddress, attribute.DataType);
             Assert.Null(attribute.CustomDataType);
+        }
+
+        [Fact]
+        public static void CustomErrorMessageSet_Get_ReturnsFalse()
+        {
+            var attribute = new EmailAddressAttribute();
+            PropertyInfo property = attribute.GetType().GetProperty("CustomErrorMessageSet", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(property);
+
+            // .NET core fixed a bug in .NET framework where EmailAddressAttribute would set
+            // CustomErrorMessageSet to true. See https://github.com/dotnet/corefx/issues/4481.
+            Assert.Equal(PlatformDetection.IsFullFramework, (bool)property.GetValue(attribute));
         }
     }
 }

--- a/src/System.ComponentModel.Annotations/tests/System.ComponentModel.Annotations.Tests.csproj
+++ b/src/System.ComponentModel.Annotations/tests/System.ComponentModel.Annotations.Tests.csproj
@@ -40,6 +40,9 @@
     <Compile Include="ValidationExceptionTests.cs" />
     <Compile Include="ValidationResultTests.cs" />
     <Compile Include="ValidatorTests.cs" />
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>Common\System\PlatformDetection.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
Fixes #4481

Doesn't seem like a better way to test this as CustomErrorMessageSet is an internal property