### PR TITLE
Fix NetworkInterface.GetAllNetworkInterfaces segfault when interface provides no address.

### DIFF
--- a/src/Native/Unix/System.Native/pal_interfaceaddresses.cpp
+++ b/src/Native/Unix/System.Native/pal_interfaceaddresses.cpp
@@ -57,6 +57,10 @@ extern "C" int32_t SystemNative_EnumerateInterfaceAddresses(IPv4AddressFound onI
         }
         
         assert(result == actualName);
+        if (current->ifa_addr == nullptr)
+        {
+            continue;
+        }
         int family = current->ifa_addr->sa_family;
         if (family == AF_INET)
         {


### PR DESCRIPTION
As documented in getifaddrs, ifa_addr may contain a null pointer.