### PR TITLE
Fix the key increment size for RSA on macOS

### DIFF
--- a/src/Common/src/System/Security/Cryptography/RSASecurityTransforms.cs
+++ b/src/Common/src/System/Security/Cryptography/RSASecurityTransforms.cs
@@ -53,8 +53,8 @@ namespace System.Security.Cryptography
                     {
                         // All values are in bits.
                         // 1024 was achieved via experimentation.
-                        // 1024 and 1024+64 both generated successfully, 1024-64 produced errSecParam.
-                        new KeySizes(minSize: 1024, maxSize: 16384, skipSize: 64),
+                        // 1024 and 1024+8 both generated successfully, 1024-8 produced errSecParam.
+                        new KeySizes(minSize: 1024, maxSize: 16384, skipSize: 8),
                     };
                 }
             }


### PR DESCRIPTION
The LegalKeySizes values seem to have been copied from the Windows (CNG)
implementation, and only the minSize value adjusted to fit the environment.

Exploratory testing has showed that macOS will create an RSA-1032 key when
requested, making the keySize increment 8 bits instead of 8 bytes.

Coverage for this scenario is already verified by the RSAKeyGeneration.GenerateSecondMinKey test, but was additionally verified by hand.