### PR TITLE
Make SqlDataRecord compatible with Framework

### DIFF
--- a/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
+++ b/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
@@ -5,6 +5,9 @@
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
+using System;
+using System.Data;
+
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Data.SqlDbType))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Data.StatementCompletedEventArgs))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Data.StatementCompletedEventHandler))]
@@ -32,7 +35,7 @@
 
 namespace Microsoft.SqlServer.Server
 {
-    public partial class SqlDataRecord
+    public partial class SqlDataRecord : System.Data.IDataRecord
     {
         public SqlDataRecord(params Microsoft.SqlServer.Server.SqlMetaData[] metaData) { }
         public virtual int FieldCount { get { throw null; } }
@@ -116,6 +119,7 @@ namespace Microsoft.SqlServer.Server
         public virtual void SetTimeSpan(int ordinal, System.TimeSpan value) { }
         public virtual void SetValue(int ordinal, object value) { }
         public virtual int SetValues(params object[] values) { throw null; }
+        IDataReader System.Data.IDataRecord.GetData(int ordinal) { throw null; }
     }
     public sealed partial class SqlMetaData
     {

--- a/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
+++ b/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
@@ -5,8 +5,6 @@
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
-using System;
-using System.Data;
 
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Data.SqlDbType))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Data.StatementCompletedEventArgs))]
@@ -119,7 +117,7 @@ namespace Microsoft.SqlServer.Server
         public virtual void SetTimeSpan(int ordinal, System.TimeSpan value) { }
         public virtual void SetValue(int ordinal, object value) { }
         public virtual int SetValues(params object[] values) { throw null; }
-        IDataReader System.Data.IDataRecord.GetData(int ordinal) { throw null; }
+        System.Data.IDataReader System.Data.IDataRecord.GetData(int ordinal) { throw null; }
     }
     public sealed partial class SqlMetaData
     {

--- a/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
+++ b/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
@@ -43,6 +43,7 @@ namespace Microsoft.SqlServer.Server
         public virtual long GetBytes(int ordinal, long fieldOffset, byte[] buffer, int bufferOffset, int length) { throw null; }
         public virtual char GetChar(int ordinal) { throw null; }
         public virtual long GetChars(int ordinal, long fieldOffset, char[] buffer, int bufferOffset, int length) { throw null; }
+        System.Data.IDataReader System.Data.IDataRecord.GetData(int ordinal) { throw null; }
         public virtual string GetDataTypeName(int ordinal) { throw null; }
         public virtual System.DateTime GetDateTime(int ordinal) { throw null; }
         public virtual System.DateTimeOffset GetDateTimeOffset(int ordinal) { throw null; }
@@ -116,7 +117,6 @@ namespace Microsoft.SqlServer.Server
         public virtual void SetTimeSpan(int ordinal, System.TimeSpan value) { }
         public virtual void SetValue(int ordinal, object value) { }
         public virtual int SetValues(params object[] values) { throw null; }
-        System.Data.IDataReader System.Data.IDataRecord.GetData(int ordinal) { throw null; }
     }
     public sealed partial class SqlMetaData
     {

--- a/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
+++ b/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
@@ -5,7 +5,6 @@
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
-
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Data.SqlDbType))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Data.StatementCompletedEventArgs))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Data.StatementCompletedEventHandler))]

--- a/src/System.Data.SqlClient/src/Microsoft/SqlServer/Server/SqlDataRecord.cs
+++ b/src/System.Data.SqlClient/src/Microsoft/SqlServer/Server/SqlDataRecord.cs
@@ -18,7 +18,7 @@ using System.Diagnostics;
 
 namespace Microsoft.SqlServer.Server
 {
-    public class SqlDataRecord
+    public class SqlDataRecord : IDataRecord
     {
         private SmiRecordBuffer _recordBuffer;
         private SmiExtendedMetaData[] _columnSmiMetaData;
@@ -730,6 +730,11 @@ namespace Microsoft.SqlServer.Server
             {
                 throw SQL.SubclassMustOverride();
             }
+        }
+
+        public IDataReader GetData(int i)
+        {
+            throw ADP.NotSupported();
         }
     }
 }


### PR DESCRIPTION
Adding the interface and modifying contracts for SqlDataRecord to make it compatible with Framework.

See https://github.com/dotnet/corefx/issues/17708 