### PR TITLE
Disable hanging test and disable parallelization in System.Net.Requests.Tests

### DIFF
--- a/src/System.Net.Requests/tests/AssemblyInfo.cs
+++ b/src/System.Net.Requests/tests/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly, DisableTestParallelization = true, MaxParallelThreads = 1)]

--- a/src/System.Net.Requests/tests/AssemblyInfo.cs
+++ b/src/System.Net.Requests/tests/AssemblyInfo.cs
@@ -4,4 +4,6 @@
 
 using Xunit;
 
+// We have to run them with no parallelism because ServicePointManager.DefaultConnectionLimit is left as 2 in netfx and when they are running in parallel
+// it leaves too many connections open at once which causes tests to hang since they are not able to get a new HttpWebRequest connection opened.
 [assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly, DisableTestParallelization = true, MaxParallelThreads = 1)]

--- a/src/System.Net.Requests/tests/HttpWebResponseHeaderTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebResponseHeaderTest.cs
@@ -104,6 +104,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17842")] // Hangs in Desktop
         public async Task HttpWebResponse_Serialize_Fails()
         {
             await LoopbackServer.CreateServerAsync(async (server, url) =>


### PR DESCRIPTION
Disabling a hanging test on Desktop to have a full daily run in jenkins. 

Also I'm adding AssemblyInfo.cs file to disable parallelization on this tests to avoid Outerloop tests hang.
