### PR TITLE
Fix CI AllConfigurations Build

### DIFF
--- a/src/System.Threading.Tasks.Dataflow/src/Base/DataflowBlock.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Base/DataflowBlock.cs
@@ -17,6 +17,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks.Dataflow.Internal;
+using System.Threading.Tasks.Dataflow.Internal.Threading;
 
 namespace System.Threading.Tasks.Dataflow
 {


### PR DESCRIPTION
This was removed on: dotnet/corefx#17880 and broke AllConfigurations Build

cc: @stephentoub 