### PR TITLE
Adjust tests to check for proper Windows 10 update version

### DIFF
--- a/src/Common/tests/System/PlatformDetection.cs
+++ b/src/Common/tests/System/PlatformDetection.cs
@@ -27,8 +27,6 @@ namespace System
             GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 14393;
         public static bool IsWindows10Version1703OrGreater { get; } = IsWindows &&
             GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 15063;
-        public static bool IsWindows10VersionInsiderPreviewOrGreater { get; } = IsWindows &&
-            GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 14917;
         // Windows OneCoreUAP SKU doesn't have httpapi.dll
         public static bool HasHttpApi { get; } = (IsWindows &&
             File.Exists(Path.Combine(Environment.GetEnvironmentVariable("windir"), "System32", "httpapi.dll")));

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -512,9 +512,10 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(3, 4)]
         public async Task GetAsync_MaxAutomaticRedirectionsNServerHops_ThrowsIfTooMany(int maxHops, int hops)
         {
-            if (PlatformDetection.IsWindows && !PlatformDetection.IsWindows10VersionInsiderPreviewOrGreater)
+            if (PlatformDetection.IsWindows && !PlatformDetection.IsWindows10Version1703OrGreater)
             {
-                // Run this test only on windows10 build greater than 14917.
+                // Skip this test if running on Windows but on a release prior to Windows 10 Creators Update.
+                _output.WriteLine("Skipping test due to Windows 10 version prior to Version 1703.");
                 return;
             }
 
@@ -1700,9 +1701,10 @@ namespace System.Net.Http.Functional.Tests
         [MemberData(nameof(Http2Servers))]
         public async Task SendAsync_RequestVersion20_ResponseVersion20IfHttp2Supported(Uri server)
         {
-            if (PlatformDetection.IsWindows && !PlatformDetection.IsWindows10VersionInsiderPreviewOrGreater)
+            if (PlatformDetection.IsWindows && !PlatformDetection.IsWindows10Version1703OrGreater)
             {
-                // Run this test only on windows10 build greater than 14917.
+                // Skip this test if running on Windows but on a release prior to Windows 10 Creators Update.
+                _output.WriteLine("Skipping test due to Windows 10 version prior to Version 1703.");
                 return;
             }
 


### PR DESCRIPTION
Remove old Windows 10 version check `IsWindows10VersionInsiderPreviewOrGreater` and use
`IsWindows10Version1703OrGreater`.

Fixes #8945, #10958