### PR TITLE
Remove function CryptoNative_GetStreamSizes

### DIFF
--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -536,26 +536,6 @@ extern "C" void CryptoNative_SslCtxSetClientCertCallback(SSL_CTX* ctx, SslClient
     SSL_CTX_set_client_cert_cb(ctx, callback);
 }
 
-extern "C" void CryptoNative_GetStreamSizes(int32_t* header, int32_t* trailer, int32_t* maximumMessage)
-{
-    // This function is kept for compatibility with RC2 builds on a jagged upgrade path.
-    // Removal is tracked via issue #8504.
-    if (header)
-    {
-        *header = SSL3_RT_HEADER_LENGTH;
-    }
-
-    if (trailer)
-    {
-        *trailer = 68;
-    }
-
-    if (maximumMessage)
-    {
-        *maximumMessage = SSL3_RT_MAX_PLAIN_LENGTH;
-    }
-}
-
 extern "C" int32_t CryptoNative_SslAddExtraChainCert(SSL* ssl, X509* x509)
 {
     if (!x509 || !ssl)


### PR DESCRIPTION
This function hasn't been called since (before) .NET Core 1.0 RTM. It was left in to allow for the
RTM binary to replace a 1.0-rc2 binary without causing exceptions.

Since there's no longer an upgrade concern for 1.0-rc2 customers to current versions of the binary,
let's go ahead and remove this dead code.

Fixes #8504.