### PR TITLE
Add TaskFromAsyncTest2 tests to Tasks

### DIFF
--- a/src/System.Threading.Tasks/tests/System.Threading.Tasks.Tests.csproj
+++ b/src/System.Threading.Tasks/tests/System.Threading.Tasks.Tests.csproj
@@ -31,6 +31,7 @@
     <Compile Include="Task\TaskContinueWhenAllTests.cs" />
     <Compile Include="Task\TaskFromAsyncWork.cs" />
     <Compile Include="Task\TaskFromAsyncTest.cs" />
+    <Compile Include="Task\TaskFromAsyncTest2.cs" />
     <Compile Include="Task\TaskCancelWaitTests.cs" />
     <Compile Include="Task\TaskCancelWaitTest.cs" />
     <Compile Include="Task\TaskRtTests.cs" />

--- a/src/System.Threading.Tasks/tests/Task/TaskFromAsyncWork.cs
+++ b/src/System.Threading.Tasks/tests/Task/TaskFromAsyncWork.cs
@@ -29,7 +29,7 @@ namespace System.Threading.Tasks.Tests
         /// <summary>
         /// Defines the amount of time the thread should sleep (to simulate workload)
         /// </summary>
-        private const int DEFAULT_TIME = 1000; // 1s
+        private const int DEFAULT_TIME = 15;
         private List<object> _inputs;
 
 
@@ -141,14 +141,15 @@ namespace System.Threading.Tasks.Tests
 
         public IAsyncResult BeginInvoke(AsyncCallback cb, object state)
         {
-            return _action.BeginInvoke(cb, state);
+            Task task = Task.Factory.StartNew(_ => _action(), state, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default);
+            task.ContinueWith(_ => cb(task));
+            return task;
         }
 
         public void EndInvoke(IAsyncResult iar)
         {
             CheckState(iar.AsyncState);
-
-            _action.EndInvoke(iar);
+            ((Task)iar).GetAwaiter().GetResult();
         }
 
         #endregion
@@ -178,14 +179,15 @@ namespace System.Threading.Tasks.Tests
 
         public IAsyncResult BeginInvoke(T t, AsyncCallback cb, object state)
         {
-            return _action.BeginInvoke(t, cb, state);
+            Task task = Task.Factory.StartNew(_ => _action(t), state, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default);
+            task.ContinueWith(_ => cb(task));
+            return task;
         }
 
         public void EndInvoke(IAsyncResult iar)
         {
             CheckState(iar.AsyncState);
-
-            _action.EndInvoke(iar);
+            ((Task)iar).GetAwaiter().GetResult();
         }
 
         #endregion
@@ -214,14 +216,15 @@ namespace System.Threading.Tasks.Tests
 
         public IAsyncResult BeginInvoke(T1 t1, T2 t2, AsyncCallback cb, object state)
         {
-            return _action.BeginInvoke(t1, t2, cb, state);
+            Task task = Task.Factory.StartNew(_ => _action(t1, t2), state, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default);
+            task.ContinueWith(_ => cb(task));
+            return task;
         }
 
         public void EndInvoke(IAsyncResult iar)
         {
             CheckState(iar.AsyncState);
-
-            _action.EndInvoke(iar);
+            ((Task)iar).GetAwaiter().GetResult();
         }
 
         #endregion
@@ -251,14 +254,15 @@ namespace System.Threading.Tasks.Tests
 
         public IAsyncResult BeginInvoke(T1 t1, T2 t2, T3 t3, AsyncCallback cb, object state)
         {
-            return _action.BeginInvoke(t1, t2, t3, cb, state);
+            Task task = Task.Factory.StartNew(_ => _action(t1, t2, t3), state, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default);
+            task.ContinueWith(_ => cb(task));
+            return task;
         }
 
         public void EndInvoke(IAsyncResult iar)
         {
             CheckState(iar.AsyncState);
-
-            _action.EndInvoke(iar);
+            ((Task)iar).GetAwaiter().GetResult();
         }
 
         #endregion
@@ -304,14 +308,15 @@ namespace System.Threading.Tasks.Tests
 
         public IAsyncResult BeginInvoke(AsyncCallback cb, object state)
         {
-            return _func.BeginInvoke(cb, state);
+            Task<ReadOnlyCollection<object>> task = Task.Factory.StartNew(_ => _func(), state, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default);
+            task.ContinueWith(_ => cb(task));
+            return task;
         }
 
         public ReadOnlyCollection<object> EndInvoke(IAsyncResult iar)
         {
             CheckState(iar.AsyncState);
-
-            return _func.EndInvoke(iar);
+            return ((Task<ReadOnlyCollection<object>>)iar).GetAwaiter().GetResult();
         }
 
         #endregion
@@ -339,14 +344,15 @@ namespace System.Threading.Tasks.Tests
 
         public IAsyncResult BeginInvoke(T t, AsyncCallback cb, object state)
         {
-            return _func.BeginInvoke(t, cb, state);
+            Task<ReadOnlyCollection<object>> task = Task.Factory.StartNew(_ => _func(t), state, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default);
+            task.ContinueWith(_ => cb(task));
+            return task;
         }
 
         public ReadOnlyCollection<object> EndInvoke(IAsyncResult iar)
         {
             CheckState(iar.AsyncState);
-
-            return _func.EndInvoke(iar);
+            return ((Task<ReadOnlyCollection<object>>)iar).GetAwaiter().GetResult();
         }
 
         #endregion
@@ -375,14 +381,15 @@ namespace System.Threading.Tasks.Tests
 
         public IAsyncResult BeginInvoke(T1 t1, T2 t2, AsyncCallback cb, object state)
         {
-            return _func.BeginInvoke(t1, t2, cb, state);
+            Task<ReadOnlyCollection<object>> task = Task.Factory.StartNew(_ => _func(t1, t2), state, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default);
+            task.ContinueWith(_ => cb(task));
+            return task;
         }
 
         public ReadOnlyCollection<object> EndInvoke(IAsyncResult iar)
         {
             CheckState(iar.AsyncState);
-
-            return _func.EndInvoke(iar);
+            return ((Task<ReadOnlyCollection<object>>)iar).GetAwaiter().GetResult();
         }
 
         #endregion
@@ -412,14 +419,15 @@ namespace System.Threading.Tasks.Tests
 
         public IAsyncResult BeginInvoke(T1 t1, T2 t2, T3 t3, AsyncCallback cb, object state)
         {
-            return _func.BeginInvoke(t1, t2, t3, cb, state);
+            Task<ReadOnlyCollection<object>> task = Task.Factory.StartNew(_ => _func(t1, t2, t3), state, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default);
+            task.ContinueWith(_ => cb(task));
+            return task;
         }
 
         public ReadOnlyCollection<object> EndInvoke(IAsyncResult iar)
         {
             CheckState(iar.AsyncState);
-
-            return _func.EndInvoke(iar);
+            return ((Task<ReadOnlyCollection<object>>)iar).GetAwaiter().GetResult();
         }
 
         #endregion


### PR DESCRIPTION
Add the file into the .csproj.  And avoid using Delegate.Begin/EndInvoke in the tests, as those aren't implemented in coreclr.
cc: @danmosemsft 
Contributes to https://github.com/dotnet/corefx/issues/17866
Related to https://github.com/dotnet/corefx/pull/17862