### PR TITLE
Expand dataflow wildcard in csproj

### DIFF
--- a/src/System.Threading.Tasks.Dataflow/tests/System.Threading.Tasks.Dataflow.Tests.csproj
+++ b/src/System.Threading.Tasks.Dataflow/tests/System.Threading.Tasks.Dataflow.Tests.csproj
@@ -7,7 +7,23 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <ItemGroup>
-    <Compile Include="Dataflow\*.cs" />
+    <Compile Include="Dataflow\ActionBlockTests.cs" />
+    <Compile Include="Dataflow\BatchBlockTests.cs" />
+    <Compile Include="Dataflow\BatchedJoinBlockTests.cs" />
+    <Compile Include="Dataflow\BroadcastBlockTests.cs" />
+    <Compile Include="Dataflow\BufferBlockTests.cs" />
+    <Compile Include="Dataflow\ConcurrentTests.cs" />
+    <Compile Include="Dataflow\DataflowBlockExtensionTests.cs" />
+    <Compile Include="Dataflow\DataflowBlockOptionsTests.cs" />
+    <Compile Include="Dataflow\DataflowTestHelper.cs" />
+    <Compile Include="Dataflow\DebugAttributeTests.cs" />
+    <Compile Include="Dataflow\DelegateBasedMocks.cs" />
+    <Compile Include="Dataflow\EtwTests.cs" />
+    <Compile Include="Dataflow\JoinBlockTests.cs" />
+    <Compile Include="Dataflow\SimpleNetworkTests.cs" />
+    <Compile Include="Dataflow\TransformBlockTests.cs" />
+    <Compile Include="Dataflow\TransformManyBlockTests.cs" />
+    <Compile Include="Dataflow\WriteOnceBlockTests.cs" />
     <Compile Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorTestBase.cs">
       <Link>Common\System\Diagnostics\RemoteExecutorTestBase.cs</Link>
     </Compile>


### PR DESCRIPTION
Wildcards are a bit insidious because files can get deleted and if they aren't depended on (eg test sources) nobody notices.

There are 17 C# files and I expanded them in the csproj.

@stephentoub 