### PR TITLE
Implement ICloneable on SqlConnection, SqlCommand and SqlParameter

### DIFF
--- a/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
+++ b/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
@@ -540,13 +540,14 @@ namespace System.Data.SqlClient
         public override string ToString() { throw null; }
     }
     public delegate void SqlInfoMessageEventHandler(object sender, System.Data.SqlClient.SqlInfoMessageEventArgs e);
-    public sealed partial class SqlParameter : System.Data.Common.DbParameter
+    public sealed partial class SqlParameter : System.Data.Common.DbParameter, System.ICloneable
     {
         public SqlParameter() { }
         public SqlParameter(string parameterName, System.Data.SqlDbType dbType) { }
         public SqlParameter(string parameterName, System.Data.SqlDbType dbType, int size) { }
         public SqlParameter(string parameterName, System.Data.SqlDbType dbType, int size, string sourceColumn) { }
         public SqlParameter(string parameterName, object value) { }
+        object ICloneable.Clone() { throw null; }
         public System.Data.SqlTypes.SqlCompareOptions CompareInfo { get { throw null; } set { } }
         public override System.Data.DbType DbType { get { throw null; } set { } }
         public override System.Data.ParameterDirection Direction { get { throw null; } set { } }
@@ -559,6 +560,7 @@ namespace System.Data.SqlClient
         public override int Size { get { throw null; } set { } }
         public override string SourceColumn { get { throw null; } set { } }
         public override bool SourceColumnNullMapping { get { throw null; } set { } }
+        public override DataRowVersion SourceVersion { get { throw null; } set { } }
         public System.Data.SqlDbType SqlDbType { get { throw null; } set { } }
         public object SqlValue { get { throw null; } set { } }
         public string TypeName { get { throw null; } set { } }

--- a/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
+++ b/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
@@ -293,7 +293,6 @@ namespace System.Data.SqlClient
         public override System.Data.UpdateRowSource UpdatedRowSource { get { throw null; } set { } }
         public event System.Data.StatementCompletedEventHandler StatementCompleted { add { } remove { } }
         public override void Cancel() { }
-        public SqlCommand Clone() { throw null; }
         object System.ICloneable.Clone() { throw null; }
         protected override System.Data.Common.DbParameter CreateDbParameter() { throw null; }
         public new System.Data.SqlClient.SqlParameter CreateParameter() { throw null; }

--- a/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
+++ b/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
@@ -314,11 +314,12 @@ namespace System.Data.SqlClient
         public System.Threading.Tasks.Task<System.Xml.XmlReader> ExecuteXmlReaderAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
         public override void Prepare() { }
     }
-    public sealed partial class SqlConnection : System.Data.Common.DbConnection
+    public sealed partial class SqlConnection : System.Data.Common.DbConnection, ICloneable
     {
         public SqlConnection() { }
         public SqlConnection(string connectionString) { }
         public System.Guid ClientConnectionId { get { throw null; } }
+        object ICloneable.Clone() { throw null; }
         public override string ConnectionString { get { throw null; } set { } }
         public override int ConnectionTimeout { get { throw null; } }
         public override string Database { get { throw null; } }

--- a/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
+++ b/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
@@ -294,7 +294,7 @@ namespace System.Data.SqlClient
         public event System.Data.StatementCompletedEventHandler StatementCompleted { add { } remove { } }
         public override void Cancel() { }
         object System.ICloneable.Clone() { throw null; }
-        public SqlCommand Clone();
+        public SqlCommand Clone() { throw null;  }
         protected override System.Data.Common.DbParameter CreateDbParameter() { throw null; }
         public new System.Data.SqlClient.SqlParameter CreateParameter() { throw null; }
         protected override System.Data.Common.DbDataReader ExecuteDbDataReader(System.Data.CommandBehavior behavior) { throw null; }

--- a/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
+++ b/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
@@ -274,7 +274,7 @@ namespace System.Data.SqlClient
         public override System.Data.Common.DbConnectionStringBuilder CreateConnectionStringBuilder() { throw null; }
         public override System.Data.Common.DbParameter CreateParameter() { throw null; }
     }
-    public sealed partial class SqlCommand : System.Data.Common.DbCommand
+    public sealed partial class SqlCommand : System.Data.Common.DbCommand, System.ICloneable
     {
         public SqlCommand() { }
         public SqlCommand(string cmdText) { }
@@ -293,6 +293,8 @@ namespace System.Data.SqlClient
         public override System.Data.UpdateRowSource UpdatedRowSource { get { throw null; } set { } }
         public event System.Data.StatementCompletedEventHandler StatementCompleted { add { } remove { } }
         public override void Cancel() { }
+        public SqlCommand Clone() { throw null; }
+        object System.ICloneable.Clone() { throw null; }
         protected override System.Data.Common.DbParameter CreateDbParameter() { throw null; }
         public new System.Data.SqlClient.SqlParameter CreateParameter() { throw null; }
         protected override System.Data.Common.DbDataReader ExecuteDbDataReader(System.Data.CommandBehavior behavior) { throw null; }

--- a/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
+++ b/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
@@ -294,6 +294,7 @@ namespace System.Data.SqlClient
         public event System.Data.StatementCompletedEventHandler StatementCompleted { add { } remove { } }
         public override void Cancel() { }
         object System.ICloneable.Clone() { throw null; }
+        public SqlCommand Clone();
         protected override System.Data.Common.DbParameter CreateDbParameter() { throw null; }
         public new System.Data.SqlClient.SqlParameter CreateParameter() { throw null; }
         protected override System.Data.Common.DbDataReader ExecuteDbDataReader(System.Data.CommandBehavior behavior) { throw null; }

--- a/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
+++ b/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
@@ -313,7 +313,7 @@ namespace System.Data.SqlClient
         public System.Threading.Tasks.Task<System.Xml.XmlReader> ExecuteXmlReaderAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
         public override void Prepare() { }
     }
-    public sealed partial class SqlConnection : System.Data.Common.DbConnection, ICloneable
+    public sealed partial class SqlConnection : System.Data.Common.DbConnection, System.ICloneable
     {
         public SqlConnection() { }
         public SqlConnection(string connectionString) { }

--- a/src/System.Data.SqlClient/src/System/Data/Common/AdapterUtil.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Common/AdapterUtil.cs
@@ -1152,7 +1152,7 @@ namespace System.Data.Common
                 case DataRowVersion.Current:
                 case DataRowVersion.Original:
                 case DataRowVersion.Proposed:
-                    Debug.Assert(false, "valid DataRowVersion " + value.ToString());
+                    Debug.Fail($"Invalid DataRowVersion {value}");
                     break;
             }
 #endif

--- a/src/System.Data.SqlClient/src/System/Data/Common/AdapterUtil.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Common/AdapterUtil.cs
@@ -1142,5 +1142,21 @@ namespace System.Data.Common
 
             return false;
         }
+
+        static internal ArgumentOutOfRangeException InvalidDataRowVersion(DataRowVersion value)
+        {
+#if DEBUG
+            switch (value)
+            {
+                case DataRowVersion.Default:
+                case DataRowVersion.Current:
+                case DataRowVersion.Original:
+                case DataRowVersion.Proposed:
+                    Debug.Assert(false, "valid DataRowVersion " + value.ToString());
+                    break;
+            }
+#endif
+            return InvalidEnumerationValue(typeof(DataRowVersion), (int)value);
+        }
     }
 }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
@@ -15,7 +15,7 @@ using Microsoft.SqlServer.Server;
 
 namespace System.Data.SqlClient
 {
-    public sealed class SqlCommand : DbCommand
+    public sealed class SqlCommand : DbCommand, ICloneable
     {
         private string _commandText;
         private CommandType _commandType;
@@ -221,6 +221,23 @@ namespace System.Data.SqlClient
             CommandText = cmdText;
             Connection = connection;
             Transaction = transaction;
+        }
+
+        private SqlCommand(SqlCommand from) : this()
+        {
+            CommandText = from.CommandText;
+            CommandTimeout = from.CommandTimeout;
+            CommandType = from.CommandType;
+            Connection = from.Connection;
+            DesignTimeVisible = from.DesignTimeVisible;
+            Transaction = from.Transaction;
+            UpdatedRowSource = from.UpdatedRowSource;
+
+            SqlParameterCollection parameters = Parameters;
+            foreach (object parameter in from.Parameters)
+            {
+                parameters.Add((parameter is ICloneable) ? (parameter as ICloneable).Clone() : parameter);
+            }
         }
 
         new public SqlConnection Connection
@@ -3229,6 +3246,16 @@ namespace System.Data.SqlClient
             catch (Exception)
             {
             }
+        }
+
+        object ICloneable.Clone()
+        {
+            return Clone();
+        }
+
+        public SqlCommand Clone()
+        {
+            return new SqlCommand(this);
         }
     }
 }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
@@ -3248,10 +3248,7 @@ namespace System.Data.SqlClient
             }
         }
 
-        object ICloneable.Clone()
-        {
-            return new SqlCommand(this);
-        }
+        object ICloneable.Clone() => new SqlCommand(this);
 
     }
 }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
@@ -3250,13 +3250,9 @@ namespace System.Data.SqlClient
 
         object ICloneable.Clone()
         {
-            return Clone();
-        }
-
-        public SqlCommand Clone()
-        {
             return new SqlCommand(this);
         }
+
     }
 }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
@@ -3248,8 +3248,9 @@ namespace System.Data.SqlClient
             }
         }
 
-        object ICloneable.Clone() => new SqlCommand(this);
+        object ICloneable.Clone() => Clone();
 
+        public SqlCommand Clone() => new SqlCommand(this);
     }
 }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
@@ -14,7 +14,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace System.Data.SqlClient
 {
-    public sealed partial class SqlConnection : DbConnection
+    public sealed partial class SqlConnection : DbConnection, ICloneable
     {
         private bool _AsyncCommandInProgress;
 
@@ -51,6 +51,15 @@ namespace System.Data.SqlClient
         public SqlConnection(string connectionString) : this()
         {
             ConnectionString = connectionString;    // setting connection string first so that ConnectionOption is available
+            CacheConnectionStringProperties();
+        }
+
+        private SqlConnection(SqlConnection connection)
+        {
+            GC.SuppressFinalize(this);
+            CopyFrom(connection);
+            _connectionString = connection._connectionString;
+
             CacheConnectionStringProperties();
         }
 
@@ -1266,6 +1275,27 @@ namespace System.Data.SqlClient
             }
             // delegate the rest of the work to the SqlStatistics class
             Statistics.UpdateStatistics();
+        }
+
+        object ICloneable.Clone()
+        {
+            return new SqlConnection(this);
+        }
+
+        private void CopyFrom(SqlConnection connection)
+        {
+            ADP.CheckArgumentNull(connection, "connection");
+            _userConnectionOptions = connection.UserConnectionOptions;
+            _poolGroup = connection.PoolGroup;
+            
+            if (DbConnectionClosedNeverOpened.SingletonInstance == connection._innerConnection)
+            {
+                _innerConnection = DbConnectionClosedNeverOpened.SingletonInstance;
+            }
+            else
+            {
+                _innerConnection = DbConnectionClosedPreviouslyOpened.SingletonInstance;
+            }
         }
     } // SqlConnection
 } // System.Data.SqlClient namespace

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
@@ -1277,14 +1277,11 @@ namespace System.Data.SqlClient
             Statistics.UpdateStatistics();
         }
 
-        object ICloneable.Clone()
-        {
-            return new SqlConnection(this);
-        }
+        object ICloneable.Clone() => new SqlConnection(this);
 
         private void CopyFrom(SqlConnection connection)
         {
-            ADP.CheckArgumentNull(connection, "connection");
+            ADP.CheckArgumentNull(connection, nameof(connection));
             _userConnectionOptions = connection.UserConnectionOptions;
             _poolGroup = connection.PoolGroup;
             

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameter.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameter.cs
@@ -1693,7 +1693,7 @@ namespace System.Data.SqlClient
             destination._isNullable = _isNullable;
         }
 
-        override public DataRowVersion SourceVersion
+        public override DataRowVersion SourceVersion
         {
             get
             {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameter.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameter.cs
@@ -116,7 +116,7 @@ namespace System.Data.SqlClient
 
         private SqlParameter(SqlParameter source) : this()
         {
-            ADP.CheckArgumentNull(source, "source");
+            ADP.CheckArgumentNull(source, nameof(source));
 
             source.CloneHelper(this);
 
@@ -1650,10 +1650,7 @@ namespace System.Data.SqlClient
             }
         }
 
-        object ICloneable.Clone()
-        {
-            return new SqlParameter(this);
-        }
+        object ICloneable.Clone() => new SqlParameter(this);
 
         private void CloneHelper(SqlParameter destination)
         {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameter.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameter.cs
@@ -54,7 +54,7 @@ namespace System.Data.SqlClient
         }
     }
 
-    public sealed partial class SqlParameter : DbParameter
+    public sealed partial class SqlParameter : DbParameter, ICloneable
     {
         private MetaType _metaType;
 
@@ -78,6 +78,8 @@ namespace System.Data.SqlClient
         private bool _coercedValueIsSqlType;
         private bool _coercedValueIsDataFeed;
         private int _actualSize = -1;
+
+        private DataRowVersion _sourceVersion;
 
         public SqlParameter() : base()
         {
@@ -110,6 +112,19 @@ namespace System.Data.SqlClient
             this.SqlDbType = dbType;
             this.Size = size;
             this.SourceColumn = sourceColumn;
+        }
+
+        private SqlParameter(SqlParameter source) : this()
+        {
+            ADP.CheckArgumentNull(source, "source");
+
+            source.CloneHelper(this);
+
+            ICloneable cloneable = (_value as ICloneable);
+            if (null != cloneable)
+            {
+                _value = cloneable.Clone();
+            }
         }
 
         //
@@ -1631,6 +1646,72 @@ namespace System.Data.SqlClient
             {
                 {
                     throw SQL.InvalidParameterTypeNameFormat();
+                }
+            }
+        }
+
+        object ICloneable.Clone()
+        {
+            return new SqlParameter(this);
+        }
+
+        private void CloneHelper(SqlParameter destination)
+        {
+            CloneHelperCore(destination);
+            destination._metaType = _metaType;
+            destination._collation = _collation;
+            destination._xmlSchemaCollectionDatabase = _xmlSchemaCollectionDatabase;
+            destination._xmlSchemaCollectionOwningSchema = _xmlSchemaCollectionOwningSchema;
+            destination._xmlSchemaCollectionName = _xmlSchemaCollectionName;
+            destination._typeName = _typeName;
+
+            destination._parameterName = _parameterName;
+            destination._precision = _precision;
+            destination._scale = _scale;
+            destination._sqlBufferReturnValue = _sqlBufferReturnValue;
+            destination._isSqlParameterSqlType = _isSqlParameterSqlType;
+            destination._internalMetaType = _internalMetaType;
+            destination.CoercedValue = CoercedValue; // copy cached value reference because of XmlReader problem
+            destination._valueAsINullable = _valueAsINullable;
+            destination._isNull = _isNull;
+            destination._coercedValueIsDataFeed = _coercedValueIsDataFeed;
+            destination._coercedValueIsSqlType = _coercedValueIsSqlType;
+            destination._actualSize = _actualSize;
+        }
+
+        private void CloneHelperCore(SqlParameter destination)
+        {
+            destination._value = _value;
+
+            destination._direction = _direction;
+            destination._size = _size;
+
+            destination._offset = _offset;
+            destination._sourceColumn = _sourceColumn;
+            destination._sourceVersion = _sourceVersion;
+            destination._sourceColumnNullMapping = _sourceColumnNullMapping;
+            destination._isNullable = _isNullable;
+        }
+
+        override public DataRowVersion SourceVersion
+        {
+            get
+            {
+                DataRowVersion sourceVersion = _sourceVersion;
+                return ((0 != sourceVersion) ? sourceVersion : DataRowVersion.Current);
+            }
+            set
+            {
+                switch (value)
+                {
+                    case DataRowVersion.Original:
+                    case DataRowVersion.Current:
+                    case DataRowVersion.Proposed:
+                    case DataRowVersion.Default:
+                        _sourceVersion = value;
+                        break;
+                    default:
+                        throw ADP.InvalidDataRowVersion(value);
                 }
             }
         }

--- a/src/System.Data.SqlClient/tests/FunctionalTests/CloneTests.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/CloneTests.cs
@@ -1,0 +1,82 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Data.SqlClient.Tests
+{
+    public class CloneTests
+    {
+        [Fact]
+        public void CloneSqlConnection()
+        {
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder();
+            builder.DataSource = "mybadServer";
+            builder.ConnectTimeout = 1;
+            builder.InitialCatalog = "northwinddb";
+            SqlConnection connection = new SqlConnection(builder.ConnectionString);
+
+            SqlConnection clonedConnection = (connection as ICloneable).Clone() as SqlConnection;
+            Assert.Equal(connection.ConnectionString, clonedConnection.ConnectionString);
+            Assert.Equal(connection.ConnectionTimeout, clonedConnection.ConnectionTimeout);
+            Assert.NotEqual(connection, clonedConnection);
+        }
+
+        [Fact]
+        public void CloneSqlCommand()
+        {
+            SqlConnection connection = new SqlConnection();
+
+            SqlCommand command = connection.CreateCommand();
+            command.CommandText = "select 1";
+            command.CommandTimeout = 45;
+            command.CommandType = CommandType.Text;
+
+            SqlParameter parameter = command.CreateParameter();
+            parameter.Direction = ParameterDirection.Input;
+            parameter.DbType = DbType.Currency;
+            parameter.Size = 10;
+            parameter.Precision = 3;
+            parameter.Scale = 5;
+
+            command.Parameters.Add(parameter);
+
+            SqlCommand clonedCommand = command.Clone();
+            compareCommands(command, clonedCommand);
+
+            SqlCommand clonedByICloneable = (command as ICloneable).Clone() as SqlCommand;
+            compareCommands(command, clonedByICloneable);
+        }
+
+        [Fact]
+        public void CloneParameters()
+        {
+            SqlParameter parameter = new SqlParameter();
+            parameter.Direction = ParameterDirection.Input;
+            parameter.DbType = DbType.Currency;
+            parameter.Size = 10;
+            parameter.Precision = 3;
+            parameter.Scale = 5;
+
+            SqlParameter clonedParameter = (parameter as ICloneable).Clone() as SqlParameter;
+
+            Assert.Equal(parameter.Direction, clonedParameter.Direction);
+            Assert.Equal(parameter.DbType, clonedParameter.DbType);
+            Assert.Equal(parameter.Size, clonedParameter.Size);
+            Assert.Equal(parameter.Precision, clonedParameter.Precision);
+            Assert.Equal(parameter.Scale, clonedParameter.Scale);
+            Assert.NotEqual(parameter, clonedParameter);
+        }
+
+        private void compareCommands(SqlCommand original, SqlCommand cloned)
+        {
+            Assert.Equal(original.CommandText, cloned.CommandText);
+            Assert.Equal(original.CommandTimeout, cloned.CommandTimeout);
+            Assert.Equal(original.CommandType, cloned.CommandType);
+            Assert.Equal(original.Connection, cloned.Connection);
+            Assert.Equal(original.Parameters.Count, cloned.Parameters.Count);
+            Assert.NotEqual(original, cloned);
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
@@ -9,6 +9,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
+    <Compile Include="CloneTests.cs" />
     <Compile Include="DiagnosticTest.cs" />
     <Compile Include="ExceptionTest.cs" />
     <Compile Include="FakeDiagnosticListenerObserver.cs" />


### PR DESCRIPTION
The PR implements ICloneable interfaces on SqlConnection, SqlCommand and SqlParameter to make them compatible with NetFx.

Code is ported from Netfx with the removal of fields related to features not available in .Net Core. 

Contributes to: https://github.com/dotnet/corefx/issues/17708