### PR TITLE
Include Dataflow internal threading only on relevant configurations

### DIFF
--- a/src/System.Threading.Tasks.Dataflow/src/Base/DataflowBlock.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Base/DataflowBlock.cs
@@ -18,7 +18,7 @@ using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks.Dataflow.Internal;
 
-#if !THREADING
+#if USE_INTERNAL_THREADING
 using System.Threading.Tasks.Dataflow.Internal.Threading;
 #endif
 

--- a/src/System.Threading.Tasks.Dataflow/src/Base/DataflowBlock.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Base/DataflowBlock.cs
@@ -17,7 +17,10 @@ using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks.Dataflow.Internal;
+
+#if !THREADING
 using System.Threading.Tasks.Dataflow.Internal.Threading;
+#endif
 
 namespace System.Threading.Tasks.Dataflow
 {

--- a/src/System.Threading.Tasks.Dataflow/src/Internal/Common.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Internal/Common.cs
@@ -14,10 +14,12 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Security;
 using System.Collections;
 using System.Runtime.ExceptionServices;
+
+#if !THREADING
 using System.Threading.Tasks.Dataflow.Internal.Threading;
+#endif
 
 namespace System.Threading.Tasks.Dataflow.Internal
 {

--- a/src/System.Threading.Tasks.Dataflow/src/Internal/Common.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Internal/Common.cs
@@ -17,7 +17,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Collections;
 using System.Runtime.ExceptionServices;
 
-#if !THREADING
+#if USE_INTERNAL_THREADING
 using System.Threading.Tasks.Dataflow.Internal.Threading;
 #endif
 

--- a/src/System.Threading.Tasks.Dataflow/src/Internal/ProducerConsumerQueues.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Internal/ProducerConsumerQueues.cs
@@ -24,10 +24,10 @@
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 using System.Collections;
-#if CONCURRENT_COLLECTIONS
-using System.Collections.Concurrent;
-#else
+#if USE_INTERNAL_CONCURRENT_COLLECTIONS
 using System.Threading.Tasks.Dataflow.Internal.Collections;
+#else
+using System.Collections.Concurrent;
 #endif
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/System.Threading.Tasks.Dataflow/src/System.Threading.Tasks.Dataflow.csproj
+++ b/src/System.Threading.Tasks.Dataflow/src/System.Threading.Tasks.Dataflow.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>System.Threading.Tasks.Dataflow</RootNamespace>
     <DocumentationFile>$(OutputPath)$(MSBuildProjectName).xml</DocumentationFile>
     <DefineConstants Condition="'$(TargetGroup)' == 'netstandard1.1' OR '$(TargetGroup)' == 'netstandard'">$(DefineConstants);CONCURRENT_COLLECTIONS;FEATURE_TRACING</DefineConstants>
+    <DefineConstants Condition="'$(TargetGroup)' == 'netstandard'">$(DefineConstants);THREADING</DefineConstants>
     <PackageTargetFramework Condition="'$(TargetGroup)' == 'netstandard1.1'">netstandard1.1;portable-net45+win8+wpa81</PackageTargetFramework>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
@@ -49,6 +50,8 @@
     <Compile Include="Internal\SpscTargetCore.cs" />
     <Compile Include="Internal\TargetCore.cs" />
     <Compile Include="Internal\TargetRegistry.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.0' OR '$(TargetGroup)' == 'netstandard1.1'">
     <Compile Include="Internal\Threading.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.0'">

--- a/src/System.Threading.Tasks.Dataflow/src/System.Threading.Tasks.Dataflow.csproj
+++ b/src/System.Threading.Tasks.Dataflow/src/System.Threading.Tasks.Dataflow.csproj
@@ -5,8 +5,9 @@
     <ProjectGuid>{2E2F7224-7C72-4A81-9625-A5241F8D836D}</ProjectGuid>
     <RootNamespace>System.Threading.Tasks.Dataflow</RootNamespace>
     <DocumentationFile>$(OutputPath)$(MSBuildProjectName).xml</DocumentationFile>
-    <DefineConstants Condition="'$(TargetGroup)' == 'netstandard1.1' OR '$(TargetGroup)' == 'netstandard'">$(DefineConstants);CONCURRENT_COLLECTIONS;FEATURE_TRACING</DefineConstants>
-    <DefineConstants Condition="'$(TargetGroup)' == 'netstandard'">$(DefineConstants);THREADING</DefineConstants>
+    <DefineConstants Condition="'$(TargetGroup)' == 'netstandard1.1' OR '$(TargetGroup)' == 'netstandard'">$(DefineConstants);FEATURE_TRACING</DefineConstants>
+    <DefineConstants Condition="'$(TargetGroup)' == 'netstandard1.0'">$(DefineConstants);USE_INTERNAL_CONCURRENT_COLLECTIONS</DefineConstants>
+    <DefineConstants Condition="'$(TargetGroup)' == 'netstandard1.0' OR '$(TargetGroup)' == 'netstandard1.1'">$(DefineConstants);USE_INTERNAL_THREADING</DefineConstants>
     <PackageTargetFramework Condition="'$(TargetGroup)' == 'netstandard1.1'">netstandard1.1;portable-net45+win8+wpa81</PackageTargetFramework>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->


### PR DESCRIPTION
This should ensure the `using`s are not removed by accident in the future (like I just did, see https://github.com/dotnet/corefx/pull/17880#discussion_r109747476) and also removes the `System.Threading.Tasks.Dataflow.Internal.Threading` types from the .Net Standard 2.0 build, since they are not used there.

This code succeeds in a local `-BuildAllConfigurations` build.

Contributes to https://github.com/dotnet/corefx/issues/17905.

cc: @stephentoub 