### PR TITLE
Added test for ISerializable Types with Delegate.

### DIFF
--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -2760,6 +2760,17 @@ public static partial class DataContractSerializerTests
         Assert.Equal(value.Area, actual.Area);
     }
 
+    [Fact]
+    public static void DCS_TypeWithDelegate()
+    {
+        var value = new TypeWithDelegate();
+        value.IntProperty = 3;
+        var actual = SerializeAndDeserialize(value, "<TypeWithDelegate xmlns=\"http://schemas.datacontract.org/2004/07/\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:x=\"http://www.w3.org/2001/XMLSchema\"><IntValue i:type=\"x:int\" xmlns=\"\">3</IntValue></TypeWithDelegate>");
+        Assert.NotNull(actual);
+        Assert.Null(actual.DelegateProperty);
+        Assert.Equal(value.IntProperty, actual.IntProperty);
+    }
+
     private static T SerializeAndDeserialize<T>(T value, string baseline, DataContractSerializerSettings settings = null, Func<DataContractSerializer> serializerFactory = null, bool skipStringCompare = false)
     {
         DataContractSerializer dcs;

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -4181,3 +4181,28 @@ public partial class CompositeTypeForXmlMembersMapping
         }
     }
 }
+
+public delegate void MyDelegate();
+
+[Serializable]
+public class TypeWithDelegate : ISerializable
+{
+    public TypeWithDelegate()
+    {
+
+    }
+
+    public TypeWithDelegate(SerializationInfo info, StreamingContext context)
+    {
+        IntProperty = info.GetInt32("IntValue");
+    }
+
+    public int IntProperty { get; set; }
+
+    public MyDelegate DelegateProperty { get; set; }
+
+    public void GetObjectData(SerializationInfo info, StreamingContext context)
+    {
+        info.AddValue("IntValue", IntProperty);
+    }
+}


### PR DESCRIPTION
Add a test covering ISerializable types having Delegate member. DCS should still be able to serialize objects of such types. 