### PR TITLE
Fix System.Drawing.Primitive tests with netfx or uwp

### DIFF
--- a/src/System.Drawing.Primitives/tests/PointFTests.cs
+++ b/src/System.Drawing.Primitives/tests/PointFTests.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Globalization;
-
+using System.Reflection;
 using Xunit;
 
 namespace System.Drawing.PrimitivesTests
@@ -132,7 +132,13 @@ namespace System.Drawing.PrimitivesTests
             var point = new PointF(0, 0);
             Assert.False(point.Equals(null));
             Assert.False(point.Equals(0));
-            Assert.True(point.Equals(new Point(0, 0))); // Implicit cast
+
+            // If PointF implements IEquatable<PointF> (e.g. in .NET Core), then classes that are implicitly 
+            // convertible to PointF can potentially be equal.
+            // See https://github.com/dotnet/corefx/issues/5255.
+            bool expectsImplicitCastToPointF = typeof(IEquatable<PointF>).IsAssignableFrom(point.GetType());
+            Assert.Equal(expectsImplicitCastToPointF, point.Equals(new Point(0, 0)));
+
             Assert.False(point.Equals((object)new Point(0, 0))); // No implicit cast
         }
 

--- a/src/System.Drawing.Primitives/tests/RectangleFTests.cs
+++ b/src/System.Drawing.Primitives/tests/RectangleFTests.cs
@@ -126,7 +126,13 @@ namespace System.Drawing.PrimitivesTest
             var rectangle = new RectangleF(0, 0, 0, 0);
             Assert.False(rectangle.Equals(null));
             Assert.False(rectangle.Equals(0));
-            Assert.True(rectangle.Equals(new Rectangle(0, 0, 0, 0))); // Implicit cast
+
+            // If RectangleF implements IEquatable<RectangleF> (e.g. in .NET Core), then classes that are implicitly 
+            // convertible to RectangleF can potentially be equal.
+            // See https://github.com/dotnet/corefx/issues/5255.
+            bool expectsImplicitCastToRectangleF = typeof(IEquatable<RectangleF>).IsAssignableFrom(rectangle.GetType());
+            Assert.Equal(expectsImplicitCastToRectangleF, rectangle.Equals(new Rectangle(0, 0, 0, 0)));
+
             Assert.False(rectangle.Equals((object)new Rectangle(0, 0, 0, 0))); // No implicit cast
         }
 

--- a/src/System.Drawing.Primitives/tests/SizeFTests.cs
+++ b/src/System.Drawing.Primitives/tests/SizeFTests.cs
@@ -108,7 +108,13 @@ namespace System.Drawing.PrimitivesTest
             var size = new SizeF(0, 0);
             Assert.False(size.Equals(null));
             Assert.False(size.Equals(0));
-            Assert.True(size.Equals(new Size(0, 0))); // Implicit cast
+
+            // If SizeF implements IEquatable<SizeF> (e.g in .NET Core), then classes that are implicitly 
+            // convertible to SizeF can potentially be equal.
+            // See https://github.com/dotnet/corefx/issues/5255.
+            bool expectsImplicitCastToSizeF = typeof(IEquatable<SizeF>).IsAssignableFrom(size.GetType());
+            Assert.Equal(expectsImplicitCastToSizeF, size.Equals(new Size(0, 0)));
+
             Assert.False(size.Equals((object)new Size(0, 0))); // No implicit cast
         }
 


### PR DESCRIPTION
I'd be happy to change these to

```
Assert.Equal(!PlatformDetection.IsFullFramework, ...)
```
instead of using reflection, but I'm not sure whether `PlatformDetection.IsFullFramework` returns `true` with UWP, and don't know how to test this. The tests now pass with netfx and netcoreapp.

From #5255: 

> @alexperovich
> The api looks good to me. I don't think the breaking change is a big problem.

Fixes #17930