### PR TITLE
Remove dead code from ExpressionBinder.BindAssignment()

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -1570,7 +1570,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                 throw Error.BindBinaryAssignmentFailedNullReference();
             }
 
-            return _binder.bindAssignment(lhs, rhs, bIsCompound);
+            return _binder.BindAssignment(lhs, rhs, bIsCompound);
         }
         #endregion
 


### PR DESCRIPTION
`ExpressionBinder.BindAssignment()` is only called from `RuntimeBinder.BindAssignment()` which creates the lhs expression with `BindProperty()`.

This can (including paths through `CreateArray`, `bindIndexer`, `BindMethodGroupToArguments`, `BindToProperty`, `CreateIndexer`, `CreateProperty`, `CreateField` and `CreateEvent`) produce expressions of type `ExprCast`, `ExprArrayIndex`, `ExprCall`, `ExprProperty`, `ExprClass`, `ExprField` or `ExprEvent`.

The path only reachable for this operand being `ExprLocal` is hence unreachable.

Remove it and those methods only reached through it.

This also means `fOp2NotAddrOp` and `fOp2WasCast` will never be true, so remove them and the path that depends on them.