### PR TITLE
Increase ObjectManager.MaxArraySize to improve BinaryFormatter deserialization time

### DIFF
--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/ObjectManager.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/ObjectManager.cs
@@ -11,7 +11,7 @@ namespace System.Runtime.Serialization
     public class ObjectManager
     {
         private const int DefaultInitialSize = 16;
-        private const int MaxArraySize = 0x1000; //MUST BE A POWER OF 2!
+        private const int MaxArraySize = 0x100000; //MUST BE A POWER OF 2!
         private const int ArrayMask = MaxArraySize - 1;
         private const int MaxReferenceDepth = 100;
 


### PR DESCRIPTION
To support fix-ups during BinaryFormatter deserialization, ObjectManager maintains a table of ObjectHolders.  This table is an array, where each element/bucket of the array is a linked list of ObjectHolders, and where the right bucket is found via `id % MaxArraySize`, where MaxArraySize is a const power of 2.  IDs are allocated monotonically and contiguously, such that the max list size is equal to the total number of object holders divided by MaxArraySize.  Every time an object is searched for, we need to find the right bucket, and then walk the list, and so for large numbers of objects, searching for every object as is done during deserialization is effectively an O(N^2) operation.

There are a variety of ways to address this.  But a very simple stop-gap is to simply increase the MaxArraySize.  Doing so doesn't impact small deserializations, as the array wouldn't have grown beyond MaxArraySize anyway, and for large deserializations, we allocate more memory for the array but only proportionally to the number of objects added to the table.  The primary downside is such a large array is more likely to end up in the LOH, which will make collecting the array more expensive, but nowhere near as expensive as the O(N^2) algorithm that would result with a smaller array of long lists.

Thus, this mitigation simply increases the MaxArraySize, from 4K to 1M.

For the repro in https://github.com/dotnet/corefx/issues/16991, before this change I get:
```
Serialization time 2.30s
Deserialization 21.11s
```
and after I get:
```
Serialization time 2.49s
Deserialization 2.07s
```

If I increase the size further, from 500K to 1M Book in the list, before I get:
```
Serialization time 4.98s
Deserialization 82.30s
```
and after I get:
```
Serialization time 4.88s
Deserialization 4.13s
```

For super huge graphs, we could still end up with long bucket lists and thus still exhibit some polynomic behavior, but the chances/impact of that are significantly decreased.

cc: @morganbr, @jkotas , @Alois-xx
Closes https://github.com/dotnet/corefx/issues/16991