### PR TITLE
Added tests for XmlLicenseTransform (coverage 93.9%)

### DIFF
--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlLicenseTransform.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlLicenseTransform.cs
@@ -125,7 +125,7 @@ namespace System.Security.Cryptography.Xml
 
         public override object GetOutput(Type type)
         {
-            if ((type != typeof(XmlDocument)) || (!type.IsSubclassOf(typeof(XmlDocument))))
+            if ((type != typeof(XmlDocument)) && (!type.IsSubclassOf(typeof(XmlDocument))))
                 throw new ArgumentException(SR.Cryptography_Xml_TransformIncorrectInputType, nameof(type));
 
             return GetOutput();

--- a/src/System.Security.Cryptography.Xml/tests/EncryptedXmlTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/EncryptedXmlTest.cs
@@ -79,7 +79,7 @@ namespace System.Security.Cryptography.Xml.Tests
             XmlDocument doc = new XmlDocument();
             doc.PreserveWhitespace = true;
             string originalXml;
-            using (Stream stream = LoadResourceStream(resourceName))
+            using (Stream stream = TestHelpers.LoadResourceStream(resourceName))
             using (StreamReader streamReader = new StreamReader(stream))
             {
                 originalXml = streamReader.ReadToEnd();
@@ -131,7 +131,7 @@ namespace System.Security.Cryptography.Xml.Tests
 
                 XmlDocument doc = new XmlDocument();
                 doc.PreserveWhitespace = true;
-                doc.Load(LoadResourceStream("System.Security.Cryptography.Xml.Tests.EncryptedXmlSample2.xml"));
+                doc.Load(TestHelpers.LoadResourceStream("System.Security.Cryptography.Xml.Tests.EncryptedXmlSample2.xml"));
                 EncryptedXml encxml = new EncryptedXml(doc);
                 EncryptedData edata = new EncryptedData();
                 edata.LoadXml(doc.DocumentElement);
@@ -974,22 +974,6 @@ namespace System.Security.Cryptography.Xml.Tests
             Assert.Equal(CipherMode.CBC, exml.Mode);
             Assert.Equal(Encoding.ASCII, exml.Encoding);
             Assert.Equal("Recipient", exml.Recipient);
-        }
-
-        private Stream LoadResourceStream(string resourceName)
-        {
-            return Assembly.GetCallingAssembly().GetManifestResourceStream(resourceName);
-        }
-
-        private byte[] LoadResource(string resourceName)
-        {
-            using (Stream stream = Assembly.GetCallingAssembly().GetManifestResourceStream(resourceName))
-            {
-                long length = stream.Length;
-                byte[] buffer = new byte[length];
-                stream.Read(buffer, 0, (int)length);
-                return buffer;
-            }
         }
 
         private void CheckEncryptionMethod(object algorithm, string uri)

--- a/src/System.Security.Cryptography.Xml/tests/System.Security.Cryptography.Xml.Tests.csproj
+++ b/src/System.Security.Cryptography.Xml/tests/System.Security.Cryptography.Xml.Tests.csproj
@@ -55,6 +55,7 @@
     <EmbeddedResource Include="EncryptedXmlSample3.xml" />
     <EmbeddedResource Include="EncryptedXmlSample2.xml" />
     <EmbeddedResource Include="EncryptedXmlSample1.xml" />
+    <EmbeddedResource Include="XmlLicenseSample.xml" />
   </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />

--- a/src/System.Security.Cryptography.Xml/tests/TestHelpers.cs
+++ b/src/System.Security.Cryptography.Xml/tests/TestHelpers.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Xml;
@@ -190,6 +191,22 @@ namespace System.Security.Cryptography.Xml.Tests
         public static X509Certificate2 GetSampleX509Certificate()
         {
             return new X509Certificate2(SamplePfx, "mono");
+        }
+
+        public static Stream LoadResourceStream(string resourceName)
+        {
+            return Assembly.GetCallingAssembly().GetManifestResourceStream(resourceName);
+        }
+
+        public static byte[] LoadResource(string resourceName)
+        {
+            using (Stream stream = Assembly.GetCallingAssembly().GetManifestResourceStream(resourceName))
+            {
+                long length = stream.Length;
+                byte[] buffer = new byte[length];
+                stream.Read(buffer, 0, (int)length);
+                return buffer;
+            }
         }
     }
 }

--- a/src/System.Security.Cryptography.Xml/tests/XmlLicenseSample.xml
+++ b/src/System.Security.Cryptography.Xml/tests/XmlLicenseSample.xml
@@ -1,0 +1,56 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<r:license xmlns:r="urn:mpeg:mpeg21:2003:01-REL-R-NS" licenseId="{00000000-0000-0000-0000-123456789012}">
+  <r:title>Test License</r:title>
+  <r:grant>
+    <r:encryptedGrant>
+      <EncryptionMethod xmlns="http://www.w3.org/2001/04/xmlenc#" Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-cbc" />
+      <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+      <EncryptedKey xmlns="http://www.w3.org/2001/04/xmlenc#">
+      <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p" />
+      <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+      <KeyValue xmlns="http://www.w3.org/2000/09/xmldsig#">
+      <RSAKeyValue>
+        <Modulus>9DC4XNdQJwMRnz5pP2a6U51MHCODRilaIoVXqUPhCUb0lJdGroeqVYT84ZyIVrcarzD7Tqs3aEOIa3rKox0N1bxQpZPqayVQeLAkjLLtzJW/ScRJx3uEDJdgT1JnM1FH0GZTinmEdCUXdLc7+Y/c/qqIkTfbwHbRZjW0bBJyExM=</Modulus>
+        <Exponent>AQAB</Exponent>
+      </RSAKeyValue>
+      </KeyValue>
+      </KeyInfo>
+      <CipherData>
+        <CipherValue>RGVjb2Rl</CipherValue>
+      </CipherData>
+      </EncryptedKey>
+      </KeyInfo>
+      <CipherData xmlns="http://www.w3.org/2001/04/xmlenc#">
+      <CipherValue>RGVjb2Rl</CipherValue>
+      </CipherData>
+    </r:encryptedGrant>
+  </r:grant>
+  <r:issuer>
+    <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
+    <SignedInfo>
+      <CanonicalizationMethod Algorithm="http://www.microsoft.com/xrml/lwc14n" />
+      <SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1" />
+      <Reference>
+        <Transforms>
+          <Transform Algorithm="urn:mpeg:mpeg21:2003:01-REL-R-NS:licenseTransform" />
+          <Transform Algorithm="http://www.microsoft.com/xrml/lwc14n" />
+        </Transforms>
+        <DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1" />
+        <DigestValue>xByYONj0RUGSJ5kQWQO3KzqFZps=</DigestValue>
+      </Reference>
+    </SignedInfo>
+    <SignatureValue>qJrCl/NkSZ66MqR/vzDHVDWT6N75UTjPmEz6wOYH1uEWQsUW4IrBxrdUxUicadFVdobxmQZRO/kazhWzSZjLGOhu+cbwgYJ+fnAAz699ZA7ObqNhQgtSKFA54hl/SbedygHJbFRIHeWOCm5P6WagodJ23258T1g1geaYtIqSdD8L8WRB/hQc8WMcNzSPYp0Dy8E3GDyDeiyK0WWnfF814H4RONYZkxwPfU7zy3jngABZQaFKoCnt2PFjCKfLiSrZgEwEgfnW+GmtCrL8W+Rkis+AV9LvPQpHg/tn4WdG4PW+9oGvxriMWAR30V8hAooiEOQ0yUBe+BlvBBvWWOZ/Aw==</SignatureValue>
+    <KeyInfo>
+      <KeyValue>
+        <RSAKeyValue>
+          <Modulus>9DC4XNdQJwMRnz5pP2a6U51MHCODRilaIoVXqUPhCUb0lJdGroeqVYT84ZyIVrcarzD7Tqs3aEOIa3rKox0N1bxQpZPqayVQeLAkjLLtzJW/ScRJx3uEDJdgT1JnM1FH0GZTinmEdCUXdLc7+Y/c/qqIkTfbwHbRZjW0bBJyExM=</Modulus>
+          <Exponent>AQAB</Exponent>
+        </RSAKeyValue>
+      </KeyValue>
+    </KeyInfo>
+    </Signature>
+    <r:details>
+      <r:timeOfIssue>2017-01-71T00:00:00Z</r:timeOfIssue>
+    </r:details>
+  </r:issuer>
+</r:license>

--- a/src/System.Security.Cryptography.Xml/tests/XmlLicenseTransformTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/XmlLicenseTransformTest.cs
@@ -15,6 +15,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // See the LICENSE file in the project root for more information.
 
+using System.IO;
 using System.Xml;
 using Xunit;
 
@@ -25,6 +26,21 @@ namespace System.Security.Cryptography.Xml.Tests
         public XmlNodeList UnprotectedGetInnerXml()
         {
             return base.GetInnerXml();
+        }
+    }
+
+    public class DummyDecryptor : IRelDecryptor
+    {
+        public string ContentToReturn { get; set; }
+
+        public Stream Decrypt(EncryptionMethod encryptionMethod, KeyInfo keyInfo, Stream toDecrypt)
+        {
+            MemoryStream stream = new MemoryStream();
+            StreamWriter writer = new StreamWriter(stream);
+            writer.Write(ContentToReturn);
+            writer.Flush();
+            stream.Position = 0;
+            return stream;
         }
     }
 
@@ -82,6 +98,75 @@ namespace System.Security.Cryptography.Xml.Tests
             // it's not a static array
             transform = new UnprotectedXmlLicenseTransform();
             Assert.NotNull(transform.OutputTypes[0]);
+        }
+
+        [Fact]
+        public void Context_Null()
+        {
+            XmlDocument doc = GetDocumentFromResource("System.Security.Cryptography.Xml.Tests.XmlLicenseSample.xml");
+
+            Assert.Throws<CryptographicException>(() => transform.LoadInput(doc));
+        }
+
+        [Fact]
+        public void NoLicenseXml()
+        {
+            XmlDocument doc = new XmlDocument();
+            doc.LoadXml("<root />");
+            transform.Context = doc.DocumentElement;
+
+            Assert.Throws<CryptographicException>(() => transform.LoadInput(doc));
+        }
+
+        [Fact]
+        public void Decryptor_Null()
+        {
+            XmlDocument doc = GetDocumentFromResource("System.Security.Cryptography.Xml.Tests.XmlLicenseSample.xml");
+
+            XmlNamespaceManager namespaceManager = new XmlNamespaceManager(doc.NameTable);
+            namespaceManager.AddNamespace("r", "urn:mpeg:mpeg21:2003:01-REL-R-NS");
+            transform.Context = doc.DocumentElement.SelectSingleNode("//r:issuer[1]", namespaceManager) as XmlElement;
+
+            Assert.Throws<CryptographicException>(() => transform.LoadInput(doc));
+        }
+
+        [Fact]
+        public void ValidLicense()
+        {
+            XmlDocument doc = GetDocumentFromResource("System.Security.Cryptography.Xml.Tests.XmlLicenseSample.xml");
+
+            XmlNamespaceManager namespaceManager = new XmlNamespaceManager(doc.NameTable);
+            namespaceManager.AddNamespace("r", "urn:mpeg:mpeg21:2003:01-REL-R-NS");
+            transform.Context = doc.DocumentElement.SelectSingleNode("//r:issuer[1]", namespaceManager) as XmlElement;
+            DummyDecryptor decryptor = new DummyDecryptor { ContentToReturn = "Encrypted Content" };
+            transform.Decryptor = decryptor;
+            transform.LoadInput(doc);
+            XmlDocument output = transform.GetOutput(typeof(XmlDocument)) as XmlDocument;
+
+            string decodedXml = @"<r:license xmlns:r=""urn:mpeg:mpeg21:2003:01-REL-R-NS"" licenseId=""{00000000-0000-0000-0000-123456789012}"">";
+            decodedXml += "<r:title>Test License</r:title><r:grant>Encrypted Content</r:grant>";
+            decodedXml += "<r:issuer><r:details><r:timeOfIssue>2017-01-71T00:00:00Z</r:timeOfIssue></r:details></r:issuer></r:license>";
+            Assert.NotNull(output);
+            Assert.Equal(decodedXml, output.OuterXml);
+        }
+
+        [Fact]
+        public void GetOutput_InvalidType()
+        {
+            Assert.Throws<ArgumentException>(() => transform.GetOutput(typeof(string)));
+        }
+
+        private XmlDocument GetDocumentFromResource(string resourceName)
+        {
+            XmlDocument doc = new XmlDocument();
+            using (Stream stream = TestHelpers.LoadResourceStream(resourceName))
+            using (StreamReader streamReader = new StreamReader(stream))
+            {
+                string originalXml = streamReader.ReadToEnd();
+                doc.LoadXml(originalXml);
+            }
+
+            return doc;
         }
     }
 }


### PR DESCRIPTION
Added tests and test data for XmlLicenseTransform.
Overall code coverage for System.Security.Cryptography.Xml is 70.4%

Part of #16781