### PR TITLE
Fix IPv6 calls to GetMulticastOptionName in shim

### DIFF
--- a/src/Native/Unix/System.Native/pal_networking.cpp
+++ b/src/Native/Unix/System.Native/pal_networking.cpp
@@ -1474,7 +1474,7 @@ extern "C" Error SystemNative_GetIPv6MulticastOption(intptr_t socket, int32_t mu
     int fd = ToFileDescriptor(socket);
 
     int optionName;
-    if (!GetMulticastOptionName(multicastOption, false, optionName))
+    if (!GetMulticastOptionName(multicastOption, true, optionName))
     {
         return PAL_EINVAL;
     }
@@ -1502,7 +1502,7 @@ extern "C" Error SystemNative_SetIPv6MulticastOption(intptr_t socket, int32_t mu
     int fd = ToFileDescriptor(socket);
 
     int optionName;
-    if (!GetMulticastOptionName(multicastOption, false, optionName))
+    if (!GetMulticastOptionName(multicastOption, true, optionName))
     {
         return PAL_EINVAL;
     }


### PR DESCRIPTION
The wrong options were being set in the native shim due to an incorrect Boolean value.  GetMulticastOptionName is used to translate the option name, with a Boolean indicating whether this is for IPv4 (false) or IPv6 (true), and false was being passed even for IPv6.

(Note that I validated the repro in https://github.com/dotnet/corefx/issues/17870 failed before this change and passes after, but we have zero automated tests for multicast functionality, other than some surface area argument validation.  I opened https://github.com/dotnet/corefx/issues/17957 to track adding some.)

Fixes https://github.com/dotnet/corefx/issues/17870
cc: @geoffkizer, @Priya91, @pgavlin 