### PR TITLE
Remove caching for keyed hash algorithm in SignedXml

### DIFF
--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/SignedXml.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/SignedXml.cs
@@ -790,7 +790,8 @@ namespace System.Security.Cryptography.Xml
 
         private byte[] GetC14NDigest(HashAlgorithm hash)
         {
-            if (!_bCacheValid || !SignedInfo.CacheValid)
+            bool isKeyedHashAlgorithm = hash is KeyedHashAlgorithm;
+            if (isKeyedHashAlgorithm || !_bCacheValid || !SignedInfo.CacheValid)
             {
                 string baseUri = (_containingDocument == null ? null : _containingDocument.BaseURI);
                 XmlResolver resolver = (_bResolverSet ? _xmlResolver : new XmlSecureResolver(new XmlUrlResolver(), baseUri));
@@ -810,7 +811,7 @@ namespace System.Security.Cryptography.Xml
                 SignedXmlDebugLog.LogCanonicalizedOutput(this, c14nMethodTransform);
                 _digestedSignedInfo = c14nMethodTransform.GetDigestedOutput(hash);
 
-                _bCacheValid = true;
+                _bCacheValid = !isKeyedHashAlgorithm;
             }
             return _digestedSignedInfo;
         }

--- a/src/System.Security.Cryptography.Xml/tests/SignedXmlTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/SignedXmlTest.cs
@@ -1239,10 +1239,8 @@ namespace System.Security.Cryptography.Xml.Tests
             Assert.Equal(more256, sign.SignatureMethod);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void VerifyHMAC_SHA256(bool useGoodKey)
+        [Fact]
+        public void VerifyHMAC_SHA256()
         {
             string xml = "<?xml version=\"1.0\" encoding=\"Windows-1252\"?><foo><Signature xmlns=\"http://www.w3.org/2000/09/xmldsig#\"><SignedInfo><CanonicalizationMethod Algorithm=\"http://www.w3.org/TR/2001/REC-xml-c14n-20010315\" /><SignatureMethod Algorithm=\"http://www.w3.org/2001/04/xmldsig-more#hmac-sha256\" /><Reference URI=\"\"><Transforms><Transform Algorithm=\"http://www.w3.org/2000/09/xmldsig#enveloped-signature\" /></Transforms><DigestMethod Algorithm=\"http://www.w3.org/2001/04/xmlenc#sha256\" /><DigestValue>sKG2hDPEHiPrzpd3QA8BZ0eMzMbSEPPMh9QqXgkP7Cs=</DigestValue></Reference></SignedInfo><SignatureValue>Faad3KInJdIpaGcBn5e04Zv080u45fSjAKqrgevdWQw=</SignatureValue></Signature></foo>";
             XmlDocument doc = new XmlDocument();
@@ -1252,7 +1250,8 @@ namespace System.Security.Cryptography.Xml.Tests
             sign.LoadXml(doc.DocumentElement["Signature"]);
 
             // verify MS-generated signature
-            Assert.Equal(useGoodKey, sign.CheckSignature(new HMACSHA256(useGoodKey ? emptyHmacKey : badKey)));
+            Assert.False(sign.CheckSignature(new HMACSHA256(badKey)));
+            Assert.True(sign.CheckSignature(new HMACSHA256(emptyHmacKey)));
         }
 
         [Theory, MemberData(nameof(HmacKeys))]
@@ -1272,10 +1271,8 @@ namespace System.Security.Cryptography.Xml.Tests
             Assert.Equal(more512, sign.SignatureMethod);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void VerifyHMAC_SHA512(bool useGoodKey)
+        [Fact]
+        public void VerifyHMAC_SHA512()
         {
             string xml = "<?xml version=\"1.0\" encoding=\"Windows-1252\"?><foo><Signature xmlns=\"http://www.w3.org/2000/09/xmldsig#\"><SignedInfo><CanonicalizationMethod Algorithm=\"http://www.w3.org/TR/2001/REC-xml-c14n-20010315\" /><SignatureMethod Algorithm=\"http://www.w3.org/2001/04/xmldsig-more#hmac-sha512\" /><Reference URI=\"\"><Transforms><Transform Algorithm=\"http://www.w3.org/2000/09/xmldsig#enveloped-signature\" /></Transforms><DigestMethod Algorithm=\"http://www.w3.org/2001/04/xmlenc#sha512\" /><DigestValue>2dvMkpTUE8Z76ResJG9pwPpVJNYo7t6s2L02V81xUVJ0oF8yJ7v8CTojjuL76s0iVdBxAOhP80Ambd1YaSkwSw==</DigestValue></Reference></SignedInfo><SignatureValue>wFenihRlm1x5/n0cifdX/TDOYqlbg2oVIbD/gyrAc0Q2hiIUTtwfBIMY5rQhKcErSz6YNoIl8RBQBmww/0rv5g==</SignatureValue></Signature></foo>";
             XmlDocument doc = new XmlDocument();
@@ -1285,7 +1282,8 @@ namespace System.Security.Cryptography.Xml.Tests
             sign.LoadXml(doc.DocumentElement["Signature"]);
 
             // verify MS-generated signature
-            Assert.Equal(useGoodKey, sign.CheckSignature(new HMACSHA512(useGoodKey ? emptyHmacKey : badKey)));
+            Assert.False(sign.CheckSignature(new HMACSHA512(badKey)));
+            Assert.True(sign.CheckSignature(new HMACSHA512(emptyHmacKey)));
         }
 
         [Theory, MemberData(nameof(HmacKeys))]
@@ -1308,10 +1306,8 @@ namespace System.Security.Cryptography.Xml.Tests
             Assert.Equal(more384, sign.SignatureMethod);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void VerifyHMAC_SHA384(bool useGoodKey)
+        [Fact]
+        public void VerifyHMAC_SHA384()
         {
             string xml = "<?xml version=\"1.0\" encoding=\"Windows-1252\"?><foo><Signature xmlns=\"http://www.w3.org/2000/09/xmldsig#\"><SignedInfo><CanonicalizationMethod Algorithm=\"http://www.w3.org/TR/2001/REC-xml-c14n-20010315\" /><SignatureMethod Algorithm=\"http://www.w3.org/2001/04/xmldsig-more#hmac-sha384\" /><Reference URI=\"\"><Transforms><Transform Algorithm=\"http://www.w3.org/2000/09/xmldsig#enveloped-signature\" /></Transforms><DigestMethod Algorithm=\"SHA384\" /><DigestValue>kH9C0LeZocNVXhjfzpz00M5fc3WJf0QU8gxK4I7pAN7HN602yHo8yYDSlG14b5YS</DigestValue></Reference></SignedInfo><SignatureValue>LgydOfhv8nqpFLFPC+xg3ZnjC8D+V3mpzxv6GOdH1HDdw1r+LH/BFM2U7dntxgf0</SignatureValue></Signature></foo>";
             XmlDocument doc = new XmlDocument();
@@ -1321,7 +1317,8 @@ namespace System.Security.Cryptography.Xml.Tests
             sign.LoadXml(doc.DocumentElement["Signature"]);
 
             // verify MS-generated signature
-            Assert.Equal(useGoodKey, sign.CheckSignature(new HMACSHA384(useGoodKey ? emptyHmacKey : badKey)));
+            Assert.False(sign.CheckSignature(new HMACSHA384(badKey)));
+            Assert.True(sign.CheckSignature(new HMACSHA384(emptyHmacKey)));
         }
 
         [Theory, MemberData(nameof(HmacKeys))]
@@ -1344,10 +1341,8 @@ namespace System.Security.Cryptography.Xml.Tests
             Assert.Equal(moreHmacMD5, sign.SignatureMethod);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void VerifyHMAC_MD5(bool useGoodKey)
+        [Fact]
+        public void VerifyHMAC_MD5()
         {
             string xml = @"<?xml version=""1.0"" encoding=""Windows-1252""?><foo><Signature xmlns=""http://www.w3.org/2000/09/xmldsig#""><SignedInfo><CanonicalizationMethod Algorithm=""http://www.w3.org/TR/2001/REC-xml-c14n-20010315"" /><SignatureMethod Algorithm=""http://www.w3.org/2001/04/xmldsig-more#hmac-md5"" /><Reference URI=""""><Transforms><Transform Algorithm=""http://www.w3.org/2000/09/xmldsig#enveloped-signature"" /></Transforms><DigestMethod Algorithm=""MD5"" /><DigestValue>TH7ysbozJWVIWh/1K5bP1w==</DigestValue></Reference></SignedInfo><SignatureValue>tJ6m5YVu1jN1WgKWv3AXFQ==</SignatureValue></Signature></foo>";
             XmlDocument doc = new XmlDocument();
@@ -1357,7 +1352,8 @@ namespace System.Security.Cryptography.Xml.Tests
             sign.LoadXml(doc.DocumentElement["Signature"]);
 
             // verify MS-generated signature
-            Assert.Equal(useGoodKey, sign.CheckSignature(new HMACMD5(useGoodKey ? emptyHmacKey : badKey)));
+            Assert.False(sign.CheckSignature(new HMACMD5(badKey)));
+            Assert.True(sign.CheckSignature(new HMACMD5(emptyHmacKey)));
         }
 
         // CVE-2009-0217


### PR DESCRIPTION
In really rare cases we can improperly not validate when correct key is being used