### PR TITLE
NS2.0 - Complete System.IO.IsolatedStorage namespace

### DIFF
--- a/src/System.IO.IsolatedStorage/src/Resources/Strings.resx
+++ b/src/System.IO.IsolatedStorage/src/Resources/Strings.resx
@@ -142,7 +142,4 @@
   <data name="PlatformNotSupported_CAS" xml:space="preserve">
     <value>Code Access Security is not supported on this platform.</value>
   </data>  
-  <data name="PlatformNotSupported_IsolatedStorageSize" xml:space="preserve">
-    <value>Determining the size of an IsolatedStorageFile is not supported on this platform.</value>
-  </data>  
 </root>

--- a/src/System.IO.IsolatedStorage/src/Resources/Strings.resx
+++ b/src/System.IO.IsolatedStorage/src/Resources/Strings.resx
@@ -142,4 +142,7 @@
   <data name="PlatformNotSupported_CAS" xml:space="preserve">
     <value>Code Access Security is not supported on this platform.</value>
   </data>  
+  <data name="PlatformNotSupported_IsolatedStorageSize" xml:space="preserve">
+    <value>Determining the size of an IsolatedStorageFile is not supported on this platform.</value>
+  </data>  
 </root>

--- a/src/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.cs
+++ b/src/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.cs
@@ -504,6 +504,50 @@ namespace System.IO.IsolatedStorage
             }
         }
 
+        public override long AvailableFreeSpace
+        {
+            get
+            {
+                return Quota - UsedSize;
+            }
+        }
+
+        [CLSCompliant(false)]
+        [Obsolete("IsolatedStorage.MaximumSize has been deprecated because it is not CLS Compliant.  To get the maximum size use IsolatedStorage.Quota")]
+        public override ulong MaximumSize
+        {
+            get
+            {
+                return long.MaxValue;
+            }
+        }
+
+        public override long Quota
+        {
+            get
+            {
+                return long.MaxValue;
+            }
+        }
+
+        public override long UsedSize
+        {
+            get
+            {
+                throw new PlatformNotSupportedException(SR.PlatformNotSupported_IsolatedStorageSize);
+            }
+        }
+
+        [CLSCompliant(false)]
+        [Obsolete("IsolatedStorage.CurrentSize has been deprecated because it is not CLS Compliant.  To get the current size use IsolatedStorage.UsedSize")]
+        public override ulong CurrentSize
+        {
+            get
+            {
+                throw new PlatformNotSupportedException(SR.PlatformNotSupported_IsolatedStorageSize);
+            }
+        }
+
         public static IsolatedStorageFile GetUserStoreForApplication()
         {
             return GetStore(IsolatedStorageScope.Application | IsolatedStorageScope.User);

--- a/src/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.cs
+++ b/src/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.cs
@@ -534,7 +534,7 @@ namespace System.IO.IsolatedStorage
         {
             get
             {
-                throw new PlatformNotSupportedException(SR.PlatformNotSupported_IsolatedStorageSize);
+                return 0; // We do not have a mechanism for tracking usage.
             }
         }
 
@@ -544,7 +544,7 @@ namespace System.IO.IsolatedStorage
         {
             get
             {
-                throw new PlatformNotSupportedException(SR.PlatformNotSupported_IsolatedStorageSize);
+                return 0; // We do not have a mechanism for tracking usage.
             }
         }
 

--- a/src/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFileStream.cs
+++ b/src/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFileStream.cs
@@ -193,6 +193,14 @@ namespace System.IO.IsolatedStorage
             }
         }
 
+        public override bool IsAsync
+        {
+            get
+            {
+                return _fs.IsAsync;
+            }
+        }
+
         protected override void Dispose(bool disposing)
         {
             try
@@ -212,6 +220,11 @@ namespace System.IO.IsolatedStorage
         public override void Flush()
         {
             _fs.Flush();
+        }
+
+        public override void Flush(bool flushToDisk)
+        {
+            _fs.Flush(flushToDisk);
         }
 
         public override Task FlushAsync(CancellationToken cancellationToken)
@@ -295,6 +308,14 @@ namespace System.IO.IsolatedStorage
         public override void Lock(long position, long length)
         {
             _fs.Lock(position, length);
+        }
+
+        public override SafeFileHandle SafeFileHandle
+        {
+            get
+            {
+                throw new IsolatedStorageException(SR.IsolatedStorage_Operation_ISFS);
+            }
         }
     }
 }


### PR DESCRIPTION
IsolatedStorageFile:

  Quota/MaximumSize
    long.MaxValue (as desktop does when there's no quota)


  UsedSize/CurrentSize:
    PNSE (there's no mechanism in this implementation to
      track usage, and I'm assuming we don't plan to
      add one...)

    I'd also be open to returning 0 from both of these -
    they're only useful for checking if you're running
    up against a quota.

  AvailableFreeSpace
    Quota - UsedSpace  (just to stay in sync with desktop)


IsolatedStorageFileStream:

  SafeFileHandle
    throw ISFException (as in desktop - this is now allows)

  Flush(bool)
  IsAsync
    Obvious delegation.