### PR TITLE
Retarget SignedXml to netstandard

### DIFF
--- a/src/System.Security.Cryptography.Xml/ref/Configurations.props
+++ b/src/System.Security.Cryptography.Xml/ref/Configurations.props
@@ -2,8 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
-      netcoreapp;
-      uap;
+      netstandard
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Cryptography.Xml/ref/System.Security.Cryptography.Xml.csproj
+++ b/src/System.Security.Cryptography.Xml/ref/System.Security.Cryptography.Xml.csproj
@@ -10,12 +10,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="System.Security.Cryptography.Xml.cs" />
-    <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />
-    <ProjectReference Include="..\..\System.Runtime.Extensions\ref\System.Runtime.Extensions.csproj" />
-    <ProjectReference Include="..\..\System.Security.Cryptography.Algorithms\ref\System.Security.Cryptography.Algorithms.csproj" />
-    <ProjectReference Include="..\..\System.Security.Cryptography.Primitives\ref\System.Security.Cryptography.Primitives.csproj" />
-    <ProjectReference Include="..\..\System.Security.Cryptography.X509Certificates\ref\System.Security.Cryptography.X509Certificates.csproj" />
-    <ProjectReference Include="..\..\System.Xml.ReaderWriter\ref\System.Xml.ReaderWriter.csproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Security.Cryptography.Xml/src/Configurations.props
+++ b/src/System.Security.Cryptography.Xml/src/Configurations.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
-      netcoreapp
+      netstandard
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/Utils.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/Utils.cs
@@ -754,7 +754,11 @@ namespace System.Security.Cryptography.Xml
 
         internal static AsymmetricAlgorithm GetAnyPublicKey(X509Certificate2 certificate)
         {
-            return (AsymmetricAlgorithm)certificate.GetRSAPublicKey() ?? certificate.GetDSAPublicKey();
+            return (AsymmetricAlgorithm)certificate.GetRSAPublicKey()
+#if netcoreapp || uap || uapaot
+             ?? certificate.GetDSAPublicKey()
+#endif
+            ;
         }
     }
 }

--- a/src/System.Security.Cryptography.Xml/tests/Configurations.props
+++ b/src/System.Security.Cryptography.Xml/tests/Configurations.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
-      netcoreapp
+      netstandard
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Cryptography.Xml/tests/XmlLicenseEncryptedRef.cs
+++ b/src/System.Security.Cryptography.Xml/tests/XmlLicenseEncryptedRef.cs
@@ -144,16 +144,18 @@ namespace System.Security.Cryptography.Xml.Tests
             // Get the encrypted content following the IV.
             toDecrypt.Read(encryptedContentValue, 0, encryptedContentValue.Length);
 
-            var msDecrypt = new MemoryStream();
+            byte[] decryptedContent;
 
+            using (var msDecrypt = new MemoryStream())
             using (ICryptoTransform decryptor = alg.CreateDecryptor(alg.Key, IV))
-            using (var csDecrypt = new CryptoStream(msDecrypt, decryptor, CryptoStreamMode.Write, leaveOpen: true))
+            using (var csDecrypt = new CryptoStream(msDecrypt, decryptor, CryptoStreamMode.Write))
             {
                 csDecrypt.Write(encryptedContentValue, 0, encryptedContentValue.Length);
+                csDecrypt.FlushFinalBlock();
+                decryptedContent = msDecrypt.ToArray();
             }
 
-            msDecrypt.Position = 0;
-            return msDecrypt;
+            return new MemoryStream(decryptedContent);
         }
 
         public static void Encrypt(Stream toEncrypt, RSA key, out KeyInfo keyInfo, out EncryptionMethod encryptionMethod, out CipherData cipherData)


### PR DESCRIPTION
If this works correctly then https://github.com/dotnet/corefx/pull/17969 can likely be closed

@bartonjs I had to revert that changes related to CryptoStream in here since overload with leaveOpen seemed to not be available on netstandard