### PR TITLE
Enhance Encoding Perf test

### DIFF
--- a/src/System.Text.Encoding/tests/Performance/Perf.Encoding.cs
+++ b/src/System.Text.Encoding/tests/Performance/Perf.Encoding.cs
@@ -13,7 +13,7 @@ namespace System.Text.Tests
     {
         public static IEnumerable<object[]> EncodingSizeData()
         {
-            int[] sizes = new int[] { 10000, 1000000 };
+            int[] sizes = new int[] { 16, 32, 64, 128, 256, 512, 10000, 1000000 };
             string[] encs = new string[] { "utf-8", "ascii" };
             foreach (int size in sizes)
                 foreach (string enc in encs)


### PR DESCRIPTION
we got a real scenarios of using short string with the encoding. the change here is to include such scenario in our perf tests

https://github.com/dotnet/coreclr/issues/10705