### PR TITLE
Change netfx vertical test build and execution to be able to have helix runs

### DIFF
--- a/Tools-Override/tests.targets
+++ b/Tools-Override/tests.targets
@@ -99,7 +99,6 @@
     </ItemGroup>
     <ItemGroup Condition="'$(BuildingNETFxVertical)' == 'true'">
       <SupplementalTestData Include="$(RuntimePath)xunit.console.exe" />
-      <SupplementalTestData Include="$(RuntimePath)xunit.console.exe.config" />
       <SupplementalTestData Include="$(RuntimePath)xunit.execution.desktop.dll" />
     </ItemGroup>
   </Target>
@@ -124,14 +123,25 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="CopyRemoteExecutionConfigFile" 
-          BeforeTargets="GenerateTestExecutionScripts" 
-          Condition="'$(BuildingNETFxVertical)' == 'true' And Exists('$(TestPath)\RemoteExecutorConsoleApp.exe')">
+  <Target Name="GenerateDesktopExecutorsConfigFiles"
+          BeforeTargets="GenerateTestExecutionScripts"
+          Condition="'$(BuildingNETFxVertical)' == 'true'">
+    <PropertyGroup>
+      <XunitRunnerNetfxConfigFile>$(TestPath)\$(XunitExecutable).config</XunitRunnerNetfxConfigFile>
+      <RemoteExecutorConfigFile>$(TestPath)\RemoteExecutorConsoleApp.exe.config</RemoteExecutorConfigFile>
+    </PropertyGroup>
 
-    <Copy SourceFiles="$(RuntimePath)\xunit.console.exe.config"
-          DestinationFiles="$(TestPath)\RemoteExecutorConsoleApp.exe.config" 
-          SkipUnchangedFiles="true"
-          />
+    <ItemGroup>
+      <ConfigFileLines Include="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;" />
+      <ConfigFileLines Include="&lt;configuration&gt;" />
+      <ConfigFileLines Include="&lt;runtime&gt;" />
+      <ConfigFileLines Include="&lt;developmentMode developerInstallation=&quot;true&quot; /&gt;" />
+      <ConfigFileLines Include="&lt;/runtime&gt;" />   
+      <ConfigFileLines Include="&lt;/configuration&gt;" />
+    </ItemGroup>
+
+    <WriteLinesToFile File="$(XunitRunnerNetfxConfigFile)" Lines="@(ConfigFileLines)" Overwrite="true"/>
+    <WriteLinesToFile Condition="Exists('$(TestPath)\RemoteExecutorConsoleApp.exe')" File="$(RemoteExecutorConfigFile)" Lines="@(ConfigFileLines)" Overwrite="true" />
   </Target>
 
   <!-- Generate the script to run the tests.  The script performs two high-level steps:
@@ -140,7 +150,7 @@
            directory.
        2.  Runs the tests. -->
   <Target Name="GenerateTestExecutionScripts"
-          DependsOnTargets="DiscoverTestInputs;SetupTestProperties">
+          DependsOnTargets="DiscoverTestInputs;SetupTestProperties;GenerateDesktopExecutorsConfigFiles">
     <PropertyGroup>
       <TargetOSTrait Condition="'$(TargetOS)'=='Windows_NT'">nonwindowstests</TargetOSTrait>
       <TargetOSTrait Condition="'$(TargetOS)'=='Linux'">nonlinuxtests</TargetOSTrait>

--- a/Tools-Override/tests.targets
+++ b/Tools-Override/tests.targets
@@ -198,6 +198,13 @@
       Overwrite="true"
       Encoding="Ascii" />
 
+      <!--======================================================
+                      Section for netfx test runs
+            ====================================================== -->
+    <ItemGroup Condition="'$(BuildingNETFxVertical)' == 'true'" >
+      <TestCommandLines Include="set DEVPATH=%RUNTIME_PATH%" />
+    </ItemGroup>
+
         <!--======================================================
                       Section for uapaot ilc test runs
             ====================================================== -->

--- a/Tools-Override/tests.targets
+++ b/Tools-Override/tests.targets
@@ -123,6 +123,8 @@
     </ItemGroup>
   </Target>
 
+  <!-- We need to generate a simple config file for desktop test executors to tell them to use DEVPATH environment variable to use their dependencies from there.
+  DEVPATH is being set for desktop runs in RunTests.cmd to the TestHostPath. We need this approach to have desktop Helix runs. -->
   <Target Name="GenerateDesktopExecutorsConfigFiles"
           BeforeTargets="GenerateTestExecutionScripts"
           Condition="'$(BuildingNETFxVertical)' == 'true'">

--- a/dir.props
+++ b/dir.props
@@ -254,6 +254,7 @@
     <BinPlaceTestSharedFramework Condition="'$(_bc_TargetGroup)' == 'netcoreapp'">true</BinPlaceTestSharedFramework>
     <BinPlaceILCInputFolder Condition="'$(_bc_TargetGroup)' == 'uapaot' And '$(BinPlaceILCInputFolder)' == ''">true</BinPlaceILCInputFolder>
     <BinPlaceUAPFramework Condition="'$(_bc_TargetGroup)' == 'uap'">true</BinPlaceUAPFramework>
+    <BinPlaceNETFXRuntime Condition="'$(_bc_TargetGroup)' == 'netfx'">true</BinPlaceNETFXRuntime>
 
     <NETCoreAppTestSharedFxVersion>9.9.9</NETCoreAppTestSharedFxVersion>
     <TestHostRootPath>$(BinDir)testhost/$(BuildConfiguration)/</TestHostRootPath>

--- a/dir.targets
+++ b/dir.targets
@@ -54,7 +54,6 @@
       <RefPath>$(BuildConfigurationRefPath)</RefPath>
       <RuntimePath>$(RuntimePath)</RuntimePath>
     </BinPlaceConfiguration>
-
     <!-- binplace to directories for packages -->
     <BinPlaceConfiguration Condition="'$(IsNETCoreApp)' == 'true' AND '$(BuildingNETCoreAppVertical)' == 'true'" Include="netcoreapp-$(_bc_OSGroup)">
       <PackageFileRefPath Condition="'$(IsNETCoreAppRef)' == 'true'">$(NETCoreAppPackageRefPath)</PackageFileRefPath>
@@ -81,8 +80,8 @@
       <RuntimePath>$(ILCFXInputFolder)</RuntimePath>
     </BinPlaceConfiguration>
     <!-- And the UAP folder for the F5 (CoreCLR UAP-debugging) scenario -->
-    <BinPlaceConfiguration Condition="'$(BinPlaceUAPFramework)' == 'true'" Include="uap-$(_bc_OSGroup)">
-      <RuntimePath>$(UAPTestSharedFrameworkPath)</RuntimePath>
+    <BinPlaceConfiguration Condition="'$(BinPlaceNETFXRuntime)' == 'true'" Include="netfx-$(_bc_OSGroup)">
+      <RuntimePath>$(TestHostRootPath)</RuntimePath>
     </BinPlaceConfiguration>
 
     <!-- binplace targeting packs which may be different from BuildConfiguration -->

--- a/dir.targets
+++ b/dir.targets
@@ -80,6 +80,9 @@
       <RuntimePath>$(ILCFXInputFolder)</RuntimePath>
     </BinPlaceConfiguration>
     <!-- And the UAP folder for the F5 (CoreCLR UAP-debugging) scenario -->
+    <BinPlaceConfiguration Condition="'$(BinPlaceUAPFramework)' == 'true'" Include="uap-$(_bc_OSGroup)">
+      <RuntimePath>$(UAPTestSharedFrameworkPath)</RuntimePath>
+    </BinPlaceConfiguration>
     <BinPlaceConfiguration Condition="'$(BinPlaceNETFXRuntime)' == 'true'" Include="netfx-$(_bc_OSGroup)">
       <RuntimePath>$(TestHostRootPath)</RuntimePath>
     </BinPlaceConfiguration>

--- a/external/netstandard/netstandard.depproj
+++ b/external/netstandard/netstandard.depproj
@@ -22,6 +22,10 @@
       <!-- only for netfx verticals will this project provide runtime assets -->
       <RuntimePath>$(RuntimePath)</RuntimePath>
     </BinPlaceConfiguration>
+    <BinPlaceConfiguration Include="$(Configuration)">
+      <!-- copy shims to the testhost as well in order to be able to run the netfx tests -->
+      <RuntimePath>$(TestHostRootPath)</RuntimePath>
+    </BinPlaceConfiguration>
   </ItemGroup>
 
   <Target Name="AddNETStandardRefs" AfterTargets="ResolveReferences"

--- a/src/Tools/CoreFx.Tools/GenerateBindingRedirect.cs
+++ b/src/Tools/CoreFx.Tools/GenerateBindingRedirect.cs
@@ -28,8 +28,80 @@ namespace Microsoft.DotNet.Build.Tasks
 
         public override bool Execute()
         {
-            XElement developmentMode = new XElement("developmentMode", new XAttribute("developerInstallation", true));
-            XDocument doc = new XDocument(new XElement("configuration", new XElement("runtime", developmentMode)));
+            ns = "urn:schemas-microsoft-com:asm.v1";
+            XElement bindingRedirectAssemblies = new XElement(ns + "assemblyBinding");
+            foreach (ITaskItem assembly in Assemblies)
+            {
+                AssemblyName result = null;
+                try
+                {
+                    using (FileStream assemblyStream = new FileStream(assembly.ItemSpec, FileMode.Open, FileAccess.Read, FileShare.Delete | FileShare.Read))
+                    using (PEReader peReader = new PEReader(assemblyStream, PEStreamOptions.LeaveOpen))
+                    {
+                        if (peReader.HasMetadata)
+                        {
+                            MetadataReader reader = peReader.GetMetadataReader();
+                            if (reader.IsAssembly)
+                            {
+                                AssemblyDefinition assemblyDef = reader.GetAssemblyDefinition();
+
+                                result = new AssemblyName();
+                                result.Name = reader.GetString(assemblyDef.Name);
+                                result.CultureName = reader.GetString(assemblyDef.Culture);
+                                result.Version = assemblyDef.Version;
+
+                                if (!assemblyDef.PublicKey.IsNil)
+                                {
+                                    result.SetPublicKey(reader.GetBlobBytes(assemblyDef.PublicKey));
+                                }
+                            }
+                        }
+                        else
+                        {
+                            //Native
+                            continue;
+                        }
+                    }
+                }
+                catch (BadImageFormatException)
+                {
+                    // not a PE
+                    continue;
+                }
+
+                string publicKeyToken = string.Empty;
+                if (result.GetPublicKeyToken() != null)
+                { 
+                    publicKeyToken = BitConverter.ToString(result.GetPublicKeyToken()).Replace("-", "");
+                }
+                if (string.IsNullOrEmpty(publicKeyToken))
+                {
+                    Log.LogMessage(MessageImportance.Low, $"Empty publicKeyToken for {result.FullName} ");
+                }
+                string culture = string.IsNullOrEmpty(result.CultureName) ? "neutral" : result.CultureName;
+                XElement assemblyIdentity = new XElement(ns + "assemblyIdentity",
+                    new XAttribute("name", result.Name),
+                    new XAttribute("publicKeyToken", publicKeyToken),
+                    new XAttribute("culture", culture));
+                XElement bindingRedirect = new XElement(ns + "bindingRedirect",
+                    new XAttribute("oldVersion", $"0.0.0.0-{result.Version}"),
+                    new XAttribute("newVersion", result.Version));
+                XElement dependentAssembly = new XElement(ns + "dependentAssembly",
+                    assemblyIdentity,
+                    bindingRedirect);
+
+                if (OutputCodeBase)
+                {
+                    XElement codeBase = new XElement(ns + "codeBase",
+                                                new XAttribute("version", result.Version),
+                                                new XAttribute("href", Path.GetFullPath(assembly.ItemSpec)));
+                    dependentAssembly.Add(codeBase);
+                }
+
+                bindingRedirectAssemblies.Add(dependentAssembly);
+
+            }
+            XDocument doc = new XDocument(new XElement("configuration", new XElement("runtime", bindingRedirectAssemblies)));
             foreach (ITaskItem executable in Executables)
             {
                 string executableName = Path.GetFileName(executable.ItemSpec);

--- a/src/Tools/CoreFx.Tools/GenerateBindingRedirect.cs
+++ b/src/Tools/CoreFx.Tools/GenerateBindingRedirect.cs
@@ -94,14 +94,16 @@ namespace Microsoft.DotNet.Build.Tasks
                 {
                     XElement codeBase = new XElement(ns + "codeBase",
                                                 new XAttribute("version", result.Version),
-                                                new XAttribute("href", Path.GetFullPath(assembly.ItemSpec)));
+                                                new XAttribute("href", Path.GetFileName(assembly.ItemSpec)));
                     dependentAssembly.Add(codeBase);
                 }
 
                 bindingRedirectAssemblies.Add(dependentAssembly);
 
             }
-            XDocument doc = new XDocument(new XElement("configuration", new XElement("runtime", bindingRedirectAssemblies)));
+
+            XElement developmentMode = new XElement("developmentMode", new XAttribute("developerInstallation", true));
+            XDocument doc = new XDocument(new XElement("configuration", new XElement("runtime", developmentMode, bindingRedirectAssemblies)));
             foreach (ITaskItem executable in Executables)
             {
                 string executableName = Path.GetFileName(executable.ItemSpec);

--- a/src/Tools/CoreFx.Tools/GenerateBindingRedirect.cs
+++ b/src/Tools/CoreFx.Tools/GenerateBindingRedirect.cs
@@ -28,82 +28,8 @@ namespace Microsoft.DotNet.Build.Tasks
 
         public override bool Execute()
         {
-            ns = "urn:schemas-microsoft-com:asm.v1";
-            XElement bindingRedirectAssemblies = new XElement(ns + "assemblyBinding");
-            foreach (ITaskItem assembly in Assemblies)
-            {
-                AssemblyName result = null;
-                try
-                {
-                    using (FileStream assemblyStream = new FileStream(assembly.ItemSpec, FileMode.Open, FileAccess.Read, FileShare.Delete | FileShare.Read))
-                    using (PEReader peReader = new PEReader(assemblyStream, PEStreamOptions.LeaveOpen))
-                    {
-                        if (peReader.HasMetadata)
-                        {
-                            MetadataReader reader = peReader.GetMetadataReader();
-                            if (reader.IsAssembly)
-                            {
-                                AssemblyDefinition assemblyDef = reader.GetAssemblyDefinition();
-
-                                result = new AssemblyName();
-                                result.Name = reader.GetString(assemblyDef.Name);
-                                result.CultureName = reader.GetString(assemblyDef.Culture);
-                                result.Version = assemblyDef.Version;
-
-                                if (!assemblyDef.PublicKey.IsNil)
-                                {
-                                    result.SetPublicKey(reader.GetBlobBytes(assemblyDef.PublicKey));
-                                }
-                            }
-                        }
-                        else
-                        {
-                            //Native
-                            continue;
-                        }
-                    }
-                }
-                catch (BadImageFormatException)
-                {
-                    // not a PE
-                    continue;
-                }
-
-                string publicKeyToken = string.Empty;
-                if (result.GetPublicKeyToken() != null)
-                { 
-                    publicKeyToken = BitConverter.ToString(result.GetPublicKeyToken()).Replace("-", "");
-                }
-                if (string.IsNullOrEmpty(publicKeyToken))
-                {
-                    Log.LogMessage(MessageImportance.Low, $"Empty publicKeyToken for {result.FullName} ");
-                }
-                string culture = string.IsNullOrEmpty(result.CultureName) ? "neutral" : result.CultureName;
-                XElement assemblyIdentity = new XElement(ns + "assemblyIdentity",
-                    new XAttribute("name", result.Name),
-                    new XAttribute("publicKeyToken", publicKeyToken),
-                    new XAttribute("culture", culture));
-                XElement bindingRedirect = new XElement(ns + "bindingRedirect",
-                    new XAttribute("oldVersion", $"0.0.0.0-{result.Version}"),
-                    new XAttribute("newVersion", result.Version));
-                XElement dependentAssembly = new XElement(ns + "dependentAssembly",
-                    assemblyIdentity,
-                    bindingRedirect);
-
-                if (OutputCodeBase)
-                {
-                    XElement codeBase = new XElement(ns + "codeBase",
-                                                new XAttribute("version", result.Version),
-                                                new XAttribute("href", Path.GetFileName(assembly.ItemSpec)));
-                    dependentAssembly.Add(codeBase);
-                }
-
-                bindingRedirectAssemblies.Add(dependentAssembly);
-
-            }
-
             XElement developmentMode = new XElement("developmentMode", new XAttribute("developerInstallation", true));
-            XDocument doc = new XDocument(new XElement("configuration", new XElement("runtime", developmentMode, bindingRedirectAssemblies)));
+            XDocument doc = new XDocument(new XElement("configuration", new XElement("runtime", developmentMode)));
             foreach (ITaskItem executable in Executables)
             {
                 string executableName = Path.GetFileName(executable.ItemSpec);

--- a/src/src.builds
+++ b/src/src.builds
@@ -9,7 +9,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 
   <UsingTask TaskName="GenerateDepsJson" AssemblyFile="$(BuildToolsTaskDir)CoreFx.Tools.dll"/>
-  <UsingTask TaskName="GenerateBindingRedirect" AssemblyFile="$(BuildToolsTaskDir)CoreFx.Tools.dll"/>
 
   <PropertyGroup>
     <!-- TODO: We should see about generating this from scratch instead of relying on a previous deps file as a template -->
@@ -33,18 +32,4 @@
                       DepsExceptions="@(ExceptionForDepsJson)"
                       OutputPath="$(_OutputTestSharedFrameworkDepsPath)"/>
   </Target>
-
-  <Target Name="GenerateXUnitRunnerConfigFile" AfterTargets="BuildAllProjects" Condition="'$(TargetGroup)' == 'netfx'">
-
-    <ItemGroup>
-      <NetFXRuntimeAssemblies Include="$(RuntimePath)*.dll" />
-      <XUnitConsoleRunnerExecutable Include="$(RuntimePath)xunit.console.exe" />
-    </ItemGroup>
-
-    <GenerateBindingRedirect  Assemblies="@(NetFXRuntimeAssemblies)" 
-                              Executables="@(XUnitConsoleRunnerExecutable)"
-                              OutputPath="$(RuntimePath)"
-                              OutputCodeBase="True" />
-  </Target>
-
 </Project>


### PR DESCRIPTION
I added bin placing to add test dependencies in the testhost folder instead of using the runtime/netfx folder. 

Also RunTests.cmd now will be called with the testhost parameter as a path and will set DEVPATH env variable to point to that path, and modified the xunit.console.exe.config to use DEVPATH to look for the test dependencies.

This is needed to run in Helix.

cc: @weshaggard @tarekgh @joperezr  