### PR TITLE
Add HttpListener tests and fix a porting bug

### DIFF
--- a/src/System.Net.HttpListener/src/System/Net/Windows/HttpListenerRequest.Windows.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/HttpListenerRequest.Windows.cs
@@ -232,7 +232,8 @@ namespace System.Net
             {
                 if (_boundaryType == BoundaryType.None)
                 {
-                    if (GetKnownHeader(HttpRequestHeader.TransferEncoding).Equals("chunked", StringComparison.OrdinalIgnoreCase))
+                    string transferEncodingHeader = GetKnownHeader(HttpRequestHeader.TransferEncoding);
+                    if (transferEncodingHeader != null && transferEncodingHeader.Equals("chunked", StringComparison.OrdinalIgnoreCase))
                     {
                         _boundaryType = BoundaryType.Chunked;
                         _contentLength = -1;

--- a/src/System.Net.HttpListener/tests/Common.cs
+++ b/src/System.Net.HttpListener/tests/Common.cs
@@ -23,7 +23,7 @@ namespace System.Net.Tests
 
         public async Task<HttpListenerResponse> GetResponse()
         {
-            // We need this to avoid hanging tests.
+            // We need to create a mock request to give the HttpListener a context.
             Task<string> clientTask = _client.GetStringAsync(_listeningUrl);
             HttpListenerContext context = await _listener.GetContextAsync();
             return context.Response;
@@ -31,7 +31,7 @@ namespace System.Net.Tests
 
         public async Task<HttpListenerRequest> GetRequest()
         {
-            // We need this to avoid hanging tests.
+            // We need to create a mock request to give the HttpListener a context.
             Task<HttpListenerContext> serverContext = _listener.GetContextAsync();
 
             _client.DefaultRequestHeaders.TransferEncodingChunked = true;

--- a/src/System.Net.HttpListener/tests/Common.cs
+++ b/src/System.Net.HttpListener/tests/Common.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Net.Tests
+{
+    public class GetContextHelper : IDisposable
+    {
+        private HttpClient _client;
+        private HttpListener _listener;
+        private string _listeningUrl;
+
+        public GetContextHelper(HttpListener listener, string listeningUrl)
+        {
+            _listener = listener;
+            _listeningUrl = listeningUrl;
+            _client = new HttpClient();
+        }
+
+        public async Task<HttpListenerResponse> GetResponse()
+        {
+            // We need this to avoid hanging tests.
+            Task<string> clientTask = _client.GetStringAsync(_listeningUrl);
+            HttpListenerContext context = await _listener.GetContextAsync();
+            return context.Response;
+        }
+        public void Dispose()
+        {
+            _client.Dispose();
+        }
+    }
+
+    public class CustomAsyncResult : IAsyncResult
+    {
+        public object AsyncState => throw new NotImplementedException();
+        public WaitHandle AsyncWaitHandle => throw new NotImplementedException();
+        public bool CompletedSynchronously => throw new NotImplementedException();
+        public bool IsCompleted => throw new NotImplementedException();
+    }
+
+    public class Common
+    {
+        public static void StubCallback(IAsyncResult result) { }
+    }
+}

--- a/src/System.Net.HttpListener/tests/Common.cs
+++ b/src/System.Net.HttpListener/tests/Common.cs
@@ -28,6 +28,19 @@ namespace System.Net.Tests
             HttpListenerContext context = await _listener.GetContextAsync();
             return context.Response;
         }
+
+        public async Task<HttpListenerRequest> GetRequest()
+        {
+            // We need this to avoid hanging tests.
+            Task<HttpListenerContext> serverContext = _listener.GetContextAsync();
+
+            _client.DefaultRequestHeaders.TransferEncodingChunked = true;
+            Task<HttpResponseMessage> clientTask = _client.PostAsync(_listeningUrl, new StringContent("Hello"));
+
+            HttpListenerContext context = await serverContext;
+            return context.Request;
+        }
+
         public void Dispose()
         {
             _client.Dispose();

--- a/src/System.Net.HttpListener/tests/GetContextHelper.cs
+++ b/src/System.Net.HttpListener/tests/GetContextHelper.cs
@@ -54,9 +54,4 @@ namespace System.Net.Tests
         public bool CompletedSynchronously => throw new NotImplementedException();
         public bool IsCompleted => throw new NotImplementedException();
     }
-
-    public class Common
-    {
-        public static void StubCallback(IAsyncResult result) { }
-    }
 }

--- a/src/System.Net.HttpListener/tests/HttpRequestStreamTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpRequestStreamTests.cs
@@ -1,0 +1,454 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Net.WebSockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Net.Tests
+{
+    public class HttpRequestStreamTests : IDisposable
+    {
+        private HttpListenerFactory _factory;
+        private HttpListener _listener;
+        private GetContextHelper _helper;
+
+        public HttpRequestStreamTests()
+        {
+            _factory = new HttpListenerFactory();
+            _listener = _factory.GetListener();
+            if (!PlatformDetection.IsWindows7)
+            {
+                _helper = new GetContextHelper(_listener, _factory.ListeningUrl);
+            }
+        }
+
+        public void Dispose()
+        {
+            _factory.Dispose();
+            _helper.Dispose();
+        }
+
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
+        [InlineData(true, "")]
+        [InlineData(false, "")]
+        [InlineData(true, "Non-Empty")]
+        [InlineData(false, "Non-Empty")]
+        public async Task Read_FullLengthAsynchronous_Success(bool transferEncodingChunked, string text)
+        {
+            byte[] expected = Encoding.UTF8.GetBytes(text);
+            Task<HttpListenerContext> contextTask = _listener.GetContextAsync();
+
+            using (HttpClient client = new HttpClient())
+            {
+                client.DefaultRequestHeaders.TransferEncodingChunked = transferEncodingChunked;
+                Task<HttpResponseMessage> clientTask = client.PostAsync(_factory.ListeningUrl, new StringContent(text));
+
+                HttpListenerContext context = await contextTask;
+                if (transferEncodingChunked)
+                {
+                    Assert.Equal(-1, context.Request.ContentLength64);
+                    Assert.Equal("chunked", context.Request.Headers["Transfer-Encoding"]);
+                }
+                else
+                {
+                    Assert.Equal(expected.Length, context.Request.ContentLength64);
+                    Assert.Null(context.Request.Headers["Transfer-Encoding"]);
+                }
+
+                byte[] buffer = new byte[expected.Length];
+                int bytesRead = await context.Request.InputStream.ReadAsync(buffer, 0, buffer.Length);
+                Assert.Equal(expected.Length, bytesRead);
+                Assert.Equal(expected, buffer);
+
+                // Subsequent reads don't do anything.
+                Assert.Equal(0, await context.Request.InputStream.ReadAsync(buffer, 0, buffer.Length));
+                Assert.Equal(expected, buffer);
+
+                context.Response.Close();
+                using (HttpResponseMessage response = await clientTask)
+                {
+                    Assert.Equal(200, (int)response.StatusCode);
+                }
+            }
+        }
+
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
+        [InlineData(true, "")]
+        [InlineData(false, "")]
+        [InlineData(true, "Non-Empty")]
+        [InlineData(false, "Non-Empty")]
+        public async Task Read_FullLengthSynchronous_Success(bool transferEncodingChunked, string text)
+        {
+            byte[] expected = Encoding.UTF8.GetBytes(text);
+            Task<HttpListenerContext> contextTask = _listener.GetContextAsync();
+
+            using (HttpClient client = new HttpClient())
+            {
+                client.DefaultRequestHeaders.TransferEncodingChunked = transferEncodingChunked;
+                Task<HttpResponseMessage> clientTask = client.PostAsync(_factory.ListeningUrl, new StringContent(text));
+
+                HttpListenerContext context = await contextTask;
+                if (transferEncodingChunked)
+                {
+                    Assert.Equal(-1, context.Request.ContentLength64);
+                    Assert.Equal("chunked", context.Request.Headers["Transfer-Encoding"]);
+                }
+                else
+                {
+                    Assert.Equal(expected.Length, context.Request.ContentLength64);
+                    Assert.Null(context.Request.Headers["Transfer-Encoding"]);
+                }
+
+                byte[] buffer = new byte[expected.Length];
+                int bytesRead = context.Request.InputStream.Read(buffer, 0, buffer.Length);
+                Assert.Equal(expected.Length, bytesRead);
+                Assert.Equal(expected, buffer);
+
+                // Subsequent reads don't do anything.
+                Assert.Equal(0, context.Request.InputStream.Read(buffer, 0, buffer.Length));
+                Assert.Equal(expected, buffer);
+
+                context.Response.Close();
+                using (HttpResponseMessage response = await clientTask)
+                {
+                    Assert.Equal(200, (int)response.StatusCode);
+                }
+            }
+        }
+
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Read_LargeLengthAsynchronous_Success(bool transferEncodingChunked)
+        {
+            string text = new string('a', 128 * 1024 + 1); // More than 128kb
+            byte[] expected = Encoding.UTF8.GetBytes(text);
+            Task<HttpListenerContext> contextTask = _listener.GetContextAsync();
+
+            using (HttpClient client = new HttpClient())
+            {
+                client.DefaultRequestHeaders.TransferEncodingChunked = transferEncodingChunked;
+                Task<HttpResponseMessage> clientTask = client.PostAsync(_factory.ListeningUrl, new StringContent(text));
+
+                HttpListenerContext context = await contextTask;
+
+                // If the size is greater than 128K, then we limit the size, and have to do multiple reads.
+                byte[] buffer = new byte[expected.Length];
+                int bytesRead = await context.Request.InputStream.ReadAsync(buffer, 0, buffer.Length);
+                Assert.Equal(expected.Length - 1, bytesRead);
+                Assert.NotEqual(expected, buffer);
+
+                bytesRead = await context.Request.InputStream.ReadAsync(buffer, buffer.Length - 1, 1);
+                Assert.Equal(1, bytesRead);
+                Assert.Equal(expected, buffer);
+
+                // Subsequent reads don't do anything.
+                Assert.Equal(0, await context.Request.InputStream.ReadAsync(buffer, 0, buffer.Length));
+                Assert.Equal(expected, buffer);
+
+                context.Response.Close();
+            }
+        }
+
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Read_LargeLengthSynchronous_Success(bool transferEncodingChunked)
+        {
+            string text = new string('a', 128 * 1024 + 1); // More than 128kb
+            byte[] expected = Encoding.UTF8.GetBytes(text);
+            Task<HttpListenerContext> contextTask = _listener.GetContextAsync();
+
+            using (HttpClient client = new HttpClient())
+            {
+                client.DefaultRequestHeaders.TransferEncodingChunked = transferEncodingChunked;
+                Task<HttpResponseMessage> clientTask = client.PostAsync(_factory.ListeningUrl, new StringContent(text));
+
+                HttpListenerContext context = await contextTask;
+
+                // If the size is greater than 128K, then we limit the size, and have to do multiple reads.
+                byte[] buffer = new byte[expected.Length];
+                int bytesRead = context.Request.InputStream.Read(buffer, 0, buffer.Length);
+                Assert.Equal(expected.Length - 1, bytesRead);
+                Assert.NotEqual(expected, buffer);
+
+                bytesRead = context.Request.InputStream.Read(buffer, buffer.Length - 1, 1);
+                Assert.Equal(1, bytesRead);
+                Assert.Equal(expected, buffer);
+
+                // Subsequent reads don't do anything.
+                Assert.Equal(0, context.Request.InputStream.Read(buffer, 0, buffer.Length));
+                Assert.Equal(expected, buffer);
+
+                context.Response.Close();
+            }
+        }
+
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Read_TooMuchAsynchronous_Success(bool transferEncodingChunked)
+        {
+            const string Text = "Some-String";
+            byte[] expected = Encoding.UTF8.GetBytes(Text);
+            Task<HttpListenerContext> contextTask = _listener.GetContextAsync();
+
+            using (HttpClient client = new HttpClient())
+            {
+                client.DefaultRequestHeaders.TransferEncodingChunked = transferEncodingChunked;
+                Task<HttpResponseMessage> clientTask = client.PostAsync(_factory.ListeningUrl, new StringContent(Text));
+
+                HttpListenerContext context = await contextTask;
+
+                byte[] buffer = new byte[expected.Length + 5];
+                int bytesRead = await context.Request.InputStream.ReadAsync(buffer, 0, buffer.Length);
+                Assert.Equal(expected.Length, bytesRead);
+                Assert.Equal(expected.Concat(new byte[5]), buffer);
+
+                context.Response.Close();
+            }
+        }
+
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Read_TooMuchSynchronous_Success(bool transferEncodingChunked)
+        {
+            const string Text = "Some-String";
+            byte[] expected = Encoding.UTF8.GetBytes(Text);
+            Task<HttpListenerContext> contextTask = _listener.GetContextAsync();
+
+            using (HttpClient client = new HttpClient())
+            {
+                client.DefaultRequestHeaders.TransferEncodingChunked = transferEncodingChunked;
+                Task<HttpResponseMessage> clientTask = client.PostAsync(_factory.ListeningUrl, new StringContent(Text));
+
+                HttpListenerContext context = await contextTask;
+
+                byte[] buffer = new byte[expected.Length + 5];
+                int bytesRead = context.Request.InputStream.Read(buffer, 0, buffer.Length);
+                Assert.Equal(expected.Length, bytesRead);
+                Assert.Equal(expected.Concat(new byte[5]), buffer);
+
+                context.Response.Close();
+            }
+        }
+
+
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Read_NotEnoughThenCloseAsynchronous_Success(bool transferEncodingChunked)
+        {
+            const string Text = "Some-String";
+            byte[] expected = Encoding.UTF8.GetBytes(Text);
+            Task<HttpListenerContext> contextTask = _listener.GetContextAsync();
+
+            using (HttpClient client = new HttpClient())
+            {
+                client.DefaultRequestHeaders.TransferEncodingChunked = transferEncodingChunked;
+                Task<HttpResponseMessage> clientTask = client.PostAsync(_factory.ListeningUrl, new StringContent(Text));
+
+                HttpListenerContext context = await contextTask;
+
+                byte[] buffer = new byte[expected.Length - 5];
+                int bytesRead = await context.Request.InputStream.ReadAsync(buffer, 0, buffer.Length);
+                Assert.Equal(buffer.Length, bytesRead);
+
+                context.Response.Close();
+            }
+        }
+
+        [Fact]
+        public async Task CanSeek_Get_ReturnsFalse()
+        {
+            HttpListenerRequest response = await _helper.GetRequest();
+            using (Stream inputStream = response.InputStream)
+            {
+                Assert.False(inputStream.CanSeek);
+
+                Assert.Throws<NotSupportedException>(() => inputStream.Length);
+                Assert.Throws<NotSupportedException>(() => inputStream.SetLength(1));
+
+                Assert.Throws<NotSupportedException>(() => inputStream.Position);
+                Assert.Throws<NotSupportedException>(() => inputStream.Position = 1);
+
+                Assert.Throws<NotSupportedException>(() => inputStream.Seek(0, SeekOrigin.Begin));
+            }
+        }
+
+        [Fact]
+        public async Task CanRead_Get_ReturnsTrue()
+        {
+            HttpListenerRequest request = await _helper.GetRequest();
+            using (Stream inputStream = request.InputStream)
+            {
+                Assert.True(inputStream.CanRead);
+            }
+        }
+
+        [Fact]
+        public async Task CanWrite_Get_ReturnsFalse()
+        {
+            HttpListenerRequest request = await _helper.GetRequest();
+            using (Stream inputStream = request.InputStream)
+            {
+                Assert.False(inputStream.CanWrite);
+
+                Assert.Throws<InvalidOperationException>(() => inputStream.Write(new byte[0], 0, 0));
+                await Assert.ThrowsAsync<InvalidOperationException>(() => inputStream.WriteAsync(new byte[0], 0, 0));
+                Assert.Throws<InvalidOperationException>(() => inputStream.EndWrite(null));
+
+                // Flushing the output stream is a no-op.
+                inputStream.Flush();
+                Assert.Equal(Task.CompletedTask, inputStream.FlushAsync(CancellationToken.None));
+            }
+        }
+
+        [Fact]
+        public async Task Read_NullBuffer_ThrowsArgumentNullException()
+        {
+            HttpListenerRequest request = await _helper.GetRequest();
+            using (Stream inputStream = request.InputStream)
+            {
+                Assert.Throws<ArgumentNullException>("buffer", () => inputStream.Read(null, 0, 0));
+                await Assert.ThrowsAsync<ArgumentNullException>("buffer", () => inputStream.ReadAsync(null, 0, 0));
+            }
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(3)]
+        public async Task Read_InvalidOffset_ThrowsArgumentOutOfRangeException(int offset)
+        {
+            HttpListenerRequest request = await _helper.GetRequest();
+            using (Stream inputStream = request.InputStream)
+            {
+                Assert.Throws<ArgumentOutOfRangeException>("offset", () => inputStream.Read(new byte[2], offset, 0));
+                await Assert.ThrowsAsync<ArgumentOutOfRangeException>("offset", () => inputStream.ReadAsync(new byte[2], offset, 0));
+            }
+        }
+
+        [Theory]
+        [InlineData(0, 3)]
+        [InlineData(1, 2)]
+        [InlineData(2, 1)]
+        public async Task Read_InvalidOffsetSize_ThrowsArgumentOutOfRangeException(int offset, int size)
+        {
+            HttpListenerRequest request = await _helper.GetRequest();
+            using (Stream inputStream = request.InputStream)
+            {
+                Assert.Throws<ArgumentOutOfRangeException>("size", () => inputStream.Read(new byte[2], offset, size));
+                await Assert.ThrowsAsync<ArgumentOutOfRangeException>("size", () => inputStream.ReadAsync(new byte[2], offset, size));
+            }
+        }
+
+        [Fact]
+        public async Task EndRead_NullCallback_ThrowsArgumentNullException()
+        {
+            HttpListenerRequest request = await _helper.GetRequest();
+
+            using (Stream inputStream = request.InputStream)
+            {
+                Assert.Throws<ArgumentNullException>("asyncResult", () => inputStream.EndRead(null));
+            }
+        }
+
+        [Fact]
+        public async Task EndRead_InvalidCallback_ThrowsArgumentException()
+        {
+            HttpListenerRequest request1 = await _helper.GetRequest();
+            HttpListenerRequest request2 = await _helper.GetRequest();
+            
+            using (Stream inputStream1 = request1.InputStream)
+            using (Stream inputStream2 = request2.InputStream)
+            {
+                IAsyncResult beginReadResult = inputStream1.BeginRead(new byte[0], 0, 0, new AsyncCallback(Common.StubCallback), null);
+
+                Assert.Throws<ArgumentException>("asyncResult", () => inputStream2.EndRead(new CustomAsyncResult()));
+                Assert.Throws<ArgumentException>("asyncResult", () => inputStream2.EndRead(beginReadResult));
+            }
+        }
+
+        [Fact]
+        public async Task EndRead_CalledTwice_ThrowsInvalidOperationException()
+        {
+            HttpListenerRequest request = await _helper.GetRequest();
+            using (Stream inputStream = request.InputStream)
+            {
+                IAsyncResult beginReadResult = inputStream.BeginRead(new byte[0], 0, 0, new AsyncCallback(Common.StubCallback), null);
+                inputStream.EndRead(beginReadResult);
+
+                Assert.Throws<InvalidOperationException>(() => inputStream.EndRead(beginReadResult));
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Read_FromClosedSocketSynchronously_ThrowsHttpListenerException(bool transferEncodingChunked)
+        {
+            const string Text = "Some-String";
+            byte[] expected = Encoding.UTF8.GetBytes(Text);
+            Task<HttpListenerContext> contextTask = _listener.GetContextAsync();
+
+            using (HttpClient client = new HttpClient())
+            {
+                client.DefaultRequestHeaders.TransferEncodingChunked = transferEncodingChunked;
+                Task<HttpResponseMessage> clientTask = client.PostAsync(_factory.ListeningUrl, new StringContent(Text));
+
+                HttpListenerContext context = await contextTask;
+
+                // Disconnect the client from the HttpListener.
+                client.Dispose();
+
+                // Reading from a closed client should fail.
+                byte[] buffer = new byte[expected.Length];
+                Assert.Throws<HttpListenerException>(() => context.Request.InputStream.Read(buffer, 0, buffer.Length));
+
+                // Closing a response from a closed client should fail.
+                Assert.Throws<HttpListenerException>(() => context.Response.Close());
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Read_FromClosedSocketASynchronously_ThrowsHttpListenerException(bool transferEncodingChunked)
+        {
+            const string Text = "Some-String";
+            byte[] expected = Encoding.UTF8.GetBytes(Text);
+            Task<HttpListenerContext> contextTask = _listener.GetContextAsync();
+
+            using (HttpClient client = new HttpClient())
+            {
+                client.DefaultRequestHeaders.TransferEncodingChunked = transferEncodingChunked;
+                Task<HttpResponseMessage> clientTask = client.PostAsync(_factory.ListeningUrl, new StringContent(Text));
+
+                HttpListenerContext context = await contextTask;
+
+                // Disconnect the client from the HttpListener.
+                client.Dispose();
+
+                // TODO: we need to sleep and wait to make sure the client closes.
+                Thread.Sleep(1000);
+
+                // Reading from a closed client should fail.
+                byte[] buffer = new byte[expected.Length];
+                await Assert.ThrowsAsync<HttpListenerException>(() => context.Request.InputStream.ReadAsync(buffer, 0, buffer.Length));
+
+                // Closing a response from a closed client should fail.
+                Assert.Throws<HttpListenerException>(() => context.Response.Close());
+            }
+        }
+    }
+}
+    

--- a/src/System.Net.HttpListener/tests/HttpResponseStreamTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpResponseStreamTests.cs
@@ -1,0 +1,515 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Net.Http;
+using System.Net.WebSockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Net.Tests
+{
+    public class HttpResponseStreamTests : IDisposable
+    {
+        private HttpListenerFactory _factory;
+        private HttpListener _listener;
+        private GetContextHelper _helper;
+
+        public HttpResponseStreamTests()
+        {
+            _factory = new HttpListenerFactory();
+            _listener = _factory.GetListener();
+            _helper = new GetContextHelper(_listener, _factory.ListeningUrl);
+        }
+
+        public void Dispose()
+        {
+            _factory.Dispose();
+            _helper.Dispose();
+        }
+
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task SimpleRequest_WriteAsynchronously_Succeeds(bool sendChunked)
+        {
+            const string expectedResponse = "hello from HttpListener";
+            Task<HttpListenerContext> serverContextTask = _listener.GetContextAsync();
+
+            using (HttpClient client = new HttpClient())
+            {
+                Task<string> clientTask = client.GetStringAsync(_factory.ListeningUrl);
+
+                HttpListenerContext serverContext = await serverContextTask;
+                using (HttpListenerResponse response = serverContext.Response)
+                {
+                    byte[] responseBuffer = Encoding.UTF8.GetBytes(expectedResponse);
+                    response.ContentLength64 = responseBuffer.Length;
+                    response.SendChunked = sendChunked;
+
+                    Stream outputStream = response.OutputStream;
+                    try
+                    {
+                        await outputStream.WriteAsync(responseBuffer, 0, responseBuffer.Length);
+                    }
+                    finally
+                    {
+                        outputStream.Close();
+                    }
+
+                    byte[] extraBytesSentAfterClose = Encoding.UTF8.GetBytes("Should not be sent.");
+                    await outputStream.WriteAsync(extraBytesSentAfterClose, 0, extraBytesSentAfterClose.Length);
+                }
+
+                string clientString = await clientTask;
+                Assert.Equal(expectedResponse, clientString);
+            }
+        }
+
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task SimpleRequest_WriteSynchronouslyNonEmpty_Succeeds(bool sendChunked)
+        {
+            const string expectedResponse = "hello from HttpListener";
+            Task<HttpListenerContext> serverContextTask = _listener.GetContextAsync();
+
+            using (HttpClient client = new HttpClient())
+            {
+                Task<string> clientTask = client.GetStringAsync(_factory.ListeningUrl);
+
+                HttpListenerContext serverContext = await serverContextTask;
+                using (HttpListenerResponse response = serverContext.Response)
+                {
+                    byte[] responseBuffer = Encoding.UTF8.GetBytes(expectedResponse);
+                    response.ContentLength64 = responseBuffer.Length;
+                    response.SendChunked = sendChunked;
+
+                    Stream outputStream = response.OutputStream;
+                    try
+                    {
+                        outputStream.Write(responseBuffer, 0, responseBuffer.Length);
+                    }
+                    finally
+                    {
+                        outputStream.Close();
+                    }
+
+                    byte[] extraBytesSentAfterClose = Encoding.UTF8.GetBytes("Should not be sent.");
+                    outputStream.Write(extraBytesSentAfterClose, 0, extraBytesSentAfterClose.Length);
+                }
+
+                string clientString = await clientTask;
+                Assert.Equal(expectedResponse, clientString);
+            }
+        }
+
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
+        public async Task SimpleRequest_WriteAsynchronouslyInParts_Succeeds()
+        {
+            const string expectedResponse = "hello from HttpListener";
+            Task<HttpListenerContext> serverContextTask = _listener.GetContextAsync();
+
+            using (HttpClient client = new HttpClient())
+            {
+                Task<string> clientTask = client.GetStringAsync(_factory.ListeningUrl);
+
+                HttpListenerContext serverContext = await serverContextTask;
+                using (HttpListenerResponse response = serverContext.Response)
+                {
+                    byte[] responseBuffer = Encoding.UTF8.GetBytes(expectedResponse);
+                    response.ContentLength64 = responseBuffer.Length;
+
+                    using (Stream outputStream = response.OutputStream)
+                    {
+                        await outputStream.WriteAsync(responseBuffer, 0, 5);
+                        await outputStream.WriteAsync(responseBuffer, 5, responseBuffer.Length - 5);
+                    }
+                }
+
+                var clientString = await clientTask;
+
+                Assert.Equal(expectedResponse, clientString);
+            }
+        }
+
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
+        public async Task SimpleRequest_WriteSynchronouslyInParts_Succeeds()
+        {
+            const string expectedResponse = "hello from HttpListener";
+            Task<HttpListenerContext> serverContextTask = _listener.GetContextAsync();
+
+            using (HttpClient client = new HttpClient())
+            {
+                Task<string> clientTask = client.GetStringAsync(_factory.ListeningUrl);
+
+                HttpListenerContext serverContext = await serverContextTask;
+                using (HttpListenerResponse response = serverContext.Response)
+                {
+                    byte[] responseBuffer = Encoding.UTF8.GetBytes(expectedResponse);
+                    response.ContentLength64 = responseBuffer.Length;
+
+                    using (Stream outputStream = response.OutputStream)
+                    {
+                        outputStream.Write(responseBuffer, 0, 5);
+                        outputStream.Write(responseBuffer, 5, responseBuffer.Length - 5);
+                    }
+                }
+
+                var clientString = await clientTask;
+
+                Assert.Equal(expectedResponse, clientString);
+            }
+        }
+
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
+        public async Task SimpleRequest_WriteAynchronouslyEmpty_Succeeds()
+        {
+            Task<HttpListenerContext> serverContextTask = _listener.GetContextAsync();
+
+            using (HttpClient client = new HttpClient())
+            {
+                Task<string> clientTask = client.GetStringAsync(_factory.ListeningUrl);
+
+                HttpListenerContext serverContext = await serverContextTask;
+                using (HttpListenerResponse response = serverContext.Response)
+                {
+                    response.ContentLength64 = 0;
+                    using (Stream outputStream = response.OutputStream)
+                    {
+                        await outputStream.WriteAsync(new byte[0], 0, 0);
+                    }
+                }
+
+                Assert.Empty(await clientTask);
+            }
+        }
+
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
+        public async Task SimpleRequest_WriteSynchronouslyEmpty_Succeeds()
+        {
+            Task<HttpListenerContext> serverContextTask = _listener.GetContextAsync();
+
+            using (HttpClient client = new HttpClient())
+            {
+                Task<string> clientTask = client.GetStringAsync(_factory.ListeningUrl);
+
+                HttpListenerContext serverContext = await serverContextTask;
+                using (HttpListenerResponse response = serverContext.Response)
+                {
+                    response.ContentLength64 = 0;
+                    using (Stream outputStream = response.OutputStream)
+                    {
+                        outputStream.Write(new byte[0], 0, 0);
+                    }
+                }
+
+                Assert.Empty(await clientTask);
+            }
+        }
+
+        [Fact]
+        public async Task CanSeek_Get_ReturnsFalse()
+        {
+            using (HttpListenerResponse response = await _helper.GetResponse())
+            using (Stream outputStream = response.OutputStream)
+            {
+                Assert.False(outputStream.CanSeek);
+
+                Assert.Throws<NotSupportedException>(() => outputStream.Length);
+                Assert.Throws<NotSupportedException>(() => outputStream.SetLength(1));
+
+                Assert.Throws<NotSupportedException>(() => outputStream.Position);
+                Assert.Throws<NotSupportedException>(() => outputStream.Position = 1);
+
+                Assert.Throws<NotSupportedException>(() => outputStream.Seek(0, SeekOrigin.Begin));
+            }
+        }
+
+        [Fact]
+        public async Task CanRead_Get_ReturnsFalse()
+        {
+            using (HttpListenerResponse response = await _helper.GetResponse())
+            using (Stream outputStream = response.OutputStream)
+            {
+                Assert.False(outputStream.CanRead);
+
+                Assert.Throws<InvalidOperationException>(() => outputStream.Read(new byte[0], 0, 0));
+                await Assert.ThrowsAsync<InvalidOperationException>(() => outputStream.ReadAsync(new byte[0], 0, 0));
+                Assert.Throws<InvalidOperationException>(() => outputStream.EndRead(null));
+            }
+        }
+
+        [Fact]
+        public async Task CanWrite_Get_ReturnsTrue()
+        {
+            using (HttpListenerResponse response = await _helper.GetResponse())
+            using (Stream outputStream = response.OutputStream)
+            {
+                Assert.True(outputStream.CanWrite);
+
+                // Flushing the output stream is a no-op.
+                outputStream.Flush();
+                Assert.Equal(Task.CompletedTask, outputStream.FlushAsync(CancellationToken.None));
+            }
+        }
+
+        [Fact]
+        public async Task Write_NullBuffer_ThrowsArgumentNullException()
+        {
+            using (HttpListenerResponse response = await _helper.GetResponse())
+            using (Stream outputStream = response.OutputStream)
+            {
+                Assert.Throws<ArgumentNullException>("buffer", () => outputStream.Write(null, 0, 0));
+                await Assert.ThrowsAsync<ArgumentNullException>("buffer", () => outputStream.WriteAsync(null, 0, 0));
+            }
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(3)]
+        public async Task Write_InvalidOffset_ThrowsArgumentOutOfRangeException(int offset)
+        {
+            using (HttpListenerResponse response = await _helper.GetResponse())
+            using (Stream outputStream = response.OutputStream)
+            {
+                Assert.Throws<ArgumentOutOfRangeException>("offset", () => outputStream.Write(new byte[2], offset, 0));
+                await Assert.ThrowsAsync<ArgumentOutOfRangeException>("offset", () => outputStream.WriteAsync(new byte[2], offset, 0));
+            }
+        }
+
+        [Theory]
+        [InlineData(0, 3)]
+        [InlineData(1, 2)]
+        [InlineData(2, 1)]
+        public async Task Write_InvalidOffsetSize_ThrowsArgumentOutOfRangeException(int offset, int size)
+        {
+            using (HttpListenerResponse response = await _helper.GetResponse())
+            using (Stream outputStream = response.OutputStream)
+            {
+                Assert.Throws<ArgumentOutOfRangeException>("size", () => outputStream.Write(new byte[2], offset, size));
+                await Assert.ThrowsAsync<ArgumentOutOfRangeException>("size", () => outputStream.WriteAsync(new byte[2], offset, size));
+            }
+        }
+
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
+        public async Task Write_TooMuch_ThrowsProtocolViolationException()
+        {
+            using (HttpClient client = new HttpClient())
+            {
+                Task<string> clientTask = client.GetStringAsync(_factory.ListeningUrl);
+
+                HttpListenerContext serverContext = await _listener.GetContextAsync();
+                using (HttpListenerResponse response = serverContext.Response)
+                {
+                    Stream output = response.OutputStream;
+                    byte[] responseBuffer = Encoding.UTF8.GetBytes("A long string");
+                    response.ContentLength64 = responseBuffer.Length - 1;
+                    try
+                    {
+                        Assert.Throws<ProtocolViolationException>(() => output.Write(responseBuffer, 0, responseBuffer.Length));
+                        await Assert.ThrowsAsync<ProtocolViolationException>(() => output.WriteAsync(responseBuffer, 0, responseBuffer.Length));
+                    }
+                    finally
+                    {
+                        // Write the remaining bytes to guarantee a successful shutdown.
+                        output.Write(responseBuffer, 0, (int)response.ContentLength64);
+                        output.Close();
+                    }
+                }
+            }
+        }
+
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
+        public async Task Write_TooLittleAsynchronouslyAndClose_ThrowsInvalidOperationException()
+        {
+            using (HttpClient client = new HttpClient())
+            {
+                Task<string> clientTask = client.GetStringAsync(_factory.ListeningUrl);
+
+                HttpListenerContext serverContext = await _listener.GetContextAsync();
+                using (HttpListenerResponse response = serverContext.Response)
+                {
+                    Stream output = response.OutputStream;
+
+                    byte[] responseBuffer = Encoding.UTF8.GetBytes("A long string");
+                    response.ContentLength64 = responseBuffer.Length + 1;
+
+                    // Throws when there are bytes left to write
+                    await output.WriteAsync(responseBuffer, 0, responseBuffer.Length);
+                    Assert.Throws<InvalidOperationException>(() => output.Close());
+
+                    // Write the final byte and make sure we can close.
+                    await output.WriteAsync(new byte[1], 0, 1);
+                    output.Close();
+                }
+            }
+        }
+
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
+        public async Task Write_TooLittleSynchronouslyAndClose_ThrowsInvalidOperationException()
+        {
+            using (HttpClient client = new HttpClient())
+            {
+                Task<string> clientTask = client.GetStringAsync(_factory.ListeningUrl);
+
+                HttpListenerContext serverContext = await _listener.GetContextAsync();
+                using (HttpListenerResponse response = serverContext.Response)
+                {
+                    Stream output = response.OutputStream;
+
+                    byte[] responseBuffer = Encoding.UTF8.GetBytes("A long string");
+                    response.ContentLength64 = responseBuffer.Length + 1;
+
+                    // Throws when there are bytes left to write
+                    output.Write(responseBuffer, 0, responseBuffer.Length);
+                    Assert.Throws<InvalidOperationException>(() => output.Close());
+
+                    // Write the final byte and make sure we can close.
+                    output.Write(new byte[1], 0, 1);
+                    output.Close();
+                }
+            }
+        }
+
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
+        [InlineData(true, "Non-Empty")]
+        [InlineData(false, "Non-Empty")]
+        public async Task Write_ToClosedSocketAsynchronously_ThrowsHttpListenerException(bool ignoreWriteExceptions, string text)
+        {
+            if (PlatformDetection.IsWindows7)
+            {
+                // Websockets in WinHttp 5.1 is only supported from Windows 8+
+                Assert.Throws<PlatformNotSupportedException>(() => new ClientWebSocket());
+                return;
+            }
+
+            using (HttpListenerFactory factory = new HttpListenerFactory())
+            {
+                UriBuilder uriBuilder = new UriBuilder(factory.ListeningUrl) { Scheme = "ws" };
+
+                HttpListener listener = factory.GetListener();
+                listener.IgnoreWriteExceptions = ignoreWriteExceptions;
+
+                Task<HttpListenerContext> serverContextTask = listener.GetContextAsync();
+                using (ClientWebSocket clientWebSocket = new ClientWebSocket())
+                {
+                    Task clientConnectTask = clientWebSocket.ConnectAsync(uriBuilder.Uri, CancellationToken.None);
+
+                    HttpListenerContext listenerContext = await serverContextTask;
+                    byte[] receiveBuffer = Encoding.UTF8.GetBytes(text);
+                    listenerContext.Response.ContentLength64 = receiveBuffer.Length;
+
+                    // Disconnect the socket from the listener.
+                    HttpListenerWebSocketContext wsContext = await listenerContext.AcceptWebSocketAsync(null);
+                    await clientConnectTask;
+                    clientWebSocket.Dispose();
+
+                    // TODO: we need to sleep and wait to make sure the socket closes.
+                    Thread.Sleep(1000);
+
+                    // Try writing to the disconnected socket.
+                    if (ignoreWriteExceptions)
+                    {
+                        await listenerContext.Response.OutputStream.WriteAsync(receiveBuffer, 0, receiveBuffer.Length);
+                    }
+                    else
+                    {
+                        await Assert.ThrowsAsync<HttpListenerException>(() => listenerContext.Response.OutputStream.WriteAsync(receiveBuffer, 0, receiveBuffer.Length));
+                    }
+                }
+            }
+        }
+
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
+        [InlineData(true, "Non-Empty")]
+        [InlineData(false, "Non-Empty")]
+        public async void Write_ToClosedSocketSynchronously_ThrowsHttpListenerException(bool ignoreWriteExceptions, string text)
+        {
+            if (PlatformDetection.IsWindows7)
+            {
+                // Websockets in WinHttp 5.1 is only supported from Windows 8+
+                Assert.Throws<PlatformNotSupportedException>(() => new ClientWebSocket());
+                return;
+            }
+
+            using (HttpListenerFactory factory = new HttpListenerFactory())
+            {
+                UriBuilder uriBuilder = new UriBuilder(factory.ListeningUrl) { Scheme = "ws" };
+
+                HttpListener listener = factory.GetListener();
+                listener.IgnoreWriteExceptions = ignoreWriteExceptions;
+
+                Task<HttpListenerContext> serverContextTask = listener.GetContextAsync();
+                using (ClientWebSocket clientWebSocket = new ClientWebSocket())
+                {
+                    Task clientConnectTask = clientWebSocket.ConnectAsync(uriBuilder.Uri, CancellationToken.None);
+
+                    HttpListenerContext listenerContext = await serverContextTask;
+                    byte[] receiveBuffer = Encoding.UTF8.GetBytes(text);
+                    listenerContext.Response.ContentLength64 = receiveBuffer.Length;
+
+                    // Disconnect the socket from the listener.
+                    HttpListenerWebSocketContext wsContext = await listenerContext.AcceptWebSocketAsync(null);
+                    await clientConnectTask;
+                    clientWebSocket.Dispose();
+
+                    // TODO: we need to sleep and wait to make sure the socket closes.
+                    Thread.Sleep(1000);
+
+                    // Try writing to the disconnected socket.
+                    if (ignoreWriteExceptions)
+                    {
+                        listenerContext.Response.OutputStream.Write(receiveBuffer, 0, receiveBuffer.Length);
+                    }
+                    else
+                    {
+                        Assert.Throws<HttpListenerException>(() => listenerContext.Response.OutputStream.Write(receiveBuffer, 0, receiveBuffer.Length));
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public async Task EndWrite_NullCallback_ThrowsArgumentNullException()
+        {
+            using (HttpListenerResponse response = await _helper.GetResponse())
+            using (Stream outputStream = response.OutputStream)
+            {
+                Assert.Throws<ArgumentNullException>("asyncResult", () => outputStream.EndWrite(null));
+            }
+        }
+
+        [Fact]
+        public async Task EndWrite_InvalidCallback_ThrowsArgumentException()
+        {
+            using (HttpListenerResponse response1 = await _helper.GetResponse())
+            using (Stream outputStream1 = response1.OutputStream)
+            using (HttpListenerResponse response2 = await _helper.GetResponse())
+            using (Stream outputStream2 = response2.OutputStream)
+            {
+                IAsyncResult beginWriteResult = outputStream1.BeginWrite(new byte[0], 0, 0, new AsyncCallback(Common.StubCallback), null);
+
+                Assert.Throws<ArgumentException>("asyncResult", () => outputStream2.EndWrite(new CustomAsyncResult()));
+                Assert.Throws<ArgumentException>("asyncResult", () => outputStream2.EndWrite(beginWriteResult));
+            }
+        }
+
+        [Fact]
+        public async Task EndWrite_CalledTwice_ThrowsInvalidOperationException()
+        {
+            using (HttpListenerResponse response1 = await _helper.GetResponse())
+            using (Stream outputStream = response1.OutputStream)
+            {
+                IAsyncResult beginWriteResult = outputStream.BeginWrite(new byte[0], 0, 0, new AsyncCallback(Common.StubCallback), null);
+                outputStream.EndWrite(beginWriteResult);
+
+                Assert.Throws<InvalidOperationException>(() => outputStream.EndWrite(beginWriteResult));
+            }
+        }
+    }
+}
+    

--- a/src/System.Net.HttpListener/tests/System.Net.HttpListener.Tests.csproj
+++ b/src/System.Net.HttpListener/tests/System.Net.HttpListener.Tests.csproj
@@ -11,6 +11,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="AuthenticationTests.cs" />
+    <Compile Include="Common.cs" />
+    <Compile Include="HttpResponseStreamTests.cs" />
     <Compile Include="SimpleHttpTests.cs" />
     <Compile Include="HttpListenerFactory.cs" />
     <Compile Include="WebSocketTests.cs" />

--- a/src/System.Net.HttpListener/tests/System.Net.HttpListener.Tests.csproj
+++ b/src/System.Net.HttpListener/tests/System.Net.HttpListener.Tests.csproj
@@ -11,7 +11,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="AuthenticationTests.cs" />
-    <Compile Include="Common.cs" />
+    <Compile Include="GetContextHelper.cs" />
     <Compile Include="HttpRequestStreamTests.cs" />
     <Compile Include="HttpResponseStreamTests.cs" />
     <Compile Include="SimpleHttpTests.cs" />

--- a/src/System.Net.HttpListener/tests/System.Net.HttpListener.Tests.csproj
+++ b/src/System.Net.HttpListener/tests/System.Net.HttpListener.Tests.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <Compile Include="AuthenticationTests.cs" />
     <Compile Include="Common.cs" />
+    <Compile Include="HttpRequestStreamTests.cs" />
     <Compile Include="HttpResponseStreamTests.cs" />
     <Compile Include="SimpleHttpTests.cs" />
     <Compile Include="HttpListenerFactory.cs" />


### PR DESCRIPTION
This covers `HttpListenerRequestStream` and `HttpListenerResponseStream`.

The tests will fail with NulLReferenceExceptions without Commit 2, which fixes #17980, a bug caused porting HttpListener to corefx.

@Priya91 @davidsh @CIPop