### PR TITLE
Fix race condition in HttpClient on Unix when canceling a request

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.CurlResponseMessage.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.CurlResponseMessage.cs
@@ -393,12 +393,13 @@ namespace System.Net.Http
 
                     // If there's a pending read request, complete it, either with 0 bytes for success
                     // or with the exception/CancellationToken for failure.
-                    if (_pendingReadRequest != null)
+                    ReadState pendingRead = _pendingReadRequest;
+                    if (pendingRead != null)
                     {
                         if (_completed == s_completionSentinel)
                         {
                             EventSourceTrace("Completing pending read with 0 bytes");
-                            _pendingReadRequest.TrySetResult(0);
+                            pendingRead.TrySetResult(0);
                         }
                         else
                         {
@@ -406,11 +407,11 @@ namespace System.Net.Http
                             OperationCanceledException oce = _completed as OperationCanceledException;
                             if (oce != null)
                             {
-                                _pendingReadRequest.TrySetCanceled(oce.CancellationToken);
+                                pendingRead.TrySetCanceled(oce.CancellationToken);
                             }
                             else
                             {
-                                _pendingReadRequest.TrySetException(MapToReadWriteIOException(_completed, isRead: true));
+                                pendingRead.TrySetException(MapToReadWriteIOException(_completed, isRead: true));
                             }
                         }
 

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
@@ -39,6 +39,7 @@ namespace System.Net.Http
             private static readonly bool s_curlDebugLogging = Environment.GetEnvironmentVariable("CURLHANDLER_DEBUG_VERBOSE") == "true";
 
             internal readonly CurlHandler _handler;
+            internal readonly MultiAgent _associatedMultiAgent;
             internal readonly HttpRequestMessage _requestMessage;
             internal readonly CurlResponseMessage _responseMessage;
             internal readonly CancellationToken _cancellationToken;
@@ -49,17 +50,22 @@ namespace System.Net.Http
             internal SafeCurlHandle _easyHandle;
             private SafeCurlSListHandle _requestHeaders;
 
-            internal MultiAgent _associatedMultiAgent;
             internal SendTransferState _sendTransferState;
             internal StrongToWeakReference<EasyRequest> _selfStrongToWeakReference;
 
             private SafeCallbackHandle _callbackHandle;
 
-            public EasyRequest(CurlHandler handler, HttpRequestMessage requestMessage, CancellationToken cancellationToken) :
+            public EasyRequest(CurlHandler handler, MultiAgent agent, HttpRequestMessage requestMessage, CancellationToken cancellationToken) :
                 base(TaskCreationOptions.RunContinuationsAsynchronously)
             {
+                Debug.Assert(handler != null, $"Expected non-null {nameof(handler)}");
+                Debug.Assert(agent != null, $"Expected non-null {nameof(agent)}");
+                Debug.Assert(requestMessage != null, $"Expected non-null {nameof(requestMessage)}");
+
                 _handler = handler;
+                _associatedMultiAgent = agent;
                 _requestMessage = requestMessage;
+
                 _cancellationToken = cancellationToken;
                 _responseMessage = new CurlResponseMessage(this);
             }

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
@@ -622,7 +622,7 @@ namespace System.Net.Http
             private void ActivateNewRequest(EasyRequest easy)
             {
                 Debug.Assert(easy != null, "We should never get a null request");
-                Debug.Assert(easy._associatedMultiAgent == null, "New requests should not be associated with an agent yet");
+                Debug.Assert(easy._associatedMultiAgent == this, "Request should be associated with this agent");
 
                 // If cancellation has been requested, complete the request proactively
                 if (easy._cancellationToken.IsCancellationRequested)
@@ -654,7 +654,6 @@ namespace System.Net.Http
                 {
                     easy.InitializeCurl();
 
-                    easy._associatedMultiAgent = this;
                     easy.SetCurlOption(Interop.Http.CURLoption.CURLOPT_PRIVATE, gcHandlePtr);
                     easy.SetCurlCallbacks(gcHandlePtr, s_receiveHeadersCallback, s_sendCallback, s_seekCallback, s_receiveBodyCallback, s_debugCallback);
 

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -476,10 +476,10 @@ namespace System.Net.Http
 
             // Create the easy request.  This associates the easy request with this handler and configures
             // it based on the settings configured for the handler.
-            var easy = new EasyRequest(this, request, cancellationToken);
+            var easy = new EasyRequest(this, _agent, request, cancellationToken);
             try
             {
-                EventSourceTrace("{0}", request, easy: easy, agent: _agent);
+                EventSourceTrace("{0}", request, easy: easy);
                 _agent.Queue(new MultiAgent.IncomingRequest { Easy = easy, Type = MultiAgent.IncomingRequestType.New });
             }
             catch (Exception exc)
@@ -731,9 +731,9 @@ namespace System.Net.Http
                 agent = easy._associatedMultiAgent;
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Log.HandlerMessage(
+            NetEventSource.Log.HandlerMessage(
                 (agent?.RunningWorkerId).GetValueOrDefault(),
-                easy != null ? easy.Task.Id : 0,
+                easy?.Task.Id ?? 0,
                 memberName,
                 message);
         }


### PR DESCRIPTION
It looks like it's possible in a rare situation for the following to occur and result in a NullReferenceException when finalizing a request:
- HttpClient.SendAsync is called, which creates an EasyRequest.  That EasyRequest isn't yet associated with a MultiAgent.
- The request is queued to the MultiAgent.
- Between the time that the request is queued and it's handled, the associated CancellationToken has cancellation requested.
- When the agent then processes the request, in ActivateNewRequest it'll see that cancellation has been requested and will immediately bail, before associating the easy request with the agent.
- Everything is dropped and eventually finalized.  At that point the response stream's finalizer is invoked, it calls SignalComplete(..., forceCancel:true), and that dereferences _associatedMultiAgent in order to issue a cancellation request... but _associatedMultiAgent hasn't yet been set.

There's no reason _associatedMultiAgent's initialization needs to be deferred until the EasyRequest is picked up by the agent.  We can instead make _associatedMultiAgent a readonly field that's initialized to the associated agent when the EasyRequest is constructed, so it won't be null even in such a situation.

I've not actually been able to repro the reported issue, so this is a speculative fix, but is goodness regardless.  I can't see any other way a null ref could happen in the finalizer as reported. I did also clean up a few accesses in the same method, but there's shouldn't be any way those could have caused a null ref, due to the locking and checking being employed.

Fixes https://github.com/dotnet/corefx/issues/17978 (I hope)
cc: @geoffkizer, @Priya91 