### PR TITLE
Added Back rd.xml for System.Linq.Expressions.csproj

### DIFF
--- a/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
+++ b/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
@@ -24,6 +24,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_DYNAMIC_DELEGATE</DefineConstants>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'uapaot'">
+    <EmbeddedResource Include="Resources\$(AssemblyName).rd.xml" />
     <!-- Needed for DynamicDelegate -->
     <ReferenceFromRuntime Include="System.Private.CoreLib" />
     <!-- Causes us to use project references to avoid duplicate definitions that the ref assemblies would give us -->

--- a/src/System.Private.Xml.Linq/src/Resources/System.Private.Xml.Linq.rd.xml
+++ b/src/System.Private.Xml.Linq/src/Resources/System.Private.Xml.Linq.rd.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
   <Library Name="System.Xml.Linq">
-    <Assembly Name="System.Private.Xml.Linq">
+    <Assembly Name="System.Xml.Linq">
       <Namespace Name="System.Xml.Linq">
         <Type Name="XElement">
           <!-- The default constructor of XElement is required for it to be serializable by XmlSerializer. -->


### PR DESCRIPTION
PR https://github.com/dotnet/corefx/pull/17909 removed the rd.xml from System.Linq.Expressions.csproj to fix https://github.com/dotnet/corefx/issues/17557. The fix was incorrect. The PR is to revert the changes for Linq.

I reopened https://github.com/dotnet/corefx/issues/17557.