### PR TITLE
Disable illink on alpine

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -41,6 +41,9 @@
     <GeneratedProjectJsonDir>$(ObjDir)generated</GeneratedProjectJsonDir>
 
     <CodeAnalysisRuleset>$(MSBuildThisFileDirectory)CodeAnalysis.ruleset</CodeAnalysisRuleset>
+
+    <!-- illink fails to run on Alpine CLI : https://github.com/dotnet/corefx/issues/18029 -->
+    <ILLinkTrimAssembly Condition="$(RuntimeOS.StartsWith('alpine'))">false</ILLinkTrimAssembly>
   </PropertyGroup>
 
   <!-- Temporarily enable local build of tools -->


### PR DESCRIPTION
The Alpine CLI was hacked together with the wrong bits for the shared
framework.  It used 1.0 assemblies and put them in the 1.1 folder.

As a result this 1.1 targeting app fails to bind when it hits an
assembly (System.Xml.ReaderWriter) that was different.

Workaround it temporarily by turning off illink for alpine.

/cc @weshaggard @mellinoe 