### PR TITLE
Fix portable System.Security.Cryptography.Native EC2M issue

### DIFF
--- a/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -36,12 +36,26 @@
 
 #ifdef FEATURE_DISTRO_AGNOSTIC_SSL
 
+#if !HAVE_OPENSSL_EC2M
+// In portable build, we need to support the following functions even if they were not present
+// on the build OS. The shim will detect their presence at runtime.
+#undef HAVE_OPENSSL_EC2M
+#define HAVE_OPENSSL_EC2M 1
+const EC_METHOD *EC_GF2m_simple_method(void);
+int EC_GROUP_get_curve_GF2m(const EC_GROUP *group, BIGNUM *p, BIGNUM *a, BIGNUM *b, BN_CTX *ctx);
+int EC_GROUP_set_curve_GF2m(EC_GROUP *group, const BIGNUM *p, const BIGNUM *a, const BIGNUM *b, BN_CTX *ctx);
+int EC_POINT_get_affine_coordinates_GF2m(const EC_GROUP *group,
+        const EC_POINT *p, BIGNUM *x, BIGNUM *y, BN_CTX *ctx);
+int EC_POINT_set_affine_coordinates_GF2m(const EC_GROUP *group, EC_POINT *p,
+        const BIGNUM *x, const BIGNUM *y, BN_CTX *ctx);
+#endif
+
 #define API_EXISTS(fn) (fn != nullptr)
 
 // List of all functions from the libssl that are used in the System.Security.Cryptography.Native.
 // Forgetting to add a function here results in build failure with message reporting the function
 // that needs to be added.
-#define FOR_ALL_UNCONDITIONAL_OPENSSL_FUNCTIONS \
+#define FOR_ALL_OPENSSL_FUNCTIONS \
     PER_FUNCTION_BLOCK(ASN1_BIT_STRING_free, true) \
     PER_FUNCTION_BLOCK(ASN1_INTEGER_get, true) \
     PER_FUNCTION_BLOCK(ASN1_OBJECT_free, true) \
@@ -315,22 +329,12 @@
     PER_FUNCTION_BLOCK(X509_verify_cert, true) \
     PER_FUNCTION_BLOCK(X509_verify_cert_error_string, true) \
     PER_FUNCTION_BLOCK(X509_VERIFY_PARAM_set_time, true) \
-
-#if HAVE_OPENSSL_EC2M
-#define FOR_ALL_OPENSSL_FUNCTIONS \
-    FOR_ALL_UNCONDITIONAL_OPENSSL_FUNCTIONS \
     PER_FUNCTION_BLOCK(EC_GF2m_simple_method, false) \
     PER_FUNCTION_BLOCK(EC_GROUP_get_curve_GF2m, false) \
     PER_FUNCTION_BLOCK(EC_GROUP_set_curve_GF2m, false) \
     PER_FUNCTION_BLOCK(EC_POINT_get_affine_coordinates_GF2m, false) \
     PER_FUNCTION_BLOCK(EC_POINT_set_affine_coordinates_GF2m, false) \
     
-#else // HAVE_OPENSSL_EC2M
-#define FOR_ALL_OPENSSL_FUNCTIONS \
-    FOR_ALL_UNCONDITIONAL_OPENSSL_FUNCTIONS
-
-#endif // HAVE_OPENSSL_EC2M
-
 // Declare pointers to all the used OpenSSL functions
 #define PER_FUNCTION_BLOCK(fn, isRequired) extern decltype(fn)* fn##_ptr;
 FOR_ALL_OPENSSL_FUNCTIONS
@@ -611,14 +615,11 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define X509_verify_cert X509_verify_cert_ptr
 #define X509_verify_cert_error_string X509_verify_cert_error_string_ptr
 #define X509_VERIFY_PARAM_set_time X509_VERIFY_PARAM_set_time_ptr
-
-#if HAVE_OPENSSL_EC2M
 #define EC_GF2m_simple_method EC_GF2m_simple_method_ptr
 #define EC_GROUP_get_curve_GF2m EC_GROUP_get_curve_GF2m_ptr
 #define EC_GROUP_set_curve_GF2m EC_GROUP_set_curve_GF2m_ptr
 #define EC_POINT_get_affine_coordinates_GF2m EC_POINT_get_affine_coordinates_GF2m_ptr
 #define EC_POINT_set_affine_coordinates_GF2m EC_POINT_set_affine_coordinates_GF2m_ptr
-#endif // HAVE_OPENSSL_EC2M
 
 #else // FEATURE_DISTRO_AGNOSTIC_SSL
 


### PR DESCRIPTION
We are building the portable dotnet core on the oldest Linux distro we
support, which is currently RHEL7.2. But the OpenSSL on that distro
doesn't support the EC2M functions and so it effectively disables them
for the portable dotnet core on all Linux distros.
This change fixes it by adding copies of declarations of the five
missing functions to opensslshim.h if they are not found at the compile
time. That enables the shim to be able to use those functions on all
distros that support them.