### PR TITLE
Disable part of test when in appcontainer

### DIFF
--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs
@@ -497,8 +497,11 @@ namespace System.IO.Tests
             watcher.Path = ".";
             Assert.Equal(".", watcher.Path);
 
-            watcher.Path = "..";
-            Assert.Equal("..", watcher.Path);
+            if (!PlatformDetection.IsWinRT)
+            {
+                watcher.Path = "..";
+                Assert.Equal("..", watcher.Path);
+            }
 
             string currentDir = Path.GetFullPath(".").TrimEnd('.', Path.DirectorySeparatorChar);
             watcher.Path = currentDir;


### PR DESCRIPTION
In appcontainer, ".." cannot be accessed.

Fixes https://github.com/dotnet/corefx/issues/17985