### PR TITLE
Disable HttpRequest.MaxResponseHeadersLength PNSE for UWP.

### DIFF
--- a/src/System.Net.Http/src/netcore50/System/Net/HttpClientHandler.cs
+++ b/src/System.Net.Http/src/netcore50/System/Net/HttpClientHandler.cs
@@ -285,7 +285,7 @@ namespace System.Net.Http
             set
             {
                 /*
-                 * https://github.com/dotnet/corefx/issues/17812
+                 * TODO:#17812
                 if (value != MaxAutomaticRedirections)
                 {
                     throw new PlatformNotSupportedException(String.Format(CultureInfo.InvariantCulture,
@@ -331,8 +331,11 @@ namespace System.Net.Http
 
             set
             {
+                /*
+                 * TODO:#18036
                 throw new PlatformNotSupportedException(String.Format(CultureInfo.InvariantCulture,
                     SR.net_http_value_not_supported, value, nameof(MaxResponseHeadersLength)));
+                */
             }
         }
 


### PR DESCRIPTION
This is necessary for app-compat , apps fails
because of PNSE exception.This is a workaround
till we get the correct fix, see #18036.
@davidsh @CIPop @vitek-karas 