### PR TITLE
Remove SingleRankNonSZArrayIndexed test.

### DIFF
--- a/src/Microsoft.CSharp/tests/ArrayHandling.cs
+++ b/src/Microsoft.CSharp/tests/ArrayHandling.cs
@@ -22,16 +22,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Fact]
-        public void SingleRankNonSZArrayIndexed()
-        {
-            dynamic d = Array.CreateInstance(typeof(int), new[] { 8 }, new[] { -2 });
-            d[3] = 32;
-            d[-1] = 28;
-            Assert.Equal(32, d[3]);
-            Assert.Equal(28, d[-1]);
-        }
-
-        [Fact]
         public void ArrayTypeNames()
         {
             dynamic d = Array.CreateInstance(typeof(int), new[] { 8 }, new[] { -2 });


### PR DESCRIPTION
Fails on netfx and experimentation suggests it should be considered incorrect behaviour and fail on core too.

cc: @safern 

(I described the case the test covers as "interesting" at https://github.com/dotnet/corefx/pull/17810#discussion_r109409208 and comparing with comparable cases with greater ranks suggests I should have blocked the case from being allowed, so I'll experiment further to be sure and fix as that experimentation suggests is appropriate).