### PR TITLE
Adding DAC support to Managed SNI

### DIFF
--- a/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
+++ b/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
@@ -142,6 +142,7 @@
     <Compile Include="System\Data\SqlClient\SNI\SslOverTdsStream.cs" />
     <Compile Include="System\Data\SqlClient\SNI\SNICommon.cs" />
     <Compile Include="System\Data\SqlClient\SNI\SspiClientContextStatus.cs" />
+    <Compile Include="System\Data\SqlClient\SNI\SSRP.cs" />
     <Compile Include="System\Data\SqlClient\TdsParserStateObjectManaged.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true' And '$(IsPartialFacadeAssembly)' != 'true' ">

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
@@ -299,18 +299,13 @@ namespace System.Data.SqlClient.SNI
             SNIHandle sniHandle = null;
             switch (details.ConnectionProtocol)
             {
+                case DataSource.Protocol.Admin:
+                case DataSource.Protocol.None: // default to using tcp if no protocol is provided
                 case DataSource.Protocol.TCP:
                     sniHandle = CreateTcpHandle(details, timerExpire, callbackObject, parallel);
                     break;
                 case DataSource.Protocol.NP:
                     sniHandle = CreateNpHandle(details, timerExpire, callbackObject, parallel);
-                    break;
-                case DataSource.Protocol.Admin:
-                    sniHandle = CreateTcpHandle(details, timerExpire, callbackObject, parallel);
-                    break;
-                case DataSource.Protocol.None:
-                    // default to using tcp if no protocol is provided
-                    sniHandle = CreateTcpHandle(details, timerExpire, callbackObject, parallel);
                     break;
                 default:
                     Debug.Fail($"Unexpected connection protocol: {details.ConnectionProtocol}");

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
@@ -18,9 +18,8 @@ namespace System.Data.SqlClient.SNI
     /// </summary>
     internal class SNIProxy
     {
-        private const char SemicolonSeparator = ';';
-        private const int SqlServerBrowserPort = 1434;
         private const int DefaultSqlServerPort = 1433;
+        private const int DefaultSqlServerDacPort = 1434;
         private const string SqlServerSpnHeader = "MSSQLSvc";
 
         internal class SspiClientContextResult
@@ -306,6 +305,9 @@ namespace System.Data.SqlClient.SNI
                 case DataSource.Protocol.NP:
                     sniHandle = CreateNpHandle(details, timerExpire, callbackObject, parallel);
                     break;
+                case DataSource.Protocol.Admin:
+                    sniHandle = CreateTcpHandle(details, timerExpire, callbackObject, parallel);
+                    break;
                 case DataSource.Protocol.None:
                     // default to using tcp if no protocol is provided
                     sniHandle = CreateTcpHandle(details, timerExpire, callbackObject, parallel);
@@ -388,127 +390,53 @@ namespace System.Data.SqlClient.SNI
             }
 
             int port = -1;
-            if (details.IsSsrpRequired)
+            if (details.ConnectionProtocol == DataSource.Protocol.Admin)
             {
-                try
+                if (details.IsSsrpRequired)
                 {
-                    port = GetPortByInstanceName(hostName, details.InstanceName);
+                    try
+                    {
+                        port = SSRP.GetDacPortByInstanceName(hostName, details.InstanceName);
+                    }
+                    catch (SocketException se)
+                    {
+                        SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.TCP_PROV, SNICommon.InvalidConnStringError, se);
+                        return null;
+                    }
                 }
-                catch (SocketException se)
+                else
                 {
-                    SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.TCP_PROV, SNICommon.InvalidConnStringError, se);
-                    return null;
+                    port = DefaultSqlServerDacPort;
                 }
-            }
-            else if (details.Port != -1)
-            {
-                port = details.Port;
             }
             else
             {
-                port = DefaultSqlServerPort;
+                if (details.IsSsrpRequired)
+                {
+                    try
+                    {
+                        port = SSRP.GetPortByInstanceName(hostName, details.InstanceName);
+                    }
+                    catch (SocketException se)
+                    {
+                        SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.TCP_PROV, SNICommon.InvalidConnStringError, se);
+                        return null;
+                    }
+                }
+                else if (details.Port != -1)
+                {
+                    port = details.Port;
+                }
+                else
+                {
+                    port = DefaultSqlServerPort;
+                }
             }
 
             return new SNITCPHandle(hostName, port, timerExpire, callbackObject, parallel);
         }
 
-        /// <summary>
-        /// Sends CLNT_UCAST_INST request for given instance name to SQL Sever Browser, and receive SVR_RESP from the Browser.
-        /// </summary>
-        /// <param name="browserHostName">SQL Sever Browser hostname</param>
-        /// <param name="instanceName">instance name for CLNT_UCAST_INST request</param>
-        /// <returns>SVR_RESP packets from SQL Sever Browser</returns>
-        private static byte[] SendInstanceInfoRequest(string browserHostName, string instanceName)
-        {
-            Debug.Assert(!string.IsNullOrWhiteSpace(browserHostName));
-            Debug.Assert(!string.IsNullOrWhiteSpace(instanceName));
-
-            byte[] instanceInfoRequest = CreateInstanceInfoRequest(instanceName);
-            byte[] responsePacket = SendUDPRequest(browserHostName, SqlServerBrowserPort, instanceInfoRequest);
-
-            const byte SvrResp = 0x05;
-            if (responsePacket == null || responsePacket.Length <= 3 || responsePacket[0] != SvrResp ||
-                BitConverter.ToUInt16(responsePacket, 1) != responsePacket.Length - 3)
-            {
-                throw new SocketException();
-            }
-
-            return responsePacket;
-        }
-
-        /// <summary>
-        /// Finds port number for given instance name.
-        /// </summary>
-        /// <param name="browserHostname">SQL Sever Browser hostname</param>
-        /// <param name="instanceName">instance name to find port number</param>
-        /// <returns>port number for given instance name</returns>
-        private static int GetPortByInstanceName(string browserHostname, string instanceName)
-        {
-            Debug.Assert(!string.IsNullOrWhiteSpace(browserHostname));
-            Debug.Assert(!string.IsNullOrWhiteSpace(instanceName));
-
-            byte[] responsePacket = SendInstanceInfoRequest(browserHostname, instanceName);
-
-            string serverMessage = Encoding.ASCII.GetString(responsePacket, 3, responsePacket.Length - 3);
-            string[] elements = serverMessage.Split(SemicolonSeparator);
-            int tcpIndex = Array.IndexOf(elements, "tcp");
-            if (tcpIndex < 0 || tcpIndex == elements.Length - 1)
-            {
-                throw new SocketException();
-            }
-
-            return ushort.Parse(elements[tcpIndex + 1]);
-        }
-
-        /// <summary>
-        /// Creates UDP request of CLNT_UCAST_INST payload in SSRP to get information about SQL Server instance
-        /// </summary>
-        /// <param name="instanceName">SQL Server instance name</param>
-        /// <returns>CLNT_UCAST_INST request packet</returns>
-        private static byte[] CreateInstanceInfoRequest(string instanceName)
-        {
-            Debug.Assert(!string.IsNullOrWhiteSpace(instanceName));
-
-            const byte ClntUcastInst = 0x04;
-            int byteCount = Encoding.ASCII.GetByteCount(instanceName);
-            byte[] requestPacket = new byte[byteCount + 1];
-            requestPacket[0] = ClntUcastInst;
-            Encoding.ASCII.GetBytes(instanceName, 0, instanceName.Length, requestPacket, 1);
-            return requestPacket;
-        }
-
-        /// <summary>
-        /// Sends UDP request to server, and receive response.
-        /// </summary>
-        /// <param name="browserHostname">UDP server hostname</param>
-        /// <param name="port">UDP server port</param>
-        /// <param name="requestPacket">request packet</param>
-        /// <returns>response packet from UDP server</returns>
-        private static byte[] SendUDPRequest(string browserHostname, int port, byte[] requestPacket)
-        {
-            Debug.Assert(!string.IsNullOrWhiteSpace(browserHostname));
-            Debug.Assert(port >= 0 || port <= 65535);
-            Debug.Assert(requestPacket != null && requestPacket.Length > 0);
-
-            const int sendTimeOut = 1000;
-            const int receiveTimeOut = 1000;
-
-            IPAddress address = null;
-            IPAddress.TryParse(browserHostname, out address);
-
-            byte[] responsePacket = null;
-            using (UdpClient client = new UdpClient(address == null ? AddressFamily.InterNetwork : address.AddressFamily))
-            {
-                Task<int> sendTask = client.SendAsync(requestPacket, requestPacket.Length, browserHostname, port);
-                Task<UdpReceiveResult> receiveTask = null;
-                if (sendTask.Wait(sendTimeOut) && (receiveTask = client.ReceiveAsync()).Wait(receiveTimeOut))
-                {
-                    responsePacket = receiveTask.Result.Buffer;
-                }
-            }
-
-            return responsePacket;
-        }
+       
 
         /// <summary>
         /// Creates an SNINpHandle object

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SSRP.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SSRP.cs
@@ -1,0 +1,149 @@
+﻿using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System.Data.SqlClient.SNI
+{
+    internal class SSRP
+    {
+        private const char SemicolonSeparator = ';';
+        private const int SqlServerBrowserPort = 1434;
+
+        /// <summary>
+        /// Finds instance port number for given instance name.
+        /// </summary>
+        /// <param name="browserHostname">SQL Sever Browser hostname</param>
+        /// <param name="instanceName">instance name to find port number</param>
+        /// <returns>port number for given instance name</returns>
+        internal static int GetPortByInstanceName(string browserHostName, string instanceName)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(browserHostName));
+            Debug.Assert(!string.IsNullOrWhiteSpace(instanceName));
+
+            byte[] instanceInfoRequest = CreateInstanceInfoRequest(instanceName);
+            byte[] responsePacket = SendUDPRequest(browserHostName, SqlServerBrowserPort, instanceInfoRequest);
+
+            const byte SvrResp = 0x05;
+            if (responsePacket == null || responsePacket.Length <= 3 || responsePacket[0] != SvrResp ||
+                BitConverter.ToUInt16(responsePacket, 1) != responsePacket.Length - 3)
+            {
+                throw new SocketException();
+            }
+
+            string serverMessage = Encoding.ASCII.GetString(responsePacket, 3, responsePacket.Length - 3);
+
+            string[] elements = serverMessage.Split(SemicolonSeparator);
+            int tcpIndex = Array.IndexOf(elements, "tcp");
+            if (tcpIndex < 0 || tcpIndex == elements.Length - 1)
+            {
+                throw new SocketException();
+            }
+
+            return ushort.Parse(elements[tcpIndex + 1]);
+        }
+
+        /// <summary>
+        /// Creates instance port lookup request (CLNT_UCAST_INST) for given instance name.
+        /// </summary>
+        /// <param name="instanceName">instance name to lookup port</param>
+        /// <returns>Byte array of instance port lookup request (CLNT_UCAST_INST)</returns>
+        private static byte[] CreateInstanceInfoRequest(string instanceName)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(instanceName));
+
+            const byte ClntUcastInst = 0x04;
+            int byteCount = Encoding.ASCII.GetByteCount(instanceName);
+
+            byte[] requestPacket = new byte[byteCount + 1];
+            requestPacket[0] = ClntUcastInst;
+            Encoding.ASCII.GetBytes(instanceName, 0, instanceName.Length, requestPacket, 1);
+
+            return requestPacket;
+        }
+
+        /// <summary>
+        /// Finds DAC port for given instance name.
+        /// </summary>
+        /// <param name="browserHostName">SQL Sever Browser hostname</param>
+        /// <param name="instanceName">instance name to lookup DAC port</param>
+        /// <returns>DAC port for given instance name</returns>
+        internal static int GetDacPortByInstanceName(string browserHostName, string instanceName)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(browserHostName));
+            Debug.Assert(!string.IsNullOrWhiteSpace(instanceName));
+
+            byte[] dacPortInfoRequest = CreateDacPortInfoRequest(instanceName);
+            byte[] responsePacket = SendUDPRequest(browserHostName, SqlServerBrowserPort, dacPortInfoRequest);
+
+            Console.WriteLine("responsePacket: " + BitConverter.ToString(responsePacket));
+
+            const byte SvrResp = 0x05;
+            const byte ProtocolVersion = 0x01;
+            const byte RespSize = 0x06;
+            if (responsePacket == null || responsePacket.Length <= 4 || responsePacket[0] != SvrResp ||
+                BitConverter.ToUInt16(responsePacket, 1) != RespSize || responsePacket[3] != ProtocolVersion)
+            {
+                throw new SocketException();
+            }
+
+            int dacPort = BitConverter.ToUInt16(responsePacket, 4);
+            return dacPort;
+        }
+
+        /// <summary>
+        /// Creates DAC port lookup request (CLNT_UCAST_DAC) for given instance name.
+        /// </summary>
+        /// <param name="instanceName">instance name to lookup DAC port</param>
+        /// <returns>Byte array of DAC port lookup request (CLNT_UCAST_DAC)</returns>
+        private static byte[] CreateDacPortInfoRequest(string instanceName)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(instanceName));
+
+            const byte ClntUcastDac = 0x0F;
+            const byte ProtocolVersion = 0x01;
+            int byteCount = Encoding.ASCII.GetByteCount(instanceName);
+
+            byte[] requestPacket = new byte[byteCount + 2];
+            requestPacket[0] = ClntUcastDac;
+            requestPacket[1] = ProtocolVersion;
+            Encoding.ASCII.GetBytes(instanceName, 0, instanceName.Length, requestPacket, 2);
+
+            return requestPacket;
+        }
+
+        /// <summary>
+        /// Sends request to server, and receives response from server by UDP.
+        /// </summary>
+        /// <param name="browserHostname">UDP server hostname</param>
+        /// <param name="port">UDP server port</param>
+        /// <param name="requestPacket">request packet</param>
+        /// <returns>response packet from UDP server</returns>
+        private static byte[] SendUDPRequest(string browserHostname, int port, byte[] requestPacket)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(browserHostname));
+            Debug.Assert(port >= 0 || port <= 65535);
+            Debug.Assert(requestPacket != null && requestPacket.Length > 0);
+
+            const int sendTimeOut = 1000;
+            const int receiveTimeOut = 1000;
+
+            IPAddress address = null;
+            IPAddress.TryParse(browserHostname, out address);
+
+            byte[] responsePacket = null;
+            using (UdpClient client = new UdpClient(address == null ? AddressFamily.InterNetwork : address.AddressFamily))
+            {
+                Task<int> sendTask = client.SendAsync(requestPacket, requestPacket.Length, browserHostname, port);
+                Task<UdpReceiveResult> receiveTask = null;
+                if (sendTask.Wait(sendTimeOut) && (receiveTask = client.ReceiveAsync()).Wait(receiveTimeOut))
+                {
+                    responsePacket = receiveTask.Result.Buffer;
+                }
+            }
+
+            return responsePacket;
+        }
+    }
+}

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SSRP.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SSRP.cs
@@ -125,7 +125,7 @@ namespace System.Data.SqlClient.SNI
         private static byte[] SendUDPRequest(string browserHostname, int port, byte[] requestPacket)
         {
             Debug.Assert(!string.IsNullOrWhiteSpace(browserHostname), "browserhostname should not be null, empty, or whitespace");
-            Debug.Assert(port >= 0 || port <= 65535, "Invalide port range");
+            Debug.Assert(port >= 0 && port <= 65535, "Invalide port range");
             Debug.Assert(requestPacket != null && requestPacket.Length > 0, "requestPacket should not be null or 0-length array");
 
             const int sendTimeOut = 1000;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SSRP.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SSRP.cs
@@ -59,7 +59,7 @@ namespace System.Data.SqlClient.SNI
             Debug.Assert(!string.IsNullOrWhiteSpace(instanceName), "instanceName should not be null, empty, or whitespace");
 
             const byte ClntUcastInst = 0x04;
-            instanceName = GetNullTerminatedString(instanceName);
+            instanceName = instanceName + Char.MinValue;
             int byteCount = Encoding.ASCII.GetByteCount(instanceName);
 
             byte[] requestPacket = new byte[byteCount + 1];
@@ -107,7 +107,7 @@ namespace System.Data.SqlClient.SNI
 
             const byte ClntUcastDac = 0x0F;
             const byte ProtocolVersion = 0x01;
-            instanceName = GetNullTerminatedString(instanceName);
+            instanceName = instanceName + Char.MinValue;
             int byteCount = Encoding.ASCII.GetByteCount(instanceName);
 
             byte[] requestPacket = new byte[byteCount + 2];
@@ -116,37 +116,6 @@ namespace System.Data.SqlClient.SNI
             Encoding.ASCII.GetBytes(instanceName, 0, instanceName.Length, requestPacket, 2);
 
             return requestPacket;
-        }
-
-        /// <summary>
-        /// Returns null-terminated string for given string.
-        /// </summary>
-        /// <param name="str">string to be null-terminated</param>
-        /// <returns>null-terminated string for given string</returns>
-        private static string GetNullTerminatedString(string str)
-        {
-            Debug.Assert(str != null, "str should not be null");
-
-            string result = null;
-            int nullCharIndex = str.IndexOf(NullChar);
-
-            // str does not have '\0'
-            if (nullCharIndex < 0)
-            {
-                result = str + NullChar;
-            }
-            // '\0' exists in the middle of str
-            else if (nullCharIndex < str.Length - 1) 
-            {
-                result = str.Substring(0, nullCharIndex + 1);
-            }
-            // str already has one '\0' at the end
-            else
-            {
-                result = str;
-            }
-
-            return str;
         }
 
         /// <summary>

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SSRP.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SSRP.cs
@@ -13,7 +13,6 @@ namespace System.Data.SqlClient.SNI
     internal class SSRP
     {
         private const char SemicolonSeparator = ';';
-        private const char NullChar = '\0';
         private const int SqlServerBrowserPort = 1434;
 
         /// <summary>
@@ -59,7 +58,7 @@ namespace System.Data.SqlClient.SNI
             Debug.Assert(!string.IsNullOrWhiteSpace(instanceName), "instanceName should not be null, empty, or whitespace");
 
             const byte ClntUcastInst = 0x04;
-            instanceName = instanceName + Char.MinValue;
+            instanceName += Char.MinValue;
             int byteCount = Encoding.ASCII.GetByteCount(instanceName);
 
             byte[] requestPacket = new byte[byteCount + 1];
@@ -107,7 +106,7 @@ namespace System.Data.SqlClient.SNI
 
             const byte ClntUcastDac = 0x0F;
             const byte ProtocolVersion = 0x01;
-            instanceName = instanceName + Char.MinValue;
+            instanceName += Char.MinValue;
             int byteCount = Encoding.ASCII.GetByteCount(instanceName);
 
             byte[] requestPacket = new byte[byteCount + 2];

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SSRP.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SSRP.cs
@@ -1,4 +1,8 @@
-﻿using System.Diagnostics;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
@@ -19,8 +23,8 @@ namespace System.Data.SqlClient.SNI
         /// <returns>port number for given instance name</returns>
         internal static int GetPortByInstanceName(string browserHostName, string instanceName)
         {
-            Debug.Assert(!string.IsNullOrWhiteSpace(browserHostName));
-            Debug.Assert(!string.IsNullOrWhiteSpace(instanceName));
+            Debug.Assert(!string.IsNullOrWhiteSpace(browserHostName), "browserHostName should not be null, empty, or whitespace");
+            Debug.Assert(!string.IsNullOrWhiteSpace(instanceName), "instanceName should not be null, empty, or whitespace");
 
             byte[] instanceInfoRequest = CreateInstanceInfoRequest(instanceName);
             byte[] responsePacket = SendUDPRequest(browserHostName, SqlServerBrowserPort, instanceInfoRequest);
@@ -51,7 +55,7 @@ namespace System.Data.SqlClient.SNI
         /// <returns>Byte array of instance port lookup request (CLNT_UCAST_INST)</returns>
         private static byte[] CreateInstanceInfoRequest(string instanceName)
         {
-            Debug.Assert(!string.IsNullOrWhiteSpace(instanceName));
+            Debug.Assert(!string.IsNullOrWhiteSpace(instanceName), "instanceName should not be null, empty, or whitespace");
 
             const byte ClntUcastInst = 0x04;
             int byteCount = Encoding.ASCII.GetByteCount(instanceName);
@@ -71,13 +75,11 @@ namespace System.Data.SqlClient.SNI
         /// <returns>DAC port for given instance name</returns>
         internal static int GetDacPortByInstanceName(string browserHostName, string instanceName)
         {
-            Debug.Assert(!string.IsNullOrWhiteSpace(browserHostName));
-            Debug.Assert(!string.IsNullOrWhiteSpace(instanceName));
+            Debug.Assert(!string.IsNullOrWhiteSpace(browserHostName), "browserHostName should not be null, empty, or whitespace");
+            Debug.Assert(!string.IsNullOrWhiteSpace(instanceName), "instanceName should not be null, empty, or whitespace");
 
             byte[] dacPortInfoRequest = CreateDacPortInfoRequest(instanceName);
             byte[] responsePacket = SendUDPRequest(browserHostName, SqlServerBrowserPort, dacPortInfoRequest);
-
-            Console.WriteLine("responsePacket: " + BitConverter.ToString(responsePacket));
 
             const byte SvrResp = 0x05;
             const byte ProtocolVersion = 0x01;
@@ -99,7 +101,7 @@ namespace System.Data.SqlClient.SNI
         /// <returns>Byte array of DAC port lookup request (CLNT_UCAST_DAC)</returns>
         private static byte[] CreateDacPortInfoRequest(string instanceName)
         {
-            Debug.Assert(!string.IsNullOrWhiteSpace(instanceName));
+            Debug.Assert(!string.IsNullOrWhiteSpace(instanceName), "instanceName should not be null, empty, or whitespace");
 
             const byte ClntUcastDac = 0x0F;
             const byte ProtocolVersion = 0x01;
@@ -122,9 +124,9 @@ namespace System.Data.SqlClient.SNI
         /// <returns>response packet from UDP server</returns>
         private static byte[] SendUDPRequest(string browserHostname, int port, byte[] requestPacket)
         {
-            Debug.Assert(!string.IsNullOrWhiteSpace(browserHostname));
-            Debug.Assert(port >= 0 || port <= 65535);
-            Debug.Assert(requestPacket != null && requestPacket.Length > 0);
+            Debug.Assert(!string.IsNullOrWhiteSpace(browserHostname), "browserhostname should not be null, empty, or whitespace");
+            Debug.Assert(port >= 0 || port <= 65535, "Invalide port range");
+            Debug.Assert(requestPacket != null && requestPacket.Length > 0, "requestPacket should not be null or 0-length array");
 
             const int sendTimeOut = 1000;
             const int receiveTimeOut = 1000;


### PR DESCRIPTION
I added DAC support to Managed SNI. Now user can connect to SQL Server as Dedicated Administrator Connection by adding `admin:` at the beginning of connection string. Integrated Authentication also works in DAC support.