### PR TITLE
Prohibit indexing of single-ranked non-SZ arrays in dynamic variables.

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft.CSharp.csproj
+++ b/src/Microsoft.CSharp/src/Microsoft.CSharp.csproj
@@ -206,6 +206,7 @@
     <Compile Include="Microsoft\CSharp\RuntimeBinder\Syntax\PredefinedType.cs" />
     <Compile Include="Microsoft\CSharp\RuntimeBinder\Syntax\TokenFacts.cs" />
     <Compile Include="Microsoft\CSharp\RuntimeBinder\Syntax\TokenKind.cs" />
+    <Compile Include="Microsoft\CSharp\RuntimeBinder\TypeExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\$(AssemblyName).rd.xml" />

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -1411,8 +1411,11 @@ namespace Microsoft.CSharp.RuntimeBinder
                 if (optionalIndexerArguments != null)
                 {
                     int numIndexArguments = ExpressionIterator.Count(optionalIndexerArguments);
-                    // We could have an array access here. See if its just an array.
-                    if ((argument.Type.IsArray && argument.Type.GetArrayRank() == numIndexArguments) ||
+                    // We could have an array access here. See if it's just an array.
+                    // Don't count single-ranked non-SZ arrays as that type cannot be handled directly in C#
+                    // so the closest C# equivalent is to try to using indexing on a value of type System.Array
+                    // which should fail.
+                    if ((argument.Type.IsArray && argument.Type.GetArrayRank() == numIndexArguments && (numIndexArguments > 1 || argument.Type.IsSZArray())) ||
                         argument.Type == typeof(string))
                     {
                         return CreateArray(callingObject, optionalIndexerArguments);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
@@ -822,11 +822,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                 ctype = _typeManager.GetArray(
                     GetCTypeFromType(t.GetElementType()), 
                     t.GetArrayRank(),
-#if netcoreapp
-                    t.IsSZArray
-#else
-                    t.GetElementType().MakeArrayType() == t
-#endif
+                    t.IsSZArray()
                     );
                 return ctype;
             }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/TypeExtensions.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/TypeExtensions.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Microsoft.CSharp.RuntimeBinder.Semantics;
+using Microsoft.CSharp.RuntimeBinder.Syntax;
+
+namespace Microsoft.CSharp.RuntimeBinder
+{
+    internal static class TypeExtensions
+    {
+        public static bool IsSZArray(this Type type)
+        {
+            // Add return type.IsSZArray if appropriate configurations are added.
+            // Replace entirely with type.IsSZArray if ever all supported configurations
+            // support it.
+            Debug.Assert(type.IsArray);
+            // Avoid creating array type to test if rank is not 1
+            return type.GetArrayRank() == 1 && type.GetElementType().MakeArrayType() == type;
+        }
+    }
+}

--- a/src/Microsoft.CSharp/tests/ArrayHandling.cs
+++ b/src/Microsoft.CSharp/tests/ArrayHandling.cs
@@ -54,5 +54,36 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
             Assert.Contains("int[,,]", ex.Message);
 
         }
+
+        [Fact]
+        public void IncorrectNumberOfIndices()
+        {
+            dynamic d = new int[2, 2, 2];
+            RuntimeBinderException ex = Assert.Throws<RuntimeBinderException>(() => d[1] = 0);
+            Assert.Contains("[]", ex.Message);
+            Assert.Contains("'3'", ex.Message);
+
+            ex = Assert.Throws<RuntimeBinderException>(() => d[1, 2, 3, 4] = 0);
+            Assert.Contains("[]", ex.Message);
+            Assert.Contains("'3'", ex.Message);
+
+            ex = Assert.Throws<RuntimeBinderException>(() => d[1]);
+            Assert.Contains("[]", ex.Message);
+            Assert.Contains("'3'", ex.Message);
+
+            ex = Assert.Throws<RuntimeBinderException>(() => d[1, 2, 3, 4]);
+            Assert.Contains("[]", ex.Message);
+            Assert.Contains("'3'", ex.Message);
+
+            d = new int[2];
+            ex = Assert.Throws<RuntimeBinderException>(() => d[1, 2, 3, 4] = 0);
+            Assert.Contains("[]", ex.Message);
+            Assert.Contains("'1'", ex.Message);
+
+            ex = Assert.Throws<RuntimeBinderException>(() => d[1, 2, 3, 4]);
+            Assert.Contains("[]", ex.Message);
+            Assert.Contains("'1'", ex.Message);
+
+        }
     }
 }

--- a/src/Microsoft.CSharp/tests/ArrayHandling.cs
+++ b/src/Microsoft.CSharp/tests/ArrayHandling.cs
@@ -22,6 +22,19 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Fact]
+        public void SingleRankNonSZArrayIndexed()
+        {
+            dynamic d = Array.CreateInstance(typeof(int), new[] { 8 }, new[] { -2 });
+            RuntimeBinderException error = Assert.Throws<RuntimeBinderException>(() => d[3] = 32);
+            // Should be similar to the error message for CS0021
+            Assert.Contains("[]", error.Message);
+            Assert.Contains("Array", error.Message);
+            error = Assert.Throws<RuntimeBinderException>(() => d[3]);
+            Assert.Contains("[]", error.Message);
+            Assert.Contains("Array", error.Message);
+        }
+
+        [Fact]
         public void ArrayTypeNames()
         {
             dynamic d = Array.CreateInstance(typeof(int), new[] { 8 }, new[] { -2 });


### PR DESCRIPTION
Fixes #18062

Also: Make exception message match CS0022 on dynamic array index-count mismatch

Fixes #18064 and included in this PR as it has to hit the same bit of code.