### PR TITLE
Don't build packages in multiple legs when OfficialBuildId is set

### DIFF
--- a/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.builds
+++ b/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.builds
@@ -11,6 +11,14 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 
+  <PropertyGroup Condition="'$(OfficialBuildId)' != ''">
+    <!-- During an official build, only build identity packages in the AllConfigurations build -->
+    <SkipBuildIdentityPackage Condition="'$(BuildAllConfigurations)' != 'true'">true</SkipBuildIdentityPackage>
+
+    <!-- During an official build, skip building runtime packages on AllConfigurations build -->
+    <SkipBuildRuntimePackage Condition="'$(BuildAllConfigurations)' == 'true'">true</SkipBuildRuntimePackage>
+  </PropertyGroup>
+
   <PropertyGroup>
     <TraversalBuildDependsOn>
       FilterProjects;
@@ -21,9 +29,11 @@
   <Target Name="FilterProjects">
     <Error Condition="'$(PackageRID)' == ''" Text="'PackageRID' property must be specified."/>
 
-    <!-- Only build packages for current RID -->
     <ItemGroup>
-      <_projectsToBuild Include="@(Project)" Condition="'%(Project.PackageTargetRuntime)' == '$(PackageRID)' OR '%(Project.PackageTargetRuntime)' == ''" />
+      <!-- Build identity package, when SkipBuildIdentityPackage is not set -->
+      <_projectsToBuild Include="@(Project)" Condition="'%(Project.PackageTargetRuntime)' == '' AND '$(SkipBuildIdentityPackage)' != 'true'" />
+      <!-- Build packages for current RID, when SkipBuildRuntimePackage is not set -->
+      <_projectsToBuild Include="@(Project)" Condition="'%(Project.PackageTargetRuntime)' == '$(PackageRID)' AND '$(SkipBuildRuntimePackage)' != 'true'" />
     </ItemGroup>
 
     <ItemGroup>

--- a/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.builds
+++ b/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.builds
@@ -11,6 +11,14 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 
+  <PropertyGroup Condition="'$(OfficialBuildId)' != ''">
+    <!-- During an official build, only build identity packages in the AllConfigurations build -->
+    <SkipBuildIdentityPackage Condition="'$(BuildAllConfigurations)' != 'true'">true</SkipBuildIdentityPackage>
+
+    <!-- During an official build, skip building runtime packages on AllConfigurations build -->
+    <SkipBuildRuntimePackage Condition="'$(BuildAllConfigurations)' == 'true'">true</SkipBuildRuntimePackage>
+  </PropertyGroup>
+
   <PropertyGroup>
     <TraversalBuildDependsOn>
       FilterProjects;
@@ -21,9 +29,11 @@
   <Target Name="FilterProjects">
     <Error Condition="'$(PackageRID)' == ''" Text="'PackageRID' property must be specified."/>
 
-    <!-- Only build packages for current RID -->
     <ItemGroup>
-      <_projectsToBuild Include="@(Project)" Condition="'%(Project.PackageTargetRuntime)' == '$(PackageRID)' OR '%(Project.PackageTargetRuntime)' == ''" />
+      <!-- Build identity package, when SkipBuildIdentityPackage is not set -->
+      <_projectsToBuild Include="@(Project)" Condition="'%(Project.PackageTargetRuntime)' == '' AND '$(SkipBuildIdentityPackage)' != 'true'" />
+      <!-- Build packages for current RID, when SkipBuildRuntimePackage is not set -->
+      <_projectsToBuild Include="@(Project)" Condition="'%(Project.PackageTargetRuntime)' == '$(PackageRID)' AND '$(SkipBuildRuntimePackage)' != 'true'" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Package publishing is tripping up on having multiple legs produce the
same package ID.

Here's a summary of all the packages we produce:
1. Framework identity packages are produced in all framework specific
legs and the -allConfigurations leg.
2. Framework runtime packages are produced in runtime+framework-specific
legs and the -allConfigurations leg.
3. Standalone library packages are produced in the -allConfigurations
leg.

To ensure a single instance in official builds we need to change this as
follows:

1. Framework identity packages should only be produced in the
-allConfigurations leg.
2. Framework runtime packages should only be produced in the runtime+
framework-specific leg, not the -allConfigurations leg.

/cc @weshaggard @MattGal @dagood 