### PR TITLE
Remove docker demand on 1.13.1

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux-Crossbuild.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux-Crossbuild.json
@@ -424,8 +424,7 @@
     }
   },
   "demands": [
-    "Agent.OS -equals linux",
-    "Docker -equals 1.13.1"
+    "Agent.OS -equals linux"
   ],
   "retentionRules": [
     {


### PR DESCRIPTION
This needs to be removed because we are trying to complete upgrade to docker 17.03.0.  Right now there is a single machine that has 1.13.1 on it for this build definition.