### PR TITLE
Share build traversal logic across framework pkgs

### DIFF
--- a/buildvertical.targets
+++ b/buildvertical.targets
@@ -96,6 +96,7 @@
   </Target>
 
   <Target Name="FilterProjects"
+          Condition="'$(FilterProjectsByBuildConfiguration)' != 'false'"
           DependsOnTargets="ExpandAllBuildConfigurations;FilterBuildConfiguration" />
 
   <!-- Runs in a leaf project (eg: csproj) to determine all configurations -->

--- a/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.builds
+++ b/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.builds
@@ -2,43 +2,11 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
-  <Import Project="$(MSBuildProjectName).props" />
-
   <ItemGroup>
-    <!-- identity project, runtime specific projects are included by props above -->
+    <!-- identity project, runtime specific projects are included through netcoreapp.rids.props -->
     <Project Include="$(MSBuildProjectName).pkgproj" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 
-  <PropertyGroup Condition="'$(OfficialBuildId)' != ''">
-    <!-- During an official build, only build identity packages in the AllConfigurations build -->
-    <SkipBuildIdentityPackage Condition="'$(BuildAllConfigurations)' != 'true'">true</SkipBuildIdentityPackage>
-
-    <!-- During an official build, skip building runtime packages on AllConfigurations build -->
-    <SkipBuildRuntimePackage Condition="'$(BuildAllConfigurations)' == 'true'">true</SkipBuildRuntimePackage>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <TraversalBuildDependsOn>
-      FilterProjects;
-      $(TraversalBuildDependsOn);
-    </TraversalBuildDependsOn>
-  </PropertyGroup>
-
-  <Target Name="FilterProjects">
-    <Error Condition="'$(PackageRID)' == ''" Text="'PackageRID' property must be specified."/>
-
-    <ItemGroup>
-      <!-- Build identity package, when SkipBuildIdentityPackage is not set -->
-      <_projectsToBuild Include="@(Project)" Condition="'%(Project.PackageTargetRuntime)' == '' AND '$(SkipBuildIdentityPackage)' != 'true'" />
-      <!-- Build packages for current RID, when SkipBuildRuntimePackage is not set -->
-      <_projectsToBuild Include="@(Project)" Condition="'%(Project.PackageTargetRuntime)' == '$(PackageRID)' AND '$(SkipBuildRuntimePackage)' != 'true'" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Project Remove="@(Project)" />
-      <Project Include="@(_projectsToBuild)" />
-    </ItemGroup>
-  </Target>
 </Project>

--- a/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.pkgproj
+++ b/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.pkgproj
@@ -16,95 +16,21 @@
 
     <NETStandardVersion>2.0</NETStandardVersion>
 
+    <IsFrameworkPackage>true</IsFrameworkPackage>
+
     <!-- Include symbols in package by default-->
     <IncludeSymbolsInPackage Condition="'$(IncludeSymbolsInPackage)' == ''">true</IncludeSymbolsInPackage>
   </PropertyGroup>
 
-  <Import Condition="'$(PackageTargetRuntime)' == ''" Project="$(RefBinDir)\*.props" />
-  <ItemGroup Condition="'$(PackageTargetRuntime)' == ''">
-    <!-- Include refs -->
-    <File Include="@(FileToPackage)">
-      <TargetPath Condition="'%(File.TargetPath)' == ''">ref/$(TargetFramework)</TargetPath>
-    </File>
-    <!-- force a missing file if ref build is absent -->
-    <File Include="$(RefBinDir)/MISSING_REF_BUILD" Condition="'@(FileToPackage)' == ''" />
-
-    <_buildRIDWithMetadata Include="@(BuildRID)">
-      <TargetRuntime>%(Identity)</TargetRuntime>
-      <Version>$(PackageVersion)</Version>
-    </_buildRIDWithMetadata>
-    <Dependency Include="@(_buildRIDWithMetadata->'runtime.%(Identity).$(Id)')" />
-
-    <Dependency Include="Microsoft.NETCore.Platforms">
-      <Version>$(PlatformPackageVersion)</Version>
-    </Dependency>
-  </ItemGroup>
-
-  <Import Condition="'$(PackageTargetRuntime)' != ''" Project="$(LibBinDir)\*.props" />
-  <ItemGroup Condition="'$(PackageTargetRuntime)' != ''">
-    <!-- Include lib -->
-    <File Include="@(FileToPackage)">
-      <TargetPath Condition="'%(File.TargetPath)' == ''">runtimes/$(PackageTargetRuntime)/lib/$(TargetFramework)</TargetPath>
-    </File>
-    <!-- force a missing file if lib build is absent -->
-    <File Include="$(LibBinDir)/MISSING_LIB_BUILD" Condition="'@(FileToPackage)' == ''" />
-
-    <!-- Include native -->
-    <ExcludeNative Include="$(NativeBinDir)/*.lib" />
-    <NativeFile Include="$(NativeBinDir)/*.*" Exclude="@(ExcludeNative)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </NativeFile>
-    <File Include="@(NativeFile)" />
-    <!-- force a missing file if native build is absent -->
-    <File Include="$(NativeBinDir)/MISSING_NATIVE_BUILD" Condition="'@(NativeFile)' == ''" />
-  </ItemGroup>
-
   <ItemGroup>
     <IgnoredReference Include="System.Private.CoreLib" />
+
+    <!-- Exclude shims from the closure verification -->
+    <ExcludeFromClosure Include="mscorlib" />
+    <ExcludeFromClosure Include="System" />
+    <ExcludeFromClosure Include="System.Core" />
+    <ExcludeFromClosure Include="System.Data" />
   </ItemGroup>
-
-  <Target Name="VerifyClosure" AfterTargets="Build">
-    <ItemGroup>
-      <!-- Exclude shims from the closure verification -->
-      <ExcludeFromClosure Include="mscorlib" />
-      <ExcludeFromClosure Include="System" />
-      <ExcludeFromClosure Include="System.Core" />
-      <ExcludeFromClosure Include="System.Data" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <_fileExisting Include="@(File)" Condition="Exists(%(FullPath))"/>
-
-      <_fileNames Include="@(_fileExisting -> '%(FileName)')" Exclude="@(ExcludeFromClosure)">
-        <Original>%(_fileExisting.Identity)</Original>
-      </_fileNames>
-      <_filesFiltered Include="@(_fileNames->'%(Original)')" />
-    </ItemGroup>
-
-    <VerifyClosure Sources="@(_filesFiltered)"
-                   IgnoredReferences="@(IgnoredReference)" />
-  </Target>
-
-  <Target Name="VerifyNETStandard" AfterTargets="Build">
-    <ItemGroup>
-      <_NETStandardFile Include="$(PackagesDir)$(NETStandardPackageId)\$(NETStandardPackageVersion)\build\netstandard$(NETStandardVersion)\ref\*.dll" />
-      <!-- force a missing file there are no files found in the package -->
-      <_NETStandardFile Include="$(PackagesDir)$(NETStandardPackageId)\$(NETStandardPackageVersion)\build\netstandard$(NETStandardVersion)\ref\MISSING_REF_BUILD" Condition="'@(_NETStandardFile)' == ''" />
-      <_NETStandardMissingFile Include="@(_NETStandardFile->'%(FileName)')" Exclude="@(File->'%(FileName)')" />
-      <_NETStandardMissingFileError Include="@(_NETStandardMissingFile)" Exclude="@(SuppressNETStandardMissingFile)" />
-      <_NETStandardSuppressedMissingFile Include="@(_NETStandardMissingFile)" Exclude="@(_NETStandardMissingFileError)" />
-    </ItemGroup>
-    <Message Condition="'@(_NETStandardSuppressedMissingFile)' != ''" Text="Files'@(_NETStandardSuppressedMissingFile)' are part of '$(NETStandardPackageId)' but missing from this package.  This error has been suppressed." />
-    <Error Condition="'@(_NETStandardMissingFileError)' != ''" Text="Files '@(_NETStandardMissingFileError)' are part of '$(NETStandardPackageId)' but missing from this package." />
-  </Target>
-
-  <Target Name="GetSymbolPackageFiles" BeforeTargets="GetPackageFiles">
-    <ItemGroup>
-      <File>
-        <IsSymbolFile Condition="'%(Extension)' == '.pdb'">true</IsSymbolFile>
-        <IsSymbolFile Condition="'$(SymbolFileExtension)' != '' AND'%(Extension)' == '$(SymbolFileExtension)'">true</IsSymbolFile>
-      </File>
-    </ItemGroup>
-  </Target>
+  
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.pkgproj
+++ b/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.pkgproj
@@ -2,29 +2,6 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
-  <Import Project="$(MSBuildProjectName).props" />
-
-  <!-- Add path globs specific to native binaries to exclude unnecessary files from packages. -->
-  <Choose>
-    <When Condition="$(PackageTargetRuntime.StartsWith('win'))"/>
-    <When Condition="$(PackageTargetRuntime.StartsWith('osx'))">
-      <PropertyGroup>
-        <LibraryFileExtension>.dylib</LibraryFileExtension>
-        <SymbolFileExtension>.dwarf</SymbolFileExtension>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup>
-        <LibraryFileExtension>.so</LibraryFileExtension>
-        <SymbolFileExtension>.dbg</SymbolFileExtension>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
-  <ItemGroup>
-    <AdditionalLibPackageExcludes Condition="'$(SymbolFileExtension)' != ''" Include="%2A%2A\%2A$(SymbolFileExtension)" />
-    <AdditionalSymbolPackageExcludes Condition="'$(LibraryFileExtension)' != ''" Include="%2A%2A\%2A.a;%2A%2A\%2A$(LibraryFileExtension)" />
-  </ItemGroup>
-
   <PropertyGroup>
     <IsLineupPackage Condition="'$(PackageTargetRuntime)' == ''">true</IsLineupPackage>
     <PreventImplementationReference Condition="'$(PackageTargetRuntime)' != ''">true</PreventImplementationReference>

--- a/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.pkgproj
+++ b/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.pkgproj
@@ -3,22 +3,16 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>
-    <IsLineupPackage Condition="'$(PackageTargetRuntime)' == ''">true</IsLineupPackage>
-    <PreventImplementationReference Condition="'$(PackageTargetRuntime)' != ''">true</PreventImplementationReference>
     <TargetFrameworkName>netcoreapp</TargetFrameworkName>
     <TargetFrameworkVersion>2.0</TargetFrameworkVersion>
     <TargetFramework>$(TargetFrameworkName)$(TargetFrameworkVersion)</TargetFramework>
-    <SkipPackageFileCheck>true</SkipPackageFileCheck>
-    <SkipValidatePackage>true</SkipValidatePackage>
 
     <RefBinDir>$(NETCoreAppPackageRefPath)</RefBinDir>
     <LibBinDir>$(NETCoreAppPackageRuntimePath)</LibBinDir>
 
-    <NETStandardVersion>2.0</NETStandardVersion>
-
     <IsFrameworkPackage>true</IsFrameworkPackage>
 
-    <!-- Include symbols in package by default-->
+    <!-- Private packages need symbols -->
     <IncludeSymbolsInPackage Condition="'$(IncludeSymbolsInPackage)' == ''">true</IncludeSymbolsInPackage>
   </PropertyGroup>
 

--- a/pkg/Microsoft.Private.CoreFx.NETCoreApp/netcoreapp.rids.props
+++ b/pkg/Microsoft.Private.CoreFx.NETCoreApp/netcoreapp.rids.props
@@ -1,11 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-  <PropertyGroup>
-    <_runtimeOSVersionIndex>$(RuntimeOS.IndexOfAny(".-0123456789"))</_runtimeOSVersionIndex>
-    <_runtimeOSFamily Condition="'$(_runtimeOSVersionIndex)' != '-1'">$(RuntimeOS.SubString(0, $(_runtimeOSVersionIndex)))</_runtimeOSFamily>
-  </PropertyGroup>
-
   <Choose>
     <When Condition="'$(PackageRID)' != ''" />
     <When Condition="'$(_runtimeOSFamily)' == 'win'">
@@ -87,22 +81,5 @@
     <OfficialBuildRID Include="win-arm64">
       <Platform>arm64</Platform>
     </OfficialBuildRID>
-
-    <!-- Ensure we have a RID-specific package for the current build, even if it isn't in our official set -->
-    <BuildRID Include="@(OfficialBuildRID)" Exclude="$(PackageRID)"/>
-    <BuildRID Include="$(PackageRID)">
-      <Platform Condition="'$(ArchGroup)' == 'x64'">amd64</Platform>
-      <Platform Condition="'$(ArchGroup)' != 'x64'">$(ArchGroup)</Platform>
-    </BuildRID>
-  </ItemGroup>
-
-  <ItemGroup>
-    <_project Include="@(BuildRID)">
-      <Platform Condition="'%(Platform)' == ''">amd64</Platform>
-      <PackageTargetRuntime>%(Identity)</PackageTargetRuntime>
-      <AdditionalProperties>PackageTargetRuntime=%(Identity);Platform=%(Platform)</AdditionalProperties>
-    </_project>
-
-    <Project Include="@(_project->'$(MSBuildProjectName).pkgproj')" />
   </ItemGroup>
 </Project>

--- a/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.builds
+++ b/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.builds
@@ -2,43 +2,11 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
-  <Import Project="$(MSBuildProjectName).props" />
-
   <ItemGroup>
-    <!-- identity project, runtime specific projects are included by props above. Will not be built on uapaot builds. -->
+    <!-- Identity project, runtime specific projects are included uap.rids.props. 
+         Will not be built on uapaot builds. https://github.com/dotnet/corefx/issues/18098 -->
     <Project Include="$(MSBuildProjectName).pkgproj" Condition="'$(TargetGroup)'=='uap'" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
-
-  <PropertyGroup Condition="'$(OfficialBuildId)' != ''">
-    <!-- During an official build, only build identity packages in the AllConfigurations build -->
-    <SkipBuildIdentityPackage Condition="'$(BuildAllConfigurations)' != 'true'">true</SkipBuildIdentityPackage>
-
-    <!-- During an official build, skip building runtime packages on AllConfigurations build -->
-    <SkipBuildRuntimePackage Condition="'$(BuildAllConfigurations)' == 'true'">true</SkipBuildRuntimePackage>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <TraversalBuildDependsOn>
-      FilterProjects;
-      $(TraversalBuildDependsOn);
-    </TraversalBuildDependsOn>
-  </PropertyGroup>
-
-  <Target Name="FilterProjects">
-    <Error Condition="'$(PackageRID)' == ''" Text="'PackageRID' property must be specified."/>
-
-    <ItemGroup>
-      <!-- Build identity package, when SkipBuildIdentityPackage is not set -->
-      <_projectsToBuild Include="@(Project)" Condition="'%(Project.PackageTargetRuntime)' == '' AND '$(SkipBuildIdentityPackage)' != 'true'" />
-      <!-- Build packages for current RID, when SkipBuildRuntimePackage is not set -->
-      <_projectsToBuild Include="@(Project)" Condition="'%(Project.PackageTargetRuntime)' == '$(PackageRID)' AND '$(SkipBuildRuntimePackage)' != 'true'" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Project Remove="@(Project)" />
-      <Project Include="@(_projectsToBuild)" />
-    </ItemGroup>
-  </Target>
 </Project>

--- a/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.pkgproj
+++ b/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.pkgproj
@@ -2,8 +2,6 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
-  <Import Project="$(MSBuildProjectName).props" />
-
   <PropertyGroup>
     <IsLineupPackage Condition="'$(PackageTargetRuntime)' == ''">true</IsLineupPackage>
     <PreventImplementationReference Condition="'$(PackageTargetRuntime)' != ''">true</PreventImplementationReference>     

--- a/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.pkgproj
+++ b/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.pkgproj
@@ -17,48 +17,11 @@
 
     <NETStandardVersion>2.0</NETStandardVersion>
 
+    <IsFrameworkPackage>true</IsFrameworkPackage>
+
     <!-- Include symbols in package by default-->
     <IncludeSymbolsInPackage Condition="'$(IncludeSymbolsInPackage)' == ''">true</IncludeSymbolsInPackage>
   </PropertyGroup>
-
-  <Import Condition="'$(PackageTargetRuntime)' == ''" Project="$(RefBinDir)\*.props" />
-  <ItemGroup Condition="'$(PackageTargetRuntime)' == ''">
-    <!-- Include refs -->
-    <File Include="@(FileToPackage)">
-      <TargetPath Condition="'%(File.TargetPath)' == ''">ref/$(TargetFramework)</TargetPath>
-    </File>
-    <!-- force a missing file if ref build is absent -->
-    <File Include="$(RefBinDir)/MISSING_REF_BUILD" Condition="'@(FileToPackage)' == ''" />
-
-    <_buildRIDWithMetadata Include="@(BuildRID)">
-      <TargetRuntime>%(Identity)</TargetRuntime>
-      <Version>$(PackageVersion)</Version>
-    </_buildRIDWithMetadata>
-    <Dependency Include="@(_buildRIDWithMetadata->'runtime.%(Identity).$(Id)')" />
-
-    <Dependency Include="Microsoft.NETCore.Platforms">
-      <Version>$(PlatformPackageVersion)</Version>
-    </Dependency>
-  </ItemGroup>
-
-  <Import Condition="'$(PackageTargetRuntime)' != ''" Project="$(LibBinDir)\*.props" />
-  <ItemGroup Condition="'$(PackageTargetRuntime)' != ''">
-    <!-- Include lib -->
-    <File Include="@(FileToPackage)">
-      <TargetPath Condition="'%(File.TargetPath)' == ''">runtimes/$(PackageTargetRuntime)/lib/$(TargetFramework)</TargetPath>
-    </File>
-    <!-- force a missing file if lib build is absent -->
-    <File Include="$(LibBinDir)/MISSING_LIB_BUILD" Condition="'@(FileToPackage)' == ''" />
-
-    <!-- Include native -->
-    <ExcludeNative Include="$(NativeBinDir)/*.lib" />
-    <NativeFile Include="$(NativeBinDir)/*.*" Exclude="@(ExcludeNative)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </NativeFile>
-    <File Include="@(NativeFile)" />
-    <!-- force a missing file if native build is absent -->
-    <File Include="$(NativeBinDir)/MISSING_NATIVE_BUILD" Condition="'@(NativeFile)' == ''" />
-  </ItemGroup>
 
   <ItemGroup>
     <IgnoredReference Include="System.Private.CoreLib" />
@@ -66,52 +29,15 @@
     <IgnoredReference Include="System.Private.Interop" />
     <IgnoredReference Include="Microsoft.Win32.Registry" /> <!-- Ignore for now since it's being exclude from closure below. Issue https://github.com/dotnet/corefx/issues/15966 -->
     <IgnoredReference Include="System.IO.IsolatedStorage" /> <!-- Ignore for now since it's being exclude from closure below. Issue https://github.com/dotnet/corefx/issues/15968 -->
+
+    <ExcludeFromClosure Include="System.IO.IsolatedStorage" /> <!-- IsolatedStorage depends on AccessControl which is not available for UAP -->
+    <ExcludeFromClosure Include="Microsoft.Win32.Registry" /> <!-- Most likely this one will be removed from the package, it's just there today for the closure -->
+    <!-- Exclude shims from the closure verification -->
+    <ExcludeFromClosure Include="mscorlib" />
+    <ExcludeFromClosure Include="System" />
+    <ExcludeFromClosure Include="System.Core" />
+    <ExcludeFromClosure Include="System.Data" />
   </ItemGroup>
 
-  <Target Name="VerifyClosure" AfterTargets="Build">
-    <ItemGroup>
-      <ExcludeFromClosure Include="System.IO.IsolatedStorage" /> <!-- IsolatedStorage depends on AccessControl which is not available for UAP -->
-      <ExcludeFromClosure Include="Microsoft.Win32.Registry" /> <!-- Most likely this one will be removed from the package, it's just there today for the closure -->
-      <!-- Exclude shims from the closure verification -->
-      <ExcludeFromClosure Include="mscorlib" />
-      <ExcludeFromClosure Include="System" />
-      <ExcludeFromClosure Include="System.Core" />
-      <ExcludeFromClosure Include="System.Data" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <_fileExisting Include="@(File)" Condition="Exists(%(FullPath))"/>
-
-      <_fileNames Include="@(_fileExisting -> '%(FileName)')" Exclude="@(ExcludeFromClosure)">
-        <Original>%(_fileExisting.Identity)</Original>
-      </_fileNames>
-      <_filesFiltered Include="@(_fileNames->'%(Original)')" />
-    </ItemGroup>
-
-    <VerifyClosure Sources="@(_filesFiltered)"
-                   IgnoredReferences="@(IgnoredReference)" />
-  </Target>
-
-  <Target Name="VerifyNETStandard" AfterTargets="Build">
-    <ItemGroup>
-      <_NETStandardFile Include="$(PackagesDir)$(NETStandardPackageId)\$(NETStandardPackageVersion)\build\netstandard$(NETStandardVersion)\ref\*.dll" />
-      <!-- force a missing file there are no files found in the package -->
-      <_NETStandardFile Include="$(PackagesDir)$(NETStandardPackageId)\$(NETStandardPackageVersion)\build\netstandard$(NETStandardVersion)\ref\MISSING_REF_BUILD" Condition="'@(_NETStandardFile)' == ''" />
-      <_NETStandardMissingFile Include="@(_NETStandardFile->'%(FileName)')" Exclude="@(File->'%(FileName)')" />
-      <_NETStandardMissingFileError Include="@(_NETStandardMissingFile)" Exclude="@(SuppressNETStandardMissingFile)" />
-      <_NETStandardSuppressedMissingFile Include="@(_NETStandardMissingFile)" Exclude="@(_NETStandardMissingFileError)" />
-    </ItemGroup>
-    <Message Condition="'@(_NETStandardSuppressedMissingFile)' != ''" Text="Files'@(_NETStandardSuppressedMissingFile)' are part of '$(NETStandardPackageId)' but missing from this package.  This error has been suppressed." />
-    <Error Condition="'@(_NETStandardMissingFileError)' != ''" Text="Files '@(_NETStandardMissingFileError)' are part of '$(NETStandardPackageId)' but missing from this package." />
-  </Target>
-
-  <Target Name="GetSymbolPackageFiles" BeforeTargets="GetPackageFiles">
-    <ItemGroup>
-      <File>
-        <IsSymbolFile Condition="'%(Extension)' == '.pdb'">true</IsSymbolFile>
-        <IsSymbolFile Condition="'$(SymbolFileExtension)' != '' AND'%(Extension)' == '$(SymbolFileExtension)'">true</IsSymbolFile>
-      </File>
-    </ItemGroup>
-  </Target>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.pkgproj
+++ b/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.pkgproj
@@ -3,23 +3,17 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>
-    <IsLineupPackage Condition="'$(PackageTargetRuntime)' == ''">true</IsLineupPackage>
-    <PreventImplementationReference Condition="'$(PackageTargetRuntime)' != ''">true</PreventImplementationReference>     
     <TargetFrameworkName>uap</TargetFrameworkName>
     <TargetFrameworkVersion>10.1</TargetFrameworkVersion>
     <TargetFramework>$(TargetFrameworkName)$(TargetFrameworkVersion)</TargetFramework>
-    <SkipPackageFileCheck>true</SkipPackageFileCheck>
-    <SkipValidatePackage>true</SkipValidatePackage>
 
     <RefBinDir>$(UAPPackageRefPath)</RefBinDir>
     <LibBinDir>$(UAPPackageRuntimePath)</LibBinDir>
     <LibBinDir Condition="$(PackageTargetRuntime.EndsWith('-aot'))">$(UAPAOTPackageRuntimePath)</LibBinDir>
 
-    <NETStandardVersion>2.0</NETStandardVersion>
-
     <IsFrameworkPackage>true</IsFrameworkPackage>
 
-    <!-- Include symbols in package by default-->
+    <!-- Private packages need symbols -->
     <IncludeSymbolsInPackage Condition="'$(IncludeSymbolsInPackage)' == ''">true</IncludeSymbolsInPackage>
   </PropertyGroup>
 

--- a/pkg/Microsoft.Private.CoreFx.UAP/uap.rids.props
+++ b/pkg/Microsoft.Private.CoreFx.UAP/uap.rids.props
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  
   <PropertyGroup>
-    <_runtimeOSVersionIndex>$(RuntimeOS.IndexOfAny(".-0123456789"))</_runtimeOSVersionIndex>
-    <_runtimeOSFamily Condition="'$(_runtimeOSVersionIndex)' != '-1'">$(RuntimeOS.SubString(0, $(_runtimeOSVersionIndex)))</_runtimeOSFamily>
     <_aotSuffix Condition="'$(TargetGroup)' == 'uapaot'">-aot</_aotSuffix>
   </PropertyGroup>
   
@@ -36,22 +33,5 @@
     <OfficialBuildRID Include="win10-arm-aot">
       <Platform>arm</Platform>
     </OfficialBuildRID>
-
-    <!-- Ensure we have a RID-specific package for the current build, even if it isn't in our official set -->
-    <BuildRID Include="@(OfficialBuildRID)" Exclude="$(PackageRID)"/>
-    <BuildRID Include="$(PackageRID)">
-      <Platform Condition="'$(ArchGroup)' == 'x64'">amd64</Platform>
-      <Platform Condition="'$(ArchGroup)' != 'x64'">$(ArchGroup)</Platform>
-    </BuildRID>
-  </ItemGroup>
-
-  <ItemGroup>
-    <_project Include="@(BuildRID)">
-      <Platform Condition="'%(Platform)' == ''">amd64</Platform>
-      <PackageTargetRuntime>%(Identity)</PackageTargetRuntime>
-      <AdditionalProperties>PackageTargetRuntime=%(Identity);Platform=%(Platform)</AdditionalProperties>
-    </_project>
-
-    <Project Include="@(_project->'$(MSBuildProjectName).pkgproj')" />
   </ItemGroup>
 </Project>

--- a/pkg/dir.props
+++ b/pkg/dir.props
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\dir.props" />
+
+  <PropertyGroup>
+    <_runtimeOSVersionIndex>$(RuntimeOS.IndexOfAny(".-0123456789"))</_runtimeOSVersionIndex>
+    <_runtimeOSFamily Condition="'$(_runtimeOSVersionIndex)' != '-1'">$(RuntimeOS.SubString(0, $(_runtimeOSVersionIndex)))</_runtimeOSFamily>
+  </PropertyGroup>
+
+  <!-- Packages opt-in to automatic RID-specific builds by placing a *.RID.props next to their project
+       that defines the following:
+       PackageRID property: the RID which we should be building for
+       OfficialBuildRID item: all RIDs targeted by the package -->
+  <Import Project="$(MSBuildProjectDirectory)\*.rids.props" />
+
+  <!-- create the "BuildRID" item which is the set of all supported RIDs, with metadata.
+       We'll add a RID for the current platform even if it isn't in the officially supported set -->
+  <ItemGroup>
+    <BuildRID Include="@(OfficialBuildRID)" Exclude="$(PackageRID)"/>
+    <BuildRID Include="$(PackageRID)">
+      <Platform Condition="'$(ArchGroup)' == 'x64'">amd64</Platform>
+      <Platform Condition="'$(ArchGroup)' != 'x64'">$(ArchGroup)</Platform>
+    </BuildRID>
+  </ItemGroup>
+
+  <!-- create the "Project" item which is the current $(MSBuildProjectName).pkgproj with meta-data for all 
+       supported RIDs -->
+  <ItemGroup>
+    <_project Include="@(BuildRID)">
+      <Platform Condition="'%(Platform)' == ''">amd64</Platform>
+      <PackageTargetRuntime>%(Identity)</PackageTargetRuntime>
+      <AdditionalProperties>PackageTargetRuntime=%(Identity);Platform=%(Platform)</AdditionalProperties>
+    </_project>
+
+    <Project Include="@(_project->'$(MSBuildProjectName).pkgproj')" />
+  </ItemGroup>
+
+  <!-- Add path globs specific to native binaries to exclude unnecessary files from packages. -->
+  <Choose>
+    <When Condition="$(PackageTargetRuntime.StartsWith('win'))"/>
+    <When Condition="$(PackageTargetRuntime.StartsWith('osx'))">
+      <PropertyGroup>
+        <LibraryFileExtension>.dylib</LibraryFileExtension>
+        <SymbolFileExtension>.dwarf</SymbolFileExtension>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <LibraryFileExtension>.so</LibraryFileExtension>
+        <SymbolFileExtension>.dbg</SymbolFileExtension>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <AdditionalLibPackageExcludes Condition="'$(SymbolFileExtension)' != ''" Include="%2A%2A\%2A$(SymbolFileExtension)" />
+    <AdditionalSymbolPackageExcludes Condition="'$(LibraryFileExtension)' != ''" Include="%2A%2A\%2A.a;%2A%2A\%2A$(LibraryFileExtension)" />
+  </ItemGroup>
+  
+</Project>

--- a/pkg/dir.targets
+++ b/pkg/dir.targets
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" InitialTargets="CheckForBuildTools" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <Import Condition="'$(IsFrameworkPackage)' == 'true'" Project="frameworkPackage.targets" />
+
   <Import Project="..\dir.targets" />
 
   <Target Name="ApplyBaselineToStaticDependencies" 

--- a/pkg/dir.traversal.targets
+++ b/pkg/dir.traversal.targets
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Import Project="..\dir.traversal.targets" />
+  
+  <PropertyGroup Condition="'$(OfficialBuildId)' != ''">
+    <!-- During an official build, only build identity packages in the AllConfigurations build -->
+    <SkipBuildIdentityPackage Condition="'$(BuildAllConfigurations)' != 'true'">true</SkipBuildIdentityPackage>
+
+    <!-- During an official build, skip building runtime packages on AllConfigurations build -->
+    <SkipBuildRuntimePackage Condition="'$(BuildAllConfigurations)' == 'true'">true</SkipBuildRuntimePackage>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <TraversalBuildDependsOn>
+      FilterProjectsPackageRID;
+      $(TraversalBuildDependsOn);
+    </TraversalBuildDependsOn>
+  </PropertyGroup>
+
+  <!-- When @(BuildRID) is set, filter the set of projects down to only those applicable to $(PackageRID) -->
+  <Target Name="FilterProjectsPackageRID" Condition="'@(BuildRID)' != ''">
+    <ItemGroup>
+      <!-- Build identity package, when SkipBuildIdentityPackage is not set -->
+      <_projectsToBuild Include="@(Project)" Condition="'%(Project.PackageTargetRuntime)' == '' AND '$(SkipBuildIdentityPackage)' != 'true'" />
+      <!-- Build packages for current RID, when SkipBuildRuntimePackage is not set -->
+      <_projectsToBuild Include="@(Project)" Condition="'%(Project.PackageTargetRuntime)' == '$(PackageRID)' AND '$(SkipBuildRuntimePackage)' != 'true'" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Project Remove="@(Project)" />
+      <Project Include="@(_projectsToBuild)" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <!-- don't use BuildConfiguration filtering -->
+      <FilterProjectsByBuildConfiguration>false</FilterProjectsByBuildConfiguration>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/pkg/frameworkPackage.targets
+++ b/pkg/frameworkPackage.targets
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" InitialTargets="CheckForBuildTools" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- Bring in ref content from binplaced ref props -->
+  <Import Condition="'$(PackageTargetRuntime)' == ''" Project="$(RefBinDir)\*.props" />
+  <ItemGroup Condition="'$(PackageTargetRuntime)' == ''">
+    <!-- Include refs -->
+    <File Include="@(FileToPackage)">
+      <TargetPath Condition="'%(File.TargetPath)' == ''">ref/$(TargetFramework)</TargetPath>
+    </File>
+    <!-- force a missing file if ref build is absent -->
+    <File Include="$(RefBinDir)/MISSING_REF_BUILD" Condition="'@(FileToPackage)' == ''" />
+
+    <_buildRIDWithMetadata Include="@(BuildRID)">
+      <TargetRuntime>%(Identity)</TargetRuntime>
+      <Version>$(PackageVersion)</Version>
+    </_buildRIDWithMetadata>
+    <Dependency Include="@(_buildRIDWithMetadata->'runtime.%(Identity).$(Id)')" />
+
+    <Dependency Include="Microsoft.NETCore.Platforms">
+      <Version>$(PlatformPackageVersion)</Version>
+    </Dependency>
+  </ItemGroup>
+
+  <!-- Bring in lib content from binplaced lib props -->
+  <Import Condition="'$(PackageTargetRuntime)' != ''" Project="$(LibBinDir)\*.props" />
+  <ItemGroup Condition="'$(PackageTargetRuntime)' != ''">
+    <!-- Include lib -->
+    <File Include="@(FileToPackage)">
+      <TargetPath Condition="'%(File.TargetPath)' == ''">runtimes/$(PackageTargetRuntime)/lib/$(TargetFramework)</TargetPath>
+    </File>
+    <!-- force a missing file if lib build is absent -->
+    <File Include="$(LibBinDir)/MISSING_LIB_BUILD" Condition="'@(FileToPackage)' == ''" />
+
+    <!-- Include native -->
+    <ExcludeNative Include="$(NativeBinDir)/*.lib" />
+    <NativeFile Include="$(NativeBinDir)/*.*" Exclude="@(ExcludeNative)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </NativeFile>
+    <File Include="@(NativeFile)" />
+    <!-- force a missing file if native build is absent -->
+    <File Include="$(NativeBinDir)/MISSING_NATIVE_BUILD" Condition="'@(NativeFile)' == ''" />
+  </ItemGroup>
+
+
+  <Target Name="VerifyClosure" AfterTargets="Build">
+    <ItemGroup>
+      <_fileExisting Include="@(File)" Condition="Exists(%(FullPath))"/>
+
+      <_fileNames Include="@(_fileExisting -> '%(FileName)')" Exclude="@(ExcludeFromClosure)">
+        <Original>%(_fileExisting.Identity)</Original>
+      </_fileNames>
+      <_filesFiltered Include="@(_fileNames->'%(Original)')" />
+    </ItemGroup>
+
+    <VerifyClosure Sources="@(_filesFiltered)"
+                   IgnoredReferences="@(IgnoredReference)" />
+  </Target>
+
+  <Target Name="VerifyNETStandard" AfterTargets="Build">
+    <ItemGroup>
+      <_NETStandardFile Include="$(PackagesDir)$(NETStandardPackageId)\$(NETStandardPackageVersion)\build\netstandard$(NETStandardVersion)\ref\*.dll" />
+      <!-- force a missing file there are no files found in the package -->
+      <_NETStandardFile Include="$(PackagesDir)$(NETStandardPackageId)\$(NETStandardPackageVersion)\build\netstandard$(NETStandardVersion)\ref\MISSING_REF_BUILD" Condition="'@(_NETStandardFile)' == ''" />
+      <_NETStandardMissingFile Include="@(_NETStandardFile->'%(FileName)')" Exclude="@(File->'%(FileName)')" />
+      <_NETStandardMissingFileError Include="@(_NETStandardMissingFile)" Exclude="@(SuppressNETStandardMissingFile)" />
+      <_NETStandardSuppressedMissingFile Include="@(_NETStandardMissingFile)" Exclude="@(_NETStandardMissingFileError)" />
+    </ItemGroup>
+    <Message Condition="'@(_NETStandardSuppressedMissingFile)' != ''" Text="Files'@(_NETStandardSuppressedMissingFile)' are part of '$(NETStandardPackageId)' but missing from this package.  This error has been suppressed." />
+    <Error Condition="'@(_NETStandardMissingFileError)' != ''" Text="Files '@(_NETStandardMissingFileError)' are part of '$(NETStandardPackageId)' but missing from this package." />
+  </Target>
+
+  <Target Name="GetSymbolPackageFiles" BeforeTargets="GetPackageFiles">
+    <ItemGroup>
+      <File>
+        <IsSymbolFile Condition="'%(Extension)' == '.pdb'">true</IsSymbolFile>
+        <IsSymbolFile Condition="'$(SymbolFileExtension)' != '' AND'%(Extension)' == '$(SymbolFileExtension)'">true</IsSymbolFile>
+      </File>
+    </ItemGroup>
+  </Target>
+</Project>

--- a/pkg/frameworkPackage.targets
+++ b/pkg/frameworkPackage.targets
@@ -1,6 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" InitialTargets="CheckForBuildTools" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <PropertyGroup>
+    <IsLineupPackage Condition="'$(PackageTargetRuntime)' == ''">true</IsLineupPackage>
+    <PreventImplementationReference Condition="'$(PackageTargetRuntime)' != ''">true</PreventImplementationReference>
+
+    <!-- these packages don't follow the patterns expected by package validation -->
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <SkipValidatePackage>true</SkipValidatePackage>
+
+    <NETStandardVersion Condition="'$(NETStandardVersion)' == ''">2.0</NETStandardVersion>
+  </PropertyGroup>
+
   <!-- Bring in ref content from binplaced ref props -->
   <Import Condition="'$(PackageTargetRuntime)' == ''" Project="$(RefBinDir)\*.props" />
   <ItemGroup Condition="'$(PackageTargetRuntime)' == ''">


### PR DESCRIPTION
Previously the build traversal logic was duplicated between the UAP and
NETCoreApp packages.

This refactors it into shared targets/props.

The mechanism for opt-in to this traversal behavior is to include a
props file in the project that matches the convention *.rids.props.
The file must define PackageRID and OfficialBuildRID items.

/cc @joperezr @chcosta @weshaggard 