### PR TITLE
Remove UAP specific code for FileVersionInfo

### DIFF
--- a/src/System.Diagnostics.FileVersionInfo/src/PinvokeAnalyzerExceptionList.analyzerdata
+++ b/src/System.Diagnostics.FileVersionInfo/src/PinvokeAnalyzerExceptionList.analyzerdata
@@ -1,0 +1,4 @@
+kernel32.dll!VerLanguageNameW
+version.dll!GetFileVersionInfoExW
+version.dll!GetFileVersionInfoSizeExW
+version.dll!VerQueryValueW

--- a/src/System.Diagnostics.FileVersionInfo/src/System.Diagnostics.FileVersionInfo.csproj
+++ b/src/System.Diagnostics.FileVersionInfo/src/System.Diagnostics.FileVersionInfo.csproj
@@ -16,7 +16,7 @@
   <ItemGroup Condition="'$(TargetGroup)' == 'uap' or '$(TargetGroup)' == 'netcoreapp'">
     <Compile Include="System\Diagnostics\FileVersionInfo.cs" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' And '$(TargetGroup)' == 'netcoreapp'">
+  <ItemGroup Condition=" '$(TargetsWindows)' == 'true'">
     <Compile Include="System\Diagnostics\FileVersionInfo.Windows.cs" />
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
@@ -43,7 +43,7 @@
       <Link>Common\Interop\Windows\Interop.VSFixedFileInfo.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="('$(TargetsUnix)' == 'true' And '$(TargetGroup)' == 'netcoreapp') OR '$(TargetGroup)' == 'uap'">
+  <ItemGroup Condition="'$(TargetsUnix)' == 'true' And '$(TargetGroup)' == 'netcoreapp'">
     <Compile Include="System\Diagnostics\FileVersionInfo.Metadata.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The current implementation (same as Unix) looks functional so perhaps this doesn't get us much beyond a single Windows binary. 

Unfortunately this flags 4 pinvokes we had previously deferred request for.