### PR TITLE
Adding support for HttpHandlerDiagnosticListener.

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.cs
@@ -14,7 +14,7 @@ namespace System.Diagnostics {
     public bool IsEnabled() { throw null; }
     public override bool IsEnabled(string name) { throw null; }
     public override bool IsEnabled(string name, object arg1, object arg2 = null) { throw null; }
-    public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.KeyValuePair<string, object>> observer) { throw null; }
+    public virtual System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.KeyValuePair<string, object>> observer) { throw null; }
     public virtual System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.KeyValuePair<string, object>> observer, System.Predicate<string> isEnabled) { throw null; }
     public virtual System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.KeyValuePair<string, object>> observer, System.Func<string, object, object, bool> isEnabled) { throw null; }
     public override void Write(string name, object parameters) { }

--- a/src/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
@@ -18,6 +18,12 @@
   <PropertyGroup Condition="'$(TargetGroup)' == 'net45' OR '$(TargetGroup)' == 'net46' OR '$(TargetGroup)' == 'netfx'">
     <DefineConstants>$(DefineConstants);ALLOW_PARTIALLY_TRUSTED_CALLERS</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetGroup)' == 'net46'">
+    <DefineConstants>$(DefineConstants);NET46</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetGroup)' == 'netfx'">
+    <DefineConstants>$(DefineConstants);NETFX</DefineConstants>
+  </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net45-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net45-Windows_NT-Release|AnyCPU'" />
@@ -58,7 +64,7 @@
   <ItemGroup Condition=" '$(TargetGroup)' == 'netcoreapp' OR '$(TargetGroup)' == 'netstandard' OR '$(TargetGroup)' == 'net45' OR '$(TargetGroup)' == 'net46' OR '$(TargetGroup)' == 'netfx'">
     <Compile Include="System\Diagnostics\Activity.Id.MachineName.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'net45' OR '$(TargetGroup)' == 'net46' OR '$(TargetGroup)' == 'netfx'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'net46' OR '$(TargetGroup)' == 'netfx'">
     <Compile Include="System\Diagnostics\HttpHandlerDiagnosticListener.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'net46' AND '$(TargetGroup)' != 'netfx'">

--- a/src/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
@@ -58,6 +58,9 @@
   <ItemGroup Condition=" '$(TargetGroup)' == 'netcoreapp' OR '$(TargetGroup)' == 'netstandard' OR '$(TargetGroup)' == 'net45' OR '$(TargetGroup)' == 'net46' OR '$(TargetGroup)' == 'netfx'">
     <Compile Include="System\Diagnostics\Activity.Id.MachineName.cs" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'net45' OR '$(TargetGroup)' == 'net46' OR '$(TargetGroup)' == 'netfx'">
+    <Compile Include="System\Diagnostics\HttpHandlerDiagnosticListener.cs" />
+  </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'net46' AND '$(TargetGroup)' != 'netfx'">
     <Reference Include="System.Collections" />
     <Reference Include="System.Diagnostics.Debug" />

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticListener.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticListener.cs
@@ -95,7 +95,7 @@ namespace System.Diagnostics
         /// <summary>
         /// Same as other Subscribe overload where the predicate is assumed to always return true.  
         /// </summary>
-        public IDisposable Subscribe(IObserver<KeyValuePair<string, object>> observer)
+        public virtual IDisposable Subscribe(IObserver<KeyValuePair<string, object>> observer)
         {
             return SubscribeInternal(observer, null, null);
         }

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticListener.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticListener.cs
@@ -42,7 +42,9 @@ namespace System.Diagnostics
         {
             get
             {
+#if NET46 || NETFX
                 GC.KeepAlive(HttpHandlerDiagnosticListener.s_instance);
+#endif
 
                 if (s_allListenerObservable == null)
                 {

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticListener.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticListener.cs
@@ -42,6 +42,8 @@ namespace System.Diagnostics
         {
             get
             {
+                GC.KeepAlive(HttpHandlerDiagnosticListener.s_instance);
+
                 if (s_allListenerObservable == null)
                 {
                     s_allListenerObservable = new AllListenerObservable();

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/HttpHandlerDiagnosticListener.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/HttpHandlerDiagnosticListener.cs
@@ -1,0 +1,370 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Net;
+using System.Reflection;
+using System.Reflection.Emit;
+
+// This HttpHandlerDiagnosticListener class is applicable only for .NET 4.5/4.6, and not for .NET core.
+// If you are making these changes, please test your changes manually via custom test applications.
+
+namespace System.Diagnostics
+{
+    /// <summary>
+    /// A HttpHandlerDiagnosticListener is a DiagnosticListener for .NET 4.5/4.6 where HttpClient
+    /// doesn't have a DiagnosticListener built-in. This class is not used for .NET Core because
+    /// HttpClient in .NET Core already emits DiagnosticSource events. This class compensates for
+    /// that in .NET 4.5/4.6. HttpHandlerDiagnosticListener has no public constructor, but it has a
+    /// singleton style Initialize method to control its creation.
+    /// 
+    /// To use this, the application just needs to call HttpHandlerDiagnosticListener.Initialize(), and this
+    /// will register itself with the DiagnosticListener's all listeners collection.
+    /// </summary>
+    internal class HttpHandlerDiagnosticListener : DiagnosticListener
+    {
+        /// <summary>
+        /// Overriding base class implementation just to give us a chance to initialize.  
+        /// </summary>
+        public override IDisposable Subscribe(IObserver<KeyValuePair<string, object>> observer, Predicate<string> isEnabled)
+        {
+            Initialize();
+            return base.Subscribe(observer, isEnabled);
+        }
+
+        /// <summary>
+        /// Overriding base class implementation just to give us a chance to initialize.  
+        /// </summary>
+        public override IDisposable Subscribe(IObserver<KeyValuePair<string, object>> observer, Func<string, object, object, bool> isEnabled)
+        {
+            Initialize();
+            return base.Subscribe(observer, isEnabled);
+        }
+
+        /// <summary>
+        /// Initializes all the reflection objects it will ever need. Reflection is costly, but it's better to take
+        /// this one time performance hit than to get it multiple times later, or do it lazily and have to worry about
+        /// threading issues. If Initialize has been called before, it will not doing anything.
+        /// </summary>
+        private void Initialize()
+        {
+            lock (this.initializationLock)
+            {
+                if (!this.initialized)
+                {
+                    // This flag makes sure we only do this once. Even if we failed to initialize in an
+                    // earlier time, we should not retry because this initialization is not cheap and
+                    // the likelihood it will succeed the second time is very small.
+                    this.initialized = true;
+
+                    try
+                    {
+                        PrepareReflectionObjects();
+                        PerformInjection();
+                    }
+                    catch (Exception)
+                    {
+                        // If anything went wrong, just no-op
+                    }
+                }
+            }
+        }
+
+#region private helper classes
+
+        /// <summary>
+        /// Helper class used for ServicePointManager.s_ServicePointTable. The goal here is to
+        /// intercept each new ServicePoint object being added to ServicePointManager.s_ServicePointTable
+        /// and replace its ConnectionGroupList hashtable field.
+        /// </summary>
+        private class ServicePointHashtable : Hashtable
+        {
+            public override object this[object key]
+            {
+                get
+                {
+                    return base[key];
+                }
+                set
+                {
+                    WeakReference weakRef = value as WeakReference;
+                    if (weakRef != null && weakRef.IsAlive)
+                    {
+                        ServicePoint servicePoint = weakRef.Target as ServicePoint;
+                        if (servicePoint != null)
+                        {
+                            // Replace the ConnectionGroup hashtable inside this ServicePoint object,
+                            // which allows us to intercept each new ConnectionGroup object added under
+                            // this ServicePoint.
+                            Hashtable originalTable = s_connectionGroupListField.GetValue(servicePoint) as Hashtable;
+                            ConnectionGroupHashtable newTable = new ConnectionGroupHashtable();
+                            if (originalTable != null)
+                            {
+                                foreach (DictionaryEntry entry in originalTable)
+                                {
+                                    newTable[entry.Key] = entry.Value;
+                                }
+                            }
+                            s_connectionGroupListField.SetValue(servicePoint, newTable);
+                        }
+                    }
+
+                    base[key] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Helper class used for ServicePoint.m_ConnectiopGroupList. The goal here is to
+        /// intercept each new ConnectionGroup object being added to ServicePoint.m_ConnectionGroupList
+        /// and replace its m_ConnectionList arraylist field.
+        /// </summary>
+        private class ConnectionGroupHashtable : Hashtable
+        {
+            public override object this[object key]
+            {
+                get
+                {
+                    return base[key];
+                }
+                set
+                {
+                    if (s_connectionGroupType.IsInstanceOfType(value))
+                    {
+                        // Replace the Connection arraylist inside this ConnectionGroup object,
+                        // which allows us to intercept each new Connection object added under
+                        // this ConnectionGroup.
+                        ArrayList originalArrayList = s_connectionListField.GetValue(value) as ArrayList;
+                        ConnectionArrayList newArrayList = new ConnectionArrayList();
+                        if (originalArrayList != null)
+                        {
+                            foreach (object entry in originalArrayList)
+                            {
+                                newArrayList.Add(entry);
+                            }
+                        }
+                        s_connectionListField.SetValue(value, newArrayList);
+                    }
+
+                    base[key] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Helper class used for ConnectionGroup.m_ConnectionList. The goal here is to
+        /// intercept each new Connection object being added to ConnectionGroup.m_ConnectionList
+        /// and replace its m_WriteList arraylist field.
+        /// </summary>
+        private class ConnectionArrayList : ArrayList
+        {
+            public override int Add(object value)
+            {
+                if (s_connectionType.IsInstanceOfType(value))
+                {
+                    // Replace the HttpWebRequest arraylist inside this Connection object,
+                    // which allows us to intercept each new HttpWebRequest object added under
+                    // this Connection.
+                    ArrayList originalArrayList = s_writeListField.GetValue(value) as ArrayList;
+                    HttpWebRequestArrayList newArrayList = new HttpWebRequestArrayList();
+                    if (originalArrayList != null)
+                    {
+                        foreach (object entry in originalArrayList)
+                        {
+                            newArrayList.Add(entry);
+                        }
+                    }
+                    s_writeListField.SetValue(value, newArrayList);
+                }
+
+                return base.Add(value);
+            }
+        }
+
+        /// <summary>
+        /// Helper class used for Connection.m_WriteList. The goal here is to
+        /// intercept all new HttpWebRequest objects being added to Connection.m_WriteList
+        /// and notify the listener about the HttpWebRequest that's about to send a request.
+        /// It also intercepts all HttpWebRequest objects that are about to get removed from
+        /// Connection.m_WriteList as they have completed the request.
+        /// </summary>
+        private class HttpWebRequestArrayList : ArrayList
+        {
+            public override int Add(object value)
+            {
+                HttpWebRequest request = value as HttpWebRequest;
+                if (request != null)
+                {
+                    s_instance.RaiseRequestEvent(request);
+                }
+
+                return base.Add(value);
+            }
+
+            public override void RemoveAt(int index)
+            {
+                HttpWebRequest request = base[index] as HttpWebRequest;
+                if (request != null)
+                {
+                    HttpWebResponse response = s_httpResponseAccessor(request);
+                    if (response != null)
+                    {
+                        s_instance.RaiseResponseEvent(request, response);
+                    }
+                }
+
+                base.RemoveAt(index);
+            }
+        }
+
+#endregion
+
+#region private methods
+
+        /// <summary>
+        /// Private constructor. Make sure every caller has to create this object via the Initialize
+        /// method.
+        /// </summary>
+        private HttpHandlerDiagnosticListener() : base(DiagnosticListenerName)
+        {
+        }
+
+        private void RaiseRequestEvent(HttpWebRequest request)
+        {
+            Guid loggingRequestId = Guid.Empty;
+
+            // If System.Net.Http.Request is on, raise the event
+            if (this.IsEnabled(RequestWriteName))
+            {
+                long timestamp = Stopwatch.GetTimestamp();
+                loggingRequestId = Guid.NewGuid();
+                this.Write(RequestWriteName,
+                    new
+                    {
+                        Request = request,
+                        //LoggingRequestId = loggingRequestId,
+                        Timestamp = timestamp
+                    }
+                );
+            }
+        }
+
+        private void RaiseResponseEvent(HttpWebRequest request, HttpWebResponse response)
+        {
+            Guid loggingRequestId = Guid.Empty;
+
+            // TODO: Figure what's the right way to detect error conditions here.
+            if (response.StatusCode >= (HttpStatusCode)400)
+            {
+                if (this.IsEnabled(ExceptionEventName))
+                {
+                    //this.Write(ExceptionEventName, new { Exception = ex, Request = request });
+                    this.Write(ExceptionEventName, new { Response = response });
+                }
+            }
+
+            if (this.IsEnabled(ResponseWriteName))
+            {
+                long timestamp = Stopwatch.GetTimestamp();
+                this.Write(ResponseWriteName,
+                    new
+                    {
+                        Request = request,
+                        Response = response,
+                        //LoggingRequestId = loggingRequestId,
+                        TimeStamp = timestamp
+                        //RequestTaskStatus = responseTask.Status
+                    }
+                );
+            }
+        }
+
+        private static void PrepareReflectionObjects()
+        {
+            // At any point, if the operation failed, it should just throw, including NullReferenceException.
+            // The caller should catch all exceptions and swallow.
+
+            // First step: Get all the reflection objects we will ever need.
+            Assembly systemNetHttpAssembly = typeof(ServicePoint).Assembly;
+            s_connectionGroupListField = typeof(ServicePoint).GetField("m_ConnectionGroupList", BindingFlags.Instance | BindingFlags.NonPublic);
+            s_connectionGroupType = systemNetHttpAssembly?.GetType("System.Net.ConnectionGroup");
+            s_connectionListField = s_connectionGroupType?.GetField("m_ConnectionList", BindingFlags.Instance | BindingFlags.NonPublic);
+            s_connectionType = systemNetHttpAssembly?.GetType("System.Net.Connection");
+            s_writeListField = s_connectionType?.GetField("m_WriteList", BindingFlags.Instance | BindingFlags.NonPublic);
+
+            // Second step: Generate an accessor for HttpWebRequest._HttpResponse
+            FieldInfo field = typeof(HttpWebRequest).GetField("_HttpResponse", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            string methodName = field?.ReflectedType.FullName + ".get_" + field.Name;
+            if (!string.IsNullOrEmpty(methodName))
+            {
+                DynamicMethod getterMethod = new DynamicMethod(methodName, typeof(HttpWebResponse), new Type[] { typeof(HttpWebRequest) }, true);
+                ILGenerator generator = getterMethod.GetILGenerator();
+                generator.Emit(OpCodes.Ldarg_0);
+                generator.Emit(OpCodes.Ldfld, field);
+                generator.Emit(OpCodes.Ret);
+                s_httpResponseAccessor = (Func<HttpWebRequest, HttpWebResponse>)getterMethod.CreateDelegate(typeof(Func<HttpWebRequest, HttpWebResponse>));
+            }
+
+            // Double checking to make sure we have all the pieces initialized
+            if (s_connectionGroupListField == null ||
+                s_connectionGroupType == null ||
+                s_connectionListField == null ||
+                s_connectionType == null ||
+                s_writeListField == null ||
+                s_httpResponseAccessor == null)
+            {
+                throw new InvalidOperationException("Unable to initialize all required reflection objects");
+            }
+        }
+
+        private static void PerformInjection()
+        {
+            FieldInfo servicePointTableField = typeof(ServicePointManager).GetField("s_ServicePointTable", BindingFlags.Static | BindingFlags.NonPublic);
+            if (servicePointTableField == null)
+            {
+                throw new InvalidOperationException("Unable to access the ServicePointTable field");
+            }
+
+            Hashtable originalTable = servicePointTableField.GetValue(null) as Hashtable;
+            ServicePointHashtable newTable = new ServicePointHashtable();
+
+            // Copy the existing entries over to the new table, and replace the field with our new table
+            if (originalTable != null)
+            {
+                foreach (DictionaryEntry entry in originalTable)
+                {
+                    newTable[entry.Key] = entry.Value;
+                }
+            }
+
+            servicePointTableField.SetValue(null, newTable);
+        }
+
+#endregion
+
+        internal static HttpHandlerDiagnosticListener s_instance = new HttpHandlerDiagnosticListener();
+
+#region private fields
+        private const string DiagnosticListenerName = "System.Net.Http.Desktop.V4";
+        private const string RequestWriteName = "System.Net.Http.Request";
+        private const string ResponseWriteName = "System.Net.Http.Response";
+        private const string ExceptionEventName = "System.Net.Http.Exception";
+
+        // Fields for controlling initialization of the HttpHandlerDiagnosticListener singleton
+        private object initializationLock = new object();
+        private bool initialized = false;
+
+        // Fields for reflection
+        private static FieldInfo s_connectionGroupListField;
+        private static Type s_connectionGroupType;
+        private static FieldInfo s_connectionListField;
+        private static Type s_connectionType;
+        private static FieldInfo s_writeListField;
+        private static Func<HttpWebRequest, HttpWebResponse> s_httpResponseAccessor;
+
+#endregion
+    }
+}

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/HttpHandlerDiagnosticListener.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/HttpHandlerDiagnosticListener.cs
@@ -14,10 +14,10 @@ using System.Runtime.Serialization;
 namespace System.Diagnostics
 {
     /// <summary>
-    /// A HttpHandlerDiagnosticListener is a DiagnosticListener for .NET 4.6 where HttpClient
-    /// doesn't have a DiagnosticListener built in. This class is not used for .NET Core because
-    /// HttpClient in .NET Core already emits DiagnosticSource events. This class compensates for
-    /// that in .NET 4.6. HttpHandlerDiagnosticListener has no public constructor. To use this, 
+    /// A HttpHandlerDiagnosticListener is a DiagnosticListener for .NET 4.6 and above where
+    /// HttpClient doesn't have a DiagnosticListener built in. This class is not used for .NET Core
+    /// because HttpClient in .NET Core already emits DiagnosticSource events. This class compensates for
+    /// that in .NET 4.6 and above. HttpHandlerDiagnosticListener has no public constructor. To use this, 
     /// the application just needs to call <see cref="DiagnosticListener.AllListeners" /> and
     /// <see cref="DiagnosticListener.AllListenerObservable.Subscribe(IObserver{DiagnosticListener})"/>,
     /// then in the <see cref="IObserver{DiagnosticListener}.OnNext(DiagnosticListener)"/> method,
@@ -195,11 +195,6 @@ namespace System.Diagnostics
             {
                 this._table.Remove(key);
             }
-            public override void OnDeserialization(object sender)
-            {
-            }
-
-            private const string ParentTableSerializationField = "ParentTable";
         }
 
         /// <summary>

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/HttpHandlerDiagnosticListener.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/HttpHandlerDiagnosticListener.cs
@@ -10,7 +10,6 @@ using System.Reflection.Emit;
 using System.Runtime.Serialization;
 
 // This HttpHandlerDiagnosticListener class is applicable only for .NET 4.6, and not for .NET core.
-// If you are making these changes, please test your changes manually via custom test applications.
 
 namespace System.Diagnostics
 {
@@ -33,16 +32,7 @@ namespace System.Diagnostics
         public override IDisposable Subscribe(IObserver<KeyValuePair<string, object>> observer, Predicate<string> isEnabled)
         {
             IDisposable result = base.Subscribe(observer, isEnabled);
-            try
-            {
-                Initialize();
-            }
-            catch (Exception ex)
-            {
-                // If anything went wrong, just no-op. Write an event so at least we can find out.
-                this.Write(InitializationFailed, new { Exception = ex });
-            }
-
+            Initialize();
             return result;
         }
 
@@ -52,16 +42,7 @@ namespace System.Diagnostics
         public override IDisposable Subscribe(IObserver<KeyValuePair<string, object>> observer, Func<string, object, object, bool> isEnabled)
         {
             IDisposable result = base.Subscribe(observer, isEnabled);
-            try
-            {
-                Initialize();
-            }
-            catch (Exception ex)
-            {
-                // If anything went wrong, just no-op. Write an event so at least we can find out.
-                this.Write(InitializationFailed, new { Exception = ex });
-            }
-
+            Initialize();
             return result;
         }
 
@@ -71,16 +52,7 @@ namespace System.Diagnostics
         public override IDisposable Subscribe(IObserver<KeyValuePair<string, object>> observer)
         {
             IDisposable result = base.Subscribe(observer);
-            try
-            {
-                Initialize();
-            }
-            catch (Exception ex)
-            {
-                // If anything went wrong, just no-op. Write an event so at least we can find out.
-                this.Write(InitializationFailed, new { Exception = ex });
-            }
-
+            Initialize();
             return result;
         }
 
@@ -93,15 +65,23 @@ namespace System.Diagnostics
         {
             lock (this)
             {
-                if (!this.initialized)
+                try
                 {
-                    // This flag makes sure we only do this once. Even if we failed to initialize in an
-                    // earlier time, we should not retry because this initialization is not cheap and
-                    // the likelihood it will succeed the second time is very small.
-                    this.initialized = true;
+                    if (!this.initialized)
+                    {
+                        // This flag makes sure we only do this once. Even if we failed to initialize in an
+                        // earlier time, we should not retry because this initialization is not cheap and
+                        // the likelihood it will succeed the second time is very small.
+                        this.initialized = true;
 
-                    PrepareReflectionObjects();
-                    PerformInjection();
+                        PrepareReflectionObjects();
+                        PerformInjection();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    // If anything went wrong, just no-op. Write an event so at least we can find out.
+                    this.Write(InitializationFailed, new { Exception = ex });
                 }
             }
         }

--- a/src/System.Diagnostics.DiagnosticSource/tests/Configurations.props
+++ b/src/System.Diagnostics.DiagnosticSource/tests/Configurations.props
@@ -6,6 +6,7 @@
       netstandard1.3;
       netstandard1.5;      
       netstandard;
+      netfx-Windows_NT;      
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Diagnostics.DiagnosticSource/tests/HttpHandlerDiagnosticListenerTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/HttpHandlerDiagnosticListenerTests.cs
@@ -1,0 +1,351 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Diagnostics.Tests
+{
+    [SkipOnTargetFramework(
+        TargetFrameworkMonikers.Net45|
+        TargetFrameworkMonikers.Net451 |
+        TargetFrameworkMonikers.Net452 |
+        TargetFrameworkMonikers.Netcore50 |
+        TargetFrameworkMonikers.Netcore50aot |
+        TargetFrameworkMonikers.Netcoreapp |
+        TargetFrameworkMonikers.Netcoreapp1_0 |
+        TargetFrameworkMonikers.Netcoreapp1_1 |
+        TargetFrameworkMonikers.NetcoreCoreRT |
+        TargetFrameworkMonikers.Uap |
+        TargetFrameworkMonikers.UapAot)]
+    public class HttpHandlerDiagnosticListenerTests
+    {
+        /// <summary>
+        /// A simple test to make sure the Http Diagnostic Source is added into the list of DiagnosticListeners.
+        /// </summary>
+        [Fact]
+        public void TestHttpDiagnosticListenerIsRegistered()
+        {
+            bool listenerFound = false;
+            DiagnosticListener.AllListeners.Subscribe(new CallbackObserver<DiagnosticListener>(diagnosticListener =>
+            {
+                if (diagnosticListener.Name == "System.Net.Http.Desktop")
+                {
+                    listenerFound = true;
+                }
+            }));
+
+            Assert.True(listenerFound, "The Http Diagnostic Listener didn't get added to the AllListeners list.");
+        }
+
+        /// <summary>
+        /// A simple test to make sure the Http Diagnostic Source is initialized properly after we subscribed to it, using
+        /// the subscribe overload with just the observer argument.
+        /// </summary>
+        [Fact]
+        public void TestReflectInitializationViaSubscription1()
+        {
+            EventObserverAndRecorder eventRecords = CreateEventRecorder();
+
+            // Send a random Http request to generate some events
+            HttpResponseMessage message = new HttpClient().GetAsync("www.bing.com").Result;
+
+            // Just make sure some events are written, to confirm we successfully subscribed to it. We should have 
+            // at least two events, one for request send, and one for response receive
+            Assert.True(eventRecords.Records.Count >= 2, "Didn't get two or more events from Http Diagnostic Listener. Something is wrong.");
+        }
+
+        /// <summary>
+        /// A simple test to make sure the Http Diagnostic Source is initialized properly after we subscribed to it, using
+        /// the subscribe overload with the observer argument and the simple predicate argument.
+        /// </summary>
+        [Fact]
+        public void TestReflectInitializationViaSubscription2()
+        {
+            EventObserverAndRecorder eventRecords = new EventObserverAndRecorder();
+            DiagnosticListener.AllListeners.Subscribe(new CallbackObserver<DiagnosticListener>(diagnosticListener =>
+            {
+                if (diagnosticListener.Name == "System.Net.Http.Desktop")
+                {
+                    diagnosticListener.Subscribe(eventRecords, (eventName) => { return true; });
+                }
+            }));
+
+            // Send a random Http request to generate some events
+            HttpResponseMessage message = new HttpClient().GetAsync("www.bing.com").Result;
+
+            // Just make sure some events are written, to confirm we successfully subscribed to it. We should have 
+            // at least two events, one for request send, and one for response receive
+            Assert.True(eventRecords.Records.Count >= 2, "Didn't get two or more events from Http Diagnostic Listener. Something is wrong.");
+        }
+
+        /// <summary>
+        /// A simple test to make sure the Http Diagnostic Source is initialized properly after we subscribed to it, using
+        /// the subscribe overload with just the observer argument and the more compolicating enable filter function.
+        /// </summary>
+        [Fact]
+        public void TestReflectInitializationViaSubscription3()
+        {
+            EventObserverAndRecorder eventRecords = new EventObserverAndRecorder();
+            DiagnosticListener.AllListeners.Subscribe(new CallbackObserver<DiagnosticListener>(diagnosticListener =>
+            {
+                if (diagnosticListener.Name == "System.Net.Http.Desktop")
+                {
+                    diagnosticListener.Subscribe(eventRecords, (eventName, obj1, obj2) => { return true; });
+                }
+            }));
+
+            // Send a random Http request to generate some events
+            HttpResponseMessage message = new HttpClient().GetAsync("www.bing.com").Result;
+
+            // Just make sure some events are written, to confirm we successfully subscribed to it. We should have 
+            // at least two events, one for request send, and one for response receive
+            Assert.True(eventRecords.Records.Count >= 2, "Didn't get two or more events from Http Diagnostic Listener. Something is wrong.");
+        }
+
+        /// <summary>
+        /// Test to make sure we get both request and response events.
+        /// </summary>
+        [Fact]
+        public void TestBasicReceiveAndResponseEvents()
+        {
+            EventObserverAndRecorder eventRecords = CreateEventRecorder();
+
+            // Send a random Http request to generate some events
+            HttpResponseMessage message = new HttpClient().GetAsync("www.bing.com").Result;
+
+            // Just make sure some events are written, to confirm we successfully subscribed to it. We should have 
+            // at least two events, one for request send, and one for response receive
+            Assert.True(eventRecords.Records.Count >= 2, "Didn't get two or more events from Http Diagnostic Listener. Something is wrong.");
+
+            // I can't use the HttpWebRequest type here since it doesn't exist in .net core, so just use "object"
+            WebRequest firstRequest = null;
+
+            // Check to make sure: The first record must be a request, the last record must be a response. Records in
+            // the middle can be anything since it depends on # of redirections
+            for (int i = 0; i < eventRecords.Records.Count; i++)
+            {
+                var pair = eventRecords.Records[i];
+                dynamic eventFields = pair.Value;
+                WebRequest thisRequest = eventFields.Request;
+
+                if (i == 0)
+                {
+                    Assert.Equal("System.Net.Http.Request", pair.Key);                    
+                    firstRequest = eventFields.Request;
+                }
+                else if (i == eventRecords.Records.Count - 1)
+                {
+                    Assert.Equal("System.Net.Http.Response", pair.Key);
+                    Assert.ReferenceEquals(firstRequest, eventFields.Request);
+                }
+                else
+                {
+                    Assert.True(pair.Key == "System.Net.Http.Response" || pair.Key == "System.Net.Http.Request", "An unexpected event of name " + pair.Key + "was received");
+                    Assert.ReferenceEquals(firstRequest, eventFields.Request);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Test to make sure every event record has the right dynamic properties.
+        /// </summary>
+        [Fact]
+        public void TestDynamicPropertiesOnReceiveAndResponseEvents()
+        {
+            EventObserverAndRecorder eventRecords = CreateEventRecorder();
+            long beginTimestamp = Stopwatch.GetTimestamp();
+
+            // Send a random Http request to generate some events
+            HttpResponseMessage message = new HttpClient().GetAsync("www.bing.com").Result;
+
+            // Just make sure some events are written, to confirm we successfully subscribed to it. We should have 
+            // at least two events, one for request send, and one for response receive
+            Assert.True(eventRecords.Records.Count >= 2, "Didn't get two or more events from Http Diagnostic Listener. Something is wrong.");
+
+            // Check to make sure: The first record must be a request, the last record must be a response. Records in
+            // the middle can be anything since it depends on # of redirections
+            for (int i = 0; i < eventRecords.Records.Count; i++)
+            {
+                var pair = eventRecords.Records[i];
+                dynamic eventFields = pair.Value;
+
+                Assert.True(pair.Key == "System.Net.Http.Response" || pair.Key == "System.Net.Http.Request", "An unexpected event of name " + pair.Key + "was received");
+
+                WebRequest request = eventFields.Request;
+                long timestamp = eventFields.Timestamp;
+
+                Assert.Equal(request.GetType().Name, "HttpWebRequest");
+
+                // Just compare the timestamp to make sure it's reasonable. In an poorman experiment, we
+                // found that 10 secs is roughly 30,000,000 ticks
+                Assert.True(timestamp - beginTimestamp > 0 && timestamp - beginTimestamp < 30 * 1000 * 1000, "The timestamp sent with the event doesn't look correct");
+
+                if (pair.Key == "System.Net.Http.Response")
+                {
+                    object response = eventFields.Response;
+                    Assert.Equal(response.GetType().Name, "HttpWebResponse");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Test to make sure every event record has the right dynamic properties.
+        /// </summary>
+        [Fact]
+        public void TestMultipleConcurrentRequests()
+        {
+            EventObserverAndRecorder eventRecords = CreateEventRecorder();
+            long beginTimestamp = Stopwatch.GetTimestamp();
+
+            Dictionary<string, Tuple<WebRequest, WebResponse>> requestData = new Dictionary<string, Tuple<WebRequest, WebResponse>>();
+            requestData.Add("www.microsoft.com", null);
+            requestData.Add("www.bing.com", null);
+            requestData.Add("www.xbox.com", null);
+            requestData.Add("www.office.com", null);
+            requestData.Add("www.microsoftstore.com", null);
+            requestData.Add("www.msn.com", null);
+            requestData.Add("outlook.live.com", null);
+            requestData.Add("build.microsoft.com", null);
+            requestData.Add("azure.microsoft.com", null);
+            requestData.Add("www.nuget.org", null);
+            requestData.Add("support.microsoft.com", null);
+            requestData.Add("www.visualstudio.com", null);
+            requestData.Add("msdn.microsoft.com", null);
+            requestData.Add("onedrive.live.com", null);
+            requestData.Add("community.dynamics.com", null);
+            requestData.Add("login.live.com", null);
+            requestData.Add("www.skype.com", null);
+            requestData.Add("channel9.msdn.com", null);
+
+            // Issue all requests simultaneously
+            HttpClient httpClient = new HttpClient();
+            List<Task<HttpResponseMessage>> tasks = new List<Task<HttpResponseMessage>>();
+            foreach (string url in requestData.Keys)
+            {
+                tasks.Add(httpClient.GetAsync(url));
+            }
+
+            Task.WaitAll(tasks.ToArray());
+
+            // Examine the result. Make sure we got them all.
+
+            // Just make sure some events are written, to confirm we successfully subscribed to it. We should have 
+            // at least two events, one for request send, and one for response receive
+            Assert.True(eventRecords.Records.Count >= requestData.Count * 2, "Didn't get two or more events on average from each request. Something is wrong.");
+
+            // Check to make sure: We have a WebRequest and a WebResponse for each URL
+            for (int i = 0; i < eventRecords.Records.Count; i++)
+            {
+                var pair = eventRecords.Records[i];
+                dynamic eventFields = pair.Value;
+
+                Assert.True(pair.Key == "System.Net.Http.Response" || pair.Key == "System.Net.Http.Request", "An unexpected event of name " + pair.Key + "was received");
+
+                WebRequest request = eventFields.Request;
+                long timestamp = eventFields.Timestamp;
+
+                Assert.Equal(request.GetType().Name, "HttpWebRequest");
+
+                // Just compare the timestamp to make sure it's reasonable. In an poorman experiment, we
+                // found that 10 secs is roughly 30,000,000 ticks
+                Assert.True(timestamp - beginTimestamp > 0 && timestamp - beginTimestamp < 30 * 1000 * 1000, "The timestamp sent with the event doesn't look correct");
+
+                if (pair.Key == "System.Net.Http.Request")
+                {
+                    // Make sure this is an URL that we recognize. If not, just skip
+                    Tuple<WebRequest, WebResponse> tuple = null;
+                    if (!requestData.TryGetValue(request.RequestUri.Host, out tuple))
+                    {
+                        continue;
+                    }
+
+                    WebRequest previousSeenRequest = tuple?.Item1;
+                    WebResponse previousSeenResponse = tuple?.Item2;
+
+                    // We see have seen an HttpWebRequest before for this URL/host, make sure it's the same one,
+                    // Then update the tuple with the request object, if we didn't have one
+                    Assert.True(previousSeenRequest == null || previousSeenRequest == request, "Didn't expect to see a different WebRequest object going to the same url host for: " + request.RequestUri.Host);
+                    requestData[request.RequestUri.Host] = new Tuple<WebRequest, WebResponse>(previousSeenRequest ?? request, previousSeenResponse);
+                }
+                else
+                {
+                    // This must be the response.
+                    WebResponse response = eventFields.Response;
+                    Assert.Equal(response.GetType().Name, "HttpWebResponse");
+
+                    // By the time we see the response, the request object may already have been redirected with a different
+                    // url. Hence, it's not reliable to just look up requestData by the URL/hostname. Instead, we have to look
+                    // through each one and match by object reference on the request object.
+                    Tuple<WebRequest, WebResponse> tuple = null;
+                    foreach (Tuple<WebRequest, WebResponse> currentTuple in requestData.Values)
+                    {
+                        if (currentTuple != null && currentTuple.Item1 == request)
+                        {
+                            // Found it!
+                            tuple = currentTuple;
+                            break;
+                        }
+                    }
+
+                    // Update the tuple with the response object
+                    Assert.NotNull(tuple);
+                    requestData[request.RequestUri.Host] = new Tuple<WebRequest, WebResponse>(request, response);
+                }
+            }
+
+            // Finally, make sure we have request and response objects for every entry
+            foreach (KeyValuePair<string, Tuple<WebRequest, WebResponse>> pair in requestData)
+            {
+                Assert.NotNull(pair.Value);
+                Assert.NotNull(pair.Value.Item1);
+                Assert.NotNull(pair.Value.Item2);
+            }
+        }
+
+        private EventObserverAndRecorder CreateEventRecorder()
+        {
+            EventObserverAndRecorder eventRecords = new EventObserverAndRecorder();
+            DiagnosticListener.AllListeners.Subscribe(new CallbackObserver<DiagnosticListener>(diagnosticListener =>
+            {
+                if (diagnosticListener.Name == "System.Net.Http.Desktop")
+                {
+                    diagnosticListener.Subscribe(eventRecords);
+                }
+            }));
+            return eventRecords;
+        }
+
+        /// <summary>
+        /// CallbackObserver is a adapter class that creates an observer (which you can pass
+        /// to IObservable.Subscribe), and calls the given callback every time the 'next' 
+        /// operation on the IObserver happens. 
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        private class CallbackObserver<T> : IObserver<T>
+        {
+            public CallbackObserver(Action<T> callback) { _callback = callback; }
+            public void OnCompleted() { }
+            public void OnError(Exception error) { }
+            public void OnNext(T value) { _callback(value); }
+
+            private Action<T> _callback;
+        }
+
+        /// <summary>
+        /// EventObserverAndRecorder is an observer that watches all Http diagnosticlistener events flowing
+        /// through, and record all of them
+        /// </summary>
+        private class EventObserverAndRecorder : IObserver<KeyValuePair<string, object>>
+        {
+            public List<KeyValuePair<string, object>> Records { get; private set; }
+
+            public void OnCompleted() { }
+            public void OnError(Exception error) { }
+            public void OnNext(KeyValuePair<string, object> record) { Records.Add(record); }
+        }
+    }
+}

--- a/src/System.Diagnostics.DiagnosticSource/tests/System.Diagnostics.DiagnosticSource.Tests.csproj
+++ b/src/System.Diagnostics.DiagnosticSource/tests/System.Diagnostics.DiagnosticSource.Tests.csproj
@@ -18,13 +18,19 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.3-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.5-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.5-Release|AnyCPU'" />
-  <ItemGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Windows_NT-Release|AnyCPU'" />
+  <ItemGroup Condition=" '$(TargetGroup)' != 'netfx'">
     <Compile Include="DiagnosticSourceEventSourceBridgeTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="DiagnosticSourceTests.cs" />
-    <Compile Include="HttpHandlerDiagnosticListenerTests.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetGroup)' != 'netstandard1.1'">
     <Compile Include="ActivityTests.cs" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetGroup)' == 'netfx'">
+    <Compile Include="HttpHandlerDiagnosticListenerTests.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Diagnostics.DiagnosticSource/tests/System.Diagnostics.DiagnosticSource.Tests.csproj
+++ b/src/System.Diagnostics.DiagnosticSource/tests/System.Diagnostics.DiagnosticSource.Tests.csproj
@@ -4,6 +4,12 @@
   <PropertyGroup>
     <ProjectGuid>{A7922FA3-306A-41B9-B8DC-CC4DBE685A85}</ProjectGuid>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetGroup)' == 'net46'">
+    <DefineConstants>$(DefineConstants);NET46</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetGroup)' == 'netfx'">
+    <DefineConstants>$(DefineConstants);NETFX</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.1-Debug|AnyCPU'" />
@@ -15,6 +21,7 @@
   <ItemGroup>
     <Compile Include="DiagnosticSourceEventSourceBridgeTests.cs" />
     <Compile Include="DiagnosticSourceTests.cs" />
+    <Compile Include="HttpHandlerDiagnosticListenerTests.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetGroup)' != 'netstandard1.1'">
     <Compile Include="ActivityTests.cs" />


### PR DESCRIPTION
This listener compensates for the fact that .NET45/46 doesn't use DiagnosticSource. This solution attempts to recreate that by inserting into the Http stack and generating events.

This HttpHandlerDiagnosticListener is a singleton, and the bulk of its initialization happens when the first subscribe subscribes.
The way this listener injects inself into the Http stack is via reflection. More details are in the code documentation.