### PR TITLE
Couple of fixes for UWP app-compat.

### DIFF
--- a/src/System.Linq.Expressions/src/Resources/System.Linq.Expressions.rd.xml
+++ b/src/System.Linq.Expressions/src/Resources/System.Linq.Expressions.rd.xml
@@ -6,6 +6,7 @@
       <TypeInstantiation Name="System.Linq.Expressions.ExpressionCreator" Arguments="System.Func{System.Boolean}" Dynamic="Required All" />
       <TypeInstantiation Name="System.Runtime.CompilerServices.CallSite" Arguments="System.Func{System.Runtime.CompilerServices.CallSite, System.Object, System.Int32}" Dynamic="Required All" /> 
       <Type Name="System.Runtime.CompilerServices.CallSiteOps" Dynamic="Required All" />
+      <Type Name="System.Runtime.CompilerServices.RuntimeOps" Dynamic="Required All" />
       <Namespace Name="System.Linq.Expressions">
         <Type Name="Expression&lt;TDelegate&gt;">
           <GenericParameter Name="TDelegate" Dynamic="Public"/>

--- a/src/System.Net.Http/src/netcore50/System/Net/HttpClientHandler.cs
+++ b/src/System.Net.Http/src/netcore50/System/Net/HttpClientHandler.cs
@@ -161,11 +161,14 @@ namespace System.Net.Http
             get { return true; }
             set
             {
+                /*
+                TODO:#18104
                 if (value != PreAuthenticate)
                 {
                     throw new PlatformNotSupportedException(String.Format(CultureInfo.InvariantCulture,
                         SR.net_http_value_not_supported, value, nameof(PreAuthenticate)));
                 }
+                */
                 CheckDisposedOrStarted();
             }
         }


### PR DESCRIPTION
1. HttpClientHandler.PreAuthenticate throws PNSE, disabling it for now - #18104 tracking proper fix
2. System.Runtime.CompilerServices.RuntimeOps need to be reflection enabled.