### PR TITLE
Fix some Console validation bugs and add tests

### DIFF
--- a/src/System.Console/src/System/ConsolePal.Windows.cs
+++ b/src/System.Console/src/System/ConsolePal.Windows.cs
@@ -629,12 +629,6 @@ namespace System
 
             set
             {
-                if (value == null)
-                    throw new ArgumentNullException(nameof(value));
-                if (value.Length > MaxConsoleTitleLength)
-                    throw new ArgumentOutOfRangeException(nameof(value), SR.ArgumentOutOfRange_ConsoleTitleTooLong);
-                Contract.EndContractBlock();
-
                 if (!Interop.Kernel32.SetConsoleTitle(value))
                     throw Win32Marshal.GetExceptionForWin32Error(Marshal.GetLastWin32Error());
             }
@@ -790,15 +784,6 @@ namespace System
 
         public static void SetCursorPosition(int left, int top)
         {
-            // Note on argument checking - the upper bounds are NOT correct 
-            // here!  But it looks slightly expensive to compute them.  Let
-            // Windows calculate them, then we'll give a nice error message.
-            if (left < 0 || left >= short.MaxValue)
-                throw new ArgumentOutOfRangeException(nameof(left), left, SR.ArgumentOutOfRange_ConsoleBufferBoundaries);
-            if (top < 0 || top >= short.MaxValue)
-                throw new ArgumentOutOfRangeException(nameof(top), top, SR.ArgumentOutOfRange_ConsoleBufferBoundaries);
-            Contract.EndContractBlock();
-
             IntPtr hConsole = OutputHandle;
             Interop.Kernel32.COORD coords = new Interop.Kernel32.COORD();
             coords.X = (short)left;
@@ -808,9 +793,9 @@ namespace System
                 // Give a nice error message for out of range sizes
                 int errorCode = Marshal.GetLastWin32Error();
                 Interop.Kernel32.CONSOLE_SCREEN_BUFFER_INFO csbi = GetBufferInfo();
-                if (left < 0 || left >= csbi.dwSize.X)
+                if (left >= csbi.dwSize.X)
                     throw new ArgumentOutOfRangeException(nameof(left), left, SR.ArgumentOutOfRange_ConsoleBufferBoundaries);
-                if (top < 0 || top >= csbi.dwSize.Y)
+                if (top >= csbi.dwSize.Y)
                     throw new ArgumentOutOfRangeException(nameof(top), top, SR.ArgumentOutOfRange_ConsoleBufferBoundaries);
 
                 throw Win32Marshal.GetExceptionForWin32Error(errorCode);

--- a/src/System.Console/src/System/ConsolePal.Windows.cs
+++ b/src/System.Console/src/System/ConsolePal.Windows.cs
@@ -97,7 +97,7 @@ namespace System
             if (enc.CodePage != Encoding.Unicode.CodePage)
             {
                 if (!Interop.Kernel32.SetConsoleCP(enc.CodePage))
-                    Win32Marshal.GetExceptionForWin32Error(Marshal.GetLastWin32Error());
+                    throw Win32Marshal.GetExceptionForWin32Error(Marshal.GetLastWin32Error());
             }
         }
 
@@ -111,7 +111,7 @@ namespace System
             if (enc.CodePage != Encoding.Unicode.CodePage)
             {
                 if (!Interop.Kernel32.SetConsoleOutputCP(enc.CodePage))
-                    Win32Marshal.GetExceptionForWin32Error(Marshal.GetLastWin32Error());
+                    throw Win32Marshal.GetExceptionForWin32Error(Marshal.GetLastWin32Error());
             }
         }
 
@@ -421,7 +421,7 @@ namespace System
 
                 int mode = 0;
                 if (!Interop.Kernel32.GetConsoleMode(handle, out mode))
-                    Win32Marshal.GetExceptionForWin32Error(Marshal.GetLastWin32Error());
+                    throw Win32Marshal.GetExceptionForWin32Error(Marshal.GetLastWin32Error());
 
                 return (mode & Interop.Kernel32.ENABLE_PROCESSED_INPUT) == 0;
             }
@@ -444,7 +444,7 @@ namespace System
                 }
 
                 if (!Interop.Kernel32.SetConsoleMode(handle, mode))
-                    Win32Marshal.GetExceptionForWin32Error(Marshal.GetLastWin32Error());
+                    throw Win32Marshal.GetExceptionForWin32Error(Marshal.GetLastWin32Error());
             }
         }
 

--- a/src/System.Console/tests/ConsoleEncoding.Windows.cs
+++ b/src/System.Console/tests/ConsoleEncoding.Windows.cs
@@ -1,0 +1,83 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Text;
+using System.Runtime.InteropServices;
+using Xunit;
+
+public partial class ConsoleEncoding
+{
+    [Fact]
+    [PlatformSpecific(TestPlatforms.Windows)]
+    public void InputEncoding_SetDefaultEncoding_Success()
+    {
+        RemoteInvoke(() =>
+        {
+            Encoding encoding = Encoding.GetEncoding(0);
+            Console.InputEncoding = encoding;
+            Assert.Equal(encoding, Console.InputEncoding);
+            Assert.Equal((uint)encoding.CodePage, GetConsoleCP());
+
+            return SuccessExitCode;
+        }).Dispose();
+    }
+
+    [Fact]
+    [PlatformSpecific(TestPlatforms.Windows)]
+    public void InputEncoding_SetUnicodeEncoding_SilentlyIgnoredInternally()
+    {
+        RemoteInvoke(() =>
+        {
+            Encoding unicodeEncoding = Encoding.Unicode;
+            Encoding oldEncoding = Console.InputEncoding;
+            Assert.NotEqual(unicodeEncoding.CodePage, oldEncoding.CodePage);
+
+            Console.InputEncoding = unicodeEncoding;
+            Assert.Equal(unicodeEncoding, Console.InputEncoding);
+            Assert.Equal((uint)oldEncoding.CodePage, GetConsoleCP());
+
+            return SuccessExitCode;
+        }).Dispose();
+    }
+
+    [Fact]
+    [PlatformSpecific(TestPlatforms.Windows)]
+    public void OutputEncoding_SetDefaultEncoding_Success()
+    {
+        RemoteInvoke(() =>
+        {
+            Encoding encoding = Encoding.GetEncoding(0);
+            Console.OutputEncoding = encoding;
+            Assert.Equal(encoding, Console.OutputEncoding);
+            Assert.Equal((uint)encoding.CodePage, GetConsoleOutputCP());
+
+            return SuccessExitCode;
+        }).Dispose();
+    }
+
+    [Fact]
+    [PlatformSpecific(TestPlatforms.Windows)]
+    public void OutputEncoding_SetUnicodeEncoding_SilentlyIgnoredInternally()
+    {
+        RemoteInvoke(() =>
+        {
+            Encoding unicodeEncoding = Encoding.Unicode;
+            Encoding oldEncoding = Console.OutputEncoding;
+            Assert.NotEqual(unicodeEncoding.CodePage, oldEncoding.CodePage);
+            Console.OutputEncoding = unicodeEncoding;
+            Assert.Equal(unicodeEncoding, Console.OutputEncoding);
+
+            Assert.Equal((uint)oldEncoding.CodePage, GetConsoleOutputCP());
+
+            return SuccessExitCode;
+        }).Dispose();
+    }
+
+    [DllImport("kernel32.dll")]
+    public extern static uint GetConsoleCP();
+
+    [DllImport("kernel32.dll")]
+    public extern static uint GetConsoleOutputCP();
+}

--- a/src/System.Console/tests/ConsoleEncoding.cs
+++ b/src/System.Console/tests/ConsoleEncoding.cs
@@ -7,10 +7,9 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
-using System.Runtime.InteropServices;
 using Xunit;
 
-public class ConsoleEncoding : RemoteExecutorTestBase
+public partial class ConsoleEncoding : RemoteExecutorTestBase
 {
     public static IEnumerable<object[]> InputData()
     {
@@ -78,7 +77,7 @@ public class ConsoleEncoding : RemoteExecutorTestBase
         }
     }
 
-    public class NoSuchCodePage : Encoding
+    public class NonexistentCodePageEncoding : Encoding
     {
         public override int CodePage => int.MinValue;
 
@@ -93,39 +92,6 @@ public class ConsoleEncoding : RemoteExecutorTestBase
     }
 
     [Fact]
-    [PlatformSpecific(TestPlatforms.Windows)]
-    public void InputEncoding_SetDefaultEncoding_Success()
-    {
-        RemoteInvoke(() =>
-        {
-            Encoding encoding = Encoding.GetEncoding(0);
-            Console.InputEncoding = encoding;
-            Assert.Equal(encoding, Console.InputEncoding);
-            Assert.Equal((uint)encoding.CodePage, GetConsoleCP());
-
-            return SuccessExitCode;
-        }).Dispose();
-    }
-
-    [Fact]
-    [PlatformSpecific(TestPlatforms.Windows)]
-    public void InputEncoding_SetUnicodeEncoding_SilentlyIgnoredInternally()
-    {
-        RemoteInvoke(() =>
-        {
-            Encoding unicodeEncoding = Encoding.Unicode;
-            Encoding oldEncoding = Console.InputEncoding;
-            Assert.NotEqual(unicodeEncoding.CodePage, oldEncoding.CodePage);
-
-            Console.InputEncoding = unicodeEncoding;
-            Assert.Equal(unicodeEncoding, Console.InputEncoding);
-            Assert.Equal((uint)oldEncoding.CodePage, GetConsoleCP());
-
-            return SuccessExitCode;
-        }).Dispose();
-    }
-
-    [Fact]
     public void InputEncoding_SetWithInInitialized_ResetsIn()
     {
         RemoteInvoke(() =>
@@ -135,7 +101,7 @@ public class ConsoleEncoding : RemoteExecutorTestBase
             Assert.NotNull(inReader);
             Assert.Same(inReader, Console.In);
 
-            // Chang the InputEncoding
+            // Change the InputEncoding
             Console.InputEncoding = Encoding.ASCII;
             Assert.Equal(Encoding.ASCII, Console.InputEncoding);
 
@@ -155,42 +121,9 @@ public class ConsoleEncoding : RemoteExecutorTestBase
     [PlatformSpecific(TestPlatforms.Windows)]
     public void InputEncoding_SetEncodingWithInvalidCodePage_ThrowsIOException()
     {
-        NoSuchCodePage invalidEncoding = new NoSuchCodePage();
+        NonexistentCodePageEncoding invalidEncoding = new NonexistentCodePageEncoding();
         Assert.Throws<IOException>(() => Console.InputEncoding = invalidEncoding);
-        Assert.NotEqual(invalidEncoding, Console.InputEncoding);
-    }
-
-    [Fact]
-    [PlatformSpecific(TestPlatforms.Windows)]
-    public void OutputEncoding_SetDefaultEncoding_Success()
-    {
-        RemoteInvoke(() =>
-        {
-            Encoding encoding = Encoding.GetEncoding(0);
-            Console.OutputEncoding = encoding;
-            Assert.Equal(encoding, Console.OutputEncoding);
-            Assert.Equal((uint)encoding.CodePage, GetConsoleOutputCP());
-
-            return SuccessExitCode;
-        }).Dispose();
-    }
-
-    [Fact]
-    [PlatformSpecific(TestPlatforms.Windows)]
-    public void OutputEncoding_SetUnicodeEncoding_SilentlyIgnoredInternally()
-    {
-        RemoteInvoke(() =>
-        {
-            Encoding unicodeEncoding = Encoding.Unicode;
-            Encoding oldEncoding = Console.OutputEncoding;
-            Assert.NotEqual(unicodeEncoding.CodePage, oldEncoding.CodePage);
-            Console.OutputEncoding = unicodeEncoding;
-            Assert.Equal(unicodeEncoding, Console.OutputEncoding);
-
-            Assert.Equal((uint)oldEncoding.CodePage, GetConsoleOutputCP());
-
-            return SuccessExitCode;
-        }).Dispose();
+        Assert.NotSame(invalidEncoding, Console.InputEncoding);
     }
 
     [Fact]
@@ -208,7 +141,7 @@ public class ConsoleEncoding : RemoteExecutorTestBase
             Assert.NotNull(outWriter);
             Assert.Same(outWriter, Console.Out);
 
-            // Chang the OutputEncoding
+            // Change the OutputEncoding
             Console.OutputEncoding = Encoding.ASCII;
             Assert.Equal(Encoding.ASCII, Console.OutputEncoding);
 
@@ -229,14 +162,8 @@ public class ConsoleEncoding : RemoteExecutorTestBase
     [PlatformSpecific(TestPlatforms.Windows)]
     public void OutputEncoding_SetEncodingWithInvalidCodePage_ThrowsIOException()
     {
-        NoSuchCodePage invalidEncoding = new NoSuchCodePage();
+        NonexistentCodePageEncoding invalidEncoding = new NonexistentCodePageEncoding();
         Assert.Throws<IOException>(() => Console.OutputEncoding = invalidEncoding);
-        Assert.NotEqual(invalidEncoding, Console.OutputEncoding);
+        Assert.NotSame(invalidEncoding, Console.OutputEncoding);
     }
-
-    [DllImport("kernel32.dll")]
-    public extern static uint GetConsoleCP();
-
-    [DllImport("kernel32.dll")]
-    public extern static uint GetConsoleOutputCP();
 }

--- a/src/System.Console/tests/ReadAndWrite.cs
+++ b/src/System.Console/tests/ReadAndWrite.cs
@@ -381,4 +381,22 @@ public class ReadAndWrite
             Console.SetIn(savedStandardInput);
         }        
     }
+
+    [Fact]
+    public static void OpenStandardInput_NegativeBufferSize_ThrowsArgumentOutOfRangeException()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>("bufferSize", () => Console.OpenStandardInput(-1));
+    }
+
+    [Fact]
+    public static void OpenStandardOutput_NegativeBufferSize_ThrowsArgumentOutOfRangeException()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>("bufferSize", () => Console.OpenStandardOutput(-1));
+    }
+
+    [Fact]
+    public static void OpenStandardError_NegativeBufferSize_ThrowsArgumentOutOfRangeException()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>("bufferSize", () => Console.OpenStandardError(-1));
+    }
 }

--- a/src/System.Console/tests/System.Console.Tests.csproj
+++ b/src/System.Console/tests/System.Console.Tests.csproj
@@ -25,6 +25,7 @@
     <Compile Include="SetOut.cs" />
     <Compile Include="NegativeTesting.cs" />
     <Compile Include="ConsoleEncoding.cs" />
+    <Compile Include="ConsoleEncoding.Windows.cs" Condition="'$(TargetsWindows)' == 'true'" />
     <Compile Include="SyncTextReader.cs" />
     <Compile Include="SyncTextWriter.cs" />
     <Compile Include="Timeout.cs" />

--- a/src/System.Console/tests/WindowAndCursorProps.cs
+++ b/src/System.Console/tests/WindowAndCursorProps.cs
@@ -162,12 +162,6 @@ public class WindowAndCursorProps : RemoteExecutorTestBase
     }
 
     [Fact]
-    public static void Title_Set_Windows_Empty_ThrowsArgumentNullException()
-    {
-        //Assert.Throws<ArgumentNullException>("value", () => Console.Title = "");
-    }
-
-    [Fact]
     public static void Title_Set_Windows_GreaterThan24500Chars_ThrowsArgumentOutOfRangeException()
     {
         string newTitle = new string('a', 24501);
@@ -184,6 +178,7 @@ public class WindowAndCursorProps : RemoteExecutorTestBase
 
     [Fact]
     [OuterLoop] // makes noise, not very inner-loop friendly
+    [PlatformSpecific(TestPlatforms.Windows)]
     public static void BeepWithFrequency()
     {
         // Nothing to verify; just run the code.

--- a/src/System.Console/tests/WindowAndCursorProps.cs
+++ b/src/System.Console/tests/WindowAndCursorProps.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -155,16 +156,22 @@ public class WindowAndCursorProps : RemoteExecutorTestBase
     }
 
     [Fact]
-    [PlatformSpecific(TestPlatforms.Windows)]  // Expected behavior specific to Windows
-    public static void Title_Set_Windows_longlength()
+    public static void Title_Set_Windows_Null_ThrowsArgumentNullException()
     {
-        RemoteInvoke(() =>
-        {
-            // Try setting a title greater than 24500 chars and check that it fails.
-            string newTitle = new string('a', 24501);
-            Assert.Throws<ArgumentOutOfRangeException>(() => { Console.Title = newTitle; });
-            return SuccessExitCode;
-        }).Dispose();
+        Assert.Throws<ArgumentNullException>("value", () => Console.Title = null);
+    }
+
+    [Fact]
+    public static void Title_Set_Windows_Empty_ThrowsArgumentNullException()
+    {
+        //Assert.Throws<ArgumentNullException>("value", () => Console.Title = "");
+    }
+
+    [Fact]
+    public static void Title_Set_Windows_GreaterThan24500Chars_ThrowsArgumentOutOfRangeException()
+    {
+        string newTitle = new string('a', 24501);
+        Assert.Throws<ArgumentOutOfRangeException>("value", () => Console.Title = newTitle);
     }
 
     [Fact]
@@ -179,20 +186,33 @@ public class WindowAndCursorProps : RemoteExecutorTestBase
     [OuterLoop] // makes noise, not very inner-loop friendly
     public static void BeepWithFrequency()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            Assert.Throws<ArgumentOutOfRangeException>(() => Console.Beep(36, 200));
-            Assert.Throws<ArgumentOutOfRangeException>(() => Console.Beep(32768, 200));
-            Assert.Throws<ArgumentOutOfRangeException>(() => Console.Beep(800, 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => Console.Beep(800, -1));
+        // Nothing to verify; just run the code.
+        Console.Beep(800, 200);
+    }
 
-            // Nothing to verify; just run the code.
-            Console.Beep(800, 200);
-        }
-        else
-        {
-            Assert.Throws<PlatformNotSupportedException>(() => Console.Beep(800, 200));
-        }
+    [Theory]
+    [PlatformSpecific(TestPlatforms.Windows)]
+    [InlineData(36)]
+    [InlineData(32768)]
+    public void BeepWithFrequency_InvalidFrequency_ThrowsArgumentOutOfRangeException(int frequency)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>("frequency", () => Console.Beep(frequency, 200));
+    }
+
+    [Theory]
+    [PlatformSpecific(TestPlatforms.Windows)]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void BeepWithFrequency_InvalidDuration_ThrowsArgumentOutOfRangeException(int duration)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>("duration", () => Console.Beep(800, duration));
+    }
+
+    [Fact]
+    [PlatformSpecific(TestPlatforms.AnyUnix)]
+    public void BeepWithFrequency_Unix_ThrowsPlatformNotSupportedException()
+    {
+        Assert.Throws<PlatformNotSupportedException>(() => Console.Beep(800, 200));
     }
 
     [Fact]
@@ -221,8 +241,15 @@ public class WindowAndCursorProps : RemoteExecutorTestBase
 
             Console.SetCursorPosition(origLeft, origTop);
         }
-        Assert.Throws<ArgumentOutOfRangeException>("left", () => Console.SetCursorPosition(-1, 100));
-        Assert.Throws<ArgumentOutOfRangeException>("top", () => Console.SetCursorPosition(100, -1));
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(short.MaxValue + 1)]
+    public void SetCursorPosition_InvalidPosition_ThrowsArgumentOutOfRangeException(int value)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>("left", () => Console.SetCursorPosition(value, 100));
+        Assert.Throws<ArgumentOutOfRangeException>("top", () => Console.SetCursorPosition(100, value));
     }
 
     [Fact]
@@ -248,158 +275,174 @@ public class WindowAndCursorProps : RemoteExecutorTestBase
     }
 
     [Fact]
-    public static void CursorSize()
+    [PlatformSpecific(TestPlatforms.Windows)]
+    public void CursorSize_SetGet_ReturnsExpected()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (!Console.IsInputRedirected && !Console.IsOutputRedirected)
         {
-            if (!Console.IsInputRedirected && !Console.IsOutputRedirected)
+            int orig = Console.CursorSize;
+            try
             {
-                Assert.Throws<ArgumentOutOfRangeException>(() => { Console.CursorSize = 0; });
-                Assert.Throws<ArgumentOutOfRangeException>(() => { Console.CursorSize = 101; });
-
-                int orig = Console.CursorSize;
-                try
-                {
-                    Console.CursorSize = 50;
-                    Assert.Equal(50, Console.CursorSize);
-                }
-                finally
-                {
-                    Console.CursorSize = orig;
-                }
+                Console.CursorSize = 50;
+                Assert.Equal(50, Console.CursorSize);
+            }
+            finally
+            {
+                Console.CursorSize = orig;
             }
         }
-        else
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(101)]
+    [PlatformSpecific(TestPlatforms.Windows)]
+    public void CursorSize_SetInvalidValue_ThrowsArgumentOutOfRangeException(int value)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>("value", () => Console.CursorSize = value);
+    }
+
+    [Fact]
+    [PlatformSpecific(TestPlatforms.AnyUnix)]
+    public void CursorSize_SetUnix_ThrowsPlatformNotSupportedException()
+    {
+        Assert.Equal(100, Console.CursorSize);
+        Assert.Throws<PlatformNotSupportedException>(() => Console.CursorSize = 1);
+    }
+
+    [Fact]
+    [PlatformSpecific(TestPlatforms.Windows)]
+    public void SetWindowPosition_GetWindowPosition_ReturnsExpected()
+    {
+        if (!Console.IsInputRedirected && !Console.IsOutputRedirected)
         {
-            Assert.Equal(100, Console.CursorSize);
-            Assert.Throws<PlatformNotSupportedException>(() => { Console.CursorSize = 50; });
+            Assert.Throws<ArgumentOutOfRangeException>("left", () => Console.SetWindowPosition(-1, Console.WindowTop));
+            Assert.Throws<ArgumentOutOfRangeException>("top", () => Console.SetWindowPosition(Console.WindowLeft, -1));
+            Assert.Throws<ArgumentOutOfRangeException>("left", () => Console.SetWindowPosition(Console.BufferWidth - Console.WindowWidth + 2, Console.WindowTop));
+            Assert.Throws<ArgumentOutOfRangeException>("top", () => Console.SetWindowPosition(Console.WindowHeight, Console.BufferHeight - Console.WindowHeight + 2));
+
+            int origTop = Console.WindowTop;
+            int origLeft = Console.WindowLeft;
+            try
+            {
+                Console.SetWindowPosition(0, 0);
+                Assert.Equal(0, Console.WindowTop);
+                Assert.Equal(0, Console.WindowLeft);
+            }
+            finally
+            {
+                Console.WindowTop = origTop;
+                Console.WindowLeft = origLeft;
+            }
         }
     }
 
     [Fact]
-    public static void SetWindowPosition()
+    [PlatformSpecific(TestPlatforms.AnyUnix)]
+    public void SetWindowPosition_Unix_ThrowsPlatformNotSupportedException()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            if (!Console.IsInputRedirected && !Console.IsOutputRedirected)
-            {
-                Assert.Throws<ArgumentOutOfRangeException>(() => Console.SetWindowPosition(-1, Console.WindowTop));
-                Assert.Throws<ArgumentOutOfRangeException>(() => Console.SetWindowPosition(Console.WindowLeft, -1));
-                Assert.Throws<ArgumentOutOfRangeException>(() => Console.SetWindowPosition(Console.BufferWidth - Console.WindowWidth + 2, Console.WindowTop));
-                Assert.Throws<ArgumentOutOfRangeException>(() => Console.SetWindowPosition(Console.WindowHeight, Console.BufferHeight - Console.WindowHeight + 2));
+        Assert.Throws<PlatformNotSupportedException>(() => Console.SetWindowPosition(50, 50));
+    }
 
-                int origTop = Console.WindowTop;
-                int origLeft = Console.WindowLeft;
-                try
-                {
-                    Console.SetWindowPosition(0, 0);
-                    Assert.Equal(0, Console.WindowTop);
-                    Assert.Equal(0, Console.WindowLeft);
-                }
-                finally
-                {
-                    Console.WindowTop = origTop;
-                    Console.WindowLeft = origLeft;
-                }
-            }
-        }
-        else
+    [Fact]
+    [PlatformSpecific(TestPlatforms.Windows)]
+    public void SetWindowSize_GetWindowSize_ReturnsExpected()
+    {
+        if (PlatformDetection.IsNotWindowsNanoServer && !Console.IsInputRedirected && !Console.IsOutputRedirected)
         {
-            Assert.Throws<PlatformNotSupportedException>(() => Console.SetWindowPosition(50, 50));
+            Assert.Throws<ArgumentOutOfRangeException>("width", () => Console.SetWindowSize(-1, Console.WindowHeight));
+            Assert.Throws<ArgumentOutOfRangeException>("height", () => Console.SetWindowSize(Console.WindowHeight, -1));
+            Assert.Throws<ArgumentOutOfRangeException>("width", () => Console.SetWindowSize(short.MaxValue - Console.WindowLeft, Console.WindowHeight));
+            Assert.Throws<ArgumentOutOfRangeException>("height", () => Console.SetWindowSize(Console.WindowWidth, short.MaxValue - Console.WindowTop));
+            Assert.Throws<ArgumentOutOfRangeException>("width", () => Console.SetWindowSize(Console.LargestWindowWidth + 1, Console.WindowHeight));
+            Assert.Throws<ArgumentOutOfRangeException>("height", () => Console.SetWindowSize(Console.WindowWidth, Console.LargestWindowHeight + 1));
+
+            int origWidth = Console.WindowWidth;
+            int origHeight = Console.WindowHeight;
+            try
+            {
+                Console.SetWindowSize(10, 10);
+                Assert.Equal(10, Console.WindowWidth);
+                Assert.Equal(10, Console.WindowHeight);
+            }
+            finally
+            {
+                Console.WindowWidth = origWidth;
+                Console.WindowHeight = origHeight;
+            }
         }
     }
 
     [Fact]
-    public static void SetWindowSize()
+    [PlatformSpecific(TestPlatforms.AnyUnix)]
+    public void SetWindowSize_Unix_ThrowsPlatformNotSupportedException()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            if (PlatformDetection.IsNotWindowsNanoServer && !Console.IsInputRedirected && !Console.IsOutputRedirected)
-            {
-                Assert.Throws<ArgumentOutOfRangeException>(() => Console.SetWindowSize(-1, Console.WindowHeight));
-                Assert.Throws<ArgumentOutOfRangeException>(() => Console.SetWindowSize(Console.WindowWidth, -1));
-                Assert.Throws<ArgumentOutOfRangeException>(() => Console.SetWindowSize(short.MaxValue - Console.WindowLeft, Console.WindowHeight));
-                Assert.Throws<ArgumentOutOfRangeException>(() => Console.SetWindowSize(Console.WindowWidth, short.MaxValue - Console.WindowTop));
-                Assert.Throws<ArgumentOutOfRangeException>(() => Console.SetWindowSize(Console.LargestWindowWidth + 1, Console.WindowHeight));
-                Assert.Throws<ArgumentOutOfRangeException>(() => Console.SetWindowSize(Console.WindowWidth, Console.LargestWindowHeight + 1));
+        Assert.Throws<PlatformNotSupportedException>(() => Console.SetWindowSize(50, 50));
+    }
 
-                int origWidth = Console.WindowWidth;
-                int origHeight = Console.WindowHeight;
-                try
-                {
-                    Console.SetWindowSize(10, 10);
-                    Assert.Equal(10, Console.WindowWidth);
-                    Assert.Equal(10, Console.WindowHeight);
-                }
-                finally
-                {
-                    Console.WindowWidth = origWidth;
-                    Console.WindowHeight = origHeight;
-                }
-            }
-        }
-        else
+    [Fact]
+    [PlatformSpecific(TestPlatforms.Windows)]
+    public void MoveBufferArea_DefaultChar()
+    {
+        if (!Console.IsInputRedirected && !Console.IsOutputRedirected)
         {
-            Assert.Throws<PlatformNotSupportedException>(() => Console.SetWindowSize(50, 50));
+            Assert.Throws<ArgumentOutOfRangeException>("sourceLeft", () => Console.MoveBufferArea(-1, 0, 0, 0, 0, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("sourceTop", () => Console.MoveBufferArea(0, -1, 0, 0, 0, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("sourceWidth", () => Console.MoveBufferArea(0, 0, -1, 0, 0, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("sourceHeight", () => Console.MoveBufferArea(0, 0, 0, -1, 0, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("targetLeft", () => Console.MoveBufferArea(0, 0, 0, 0, -1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("targetTop", () => Console.MoveBufferArea(0, 0, 0, 0, 0, -1));
+            Assert.Throws<ArgumentOutOfRangeException>("sourceLeft", () => Console.MoveBufferArea(Console.BufferWidth + 1, 0, 0, 0, 0, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("targetLeft", () => Console.MoveBufferArea(0, 0, 0, 0, Console.BufferWidth + 1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("sourceTop", () => Console.MoveBufferArea(0, Console.BufferHeight + 1, 0, 0, 0, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("targetTop", () => Console.MoveBufferArea(0, 0, 0, 0, 0, Console.BufferHeight + 1));
+            Assert.Throws<ArgumentOutOfRangeException>("sourceHeight", () => Console.MoveBufferArea(0, 1, 0, Console.BufferHeight, 0, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("sourceWidth", () => Console.MoveBufferArea(1, 0, Console.BufferWidth, 0, 0, 0));
+
+            // Nothing to verify; just run the code.
+            Console.MoveBufferArea(0, 0, 1, 1, 2, 2);
         }
     }
 
     [Fact]
-    public static void MoveBufferArea_DefaultChar()
+    [PlatformSpecific(TestPlatforms.Windows)]
+    public void MoveBufferArea()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (!Console.IsInputRedirected && !Console.IsOutputRedirected)
         {
-            if (!Console.IsInputRedirected && !Console.IsOutputRedirected)
-            {
-                Assert.Throws<ArgumentOutOfRangeException>(() => Console.MoveBufferArea(-1, 0, 0, 0, 0, 0));
-                Assert.Throws<ArgumentOutOfRangeException>(() => Console.MoveBufferArea(0, -1, 0, 0, 0, 0));
-                Assert.Throws<ArgumentOutOfRangeException>(() => Console.MoveBufferArea(0, 0, -1, 0, 0, 0));
-                Assert.Throws<ArgumentOutOfRangeException>(() => Console.MoveBufferArea(0, 0, 0, -1, 0, 0));
-                Assert.Throws<ArgumentOutOfRangeException>(() => Console.MoveBufferArea(0, 0, 0, 0, -1, 0));
-                Assert.Throws<ArgumentOutOfRangeException>(() => Console.MoveBufferArea(0, 0, 0, 0, 0, -1));
-                Assert.Throws<ArgumentOutOfRangeException>(() => Console.MoveBufferArea(Console.BufferWidth + 1, 0, 0, 0, 0, 0));
-                Assert.Throws<ArgumentOutOfRangeException>(() => Console.MoveBufferArea(0, 0, 0, 0, Console.BufferWidth + 1, 0));
-                Assert.Throws<ArgumentOutOfRangeException>(() => Console.MoveBufferArea(0, Console.BufferHeight + 1, 0, 0, 0, 0));
-                Assert.Throws<ArgumentOutOfRangeException>(() => Console.MoveBufferArea(0, 0, 0, 0, 0, Console.BufferHeight + 1));
-                Assert.Throws<ArgumentOutOfRangeException>(() => Console.MoveBufferArea(0, 1, 0, Console.BufferHeight, 0, 0));
-                Assert.Throws<ArgumentOutOfRangeException>(() => Console.MoveBufferArea(1, 0, Console.BufferWidth, 0, 0, 0));
-                // Nothing to verify; just run the code.
-                Console.MoveBufferArea(0, 0, 1, 1, 2, 2);
-            }
-        }
-        else
-        {
-            Assert.Throws<PlatformNotSupportedException>(() => Console.MoveBufferArea(0, 0, 0, 0, 0, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Console.MoveBufferArea(-1, 0, 0, 0, 0, 0, '0', ConsoleColor.Black, ConsoleColor.White));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Console.MoveBufferArea(0, -1, 0, 0, 0, 0, '0', ConsoleColor.Black, ConsoleColor.White));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Console.MoveBufferArea(0, 0, -1, 0, 0, 0, '0', ConsoleColor.Black, ConsoleColor.White));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Console.MoveBufferArea(0, 0, 0, -1, 0, 0, '0', ConsoleColor.Black, ConsoleColor.White));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Console.MoveBufferArea(0, 0, 0, 0, -1, 0, '0', ConsoleColor.Black, ConsoleColor.White));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Console.MoveBufferArea(0, 0, 0, 0, 0, -1, '0', ConsoleColor.Black, ConsoleColor.White));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Console.MoveBufferArea(Console.BufferWidth + 1, 0, 0, 0, 0, 0, '0', ConsoleColor.Black, ConsoleColor.White));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Console.MoveBufferArea(0, 0, 0, 0, Console.BufferWidth + 1, 0, '0', ConsoleColor.Black, ConsoleColor.White));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Console.MoveBufferArea(0, Console.BufferHeight + 1, 0, 0, 0, 0, '0', ConsoleColor.Black, ConsoleColor.White));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Console.MoveBufferArea(0, 0, 0, 0, 0, Console.BufferHeight + 1, '0', ConsoleColor.Black, ConsoleColor.White));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Console.MoveBufferArea(0, 1, 0, Console.BufferHeight, 0, 0, '0', ConsoleColor.Black, ConsoleColor.White));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Console.MoveBufferArea(1, 0, Console.BufferWidth, 0, 0, 0, '0', ConsoleColor.Black, ConsoleColor.White));
+
+            // Nothing to verify; just run the code.
+            Console.MoveBufferArea(0, 0, 1, 1, 2, 2, 'a', ConsoleColor.Black, ConsoleColor.White);
         }
     }
 
-    [Fact]
-    public static void MoveBufferArea()
+    [Theory]
+    [InlineData(ConsoleColor.Black - 1)]
+    [InlineData(ConsoleColor.White + 1)]
+    [PlatformSpecific(TestPlatforms.Windows)]
+    public void MoveBufferArea_InvalidColor_ThrowsException(ConsoleColor color)
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            if (!Console.IsInputRedirected && !Console.IsOutputRedirected)
-            {
-                Assert.Throws<ArgumentOutOfRangeException>(() => Console.MoveBufferArea(-1, 0, 0, 0, 0, 0, '0', ConsoleColor.Black, ConsoleColor.White));
-                Assert.Throws<ArgumentOutOfRangeException>(() => Console.MoveBufferArea(0, -1, 0, 0, 0, 0, '0', ConsoleColor.Black, ConsoleColor.White));
-                Assert.Throws<ArgumentOutOfRangeException>(() => Console.MoveBufferArea(0, 0, -1, 0, 0, 0, '0', ConsoleColor.Black, ConsoleColor.White));
-                Assert.Throws<ArgumentOutOfRangeException>(() => Console.MoveBufferArea(0, 0, 0, -1, 0, 0, '0', ConsoleColor.Black, ConsoleColor.White));
-                Assert.Throws<ArgumentOutOfRangeException>(() => Console.MoveBufferArea(0, 0, 0, 0, -1, 0, '0', ConsoleColor.Black, ConsoleColor.White));
-                Assert.Throws<ArgumentOutOfRangeException>(() => Console.MoveBufferArea(0, 0, 0, 0, 0, -1, '0', ConsoleColor.Black, ConsoleColor.White));
-                Assert.Throws<ArgumentOutOfRangeException>(() => Console.MoveBufferArea(Console.BufferWidth + 1, 0, 0, 0, 0, 0, '0', ConsoleColor.Black, ConsoleColor.White));
-                Assert.Throws<ArgumentOutOfRangeException>(() => Console.MoveBufferArea(0, 0, 0, 0, Console.BufferWidth + 1, 0, '0', ConsoleColor.Black, ConsoleColor.White));
-                Assert.Throws<ArgumentOutOfRangeException>(() => Console.MoveBufferArea(0, Console.BufferHeight + 1, 0, 0, 0, 0, '0', ConsoleColor.Black, ConsoleColor.White));
-                Assert.Throws<ArgumentOutOfRangeException>(() => Console.MoveBufferArea(0, 0, 0, 0, 0, Console.BufferHeight + 1, '0', ConsoleColor.Black, ConsoleColor.White));
-                Assert.Throws<ArgumentOutOfRangeException>(() => Console.MoveBufferArea(0, 1, 0, Console.BufferHeight, 0, 0, '0', ConsoleColor.Black, ConsoleColor.White));
-                Assert.Throws<ArgumentOutOfRangeException>(() => Console.MoveBufferArea(1, 0, Console.BufferWidth, 0, 0, 0, '0', ConsoleColor.Black, ConsoleColor.White));
+        Assert.Throws<ArgumentException>("sourceForeColor", () => Console.MoveBufferArea(0, 0, 0, 0, 0, 0, 'a', color, ConsoleColor.Black));
+        Assert.Throws<ArgumentException>("sourceBackColor", () => Console.MoveBufferArea(0, 0, 0, 0, 0, 0, 'a', ConsoleColor.Black, color));
+    }
 
-                // Nothing to verify; just run the code.
-                Console.MoveBufferArea(0, 0, 1, 1, 2, 2, 'a', ConsoleColor.Black, ConsoleColor.White);
-            }
-        }
-        else
-        {
-            Assert.Throws<PlatformNotSupportedException>(() => Console.MoveBufferArea(0, 0, 0, 0, 0, 0));
-        }
+    [Fact]
+    [PlatformSpecific(TestPlatforms.AnyUnix)]
+    public void MoveBufferArea_Unix_ThrowsPlatformNotSupportedException()
+    {
+        Assert.Throws<PlatformNotSupportedException>(() => Console.MoveBufferArea(0, 0, 0, 0, 0, 0));
+        Assert.Throws<PlatformNotSupportedException>(() => Console.MoveBufferArea(0, 0, 0, 0, 0, 0, 'c', ConsoleColor.White, ConsoleColor.Black));
     }
 }


### PR DESCRIPTION
Fixes #18121

I'm not actually sure how to test the fix I made by inspection to `TreatControlCAsInput`:
```cs
public static bool TreatControlCAsInput
{
    get
    {
        IntPtr handle = InputHandle;
        if (handle == s_InvalidHandleValue)
            throw new IOException(SR.IO_NoConsole);

        int mode = 0;
        if (!Interop.Kernel32.GetConsoleMode(handle, out mode))
            throw Win32Marshal.GetExceptionForWin32Error(Marshal.GetLastWin32Error());

        return (mode & Interop.Kernel32.ENABLE_PROCESSED_INPUT) == 0;
    }
    set
    {
        IntPtr handle = InputHandle;
        if (handle == s_InvalidHandleValue)
            throw new IOException(SR.IO_NoConsole);

        int mode = 0;
        Interop.Kernel32.GetConsoleMode(handle, out mode); // failure ignored in full framework

        if (value)
        {
            mode &= ~Interop.Kernel32.ENABLE_PROCESSED_INPUT;
        }
        else
        {
            mode |= Interop.Kernel32.ENABLE_PROCESSED_INPUT;
        }

        if (!Interop.Kernel32.SetConsoleMode(handle, mode))
            throw Win32Marshal.GetExceptionForWin32Error(Marshal.GetLastWin32Error());
    }
}
```

before, the `throw` in `throw Win32Marshal` is missing. I'm all ears if you know how to test this fix (desktop is fixed already, so no compat issue)

Second commit is probably best reviewed with `?w=1`

@stephentoub