### PR TITLE
Remove dead code for system.threading, system.text.regularexpressions, system.threading.overlapped

### DIFF
--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCapture.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCapture.cs
@@ -102,20 +102,5 @@ namespace System.Text.RegularExpressions
             return _text.Substring(_index + _length, _text.Length - _index - _length);
         }
 
-#if DEBUG
-        internal virtual string Description()
-        {
-            StringBuilder Sb = new StringBuilder();
-
-            Sb.Append("(I = ");
-            Sb.Append(_index);
-            Sb.Append(", L = ");
-            Sb.Append(_length);
-            Sb.Append("): ");
-            Sb.Append(_text, _index, _length);
-
-            return Sb.ToString();
-        }
-#endif
     }
 }

--- a/src/System.Threading/src/System/Threading/CDSsyncETWBCLProvider.cs
+++ b/src/System.Threading/src/System/Threading/CDSsyncETWBCLProvider.cs
@@ -49,34 +49,6 @@ namespace System.Threading
         private const int SPINWAIT_NEXTSPINWILLYIELD_ID = 2;
         private const int BARRIER_PHASEFINISHED_ID = 3;
 
-        /////////////////////////////////////////////////////////////////////////////////////
-        //
-        // SpinLock Events
-        //
-
-        [Event(SPINLOCK_FASTPATHFAILED_ID, Level = EventLevel.Warning)]
-        public void SpinLock_FastPathFailed(int ownerID)
-        {
-            if (IsEnabled(EventLevel.Warning, ALL_KEYWORDS))
-            {
-                WriteEvent(SPINLOCK_FASTPATHFAILED_ID, ownerID);
-            }
-        }
-
-        /////////////////////////////////////////////////////////////////////////////////////
-        //
-        // SpinWait Events
-        //
-
-        [Event(SPINWAIT_NEXTSPINWILLYIELD_ID, Level = EventLevel.Informational)]
-        public void SpinWait_NextSpinWillYield()
-        {
-            if (IsEnabled(EventLevel.Informational, ALL_KEYWORDS))
-            {
-                WriteEvent(SPINWAIT_NEXTSPINWILLYIELD_ID);
-            }
-        }
-
 
         //
         // Events below this point are used by the CDS types in System.dll


### PR DESCRIPTION
Remove dead code according to #17905
Change for 
System.Threading:
http://tempcoverage.blob.core.windows.net/report2/System.Threading.diff.html

System.Text.RegularExpressions:
http://tempcoverage.blob.core.windows.net/report2/System.Text.RegularExpressions.diff.html
I don't delete the line "public static bool operator !=(CachedCodeEntryKey left, CachedCodeEntryKey right);" , there is an error CS0216 : The operator 'CachedCodeEntryKey.operator ==(CachedCodeEntryKey, CachedCodeEntryKey)' requires a matching operator '!=' to also be defined if I delete this line.

System.Threading.Overlapped:
http://tempcoverage.blob.core.windows.net/report2/System.Threading.Overlapped.diff.html