### PR TITLE
Fix app-compat differences in System.Net.Requests

### DIFF
--- a/src/System.Net.Requests/src/Resources/Strings.resx
+++ b/src/System.Net.Requests/src/Resources/Strings.resx
@@ -88,8 +88,14 @@
   <data name="net_MethodNotImplementedException" xml:space="preserve">
     <value>This method is not implemented by this class.</value>
   </data>
+  <data name="net_OperationNotSupportedException" xml:space="preserve">
+    <value>This operation is not supported.</value>
+  </data>
   <data name="net_PropertyNotImplementedException" xml:space="preserve">
     <value>This property is not implemented by this class.</value>
+  </data>
+  <data name="net_PropertyNotSupportedException" xml:space="preserve">
+    <value>This property is not supported by this class.</value>
   </data>
   <data name="net_nouploadonget" xml:space="preserve">
     <value>Cannot send a content-body with this verb-type.</value>

--- a/src/System.Net.Requests/src/System/Net/AuthenticationManager.cs
+++ b/src/System.Net.Requests/src/System/Net/AuthenticationManager.cs
@@ -27,6 +27,10 @@ namespace System.Net
 
         public static void Register(IAuthenticationModule authenticationModule)
         {
+            if (authenticationModule == null)
+            {
+                throw new ArgumentNullException();
+            }
         }
 
         public static void Unregister(IAuthenticationModule authenticationModule)

--- a/src/System.Net.Requests/src/System/Net/AuthenticationManager.cs
+++ b/src/System.Net.Requests/src/System/Net/AuthenticationManager.cs
@@ -29,7 +29,7 @@ namespace System.Net
         {
             if (authenticationModule == null)
             {
-                throw new ArgumentNullException();
+                throw new ArgumentNullException(nameof(authenticationModule));
             }
         }
 

--- a/src/System.Net.Requests/src/System/Net/FileWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/FileWebRequest.cs
@@ -306,8 +306,9 @@ namespace System.Net
 
         public override bool UseDefaultCredentials
         {
-            get { throw NotImplemented.ByDesignWithMessage(SR.net_PropertyNotImplementedException); }
-            set { throw NotImplemented.ByDesignWithMessage(SR.net_PropertyNotImplementedException); }
+            // Same behavior as .NET Framework.
+            get { throw new NotSupportedException(SR.net_PropertyNotSupportedException); }
+            set { throw new NotSupportedException(SR.net_PropertyNotSupportedException); }
         }
 
         public override void Abort()

--- a/src/System.Net.Requests/src/System/Net/FileWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/FileWebRequest.cs
@@ -306,7 +306,6 @@ namespace System.Net
 
         public override bool UseDefaultCredentials
         {
-            // Same behavior as .NET Framework.
             get { throw new NotSupportedException(SR.net_PropertyNotSupportedException); }
             set { throw new NotSupportedException(SR.net_PropertyNotSupportedException); }
         }

--- a/src/System.Net.Requests/src/System/Net/FtpWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/FtpWebRequest.cs
@@ -1576,7 +1576,7 @@ namespace System.Net
         {
             get
             {
-                return false;
+                return true;
             }
             set
             {

--- a/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -136,7 +136,6 @@ namespace System.Net
 
         public virtual bool AllowReadStreamBuffering
         {
-            // Same behavior as .NET Framework.
             get
             {
                 return false;

--- a/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -136,16 +136,20 @@ namespace System.Net
 
         public virtual bool AllowReadStreamBuffering
         {
+            // Same behavior as .NET Framework.
             get
             {
-                return _allowReadStreamBuffering;
+                return false;
             }
             set
             {
-                _allowReadStreamBuffering = value;
-            }
+                if (value)
+                {
+                    throw new InvalidOperationException(SR.net_OperationNotSupportedException);
+                }
+            }            
         }
-    
+
         public int MaximumResponseHeadersLength
         {
             get

--- a/src/System.Net.Requests/tests/AuthenticationManagerTest.cs
+++ b/src/System.Net.Requests/tests/AuthenticationManagerTest.cs
@@ -12,29 +12,41 @@ namespace System.Net.Tests
 {
     public class AuthenticationManagerTest
     {
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "AuthenticationManager supported on NETFX")]
         [Fact]
-        public static void Authenticate_NotSupported()
+        public void Authenticate_NotSupported()
         {
             Assert.Throws<PlatformNotSupportedException>(() => AuthenticationManager.Authenticate(null, null, null));
             Assert.Throws<PlatformNotSupportedException>(() => AuthenticationManager.PreAuthenticate(null, null));
         }
 
         [Fact]
-        public static void Register_Unregister_Nop()
+        public void Register_Null_Throws()
         {
-            AuthenticationManager.Register(null);
-
-            int count = 0;
-            IEnumerator modules = AuthenticationManager.RegisteredModules;
-            while (modules.MoveNext()) count++;
-            Assert.Equal(0, count);
-
-            AuthenticationManager.Unregister((IAuthenticationModule)null);
-            AuthenticationManager.Unregister((string)null);
+            Assert.Throws<ArgumentNullException>(() => AuthenticationManager.Register(null));
         }
 
         [Fact]
-        public static void CredentialPolicy_Roundtrip()
+        public void Register_Unregister_ModuleCountUnchanged()
+        {
+            int initialCount = GetModuleCount();
+            IAuthenticationModule module = new CustomModule();
+            AuthenticationManager.Register(module);
+            AuthenticationManager.Unregister(module);
+            Assert.Equal(initialCount, GetModuleCount());
+        }
+
+        [Fact]
+        public static void RegisteredModules_DefaultCount_ExpectedValue()
+        {
+            int count = 0;
+            IEnumerator modules = AuthenticationManager.RegisteredModules;
+            while (modules.MoveNext()) count++;
+            Assert.Equal(PlatformDetection.IsFullFramework ? 5 : 0, count);
+        }
+
+        [Fact]
+        public void CredentialPolicy_Roundtrip()
         {
             Assert.Null(AuthenticationManager.CredentialPolicy);
 
@@ -47,22 +59,63 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        public static void CustomTargetNameDictionary_ValidCollection()
+        public void CustomTargetNameDictionary_ValidCollection()
         {
             Assert.NotNull(AuthenticationManager.CustomTargetNameDictionary);
             Assert.Empty(AuthenticationManager.CustomTargetNameDictionary);
             Assert.Same(AuthenticationManager.CustomTargetNameDictionary, AuthenticationManager.CustomTargetNameDictionary);
 
-            AuthenticationManager.CustomTargetNameDictionary.Add("some key", "some value");
-            Assert.Equal("some value", AuthenticationManager.CustomTargetNameDictionary["some key"]);
+            string theKey = "http://www.contoso.com";
+            string theValue = "HTTP/www.contoso.com"; 
+            AuthenticationManager.CustomTargetNameDictionary.Add(theKey, theValue);
+            Assert.Equal(theValue, AuthenticationManager.CustomTargetNameDictionary[theKey]);
 
             AuthenticationManager.CustomTargetNameDictionary.Clear();
             Assert.Equal(0, AuthenticationManager.CustomTargetNameDictionary.Count);
+        }
+
+        private int GetModuleCount()
+        {
+            int count = 0;
+            IEnumerator modules = AuthenticationManager.RegisteredModules;
+            while (modules.MoveNext()) count++;
+
+            return count;
         }
 
         private sealed class DummyCredentialPolicy : ICredentialPolicy
         {
             public bool ShouldSendCredential(Uri challengeUri, WebRequest request, NetworkCredential credential, IAuthenticationModule authenticationModule) => true;
         }
+
+        private sealed class CustomModule : IAuthenticationModule
+        {
+            public bool CanPreAuthenticate
+            {
+                get
+                {
+                    return false;
+                }
+            }
+
+            public string AuthenticationType
+            {
+                get
+                {
+                    return "custom";
+                }
+            }
+
+            public Authorization Authenticate(string challenge, WebRequest request, ICredentials credentials)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Authorization PreAuthenticate(WebRequest request, ICredentials credentials)
+            {
+                throw new NotImplementedException();
+            }
+        }    
     }
+    
 }

--- a/src/System.Net.Requests/tests/AuthenticationManagerTest.cs
+++ b/src/System.Net.Requests/tests/AuthenticationManagerTest.cs
@@ -37,7 +37,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        public static void RegisteredModules_DefaultCount_ExpectedValue()
+        public void RegisteredModules_DefaultCount_ExpectedValue()
         {
             int count = 0;
             IEnumerator modules = AuthenticationManager.RegisteredModules;

--- a/src/System.Net.Requests/tests/FileWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/FileWebRequestTest.cs
@@ -78,11 +78,11 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        public void NotImplementedMembers_Throws()
+        public void UseDefaultCredentials_GetOrSet_Throws()
         {
             WebRequest request = WebRequest.Create("file://anything");
-            Assert.Throws<NotImplementedException>(() => request.UseDefaultCredentials);
-            Assert.Throws<NotImplementedException>(() => request.UseDefaultCredentials = true);
+            Assert.Throws<NotSupportedException>(() => request.UseDefaultCredentials);
+            Assert.Throws<NotSupportedException>(() => request.UseDefaultCredentials = true);
         }
     }
 
@@ -91,6 +91,7 @@ namespace System.Net.Tests
         public abstract Task<WebResponse> GetResponseAsync(WebRequest request);
         public abstract Task<Stream> GetRequestStreamAsync(WebRequest request);
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17842")]
         [Fact]
         public async Task ReadFile_ContainsExpectedContent()
         {
@@ -230,6 +231,7 @@ namespace System.Net.Tests
 
     public abstract class AsyncFileWebRequestTestBase : FileWebRequestTestBase
     {
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17842")]
         [Fact]
         public async Task ConcurrentReadWrite_ResponseBlocksThenGetsNullStream()
         {

--- a/src/System.Net.Requests/tests/FtpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/FtpWebRequestTest.cs
@@ -40,7 +40,7 @@ namespace System.Net.Tests
             Assert.False(request.EnableSsl);
             Assert.NotNull(request.Headers);
             Assert.Equal(0, request.Headers.Count);
-            Assert.False(request.KeepAlive);
+            Assert.True(request.KeepAlive);
             Assert.Equal(request.Method, WebRequestMethods.Ftp.DownloadFile);
             Assert.Null(request.Proxy);
             Assert.Equal(request.ReadWriteTimeout, 5 * 60 * 1000);

--- a/src/System.Net.Requests/tests/GlobalProxySelectionTest.cs
+++ b/src/System.Net.Requests/tests/GlobalProxySelectionTest.cs
@@ -38,6 +38,7 @@ namespace System.Net.Tests
             }
         }
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17842")]
         [Fact]
         public void Select_Success()
         {
@@ -86,6 +87,7 @@ namespace System.Net.Tests
             }).Dispose();
         }
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17842")]
         [Fact]
         public void GetEmptyWebProxy_Success()
         {

--- a/src/System.Net.Requests/tests/HttpWebRequestHeaderTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestHeaderTest.cs
@@ -102,7 +102,7 @@ namespace System.Net.Tests
         }
 
         [Theory, MemberData(nameof(EchoServers))]
-        public void HttpWebRequest_EndGetRequestStreamContext_Null(Uri remoteServer)
+        public void HttpWebRequest_EndGetRequestStreamContext_ExpectedValue(Uri remoteServer)
         {
             System.Net.TransportContext context;
             HttpWebRequest httpWebRequest = HttpWebRequest.CreateHttp(remoteServer);
@@ -110,7 +110,14 @@ namespace System.Net.Tests
 
             using (httpWebRequest.EndGetRequestStream(httpWebRequest.BeginGetRequestStream(null, null), out context))
             {
-                Assert.Equal(null, context); // NetFX behavior difference.
+                if (PlatformDetection.IsFullFramework)
+                {
+                    Assert.NotNull(context);
+                }
+                else
+                {
+                    Assert.Null(context);
+                }
             }
         }
 
@@ -127,6 +134,7 @@ namespace System.Net.Tests
             Assert.Equal(Cache.RequestCacheLevel.BypassCache, HttpWebRequest.DefaultCachePolicy.Level);
         }
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17842")] //Test hangs in desktop.
         [OuterLoop]
         [Theory, MemberData(nameof(EchoServers))]
         public void HttpWebRequest_ProxySetAfterGetResponse_Fails(Uri remoteServer)

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -105,11 +105,10 @@ namespace System.Net.Tests
         }
 
         [Theory, MemberData(nameof(EchoServers))]
-        public void AllowReadStreamBuffering_SetTrueThenGet_ExpectTrue(Uri remoteServer)
+        public void AllowReadStreamBuffering_SetTrue_Throws(Uri remoteServer)
         {
             HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
-            request.AllowReadStreamBuffering = true;
-            Assert.True(request.AllowReadStreamBuffering);
+            Assert.Throws<InvalidOperationException>(() => { request.AllowReadStreamBuffering = true; });            
         }
 
         [Theory, MemberData(nameof(EchoServers))]
@@ -243,7 +242,7 @@ namespace System.Net.Tests
         }
 
         [Theory, MemberData(nameof(EchoServers))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #16928")] //Test hang forever in desktop.
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17842")] //Test hang forever in desktop.
         public void BeginGetRequestStream_CreatePostRequestThenCallTwice_ThrowsInvalidOperationException(Uri remoteServer)
         {
             _savedHttpWebRequest = HttpWebRequest.CreateHttp(remoteServer);
@@ -257,7 +256,7 @@ namespace System.Net.Tests
         }
 
         [Theory, MemberData(nameof(EchoServers))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #16928")] //Test hang forever in desktop.
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17842")] //Test hang forever in desktop.
         public void BeginGetRequestStream_CreateRequestThenBeginGetResponsePrior_ThrowsInvalidOperationException(Uri remoteServer)
         {
             _savedHttpWebRequest = HttpWebRequest.CreateHttp(remoteServer);
@@ -270,7 +269,7 @@ namespace System.Net.Tests
         }
 
         [Theory, MemberData(nameof(EchoServers))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #16928")] //Test hang forever in desktop.
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17842")] //Test hang forever in desktop.
         public void BeginGetResponse_CreateRequestThenCallTwice_ThrowsInvalidOperationException(Uri remoteServer)
         {
             _savedHttpWebRequest = HttpWebRequest.CreateHttp(remoteServer);
@@ -283,7 +282,7 @@ namespace System.Net.Tests
         }
 
         [Theory, MemberData(nameof(EchoServers))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #16928")] //Test hang forever in desktop.
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17842")] //Test hang forever in desktop.
         public void BeginGetResponse_CreatePostRequestThenAbort_ThrowsWebException(Uri remoteServer)
         {
             HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
@@ -294,7 +293,7 @@ namespace System.Net.Tests
         }
 
         [Theory, MemberData(nameof(EchoServers))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #16928")] //Test hang forever in desktop.
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17842")] //Test hang forever in desktop.
         public async Task GetRequestStreamAsync_WriteAndDisposeRequestStreamThenOpenRequestStream_ThrowsArgumentException(Uri remoteServer)
         {
             HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
@@ -311,7 +310,7 @@ namespace System.Net.Tests
         }
 
         [Theory, MemberData(nameof(EchoServers))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #16928")] //Test hang forever in desktop.
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17842")] //Test hang forever in desktop.
         public async Task GetRequestStreamAsync_SetPOSTThenGet_ExpectNotNull(Uri remoteServer)
         {
             HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
@@ -321,7 +320,7 @@ namespace System.Net.Tests
         }
 
         [Theory, MemberData(nameof(EchoServers))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #16928")] //Test hang forever in desktop.
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17842")] //Test hang forever in desktop.
         public async Task GetResponseAsync_GetResponseStream_ExpectNotNull(Uri remoteServer)
         {
             HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
@@ -366,7 +365,7 @@ namespace System.Net.Tests
 
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotFedoraOrRedHatOrCentos))] // #16201
         [MemberData(nameof(EchoServers))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #16928")] //Test hang forever in desktop.
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17842")] //Test hang forever in desktop.
         public async Task GetResponseAsync_UseDefaultCredentials_ExpectSuccess(Uri remoteServer)
         {
             HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
@@ -401,7 +400,7 @@ namespace System.Net.Tests
         }
 
         [Theory, MemberData(nameof(EchoServers))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #16928")] //Test hang forever in desktop.
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17842")] //Test hang forever in desktop.
         public async Task HaveResponse_GetResponseAsync_ExpectTrue(Uri remoteServer)
         {
             HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
@@ -411,7 +410,7 @@ namespace System.Net.Tests
 
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotFedoraOrRedHatOrCentos))] // #16201
         [MemberData(nameof(EchoServers))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #16928")] //Test hang forever in desktop.
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17842")] //Test hang forever in desktop.
         public async Task Headers_GetResponseHeaders_ContainsExpectedValue(Uri remoteServer)
         {
             HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
@@ -467,7 +466,7 @@ namespace System.Net.Tests
         }
 
         [Theory, MemberData(nameof(EchoServers))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #16928")] //Test hang forever in desktop.
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17842")] //Test hang forever in desktop.
         public async Task SimpleScenario_UseGETVerb_Success(Uri remoteServer)
         {
             HttpWebRequest request = HttpWebRequest.CreateHttp(remoteServer);
@@ -524,6 +523,7 @@ namespace System.Net.Tests
             Assert.True(responseBody.Contains("Content-Type"));
         }
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17842")]
         [Theory, MemberData(nameof(EchoServers))]
         public void Abort_BeginGetRequestStreamThenAbort_EndGetRequestStreamThrowsWebException(Uri remoteServer)
         {
@@ -538,6 +538,7 @@ namespace System.Net.Tests
             Assert.Equal(WebExceptionStatus.RequestCanceled, wex.Status);
         }
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17842")]
         [Theory, MemberData(nameof(EchoServers))]
         public void Abort_BeginGetResponseThenAbort_ResponseCallbackCalledBeforeAbortReturns(Uri remoteServer)
         {
@@ -549,6 +550,7 @@ namespace System.Net.Tests
             Assert.Equal(1, _responseCallbackCallCount);
         }
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17842")]
         [Theory, MemberData(nameof(EchoServers))]
         public void Abort_BeginGetResponseThenAbort_EndGetResponseThrowsWebException(Uri remoteServer)
         {
@@ -611,6 +613,7 @@ namespace System.Net.Tests
             }
         }
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17842")]
         [Fact]
         public void HttpWebRequest_Serialize_Fails()
         {


### PR DESCRIPTION
Fix some product code behavior differences between .NET Core
and .NET Framework (Desktop).

Adjust tests. Disable more tests not working on Desktop.

Fixes #18151.
Contributes to #17842.