### PR TITLE
NS2.0 Finish XmlDictionaryWriter surface area.

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryWriter.cs
@@ -84,6 +84,12 @@ namespace System.Xml
             return dictionaryWriter;
         }
 
+        public override Task WriteBase64Async(byte[] buffer, int index, int count)
+        {
+            WriteBase64(buffer, index, count);
+            return Task.CompletedTask;
+        }
+
         public void WriteStartElement(XmlDictionaryString localName, XmlDictionaryString namespaceUri)
         {
             WriteStartElement((string)null, localName, namespaceUri);


### PR DESCRIPTION
This override appears to be something that's supposed to
be overridden by the actual implementation class by something
decent, but in keeping with the desktop (and with methods
like WriteValueAsync(IStreamProvider)), we'll provide
a default implementation that satisfies the letter
(if not quite the spirit) of the contract...