### PR TITLE
Fix Fedora issue with gethostbyname

### DIFF
--- a/src/Common/src/System/Net/Sockets/SocketErrorPal.Unix.cs
+++ b/src/Common/src/System/Net/Sockets/SocketErrorPal.Unix.cs
@@ -138,9 +138,17 @@ namespace System.Net.Sockets
         internal static Interop.Error GetNativeErrorForSocketError(SocketError error)
         {
             Interop.Error errno;
-            return s_socketErrorToNativeError.TryGetValue(error, out errno) ?
-                errno :
-                (Interop.Error)(int)error; // pass through the SocketError's value, as it at least retains some useful info
-        } 
+            if (!TryGetNativeErrorForSocketError(error, out errno))
+            {
+                // Use the SocketError's value, as it at least retains some useful info
+                errno = (Interop.Error)(int)error;
+            }
+            return errno;
+        }
+
+        internal static bool TryGetNativeErrorForSocketError(SocketError error, out Interop.Error errno)
+        {
+            return s_socketErrorToNativeError.TryGetValue(error, out errno);
+        }
     }
 }

--- a/src/Native/Unix/System.Native/pal_networking.cpp
+++ b/src/Native/Unix/System.Native/pal_networking.cpp
@@ -576,11 +576,8 @@ static int GetHostByNameHelper(const uint8_t* hostname, hostent** entry)
         {
             free(buffer);
             *entry = nullptr;
-            if (!err || (err == EINVAL && (getHostErrno == HOST_NOT_FOUND || getHostErrno == NO_DATA)))
-            {
-                err = HOST_NOT_FOUND;
-            }
-            return err;
+            assert(getHostErrno != 0);
+            return getHostErrno;
         }
     }
 }
@@ -659,11 +656,8 @@ static int GetHostByAddrHelper(const uint8_t* addr, const socklen_t addrLen, int
         {
             free(buffer);
             *entry = nullptr;
-            if (!err || (err == EINVAL && (getHostErrno == HOST_NOT_FOUND || getHostErrno == NO_DATA)))
-            {
-                err = HOST_NOT_FOUND;
-            }
-            return err;
+            assert(getHostErrno != 0);
+            return getHostErrno;
         }
     }
 }

--- a/src/Native/Unix/System.Native/pal_networking.cpp
+++ b/src/Native/Unix/System.Native/pal_networking.cpp
@@ -576,8 +576,7 @@ static int GetHostByNameHelper(const uint8_t* hostname, hostent** entry)
         {
             free(buffer);
             *entry = nullptr;
-            assert(getHostErrno != 0);
-            return getHostErrno;
+            return getHostErrno ? getHostErrno : HOST_NOT_FOUND;
         }
     }
 }
@@ -656,8 +655,7 @@ static int GetHostByAddrHelper(const uint8_t* addr, const socklen_t addrLen, int
         {
             free(buffer);
             *entry = nullptr;
-            assert(getHostErrno != 0);
-            return getHostErrno;
+            return getHostErrno ? getHostErrno : HOST_NOT_FOUND;
         }
     }
 }

--- a/src/Native/Unix/System.Native/pal_networking.cpp
+++ b/src/Native/Unix/System.Native/pal_networking.cpp
@@ -554,7 +554,7 @@ static int GetHostByNameHelper(const uint8_t* hostname, hostent** entry)
         hostent* result = reinterpret_cast<hostent*>(buffer);
         char* scratch = reinterpret_cast<char*>(&buffer[sizeof(hostent)]);
 
-        int getHostErrno;
+        int getHostErrno = 0;
         int err = gethostbyname_r(reinterpret_cast<const char*>(hostname), result, scratch, scratchLen, entry, &getHostErrno);
         if (!err && *entry != nullptr)
         {
@@ -576,7 +576,11 @@ static int GetHostByNameHelper(const uint8_t* hostname, hostent** entry)
         {
             free(buffer);
             *entry = nullptr;
-            return err ? err : HOST_NOT_FOUND;
+            if (!err || (err == EINVAL && (getHostErrno == HOST_NOT_FOUND || getHostErrno == NO_DATA)))
+            {
+                err = HOST_NOT_FOUND;
+            }
+            return err;
         }
     }
 }
@@ -633,7 +637,7 @@ static int GetHostByAddrHelper(const uint8_t* addr, const socklen_t addrLen, int
         hostent* result = reinterpret_cast<hostent*>(buffer);
         char* scratch = reinterpret_cast<char*>(&buffer[sizeof(hostent)]);
 
-        int getHostErrno;
+        int getHostErrno = 0;
         int err = gethostbyaddr_r(addr, addrLen, type, result, scratch, scratchLen, entry, &getHostErrno);
         if (!err && *entry != nullptr)
         {
@@ -655,7 +659,11 @@ static int GetHostByAddrHelper(const uint8_t* addr, const socklen_t addrLen, int
         {
             free(buffer);
             *entry = nullptr;
-            return err ? err : HOST_NOT_FOUND;
+            if (!err || (err == EINVAL && (getHostErrno == HOST_NOT_FOUND || getHostErrno == NO_DATA)))
+            {
+                err = HOST_NOT_FOUND;
+            }
+            return err;
         }
     }
 }

--- a/src/System.Net.Primitives/src/System/Net/SocketException.Unix.cs
+++ b/src/System.Net.Primitives/src/System/Net/SocketException.Unix.cs
@@ -28,9 +28,10 @@ namespace System.Net.Sockets
             int nativeErr = (int)error;
             if (error != SocketError.SocketError)
             {
-                Interop.Error interopErr = SocketErrorPal.GetNativeErrorForSocketError(error);
-                // If an interopErr was not found, then don't invoke Info().RawErrno as that will fail with assert.
-                if (nativeErr != (int)interopErr)
+                Interop.Error interopErr;
+
+                // If an interop error was not found, then don't invoke Info().RawErrno as that will fail with assert.
+                if (SocketErrorPal.TryGetNativeErrorForSocketError(error, out interopErr))
                 {
                     nativeErr = interopErr.Info().RawErrno;
                 }

--- a/src/System.Net.Primitives/src/System/Net/SocketException.Unix.cs
+++ b/src/System.Net.Primitives/src/System/Net/SocketException.Unix.cs
@@ -25,9 +25,18 @@ namespace System.Net.Sockets
 
         private static int GetNativeErrorForSocketError(SocketError error)
         {
-            return error != SocketError.SocketError ?
-                SocketErrorPal.GetNativeErrorForSocketError(error).Info().RawErrno :
-                (int)error;
+            int nativeErr = (int)error;
+            if (error != SocketError.SocketError)
+            {
+                Interop.Error interopErr = SocketErrorPal.GetNativeErrorForSocketError(error);
+                // If an interopErr was not found, then don't invoke Info().RawErrno as that will fail with assert.
+                if (nativeErr != (int)interopErr)
+                {
+                    nativeErr = interopErr.Info().RawErrno;
+                }
+            }
+
+            return nativeErr;
         }
     }
 }


### PR DESCRIPTION
Per https://github.com/dotnet/corefx/issues/17749, fix the issue with Fedora 24 assert (debug build).

Fedora is returning error code 22 (EINVAL) for some recently added negative test(s)

Fix is to check for EINVAL and if the last parameter of gethostbyname_r is either NO_DATA or HOST_NOT_FOUND then return HOST_NOT_FOUND. This results in a consistent return value across other unix flavors.