### PR TITLE
Add test for thread pool concurrent initialization

### DIFF
--- a/src/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
+++ b/src/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
@@ -14,6 +14,43 @@ namespace System.Threading.ThreadPools.Tests
         private const int ExpectedTimeoutMilliseconds = ThreadTestHelpers.ExpectedTimeoutMilliseconds;
         private const int MaxPossibleThreadCount = 0x7fff;
 
+        static ThreadPoolTests()
+        {
+            // Run the following tests before any others
+            ConcurrentInitializeTest();
+        }
+
+        [Fact]
+        public static void ConcurrentInitializeTest()
+        {
+            int processorCount = Environment.ProcessorCount;
+            var threadReady = new AutoResetEvent(false);
+            var continueThreads = new ManualResetEvent(false);
+            Action threadMain =
+                () =>
+                {
+                    threadReady.Set();
+                    continueThreads.CheckedWait();
+                    Assert.True(ThreadPool.SetMinThreads(processorCount, processorCount));
+                };
+
+            var waitForThreadArray = new Action[processorCount];
+            for (int i = 0; i < processorCount; ++i)
+            {
+                var t = ThreadTestHelpers.CreateGuardedThread(out waitForThreadArray[i], threadMain);
+                t.IsBackground = true;
+                t.Start();
+                threadReady.CheckedWait();
+            }
+
+            continueThreads.Set();
+
+            foreach (Action waitForThread in waitForThreadArray)
+            {
+                waitForThread();
+            }
+        }
+
         [Fact]
         public static void GetMinMaxThreadsTest()
         {

--- a/src/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
+++ b/src/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
@@ -24,13 +24,12 @@ namespace System.Threading.ThreadPools.Tests
         public static void ConcurrentInitializeTest()
         {
             int processorCount = Environment.ProcessorCount;
-            var threadReady = new AutoResetEvent(false);
-            var continueThreads = new ManualResetEvent(false);
+            var countdownEvent = new CountdownEvent(processorCount);
             Action threadMain =
                 () =>
                 {
-                    threadReady.Set();
-                    continueThreads.CheckedWait();
+                    countdownEvent.Signal();
+                    countdownEvent.Wait(ThreadTestHelpers.UnexpectedTimeoutMilliseconds);
                     Assert.True(ThreadPool.SetMinThreads(processorCount, processorCount));
                 };
 
@@ -40,10 +39,7 @@ namespace System.Threading.ThreadPools.Tests
                 var t = ThreadTestHelpers.CreateGuardedThread(out waitForThreadArray[i], threadMain);
                 t.IsBackground = true;
                 t.Start();
-                threadReady.CheckedWait();
             }
-
-            continueThreads.Set();
 
             foreach (Action waitForThread in waitForThreadArray)
             {


### PR DESCRIPTION
Depends on dotnet/coreclr#10869
Fixes dotnet/coreclr#10521