### PR TITLE
Fix MMVS.PointerOffset to be correct

### DIFF
--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedView.Unix.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedView.Unix.cs
@@ -132,7 +132,8 @@ namespace System.IO.MemoryMappedFiles
             viewHandle.Initialize((ulong)nativeSize);
             return new MemoryMappedView(
                 viewHandle,
-                extraMemNeeded,       // the view points to offset - extraMemNeeded, so we need to shift back by extraMemNeeded
+                requestedOffset,       // the view points to offset - extraMemNeeded, so we need to shift back by extraMemNeeded
+                extraMemNeeded,
                 requestedSize,        // only allow access to the actual size requested
                 access);
         }

--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedView.Windows.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedView.Windows.cs
@@ -89,7 +89,7 @@ namespace System.IO.MemoryMappedFiles
             }
 
             viewHandle.Initialize((ulong)size + (ulong)extraMemNeeded);
-            return new MemoryMappedView(viewHandle, extraMemNeeded, size, access);
+            return new MemoryMappedView(viewHandle, offset, extraMemNeeded, size, access);
         }
 
         // Flushes the changes such that they are in sync with the FileStream bits (ones obtained

--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedView.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedView.cs
@@ -16,7 +16,7 @@ namespace System.IO.MemoryMappedFiles
         private readonly MemoryMappedFileAccess _access;
 
         [SecurityCritical]
-        private unsafe MemoryMappedView(SafeMemoryMappedViewHandle viewHandle, long pointerOffset,
+        private unsafe MemoryMappedView(SafeMemoryMappedViewHandle viewHandle, long pointerOffset, long nativeViewOffset,
                                         long size, MemoryMappedFileAccess access)
         {
             Debug.Assert(viewHandle != null);
@@ -25,6 +25,7 @@ namespace System.IO.MemoryMappedFiles
             _pointerOffset = pointerOffset;
             _size = size;
             _access = access;
+            NativeViewOffset = nativeViewOffset;
         }
 
         public SafeMemoryMappedViewHandle ViewHandle
@@ -37,6 +38,8 @@ namespace System.IO.MemoryMappedFiles
         {
             get { return _pointerOffset; }
         }
+
+        internal long NativeViewOffset { get; }
 
         public long Size
         {

--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedViewAccessor.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedViewAccessor.cs
@@ -18,7 +18,7 @@ namespace System.IO.MemoryMappedFiles
             Debug.Assert(view != null, "view is null");
 
             _view = view;
-            Initialize(_view.ViewHandle, _view.PointerOffset, _view.Size, MemoryMappedFile.GetFileAccess(_view.Access));
+            Initialize(_view.ViewHandle, _view.NativeViewOffset, _view.Size, MemoryMappedFile.GetFileAccess(_view.Access));
         }
 
         public SafeMemoryMappedViewHandle SafeMemoryMappedViewHandle

--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedViewStream.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedViewStream.cs
@@ -18,7 +18,7 @@ namespace System.IO.MemoryMappedFiles
             Debug.Assert(view != null, "view is null");
 
             _view = view;
-            Initialize(_view.ViewHandle, _view.PointerOffset, _view.Size, MemoryMappedFile.GetFileAccess(_view.Access));
+            Initialize(_view.ViewHandle, _view.NativeViewOffset, _view.Size, MemoryMappedFile.GetFileAccess(_view.Access));
         }
 
         public SafeMemoryMappedViewHandle SafeMemoryMappedViewHandle

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream.Tests.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream.Tests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Win32.SafeHandles;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Xunit;
@@ -161,6 +162,39 @@ namespace System.IO.MemoryMappedFiles.Tests
                             RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? MapLength : 0, 
                             s.PointerOffset);
                     }
+                }
+            }
+        }
+
+        [Fact]
+        public void LargePointerOffsetMatches()
+        {
+            var bytes = Enumerable.Range(1, 70000).Select(i => unchecked((byte)i)).ToArray();
+            var file = GetTestFilePath();
+            File.WriteAllBytes(file, bytes);
+            using (var mmf = MemoryMappedFile.CreateFromFile(file))
+            {
+                using (var stream = mmf.CreateViewStream(68000, 10))
+                {
+                    Assert.Equal(68000, stream.PointerOffset);
+                }
+            }
+        }
+
+        [Fact]
+        public void NonAlignedOffsets()
+        {
+            var bytes = Enumerable.Range(1, 70000).Select(i => unchecked((byte)i)).ToArray();
+            var file = GetTestFilePath();
+            File.WriteAllBytes(file, bytes);
+            using (var mmf = MemoryMappedFile.CreateFromFile(file))
+            {
+                using (var stream = mmf.CreateViewStream(68000, 10))
+                {
+                    Assert.Equal(unchecked((byte)68001), stream.ReadByte());
+                    Assert.Equal(unchecked((byte)68002), stream.ReadByte());
+                    Assert.Equal(unchecked((byte)68003), stream.ReadByte());
+                    Assert.Equal(unchecked((byte)68004), stream.ReadByte());
                 }
             }
         }


### PR DESCRIPTION
This change fixes the PointerOffset property to be correct when the
requested offset is larger than the allocation size of the OS.

Fixes #18095