### PR TITLE
Restore portable external assets

### DIFF
--- a/external/dir.props
+++ b/external/dir.props
@@ -2,11 +2,9 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <IntermediateOutputPath>$(IntermediateOutputPath)$(OSGroup)-$(ArchGroup)/</IntermediateOutputPath>
-    <!-- TODO: Enable this when Core-Setup is also publishing packages for portable RIDs.
     <RuntimeOS Condition="'$(PortableBuild)' == 'true' and '$(OSGroup)' == 'Windows_NT'">win</RuntimeOS>
     <RuntimeOS Condition="'$(PortableBuild)' == 'true' and '$(OSGroup)' == 'OSX'">osx</RuntimeOS>
     <RuntimeOS Condition="'$(PortableBuild)' == 'true' and '$(OSGroup)' == 'Linux'">linux</RuntimeOS>
-    -->
     <NugetRuntimeIdentifier>$(RuntimeOS)-$(ArchGroup)</NugetRuntimeIdentifier>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Now that Core-Setup is also producing portable RID assets, enable portable external assets to be restored for CoreFX.

@weshaggard PTAL - this is the artifact we discussed to enable once Core-Setup published portable assets.