### PR TITLE
Minor cleanup after moving to 2.0 toolset

### DIFF
--- a/Tools-Override/crossgen.sh
+++ b/Tools-Override/crossgen.sh
@@ -31,6 +31,7 @@ restore_crossgen()
     fi
     cp $__crossgenInPackage $__sharedFxDir
     __crossgen=$__sharedFxDir/crossgen
+    # Executables restored with .NET Core 2.0 do not have executable permission flags. https://github.com/NuGet/Home/issues/4424
     chmod +x $__crossgen
 }
 

--- a/Tools-Override/tests.targets
+++ b/Tools-Override/tests.targets
@@ -287,6 +287,7 @@
       <TestCommandLines  Condition="'$(TargetOS)'!='Windows_NT' and '$(TestGCStressLevel)' != ''" Include="export COMPlus_GCStress=$(TestGCStressLevel)"/>
       <TestCommandLines  Condition="'$(TargetOS)'!='Windows_NT' and '$(OuterLoop)' == 'true'" Include="export XUNIT_PERFORMANCE_MIN_ITERATION=1"/>
       <TestCommandLines  Condition="'$(TargetOS)'!='Windows_NT' and '$(OuterLoop)' == 'true'" Include="export XUNIT_PERFORMANCE_MAX_ITERATION=1"/>
+      <!-- Executables restored with .NET Core 2.0 do not have executable permission flags. https://github.com/NuGet/Home/issues/4424 -->
       <TestCommandLines  Condition="'$(TargetOS)'!='Windows_NT'" Include="chmod +x $(TestProgram)"/>
       <TestCommandLines  Condition="'$(TargetOS)'!='Windows_NT'" Include="$(TestCommandLine)"/>
     </ItemGroup>
@@ -306,6 +307,7 @@
       RunnerScriptTemplate="$(MSBuildThisFileDirectory)/$(RunnerTemplateName)"
       ScriptOutputPath ="$(OutputPathForScriptGenerator)"
     />
+    <!-- Executables restored with .NET Core 2.0 do not have executable permission flags. https://github.com/NuGet/Home/issues/4424 -->
     <Exec Condition="'$(TargetOS)'!='Windows_NT'" Command="chmod +x $(OutputPathForScriptGenerator)" />
   </Target>
 

--- a/external/ilasm/ilasm.depproj
+++ b/external/ilasm/ilasm.depproj
@@ -22,7 +22,7 @@
     </PackageReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
-  <!-- When zipped/unzipped in a package, ilasm loses its executable flag. Reset it. -->
+  <!-- Executables restored with .NET Core 2.0 do not have executable permission flags. https://github.com/NuGet/Home/issues/4424 -->
   <Target Name="MakeIlasmExecutable" AfterTargets="CopyFilesToOutputDirectory" Condition="'$(RunningOnUnix)' == 'true'">
     <Exec Command="chmod +x $(OutputPath)ilasm" />
   </Target>

--- a/init-tools.msbuild
+++ b/init-tools.msbuild
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+    <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)Tools/$(BuildToolsPackageVersion)</BaseIntermediateOutputPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.BuildTools" Version="$(BuildToolsPackageVersion)" />
+  </ItemGroup>
+</Project>

--- a/init-tools.sh
+++ b/init-tools.sh
@@ -141,6 +141,7 @@ if [ ! -e $__INIT_TOOLS_DONE_MARKER ]; then
         echo "Initializing BuildTools..."
         echo "Running: $__BUILD_TOOLS_PATH/init-tools.sh $__scriptpath $__DOTNET_CMD $__TOOLRUNTIME_DIR" >> $__init_tools_log
 
+        # Executables restored with .NET Core 2.0 do not have executable permission flags. https://github.com/NuGet/Home/issues/4424
         chmod +x $__BUILD_TOOLS_PATH/init-tools.sh
         $__BUILD_TOOLS_PATH/init-tools.sh $__scriptpath $__DOTNET_CMD $__TOOLRUNTIME_DIR >> $__init_tools_log
         if [ "$?" != "0" ]; then
@@ -152,6 +153,7 @@ if [ ! -e $__INIT_TOOLS_DONE_MARKER ]; then
     Tools-Override/crossgen.sh $__scriptpath/Tools
 
     echo "Making all .sh files executable under Tools."
+    # Executables restored with .NET Core 2.0 do not have executable permission flags. https://github.com/NuGet/Home/issues/4424
     ls $__scriptpath/Tools/*.sh | xargs chmod +x
     ls $__scriptpath/Tools/scripts/docker/*.sh | xargs chmod +x
 


### PR DESCRIPTION
Includes two minor improvements based on PR feedback in https://github.com/dotnet/corefx/pull/18035.

* There is now an init-tools.msbuild file, which is used to restore the buildtools package. This has the same content as the file we used to be automatically generating in init-tools.cmd/sh. Since we're using an MSBuild project now, we can just parameterize the version of the package by using an MSBuild property, and then pass that into `dotnet restore`.
* I've added comments to the new usages of `chmod`, with a link to this nuget issue: https://github.com/NuGet/Home/issues/4424

@weshaggard 