### PR TITLE
Copy desktop runner config file to test folder

### DIFF
--- a/Tools-Override/tests.targets
+++ b/Tools-Override/tests.targets
@@ -125,25 +125,25 @@
 
   <!-- We need to generate a simple config file for desktop test executors to tell them to use DEVPATH environment variable to use their dependencies from there.
   DEVPATH is being set for desktop runs in RunTests.cmd to the TestHostPath. We need this approach to have desktop Helix runs. -->
-  <Target Name="GenerateDesktopExecutorsConfigFiles"
+  <Target Name="CopyDesktopExecutorsConfigFiles"
           BeforeTargets="GenerateTestExecutionScripts"
           Condition="'$(BuildingNETFxVertical)' == 'true'">
     <PropertyGroup>
-      <XunitRunnerNetfxConfigFile>$(TestPath)\$(XunitExecutable).config</XunitRunnerNetfxConfigFile>
+      <NETFxTestRunnerAppConfig Condition="'$(NETFxTestRunnerAppConfig)' == ''">$(ToolsDir)\DesktopRunnerConfigFile.config</NETFxTestRunnerAppConfig>
+      <XunitRunnerNETFxConfigFile>$(TestPath)\$(XunitExecutable).config</XunitRunnerNETFxConfigFile>
       <RemoteExecutorConfigFile>$(TestPath)\RemoteExecutorConsoleApp.exe.config</RemoteExecutorConfigFile>
     </PropertyGroup>
 
-    <ItemGroup>
-      <ConfigFileLines Include="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;" />
-      <ConfigFileLines Include="&lt;configuration&gt;" />
-      <ConfigFileLines Include="&lt;runtime&gt;" />
-      <ConfigFileLines Include="&lt;developmentMode developerInstallation=&quot;true&quot; /&gt;" />
-      <ConfigFileLines Include="&lt;/runtime&gt;" />   
-      <ConfigFileLines Include="&lt;/configuration&gt;" />
-    </ItemGroup>
+    <Copy SourceFiles="$(NETFxTestRunnerAppConfig)"
+          DestinationFiles="$(XunitRunnerNETFxConfigFile)" 
+          SkipUnchangedFiles="true"
+          />
 
-    <WriteLinesToFile File="$(XunitRunnerNetfxConfigFile)" Lines="@(ConfigFileLines)" Overwrite="true"/>
-    <WriteLinesToFile Condition="Exists('$(TestPath)\RemoteExecutorConsoleApp.exe')" File="$(RemoteExecutorConfigFile)" Lines="@(ConfigFileLines)" Overwrite="true" />
+    <Copy Condition="Exists('$(TestPath)\RemoteExecutorConsoleApp.exe')"
+          SourceFiles="$(NETFxTestRunnerAppConfig)"
+          DestinationFiles="$(RemoteExecutorConfigFile)" 
+          SkipUnchangedFiles="true"
+          />
   </Target>
 
   <!-- Generate the script to run the tests.  The script performs two high-level steps:
@@ -152,7 +152,7 @@
            directory.
        2.  Runs the tests. -->
   <Target Name="GenerateTestExecutionScripts"
-          DependsOnTargets="DiscoverTestInputs;SetupTestProperties;GenerateDesktopExecutorsConfigFiles">
+          DependsOnTargets="DiscoverTestInputs;SetupTestProperties">
     <PropertyGroup>
       <TargetOSTrait Condition="'$(TargetOS)'=='Windows_NT'">nonwindowstests</TargetOSTrait>
       <TargetOSTrait Condition="'$(TargetOS)'=='Linux'">nonlinuxtests</TargetOSTrait>


### PR DESCRIPTION
This changes where reverted here: https://github.com/dotnet/corefx/pull/18113#issuecomment-292738439

Because of an issue the new version of buildtools was causing OSX not to initialize the tools. This issue was fixed and build tools version was updated so I'm updating tests.targets to copy the config file for Desktop tests instead of writing it every time.

cc: @weshaggard @tarekgh @joperezr 