### PR TITLE
Fix difference in behavior DelimitedListTraceListener.WriteFooter

### DIFF
--- a/src/System.Diagnostics.TextWriterTraceListener/src/System.Diagnostics.TextWriterTraceListener.csproj
+++ b/src/System.Diagnostics.TextWriterTraceListener/src/System.Diagnostics.TextWriterTraceListener.csproj
@@ -19,6 +19,7 @@
     <Compile Include="System\Diagnostics\TextWriterTraceListener.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="System.Collections.NonGeneric" />
     <Reference Include="System.Diagnostics.Tools" />
     <Reference Include="System.Diagnostics.TraceSource" />
     <Reference Include="System.Resources.ResourceManager" />

--- a/src/System.Diagnostics.TextWriterTraceListener/src/System/Diagnostics/DelimitedListTraceListener.cs
+++ b/src/System.Diagnostics.TextWriterTraceListener/src/System/Diagnostics/DelimitedListTraceListener.cs
@@ -164,6 +164,10 @@ namespace System.Diagnostics
                     Write(eventCache.ProcessId.ToString(CultureInfo.InvariantCulture));
                 Write(Delimiter); // Use get_Delimiter
 
+                if (IsEnabled(TraceOptions.LogicalOperationStack))
+                    WriteStackEscaped(eventCache.LogicalOperationStack);
+                Write(Delimiter); // Use get_Delimiter
+
                 if (IsEnabled(TraceOptions.ThreadId))
                     WriteEscaped(eventCache.ThreadId);
                 Write(Delimiter); // Use get_Delimiter
@@ -187,22 +191,46 @@ namespace System.Diagnostics
 
         private void WriteEscaped(string message)
         {
-            if (!String.IsNullOrEmpty(message))
+            if (!string.IsNullOrEmpty(message))
             {
                 StringBuilder sb = new StringBuilder("\"");
-                int index;
-                int lastindex = 0;
-                while ((index = message.IndexOf('"', lastindex)) != -1)
-                {
-                    sb.Append(message, lastindex, index - lastindex);
-                    sb.Append("\"\"");
-                    lastindex = index + 1;
-                }
-
-                sb.Append(message, lastindex, message.Length - lastindex);
+                EscapeMessage(message, sb);
                 sb.Append("\"");
                 Write(sb.ToString());
             }
+        }
+
+        private void WriteStackEscaped(Stack stack)
+        {
+            StringBuilder sb = new StringBuilder("\"");
+            bool first = true;
+            foreach (object obj in stack)
+            {
+                if (!first)
+                    sb.Append(", ");
+                else
+                    first = false;
+                
+                string operation = obj.ToString();
+                EscapeMessage(operation, sb);
+            }
+
+            sb.Append("\"");
+            Write(sb.ToString());
+        }
+
+        private void EscapeMessage(string message, StringBuilder sb)
+        {
+            int index;
+            int lastindex = 0;
+            while ((index = message.IndexOf('"', lastindex)) != -1)
+            {
+                sb.Append(message, lastindex, index - lastindex);
+                sb.Append("\"\"");
+                lastindex = index + 1;
+            }
+
+            sb.Append(message, lastindex, message.Length - lastindex);
         }
 
         private bool IsEnabled(TraceOptions opts)

--- a/src/System.Diagnostics.TextWriterTraceListener/src/System/Diagnostics/DelimitedListTraceListener.cs
+++ b/src/System.Diagnostics.TextWriterTraceListener/src/System/Diagnostics/DelimitedListTraceListener.cs
@@ -207,9 +207,13 @@ namespace System.Diagnostics
             foreach (object obj in stack)
             {
                 if (!first)
+                {
                     sb.Append(", ");
+                }
                 else
+                {
                     first = false;
+                }
                 
                 string operation = obj.ToString();
                 EscapeMessage(operation, sb);

--- a/src/System.Diagnostics.TextWriterTraceListener/tests/CommonUtilities.cs
+++ b/src/System.Diagnostics.TextWriterTraceListener/tests/CommonUtilities.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
 using System.Globalization;
 using System.IO;
 using System.Text;
@@ -86,6 +87,8 @@ namespace System.Diagnostics.TextWriterTraceListenerTests
             {
                 builder.Append(cache.ProcessId);
                 builder.Append(delimiter);
+                builder.Append(EscapedStack(cache.LogicalOperationStack));
+                builder.Append(delimiter);
                 builder.Append(EscapedString(cache.ThreadId));
                 builder.Append(delimiter);
                 builder.Append(EscapedString(cache.DateTime.ToString("o", CultureInfo.InvariantCulture)));
@@ -102,19 +105,47 @@ namespace System.Diagnostics.TextWriterTraceListenerTests
 
         private static string EscapedString(string str)
         {
+            if (!string.IsNullOrEmpty(str))
+            {
+                StringBuilder sb = new StringBuilder("\"");
+                EscapeMessage(str, sb);
+                sb.Append("\"");
+                return sb.ToString();
+            }
+            return string.Empty;
+        }
+
+        private static string EscapedStack(Stack stack)
+        {
+            StringBuilder sb = new StringBuilder("\"");
+            bool first = true;
+            foreach (object obj in stack)
+            {
+                if (!first)
+                    sb.Append(", ");
+                else
+                    first = false;
+                
+                string operation = obj.ToString();
+                EscapeMessage(operation, sb);
+            }
+
+            sb.Append("\"");
+            return sb.ToString();
+        }
+
+        private static void EscapeMessage(string message, StringBuilder sb)
+        {
             int index;
             int lastindex = 0;
-            StringBuilder sb = new StringBuilder("\"");
-            while ((index = str.IndexOf('"', lastindex)) != -1)
+            while ((index = message.IndexOf('"', lastindex)) != -1)
             {
-                sb.Append(str, lastindex, index - lastindex);
+                sb.Append(message, lastindex, index - lastindex);
                 sb.Append("\"\"");
                 lastindex = index + 1;
             }
 
-            sb.Append(str, lastindex, str.Length - lastindex);
-            sb.Append("\"");
-            return sb.ToString();
+            sb.Append(message, lastindex, message.Length - lastindex);
         }
     }
 }

--- a/src/System.Diagnostics.TextWriterTraceListener/tests/CommonUtilities.cs
+++ b/src/System.Diagnostics.TextWriterTraceListener/tests/CommonUtilities.cs
@@ -122,9 +122,13 @@ namespace System.Diagnostics.TextWriterTraceListenerTests
             foreach (object obj in stack)
             {
                 if (!first)
+                {
                     sb.Append(", ");
+                }
                 else
+                {
                     first = false;
+                }
                 
                 string operation = obj.ToString();
                 EscapeMessage(operation, sb);

--- a/src/System.Diagnostics.TextWriterTraceListener/tests/DelimiterWriteMethodTests.cs
+++ b/src/System.Diagnostics.TextWriterTraceListener/tests/DelimiterWriteMethodTests.cs
@@ -50,7 +50,7 @@ namespace System.Diagnostics.TextWriterTraceListenerTests
             using (var target = new DelimitedListTraceListener(_stream))
             {
                 target.Filter = filter;
-                target.TraceOutputOptions = TraceOptions.ProcessId | TraceOptions.ThreadId | TraceOptions.DateTime | TraceOptions.Timestamp;
+                target.TraceOutputOptions = TraceOptions.ProcessId | TraceOptions.ThreadId | TraceOptions.DateTime | TraceOptions.Timestamp | TraceOptions.LogicalOperationStack;
                 target.TraceEvent(eventCache, source, eventType, id, format, args);
             }
 
@@ -66,7 +66,7 @@ namespace System.Diagnostics.TextWriterTraceListenerTests
             using (var target = new DelimitedListTraceListener(_stream))
             {
                 target.Filter = filter;
-                target.TraceOutputOptions = TraceOptions.ProcessId | TraceOptions.ThreadId | TraceOptions.DateTime | TraceOptions.Timestamp;
+                target.TraceOutputOptions = TraceOptions.ProcessId | TraceOptions.ThreadId | TraceOptions.DateTime | TraceOptions.Timestamp | TraceOptions.LogicalOperationStack;
                 target.TraceEvent(eventCache, source, eventType, id, message);
             }
 
@@ -102,7 +102,7 @@ namespace System.Diagnostics.TextWriterTraceListenerTests
             using (var target = new DelimitedListTraceListener(_stream))
             {
                 target.Filter = filter;
-                target.TraceOutputOptions = TraceOptions.ProcessId | TraceOptions.ThreadId | TraceOptions.DateTime | TraceOptions.Timestamp;
+                target.TraceOutputOptions = TraceOptions.ProcessId | TraceOptions.ThreadId | TraceOptions.DateTime | TraceOptions.Timestamp | TraceOptions.LogicalOperationStack;
                 target.TraceData(eventCache, source, eventType, id, data);
             }
 
@@ -138,7 +138,7 @@ namespace System.Diagnostics.TextWriterTraceListenerTests
             {
                 target.Delimiter = delimiter;
                 target.Filter = filter;
-                target.TraceOutputOptions = TraceOptions.ProcessId | TraceOptions.ThreadId | TraceOptions.DateTime | TraceOptions.Timestamp;
+                target.TraceOutputOptions = TraceOptions.ProcessId | TraceOptions.ThreadId | TraceOptions.DateTime | TraceOptions.Timestamp | TraceOptions.LogicalOperationStack;
                 target.TraceData(eventCache, source, eventType, id, data);
             }
 


### PR DESCRIPTION
There was a difference in behavior in between .NET Core and desktop where `DelimitedListTraceListener.WriteFooter` was not writing the `TraceEventCache.LogicalOperationStack` on .NET Core.

This difference in behavior was causing the tests in Desktop to fail.

Fixes: https://github.com/dotnet/corefx/issues/10880

cc: @danmosemsft @brianrob @vancem 