### PR TITLE
Disable intermittent HttpListener tests

### DIFF
--- a/src/System.Net.HttpListener/tests/HttpResponseStreamTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpResponseStreamTests.cs
@@ -403,6 +403,7 @@ namespace System.Net.Tests
         [InlineData(true)]
         [InlineData(false)]
         [ActiveIssue(18128, platforms: TestPlatforms.AnyUnix)] // No exception thrown
+        [ActiveIssue(18188, platforms: TestPlatforms.Windows)] // Indeterminate failure - socket not always fully disconnected.        
         public async Task Write_HeadersToClosedConnectionAsynchronously_ThrowsHttpListenerException(bool ignoreWriteExceptions)
         {
             const string Text = "Some-String";
@@ -418,7 +419,7 @@ namespace System.Net.Tests
                 HttpListenerContext context = await listener.GetContextAsync();
 
                 // Disconnect the Socket from the HttpListener.
-                client.Dispose();
+                client.Close();
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
 
@@ -434,6 +435,7 @@ namespace System.Net.Tests
         [InlineData(true)]
         [InlineData(false)]
         [ActiveIssue(18128, platforms: TestPlatforms.AnyUnix)] // No exception thrown
+        [ActiveIssue(18188, platforms: TestPlatforms.Windows)] // Indeterminate failure - socket not always fully disconnected.
         public async Task Write_HeadersToClosedConnectionSynchronously_ThrowsHttpListenerException(bool ignoreWriteExceptions)
         {
             const string Text = "Some-String";
@@ -465,6 +467,7 @@ namespace System.Net.Tests
         [InlineData(true)]
         [InlineData(false)]
         [ActiveIssue(18128, platforms: TestPlatforms.AnyUnix)] // No exception thrown
+        [ActiveIssue(18188, platforms: TestPlatforms.Windows)] // Indeterminate failure - socket not always fully disconnected.
         public async Task Write_ContentToClosedConnectionAsynchronously_ThrowsHttpListenerException(bool ignoreWriteExceptions)
         {
             const string Text = "Some-String";
@@ -506,6 +509,7 @@ namespace System.Net.Tests
         [InlineData(true)]
         [InlineData(false)]
         [ActiveIssue(18128, platforms: TestPlatforms.AnyUnix)] // No exception thrown
+        [ActiveIssue(18188, platforms: TestPlatforms.Windows)] // Indeterminate failure - socket not always fully disconnected.
         public async Task Write_ContentToClosedConnectionSynchronously_ThrowsHttpListenerException(bool ignoreWriteExceptions)
         {
             const string Text = "Some-String";


### PR DESCRIPTION
See #18188

The test code for this style of tests is:
```cs
[ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
[InlineData(true)]
[InlineData(false)]
public async Task Write_HeadersToClosedConnectionSynchronously_ThrowsHttpListenerException(bool ignoreWriteExceptions)
{
    const string Text = "Some-String";
    byte[] buffer = Encoding.UTF8.GetBytes(Text);

    using (HttpListenerFactory factory = new HttpListenerFactory())
    using (Socket client = factory.GetConnectedSocket())
    {
        // Send a header to the HttpListener to give it a context.
        client.Send(factory.GetContent(RequestTypes.POST, Text, headerOnly: true));
        HttpListener listener = factory.GetListener();
        listener.IgnoreWriteExceptions = ignoreWriteExceptions;
        HttpListenerContext context = await listener.GetContextAsync();

        // Disconnect the Socket from the HttpListener.
        client.Close();
        GC.Collect();
        GC.WaitForPendingFinalizers();
        
        // Writing to, a closed connection should fail.
        Assert.Throws<HttpListenerException>(() => context.Response.OutputStream.Write(buffer, 0, buffer.Length));
        
        // Closing a response from a closed client if a writing has already failed should not fail.
        context.Response.Close();
    }
}
```

It seems that closing the socket doesn't happen instantly, even though we waited for the GC, and then waited for finalizers to run.

For some reason, this code doesn't work:
```cs
client.Close();
GC.Collect();
GC.WaitForPendingFinalizers();

// Ooops. Client not closed.
```

From #17999:

> @hughbe Socket.dispose, is calling safehandle.dispose. It could be the case that there were some references to the safe handle that prevents it from disposing, and with explicilty waiting for gc, that got disposed. Or it could be that the safehandle was put in finalizer queue, and the finalizer hadn't run to free up the resources before you tried to use the stream on the native connection.

We need to find a better solution for what the test is trying to do: open a connection, then close the socket, then write to a closed socket.

Could be the `using` block that is screwing things up for the GC? I have not encountered a failure on my PC yet in the current code. @stephentoub @Priya91 any ideas? I'd like to keep these tests as they cover a bunch of code in HttpListener.

@danmosemsft FYI
