### PR TITLE
Remove duplicate string resource from System.Net.Requests

### DIFF
--- a/src/System.Net.Requests/src/Resources/Strings.resx
+++ b/src/System.Net.Requests/src/Resources/Strings.resx
@@ -94,9 +94,6 @@
   <data name="net_PropertyNotImplementedException" xml:space="preserve">
     <value>This property is not implemented by this class.</value>
   </data>
-  <data name="net_PropertyNotSupportedException" xml:space="preserve">
-    <value>This property is not supported by this class.</value>
-  </data>
   <data name="net_nouploadonget" xml:space="preserve">
     <value>Cannot send a content-body with this verb-type.</value>
   </data>


### PR DESCRIPTION
Caused by PR #18163. Looks like compile warnings from strings.resx are
not caught by CI.

Fixes #18211