### PR TITLE
Fix System.Diagnostics.Process tests for uapaot runs

### DIFF
--- a/src/Common/src/Interop/Windows/user32/Interop.GetWindowLong.cs
+++ b/src/Common/src/Interop/Windows/user32/Interop.GetWindowLong.cs
@@ -9,7 +9,7 @@ internal partial class Interop
 {
     internal partial class User32
     {
-        [DllImport(Libraries.User32)]
+        [DllImport(Libraries.User32, EntryPoint = "GetWindowLongW")]
         public static extern int GetWindowLong(IntPtr hWnd, int uCmd);
     }
 }

--- a/src/Common/src/Interop/Windows/user32/Interop.GetWindowText.cs
+++ b/src/Common/src/Interop/Windows/user32/Interop.GetWindowText.cs
@@ -10,7 +10,7 @@ internal partial class Interop
 {
     internal partial class User32
     {
-        [DllImport(Libraries.User32)]
+        [DllImport(Libraries.User32, EntryPoint = "GetWindowTextW")]
         public static extern int GetWindowText(IntPtr hWnd, [Out]StringBuilder lpString, int nMaxCount);
     }
 }

--- a/src/Common/src/Interop/Windows/user32/Interop.GetWindowTextLength.cs
+++ b/src/Common/src/Interop/Windows/user32/Interop.GetWindowTextLength.cs
@@ -9,7 +9,7 @@ internal partial class Interop
 {
     internal partial class User32
     {
-        [DllImport(Libraries.User32)]
+        [DllImport(Libraries.User32, EntryPoint = "GetWindowTextLengthW")]
         public static extern int GetWindowTextLength(IntPtr hWnd);
     }
 }

--- a/src/Common/src/Interop/Windows/user32/Interop.PostMessage.cs
+++ b/src/Common/src/Interop/Windows/user32/Interop.PostMessage.cs
@@ -9,7 +9,7 @@ internal partial class Interop
 {
     internal partial class User32
     {
-        [DllImport(Libraries.User32)]
+        [DllImport(Libraries.User32, EntryPoint = "PostMessageW")]
         public static extern int PostMessage(IntPtr hwnd, int msg, IntPtr wparam, IntPtr lparam);
     }
 }

--- a/src/Common/src/Interop/Windows/user32/Interop.SendMessageTimeout.cs
+++ b/src/Common/src/Interop/Windows/user32/Interop.SendMessageTimeout.cs
@@ -9,7 +9,7 @@ internal partial class Interop
 {
     internal partial class User32
     {
-	    [DllImport(Libraries.User32)]
+	    [DllImport(Libraries.User32, EntryPoint = "SendMessageTimeoutW")]
         public static extern IntPtr SendMessageTimeout(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam, int flags, int timeout, out IntPtr pdwResult);
     }
 }

--- a/src/System.Diagnostics.Process/System.Diagnostics.Process.sln
+++ b/src/System.Diagnostics.Process/System.Diagnostics.Process.sln
@@ -31,10 +31,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{E1114510-844C-4BB2-BBAD-8595BD16E24B}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{E1114510-844C-4BB2-BBAD-8595BD16E24B}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{E1114510-844C-4BB2-BBAD-8595BD16E24B}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{E1114510-844C-4BB2-BBAD-8595BD16E24B}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{E1114510-844C-4BB2-BBAD-8595BD16E24B}.Debug|Any CPU.ActiveCfg = netstandard-Windows_NT-Debug|Any CPU
+		{E1114510-844C-4BB2-BBAD-8595BD16E24B}.Debug|Any CPU.Build.0 = netstandard-Windows_NT-Debug|Any CPU
+		{E1114510-844C-4BB2-BBAD-8595BD16E24B}.Release|Any CPU.ActiveCfg = netstandard-Windows_NT-Release|Any CPU
+		{E1114510-844C-4BB2-BBAD-8595BD16E24B}.Release|Any CPU.Build.0 = netstandard-Windows_NT-Release|Any CPU
 		{4E05E43A-1DC9-47C7-8280-13CF4EF741EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4E05E43A-1DC9-47C7-8280-13CF4EF741EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4E05E43A-1DC9-47C7-8280-13CF4EF741EA}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/src/System.Diagnostics.Process/src/PinvokeAnalyzerExceptionList.analyzerdata
+++ b/src/System.Diagnostics.Process/src/PinvokeAnalyzerExceptionList.analyzerdata
@@ -24,11 +24,11 @@ ntdll.dll!NtQueryInformationProcess
 ntdll.dll!NtQuerySystemInformation
 user32.dll!EnumWindows
 user32.dll!GetWindow
-user32.dll!GetWindowLong
-user32.dll!GetWindowText
-user32.dll!GetWindowTextLength
+user32.dll!GetWindowLongW
+user32.dll!GetWindowTextW
+user32.dll!GetWindowTextLengthW
 user32.dll!GetWindowThreadProcessId
 user32.dll!IsWindowVisible
-user32.dll!PostMessage
-user32.dll!SendMessageTimeout
+user32.dll!PostMessageW
+user32.dll!SendMessageTimeoutW
 user32.dll!WaitForInputIdle

--- a/src/System.Diagnostics.Process/tests/Configurations.props
+++ b/src/System.Diagnostics.Process/tests/Configurations.props
@@ -2,7 +2,8 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
-      netstandard;
+      netstandard-Windows_NT;
+      netstandard-Unix;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Diagnostics.Process/tests/Interop.Unix.cs
+++ b/src/System.Diagnostics.Process/tests/Interop.Unix.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Security.Principal;
+
+namespace System.Diagnostics.Tests
+{
+    internal partial class Interop
+    {
+        [DllImport("libc")]
+        internal static extern int getpid();
+
+        [DllImport("libc")]
+        internal static extern int getsid(int pid);
+    }
+}

--- a/src/System.Diagnostics.Process/tests/Interop.cs
+++ b/src/System.Diagnostics.Process/tests/Interop.cs
@@ -9,7 +9,7 @@ using System.Security.Principal;
 
 namespace System.Diagnostics.Tests
 {
-    internal class Interop
+    internal partial class Interop
     {
         [StructLayout(LayoutKind.Sequential, Size = 40)]
         public struct PROCESS_MEMORY_COUNTERS
@@ -57,12 +57,6 @@ namespace System.Diagnostics.Tests
         
         [DllImport("kernel32.dll")]
         internal static extern int GetCurrentProcessId();
-
-        [DllImport("libc")]
-        internal static extern int getpid();
-
-        [DllImport("libc")]
-        internal static extern int getsid(int pid);
 
         [DllImport("kernel32.dll")]
         internal static extern bool ProcessIdToSessionId(uint dwProcessId, out uint pSessionId);

--- a/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -16,8 +16,8 @@ namespace System.Diagnostics.Tests
 {
     public partial class ProcessTests : ProcessTestBase
     {
-        [PlatformSpecific(TestPlatforms.AnyUnix)]  // Uses P/Invokes to set permissions
         [Fact]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]  // Uses P/Invokes to set permissions
         public void TestStartOnUnixWithBadPermissions()
         {
             string path = GetTestFilePath();
@@ -28,8 +28,8 @@ namespace System.Diagnostics.Tests
             Assert.NotEqual(0, e.NativeErrorCode);
         }
 
-        [PlatformSpecific(TestPlatforms.AnyUnix)]  // Uses P/Invokes to set permissions
         [Fact]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]  // Uses P/Invokes to set permissions
         public void TestStartOnUnixWithBadFormat()
         {
             string path = GetTestFilePath();

--- a/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Security;
+using Xunit;
+using Xunit.NetCore.Extensions;
+
+namespace System.Diagnostics.Tests
+{
+    public partial class ProcessTests : ProcessTestBase
+    {
+        [PlatformSpecific(TestPlatforms.AnyUnix)]  // Uses P/Invokes to set permissions
+        [Fact]
+        public void TestStartOnUnixWithBadPermissions()
+        {
+            string path = GetTestFilePath();
+            File.Create(path).Dispose();
+            Assert.Equal(0, chmod(path, 644)); // no execute permissions
+
+            Win32Exception e = Assert.Throws<Win32Exception>(() => Process.Start(path));
+            Assert.NotEqual(0, e.NativeErrorCode);
+        }
+
+        [PlatformSpecific(TestPlatforms.AnyUnix)]  // Uses P/Invokes to set permissions
+        [Fact]
+        public void TestStartOnUnixWithBadFormat()
+        {
+            string path = GetTestFilePath();
+            File.Create(path).Dispose();
+            Assert.Equal(0, chmod(path, 744)); // execute permissions
+
+            using (Process p = Process.Start(path))
+            {
+                p.WaitForExit();
+                Assert.NotEqual(0, p.ExitCode);
+            }
+        }
+
+        [DllImport("libc")]
+        private static extern int chmod(string path, int mode);
+    }
+}

--- a/src/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
@@ -105,6 +105,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Issue https://github.com/dotnet/corefx/issues/18210")]
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(127)]

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests.csproj
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests.csproj
@@ -7,8 +7,10 @@
     <DefineConstants Condition="'$(TargetsWindows)' == 'true'">$(DefineConstants);TargetsWindows</DefineConstants>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Unix-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Unix-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
       <Link>Common\tests\System\PlatformDetection.cs</Link>

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests.csproj
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <ProjectGuid>{E1114510-844C-4BB2-BBAD-8595BD16E24B}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DefineConstants Condition="'$(TargetsWindows)' == 'true'">$(DefineConstants);TargetsWindows</DefineConstants>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
@@ -22,12 +23,14 @@
       <Link>Common\System\ShouldNotBeInvokedException.cs</Link>
     </Compile>
     <Compile Include="Interop.cs" />
+    <Compile Include="Interop.Unix.cs" Condition="'$(TargetsWindows)' != 'true'" />
     <Compile Include="ProcessCollectionTests.cs" />
     <Compile Include="ProcessModuleTests.cs" />
     <Compile Include="ProcessStandardConsoleTests.cs" />
     <Compile Include="ProcessStartInfoTests.cs" />
     <Compile Include="ProcessStreamReadTests.cs" />
     <Compile Include="ProcessTests.cs" />
+    <Compile Include="ProcessTests.Unix.cs" Condition="'$(TargetsWindows)' != 'true'" />
     <Compile Include="ProcessTestBase.cs" />
     <Compile Include="ProcessThreadTests.cs" />
     <Compile Include="ProcessWaitingTests.cs" />


### PR DESCRIPTION
cc: @danmosemsft @Priya91 

FYI: @alexperovich 

System.Diagnostics.Process tests were crashing on when executed on ILC runs, this PR fixes all of them so that execution succeeds.