### PR TITLE
Fix breaks in the official build

### DIFF
--- a/Tools-Override/OptimizationData.msbuild
+++ b/Tools-Override/OptimizationData.msbuild
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp1.0;net46</TargetFrameworks>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="$(OptimizationDataPackageName)" Version="$(OptimizationDataVersion)" />
+  </ItemGroup>
+</Project>

--- a/Tools-Override/codeOptimization.targets
+++ b/Tools-Override/codeOptimization.targets
@@ -44,27 +44,22 @@
 
   <!-- We need the OptimizationData package in order to be able to optimize the assembly -->
   <Target Name="RestoreOptimizationDataPackage" BeforeTargets="CoreCompile"
-          Condition="'$(EnableProfileGuidedOptimization)'=='true' and !Exists('$(OptimizationDataDir)project.json')">
-
+          Condition="'$(EnableProfileGuidedOptimization)'=='true' and !Exists('$(OptimizationDataDir)project.csproj')">
     <!-- Dynamically create a project.json file used to restore the optimization data-->
-    <Message Text="Generating project.json for optimization data"  Importance="low" />
-    <ItemGroup>
-      <_OptimizationDataJsonLine Include="{&quot;dependencies&quot;: {" />
-      <_OptimizationDataJsonLine Include="&quot;$(OptimizationDataPackageName)&quot; : &quot;$(OptimizationDataVersion)&quot; " />
-      <_OptimizationDataJsonLine Include="},&quot;frameworks&quot;: {&quot;netcoreapp1.0&quot;: {},&quot;net46&quot;: {}}}"/>
-    </ItemGroup>
+    <PropertyGroup>
+      <OptimizationDataSourceProject>$(MSBuildThisFileDirectory)OptimizationData.msbuild</OptimizationDataSourceProject>
+    </PropertyGroup>
     
     <PropertyGroup>
-      <OptimizationDataProjectJson>$(OptimizationDataDir)project.json</OptimizationDataProjectJson>
+      <OptimizationDataRestoreTarget>$(OptimizationDataDir)project.csproj</OptimizationDataRestoreTarget>
       <OptimizationDataNuGetFeed Condition="'$(OptimizationDataNuGetFeed)'==''">https:%2F%2Fdotnet.myget.org/F/roslyn/api/v3/index.json</OptimizationDataNuGetFeed>
     </PropertyGroup>
 
     <MakeDir Directories="$(OptimizationDataDir)" ContinueOnError="true" />
-    <WriteLinesToFile File="$(OptimizationDataProjectJson)" Lines="@(_OptimizationDataJsonLine)" Overwrite="true" />
+    <Copy SourceFiles="$(OptimizationDataSourceProject)" DestinationFiles="$(OptimizationDataRestoreTarget)" />
 
     <!-- Restore the OptimizationData package -->
-    <Exec Command="$(DnuRestoreCommand) $(OptimizationDataProjectJson) --source $(OptimizationDataNuGetFeed)"
-          StandardOutputImportance="Low"/>
+    <Exec Command="$(DnuRestoreCommand) $(OptimizationDataRestoreTarget) --source $(OptimizationDataNuGetFeed) /p:OptimizationDataPackageName=$(OptimizationDataPackageName) /p:OptimizationDataVersion=$(OptimizationDataVersion)" StandardOutputImportance="Low"/>
 
     <!-- Copy the restored files into a more accessible location -->
     <ItemGroup>

--- a/Tools-Override/codeOptimization.targets
+++ b/Tools-Override/codeOptimization.targets
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <UsingTask TaskName="ZipFileExtractToDirectory" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
+
+  <PropertyGroup>
+    <OptimizationDataVersion Condition="'$(OptimizationDataVersion)'==''">2.0.0-rc-61101-16</OptimizationDataVersion>
+    <OptimizationDataPackageName Condition="'$(OptimizationDataPackageName)'==''">RoslynDependencies.OptimizationData</OptimizationDataPackageName>
+    <OptimizationDataDir Condition="'$(OptimizationDataDir)'==''">$(ToolsDir)OptimizationData/</OptimizationDataDir>
+  </PropertyGroup>
+
+  <!-- We should only run this target on Windows and only if EnableProfileGuidedOptimization is set and we have training data -->
+  <Target Name="OptimizeWithTrainingData"
+          AfterTargets="AfterBuild"
+          BeforeTargets="CopyFilesToOutputDirectory"
+          DependsOnTargets="RestoreOptimizationDataPackage;ResolveOptionalTools"
+          Condition="'$(OS)'=='Windows_NT' and '$(EnableProfileGuidedOptimization)'=='true' and Exists('$(OptimizationDataDir)$(AssemblyName).pgo')">
+
+    <!-- Find IBCMerge as a resolved optional tool. -->
+    <PropertyGroup>
+      <IBCMergeToolPath Condition="'%(Filename)%(Extension)'=='ibcmerge.exe'">@(ResolvedOptionalToolReferences)</IBCMergeToolPath>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <OptimizedAssemblyDir>$(IntermediateOutputPath)/OptimizedAssembly</OptimizedAssemblyDir>
+      <OptimizedAssemblyFile>$(OptimizedAssemblyDir)/$(AssemblyName).dll</OptimizedAssemblyFile>
+    </PropertyGroup>
+
+    <!-- Copy the compiled assembly into a folder for further processing -->
+    <MakeDir Directories="$(OptimizedAssemblyDir)" />
+    <Copy SourceFiles="@(IntermediateAssembly)" DestinationFolder="$(OptimizedAssemblyDir)" />
+
+    <!-- Apply optimization data to the compiled assembly -->
+    <Exec Command="$(IBCMergeToolPath) -q -f -partialNGEN -minify -mo $(OptimizedAssemblyFile) -incremental $(OptimizationDataDir)$(AssemblyName).pgo" />
+
+    <!-- Verify that the optimization data has been applied -->
+    <Exec Command="$(IBCMergeToolPath) -mi $(OptimizedAssemblyFile)" />
+
+    <!-- We need to make sure that the assembly that gets packaged is the one with the optimization data -->
+    <ItemGroup>
+      <IntermediateAssembly Remove="@(IntermediateAssembly)"/>
+      <IntermediateAssembly Include="$(OptimizedAssemblyDir)/$(AssemblyName).dll"/>
+    </ItemGroup>
+  </Target>
+
+  <!-- We need the OptimizationData package in order to be able to optimize the assembly -->
+  <Target Name="RestoreOptimizationDataPackage" BeforeTargets="CoreCompile"
+          Condition="'$(EnableProfileGuidedOptimization)'=='true' and !Exists('$(OptimizationDataDir)project.json')">
+
+    <!-- Dynamically create a project.json file used to restore the optimization data-->
+    <Message Text="Generating project.json for optimization data"  Importance="low" />
+    <ItemGroup>
+      <_OptimizationDataJsonLine Include="{&quot;dependencies&quot;: {" />
+      <_OptimizationDataJsonLine Include="&quot;$(OptimizationDataPackageName)&quot; : &quot;$(OptimizationDataVersion)&quot; " />
+      <_OptimizationDataJsonLine Include="},&quot;frameworks&quot;: {&quot;netcoreapp1.0&quot;: {},&quot;net46&quot;: {}}}"/>
+    </ItemGroup>
+    
+    <PropertyGroup>
+      <OptimizationDataProjectJson>$(OptimizationDataDir)project.json</OptimizationDataProjectJson>
+      <OptimizationDataNuGetFeed Condition="'$(OptimizationDataNuGetFeed)'==''">https:%2F%2Fdotnet.myget.org/F/roslyn/api/v3/index.json</OptimizationDataNuGetFeed>
+    </PropertyGroup>
+
+    <MakeDir Directories="$(OptimizationDataDir)" ContinueOnError="true" />
+    <WriteLinesToFile File="$(OptimizationDataProjectJson)" Lines="@(_OptimizationDataJsonLine)" Overwrite="true" />
+
+    <!-- Restore the OptimizationData package -->
+    <Exec Command="$(DnuRestoreCommand) $(OptimizationDataProjectJson) --source $(OptimizationDataNuGetFeed)"
+          StandardOutputImportance="Low"/>
+
+    <!-- Copy the restored files into a more accessible location -->
+    <ItemGroup>
+      <_OptimizationDataFiles Include="$(PackagesDir)/$(OptimizationDataPackageName)/$(OptimizationDataVersion)/content/OptimizationData/*.pgo" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(_OptimizationDataFiles)"
+          DestinationFiles="@(_OptimizationDataFiles->'$(OptimizationDataDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true"
+          ContinueOnError="true"/>
+  </Target>
+</Project>

--- a/dependencies.props
+++ b/dependencies.props
@@ -172,5 +172,8 @@
       <PackageId>microsoft.xunit.runner.uwp</PackageId>
       <Version>$(AppXRunnerVersion)</Version>
     </DependencyBuildInfo>
+
+    <!-- project.json files to update -->
+    <ProjectJsonFiles Include="$(MSBuildThisFileDirectory)external\**\optional.json" />
   </ItemGroup>
 </Project>

--- a/external/test-runtime/optional.json
+++ b/external/test-runtime/optional.json
@@ -4,7 +4,7 @@
       "dependencies": {
         "Microsoft.DotNet.IBCMerge": "4.6.0-alpha-00001",
         "Microsoft.DotNet.UAP.TestTools": "1.0.2",
-        "TestILCNugetPackageForCoreFX": "1.0.0-beta-25210-00"
+        "TestILCNugetPackageForCoreFX": "1.0.0-beta-25211-00"
       }
     }
   }


### PR DESCRIPTION
There were two issues related to my recent change ( #18035 ):

* codeOptimization.targets was still trying to generate and restore a project.json file. This only happens when `EnableProfileGuidedOptimization` is set to `true`, which doesn't happen in CI builds. I've modified the targets file to use a checked-in MSBuild project instead. An unchanged version of codeOptimization.targets was checked in in order to show the diff (look at the second commit to see just the diff).
* optional.json was not being updated anymore, because I accidentally removed it from the list of projects being updated in dependencies.props. It was still being restored correctly, but the version numbers no longer matched up and the files from the packages were no longer being found. I've added it back into dependencies.props and manually sync'd back up the version numbers.
  * NOTE: optional.json is still a "project.json-based project". We don't use the CLI to restore this project; we use some built-in nuget task which supports encrypted credentials. This task still supports project.json restores.

@weshaggard