### PR TITLE
Disable some System.Console tests on uapaot

### DIFF
--- a/src/System.Console/tests/ConsoleEncoding.cs
+++ b/src/System.Console/tests/ConsoleEncoding.cs
@@ -21,6 +21,7 @@ public partial class ConsoleEncoding : RemoteExecutorTestBase
     }
 
     [Theory]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Issue https://github.com/dotnet/corefx/issues/18220")]
     [MemberData(nameof(InputData))]
     public void TestEncoding(string inputString)
     {
@@ -92,6 +93,7 @@ public partial class ConsoleEncoding : RemoteExecutorTestBase
     }
 
     [Fact]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Issue https://github.com/dotnet/corefx/issues/18220")]
     public void InputEncoding_SetWithInInitialized_ResetsIn()
     {
         RemoteInvoke(() =>
@@ -127,6 +129,7 @@ public partial class ConsoleEncoding : RemoteExecutorTestBase
     }
 
     [Fact]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Issue https://github.com/dotnet/corefx/issues/18220")]
     public void OutputEncoding_SetWithErrorAndOutputInitialized_ResetsErrorAndOutput()
     {
         RemoteInvoke(() =>
@@ -159,6 +162,7 @@ public partial class ConsoleEncoding : RemoteExecutorTestBase
     }
 
     [Fact]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Issue https://github.com/dotnet/corefx/issues/18220")]
     [PlatformSpecific(TestPlatforms.Windows)]
     public void OutputEncoding_SetEncodingWithInvalidCodePage_ThrowsIOException()
     {

--- a/src/System.Console/tests/SyncTextReader.cs
+++ b/src/System.Console/tests/SyncTextReader.cs
@@ -7,6 +7,8 @@ using System.IO;
 using System.Text;
 using Xunit;
 
+
+[SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Issue https://github.com/dotnet/corefx/issues/18220")]
 public class SyncTextReader
 {
     // NOTE: These tests test the underlying SyncTextReader by


### PR DESCRIPTION
Disable System.Console tests on uapaot run.

cc: @ianhays @danmosemsft @alexperovich 