### PR TITLE
Throw different exception when adding disposed cert to X509Store

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Store.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Store.cs
@@ -129,11 +129,12 @@ namespace System.Security.Cryptography.X509Certificates
             if (certificate == null)
                 throw new ArgumentNullException(nameof(certificate));
             
-            if (certificate.Handle == IntPtr.Zero)
-                throw new ArgumentNullException(nameof(certificate));
-
             if (_storePal == null)
                 throw new CryptographicException(SR.Cryptography_X509_StoreNotOpen);
+
+            if (certificate.Handle == IntPtr.Zero)
+                throw new CryptographicException(SR.Cryptography_InvalidHandle, "pCertContext");
+
 
             _storePal.Add(certificate.Pal);
         }

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Store.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Store.cs
@@ -128,6 +128,9 @@ namespace System.Security.Cryptography.X509Certificates
         {
             if (certificate == null)
                 throw new ArgumentNullException(nameof(certificate));
+            
+            if (certificate.Handle == IntPtr.Zero)
+                throw new ArgumentNullException(nameof(certificate));
 
             if (_storePal == null)
                 throw new CryptographicException(SR.Cryptography_X509_StoreNotOpen);

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Store.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Store.cs
@@ -128,13 +128,12 @@ namespace System.Security.Cryptography.X509Certificates
         {
             if (certificate == null)
                 throw new ArgumentNullException(nameof(certificate));
-            
+
             if (_storePal == null)
                 throw new CryptographicException(SR.Cryptography_X509_StoreNotOpen);
 
             if (certificate.Handle == IntPtr.Zero)
                 throw new CryptographicException(SR.Cryptography_InvalidHandle, "pCertContext");
-
 
             _storePal.Add(certificate.Pal);
         }

--- a/src/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
@@ -159,7 +159,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 store.Open(OpenFlags.ReadWrite);
 
                 cert.Dispose();
-                Assert.ThrowsAny<CryptographicException>(() => store.Add(cert));
+                Assert.Throws<CryptographicException>(() => store.Add(cert));
             }
         }
 

--- a/src/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
@@ -151,6 +151,28 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        public static void AddDisposedThrowsArgumentNullException()
+        {
+            using (X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
+            using (X509Certificate2 cert = new X509Certificate2(TestData.MsCertificate))
+            {
+                store.Open(OpenFlags.ReadWrite);
+
+                using (var coll = new ImportedCollection(store.Certificates))
+                {
+                    // Add only throws when it has to do work.  If, for some reason, this certificate
+                    // is already present in the CurrentUser\My store, we can't really test this
+                    // functionality.
+                    if (!coll.Collection.Contains(cert))
+                    {
+                        cert.Dispose();
+                        Assert.ThrowsAny<ArgumentNullException>(() => store.Add(cert));
+                    }
+                }
+            }
+        }
+
+        [Fact]
         public static void AddReadOnlyThrowsWhenCertificateExists()
         {
             using (X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser))

--- a/src/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
@@ -158,17 +158,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             {
                 store.Open(OpenFlags.ReadWrite);
 
-                using (var coll = new ImportedCollection(store.Certificates))
-                {
-                    // Add only throws when it has to do work.  If, for some reason, this certificate
-                    // is already present in the CurrentUser\My store, we can't really test this
-                    // functionality.
-                    if (!coll.Collection.Contains(cert))
-                    {
-                        cert.Dispose();
-                        Assert.ThrowsAny<ArgumentNullException>(() => store.Add(cert));
-                    }
-                }
+                cert.Dispose();
+                Assert.ThrowsAny<ArgumentNullException>(() => store.Add(cert));
             }
         }
 

--- a/src/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
@@ -151,7 +151,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        public static void AddDisposedThrowsArgumentNullException()
+        public static void AddDisposedThrowsCryptographicException()
         {
             using (X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
             using (X509Certificate2 cert = new X509Certificate2(TestData.MsCertificate))
@@ -159,7 +159,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 store.Open(OpenFlags.ReadWrite);
 
                 cert.Dispose();
-                Assert.ThrowsAny<ArgumentNullException>(() => store.Add(cert));
+                Assert.ThrowsAny<CryptographicException>(() => store.Add(cert));
             }
         }
 


### PR DESCRIPTION
As discussed in #12223 this PR changes the exception that is thrown when an already disposed certificate is being added to a store.

Fixes #12223