### PR TITLE
Removed static test values for cultures which could change, e.g. Win1…

### DIFF
--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoPercentNegativePattern.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoPercentNegativePattern.cs
@@ -20,6 +20,8 @@ namespace System.Globalization.Tests
         /// <summary>
         /// Not testing for Windows as the culture data can change
         /// https://blogs.msdn.microsoft.com/shawnste/2005/04/05/culture-data-shouldnt-be-considered-stable-except-for-invariant/
+        /// In the CultureInfoAll test class we are testing the expected behavior 
+        /// for Windows by enumerating all locales on the system and then test them. 
         /// </summary>
         [Theory]
         [PlatformSpecific(TestPlatforms.AnyUnix)]

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoPercentNegativePattern.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoPercentNegativePattern.cs
@@ -12,18 +12,27 @@ namespace System.Globalization.Tests
     {
         public static IEnumerable<object[]> PercentNegativePattern_TestData()
         {
-            yield return new object[] { NumberFormatInfo.InvariantInfo, 0, 0 };
-            yield return new object[] { new CultureInfo("en-US").NumberFormat, 0, 1 };
-            yield return new object[] { new CultureInfo("en-MY").NumberFormat, 1, 1 };
-            yield return new object[] { new CultureInfo("tr").NumberFormat, 2, 2 };
+            yield return new object[] { new CultureInfo("en-US").NumberFormat, 1 };
+            yield return new object[] { new CultureInfo("en-MY").NumberFormat, 1 };
+            yield return new object[] { new CultureInfo("tr").NumberFormat, 2 };
+        }
+
+        /// <summary>
+        /// Not testing for Windows as the culture data can change
+        /// https://blogs.msdn.microsoft.com/shawnste/2005/04/05/culture-data-shouldnt-be-considered-stable-except-for-invariant/
+        /// </summary>
+        [Theory]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        [MemberData(nameof(PercentNegativePattern_TestData))]
+        public void PercentNegativePattern_Get(NumberFormatInfo format, int expected)
+        {
+            Assert.Equal(expected, format.PercentNegativePattern);
         }
 
         [Theory]
-        [MemberData(nameof(PercentNegativePattern_TestData))]
-        public void PercentNegativePattern_Get(NumberFormatInfo format, int expectedWindows, int expectedIcu)
+        public void PercentNegativePattern_Invariant_Get()
         {
-            int expected = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? expectedWindows : expectedIcu;
-            Assert.Equal(expected, format.PercentNegativePattern);
+            Assert.Equal(0, NumberFormatInfo.InvariantInfo.PercentNegativePattern);
         }
 
         [Theory]

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoPercentNegativePattern.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoPercentNegativePattern.cs
@@ -29,7 +29,7 @@ namespace System.Globalization.Tests
             Assert.Equal(expected, format.PercentNegativePattern);
         }
 
-        [Theory]
+        [Fact]
         public void PercentNegativePattern_Invariant_Get()
         {
             Assert.Equal(0, NumberFormatInfo.InvariantInfo.PercentNegativePattern);

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoPercentPositivePattern.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoPercentPositivePattern.cs
@@ -20,6 +20,8 @@ namespace System.Globalization.Tests
         /// <summary>
         /// Not testing for Windows as the culture data can change
         /// https://blogs.msdn.microsoft.com/shawnste/2005/04/05/culture-data-shouldnt-be-considered-stable-except-for-invariant/
+        /// In the CultureInfoAll test class we are testing the expected behavior 
+        /// for Windows by enumerating all locales on the system and then test them. 
         /// </summary>
         [Theory]
         [PlatformSpecific(TestPlatforms.AnyUnix)]

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoPercentPositivePattern.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoPercentPositivePattern.cs
@@ -12,18 +12,27 @@ namespace System.Globalization.Tests
     {
         public static IEnumerable<object[]> PercentPositivePattern_TestData()
         {
-            yield return new object[] { NumberFormatInfo.InvariantInfo, 0, 0 };
-            yield return new object[] { new CultureInfo("en-US").NumberFormat, 0, 1 };
-            yield return new object[] { new CultureInfo("en-MY").NumberFormat, 1, 1 };
-            yield return new object[] { new CultureInfo("tr").NumberFormat, 2, 2 };
+            yield return new object[] { new CultureInfo("en-US").NumberFormat, 1 };
+            yield return new object[] { new CultureInfo("en-MY").NumberFormat, 1 };
+            yield return new object[] { new CultureInfo("tr").NumberFormat, 2 };
+        }
+
+        /// <summary>
+        /// Not testing for Windows as the culture data can change
+        /// https://blogs.msdn.microsoft.com/shawnste/2005/04/05/culture-data-shouldnt-be-considered-stable-except-for-invariant/
+        /// </summary>
+        [Theory]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        [MemberData(nameof(PercentPositivePattern_TestData))]
+        public void PercentPositivePattern_Get(NumberFormatInfo format, int expected)
+        {
+            Assert.Equal(expected, format.PercentPositivePattern);
         }
 
         [Theory]
-        [MemberData(nameof(PercentPositivePattern_TestData))]
-        public void PercentPositivePattern_Get(NumberFormatInfo format, int expectedWindows, int expectedIcu)
+        public void PercentPositivePattern_Invariant_Get()
         {
-            int expected = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? expectedWindows : expectedIcu;
-            Assert.Equal(expected, format.PercentPositivePattern);
+            Assert.Equal(0, NumberFormatInfo.InvariantInfo.PercentPositivePattern);
         }
 
         [Theory]

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoPercentPositivePattern.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoPercentPositivePattern.cs
@@ -29,7 +29,7 @@ namespace System.Globalization.Tests
             Assert.Equal(expected, format.PercentPositivePattern);
         }
 
-        [Theory]
+        [Fact]
         public void PercentPositivePattern_Invariant_Get()
         {
             Assert.Equal(0, NumberFormatInfo.InvariantInfo.PercentPositivePattern);


### PR DESCRIPTION
Removed static test values for cultures which could change, e.g. Win10 Insider builds

fixes https://github.com/dotnet/corefx/issues/18208