### PR TITLE
Add netfx to ValueTuple ref contract

### DIFF
--- a/src/System.ValueTuple/ref/Configurations.props
+++ b/src/System.ValueTuple/ref/Configurations.props
@@ -5,6 +5,7 @@
       netcoreapp;
       uap;
       portable_net40+sl4+win8+wp8;
+      netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Due to a bug when producing the netstandard.dll shim there is no TypeForwards to ValueTuple members. This will fix that to have it on our surface area and to be able to run tests on netfx.

cc: @weshaggard @joperezr 