### PR TITLE
Fix System.Private.Xml.Linq.rd.xml

### DIFF
--- a/src/System.Private.Xml.Linq/src/Resources/System.Private.Xml.Linq.rd.xml
+++ b/src/System.Private.Xml.Linq/src/Resources/System.Private.Xml.Linq.rd.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
   <Library Name="System.Xml.Linq">
-    <Assembly Name="System.Xml.Linq">
+    <Assembly Name="System.Private.Xml.Linq">
       <Namespace Name="System.Xml.Linq">
         <Type Name="XElement">
           <!-- The default constructor of XElement is required for it to be serializable by XmlSerializer. -->


### PR DESCRIPTION
Tests under System.Private.Xml/tests/XmlSerializer are not showing the warning anymore but for some reason still getting some warning under System.Runtime.Serialization.Xml/tests:
```
System.Xml.Resources.System.Private.Xml.Linq.rd.xml(5-5): warning : ILTransform : warning ILT0027: Namespace 'System.Private.Xml.Linq' within '' could not be found. 
```

This does not make much sense to me since namespace is correct in rd.xml - possibly wrong rd.xml or dll is being used

Fixes: https://github.com/dotnet/corefx/issues/17557