### PR TITLE
Reduce memory usage of BigInteger's LargeValueLogTests.

### DIFF
--- a/src/System.Runtime.Numerics/tests/BigInteger/log.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/log.cs
@@ -159,11 +159,11 @@ namespace System.Numerics.Tests
 
                 for (int j = 0; j<bigShiftLoopLimit; j++)
                 {
-                    temp = temp << (int.MaxValue / 2);
+                    temp = temp << (int.MaxValue / 10);
                     double expected =
                         (double)startShift +
                         smallShift * (double)(i + 1) +
-                        (int.MaxValue / 2) * (double)(j + 1);
+                        (int.MaxValue / 10) * (double)(j + 1);
                     Assert.True(ApproxEqual(BigInteger.Log(temp, logbase), expected));
                 }
                 


### PR DESCRIPTION
More memory usage reduction in the BigInteger tests.

As an aside, I noticed that if I set the "large address aware" flag on `dotnet.exe` (by using `editbin /largeaddressaware`), I'm able to run these tests fine. This brought to my attention that 32-bit .NET Core apps are limited to 2GB of memory on Windows. I don't really know the intricacies of the "large address aware" flag, and it seems to be "off" by default for 32-bit .NET Framework applications. But, is this something we should turn by default? Is there some obvious downside I'm not familiar with?
@gkhanna79 @weshaggard @ericstj 