### PR TITLE
Disable UDP test

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -61,6 +61,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [ActiveIssue(16945)] // Packet loss, potentially due to other tests running at the same time
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(Loopbacks))]


### PR DESCRIPTION
I contemplated just deleting the whole test, but I've instead disabled it for now, and I'm pushing the associated issue out to Future.  Other UDP tests similar to this were hardened against packet loss, but this one wasn't.  And if this one is hardened, it will end up looking basically like the other tests that already exist.   (We don't yet know whether it's actually packet loss or whether it just looks like it due to other tests running at the same time consuming the packets, but either way, this test is in the same bucket as a bunch of other UDP tests that were previously hardened for it; this one was just missed.)

cc: @steveharter 
https://github.com/dotnet/corefx/issues/16945