### PR TITLE
Temporary remove UAP target for DiagnosticSource

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/src/Configurations.props
+++ b/src/System.Diagnostics.DiagnosticSource/src/Configurations.props
@@ -1,14 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <BuildConfigurations>
+    <PackageConfigurations>
       netstandard1.3;
       netstandard;
-      uap-Windows_NT;
       netcoreapp;
       net45-Windows_NT;      
       net46-Windows_NT;
       netfx-Windows_NT;      
+    </PackageConfigurations>  
+    <BuildConfigurations>
+      uap-Windows_NT;
+      $(PackageConfigurations);
     </BuildConfigurations>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
DiagnosticSource nuget package preview should be published to nuget.org to be consumed by ApplicationInsights SDK (in preview).

On UWP, DiagnosticSource depends on Microsoft.NETCore.Platforms for UWP, that will not be published yet.

This change **temporary** removes UAP target from DiagnosticSource and removes dependency on it from System.Net.Http for UAP.

This change will be reverted once DiagnosticSource is build, published on MyGet and verified.