### PR TITLE
Revert "Reenabled DirectoryLongerThanMaxLongPath test"

### DIFF
--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -242,6 +242,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [ActiveIssue(11687)]
         [PlatformSpecific(TestPlatforms.Windows)]  // long directory path throws PathTooLongException
         public void DirectoryLongerThanMaxLongPath_ThrowsPathTooLongException()
         {


### PR DESCRIPTION
Reverts dotnet/corefx#17343

See here: https://github.com/dotnet/corefx/issues/17536#issuecomment-293715534