### PR TITLE
Change UrlDecode behavior and merge test cases for .Net core and desktop

### DIFF
--- a/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
@@ -283,45 +283,14 @@ namespace System.Web.Util
                 }
                 else if (b == '%' && i < count - 2)
                 {
-                    if (bytes[pos + 1] == 'u' && i < count - 5)
-                    {
-                        int h1 = HttpEncoderUtility.HexToInt((char)bytes[pos + 2]);
-                        int h2 = HttpEncoderUtility.HexToInt((char)bytes[pos + 3]);
-                        int h3 = HttpEncoderUtility.HexToInt((char)bytes[pos + 4]);
-                        int h4 = HttpEncoderUtility.HexToInt((char)bytes[pos + 5]);
+                    int h1 = HttpEncoderUtility.HexToInt((char)bytes[pos + 1]);
+                    int h2 = HttpEncoderUtility.HexToInt((char)bytes[pos + 2]);
 
-                        if (h1 >= 0 && h2 >= 0 && h3 >= 0 && h4 >= 0)
-                        {
-                            // valid 4 hex chars
-                            char ch = (char)((h1 << 12) | (h2 << 8) | (h3 << 4) | h4);
-                            i += 5;
-
-                            byte[] chBytes = Encoding.UTF8.GetBytes(new[] { ch });
-                            if (chBytes.Length == 1)
-                            {
-                                b = chBytes[0];
-                            }
-                            else
-                            {
-                                for (int j = 0; j < chBytes.Length - 1; j++)
-                                {
-                                    decodedBytes[decodedBytesCount++] = chBytes[j];
-                                }
-                                b = chBytes[chBytes.Length - 1];
-                            }
-                        }
-                    }
-                    else
-                    {
-                        int h1 = HttpEncoderUtility.HexToInt((char)bytes[pos + 1]);
-                        int h2 = HttpEncoderUtility.HexToInt((char)bytes[pos + 2]);
-
-                        if (h1 >= 0 && h2 >= 0)
-                        {
-                            // valid 2 hex chars
-                            b = (byte)((h1 << 4) | h2);
-                            i += 2;
-                        }
+                    if (h1 >= 0 && h2 >= 0)
+                    {   
+                        // valid 2 hex chars
+                        b = (byte)((h1 << 4) | h2);
+                        i += 2;
                     }
                 }
 

--- a/src/System.Web.HttpUtility/tests/HttpUtility/HttpUtilityTest.cs
+++ b/src/System.Web.HttpUtility/tests/HttpUtility/HttpUtilityTest.cs
@@ -412,29 +412,15 @@ namespace System.Web.Tests
                 new object[] {"http://127.0.0.1:8080/app%%Dir/page.aspx?foo=b%%r", "http://127.0.0.1:8080/app%%Dir/page.aspx?foo=b%%r"},
                 new object[] {"http://127.0.0.1:8080/appDir/page.aspx?foo=ba%r", "http://127.0.0.1:8080/appDir/page.aspx?foo=b%61%r"},
                 new object[] {"http://127.0.0.1:8080/appDir/page.aspx?foo=b%uu0061r", "http://127.0.0.1:8080/appDir/page.aspx?foo=b%uu0061r"},
+                new object[] {"http://127.0.0.1:8080/appDir/page.aspx?foo=b%u0061r", "http://127.0.0.1:8080/appDir/page.aspx?foo=b%u0061r"},
+                new object[] {"http://127.0.0.1:8080/appDir/page.aspx?foo=b%%u0061r", "http://127.0.0.1:8080/appDir/page.aspx?foo=b%%u0061r"},
             };
-
-        public static IEnumerable<object[]> UrlDecodeDataToBytes_netcoreapp =>
-            new[]
-            {
-                new object[] {"http://127.0.0.1:8080/appDir/page.aspx?foo=bar", "http://127.0.0.1:8080/appDir/page.aspx?foo=b%u0061r"},
-                new object[] {"http://127.0.0.1:8080/appDir/page.aspx?foo=b%ar", "http://127.0.0.1:8080/appDir/page.aspx?foo=b%%u0061r"},
-            };
-
 
         [Theory]
         [MemberData(nameof(UrlDecodeData))]
         public void UrlDecode(string decoded, string encoded)
         {
             Assert.Equal(decoded, HttpUtility.UrlDecode(encoded));
-        }
-
-        [Theory]
-        [MemberData(nameof(UrlDecodeDataToBytes_netcoreapp))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17627")]
-        public void UrlDecodeToBytes_Netcoreapp(string decoded, string encoded)
-        {
-            Assert.Equal(decoded, Encoding.UTF8.GetString(HttpUtility.UrlDecodeToBytes(encoded, Encoding.UTF8)));
         }
 
         [Theory]


### PR DESCRIPTION
1. Tested in .Net framework, confirmed the difference. Also confirmed the correctness of documentation
2. Merge the test for .Net core and desktop. Since now their behaviors match, no need to test separately (https://github.com/dotnet/corefx/pull/17618#issuecomment-289933351)

Fix #17627 