### PR TITLE
Allow S.L.Expressions to use delegates with private Invoke methods.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/DelegateHelpers.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/DelegateHelpers.cs
@@ -42,7 +42,7 @@ namespace System.Dynamic.Utils
         // return (TRet)ret;
         private static Delegate CreateObjectArrayDelegateRefEmit(Type delegateType, Func<object[], object> handler)
         {
-            MethodInfo delegateInvokeMethod = delegateType.GetMethod("Invoke");
+            MethodInfo delegateInvokeMethod = delegateType.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
 
             Type returnType = delegateInvokeMethod.ReturnType;
             bool hasReturnValue = returnType != typeof(void);

--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/DelegateHelpers.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/DelegateHelpers.cs
@@ -42,7 +42,7 @@ namespace System.Dynamic.Utils
         // return (TRet)ret;
         private static Delegate CreateObjectArrayDelegateRefEmit(Type delegateType, Func<object[], object> handler)
         {
-            MethodInfo delegateInvokeMethod = delegateType.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            MethodInfo delegateInvokeMethod = delegateType.GetInvokeMethod();
 
             Type returnType = delegateInvokeMethod.ReturnType;
             bool hasReturnValue = returnType != typeof(void);

--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
@@ -775,6 +775,12 @@ namespace System.Dynamic.Utils
             return true;
         }
 
+        public static MethodInfo GetInvokeMethod(this Type delegateType)
+        {
+            Debug.Assert(typeof(Delegate).IsAssignableFrom(delegateType));
+            return delegateType.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        }
+
 #if FEATURE_COMPILE
 
         internal static bool IsUnsigned(this Type type) => IsUnsigned(GetNonNullableType(type).GetTypeCode());

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
@@ -1434,7 +1434,7 @@ namespace System.Linq.Expressions
 
             Type delegateType = conversion.Type;
             Debug.Assert(typeof(System.MulticastDelegate).IsAssignableFrom(delegateType) && delegateType != typeof(System.MulticastDelegate));
-            MethodInfo method = delegateType.GetMethod("Invoke");
+            MethodInfo method = delegateType.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
             if (method.ReturnType == typeof(void))
             {
                 throw Error.UserDefinedOperatorMustNotBeVoid(conversion, nameof(conversion));
@@ -1590,7 +1590,7 @@ namespace System.Linq.Expressions
         {
             Type delegateType = conversion.Type;
             Debug.Assert(typeof(System.MulticastDelegate).IsAssignableFrom(delegateType) && delegateType != typeof(System.MulticastDelegate));
-            MethodInfo mi = delegateType.GetMethod("Invoke");
+            MethodInfo mi = delegateType.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
             ParameterInfo[] pms = mi.GetParametersCached();
             Debug.Assert(pms.Length == conversion.ParameterCount);
             if (pms.Length != 1)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
@@ -1434,7 +1434,7 @@ namespace System.Linq.Expressions
 
             Type delegateType = conversion.Type;
             Debug.Assert(typeof(System.MulticastDelegate).IsAssignableFrom(delegateType) && delegateType != typeof(System.MulticastDelegate));
-            MethodInfo method = delegateType.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            MethodInfo method = delegateType.GetInvokeMethod();
             if (method.ReturnType == typeof(void))
             {
                 throw Error.UserDefinedOperatorMustNotBeVoid(conversion, nameof(conversion));
@@ -1590,7 +1590,7 @@ namespace System.Linq.Expressions
         {
             Type delegateType = conversion.Type;
             Debug.Assert(typeof(System.MulticastDelegate).IsAssignableFrom(delegateType) && delegateType != typeof(System.MulticastDelegate));
-            MethodInfo mi = delegateType.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            MethodInfo mi = delegateType.GetInvokeMethod();
             ParameterInfo[] pms = mi.GetParametersCached();
             Debug.Assert(pms.Length == conversion.ParameterCount);
             if (pms.Length != 1)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
@@ -187,7 +187,7 @@ namespace System.Linq.Expressions.Compiler
                 expr = Expression.Call(expr, expr.Type.GetMethod("Compile", Array.Empty<Type>()));
             }
 
-            EmitMethodCall(expr, expr.Type.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic), node, CompilationFlags.EmitAsNoTail | CompilationFlags.EmitExpressionStart);
+            EmitMethodCall(expr, expr.Type.GetInvokeMethod(), node, CompilationFlags.EmitAsNoTail | CompilationFlags.EmitExpressionStart);
         }
 
         private void EmitInlinedInvoke(InvocationExpression invoke, CompilationFlags flags)
@@ -199,7 +199,7 @@ namespace System.Linq.Expressions.Compiler
             // stack it is entirely doable.
 
             // 1. Emit invoke arguments
-            List<WriteBack> wb = EmitArguments(lambda.Type.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic), invoke);
+            List<WriteBack> wb = EmitArguments(lambda.Type.GetInvokeMethod(), invoke);
 
             // 2. Create the nested LambdaCompiler
             var inner = new LambdaCompiler(this, lambda, invoke);
@@ -594,7 +594,7 @@ namespace System.Linq.Expressions.Compiler
             object site = node.CreateCallSite();
             Type siteType = site.GetType();
 
-            MethodInfo invoke = node.DelegateType.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            MethodInfo invoke = node.DelegateType.GetInvokeMethod();
 
             // site.Target.Invoke(site, args)
             EmitConstant(site, siteType);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
@@ -187,7 +187,7 @@ namespace System.Linq.Expressions.Compiler
                 expr = Expression.Call(expr, expr.Type.GetMethod("Compile", Array.Empty<Type>()));
             }
 
-            EmitMethodCall(expr, expr.Type.GetMethod("Invoke"), node, CompilationFlags.EmitAsNoTail | CompilationFlags.EmitExpressionStart);
+            EmitMethodCall(expr, expr.Type.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic), node, CompilationFlags.EmitAsNoTail | CompilationFlags.EmitExpressionStart);
         }
 
         private void EmitInlinedInvoke(InvocationExpression invoke, CompilationFlags flags)
@@ -199,7 +199,7 @@ namespace System.Linq.Expressions.Compiler
             // stack it is entirely doable.
 
             // 1. Emit invoke arguments
-            List<WriteBack> wb = EmitArguments(lambda.Type.GetMethod("Invoke"), invoke);
+            List<WriteBack> wb = EmitArguments(lambda.Type.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic), invoke);
 
             // 2. Create the nested LambdaCompiler
             var inner = new LambdaCompiler(this, lambda, invoke);
@@ -594,7 +594,7 @@ namespace System.Linq.Expressions.Compiler
             object site = node.CreateCallSite();
             Type siteType = site.GetType();
 
-            MethodInfo invoke = node.DelegateType.GetMethod("Invoke");
+            MethodInfo invoke = node.DelegateType.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
 
             // site.Target.Invoke(site, args)
             EmitConstant(site, siteType);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Logical.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Logical.cs
@@ -144,7 +144,7 @@ namespace System.Linq.Expressions.Compiler
                 }
 
                 // emit call to invoke
-                _ilg.Emit(OpCodes.Callvirt, b.Conversion.Type.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic));
+                _ilg.Emit(OpCodes.Callvirt, b.Conversion.Type.GetInvokeMethod());
             }
             else if (!TypeUtils.AreEquivalent(b.Type, nnLeftType))
             {
@@ -194,7 +194,7 @@ namespace System.Linq.Expressions.Compiler
             FreeLocal(loc);
 
             // emit call to invoke
-            _ilg.Emit(OpCodes.Callvirt, b.Conversion.Type.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic));
+            _ilg.Emit(OpCodes.Callvirt, b.Conversion.Type.GetInvokeMethod());
 
             _ilg.MarkLabel(labEnd);
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Logical.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Logical.cs
@@ -144,7 +144,7 @@ namespace System.Linq.Expressions.Compiler
                 }
 
                 // emit call to invoke
-                _ilg.Emit(OpCodes.Callvirt, b.Conversion.Type.GetMethod("Invoke"));
+                _ilg.Emit(OpCodes.Callvirt, b.Conversion.Type.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic));
             }
             else if (!TypeUtils.AreEquivalent(b.Type, nnLeftType))
             {
@@ -194,7 +194,7 @@ namespace System.Linq.Expressions.Compiler
             FreeLocal(loc);
 
             // emit call to invoke
-            _ilg.Emit(OpCodes.Callvirt, b.Conversion.Type.GetMethod("Invoke"));
+            _ilg.Emit(OpCodes.Callvirt, b.Conversion.Type.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic));
 
             _ilg.MarkLabel(labEnd);
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.cs
@@ -172,7 +172,7 @@ namespace System.Linq.Expressions.Compiler
 
             if (cr.Action == RewriteAction.SpillStack)
             {
-                RequireNoRefArgs(node.DelegateType.GetMethod("Invoke"));
+                RequireNoRefArgs(node.DelegateType.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic));
             }
 
             return cr.Finish(cr.Rewrite ? node.Rewrite(cr[0, -1]) : expr);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.cs
@@ -172,7 +172,7 @@ namespace System.Linq.Expressions.Compiler
 
             if (cr.Action == RewriteAction.SpillStack)
             {
-                RequireNoRefArgs(node.DelegateType.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic));
+                RequireNoRefArgs(node.DelegateType.GetInvokeMethod());
             }
 
             return cr.Finish(cr.Rewrite ? node.Rewrite(cr[0, -1]) : expr);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/DynamicExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/DynamicExpression.cs
@@ -22,7 +22,7 @@ namespace System.Linq.Expressions
     {
         internal DynamicExpression(Type delegateType, CallSiteBinder binder)
         {
-            Debug.Assert(delegateType.GetMethod("Invoke").GetReturnType() == typeof(object) || GetType() != typeof(DynamicExpression));
+            Debug.Assert(delegateType.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).GetReturnType() == typeof(object) || GetType() != typeof(DynamicExpression));
             DelegateType = delegateType;
             Binder = binder;
         }
@@ -516,7 +516,7 @@ namespace System.Linq.Expressions
         internal TypedDynamicExpressionN(Type returnType, Type delegateType, CallSiteBinder binder, IReadOnlyList<Expression> arguments)
             : base(delegateType, binder, arguments)
         {
-            Debug.Assert(delegateType.GetMethod("Invoke").GetReturnType() == returnType);
+            Debug.Assert(delegateType.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).GetReturnType() == returnType);
             Type = returnType;
         }
 
@@ -1014,7 +1014,7 @@ namespace System.Linq.Expressions
 
         private static MethodInfo GetValidMethodForDynamic(Type delegateType)
         {
-            var method = delegateType.GetMethod("Invoke");
+            var method = delegateType.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
             var pi = method.GetParametersCached();
             if (pi.Length == 0 || pi[0].ParameterType != typeof(CallSite)) throw Error.FirstArgumentMustBeCallSite();
             return method;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/DynamicExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/DynamicExpression.cs
@@ -22,7 +22,7 @@ namespace System.Linq.Expressions
     {
         internal DynamicExpression(Type delegateType, CallSiteBinder binder)
         {
-            Debug.Assert(delegateType.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).GetReturnType() == typeof(object) || GetType() != typeof(DynamicExpression));
+            Debug.Assert(delegateType.GetInvokeMethod().GetReturnType() == typeof(object) || GetType() != typeof(DynamicExpression));
             DelegateType = delegateType;
             Binder = binder;
         }
@@ -516,7 +516,7 @@ namespace System.Linq.Expressions
         internal TypedDynamicExpressionN(Type returnType, Type delegateType, CallSiteBinder binder, IReadOnlyList<Expression> arguments)
             : base(delegateType, binder, arguments)
         {
-            Debug.Assert(delegateType.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).GetReturnType() == returnType);
+            Debug.Assert(delegateType.GetInvokeMethod().GetReturnType() == returnType);
             Type = returnType;
         }
 
@@ -1014,7 +1014,7 @@ namespace System.Linq.Expressions
 
         private static MethodInfo GetValidMethodForDynamic(Type delegateType)
         {
-            var method = delegateType.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            var method = delegateType.GetInvokeMethod();
             var pi = method.GetParametersCached();
             if (pi.Length == 0 || pi[0].ParameterType != typeof(CallSite)) throw Error.FirstArgumentMustBeCallSite();
             return method;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -2611,7 +2611,7 @@ namespace System.Linq.Expressions.Interpreter
                 _instructions.EmitStoreLocal(local.Index);
 
                 CompileMethodCallExpression(
-                    Expression.Call(node.Conversion, node.Conversion.Type.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic), new[] { temp })
+                    Expression.Call(node.Conversion, node.Conversion.Type.GetInvokeMethod(), new[] { temp })
                 );
 
                 _locals.UndefineLocal(local, _instructions.Count);
@@ -2640,14 +2640,14 @@ namespace System.Linq.Expressions.Interpreter
                         node.Expression,
                         compMethod
                     ),
-                    compMethod.ReturnType.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic),
+                    compMethod.ReturnType.GetInvokeMethod(),
                     node
                 );
             }
             else
             {
                 CompileMethodCallExpression(
-                    node.Expression, node.Expression.Type.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic), node
+                    node.Expression, node.Expression.Type.GetInvokeMethod(), node
                 );
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -2611,7 +2611,7 @@ namespace System.Linq.Expressions.Interpreter
                 _instructions.EmitStoreLocal(local.Index);
 
                 CompileMethodCallExpression(
-                    Expression.Call(node.Conversion, node.Conversion.Type.GetMethod("Invoke"), new[] { temp })
+                    Expression.Call(node.Conversion, node.Conversion.Type.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic), new[] { temp })
                 );
 
                 _locals.UndefineLocal(local, _instructions.Count);
@@ -2640,14 +2640,14 @@ namespace System.Linq.Expressions.Interpreter
                         node.Expression,
                         compMethod
                     ),
-                    compMethod.ReturnType.GetMethod("Invoke"),
+                    compMethod.ReturnType.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic),
                     node
                 );
             }
             else
             {
                 CompileMethodCallExpression(
-                    node.Expression, node.Expression.Type.GetMethod("Invoke"), node
+                    node.Expression, node.Expression.Type.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic), node
                 );
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightLambda.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightLambda.cs
@@ -207,7 +207,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private static Func<LightLambda, Delegate> MakeRunDelegateCtor(Type delegateType)
         {
-            MethodInfo method = delegateType.GetMethod("Invoke");
+            MethodInfo method = delegateType.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
             ParameterInfo[] paramInfos = method.GetParametersCached();
             Type[] paramTypes;
             string name = "Run";
@@ -287,7 +287,7 @@ namespace System.Linq.Expressions.Interpreter
         {
             //PerfTrack.NoteEvent(PerfTrack.Categories.Compiler, "Synchronously compiling a custom delegate");
 
-            MethodInfo method = delegateType.GetMethod("Invoke");
+            MethodInfo method = delegateType.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
             ParameterInfo[] paramInfos = method.GetParametersCached();
             var parameters = new ParameterExpression[paramInfos.Length];
             var parametersAsObject = new Expression[paramInfos.Length];
@@ -355,7 +355,7 @@ namespace System.Linq.Expressions.Interpreter
         internal Delegate MakeDelegate(Type delegateType)
         {
 #if !NO_FEATURE_STATIC_DELEGATE
-            MethodInfo method = delegateType.GetMethod("Invoke");
+            MethodInfo method = delegateType.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
             if (method.ReturnType == typeof(void))
             {
                 return System.Dynamic.Utils.DelegateHelpers.CreateObjectArrayDelegate(delegateType, RunVoid);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightLambda.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightLambda.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Dynamic.Utils;
 using System.Globalization;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -207,7 +208,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private static Func<LightLambda, Delegate> MakeRunDelegateCtor(Type delegateType)
         {
-            MethodInfo method = delegateType.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            MethodInfo method = delegateType.GetInvokeMethod();
             ParameterInfo[] paramInfos = method.GetParametersCached();
             Type[] paramTypes;
             string name = "Run";
@@ -287,7 +288,7 @@ namespace System.Linq.Expressions.Interpreter
         {
             //PerfTrack.NoteEvent(PerfTrack.Categories.Compiler, "Synchronously compiling a custom delegate");
 
-            MethodInfo method = delegateType.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            MethodInfo method = delegateType.GetInvokeMethod();
             ParameterInfo[] paramInfos = method.GetParametersCached();
             var parameters = new ParameterExpression[paramInfos.Length];
             var parametersAsObject = new Expression[paramInfos.Length];
@@ -355,7 +356,7 @@ namespace System.Linq.Expressions.Interpreter
         internal Delegate MakeDelegate(Type delegateType)
         {
 #if !NO_FEATURE_STATIC_DELEGATE
-            MethodInfo method = delegateType.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            MethodInfo method = delegateType.GetInvokeMethod();
             if (method.ReturnType == typeof(void))
             {
                 return System.Dynamic.Utils.DelegateHelpers.CreateObjectArrayDelegate(delegateType, RunVoid);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/InvocationExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/InvocationExpression.cs
@@ -764,7 +764,7 @@ namespace System.Linq.Expressions
                 delegateType = exprType.GetGenericArguments()[0];
             }
 
-            return delegateType.GetMethod("Invoke");
+            return delegateType.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
         }
     }
 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/InvocationExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/InvocationExpression.cs
@@ -764,7 +764,7 @@ namespace System.Linq.Expressions
                 delegateType = exprType.GetGenericArguments()[0];
             }
 
-            return delegateType.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            return delegateType.GetInvokeMethod();
         }
     }
 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
@@ -66,7 +66,7 @@ namespace System.Linq.Expressions
         /// <summary>
         /// Gets the return type of the lambda expression.
         /// </summary>
-        public Type ReturnType => Type.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).ReturnType;
+        public Type ReturnType => Type.GetInvokeMethod().ReturnType;
 
         /// <summary>
         /// Gets the value that indicates if the lambda expression will be compiled with
@@ -897,7 +897,7 @@ namespace System.Linq.Expressions
             CacheDict<Type, MethodInfo> ldc = s_lambdaDelegateCache;
             if (!ldc.TryGetValue(delegateType, out mi))
             {
-                mi = delegateType.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                mi = delegateType.GetInvokeMethod();
                 if (delegateType.CanCache())
                 {
                     ldc[delegateType] = mi;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
@@ -66,7 +66,7 @@ namespace System.Linq.Expressions
         /// <summary>
         /// Gets the return type of the lambda expression.
         /// </summary>
-        public Type ReturnType => Type.GetMethod("Invoke").ReturnType;
+        public Type ReturnType => Type.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).ReturnType;
 
         /// <summary>
         /// Gets the value that indicates if the lambda expression will be compiled with
@@ -897,7 +897,7 @@ namespace System.Linq.Expressions
             CacheDict<Type, MethodInfo> ldc = s_lambdaDelegateCache;
             if (!ldc.TryGetValue(delegateType, out mi))
             {
-                mi = delegateType.GetMethod("Invoke");
+                mi = delegateType.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
                 if (delegateType.CanCache())
                 {
                     ldc[delegateType] = mi;

--- a/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSite.cs
+++ b/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSite.cs
@@ -273,14 +273,14 @@ namespace System.Runtime.CompilerServices
         {
 #if !FEATURE_COMPILE
             Type target = typeof(T);
-            MethodInfo invoke = target.GetMethod("Invoke");
+            MethodInfo invoke = target.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
 
             s_cachedNoMatch = CreateCustomNoMatchDelegate(invoke);
             return CreateCustomUpdateDelegate(invoke);
 #else
             Type target = typeof(T);
             Type[] args;
-            MethodInfo invoke = target.GetMethod("Invoke");
+            MethodInfo invoke = target.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
 
             if (target.IsGenericType && IsSimpleSignature(invoke, out args))
             {

--- a/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSite.cs
+++ b/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSite.cs
@@ -273,14 +273,14 @@ namespace System.Runtime.CompilerServices
         {
 #if !FEATURE_COMPILE
             Type target = typeof(T);
-            MethodInfo invoke = target.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            MethodInfo invoke = target.GetInvokeMethod();
 
             s_cachedNoMatch = CreateCustomNoMatchDelegate(invoke);
             return CreateCustomUpdateDelegate(invoke);
 #else
             Type target = typeof(T);
             Type[] args;
-            MethodInfo invoke = target.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            MethodInfo invoke = target.GetInvokeMethod();
 
             if (target.IsGenericType && IsSimpleSignature(invoke, out args))
             {

--- a/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSiteBinder.cs
+++ b/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSiteBinder.cs
@@ -65,7 +65,7 @@ namespace System.Runtime.CompilerServices
                     throw System.Linq.Expressions.Error.TypeParameterIsNotDelegate(target);
                 }
 
-                MethodInfo invoke = target.GetMethod("Invoke");
+                MethodInfo invoke = target.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
                 ParameterInfo[] pis = invoke.GetParametersCached();
                 if (pis[0].ParameterType != typeof(CallSite))
                 {

--- a/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSiteBinder.cs
+++ b/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSiteBinder.cs
@@ -65,7 +65,7 @@ namespace System.Runtime.CompilerServices
                     throw System.Linq.Expressions.Error.TypeParameterIsNotDelegate(target);
                 }
 
-                MethodInfo invoke = target.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                MethodInfo invoke = target.GetInvokeMethod();
                 ParameterInfo[] pis = invoke.GetParametersCached();
                 if (pis[0].ParameterType != typeof(CallSite))
                 {

--- a/src/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
+++ b/src/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests
@@ -237,13 +239,48 @@ namespace System.Linq.Expressions.Tests
             Assert.NotSame(invoke, new ParameterChangingVisitor().Visit(invoke));
         }
 
-
         [Theory, MemberData(nameof(InvocationExpressions))]
         public static void LambdaAndArgChangeVisit(InvocationExpression invoke)
         {
             Assert.NotSame(invoke, new ParameterAndConstantChangingVisitor().Visit(invoke));
         }
 
+#if FEATURE_COMPILE // When we don't have FEATURE_COMPILE we don't have the Reflection.Emit used in the tests.
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void InvokePrivateDelegate(bool useInterpreter)
+        {
+            AssemblyBuilder assembly = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Name"), AssemblyBuilderAccess.Run);
+            ModuleBuilder module = assembly.DefineDynamicModule("Name");
+            TypeBuilder builder = module.DefineType("Type", TypeAttributes.Class | TypeAttributes.NotPublic | TypeAttributes.Sealed | TypeAttributes.AnsiClass | TypeAttributes.AutoClass, typeof(MulticastDelegate));
+            builder.DefineConstructor(MethodAttributes.RTSpecialName | MethodAttributes.HideBySig | MethodAttributes.Public, CallingConventions.Standard, new[] { typeof(object), typeof(IntPtr) }).SetImplementationFlags(MethodImplAttributes.Runtime | MethodImplAttributes.Managed);
+            builder.DefineMethod("Invoke", MethodAttributes.Private | MethodAttributes.HideBySig | MethodAttributes.NewSlot | MethodAttributes.Virtual, typeof(int), Type.EmptyTypes).SetImplementationFlags(MethodImplAttributes.Runtime | MethodImplAttributes.Managed);
+            Type delType = builder.CreateTypeInfo();
+            LambdaExpression lambda = Expression.Lambda(delType, Expression.Constant(42));
+            Delegate del = lambda.Compile(useInterpreter);
+            var invoke = Expression.Invoke(Expression.Constant(del));
+            var invLambda = Expression.Lambda<Func<int>>(invoke);
+            var invFunc = invLambda.Compile(useInterpreter);
+            Assert.Equal(42, invFunc());
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void InvokePrivateDelegateTypeLambda(bool useInterpreter)
+        {
+            AssemblyBuilder assembly = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Name"), AssemblyBuilderAccess.Run);
+            ModuleBuilder module = assembly.DefineDynamicModule("Name");
+            TypeBuilder builder = module.DefineType("Type", TypeAttributes.Class | TypeAttributes.NotPublic | TypeAttributes.Sealed | TypeAttributes.AnsiClass | TypeAttributes.AutoClass, typeof(MulticastDelegate));
+            builder.DefineConstructor(MethodAttributes.RTSpecialName | MethodAttributes.HideBySig | MethodAttributes.Public, CallingConventions.Standard, new[] { typeof(object), typeof(IntPtr) }).SetImplementationFlags(MethodImplAttributes.Runtime | MethodImplAttributes.Managed);
+            builder.DefineMethod("Invoke", MethodAttributes.Private | MethodAttributes.HideBySig | MethodAttributes.NewSlot | MethodAttributes.Virtual, typeof(int), Type.EmptyTypes).SetImplementationFlags(MethodImplAttributes.Runtime | MethodImplAttributes.Managed);
+            Type delType = builder.CreateTypeInfo();
+            LambdaExpression lambda = Expression.Lambda(delType, Expression.Constant(42));
+            var invoke = Expression.Invoke(lambda);
+            var invLambda = Expression.Lambda<Func<int>>(invoke);
+            var invFunc = invLambda.Compile(useInterpreter);
+            Assert.Equal(42, invFunc());
+        }
+
+#endif
 
     }
 }

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Reflection;
+using System.Reflection.Emit;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests
@@ -794,5 +795,25 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<ArgumentException>("delegateType", () => Expression.Lambda(typeof(Action<>), Expression.Empty(), false));
             Assert.Throws<ArgumentException>("delegateType", () => Expression.Lambda(typeof(Action<>), Expression.Empty(), false, Enumerable.Empty<ParameterExpression>()));
         }
+
+#if FEATURE_COMPILE // When we don't have FEATURE_COMPILE we don't have the Reflection.Emit used in the tests.
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void PrivateDelegate(bool useInterpreter)
+        {
+            AssemblyBuilder assembly = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Name"), AssemblyBuilderAccess.Run);
+            ModuleBuilder module = assembly.DefineDynamicModule("Name");
+            TypeBuilder builder = module.DefineType("Type", TypeAttributes.Class | TypeAttributes.NotPublic | TypeAttributes.Sealed | TypeAttributes.AnsiClass | TypeAttributes.AutoClass, typeof(MulticastDelegate));
+            builder.DefineConstructor(MethodAttributes.RTSpecialName | MethodAttributes.HideBySig | MethodAttributes.Public, CallingConventions.Standard, new[] { typeof(object), typeof(IntPtr) }).SetImplementationFlags(MethodImplAttributes.Runtime | MethodImplAttributes.Managed);
+            builder.DefineMethod("Invoke", MethodAttributes.Private | MethodAttributes.HideBySig | MethodAttributes.NewSlot | MethodAttributes.Virtual, typeof(int), Type.EmptyTypes).SetImplementationFlags(MethodImplAttributes.Runtime | MethodImplAttributes.Managed);
+            Type delType = builder.CreateTypeInfo();
+            LambdaExpression lambda = Expression.Lambda(delType, Expression.Constant(42));
+            Delegate del = lambda.Compile(useInterpreter);
+            Assert.IsType(delType, del);
+            Assert.Equal(42, del.DynamicInvoke());
+        }
+
+#endif
+
     }
 }


### PR DESCRIPTION
Fixes #16924

Such delegates can't be defined directly in C# without using reflection, but can in F#.