### PR TITLE
Add PreferInbox=true to corefx assemblies

### DIFF
--- a/Tools-Override/Build.Common.targets
+++ b/Tools-Override/Build.Common.targets
@@ -32,6 +32,9 @@
     <AssemblyMetadata Include="Serviceable">
       <Value>True</Value>
     </AssemblyMetadata>
+    <AssemblyMetadata Include="PreferInbox">
+      <Value>True</Value>
+    </AssemblyMetadata>
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
This adds `[assembly:System.Reflection.AssemblyMetadata("PreferInbox", "True")]`
to all corefx assemblies.

Mono will use this to ignore the assembly if it's in the application directory
and it has the same assembly in its framework.

Fixes #15112

/cc @marek-safar 