### PR TITLE
Fix newly added GetProcessesByName_NoSuchProcess_ReturnsEmpty test

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -841,12 +841,10 @@ namespace System.Diagnostics.Tests
             Assert.Throws<PlatformNotSupportedException>(() => Process.GetProcessesByName(currentProcess.ProcessName, machineName));
         }
 
-        [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        [InlineData("NoSuchProcess")]
-        public void GetProcessesByName_NoSuchProcess_ReturnsEmpty(string processName)
+        [Fact]
+        public void GetProcessesByName_NoSuchProcess_ReturnsEmpty()
         {
+            string processName = Guid.NewGuid().ToString("N");
             Assert.Empty(Process.GetProcessesByName(processName));
         }
 


### PR DESCRIPTION
On macOS, we may be able to discover that a process exists but not be able to get some detail about it, like its name, if the process is running at a higher privilege level.  As a result, the GetProcessesByName_NoSuchProcess_ReturnsEmpty frequently fails in CI, as it expects to find no processes with an empty name but does.

Fixes https://github.com/dotnet/corefx/issues/18321
Fixes https://github.com/dotnet/corefx/issues/18317
cc: @hughbe, @danmosemsft, @Priya91 