### PR TITLE
Fix Begin/EndSendFile hang on macOS

### DIFF
--- a/src/Native/Unix/System.Native/pal_networking.cpp
+++ b/src/Native/Unix/System.Native/pal_networking.cpp
@@ -2840,27 +2840,48 @@ extern "C" Error SystemNative_SendFile(intptr_t out_fd, intptr_t in_fd, int64_t 
 
     *sent = 0;
     return SystemNative_ConvertErrorPlatformToPal(errno);
+
 #elif HAVE_SENDFILE_6
-    off_t len = count;
-    ssize_t res;
-    while (CheckInterrupted(res = sendfile(infd, outfd, static_cast<off_t>(offset), &len, nullptr, 0)));
-    if (res != -1)
+    *sent = 0;
+    while (true) // in case we need to retry for an EINTR
     {
-        if (len == 0)
+        off_t len = count;
+        ssize_t res = sendfile(infd, outfd, static_cast<off_t>(offset), &len, nullptr, 0);
+        assert(len >= 0);
+
+        // If the call succeeded, store the number of bytes sent, and return.  We add
+        // rather than copy len because a previous call to sendfile could have sent bytes
+        // but been interrupted by EINTR, in which case we need to add to that.
+        if (res != -1)
         {
-            // This indicates EOF
-            *sent = count;
+            *sent += len;
+            return PAL_SUCCESS;
         }
-        else
+
+        // We got an error. If sendfile "fails" with EINTR or EAGAIN, it may have sent
+        // some data that needs to be counted.
+        if (errno == EAGAIN || errno == EINTR)
         {
-            *sent = len;
+            *sent += len;
+            offset += len;
+            count -= len;
+
+            // If we actually transferred everything in spite of the error, return success.
+            assert(count >= 0);
+            if (count == 0) return PAL_SUCCESS;
+
+            // For EINTR, loop around and go again.
+            if (errno == EINTR) continue;
         }
-        return PAL_SUCCESS;
+
+        // For everything other than EINTR, bail.
+        return SystemNative_ConvertErrorPlatformToPal(errno);
     }
 
-    *sent = 0;
-    return SystemNative_ConvertErrorPlatformToPal(errno);
-#else
+#else    
+    // If we ever need to run on a platform that doesn't have sendfile,
+    // we can implement this with a simple read/send loop.  For now,
+    // we just mark it as not supported.
     (void)outfd;
     (void)infd;
     (void)offset;

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -232,12 +232,6 @@ namespace System.Net.Sockets
         {
             long bytesSent; 
             errno = Interop.Sys.SendFile(socket, fileHandle, offset, count, out bytesSent);
-
-            if (errno != Interop.Error.SUCCESS)
-            {
-                return -1;
-            }
-
             offset += bytesSent;
             count -= bytesSent;
             return bytesSent;
@@ -732,6 +726,7 @@ namespace System.Net.Sockets
                 try
                 {
                     sent = SendFile(socket, handle, ref offset, ref count, out errno);
+                    bytesSent += sent;
                 }
                 catch (ObjectDisposedException)
                 {
@@ -740,7 +735,7 @@ namespace System.Net.Sockets
                     return true;
                 }
 
-                if (sent == -1)
+                if (errno != Interop.Error.SUCCESS)
                 {
                     if (errno != Interop.Error.EAGAIN && errno != Interop.Error.EWOULDBLOCK)
                     {
@@ -751,8 +746,6 @@ namespace System.Net.Sockets
                     errorCode = SocketError.Success;
                     return false;
                 }
-
-                bytesSent += sent;
 
                 if (sent == 0 || count == 0)
                 {

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
@@ -13,17 +13,16 @@ namespace System.Net.Sockets.Tests
 {
     public class SendFileTest
     {
-        public static IEnumerable<object[]> SendFile_MemberData_Small() => SendFile_MemberData(1024);
-
-        public static IEnumerable<object[]> SendFile_MemberData_Large() => SendFile_MemberData(12345678);
-
-        public static IEnumerable<object[]> SendFile_MemberData(int bytesToSend)
+        public static IEnumerable<object[]> SendFile_MemberData()
         {
             foreach (IPAddress listenAt in new[] { IPAddress.Loopback, IPAddress.IPv6Loopback })
             {
                 foreach (bool sendPreAndPostBuffers in new[] { true, false })
                 {
-                    yield return new object[] { listenAt, sendPreAndPostBuffers, bytesToSend };
+                    foreach (int bytesToSend in new[] { 512, 1024, 12345678 })
+                    {
+                        yield return new object[] { listenAt, sendPreAndPostBuffers, bytesToSend };
+                    }
                 }
             }
         }
@@ -98,8 +97,7 @@ namespace System.Net.Sockets.Tests
 
         [OuterLoop] // TODO: Issue #11345
         [Theory]
-        [MemberData(nameof(SendFile_MemberData_Small))]
-        [MemberData(nameof(SendFile_MemberData_Large))]
+        [MemberData(nameof(SendFile_MemberData))]
         public void SendFile_Synchronous(IPAddress listenAt, bool sendPreAndPostBuffers, int bytesToSend)
         {
             const int ListenBacklog = 1;
@@ -169,14 +167,7 @@ namespace System.Net.Sockets.Tests
 
         [OuterLoop] // TODO: Issue #11345
         [Theory]
-        [MemberData(nameof(SendFile_MemberData_Large))]
-        [ActiveIssue(17188, TestPlatforms.OSX)] // recombine into SendFile_APM once fixed
-        public void SendFile_APM_Large(IPAddress listenAt, bool sendPreAndPostBuffers, int bytesToSend) =>
-            SendFile_APM(listenAt, sendPreAndPostBuffers, bytesToSend);
-
-        [OuterLoop] // TODO: Issue #11345
-        [Theory]
-        [MemberData(nameof(SendFile_MemberData_Small))]
+        [MemberData(nameof(SendFile_MemberData))]
         public void SendFile_APM(IPAddress listenAt, bool sendPreAndPostBuffers, int bytesToSend)
         {
             const int ListenBacklog = 1;


### PR DESCRIPTION
Unlike sendfile on Linux, the sendfile variant on macOS can return with an error of EAGAIN or EINTR but having sent some of the data.  Currently that data isn't being tracked, resulting in hangs.  This fixes the implementation to appropriately track data transferred even during EAGAIN or EINTR failures.

Fixes #17188 
cc: @geoffkizer, @Priya91, @steveharter 