### PR TITLE
Reflection Test fixes for uwpaot.

### DIFF
--- a/src/System.Reflection/tests/EventInfoTests.cs
+++ b/src/System.Reflection/tests/EventInfoTests.cs
@@ -147,7 +147,10 @@ namespace System.Reflection.Tests
             EventInfo eventInfo1 = GetEventInfo(type1, name1);
             EventInfo eventInfo2 = GetEventInfo(type2, name2);
             Assert.Equal(expected, eventInfo1.Equals(eventInfo2));
-            Assert.Equal(expected, eventInfo1.GetHashCode().Equals(eventInfo2.GetHashCode()));
+            if (expected)
+            {
+                Assert.Equal(expected, eventInfo1.GetHashCode().Equals(eventInfo2.GetHashCode()));
+            }
         }
 
         [Theory]

--- a/src/System.Reflection/tests/FieldInfoTests.cs
+++ b/src/System.Reflection/tests/FieldInfoTests.cs
@@ -525,6 +525,11 @@ namespace System.Reflection.Tests
 
         struct FieldData
         {
+            public Inner inner;
+        }
+
+        struct Inner
+        {
             public object field;
         }
 
@@ -540,12 +545,14 @@ namespace System.Reflection.Tests
         [InlineData(null)]
         public static void SetValueDirect_GetValueDirectRoundDataTest(object value)
         {
-            FieldData testField = new FieldData { field = -1 };
+            FieldData testField = new FieldData { inner = new Inner() { field = -1 } };
+            FieldInfo innerFieldIinfo = typeof(FieldData).GetField(nameof(FieldData.inner));
+            FieldInfo[] fields = { innerFieldIinfo };
+            FieldInfo fieldFieldInfo = typeof(Inner).GetField(nameof(Inner.field));
+            TypedReference reference = TypedReference.MakeTypedReference(testField, fields);
+            fieldFieldInfo.SetValueDirect(reference, value);
+            object result = fieldFieldInfo.GetValueDirect(reference);
 
-            FieldInfo info = testField.GetType().GetField("field");
-            TypedReference reference = __makeref(testField);
-            info.SetValueDirect(reference, value);
-            object result = info.GetValueDirect(reference);
             Assert.Equal(value, result);
         }
     }


### PR DESCRIPTION
- Eliminate use of __makeref (prevents test from compiling
  under .NET native)

- Fix EventInfo test (it's not valid to compare hashcodes
  for non-equal objects.)