### PR TITLE
Fix for Getting a Random Number for generating Activity IDs

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -404,8 +404,9 @@ namespace System.Diagnostics
 #endif
         private static unsafe long GetRandomNumber()
         {
+            // Use the first 8 bytes of the GUID as a random number.  
             Guid g = Guid.NewGuid();
-            return (long)&g;
+            return *((long*)&g);
         }
 
         private string _rootId;


### PR DESCRIPTION
I noticed this when reviewing how likely our IDs were to collide.
By mistake the original code generated a number from a stack address, when it was
trying to take the first bytes of the GUID as a random number.   Trivial fix.