### PR TITLE
More reflection Test fixes for uwpaot.

### DIFF
--- a/src/System.Reflection/tests/AssemblyTests.cs
+++ b/src/System.Reflection/tests/AssemblyTests.cs
@@ -194,7 +194,7 @@ namespace System.Reflection.Tests
         [Fact]
         public void Load_Invalid()
         {
-            Assert.Throws<ArgumentNullException>("assemblyRef", () => Assembly.Load((AssemblyName)null)); // AssemblyRef is null
+            Assert.Throws<ArgumentNullException>(() => Assembly.Load((AssemblyName)null)); // AssemblyRef is null
             Assert.Throws<FileNotFoundException>(() => Assembly.Load(new AssemblyName("no such assembly"))); // No such assembly
         }
 

--- a/src/System.Reflection/tests/ConstructorInfoTests.cs
+++ b/src/System.Reflection/tests/ConstructorInfoTests.cs
@@ -63,6 +63,7 @@ namespace System.Reflection.Tests
         public void Invoke_StaticConstructor_NullObject_NullParameters()
         {
             ConstructorInfo[] constructors = GetConstructors(typeof(ClassWithStaticConstructor));
+            Assert.Equal(1, constructors.Length);
             object obj = constructors[0].Invoke(null, new object[] { });
             Assert.Null(obj);
         }
@@ -71,6 +72,7 @@ namespace System.Reflection.Tests
         public void Invoke_StaticConstructor_ThrowsMemberAccessException()
         {
             ConstructorInfo[] constructors = GetConstructors(typeof(ClassWithStaticConstructor));
+            Assert.Equal(1, constructors.Length);
             Assert.Throws<MemberAccessException>(() => constructors[0].Invoke(new object[0]));
         }
 
@@ -137,7 +139,7 @@ namespace System.Reflection.Tests
         public void Invoke_ParameterWrongType_ThrowsArgumentException()
         {
             ConstructorInfo[] constructors = GetConstructors(typeof(ClassWith3Constructors));
-            Assert.Throws<ArgumentException>(null, () => (ClassWith3Constructors)constructors[1].Invoke(new object[] { "hello" }));
+            Assert.Throws<ArgumentException>(() => (ClassWith3Constructors)constructors[1].Invoke(new object[] { "hello" }));
         }
 
         [Fact]
@@ -227,7 +229,7 @@ namespace System.Reflection.Tests
         public string Method1(DateTime dt) => "";
     }
 
-    public class ClassWithStaticConstructor
+    public static class ClassWithStaticConstructor
     {
         static ClassWithStaticConstructor() { }
     }

--- a/src/System.Reflection/tests/EventInfoTests.cs
+++ b/src/System.Reflection/tests/EventInfoTests.cs
@@ -149,7 +149,7 @@ namespace System.Reflection.Tests
             Assert.Equal(expected, eventInfo1.Equals(eventInfo2));
             if (expected)
             {
-                Assert.Equal(expected, eventInfo1.GetHashCode().Equals(eventInfo2.GetHashCode()));
+                Assert.Equal(eventInfo1.GetHashCode(), eventInfo2.GetHashCode());
             }
         }
 

--- a/src/System.Reflection/tests/FieldInfoTests.cs
+++ b/src/System.Reflection/tests/FieldInfoTests.cs
@@ -366,8 +366,8 @@ namespace System.Reflection.Tests
             fieldInfo.SetValue(obj, BTypeWithAllB_Contra);
             Assert.Equal(BTypeWithAllB_Contra, fieldInfo.GetValue(obj));
 
-            Assert.Throws<ArgumentException>(null, () => fieldInfo.SetValue(obj, new int[] { 1, -1, 2, -2 }));
-            Assert.Throws<ArgumentException>(null, () => fieldInfo.SetValue(obj, new byte[] { 2, 3, 4 }));
+            Assert.Throws<ArgumentException>(() => fieldInfo.SetValue(obj, new int[] { 1, -1, 2, -2 }));
+            Assert.Throws<ArgumentException>(() => fieldInfo.SetValue(obj, new byte[] { 2, 3, 4 }));
         }
 
         public static IEnumerable<object[]> FieldInfoRTGenericTests_TestData()
@@ -546,8 +546,8 @@ namespace System.Reflection.Tests
         public static void SetValueDirect_GetValueDirectRoundDataTest(object value)
         {
             FieldData testField = new FieldData { inner = new Inner() { field = -1 } };
-            FieldInfo innerFieldIinfo = typeof(FieldData).GetField(nameof(FieldData.inner));
-            FieldInfo[] fields = { innerFieldIinfo };
+            FieldInfo innerFieldInfo = typeof(FieldData).GetField(nameof(FieldData.inner));
+            FieldInfo[] fields = { innerFieldInfo };
             FieldInfo fieldFieldInfo = typeof(Inner).GetField(nameof(Inner.field));
             TypedReference reference = TypedReference.MakeTypedReference(testField, fields);
             fieldFieldInfo.SetValueDirect(reference, value);

--- a/src/System.Reflection/tests/GetTypeTests.cs
+++ b/src/System.Reflection/tests/GetTypeTests.cs
@@ -26,7 +26,7 @@ namespace System.Reflection.Tests
             Assert.Null(Type.GetType(aqn, throwOnError: false));
 
             Assert.Throws<TypeLoadException>(() => Type.GetType(typeName, throwOnError: true));
-            Assert.Throws<ArgumentException>("typeName@0", () => Type.GetType(aqn, throwOnError: true));
+            Assert.Throws<ArgumentException>(() => Type.GetType(aqn, throwOnError: true));
 
             Assert.Null(Type.GetType(typeName, throwOnError: false, ignoreCase: false));
             Assert.Null(Type.GetType(typeName, throwOnError: false, ignoreCase: true));
@@ -35,33 +35,33 @@ namespace System.Reflection.Tests
 
             Assert.Throws<TypeLoadException>(() => Type.GetType(typeName, throwOnError: true, ignoreCase: false));
             Assert.Throws<TypeLoadException>(() => Type.GetType(typeName, throwOnError: true, ignoreCase: true));
-            Assert.Throws<ArgumentException>("typeName@0", () => Type.GetType(aqn, throwOnError: true, ignoreCase: false));
-            Assert.Throws<ArgumentException>("typeName@0", () => Type.GetType(aqn, throwOnError: true, ignoreCase: true));
+            Assert.Throws<ArgumentException>(() => Type.GetType(aqn, throwOnError: true, ignoreCase: false));
+            Assert.Throws<ArgumentException>(() => Type.GetType(aqn, throwOnError: true, ignoreCase: true));
 
             // Assembly.GetType
-            Assert.Throws<ArgumentException>(null, () => a.GetType(typeName));
+            Assert.Throws<ArgumentException>(() => a.GetType(typeName));
             Assert.Null(a.GetType(aqn));
 
-            Assert.Throws<ArgumentException>(null, () => a.GetType(typeName, throwOnError: false, ignoreCase: false));
-            Assert.Throws<ArgumentException>(null, () => a.GetType(typeName, throwOnError: false, ignoreCase: true));
+            Assert.Throws<ArgumentException>(() => a.GetType(typeName, throwOnError: false, ignoreCase: false));
+            Assert.Throws<ArgumentException>(() => a.GetType(typeName, throwOnError: false, ignoreCase: true));
             Assert.Null(a.GetType(aqn, throwOnError: false, ignoreCase: false));
             Assert.Null(a.GetType(aqn, throwOnError: false, ignoreCase: true));
 
-            Assert.Throws<ArgumentException>(null, () => a.GetType(typeName, throwOnError: true, ignoreCase: false));
-            Assert.Throws<ArgumentException>(null, () => a.GetType(typeName, throwOnError: true, ignoreCase: true));
-            Assert.Throws<ArgumentException>("typeName@0", () => a.GetType(aqn, throwOnError: true, ignoreCase: false));
-            Assert.Throws<ArgumentException>("typeName@0", () => a.GetType(aqn, throwOnError: true, ignoreCase: true));
+            Assert.Throws<ArgumentException>(() => a.GetType(typeName, throwOnError: true, ignoreCase: false));
+            Assert.Throws<ArgumentException>(() => a.GetType(typeName, throwOnError: true, ignoreCase: true));
+            Assert.Throws<ArgumentException>(() => a.GetType(aqn, throwOnError: true, ignoreCase: false));
+            Assert.Throws<ArgumentException>(() => a.GetType(aqn, throwOnError: true, ignoreCase: true));
 
             // Module.GetType
-            Assert.Throws<ArgumentException>(null, () => m.GetType(typeName, throwOnError: false, ignoreCase: false));
-            Assert.Throws<ArgumentException>(null, () => m.GetType(typeName, throwOnError: false, ignoreCase: true));
+            Assert.Throws<ArgumentException>(() => m.GetType(typeName, throwOnError: false, ignoreCase: false));
+            Assert.Throws<ArgumentException>(() => m.GetType(typeName, throwOnError: false, ignoreCase: true));
             Assert.Null(m.GetType(aqn, throwOnError: false, ignoreCase: false));
             Assert.Null(m.GetType(aqn, throwOnError: false, ignoreCase: true));
 
-            Assert.Throws<ArgumentException>(null, () => m.GetType(typeName, throwOnError: true, ignoreCase: false));
-            Assert.Throws<ArgumentException>(null, () => m.GetType(typeName, throwOnError: true, ignoreCase: true));
-            Assert.Throws<ArgumentException>("typeName@0", () => m.GetType(aqn, throwOnError: true, ignoreCase: false));
-            Assert.Throws<ArgumentException>("typeName@0", () => m.GetType(aqn, throwOnError: true, ignoreCase: true));
+            Assert.Throws<ArgumentException>(() => m.GetType(typeName, throwOnError: true, ignoreCase: false));
+            Assert.Throws<ArgumentException>(() => m.GetType(typeName, throwOnError: true, ignoreCase: true));
+            Assert.Throws<ArgumentException>(() => m.GetType(aqn, throwOnError: true, ignoreCase: false));
+            Assert.Throws<ArgumentException>(() => m.GetType(aqn, throwOnError: true, ignoreCase: true));
         }
 
         public static IEnumerable<object[]> GetType_TestData()
@@ -126,8 +126,8 @@ namespace System.Reflection.Tests
 
                 Assert.Throws<TypeLoadException>(() => a.GetType(typeName, throwOnError: true, ignoreCase: false));
                 Assert.Throws<TypeLoadException>(() => a.GetType(typeName, throwOnError: true, ignoreCase: true));
-                Assert.Throws<ArgumentException>(null, () => a.GetType(aqn, throwOnError: true, ignoreCase: false));
-                Assert.Throws<ArgumentException>(null, () => a.GetType(aqn, throwOnError: true, ignoreCase: true));
+                Assert.Throws<ArgumentException>(() => a.GetType(aqn, throwOnError: true, ignoreCase: false));
+                Assert.Throws<ArgumentException>(() => a.GetType(aqn, throwOnError: true, ignoreCase: true));
 
                 // Module.GetType
                 Assert.Null(m.GetType(typeName, throwOnError: false, ignoreCase: false));
@@ -137,8 +137,8 @@ namespace System.Reflection.Tests
 
                 Assert.Throws<TypeLoadException>(() => m.GetType(typeName, throwOnError: true, ignoreCase: false));
                 Assert.Throws<TypeLoadException>(() => m.GetType(typeName, throwOnError: true, ignoreCase: true));
-                Assert.Throws<ArgumentException>(null, () => m.GetType(aqn, throwOnError: true, ignoreCase: false));
-                Assert.Throws<ArgumentException>(null, () => m.GetType(aqn, throwOnError: true, ignoreCase: true));
+                Assert.Throws<ArgumentException>(() => m.GetType(aqn, throwOnError: true, ignoreCase: false));
+                Assert.Throws<ArgumentException>(() => m.GetType(aqn, throwOnError: true, ignoreCase: true));
             }
             else if (expectedResult.FullName == typeName)
             {
@@ -180,8 +180,8 @@ namespace System.Reflection.Tests
 
                 Assert.Equal(expectedResult, a.GetType(typeName, throwOnError: true, ignoreCase: false));
                 Assert.Equal(expectedName, a.GetType(typeName, throwOnError: true, ignoreCase: true).AssemblyQualifiedName, StringComparer.OrdinalIgnoreCase);
-                Assert.Throws<ArgumentException>(null, () => a.GetType(aqn, throwOnError: true, ignoreCase: false));
-                Assert.Throws<ArgumentException>(null, () => a.GetType(aqn, throwOnError: true, ignoreCase: true));
+                Assert.Throws<ArgumentException>(() => a.GetType(aqn, throwOnError: true, ignoreCase: false));
+                Assert.Throws<ArgumentException>(() => a.GetType(aqn, throwOnError: true, ignoreCase: true));
 
                 // Module.GetType
                 Assert.Equal(expectedResult, m.GetType(typeName, throwOnError: false, ignoreCase: false));
@@ -191,8 +191,8 @@ namespace System.Reflection.Tests
 
                 Assert.Equal(expectedResult, m.GetType(typeName, throwOnError: true, ignoreCase: false));
                 Assert.Equal(expectedName, m.GetType(typeName, throwOnError: true, ignoreCase: true).AssemblyQualifiedName, StringComparer.OrdinalIgnoreCase);
-                Assert.Throws<ArgumentException>(null, () => m.GetType(aqn, throwOnError: true, ignoreCase: false));
-                Assert.Throws<ArgumentException>(null, () => m.GetType(aqn, throwOnError: true, ignoreCase: true));
+                Assert.Throws<ArgumentException>(() => m.GetType(aqn, throwOnError: true, ignoreCase: false));
+                Assert.Throws<ArgumentException>(() => m.GetType(aqn, throwOnError: true, ignoreCase: true));
             }
             else if (expectedResult.FullName.Equals(typeName, StringComparison.OrdinalIgnoreCase))
             {
@@ -234,8 +234,8 @@ namespace System.Reflection.Tests
 
                 Assert.Throws<TypeLoadException>(() => a.GetType(typeName, throwOnError: true, ignoreCase: false));
                 Assert.Equal(expectedName, a.GetType(typeName, throwOnError: true, ignoreCase: true).AssemblyQualifiedName, StringComparer.OrdinalIgnoreCase);
-                Assert.Throws<ArgumentException>(null, () => a.GetType(aqn, throwOnError: true, ignoreCase: false));
-                Assert.Throws<ArgumentException>(null, () => a.GetType(aqn, throwOnError: true, ignoreCase: true));
+                Assert.Throws<ArgumentException>(() => a.GetType(aqn, throwOnError: true, ignoreCase: false));
+                Assert.Throws<ArgumentException>(() => a.GetType(aqn, throwOnError: true, ignoreCase: true));
 
                 // Module.GetType
                 Assert.Null(m.GetType(typeName, throwOnError: false, ignoreCase: false));
@@ -245,8 +245,8 @@ namespace System.Reflection.Tests
 
                 Assert.Throws<TypeLoadException>(() => m.GetType(typeName, throwOnError: true, ignoreCase: false));
                 Assert.Equal(expectedName, m.GetType(typeName, throwOnError: true, ignoreCase: true).AssemblyQualifiedName, StringComparer.OrdinalIgnoreCase);
-                Assert.Throws<ArgumentException>(null, () => m.GetType(aqn, throwOnError: true, ignoreCase: false));
-                Assert.Throws<ArgumentException>(null, () => m.GetType(aqn, throwOnError: true, ignoreCase: true));
+                Assert.Throws<ArgumentException>(() => m.GetType(aqn, throwOnError: true, ignoreCase: false));
+                Assert.Throws<ArgumentException>(() => m.GetType(aqn, throwOnError: true, ignoreCase: true));
             }
             else
             {

--- a/src/System.Reflection/tests/MethodInfoTests.cs
+++ b/src/System.Reflection/tests/MethodInfoTests.cs
@@ -318,14 +318,14 @@ namespace System.Reflection.Tests
         [Fact]
         public void MakeGenericMethod_Invalid()
         {
-            Assert.Throws<ArgumentNullException>("methodInstantiation", () => GetMethod(typeof(MI_SubClass), nameof(MI_SubClass.GenericMethod1)).MakeGenericMethod(null)); // TypeArguments is null
-            Assert.Throws<ArgumentNullException>(null, () => GetMethod(typeof(MI_SubClass), nameof(MI_SubClass.GenericMethod2)).MakeGenericMethod(typeof(string), null)); // TypeArguments has null Type
+            Assert.Throws<ArgumentNullException>(() => GetMethod(typeof(MI_SubClass), nameof(MI_SubClass.GenericMethod1)).MakeGenericMethod(null)); // TypeArguments is null
+            Assert.Throws<ArgumentNullException>(() => GetMethod(typeof(MI_SubClass), nameof(MI_SubClass.GenericMethod2)).MakeGenericMethod(typeof(string), null)); // TypeArguments has null Type
             Assert.Throws<InvalidOperationException>(() => GetMethod(typeof(MI_SubClass), nameof(MI_SubClass.VoidMethodReturningInt)).MakeGenericMethod(typeof(int))); // Method is non generic
 
             // Number of typeArguments does not match
-            Assert.Throws<ArgumentException>(null, () => GetMethod(typeof(MI_SubClass), nameof(MI_SubClass.GenericMethod1)).MakeGenericMethod());
-            Assert.Throws<ArgumentException>(null, () => GetMethod(typeof(MI_SubClass), nameof(MI_SubClass.GenericMethod1)).MakeGenericMethod(typeof(string), typeof(int)));
-            Assert.Throws<ArgumentException>(null, () => GetMethod(typeof(MI_SubClass), nameof(MI_SubClass.GenericMethod2)).MakeGenericMethod(typeof(int)));
+            Assert.Throws<ArgumentException>(() => GetMethod(typeof(MI_SubClass), nameof(MI_SubClass.GenericMethod1)).MakeGenericMethod());
+            Assert.Throws<ArgumentException>(() => GetMethod(typeof(MI_SubClass), nameof(MI_SubClass.GenericMethod1)).MakeGenericMethod(typeof(string), typeof(int)));
+            Assert.Throws<ArgumentException>(() => GetMethod(typeof(MI_SubClass), nameof(MI_SubClass.GenericMethod2)).MakeGenericMethod(typeof(int)));
         }
 
         [Theory]

--- a/src/System.Reflection/tests/TypeInfoTests.cs
+++ b/src/System.Reflection/tests/TypeInfoTests.cs
@@ -388,8 +388,8 @@ namespace System.Reflection.Tests
         [Fact]
         public void GetEnumName_Invalid()
         {
-            Assert.Throws<ArgumentException>("value", () => typeof(NonGenericClassWithNoInterfaces).GetTypeInfo().GetEnumName(""));
-            Assert.Throws<ArgumentNullException>("value", () => typeof(IntEnum).GetTypeInfo().GetEnumName(null));
+            Assert.Throws<ArgumentException>(() => typeof(NonGenericClassWithNoInterfaces).GetTypeInfo().GetEnumName(""));
+            Assert.Throws<ArgumentNullException>(() => typeof(IntEnum).GetTypeInfo().GetEnumName(null));
         }
 
         public static IEnumerable<object[]> GetEnumNames_TestData()
@@ -408,7 +408,7 @@ namespace System.Reflection.Tests
         [Fact]
         public void GetEnumNames_TypeNotEnum_ThrowsArgumentException()
         {
-            Assert.Throws<ArgumentException>("enumType", () => typeof(NonGenericClassWithNoInterfaces).GetTypeInfo().GetEnumNames());
+            Assert.Throws<ArgumentException>(() => typeof(NonGenericClassWithNoInterfaces).GetTypeInfo().GetEnumNames());
         }
 
         [Theory]
@@ -422,7 +422,7 @@ namespace System.Reflection.Tests
         [Fact]
         public void GetEnumUnderlyingType_TypeNotEnum_ThrowsArgumentException()
         {
-            Assert.Throws<ArgumentException>("enumType", () => typeof(NonGenericClassWithNoInterfaces).GetTypeInfo().GetEnumUnderlyingType());
+            Assert.Throws<ArgumentException>(() => typeof(NonGenericClassWithNoInterfaces).GetTypeInfo().GetEnumUnderlyingType());
         }
 
         [Theory]
@@ -436,7 +436,7 @@ namespace System.Reflection.Tests
         [Fact]
         public void GetEnumValues_TypeNotEnum_ThrowsArgumentException()
         {
-            Assert.Throws<ArgumentException>("enumType", () => typeof(NonGenericClassWithNoInterfaces).GetTypeInfo().GetEnumUnderlyingType());
+            Assert.Throws<ArgumentException>(() => typeof(NonGenericClassWithNoInterfaces).GetTypeInfo().GetEnumUnderlyingType());
         }
 
         [Theory]
@@ -450,8 +450,8 @@ namespace System.Reflection.Tests
         [Fact]
         public void IsEnumDefined_Invalid()
         {
-            Assert.Throws<ArgumentException>("", () => typeof(NonGenericClassWithNoInterfaces).GetTypeInfo().IsEnumDefined(10));
-            Assert.Throws<ArgumentNullException>("value", () => typeof(IntEnum).GetTypeInfo().IsEnumDefined(null));
+            Assert.Throws<ArgumentException>(() => typeof(NonGenericClassWithNoInterfaces).GetTypeInfo().IsEnumDefined(10));
+            Assert.Throws<ArgumentNullException>(() => typeof(IntEnum).GetTypeInfo().IsEnumDefined(null));
             Assert.Throws<InvalidOperationException>(() => typeof(IntEnum).GetTypeInfo().IsEnumDefined(new NonGenericClassWithNoInterfaces()));
         }
 
@@ -695,9 +695,9 @@ namespace System.Reflection.Tests
         [Fact]
         public void GetMethod_Invalid()
         {
-            Assert.Throws<ArgumentNullException>("name", () => typeof(MembersClass).GetTypeInfo().GetMethod(null));
-            Assert.Throws<ArgumentNullException>("types", () => typeof(MembersClass).GetTypeInfo().GetMethod("p", null));
-            Assert.Throws<ArgumentNullException>("types", () => typeof(MembersClass).GetTypeInfo().GetMethod("p", new Type[] { typeof(int), null }));
+            Assert.Throws<ArgumentNullException>(() => typeof(MembersClass).GetTypeInfo().GetMethod(null));
+            Assert.Throws<ArgumentNullException>(() => typeof(MembersClass).GetTypeInfo().GetMethod("p", null));
+            Assert.Throws<ArgumentNullException>(() => typeof(MembersClass).GetTypeInfo().GetMethod("p", new Type[] { typeof(int), null }));
         }
 
         [Theory]
@@ -837,7 +837,7 @@ namespace System.Reflection.Tests
         [Fact]
         public void GetEvent_NullName_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(null, () => typeof(MembersClass).GetTypeInfo().GetEvent(null));
+            Assert.Throws<ArgumentNullException>(() => typeof(MembersClass).GetTypeInfo().GetEvent(null));
         }
 
         [Theory]
@@ -877,7 +877,7 @@ namespace System.Reflection.Tests
         [Fact]
         public void GetField_NullName_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(null, () => typeof(MembersClass).GetTypeInfo().GetField(null));
+            Assert.Throws<ArgumentNullException>(() => typeof(MembersClass).GetTypeInfo().GetField(null));
         }
 
         [Theory]
@@ -930,19 +930,19 @@ namespace System.Reflection.Tests
         [Fact]
         public void GetDeclaredEvent_NullName_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(null, () => typeof(TI_BaseClass).GetTypeInfo().GetDeclaredEvent(null));
+            Assert.Throws<ArgumentNullException>(() => typeof(TI_BaseClass).GetTypeInfo().GetDeclaredEvent(null));
         }
 
         [Fact]
         public void GetDeclaredField_NullName_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(null, () => typeof(TI_BaseClass).GetTypeInfo().GetDeclaredField(null));
+            Assert.Throws<ArgumentNullException>(() => typeof(TI_BaseClass).GetTypeInfo().GetDeclaredField(null));
         }
 
         [Fact]
         public void GetDeclaredMethod_NullName_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>("name", () => typeof(TI_BaseClass).GetTypeInfo().GetDeclaredMethod(null));
+            Assert.Throws<ArgumentNullException>(() => typeof(TI_BaseClass).GetTypeInfo().GetDeclaredMethod(null));
         }
 
         [Theory]
@@ -958,7 +958,7 @@ namespace System.Reflection.Tests
         [Fact]
         public void GetDeclaredNestedType_NullName_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(null, () => typeof(TI_BaseClass).GetTypeInfo().GetDeclaredNestedType(null));
+            Assert.Throws<ArgumentNullException>(() => typeof(TI_BaseClass).GetTypeInfo().GetDeclaredNestedType(null));
         }
 
         [Theory]


### PR DESCRIPTION
- Fix dependency on GetConstructor() ordering output.

- Stop checking ArgumentException.ParamNames values.
  These are debugging aids, not things to be depended
  on. The .NET Native toolchain intentionally optimizes
  these away when compiling in release mode.