### PR TITLE
Disable merging IBC data to unblock build

### DIFF
--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -221,7 +221,7 @@
       },
       "BuildParameters": {
         "PB_ConfigurationGroup": "Release",
-        "PB_PipelineBuildMSBuildArguments": "/p:EnableProfileGuidedOptimization=true"
+        "PB_PipelineBuildMSBuildArguments": "/p:EnableProfileGuidedOptimization=false"
       },
       "Definitions": [
         {


### PR DESCRIPTION
Temporarily disable `EnableProfileGuidedOptimization`. Currently it tries to restore a package during the first project build that needs it: this seems to lead to a race condition causing official build failures.

I am also working on moving the package restore to the Sync step, but this PR is a more immediate fix to get builds unblocked for now.

@ericstj @MattGal @shawnro 