### PR TITLE
Only build netfx package on allconfigurations

### DIFF
--- a/pkg/NETStandard.Library.NETFramework/NETStandard.Library.NETFramework.builds
+++ b/pkg/NETStandard.Library.NETFramework/NETStandard.Library.NETFramework.builds
@@ -2,7 +2,8 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
-  <ItemGroup>
+  <!-- for official builds, only build during the AllConfigurations leg -->
+  <ItemGroup Condition="'$(OfficialBuildId)' == '' Or '$(BuildAllConfigurations)' == 'true'">
     <Project Include="$(MSBuildProjectName).pkgproj" />
   </ItemGroup>
 

--- a/src/publish.proj
+++ b/src/publish.proj
@@ -8,6 +8,15 @@
     <PublishPattern Condition="'$(PublishPattern)' == ''">$(PackageOutputRoot)**\*.nupkg</PublishPattern>
   </PropertyGroup>
 
+  <ItemGroup>
+    <_PackagesToPublish Include="$(PublishPattern)" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <!-- only try to publish if there are .nupkgs produced -->
+    <PublishBuildDependsOn Condition="'@(_PackagesToPublish)' != ''">CreateContainerName;UploadToAzure</PublishBuildDependsOn>
+  </PropertyGroup>
+
   <Target Name="CreateContainerName"
           DependsOnTargets="CreateVersionFileDuringBuild"
           Condition="'$(ContainerName)' == ''">
@@ -16,5 +25,5 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="Build" DependsOnTargets="CreateContainerName;UploadToAzure" />
+  <Target Name="Build" DependsOnTargets="$(PublishBuildDependsOn)" />
 </Project>

--- a/src/publish.proj
+++ b/src/publish.proj
@@ -11,12 +11,7 @@
   <ItemGroup>
     <_PackagesToPublish Include="$(PublishPattern)" />
   </ItemGroup>
-
-  <PropertyGroup>
-    <!-- only try to publish if there are .nupkgs produced -->
-    <PublishBuildDependsOn Condition="'@(_PackagesToPublish)' != ''">CreateContainerName;UploadToAzure</PublishBuildDependsOn>
-  </PropertyGroup>
-
+  
   <Target Name="CreateContainerName"
           DependsOnTargets="CreateVersionFileDuringBuild"
           Condition="'$(ContainerName)' == ''">
@@ -25,5 +20,8 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="Build" DependsOnTargets="$(PublishBuildDependsOn)" />
+  <Target Name="Build" DependsOnTargets="CreateContainerName">
+    <!-- skip uploadToAzure when there are no nupkgs -->
+    <CallTarget Targets="UploadToAzure" Condition="'@(_PackagesToPublish)' != ''" />
+  </Target>  
 </Project>


### PR DESCRIPTION
cc: @weshaggard @ericstj @MattGal 

Fixing netfx official build by:
 - Only producing the new netfx package on the AllConfigurations leg
 - Skipping the publish step if there are no packages to publish