### PR TITLE
Add a safegaurd to not mark System.Memory stable

### DIFF
--- a/pkg/baseline/baseline.props
+++ b/pkg/baseline/baseline.props
@@ -7,6 +7,8 @@
     <PackageIndexFile>$(MSBuildThisFileDirectory)..\Microsoft.Private.PackageBaseline\packageIndex.json</PackageIndexFile>
   </PropertyGroup>
 
-  <!-- make RestorePackages run before HarvestStablePackage to ensure we'll restore the baseline before harvesting  -->
-  <Target Name="EnsureRestore" BeforeTargets="HarvestStablePackage" DependsOnTargets="RestorePackages" />
+  <Target Name="BlockStable" Condition="'$(BlockStable)' == 'true'" AfterTargets="CalculatePackageVersion">
+    <!-- DO NOT ship this packages as stable in .NET Core 2.0. -->
+    <Error Condition="!$(PackageVersion.Contains('-'))" Text="Package $(Id) should not be built stable" />
+  </Target>
 </Project>

--- a/src/System.Memory/dir.props
+++ b/src/System.Memory/dir.props
@@ -4,5 +4,8 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
+    <!-- DO NOT ship this as stable for .NET Core 2.0. -->
+    <BlockStable>true</BlockStable>
+    <IsNETCoreApp>false</IsNETCoreApp>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
We don't want to ship this package as stable in 2.0.
This change just adds an extra safegaurd to avoid that.

It's just code so folks can still delete it, but it adds
an extra hurdle that will be more likely to be caught in
code review.

Fixes #17611 

/cc @Petermarcu @weshaggard 