### PR TITLE
Lift Microsoft.NETCore.Targets to reduce v1 conflicts

### DIFF
--- a/pkg/Microsoft.NETCore.Targets/Microsoft.NETCore.Targets.builds
+++ b/pkg/Microsoft.NETCore.Targets/Microsoft.NETCore.Targets.builds
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="Microsoft.NETCore.Targets.pkgproj"/>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/pkg/Microsoft.NETCore.Targets/Microsoft.NETCore.Targets.pkgproj
+++ b/pkg/Microsoft.NETCore.Targets/Microsoft.NETCore.Targets.pkgproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <PropertyGroup>
+    <PackageVersion>2.0.0</PackageVersion>
+    <SkipValidatePackage>true</SkipValidatePackage>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- make this package installable and noop in a packages.config-based project -->
+    <File Include="$(PlaceHolderFile)">
+      <TargetPath>lib/netstandard1.0</TargetPath>
+    </File>
+
+    <File Include="runtime.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/Microsoft.NETCore.Targets/runtime.json
+++ b/pkg/Microsoft.NETCore.Targets/runtime.json
@@ -1,0 +1,92 @@
+{
+    "supports": {
+        "uwp.10.0.app": {
+            "uap10.0": [
+                "win10-x86",
+                "win10-x86-aot",
+                "win10-x64",
+                "win10-x64-aot",
+                "win10-arm",
+                "win10-arm-aot"
+            ]
+        },
+        "net45.app": {
+            "net45": [
+                "",
+                "win-x86",
+                "win-x64"
+            ]
+        },
+        "net451.app": {
+            "net451": [
+                "",
+                "win-x86",
+                "win-x64"
+            ]
+        },
+        "net452.app": {
+            "net452": [
+                "",
+                "win-x86",
+                "win-x64"
+            ]
+        },
+        "net46.app": {
+            "net46": [
+                "",
+                "win-x86",
+                "win-x64"
+            ]
+        },
+        "net461.app": {
+            "net461": [
+                "",
+                "win-x86",
+                "win-x64"
+            ]
+        },
+        "net462.app": {
+            "net462": [
+                "",
+                "win-x86",
+                "win-x64"
+            ]
+        },
+        "netcoreapp1.0.app": {
+            "netcoreapp1.0": [
+                "win7-x86",
+                "win7-x64",
+                "osx.10.11-x64",
+                "centos.7-x64",
+                "debian.8-x64",
+                "linuxmint.17-x64",
+                "opensuse.13.2-x64",
+                "rhel.7.2-x64",
+                "ubuntu.14.04-x64",
+                "ubuntu.16.04-x64"
+            ]
+        },
+        "win8.app": {
+          "win8": ""
+        },
+        "win81.app": {
+          "win81": ""
+        },
+        "wp8.app": {
+          "wp8": ""
+        },
+        "wp81.app": {
+          "wp81": ""
+        },
+        "wpa81.app": {
+          "wpa81": ""
+        },
+        "dnxcore50.app": {
+            "dnxcore50": [
+                "win7-x86",
+                "win7-x64"
+            ]
+        }
+    }
+ }
+

--- a/pkg/frameworkPackage.targets
+++ b/pkg/frameworkPackage.targets
@@ -43,6 +43,15 @@
       <Version>$(PlatformPackageVersion)</Version>
       <TargetFramework>$(TargetFramework)</TargetFramework>
     </Dependency>
+
+    <!-- Include the update to v1 lineup package, which now has no runtime package mappings.
+         This will reduce the number of packages downloaded when mixing v1 and later
+         packages as well as reduce our dependence on conflict resolution for dropping
+         those v1 runtime packages -->
+    <Dependency Condition="'$(IsLineupPackage)' == 'true'" Include="Microsoft.NETCore.Targets">
+      <Version>2.0.0</Version>
+      <TargetFramework>$(TargetFramework)</TargetFramework>
+    </Dependency>
   </ItemGroup>
 
   <!-- Bring in lib content from binplaced lib props -->


### PR DESCRIPTION
Include the update to v1 lineup package, which now has no runtime package
mappings.

This will reduce the number of packages downloaded when mixing v1 and
later packages as well as reduce our dependence on conflict resolution
for dropping those v1 runtime packages.

Fixes #18088

Requires https://github.com/dotnet/core-setup/pull/2053

/cc @weshaggard @joperezr 