### PR TITLE
Enable merging IBC data: fix IBC data package restore by moving it to Sync

### DIFF
--- a/Tools-Override/codeOptimization.targets
+++ b/Tools-Override/codeOptimization.targets
@@ -13,7 +13,7 @@
   <!-- If IBC data hasn't been merged with the IL yet, preprocess it first -->
   <Target Name="PreProcessIBCData"
           BeforeTargets="OptimizeWithTrainingData"
-          DependsOnTargets="RestoreOptimizationDataPackage;ResolveOptionalTools"
+          DependsOnTargets="ResolveOptionalTools"
           Condition="'$(OS)'=='Windows_NT' and '$(EnableProfileGuidedOptimization)'=='true' and Exists('$(OptimizationDataDir)$(AssemblyName).dll')">
 
     <!-- Find IBCMerge as a resolved optional tool. -->
@@ -44,7 +44,7 @@
   <Target Name="OptimizeWithTrainingData"
           AfterTargets="AfterBuild"
           BeforeTargets="CopyFilesToOutputDirectory"
-          DependsOnTargets="RestoreOptimizationDataPackage;ResolveOptionalTools"
+          DependsOnTargets="ResolveOptionalTools"
           Condition="'$(OS)'=='Windows_NT' and '$(EnableProfileGuidedOptimization)'=='true' and Exists('$(OptimizationDataDir)$(AssemblyName).pgo')">
 
     <!-- Find IBCMerge as a resolved optional tool. -->
@@ -81,7 +81,8 @@
   </Target>
 
   <!-- We need the OptimizationData package in order to be able to optimize the assembly -->
-  <Target Name="RestoreOptimizationDataPackage" BeforeTargets="CoreCompile"
+  <Target Name="RestoreOptimizationDataPackage"
+          BeforeTargets="Sync"
           Condition="'$(EnableProfileGuidedOptimization)'=='true' and '$(RestoreDefaultOptimizationDataPackage)'=='true' and !Exists('$(OptimizationDataDir)project.csproj')">
     <!-- Dynamically create a project.json file used to restore the optimization data-->
     <PropertyGroup>

--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
@@ -105,7 +105,7 @@
       },
       "inputs": {
         "filename": "$(Build.SourcesDirectory)\\corefx\\sync.cmd",
-        "arguments": "$(PB_SyncArguments) $(PB_OptionalToolingSyncArguments)",
+        "arguments": "$(PB_SyncArguments) $(PB_OptionalToolingSyncArguments) $(PB_PipelineBuildMSBuildArguments)",
         "workingFolder": "corefx",
         "failOnStandardError": "false"
       }

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -221,7 +221,7 @@
       },
       "BuildParameters": {
         "PB_ConfigurationGroup": "Release",
-        "PB_PipelineBuildMSBuildArguments": "/p:EnableProfileGuidedOptimization=false"
+        "PB_PipelineBuildMSBuildArguments": "/p:EnableProfileGuidedOptimization=true"
       },
       "Definitions": [
         {


### PR DESCRIPTION
Reverts https://github.com/dotnet/corefx/pull/18336 to reenable IBC data merging. Fixes the build break by restoring the IBC data/OptimizationData package during the `Sync` step of the build rather than during the parallel product build.

I've mirrored the Tools-Override change to https://github.com/dotnet/buildtools/pull/1434.