### PR TITLE
Change FileSystemInfo.CreationTime fall back on Unix

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/FileSystemInfo.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileSystemInfo.Unix.cs
@@ -163,16 +163,16 @@ namespace System.IO
             get
             {
                 EnsureStatInitialized();
-                return (_fileStatus.Flags & Interop.Sys.FileStatusFlags.HasBirthTime) != 0 ?
-                    DateTimeOffset.FromUnixTimeSeconds(_fileStatus.BirthTime).ToLocalTime() :
-                    default(DateTimeOffset);
+                long rawTime = (_fileStatus.Flags & Interop.Sys.FileStatusFlags.HasBirthTime) != 0 ?
+                    _fileStatus.BirthTime :
+                    Math.Min(_fileStatus.ATime, Math.Min(_fileStatus.CTime, _fileStatus.MTime)); // fall back to the oldest time we have
+                return DateTimeOffset.FromUnixTimeSeconds(rawTime).ToLocalTime();
             }
             set
             {
-                // The ctime in Unix can be interpreted differently by different formats so there isn't
-                // a reliable way to set this; however, we can't just do nothing since the FileSystemWatcher
-                // specifically looks for this call to make a Metatdata Change, so we should set the
-                // LastAccessTime of the file to cause the metadata change we need.
+                // There isn't a reliable way to set this; however, we can't just do nothing since the
+                // FileSystemWatcher specifically looks for this call to make a Metatdata Change, so we
+                // should set the LastAccessTime of the file to cause the metadata change we need.
                 LastAccessTime = LastAccessTime;
             }
         }

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetCreationTimeTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetCreationTimeTests.cs
@@ -63,12 +63,16 @@ namespace System.IO.IsolatedStorage
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
             {
+                DateTimeOffset before = DateTimeOffset.Now;
+
                 string file = "GetCreationTime_GetsTime";
                 isf.CreateTestFile(file);
 
-                // Filesystem timestamps vary in granularity, we can't make a positive assertion that
-                // the time will come before or after the current time.
-                Assert.Equal(default(DateTimeOffset).ToLocalTime(), isf.GetCreationTime(file));
+                DateTimeOffset after = DateTimeOffset.Now;
+
+                DateTimeOffset creationTime = isf.GetCreationTime(file);
+                Assert.InRange(creationTime, before.AddSeconds(-10), after.AddSeconds(10)); // +/- 10 for some wiggle room
+                Assert.Equal(creationTime, isf.GetCreationTime(file));
             }
         }
 


### PR DESCRIPTION
If birth time isn't available, CreationTime currently falls back to `default(DateTimeOffset)`.  This changes it to instead fall back to the last access (st_atime) or status change time (st_ctime), whichever is older.

cc: @ianhays, @billwert, @terrajobst, @JeremyKuhne 
Closes https://github.com/dotnet/corefx/issues/16782