### PR TITLE
Remove unresolvable directive from System.Linq.Expression.rd.xml

### DIFF
--- a/src/System.Linq.Expressions/src/Resources/System.Linq.Expressions.rd.xml
+++ b/src/System.Linq.Expressions/src/Resources/System.Linq.Expressions.rd.xml
@@ -2,7 +2,6 @@
 <Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
   <Library Name="*System.Linq.Expressions*">
     <Assembly Name="System.Linq.Expressions">
-      <Type Name="Microsoft.CSharp.RuntimeBinder.RuntimeBinderException" Dynamic="Required All" />
       <TypeInstantiation Name="System.Linq.Expressions.ExpressionCreator" Arguments="System.Func{System.Boolean}" Dynamic="Required All" />
       <TypeInstantiation Name="System.Runtime.CompilerServices.CallSite" Arguments="System.Func{System.Runtime.CompilerServices.CallSite, System.Object, System.Int32}" Dynamic="Required All" /> 
       <Type Name="System.Runtime.CompilerServices.CallSiteOps" Dynamic="Required All" />


### PR DESCRIPTION
Since System.Linq.Expressions doesn't have Microsoft.CSharp in its closure, so it should not have directives for types from it, since those directives might not be always resolvable.