### PR TITLE
System.Runtime.Tests Uap-api work...

### DIFF
--- a/src/System.Reflection/tests/AssemblyTests.cs
+++ b/src/System.Reflection/tests/AssemblyTests.cs
@@ -207,12 +207,14 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "CodeBase is not supported on UapAot")]
         public void CodeBase()
         {
             Assert.NotEmpty(Helpers.ExecutingAssembly.CodeBase);
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "ImageRuntimeVersion is not supported on UapAot.")]
         public void ImageRuntimeVersion()
         {
             Assert.NotEmpty(Helpers.ExecutingAssembly.ImageRuntimeVersion);
@@ -263,6 +265,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "GetReferencedAssemblies is not supported on UapAot.")]
         public void GetReferencedAssemblies()
         {
             // It is too brittle to depend on the assembly references so we just call the method and check that it does not throw.

--- a/src/System.Reflection/tests/ManifestResourceInfoTests.cs
+++ b/src/System.Reflection/tests/ManifestResourceInfoTests.cs
@@ -9,6 +9,7 @@ namespace System.Reflection.Tests
     public class ManifestResourceInfoTests
     {
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.GetManifestResourceInfo() not supported on UapAot")]
         public void FileName()
         {
             Assembly assembly = typeof(ManifestResourceInfoTests).GetTypeInfo().Assembly;
@@ -17,6 +18,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.GetManifestResourceInfo() not supported on UapAot")]
         public void ReferencedAssembly()
         {
             Assembly assembly = typeof(ManifestResourceInfoTests).GetTypeInfo().Assembly;
@@ -25,6 +27,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.GetManifestResourceInfo() not supported on UapAot")]
         public void ResourceLocation()
         {
             Assembly assembly = typeof(ManifestResourceInfoTests).GetTypeInfo().Assembly;

--- a/src/System.Reflection/tests/TypeInfoTests.cs
+++ b/src/System.Reflection/tests/TypeInfoTests.cs
@@ -1029,7 +1029,7 @@ namespace System.Reflection.Tests
 
         [Theory]
         [InlineData(typeof(string))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Multidim arrays of rank 1 not supported on UapAot")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Multidim arrays of rank 1 not supported on UapAot: https://github.com/dotnet/corert/issues/3331")]
         public void MakeArrayType_IntRank1(Type type)
         {
             Type arrayType = type.GetType().MakeArrayType(1);

--- a/src/System.Reflection/tests/TypeInfoTests.cs
+++ b/src/System.Reflection/tests/TypeInfoTests.cs
@@ -425,10 +425,19 @@ namespace System.Reflection.Tests
             Assert.Throws<ArgumentException>(() => typeof(NonGenericClassWithNoInterfaces).GetTypeInfo().GetEnumUnderlyingType());
         }
 
-        [Theory]
-        [InlineData(typeof(IntEnum), new IntEnum[] { (IntEnum)1, (IntEnum)2, (IntEnum)10, (IntEnum)18, (IntEnum)45 })]
-        [InlineData(typeof(UIntEnum), new UIntEnum[] { (UIntEnum)1, (UIntEnum)10 })]
-        public static void GetEnumValues(Type enumType, Array expected)
+        [Fact]
+        public static void GetEnumValues_Int()
+        {
+            GetEnumValues(typeof(IntEnum), new IntEnum[] { (IntEnum)1, (IntEnum)2, (IntEnum)10, (IntEnum)18, (IntEnum)45 });
+        }
+
+        [Fact]
+        public static void GetEnumValues_UInt()
+        {
+            GetEnumValues(typeof(UIntEnum), new UIntEnum[] { (UIntEnum)1, (UIntEnum)10 });
+        }
+
+        private static void GetEnumValues(Type enumType, Array expected)
         {
             Assert.Equal(expected, enumType.GetTypeInfo().GetEnumValues());
         }
@@ -1008,7 +1017,6 @@ namespace System.Reflection.Tests
         }
 
         [Theory]
-        [InlineData(typeof(string), 1)]
         [InlineData(typeof(int), 2)]
         [InlineData(typeof(char*), 3)]
         [InlineData(typeof(int), 3)]
@@ -1017,6 +1025,16 @@ namespace System.Reflection.Tests
             Type arrayType = type.GetType().MakeArrayType(rank);
             Assert.True(arrayType.IsArray);
             Assert.Equal(rank, arrayType.GetArrayRank());
+        }
+
+        [Theory]
+        [InlineData(typeof(string))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Multidim arrays of rank 1 not supported on UapAot")]
+        public void MakeArrayType_IntRank1(Type type)
+        {
+            Type arrayType = type.GetType().MakeArrayType(1);
+            Assert.True(arrayType.IsArray);
+            Assert.Equal(1, arrayType.GetArrayRank());
         }
 
         [Theory]


### PR DESCRIPTION
Mark the PlatformNotSupported ones as Skip.

De-theorize GetEnumValues() test to work around
https://github.com/dotnet/corert/issues/3328