### PR TITLE
Remove reflection-based lightup S.R.M for netcoreapp

### DIFF
--- a/src/System.Private.Reflection.Metadata.Ecma335/src/System.Private.Reflection.Metadata.Ecma335.csproj
+++ b/src/System.Private.Reflection.Metadata.Ecma335/src/System.Private.Reflection.Metadata.Ecma335.csproj
@@ -96,13 +96,13 @@
     <Compile Include="$(SystemReflectionMetadataPath)System\Reflection\Internal\Utilities\StringUtils.cs" />
     <Compile Include="$(SystemReflectionMetadataPath)System\Reflection\Internal\Utilities\EmptyArray.cs" />
     <Compile Include="$(SystemReflectionMetadataPath)System\Reflection\Internal\Utilities\EncodingHelper.cs" />
-    <Compile Include="$(SystemReflectionMetadataPath)System\Reflection\Internal\Utilities\FileStreamReadLightUp.cs" />
+    <Compile Include="$(SystemReflectionMetadataPath)System\Reflection\Internal\Utilities\FileStreamReadLightUp.netstandard1.1.cs" />
     <Compile Include="$(SystemReflectionMetadataPath)System\Reflection\Internal\Utilities\Hash.cs" />
     <Compile Include="$(SystemReflectionMetadataPath)System\Reflection\Internal\Utilities\ImmutableByteArrayInterop.cs" />
     <Compile Include="$(SystemReflectionMetadataPath)System\Reflection\Internal\Utilities\ImmutableMemoryStream.cs" />
     <Compile Include="$(SystemReflectionMetadataPath)System\Reflection\Internal\Utilities\LightUpHelper.cs" />
     <Compile Include="$(SystemReflectionMetadataPath)System\Reflection\Internal\Utilities\MemoryBlock.cs" />
-    <Compile Include="$(SystemReflectionMetadataPath)System\Reflection\Internal\Utilities\MemoryMapLightUp.cs" />
+    <Compile Include="$(SystemReflectionMetadataPath)System\Reflection\Internal\Utilities\MemoryMapLightUp.netstandard1.1.cs" />
     <Compile Include="$(SystemReflectionMetadataPath)System\Reflection\Internal\Utilities\PooledStringBuilder.cs" />
     <Compile Include="$(SystemReflectionMetadataPath)System\Reflection\Internal\Utilities\ObjectPool`1.cs" />
     <Compile Include="$(SystemReflectionMetadataPath)System\Reflection\Internal\Utilities\ReadOnlyUnmanagedMemoryStream.cs" />

--- a/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
+++ b/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
@@ -96,14 +96,17 @@
     <Compile Include="System\Reflection\Internal\Utilities\BitArithmetic.cs" />
     <Compile Include="System\Reflection\Internal\Utilities\StringUtils.cs" />
     <Compile Include="System\Reflection\Internal\Utilities\EmptyArray.cs" />
-    <Compile Include="System\Reflection\Internal\Utilities\EncodingHelper.cs" />
-    <Compile Include="System\Reflection\Internal\Utilities\FileStreamReadLightUp.cs" />
+    <Compile Include="System\Reflection\Internal\Utilities\EncodingHelper.cs" Condition="'$(TargetGroup)' != 'netcoreapp'" />
+    <Compile Include="System\Reflection\Internal\Utilities\EncodingHelper.netcoreapp.cs" Condition="'$(TargetGroup)' == 'netcoreapp'" />
+    <Compile Include="System\Reflection\Internal\Utilities\FileStreamReadLightUp.cs" Condition="'$(TargetGroup)' != 'netstandard1.1'" />
+    <Compile Include="System\Reflection\Internal\Utilities\FileStreamReadLightUp.netstandard1.1.cs" Condition="'$(TargetGroup)' == 'netstandard1.1'" />
     <Compile Include="System\Reflection\Internal\Utilities\Hash.cs" />
     <Compile Include="System\Reflection\Internal\Utilities\ImmutableByteArrayInterop.cs" />
     <Compile Include="System\Reflection\Internal\Utilities\ImmutableMemoryStream.cs" />
-    <Compile Include="System\Reflection\Internal\Utilities\LightUpHelper.cs" />
+    <Compile Include="System\Reflection\Internal\Utilities\LightUpHelper.cs" Condition="'$(TargetGroup)' != 'netcoreapp'" />
     <Compile Include="System\Reflection\Internal\Utilities\MemoryBlock.cs" />
-    <Compile Include="System\Reflection\Internal\Utilities\MemoryMapLightUp.cs" />
+    <Compile Include="System\Reflection\Internal\Utilities\MemoryMapLightUp.cs" Condition="'$(TargetGroup)' != 'netstandard1.1'" />
+    <Compile Include="System\Reflection\Internal\Utilities\MemoryMapLightUp.netstandard1.1.cs" Condition="'$(TargetGroup)' == 'netstandard1.1'" />
     <Compile Include="System\Reflection\Internal\Utilities\PooledStringBuilder.cs" />
     <Compile Include="System\Reflection\Internal\Utilities\ObjectPool`1.cs" />
     <Compile Include="System\Reflection\Internal\Utilities\ReadOnlyUnmanagedMemoryStream.cs" />
@@ -257,6 +260,8 @@
     <Reference Include="System.Text.Encoding" />
     <Reference Include="System.Text.Encoding.Extensions" />
     <Reference Include="System.Threading" />
+    <Reference Include="System.IO.MemoryMappedFiles" Condition="'$(TargetGroup)' != 'netstandard1.1'" />
+    <Reference Include="System.Buffers" Condition="'$(TargetGroup)' == 'netcoreapp'" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/EncodingHelper.netcoreapp.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/EncodingHelper.netcoreapp.cs
@@ -60,13 +60,6 @@ namespace System.Reflection.Internal
             return result;
         }
 
-        public static string GetString(this Encoding encoding, byte* bytes, int byteCount)
-        {
-            Debug.Assert(encoding != null);
-
-            return encoding.GetString(bytes, byteCount);
-        }
-
         // Test hook to force portable implementation and ensure light is functioning.
         internal static bool TestOnly_LightUpEnabled
         {

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/EncodingHelper.netcoreapp.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/EncodingHelper.netcoreapp.cs
@@ -1,0 +1,77 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection.Metadata;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace System.Reflection.Internal
+{
+    /// <summary>
+    /// Provides helpers to decode strings from unmanaged memory to System.String while avoiding
+    /// intermediate allocation.
+    /// </summary>
+    internal static unsafe class EncodingHelper
+    {
+        public static string DecodeUtf8(byte* bytes, int byteCount, byte[] prefix, MetadataStringDecoder utf8Decoder)
+        {
+            Debug.Assert(utf8Decoder != null);
+
+            if (prefix != null)
+            {
+                return DecodeUtf8Prefixed(bytes, byteCount, prefix, utf8Decoder);
+            }
+
+            if (byteCount == 0)
+            {
+                return String.Empty;
+            }
+
+            return utf8Decoder.GetString(bytes, byteCount);
+        }
+
+        private static string DecodeUtf8Prefixed(byte* bytes, int byteCount, byte[] prefix, MetadataStringDecoder utf8Decoder)
+        {
+            Debug.Assert(utf8Decoder != null);
+
+            int prefixedByteCount = byteCount + prefix.Length;
+
+            if (prefixedByteCount == 0)
+            {
+                return String.Empty;
+            }
+
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(prefixedByteCount);
+
+            prefix.CopyTo(buffer, 0);
+            Marshal.Copy((IntPtr)bytes, buffer, prefix.Length, byteCount);
+
+            string result;
+            fixed (byte* prefixedBytes = &buffer[0])
+            {
+                result = utf8Decoder.GetString(prefixedBytes, prefixedByteCount);
+            }
+
+            ArrayPool<byte>.Shared.Return(buffer);
+            return result;
+        }
+
+        public static string GetString(this Encoding encoding, byte* bytes, int byteCount)
+        {
+            Debug.Assert(encoding != null);
+
+            return encoding.GetString(bytes, byteCount);
+        }
+
+        // Test hook to force portable implementation and ensure light is functioning.
+        internal static bool TestOnly_LightUpEnabled
+        {
+            get { return true; }
+            set { }
+        }
+    }
+}

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.cs
@@ -11,8 +11,7 @@ namespace System.Reflection.Internal
     internal static class FileStreamReadLightUp
     {
         // internal for testing
-        internal static bool readFileCompatNotAvailable = Path.DirectorySeparatorChar != '\\'; // Available on Windows only
-        internal static bool readFileModernNotAvailable = true;
+        internal static bool readFileNotAvailable = Path.DirectorySeparatorChar != '\\'; // Available on Windows only
         internal static bool safeFileHandleNotAvailable = false;
 
         internal static bool IsFileStream(Stream stream) => stream is FileStream;
@@ -43,7 +42,7 @@ namespace System.Reflection.Internal
 
         internal static unsafe bool TryReadFile(Stream stream, byte* buffer, long start, int size)
         {
-            if (readFileCompatNotAvailable)
+            if (readFileNotAvailable)
             {
                 return false;
             }
@@ -63,7 +62,7 @@ namespace System.Reflection.Internal
             }
             catch
             {
-                readFileCompatNotAvailable = true;
+                readFileNotAvailable = true;
                 return false;
             }
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.cs
@@ -59,7 +59,7 @@ namespace System.Reflection.Internal
 
             try
             {
-                result = ReadFileCompat(handle, buffer, size, out bytesRead, IntPtr.Zero);
+                result = ReadFile(handle, buffer, size, out bytesRead, IntPtr.Zero);
             }
             catch
             {
@@ -83,7 +83,7 @@ namespace System.Reflection.Internal
 #pragma warning disable BCL0015 // Disable Pinvoke analyzer errors.
         [DllImport(@"kernel32.dll", EntryPoint = "ReadFile", ExactSpelling = true, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static unsafe extern bool ReadFileCompat(
+        internal static unsafe extern bool ReadFile(
              SafeHandle fileHandle,
              byte* buffer,
              int byteCount,

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.cs
@@ -10,68 +10,21 @@ namespace System.Reflection.Internal
 {
     internal static class FileStreamReadLightUp
     {
-        internal static Lazy<Type> FileStreamType = new Lazy<Type>(() =>
-        {
-            const string systemIOFileSystem = "System.IO.FileSystem, Version=4.0.0.0, Culture=neutral, PublicKeyToken = b03f5f7f11d50a3a";
-            const string mscorlib = "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089";
-
-            return LightUpHelper.GetType("System.IO.FileStream", systemIOFileSystem, mscorlib);
-        });
-
-        internal static Lazy<PropertyInfo> SafeFileHandle = new Lazy<PropertyInfo>(() =>
-        {
-            return FileStreamType.Value.GetTypeInfo().GetDeclaredProperty("SafeFileHandle");
-        });
-
         // internal for testing
-        internal static bool readFileCompatNotAvailable;
-        internal static bool readFileModernNotAvailable;
-        internal static bool safeFileHandleNotAvailable;
+        internal static bool readFileCompatNotAvailable = Path.DirectorySeparatorChar != '\\'; // Available on Windows only
+        internal static bool readFileModernNotAvailable = true;
+        internal static bool safeFileHandleNotAvailable = false;
 
-        internal static bool IsFileStream(Stream stream)
-        {
-            if (FileStreamType.Value == null)
-            {
-                return false;
-            }
-
-            var type = stream.GetType();
-            return type == FileStreamType.Value || type.GetTypeInfo().IsSubclassOf(FileStreamType.Value);
-        }
+        internal static bool IsFileStream(Stream stream) => stream is FileStream;
 
         internal static SafeHandle GetSafeFileHandle(Stream stream)
         {
-            Debug.Assert(FileStreamType.IsValueCreated && FileStreamType.Value != null && IsFileStream(stream));
-
-            if (safeFileHandleNotAvailable)
-            {
-                return null;
-            }
-
-            PropertyInfo safeFileHandleProperty = SafeFileHandle.Value;
-            if (safeFileHandleProperty == null)
-            {
-                safeFileHandleNotAvailable = true;
-                return null;
-            }
-
             SafeHandle handle;
             try
             {
-                handle = (SafeHandle)safeFileHandleProperty.GetValue(stream);
+                handle = ((FileStream)stream).SafeFileHandle;
             }
-            catch (MemberAccessException)
-            {
-                safeFileHandleNotAvailable = true;
-                return null;
-            }
-            catch (InvalidOperationException)
-            {
-                // thrown when accessing unapproved API in a Windows Store app
-                safeFileHandleNotAvailable = true;
-                return null;
-            }
-            catch (TargetInvocationException)
+            catch
             {
                 // Some FileStream implementations (e.g. IsolatedStorage) restrict access to the underlying handle by throwing 
                 // Tolerate it and fall back to slow path.
@@ -90,7 +43,7 @@ namespace System.Reflection.Internal
 
         internal static unsafe bool TryReadFile(Stream stream, byte* buffer, long start, int size)
         {
-            if (readFileModernNotAvailable && readFileCompatNotAvailable)
+            if (readFileCompatNotAvailable)
             {
                 return false;
             }
@@ -104,29 +57,14 @@ namespace System.Reflection.Internal
             bool result = false;
             int bytesRead = 0;
 
-            if (!readFileModernNotAvailable)
+            try
             {
-                try
-                {
-                    result = NativeMethods.ReadFileModern(handle, buffer, size, out bytesRead, IntPtr.Zero);
-                }
-                catch
-                {
-                    readFileModernNotAvailable = true;
-                }
+                result = ReadFileCompat(handle, buffer, size, out bytesRead, IntPtr.Zero);
             }
-
-            if (readFileModernNotAvailable)
+            catch
             {
-                try
-                {
-                    result = NativeMethods.ReadFileCompat(handle, buffer, size, out bytesRead, IntPtr.Zero);
-                }
-                catch
-                {
-                    readFileCompatNotAvailable = true;
-                    return false;
-                }
+                readFileCompatNotAvailable = true;
+                return false;
             }
 
             if (!result || bytesRead != size)
@@ -142,33 +80,16 @@ namespace System.Reflection.Internal
             return true;
         }
 
-
-// The library guards against unavailable entrypoints by using EntryPointNotFoundException.
-#pragma warning disable BCL0015 // Diasable Pinvoke analyzer errors.
-        private static unsafe class NativeMethods
-        {
-            // API sets available on modern platforms:
-            [DllImport(@"api-ms-win-core-file-l1-1-0.dll", EntryPoint = "ReadFile", ExactSpelling = true, SetLastError = true)]
-            [return: MarshalAs(UnmanagedType.Bool)]
-            internal static extern bool ReadFileModern(
-                 SafeHandle fileHandle,
-                 byte* buffer,
-                 int byteCount,
-                 out int bytesRead,
-                 IntPtr overlapped
-            );
-
-            // older Windows systems:
-            [DllImport(@"kernel32.dll", EntryPoint = "ReadFile", ExactSpelling = true, SetLastError = true)]
-            [return: MarshalAs(UnmanagedType.Bool)]
-            internal static extern bool ReadFileCompat(
-                 SafeHandle fileHandle,
-                 byte* buffer,
-                 int byteCount,
-                 out int bytesRead,
-                 IntPtr overlapped
-            );
-        }
+#pragma warning disable BCL0015 // Disable Pinvoke analyzer errors.
+        [DllImport(@"kernel32.dll", EntryPoint = "ReadFile", ExactSpelling = true, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static unsafe extern bool ReadFileCompat(
+             SafeHandle fileHandle,
+             byte* buffer,
+             int byteCount,
+             out int bytesRead,
+             IntPtr overlapped
+        );
 #pragma warning restore BCL0015
     }
 }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.netstandard1.1.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.netstandard1.1.cs
@@ -1,0 +1,174 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace System.Reflection.Internal
+{
+    internal static class FileStreamReadLightUp
+    {
+        internal static Lazy<Type> FileStreamType = new Lazy<Type>(() =>
+        {
+            const string systemIOFileSystem = "System.IO.FileSystem, Version=4.0.0.0, Culture=neutral, PublicKeyToken = b03f5f7f11d50a3a";
+            const string mscorlib = "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089";
+
+            return LightUpHelper.GetType("System.IO.FileStream", systemIOFileSystem, mscorlib);
+        });
+
+        internal static Lazy<PropertyInfo> SafeFileHandle = new Lazy<PropertyInfo>(() =>
+        {
+            return FileStreamType.Value.GetTypeInfo().GetDeclaredProperty("SafeFileHandle");
+        });
+
+        // internal for testing
+        internal static bool readFileCompatNotAvailable;
+        internal static bool readFileModernNotAvailable;
+        internal static bool safeFileHandleNotAvailable;
+
+        internal static bool IsFileStream(Stream stream)
+        {
+            if (FileStreamType.Value == null)
+            {
+                return false;
+            }
+
+            var type = stream.GetType();
+            return type == FileStreamType.Value || type.GetTypeInfo().IsSubclassOf(FileStreamType.Value);
+        }
+
+        internal static SafeHandle GetSafeFileHandle(Stream stream)
+        {
+            Debug.Assert(FileStreamType.IsValueCreated && FileStreamType.Value != null && IsFileStream(stream));
+
+            if (safeFileHandleNotAvailable)
+            {
+                return null;
+            }
+
+            PropertyInfo safeFileHandleProperty = SafeFileHandle.Value;
+            if (safeFileHandleProperty == null)
+            {
+                safeFileHandleNotAvailable = true;
+                return null;
+            }
+
+            SafeHandle handle;
+            try
+            {
+                handle = (SafeHandle)safeFileHandleProperty.GetValue(stream);
+            }
+            catch (MemberAccessException)
+            {
+                safeFileHandleNotAvailable = true;
+                return null;
+            }
+            catch (InvalidOperationException)
+            {
+                // thrown when accessing unapproved API in a Windows Store app
+                safeFileHandleNotAvailable = true;
+                return null;
+            }
+            catch (TargetInvocationException)
+            {
+                // Some FileStream implementations (e.g. IsolatedStorage) restrict access to the underlying handle by throwing 
+                // Tolerate it and fall back to slow path.
+                return null;
+            }
+
+            if (handle != null && handle.IsInvalid)
+            {
+                // Also allow for FileStream implementations that do return a non-null, but invalid underlying OS handle.
+                // This is how brokered files on WinRT will work. Fall back to slow path.
+                return null;
+            }
+
+            return handle;
+        }
+
+        internal static unsafe bool TryReadFile(Stream stream, byte* buffer, long start, int size)
+        {
+            if (readFileModernNotAvailable && readFileCompatNotAvailable)
+            {
+                return false;
+            }
+
+            SafeHandle handle = GetSafeFileHandle(stream);
+            if (handle == null)
+            {
+                return false;
+            }
+
+            bool result = false;
+            int bytesRead = 0;
+
+            if (!readFileModernNotAvailable)
+            {
+                try
+                {
+                    result = NativeMethods.ReadFileModern(handle, buffer, size, out bytesRead, IntPtr.Zero);
+                }
+                catch
+                {
+                    readFileModernNotAvailable = true;
+                }
+            }
+
+            if (readFileModernNotAvailable)
+            {
+                try
+                {
+                    result = NativeMethods.ReadFileCompat(handle, buffer, size, out bytesRead, IntPtr.Zero);
+                }
+                catch
+                {
+                    readFileCompatNotAvailable = true;
+                    return false;
+                }
+            }
+
+            if (!result || bytesRead != size)
+            {
+                // We used to throw here, but this is where we land if the FileStream was 
+                // opened with useAsync: true, which is currently the default on .NET Core. 
+                // Issue #987 filed to look in to how best to handle this, but in the meantime,
+                // we'll fall back to the slower code path just as in the case where the native
+                // API is unavailable in the current platform. 
+                return false;
+            }
+
+            return true;
+        }
+
+
+// The library guards against unavailable entrypoints by using EntryPointNotFoundException.
+#pragma warning disable BCL0015 // Diasable Pinvoke analyzer errors.
+        private static unsafe class NativeMethods
+        {
+            // API sets available on modern platforms:
+            [DllImport(@"api-ms-win-core-file-l1-1-0.dll", EntryPoint = "ReadFile", ExactSpelling = true, SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            internal static extern bool ReadFileModern(
+                 SafeHandle fileHandle,
+                 byte* buffer,
+                 int byteCount,
+                 out int bytesRead,
+                 IntPtr overlapped
+            );
+
+            // older Windows systems:
+            [DllImport(@"kernel32.dll", EntryPoint = "ReadFile", ExactSpelling = true, SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            internal static extern bool ReadFileCompat(
+                 SafeHandle fileHandle,
+                 byte* buffer,
+                 int byteCount,
+                 out int bytesRead,
+                 IntPtr overlapped
+            );
+        }
+#pragma warning restore BCL0015
+    }
+}

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.netstandard1.1.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.netstandard1.1.cs
@@ -105,7 +105,7 @@ namespace System.Reflection.Internal
 
             try
             {
-                result = NativeMethods.ReadFileCompat(handle, buffer, size, out bytesRead, IntPtr.Zero);
+                result = ReadFile(handle, buffer, size, out bytesRead, IntPtr.Zero);
             }
             catch
             {

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/MemoryMapLightUp.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/MemoryMapLightUp.cs
@@ -2,271 +2,49 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
 using System.IO;
-using System.Runtime.ExceptionServices;
+using System.IO.MemoryMappedFiles;
 using System.Runtime.InteropServices;
 
 namespace System.Reflection.Internal
 {
     internal static class MemoryMapLightUp
     {
-        private static Type s_lazyMemoryMappedFileType;
-        private static Type s_lazyMemoryMappedViewAccessorType;
-        private static Type s_lazyMemoryMappedFileAccessType;
-        private static Type s_lazyMemoryMappedFileSecurityType;
-        private static Type s_lazyHandleInheritabilityType;
-        private static MethodInfo s_lazyCreateFromFile;
-        private static MethodInfo s_lazyCreateFromFileClassic;
-        private static MethodInfo s_lazyCreateViewAccessor;
-        private static PropertyInfo s_lazySafeMemoryMappedViewHandle;
-        private static PropertyInfo s_lazyPointerOffset;
-        private static FieldInfo s_lazyInternalViewField;
-        private static PropertyInfo s_lazyInternalPointerOffset;
-
-        private static readonly object s_MemoryMappedFileAccess_Read = 1;
-        private static readonly object s_HandleInheritability_None = 0;
-        private static readonly object s_LongZero = (long)0;
-        private static readonly object s_True = true;
-
-        private static bool? s_lazyIsAvailable;
-
-        internal static bool IsAvailable
-        {
-            get
-            {
-                if (!s_lazyIsAvailable.HasValue)
-                {
-                    s_lazyIsAvailable = TryLoadTypes();
-                }
-
-                return s_lazyIsAvailable.Value;
-            }
-        }
-
-        private static bool TryLoadType(string typeName, string modernAssembly, string classicAssembly, out Type type)
-        {
-            type = LightUpHelper.GetType(typeName, modernAssembly, classicAssembly);
-            return type != null;
-        }
-
-        private static bool TryLoadTypes()
-        {
-            const string systemIOMemoryMappedFiles = "System.IO.MemoryMappedFiles, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a";
-            const string systemRuntimeHandles = "System.Runtime.Handles, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a";
-            const string systemCore = "System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089";
-
-            TryLoadType("System.IO.MemoryMappedFiles.MemoryMappedFileSecurity", systemIOMemoryMappedFiles, systemCore, out s_lazyMemoryMappedFileSecurityType);
-
-            return FileStreamReadLightUp.FileStreamType.Value != null
-                && TryLoadType("System.IO.MemoryMappedFiles.MemoryMappedFile", systemIOMemoryMappedFiles, systemCore, out s_lazyMemoryMappedFileType)
-                && TryLoadType("System.IO.MemoryMappedFiles.MemoryMappedViewAccessor", systemIOMemoryMappedFiles, systemCore, out s_lazyMemoryMappedViewAccessorType)
-                && TryLoadType("System.IO.MemoryMappedFiles.MemoryMappedFileAccess", systemIOMemoryMappedFiles, systemCore, out s_lazyMemoryMappedFileAccessType)
-                && TryLoadType("System.IO.HandleInheritability", systemRuntimeHandles, systemCore, out s_lazyHandleInheritabilityType)
-                && TryLoadMembers();
-        }
-
-        private static bool TryLoadMembers()
-        {
-            // .NET Core, .NET 4.6+ 
-            s_lazyCreateFromFile = LightUpHelper.GetMethod(
-                s_lazyMemoryMappedFileType,
-                "CreateFromFile",
-                FileStreamReadLightUp.FileStreamType.Value,
-                typeof(string),
-                typeof(long),
-                s_lazyMemoryMappedFileAccessType,
-                s_lazyHandleInheritabilityType,
-                typeof(bool)
-                );
-
-            // .NET < 4.6
-            if (s_lazyCreateFromFile == null)
-            {
-                if (s_lazyMemoryMappedFileSecurityType != null)
-                {
-                    s_lazyCreateFromFileClassic = LightUpHelper.GetMethod(
-                        s_lazyMemoryMappedFileType,
-                        "CreateFromFile",
-                        FileStreamReadLightUp.FileStreamType.Value,
-                        typeof(string),
-                        typeof(long),
-                        s_lazyMemoryMappedFileAccessType,
-                        s_lazyMemoryMappedFileSecurityType,
-                        s_lazyHandleInheritabilityType,
-                        typeof(bool));
-                }
-
-                if (s_lazyCreateFromFileClassic == null)
-                {
-                    return false;
-                }
-            }
-
-            s_lazyCreateViewAccessor = LightUpHelper.GetMethod(
-                s_lazyMemoryMappedFileType,
-                "CreateViewAccessor",
-                typeof(long),
-                typeof(long),
-                s_lazyMemoryMappedFileAccessType);
-
-            if (s_lazyCreateViewAccessor == null)
-            {
-                return false;
-            }
-
-            s_lazySafeMemoryMappedViewHandle = s_lazyMemoryMappedViewAccessorType.GetTypeInfo().GetDeclaredProperty("SafeMemoryMappedViewHandle");
-            if (s_lazySafeMemoryMappedViewHandle == null)
-            {
-                return false;
-            }
-
-            // .NET Core, .NET 4.5.1+
-            s_lazyPointerOffset = s_lazyMemoryMappedViewAccessorType.GetTypeInfo().GetDeclaredProperty("PointerOffset");
-
-            // .NET < 4.5.1
-            if (s_lazyPointerOffset == null)
-            {
-                s_lazyInternalViewField = s_lazyMemoryMappedViewAccessorType.GetTypeInfo().GetDeclaredField("m_view");
-                if (s_lazyInternalViewField == null)
-                {
-                    return false;
-                }
-
-                s_lazyInternalPointerOffset = s_lazyInternalViewField.FieldType.GetTypeInfo().GetDeclaredProperty("PointerOffset");
-                if (s_lazyInternalPointerOffset == null)
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
+        internal static bool IsAvailable => true;
 
         internal static IDisposable CreateMemoryMap(Stream stream)
         {
-            Debug.Assert(s_lazyIsAvailable.GetValueOrDefault());
-
-            try
-            {
-                if (s_lazyCreateFromFile != null)
-                {
-                    return (IDisposable)s_lazyCreateFromFile.Invoke(null, new object[6]
-                    {
-                        stream,                        // fileStream
-                        null,                          // mapName
-                        s_LongZero,                    // capacity
-                        s_MemoryMappedFileAccess_Read, // access
-                        s_HandleInheritability_None,   // inheritability
-                        s_True,                        // leaveOpen
-                    });
-                }
-                else
-                {
-                    Debug.Assert(s_lazyCreateFromFileClassic != null);
-                    return (IDisposable)s_lazyCreateFromFileClassic.Invoke(null, new object[7]
-                    {
-                        stream,                        // fileStream
-                        null,                          // mapName
-                        s_LongZero,                    // capacity
-                        s_MemoryMappedFileAccess_Read, // access
-                        null,                          // memoryMappedFileSecurity
-                        s_HandleInheritability_None,   // inheritability
-                        s_True,                        // leaveOpen
-                    });
-                }
-            }
-            catch (MemberAccessException)
-            {
-                s_lazyIsAvailable = false;
-                return null;
-            }
-            catch (InvalidOperationException)
-            {
-                // thrown when accessing unapproved API in a Windows Store app
-                s_lazyIsAvailable = false;
-                return null;
-            }
-            catch (TargetInvocationException ex)
-            {
-                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
-                throw;
-            }
+            return MemoryMappedFile.CreateFromFile(
+                (FileStream)stream, 
+                mapName: null,
+                capacity: 0, 
+                access: MemoryMappedFileAccess.Read, 
+                inheritability: HandleInheritability.None, 
+                leaveOpen: true);
         }
 
         internal static IDisposable CreateViewAccessor(object memoryMap, long start, int size)
         {
-            Debug.Assert(s_lazyIsAvailable.GetValueOrDefault());
             try
             {
-                return (IDisposable)s_lazyCreateViewAccessor.Invoke(memoryMap, new object[3]
-                {
-                    start,                       // start
-                    (long)size,                  // size
-                    s_MemoryMappedFileAccess_Read, // access
-                });
+                return ((MemoryMappedFile)memoryMap).CreateViewAccessor(start, size, MemoryMappedFileAccess.Read);
             }
-            catch (MemberAccessException)
+            catch (UnauthorizedAccessException e)
             {
-                s_lazyIsAvailable = false;
-                return null;
-            }
-            catch (InvalidOperationException)
-            {
-                s_lazyIsAvailable = false;
-                return null;
-            }
-            catch (TargetInvocationException ex) when (ex.InnerException is UnauthorizedAccessException)
-            {
-                throw new IOException(ex.InnerException.Message, ex.InnerException);
-            }
-            catch (TargetInvocationException ex)
-            {
-                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
-                throw;
+                throw new IOException(e.Message, e);
             }
         }
 
         internal static unsafe byte* AcquirePointer(object accessor, out SafeBuffer safeBuffer)
         {
-            Debug.Assert(s_lazyIsAvailable.GetValueOrDefault());
+            var memoryMappedViewAccessor = (MemoryMappedViewAccessor)accessor;
 
-            safeBuffer = (SafeBuffer)s_lazySafeMemoryMappedViewHandle.GetValue(accessor);
+            safeBuffer = memoryMappedViewAccessor.SafeMemoryMappedViewHandle;
 
             byte* ptr = null;
             safeBuffer.AcquirePointer(ref ptr);
 
-            try
-            {
-                long offset;
-                if (s_lazyPointerOffset != null)
-                {
-                    offset = (long)s_lazyPointerOffset.GetValue(accessor);
-                }
-                else
-                {
-                    object internalView = s_lazyInternalViewField.GetValue(accessor);
-                    offset = (long)s_lazyInternalPointerOffset.GetValue(internalView);
-                }
-
-                return ptr + offset;
-            }
-            catch (MemberAccessException)
-            {
-                s_lazyIsAvailable = false;
-                return null;
-            }
-            catch (InvalidOperationException)
-            {
-                // thrown when accessing unapproved API in a Windows Store app
-                s_lazyIsAvailable = false;
-                return null;
-            }
-            catch (TargetInvocationException ex)
-            {
-                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
-                throw;
-            }
+            return ptr + memoryMappedViewAccessor.PointerOffset;
         }
     }
 }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/MemoryMapLightUp.netstandard1.1.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/MemoryMapLightUp.netstandard1.1.cs
@@ -1,0 +1,272 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.ExceptionServices;
+using System.Runtime.InteropServices;
+
+namespace System.Reflection.Internal
+{
+    internal static class MemoryMapLightUp
+    {
+        private static Type s_lazyMemoryMappedFileType;
+        private static Type s_lazyMemoryMappedViewAccessorType;
+        private static Type s_lazyMemoryMappedFileAccessType;
+        private static Type s_lazyMemoryMappedFileSecurityType;
+        private static Type s_lazyHandleInheritabilityType;
+        private static MethodInfo s_lazyCreateFromFile;
+        private static MethodInfo s_lazyCreateFromFileClassic;
+        private static MethodInfo s_lazyCreateViewAccessor;
+        private static PropertyInfo s_lazySafeMemoryMappedViewHandle;
+        private static PropertyInfo s_lazyPointerOffset;
+        private static FieldInfo s_lazyInternalViewField;
+        private static PropertyInfo s_lazyInternalPointerOffset;
+
+        private static readonly object s_MemoryMappedFileAccess_Read = 1;
+        private static readonly object s_HandleInheritability_None = 0;
+        private static readonly object s_LongZero = (long)0;
+        private static readonly object s_True = true;
+
+        private static bool? s_lazyIsAvailable;
+
+        internal static bool IsAvailable
+        {
+            get
+            {
+                if (!s_lazyIsAvailable.HasValue)
+                {
+                    s_lazyIsAvailable = TryLoadTypes();
+                }
+
+                return s_lazyIsAvailable.Value;
+            }
+        }
+
+        private static bool TryLoadType(string typeName, string modernAssembly, string classicAssembly, out Type type)
+        {
+            type = LightUpHelper.GetType(typeName, modernAssembly, classicAssembly);
+            return type != null;
+        }
+
+        private static bool TryLoadTypes()
+        {
+            const string systemIOMemoryMappedFiles = "System.IO.MemoryMappedFiles, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a";
+            const string systemRuntimeHandles = "System.Runtime.Handles, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a";
+            const string systemCore = "System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089";
+
+            TryLoadType("System.IO.MemoryMappedFiles.MemoryMappedFileSecurity", systemIOMemoryMappedFiles, systemCore, out s_lazyMemoryMappedFileSecurityType);
+
+            return FileStreamReadLightUp.FileStreamType.Value != null
+                && TryLoadType("System.IO.MemoryMappedFiles.MemoryMappedFile", systemIOMemoryMappedFiles, systemCore, out s_lazyMemoryMappedFileType)
+                && TryLoadType("System.IO.MemoryMappedFiles.MemoryMappedViewAccessor", systemIOMemoryMappedFiles, systemCore, out s_lazyMemoryMappedViewAccessorType)
+                && TryLoadType("System.IO.MemoryMappedFiles.MemoryMappedFileAccess", systemIOMemoryMappedFiles, systemCore, out s_lazyMemoryMappedFileAccessType)
+                && TryLoadType("System.IO.HandleInheritability", systemRuntimeHandles, systemCore, out s_lazyHandleInheritabilityType)
+                && TryLoadMembers();
+        }
+
+        private static bool TryLoadMembers()
+        {
+            // .NET Core, .NET 4.6+ 
+            s_lazyCreateFromFile = LightUpHelper.GetMethod(
+                s_lazyMemoryMappedFileType,
+                "CreateFromFile",
+                FileStreamReadLightUp.FileStreamType.Value,
+                typeof(string),
+                typeof(long),
+                s_lazyMemoryMappedFileAccessType,
+                s_lazyHandleInheritabilityType,
+                typeof(bool)
+                );
+
+            // .NET < 4.6
+            if (s_lazyCreateFromFile == null)
+            {
+                if (s_lazyMemoryMappedFileSecurityType != null)
+                {
+                    s_lazyCreateFromFileClassic = LightUpHelper.GetMethod(
+                        s_lazyMemoryMappedFileType,
+                        "CreateFromFile",
+                        FileStreamReadLightUp.FileStreamType.Value,
+                        typeof(string),
+                        typeof(long),
+                        s_lazyMemoryMappedFileAccessType,
+                        s_lazyMemoryMappedFileSecurityType,
+                        s_lazyHandleInheritabilityType,
+                        typeof(bool));
+                }
+
+                if (s_lazyCreateFromFileClassic == null)
+                {
+                    return false;
+                }
+            }
+
+            s_lazyCreateViewAccessor = LightUpHelper.GetMethod(
+                s_lazyMemoryMappedFileType,
+                "CreateViewAccessor",
+                typeof(long),
+                typeof(long),
+                s_lazyMemoryMappedFileAccessType);
+
+            if (s_lazyCreateViewAccessor == null)
+            {
+                return false;
+            }
+
+            s_lazySafeMemoryMappedViewHandle = s_lazyMemoryMappedViewAccessorType.GetTypeInfo().GetDeclaredProperty("SafeMemoryMappedViewHandle");
+            if (s_lazySafeMemoryMappedViewHandle == null)
+            {
+                return false;
+            }
+
+            // .NET Core, .NET 4.5.1+
+            s_lazyPointerOffset = s_lazyMemoryMappedViewAccessorType.GetTypeInfo().GetDeclaredProperty("PointerOffset");
+
+            // .NET < 4.5.1
+            if (s_lazyPointerOffset == null)
+            {
+                s_lazyInternalViewField = s_lazyMemoryMappedViewAccessorType.GetTypeInfo().GetDeclaredField("m_view");
+                if (s_lazyInternalViewField == null)
+                {
+                    return false;
+                }
+
+                s_lazyInternalPointerOffset = s_lazyInternalViewField.FieldType.GetTypeInfo().GetDeclaredProperty("PointerOffset");
+                if (s_lazyInternalPointerOffset == null)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        internal static IDisposable CreateMemoryMap(Stream stream)
+        {
+            Debug.Assert(s_lazyIsAvailable.GetValueOrDefault());
+
+            try
+            {
+                if (s_lazyCreateFromFile != null)
+                {
+                    return (IDisposable)s_lazyCreateFromFile.Invoke(null, new object[6]
+                    {
+                        stream,                        // fileStream
+                        null,                          // mapName
+                        s_LongZero,                    // capacity
+                        s_MemoryMappedFileAccess_Read, // access
+                        s_HandleInheritability_None,   // inheritability
+                        s_True,                        // leaveOpen
+                    });
+                }
+                else
+                {
+                    Debug.Assert(s_lazyCreateFromFileClassic != null);
+                    return (IDisposable)s_lazyCreateFromFileClassic.Invoke(null, new object[7]
+                    {
+                        stream,                        // fileStream
+                        null,                          // mapName
+                        s_LongZero,                    // capacity
+                        s_MemoryMappedFileAccess_Read, // access
+                        null,                          // memoryMappedFileSecurity
+                        s_HandleInheritability_None,   // inheritability
+                        s_True,                        // leaveOpen
+                    });
+                }
+            }
+            catch (MemberAccessException)
+            {
+                s_lazyIsAvailable = false;
+                return null;
+            }
+            catch (InvalidOperationException)
+            {
+                // thrown when accessing unapproved API in a Windows Store app
+                s_lazyIsAvailable = false;
+                return null;
+            }
+            catch (TargetInvocationException ex)
+            {
+                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                throw;
+            }
+        }
+
+        internal static IDisposable CreateViewAccessor(object memoryMap, long start, int size)
+        {
+            Debug.Assert(s_lazyIsAvailable.GetValueOrDefault());
+            try
+            {
+                return (IDisposable)s_lazyCreateViewAccessor.Invoke(memoryMap, new object[3]
+                {
+                    start,                       // start
+                    (long)size,                  // size
+                    s_MemoryMappedFileAccess_Read, // access
+                });
+            }
+            catch (MemberAccessException)
+            {
+                s_lazyIsAvailable = false;
+                return null;
+            }
+            catch (InvalidOperationException)
+            {
+                s_lazyIsAvailable = false;
+                return null;
+            }
+            catch (TargetInvocationException ex) when (ex.InnerException is UnauthorizedAccessException)
+            {
+                throw new IOException(ex.InnerException.Message, ex.InnerException);
+            }
+            catch (TargetInvocationException ex)
+            {
+                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                throw;
+            }
+        }
+
+        internal static unsafe byte* AcquirePointer(object accessor, out SafeBuffer safeBuffer)
+        {
+            Debug.Assert(s_lazyIsAvailable.GetValueOrDefault());
+
+            safeBuffer = (SafeBuffer)s_lazySafeMemoryMappedViewHandle.GetValue(accessor);
+
+            byte* ptr = null;
+            safeBuffer.AcquirePointer(ref ptr);
+
+            try
+            {
+                long offset;
+                if (s_lazyPointerOffset != null)
+                {
+                    offset = (long)s_lazyPointerOffset.GetValue(accessor);
+                }
+                else
+                {
+                    object internalView = s_lazyInternalViewField.GetValue(accessor);
+                    offset = (long)s_lazyInternalPointerOffset.GetValue(internalView);
+                }
+
+                return ptr + offset;
+            }
+            catch (MemberAccessException)
+            {
+                s_lazyIsAvailable = false;
+                return null;
+            }
+            catch (InvalidOperationException)
+            {
+                // thrown when accessing unapproved API in a Windows Store app
+                s_lazyIsAvailable = false;
+                return null;
+            }
+            catch (TargetInvocationException ex)
+            {
+                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                throw;
+            }
+        }
+    }
+}

--- a/src/System.Reflection.Metadata/tests/Utilities/AbstractMemoryBlockTests.cs
+++ b/src/System.Reflection.Metadata/tests/Utilities/AbstractMemoryBlockTests.cs
@@ -118,32 +118,16 @@ namespace System.Reflection.Internal.Tests
         }
 
         [Fact]
-        public void FileStreamWin7()
-        {
-            try
-            {
-                FileStreamReadLightUp.readFileModernNotAvailable = true;
-                FileStream();
-            }
-            finally
-            {
-                FileStreamReadLightUp.readFileModernNotAvailable = false;
-            }
-        }
-
-        [Fact]
         public void FileStreamUnix()
         {
             try
             {
-                FileStreamReadLightUp.readFileModernNotAvailable = true;
-                FileStreamReadLightUp.readFileCompatNotAvailable = true;
+                FileStreamReadLightUp.readFileNotAvailable = true;
                 FileStream();
             }
             finally
             {
-                FileStreamReadLightUp.readFileModernNotAvailable = false;
-                FileStreamReadLightUp.readFileCompatNotAvailable = false;
+                FileStreamReadLightUp.readFileNotAvailable = false;
             }
         }
 


### PR DESCRIPTION
S.R.Metadata has netcoreapp specific build. We can take advantage of it to avoid reflection and trial and error (avoids exception to be thrown and swallowed in some cases). The existing logic is preserved for the netstandard builds.