### PR TITLE
Add Attribute SkipOnTargetFramework for Issue 18274.

### DIFF
--- a/src/System.Runtime.Serialization.Xml/tests/XmlDictionaryWriterTest.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/XmlDictionaryWriterTest.cs
@@ -166,6 +166,7 @@ public static class XmlDictionaryWriterTest
     }
 
     [Fact]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "is implemented on full framework")]
     public static void CreateMtomReaderWriter_Throw_PNSE()
     {
         using (var stream = new MemoryStream())


### PR DESCRIPTION
Add [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "is implemented on full framework")] for method CreateMtomReaderWriter_Throw_PNSE() in src\System.Runtime.Serialization.Xml\tests\XmlDictionaryWriterTest.cs