### PR TITLE
Loading OpenSSL from a well-known location on macOS

### DIFF
--- a/src/Native/Unix/System.Security.Cryptography.Native/CMakeLists.txt
+++ b/src/Native/Unix/System.Security.Cryptography.Native/CMakeLists.txt
@@ -81,13 +81,13 @@ if (APPLE)
     add_custom_command(TARGET System.Security.Cryptography.Native POST_BUILD
         COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib @rpath/libcrypto.1.0.0.dylib $<TARGET_FILE:System.Security.Cryptography.Native>
         COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change /usr/local/opt/openssl/lib/libssl.1.0.0.dylib @rpath/libssl.1.0.0.dylib $<TARGET_FILE:System.Security.Cryptography.Native>
-        COMMAND ${CMAKE_INSTALL_NAME_TOOL} -add_rpath @loader_path $<TARGET_FILE:System.Security.Cryptography.Native>
+        COMMAND ${CMAKE_INSTALL_NAME_TOOL} -add_rpath @loader_path -add_rpath /usr/local/lib -add_rpath /usr/local/share/dotnet/redist $<TARGET_FILE:System.Security.Cryptography.Native>
         )
 
     add_custom_command(TARGET System.Security.Cryptography.Native.OpenSsl POST_BUILD
         COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib @rpath/libcrypto.1.0.0.dylib $<TARGET_FILE:System.Security.Cryptography.Native.OpenSsl>
         COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change /usr/local/opt/openssl/lib/libssl.1.0.0.dylib @rpath/libssl.1.0.0.dylib $<TARGET_FILE:System.Security.Cryptography.Native.OpenSsl>
-        COMMAND ${CMAKE_INSTALL_NAME_TOOL} -add_rpath @loader_path $<TARGET_FILE:System.Security.Cryptography.Native.OpenSsl>
+        COMMAND ${CMAKE_INSTALL_NAME_TOOL} -add_rpath @loader_path -add_rpath /usr/local/lib -add_rpath /usr/local/share/dotnet/redist $<TARGET_FILE:System.Security.Cryptography.Native.OpenSsl>
         )
 endif()
 

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/dir.props
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/dir.props
@@ -1,0 +1,7 @@
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)\.., dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageVersion>4.3.1</PackageVersion>
+  </PropertyGroup>
+</Project>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="dir.props" />
   <PropertyGroup>
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <SkipValidatePackage>true</SkipValidatePackage>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/dir.props
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/dir.props
@@ -1,0 +1,7 @@
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)\.., dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageVersion>4.3.1</PackageVersion>
+  </PropertyGroup>
+</Project>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/runtime.native.System.Security.Cryptography.pkgproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="dir.props" />
   <PropertyGroup>
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <SkipValidatePackage>true</SkipValidatePackage>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -53,6 +53,18 @@
     </Project>
   </ItemGroup>
 
+  <ItemGroup Condition="'$(BuildAllPackages)' == 'false' AND '$(SkipNativePackageBuild)' != 'true'" >
+    <!-- add specific native builds / pkgproj's here to include in servicing builds -->
+    <Project Include="Native\pkg\runtime.native.System.Security.Cryptography\runtime.native.System.Security.Cryptography.builds">
+      <AdditionalProperties>$(AdditionalProperties);SkipCreatePackageOnMissingFiles=true</AdditionalProperties>
+      <BuildAllOSGroups>$(BuildAllOSGroups)</BuildAllOSGroups>
+    </Project>
+    <Project Include="Native\pkg\runtime.native.System.Security.Cryptography.OpenSsl\runtime.native.System.Security.Cryptography.OpenSsl.builds">
+      <AdditionalProperties>$(AdditionalProperties);SkipCreatePackageOnMissingFiles=true</AdditionalProperties>
+      <BuildAllOSGroups>$(BuildAllOSGroups)</BuildAllOSGroups>
+    </Project>
+  </ItemGroup>
+
   <UsingTask TaskName="GenerateNetStandardSupportTable" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll" />
   <Target Name="GenerateNETStandardDocs">
     <Error Condition="'$(WcfPackageReportDir)' == ''"


### PR DESCRIPTION
Allow OpenSSL to be loaded from a well-known location to allow anyone upstream to install OpenSSL to this location. This will simplify and eliminate the manual user steps necessary to run .NET Core.

/cc @Petermarcu @mhutch @bartonjs 