### PR TITLE
Add SkipOnTargetFramework for Issue 18313.

### DIFF
--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -2682,6 +2682,7 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework has an implementation and does not throw InvalidOperationException")]
     public static void XsdDataContractExporterTest()
     {
         XsdDataContractExporter exporter = new XsdDataContractExporter();


### PR DESCRIPTION
Add [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework has an implementation and does not throw InvalidOperationException")] for method XsdDataContractExporterTest() in src\System.Runtime.Serialization.Xml\tests\DataContractSerializer.cs