### PR TITLE
Remove ActiveIssue1050 from CanReadFromSameMemoryMappedPEReaderInParallel() in MetadataReaderTests.cs

### DIFF
--- a/src/System.Reflection.Metadata/tests/Metadata/MetadataReaderTests.cs
+++ b/src/System.Reflection.Metadata/tests/Metadata/MetadataReaderTests.cs
@@ -2636,7 +2636,6 @@ namespace System.Reflection.Metadata.Tests
         }
 
         [Fact]
-        [ActiveIssue(1050)]
         public void CanReadFromSameMemoryMappedPEReaderInParallel()
         {
             // See http://roslyn.codeplex.com/workitem/299


### PR DESCRIPTION
Remove ActiveIssue1050 from CanReadFromSameMemoryMappedPEReaderInParallel() in src/System.Reflection.Metadata/tests/Metadata/MetadataReaderTests.cs