### PR TITLE
Fix very long running Sockets test

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -703,9 +703,8 @@ namespace System.Net.Sockets.Tests
                     client.SendBufferSize = 0;
                     server.ReceiveBufferSize = 0;
 
-                    var sendBuffer = new byte[5000000];
+                    var sendBuffer = new byte[10000];
                     Task sendTask = SendAsync(client, new ArraySegment<byte>(sendBuffer));
-                    Assert.False(sendTask.IsCompleted);
 
                     int totalReceived = 0;
                     var receiveBuffer = new ArraySegment<byte>(new byte[4096]);


### PR DESCRIPTION
This one test is taking ~14 minutes on some Linux distros. Ugh.
cc: @danmosemsft, @steveharter, @Priya91 