### PR TITLE
Remove unnecessary pinvoke suppressions

### DIFF
--- a/src/Common/src/Interop/Windows/advapi32/Interop.ImpersonateNamedPipeClient.cs
+++ b/src/Common/src/Interop/Windows/advapi32/Interop.ImpersonateNamedPipeClient.cs
@@ -10,10 +10,8 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-#pragma warning disable BCL0015
         [DllImport(Interop.Libraries.Advapi32, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool ImpersonateNamedPipeClient(SafePipeHandle hNamedPipe);
-#pragma warning restore BCL0015
     }
 }

--- a/src/Common/src/Interop/Windows/shell32/Interop.SHGetKnownFolderPath.cs
+++ b/src/Common/src/Interop/Windows/shell32/Interop.SHGetKnownFolderPath.cs
@@ -21,15 +21,12 @@ internal partial class Interop
 
         private static bool s_skipShellFolders;
 
-// Disabling the warning about availability.
-#pragma warning disable BCL0015
         [DllImport(Libraries.Shell32, CharSet = CharSet.Unicode, SetLastError = false, BestFitMapping = false, ExactSpelling = true, EntryPoint = "SHGetKnownFolderPath")]
         private static extern int SHGetKnownFolderPath_Shell32(
             [MarshalAs(UnmanagedType.LPStruct)] Guid rfid,
             uint dwFlags,
             IntPtr hToken,
             out string ppszPath);
-#pragma warning restore BCL0015
 
         internal static int SHGetKnownFolderPath(
             Guid rfid,

--- a/src/System.IO.Pipes/src/PinvokeAnalyzerExceptionList.analyzerdata
+++ b/src/System.IO.Pipes/src/PinvokeAnalyzerExceptionList.analyzerdata
@@ -1,3 +1,4 @@
+advapi32.dll!ImpersonateNamedPipeClient
 advapi32.dll!RevertToSelf
 kernel32.dll!ConnectNamedPipe
 kernel32.dll!CreateFileW


### PR DESCRIPTION
The Pipes one should never have been suppressed, and means I have a new WACK ask.

The Shell32 one I do not understand .. both have the same entrypoint in the same module. @stephentoub ?  However, removing the suppression does not cause any violations.