### PR TITLE
Fix zero-length async receives on macOS

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -575,13 +575,39 @@ namespace System.Net.Sockets
             {
                 Interop.Error errno;
                 int received;
+
                 if (buffers != null)
                 {
+                    // Receive into a set of buffers
                     Debug.Assert(buffer == null);
                     received = Receive(socket, flags, buffers, socketAddress, ref socketAddressLen, out receivedFlags, out errno);
                 }
+                else if (count == 0)
+                {
+                    // Special case a receive of 0 bytes into a single buffer.  A common pattern is to ReceiveAsync 0 bytes in order
+                    // to be asynchronously notified when data is available, without needing to dedicate a buffer.  Some platforms (e.g. macOS),
+                    // however, special-case a receive of 0 to always succeed immediately even if data isn't available.  As such, we treat 0
+                    // specially, checking whether any bytes are available rather than doing an actual receive.
+                    receivedFlags = SocketFlags.None;
+                    received = -1;
+
+                    int available = 0;
+                    errno = Interop.Sys.GetBytesAvailable(socket, &available);
+                    if (errno == Interop.Error.SUCCESS)
+                    {
+                        if (available > 0)
+                        {
+                            bytesReceived = 0;
+                            errorCode = SocketError.Success;
+                            return true;
+                        }
+
+                        errno = Interop.Error.EAGAIN; // simulate a receive with no data available
+                    }
+                }
                 else
                 {
+                    // Receive > 0 bytes into a single buffer
                     received = Receive(socket, flags, buffer, offset, count, socketAddress, ref socketAddressLen, out receivedFlags, out errno);
                 }
 

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -605,7 +605,6 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [ActiveIssue(13778, TestPlatforms.OSX)]
         [Fact]
         public async Task SendRecv_0ByteReceive_Success()
         {
@@ -635,7 +634,7 @@ namespace System.Net.Sockets.Tests
 
                         // The client should now wake up, getting 0 bytes with 1 byte available.
                         Assert.Equal(0, await receive);
-                        Assert.Equal(1, client.Available); // Due to #13778, this sometimes fails on macOS
+                        Assert.Equal(1, client.Available);
 
                         // Receive that byte
                         Assert.Equal(1, await ReceiveAsync(client, new ArraySegment<byte>(new byte[1])));

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -636,7 +636,11 @@ namespace System.Net.Sockets.Tests
                         Assert.Equal(0, await receive);
                         Assert.Equal(1, client.Available);
 
-                        // Receive that byte
+                        // We should be able to do another 0-byte receive that completes immediateliy
+                        Assert.Equal(0, await ReceiveAsync(client, new ArraySegment<byte>(new byte[1], 0, 0)));
+                        Assert.Equal(1, client.Available);
+
+                        // Then receive the byte
                         Assert.Equal(1, await ReceiveAsync(client, new ArraySegment<byte>(new byte[1])));
                         Assert.Equal(0, client.Available);
                     }


### PR DESCRIPTION
macOS appears to special-case a zero-length non-blocking receive call to complete successfully immediately even if there's no data available.  This breaks a commonly used pattern that works on both Windows and Linux of using a zero-length ReceiveAsync to be asynchronously notified of data being available.  As a fix, we special-case a zero-length ReceiveAsync to check whether any data is available as a stand-in for a receive, simulating EAGAIN if no data is currently available.

Fixes https://github.com/dotnet/corefx/issues/13778
cc: @geoffkizer, @steveharter, @Priya91 