### PR TITLE
Reduce XmlSchemaTests from ~3 minutes to ~3 seconds

### DIFF
--- a/src/System.Private.Xml/src/System/Xml/Schema/ContentValidator.cs
+++ b/src/System.Private.Xml/src/System/Xml/Schema/ContentValidator.cs
@@ -1287,9 +1287,12 @@ namespace System.Xml.Schema
             }
 
 #if DEBUG
-            StringBuilder bb = new StringBuilder();
-            _contentNode.Dump(bb, _symbols, _positions);
-            Debug.WriteLineIf(DiagnosticsSwitches.XmlSchemaContentModel.Enabled, "\t\t\tContent :   " + bb.ToString());
+            if (DiagnosticsSwitches.XmlSchemaContentModel.Enabled)
+            {
+                var bb = new StringBuilder();
+                _contentNode.Dump(bb, _symbols, _positions);
+                Debug.WriteLine("\t\t\tContent :   " + bb.ToString());
+            }
 #endif
 
             // Add end marker
@@ -1302,9 +1305,12 @@ namespace System.Xml.Schema
             _contentNode.ExpandTree(contentRoot, _symbols, _positions);
 
 #if DEBUG
-            bb = new StringBuilder();
-            contentRoot.LeftChild.Dump(bb, _symbols, _positions);
-            Debug.WriteLineIf(DiagnosticsSwitches.XmlSchemaContentModel.Enabled, "\t\t\tExpended:   " + bb.ToString());
+            if (DiagnosticsSwitches.XmlSchemaContentModel.Enabled)
+            {
+                var bb = new StringBuilder();
+                contentRoot.LeftChild.Dump(bb, _symbols, _positions);
+                Debug.WriteLine("\t\t\tExpended:   " + bb.ToString());
+            }
 #endif
 
             // calculate followpos
@@ -1319,8 +1325,11 @@ namespace System.Xml.Schema
             }
             contentRoot.ConstructPos(firstpos, lastpos, followpos);
 #if DEBUG
-            Debug.WriteLineIf(DiagnosticsSwitches.XmlSchemaContentModel.Enabled, "firstpos, lastpos, followpos");
-            SequenceNode.WritePos(firstpos, lastpos, followpos);
+            if (DiagnosticsSwitches.XmlSchemaContentModel.Enabled)
+            {
+                Debug.WriteLine("firstpos, lastpos, followpos");
+                SequenceNode.WritePos(firstpos, lastpos, followpos);
+            }
 #endif
             if (_minMaxNodesCount > 0)
             { //If the tree has any terminal range nodes
@@ -1355,9 +1364,12 @@ namespace System.Xml.Schema
                     transitionTable = BuildTransitionTable(firstpos, followpos, endMarker.Pos);
                 }
 #if DEBUG
-                bb = new StringBuilder();
-                Dump(bb, followpos, transitionTable);
-                Debug.WriteLineIf(DiagnosticsSwitches.XmlSchemaContentModel.Enabled, bb.ToString());
+                if (DiagnosticsSwitches.XmlSchemaContentModel.Enabled)
+                {
+                    var bb = new StringBuilder();
+                    Dump(bb, followpos, transitionTable);
+                    Debug.WriteLine(bb.ToString());
+                }
 #endif
                 if (transitionTable != null)
                 {

--- a/src/System.Private.Xml/src/System/Xml/Schema/SchemaCollectionCompiler.cs
+++ b/src/System.Private.Xml/src/System/Xml/Schema/SchemaCollectionCompiler.cs
@@ -2465,8 +2465,11 @@ namespace System.Xml.Schema
             {
                 ParticleContentValidator contentValidator = new ParticleContentValidator(complexType.ContentType);
 #if DEBUG
-                string name = complexType.Name != null ? complexType.Name : string.Empty;
-                Debug.WriteLineIf(DiagnosticsSwitches.XmlSchema.TraceVerbose, "CompileComplexContent: " + name + DumpContentModel(particle));
+                if (DiagnosticsSwitches.XmlSchema.TraceVerbose)
+                {
+                    string name = complexType.Name != null ? complexType.Name : string.Empty;
+                    Debug.WriteLine("CompileComplexContent: " + name + DumpContentModel(particle));
+                }
 #endif
                 try
                 {

--- a/src/System.Private.Xml/src/System/Xml/Schema/SchemaSetCompiler.cs
+++ b/src/System.Private.Xml/src/System/Xml/Schema/SchemaSetCompiler.cs
@@ -2902,8 +2902,11 @@ namespace System.Xml.Schema
             {
                 ParticleContentValidator contentValidator = new ParticleContentValidator(complexType.ContentType, CompilationSettings.EnableUpaCheck);
 #if DEBUG
-                string name = complexType.Name != null ? complexType.Name : string.Empty;
-                Debug.WriteLineIf(DiagnosticsSwitches.XmlSchema.TraceVerbose, "CompileComplexContent: " + name + DumpContentModel(particle));
+                if (DiagnosticsSwitches.XmlSchema.TraceVerbose)
+                {
+                    string name = complexType.Name != null ? complexType.Name : string.Empty;
+                    Debug.WriteLine("CompileComplexContent: " + name + DumpContentModel(particle));
+                }
 #endif
                 try
                 {

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Add_URL.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Add_URL.cs
@@ -377,8 +377,7 @@ namespace System.Xml.Tests
 
         [OuterLoop]
         [Theory]
-        [InlineData(5000, "5000s.xsd")]
-        [InlineData(10000, "10000s.xsd")]
+        [InlineData(1000, "1000s.xsd")]
         //[Variation(Desc = "Bug 298991 XMLSchemaSet.Compile cause StackOverflow - Sequence, 5000", Params = new object[] { 5000, "5000s.xsd" })]
         //[Variation(Desc = "Bug 298991 XMLSchemaSet.Compile cause StackOverflow - Sequence, 10000", Params = new object[] { 10000, "10000s.xsd" })]
         public void bug298991Sequence(int size, string xsdFileName)


### PR DESCRIPTION
The System.Xml schema tests are currently taking ~3 minutes in CI, making it one of the longest running test suites by far in corefx.  This is due to:
- Tests doing a lot of `Dump`ing of state even when the relevant trace sources are not enabled, and
- One test that has a huge input that's causing a ton of time to be spent in BitSet.Or

This change addresses that by:
- putting the relevant `Dump`ing behind the same trace sources, and
- reducing the input sizes to the offending test

This reduces the running time of the test suite from ~3 minutes to ~3 seconds.

cc: @krwq, @sepidehMS