### PR TITLE
Retry ping when the output was not in expected syntax.

### DIFF
--- a/src/System.Net.Ping/tests/FunctionalTests/UnixPingUtilityTests.cs
+++ b/src/System.Net.Ping/tests/FunctionalTests/UnixPingUtilityTests.cs
@@ -36,9 +36,9 @@ namespace System.Net.NetworkInformation.Tests
             psi.RedirectStandardError = true;
             psi.RedirectStandardOutput = true;
             Process p = Process.Start(psi);
-            Assert.True(p.WaitForExit(TestSettings.PingTimeout), "Ping process did not exit in " + TestSettings.PingTimeout + " ms.");
 
             string pingOutput = p.StandardOutput.ReadToEnd();
+            Assert.True(p.WaitForExit(TestSettings.PingTimeout), "Ping process did not exit in " + TestSettings.PingTimeout + " ms.");
 
             try
             {


### PR DESCRIPTION
Add retry to ping, when the expected syntax is not got from ping6 output. This behavior is observed from OSX 10.12 update, not sure why the ping6 output sometimes doens't have the full text.

In relation to issue #18125 

cc @danmosemsft 