### PR TITLE
Fix runtime desktop failure in Cryptography tests

### DIFF
--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTests.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTests.cs
@@ -517,6 +517,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
             Assert.True(ecdsa.VerifyData(halfData, dataSignature, HashAlgorithmName.SHA256));
         }
 
+#if netcoreapp // uses ECParameters not available in desktop.
         [Fact]
         public void PublicKey_CannotSign()
         {
@@ -530,6 +531,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
                     () => ecdsa.SignData(new byte[] { 1, 2, 3, 4, 5 }, HashAlgorithmName.SHA256));
             }
         }
+#endif
 
         //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
`ECDsaTest.PublicKey_CannotSign` uses ECParameters which is not available for Desktop until 4.7 so I wrapped it up under #if netcoreapp to stop having this failure. 

Fixes #18198 

cc: @bartonjs @danmosemsft 