### PR TITLE
Fix tests to test difference in behavior correctly in ProcessStartInfo

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -234,7 +234,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [PlatformSpecific(TestPlatforms.Windows)] // UseShellExecute currently not supported on Windows
+        [PlatformSpecific(TestPlatforms.Windows)] // UseShellExecute currently not supported on Windows on .NET Core
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Desktop UseShellExecute is set to true by default but UseShellExecute=true is not supported on Core")]
         public void UseShellExecute_GetSetWindows_Success_Netcore()
@@ -250,7 +250,7 @@ namespace System.Diagnostics.Tests
             Assert.False(psi.UseShellExecute, "UseShellExecute=true is not supported on onecore.");
         }
 
-        [PlatformSpecific(TestPlatforms.Windows)] // UseShellExecute currently not supported on Windows
+        [PlatformSpecific(TestPlatforms.Windows)]
         [Fact]
         [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "Desktop UseShellExecute is set to true by default but UseShellExecute=true is not supported on Core")]
         public void UseShellExecute_GetSetWindows_Success_Netfx()

--- a/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -236,7 +236,8 @@ namespace System.Diagnostics.Tests
 
         [PlatformSpecific(TestPlatforms.Windows)] // UseShellExecute currently not supported on Windows
         [Fact]
-        public void UseShellExecute_GetSetWindows_Success()
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Desktop UseShellExecute is set to true by default but UseShellExecute=true is not supported on Core")]
+        public void UseShellExecute_GetSetWindows_Success_Netcore()
         {
             ProcessStartInfo psi = new ProcessStartInfo();
             Assert.False(psi.UseShellExecute);
@@ -247,6 +248,21 @@ namespace System.Diagnostics.Tests
 
             // Calling the getter
             Assert.False(psi.UseShellExecute, "UseShellExecute=true is not supported on onecore.");
+        }
+
+        [PlatformSpecific(TestPlatforms.Windows)] // UseShellExecute currently not supported on Windows
+        [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "Desktop UseShellExecute is set to true by default but UseShellExecute=true is not supported on Core")]
+        public void UseShellExecute_GetSetWindows_Success_Netfx()
+        {
+            ProcessStartInfo psi = new ProcessStartInfo();
+            Assert.True(psi.UseShellExecute);
+
+            psi.UseShellExecute = false;
+            Assert.False(psi.UseShellExecute);
+
+            psi.UseShellExecute = true;
+            Assert.True(psi.UseShellExecute);
         }
 
         [PlatformSpecific(TestPlatforms.AnyUnix)] // UseShellExecute currently not supported on Windows


### PR DESCRIPTION
While investigating an exception thrown in the tests I found that this test was failing because of a difference in behavior by design in between .NET Core and Desktop so I added the test for desktop and skipped on desktop the .NET Core specific.

cc: @stephentoub @Priya91 