### PR TITLE
Remove dead code from S.L.Expressions

### DIFF
--- a/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
+++ b/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
@@ -65,9 +65,6 @@
     </Compile>
     <Compile Include="System\Dynamic\Utils\CacheDict.cs" />
     <Compile Include="System\Dynamic\Utils\ContractUtils.cs" />
-    <Compile Include="$(CommonPath)\System\NotImplemented.cs">
-      <Link>Common\System\NotImplemented.cs</Link>
-    </Compile>
     <Compile Include="System\Dynamic\Utils\ExpressionUtils.cs" />
     <Compile Include="System\Dynamic\Utils\ExpressionVisitorUtils.cs" />
     <Compile Include="System\Dynamic\Utils\ListArgumentProvider.cs" />

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/AnalyzedTree.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/AnalyzedTree.cs
@@ -10,10 +10,5 @@ namespace System.Linq.Expressions.Compiler
     {
         internal readonly Dictionary<object, CompilerScope> Scopes = new Dictionary<object, CompilerScope>();
         internal readonly Dictionary<LambdaExpression, BoundConstants> Constants = new Dictionary<LambdaExpression, BoundConstants>();
-
-        // Created by VariableBinder
-        internal AnalyzedTree()
-        {
-        }
     }
 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/DynamicExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/DynamicExpression.cs
@@ -818,7 +818,7 @@ namespace System.Linq.Expressions
 
     #endregion
 
-    internal class ExpressionExtension
+    internal static class ExpressionExtension
     {
         /// <summary>
         /// Creates a <see cref="DynamicExpression" /> that represents a dynamic operation bound by the provided <see cref="CallSiteBinder" />.

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ArrayOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ArrayOperations.cs
@@ -149,7 +149,7 @@ namespace System.Linq.Expressions.Interpreter
         }
     }
 
-    internal sealed class ConvertHelper
+    internal static class ConvertHelper
     {
         public static int ToInt32NoNull(object val)
         {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/BranchLabel.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/BranchLabel.cs
@@ -40,8 +40,6 @@ namespace System.Linq.Expressions.Interpreter
         // that need to be updated after we emit the label.
         private List<int> _forwardBranchFixups;
 
-        public BranchLabel() { }
-
         internal int LabelIndex { get; set; } = UnknownIndex;
         internal bool HasRuntimeLabel => LabelIndex != UnknownIndex;
         internal int TargetIndex => _targetIndex;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
@@ -16,8 +16,6 @@ namespace System.Linq.Expressions.Interpreter
 
         #region Construction
 
-        internal CallInstruction() { }
-
         public override string InstructionName => "Call";
 
 #if FEATURE_DLG_INVOKE

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
@@ -62,8 +62,6 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-        internal BranchFalseInstruction() { }
-
         public override string InstructionName => "BranchFalse";
         public override int ConsumedStack => 1;
 
@@ -96,8 +94,6 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-        internal BranchTrueInstruction() { }
-
         public override string InstructionName => "BranchTrue";
         public override int ConsumedStack => 1;
 
@@ -129,8 +125,6 @@ namespace System.Linq.Expressions.Interpreter
                 return s_cache;
             }
         }
-
-        internal CoalescingBranchInstruction() { }
 
         public override string InstructionName => "CoalescingBranch";
         public override int ConsumedStack => 1;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
@@ -821,19 +821,9 @@ namespace System.Linq.Expressions.Interpreter
             Emit(new DefaultValueInstruction(type));
         }
 
-        public void EmitNew(ConstructorInfo constructorInfo)
-        {
-            EmitNew(constructorInfo, constructorInfo.GetParametersCached());
-        }
-
         public void EmitNew(ConstructorInfo constructorInfo, ParameterInfo[] parameters)
         {
             Emit(new NewInstruction(constructorInfo, parameters.Length));
-        }
-
-        public void EmitByRefNew(ConstructorInfo constructorInfo, ByRefUpdater[] updaters)
-        {
-            EmitByRefNew(constructorInfo, constructorInfo.GetParametersCached(), updaters);
         }
 
         public void EmitByRefNew(ConstructorInfo constructorInfo, ParameterInfo[] parameters, ByRefUpdater[] updaters)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalAccess.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalAccess.cs
@@ -219,8 +219,6 @@ namespace System.Linq.Expressions.Interpreter
     {
         public static readonly ValueTypeCopyInstruction Instruction = new ValueTypeCopyInstruction();
 
-        public ValueTypeCopyInstruction() { }
-
         public override int ConsumedStack => 1;
         public override int ProducedStack => 1;
         public override string InstructionName => "ValueTypeCopy";

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
@@ -180,12 +180,7 @@ namespace System.Linq.Expressions.Interpreter
     {
         private KeyValuePair<TKey, TValue>[] _keysAndValues;
         private Dictionary<TKey, TValue> _dict;
-        private int _count;
         private const int ArraySize = 10;
-
-        public HybridReferenceDictionary()
-        {
-        }
 
         public bool TryGetValue(TKey key, out TValue value)
         {
@@ -210,13 +205,13 @@ namespace System.Linq.Expressions.Interpreter
             return false;
         }
 
-        public bool Remove(TKey key)
+        public void Remove(TKey key)
         {
             Debug.Assert(key != null);
 
             if (_dict != null)
             {
-                return _dict.Remove(key);
+                _dict.Remove(key);
             }
             else if (_keysAndValues != null)
             {
@@ -225,13 +220,10 @@ namespace System.Linq.Expressions.Interpreter
                     if (_keysAndValues[i].Key == key)
                     {
                         _keysAndValues[i] = new KeyValuePair<TKey, TValue>();
-                        _count--;
-                        return true;
+                        return;
                     }
                 }
             }
-
-            return false;
         }
 
         public bool ContainsKey(TKey key)
@@ -242,11 +234,13 @@ namespace System.Linq.Expressions.Interpreter
             {
                 return _dict.ContainsKey(key);
             }
-            else if (_keysAndValues != null)
+
+            KeyValuePair<TKey, TValue>[] keysAndValues = _keysAndValues;
+            if (keysAndValues != null)
             {
-                for (int i = 0; i < _keysAndValues.Length; i++)
+                for (int i = 0; i < keysAndValues.Length; i++)
                 {
-                    if (_keysAndValues[i].Key == key)
+                    if (keysAndValues[i].Key == key)
                     {
                         return true;
                     }
@@ -254,18 +248,6 @@ namespace System.Linq.Expressions.Interpreter
             }
 
             return false;
-        }
-
-        public int Count
-        {
-            get
-            {
-                if (_dict != null)
-                {
-                    return _dict.Count;
-                }
-                return _count;
-            }
         }
 
         public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
@@ -341,7 +323,6 @@ namespace System.Linq.Expressions.Interpreter
 
                     if (index != -1)
                     {
-                        _count++;
                         _keysAndValues[index] = new KeyValuePair<TKey, TValue>(key, value);
                     }
                     else


### PR DESCRIPTION
Either truly dead, or default constructors with default access and no XML comment and so same as compiler will produce.

After this the only code in this project mentioned at #17905 is either from common files and used elsewhere, constants that are used, or perhaps will be brought into use with CompileToMethod and/or PDB generation.