### PR TITLE
Fix CopyTo<T>(this T[] array, Span<T> destination) for covariant arrays

### DIFF
--- a/src/System.Memory/src/System/SpanExtensions.cs
+++ b/src/System.Memory/src/System/SpanExtensions.cs
@@ -293,7 +293,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void CopyTo<T>(this T[] array, Span<T> destination)
         {
-            array.AsSpan().CopyTo(destination);
+            new ReadOnlySpan<T>(array).CopyTo(destination);
         }
     }
 }

--- a/src/System.Memory/tests/Span/CopyTo.cs
+++ b/src/System.Memory/tests/Span/CopyTo.cs
@@ -182,6 +182,15 @@ namespace System.SpanTests
             Assert.Equal<int>(expected, dst);  // CopyTo() checks for sufficient space before doing any copying.
         }
 
+        [Fact]
+        public static void CopyToCovariantArray()
+        {
+            string[] src = new string[] { "Hello" };
+            object[] dst = new object[] { "world" };
+
+            src.CopyTo<object>(dst);
+            Assert.Equal("Hello", dst[0]);
+        }
 
         // This test case tests the Span.CopyTo method for large buffers of size 4GB or more. In the fast path,
         // the CopyTo method performs copy in chunks of size 4GB (uint.MaxValue) with final iteration copying


### PR DESCRIPTION
CopyTo was creating writeable Span where it should have been only creating readonly Span.

It made it slower than necessary for reference types because of the covariance check in writeable Span constructor, and also made it fail for no good reason on covariant arrays.