### PR TITLE
Reduce System.Collections.Tests running time from ~30s to ~8s

### DIFF
--- a/src/Common/tests/System/Collections/ISet.Generic.Tests.cs
+++ b/src/Common/tests/System/Collections/ISet.Generic.Tests.cs
@@ -54,7 +54,7 @@ namespace System.Collections.Tests
             }
         }
 
-        protected virtual int ISet_Large_Capacity => 4000;
+        protected virtual int ISet_Large_Capacity => 1000;
 
         #endregion
 
@@ -492,7 +492,7 @@ namespace System.Collections.Tests
 
         #endregion
 
-        #region Set Function tests on a very large Set
+        #region Set Function tests on a large Set
 
         [Fact]
         [OuterLoop]


### PR DESCRIPTION
Just lowered the set capacity for some of the tests from 4000 to 1000.
cc: @ianhays 