### PR TITLE
Fix FileVersionInfo on Unix for non-regular files

### DIFF
--- a/src/System.Diagnostics.FileVersionInfo/src/Resources/Strings.resx
+++ b/src/System.Diagnostics.FileVersionInfo/src/Resources/Strings.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="IO_FileNotFound_FileName" xml:space="preserve">
+    <value>Could not find file '{0}'.</value>
+  </data>
+</root>

--- a/src/System.Diagnostics.FileVersionInfo/src/System.Diagnostics.FileVersionInfo.csproj
+++ b/src/System.Diagnostics.FileVersionInfo/src/System.Diagnostics.FileVersionInfo.csproj
@@ -44,12 +44,22 @@
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' == 'true' And '$(TargetGroup)' == 'netcoreapp'">
-    <Compile Include="System\Diagnostics\FileVersionInfo.Metadata.cs" />
+    <Compile Include="System\Diagnostics\FileVersionInfo.Unix.cs" />
+    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+      <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Errors.cs">
+      <Link>Common\Interop\Unix\Interop.Errors.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Stat.cs">
+      <Link>Common\Interop\Unix\Interop.Stat.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Diagnostics.Tools" />
     <Reference Include="System.Globalization" />
     <Reference Include="System.IO.FileSystem" />
+    <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.InteropServices" />
   </ItemGroup>

--- a/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/Configurations.props
+++ b/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/Configurations.props
@@ -2,7 +2,8 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
-      netstandard;
+      netstandard-Windows_NT;
+      netstandard-Unix;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/FileVersionInfoTest.Unix.cs
+++ b/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/FileVersionInfoTest.Unix.cs
@@ -1,0 +1,84 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace System.Diagnostics.Tests
+{
+    public partial class FileVersionInfoTest
+    {
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        [Fact]
+        public void NonRegularFile_Throws()
+        {
+            string pipePath = GetTestFilePath();
+            Assert.Equal(0, mkfifo(pipePath, 0));
+            Assert.Throws<FileNotFoundException>(() => FileVersionInfo.GetVersionInfo(pipePath));
+        }
+
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        [Fact]
+        public void Symlink_ValidFile_Succeeds()
+        {
+            string filePath = Path.Combine(Directory.GetCurrentDirectory(), TestAssemblyFileName);
+            string linkPath = GetTestFilePath();
+
+            Assert.Equal(0, symlink(filePath, linkPath));
+
+            // Assembly1.dll
+            VerifyVersionInfo(linkPath, new MyFVI()
+            {
+                Comments = "Have you played a Contoso amusement device today?",
+                CompanyName = "The name of the company.",
+                FileBuildPart = 2,
+                FileDescription = "My File",
+                FileMajorPart = 4,
+                FileMinorPart = 3,
+                FileName = linkPath,
+                FilePrivatePart = 1,
+                FileVersion = "4.3.2.1",
+                InternalName = Path.GetFileName(linkPath),
+                IsDebug = false,
+                IsPatched = false,
+                IsPrivateBuild = false,
+                IsPreRelease = false,
+                IsSpecialBuild = false,
+                Language = GetFileVersionLanguage(0x0000),
+                Language2 = null,
+                LegalCopyright = "Copyright, you betcha!",
+                LegalTrademarks = "TM",
+                OriginalFilename = Path.GetFileName(linkPath),
+                PrivateBuild = "",
+                ProductBuildPart = 3,
+                ProductMajorPart = 1,
+                ProductMinorPart = 2,
+                ProductName = "The greatest product EVER",
+                ProductPrivatePart = 0,
+                ProductVersion = "1.2.3-beta.4",
+                SpecialBuild = "",
+            });
+        }
+
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        [Fact]
+        public void Symlink_InvalidFile_Throws()
+        {
+            string filePath = Path.Combine(Directory.GetCurrentDirectory(), TestAssemblyFileName);
+            string linkPath = GetTestFilePath();
+            Assert.Equal(0, symlink(filePath, linkPath));
+            File.Delete(filePath);
+            Assert.Throws<FileNotFoundException>(() => FileVersionInfo.GetVersionInfo(linkPath));
+        }
+
+        private static string GetFileVersionLanguage(uint langid) => "Language Neutral";
+
+        [DllImport("libc", SetLastError = true)]
+        private static extern int mkfifo(string path, int mode);
+
+        [DllImport("libc", SetLastError = true)]
+        private static extern int symlink(string target, string linkpath);
+    }
+}

--- a/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/FileVersionInfoTest.Windows.cs
+++ b/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/FileVersionInfoTest.Windows.cs
@@ -1,0 +1,137 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using Xunit;
+
+namespace System.Diagnostics.Tests
+{
+    public partial class FileVersionInfoTest
+    {
+        private const string NativeConsoleAppFileName = "NativeConsoleApp.exe";
+        private const string NativeLibraryFileName = "NativeLibrary.dll";
+        private const string SecondNativeLibraryFileName = "SecondNativeLibrary.dll";
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)] // native PE files only supported on Windows
+        public void FileVersionInfo_Normal()
+        {
+            // NativeConsoleApp (English)
+            VerifyVersionInfo(Path.Combine(Directory.GetCurrentDirectory(), NativeConsoleAppFileName), new MyFVI()
+            {
+                Comments = "",
+                CompanyName = "Microsoft Corporation",
+                FileBuildPart = 3,
+                FileDescription = "This is the description for the native console application.",
+                FileMajorPart = 5,
+                FileMinorPart = 4,
+                FileName = Path.Combine(Directory.GetCurrentDirectory(), NativeConsoleAppFileName),
+                FilePrivatePart = 2,
+                FileVersion = "5.4.3.2",
+                InternalName = NativeConsoleAppFileName,
+                IsDebug = false,
+                IsPatched = false,
+                IsPrivateBuild = false,
+                IsPreRelease = true,
+                IsSpecialBuild = true,
+                Language = GetFileVersionLanguage(0x0409), //English (United States)
+                LegalCopyright = "Copyright (C) 2050",
+                LegalTrademarks = "",
+                OriginalFilename = NativeConsoleAppFileName,
+                PrivateBuild = "",
+                ProductBuildPart = 3,
+                ProductMajorPart = 5,
+                ProductMinorPart = 4,
+                ProductName = Path.GetFileNameWithoutExtension(NativeConsoleAppFileName),
+                ProductPrivatePart = 2,
+                ProductVersion = "5.4.3.2",
+                SpecialBuild = ""
+            });
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)] // native PE files only supported on Windows
+        public void FileVersionInfo_Chinese()
+        {
+            // NativeLibrary.dll (Chinese)
+            VerifyVersionInfo(Path.Combine(Directory.GetCurrentDirectory(), NativeLibraryFileName), new MyFVI()
+            {
+                Comments = "",
+                CompanyName = "A non-existent company",
+                FileBuildPart = 3,
+                FileDescription = "Here is the description of the native library.",
+                FileMajorPart = 9,
+                FileMinorPart = 9,
+                FileName = Path.Combine(Directory.GetCurrentDirectory(), NativeLibraryFileName),
+                FilePrivatePart = 3,
+                FileVersion = "9.9.3.3",
+                InternalName = "NativeLibrary.dll",
+                IsDebug = false,
+                IsPatched = true,
+                IsPrivateBuild = false,
+                IsPreRelease = true,
+                IsSpecialBuild = false,
+                Language = GetFileVersionLanguage(0x0004),//Chinese (Simplified)
+                Language2 = GetFileVersionLanguage(0x0804),//Chinese (Simplified, PRC) - changed, but not yet on all platforms
+                LegalCopyright = "None",
+                LegalTrademarks = "",
+                OriginalFilename = "NativeLibrary.dll",
+                PrivateBuild = "",
+                ProductBuildPart = 40,
+                ProductMajorPart = 20,
+                ProductMinorPart = 30,
+                ProductName = "I was never given a name.",
+                ProductPrivatePart = 50,
+                ProductVersion = "20.30.40.50",
+                SpecialBuild = "",
+            });
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)] // native PE files only supported on Windows
+        public void FileVersionInfo_DifferentFileVersionAndProductVersion()
+        {
+            // Mtxex.dll
+            VerifyVersionInfo(Path.Combine(Directory.GetCurrentDirectory(), SecondNativeLibraryFileName), new MyFVI()
+            {
+                Comments = "",
+                CompanyName = "",
+                FileBuildPart = 0,
+                FileDescription = "",
+                FileMajorPart = 0,
+                FileMinorPart = 65535,
+                FileName = Path.Combine(Directory.GetCurrentDirectory(), SecondNativeLibraryFileName),
+                FilePrivatePart = 2,
+                FileVersion = "0.65535.0.2",
+                InternalName = "SecondNativeLibrary.dll",
+                IsDebug = false,
+                IsPatched = false,
+                IsPrivateBuild = false,
+                IsPreRelease = false,
+                IsSpecialBuild = false,
+                Language = GetFileVersionLanguage(0x0400),//Process Default Language
+                LegalCopyright = "Copyright (C) 1 - 2014",
+                LegalTrademarks = "",
+                OriginalFilename = "SecondNativeLibrary.dll",
+                PrivateBuild = "",
+                ProductBuildPart = 0,
+                ProductMajorPart = 1,
+                ProductMinorPart = 0,
+                ProductName = "Unknown_Product_Name",
+                ProductPrivatePart = 1,
+                ProductVersion = "1.0.0.1",
+                SpecialBuild = "",
+            });
+        }
+
+        private static string GetFileVersionLanguage(uint langid)
+        {
+            var lang = new StringBuilder(256);
+            Interop.Kernel32.VerLanguageName(langid, lang, (uint)lang.Capacity);
+            return lang.ToString();
+        }
+    }
+}

--- a/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/FileVersionInfoTest.cs
+++ b/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/FileVersionInfoTest.cs
@@ -2,136 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Diagnostics;
-using System.Globalization;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Text;
 using Xunit;
 
 namespace System.Diagnostics.Tests
 {
-    public class FileVersionInfoTest
+    public partial class FileVersionInfoTest : FileCleanupTestBase
     {
-        private const string NativeConsoleAppFileName = "NativeConsoleApp.exe";
-        private const string NativeLibraryFileName = "NativeLibrary.dll";
-        private const string SecondNativeLibraryFileName = "SecondNativeLibrary.dll";
         private const string TestAssemblyFileName = "System.Diagnostics.FileVersionInfo.TestAssembly.dll";
         private const string TestCsFileName = "Assembly1.cs";
         private const string TestNotFoundFileName = "notfound.dll";
-
-        [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)] // native PE files only supported on Windows
-        public void FileVersionInfo_Normal()
-        {
-            // NativeConsoleApp (English)
-            VerifyVersionInfo(Path.Combine(Directory.GetCurrentDirectory(), NativeConsoleAppFileName), new MyFVI()
-            {
-                Comments = "",
-                CompanyName = "Microsoft Corporation",
-                FileBuildPart = 3,
-                FileDescription = "This is the description for the native console application.",
-                FileMajorPart = 5,
-                FileMinorPart = 4,
-                FileName = Path.Combine(Directory.GetCurrentDirectory(), NativeConsoleAppFileName),
-                FilePrivatePart = 2,
-                FileVersion = "5.4.3.2",
-                InternalName = NativeConsoleAppFileName,
-                IsDebug = false,
-                IsPatched = false,
-                IsPrivateBuild = false,
-                IsPreRelease = true,
-                IsSpecialBuild = true,
-                Language = GetFileVersionLanguage(0x0409), //English (United States)
-                LegalCopyright = "Copyright (C) 2050",
-                LegalTrademarks = "",
-                OriginalFilename = NativeConsoleAppFileName,
-                PrivateBuild = "",
-                ProductBuildPart = 3,
-                ProductMajorPart = 5,
-                ProductMinorPart = 4,
-                ProductName = Path.GetFileNameWithoutExtension(NativeConsoleAppFileName),
-                ProductPrivatePart = 2,
-                ProductVersion = "5.4.3.2",
-                SpecialBuild = ""
-            });
-        }
-
-        [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)] // native PE files only supported on Windows
-        public void FileVersionInfo_Chinese()
-        {
-            // NativeLibrary.dll (Chinese)
-            VerifyVersionInfo(Path.Combine(Directory.GetCurrentDirectory(), NativeLibraryFileName), new MyFVI()
-            {
-                Comments = "",
-                CompanyName = "A non-existent company",
-                FileBuildPart = 3,
-                FileDescription = "Here is the description of the native library.",
-                FileMajorPart = 9,
-                FileMinorPart = 9,
-                FileName = Path.Combine(Directory.GetCurrentDirectory(), NativeLibraryFileName),
-                FilePrivatePart = 3,
-                FileVersion = "9.9.3.3",
-                InternalName = "NativeLibrary.dll",
-                IsDebug = false,
-                IsPatched = true,
-                IsPrivateBuild = false,
-                IsPreRelease = true,
-                IsSpecialBuild = false,
-                Language = GetFileVersionLanguage(0x0004),//Chinese (Simplified)
-                Language2 = GetFileVersionLanguage(0x0804),//Chinese (Simplified, PRC) - changed, but not yet on all platforms
-                LegalCopyright = "None",
-                LegalTrademarks = "",
-                OriginalFilename = "NativeLibrary.dll",
-                PrivateBuild = "",
-                ProductBuildPart = 40,
-                ProductMajorPart = 20,
-                ProductMinorPart = 30,
-                ProductName = "I was never given a name.",
-                ProductPrivatePart = 50,
-                ProductVersion = "20.30.40.50",
-                SpecialBuild = "",
-            });
-        }
-
-        [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)] // native PE files only supported on Windows
-        public void FileVersionInfo_DifferentFileVersionAndProductVersion()
-        {
-            // Mtxex.dll
-            VerifyVersionInfo(Path.Combine(Directory.GetCurrentDirectory(), SecondNativeLibraryFileName), new MyFVI()
-            {
-                Comments = "",
-                CompanyName = "",
-                FileBuildPart = 0,
-                FileDescription = "",
-                FileMajorPart = 0,
-                FileMinorPart = 65535,
-                FileName = Path.Combine(Directory.GetCurrentDirectory(), SecondNativeLibraryFileName),
-                FilePrivatePart = 2,
-                FileVersion = "0.65535.0.2",
-                InternalName = "SecondNativeLibrary.dll",
-                IsDebug = false,
-                IsPatched = false,
-                IsPrivateBuild = false,
-                IsPreRelease = false,
-                IsSpecialBuild = false,
-                Language = GetFileVersionLanguage(0x0400),//Process Default Language
-                LegalCopyright = "Copyright (C) 1 - 2014",
-                LegalTrademarks = "",
-                OriginalFilename = "SecondNativeLibrary.dll",
-                PrivateBuild = "",
-                ProductBuildPart = 0,
-                ProductMajorPart = 1,
-                ProductMinorPart = 0,
-                ProductName = "Unknown_Product_Name",
-                ProductPrivatePart = 1,
-                ProductVersion = "1.0.0.1",
-                SpecialBuild = "",
-            });
-        }
 
         [Fact]
         public void FileVersionInfo_CustomManagedAssembly()
@@ -154,7 +35,7 @@ namespace System.Diagnostics.Tests
                 IsPrivateBuild = false,
                 IsPreRelease = false,
                 IsSpecialBuild = false,
-                Language = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? GetFileVersionLanguage(0x0000) : "Language Neutral",
+                Language = GetFileVersionLanguage(0x0000),
                 LegalCopyright = "Copyright, you betcha!",
                 LegalTrademarks = "TM",
                 OriginalFilename = TestAssemblyFileName,
@@ -206,7 +87,14 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
-        public void FileVersionInfo_FileNotFound()
+        public void FileVersionInfo_CurrentDirectory_FileNotFound()
+        {
+            Assert.Throws<FileNotFoundException>(() =>
+            FileVersionInfo.GetVersionInfo(Directory.GetCurrentDirectory()));
+        }
+
+        [Fact]
+        public void FileVersionInfo_NonExistentFile_FileNotFound()
         {
             Assert.Throws<FileNotFoundException>(() =>
                 FileVersionInfo.GetVersionInfo(Path.Combine(Directory.GetCurrentDirectory(), TestNotFoundFileName)));
@@ -217,7 +105,7 @@ namespace System.Diagnostics.Tests
         // [] DLL has unknown codepage info
         // [] DLL language/codepage is 8-hex-digits (locale > 0x999) (different codepath)
 
-        private void VerifyVersionInfo(String filePath, MyFVI expected)
+        private void VerifyVersionInfo(string filePath, MyFVI expected)
         {
             FileVersionInfo fvi = FileVersionInfo.GetVersionInfo(filePath);
             Assert.Equal(expected.Comments, fvi.Comments);
@@ -249,7 +137,7 @@ namespace System.Diagnostics.Tests
             Assert.Equal(expected.SpecialBuild, fvi.SpecialBuild);
 
             //ToString
-            String nl = Environment.NewLine;
+            string nl = Environment.NewLine;
             Assert.Equal("File:             " + fvi.FileName + nl +
                       "InternalName:     " + fvi.InternalName + nl +
                       "OriginalFilename: " + fvi.OriginalFilename + nl +
@@ -340,13 +228,6 @@ namespace System.Diagnostics.Tests
             }
             buffer.Append("\"");
             return (buffer.ToString());
-        }
-
-        private static string GetFileVersionLanguage(uint langid)
-        {
-            var lang = new StringBuilder(256);
-            Interop.Kernel32.VerLanguageName(langid, lang, (uint)lang.Capacity);
-            return lang.ToString();
         }
     }
 }

--- a/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/System.Diagnostics.FileVersionInfo.Tests.csproj
+++ b/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/System.Diagnostics.FileVersionInfo.Tests.csproj
@@ -1,8 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <Configuration Condition="'$(Configuration)'==''">Windows_Debug</Configuration>
-  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Diagnostics.FileVersionInfo.Tests</AssemblyName>
@@ -28,12 +25,21 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="FileVersionInfoTest.cs" />
+    <Compile Include="$(CommonTestPath)\System\IO\FileCleanupTestBase.cs">
+      <Link>Common\System\IO\FileCleanupTestBase.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
+    <Compile Include="FileVersionInfoTest.Windows.cs" />
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>ProductionCode\Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.VerLanguageName.cs">
       <Link>ProductionCode\Common\Interop\Windows\kernel32\Interop.VerLanguageName.cs</Link>
     </Compile>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
+    <Compile Include="FileVersionInfoTest.Unix.cs" />
   </ItemGroup>
   <!-- References used -->
   <ItemGroup>


### PR DESCRIPTION
FileVersionInfo.GetVersionInfo on Unix attempts to read from the file in order to parse out the metadata stored in it.  This is only intended to work with regular files.  If it instead is given something non-regular, like a named pipe, it could hang trying to read from it, and regardless it won't successfully parse any metadata.

The fix is to change GetVersionInfo to detect the file type and throw for anything other than files.  For the test project, because the test involved adding a P/Invoke that won't work in UWP, I've split the test project into a Windows build and a Unix build.

Fixes https://github.com/dotnet/corefx/issues/18409
cc: @ianhays, @Priya91, @PaulHigin