### PR TITLE
Disable ProcessStreamReadTest.TestAsyncHalfCharacterAtATime

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
@@ -124,6 +124,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "There is 2 bugs in Desktop in this codepath, see: dotnet/corefx #18437 and #18436")]
         public void TestAsyncHalfCharacterAtATime()
         {
             var receivedOutput = false;
@@ -150,9 +151,9 @@ namespace System.Diagnostics.Tests
                 {
                     if (!receivedOutput)
                     {
+                        receivedOutput = true;
                         Assert.Equal(e.Data, "a");
                     }
-                    receivedOutput = true;
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
This test was hitting a `IndexOutOfRangeException` which was causing the tests execution to break and not producing test results. This is caused by 2 desktop bugs, see: #18437 and #18436.

Also I moved `receivedOutput=true` to be updated before `Assert.Equal(e.Data, "a");` because if this Assert fails received output will never be set to true because the try catch will catch the xunit assert failure exception before updating the value. This will cause `Assert.True(receivedOutput);` to fail and the test will exit at that point causing

```cs
if (collectedExceptions.Count > 0)
{
       // Re-throw collected exceptions
       throw new AggregateException(collectedExceptions);
}
```

To never be hitted so the real `Assert.Equal(e.Data, "a");` failure will never be thrown and the actual shown failure in the test execution will be `Assert.True(receivedOutput);` which would make it harder to debug as we did actually received output but not the expected.

cc: @stephentoub @Priya91 @danmosemsft 

Contributes to #18262