### PR TITLE
Disable Private.Uri tests due to quirked behavior

### DIFF
--- a/src/System.Private.Uri/tests/FunctionalTests/UriBuilderTests.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriBuilderTests.cs
@@ -292,8 +292,8 @@ namespace System.PrivateUri.Tests
         [Theory]
         [InlineData("#fragment", "#fragment")]
         [InlineData("#", "#")]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "See: dotnet/corefx #15145")]
-        public void Fragment_Get_Set_Netcore(string value, string expected)
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "In NET Core if the value starts with # then no other # is prepended, in Desktop we always prepend #")]
+        public void Fragment_Get_Set_StartsWithPound(string value, string expected)
         {
             var uriBuilder = new UriBuilder();
             uriBuilder.Fragment = value;

--- a/src/System.Private.Uri/tests/FunctionalTests/UriBuilderTests.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriBuilderTests.cs
@@ -13,6 +13,7 @@ namespace System.PrivateUri.Tests
         //This test tests a case where the Core implementation of UriBuilder differs from Desktop Framework UriBuilder.
         //The Query property will not longer prepend a ? character if the string being assigned is already prepended.
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Difference in behavior")]
         public static void TestQuery()
         {
             var uriBuilder = new UriBuilder(@"http://foo/bar/baz?date=today");
@@ -289,9 +290,23 @@ namespace System.PrivateUri.Tests
         }
 
         [Theory]
-        [InlineData("fragment", "#fragment")]
         [InlineData("#fragment", "#fragment")]
         [InlineData("#", "#")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "See: dotnet/corefx #15145")]
+        public void Fragment_Get_Set_Netcore(string value, string expected)
+        {
+            var uriBuilder = new UriBuilder();
+            uriBuilder.Fragment = value;
+            Assert.Equal(expected, uriBuilder.Fragment);
+
+            Uri oldUri = uriBuilder.Uri;
+            uriBuilder.Fragment = value;
+            Assert.NotSame(uriBuilder.Uri, oldUri); // Should generate new uri
+            Assert.Equal(uriBuilder.Fragment, uriBuilder.Uri.Fragment);
+        }
+
+        [Theory]
+        [InlineData("fragment", "#fragment")]
         [InlineData("", "")]
         [InlineData(null, "")]
         public void Fragment_Get_Set(string value, string expected)

--- a/src/System.Private.Uri/tests/FunctionalTests/UriRelativeResolutionTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriRelativeResolutionTest.cs
@@ -136,6 +136,7 @@ namespace System.PrivateUri.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "See: dotnet/corefx #15145")]
         public void Uri_Relative_SimplePartialPathWithUnknownScheme_Unicode_ReturnsPartialPathWithScheme()
         {
             string schemeAndRelative = "scheme:\u011E";
@@ -146,6 +147,7 @@ namespace System.PrivateUri.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "See: dotnet/corefx #15145")]
         public void Uri_Relative_SimplePartialPathWithScheme_Unicode_ReturnsPartialPathWithScheme()
         {
             string schemeAndRelative = "http:\u00C7";
@@ -156,6 +158,7 @@ namespace System.PrivateUri.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "See: dotnet/corefx #15145")]
         public void Uri_Relative_RightToLeft()
         {
             var loremIpsumArabic = "\u0643\u0644 \u0627\u0644\u0649 \u0627\u0644\u0639\u0627\u0644\u0645";
@@ -168,6 +171,7 @@ namespace System.PrivateUri.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "See: dotnet/corefx #15145")]
         public void Uri_Relative_Unicode_Glitchy()
         {
             var glitchy = "4\u0308\u0311\u031A\u030B\u0352\u034A\u030D\u036C\u036C\u036B\u0344\u0312\u0322\u0334\u0328\u0319\u0323\u0359\u0317\u0324\u0319\u032D\u0331\u0319\u031F\u0331\u0330\u0347\u0353\u0318\u032F\u032C\u03162\u0303\u0313\u031A\u0368\u036E\u0368\u0301\u0367\u0368\u0306\u0305\u0350\u036A\u036F\u0307\u0328\u035F\u0321\u0361\u0320\u032F\u032B\u034E\u0326\u033B";
@@ -180,6 +184,7 @@ namespace System.PrivateUri.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "See: dotnet/corefx #15145")]
         public void Uri_Unicode_Format_Character_Combinations_Scheme()
         {
             var combinations = CartesianProductAll(_ => CharUnicodeInfo.GetUnicodeCategory(_) == UnicodeCategory.Format && !UriHelper.IsIriDisallowedBidi(_));
@@ -227,6 +232,7 @@ namespace System.PrivateUri.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "See: dotnet/corefx #15145")]
         public void Uri_Unicode_SurrogatePairs_Scheme()
         {
             var combinations = CartesianProductAll(char.IsHighSurrogate, char.IsLowSurrogate, false);


### PR DESCRIPTION
Fixes: #18314 
Fixes: #18315
Fixes: #18316 

I'm closing the above issues with this PR by disabling tests as this is already tracked by: #15145 

cc: @davidsh @CIPop @danmosemsft 
