### PR TITLE
Optimise IL for nullable unary S.L.Expressions expressions.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Common/CachedReflectionInfo.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Common/CachedReflectionInfo.cs
@@ -10,11 +10,6 @@ namespace System.Linq.Expressions
 {
     internal static partial class CachedReflectionInfo
     {
-        private static Type[] s_ArrayOfType_Bool;
-        public  static Type[]   ArrayOfType_Bool =>
-                              s_ArrayOfType_Bool ??
-                             (s_ArrayOfType_Bool = new[] { typeof(bool) });
-
         private static ConstructorInfo s_Nullable_Boolean_Ctor;
 
         public static ConstructorInfo Nullable_Boolean_Ctor

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Unary.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Unary.cs
@@ -105,91 +105,49 @@ namespace System.Linq.Expressions.Compiler
             {
                 switch (op)
                 {
-                    case ExpressionType.Not:
-                        {
-                            if (operandType != typeof(bool?))
-                            {
-                                goto case ExpressionType.Negate;
-                            }
-                            Label labEnd = _ilg.DefineLabel();
-                            LocalBuilder loc = GetLocal(operandType);
-
-                            // store values (reverse order since they are already on the stack)
-                            _ilg.Emit(OpCodes.Stloc, loc);
-
-                            // test for null
-                            _ilg.Emit(OpCodes.Ldloca, loc);
-                            _ilg.EmitHasValue(operandType);
-                            _ilg.Emit(OpCodes.Brfalse_S, labEnd);
-
-                            // do op on non-null value
-                            _ilg.Emit(OpCodes.Ldloca, loc);
-                            _ilg.EmitGetValueOrDefault(operandType);
-                            Type nnOperandType = operandType.GetNonNullableType();
-                            EmitUnaryOperator(op, nnOperandType, typeof(bool));
-
-                            // construct result
-                            ConstructorInfo ci = resultType.GetConstructor(ArrayOfType_Bool);
-                            _ilg.Emit(OpCodes.Newobj, ci);
-                            _ilg.Emit(OpCodes.Stloc, loc);
-
-                            _ilg.MarkLabel(labEnd);
-                            _ilg.Emit(OpCodes.Ldloc, loc);
-                            FreeLocal(loc);
-                            return;
-                        }
                     case ExpressionType.UnaryPlus:
-                    case ExpressionType.NegateChecked:
-                    case ExpressionType.Negate:
-                    case ExpressionType.Increment:
-                    case ExpressionType.Decrement:
-                    case ExpressionType.OnesComplement:
-                    case ExpressionType.IsFalse:
-                    case ExpressionType.IsTrue:
-                        {
-                            Debug.Assert(TypeUtils.AreEquivalent(operandType, resultType));
-                            Label labIfNull = _ilg.DefineLabel();
-                            Label labEnd = _ilg.DefineLabel();
-                            LocalBuilder loc = GetLocal(operandType);
-
-                            // check for null
-                            _ilg.Emit(OpCodes.Stloc, loc);
-                            _ilg.Emit(OpCodes.Ldloca, loc);
-                            _ilg.EmitHasValue(operandType);
-                            _ilg.Emit(OpCodes.Brfalse_S, labIfNull);
-
-                            // apply operator to non-null value
-                            _ilg.Emit(OpCodes.Ldloca, loc);
-                            _ilg.EmitGetValueOrDefault(operandType);
-                            Type nnOperandType = resultType.GetNonNullableType();
-                            EmitUnaryOperator(op, nnOperandType, nnOperandType);
-
-                            // construct result
-                            ConstructorInfo ci = resultType.GetConstructor(new Type[] { nnOperandType });
-                            _ilg.Emit(OpCodes.Newobj, ci);
-                            _ilg.Emit(OpCodes.Stloc, loc);
-                            _ilg.Emit(OpCodes.Br_S, labEnd);
-
-                            // if null then create a default one
-                            _ilg.MarkLabel(labIfNull);
-                            _ilg.Emit(OpCodes.Ldloca, loc);
-                            _ilg.Emit(OpCodes.Initobj, resultType);
-
-                            _ilg.MarkLabel(labEnd);
-                            _ilg.Emit(OpCodes.Ldloc, loc);
-                            FreeLocal(loc);
-                            return;
-                        }
+                        return;
                     case ExpressionType.TypeAs:
-                        _ilg.Emit(OpCodes.Box, operandType);
-                        _ilg.Emit(OpCodes.Isinst, resultType);
-                        if (resultType.IsNullableType())
+                        if (operandType != resultType)
                         {
-                            _ilg.Emit(OpCodes.Unbox_Any, resultType);
+                            _ilg.Emit(OpCodes.Box, operandType);
+                            _ilg.Emit(OpCodes.Isinst, resultType);
+                            if (resultType.IsNullableType())
+                            {
+                                _ilg.Emit(OpCodes.Unbox_Any, resultType);
+                            }
                         }
+
                         return;
                     default:
-                        throw Error.UnhandledUnary(op, nameof(op));
+                        Debug.Assert(TypeUtils.AreEquivalent(operandType, resultType));
+                        Label labIfNull = _ilg.DefineLabel();
+                        Label labEnd = _ilg.DefineLabel();
+                        LocalBuilder loc = GetLocal(operandType);
+
+                        // check for null
+                        _ilg.Emit(OpCodes.Stloc, loc);
+                        _ilg.Emit(OpCodes.Ldloca, loc);
+                        _ilg.EmitHasValue(operandType);
+                        _ilg.Emit(OpCodes.Brfalse_S, labIfNull);
+
+                        // apply operator to non-null value
+                        _ilg.Emit(OpCodes.Ldloca, loc);
+                        _ilg.EmitGetValueOrDefault(operandType);
+                        Type nnOperandType = resultType.GetNonNullableType();
+                        EmitUnaryOperator(op, nnOperandType, nnOperandType);
+
+                        // construct result
+                        ConstructorInfo ci = resultType.GetConstructor(new Type[] { nnOperandType });
+                        _ilg.Emit(OpCodes.Newobj, ci);
+                        _ilg.Emit(OpCodes.Br_S, labEnd);
+
+                        // if null then push back on stack.
+                        _ilg.MarkLabel(labIfNull);
+                        _ilg.Emit(OpCodes.Ldloc, loc);
+                        FreeLocal(loc);
+                        _ilg.MarkLabel(labEnd);
+                        return;
                 }
             }
             else
@@ -233,15 +191,20 @@ namespace System.Linq.Expressions.Compiler
                         // (integer NegateChecked was rewritten to 0 - operand and doesn't hit here).
                         return;
                     case ExpressionType.TypeAs:
-                        if (operandType.IsValueType)
+                        if (operandType != resultType)
                         {
-                            _ilg.Emit(OpCodes.Box, operandType);
+                            if (operandType.IsValueType)
+                            {
+                                _ilg.Emit(OpCodes.Box, operandType);
+                            }
+
+                            _ilg.Emit(OpCodes.Isinst, resultType);
+                            if (resultType.IsNullableType())
+                            {
+                                _ilg.Emit(OpCodes.Unbox_Any, resultType);
+                            }
                         }
-                        _ilg.Emit(OpCodes.Isinst, resultType);
-                        if (resultType.IsNullableType())
-                        {
-                            _ilg.Emit(OpCodes.Unbox_Any, resultType);
-                        }
+
                         // Not an arithmetic operation -> no conversion
                         return;
                     case ExpressionType.Increment:


### PR DESCRIPTION
`UnaryPlus` is a nop for all possible inputs, so do nothing.

Don't construct new value for null operand, just push previous value back on stack.

Conversely, don't store then load computed value, just leave it on the stack.

Separate path for `Not` on `bool?` values now has no advantage, so roll into rest.

Only two paths differ from others, so handle majority as default branch (previous default is unreachable and if not would result in same exception this way anyway).

`TypeAs` is nop when result type is same as operand type, so do nothing. (Do this for non-nullable case too).