### PR TITLE
Performance improvement of CopyTo method of System.Collections.Generic.Stack

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/Stack.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Stack.cs
@@ -127,9 +127,9 @@ namespace System.Collections.Generic
             int srcIndex = 0;
             int dstIndex = arrayIndex + _size;
             while(srcIndex < _size)
-			{
+            {
                 array[--dstIndex] = _array[srcIndex++];
-			}
+            }
         }
 
         void ICollection.CopyTo(Array array, int arrayIndex)

--- a/src/System.Collections/src/System/Collections/Generic/Stack.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Stack.cs
@@ -126,8 +126,10 @@ namespace System.Collections.Generic
             Debug.Assert(array != _array);
             int srcIndex = 0;
             int dstIndex = arrayIndex + _size;
-            for (int i = 0; i < _size; i++)
+            while(srcIndex < _size)
+			{
                 array[--dstIndex] = _array[srcIndex++];
+			}
         }
 
         void ICollection.CopyTo(Array array, int arrayIndex)


### PR DESCRIPTION
The CopyTo method does not require a for loop since an index(srcIndex) to check for algorithm termination already exists. While this is not a major improvement, it still saves 4 lines of MSIL and results in having an integer less on the stack. From my tests performance improvements average out at ~0.75ms(~22.5ms vs ~23.25ms) for 10 million records )

Here is the MSIL for my implementation:
```
ldloc.2
ldloc.s 4
ldc.i4.1
sub
dup
stloc.s 4
ldloc.1
ldloc.3
dup
ldc.i4.1
add
stloc.3
ldelem.i4
stelem.i4

ldloc.3
ldloc.0
```

And here for the current implementation:
```
ldloc.2
ldloc.s 4
ldc.i4.1
sub
dup
stloc.s 4
ldloc.1
ldloc.3
dup
ldc.i4.1
add
stloc.3
ldelem.i4
stelem.i4
ldloc.s 5 //Loads for-loop index
ldc.i4.1  //Loads 1 constant
add       //Adds constant to index
stloc.s 5 //Stores index

ldloc.s 5
ldloc.0
```