### PR TITLE
Fix GetAllCompilerInfo_ReturnsMinimumOfCSharpAndVB test in desktop

### DIFF
--- a/src/System.CodeDom/tests/Compiler/CodeDomProviderTests.cs
+++ b/src/System.CodeDom/tests/Compiler/CodeDomProviderTests.cs
@@ -16,7 +16,7 @@ namespace System.CodeDom.Compiler.Tests
         [Fact]
         public void GetAllCompilerInfo_ReturnsMinimumOfCSharpAndVB()
         {
-            Type[] compilerInfos = CodeDomProvider.GetAllCompilerInfo().Select(provider => provider.CodeDomProviderType).ToArray();
+            Type[] compilerInfos = CodeDomProvider.GetAllCompilerInfo().Where(provider => provider.IsCodeDomProviderTypeValid).Select(provider => provider.CodeDomProviderType).ToArray();
             Assert.True(compilerInfos.Length >= 2);
             Assert.Contains(typeof(CSharpCodeProvider), compilerInfos);
             Assert.Contains(typeof(VBCodeProvider), compilerInfos);


### PR DESCRIPTION
When calling in desktop `CodeDomProvider.GetAllCompilerInfo()` it will return a `CompilerInfo[]` with 4 objects describing the following types: 

Microsoft.CSharp.CSharpCodeProvider
Microsoft.VisualBasic.VBCodeProvider
Microsoft.JScript.JScriptCodeProvider
Microsoft.VisualC.CppCodeProvider

JScriptCodeProvider and CppCodeProvider are available when installing the necessary tools, i.e Microsoft Visual C++ tools. If we run the tests in a computer that doesn't have this tools installed (the case of helix machines) when trying to load the `Type` object from `CompilerInfo` if the type is `null` because it was not found it will throw an exception like this:

```
System.Configuration.ConfigurationErrorsException : The CodeDom provider type "Microsoft.VisualC.CppCodeProvider, CppCodeProvider, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" could not be located.
```

Since VBCodeProvider and CSharpCodeProvider are part of the Framework so will always be available. 

To fix this test failure I'm just ensuring that the type exists through `CompilerInfo.IsCodeDomProviderTypeValid` before trying to get all the compiler info types.

Fixes: #18194

cc: @stephentoub @danmosemsft @Priya91 