### PR TITLE
Remove some dead code in S.L.Expressions LambdaCompiler

### DIFF
--- a/src/System.Linq.Expressions/src/Resources/Strings.resx
+++ b/src/System.Linq.Expressions/src/Resources/Strings.resx
@@ -436,9 +436,6 @@
   <data name="InvalidLvalue" xml:space="preserve">
     <value>Invalid lvalue for assignment: {0}.</value>
   </data>
-  <data name="UnknownLiftType" xml:space="preserve">
-    <value>unknown lift type: '{0}'.</value>
-  </data>
   <data name="UndefinedVariable" xml:space="preserve">
     <value>variable '{0}' of type '{1}' referenced from scope '{2}', but it is not defined</value>
   </data>

--- a/src/System.Linq.Expressions/src/Resources/Strings.resx
+++ b/src/System.Linq.Expressions/src/Resources/Strings.resx
@@ -352,9 +352,6 @@
   <data name="TypeNotIEnumerable" xml:space="preserve">
     <value>Type '{0}' is not IEnumerable</value>
   </data>
-  <data name="InvalidCast" xml:space="preserve">
-    <value>Cannot cast from type '{0}' to type '{1}</value>
-  </data>
   <data name="UnhandledBinary" xml:space="preserve">
     <value>Unhandled binary: {0}</value>
   </data>

--- a/src/System.Linq.Expressions/src/Resources/Strings.resx
+++ b/src/System.Linq.Expressions/src/Resources/Strings.resx
@@ -427,9 +427,6 @@
   <data name="NonLocalJumpWithValue" xml:space="preserve">
     <value>Cannot jump to non-local label '{0}' with a value. Only jumps to labels defined in outer blocks can pass values.</value>
   </data>
-  <data name="ExtensionNotReduced" xml:space="preserve">
-    <value>Extension should have been reduced.</value>
-  </data>
   <data name="CannotCompileConstant" xml:space="preserve">
     <value>CompileToMethod cannot compile constant '{0}' because it is a non-trivial value, such as a live object. Instead, create an expression tree that can construct this value.</value>
   </data>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -679,25 +679,18 @@ namespace System.Linq.Expressions.Compiler
 
         private static void EmitCastToType(this ILGenerator il, Type typeFrom, Type typeTo)
         {
-            if (!typeFrom.IsValueType && typeTo.IsValueType)
+            if (typeFrom.IsValueType)
             {
-                il.Emit(OpCodes.Unbox_Any, typeTo);
-            }
-            else if (typeFrom.IsValueType && !typeTo.IsValueType)
-            {
+                Debug.Assert(!typeTo.IsValueType);
                 il.Emit(OpCodes.Box, typeFrom);
                 if (typeTo != typeof(object))
                 {
                     il.Emit(OpCodes.Castclass, typeTo);
                 }
             }
-            else if (!typeFrom.IsValueType && !typeTo.IsValueType)
-            {
-                il.Emit(OpCodes.Castclass, typeTo);
-            }
             else
             {
-                throw Error.InvalidCast(typeFrom, typeTo);
+                il.Emit(typeTo.IsValueType ? OpCodes.Unbox_Any : OpCodes.Castclass, typeTo);
             }
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Address.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Address.cs
@@ -72,20 +72,7 @@ namespace System.Linq.Expressions.Compiler
             {
                 EmitExpression(node.Left);
                 EmitExpression(node.Right);
-                Type rightType = node.Right.Type;
-                if (rightType.IsNullableType())
-                {
-                    LocalBuilder loc = GetLocal(rightType);
-                    _ilg.Emit(OpCodes.Stloc, loc);
-                    _ilg.Emit(OpCodes.Ldloca, loc);
-                    _ilg.EmitGetValue(rightType);
-                    FreeLocal(loc);
-                }
-                Type indexType = rightType.GetNonNullableType();
-                if (indexType != typeof(int))
-                {
-                    _ilg.EmitConvertToType(indexType, typeof(int), isChecked: true, locals: this);
-                }
+                Debug.Assert(node.Right.Type == typeof(int));
                 _ilg.Emit(OpCodes.Ldelema, node.Type);
             }
             else

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
@@ -114,10 +114,10 @@ namespace System.Linq.Expressions.Compiler
 
                     resultType = typeof(bool);
                 }
-                var variables = new ParameterExpression[] { p1, p2 };
-                var arguments = new Expression[] { b.Left, b.Right };
-                ValidateLift(variables, arguments);
-                EmitLift(b.NodeType, resultType, mc, variables, arguments);
+
+                Debug.Assert(TypeUtils.AreReferenceAssignable(p1.Type, b.Left.Type.GetNonNullableType()));
+                Debug.Assert(TypeUtils.AreReferenceAssignable(p2.Type, b.Right.Type.GetNonNullableType()));
+                EmitLift(b.NodeType, resultType, mc, new[] {p1, p2}, new[] {b.Left, b.Right});
             }
             else
             {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
@@ -105,20 +105,14 @@ namespace System.Linq.Expressions.Compiler
                 else
                 {
                     Debug.Assert(mc.Type == typeof(bool));
-                    switch (b.NodeType)
-                    {
-                        case ExpressionType.Equal:
-                        case ExpressionType.NotEqual:
-                        case ExpressionType.LessThan:
-                        case ExpressionType.LessThanOrEqual:
-                        case ExpressionType.GreaterThan:
-                        case ExpressionType.GreaterThanOrEqual:
-                            resultType = typeof(bool);
-                            break;
-                        default:
-                            resultType = mc.Type.GetNullableType();
-                            break;
-                    }
+                    Debug.Assert(b.NodeType == ExpressionType.Equal
+                        || b.NodeType == ExpressionType.NotEqual
+                        || b.NodeType == ExpressionType.LessThan
+                        || b.NodeType == ExpressionType.LessThanOrEqual
+                        || b.NodeType == ExpressionType.GreaterThan
+                        || b.NodeType == ExpressionType.GreaterThanOrEqual);
+
+                    resultType = typeof(bool);
                 }
                 var variables = new ParameterExpression[] { p1, p2 };
                 var arguments = new Expression[] { b.Left, b.Right };

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
@@ -266,8 +266,6 @@ namespace System.Linq.Expressions.Compiler
                     _ilg.Emit(leftType.IsUnsigned() ? OpCodes.Shr_Un : OpCodes.Shr);
                     // Guaranteed to fit within result type: no conversion
                     return;
-                default:
-                    throw ContractUtils.Unreachable;
             }
 
             EmitConvertArithmeticResult(op, leftType);
@@ -378,10 +376,6 @@ namespace System.Linq.Expressions.Compiler
                         EmitLiftedRelational(op, leftType);
                     }
                     break;
-                case ExpressionType.AndAlso:
-                case ExpressionType.OrElse:
-                default:
-                    throw ContractUtils.Unreachable;
             }
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
@@ -104,6 +104,7 @@ namespace System.Linq.Expressions.Compiler
                 }
                 else
                 {
+                    Debug.Assert(mc.Type == typeof(bool));
                     switch (b.NodeType)
                     {
                         case ExpressionType.Equal:
@@ -112,10 +113,6 @@ namespace System.Linq.Expressions.Compiler
                         case ExpressionType.LessThanOrEqual:
                         case ExpressionType.GreaterThan:
                         case ExpressionType.GreaterThanOrEqual:
-                            if (mc.Type != typeof(bool))
-                            {
-                                throw Error.ArgumentMustBeBoolean(nameof(b));
-                            }
                             resultType = typeof(bool);
                             break;
                         default:

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
@@ -1179,17 +1179,12 @@ namespace System.Linq.Expressions.Compiler
                         }
                         else
                         {
-                            switch (nodeType)
-                            {
-                                case ExpressionType.LessThan:
-                                case ExpressionType.LessThanOrEqual:
-                                case ExpressionType.GreaterThan:
-                                case ExpressionType.GreaterThanOrEqual:
-                                    _ilg.Emit(OpCodes.Ldc_I4_0);
-                                    break;
-                                default:
-                                    throw Error.UnknownLiftType(nodeType);
-                            }
+                            Debug.Assert(nodeType == ExpressionType.LessThan
+                                || nodeType == ExpressionType.LessThanOrEqual
+                                || nodeType == ExpressionType.GreaterThan
+                                || nodeType == ExpressionType.GreaterThanOrEqual);
+
+                            _ilg.Emit(OpCodes.Ldc_I4_0);
                         }
                         _ilg.MarkLabel(exit);
                         FreeLocal(anyNull);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
@@ -1117,24 +1117,6 @@ namespace System.Linq.Expressions.Compiler
 
         #region Expression helpers
 
-        internal static void ValidateLift(IReadOnlyList<ParameterExpression> variables, IReadOnlyList<Expression> arguments)
-        {
-            Debug.Assert(variables != null);
-            Debug.Assert(arguments != null);
-
-            if (variables.Count != arguments.Count)
-            {
-                throw Error.IncorrectNumberOfIndexes();
-            }
-            for (int i = 0, n = variables.Count; i < n; i++)
-            {
-                if (!TypeUtils.AreReferenceAssignable(variables[i].Type, arguments[i].Type.GetNonNullableType()))
-                {
-                    throw Error.ArgumentTypesMustMatch();
-                }
-            }
-        }
-
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity")]
         private void EmitLift(ExpressionType nodeType, Type resultType, MethodCallExpression mc, ParameterExpression[] paramList, Expression[] argList)
         {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
@@ -921,12 +921,6 @@ namespace System.Linq.Expressions.Compiler
             return;
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "expr")]
-        private static void EmitExtensionExpression(Expression expr)
-        {
-            throw Error.ExtensionNotReduced();
-        }
-
         #region ListInit, MemberInit
 
         private void EmitListInitExpression(Expression expr)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
@@ -181,12 +181,7 @@ namespace System.Linq.Expressions.Compiler
             }
 
             expr = node.Expression;
-            if (typeof(LambdaExpression).IsAssignableFrom(expr.Type))
-            {
-                // if the invoke target is a lambda expression tree, first compile it into a delegate
-                expr = Expression.Call(expr, expr.Type.GetMethod("Compile", Array.Empty<Type>()));
-            }
-
+            Debug.Assert(!typeof(LambdaExpression).IsAssignableFrom(expr.Type));
             EmitMethodCall(expr, expr.Type.GetInvokeMethod(), node, CompilationFlags.EmitAsNoTail | CompilationFlags.EmitExpressionStart);
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Generated.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Generated.cs
@@ -165,9 +165,6 @@ namespace System.Linq.Expressions.Compiler
                 case ExpressionType.Try:
                     EmitTryExpression(node);
                     break;
-
-                default:
-                    throw ContractUtils.Unreachable;
             }
 
             if (emitStart)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Generated.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Generated.cs
@@ -144,9 +144,6 @@ namespace System.Linq.Expressions.Compiler
                 case ExpressionType.Default:
                     EmitDefaultExpression(node);
                     break;
-                case ExpressionType.Extension:
-                    EmitExtensionExpression(node);
-                    break;
                 case ExpressionType.Goto:
                     EmitGotoExpression(node, flags);
                     break;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Unary.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Unary.cs
@@ -32,10 +32,8 @@ namespace System.Linq.Expressions.Compiler
                 _scope.EmitGet(_scope.NearestHoistedLocals.SelfVariable);
                 _ilg.Emit(OpCodes.Call, RuntimeOps_Quote);
 
-                if (quote.Type != typeof(Expression))
-                {
-                    _ilg.Emit(OpCodes.Castclass, quote.Type);
-                }
+                Debug.Assert(typeof(LambdaExpression).IsAssignableFrom(quote.Type));
+                _ilg.Emit(OpCodes.Castclass, quote.Type);
             }
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Unary.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Unary.cs
@@ -252,8 +252,6 @@ namespace System.Linq.Expressions.Compiler
                         EmitConstantOne(resultType);
                         _ilg.Emit(OpCodes.Sub);
                         break;
-                    default:
-                        throw Error.UnhandledUnary(op, nameof(op));
                 }
 
                 EmitConvertArithmeticResult(op, resultType);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Unary.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Unary.cs
@@ -260,12 +260,6 @@ namespace System.Linq.Expressions.Compiler
         {
             switch (type.GetTypeCode())
             {
-                case TypeCode.UInt16:
-                case TypeCode.UInt32:
-                case TypeCode.Int16:
-                case TypeCode.Int32:
-                    _ilg.Emit(OpCodes.Ldc_I4_1);
-                    break;
                 case TypeCode.Int64:
                 case TypeCode.UInt64:
                     _ilg.Emit(OpCodes.Ldc_I4_1);
@@ -278,9 +272,8 @@ namespace System.Linq.Expressions.Compiler
                     _ilg.Emit(OpCodes.Ldc_R8, 1.0d);
                     break;
                 default:
-                    // we only have to worry about arithmetic types, see
-                    // TypeUtils.IsArithmetic
-                    throw ContractUtils.Unreachable;
+                    _ilg.Emit(OpCodes.Ldc_I4_1);
+                    break;
             }
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.cs
@@ -154,12 +154,7 @@ namespace System.Linq.Expressions.Compiler
             AddReturnLabel(_lambda);
             _boundConstants.EmitCacheConstants(this);
         }
-
-        public override string ToString()
-        {
-            return _method.ToString();
-        }
-
+        
         internal ILGenerator IL => _ilg;
 
         internal IParameterProvider Parameters => _lambda;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
@@ -1076,13 +1076,7 @@ namespace System.Linq.Expressions
         {
             return new InvalidOperationException(Strings.NonLocalJumpWithValue(p0));
         }
-        /// <summary>
-        /// InvalidOperationException with message like "Extension should have been reduced."
-        /// </summary>
-        internal static Exception ExtensionNotReduced()
-        {
-            return new InvalidOperationException(Strings.ExtensionNotReduced);
-        }
+
 #if FEATURE_COMPILE_TO_METHODBUILDER
         /// <summary>
         /// InvalidOperationException with message like "CompileToMethod cannot compile constant '{0}' because it is a non-trivial value, such as a live object. Instead, create an expression tree that can construct this value."

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
@@ -1107,13 +1107,6 @@ namespace System.Linq.Expressions
         {
             return new InvalidOperationException(Strings.InvalidLvalue(p0));
         }
-        /// <summary>
-        /// InvalidOperationException with message like "unknown lift type: '{0}'."
-        /// </summary>
-        internal static Exception UnknownLiftType(object p0)
-        {
-            return new InvalidOperationException(Strings.UnknownLiftType(p0));
-        }
 
         /// <summary>
         /// InvalidOperationException with message like "variable '{0}' of type '{1}' referenced from scope '{2}', but it is not defined"

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
@@ -901,13 +901,6 @@ namespace System.Linq.Expressions
         }
 
         /// <summary>
-        /// InvalidOperationException with message like "Cannot cast from type '{0}' to type '{1}"
-        /// </summary>
-        internal static Exception InvalidCast(object p0, object p1)
-        {
-            return new InvalidOperationException(Strings.InvalidCast(p0, p1));
-        }
-        /// <summary>
         /// ArgumentException with message like "Unhandled binary: {0}"
         /// </summary>
         internal static Exception UnhandledBinary(object p0, string paramName)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
@@ -570,11 +570,6 @@ namespace System.Linq.Expressions
         internal static string TypeNotIEnumerable(object p0) => SR.Format(SR.TypeNotIEnumerable, p0);
 
         /// <summary>
-        /// A string like "Cannot cast from type '{0}' to type '{1}"
-        /// </summary>
-        internal static string InvalidCast(object p0, object p1) => SR.Format(SR.InvalidCast, p0, p1);
-
-        /// <summary>
         /// A string like "Unhandled binary: {0}"
         /// </summary>
         internal static string UnhandledBinary(object p0) => SR.Format(SR.UnhandledBinary, p0);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
@@ -717,11 +717,6 @@ namespace System.Linq.Expressions
         internal static string InvalidLvalue(object p0) => SR.Format(SR.InvalidLvalue, p0);
 
         /// <summary>
-        /// A string like "unknown lift type: '{0}'."
-        /// </summary>
-        internal static string UnknownLiftType(object p0) => SR.Format(SR.UnknownLiftType, p0);
-
-        /// <summary>
         /// A string like "variable '{0}' of type '{1}' referenced from scope '{2}', but it is not defined"
         /// </summary>
         internal static string UndefinedVariable(object p0, object p1, object p2) => SR.Format(SR.UndefinedVariable, p0, p1, p2);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
@@ -694,11 +694,6 @@ namespace System.Linq.Expressions
         /// </summary>
         internal static string NonLocalJumpWithValue(object p0) => SR.Format(SR.NonLocalJumpWithValue, p0);
 
-        /// <summary>
-        /// A string like "Extension should have been reduced."
-        /// </summary>
-        internal static string ExtensionNotReduced => SR.ExtensionNotReduced;
-
 #if FEATURE_COMPILE_TO_METHODBUILDER
         /// <summary>
         /// A string like "CompileToMethod cannot compile constant '{0}' because it is a non-trivial value, such as a live object. Instead, create an expression tree that can construct this value."


### PR DESCRIPTION
Contributes to #11409 by removing coverage gaps that can never be covered.

Each commit is relatively small, but in some cases the code that makes the removed code unreachable is quite far away from it, so probably best reviewed separately then squash if accepting.