### PR TITLE
Remove more noise from System.Reflection tests on UapAot

### DIFF
--- a/src/System.Reflection/tests/ConstructorInfoTests.cs
+++ b/src/System.Reflection/tests/ConstructorInfoTests.cs
@@ -60,6 +60,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Invoking static constructors are not supported on UapAot.")]
         public void Invoke_StaticConstructor_NullObject_NullParameters()
         {
             ConstructorInfo[] constructors = GetConstructors(typeof(ClassWithStaticConstructor));

--- a/src/System.Reflection/tests/MemberInfoTests.cs
+++ b/src/System.Reflection/tests/MemberInfoTests.cs
@@ -21,12 +21,11 @@ namespace System.Reflection.Tests
             Assert.Equal(GetMembers(new Dictionary<int, string>().GetType()), GetMembers(new Dictionary<int, int>().GetType()));
             Assert.Equal(GetMembers(typeof(int)), GetMembers(typeof(int)));
             Assert.Equal(GetMembers(typeof(Dictionary<,>)), GetMembers(typeof(Dictionary<,>)));
-            Assert.NotEqual(GetMembers(new Dictionary<int, string>().GetType()), GetMembers(new HashSet<int>().GetType()));
         }
 
         private IEnumerable<int> GetMembers(Type type)
         {
-            return type.GetTypeInfo().GetMembers(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).Select(m => m.MetadataToken);
+            return type.GetTypeInfo().GetMembers(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).Select(m => m.HasMetadataToken() ? m.MetadataToken : 0);
         }
 
 #pragma warning disable 0067, 0169

--- a/src/System.Reflection/tests/ModuleTests.cs
+++ b/src/System.Reflection/tests/ModuleTests.cs
@@ -44,7 +44,8 @@ namespace System.Reflection.Tests
         [InlineData(typeof(Int32Attr), 77, "Int32AttrSimple")]
         [InlineData(typeof(Int64Attr), (long)77, "Int64AttrSimple")]
         [InlineData(typeof(StringAttr), "hello", "StringAttrSimple")]
-        [InlineData(typeof(EnumAttr), PublicEnum.Case1, "EnumAttrSimple")]        
+        [InlineData(typeof(EnumAttr), PublicEnum.Case1, "EnumAttrSimple")]  
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Custom Attributes on Modules not supported on UapAot.")]
         public void CustomAttributes<CtorArg, NamedArg>(Type attrType, CtorArg expectedCtorValue, NamedArg expectedNamedValue)
         {
             Module module = typeof(ModuleTest).GetTypeInfo().Module;


### PR DESCRIPTION
- Module custom attributes not supported by .Net Native toolchain.

- Invoking type constructors not supported by .Net Native toolchain
  (cannot reliably implement on .Net Native as the toolchain usually
  optimizes away simple type constructors by executing them at
  compile time and turning them into raw init blocks.)

- Cannot call MetadataToken unconditionally.

- Comparing type metadata tokens of two different framework
  types is not a valid test. This is only reliable if they
  live in the same module/assembly and we make no promises as to
  where things live.