### PR TITLE
DiagnosticSource: return packaging for UAP target

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/src/Configurations.props
+++ b/src/System.Diagnostics.DiagnosticSource/src/Configurations.props
@@ -1,17 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <PackageConfigurations>
+    <BuildConfigurations>
       netstandard1.3;
       netstandard;
+      uap-Windows_NT;      
       netcoreapp;
       net45-Windows_NT;      
       net46-Windows_NT;
       netfx-Windows_NT;      
-    </PackageConfigurations>  
-    <BuildConfigurations>
-      uap-Windows_NT;
-      $(PackageConfigurations);
     </BuildConfigurations>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
UAP target was removed temporarily to build DiagnosticSource and publish it on nuget.org where UAP dependencies are missing (#18295).

This change reverts it and returns UAP target to DiagnosticSource package.

It fixes #18296