### PR TITLE
Don't run perf tests in parallel in outerloop runs

### DIFF
--- a/Tools-Override/tests.targets
+++ b/Tools-Override/tests.targets
@@ -52,6 +52,8 @@
     <XunitOptions>$(XunitOptions) -xml $(XunitResultsFileName)</XunitOptions>
 
     <XunitOptions Condition="'$(Performance)'!='true' and '$(Outerloop)' != 'true'">$(XunitOptions) -notrait Benchmark=true</XunitOptions>
+    <!-- Don't run performance tests in parallel, even in "functional" outerloop runs. -->
+    <XunitOptions Condition="'$(Performance)'!='true' and '$(Outerloop)' == 'true' and '$(IncludePerformanceTests)' == 'true'">$(XunitOptions) -parallel none</XunitOptions>
     <XunitOptions Condition="'$(BuildingUAPAOTVertical)'=='true'">$(XunitOptions) -redirectoutput</XunitOptions>
 
     <XunitOptions>$(XunitOptions) -notrait category=non$(_bc_TargetGroup)tests</XunitOptions>


### PR DESCRIPTION
Some of our perf tests allocate lots of memory or open lots of files, since they weren't intended to be run in parallel. Now that we are running them in "regular" outerloop runs, with the regular xunit test runner, they started running in parallel. This led to some spurious failures.

This change disables parallel test execution for projects that have `IncludePerformanceTests` set to `true`.

@danmosemsft 