### PR TITLE
Disable MonoTests.System.Configuration.ConfigurationSaveTest.NotModifiedAfterSave

### DIFF
--- a/src/System.Configuration.ConfigurationManager/tests/Mono/ConfigurationSaveTest.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/Mono/ConfigurationSaveTest.cs
@@ -659,6 +659,7 @@ namespace MonoTests.System.Configuration
         }
 
         [Fact]
+        [ActiveIssue(18431)]
         public void TestElementWithCollection()
         {
             Run<DefaultMachineConfig2>("TestElementWithCollection", (config, label) =>

--- a/src/System.Configuration.ConfigurationManager/tests/Mono/ConfigurationSaveTest.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/Mono/ConfigurationSaveTest.cs
@@ -504,6 +504,7 @@ namespace MonoTests.System.Configuration
         }
 
         [Fact]
+        [ActiveIssue(18431)]
         public void NotModifiedAfterSave()
         {
             Run<DefaultMachineConfig>("NotModifiedAfterSave", (config, label) =>


### PR DESCRIPTION
cc: @stephentoub @JeremyKuhne 

Failed on: https://github.com/dotnet/corefx/pull/18503