### PR TITLE
Fix typo in S.Diagnostics.Tracing csproj

### DIFF
--- a/src/System.Diagnostics.Tracing/src/System.Diagnostics.Tracing.csproj
+++ b/src/System.Diagnostics.Tracing/src/System.Diagnostics.Tracing.csproj
@@ -8,7 +8,7 @@
     <!-- CSC adds a typeforward for the internal nested type EventSource.EventMetadata but
          GenFacades doesn't consider this as a viable target for a typeforward since it's internal -->
     <GenFacadesIgnoreMissingTypes Condition="'$(TargetGroup)' == 'netfx'">true</GenFacadesIgnoreMissingTypes>
-    <DefineContants Condition="'$(TargetGroup)' != 'netfx'">$(DefineConstants);SUPPORTS_EVENTCOMMANDEXECUTED</DefineContants>
+    <DefineConstants Condition="'$(TargetGroup)' != 'netfx'">$(DefineConstants);SUPPORTS_EVENTCOMMANDEXECUTED</DefineConstants>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />


### PR DESCRIPTION
I have no idea what this define does but I assume this wasn't intended.