### PR TITLE
Remove some bogus tests from System.Reflection.Tests

### DIFF
--- a/src/System.Reflection/tests/AssemblyNameTests.cs
+++ b/src/System.Reflection/tests/AssemblyNameTests.cs
@@ -31,10 +31,6 @@ namespace System.Reflection.Tests
             yield return new object[] { "name with spaces", "name with spaces" };
             yield return new object[] { "\uD800\uDC00", "\uD800\uDC00" };
             yield return new object[] { "привет", "привет" };
-
-            // Invalid Unicode
-            yield return new object[] { "\uD800", "\uFFFD" };
-            yield return new object[] { "\uDC00", "\uFFFD" };
         }
 
         [Fact]

--- a/src/System.Reflection/tests/ModuleTests.cs
+++ b/src/System.Reflection/tests/ModuleTests.cs
@@ -29,17 +29,6 @@ namespace System.Reflection.Tests
         }
 
         [Theory]
-        [InlineData(typeof(int))]
-        [InlineData(typeof(List<>))]
-        [InlineData(typeof(ModuleTest))]
-        public void FullyQualifiedName(TypeInfo typeInfo)
-        {
-            Module module = typeInfo.Module;
-            Assert.Contains(typeInfo.Assembly.GetName().Name, module.FullyQualifiedName, StringComparison.CurrentCultureIgnoreCase);
-            Assert.Contains(typeInfo.Assembly.GetName().Name, module.Name, StringComparison.CurrentCultureIgnoreCase);
-        }
-
-        [Theory]
         [InlineData(typeof(Attr), 77, "AttrSimple")]
         [InlineData(typeof(Int32Attr), 77, "Int32AttrSimple")]
         [InlineData(typeof(Int64Attr), (long)77, "Int64AttrSimple")]


### PR DESCRIPTION
- I choose not to be bug-for-bug compatible with
  invalid unicode strings passed to AssemblyName::ctor(),
  especially since CoreCLR's response to that isn't
  very helpful.

- ModuleTest.FullyQualifiedName

  Test isn't correct even on non-Uat-Aot platforms.
  There's no required relationship between the
  assembly name and its module names. On
  the full framework, Module.Name and Module.FullyQualifiedName
  return the filename and fully qualified filename
  of the module... which can be anything I rename the file to.