### PR TITLE
Remove tests that check inability to create ByRefs over Pointers

### DIFF
--- a/src/System.Reflection/tests/TypeInfoTests.cs
+++ b/src/System.Reflection/tests/TypeInfoTests.cs
@@ -1046,13 +1046,6 @@ namespace System.Reflection.Tests
             Assert.True(byRefType.IsByRef);
         }
 
-        [Fact]
-        public void MakeByRefType_TypeAlreadyByRef_ThrowsTypeLoadException()
-        {
-            Type byRefType = typeof(string).GetTypeInfo().MakeByRefType();
-            Assert.Throws<TypeLoadException>(() => byRefType.GetTypeInfo().MakeByRefType());
-        }
-
         [Theory]
         [InlineData(typeof(int))]
         [InlineData(typeof(string))]
@@ -1060,13 +1053,6 @@ namespace System.Reflection.Tests
         {
             Type pointerType = type.GetTypeInfo().MakePointerType();
             Assert.True(pointerType.IsPointer);
-        }
-
-        [Fact]
-        public void MakePointerType_TypeAlreadyByRef_ThrowsTypeLoadException()
-        {
-            Type byRefType = typeof(string).GetTypeInfo().MakeByRefType();
-            Assert.Throws<TypeLoadException>(() => byRefType.MakePointerType());
         }
 
         [Theory]


### PR DESCRIPTION
I went back and forth on this but finally went down the route of:

- Not a breaking change to make something work that didn't before.

- There's nothing fundamentally wrong about talking about byrefs
  to byrefs or pointers - it's just that we don't support that combo in
  our runtimes. There's no need to enforce this limitation
  at every turn - if an app tries to get a TypeHandle or
  activate/instance one of these things, he'll get the exception.

- We've been kicking ourselves for years for making Reflection
  so tied to the underlying runtime - don't want to add code
  and overhead to CoreRT that takes us back in that direction