### PR TITLE
Adding type-forwards for ValueTuple to desktop 4.7

### DIFF
--- a/external/netfx/Configurations.props
+++ b/external/netfx/Configurations.props
@@ -9,6 +9,7 @@
       net461;
       net462;
       net463;
+      net47;
       netfx;
       netcoreapp;
       uap;

--- a/external/netfx/netfx.depproj
+++ b/external/netfx/netfx.depproj
@@ -19,7 +19,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="$(TargetingPackNugetPackageId)">
-      <Version>1.0.1</Version>
+      <Version Condition="'$(TargetGroup)' != 'net47'">1.0.1</Version>
+      <Version Condition="'$(TargetGroup)' == 'net47'">1.0.0-prerelease</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/System.ValueTuple/ref/Configurations.props
+++ b/src/System.ValueTuple/ref/Configurations.props
@@ -4,6 +4,7 @@
     <PackageConfigurations>
       portable_net40+sl4+win8+wp8;
       netfx;
+      net47;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);

--- a/src/System.ValueTuple/ref/System.ValueTuple.csproj
+++ b/src/System.ValueTuple/ref/System.ValueTuple.csproj
@@ -9,14 +9,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net47-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net47-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'portable_net40+sl4+win8+wp8-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'portable_net40+sl4+win8+wp8-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)' != 'netcoreapp' And '$(TargetGroup)' != 'uap'">
+  <ItemGroup Condition="'$(TargetGroup)' != 'netcoreapp' And '$(TargetGroup)' != 'uap' And '$(TargetGroup)' != 'net47'">
     <Compile Include="System.ValueTuple.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'portable_net40+sl4+win8+wp8'">
@@ -27,13 +27,13 @@
       <Link>Common\System\Reflection\AssemblyMetadataAttribute.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp' Or '$(TargetGroup)' == 'uap'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp' Or '$(TargetGroup)' == 'uap' Or '$(TargetGroup)' == 'net47'">
     <Compile Include="System.ValueTuple.TypeForwards.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.0'">
     <Reference Include="System.Runtime" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'portable_net40+sl4+win8+wp8' or '$(TargetGroup)' == 'netfx'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'portable_net40+sl4+win8+wp8' or '$(TargetGroup)' == 'netfx' or '$(TargetGroup)' == 'net47'">
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/System.ValueTuple/src/Configurations.props
+++ b/src/System.ValueTuple/src/Configurations.props
@@ -5,6 +5,7 @@
       portable_net40+sl4+win8+wp8;
       netstandard1.0;
       netfx;
+      net47;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);

--- a/src/System.ValueTuple/src/System.ValueTuple.csproj
+++ b/src/System.ValueTuple/src/System.ValueTuple.csproj
@@ -5,7 +5,7 @@
     <!-- rev'ed to 4.0.1.0 even though 4.0.0.0 never shipped so that we can drop pre-release down to beta -->
     <ProjectGuid>{4C2655DB-BD9E-4C86-83A6-744ECDDBDF29}</ProjectGuid>
     <DocumentationFile>$(OutputPath)$(MSBuildProjectName).xml</DocumentationFile>
-    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netcoreapp' OR '$(TargetGroup)' == 'uap'">true</IsPartialFacadeAssembly>
+    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netcoreapp' OR '$(TargetGroup)' == 'uap' OR '$(TargetGroup)' == 'net47'">true</IsPartialFacadeAssembly>
     <RunApiCompat Condition="'$(TargetGroup)' != 'netcoreapp' AND '$(TargetGroup)' != 'uap'">false</RunApiCompat>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
@@ -13,6 +13,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net47-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net47-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.0-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.0-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'portable_net40+sl4+win8+wp8-Debug|AnyCPU'" />
@@ -39,7 +41,7 @@
       <Link>Common\System\Reflection\AssemblyMetadataAttribute.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'portable_net40+sl4+win8+wp8' OR '$(TargetGroup)' == 'netfx'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'portable_net40+sl4+win8+wp8' OR '$(TargetGroup)' == 'netfx' OR '$(TargetGroup)' == 'net47'">
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/System.ValueTuple/src/System.ValueTuple.csproj
+++ b/src/System.ValueTuple/src/System.ValueTuple.csproj
@@ -7,6 +7,8 @@
     <DocumentationFile>$(OutputPath)$(MSBuildProjectName).xml</DocumentationFile>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netcoreapp' OR '$(TargetGroup)' == 'uap' OR '$(TargetGroup)' == 'net47'">true</IsPartialFacadeAssembly>
     <RunApiCompat Condition="'$(TargetGroup)' != 'netcoreapp' AND '$(TargetGroup)' != 'uap'">false</RunApiCompat>
+    <!-- We've explicitly authored a reference facade so we do not need to use the desktop implementation as ref -->
+    <PackageDesktopAsRef>false</PackageDesktopAsRef>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />

--- a/src/Tools/GenerateProps/targetgroups.props
+++ b/src/Tools/GenerateProps/targetgroups.props
@@ -184,6 +184,13 @@
       <Imports>net462</Imports>
       <CompatibleWith>netstandard2.0</CompatibleWith>
     </TargetGroups>
+    <TargetGroups Include="net47">
+      <TargetingPackNugetPackageId>Microsoft.TargetingPack.NETFramework.v4.7</TargetingPackNugetPackageId>
+      <NuGetTargetMoniker>.NETFramework,Version=v4.7</NuGetTargetMoniker>
+      <NuGetTargetMonikerShort>net47</NuGetTargetMonikerShort>
+      <Imports>net462</Imports>
+      <CompatibleWith>netstandard2.0</CompatibleWith>
+    </TargetGroups>
     <TargetGroups Include="netfx">
       <TargetingPackNugetPackageId>Microsoft.TargetingPack.NETFramework.v4.6.1</TargetingPackNugetPackageId>
       <NuGetTargetMoniker>.NETFramework,Version=v4.6.1</NuGetTargetMoniker>


### PR DESCRIPTION
@weshaggard @ericstj @AlexGhiondea for review.

Fixes https://github.com/dotnet/corefx/issues/15175

I filed a follow-up issue (https://github.com/dotnet/corefx/issues/18518) to reference the shipped targeting pack instead of the pre-release one from myget.

Do you have any tips on validation?
So far, I inspected the produced package, and verified that it adds a "net47" folder under "lib" and "ref", and that it contains assemblies with type-forwards, and only referencing `mscorlib`.

Ref folder before:
![image](https://cloud.githubusercontent.com/assets/12466233/25108070/29bf2d8c-2388-11e7-8596-e81bfe7ad438.png)
And after change:
![image](https://cloud.githubusercontent.com/assets/12466233/25108122/7c6d8aba-2388-11e7-8747-be4047f430e3.png)


Lib folder before:
![image](https://cloud.githubusercontent.com/assets/12466233/25108089/46442dae-2388-11e7-9aca-e45b71d12a97.png)
And after change;
![image](https://cloud.githubusercontent.com/assets/12466233/25108103/643ddb16-2388-11e7-91de-096a34490c1b.png)


