### PR TITLE
Remove System.Security.Cryptography.Native

### DIFF
--- a/src/Native/Unix/System.Security.Cryptography.Native/CMakeLists.txt
+++ b/src/Native/Unix/System.Security.Cryptography.Native/CMakeLists.txt
@@ -79,20 +79,10 @@ if (FEATURE_DISTRO_AGNOSTIC_SSL)
         VERBATIM
     )
 
-    # Link with libdl.so to get the dlopen / dlsym / dlclose
-    target_link_libraries(System.Security.Cryptography.Native
-      dl
-    )
-
     target_link_libraries(System.Security.Cryptography.Native.OpenSsl
       dl
     )
 else()
-    target_link_libraries(System.Security.Cryptography.Native
-      ${OPENSSL_CRYPTO_LIBRARY}
-      ${OPENSSL_SSL_LIBRARY}
-    )
-  
     target_link_libraries(System.Security.Cryptography.Native.OpenSsl
       ${OPENSSL_CRYPTO_LIBRARY}
       ${OPENSSL_SSL_LIBRARY}


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/13124

cc: @bartonjs

<s>There is also bunch of files in here:
`src/Common/src/Interop/Unix/System.Security.Cryptography.Native`

but they seem to be used by few projects i.e. `System.Security.Cryptography.X509Certificates`.
I took a quick attempt at removing them but they seem to be needed and I didn't find any good substitutes - please let me know if we really care about removing those (I think might be worth post 2.0 but wouldn't prioritize this right now)</s>
Misunderstood the issue.

I'm also not sure if I need to do anything special for removing the package.
Currently I'm mostly interested if this will pass on all of the OSes.