### PR TITLE
Use hashtable path if S.L.Expressions Switch method is string.Equals

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Common/CachedReflectionInfo.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Common/CachedReflectionInfo.cs
@@ -89,6 +89,11 @@ namespace System.Linq.Expressions
                                   s_String_op_Equality_String_String ??
                                  (s_String_op_Equality_String_String = typeof(string).GetMethod("op_Equality", new[] { typeof(string), typeof(string) }));
 
+        private static MethodInfo s_String_Equals_String_String;
+        public  static MethodInfo   String_Equals_String_String =>
+                                  s_String_Equals_String_String ??
+                                 (s_String_Equals_String_String = typeof(string).GetMethod("Equals", new[] { typeof(string), typeof(string) }));
+
         private static MethodInfo s_DictionaryOfStringInt32_Add_String_Int32;
         public  static MethodInfo   DictionaryOfStringInt32_Add_String_Int32 =>
                                   s_DictionaryOfStringInt32_Add_String_Int32 ??

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Statements.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Statements.cs
@@ -633,13 +633,7 @@ namespace System.Linq.Expressions.Compiler
         private bool TryEmitHashtableSwitch(SwitchExpression node, CompilationFlags flags)
         {
             // If we have a comparison other than string equality, bail
-            MethodInfo equality = String_op_Equality_String_String;
-            if (equality != null && !equality.IsStatic)
-            {
-                equality = null;
-            }
-
-            if (node.Comparison != equality)
+            if (node.Comparison != String_op_Equality_String_String && node.Comparison != String_Equals_String_String)
             {
                 return false;
             }

--- a/src/System.Linq.Expressions/tests/Switch/SwitchTests.cs
+++ b/src/System.Linq.Expressions/tests/Switch/SwitchTests.cs
@@ -787,6 +787,34 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void SwitchOnStringEqualsMethod(bool useInterpreter)
+        {
+            var values = new string[] { "foobar", "foo", "bar", "baz", "qux", "quux", "corge", "grault", "garply", "waldo", "fred", "plugh", "xyzzy", "thud", null };
+
+            for (var i = 1; i <= values.Length; i++)
+            {
+                SwitchCase[] cases = values.Take(i).Select((s, j) => Expression.SwitchCase(Expression.Constant(j), Expression.Constant(values[j], typeof(string)))).ToArray();
+                ParameterExpression value = Expression.Parameter(typeof(string));
+                Expression<Func<string, int>> e = Expression.Lambda<Func<string, int>>(Expression.Switch(value, Expression.Constant(-1), typeof(string).GetMethod("Equals", new[] { typeof(string), typeof(string) }), cases), value);
+                Func<string, int> f = e.Compile(useInterpreter);
+
+                int k = 0;
+                foreach (var str in values.Take(i))
+                {
+                    Assert.Equal(k, f(str));
+                    k++;
+                }
+
+                foreach (var str in values.Skip(i).Concat(new[] { "whatever", "FOO" }))
+                {
+                    Assert.Equal(-1, f(str));
+                    k++;
+                }
+            }
+        }
+
         [Fact]
         public void ToStringTest()
         {


### PR DESCRIPTION
The `string.Equals(string, string)` method has the same behaviour as the default equality operator, so the optimised path taken for that default equality operator is just as applicable, so use it.