### PR TITLE
Tlbattributes

### DIFF
--- a/src/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -467,12 +467,8 @@ namespace System.Runtime.InteropServices
     [AttributeUsage(AttributeTargets.Assembly, Inherited = false)]
     public sealed class ImportedFromTypeLibAttribute : Attribute
     {
-        internal String _val;
-        public ImportedFromTypeLibAttribute(String tlbFile)
-        {
-            _val = tlbFile;
-        }
-        public String Value { get {return _val;} }
+        public ImportedFromTypeLibAttribute(String tlbFile) { }
+        public String Value { get { throw null; } }
     }         
     [System.AttributeUsageAttribute((System.AttributeTargets)(2048), Inherited = false)]
     public sealed partial class InAttribute : System.Attribute
@@ -835,12 +831,8 @@ namespace System.Runtime.InteropServices
     [AttributeUsage(AttributeTargets.Interface, Inherited = false)]
     public sealed class TypeLibImportClassAttribute : Attribute
     {
-        internal String _importClassName;
-        public TypeLibImportClassAttribute(Type importClass)
-        {
-            _importClassName = importClass.ToString();
-        }
-        public String Value { get { return _importClassName; } }
+        public TypeLibImportClassAttribute(Type importClass) { }
+        public String Value { get { throw null; } }
     }
     [Serializable]
     [Flags()]
@@ -900,60 +892,31 @@ namespace System.Runtime.InteropServices
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Enum | AttributeTargets.Struct, Inherited = false)]
     public sealed class  TypeLibTypeAttribute : Attribute
     {
-        internal TypeLibTypeFlags _val;
-        public TypeLibTypeAttribute(TypeLibTypeFlags flags)
-        {
-            _val = flags;
-        }
-        public TypeLibTypeAttribute(short flags)
-        {
-            _val = (TypeLibTypeFlags)flags;
-        }
-        public TypeLibTypeFlags Value { get {return _val;} }
+        public TypeLibTypeAttribute(TypeLibTypeFlags flags)  {}
+        public TypeLibTypeAttribute(short flags) { }
+        public TypeLibTypeFlags Value { get { throw null; } }
     }
     [AttributeUsage(AttributeTargets.Method, Inherited = false)]
     public sealed class TypeLibFuncAttribute : Attribute
     {
-        internal TypeLibFuncFlags _val;
-        public TypeLibFuncAttribute(TypeLibFuncFlags flags)
-        {
-            _val = flags;
-        }
-        public TypeLibFuncAttribute(short flags)
-        {
-            _val = (TypeLibFuncFlags)flags;
-        }
-        public TypeLibFuncFlags Value { get {return _val;} }
+        public TypeLibFuncAttribute(TypeLibFuncFlags flags) { }
+        public TypeLibFuncAttribute(short flags) { }
+        public TypeLibFuncFlags Value { get { throw null; } }
     }
     [AttributeUsage(AttributeTargets.Field, Inherited = false)]
     public sealed class TypeLibVarAttribute : Attribute
     {
-        internal TypeLibVarFlags _val;
-        public TypeLibVarAttribute(TypeLibVarFlags flags)
-        {
-            _val = flags;
-        }
-        public TypeLibVarAttribute(short flags)
-        {
-            _val = (TypeLibVarFlags)flags;
-        }
-        public TypeLibVarFlags Value { get {return _val;} }
+        public TypeLibVarAttribute(TypeLibVarFlags flags) { }
+        public TypeLibVarAttribute(short flags) { }
+        public TypeLibVarFlags Value { get { throw null; } }
     }
     [AttributeUsage(AttributeTargets.Assembly, Inherited = false)]
     [System.Runtime.InteropServices.ComVisible(true)]
     public sealed class TypeLibVersionAttribute : Attribute
     {
-        internal int _major;
-        internal int _minor;
-
-        public TypeLibVersionAttribute(int major, int minor)
-        {
-            _major = major;
-            _minor = minor;
-        }
-
-        public int MajorVersion { get {return _major;} }
-        public int MinorVersion { get {return _minor;} }
+        public TypeLibVersionAttribute(int major, int minor) {}
+        public int MajorVersion { get { throw null; } }
+        public int MinorVersion { get { throw null; } }
     }   
     [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
     [System.ObsoleteAttribute("UnknownWrapper and support for marshalling to the VARIANT type may be unavailable in future releases.")]

--- a/src/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -464,6 +464,16 @@ namespace System.Runtime.InteropServices
     {
         System.Runtime.InteropServices.CustomQueryInterfaceResult GetInterface(ref System.Guid iid, out System.IntPtr ppv);
     }
+    [AttributeUsage(AttributeTargets.Assembly, Inherited = false)]
+    public sealed class ImportedFromTypeLibAttribute : Attribute
+    {
+        internal String _val;
+        public ImportedFromTypeLibAttribute(String tlbFile)
+        {
+            _val = tlbFile;
+        }
+        public String Value { get {return _val;} }
+    }         
     [System.AttributeUsageAttribute((System.AttributeTargets)(2048), Inherited = false)]
     public sealed partial class InAttribute : System.Attribute
     {
@@ -822,6 +832,129 @@ namespace System.Runtime.InteropServices
         public string Identifier { get { throw null; } }
         public string Scope { get { throw null; } }
     }
+    [AttributeUsage(AttributeTargets.Interface, Inherited = false)]
+    public sealed class TypeLibImportClassAttribute : Attribute
+    {
+        internal String _importClassName;
+        public TypeLibImportClassAttribute(Type importClass)
+        {
+            _importClassName = importClass.ToString();
+        }
+        public String Value { get { return _importClassName; } }
+    }
+    [Serializable]
+    [Flags()]
+    public enum TypeLibTypeFlags
+    {
+        FAppObject      = 0x0001,
+        FCanCreate      = 0x0002,
+        FLicensed       = 0x0004,
+        FPreDeclId      = 0x0008,
+        FHidden         = 0x0010,
+        FControl        = 0x0020,
+        FDual           = 0x0040,
+        FNonExtensible  = 0x0080,
+        FOleAutomation  = 0x0100,
+        FRestricted     = 0x0200,
+        FAggregatable   = 0x0400,
+        FReplaceable    = 0x0800,
+        FDispatchable   = 0x1000,
+        FReverseBind    = 0x2000,
+    }
+    [Serializable]
+    [Flags()]
+    public enum TypeLibFuncFlags
+    {
+        FRestricted         = 0x0001,
+        FSource             = 0x0002,
+        FBindable           = 0x0004,
+        FRequestEdit        = 0x0008,
+        FDisplayBind        = 0x0010,
+        FDefaultBind        = 0x0020,
+        FHidden             = 0x0040,
+        FUsesGetLastError   = 0x0080,
+        FDefaultCollelem    = 0x0100,
+        FUiDefault          = 0x0200,
+        FNonBrowsable       = 0x0400,
+        FReplaceable        = 0x0800,
+        FImmediateBind      = 0x1000,
+    }
+    [Serializable]
+    [Flags()]
+    public enum TypeLibVarFlags
+    {
+        FReadOnly           = 0x0001,
+        FSource             = 0x0002,
+        FBindable           = 0x0004,
+        FRequestEdit        = 0x0008,
+        FDisplayBind        = 0x0010,
+        FDefaultBind        = 0x0020,
+        FHidden             = 0x0040,
+        FRestricted         = 0x0080,
+        FDefaultCollelem    = 0x0100,
+        FUiDefault          = 0x0200,
+        FNonBrowsable       = 0x0400,
+        FReplaceable        = 0x0800,
+        FImmediateBind      = 0x1000,
+    }
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Enum | AttributeTargets.Struct, Inherited = false)]
+    public sealed class  TypeLibTypeAttribute : Attribute
+    {
+        internal TypeLibTypeFlags _val;
+        public TypeLibTypeAttribute(TypeLibTypeFlags flags)
+        {
+            _val = flags;
+        }
+        public TypeLibTypeAttribute(short flags)
+        {
+            _val = (TypeLibTypeFlags)flags;
+        }
+        public TypeLibTypeFlags Value { get {return _val;} }
+    }
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    public sealed class TypeLibFuncAttribute : Attribute
+    {
+        internal TypeLibFuncFlags _val;
+        public TypeLibFuncAttribute(TypeLibFuncFlags flags)
+        {
+            _val = flags;
+        }
+        public TypeLibFuncAttribute(short flags)
+        {
+            _val = (TypeLibFuncFlags)flags;
+        }
+        public TypeLibFuncFlags Value { get {return _val;} }
+    }
+    [AttributeUsage(AttributeTargets.Field, Inherited = false)]
+    public sealed class TypeLibVarAttribute : Attribute
+    {
+        internal TypeLibVarFlags _val;
+        public TypeLibVarAttribute(TypeLibVarFlags flags)
+        {
+            _val = flags;
+        }
+        public TypeLibVarAttribute(short flags)
+        {
+            _val = (TypeLibVarFlags)flags;
+        }
+        public TypeLibVarFlags Value { get {return _val;} }
+    }
+    [AttributeUsage(AttributeTargets.Assembly, Inherited = false)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+    public sealed class TypeLibVersionAttribute : Attribute
+    {
+        internal int _major;
+        internal int _minor;
+
+        public TypeLibVersionAttribute(int major, int minor)
+        {
+            _major = major;
+            _minor = minor;
+        }
+
+        public int MajorVersion { get {return _major;} }
+        public int MinorVersion { get {return _minor;} }
+    }   
     [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
     [System.ObsoleteAttribute("UnknownWrapper and support for marshalling to the VARIANT type may be unavailable in future releases.")]
     public sealed partial class UnknownWrapper

--- a/src/System.Runtime.InteropServices/src/System/Runtime/InteropServices/Attributes.cs
+++ b/src/System.Runtime.InteropServices/src/System/Runtime/InteropServices/Attributes.cs
@@ -95,7 +95,6 @@ namespace System.Runtime.InteropServices
         SystemDefinedImpl = 0,
     }
 
-
     [AttributeUsage(AttributeTargets.Assembly, Inherited = false)]
     public sealed class ImportedFromTypeLibAttribute : Attribute
     {

--- a/src/System.Runtime.InteropServices/src/System/Runtime/InteropServices/Attributes.cs
+++ b/src/System.Runtime.InteropServices/src/System/Runtime/InteropServices/Attributes.cs
@@ -103,7 +103,7 @@ namespace System.Runtime.InteropServices
         {
             _val = tlbFile;
         }
-        public String Value { get {return _val;} }
+        public String Value { get { return _val; } }
     }
 
     [AttributeUsage(AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
@@ -222,7 +222,7 @@ namespace System.Runtime.InteropServices
         {
             _val = (TypeLibTypeFlags)flags;
         }
-        public TypeLibTypeFlags Value { get {return _val;} }
+        public TypeLibTypeFlags Value { get { return _val; } }
     }
 
     [AttributeUsage(AttributeTargets.Method, Inherited = false)]
@@ -237,7 +237,7 @@ namespace System.Runtime.InteropServices
         {
             _val = (TypeLibFuncFlags)flags;
         }
-        public TypeLibFuncFlags Value { get {return _val;} }
+        public TypeLibFuncFlags Value { get { return _val; } }
     }
 
     [AttributeUsage(AttributeTargets.Field, Inherited = false)]
@@ -252,7 +252,7 @@ namespace System.Runtime.InteropServices
         {
             _val = (TypeLibVarFlags)flags;
         }
-        public TypeLibVarFlags Value { get {return _val;} }
+        public TypeLibVarFlags Value { get { return _val; } }
     }
 
     [AttributeUsage(AttributeTargets.Assembly, Inherited = false)]
@@ -268,7 +268,7 @@ namespace System.Runtime.InteropServices
             _minor = minor;
         }
 
-        public int MajorVersion { get {return _major;} }
-        public int MinorVersion { get {return _minor;} }
+        public int MajorVersion { get { return _major; } }
+        public int MinorVersion { get { return _minor; } }
     }
 }

--- a/src/System.Runtime.InteropServices/src/System/Runtime/InteropServices/Attributes.cs
+++ b/src/System.Runtime.InteropServices/src/System/Runtime/InteropServices/Attributes.cs
@@ -98,12 +98,11 @@ namespace System.Runtime.InteropServices
     [AttributeUsage(AttributeTargets.Assembly, Inherited = false)]
     public sealed class ImportedFromTypeLibAttribute : Attribute
     {
-        internal String _val;
         public ImportedFromTypeLibAttribute(String tlbFile)
         {
-            _val = tlbFile;
+            Value = tlbFile;
         }
-        public String Value { get { return _val; } }
+        public string Value { get; }
     }
 
     [AttributeUsage(AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
@@ -144,16 +143,15 @@ namespace System.Runtime.InteropServices
     [AttributeUsage(AttributeTargets.Interface, Inherited = false)]
     public sealed class TypeLibImportClassAttribute : Attribute
     {
-        internal String _importClassName;
         public TypeLibImportClassAttribute(Type importClass)
         {
-            _importClassName = importClass.ToString();
+            Value = importClass.ToString();
         }
-        public String Value { get { return _importClassName; } }
+        public string Value { get; }
     }
 
     [Serializable]
-    [Flags()]
+    [Flags]
     public enum TypeLibTypeFlags
     {
         FAppObject      = 0x0001,
@@ -173,7 +171,7 @@ namespace System.Runtime.InteropServices
     }
 
     [Serializable]
-    [Flags()]
+    [Flags]
     public enum TypeLibFuncFlags
     {
         FRestricted         = 0x0001,
@@ -192,7 +190,7 @@ namespace System.Runtime.InteropServices
     }
 
     [Serializable]
-    [Flags()]
+    [Flags]
     public enum TypeLibVarFlags
     {
         FReadOnly           = 0x0001,
@@ -213,62 +211,56 @@ namespace System.Runtime.InteropServices
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Enum | AttributeTargets.Struct, Inherited = false)]
     public sealed class  TypeLibTypeAttribute : Attribute
     {
-        internal TypeLibTypeFlags _val;
         public TypeLibTypeAttribute(TypeLibTypeFlags flags)
         {
-            _val = flags;
+            Value = flags;
         }
         public TypeLibTypeAttribute(short flags)
         {
-            _val = (TypeLibTypeFlags)flags;
+            Value = (TypeLibTypeFlags)flags;
         }
-        public TypeLibTypeFlags Value { get { return _val; } }
+        public TypeLibTypeFlags Value { get; }
     }
 
     [AttributeUsage(AttributeTargets.Method, Inherited = false)]
     public sealed class TypeLibFuncAttribute : Attribute
     {
-        internal TypeLibFuncFlags _val;
         public TypeLibFuncAttribute(TypeLibFuncFlags flags)
         {
-            _val = flags;
+            Value = flags;
         }
         public TypeLibFuncAttribute(short flags)
         {
-            _val = (TypeLibFuncFlags)flags;
+            Value = (TypeLibFuncFlags)flags;
         }
-        public TypeLibFuncFlags Value { get { return _val; } }
+        public TypeLibFuncFlags Value { get; }
     }
 
     [AttributeUsage(AttributeTargets.Field, Inherited = false)]
     public sealed class TypeLibVarAttribute : Attribute
     {
-        internal TypeLibVarFlags _val;
         public TypeLibVarAttribute(TypeLibVarFlags flags)
         {
-            _val = flags;
+            Value = flags;
         }
         public TypeLibVarAttribute(short flags)
         {
-            _val = (TypeLibVarFlags)flags;
+            Value = (TypeLibVarFlags)flags;
         }
-        public TypeLibVarFlags Value { get { return _val; } }
+        public TypeLibVarFlags Value { get; }
     }
 
     [AttributeUsage(AttributeTargets.Assembly, Inherited = false)]
     [System.Runtime.InteropServices.ComVisible(true)]
     public sealed class TypeLibVersionAttribute : Attribute
     {
-        internal int _major;
-        internal int _minor;
-
         public TypeLibVersionAttribute(int major, int minor)
         {
-            _major = major;
-            _minor = minor;
+            MajorVersion = major;
+            MinorVersion = minor;
         }
 
-        public int MajorVersion { get { return _major; } }
-        public int MinorVersion { get { return _minor; } }
+        public int MajorVersion { get; }
+        public int MinorVersion { get; }
     }
 }

--- a/src/System.Runtime.InteropServices/src/System/Runtime/InteropServices/Attributes.cs
+++ b/src/System.Runtime.InteropServices/src/System/Runtime/InteropServices/Attributes.cs
@@ -95,6 +95,18 @@ namespace System.Runtime.InteropServices
         SystemDefinedImpl = 0,
     }
 
+
+    [AttributeUsage(AttributeTargets.Assembly, Inherited = false)]
+    public sealed class ImportedFromTypeLibAttribute : Attribute
+    {
+        internal String _val;
+        public ImportedFromTypeLibAttribute(String tlbFile)
+        {
+            _val = tlbFile;
+        }
+        public String Value { get {return _val;} }
+    }
+
     [AttributeUsage(AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
     public sealed class ManagedToNativeComInteropStubAttribute : Attribute
     {
@@ -128,5 +140,136 @@ namespace System.Runtime.InteropServices
         public SetWin32ContextInIDispatchAttribute()
         {
         }
+    }
+
+    [AttributeUsage(AttributeTargets.Interface, Inherited = false)]
+    public sealed class TypeLibImportClassAttribute : Attribute
+    {
+        internal String _importClassName;
+        public TypeLibImportClassAttribute(Type importClass)
+        {
+            _importClassName = importClass.ToString();
+        }
+        public String Value { get { return _importClassName; } }
+    }
+
+    [Serializable]
+    [Flags()]
+    public enum TypeLibTypeFlags
+    {
+        FAppObject      = 0x0001,
+        FCanCreate      = 0x0002,
+        FLicensed       = 0x0004,
+        FPreDeclId      = 0x0008,
+        FHidden         = 0x0010,
+        FControl        = 0x0020,
+        FDual           = 0x0040,
+        FNonExtensible  = 0x0080,
+        FOleAutomation  = 0x0100,
+        FRestricted     = 0x0200,
+        FAggregatable   = 0x0400,
+        FReplaceable    = 0x0800,
+        FDispatchable   = 0x1000,
+        FReverseBind    = 0x2000,
+    }
+
+    [Serializable]
+    [Flags()]
+    public enum TypeLibFuncFlags
+    {
+        FRestricted         = 0x0001,
+        FSource             = 0x0002,
+        FBindable           = 0x0004,
+        FRequestEdit        = 0x0008,
+        FDisplayBind        = 0x0010,
+        FDefaultBind        = 0x0020,
+        FHidden             = 0x0040,
+        FUsesGetLastError   = 0x0080,
+        FDefaultCollelem    = 0x0100,
+        FUiDefault          = 0x0200,
+        FNonBrowsable       = 0x0400,
+        FReplaceable        = 0x0800,
+        FImmediateBind      = 0x1000,
+    }
+
+    [Serializable]
+    [Flags()]
+    public enum TypeLibVarFlags
+    {
+        FReadOnly           = 0x0001,
+        FSource             = 0x0002,
+        FBindable           = 0x0004,
+        FRequestEdit        = 0x0008,
+        FDisplayBind        = 0x0010,
+        FDefaultBind        = 0x0020,
+        FHidden             = 0x0040,
+        FRestricted         = 0x0080,
+        FDefaultCollelem    = 0x0100,
+        FUiDefault          = 0x0200,
+        FNonBrowsable       = 0x0400,
+        FReplaceable        = 0x0800,
+        FImmediateBind      = 0x1000,
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Enum | AttributeTargets.Struct, Inherited = false)]
+    public sealed class  TypeLibTypeAttribute : Attribute
+    {
+        internal TypeLibTypeFlags _val;
+        public TypeLibTypeAttribute(TypeLibTypeFlags flags)
+        {
+            _val = flags;
+        }
+        public TypeLibTypeAttribute(short flags)
+        {
+            _val = (TypeLibTypeFlags)flags;
+        }
+        public TypeLibTypeFlags Value { get {return _val;} }
+    }
+
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    public sealed class TypeLibFuncAttribute : Attribute
+    {
+        internal TypeLibFuncFlags _val;
+        public TypeLibFuncAttribute(TypeLibFuncFlags flags)
+        {
+            _val = flags;
+        }
+        public TypeLibFuncAttribute(short flags)
+        {
+            _val = (TypeLibFuncFlags)flags;
+        }
+        public TypeLibFuncFlags Value { get {return _val;} }
+    }
+
+    [AttributeUsage(AttributeTargets.Field, Inherited = false)]
+    public sealed class TypeLibVarAttribute : Attribute
+    {
+        internal TypeLibVarFlags _val;
+        public TypeLibVarAttribute(TypeLibVarFlags flags)
+        {
+            _val = flags;
+        }
+        public TypeLibVarAttribute(short flags)
+        {
+            _val = (TypeLibVarFlags)flags;
+        }
+        public TypeLibVarFlags Value { get {return _val;} }
+    }
+
+    [AttributeUsage(AttributeTargets.Assembly, Inherited = false)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+    public sealed class TypeLibVersionAttribute : Attribute
+    {
+        internal int _major;
+        internal int _minor;
+
+        public TypeLibVersionAttribute(int major, int minor)
+        {
+            _major = major;
+            _minor = minor;
+        }
+
+        public int MajorVersion { get {return _major;} }
+        public int MinorVersion { get {return _minor;} }
     }
 }


### PR DESCRIPTION
Not strictly required for net standard 2.0 but nice to have for tlbimp created dll to not have dangling references.
This is the same PR as https://github.com/dotnet/coreclr/pull/10975 but done in corefx repo. 
@jkotas @danmosemsft PTAL 
