### PR TITLE
Disable 2 IO tests for netfx

### DIFF
--- a/src/System.IO/tests/StreamWriter/StreamWriter.WriteTests.cs
+++ b/src/System.IO/tests/StreamWriter/StreamWriter.WriteTests.cs
@@ -195,6 +195,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework throws NullReferenceException")]
         public async Task NullNewLineAsync()
         {
             using (MemoryStream ms = new MemoryStream())

--- a/src/System.IO/tests/StringWriter/StringWriterTests.cs
+++ b/src/System.IO/tests/StringWriter/StringWriterTests.cs
@@ -391,6 +391,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework throws NullReferenceException")]
         public async Task NullNewLineAsync()
         {
             using (MemoryStream ms = new MemoryStream())


### PR DESCRIPTION
These protect a breaking change made after discussoin in https://github.com/dotnet/corefx/issues/14563

@safern I see a bunch of failures in https://mc.dot.net/#/product/netcore/master/source/official~2Fcorefx~2Fmaster~2F/type/test~2Ffunctional~2Fdesktop~2Fcli~2F/build/20170418.01/workItem/System.IO.Tests/analysis/xunit/System.IO.Tests.WriteTests~2FNullNewLineAsync but I don't see a bug for it.