### PR TITLE
Fix S.G.Extensions tests for netfx

### DIFF
--- a/src/System.Globalization.Extensions/tests/Normalization/StringNormalizationTests.cs
+++ b/src/System.Globalization.Extensions/tests/Normalization/StringNormalizationTests.cs
@@ -30,7 +30,12 @@ namespace System.Globalization.Tests
 
             Assert.Throws<ArgumentException>("strInput", () => "\uFFFE".IsNormalized()); // Invalid codepoint
             Assert.Throws<ArgumentException>("strInput", () => "\uD800\uD800".IsNormalized()); // Invalid surrogate pair
+        }
 
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Regular method on full framework: no point invoking on a null reference")]
+        public void IsNormalized_Null()
+        {
             Assert.Throws<ArgumentNullException>("strInput", () => StringNormalizationExtensions.IsNormalized(null));
         }
 
@@ -62,7 +67,12 @@ namespace System.Globalization.Tests
 
             Assert.Throws<ArgumentException>("strInput", () => "\uFFFE".Normalize()); // Invalid codepoint
             Assert.Throws<ArgumentException>("strInput", () => "\uD800\uD800".Normalize()); // Invalid surrogate pair
+        }
 
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Regular method on full framework: no point invoking on a null reference")]
+        public void Normalize_Null()
+        {
             Assert.Throws<ArgumentNullException>("strInput", () => StringNormalizationExtensions.Normalize(null));
         }
     }


### PR DESCRIPTION
@safern again I see the failures in MC but for some reason don't find issues for them https://mc.dot.net/#/product/netcore/master/source/official~2Fcorefx~2Fmaster~2F/type/test~2Ffunctional~2Fdesktop~2Fcli~2F/build/20170418.01/workItem/System.Globalization.Extensions.Tests