### PR TITLE
Fix XsPerformanceTest.

### DIFF
--- a/src/System.Private.Xml/tests/XmlSerializer/Performance/XsPerformanceTest.cs
+++ b/src/System.Private.Xml/tests/XmlSerializer/Performance/XsPerformanceTest.cs
@@ -20,14 +20,18 @@ namespace System.Xml.XmlSerializer.Tests.Performance
             foreach (PerfTestConfig config in PerformanceTestCommon.PerformanceTestConfigurations())
             {
                 // XmlSerializer doesn't support Dictionary type
-                if (config.PerfTestType == TestType.Dictionary) continue;
+                if (config.PerfTestType == TestType.Dictionary
+                  || config.PerfTestType == TestType.DictionaryOfSimpleType) 
+                {
+                    continue;
+                }
+
                 yield return config.ToObjectArray();
             }
         }
 
         [Benchmark]
         [MemberData(nameof(SerializeMemberData))]
-        [ActiveIssue(18249)]
         public void XsSerializationTest(int numberOfRuns, TestType testType, int testSize)
         {
             PerformanceTestCommon.RunSerializationPerformanceTest(numberOfRuns, testType, testSize, XsSerializerFactory.GetInstance());
@@ -35,7 +39,6 @@ namespace System.Xml.XmlSerializer.Tests.Performance
 
         [Benchmark]
         [MemberData(nameof(SerializeMemberData))]
-        [ActiveIssue(18249)]
         public void XsDeSerializationTest(int numberOfRuns, TestType testType, int testSize)
         {
             PerformanceTestCommon.RunDeserializationPerformanceTest(numberOfRuns, testType, testSize, XsSerializerFactory.GetInstance());


### PR DESCRIPTION
XmlSerializer does not support Dictionary type. The fix is to skip DictionaryOfSimpleType for XmlSeriazlier.

Fix #18249.