### PR TITLE
Free S.L.Expressions.Compiler.CompilerScope.Storage locals when possible

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/CompilerScope.Storage.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/CompilerScope.Storage.cs
@@ -47,7 +47,9 @@ namespace System.Linq.Expressions.Compiler
                 // the compiler when emitting an inlined lambda invoke, to
                 // handle ByRef parameters. BlockExpression prevents this
                 // from being exposed to user created trees.
-                _local = compiler.GetNamedLocal(variable.IsByRef ? variable.Type.MakeByRefType() : variable.Type, variable);
+
+                // Set name if DebugInfoGenerator support is brought back.
+                _local = compiler.GetLocal(variable.IsByRef ? variable.Type.MakeByRefType() : variable.Type);
             }
 
             internal override void EmitLoad()
@@ -63,6 +65,11 @@ namespace System.Linq.Expressions.Compiler
             internal override void EmitAddress()
             {
                 Compiler.IL.Emit(OpCodes.Ldloca, _local);
+            }
+
+            internal override void FreeLocal()
+            {
+                Compiler.FreeLocal(_local);
             }
         }
 
@@ -156,7 +163,9 @@ namespace System.Linq.Expressions.Compiler
             {
                 Type boxType = typeof(StrongBox<>).MakeGenericType(variable.Type);
                 _boxValueField = boxType.GetField("Value");
-                _boxLocal = compiler.GetNamedLocal(boxType, variable);
+
+                // Set name if DebugInfoGenerator support is brought back.
+                _boxLocal = compiler.GetLocal(boxType);
             }
 
             internal override void EmitLoad()
@@ -191,6 +200,11 @@ namespace System.Linq.Expressions.Compiler
             internal void EmitStoreBox()
             {
                 Compiler.IL.Emit(OpCodes.Stloc, _boxLocal);
+            }
+
+            internal override void FreeLocal()
+            {
+                Compiler.FreeLocal(_boxLocal);
             }
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.cs
@@ -230,14 +230,6 @@ namespace System.Linq.Expressions.Compiler
             _freeLocals.Push(local.LocalType, local);
         }
 
-        internal LocalBuilder GetNamedLocal(Type type, ParameterExpression variable)
-        {
-            Debug.Assert(type != null && variable != null);
-
-            LocalBuilder lb = _ilg.DeclareLocal(type);
-            return lb;
-        }
-
         /// <summary>
         /// Gets the argument slot corresponding to the parameter at the given
         /// index. Assumes that the method takes a certain number of prefix


### PR DESCRIPTION
The separate `GetNamedLocal` -seems to exist to possibly write to a `DebugInfoGenerator`, and that feature not used. Using `GetLocal` allows the local to be reused when the scope finishes, so do so.