### PR TITLE
Expose the ExternalAttributes field in ZipArchive

### DIFF
--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -59,7 +59,7 @@
       <Version>2.5.0</Version>
     </PackageReference>
     <PackageReference Include="System.IO.Compression.TestData">
-      <Version>1.0.4-prerelease</Version>
+      <Version>1.0.5-prerelease</Version>
     </PackageReference>
     <PackageReference Include="System.IO.Packaging.TestData">
       <Version>1.0.0-prerelease</Version>

--- a/src/System.IO.Compression.ZipFile/tests/System.IO.Compression.ZipFile.Tests.csproj
+++ b/src/System.IO.Compression.ZipFile/tests/System.IO.Compression.ZipFile.Tests.csproj
@@ -44,7 +44,7 @@
     <Compile Include="ZipFileConvenienceMethods.netcoreapp1.1.cs" />
   </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)System.IO.Compression.TestData\1.0.5-prerelease\content\**\*.*">
+    <SupplementalTestData Include="$(PackagesDir)system.io.compression.testdata\1.0.5-prerelease\content\**\*.*">
       <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
     </SupplementalTestData>
   </ItemGroup>

--- a/src/System.IO.Compression.ZipFile/tests/System.IO.Compression.ZipFile.Tests.csproj
+++ b/src/System.IO.Compression.ZipFile/tests/System.IO.Compression.ZipFile.Tests.csproj
@@ -44,7 +44,7 @@
     <Compile Include="ZipFileConvenienceMethods.netcoreapp1.1.cs" />
   </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)system.io.compression.testdata\1.0.4-prerelease\content\**\*.*">
+    <SupplementalTestData Include="$(PackagesDir)System.IO.Compression.TestData\1.0.5-prerelease\content\**\*.*">
       <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
     </SupplementalTestData>
   </ItemGroup>

--- a/src/System.IO.Compression/ref/System.IO.Compression.cs
+++ b/src/System.IO.Compression/ref/System.IO.Compression.cs
@@ -90,6 +90,7 @@ namespace System.IO.Compression
         internal ZipArchiveEntry() { }
         public System.IO.Compression.ZipArchive Archive { get { throw null; } }
         public long CompressedLength { get { throw null; } }
+        public int ExternalAttributes { get { throw null; } set { } }
         public string FullName { get { throw null; } }
         public System.DateTimeOffset LastWriteTime { get { throw null; } set { } }
         public long Length { get { throw null; } }

--- a/src/System.IO.Compression/tests/Configurations.props
+++ b/src/System.IO.Compression/tests/Configurations.props
@@ -4,6 +4,8 @@
     <BuildConfigurations>
       netstandard-Unix;
       netstandard-Windows_NT;
+      netcoreapp-Unix;
+      netcoreapp-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.Compression/tests/Performance/System.IO.Compression.Performance.Tests.csproj
+++ b/src/System.IO.Compression/tests/Performance/System.IO.Compression.Performance.Tests.csproj
@@ -23,7 +23,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)system.io.compression.testdata\1.0.4-prerelease\content\**\*.*">
+    <SupplementalTestData Include="$(PackagesDir)System.IO.Compression.TestData\1.0.5-prerelease\content\**\*.*">
       <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
     </SupplementalTestData>
   </ItemGroup>

--- a/src/System.IO.Compression/tests/Performance/System.IO.Compression.Performance.Tests.csproj
+++ b/src/System.IO.Compression/tests/Performance/System.IO.Compression.Performance.Tests.csproj
@@ -23,7 +23,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)System.IO.Compression.TestData\1.0.5-prerelease\content\**\*.*">
+    <SupplementalTestData Include="$(PackagesDir)system.io.compression.testdata\1.0.5-prerelease\content\**\*.*">
       <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
     </SupplementalTestData>
   </ItemGroup>

--- a/src/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
+++ b/src/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
@@ -53,7 +53,7 @@
       <Compile Include="ZipArchive\zip_netcoreappTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)System.IO.Compression.TestData\1.0.5-prerelease\content\**\*.*">
+    <SupplementalTestData Include="$(PackagesDir)system.io.compression.testdata\1.0.5-prerelease\content\**\*.*">
       <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
     </SupplementalTestData>
   </ItemGroup>

--- a/src/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
+++ b/src/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
@@ -4,6 +4,10 @@
   <PropertyGroup>
     <ProjectGuid>{BC2E1649-291D-412E-9529-EDDA94FA7AD6}</ProjectGuid>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Unix-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Unix-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Debug|AnyCPU'" />
@@ -45,8 +49,11 @@
       <Link>Common\System\IO\Compression\ZipTestHelper.cs</Link>
     </Compile>
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
+      <Compile Include="ZipArchive\zip_netcoreappTests.cs" />
+  </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)system.io.compression.testdata\1.0.4-prerelease\content\**\*.*">
+    <SupplementalTestData Include="$(PackagesDir)System.IO.Compression.TestData\1.0.5-prerelease\content\**\*.*">
       <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
     </SupplementalTestData>
   </ItemGroup>

--- a/src/System.IO.Compression/tests/ZipArchive/zip_netcoreappTests.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_netcoreappTests.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.IO.Compression.Tests
+{
+    public class zip_netcoreappTests : ZipFileTestBase
+    {
+        [Theory]
+        [InlineData("sharpziplib.zip", 0)]
+        [InlineData("Linux_RW_RW_R__.zip", 0x8000 + 0x0100 + 0x0080 + 0x0020 + 0x0010 + 0x0004)]
+        [InlineData("Linux_RWXRW_R__.zip", 0x8000 + 0x01C0 + 0x0020 + 0x0010 + 0x0004)]
+        [InlineData("OSX_RWXRW_R__.zip", 0x8000 + 0x01C0 + 0x0020 + 0x0010 + 0x0004)]
+        public static async Task Read_UnixFilePermissions(string zipName, uint expectedAttr)
+        {
+            using (ZipArchive archive = new ZipArchive(await StreamHelpers.CreateTempCopyStream(compat(zipName)), ZipArchiveMode.Read))
+            {
+                foreach (ZipArchiveEntry e in archive.Entries)
+                {
+                    Assert.Equal(expectedAttr, ((uint)e.ExternalAttributes) >> 16);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(int.MaxValue)]
+        [InlineData(int.MinValue)]
+        [InlineData(0)]
+        public static async Task RoundTrips_UnixFilePermissions(int expectedAttr)
+        {
+            using (ZipArchive archive = new ZipArchive(await StreamHelpers.CreateTempCopyStream(zfile("normal.zip")), ZipArchiveMode.Update))
+            {
+                foreach (ZipArchiveEntry e in archive.Entries)
+                {
+                    e.ExternalAttributes = expectedAttr;
+                    Assert.Equal(expectedAttr, e.ExternalAttributes);
+                }
+            }
+        }
+    }
+}

--- a/src/System.IO.Compression/tests/ZipArchive/zip_netcoreappTests.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_netcoreappTests.cs
@@ -30,14 +30,25 @@ namespace System.IO.Compression.Tests
         [InlineData(int.MaxValue)]
         [InlineData(int.MinValue)]
         [InlineData(0)]
+        [InlineData((0x8000 + 0x01C0 + 0x0020 + 0x0010 + 0x0004) << 16)]
         public static async Task RoundTrips_UnixFilePermissions(int expectedAttr)
         {
-            using (ZipArchive archive = new ZipArchive(await StreamHelpers.CreateTempCopyStream(zfile("normal.zip")), ZipArchiveMode.Update))
+            using (var stream = await StreamHelpers.CreateTempCopyStream(zfile("normal.zip")))
             {
-                foreach (ZipArchiveEntry e in archive.Entries)
+                using (ZipArchive archive = new ZipArchive(stream, ZipArchiveMode.Update, true))
                 {
-                    e.ExternalAttributes = expectedAttr;
-                    Assert.Equal(expectedAttr, e.ExternalAttributes);
+                    foreach (ZipArchiveEntry e in archive.Entries)
+                    {
+                        e.ExternalAttributes = expectedAttr;
+                        Assert.Equal(expectedAttr, e.ExternalAttributes);
+                    }
+                }
+                using (ZipArchive archive = new ZipArchive(stream, ZipArchiveMode.Read))
+                {
+                    foreach (ZipArchiveEntry e in archive.Entries)
+                    {
+                        Assert.Equal(expectedAttr, e.ExternalAttributes);
+                    }
                 }
             }
         }


### PR DESCRIPTION
The ExternalFileAttributes field of a ZipArchiveEntry is currently hidden within the implementation and not accessible. This has been fine in the Windows world since it's not used but it is used by Unix's zip/unzip programs to store file permissions of an entry. As it currently stands, there is no way to carry Unix RWX permissions within a zip, so at unzip time the unzipper has to guess at permissions and manually chmod the entries. This PR simply exposes the raw field so that it may be used in any circumstance that requires access to the field. Tests are added to ensure that this field is set, read, and roundtrips properly with zips created from other common programs which use the field.

Note: Unix `unzip` doesn't apply permissions in the external file attributes field of a zip produced on Windows. So if you modify the externalfileattributes of a zip on Windows, `unzip` will use the defaults instead of what is set in the field. This isn't easily resolvable on our side since the platformmadeby byte determines a number of other things that we don't want to mess with (e.g. file name validity), so it would be unwise to lie about the platform on which the zip was written. 

resolves https://github.com/dotnet/corefx/issues/17067

cc: @eerhardt @danmosemsft @stephentoub 