### PR TITLE
Remove some bad Registry tests

### DIFF
--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_CreateSubKey_str.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_CreateSubKey_str.cs
@@ -41,23 +41,6 @@ namespace Microsoft.Win32.RegistryTests
             });
         }
 
-        [ActiveIssue(10546)]
-        [Fact]
-        public void NegativeTest_DeeplyNestedKey()
-        {
-            // Max number of parts to the registry key path is 509 (failing once it hits 510). 
-            // As TestRegistryKey is already a subkey, that gives us 507 remaining parts before an 
-            // exception is thrown.
-            const int maxNestedLevel = 507;
-            string exceedsNestedSubkeyName = string.Join(@"\", Enumerable.Repeat("a", maxNestedLevel));
-            using (RegistryKey k = TestRegistryKey.CreateSubKey(exceedsNestedSubkeyName))
-            {
-                // Verify TestRegistryKey is already nested, with 508 slashes meaning 509 parts
-                Assert.Equal(maxNestedLevel + 1, k.Name.Count(c => c == '\\'));
-            }
-            Assert.Throws<IOException>(() => TestRegistryKey.CreateSubKey(exceedsNestedSubkeyName + @"\" + maxNestedLevel));
-        }
-
         [Fact]
         public void CreateSubkeyWithEmptyName()
         {

--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_CreateSubKey_str_rkpc.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_CreateSubKey_str_rkpc.cs
@@ -111,17 +111,6 @@ namespace Microsoft.Win32.RegistryTests
             });
         }
 
-        [ActiveIssue(10546)]
-        [Fact]
-        public void NegativeTest_DeeplyNestedKey()
-        {
-            //According to msdn documentation max nesting level exceeds is 510 but actual is 508
-            const int maxNestedLevel = 508;
-            string exceedsNestedSubkeyName = string.Join(@"\", Enumerable.Repeat("a", maxNestedLevel));
-            Assert.Throws<IOException>(() => TestRegistryKey.CreateSubKey(exceedsNestedSubkeyName, true));
-            Assert.Throws<IOException>(() => TestRegistryKey.CreateSubKey(exceedsNestedSubkeyName, RegistryKeyPermissionCheck.ReadWriteSubTree));
-        }
-
         [Fact]
         public void CreateWritableSubkeyWithEmptyName()
         {


### PR DESCRIPTION
These tests assert a Windows limitation that was removed in win10 anniversary. They're testing windows behavior, not netcore behavior, so should be removed.

cc: @alexperovich @JeremyKuhne 