### PR TITLE
Fix attribute handling of hidden directories ending with slashes

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/FileSystemInfo.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileSystemInfo.Unix.cs
@@ -49,7 +49,15 @@ namespace System.IO
                 {
                     attrs |= FileAttributes.ReparsePoint;
                 }
-                if (Path.GetFileName(FullPath).StartsWith("."))
+
+                // If the filename starts with a period, it's hidden. Or if this is a directory ending in a slash,
+                // if the directory name starts with a period, it's hidden.
+                string fileName = Path.GetFileName(FullPath);
+                if (string.IsNullOrEmpty(fileName))
+                {
+                    fileName = Path.GetFileName(Path.GetDirectoryName(FullPath));
+                }
+                if (!string.IsNullOrEmpty(fileName) && fileName[0] == '.')
                 {
                     attrs |= FileAttributes.Hidden;
                 }

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/GetSetAttributes.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/GetSetAttributes.cs
@@ -59,6 +59,17 @@ namespace System.IO.Tests
         }
 
         [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        public void UnixDirectoryBeginningWithPeriodIsHidden(bool endsWithSlash)
+        {
+            string testDir = "." + GetTestFileName();
+            Directory.CreateDirectory(Path.Combine(TestDirectory, testDir));
+            Assert.True(0 != (new DirectoryInfo(Path.Combine(TestDirectory, testDir) + (endsWithSlash ? "/" : "")).Attributes & FileAttributes.Hidden));
+        }
+
+        [Theory]
         [InlineData(FileAttributes.ReadOnly)]
         [InlineData(FileAttributes.Hidden)]
         [InlineData(FileAttributes.System)]


### PR DESCRIPTION
We currently consider a file to be hidden if its name starts with a period.  That applies to directories as well.  But if the directory name in the FileSystemInfo ends with a '/', then the file name that comes back from GetFileName is empty, and it's actually the GetDirectoryName value we want to check for a period.

Fixes https://github.com/dotnet/corefx/issues/18520
cc: @ianhays, @bording