### PR TITLE
disable all failing desktop System.Security.Cryptography.Primitives tests (verified no regression)

### DIFF
--- a/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/HMAC.cs
+++ b/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/HMAC.cs
@@ -41,6 +41,9 @@ namespace System.Security.Cryptography
             }
             set
             {
+                if (value == null)
+                    throw new ArgumentNullException(nameof(HashName));
+
                 // On the desktop, setting the HashName selects (or switches over to) a new hashing algorithm via CryptoConfig.
                 // Our intended refactoring turns HMAC back into an abstract class with no algorithm-specific implementation.
                 // Changing the HashName would not have the intended effect so throw a proper exception so the developer knows what's up.
@@ -50,6 +53,7 @@ namespace System.Security.Cryptography
 
                 if (_hashName != null && value != _hashName)
                     throw new PlatformNotSupportedException(SR.HashNameMultipleSetNotSupported);
+
                 _hashName = value;
             }
         }

--- a/src/System.Security.Cryptography.Primitives/tests/AsymmetricAlgorithm/Trivial.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/AsymmetricAlgorithm/Trivial.cs
@@ -42,6 +42,8 @@ namespace System.Security.Cryptography.Encryption.Tests.Asymmetric
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework,
+            "Change needs to be ported to netfx")]
         public static void ValidKeySizeUsesProperty()
         {
             using (AsymmetricAlgorithm aa = new DoesNotSetLegalKeySizesField())

--- a/src/System.Security.Cryptography.Primitives/tests/AsymmetricAlgorithm/Trivial.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/AsymmetricAlgorithm/Trivial.cs
@@ -43,7 +43,7 @@ namespace System.Security.Cryptography.Encryption.Tests.Asymmetric
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework,
-            "Change needs to be ported to netfx")]
+            "Throws NRE on netfx")]
         public static void ValidKeySizeUsesProperty()
         {
             using (AsymmetricAlgorithm aa = new DoesNotSetLegalKeySizesField())

--- a/src/System.Security.Cryptography.Primitives/tests/Configurations.props
+++ b/src/System.Security.Cryptography.Primitives/tests/Configurations.props
@@ -4,6 +4,7 @@
     <BuildConfigurations>
       netcoreapp;
       netstandard;
+      netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Cryptography.Primitives/tests/Configurations.props
+++ b/src/System.Security.Cryptography.Primitives/tests/Configurations.props
@@ -4,7 +4,6 @@
     <BuildConfigurations>
       netcoreapp;
       netstandard;
-      netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Cryptography.Primitives/tests/CryptographicException.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/CryptographicException.cs
@@ -17,11 +17,15 @@ namespace System.Security.Cryptography.Encryption.Tests.Asymmetric
             Assert.NotNull(new CryptographicException().Message);
             Assert.Equal(message, new CryptographicException(message).Message);
             Assert.Equal(message + " 12345", new CryptographicException(message + " {0}", "12345").Message);
-#if netfx
-            Assert.Equal(unchecked((int)0x80070005), new CryptographicException(5).HResult);
-#else
-            Assert.Equal(5, new CryptographicException(5).HResult);
-#endif
+            if (PlatformDetection.IsFullFramework)
+            {
+                Assert.Equal(unchecked((int)0x80070005), new CryptographicException(5).HResult);
+            }
+            else
+            {
+                Assert.Equal(5, new CryptographicException(5).HResult);
+            }
+
             Assert.Same(inner, new CryptographicException(message, inner).InnerException);
             Assert.Equal(message, new CryptographicException(message, inner).Message);
         }

--- a/src/System.Security.Cryptography.Primitives/tests/CryptographicException.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/CryptographicException.cs
@@ -17,7 +17,9 @@ namespace System.Security.Cryptography.Encryption.Tests.Asymmetric
             Assert.NotNull(new CryptographicException().Message);
             Assert.Equal(message, new CryptographicException(message).Message);
             Assert.Equal(message + " 12345", new CryptographicException(message + " {0}", "12345").Message);
-#if !netfx
+#if netfx
+            Assert.Equal(unchecked((int)0x80070005), new CryptographicException(5).HResult);
+#else
             Assert.Equal(5, new CryptographicException(5).HResult);
 #endif
             Assert.Same(inner, new CryptographicException(message, inner).InnerException);

--- a/src/System.Security.Cryptography.Primitives/tests/CryptographicException.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/CryptographicException.cs
@@ -17,7 +17,9 @@ namespace System.Security.Cryptography.Encryption.Tests.Asymmetric
             Assert.NotNull(new CryptographicException().Message);
             Assert.Equal(message, new CryptographicException(message).Message);
             Assert.Equal(message + " 12345", new CryptographicException(message + " {0}", "12345").Message);
+#if !netfx
             Assert.Equal(5, new CryptographicException(5).HResult);
+#endif
             Assert.Same(inner, new CryptographicException(message, inner).InnerException);
             Assert.Equal(message, new CryptographicException(message, inner).Message);
         }

--- a/src/System.Security.Cryptography.Primitives/tests/HmacAlgorithmTest.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/HmacAlgorithmTest.cs
@@ -9,6 +9,8 @@ namespace System.Security.Cryptography.Hashing.Tests
     public class HmacAlgorithmTest
     {
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework,
+            "Change needs to be ported to netfx")]
         public void SetNullAlgorithmName()
         {
             using (HMAC hmac = new TestHMAC())
@@ -35,6 +37,8 @@ namespace System.Security.Cryptography.Hashing.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework,
+            "Change needs to be ported to netfx")]
         public void ResetAlgorithmName()
         {
             using (HMAC hmac = new TestHMAC())
@@ -67,6 +71,8 @@ namespace System.Security.Cryptography.Hashing.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework,
+            "Change needs to be ported to netfx")]
         public void TrivialDerivationThrows()
         {
             using (HMAC hmac = new TestHMAC())

--- a/src/System.Security.Cryptography.Primitives/tests/HmacAlgorithmTest.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/HmacAlgorithmTest.cs
@@ -13,15 +13,7 @@ namespace System.Security.Cryptography.Hashing.Tests
         {
             using (HMAC hmac = new TestHMAC())
             {
-                if (PlatformDetection.IsFullFramework)
-                {
-                    Assert.Throws<ArgumentNullException>(() => hmac.HashName = null);
-                }
-                else
-                {
-                    hmac.HashName = null;
-                }
-
+                Assert.Throws<ArgumentNullException>(() => hmac.HashName = null);
                 Assert.Null(hmac.HashName);
             }
         }

--- a/src/System.Security.Cryptography.Primitives/tests/HmacAlgorithmTest.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/HmacAlgorithmTest.cs
@@ -9,14 +9,15 @@ namespace System.Security.Cryptography.Hashing.Tests
     public class HmacAlgorithmTest
     {
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework,
-            "Change needs to be ported to netfx")]
         public void SetNullAlgorithmName()
         {
             using (HMAC hmac = new TestHMAC())
             {
-                // Assert.NoThrows is implicit
+#if netfx
+                Assert.Throws<ArgumentNullException>(() => hmac.HashName = null);
+#else
                 hmac.HashName = null;
+#endif
 
                 Assert.Null(hmac.HashName);
             }
@@ -37,8 +38,6 @@ namespace System.Security.Cryptography.Hashing.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework,
-            "Change needs to be ported to netfx")]
         public void ResetAlgorithmName()
         {
             using (HMAC hmac = new TestHMAC())
@@ -47,9 +46,13 @@ namespace System.Security.Cryptography.Hashing.Tests
 
                 // On desktop builds this next line will succeed (modulo FIPS prohibitions on MD5).
                 // On CoreFX it throws.
+#if netfx
+                hmac.HashName = "MD5";
+                Assert.Equal("MD5", hmac.HashName);
+#else
                 Assert.Throws<PlatformNotSupportedException>(() => hmac.HashName = "MD5");
-
                 Assert.Equal("SHA1", hmac.HashName);
+#endif
             }
         }
 
@@ -71,8 +74,6 @@ namespace System.Security.Cryptography.Hashing.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework,
-            "Change needs to be ported to netfx")]
         public void TrivialDerivationThrows()
         {
             using (HMAC hmac = new TestHMAC())
@@ -81,7 +82,11 @@ namespace System.Security.Cryptography.Hashing.Tests
                 hmac.Key = Array.Empty<byte>();
 
                 byte[] ignored;
+#if netfx
+                ignored = hmac.ComputeHash(Array.Empty<byte>());
+#else
                 Assert.Throws<PlatformNotSupportedException>(() => ignored = hmac.ComputeHash(Array.Empty<byte>()));
+#endif
             }
         }
 

--- a/src/System.Security.Cryptography.Primitives/tests/HmacAlgorithmTest.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/HmacAlgorithmTest.cs
@@ -13,11 +13,14 @@ namespace System.Security.Cryptography.Hashing.Tests
         {
             using (HMAC hmac = new TestHMAC())
             {
-#if netfx
-                Assert.Throws<ArgumentNullException>(() => hmac.HashName = null);
-#else
-                hmac.HashName = null;
-#endif
+                if (PlatformDetection.IsFullFramework)
+                {
+                    Assert.Throws<ArgumentNullException>(() => hmac.HashName = null);
+                }
+                else
+                {
+                    hmac.HashName = null;
+                }
 
                 Assert.Null(hmac.HashName);
             }
@@ -46,13 +49,16 @@ namespace System.Security.Cryptography.Hashing.Tests
 
                 // On desktop builds this next line will succeed (modulo FIPS prohibitions on MD5).
                 // On CoreFX it throws.
-#if netfx
-                hmac.HashName = "MD5";
-                Assert.Equal("MD5", hmac.HashName);
-#else
-                Assert.Throws<PlatformNotSupportedException>(() => hmac.HashName = "MD5");
-                Assert.Equal("SHA1", hmac.HashName);
-#endif
+                if (PlatformDetection.IsFullFramework)
+                {
+                    hmac.HashName = "MD5";
+                    Assert.Equal("MD5", hmac.HashName);
+                }
+                else
+                {
+                    Assert.Throws<PlatformNotSupportedException>(() => hmac.HashName = "MD5");
+                    Assert.Equal("SHA1", hmac.HashName);
+                }
             }
         }
 
@@ -82,11 +88,14 @@ namespace System.Security.Cryptography.Hashing.Tests
                 hmac.Key = Array.Empty<byte>();
 
                 byte[] ignored;
-#if netfx
-                ignored = hmac.ComputeHash(Array.Empty<byte>());
-#else
-                Assert.Throws<PlatformNotSupportedException>(() => ignored = hmac.ComputeHash(Array.Empty<byte>()));
-#endif
+                if (PlatformDetection.IsFullFramework)
+                {
+                    ignored = hmac.ComputeHash(Array.Empty<byte>());
+                }
+                else
+                {
+                    Assert.Throws<PlatformNotSupportedException>(() => ignored = hmac.ComputeHash(Array.Empty<byte>()));
+                }
             }
         }
 

--- a/src/System.Security.Cryptography.Primitives/tests/KeyedHashAlgorithmTests.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/KeyedHashAlgorithmTests.cs
@@ -67,7 +67,7 @@ namespace System.Security.Cryptography.Hashing.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework,
-            "Change needs to be ported to netfx")]
+            "Throws NRE on netfx")]
         public void SetKeyNull()
         {
             using (var keyedHash = new TestKeyedHashAlgorithm())

--- a/src/System.Security.Cryptography.Primitives/tests/KeyedHashAlgorithmTests.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/KeyedHashAlgorithmTests.cs
@@ -50,7 +50,7 @@ namespace System.Security.Cryptography.Hashing.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework,
-            "Change needs to be ported to netfx")]
+            "Throws NRE on netfx")]
         public void EnsureDisposeFreesKey()
         {
             byte[] key = new[] { (byte)0x00, (byte)0x01, (byte)0x02, (byte)0x03, (byte)0x04, (byte)0x05, };

--- a/src/System.Security.Cryptography.Primitives/tests/KeyedHashAlgorithmTests.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/KeyedHashAlgorithmTests.cs
@@ -49,6 +49,8 @@ namespace System.Security.Cryptography.Hashing.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework,
+            "Change needs to be ported to netfx")]
         public void EnsureDisposeFreesKey()
         {
             byte[] key = new[] { (byte)0x00, (byte)0x01, (byte)0x02, (byte)0x03, (byte)0x04, (byte)0x05, };
@@ -64,6 +66,8 @@ namespace System.Security.Cryptography.Hashing.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework,
+            "Change needs to be ported to netfx")]
         public void SetKeyNull()
         {
             using (var keyedHash = new TestKeyedHashAlgorithm())

--- a/src/System.Security.Cryptography.Primitives/tests/SymmetricAlgorithm/Trivial.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/SymmetricAlgorithm/Trivial.cs
@@ -113,15 +113,18 @@ namespace System.Security.Cryptography.Encryption.Tests.Symmetric
                     }
                 }
 
-#if !netfx
                 // Test overflow
                 try
                 {
                     byte[] hugeKey = new byte[536870917]; // value chosen so that when multiplied by 8 (bits) it overflows to the value 40
+#if netfx
+                    // This change should be ported to netfx
+                    s.Key = hugeKey;
+#else
                     Assert.Throws<CryptographicException>(() => s.Key = hugeKey);
+#endif
                 }
                 catch (OutOfMemoryException) { } // in case there isn't enough memory at test-time to allocate the large array
-#endif
             }
         }
 
@@ -284,7 +287,7 @@ namespace System.Security.Cryptography.Encryption.Tests.Symmetric
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework,
-            "Change needs to be ported to netfx")]
+            "Throws NRE on netfx")]
         public static void SetBlockSize_Uses_LegalBlockSizesProperty()
         {
             using (SymmetricAlgorithm s = new DoesNotSetKeySizesFields())

--- a/src/System.Security.Cryptography.Primitives/tests/SymmetricAlgorithm/Trivial.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/SymmetricAlgorithm/Trivial.cs
@@ -117,12 +117,15 @@ namespace System.Security.Cryptography.Encryption.Tests.Symmetric
                 try
                 {
                     byte[] hugeKey = new byte[536870917]; // value chosen so that when multiplied by 8 (bits) it overflows to the value 40
-#if netfx
-                    // This change should be ported to netfx
-                    s.Key = hugeKey;
-#else
-                    Assert.Throws<CryptographicException>(() => s.Key = hugeKey);
-#endif
+                    if (PlatformDetection.IsFullFramework)
+                    {
+                        // This change should be ported to netfx
+                        s.Key = hugeKey;
+                    }
+                    else
+                    {
+                        Assert.Throws<CryptographicException>(() => s.Key = hugeKey);
+                    }
                 }
                 catch (OutOfMemoryException) { } // in case there isn't enough memory at test-time to allocate the large array
             }

--- a/src/System.Security.Cryptography.Primitives/tests/SymmetricAlgorithm/Trivial.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/SymmetricAlgorithm/Trivial.cs
@@ -113,6 +113,7 @@ namespace System.Security.Cryptography.Encryption.Tests.Symmetric
                     }
                 }
 
+#if !netfx
                 // Test overflow
                 try
                 {
@@ -120,6 +121,7 @@ namespace System.Security.Cryptography.Encryption.Tests.Symmetric
                     Assert.Throws<CryptographicException>(() => s.Key = hugeKey);
                 }
                 catch (OutOfMemoryException) { } // in case there isn't enough memory at test-time to allocate the large array
+#endif
             }
         }
 
@@ -281,6 +283,8 @@ namespace System.Security.Cryptography.Encryption.Tests.Symmetric
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework,
+            "Change needs to be ported to netfx")]
         public static void SetBlockSize_Uses_LegalBlockSizesProperty()
         {
             using (SymmetricAlgorithm s = new DoesNotSetKeySizesFields())
@@ -289,7 +293,7 @@ namespace System.Security.Cryptography.Encryption.Tests.Symmetric
                 s.BlockSize = 8;
             }
         }
-        
+
         private static byte[] GenerateRandom(int size)
         {
             byte[] data = new byte[size];

--- a/src/System.Security.Cryptography.Primitives/tests/System.Security.Cryptography.Primitives.Tests.csproj
+++ b/src/System.Security.Cryptography.Primitives/tests/System.Security.Cryptography.Primitives.Tests.csproj
@@ -5,7 +5,6 @@
   <PropertyGroup>
     <ProjectGuid>{101EB757-55A4-4F48-841C-C088640B8F57}</ProjectGuid>
     <DefineConstants Condition="'$(TargetGroup)' == 'netcoreapp'">$(DefineConstants);netcoreapp</DefineConstants>
-    <DefineConstants Condition="'$(TargetGroup)' == 'netfx'">$(DefineConstants);netfx</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
@@ -24,6 +23,9 @@
     <Compile Include="CryptographicException.cs" />
     <Compile Include="$(CommonTestPath)\System\IO\PositionValueStream.cs">
       <Link>CommonTest\System\IO\PositionValueStream.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>CommonTest\System\PlatformDetection.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)'=='netcoreapp'">

--- a/src/System.Security.Cryptography.Primitives/tests/System.Security.Cryptography.Primitives.Tests.csproj
+++ b/src/System.Security.Cryptography.Primitives/tests/System.Security.Cryptography.Primitives.Tests.csproj
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <ProjectGuid>{101EB757-55A4-4F48-841C-C088640B8F57}</ProjectGuid>
     <DefineConstants Condition="'$(TargetGroup)' == 'netcoreapp'">$(DefineConstants);netcoreapp</DefineConstants>
+    <DefineConstants Condition="'$(TargetGroup)' == 'netfx'">$(DefineConstants);netfx</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />


### PR DESCRIPTION
Fixes:
- https://github.com/dotnet/corefx/issues/18475 (ValidKeySizeUsesProperty)
- https://github.com/dotnet/corefx/issues/18476 (TestKey)
- https://github.com/dotnet/corefx/issues/18139 (CryptographicExceptionTests.Ctor)
- https://github.com/dotnet/corefx/issues/18479 (SetNullAlgorithmName)
- https://github.com/dotnet/corefx/issues/18478 (ResetAlgorithmName, TrivialDerivationThrows)
- https://github.com/dotnet/corefx/issues/18477 (SetKeyNull)

I have verified each one of them is also failing on Desktop with the same exception. Any additional improvements we can plan for 2.0 (ideally fix all of those differences)
cc: @bartonjs 