### PR TITLE
Fix or disable failing Reflection tests in System.Runtime.Tests.dll

### DIFF
--- a/src/System.Runtime/tests/System/Reflection/AssemblyNameTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/AssemblyNameTests.cs
@@ -30,6 +30,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "AssemblyName.CodeBase and EscapedCodeBase not supported on UapAot")]
         public static void Verify_EscapedCodeBase()
         {
             AssemblyName n = new AssemblyName("MyAssemblyName");
@@ -75,6 +76,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "AssemblyName.GetAssemblyName() not supported on UapAot")]
         public static void GetAssemblyName()
         {
             AssertExtensions.Throws<ArgumentNullException>("assemblyFile", () => AssemblyName.GetAssemblyName(null));

--- a/src/System.Runtime/tests/System/Reflection/AssemblyTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/AssemblyTests.cs
@@ -32,6 +32,8 @@ namespace System.Reflection.Tests
 
         static AssemblyTests()
         {
+            loadFromTestPath = null;
+#if !uapaot  // Assembly.Location not supported (properly) on uapaot.
             // Move TestAssembly.dll to subfolder TestAssembly
             Directory.CreateDirectory(Path.GetDirectoryName(destTestAssemblyPath));
             if (File.Exists(sourceTestAssemblyPath))
@@ -42,6 +44,7 @@ namespace System.Reflection.Tests
             string currAssemblyPath = typeof(AssemblyTests).Assembly.Location;
             loadFromTestPath = Path.Combine(Path.GetDirectoryName(currAssemblyPath), "TestAssembly", Path.GetFileName(currAssemblyPath));
             File.Copy(currAssemblyPath, loadFromTestPath, true);
+#endif
         }
 
         public static IEnumerable<object[]> Equality_TestData()
@@ -99,6 +102,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.GetSatelliteAssembly() not supported on UapAot")]
         public static void GetSatelliteAssemblyNeg()
         {
             Assert.Throws<ArgumentNullException>(() => (typeof(AssemblyTests).Assembly.GetSatelliteAssembly(null)));
@@ -106,6 +110,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.Load(String) not supported on UapAot")]
         public static void AssemblyLoadFromString()
         {
             AssemblyName an = typeof(AssemblyTests).Assembly.GetName();
@@ -132,6 +137,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.Load(byte[]) not supported on UapAot")]
         public static void AssemblyLoadFromBytes()
         {
             Assembly assembly = typeof(AssemblyTests).Assembly;
@@ -143,6 +149,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.Load(byte[]) not supported on UapAot")]
         public static void AssemblyLoadFromBytesNeg()
         {
             Assert.Throws<ArgumentNullException>(() => Assembly.Load((byte[])null));
@@ -150,6 +157,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.Load(byte[]) not supported on UapAot")]
         public static void AssemblyLoadFromBytesWithSymbols()
         {
             Assembly assembly = typeof(AssemblyTests).Assembly;
@@ -161,12 +169,14 @@ namespace System.Reflection.Tests
             Assert.Equal(assembly.FullName, loadedAssembly.FullName);
         }
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.ReflectionOnlyLoad() not supported on UapAot")]
         public static void AssemblyReflectionOnlyLoadFromString()
         {
             AssemblyName an = typeof(AssemblyTests).Assembly.GetName();
             Assert.Throws<NotSupportedException>(() => Assembly.ReflectionOnlyLoad(an.FullName));
         }
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.ReflectionOnlyLoad() not supported on UapAot")]
         public static void AssemblyReflectionOnlyLoadFromBytes()
         {
             Assembly assembly = typeof(AssemblyTests).Assembly;
@@ -174,6 +184,7 @@ namespace System.Reflection.Tests
             Assert.Throws<NotSupportedException>(() => Assembly.ReflectionOnlyLoad(aBytes));
         }
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.ReflectionOnlyLoad() not supported on UapAot")]
         public static void AssemblyReflectionOnlyLoadFromNeg()
         {
             Assert.Throws<ArgumentNullException>(() => Assembly.ReflectionOnlyLoad((string)null));
@@ -190,6 +201,7 @@ namespace System.Reflection.Tests
 
         [Theory]
         [MemberData(nameof(GetModules_TestData))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.GetModules() is not supported on UapAot.")]
         public static void GetModules_GetModule(Assembly assembly)
         {
             Assert.NotEmpty(assembly.GetModules());
@@ -200,6 +212,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.GetLoadedModules() is not supported on UapAot.")]
         public static void GetLoadedModules()
         {
             Assembly assembly = typeof(AssemblyTests).Assembly;
@@ -283,6 +296,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.LoadFile() not supported on UapAot")]
         public static void Test_LoadFile()
         {
             Assembly currentAssembly = typeof(AssemblyTests).Assembly;
@@ -314,7 +328,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "The full .NET Framework has a bug and throws a NullReferenceException")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework | TargetFrameworkMonikers.UapAot, "The full .NET Framework has a bug and throws a NullReferenceException")]
         public static void LoadFile_NullPath_Netcore_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>("path", () => Assembly.LoadFile(null));
@@ -328,13 +342,14 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.LoadFile() not supported on UapAot")]
         public static void LoadFile_NoSuchPath_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => Assembly.LoadFile("System.Runtime.Tests.dll"));
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "The full .NET Framework supports Assembly.LoadFrom")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework | TargetFrameworkMonikers.UapAot, "The full .NET Framework supports Assembly.LoadFrom")]
         public static void Test_LoadFromUsingHashValue_Netcore()
         {
             Assert.Throws<NotSupportedException>(() => Assembly.LoadFrom("abc", null, System.Configuration.Assemblies.AssemblyHashAlgorithm.SHA1));
@@ -348,7 +363,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "The full .NET Framework supports more than one module per assembly")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework | TargetFrameworkMonikers.UapAot, "The full .NET Framework supports more than one module per assembly")]
         public static void Test_LoadModule_Netcore()
         {
             Assembly assembly = typeof(AssemblyTests).Assembly;
@@ -367,6 +382,7 @@ namespace System.Reflection.Tests
 
 #pragma warning disable 618
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.LoadFromWithPartialName() not supported on UapAot")]
         public static void Test_LoadWithPartialName()
         {
             string simplename = typeof(AssemblyTests).Assembly.GetName().Name;
@@ -376,6 +392,7 @@ namespace System.Reflection.Tests
 #pragma warning restore 618
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.LoadFrom() not supported on UapAot")]
         public void LoadFrom_SamePath_ReturnsEqualAssemblies()
         {
             Assembly assembly1 = Assembly.LoadFrom(destTestAssemblyPath);
@@ -384,6 +401,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.LoadFrom() not supported on UapAot")]
         public void LoadFrom_SameIdentityAsAssemblyWithDifferentPath_ReturnsEqualAssemblies()
         {
             Assembly assembly1 = Assembly.LoadFrom(typeof(AssemblyTests).Assembly.Location);
@@ -402,6 +420,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.LoadFrom() not supported on UapAot")]
         public void LoadFrom_NullAssemblyFile_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>("assemblyFile", () => Assembly.LoadFrom(null));
@@ -409,6 +428,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.LoadFrom() not supported on UapAot")]
         public void LoadFrom_EmptyAssemblyFile_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(null, (() => Assembly.LoadFrom("")));
@@ -416,6 +436,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.LoadFrom() not supported on UapAot")]
         public void LoadFrom_NoSuchFile_ThrowsFileNotFoundException()
         {
             Assert.Throws<FileNotFoundException>(() => Assembly.LoadFrom("NoSuchPath"));
@@ -423,6 +444,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.UnsafeLoadFrom() not supported on UapAot")]
         public void UnsafeLoadFrom_SamePath_ReturnsEqualAssemblies()
         {
             Assembly assembly1 = Assembly.UnsafeLoadFrom(destTestAssemblyPath);
@@ -431,13 +453,14 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "The implementation of LoadFrom(string, byte[], AssemblyHashAlgorithm is not supported in .NET Core.")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework | TargetFrameworkMonikers.UapAot, "The implementation of LoadFrom(string, byte[], AssemblyHashAlgorithm is not supported in .NET Core.")]
         public void LoadFrom_WithHashValue_NetCoreCore_ThrowsNotSupportedException()
         {
             Assert.Throws<NotSupportedException>(() => Assembly.LoadFrom(destTestAssemblyPath, new byte[0], Configuration.Assemblies.AssemblyHashAlgorithm.None));
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.GetFile() not supported on UapAot")]
         public void GetFile()
         {
             Assert.Throws<ArgumentNullException>(() => typeof(AssemblyTests).Assembly.GetFile(null));
@@ -448,6 +471,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.GetFiles() not supported on UapAot")]
         public void GetFiles()
         {
             Assert.NotNull(typeof(AssemblyTests).Assembly.GetFiles());

--- a/src/System.Runtime/tests/System/Reflection/ConstructorInfoTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/ConstructorInfoTests.cs
@@ -40,6 +40,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Invoking static constructors not supported on UapAot")]
         public static void TestInvoke_Nullery()
         {
             ConstructorInfo[] cis = GetConstructors(typeof(ConstructorInfoClassA));
@@ -213,7 +214,7 @@ namespace System.Reflection.Tests
         }
     }
 
-    public class ConstructorInfoClassA
+    public static class ConstructorInfoClassA
     {
         static ConstructorInfoClassA()
         {

--- a/src/System.Runtime/tests/System/Reflection/MethodBaseTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/MethodBaseTests.cs
@@ -64,6 +64,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "MethodBase.GetMethodBody() not supported on UapAot")]
         public static void TestMethodBody()
         {
             MethodBase mbase = typeof(MethodBaseTests).GetMethod("MyOtherMethod", BindingFlags.Static | BindingFlags.Public);

--- a/src/System.Runtime/tests/System/Reflection/MethodBodyTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/MethodBodyTests.cs
@@ -13,6 +13,7 @@ namespace System.Reflection.Tests
     public static class MethodBodyTests
     {
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Method.GetMethodBody() not supported on UapAot")]
         public static void Test_MethodBody_ExceptionHandlingClause()
         {
             MethodInfo mi = typeof(MethodBodyTests).GetMethod("MethodBodyExample");

--- a/src/System.Runtime/tests/System/Reflection/ModuleTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/ModuleTests.cs
@@ -58,6 +58,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Module CustomAttributes not supported on UapAot.")]
         public void CustomAttributes()
         {
             List<CustomAttributeData> customAttributes = Module.CustomAttributes.ToList();
@@ -132,6 +133,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Module.GetField apis not supported on UapAot.")]
         public void GetField_NullName()
         {
             ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() =>
@@ -152,6 +154,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Module.GetField apis not supported on UapAot.")]
         public void GetField()
         {
             FieldInfo testInt = TestModule.GetField("TestInt", BindingFlags.Public | BindingFlags.Static);
@@ -165,6 +168,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Module.GetField apis not supported on UapAot.")]
         public void GetFields()
         {
             List<FieldInfo> fields = TestModule.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static).OrderBy(f => f.Name).ToList();
@@ -178,6 +182,7 @@ namespace System.Reflection.Tests
 
         [Theory]
         [MemberData(nameof(Types))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Module.Resolve apis not supported on UapAot.")]
         public void ResolveType(Type t)
         {
             Assert.Equal(t, Module.ResolveType(t.MetadataToken));
@@ -192,6 +197,7 @@ namespace System.Reflection.Tests
 
         [Theory]
         [MemberData(nameof(BadResolveTypes))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Module.Resolve apis not supported on UapAot.")]
         public void ResolveTypeFail(int token)
         {
             Assert.ThrowsAny<ArgumentException>(() =>
@@ -205,6 +211,7 @@ namespace System.Reflection.Tests
 
         [Theory]
         [MemberData(nameof(Methods))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Module.Resolve apis not supported on UapAot.")]
         public void ResolveMethod(MethodInfo t)
         {
             Assert.Equal(t, Module.ResolveMethod(t.MetadataToken));
@@ -220,6 +227,7 @@ namespace System.Reflection.Tests
 
         [Theory]
         [MemberData(nameof(BadResolveMethods))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Module.Resolve apis not supported on UapAot.")]
         public void ResolveMethodFail(int token)
         {
             Assert.ThrowsAny<ArgumentException>(() =>
@@ -233,6 +241,7 @@ namespace System.Reflection.Tests
 
         [Theory]
         [MemberData(nameof(Fields))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Module.Resolve apis not supported on UapAot.")]
         public void ResolveField(FieldInfo t)
         {
             Assert.Equal(t, Module.ResolveField(t.MetadataToken));
@@ -248,6 +257,7 @@ namespace System.Reflection.Tests
 
         [Theory]
         [MemberData(nameof(BadResolveFields))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Module.Resolve apis not supported on UapAot.")]
         public void ResolveFieldFail(int token)
         {
             Assert.ThrowsAny<ArgumentException>(() =>
@@ -266,6 +276,7 @@ namespace System.Reflection.Tests
 
         [Theory]
         [MemberData(nameof(BadResolveStrings))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Module.Resolve apis not supported on UapAot.")]
         public void ResolveStringFail(int token)
         {
             Assert.ThrowsAny<ArgumentException>(() =>
@@ -278,12 +289,14 @@ namespace System.Reflection.Tests
         [MemberData(nameof(Types))]
         [MemberData(nameof(Methods))]
         [MemberData(nameof(Fields))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Module.Resolve apis not supported on UapAot.")]
         public void ResolveMember(MemberInfo member)
         {
             Assert.Equal(member, Module.ResolveMember(member.MetadataToken));
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Module.Resolve apis not supported on UapAot.")]
         public void ResolveMethodOfGenericClass()
         {
             Type t = typeof(Foo<>);

--- a/src/System.Runtime/tests/System/Reflection/PointerTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/PointerTests.cs
@@ -83,6 +83,7 @@ namespace System.Reflection.Tests
 
         [Theory]
         [MemberData(nameof(Pointers))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Pointers through Invoke not implemented: https://github.com/dotnet/corert/issues/2113")]
         public void PointerFieldSetValue(int value)
         {
             var obj = new PointerHolder();
@@ -93,6 +94,7 @@ namespace System.Reflection.Tests
 
         [Theory]
         [MemberData(nameof(Pointers))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Pointers through Invoke not implemented: https://github.com/dotnet/corert/issues/2113")]
         public void IntPtrFieldSetValue(int value)
         {
             var obj = new PointerHolder();
@@ -103,6 +105,7 @@ namespace System.Reflection.Tests
 
         [Theory]
         [MemberData(nameof(Pointers))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Pointers through Invoke not implemented: https://github.com/dotnet/corert/issues/2113")]
         public void PointerFieldSetValue_InvalidType(int value)
         {
             var obj = new PointerHolder();
@@ -129,6 +132,7 @@ namespace System.Reflection.Tests
 
         [Theory]
         [MemberData(nameof(Pointers))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Pointers through Invoke not implemented: https://github.com/dotnet/corert/issues/2113")]
         public void PointerPropertySetValue(int value)
         {
             var obj = new PointerHolder();
@@ -139,6 +143,7 @@ namespace System.Reflection.Tests
 
         [Theory]
         [MemberData(nameof(Pointers))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Pointers through Invoke not implemented: https://github.com/dotnet/corert/issues/2113")]
         public void IntPtrPropertySetValue(int value)
         {
             var obj = new PointerHolder();
@@ -149,6 +154,7 @@ namespace System.Reflection.Tests
 
         [Theory]
         [MemberData(nameof(Pointers))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Pointers through Invoke not implemented: https://github.com/dotnet/corert/issues/2113")]
         public void PointerPropertySetValue_InvalidType(int value)
         {
             var obj = new PointerHolder();
@@ -161,6 +167,7 @@ namespace System.Reflection.Tests
 
         [Theory]
         [MemberData(nameof(Pointers))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Pointers through Invoke not implemented: https://github.com/dotnet/corert/issues/2113")]
         public void PointerPropertyGetValue(int value)
         {
             var obj = new PointerHolder();
@@ -174,6 +181,7 @@ namespace System.Reflection.Tests
 
         [Theory]
         [MemberData(nameof(Pointers))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Pointers through Invoke not implemented: https://github.com/dotnet/corert/issues/2113")]
         public void PointerMethodParameter(int value)
         {
             var obj = new PointerHolder();
@@ -183,6 +191,7 @@ namespace System.Reflection.Tests
 
         [Theory]
         [MemberData(nameof(Pointers))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Pointers through Invoke not implemented: https://github.com/dotnet/corert/issues/2113")]
         public void IntPtrMethodParameter(int value)
         {
             var obj = new PointerHolder();
@@ -192,6 +201,7 @@ namespace System.Reflection.Tests
 
         [Theory]
         [MemberData(nameof(Pointers))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Pointers through Invoke not implemented: https://github.com/dotnet/corert/issues/2113")]
         public void PointerMethodParameter_InvalidType(int value)
         {
             var obj = new PointerHolder();
@@ -204,6 +214,7 @@ namespace System.Reflection.Tests
 
         [Theory]
         [MemberData(nameof(Pointers))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Pointers through Invoke not implemented: https://github.com/dotnet/corert/issues/2113")]
         public void PointerMethodReturn(int value)
         {
             var obj = new PointerHolder();

--- a/src/System.Runtime/tests/System/Reflection/RuntimeReflectionExtensionsTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/RuntimeReflectionExtensionsTests.cs
@@ -20,7 +20,20 @@ namespace System.Reflection.Tests
         [Fact]
         public void GetRuntimeBaseDefinition()
         {
-            Assert.Equal(typeof(Stream).GetMethod("Read"), typeof(MemoryStream).GetMethod("Read").GetRuntimeBaseDefinition());
+            MethodInfo derivedFoo = typeof(TestDerived).GetMethod(nameof(TestDerived.Foo));
+            MethodInfo baseFoo = typeof(TestBase).GetMethod(nameof(TestBase.Foo));
+            MethodInfo actual = derivedFoo.GetRuntimeBaseDefinition();
+            Assert.Equal(baseFoo, actual);
+        }
+
+        private abstract class TestBase
+        {
+            public abstract void Foo();
+        }
+
+        private class TestDerived : TestBase
+        {
+            public override void Foo() { throw null; }
         }
 
         [Fact]


### PR DESCRIPTION
- SkipOnTarget for those exercising PNSE apis.

- Block a PNSE that happens in a class constructor and
  prevents all assembly tests from running.

- Delete GetCallingAssembly() tests. This is iffy
  even in jitted frameworks. (I might have been more
  generous if the offending api call didn't happen
  inside Theory data where it's impossible to skip easily...
  as it is, not enough value to refactor.)

- Delete all testing of contents of Module names and strings.

- Avoid unnecessary MME's by not using framework types
  as test data.