### PR TITLE
Fix PLINQ tests for desktop

### DIFF
--- a/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
@@ -776,6 +776,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(UnaryCancelingOperators))]
         [MemberData(nameof(BinaryCancelingOperators))]
         [MemberData(nameof(OrderCancelingOperators))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Core bug fix https://github.com/dotnet/corefx/pull/2307")]
         public static void ToArray_OperationCanceledException_PreCanceled(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
         {
             AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).ToArray());

--- a/src/System.Linq.Parallel/tests/Helpers/Sources.cs
+++ b/src/System.Linq.Parallel/tests/Helpers/Sources.cs
@@ -44,7 +44,7 @@ namespace System.Linq.Parallel.Tests
             {
                 foreach (T mod in modifiers((int)parms[1]))
                 {
-                    yield return parms.Append(mod).ToArray();
+                    yield return parms.Concat(new object[] { mod }).ToArray();
                 }
             }
         }

--- a/src/System.Linq.Parallel/tests/Helpers/UnorderedSources.cs
+++ b/src/System.Linq.Parallel/tests/Helpers/UnorderedSources.cs
@@ -194,7 +194,7 @@ namespace System.Linq.Parallel.Tests
             foreach (object[] parms in Ranges(counts))
             {
                 int count = (int)parms[1];
-                yield return parms.Append(modifiers(count)).ToArray();
+                yield return parms.Concat(new object[] { modifiers(count) }).ToArray();
             }
         }
 
@@ -217,7 +217,7 @@ namespace System.Linq.Parallel.Tests
             {
                 foreach (T mod in modifiers((int)parms[1]))
                 {
-                    yield return parms.Append(mod).ToArray();
+                    yield return parms.Concat(new object[] { mod }).ToArray();
                 }
             }
         }

--- a/src/System.Linq.Parallel/tests/QueryOperators/CastTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/CastTests.cs
@@ -144,6 +144,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Core bug fix https://github.com/dotnet/corefx/pull/1970 not available in desktop")]
         public static void Cast_ArgumentNullException()
         {
             AssertExtensions.Throws<ArgumentNullException>("source", () => ((ParallelQuery<object>)null).Cast<int>());

--- a/src/System.Linq.Parallel/tests/QueryOperators/OrderByThenByTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/OrderByThenByTests.cs
@@ -391,6 +391,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Validates .NET Core bug fix https://github.com/dotnet/corefx/pull/2305")]
         public static void OrderBy_NotPipelined_ExtremeComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = 0;
@@ -401,6 +402,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Validates .NET Core bug fix https://github.com/dotnet/corefx/pull/2305")]
         public static void OrderByDescending_NotPipelined_ExtremeComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = count - 1;
@@ -948,6 +950,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Validates .NET Core bug fix https://github.com/dotnet/corefx/pull/2305")]
         // Regression test for the PLINQ version of #2239 - comparer returning max/min value.
         public static void ThenBy_ExtremeComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
@@ -963,6 +966,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Validates .NET Core bug fix https://github.com/dotnet/corefx/pull/2305")]
         // Regression test for the PLINQ version of #2239 - comparer returning max/min value.
         public static void ThenByDescending_ExtremeComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
@@ -977,6 +981,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Validates .NET Core bug fix https://github.com/dotnet/corefx/pull/2305")]
         public static void ThenBy_NotPipelined_ExtremeComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = 0;
@@ -987,7 +992,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "https://github.com/dotnet/corefx/issues/18141")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Core bug fix https://github.com/dotnet/corefx/pull/2305")]
         public static void ThenByDescending_NotPipelined_ExtremeComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = count - 1;

--- a/src/System.Linq.Parallel/tests/QueryOperators/SumTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/SumTests.cs
@@ -126,6 +126,7 @@ namespace System.Linq.Parallel.Tests
         [InlineData(1)]
         [InlineData(2)]
         [InlineData(16)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Core bug fix https://github.com/dotnet/corefx/pull/1215")]
         public static void Sum_Float(int count)
         {
             Assert.Equal(Functions.SumRange(0, count), ParallelEnumerable.Range(0, count).Select(x => (float)x).Sum());

--- a/src/System.Linq.Parallel/tests/QueryOperators/ToArrayTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ToArrayTests.cs
@@ -46,6 +46,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Core bug fix https://github.com/dotnet/corefx/pull/2307")]
         public static void ToArray_OperationCanceledException_PreCanceled()
         {
             AssertThrows.AlreadyCanceled(source => source.ToArray());


### PR DESCRIPTION
- Avoid using Enumerable.Append, which isn't available in desktop
- Suppress tests on desktop where the test is verifying a bug fix in core

Fixes https://github.com/dotnet/corefx/issues/18598
Fixes https://github.com/dotnet/corefx/issues/18599
Fixes https://github.com/dotnet/corefx/issues/18600
Fixes https://github.com/dotnet/corefx/issues/18597

cc: @alexperovich, @kouvel 
