### PR TITLE
Skip two transactions tests on desktop

### DIFF
--- a/src/System.Transactions.Local/tests/LTMEnlistmentTests.cs
+++ b/src/System.Transactions.Local/tests/LTMEnlistmentTests.cs
@@ -76,6 +76,7 @@ namespace System.Transactions.Tests
         [InlineData(0, EnlistmentOptions.None, EnlistmentOptions.None, Phase1Vote.Prepared, Phase1Vote.Prepared, true, EnlistmentOutcome.Aborted, EnlistmentOutcome.Aborted, TransactionStatus.Aborted)]
         [InlineData(1, EnlistmentOptions.None, EnlistmentOptions.None, Phase1Vote.Prepared, Phase1Vote.Prepared, true, EnlistmentOutcome.Aborted, EnlistmentOutcome.Aborted, TransactionStatus.Aborted)]
         [InlineData(2, EnlistmentOptions.None, EnlistmentOptions.None, Phase1Vote.Prepared, Phase1Vote.Prepared, true, EnlistmentOutcome.Aborted, EnlistmentOutcome.Aborted, TransactionStatus.Aborted)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Expects PNSE due to not being supported on core")]
         public void TwoPhaseDurable(int volatileCount, EnlistmentOptions volatileEnlistmentOption, EnlistmentOptions durableEnlistmentOption, Phase1Vote volatilePhase1Vote, Phase1Vote durablePhase1Vote, bool commit, EnlistmentOutcome expectedVolatileOutcome, EnlistmentOutcome expectedDurableOutcome, TransactionStatus expectedTxStatus)
         {
             Transaction tx = null;

--- a/src/System.Transactions.Local/tests/NonMsdtcPromoterTests.cs
+++ b/src/System.Transactions.Local/tests/NonMsdtcPromoterTests.cs
@@ -2287,6 +2287,7 @@ namespace System.Transactions.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Expects PNSE due to not being supported on core")]
         public void SimpleTransactionSuperior()
         {
             MySimpleTransactionSuperior superior = new MySimpleTransactionSuperior();


### PR DESCRIPTION
The tests are expecting a PlatformNotSupportedException, as it the operation isn't supported on core.

Fixes https://github.com/dotnet/corefx/issues/18602