### PR TITLE
Add test for failfast in event of corrupted state exception. Add test…

### DIFF
--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -208,6 +208,7 @@
       <Link>System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
     </Compile>
     <Compile Include="System\Runtime\NgenServicingAttributesTests.cs" />
+    <Compile Include="System\Runtime\ExceptionServices\HandleProcessCorruptedStateExceptions.cs" />
     <Compile Include="System\Attributes.cs" />
     <Compile Include="System\HandleTests.cs" />
     <Compile Include="System\AppContext\AppContext.Switch.cs" />

--- a/src/System.Runtime/tests/System/Reflection/AssemblyTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/AssemblyTests.cs
@@ -455,6 +455,15 @@ namespace System.Reflection.Tests
             Assert.Equal(typeof(AssemblyTests).Assembly.GetFiles()[0].Name, typeof(AssemblyTests).Assembly.Location);
         }
 
+        [Fact]
+        public static void Load_AssemblyNameWithCodeBase()
+        {
+            AssemblyName an = typeof(AssemblyTests).Assembly.GetName();
+            Assert.NotNull(an.CodeBase); 
+            Assembly a = Assembly.Load(an);
+            Assert.Equal(a, typeof(AssemblyTests).Assembly);
+        }
+
         // Helpers
         private static Assembly GetGetCallingAssembly()
         {

--- a/src/System.Runtime/tests/System/Runtime/ExceptionServices/HandleProcessCorruptedStateExceptions.cs
+++ b/src/System.Runtime/tests/System/Runtime/ExceptionServices/HandleProcessCorruptedStateExceptions.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime;
+using System.Runtime.ExceptionServices;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using System.Threading;
+using Xunit;
+
+namespace System.Runtime.ExceptionServices.Tests
+{
+    public class HandleProcessCorruptedStateExceptionsTests : RemoteExecutorTestBase
+    {
+        [DllImport("kernel32.dll")]
+        static extern void RaiseException(uint dwExceptionCode, uint dwExceptionFlags, uint nNumberOfArguments, IntPtr lpArguments);
+
+        [HandleProcessCorruptedStateExceptions]
+        static void causeAVInNative()
+        {
+            try {
+                RaiseException(0xC0000005, 0, 0, IntPtr.Zero);
+            }
+            catch (AccessViolationException)
+            {
+            }
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)] // Feature Corrupting Exceptions not present for Linux
+        public static void ProcessExit_Called()
+        {
+            using (Process p = RemoteInvoke(() => { causeAVInNative(); return SuccessExitCode; }).Process)
+            {
+                p.WaitForExit();
+                if (PlatformDetection.IsFullFramework)
+                    Assert.Equal(SuccessExitCode, p.ExitCode);
+                else
+                    Assert.NotEqual(SuccessExitCode, p.ExitCode);
+            }            
+        }
+    }
+}

--- a/src/System.Runtime/tests/System/Runtime/ExceptionServices/HandleProcessCorruptedStateExceptions.cs
+++ b/src/System.Runtime/tests/System/Runtime/ExceptionServices/HandleProcessCorruptedStateExceptions.cs
@@ -33,7 +33,7 @@ namespace System.Runtime.ExceptionServices.Tests
         [PlatformSpecific(TestPlatforms.Windows)] // Feature Corrupting Exceptions not present for Linux
         public static void ProcessExit_Called()
         {
-            using (Process p = RemoteInvoke(() => { causeAVInNative(); return SuccessExitCode; }).Process)
+            using (Process p = RemoteInvoke(() => { CauseAVInNative(); return SuccessExitCode; }).Process)
             {
                 p.WaitForExit();
                 if (PlatformDetection.IsFullFramework)

--- a/src/System.Runtime/tests/System/Runtime/ExceptionServices/HandleProcessCorruptedStateExceptions.cs
+++ b/src/System.Runtime/tests/System/Runtime/ExceptionServices/HandleProcessCorruptedStateExceptions.cs
@@ -18,9 +18,10 @@ namespace System.Runtime.ExceptionServices.Tests
         static extern void RaiseException(uint dwExceptionCode, uint dwExceptionFlags, uint nNumberOfArguments, IntPtr lpArguments);
 
         [HandleProcessCorruptedStateExceptions]
-        static void causeAVInNative()
+        static void CauseAVInNative()
         {
-            try {
+            try 
+            {
                 RaiseException(0xC0000005, 0, 0, IntPtr.Zero);
             }
             catch (AccessViolationException)


### PR DESCRIPTION
… for Assembly.Load by AssemblyName when AssemblyName.CodeBase property is set