### PR TITLE
Add support for UseDefaultCredentials to CurlHandler

### DIFF
--- a/src/Common/src/System/Net/Http/HttpHandlerDefaults.cs
+++ b/src/Common/src/System/Net/Http/HttpHandlerDefaults.cs
@@ -18,6 +18,7 @@ namespace System.Net.Http
         public const bool DefaultPreAuthenticate = false;
         public const ClientCertificateOption DefaultClientCertificateOption = ClientCertificateOption.Manual;
         public const bool DefaultUseProxy = true;
+        public const bool DefaultUseDefaultCredentials = false;
         public static TimeSpan DefaultConnectTimeout => TimeSpan.FromSeconds(60);
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -138,6 +138,7 @@ namespace System.Net.Http
         private DecompressionMethods _automaticDecompression = HttpHandlerDefaults.DefaultAutomaticDecompression;
         private bool _preAuthenticate = HttpHandlerDefaults.DefaultPreAuthenticate;
         private CredentialCache _credentialCache = null; // protected by LockObject
+        private bool _useDefaultCredentials = HttpHandlerDefaults.DefaultUseDefaultCredentials;
         private CookieContainer _cookieContainer = new CookieContainer();
         private bool _useCookie = HttpHandlerDefaults.DefaultUseCookies;
         private TimeSpan _connectTimeout = Timeout.InfiniteTimeSpan;
@@ -405,8 +406,12 @@ namespace System.Net.Http
 
         internal bool UseDefaultCredentials
         {
-            get { return false; }
-            set { }
+            get { return _useDefaultCredentials; }
+            set
+            {
+                CheckDisposedOrStarted();
+                _useDefaultCredentials = value;
+            }
         }
 
         public IDictionary<string, object> Properties


### PR DESCRIPTION
Rely on libcurl internally using gssapi and kerberos infrastructure.
Fixes https://github.com/dotnet/corefx/issues/12618
cc: @hongdai, @Priya91, @davidsh, @geoffkizer