### PR TITLE
Fix exception thrown from PipeStream for unexpected cancellation

### DIFF
--- a/src/System.IO.Pipes/src/System/IO/Error.cs
+++ b/src/System.IO.Pipes/src/System/IO/Error.cs
@@ -31,10 +31,5 @@ namespace System.IO
         {
             return new NotSupportedException(SR.NotSupported_UnwritableStream);
         }
-
-        internal static Exception GetOperationAborted()
-        {
-            return new IOException(SR.IO_OperationAborted);
-        }
     }
 }

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeCompletionSource.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeCompletionSource.cs
@@ -162,8 +162,9 @@ namespace System.IO.Pipes
                 {
                     if (_cancellationToken.CanBeCanceled && !_cancellationToken.IsCancellationRequested)
                     {
-                        // If this is unexpected abortion
-                        TrySetException(Error.GetOperationAborted());
+                        // If this is unexpected abortion, we don't want to store _cancellationToken,
+                        // so just generically say it's been canceled.
+                        TrySetCanceled();
                     }
                     else
                     {

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Simple.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Simple.cs
@@ -254,7 +254,7 @@ namespace System.IO.Pipes.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // P/Invoking to Win32 functions
-        public async Task CancelTokenOn_ServerWaitForConnectionAsyncWithOuterCancellation_Throws_IOException()
+        public async Task CancelTokenOn_ServerWaitForConnectionAsyncWithOuterCancellation_Throws_OperationCanceledException()
         {
             using (NamedPipePair pair = CreateNamedPipePair())
             {
@@ -263,7 +263,7 @@ namespace System.IO.Pipes.Tests
                 Task waitForConnectionTask = server.WaitForConnectionAsync(cts.Token);
 
                 Assert.True(Interop.CancelIoEx(server.SafePipeHandle), "Outer cancellation failed");
-                await Assert.ThrowsAsync<IOException>(() => waitForConnectionTask);
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => waitForConnectionTask);
             }
         }
 
@@ -593,7 +593,7 @@ namespace System.IO.Pipes.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // P/Invoking to Win32 functions
-        public async Task CancelTokenOn_Server_ReadWriteCancelledToken_Throws_IOException()
+        public async Task CancelTokenOn_Server_ReadWriteCancelledToken_Throws_OperationCanceledException()
         {
             using (NamedPipePair pair = CreateNamedPipePair())
             {
@@ -608,7 +608,7 @@ namespace System.IO.Pipes.Tests
                     Task serverReadToken = server.ReadAsync(buffer, 0, buffer.Length, cts.Token);
 
                     Assert.True(Interop.CancelIoEx(server.SafePipeHandle), "Outer cancellation failed");
-                    await Assert.ThrowsAsync<IOException>(() => serverReadToken);
+                    await Assert.ThrowsAnyAsync<OperationCanceledException>(() => serverReadToken);
                 }
                 if (server.CanWrite)
                 {
@@ -616,7 +616,7 @@ namespace System.IO.Pipes.Tests
                     Task serverWriteToken = server.WriteAsync(buffer, 0, buffer.Length, cts.Token);
 
                     Assert.True(Interop.CancelIoEx(server.SafePipeHandle), "Outer cancellation failed");
-                    await Assert.ThrowsAsync<IOException>(() => serverWriteToken);
+                    await Assert.ThrowsAnyAsync<OperationCanceledException>(() => serverWriteToken);
                 }
             }
         }
@@ -689,7 +689,7 @@ namespace System.IO.Pipes.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // P/Invoking to Win32 functions
-        public async Task CancelTokenOn_Client_ReadWriteCancelledToken_Throws_IOException()
+        public async Task CancelTokenOn_Client_ReadWriteCancelledToken_Throws_OperationCanceledException()
         {
             using (NamedPipePair pair = CreateNamedPipePair())
             {
@@ -703,7 +703,7 @@ namespace System.IO.Pipes.Tests
                     Task clientReadToken = client.ReadAsync(buffer, 0, buffer.Length, cts.Token);
 
                     Assert.True(Interop.CancelIoEx(client.SafePipeHandle), "Outer cancellation failed");
-                    await Assert.ThrowsAsync<IOException>(() => clientReadToken);
+                    await Assert.ThrowsAnyAsync<OperationCanceledException>(() => clientReadToken);
                 }
                 if (client.CanWrite)
                 {
@@ -711,7 +711,7 @@ namespace System.IO.Pipes.Tests
                     Task clientWriteToken = client.WriteAsync(buffer, 0, buffer.Length, cts.Token);
 
                     Assert.True(Interop.CancelIoEx(client.SafePipeHandle), "Outer cancellation failed");
-                    await Assert.ThrowsAsync<IOException>(() => clientWriteToken);
+                    await Assert.ThrowsAnyAsync<OperationCanceledException>(() => clientWriteToken);
                 }
             }
         }


### PR DESCRIPTION
When an operation is aborted but not because of the supplied CancellationToken, desktop still throws an OperationCanceledException but core throws an IOException.  We should unify on the OCE, as there's little value in being different.  This does that.

Fixes https://github.com/dotnet/corefx/issues/18544
cc: @ianhays 