### PR TITLE
Harden finalizers

### DIFF
--- a/src/System.Private.Reflection.Metadata.Ecma335/src/System.Private.Reflection.Metadata.Ecma335.csproj
+++ b/src/System.Private.Reflection.Metadata.Ecma335/src/System.Private.Reflection.Metadata.Ecma335.csproj
@@ -92,6 +92,8 @@
     <Compile Include="$(SystemReflectionMetadataPath)System\Reflection\Internal\MemoryBlocks\NativeHeapMemoryBlock.cs" />
     <Compile Include="$(SystemReflectionMetadataPath)System\Reflection\Internal\MemoryBlocks\StreamConstraints.cs" />
     <Compile Include="$(SystemReflectionMetadataPath)System\Reflection\Internal\MemoryBlocks\StreamMemoryBlockProvider.cs" />
+    <Compile Include="$(SystemReflectionMetadataPath)System\Reflection\Internal\Utilities\CriticalDisposableObject.cs" />
+    <Compile Include="$(SystemReflectionMetadataPath)System\Reflection\Internal\Utilities\PinnedObject.cs" />
     <Compile Include="$(SystemReflectionMetadataPath)System\Reflection\Internal\Utilities\BitArithmetic.cs" />
     <Compile Include="$(SystemReflectionMetadataPath)System\Reflection\Internal\Utilities\StringUtils.cs" />
     <Compile Include="$(SystemReflectionMetadataPath)System\Reflection\Internal\Utilities\EmptyArray.cs" />

--- a/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
+++ b/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
@@ -22,7 +22,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="System\Reflection\Internal\Utilities\PinnedObject.cs" />
-    <Compile Include="System\Reflection\Internal\Utilities\CriticalDisposableObject.cs" />
+    <Compile Include="System\Reflection\Internal\Utilities\CriticalDisposableObject.cs" Condition="'$(TargetGroup)' != 'netstandard1.1'" />
+    <Compile Include="System\Reflection\Internal\Utilities\CriticalDisposableObject.netstandard1.1.cs" Condition="'$(TargetGroup)' == 'netstandard1.1'" />
     <Compile Include="System\Reflection\Internal\Utilities\ExceptionUtilities.cs" />
     <Compile Include="System\Reflection\Internal\Utilities\PathUtilities.cs" />
     <Compile Include="System\Reflection\Metadata\Ecma335\Encoding\FunctionPointerAttributes.cs" />

--- a/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
+++ b/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
@@ -10,6 +10,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <NoWarn>1591</NoWarn>
     <CLSCompliant>false</CLSCompliant>
+    <DefineConstants Condition="'$(TargetGroup)' == 'netstandard1.1'">NETSTANDARD11</DefineConstants>
     <PackageTargetFramework Condition="'$(TargetGroup)' == 'netstandard1.1'">netstandard1.1;portable-net45+win8</PackageTargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />

--- a/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
+++ b/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
@@ -21,6 +21,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
+    <Compile Include="System\Reflection\Internal\Utilities\PinnedObject.cs" />
+    <Compile Include="System\Reflection\Internal\Utilities\CriticalDisposableObject.cs" />
     <Compile Include="System\Reflection\Internal\Utilities\ExceptionUtilities.cs" />
     <Compile Include="System\Reflection\Internal\Utilities\PathUtilities.cs" />
     <Compile Include="System\Reflection\Metadata\Ecma335\Encoding\FunctionPointerAttributes.cs" />

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/AbstractMemoryBlock.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/AbstractMemoryBlock.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Immutable;
 using System.Reflection.Metadata;
-using System.Runtime.ConstrainedExecution;
 
 namespace System.Reflection.Internal
 {

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/AbstractMemoryBlock.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/AbstractMemoryBlock.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Immutable;
 using System.Reflection.Metadata;
+using System.Runtime.ConstrainedExecution;
 
 namespace System.Reflection.Internal
 {
@@ -44,18 +45,11 @@ namespace System.Reflection.Internal
         /// Disposes the block. 
         /// </summary>
         /// <remarks>
-        /// The operation is idempotent, but must not be called concurrently with any other operations on the block
-        /// or with another call to Dispose.
+        /// The operation is idempotent, but must not be called concurrently with any other operations on the block.
         /// 
         /// Using the block after dispose is an error in our code and therefore no effort is made to throw a tidy 
         /// ObjectDisposedException and null ref or AV is possible.
         /// </remarks>
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        protected abstract void Dispose(bool disposing);
+        public abstract void Dispose();
     }
 }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/ByteArrayMemoryBlock.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/ByteArrayMemoryBlock.cs
@@ -23,9 +23,8 @@ namespace System.Reflection.Internal
             _start = start;
         }
 
-        protected override void Dispose(bool disposing)
+        public override void Dispose()
         {
-            Debug.Assert(disposing);
             _provider = null;
         }
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/ExternalMemoryBlock.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/ExternalMemoryBlock.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Immutable;
-using System.Diagnostics;
-
 namespace System.Reflection.Internal
 {
     /// <summary>
@@ -25,9 +22,8 @@ namespace System.Reflection.Internal
             _size = size;
         }
 
-        protected override void Dispose(bool disposing)
+        public override void Dispose()
         {
-            Debug.Assert(disposing);
             _buffer = null;
             _size = 0;
         }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/MemoryMappedFileBlock.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/MemoryMappedFileBlock.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
-using System.Runtime.ConstrainedExecution;
 using System.Runtime.InteropServices;
 using System.Threading;
 
@@ -35,7 +34,7 @@ namespace System.Reflection.Internal
                 }
             }
 
-            protected override void Dispose(bool disposing)
+            protected override void Release()
             {
                 // Make sure the current thread isn't aborted in between zeroing the references and releasing/disposing.
                 // Safe buffer only frees the underlying resource if its ref count drops to zero, so we have to make sure it does.

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/MemoryMappedFileBlock.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/MemoryMappedFileBlock.cs
@@ -19,7 +19,9 @@ namespace System.Reflection.Internal
             public DisposableData(IDisposable accessor, SafeBuffer safeBuffer, long offset)
             {
                 // Make sure the current thread isn't aborted in between acquiring the pointer and assigning the fields.
+#if !NETSTANDARD11
                 RuntimeHelpers.PrepareConstrainedRegions();
+#endif
                 try
                 {
                 }
@@ -38,7 +40,9 @@ namespace System.Reflection.Internal
             {
                 // Make sure the current thread isn't aborted in between zeroing the references and releasing/disposing.
                 // Safe buffer only frees the underlying resource if its ref count drops to zero, so we have to make sure it does.
+#if !NETSTANDARD11
                 RuntimeHelpers.PrepareConstrainedRegions();
+#endif
                 try
                 {
                 }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/MemoryMappedFileBlock.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/MemoryMappedFileBlock.cs
@@ -2,49 +2,70 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
+using System.Runtime.ConstrainedExecution;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace System.Reflection.Internal
 {
     internal unsafe sealed class MemoryMappedFileBlock : AbstractMemoryBlock
     {
-        private readonly int _size;
-        private IDisposable _accessor; // MemoryMappedViewAccessor
-        private byte* _pointer;
-        private SafeBuffer _safeBuffer;
-
-        internal unsafe MemoryMappedFileBlock(IDisposable accessor, SafeBuffer safeBuffer, byte* pointer, int size)
+        private sealed class DisposableData : CriticalDisposableObject
         {
-            _accessor = accessor;
-            _safeBuffer = safeBuffer;
-            _pointer = pointer;
+            private IDisposable _accessor; // MemoryMappedViewAccessor
+            private SafeBuffer _safeBuffer;
+            private byte* _pointer;
+
+            public DisposableData(IDisposable accessor, SafeBuffer safeBuffer, long offset)
+            {
+                // Make sure the current thread isn't aborted in between acquiring the pointer and assigning the fields.
+                RuntimeHelpers.PrepareConstrainedRegions();
+                try
+                {
+                }
+                finally
+                {
+                    byte* basePointer = null;
+                    safeBuffer.AcquirePointer(ref basePointer);
+
+                    _accessor = accessor;
+                    _safeBuffer = safeBuffer;
+                    _pointer = basePointer + offset;
+                }
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                // Make sure the current thread isn't aborted in between zeroing the references and releasing/disposing.
+                // Safe buffer only frees the underlying resource if its ref count drops to zero, so we have to make sure it does.
+                RuntimeHelpers.PrepareConstrainedRegions();
+                try
+                {
+                }
+                finally
+                {
+                    Interlocked.Exchange(ref _safeBuffer, null)?.ReleasePointer();
+                    Interlocked.Exchange(ref _accessor, null)?.Dispose();
+                }
+
+                _pointer = null;
+            }
+
+            public byte* Pointer => _pointer;
+        }
+
+        private readonly DisposableData _data;
+        private readonly int _size;
+
+        internal unsafe MemoryMappedFileBlock(IDisposable accessor, SafeBuffer safeBuffer, long offset, int size)
+        {
+            _data = new DisposableData(accessor, safeBuffer, offset);
             _size = size;
         }
 
-        ~MemoryMappedFileBlock()
-        {
-            Dispose(false);
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            if (_safeBuffer != null)
-            {
-                _safeBuffer.ReleasePointer();
-                _safeBuffer = null;
-            }
-
-            if (_accessor != null)
-            {
-                _accessor.Dispose();
-                _accessor = null;
-            }
-
-            _pointer = null;
-        }
-
-        public override byte* Pointer => _pointer;
+        public override void Dispose() => _data.Dispose();
+        public override byte* Pointer => _data.Pointer;
         public override int Size => _size;
     }
 }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/NativeHeapMemoryBlock.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/NativeHeapMemoryBlock.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
-using System.Runtime.ConstrainedExecution;
 using System.Runtime.InteropServices;
 using System.Threading;
 
@@ -34,7 +33,7 @@ namespace System.Reflection.Internal
                 }
             }
                         
-            protected override void Dispose(bool disposing)
+            protected override void Release()
             {
                 // make sure the current thread isn't aborted in between zeroing the pointer and freeing the memory
                 RuntimeHelpers.PrepareConstrainedRegions();

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/NativeHeapMemoryBlock.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/NativeHeapMemoryBlock.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
+using System.Runtime.ConstrainedExecution;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace System.Reflection.Internal
 {
@@ -13,29 +15,56 @@ namespace System.Reflection.Internal
     /// <remarks>
     /// Owns the native memory resource.
     /// </remarks>
-    internal unsafe sealed class NativeHeapMemoryBlock : AbstractMemoryBlock
+    internal sealed class NativeHeapMemoryBlock : AbstractMemoryBlock
     {
-        private byte* _pointer;
+        private unsafe sealed class DisposableData : CriticalDisposableObject
+        {
+            private IntPtr _pointer;
+
+            public DisposableData(int size)
+            {
+                // make sure the current thread isn't aborted in between allocating and storing the pointer
+                RuntimeHelpers.PrepareConstrainedRegions();
+                try
+                {
+                }
+                finally
+                {
+                    _pointer = Marshal.AllocHGlobal(size);
+                }
+            }
+                        
+            protected override void Dispose(bool disposing)
+            {
+                // make sure the current thread isn't aborted in between zeroing the pointer and freeing the memory
+                RuntimeHelpers.PrepareConstrainedRegions();
+                try
+                {
+                }
+                finally
+                {
+                    IntPtr ptr = Interlocked.Exchange(ref _pointer, IntPtr.Zero);
+                    if (ptr != IntPtr.Zero)
+                    {
+                        Marshal.FreeHGlobal(ptr);
+                    }
+                }
+            }
+
+            public byte* Pointer => (byte*)_pointer;
+        }
+
+        private readonly DisposableData _data;
         private readonly int _size;
 
         internal NativeHeapMemoryBlock(int size)
         {
-            _pointer = (byte*)Marshal.AllocHGlobal(size);
+            _data = new DisposableData(size);
             _size = size;
         }
 
-        ~NativeHeapMemoryBlock()
-        {
-            Dispose(false);
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            Marshal.FreeHGlobal((IntPtr)_pointer);
-            _pointer = null;
-        }
-
-        public override byte* Pointer => _pointer;
+        public override void Dispose() => _data.Dispose();
+        public unsafe override byte* Pointer => _data.Pointer;
         public override int Size => _size;
     }
 }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/NativeHeapMemoryBlock.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/NativeHeapMemoryBlock.cs
@@ -23,7 +23,9 @@ namespace System.Reflection.Internal
             public DisposableData(int size)
             {
                 // make sure the current thread isn't aborted in between allocating and storing the pointer
+#if !NETSTANDARD11
                 RuntimeHelpers.PrepareConstrainedRegions();
+#endif
                 try
                 {
                 }
@@ -36,7 +38,9 @@ namespace System.Reflection.Internal
             protected override void Release()
             {
                 // make sure the current thread isn't aborted in between zeroing the pointer and freeing the memory
+#if !NETSTANDARD11
                 RuntimeHelpers.PrepareConstrainedRegions();
+#endif
                 try
                 {
                 }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/CriticalDisposableObject.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/CriticalDisposableObject.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.ConstrainedExecution;
+
+namespace System.Reflection.Internal
+{
+    internal abstract class CriticalDisposableObject : CriticalFinalizerObject, IDisposable
+    {
+        protected abstract void Dispose(bool disposing);
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        ~CriticalDisposableObject()
+        {
+            Dispose(false);
+        }
+    }
+}

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/CriticalDisposableObject.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/CriticalDisposableObject.cs
@@ -1,24 +1,23 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
 using System.Runtime.ConstrainedExecution;
 
 namespace System.Reflection.Internal
 {
     internal abstract class CriticalDisposableObject : CriticalFinalizerObject, IDisposable
     {
-        protected abstract void Dispose(bool disposing);
+        protected abstract void Release();
 
         public void Dispose()
         {
-            Dispose(true);
+            Release();
             GC.SuppressFinalize(this);
         }
 
         ~CriticalDisposableObject()
         {
-            Dispose(false);
+            Release();
         }
     }
 }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/CriticalDisposableObject.netstandard1.1.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/CriticalDisposableObject.netstandard1.1.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+namespace System.Reflection.Internal
+{
+    // HACK: CriticalFinalizerObject is not available in netstandard 1.x
+    // Use CriticalHandle instead -- we don't actually use the handle,
+    // just the fact that CriticalHandle derives from CriticalFinalizerObject to ensure critical finalizer.
+    internal abstract class CriticalDisposableObject : CriticalHandle
+    {
+        public CriticalDisposableObject()
+            : base(IntPtr.Zero)
+        {
+        }
+
+        public sealed override bool IsInvalid => true;
+
+        protected sealed override bool ReleaseHandle() =>
+            throw ExceptionUtilities.Unreachable;
+
+        protected new void SetHandle(IntPtr handle) =>
+            throw ExceptionUtilities.Unreachable;
+
+        protected sealed override void Dispose(bool disposing)
+        {
+            // do not call base dispose
+            Release();
+
+            if (disposing)
+            {
+                GC.SuppressFinalize(this);
+            }
+        }
+
+        protected abstract void Release();
+    }
+}

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/MemoryMapLightUp.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/MemoryMapLightUp.cs
@@ -35,16 +35,12 @@ namespace System.Reflection.Internal
             }
         }
 
-        internal static unsafe byte* AcquirePointer(object accessor, out SafeBuffer safeBuffer)
+        internal static bool TryGetSafeBufferAndPointerOffset(object accessor, out SafeBuffer safeBuffer, out long offset)
         {
-            var memoryMappedViewAccessor = (MemoryMappedViewAccessor)accessor;
-
-            safeBuffer = memoryMappedViewAccessor.SafeMemoryMappedViewHandle;
-
-            byte* ptr = null;
-            safeBuffer.AcquirePointer(ref ptr);
-
-            return ptr + memoryMappedViewAccessor.PointerOffset;
+            var viewAccessor = (MemoryMappedViewAccessor)accessor;
+            safeBuffer = viewAccessor.SafeMemoryMappedViewHandle;
+            offset = viewAccessor.PointerOffset;
+            return true;
         }
     }
 }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/PinnedObject.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/PinnedObject.cs
@@ -25,7 +25,7 @@ namespace System.Reflection.Internal
             }
         }
 
-        protected override void Dispose(bool disposing)
+        protected override void Release()
         {
             // Make sure the current thread isn't aborted in between zeroing the handle and freeing it.
             RuntimeHelpers.PrepareConstrainedRegions();

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/PinnedObject.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/PinnedObject.cs
@@ -15,7 +15,9 @@ namespace System.Reflection.Internal
         public PinnedObject(object obj)
         {
             // Make sure the current thread isn't aborted in between allocating the handle and storing it.
+#if !NETSTANDARD11
             RuntimeHelpers.PrepareConstrainedRegions();
+#endif
             try
             {
             }
@@ -28,7 +30,9 @@ namespace System.Reflection.Internal
         protected override void Release()
         {
             // Make sure the current thread isn't aborted in between zeroing the handle and freeing it.
+#if !NETSTANDARD11
             RuntimeHelpers.PrepareConstrainedRegions();
+#endif
             try
             {
             }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/PinnedObject.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/PinnedObject.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace System.Reflection.Internal
+{
+    internal sealed class PinnedObject : CriticalDisposableObject
+    {
+        // can't be read-only since GCHandle is a mutable struct
+        private GCHandle _handle;
+
+        public PinnedObject(object obj)
+        {
+            // Make sure the current thread isn't aborted in between allocating the handle and storing it.
+            RuntimeHelpers.PrepareConstrainedRegions();
+            try
+            {
+            }
+            finally
+            {
+                _handle = GCHandle.Alloc(obj, GCHandleType.Pinned);
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            // Make sure the current thread isn't aborted in between zeroing the handle and freeing it.
+            RuntimeHelpers.PrepareConstrainedRegions();
+            try
+            {
+            }
+            finally
+            {
+                _handle.Free();
+            }
+        }
+
+        public unsafe byte* Pointer => (byte*)_handle.AddrOfPinnedObject();
+    }
+}

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Internal/BlobHeap.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Internal/BlobHeap.cs
@@ -121,17 +121,15 @@ namespace System.Reflection.Metadata.Ecma335
         {
             var heap = VirtualHeap.GetOrCreateVirtualHeap(ref _lazyVirtualHeap);
 
-            VirtualHeapBlob virtualBlob;
             lock (heap)
             {
-                if (!heap.Table.TryGetValue(handle.RawValue, out virtualBlob))
+                if (!heap.TryGetMemoryBlock(handle.RawValue, out var block))
                 {
-                    virtualBlob = new VirtualHeapBlob(GetVirtualBlobBytes(handle, unique: false));
-                    heap.Table.Add(handle.RawValue, virtualBlob);
+                    block = heap.AddBlob(handle.RawValue, GetVirtualBlobBytes(handle, unique: false));
                 }
-            }
 
-            return virtualBlob.GetMemoryBlock();
+                return block;
+            }
         }
 
         internal BlobReader GetBlobReader(BlobHandle handle)

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Internal/StringHeap.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Internal/StringHeap.cs
@@ -213,10 +213,9 @@ namespace System.Reflection.Metadata.Ecma335
             Debug.Assert(handle.IsVirtual);
             var heap = VirtualHeap.GetOrCreateVirtualHeap(ref _lazyVirtualHeap);
 
-            VirtualHeapBlob virtualBlob;
             lock (heap)
             {
-                if (!heap.Table.TryGetValue(handle.RawValue, out virtualBlob))
+                if (!heap.TryGetMemoryBlock(handle.RawValue, out var block))
                 {
                     byte[] bytes;
                     switch (handle.StringKind)
@@ -232,13 +231,12 @@ namespace System.Reflection.Metadata.Ecma335
                         default:
                             throw ExceptionUtilities.UnexpectedValue(handle.StringKind);
                     }
-            
-                    virtualBlob = new VirtualHeapBlob(bytes);
-                    heap.Table.Add(handle.RawValue, virtualBlob);
-                }
-            }
 
-            return virtualBlob.GetMemoryBlock();
+                    block = heap.AddBlob(handle.RawValue, bytes);
+                }
+
+                return block;
+            }
         }
 
         internal BlobReader GetBlobReader(StringHandle handle)

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Internal/VirtualHeap.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Internal/VirtualHeap.cs
@@ -4,33 +4,13 @@
 
 using System.Collections.Generic;
 using System.Reflection.Internal;
+using System.Runtime.CompilerServices;
+using System.Runtime.ConstrainedExecution;
 using System.Runtime.InteropServices;
 using System.Threading;
 
 namespace System.Reflection.Metadata.Ecma335
 {
-    internal struct VirtualHeapBlob
-    {
-        private GCHandle _pinned;
-        private readonly byte[] _array;
-
-        public VirtualHeapBlob(byte[] array)
-        {
-            _pinned = GCHandle.Alloc(array, GCHandleType.Pinned);
-            _array = array;
-        }
-
-        public unsafe MemoryBlock GetMemoryBlock()
-        {
-            return new MemoryBlock((byte*)_pinned.AddrOfPinnedObject(), _array.Length);
-        }
-
-        public void Free()
-        {
-            _pinned.Free();
-        }
-    }
-
     // Container for virtual heap blobs that unpins handles on finalization.
     // This is not handled via dispose because the only resource is managed memory
     // and we don't have user visible disposable object that could own this memory.
@@ -38,24 +18,94 @@ namespace System.Reflection.Metadata.Ecma335
     // Since the number of virtual blobs we need is small (the number of attribute classes in .winmd files)
     // we can create a pinned handle for each of them.
     // If we needed many more blobs we could create and pin a single byte[] and allocate blobs there.
-    internal sealed class VirtualHeap
+    internal sealed class VirtualHeap : CriticalDisposableObject
     {
-        public readonly Dictionary<uint, VirtualHeapBlob> Table;
+        private struct PinnedBlob
+        {
+            // can't be read-only since GCHandle is a mutable struct
+            public GCHandle Handle;
+
+            public readonly int Length;
+
+            public PinnedBlob(GCHandle handle, int length)
+            {
+                Handle = handle;
+                Length = length;
+            }
+
+            public unsafe MemoryBlock GetMemoryBlock() => 
+                new MemoryBlock((byte*)Handle.AddrOfPinnedObject(), Length);
+        }
+
+        // maps raw value of StringHandle or BlobHandle to the corresponding pinned array
+        private Dictionary<uint, PinnedBlob> _blobs;
 
         private VirtualHeap()
         {
-            Table = new Dictionary<uint, VirtualHeapBlob>();
+            _blobs = new Dictionary<uint, PinnedBlob>();
         }
 
-        ~VirtualHeap()
+        protected override void Dispose(bool disposing)
         {
-            if (Table != null)
+            // Make sure the current thread isn't aborted in the middle of the operation.
+            RuntimeHelpers.PrepareConstrainedRegions();
+            try
             {
-                foreach (var blobPair in Table)
+            }
+            finally
+            {
+                var blobs = Interlocked.Exchange(ref _blobs, null);
+
+                if (blobs != null)
                 {
-                    blobPair.Value.Free();
+                    foreach (var blobPair in blobs)
+                    {
+                        blobPair.Value.Handle.Free();
+                    }
                 }
             }
+        }
+
+        private Dictionary<uint, PinnedBlob> GetBlobs()
+        {
+            var blobs = _blobs;
+            if (blobs == null)
+            {
+                throw new ObjectDisposedException(nameof(VirtualHeap));
+            }
+
+            return blobs;
+        }
+
+        public bool TryGetMemoryBlock(uint rawHandle, out MemoryBlock block)
+        {
+            if (!GetBlobs().TryGetValue(rawHandle, out var blob))
+            {
+                block = default(MemoryBlock);
+                return false;
+            }
+
+            block = blob.GetMemoryBlock();
+            return true;
+        }
+
+        internal MemoryBlock AddBlob(uint rawHandle, byte[] value)
+        {
+            var blobs = GetBlobs();
+
+            MemoryBlock result;
+            RuntimeHelpers.PrepareConstrainedRegions();
+            try
+            {
+            }
+            finally
+            {
+                var blob = new PinnedBlob(GCHandle.Alloc(value, GCHandleType.Pinned), value.Length);
+                blobs.Add(rawHandle, blob);
+                result = blob.GetMemoryBlock();
+            }
+
+            return result;
         }
 
         internal static VirtualHeap GetOrCreateVirtualHeap(ref VirtualHeap lazyHeap)

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Internal/VirtualHeap.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Internal/VirtualHeap.cs
@@ -5,7 +5,6 @@
 using System.Collections.Generic;
 using System.Reflection.Internal;
 using System.Runtime.CompilerServices;
-using System.Runtime.ConstrainedExecution;
 using System.Runtime.InteropServices;
 using System.Threading;
 
@@ -45,7 +44,7 @@ namespace System.Reflection.Metadata.Ecma335
             _blobs = new Dictionary<uint, PinnedBlob>();
         }
 
-        protected override void Dispose(bool disposing)
+        protected override void Release()
         {
             // Make sure the current thread isn't aborted in the middle of the operation.
             RuntimeHelpers.PrepareConstrainedRegions();

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Internal/VirtualHeap.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Internal/VirtualHeap.cs
@@ -47,7 +47,9 @@ namespace System.Reflection.Metadata.Ecma335
         protected override void Release()
         {
             // Make sure the current thread isn't aborted in the middle of the operation.
+#if !NETSTANDARD11
             RuntimeHelpers.PrepareConstrainedRegions();
+#endif
             try
             {
             }
@@ -93,7 +95,9 @@ namespace System.Reflection.Metadata.Ecma335
             var blobs = GetBlobs();
 
             MemoryBlock result;
+#if !NETSTANDARD11
             RuntimeHelpers.PrepareConstrainedRegions();
+#endif
             try
             {
             }


### PR DESCRIPTION
Make memory block disposal thread safe. This addresses reentrancy issue occurring on CLR shutdown described in https://github.com/dotnet/corefx/issues/18632 and makes the Dispose method thread safe.

Hardens all finalizers against thread abort and race conditions.

Fixes https://github.com/dotnet/corefx/issues/18632 (internal bug 360526)
