### PR TITLE
Fix several System.IO.Packaging issues with differing desktop behavior

### DIFF
--- a/src/System.IO.Packaging/src/Resources/Strings.resx
+++ b/src/System.IO.Packaging/src/Resources/Strings.resx
@@ -355,4 +355,10 @@
   <data name="XsdDateTimeExpected" xml:space="preserve">
     <value>Core Properties part: Text data of XSD type 'DateTime' was expected.</value>
   </data>
+  <data name="CreateNewOnNonEmptyStream" xml:space="preserve">
+    <value>CreateNew is not a valid FileMode for a non-empty stream.</value>
+  </data>
+  <data name="ZipZeroSizeFileIsNotValidArchive" xml:space="preserve">
+    <value>Archive file cannot be size 0.</value>
+  </data>
 </root>

--- a/src/System.IO.Packaging/src/System/IO/Packaging/ZipPackage.cs
+++ b/src/System.IO.Packaging/src/System/IO/Packaging/ZipPackage.cs
@@ -311,6 +311,33 @@ namespace System.IO.Packaging
 
             try
             {
+                if (s.CanSeek)
+                {
+                    switch (packageFileMode)
+                    {
+                        case FileMode.Open:
+                            if (s.Length == 0)
+                            {
+                                throw new FileFormatException(SR.ZipZeroSizeFileIsNotValidArchive);
+                            }
+                            break;
+
+                        case FileMode.CreateNew:
+                            if (s.Length != 0)
+                            {
+                                throw new IOException(SR.CreateNewOnNonEmptyStream);
+                            }
+                            break;
+
+                        case FileMode.Create:
+                            if (s.Length != 0)
+                            {
+                                s.SetLength(0); // Discard existing data
+                            }
+                            break;
+                    }
+                }
+
                 ZipArchiveMode zipArchiveMode = ZipArchiveMode.Update;
                 if (packageFileAccess == FileAccess.Read)
                     zipArchiveMode = ZipArchiveMode.Read;

--- a/src/System.IO.Packaging/tests/Tests.cs
+++ b/src/System.IO.Packaging/tests/Tests.cs
@@ -2,12 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
 using Xunit;
@@ -133,8 +129,29 @@ namespace System.IO.Packaging.Tests
             {
                 ms.Write(ba, 0, ba.Length);
                 Package package = Package.Open(ms, FileMode.Create, FileAccess.ReadWrite);
+                Assert.Equal(0, ms.Length);
                 PackagePart packagePartDocument = null;
                 Assert.Throws<ArgumentException>(() => { packagePartDocument = package.CreatePart(partUriDocument, "image/jpeg; prop= ;"); });
+            }
+        }
+
+        [Fact]
+        public void PackageOpen_CreateNew_NonEmptyStream_Throws()
+        {
+            byte[] ba = File.ReadAllBytes("plain.docx");
+            using (var ms = new MemoryStream())
+            {
+                ms.Write(ba, 0, ba.Length);
+                Assert.Throws<IOException>(() => Package.Open(ms, FileMode.CreateNew, FileAccess.ReadWrite));
+            }
+        }
+
+        [Fact]
+        public void PackageOpen_Open_EmptyStream_Throws()
+        {
+            using (var ms = new MemoryStream())
+            {
+                Assert.Throws<FileFormatException>(() => Package.Open(ms, FileMode.Open, FileAccess.ReadWrite));
             }
         }
 
@@ -514,7 +531,7 @@ namespace System.IO.Packaging.Tests
             using (MemoryStream ms = new MemoryStream())
             {
                 ms.Write(ba, 0, ba.Length);
-                using (Package package = Package.Open(ms, FileMode.Create, FileAccess.ReadWrite))
+                using (Package package = Package.Open(ms, FileMode.Open, FileAccess.ReadWrite))
                 {
                     Assert.Throws<XmlException>(() =>
                         {
@@ -572,7 +589,7 @@ namespace System.IO.Packaging.Tests
             using (MemoryStream ms = new MemoryStream())
             {
                 ms.Write(ba, 0, ba.Length);
-                using (Package package = Package.Open(ms, FileMode.Create, FileAccess.ReadWrite))
+                using (Package package = Package.Open(ms, FileMode.Open, FileAccess.ReadWrite))
                 {
                     Assert.Throws<FileFormatException>(() =>
                     {
@@ -593,7 +610,7 @@ namespace System.IO.Packaging.Tests
             using (MemoryStream ms = new MemoryStream())
             {
                 ms.Write(ba, 0, ba.Length);
-                using (Package package = Package.Open(ms, FileMode.Create, FileAccess.ReadWrite))
+                using (Package package = Package.Open(ms, FileMode.Open, FileAccess.ReadWrite))
                 {
                     Assert.Throws<FileFormatException>(() =>
                     {
@@ -1710,7 +1727,7 @@ namespace System.IO.Packaging.Tests
             using (MemoryStream ms = new MemoryStream())
             {
                 ms.Write(ba, 0, ba.Length);
-                using (Package package = Package.Open(ms, FileMode.Create, FileAccess.ReadWrite))
+                using (Package package = Package.Open(ms, FileMode.Open, FileAccess.ReadWrite))
                 {
                     Uri documentUri = new Uri("/word/document.xml", UriKind.Relative);
                     package.DeletePart(documentUri);
@@ -1728,7 +1745,7 @@ namespace System.IO.Packaging.Tests
             using (MemoryStream ms = new MemoryStream())
             {
                 ms.Write(ba, 0, ba.Length);
-                using (Package package = Package.Open(ms, FileMode.Create, FileAccess.ReadWrite))
+                using (Package package = Package.Open(ms, FileMode.Open, FileAccess.ReadWrite))
                 {
                     PackageRelationship docPackageRelationship =
                         package.GetRelationshipsByType(DocumentRelationshipType).FirstOrDefault();
@@ -1750,7 +1767,7 @@ namespace System.IO.Packaging.Tests
             using (MemoryStream ms = new MemoryStream())
             {
                 ms.Write(ba, 0, ba.Length);
-                using (Package package = Package.Open(ms, FileMode.Create, FileAccess.ReadWrite))
+                using (Package package = Package.Open(ms, FileMode.Open, FileAccess.ReadWrite))
                 {
                     PackageRelationship docPackageRelationship =
                         package.GetRelationshipsByType(DocumentRelationshipType).FirstOrDefault();
@@ -1777,7 +1794,7 @@ namespace System.IO.Packaging.Tests
             using (MemoryStream ms = new MemoryStream())
             {
                 ms.Write(ba, 0, ba.Length);
-                using (Package package = Package.Open(ms, FileMode.Create, FileAccess.ReadWrite))
+                using (Package package = Package.Open(ms, FileMode.Open, FileAccess.ReadWrite))
                 {
                     PackageRelationship docPackageRelationship =
                                   package


### PR DESCRIPTION
On desktop, calling Package.Open(stream, FileMode.Create, ...) on a seekable stream sets the length to 0, since the ZipArchive that gets created from it will seek around in the stream and considers it to start from position 0 rather than the current position.  The core implementation was not doing that.  Then tests were written against core; those tests should have used FileMode.Open but used FileMode.Create (presumably by accident), and thus on desktop the stream was being cleared whereas on core it was not.

This change fixes the core implementation to do the same stream validation/mutation that's done on desktop (additional code a direct copy of what's in desktop), and updates the tests to use FileMode.Open instead of FileMode.Create in the few problematic cases.  I then added a couple of additional tests.

Fixes https://github.com/dotnet/corefx/issues/10898
Fixes https://github.com/dotnet/corefx/issues/10897
cc: @EricWhiteDev, @mellinoe 