### PR TITLE
Add type forwarders for newly added types in System.Runtime.CompilerServices

### DIFF
--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -6488,7 +6488,16 @@ namespace System.Runtime.CompilerServices
         Default = 0,
         Sometimes = 2,
     }
-    
+    public static class RuntimeFeature
+    {
+        public static bool IsSupported(string feature) { throw null; }
+    }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    [AttributeUsage(AttributeTargets.All, Inherited = false)]
+    public sealed class IsReadOnlyAttribute : Attribute
+    {
+        public IsReadOnlyAttribute() { }
+    }
     public sealed partial class RuntimeWrappedException : System.Exception
     {
         internal RuntimeWrappedException() { }


### PR DESCRIPTION
Specifically `RuntimeFeature` and `IsReadOnlyAttribute`. Both types were added to `dotnet/coreclr` and `dotnet/corert`.
cc @jcouv @dotnet/roslyn-compiler @jkotas 

From what I can see in source, this is the only place that forwards types.
Do they need to be coped somewhere in this repo?