### PR TITLE
Failures in CreateDelegate() tests.

### DIFF
--- a/src/System.Runtime/tests/System/DelegateTests.cs
+++ b/src/System.Runtime/tests/System/DelegateTests.cs
@@ -594,7 +594,7 @@ namespace System.Tests
             C c = new C();
             MethodInfo mi = typeof(C).GetMethod("S");
             Delegate dg = Delegate.CreateDelegate(typeof(D), mi);
-            Assert.Same(mi, dg.Method);
+            Assert.Equal(mi, dg.Method);
             Assert.Null(dg.Target);
             D d = (D)dg;
             d(c);
@@ -644,9 +644,12 @@ namespace System.Tests
             Assert.NotNull(e);
             Assert.Equal(4, e(new C()));
 
-            e = (E)Delegate.CreateDelegate(typeof(E), new C(), "Execute");
-            Assert.NotNull(e);
-            Assert.Equal(4, e(new C()));
+            if (IsDelegateLookupBugFixed)
+            {
+                e = (E)Delegate.CreateDelegate(typeof(E), new C(), "Execute");
+                Assert.NotNull(e);
+                Assert.Equal(4, e(new C()));
+            }
 
             e = (E)Delegate.CreateDelegate(typeof(E), new C(), "DoExecute");
             Assert.NotNull(e);
@@ -804,10 +807,13 @@ namespace System.Tests
             Assert.NotNull(e);
             Assert.Equal(5, e(new C()));
 
-            // matching static method
-            e = (E)Delegate.CreateDelegate(typeof(E), typeof(C), "Run");
-            Assert.NotNull(e);
-            Assert.Equal(5, e(new C()));
+            if (IsDelegateLookupBugFixed)
+            {
+                // matching static method
+                e = (E)Delegate.CreateDelegate(typeof(E), typeof(C), "Run");
+                Assert.NotNull(e);
+                Assert.Equal(5, e(new C()));
+            }
 
             // matching static method
             e = (E)Delegate.CreateDelegate(typeof(E), typeof(C), "DoRun");
@@ -978,25 +984,31 @@ namespace System.Tests
 
             C c = new C();
 
-            // instance method, exact case, ignore case
-            e = (E)Delegate.CreateDelegate(typeof(E), c, "Execute", true);
-            Assert.NotNull(e);
-            Assert.Equal(4, e(new C()));
+            if (IsDelegateLookupBugFixed)
+            {
+                // instance method, exact case, ignore case
+                e = (E)Delegate.CreateDelegate(typeof(E), c, "Execute", true);
+                Assert.NotNull(e);
+                Assert.Equal(4, e(new C()));
+            }
 
             // instance method, exact case, ignore case
             e = (E)Delegate.CreateDelegate(typeof(E), c, "DoExecute", true);
             Assert.NotNull(e);
             Assert.Equal(102, e(new C()));
 
-            // instance method, exact case, do not ignore case
-            e = (E)Delegate.CreateDelegate(typeof(E), c, "Execute", false);
-            Assert.NotNull(e);
-            Assert.Equal(4, e(new C()));
+            if (IsDelegateLookupBugFixed)
+            {
+                // instance method, exact case, do not ignore case
+                e = (E)Delegate.CreateDelegate(typeof(E), c, "Execute", false);
+                Assert.NotNull(e);
+                Assert.Equal(4, e(new C()));
 
-            // instance method, case mismatch, ignore case
-            e = (E)Delegate.CreateDelegate(typeof(E), c, "ExecutE", true);
-            Assert.NotNull(e);
-            Assert.Equal(4, e(new C()));
+                // instance method, case mismatch, ignore case
+                e = (E)Delegate.CreateDelegate(typeof(E), c, "ExecutE", true);
+                Assert.NotNull(e);
+                Assert.Equal(4, e(new C()));
+            }
         }
 
         [Fact]
@@ -1171,29 +1183,32 @@ namespace System.Tests
             Assert.NotNull(e);
             Assert.Equal(4, e(new C()));
 
-            // do not ignore case, do not throw bind failure
-            e = (E)Delegate.CreateDelegate(typeof(E), new C(),
-                "Execute", false, false);
-            Assert.NotNull(e);
-            Assert.Equal(4, e(new C()));
+            if (IsDelegateLookupBugFixed)
+            {
+                // do not ignore case, do not throw bind failure
+                e = (E)Delegate.CreateDelegate(typeof(E), new C(),
+                    "Execute", false, false);
+                Assert.NotNull(e);
+                Assert.Equal(4, e(new C()));
 
-            // do not ignore case, throw bind failure
-            e = (E)Delegate.CreateDelegate(typeof(E), new C(),
-                "Execute", false, true);
-            Assert.NotNull(e);
-            Assert.Equal(4, e(new C()));
+                // do not ignore case, throw bind failure
+                e = (E)Delegate.CreateDelegate(typeof(E), new C(),
+                    "Execute", false, true);
+                Assert.NotNull(e);
+                Assert.Equal(4, e(new C()));
 
-            // ignore case, do not throw bind failure
-            e = (E)Delegate.CreateDelegate(typeof(E), new C(),
-                "Execute", true, false);
-            Assert.NotNull(e);
-            Assert.Equal(4, e(new C()));
+                // ignore case, do not throw bind failure
+                e = (E)Delegate.CreateDelegate(typeof(E), new C(),
+                    "Execute", true, false);
+                Assert.NotNull(e);
+                Assert.Equal(4, e(new C()));
 
-            // ignore case, throw bind failure
-            e = (E)Delegate.CreateDelegate(typeof(E), new C(),
-                "Execute", true, true);
-            Assert.NotNull(e);
-            Assert.Equal(4, e(new C()));
+                // ignore case, throw bind failure
+                e = (E)Delegate.CreateDelegate(typeof(E), new C(),
+                    "Execute", true, true);
+                Assert.NotNull(e);
+                Assert.Equal(4, e(new C()));
+            }
 
             // do not ignore case, do not throw bind failure
             e = (E)Delegate.CreateDelegate(typeof(E), new C(),
@@ -1405,6 +1420,23 @@ namespace System.Tests
                 Assert.NotNull(ex.Message);
                 Assert.NotNull(ex.ParamName);
                 Assert.Equal("type", ex.ParamName);
+            }
+        }
+
+        // @todo: https://github.com/dotnet/corert/issues/3387
+        // Once issue 3387 is fixed in CoreRT, delete this property.
+        private static bool IsDelegateLookupBugFixed
+        {
+            get
+            {
+#if !uapaot
+                return true;
+#else
+                // "Execute" is defined as a private method (with the wrong return type) in C and as a private method
+                // (with the right return type) in C's base class. CoreCLR finds it anyway. CoreRT does not.
+                Delegate d = Delegate.CreateDelegate(typeof(E), new C(), "Execute", ignoreCase: false, throwOnBindFailure: false);
+                return d != null;
+#endif
             }
         }
 


### PR DESCRIPTION
- Reflection does not guarantee reference equality
  for MethodInfo's. This test only works by accident on CoreCLR

  Changed test to use MethodInfo.Equals() which is guaranteed
  on CoreRT and no worse than before on CoreCLR (MethodInfo.Equals()
  is just reference equality on CoreCLR.)

  (the long sad story of Reflection equality lives in
  https://github.com/dotnet/corefx/issues/8130.)

- Found an interesting corner case in the method
  lookup rules for CreateDelegate(). This will take
  time to study and is unlikely to block anything real world
  so I'm disabling these for UapAot and tracking via this issue:

  https://github.com/dotnet/corert/issues/3387