### PR TITLE
Remove unneeded property

### DIFF
--- a/src/System.Dynamic.Runtime/src/System.Dynamic.Runtime.csproj
+++ b/src/System.Dynamic.Runtime/src/System.Dynamic.Runtime.csproj
@@ -6,8 +6,6 @@
     <AssemblyName>System.Dynamic.Runtime</AssemblyName>
     <RootNamespace>System.Dynamic.Runtime</RootNamespace>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
-    <!-- Disable binplacing for now since we need to use the uapaot version of this assembly -->
-    <BinPlaceILCInputFolder>false</BinPlaceILCInputFolder>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />


### PR DESCRIPTION
This property is causing many test failures. The wrong assembly was
being included in the ILC input folder