### PR TITLE
Fix XmlDictionaryReader.ReadElementContentAsDateTime().

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryReader.cs
@@ -856,7 +856,7 @@ namespace System.Xml
             else
             {
                 ReadStartElement();
-                value = ReadContentAsDateTimeOffset().DateTime;
+                value = ReadContentAsDateTime();
                 ReadEndElement();
             }
 
@@ -1667,22 +1667,7 @@ namespace System.Xml
 
             public override DateTime ReadContentAsDateTime()
             {
-                try
-                {
-                    return _reader.ReadContentAsDateTimeOffset().DateTime;
-                }
-                catch (ArgumentException exception)
-                {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException("DateTime", exception));
-                }
-                catch (FormatException exception)
-                {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException("DateTime", exception));
-                }
-                catch (OverflowException exception)
-                {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException("DateTime", exception));
-                }
+                return _reader.ReadContentAsDateTime();
             }
 
             public override Decimal ReadContentAsDecimal()

--- a/src/System.Runtime.Serialization.Xml/tests/XmlDictionaryReaderTests.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/XmlDictionaryReaderTests.cs
@@ -93,12 +93,13 @@ namespace System.Runtime.Serialization.Xml.Tests
         [Fact]
         public static void ReadElementContentAsDateTimeTest()
         {
-            string xmlFileContent = @"<root><date>2003-01-08T15:00:00-00:00</date></root>";
+            string xmlFileContent = @"<root><date>2013-01-02T03:04:05.006Z</date></root>";
             Stream sm = GenerateStreamFromString(xmlFileContent);
             XmlDictionaryReader reader = XmlDictionaryReader.CreateTextReader(sm, XmlDictionaryReaderQuotas.Max);
             reader.ReadToFollowing("date");
             DateTime dt = reader.ReadElementContentAsDateTime();
-            Assert.Equal(new DateTime(2003, 1, 8, 15, 0, 0), dt);
+            DateTime expected = new DateTime(2013, 1, 2, 3, 4, 5, 6, DateTimeKind.Utc);
+            Assert.Equal(expected, dt);
         }
 
         [Fact]


### PR DESCRIPTION
The bug is with [`XmlDictionaryReader.ReadElementContentAsDateTime()`](https://github.com/dotnet/corefx/blob/6c53c9572258b5b208e9a74efc170494de4de822/src/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryReader.cs#L859). The method should use `ReadContentAsDateTime` instead of `ReadContentAsDateTimeOffset` to read string into DateTime. 

The test was verifying the behavior on NetCore, which was wrong. Since we started running the test on Desktop recently, the test started failing. 

The PR fixed both the code and the test.

Fix #18205 