### PR TITLE
Disable all tests for M.W32.Registry on uap

### DIFF
--- a/src/Microsoft.Win32.Registry/Microsoft.Win32.Registry.sln
+++ b/src/Microsoft.Win32.Registry/Microsoft.Win32.Registry.sln
@@ -26,10 +26,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{20A2BA2C-5517-483F-8FFE-643441A59852}.Debug|Any CPU.ActiveCfg = netstandard-Windows_NT-Debug|Any CPU
-		{20A2BA2C-5517-483F-8FFE-643441A59852}.Debug|Any CPU.Build.0 = netstandard-Windows_NT-Debug|Any CPU
-		{20A2BA2C-5517-483F-8FFE-643441A59852}.Release|Any CPU.ActiveCfg = netstandard-Windows_NT-Release|Any CPU
-		{20A2BA2C-5517-483F-8FFE-643441A59852}.Release|Any CPU.Build.0 = netstandard-Windows_NT-Release|Any CPU
+		{20A2BA2C-5517-483F-8FFE-643441A59852}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
+		{20A2BA2C-5517-483F-8FFE-643441A59852}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
+		{20A2BA2C-5517-483F-8FFE-643441A59852}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
+		{20A2BA2C-5517-483F-8FFE-643441A59852}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
 		{D3F18ACC-D327-4ABB-BA6C-E9C34A041B2F}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
 		{D3F18ACC-D327-4ABB-BA6C-E9C34A041B2F}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
 		{D3F18ACC-D327-4ABB-BA6C-E9C34A041B2F}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU

--- a/src/Microsoft.Win32.Registry/tests/Configurations.props
+++ b/src/Microsoft.Win32.Registry/tests/Configurations.props
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <BuildConfigurations>
       netcoreapp-Windows_NT;
-      netstandard;
       netfx-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/Microsoft.Win32.Registry/tests/Configurations.props
+++ b/src/Microsoft.Win32.Registry/tests/Configurations.props
@@ -2,7 +2,9 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
-      netstandard-Windows_NT;
+      netcoreapp-Windows_NT;
+      netstandard;
+      netfx-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.Win32.Registry/tests/Microsoft.Win32.Registry.Tests.csproj
+++ b/src/Microsoft.Win32.Registry/tests/Microsoft.Win32.Registry.Tests.csproj
@@ -5,9 +5,13 @@
     <ProjectGuid>{20A2BA2C-5517-483F-8FFE-643441A59852}</ProjectGuid>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Release|AnyCPU'" />
-  <ItemGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
+  <ItemGroup Condition="'$(TargetGroup)' != 'netstandard'">
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>

--- a/src/Microsoft.Win32.Registry/tests/Microsoft.Win32.Registry.Tests.csproj
+++ b/src/Microsoft.Win32.Registry/tests/Microsoft.Win32.Registry.Tests.csproj
@@ -9,9 +9,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Windows_NT-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)' != 'netstandard'">
+  <ItemGroup>
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>


### PR DESCRIPTION
These tests all need to be disabled because the implementation does nothing but throw PlatformNotSupported on uap

Fixes https://github.com/dotnet/corefx/issues/18652