### PR TITLE
Validate the DER components of user-provided data

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/Pkcs10CertificationRequestInfo.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/Pkcs10CertificationRequestInfo.cs
@@ -74,10 +74,13 @@ namespace System.Security.Cryptography.X509Certificates
 
             byte[] encoded = Encode();
             byte[] signature = signatureGenerator.SignData(encoded, hashAlgorithm);
+            byte[] signatureAlgorithm = signatureGenerator.GetSignatureAlgorithmIdentifier(hashAlgorithm);
+
+            EncodingHelpers.ValidateSignatureAlgorithm(signatureAlgorithm);
 
             return DerEncoder.ConstructSequence(
                 encoded.WrapAsSegmentedForSequence(),
-                signatureGenerator.GetSignatureAlgorithmIdentifier(hashAlgorithm).WrapAsSegmentedForSequence(),
+                signatureAlgorithm.WrapAsSegmentedForSequence(),
                 DerEncoder.SegmentedEncodeBitString(signature));
         }
     }


### PR DESCRIPTION
The parameters value for the PublicKey and the generator's SignatureAlgorithm
both are supposed to be DER-encoded; so validate that claim.

For the most part this isn't necessary, since rehydrating the signed cert is going
to fail to parse the certificate anyways; but being defensive is good.

Fixes #18509.