### PR TITLE
Fix recently added KeepAlive test on desktop

### DIFF
--- a/src/System.Net.Requests/tests/HttpWebRequestHeaderTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestHeaderTest.cs
@@ -241,7 +241,9 @@ namespace System.Net.Tests
                 string content = body.ReadToEnd();
                 if (!keepAlive.HasValue || keepAlive.Value)
                 {
-                    Assert.Contains("\"Connection\": \"Keep-Alive\"", content, StringComparison.OrdinalIgnoreCase);
+                    // Validate that the request doesn't contain Connection: "close", but we can't validate
+                    // that it does contain Connection: "keep-alive", as that's optional as of HTTP 1.1.
+                    Assert.DoesNotContain("\"Connection\": \"close\"", content, StringComparison.OrdinalIgnoreCase);
                 }
                 else
                 {


### PR DESCRIPTION
The WinHTTP implementation sends Connection: "keep-alive", the desktop implementation does not.  Just change the test to validate whether Connection: "close" is sent or not.

Fixes https://github.com/dotnet/corefx/issues/18657