### PR TITLE
Fix System.Net.NameResolution tests on desktop

### DIFF
--- a/src/System.Net.NameResolution/tests/UnitTests/Fakes/FakeExceptionDispatchInfo.cs
+++ b/src/System.Net.NameResolution/tests/UnitTests/Fakes/FakeExceptionDispatchInfo.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Runtime.ExceptionServices
+{
+    internal class ExceptionDispatchInfo
+    {
+        public static ExceptionDispatchInfo Capture(Exception source) => null;
+        public static void Throw(Exception source) => throw source;
+        public void Throw() => throw null;
+    }
+}

--- a/src/System.Net.NameResolution/tests/UnitTests/System.Net.NameResolution.Unit.Tests.csproj
+++ b/src/System.Net.NameResolution/tests/UnitTests/System.Net.NameResolution.Unit.Tests.csproj
@@ -5,6 +5,7 @@
     <ProjectGuid>{239347DB-D566-48C9-9551-28AB3AD12EC3}</ProjectGuid>
     <StringResourcesPath>../../src/Resources/Strings.resx</StringResourcesPath>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>0436</NoWarn> <!-- Avoid warnings about type conflicts for types we're building in -->
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <!-- Do not reference these assemblies from the TargetingPack since we are building part of the source code for tests. -->
@@ -20,14 +21,13 @@
     <TargetingPackExclusions Include="System.Net.NameResolution" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
+  <ItemGroup>
     <Compile Include="..\..\src\System\Net\IPHostEntry.cs">
       <Link>ProductionCode\System\Net\IPHostEntry.cs</Link>
     </Compile>
     <Compile Include="..\..\src\System\Net\DNS.cs">
       <Link>ProductionCode\System\Net\DNS.cs</Link>
     </Compile>
-
   </ItemGroup>
   
   <ItemGroup>
@@ -35,6 +35,7 @@
     <Compile Include="XunitTestAssemblyAtrributes.cs" />
     <!-- Fakes -->
     <Compile Include="Fakes\FakeContextAwareResult.cs" />
+    <Compile Include="Fakes\FakeExceptionDispatchInfo.cs" />
     <Compile Include="Fakes\FakeNameResolutionPal.cs" />
     <Compile Include="Fakes\FakeNameResolutionUtilities.cs" />
     <Compile Include="Fakes\FakeSocketExceptionFactory.cs" />


### PR DESCRIPTION
A bunch of the unit tests try to validate that sockets were correctly initialized.  They do so with fakes that intercept the calls.  But on desktop, the real methods were being used, bypassing that interception.  I've fixed it by making the unit tests on desktop compile like core so as to use the fakes.

Fixes https://github.com/dotnet/corefx/issues/18656
cc: @cipop, @davidsh, @Priya91 