### PR TITLE
Disable Xml quirk test on NetFx

### DIFF
--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateElement.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateElement.cs
@@ -457,7 +457,7 @@ namespace System.Xml.Tests
             return;
         }
 
-        //Dev10_40497
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "This checks a quirked behavior and Full Framework always gets old behavior as Xunit runner always targets 4.5.2 TFM ")]
         [Fact]
         public void StringPassedToValidateEndElementDoesNotSatisfyIdentityConstraints()
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/18548. Disables the test with quirk behavior on Desktop runs as Xunit runner will always run against older TFM (4.5.2). As a result, netfx test runs always get the old behavior, which does not match what's expected.

Issue tracking the problem: https://github.com/dotnet/corefx/issues/15136

cc: @safern 