### PR TITLE
Fix Test Xml_HiddenDerivedFieldTest.

### DIFF
--- a/src/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
@@ -616,8 +616,7 @@ namespace System.Xml.Serialization
 
         private static void SetMemberValue(object o, object value, string memberName)
         {
-            MemberInfo[] memberInfos = o.GetType().GetMember(memberName);
-            MemberInfo memberInfo = memberInfos[0];
+            MemberInfo memberInfo = ReflectionXmlSerializationHelper.GetMember(o.GetType(), memberName);
             SetMemberValue(o, value, memberInfo);
         }
 

--- a/src/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationWriter.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationWriter.cs
@@ -642,13 +642,7 @@ namespace System.Xml.Serialization
 
         private object GetMemberValue(object o, string memberName)
         {
-            MemberInfo[] memberInfos = o.GetType().GetMember(memberName);
-            if (memberInfos == null)
-            {
-                throw new InvalidOperationException(SR.Format(SR.XmlInternalError, memberName));
-            }
-
-            MemberInfo memberInfo = memberInfos[0];
+            MemberInfo memberInfo = ReflectionXmlSerializationHelper.GetMember(o.GetType(), memberName);
             object memberValue = GetMemberValue(o, memberInfo);
             return memberValue;
         }
@@ -1384,6 +1378,33 @@ namespace System.Xml.Serialization
             WriteElementString = 4,
             WriteNullableStringLiteral = 8,
             Encoded = 16
+        }
+    }
+
+    internal class ReflectionXmlSerializationHelper
+    {
+        public static MemberInfo GetMember(Type declaringType, string memberName)
+        {
+            MemberInfo[] memberInfos = declaringType.GetMember(memberName);
+            if (memberInfos == null || memberInfos.Length == 0)
+            {
+                throw new InvalidOperationException(SR.Format(SR.XmlInternalError, memberName));
+            }
+
+            MemberInfo memberInfo = memberInfos[0];
+            if (memberInfos.Length != 1)
+            {
+                foreach (MemberInfo mi in memberInfos)
+                {
+                    if (declaringType == mi.DeclaringType)
+                    {
+                        memberInfo = mi;
+                        break;
+                    }
+                }
+            }
+
+            return memberInfo;
         }
     }
 }

--- a/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -3224,10 +3224,7 @@ string.Format(@"<?xml version=""1.0"" encoding=""utf-8""?>
         Assert.Equal(requestBodyValue.composite.BoolValue, requestBodyActual.composite.BoolValue);
         Assert.Equal(requestBodyValue.composite.StringValue, requestBodyActual.composite.StringValue);
     }
-    
-#if ReflectionOnly
-    [ActiveIssue(18076)]
-#endif
+
     [Fact]
     public static void Xml_HiddenDerivedFieldTest()
     {


### PR DESCRIPTION
Fixed a bug with reflection based serialization handling hidden derived fields. See the example below. DerivedClass.value was not serialized correctly.

```c#
public class BaseClass
{
    public string value { get; set; }
    public string Value;
}

public class DerivedClass : BaseClass
{
    public new string value;
    public new string Value { get; set; }
}
```

Fix #18076 