### PR TITLE
Update defaults of SignedXml to use SHA256

### DIFF
--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/Reference.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/Reference.cs
@@ -38,7 +38,7 @@ namespace System.Security.Cryptography.Xml
             _refTarget = null;
             _refTargetType = ReferenceTargetType.UriReference;
             _cachedXml = null;
-            _digestMethod = SignedXml.XmlDsigSHA1Url;
+            _digestMethod = SignedXml.XmlDsigSHA256Url;
         }
 
         public Reference(Stream stream)
@@ -47,7 +47,7 @@ namespace System.Security.Cryptography.Xml
             _refTarget = stream;
             _refTargetType = ReferenceTargetType.Stream;
             _cachedXml = null;
-            _digestMethod = SignedXml.XmlDsigSHA1Url;
+            _digestMethod = SignedXml.XmlDsigSHA256Url;
         }
 
         public Reference(string uri)
@@ -57,7 +57,7 @@ namespace System.Security.Cryptography.Xml
             _uri = uri;
             _refTargetType = ReferenceTargetType.UriReference;
             _cachedXml = null;
-            _digestMethod = SignedXml.XmlDsigSHA1Url;
+            _digestMethod = SignedXml.XmlDsigSHA256Url;
         }
 
         internal Reference(XmlElement element)
@@ -66,7 +66,7 @@ namespace System.Security.Cryptography.Xml
             _refTarget = element;
             _refTargetType = ReferenceTargetType.XmlElement;
             _cachedXml = null;
-            _digestMethod = SignedXml.XmlDsigSHA1Url;
+            _digestMethod = SignedXml.XmlDsigSHA256Url;
         }
 
         //

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/Reference.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/Reference.cs
@@ -15,6 +15,8 @@ namespace System.Security.Cryptography.Xml
 {
     public class Reference
     {
+        internal const string DefaultDigestMethod = SignedXml.XmlDsigSHA256Url;
+
         private string _id;
         private string _uri;
         private string _type;
@@ -38,7 +40,7 @@ namespace System.Security.Cryptography.Xml
             _refTarget = null;
             _refTargetType = ReferenceTargetType.UriReference;
             _cachedXml = null;
-            _digestMethod = SignedXml.XmlDsigSHA256Url;
+            _digestMethod = DefaultDigestMethod;
         }
 
         public Reference(Stream stream)
@@ -47,7 +49,7 @@ namespace System.Security.Cryptography.Xml
             _refTarget = stream;
             _refTargetType = ReferenceTargetType.Stream;
             _cachedXml = null;
-            _digestMethod = SignedXml.XmlDsigSHA256Url;
+            _digestMethod = DefaultDigestMethod;
         }
 
         public Reference(string uri)
@@ -57,7 +59,7 @@ namespace System.Security.Cryptography.Xml
             _uri = uri;
             _refTargetType = ReferenceTargetType.UriReference;
             _cachedXml = null;
-            _digestMethod = SignedXml.XmlDsigSHA256Url;
+            _digestMethod = DefaultDigestMethod;
         }
 
         internal Reference(XmlElement element)
@@ -66,7 +68,7 @@ namespace System.Security.Cryptography.Xml
             _refTarget = element;
             _refTargetType = ReferenceTargetType.XmlElement;
             _cachedXml = null;
-            _digestMethod = SignedXml.XmlDsigSHA256Url;
+            _digestMethod = DefaultDigestMethod;
         }
 
         //

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/SignedXml.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/SignedXml.cs
@@ -911,7 +911,7 @@ namespace System.Security.Cryptography.Xml
             {
                 // If no DigestMethod has yet been set, default it to sha1
                 if (reference.DigestMethod == null)
-                    reference.DigestMethod = XmlDsigSHA256Url;
+                    reference.DigestMethod = Reference.DefaultDigestMethod;
 
                 SignedXmlDebugLog.LogSigningReference(this, reference);
 

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/SignedXml.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/SignedXml.cs
@@ -911,7 +911,7 @@ namespace System.Security.Cryptography.Xml
             {
                 // If no DigestMethod has yet been set, default it to sha1
                 if (reference.DigestMethod == null)
-                    reference.DigestMethod = XmlDsigSHA1Url;
+                    reference.DigestMethod = XmlDsigSHA256Url;
 
                 SignedXmlDebugLog.LogSigningReference(this, reference);
 

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/SignedXml.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/SignedXml.cs
@@ -401,7 +401,7 @@ namespace System.Security.Cryptography.Xml
                 {
                     // Default to RSA-SHA1
                     if (SignedInfo.SignatureMethod == null)
-                        SignedInfo.SignatureMethod = XmlDsigRSASHA1Url;
+                        SignedInfo.SignatureMethod = XmlDsigRSASHA256Url;
                 }
                 else
                 {

--- a/src/System.Security.Cryptography.Xml/tests/ReferenceTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/ReferenceTest.cs
@@ -43,7 +43,7 @@ namespace System.Security.Cryptography.Xml.Tests
         public void Ctor_Uri(string uri)
         {
             Reference reference = new Reference(uri);
-            Assert.Equal("http://www.w3.org/2000/09/xmldsig#sha1", reference.DigestMethod);
+            Assert.Equal("http://www.w3.org/2001/04/xmlenc#sha256", reference.DigestMethod);
             Assert.Null(reference.DigestValue);
             Assert.Null(reference.Id);
             Assert.Null(reference.Type);
@@ -61,7 +61,7 @@ namespace System.Security.Cryptography.Xml.Tests
             using (MemoryStream memoryStream = data != null ? new MemoryStream(Encoding.UTF8.GetBytes(data)) : null)
             {
                 Reference reference = new Reference(memoryStream);
-                Assert.Equal("http://www.w3.org/2000/09/xmldsig#sha1", reference.DigestMethod);
+                Assert.Equal("http://www.w3.org/2001/04/xmlenc#sha256", reference.DigestMethod);
                 Assert.Null(reference.DigestValue);
                 Assert.Null(reference.Id);
                 Assert.Null(reference.Type);
@@ -187,6 +187,7 @@ namespace System.Security.Cryptography.Xml.Tests
             Reference reference = new Reference();
             // adding an empty hash value
             byte[] hash = new byte[20];
+            reference.DigestMethod = SignedXml.XmlDsigSHA1Url;
             reference.DigestValue = hash;
             XmlElement xel = reference.GetXml();
             // this is the minimal Reference (DigestValue)!

--- a/src/System.Security.Cryptography.Xml/tests/SignedXmlTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/SignedXmlTest.cs
@@ -188,7 +188,7 @@ namespace System.Security.Cryptography.Xml.Tests
             signedXml.ComputeSignature();
 
             Assert.Null(signedXml.SigningKeyName);
-            Assert.Equal(SignedXml.XmlDsigRSASHA1Url, signedXml.SignatureMethod);
+            Assert.Equal(SignedXml.XmlDsigRSASHA256Url, signedXml.SignatureMethod);
             Assert.Equal(key.KeySize / 8, signedXml.SignatureValue.Length);
             Assert.Null(signedXml.SigningKeyName);
 
@@ -659,6 +659,7 @@ namespace System.Security.Cryptography.Xml.Tests
             SignedXml signedXml = new SignedXml(doc);
             signedXml.SigningKey = cert.PrivateKey;
             signedXml.SignedInfo.CanonicalizationMethod = SignedXml.XmlDsigExcC14NTransformUrl;
+            signedXml.SignedInfo.SignatureMethod = SignedXml.XmlDsigRSASHA1Url;
 
             Reference reference = new Reference();
             reference.DigestMethod = SignedXml.XmlDsigSHA1Url;
@@ -716,6 +717,7 @@ namespace System.Security.Cryptography.Xml.Tests
             X509Certificate2 cert = new X509Certificate2(_pkcs12, "mono");
             SignedXml signedXml = new SignedXml(doc);
             signedXml.SigningKey = cert.PrivateKey;
+            signedXml.SignedInfo.SignatureMethod = SignedXml.XmlDsigRSASHA1Url;
             signedXml.SignedInfo.CanonicalizationMethod = SignedXml.XmlDsigExcC14NTransformUrl;
 
             Reference reference = new Reference();
@@ -957,6 +959,7 @@ namespace System.Security.Cryptography.Xml.Tests
             SignedXml signedXml = new SignedXml(doc);
             signedXml.SigningKey = cert.PrivateKey;
             signedXml.SignedInfo.CanonicalizationMethod = canonicalizationMethod;
+            signedXml.SignedInfo.SignatureMethod = SignedXml.XmlDsigRSASHA1Url;
 
             Reference reference = new Reference();
             reference.DigestMethod = SignedXml.XmlDsigSHA1Url;


### PR DESCRIPTION
SignedXml has previously used SHA1 by default. As SHA1 gets weaker, time has come that update of defaults is needed.

**This is a potentially breaking change.** If the other side of document exchange does not support SHA256 this will cause problems. Currently there is very little places which do not support it.
If you need to bring back the old behavior use:
```csharp
// SignatureMethod
SignedXml sxml = ...;
sxml.SignedInfo.SignatureMethod = SignedXml.XmlDsigRSASHA1Url;

// DigestMethod
Reference reference = ...;
reference.DigestMethod = SignedXml.XmlDsigSHA1Url;
...
```

FYI: @terrajobst @ericstj 

Fixes: https://github.com/dotnet/corefx/issues/18677