### PR TITLE
Add back Cryptography.Cng package

### DIFF
--- a/external/harvestPackages/harvestPackages.netstandard1.6.depproj
+++ b/external/harvestPackages/harvestPackages.netstandard1.6.depproj
@@ -98,6 +98,9 @@
     <PackageReference Include="System.Security.AccessControl">
      <Version>4.3.0</Version>
     </PackageReference>
+    <PackageReference Include="System.Security.Cryptography.Cng">
+     <Version>4.3.0</Version>
+    </PackageReference>
     <PackageReference Include="System.Security.Cryptography.OpenSsl">
      <Version>4.3.0</Version>
     </PackageReference>

--- a/external/netstandard/netstandard.depproj
+++ b/external/netstandard/netstandard.depproj
@@ -35,6 +35,12 @@
     <PackageReference Condition="'$(NETStandardVersion)' &gt;= 1.2" Include="System.Data.SqlClient">
       <Version>4.3.0</Version>
     </PackageReference>
+    <PackageReference Condition="'$(NETStandardVersion)' &gt;= 1.3" Include="System.Security.Cryptography.Cng">
+      <Version>4.3.0</Version>
+    </PackageReference>
+    <PackageReference Condition="'$(NETStandardVersion)' &gt;= 1.4" Include="System.Security.Cryptography.Cng">
+      <Version>4.3.0</Version>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/external/netstandard/netstandard.depproj
+++ b/external/netstandard/netstandard.depproj
@@ -38,9 +38,6 @@
     <PackageReference Condition="'$(NETStandardVersion)' &gt;= 1.3" Include="System.Security.Cryptography.Cng">
       <Version>4.3.0</Version>
     </PackageReference>
-    <PackageReference Condition="'$(NETStandardVersion)' &gt;= 1.4" Include="System.Security.Cryptography.Cng">
-      <Version>4.3.0</Version>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -3817,17 +3817,13 @@
         "4.3.0"
       ],
       "BaselineVersion": "4.3.0",
-      "InboxOn": {
-        "netcoreapp2.0": "4.3.0.0",
-        "net461": "4.2.0.0",
-        "netstandard2.0": "4.2.0.0",
-        "uap10.1": "4.3.0.0"
-      },
+      "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.2.0",
         "4.1.0.0": "4.2.0",
         "4.2.0.0": "4.2.0",
-        "4.2.1.0": "4.3.0"
+        "4.2.1.0": "4.3.0",
+        "4.3.0.0": "4.4.0"
       }
     },
     "System.Security.Cryptography.Csp": {

--- a/src/System.Security.Cryptography.Cng/dir.props
+++ b/src/System.Security.Cryptography.Cng/dir.props
@@ -5,6 +5,9 @@
     <AssemblyVersion>4.3.0.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsNETCoreAppRef>false</IsNETCoreAppRef>
+    <IsDesktopFacade>true</IsDesktopFacade>
     <IsUAP>true</IsUAP>
+    <IsUAPRef>false</IsUAPRef>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Cryptography.Cng/dir.props
+++ b/src/System.Security.Cryptography.Cng/dir.props
@@ -6,7 +6,6 @@
     <AssemblyKey>MSFT</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>
-    <IsDesktopFacade>true</IsDesktopFacade>
     <IsUAP>true</IsUAP>
     <IsUAPRef>false</IsUAPRef>
   </PropertyGroup>

--- a/src/System.Security.Cryptography.Cng/pkg/System.Security.Cryptography.Cng.pkgproj
+++ b/src/System.Security.Cryptography.Cng/pkg/System.Security.Cryptography.Cng.pkgproj
@@ -3,20 +3,19 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Security.Cryptography.Cng.csproj">
-      <SupportedFramework>net461;netcoreapp2.0;uap10.1</SupportedFramework>
+      <SupportedFramework>net461;netcoreapp2.0;uap10.1;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.Cryptography.Cng.csproj" />
     
     <!-- All elements from previous packages that will be included in the newly built package -->
     <HarvestIncludePaths Include="ref/net46;lib/net46;runtimes/win/lib/net46" />
     <HarvestIncludePaths Include="ref/netstandard1.3" />
-    <HarvestIncludePaths Include="ref/netstandard1.4;runtimes/win/lib/netstandard1.4" />
-    <HarvestIncludePaths Include="ref/netstandard1.6;runtimes/win/lib/netstandard1.6;runtimes/unix/lib/netstandard1.6" />
-    
-    <!-- net461 was previously included under an older assembly version. Explicitly replace it to avoid conflicts. -->
-    <HarvestExcludePaths Include="ref/net461;lib/net461;runtimes/win/lib/net461" /> 
-    <!-- since the latest assembly is being included for net461, the net463-specific assembly from previous packages is no longer required --> 
-    <HarvestExcludePaths Include="ref/net463;lib/net463;runtimes/win/lib/net463" />
+    <HarvestIncludePaths Include="ref/netstandard1.4;runtimes/win/lib/netstandard1.4" />   
+    <HarvestIncludePaths Include="ref/netstandard1.6;runtimes/win/lib/netstandard1.6" />
+    <HarvestIncludePaths Include="runtimes/unix/lib/netstandard1.6">
+      <!-- package unix impl (platform not supported) as RID agnostic -->
+      <TargetPath>lib/netstandard1.6</TargetPath>
+    </HarvestIncludePaths>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Security.Cryptography.Cng/pkg/System.Security.Cryptography.Cng.pkgproj
+++ b/src/System.Security.Cryptography.Cng/pkg/System.Security.Cryptography.Cng.pkgproj
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\ref\System.Security.Cryptography.Cng.csproj">
+      <SupportedFramework>net461;netcoreapp2.0;uap10.1</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Security.Cryptography.Cng.csproj" />
+    
+    <!-- All elements from previous packages that will be included in the newly built package -->
+    <HarvestIncludePaths Include="ref/net46;lib/net46;runtimes/win/lib/net46" />
+    <HarvestIncludePaths Include="ref/netstandard1.3" />
+    <HarvestIncludePaths Include="ref/netstandard1.4;runtimes/win/lib/netstandard1.4" />
+    <HarvestIncludePaths Include="ref/netstandard1.6;runtimes/win/lib/netstandard1.6;runtimes/unix/lib/netstandard1.6" />
+    
+    <!-- net461 was previously included under an older assembly version. Explicitly replace it to avoid conflicts. -->
+    <HarvestExcludePaths Include="ref/net461;lib/net461;runtimes/win/lib/net461" /> 
+    <!-- since the latest assembly is being included for net461, the net463-specific assembly from previous packages is no longer required --> 
+    <HarvestExcludePaths Include="ref/net463;lib/net463;runtimes/win/lib/net463" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Security.Cryptography.Cng/src/Configurations.props
+++ b/src/System.Security.Cryptography.Cng/src/Configurations.props
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <BuildConfigurations>
       netstandard;
+      netstandard1.3;
+      netstandard1.4;
       netfx-Windows_NT;
       netcoreapp-Windows_NT;
       uap-Windows_NT;

--- a/src/System.Security.Cryptography.Cng/src/Configurations.props
+++ b/src/System.Security.Cryptography.Cng/src/Configurations.props
@@ -2,9 +2,9 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
+      netstandard;
       netfx-Windows_NT;
       netcoreapp-Windows_NT;
-      netcoreapp-Unix;
       uap-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.csproj
+++ b/src/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.csproj
@@ -8,14 +8,23 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netfx'">true</IsPartialFacadeAssembly>
     <ResourcesSourceOutputDirectory Condition="'$(IsPartialFacadeAssembly)' == 'true'">None</ResourcesSourceOutputDirectory>
-    <GeneratePlatformNotSupportedAssembly Condition="'$(TargetGroup)' == 'netstandard'">true</GeneratePlatformNotSupportedAssembly>
     <GenFacadesIgnoreMissingTypes Condition="'$(TargetGroup)'=='netfx'">true</GenFacadesIgnoreMissingTypes>
     <DefineConstants Condition="'$(TargetGroup)' == 'uap'">$(DefineConstants);uap</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetGroup)' == 'netstandard1.3' OR '$(TargetGroup)' == 'netstandard1.4' OR '$(TargetGroup)' == 'netstandard'">
+    <GeneratePlatformNotSupportedAssembly>true</GeneratePlatformNotSupportedAssembly>
+    <OmitResources>true</OmitResources>
+    <AssemblyVersion Condition="'$(TargetGroup)' == 'netstandard1.3'">4.0.0.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(TargetGroup)' == 'netstandard1.4'">4.1.0.0</AssemblyVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Windows_NT-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.3-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.3-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.4-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.4-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
@@ -258,6 +267,10 @@
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' == 'true'">
     <Reference Include="mscorlib" />
     <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.3' OR '$(TargetGroup)' == 'netstandard1.4'">
+    <Reference Include="System.IO" />
+    <Reference Include="System.Runtime.Handles" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
     <Reference Include="System.Diagnostics.Debug" />

--- a/src/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.csproj
+++ b/src/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.csproj
@@ -8,14 +8,14 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netfx'">true</IsPartialFacadeAssembly>
     <ResourcesSourceOutputDirectory Condition="'$(IsPartialFacadeAssembly)' == 'true'">None</ResourcesSourceOutputDirectory>
-    <GeneratePlatformNotSupportedAssembly Condition="'$(TargetsUnix)' == 'true'">true</GeneratePlatformNotSupportedAssembly>
+    <GeneratePlatformNotSupportedAssembly Condition="'$(TargetGroup)' == 'netstandard'">true</GeneratePlatformNotSupportedAssembly>
     <GenFacadesIgnoreMissingTypes Condition="'$(TargetGroup)'=='netfx'">true</GenFacadesIgnoreMissingTypes>
     <DefineConstants Condition="'$(TargetGroup)' == 'uap'">$(DefineConstants);uap</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Windows_NT-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />


### PR DESCRIPTION
The cng package was removed so that the assembly could be included in the netstandard meta-package. However, Cng was later removed from netstandard, so the standalone package needs to be added back.

resolves #17667

cc: @ericstj @bartonjs 