### PR TITLE
Identify suppressed-on-netfx tests with an issue

### DIFF
--- a/src/System.Security.Cryptography.Primitives/tests/AsymmetricAlgorithm/Trivial.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/AsymmetricAlgorithm/Trivial.cs
@@ -43,7 +43,7 @@ namespace System.Security.Cryptography.Encryption.Tests.Asymmetric
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework,
-            "Throws NRE on netfx")]
+            "Throws NRE on netfx (https://github.com/dotnet/corefx/issues/18690)")]
         public static void ValidKeySizeUsesProperty()
         {
             using (AsymmetricAlgorithm aa = new DoesNotSetLegalKeySizesField())

--- a/src/System.Security.Cryptography.Primitives/tests/AsymmetricAlgorithm/Trivial.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/AsymmetricAlgorithm/Trivial.cs
@@ -42,8 +42,7 @@ namespace System.Security.Cryptography.Encryption.Tests.Asymmetric
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework,
-            "Throws NRE on netfx (https://github.com/dotnet/corefx/issues/18690)")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Throws NRE on netfx (https://github.com/dotnet/corefx/issues/18690)")]
         public static void ValidKeySizeUsesProperty()
         {
             using (AsymmetricAlgorithm aa = new DoesNotSetLegalKeySizesField())

--- a/src/System.Security.Cryptography.Primitives/tests/KeyedHashAlgorithmTests.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/KeyedHashAlgorithmTests.cs
@@ -50,7 +50,7 @@ namespace System.Security.Cryptography.Hashing.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework,
-            "Throws NRE on netfx")]
+            "Throws NRE on netfx (https://github.com/dotnet/corefx/issues/18690)")]
         public void EnsureDisposeFreesKey()
         {
             byte[] key = new[] { (byte)0x00, (byte)0x01, (byte)0x02, (byte)0x03, (byte)0x04, (byte)0x05, };
@@ -67,7 +67,7 @@ namespace System.Security.Cryptography.Hashing.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework,
-            "Throws NRE on netfx")]
+            "Throws NRE on netfx (https://github.com/dotnet/corefx/issues/18690)")]
         public void SetKeyNull()
         {
             using (var keyedHash = new TestKeyedHashAlgorithm())

--- a/src/System.Security.Cryptography.Primitives/tests/KeyedHashAlgorithmTests.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/KeyedHashAlgorithmTests.cs
@@ -49,8 +49,7 @@ namespace System.Security.Cryptography.Hashing.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework,
-            "Throws NRE on netfx (https://github.com/dotnet/corefx/issues/18690)")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Throws NRE on netfx (https://github.com/dotnet/corefx/issues/18690)")]
         public void EnsureDisposeFreesKey()
         {
             byte[] key = new[] { (byte)0x00, (byte)0x01, (byte)0x02, (byte)0x03, (byte)0x04, (byte)0x05, };
@@ -66,8 +65,7 @@ namespace System.Security.Cryptography.Hashing.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework,
-            "Throws NRE on netfx (https://github.com/dotnet/corefx/issues/18690)")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Throws NRE on netfx (https://github.com/dotnet/corefx/issues/18690)")]
         public void SetKeyNull()
         {
             using (var keyedHash = new TestKeyedHashAlgorithm())

--- a/src/System.Security.Cryptography.Primitives/tests/SymmetricAlgorithm/Trivial.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/SymmetricAlgorithm/Trivial.cs
@@ -290,7 +290,7 @@ namespace System.Security.Cryptography.Encryption.Tests.Symmetric
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework,
-            "Throws NRE on netfx")]
+            "Throws NRE on netfx (https://github.com/dotnet/corefx/issues/18690)")]
         public static void SetBlockSize_Uses_LegalBlockSizesProperty()
         {
             using (SymmetricAlgorithm s = new DoesNotSetKeySizesFields())

--- a/src/System.Security.Cryptography.Primitives/tests/SymmetricAlgorithm/Trivial.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/SymmetricAlgorithm/Trivial.cs
@@ -289,8 +289,7 @@ namespace System.Security.Cryptography.Encryption.Tests.Symmetric
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework,
-            "Throws NRE on netfx (https://github.com/dotnet/corefx/issues/18690)")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Throws NRE on netfx (https://github.com/dotnet/corefx/issues/18690)")]
         public static void SetBlockSize_Uses_LegalBlockSizesProperty()
         {
             using (SymmetricAlgorithm s = new DoesNotSetKeySizesFields())


### PR DESCRIPTION
Tag the SkipOnTargetFramework attributes from #18575 with a port-consider issue number (#18690) so there's a paper trail that will hopefully result in bugs getting fixed.

FYI @karelz 