### PR TITLE
Fix expected exception for PipeStream test

### DIFF
--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CreateServer.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CreateServer.cs
@@ -194,6 +194,7 @@ namespace System.IO.Pipes.Tests
         [InlineData(PipeDirection.In)]
         [InlineData(PipeDirection.InOut)]
         [InlineData(PipeDirection.Out)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "This scenario is not handled with System.ArgumentException on Full Framework")]
         [PlatformSpecific(TestPlatforms.Windows)] // accessing SafePipeHandle on Unix fails for a non-connected stream
         public static void Windows_CreateFromDisposedServerHandle_Throws_ObjectDisposedException(PipeDirection direction)
         {
@@ -203,6 +204,22 @@ namespace System.IO.Pipes.Tests
             pipe.Dispose();
             Assert.Throws<ObjectDisposedException>(() => new NamedPipeServerStream(direction, true, true, pipe.SafePipeHandle).Dispose());
         }
+
+        [Theory]
+        [InlineData(PipeDirection.In)]
+        [InlineData(PipeDirection.InOut)]
+        [InlineData(PipeDirection.Out)]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, ".NET Core handles this scenario by throwing ArgumentException instead")]
+        [PlatformSpecific(TestPlatforms.Windows)] // accessing SafePipeHandle on Unix fails for a non-connected stream
+        public static void Windows_CreateFromAlreadyBoundHandle_Throws_ApplicationException(PipeDirection direction)
+        {
+            // The pipe is already bound
+            using (var pipe = new NamedPipeServerStream(GetUniquePipeName(), direction, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous))
+            {
+                SafePipeHandle handle = pipe.SafePipeHandle;
+                Assert.Throws<ApplicationException>(() => new NamedPipeServerStream(direction, true, true, handle));
+             }
+         }
 
         [Fact]
         [PlatformSpecific(TestPlatforms.AnyUnix)] // accessing SafePipeHandle on Unix fails for a non-connected stream


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/18543
Behavior is the same among Desktop and Core. Core wraps (System.ApplicationException): The parameter is incorrect. (Exception from HRESULT: 0x80070057 (E_INVALIDARG)) into a nicer-looking System.ArgumentException to handle the scenario, though.

cc: @ianhays @danmosemsft @stephentoub 