### PR TITLE
Fix building with only VS2017 installed.

### DIFF
--- a/run.cmd
+++ b/run.cmd
@@ -43,6 +43,13 @@ xcopy %~dp0Tools-Override\* %~dp0Tools /y >nul
 
 set _toolRuntime=%~dp0Tools
 set _dotnet=%_toolRuntime%\dotnetcli\dotnet.exe
+set _json=%~dp0config.json
 
-call %_dotnet% %_toolRuntime%\run.exe %*
+:: run.exe depends on running in the root directory, notably because the config.json specifies
+:: a relative path to the binclash logger
+
+pushd %~dp0
+call %_dotnet% %_toolRuntime%\run.exe "%_json%" %*
+popd
+
 exit /b %ERRORLEVEL%

--- a/src/Native/Windows/gen-buildsys-win.bat
+++ b/src/Native/Windows/gen-buildsys-win.bat
@@ -10,8 +10,13 @@ if %1=="/?" GOTO :USAGE
 
 setlocal
 set __sourceDir=%~dp0
+
 :: VS 2015 is the minimum supported toolset
-set __VSString=14 2015
+if "%__VSVersion%" == "vs2017" (
+  set __VSString=15 2017
+) else (
+  set __VSString=14 2015
+)
 
 :: Set the target architecture to a format cmake understands. ANYCPU defaults to x64
 if /i "%3" == "x86"     (set __VSString=%__VSString%)
@@ -35,7 +40,7 @@ GOTO :DONE
   echo "Usage..."
   echo "gen-buildsys-win.bat <path to top level CMakeLists.txt> <VSVersion> <Target Architecture"
   echo "Specify the path to the top level CMake file - <ProjectK>/src/NDP"
-  echo "Specify the VSVersion to be used - VS2013 or VS2015"
+  echo "Specify the VSVersion to be used - VS2015 or VS2017"
   echo "Specify the Target Architecture - x86, AnyCPU, ARM, or x64."
   EXIT /B 1
 

--- a/src/Native/build-native.cmd
+++ b/src/Native/build-native.cmd
@@ -55,10 +55,10 @@ goto :Arg_Loop
 :: can be found.
 if not defined VisualStudioVersion (
     if defined VS150COMNTOOLS (
-        call "%VS150COMNTOOLS%\VsDevCmd.bat"
+        call "%VS150COMNTOOLS%VsDevCmd.bat"
         goto :VS2017
     ) else if defined VS140COMNTOOLS (
-        call "%VS140COMNTOOLS%\VsDevCmd.bat"
+        call "%VS140COMNTOOLS%VsDevCmd.bat"
         goto :VS2015
     )
     goto :MissingVersion
@@ -82,7 +82,7 @@ set __VSVersion=vs2017
 set __PlatformToolset=v141
 if NOT "%__BuildArch%" == "arm64" (
     :: Set the environment for the native build
-    call "%VS150COMNTOOLS%\..\..\VC\Auxiliary\Build\vcvarsall.bat" %__VCBuildArch%
+    call "%VS150COMNTOOLS%..\..\VC\Auxiliary\Build\vcvarsall.bat" %__VCBuildArch%
 )
 goto :SetupDirs
 
@@ -92,7 +92,7 @@ set __VSVersion=vs2015
 set __PlatformToolset=v140
 if NOT "%__BuildArch%" == "arm64" (
     :: Set the environment for the native build
-    call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" %__VCBuildArch%
+    call "%VS140COMNTOOLS%..\..\VC\vcvarsall.bat" %__VCBuildArch%
 )
 goto :SetupDirs
 


### PR DESCRIPTION
We weren't passing the right setting to CMAKE.

Also fixes issue with current working directory getting changed during the build. Run.exe currently must be run with the current working directory set to the repo root. One part of this was the config.json file- which I've explicitly specified now.

The other (as of yet unfixable) problem is that we specify the location of the binclash logger as a relative path. Afaik there currently is no way to make this happen with run.cmd without making this logger an explicit  (as opposed to default) option. Could possibly extend run.exe's parsing to allow specifying environment variables or reference to other parameters...

I haven't nailed down who is changing the working directory- while it appears to be a 2017 specific problem I can't guarantee that it isn't some other variable.