### PR TITLE
Activity: put a limit on baggage key and value

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -191,7 +191,19 @@ namespace System.Diagnostics
         /// <returns>'this' for convenient chaining</returns>
         public Activity AddBaggage(string key, string value)
         {
-            _baggage = new KeyValueListNode() { keyValue = new KeyValuePair<string, string>(key, value), Next = _baggage };
+            if (string.IsNullOrEmpty(key) || key.Length > 32)
+            {
+                NotifyError(new ArgumentException($"Trying to add baggage with invalid key '{key}'"));
+            }
+            else if (string.IsNullOrEmpty(value) || value.Length > 42)
+            {
+                NotifyError(new ArgumentException($"Trying to add baggage with invalid value '{value}'"));
+            }
+            else
+            {
+                _baggage = new KeyValueListNode() { keyValue = new KeyValuePair<string, string>(key, value), Next = _baggage };
+            }
+
             return this;
         }
 

--- a/src/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
@@ -490,6 +490,27 @@ namespace System.Diagnostics.Tests
             Assert.Same(originalActivity, Activity.Current);
         }
 
+        [Fact]
+        public void InvalidBaggage()
+        {
+            var activity = new Activity("test");
+
+            activity.AddBaggage(null, "value");
+            activity.AddBaggage("", "value");
+            activity.AddBaggage("_____33 characters long key______", "value");
+            activity.AddBaggage("key", null);
+            activity.AddBaggage("key", "");
+            activity.AddBaggage("key", "_________43 characters long value__________");
+            Assert.Empty(activity.Baggage);
+
+            var key32 = "_____32 characters long key_____";
+            var value42 = "_________42 characters long value_________";
+            activity.AddBaggage(key32, value42);
+            Assert.Equal(1, activity.Baggage.Count());
+            Assert.Equal(key32, activity.Baggage.First().Key);
+            Assert.Equal(value42, activity.Baggage.First().Value);
+        }
+
         private class TestObserver : IObserver<KeyValuePair<string, object>>
         {
             public string EventName { get; private set; }


### PR DESCRIPTION
Baggage is a context (property bag) that propagates from one process to another through HTTP or other protocol.
It is used for tracing purposes only: to augment and correlate or group telemetry.

In case of HTTP, it is propagated in HTTP headers in practice have significant size restrictions.
Also, baggage could be misused as a generic way to pass data between the services that we want to restrict.

This changes adds limit on the baggage 
* key length  - 32 bytes inclusively
* value length - 42 bytes inclusively

/cc @vancem
