### PR TITLE
Fix handling of unexpected cancellation in PipeStream.

### DIFF
--- a/src/System.IO.Pipes/src/System/IO/Error.cs
+++ b/src/System.IO.Pipes/src/System/IO/Error.cs
@@ -31,5 +31,10 @@ namespace System.IO
         {
             return new NotSupportedException(SR.NotSupported_UnwritableStream);
         }
+
+        internal static Exception GetOperationAborted()
+        {
+            return new IOException(SR.IO_OperationAborted);
+        }
     }
 }

--- a/src/System.IO.Pipes/src/System/IO/Pipes/ConnectionCompletionSource.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/ConnectionCompletionSource.cs
@@ -38,6 +38,8 @@ namespace System.IO.Pipes
         {
             TrySetException(Win32Marshal.GetExceptionForWin32Error(errorCode));
         }
+
+        protected override void HandleUnexpectedCancellation() => TrySetException(Error.GetOperationAborted());
     }
 
     internal struct VoidResult { }

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeCompletionSource.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeCompletionSource.cs
@@ -162,9 +162,8 @@ namespace System.IO.Pipes
                 {
                     if (_cancellationToken.CanBeCanceled && !_cancellationToken.IsCancellationRequested)
                     {
-                        // If this is unexpected abortion, we don't want to store _cancellationToken,
-                        // so just generically say it's been canceled.
-                        TrySetCanceled();
+                        // If this is unexpected abortion
+                        TrySetException(Error.GetOperationAborted());
                     }
                     else
                     {

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeCompletionSource.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeCompletionSource.cs
@@ -150,6 +150,8 @@ namespace System.IO.Pipes
             }
         }
 
+        protected virtual void HandleUnexpectedCancellation() => TrySetCanceled();
+
         private void CompleteCallback(int resultState)
         {
             Debug.Assert(resultState == ResultSuccess || resultState == ResultError, "Unexpected result state " + resultState);
@@ -162,8 +164,7 @@ namespace System.IO.Pipes
                 {
                     if (_cancellationToken.CanBeCanceled && !_cancellationToken.IsCancellationRequested)
                     {
-                        // If this is unexpected abortion
-                        TrySetException(Error.GetOperationAborted());
+                        HandleUnexpectedCancellation();
                     }
                     else
                     {

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Simple.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Simple.cs
@@ -254,7 +254,7 @@ namespace System.IO.Pipes.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // P/Invoking to Win32 functions
-        public async Task CancelTokenOn_ServerWaitForConnectionAsyncWithOuterCancellation_Throws_OperationCanceledException()
+        public async Task CancelTokenOn_ServerWaitForConnectionAsyncWithOuterCancellation_Throws_IOException()
         {
             using (NamedPipePair pair = CreateNamedPipePair())
             {
@@ -263,7 +263,7 @@ namespace System.IO.Pipes.Tests
                 Task waitForConnectionTask = server.WaitForConnectionAsync(cts.Token);
 
                 Assert.True(Interop.CancelIoEx(server.SafePipeHandle), "Outer cancellation failed");
-                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => waitForConnectionTask);
+                await Assert.ThrowsAsync<IOException>(() => waitForConnectionTask);
             }
         }
 
@@ -593,7 +593,7 @@ namespace System.IO.Pipes.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // P/Invoking to Win32 functions
-        public async Task CancelTokenOn_Server_ReadWriteCancelledToken_Throws_OperationCanceledException()
+        public async Task CancelTokenOn_Server_ReadWriteCancelledToken_Throws_IOException()
         {
             using (NamedPipePair pair = CreateNamedPipePair())
             {
@@ -608,7 +608,7 @@ namespace System.IO.Pipes.Tests
                     Task serverReadToken = server.ReadAsync(buffer, 0, buffer.Length, cts.Token);
 
                     Assert.True(Interop.CancelIoEx(server.SafePipeHandle), "Outer cancellation failed");
-                    await Assert.ThrowsAnyAsync<OperationCanceledException>(() => serverReadToken);
+                    await Assert.ThrowsAsync<IOException>(() => serverReadToken);
                 }
                 if (server.CanWrite)
                 {
@@ -616,7 +616,7 @@ namespace System.IO.Pipes.Tests
                     Task serverWriteToken = server.WriteAsync(buffer, 0, buffer.Length, cts.Token);
 
                     Assert.True(Interop.CancelIoEx(server.SafePipeHandle), "Outer cancellation failed");
-                    await Assert.ThrowsAnyAsync<OperationCanceledException>(() => serverWriteToken);
+                    await Assert.ThrowsAsync<IOException>(() => serverWriteToken);
                 }
             }
         }
@@ -689,7 +689,7 @@ namespace System.IO.Pipes.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // P/Invoking to Win32 functions
-        public async Task CancelTokenOn_Client_ReadWriteCancelledToken_Throws_OperationCanceledException()
+        public async Task CancelTokenOn_Client_ReadWriteCancelledToken_Throws_IOException()
         {
             using (NamedPipePair pair = CreateNamedPipePair())
             {
@@ -703,7 +703,7 @@ namespace System.IO.Pipes.Tests
                     Task clientReadToken = client.ReadAsync(buffer, 0, buffer.Length, cts.Token);
 
                     Assert.True(Interop.CancelIoEx(client.SafePipeHandle), "Outer cancellation failed");
-                    await Assert.ThrowsAnyAsync<OperationCanceledException>(() => clientReadToken);
+                    await Assert.ThrowsAsync<IOException>(() => clientReadToken);
                 }
                 if (client.CanWrite)
                 {
@@ -711,7 +711,7 @@ namespace System.IO.Pipes.Tests
                     Task clientWriteToken = client.WriteAsync(buffer, 0, buffer.Length, cts.Token);
 
                     Assert.True(Interop.CancelIoEx(client.SafePipeHandle), "Outer cancellation failed");
-                    await Assert.ThrowsAnyAsync<OperationCanceledException>(() => clientWriteToken);
+                    await Assert.ThrowsAsync<IOException>(() => clientWriteToken);
                 }
             }
         }

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Simple.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Simple.cs
@@ -593,7 +593,7 @@ namespace System.IO.Pipes.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // P/Invoking to Win32 functions
-        public async Task CancelTokenOn_Server_ReadWriteCancelledToken_Throws_IOException()
+        public async Task CancelTokenOn_Server_ReadWriteCancelledToken_Throws_OperationCanceledException()
         {
             using (NamedPipePair pair = CreateNamedPipePair())
             {
@@ -608,7 +608,7 @@ namespace System.IO.Pipes.Tests
                     Task serverReadToken = server.ReadAsync(buffer, 0, buffer.Length, cts.Token);
 
                     Assert.True(Interop.CancelIoEx(server.SafePipeHandle), "Outer cancellation failed");
-                    await Assert.ThrowsAsync<IOException>(() => serverReadToken);
+                    await Assert.ThrowsAnyAsync<OperationCanceledException>(() => serverReadToken);
                 }
                 if (server.CanWrite)
                 {
@@ -616,7 +616,7 @@ namespace System.IO.Pipes.Tests
                     Task serverWriteToken = server.WriteAsync(buffer, 0, buffer.Length, cts.Token);
 
                     Assert.True(Interop.CancelIoEx(server.SafePipeHandle), "Outer cancellation failed");
-                    await Assert.ThrowsAsync<IOException>(() => serverWriteToken);
+                    await Assert.ThrowsAnyAsync<OperationCanceledException>(() => serverWriteToken);
                 }
             }
         }
@@ -689,7 +689,7 @@ namespace System.IO.Pipes.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // P/Invoking to Win32 functions
-        public async Task CancelTokenOn_Client_ReadWriteCancelledToken_Throws_IOException()
+        public async Task CancelTokenOn_Client_ReadWriteCancelledToken_Throws_OperationCanceledException()
         {
             using (NamedPipePair pair = CreateNamedPipePair())
             {
@@ -703,7 +703,7 @@ namespace System.IO.Pipes.Tests
                     Task clientReadToken = client.ReadAsync(buffer, 0, buffer.Length, cts.Token);
 
                     Assert.True(Interop.CancelIoEx(client.SafePipeHandle), "Outer cancellation failed");
-                    await Assert.ThrowsAsync<IOException>(() => clientReadToken);
+                    await Assert.ThrowsAnyAsync<OperationCanceledException>(() => clientReadToken);
                 }
                 if (client.CanWrite)
                 {
@@ -711,7 +711,7 @@ namespace System.IO.Pipes.Tests
                     Task clientWriteToken = client.WriteAsync(buffer, 0, buffer.Length, cts.Token);
 
                     Assert.True(Interop.CancelIoEx(client.SafePipeHandle), "Outer cancellation failed");
-                    await Assert.ThrowsAsync<IOException>(() => clientWriteToken);
+                    await Assert.ThrowsAnyAsync<OperationCanceledException>(() => clientWriteToken);
                 }
             }
         }


### PR DESCRIPTION
My previous fix was overly aggressive in changing from IOException to OperationCanceledException (I must have been running the tests incorrectly or something).  Specifically, desktop handles unexpected cancellation for some operations differently than it does for others: for most operations it always uses an OperationCanceledException, but for WaitForConnectionAsync, it uses IOException.  This PR fixes the core behavior to match and updates the tests accordingly.

Fixes https://github.com/dotnet/corefx/issues/18544
cc: @sepidehMS, @ianhays 