### PR TITLE
Allow HttpWebRequest.AllowReadStreamBuffering to be set to true

### DIFF
--- a/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -138,14 +138,11 @@ namespace System.Net
         {
             get
             {
-                return false;
+                return _allowReadStreamBuffering;
             }
             set
             {
-                if (value)
-                {
-                    throw new InvalidOperationException(SR.net_OperationNotSupportedException);
-                }
+                _allowReadStreamBuffering = value;
             }            
         }
 

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -42,6 +42,7 @@ namespace System.Net.Tests
             HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
             Assert.Null(request.Accept);
             Assert.False(request.AllowReadStreamBuffering);
+            Assert.True(request.AllowWriteStreamBuffering);
             Assert.Null(request.ContentType);
             Assert.Equal(350, request.ContinueTimeout);
             Assert.Null(request.CookieContainer);
@@ -104,11 +105,13 @@ namespace System.Net.Tests
             Assert.False(request.AllowReadStreamBuffering);
         }
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "not supported on .NET Framework")]
         [Theory, MemberData(nameof(EchoServers))]
-        public void AllowReadStreamBuffering_SetTrue_Throws(Uri remoteServer)
+        public void AllowReadStreamBuffering_SetTrueThenGet_ExpectTrue(Uri remoteServer)
         {
             HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
-            Assert.Throws<InvalidOperationException>(() => { request.AllowReadStreamBuffering = true; });            
+            request.AllowReadStreamBuffering = true;
+            Assert.True(request.AllowReadStreamBuffering);
         }
 
         [Theory, MemberData(nameof(EchoServers))]


### PR DESCRIPTION
While fixing various .NET Framework app-compat differences, PR #18163 changed the
AllowReadStreamBuffering property to match .NET Framework. This resulted in having
the property throw an exception when set to true. That behavior is what .NET Framework
currently does.

Historically, this property did not always exist in .NET Framework at all. Other portable
versions of .NET (Windows Phone, Silverlight) for the HTTP stack were implemented differently
and had this property which worked. When .NET Framework APIs were reconciled in 2015, this
virtual property was added to .NET Framework but the functionality on Desktop was limited.

This PR will put back this property's functionality for .NET Core which is also used for UWP apps.

Fixes #18668.