### PR TITLE
Do not run "infinite far plane" Matrix4x4 tests on .NET Framework.

### DIFF
--- a/src/System.Numerics.Vectors/tests/Matrix4x4Tests.cs
+++ b/src/System.Numerics.Vectors/tests/Matrix4x4Tests.cs
@@ -2518,6 +2518,7 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void PerspectiveFarPlaneAtInfinityTest()
         {
             var nearPlaneDistance = 0.125f;
@@ -2527,6 +2528,7 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void PerspectiveFieldOfViewFarPlaneAtInfinityTest()
         {
             var nearPlaneDistance = 0.125f;
@@ -2536,6 +2538,7 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void PerspectiveOffCenterFarPlaneAtInfinityTest()
         {
             var nearPlaneDistance = 0.125f;


### PR DESCRIPTION
https://github.com/dotnet/corefx/pull/17090 fixed an issue where `PositiveInfinity` could not be used as a far plane value in Matrix4x4, and added some tests to validate that behavior. These tests can't be run on .NET Framework.

Fixes https://github.com/dotnet/corefx/issues/18709