### PR TITLE
Fix multiple intermittent failures in System.Security

### DIFF
--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/AES/AesCipherTests.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/AES/AesCipherTests.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using Test.Cryptography;
 using Xunit;
 
@@ -609,40 +608,14 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
 
         private static byte[] AesEncryptDirectKey(Aes aes, byte[] key, byte[] iv, byte[] plainBytes)
         {
-            try
+            using (MemoryStream output = new MemoryStream())
+            using (CryptoStream cryptoStream = new CryptoStream(output, aes.CreateEncryptor(key, iv), CryptoStreamMode.Write))
             {
-                using (MemoryStream output = new MemoryStream())
-                using (CryptoStream cryptoStream = new CryptoStream(output, aes.CreateEncryptor(key, iv), CryptoStreamMode.Write))
-                {
-                    cryptoStream.Write(plainBytes, 0, plainBytes.Length);
-                    cryptoStream.FlushFinalBlock();
+                cryptoStream.Write(plainBytes, 0, plainBytes.Length);
+                cryptoStream.FlushFinalBlock();
 
-                    return output.ToArray();
-                }
+                return output.ToArray();
             }
-            catch (Exception e)
-            {
-                throw new Exception(
-                    $"key.Length = {key.Length};\n"
-                    + $"iv.Length = {iv.Length};\n"
-                    + $"aes.KeySize = {aes.KeySize};\n"
-                    + $"aes.GetType().FullName = {aes.GetType().FullName};\n"
-                    + $"aes.ValidKeySize(192)? = {aes.ValidKeySize(192)};\n"
-                    + $"aes.LegalKeySizes = {{{KeySizesStringifier(aes.LegalKeySizes)}}}",
-                    e);
-            }
-        }
-
-        private static string KeySizesStringifier(KeySizes[] keySizes)
-        {
-            if (keySizes == null)
-            {
-                return "null";
-            }
-
-            return string.Join(", ", keySizes.Select((ks) => {
-                return $"KeySizes(MinSize = {ks.MinSize}, MaxSize = {ks.MaxSize}, SkipSize = {ks.SkipSize})";
-            }));
         }
 
         private static byte[] AesDecryptDirectKey(Aes aes, byte[] key, byte[] iv, byte[] cipherBytes)

--- a/src/System.Security.Cryptography.Algorithms/tests/AesTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/AesTests.cs
@@ -21,6 +21,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Causing other tests to intermittently fail on netfx")]
         public static void EnsureLegalSizesValuesIsolated()
         {
             new AesLegalSizesBreaker().Dispose();

--- a/src/System.Security.Cryptography.Algorithms/tests/AesTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/AesTests.cs
@@ -21,7 +21,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Causing other tests to intermittently fail on netfx")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Causing other tests to intermittently fail on netfx (https://github.com/dotnet/corefx/issues/18690)")]
         public static void EnsureLegalSizesValuesIsolated()
         {
             new AesLegalSizesBreaker().Dispose();

--- a/src/System.Security.Cryptography.Algorithms/tests/TripleDesTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/TripleDesTests.cs
@@ -77,6 +77,7 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Causing other tests to intermittently fail on netfx")]
         public static void EnsureLegalSizesValuesIsolated()
         {
             new TripleDESLegalSizesBreaker().Dispose();

--- a/src/System.Security.Cryptography.Algorithms/tests/TripleDesTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/TripleDesTests.cs
@@ -77,7 +77,7 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Causing other tests to intermittently fail on netfx")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Causing other tests to intermittently fail on netfx (https://github.com/dotnet/corefx/issues/18690)")]
         public static void EnsureLegalSizesValuesIsolated()
         {
             new TripleDESLegalSizesBreaker().Dispose();


### PR DESCRIPTION
- Added more diagnostics to be able to easier identify what has happened in the future if similar issue has happened
- Updated https://github.com/dotnet/corefx/issues/18690 to mention issue #8601

Issue is caused by not handling LegalKeySizes correctly in multithreaded scenarios. This was fixed by @bartonjs as part of this https://github.com/dotnet/corefx/issues/8601

Fixes:
- https://github.com/dotnet/corefx/issues/18270
- https://github.com/dotnet/corefx/issues/18271
- https://github.com/dotnet/corefx/issues/18197

possibly more

I've seen around 40 failures less on my local machines. We are down to 18 failures for System.Security.Cryptography.Algorithms on netfx (on my box on Windows at least)
