### PR TITLE
Fix non-zero-lower-bound fails in System.Reflection.TypeExtensions 

### DIFF
--- a/src/System.Reflection.TypeExtensions/tests/ConstructorInfo/ConstructorInfoInvokeArrayTests.cs
+++ b/src/System.Reflection.TypeExtensions/tests/ConstructorInfo/ConstructorInfoInvokeArrayTests.cs
@@ -141,10 +141,10 @@ namespace System.Reflection.Tests
 
                             int baseNum = 3;
                             int baseNum4 = baseNum * baseNum * baseNum * baseNum;
-                            int[] validLengths1 = new int[baseNum4];
                             int[] validLowerBounds1 = new int[baseNum4];
-                            int[] validLengths2 = new int[baseNum4];
                             int[] validLowerBounds2 = new int[baseNum4];
+                            int[] validLengths1 = new int[baseNum4];
+                            int[] validLengths2 = new int[baseNum4];
 
                             int cnt = 0;
                             for (int pos1 = 0; pos1 < baseNum; pos1++)
@@ -153,40 +153,40 @@ namespace System.Reflection.Tests
                                         for (int pos4 = 0; pos4 < baseNum; pos4++)
                                         {
                                             int saved = cnt;
-                                            validLengths1[cnt] = saved % baseNum;
-                                            saved = saved / baseNum;
-                                            validLengths2[cnt] = saved % baseNum;
-                                            saved = saved / baseNum;
                                             validLowerBounds1[cnt] = saved % baseNum;
                                             saved = saved / baseNum;
+                                            validLengths1[cnt] = saved % baseNum;
+                                            saved = saved / baseNum;
                                             validLowerBounds2[cnt] = saved % baseNum;
+                                            saved = saved / baseNum;
+                                            validLengths2[cnt] = saved % baseNum;
                                             cnt++;
                                         }
 
-                            for (int j = 0; j < validLengths2.Length; j++)
+                            for (int j = 0; j < validLengths1.Length; j++)
                             {
-                                int[,] arr = (int[,])constructors[i].Invoke(new object[] { validLengths1[j], validLengths2[j], validLowerBounds1[j], validLowerBounds2[j] });
-                                Assert.Equal(validLengths1[j], arr.GetLowerBound(0));
-                                Assert.Equal(validLengths1[j] + validLengths2[j] - 1, arr.GetUpperBound(0));
-                                Assert.Equal(validLowerBounds1[j], arr.GetLowerBound(1));
-                                Assert.Equal(validLowerBounds1[j] + validLowerBounds2[j] - 1, arr.GetUpperBound(1));
-                                Assert.Equal(validLengths2[j] * validLowerBounds2[j], arr.Length);
+                                int[,] arr = (int[,])constructors[i].Invoke(new object[] { validLowerBounds1[j], validLengths1[j], validLowerBounds2[j], validLengths2[j] });
+                                Assert.Equal(validLowerBounds1[j], arr.GetLowerBound(0));
+                                Assert.Equal(validLowerBounds1[j] + validLengths1[j] - 1, arr.GetUpperBound(0));
+                                Assert.Equal(validLowerBounds2[j], arr.GetLowerBound(1));
+                                Assert.Equal(validLowerBounds2[j] + validLengths2[j] - 1, arr.GetUpperBound(1));
+                                Assert.Equal(validLengths1[j] * validLengths2[j], arr.Length);
                             }
 
                             // Lower can be < 0
-                            validLengths1 = new int[] { 10, 10, 65535, 40, 0, -10, -10, -20, -40, 0 };
-                            validLowerBounds1 = new int[] { 5, 99, -100, 30, 4, -5, 99, 100, -30, 0 };
-                            validLengths2 = new int[] { 1, 200, 2, 40, 0, 1, 200, 2, 40, 65535 };
-                            validLowerBounds2 = new int[] { 5, 10, 1, 0, 4, 5, 65535, 1, 0, 4 };
+                            validLowerBounds1 = new int[] { 10, 10, 65535, 40, 0, -10, -10, -20, -40, 0 };
+                            validLowerBounds2 = new int[] { 5, 99, -100, 30, 4, -5, 99, 100, -30, 0 };
+                            validLengths1 = new int[] { 1, 200, 2, 40, 0, 1, 200, 2, 40, 65535 };
+                            validLengths2 = new int[] { 5, 10, 1, 0, 4, 5, 65535, 1, 0, 4 };
 
-                            for (int j = 0; j < validLengths2.Length; j++)
+                            for (int j = 0; j < validLengths1.Length; j++)
                             {
-                                int[,] arr = (int[,])constructors[i].Invoke(new object[] { validLengths1[j], validLengths2[j], validLowerBounds1[j], validLowerBounds2[j] });
-                                Assert.Equal(validLengths1[j], arr.GetLowerBound(0));
-                                Assert.Equal(validLengths1[j] + validLengths2[j] - 1, arr.GetUpperBound(0));
-                                Assert.Equal(validLowerBounds1[j], arr.GetLowerBound(1));
-                                Assert.Equal(validLowerBounds1[j] + validLowerBounds2[j] - 1, arr.GetUpperBound(1));
-                                Assert.Equal(validLengths2[j] * validLowerBounds2[j], arr.Length);
+                                int[,] arr = (int[,])constructors[i].Invoke(new object[] { validLowerBounds1[j], validLengths1[j], validLowerBounds2[j], validLengths2[j] });
+                                Assert.Equal(validLowerBounds1[j], arr.GetLowerBound(0));
+                                Assert.Equal(validLowerBounds1[j] + validLengths1[j] - 1, arr.GetUpperBound(0));
+                                Assert.Equal(validLowerBounds2[j], arr.GetLowerBound(1));
+                                Assert.Equal(validLowerBounds2[j] + validLengths2[j] - 1, arr.GetUpperBound(1));
+                                Assert.Equal(validLengths1[j] * validLengths2[j], arr.Length);
                             }
                         }
                         break;

--- a/src/System.Reflection.TypeExtensions/tests/ConstructorInfo/ConstructorInfoInvokeArrayTests.cs
+++ b/src/System.Reflection.TypeExtensions/tests/ConstructorInfo/ConstructorInfoInvokeArrayTests.cs
@@ -33,6 +33,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Multidim arrays of rank 1 not supported on UapAot: https://github.com/dotnet/corert/issues/3331")]
         public void Invoke_1DArrayConstructor()
         {
             Type type = Type.GetType("System.Char[*]");
@@ -134,6 +135,12 @@ namespace System.Reflection.Tests
                             int[] invalidLengths3 = new int[] { -11, -10, 0 };
                             int[] invalidLengths4 = new int[] { -33, 0, -20 };
 
+                            if (!PlatformDetection.IsNonZeroLowerBoundArraySupported)
+                            {
+                                Array.Clear(invalidLowerBounds1, 0, invalidLowerBounds1.Length);
+                                Array.Clear(invalidLowerBounds2, 0, invalidLowerBounds2.Length);
+                            }
+
                             for (int j = 0; j < invalidLengths3.Length; j++)
                             {
                                 Assert.Throws<OverflowException>(() => constructors[i].Invoke(new object[] { invalidLowerBounds1[j], invalidLengths3[j], invalidLowerBounds2[j], invalidLengths4[j] }));
@@ -163,6 +170,12 @@ namespace System.Reflection.Tests
                                             cnt++;
                                         }
 
+                            if (!PlatformDetection.IsNonZeroLowerBoundArraySupported)
+                            {
+                                Array.Clear(validLowerBounds1, 0, validLowerBounds1.Length);
+                                Array.Clear(validLowerBounds2, 0, validLowerBounds2.Length);
+                            }
+
                             for (int j = 0; j < validLengths1.Length; j++)
                             {
                                 int[,] arr = (int[,])constructors[i].Invoke(new object[] { validLowerBounds1[j], validLengths1[j], validLowerBounds2[j], validLengths2[j] });
@@ -178,6 +191,12 @@ namespace System.Reflection.Tests
                             validLowerBounds2 = new int[] { 5, 99, -100, 30, 4, -5, 99, 100, -30, 0 };
                             validLengths1 = new int[] { 1, 200, 2, 40, 0, 1, 200, 2, 40, 65535 };
                             validLengths2 = new int[] { 5, 10, 1, 0, 4, 5, 65535, 1, 0, 4 };
+
+                            if (!PlatformDetection.IsNonZeroLowerBoundArraySupported)
+                            {
+                                Array.Clear(validLowerBounds1, 0, validLowerBounds1.Length);
+                                Array.Clear(validLowerBounds2, 0, validLowerBounds2.Length);
+                            }
 
                             for (int j = 0; j < validLengths1.Length; j++)
                             {

--- a/src/System.Reflection.TypeExtensions/tests/MethodInfoTests.cs
+++ b/src/System.Reflection.TypeExtensions/tests/MethodInfoTests.cs
@@ -13,7 +13,7 @@ namespace System.Reflection.Tests
         [Theory]
         [InlineData(typeof(MI_NonGenericClass), nameof(MI_NonGenericClass.PublicMethod))]
         [InlineData(typeof(MI_NonGenericClass), nameof(MI_NonGenericClass.PublicStaticMethod))]
-        [InlineData(typeof(string), nameof(string.IsNullOrEmpty))]
+        [InlineData(typeof(StringImpersonator), nameof(StringImpersonator.IsNullOrEmpty))]
         public void Properties(Type type, string name)
         {
             MethodInfo method = Helpers.GetMethod(type, name);

--- a/src/System.Reflection.TypeExtensions/tests/System.Reflection.TypeExtensions.Tests.csproj
+++ b/src/System.Reflection.TypeExtensions/tests/System.Reflection.TypeExtensions.Tests.csproj
@@ -25,5 +25,10 @@
     <Compile Include="FieldInfoTests.cs" />
     <Compile Include="MethodBaseTests.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>Common\System\PlatformDetection.cs</Link>
+    </Compile>
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Reflection.TypeExtensions/tests/TypeTests.cs
+++ b/src/System.Reflection.TypeExtensions/tests/TypeTests.cs
@@ -970,6 +970,7 @@ namespace System.Reflection.Tests
         [IndexerName("Chars")]
         public char this[int index] { get { throw null; } }
         public int Length { get { throw null; } }
+        public static bool IsNullOrEmpty(string value) { throw null; }
         internal char FirstChar { get { throw null; } }
     }
 


### PR DESCRIPTION
- Invoke_2DArrayConstructor

  The test still has value even if we can only zero lower bounds
  so we'll degrade it gracefully on Aot platforms.

- Another case of reflecting on framework types needlessly.