### PR TITLE
Fix the System.Linq tests that want metadata.

### DIFF
--- a/src/System.Linq/tests/Resources/System.Linq.Tests.rd.xml
+++ b/src/System.Linq/tests/Resources/System.Linq.Tests.rd.xml
@@ -1,0 +1,15 @@
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Library>
+    <!-- Needed because of StringComparer instance in [Theory] data which causes xunit to reflect on its ToString() -->
+    <Type Name="System.StringComparer" Dynamic="Required Public" />
+
+    <!-- ConsistencyTests.MatchSequencePattern() test explicitly probes these types -->
+    <Type Name="System.Linq.Enumerable" Dynamic="Required Public" />
+    <Type Name="System.Linq.Queryable" Dynamic="Required Public" />
+
+    <!-- GroupByTests.GroupingKeyIsPublic() needs this to be reflectable because... well, the name speaks for itself -->
+    <Type Name="System.Linq.Grouping`2" Dynamic="Required Public" />
+  </Library>
+</Directives>
+
+

--- a/src/System.Linq/tests/System.Linq.Tests.csproj
+++ b/src/System.Linq/tests/System.Linq.Tests.csproj
@@ -89,5 +89,8 @@
       <Link>Common\System\Linq\SkipTakeData.cs</Link>
     </Compile>
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\$(AssemblyName).rd.xml" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
(the remaining failures are DebuggerAttribute-checking
stuff which is a whole another subject that affects
Collections too.)