### PR TITLE
Remove assert that trips on Windows 7

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.PrivateKey.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.PrivateKey.cs
@@ -403,8 +403,6 @@ namespace Internal.Cryptography.Pal
                 return 0;
             }
 
-            const int NTE_BAD_KEYSET = unchecked((int)0x80090016);
-
             try
             {
                 CngKeyOpenOptions options = machineKey ? CngKeyOpenOptions.MachineKey : CngKeyOpenOptions.None;
@@ -415,11 +413,12 @@ namespace Internal.Cryptography.Pal
                     return 0;
                 }
             }
-            catch (CryptographicException e)
+            catch (CryptographicException)
             {
-                Debug.Assert(
-                    e.HResult == NTE_BAD_KEYSET,
-                    $"CngKey.Open had unexpected error: 0x{e.HResult:X8}: {e.Message}");
+                // While NTE_BAD_KEYSET is what we generally expect here for RSA, on Windows 7
+                // PROV_DSS produces NTE_BAD_PROV_TYPE, and PROV_DSS_DH produces NTE_NO_KEY.
+                //
+                // So we'll just try the CAPI fallback for any error code, and see what happens.
 
                 CspParameters cspParameters = new CspParameters
                 {


### PR DESCRIPTION
Win7 is getting different failure codes from the CAPI-via-CNG tests with DSA,
and removing the assert makes the tests pass.  So replacing the assert with a
comment.

Since this is opportunistic recovery from an exception, it seems reasonable to try
no matter what the exception is.