### PR TITLE
Construct the baseline at runtime and embed the DateTime string into the baseline

### DIFF
--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -2513,7 +2513,6 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    [ActiveIssue(18539, TestPlatforms.Linux)]
     public static void DCJS_VerifyDateTimeForFormatStringDCJsonSerSettings()
     {
         var jsonTypes = new JsonTypes();

--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -2548,18 +2548,27 @@ public static partial class DataContractJsonSerializerTests
 
         var dt35832 = new DateTime(DateTime.Now.Year, DateTime.Now.Month, DateTime.Now.Day, 3, 58, 32);
         var dt = new DateTime(DateTime.Now.Year, DateTime.Now.Month, DateTime.Now.Day);
-        var expected_DT_list = "[\"03:58:32.00 a.m.\",\"12:00:00.00 a.m.\",\"12:00:00.00 a.m.\",\"03:58:32.00 a.m.\"]";         
         dcjsSettings = new DataContractJsonSerializerSettings() { DateTimeFormat = jsonTypes.DTF_hmsFt };
-        var actual4 = SerializeAndDeserialize(jsonTypes.DT_List, expected_DT_list, dcjsSettings);
+        var dcjs = new DataContractJsonSerializer(typeof(DateTime), dcjsSettings);
+        string actualam;
+        using (var ms = new MemoryStream())
+        {
+            dcjs.WriteObject(ms, new DateTime());
+            ms.Position = 0;
+            var temp = new StreamReader(ms).ReadToEnd();
+            actualam = temp.Substring(temp.IndexOf('a'));
+        }
+
+        var baselinelist = $"[\"03:58:32.00 {actualam},\"12:00:00.00 {actualam},\"12:00:00.00 {actualam},\"03:58:32.00 {actualam}]";
+        var actual4 = SerializeAndDeserialize(jsonTypes.DT_List, baselinelist, dcjsSettings);
         Assert.NotNull(actual4);
         Assert.True(actual4[0] == dt35832);
         Assert.True(actual4[1] == dt);
         Assert.True(actual4[2] == dt);
         Assert.True(actual4[3] == dt35832);
 
-        var expected_DT_dictionary = "[{\"Key\":\"03:58:32.00 a.m.\",\"Value\":\"03:58:32.00 a.m.\"},{\"Key\":\"12:00:00.00 a.m.\",\"Value\":\"12:00:00.00 a.m.\"}]";
-        dcjsSettings = new DataContractJsonSerializerSettings() { DateTimeFormat = jsonTypes.DTF_hmsFt };
-        var actual5 = SerializeAndDeserialize(jsonTypes.DT_Dictionary, expected_DT_dictionary, dcjsSettings);
+        var baselinedictionary = $"[{{\"Key\":\"03:58:32.00 {actualam},\"Value\":\"03:58:32.00 {actualam}}},{{\"Key\":\"12:00:00.00 {actualam},\"Value\":\"12:00:00.00 {actualam}}}]";
+        var actual5 = SerializeAndDeserialize(jsonTypes.DT_Dictionary, baselinedictionary, dcjsSettings);
         Assert.NotNull(actual5);
         Assert.True(actual5[dt35832] == dt35832);
         Assert.True(actual5[dt] == dt);

--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -2494,7 +2494,6 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    [ActiveIssue(18538, TestPlatforms.FreeBSD | TestPlatforms.Linux | TestPlatforms.NetBSD)]
     public static void DCJS_VerifyDateTimeForFormatStringDCJsonSerSetting()
     {
         var dcjsSettings = new DataContractJsonSerializerSettings()
@@ -2507,7 +2506,7 @@ public static partial class DataContractJsonSerializerTests
         var value = new DateTime(2010, 12, 1);
         var offsetMinutes = (int)TimeZoneInfo.Local.GetUtcOffset(new DateTime()).TotalMinutes;
         var timeZoneString = string.Format("{0:+;-}{1}", offsetMinutes, new TimeSpan(0, offsetMinutes, 0).ToString(@"hhmm"));
-        var baseline = $"\"\\/Date(1291190400000{timeZoneString})\\/\"";
+        var baseline = $"\"\\/Date({1291161600000 - offsetMinutes * 60 * 1000}{timeZoneString})\\/\"";
         var actual = SerializeAndDeserialize(value, baseline, dcjsSettings);
         Assert.Equal(value, actual);
     }


### PR DESCRIPTION
Fix https://github.com/dotnet/corefx/issues/18539
Fix #18538 
Fix https://github.com/dotnet/corefx/issues/18802

@shmao  please help review the code.