### PR TITLE
Ensure several VB types are annotated as Serializable

### DIFF
--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/ExceptionUtils.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/ExceptionUtils.vb
@@ -58,6 +58,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
 
     End Class
 
+    <Serializable()>
     Public NotInheritable Class InternalErrorException
         Inherits System.Exception
 
@@ -73,6 +74,11 @@ Namespace Microsoft.VisualBasic.CompilerServices
         Public Sub New()
             MyBase.New(GetResourceString(SR.InternalError))
         End Sub
+
+        Private Sub New(ByVal info As System.Runtime.Serialization.SerializationInfo, ByVal context As System.Runtime.Serialization.StreamingContext)
+            MyBase.New(info, context)
+        End Sub
+
     End Class
 
 End Namespace

--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/IncompleteInitialization.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/IncompleteInitialization.vb
@@ -5,10 +5,19 @@
 Namespace Global.Microsoft.VisualBasic.CompilerServices
     <Global.System.Diagnostics.DebuggerNonUserCode()>
     <Global.System.ComponentModel.EditorBrowsable(Global.System.ComponentModel.EditorBrowsableState.Never)>
+    <Global.System.Serializable>
     Public Class IncompleteInitialization
         Inherits Global.System.Exception
         Public Sub New()
             MyBase.New()
         End Sub
+
+#Disable Warning CA2229 ' Rule wants ctor to be protected, but private to match desktop
+        <Global.System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)>
+        Private Sub New(ByVal info As System.Runtime.Serialization.SerializationInfo, ByVal context As System.Runtime.Serialization.StreamingContext)
+            MyBase.New(info, context)
+        End Sub
+#Enable Warning CA2229 ' Implement Serialization constructor
+
     End Class
 End Namespace

--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/StaticLocalInitFlag.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/StaticLocalInitFlag.vb
@@ -5,6 +5,7 @@
 Namespace Global.Microsoft.VisualBasic.CompilerServices
     <Global.System.Diagnostics.DebuggerNonUserCode()>
     <Global.System.ComponentModel.EditorBrowsable(Global.System.ComponentModel.EditorBrowsableState.Never)>
+    <Global.System.Serializable()>
     Public Class StaticLocalInitFlag
         Public State As Short
     End Class

--- a/src/Microsoft.VisualBasic/tests/Microsoft.VisualBasic.Tests.csproj
+++ b/src/Microsoft.VisualBasic/tests/Microsoft.VisualBasic.Tests.csproj
@@ -7,7 +7,11 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <ItemGroup>
+    <Compile Include="SerializationTests.cs" />
     <Compile Include="StringsTests.cs" />
+    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
+      <Link>Common\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/Microsoft.VisualBasic/tests/SerializationTests.cs
+++ b/src/Microsoft.VisualBasic/tests/SerializationTests.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.Serialization.Formatters.Tests;
+using Microsoft.VisualBasic.CompilerServices;
+using Xunit;
+
+namespace Microsoft.VisualBasic.Tests
+{
+    public class SerializationTests
+    {
+        [Fact]
+        public void SerializeDeserialize_Roundtrip_Success()
+        {
+            BinaryFormatterHelpers.AssertRoundtrips(new IncompleteInitialization());
+
+            var initFlag = new StaticLocalInitFlag { State = 42 };
+            var clonedInitFlag = BinaryFormatterHelpers.Clone(initFlag);
+            Assert.Equal(42, clonedInitFlag.State);
+        }
+    }
+}


### PR DESCRIPTION
To match desktop.  Our tools for ensuring we'd ported all necessary serialization to corefx only looked at .cs files, hence these were missed.

Contributes to https://github.com/dotnet/corefx/issues/18780
cc: @billwert, @VSadov 

@weshaggard, @VSadov, the InternalErrorException type is public in the src (matching desktop) but missing from the ref.  Should it be added to the ref, made internal in the src, or just left as is?