### PR TITLE
Don't run DebugView/DebuggerAttribute tests in aot.

### DIFF
--- a/src/System.Linq/tests/Configurations.props
+++ b/src/System.Linq/tests/Configurations.props
@@ -4,6 +4,7 @@
     <BuildConfigurations>
       netcoreapp;
       netstandard;
+      uapaot;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Linq/tests/GroupByTests.DebuggerAttributes.cs
+++ b/src/System.Linq/tests/GroupByTests.DebuggerAttributes.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using Xunit;
+
+namespace System.Linq.Tests
+{
+    public partial class GroupByTests : EnumerableTests
+    {
+        [Theory]
+        [MemberData(nameof(DebuggerAttributesValid_Data))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Grouping<TKey, TValue> doesn't have a Debugger proxy in the full .NET Framework. See https://github.com/dotnet/corefx/issues/14790.")]
+        public void DebuggerAttributesValid<TKey, TElement>(IGrouping<TKey, TElement> grouping, string keyString, TKey dummy1, TElement dummy2)
+        {
+            // The dummy parameters can be removed once https://github.com/dotnet/buildtools/pull/1300 is brought in.
+            Assert.Equal($"Key = {keyString}", DebuggerAttributes.ValidateDebuggerDisplayReferences(grouping));
+            
+            object proxyObject = DebuggerAttributes.GetProxyObject(grouping);
+            
+            // Validate proxy fields
+            Assert.Empty(DebuggerAttributes.GetDebuggerVisibleFields(proxyObject.GetType()));
+
+            // Validate proxy properties
+            IEnumerable<PropertyInfo> properties = DebuggerAttributes.GetDebuggerVisibleProperties(proxyObject.GetType());
+            Assert.Equal(2, properties.Count());
+            
+            // Key
+            TKey key = (TKey)properties.Single(property => property.Name == "Key").GetValue(proxyObject);
+            Assert.Equal(grouping.Key, key);
+
+            // Values
+            PropertyInfo valuesProperty = properties.Single(property => property.Name == "Values");
+            Assert.Equal(DebuggerBrowsableState.RootHidden, DebuggerAttributes.GetDebuggerBrowsableState(valuesProperty));
+            TElement[] values = (TElement[])valuesProperty.GetValue(proxyObject);
+            Assert.IsType<TElement[]>(values); // Arrays can be covariant / of assignment-compatible types
+            Assert.Equal(grouping, values);
+            Assert.Same(values, valuesProperty.GetValue(proxyObject)); // The result should be cached, as Grouping is immutable.
+        }
+
+        public static IEnumerable<object[]> DebuggerAttributesValid_Data()
+        {
+            IEnumerable<int> source = new[] { 1 };
+            yield return new object[] { source.GroupBy(i => i).Single(), "1", 0, 0 };
+            yield return new object[] { source.GroupBy(i => i.ToString(), i => i).Single(), @"""1""", string.Empty, 0 };
+            yield return new object[] { source.GroupBy(i => TimeSpan.FromSeconds(i), i => i).Single(), "{00:00:01}", TimeSpan.Zero, 0 };
+
+            yield return new object[] { new string[] { null }.GroupBy(x => x).Single(), "null", string.Empty, string.Empty };
+            // This test won't even work with the work-around because nullables lose their type once boxed, so xUnit sees an `int` and thinks
+            // we're trying to pass an IGrouping<int, int> rather than an IGrouping<int?, int?>.
+            // However, it should also be fixed once that PR is brought in, so leaving in this comment.
+            // yield return new object[] { new int?[] { null }.GroupBy(x => x).Single(), "null", new int?(0), new int?(0) };
+        }
+    }
+}

--- a/src/System.Linq/tests/GroupByTests.cs
+++ b/src/System.Linq/tests/GroupByTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace System.Linq.Tests
 {
-    public class GroupByTests : EnumerableTests
+    public partial class GroupByTests : EnumerableTests
     {
         public static void AssertGroupingCorrect<TKey, TElement>(IEnumerable<TKey> keys, IEnumerable<TElement> elements, IEnumerable<IGrouping<TKey, TElement>> grouping)
         {
@@ -863,50 +863,6 @@ namespace System.Linq.Tests
             Type grouptype = group.GetType();
             PropertyInfo key = grouptype.GetProperty("Key", BindingFlags.Instance | BindingFlags.Public);
             Assert.NotNull(key);
-        }
-
-        [Theory]
-        [MemberData(nameof(DebuggerAttributesValid_Data))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Grouping<TKey, TValue> doesn't have a Debugger proxy in the full .NET Framework. See https://github.com/dotnet/corefx/issues/14790.")]
-        public void DebuggerAttributesValid<TKey, TElement>(IGrouping<TKey, TElement> grouping, string keyString, TKey dummy1, TElement dummy2)
-        {
-            // The dummy parameters can be removed once https://github.com/dotnet/buildtools/pull/1300 is brought in.
-            Assert.Equal($"Key = {keyString}", DebuggerAttributes.ValidateDebuggerDisplayReferences(grouping));
-            
-            object proxyObject = DebuggerAttributes.GetProxyObject(grouping);
-            
-            // Validate proxy fields
-            Assert.Empty(DebuggerAttributes.GetDebuggerVisibleFields(proxyObject.GetType()));
-
-            // Validate proxy properties
-            IEnumerable<PropertyInfo> properties = DebuggerAttributes.GetDebuggerVisibleProperties(proxyObject.GetType());
-            Assert.Equal(2, properties.Count());
-            
-            // Key
-            TKey key = (TKey)properties.Single(property => property.Name == "Key").GetValue(proxyObject);
-            Assert.Equal(grouping.Key, key);
-
-            // Values
-            PropertyInfo valuesProperty = properties.Single(property => property.Name == "Values");
-            Assert.Equal(DebuggerBrowsableState.RootHidden, DebuggerAttributes.GetDebuggerBrowsableState(valuesProperty));
-            TElement[] values = (TElement[])valuesProperty.GetValue(proxyObject);
-            Assert.IsType<TElement[]>(values); // Arrays can be covariant / of assignment-compatible types
-            Assert.Equal(grouping, values);
-            Assert.Same(values, valuesProperty.GetValue(proxyObject)); // The result should be cached, as Grouping is immutable.
-        }
-
-        public static IEnumerable<object[]> DebuggerAttributesValid_Data()
-        {
-            IEnumerable<int> source = new[] { 1 };
-            yield return new object[] { source.GroupBy(i => i).Single(), "1", 0, 0 };
-            yield return new object[] { source.GroupBy(i => i.ToString(), i => i).Single(), @"""1""", string.Empty, 0 };
-            yield return new object[] { source.GroupBy(i => TimeSpan.FromSeconds(i), i => i).Single(), "{00:00:01}", TimeSpan.Zero, 0 };
-
-            yield return new object[] { new string[] { null }.GroupBy(x => x).Single(), "null", string.Empty, string.Empty };
-            // This test won't even work with the work-around because nullables lose their type once boxed, so xUnit sees an `int` and thinks
-            // we're trying to pass an IGrouping<int, int> rather than an IGrouping<int?, int?>.
-            // However, it should also be fixed once that PR is brought in, so leaving in this comment.
-            // yield return new object[] { new int?[] { null }.GroupBy(x => x).Single(), "null", new int?(0), new int?(0) };
         }
     }
 }

--- a/src/System.Linq/tests/System.Linq.Tests.csproj
+++ b/src/System.Linq/tests/System.Linq.Tests.csproj
@@ -88,6 +88,8 @@
     </Compile>
   </ItemGroup>
 
+  <!-- DebuggerAttribute tests require internal framework Reflection and will not work on AoT platforms.
+       The proper way to test these is via the debugger expression evaluator, not Reflection. -->
   <ItemGroup Condition="'$(TargetGroup)'!='uapaot'">
     <Compile Include="$(CommonTestPath)\System\Diagnostics\DebuggerAttributes.cs">
       <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>

--- a/src/System.Linq/tests/System.Linq.Tests.csproj
+++ b/src/System.Linq/tests/System.Linq.Tests.csproj
@@ -9,6 +9,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Release|AnyCPU'" />
   <ItemGroup Condition="'$(TargetGroup)'=='netcoreapp'">
     <Compile Include="AppendPrependTests.cs" />
     <Compile Include="SkipLastTests.cs" />
@@ -34,7 +36,6 @@
     <Compile Include="ElementAtTests.cs" />
     <Compile Include="EmptyEnumerable.cs" />
     <Compile Include="EmptyPartitionTests.cs" />
-    <Compile Include="EnumerableDebugViewTests.cs" />
     <Compile Include="EnumerableTests.cs" />
     <Compile Include="ExceptTests.cs" />
     <Compile Include="FirstOrDefaultTests.cs" />
@@ -79,9 +80,6 @@
     <Compile Include="$(CommonTestPath)\System\AssertExtensions.cs">
       <Link>Common\System\AssertExtensions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Diagnostics\DebuggerAttributes.cs">
-      <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
-    </Compile>
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
       <Link>Common\System\PlatformDetection.cs</Link>
     </Compile>
@@ -89,6 +87,16 @@
       <Link>Common\System\Linq\SkipTakeData.cs</Link>
     </Compile>
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetGroup)'!='uapaot'">
+    <Compile Include="$(CommonTestPath)\System\Diagnostics\DebuggerAttributes.cs">
+      <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
+    </Compile>
+    <Compile Include="GroupByTests.DebuggerAttributes.cs" />
+    <Compile Include="ToLookupTests.DebuggerAttributes.cs" />
+    <Compile Include="EnumerableDebugViewTests.cs" />
+  </ItemGroup>
+
   <ItemGroup>
     <EmbeddedResource Include="Resources\$(AssemblyName).rd.xml" />
   </ItemGroup>

--- a/src/System.Linq/tests/ToLookupTests.DebuggerAttributes.cs
+++ b/src/System.Linq/tests/ToLookupTests.DebuggerAttributes.cs
@@ -1,0 +1,60 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using Xunit;
+
+namespace System.Linq.Tests
+{
+    public partial class ToLookupTests : EnumerableTests
+    {
+        [Theory]
+        [MemberData(nameof(DebuggerAttributesValid_Data))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Lookup<T> doesn't have a Debugger proxy in the full .NET framework. See https://github.com/dotnet/corefx/issues/14790.")]
+        public void DebuggerAttributesValid<TKey, TElement>(ILookup<TKey, TElement> lookup, TKey dummy1, TElement dummy2)
+        {
+            // The dummy parameters can be removed once https://github.com/dotnet/buildtools/pull/1300 is brought in.
+            Assert.Equal($"Count = {lookup.Count}", DebuggerAttributes.ValidateDebuggerDisplayReferences(lookup));
+            
+            object proxyObject = DebuggerAttributes.GetProxyObject(lookup);
+
+            // Validate proxy fields
+            Assert.Empty(DebuggerAttributes.GetDebuggerVisibleFields(proxyObject.GetType()));
+
+            // Validate proxy properties
+            IEnumerable<PropertyInfo> properties = DebuggerAttributes.GetDebuggerVisibleProperties(proxyObject.GetType());
+            Assert.Equal(1, properties.Count());
+
+            // Groupings
+            PropertyInfo groupingsProperty = properties.Single(property => property.Name == "Groupings");
+            Assert.Equal(DebuggerBrowsableState.RootHidden, DebuggerAttributes.GetDebuggerBrowsableState(groupingsProperty));
+            var groupings = (IGrouping<TKey, TElement>[])groupingsProperty.GetValue(proxyObject);
+            Assert.IsType<IGrouping<TKey, TElement>[]>(groupings); // Arrays can be covariant / of assignment-compatible types
+
+            Assert.All(groupings.Zip(lookup, (l, r) => Tuple.Create(l, r)), tuple =>
+            {
+                Assert.Same(tuple.Item1, tuple.Item2);
+            });
+
+            Assert.Same(groupings, groupingsProperty.GetValue(proxyObject)); // The result should be cached, as Lookup is immutable.
+        }
+
+        public static IEnumerable<object[]> DebuggerAttributesValid_Data()
+        {
+            IEnumerable<int> source = new[] { 1 };
+            yield return new object[] { source.ToLookup(i => i), 0, 0 };
+            yield return new object[] { source.ToLookup(i => i.ToString(), i => i), string.Empty, 0 };
+            yield return new object[] { source.ToLookup(i => TimeSpan.FromSeconds(i), i => i), TimeSpan.Zero, 0 };
+
+            yield return new object[] { new string[] { null }.ToLookup(x => x), string.Empty, string.Empty };
+            // This test won't even work with the work-around because nullables lose their type once boxed, so xUnit sees an `int` and thinks
+            // we're trying to pass an ILookup<int, int> rather than an ILookup<int?, int?>.
+            // However, it should also be fixed once that PR is brought in, so leaving in this comment.
+            // yield return new object[] { new int?[] { null }.ToLookup(x => x), new int?(0), new int?(0) };
+        }
+    }
+}

--- a/src/System.Linq/tests/ToLookupTests.cs
+++ b/src/System.Linq/tests/ToLookupTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace System.Linq.Tests
 {
-    public class ToLookupTests : EnumerableTests
+    public partial class ToLookupTests : EnumerableTests
     {
         private static void AssertMatches<K, T>(IEnumerable<K> keys, IEnumerable<T> elements, System.Linq.ILookup<K, T> lookup)
         {
@@ -288,51 +288,6 @@ namespace System.Linq.Tests
             };
 
             Assert.Equal(expected, result);
-        }
-
-        [Theory]
-        [MemberData(nameof(DebuggerAttributesValid_Data))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Lookup<T> doesn't have a Debugger proxy in the full .NET framework. See https://github.com/dotnet/corefx/issues/14790.")]
-        public void DebuggerAttributesValid<TKey, TElement>(ILookup<TKey, TElement> lookup, TKey dummy1, TElement dummy2)
-        {
-            // The dummy parameters can be removed once https://github.com/dotnet/buildtools/pull/1300 is brought in.
-            Assert.Equal($"Count = {lookup.Count}", DebuggerAttributes.ValidateDebuggerDisplayReferences(lookup));
-            
-            object proxyObject = DebuggerAttributes.GetProxyObject(lookup);
-
-            // Validate proxy fields
-            Assert.Empty(DebuggerAttributes.GetDebuggerVisibleFields(proxyObject.GetType()));
-
-            // Validate proxy properties
-            IEnumerable<PropertyInfo> properties = DebuggerAttributes.GetDebuggerVisibleProperties(proxyObject.GetType());
-            Assert.Equal(1, properties.Count());
-
-            // Groupings
-            PropertyInfo groupingsProperty = properties.Single(property => property.Name == "Groupings");
-            Assert.Equal(DebuggerBrowsableState.RootHidden, DebuggerAttributes.GetDebuggerBrowsableState(groupingsProperty));
-            var groupings = (IGrouping<TKey, TElement>[])groupingsProperty.GetValue(proxyObject);
-            Assert.IsType<IGrouping<TKey, TElement>[]>(groupings); // Arrays can be covariant / of assignment-compatible types
-
-            Assert.All(groupings.Zip(lookup, (l, r) => Tuple.Create(l, r)), tuple =>
-            {
-                Assert.Same(tuple.Item1, tuple.Item2);
-            });
-
-            Assert.Same(groupings, groupingsProperty.GetValue(proxyObject)); // The result should be cached, as Lookup is immutable.
-        }
-
-        public static IEnumerable<object[]> DebuggerAttributesValid_Data()
-        {
-            IEnumerable<int> source = new[] { 1 };
-            yield return new object[] { source.ToLookup(i => i), 0, 0 };
-            yield return new object[] { source.ToLookup(i => i.ToString(), i => i), string.Empty, 0 };
-            yield return new object[] { source.ToLookup(i => TimeSpan.FromSeconds(i), i => i), TimeSpan.Zero, 0 };
-
-            yield return new object[] { new string[] { null }.ToLookup(x => x), string.Empty, string.Empty };
-            // This test won't even work with the work-around because nullables lose their type once boxed, so xUnit sees an `int` and thinks
-            // we're trying to pass an ILookup<int, int> rather than an ILookup<int?, int?>.
-            // However, it should also be fixed once that PR is brought in, so leaving in this comment.
-            // yield return new object[] { new int?[] { null }.ToLookup(x => x), new int?(0), new int?(0) };
         }
 
         public class Membership


### PR DESCRIPTION
This is a big bucket of tests that inherently depend
on private framework Reflection and will
never work on .Net Native. The proper way to test
these is by using the debugger expression evaluator,
not Reflection.