### PR TITLE
Fix System.Security.Cryptography.Algorithms.Tests on UWPAOT

### DIFF
--- a/src/System.Security.Cryptography.Algorithms/tests/DefaultECDsaProvider.Unix.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/DefaultECDsaProvider.Unix.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+namespace System.Security.Cryptography.EcDsa.Tests
+{
+    public partial class ECDsaProvider : IECDsaProvider
+    {
+        public bool IsCurveValid(Oid oid)
+        {
+            if (PlatformDetection.IsOSX)
+            {
+                return false;
+            }
+            if (!string.IsNullOrEmpty(oid.Value))
+            {
+                // Value is passed before FriendlyName
+                return IsValueOrFriendlyNameValid(oid.Value);
+            }
+            return IsValueOrFriendlyNameValid(oid.FriendlyName);
+        }
+
+        public bool ExplicitCurvesSupported
+        {
+            get
+            {
+                if (PlatformDetection.IsOSX)
+                {
+                    return false;
+                }
+
+                return true;
+            }
+        }
+
+        private static bool IsValueOrFriendlyNameValid(string friendlyNameOrValue)
+        {
+            if (string.IsNullOrEmpty(friendlyNameOrValue))
+            {
+                return false;
+            }
+
+            IntPtr key = Interop.Crypto.EcKeyCreateByOid(friendlyNameOrValue);
+            if (key != IntPtr.Zero)
+            {
+                Interop.Crypto.EcKeyDestroy(key);
+                return true;
+            }
+            return false;
+        }
+    }
+}
+
+internal static partial class Interop
+{
+    internal static partial class Crypto
+    {
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcKeyCreateByOid")]
+        internal static extern System.IntPtr EcKeyCreateByOid(string oid);
+
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcKeyDestroy")]
+        internal static extern void EcKeyDestroy(System.IntPtr r);
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/tests/DefaultECDsaProvider.Windows.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/DefaultECDsaProvider.Windows.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+namespace System.Security.Cryptography.EcDsa.Tests
+{
+    public partial class ECDsaProvider : IECDsaProvider
+    {
+        public bool IsCurveValid(Oid oid)
+        {
+            // Friendly name required for windows
+            return NativeOidFriendlyNameExists(oid.FriendlyName);
+        }
+
+        public bool ExplicitCurvesSupported
+        {
+            get
+            {
+                return PlatformDetection.WindowsVersion >= 10;
+            }
+        }
+
+        private static bool NativeOidFriendlyNameExists(string oidFriendlyName)
+        {
+            if (string.IsNullOrEmpty(oidFriendlyName))
+                return false;
+
+            try
+            {
+                // By specifying OidGroup.PublicKeyAlgorithm, no caches are used
+                // Note: this throws when there is no oid value, even when friendly name is valid
+                // so it cannot be used for curves with no oid value such as curve25519
+                return !string.IsNullOrEmpty(Oid.FromFriendlyName(oidFriendlyName, OidGroup.PublicKeyAlgorithm).FriendlyName);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+    }
+}
+

--- a/src/System.Security.Cryptography.Algorithms/tests/DefaultECDsaProvider.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/DefaultECDsaProvider.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 
 namespace System.Security.Cryptography.EcDsa.Tests
 {
-    public class ECDsaProvider : IECDsaProvider
+    public partial class ECDsaProvider : IECDsaProvider
     {
         public ECDsa Create()
         {
@@ -26,77 +26,6 @@ namespace System.Security.Cryptography.EcDsa.Tests
             return ECDsa.Create(curve);
         }
 #endif
-
-        public bool IsCurveValid(Oid oid)
-        {
-            if (PlatformDetection.IsWindows)
-            {
-                // Friendly name required for windows
-                return NativeOidFriendlyNameExists(oid.FriendlyName);
-            }
-            if (PlatformDetection.IsOSX)
-            {
-                return false;
-            }
-            if (!string.IsNullOrEmpty(oid.Value))
-            {
-                // Value is passed before FriendlyName
-                return IsValueOrFriendlyNameValid(oid.Value);
-            }
-            return IsValueOrFriendlyNameValid(oid.FriendlyName);
-        }
-
-        public bool ExplicitCurvesSupported
-        {
-            get
-            {
-                if (PlatformDetection.IsWindows)
-                {
-                    return PlatformDetection.WindowsVersion >= 10;
-                }
-
-                if (PlatformDetection.IsOSX)
-                {
-                    return false;
-                }
-
-                return true;
-            }
-        }
-
-        private static bool NativeOidFriendlyNameExists(string oidFriendlyName)
-        {
-            if (string.IsNullOrEmpty(oidFriendlyName))
-                return false;
-
-            try
-            {
-                // By specifying OidGroup.PublicKeyAlgorithm, no caches are used
-                // Note: this throws when there is no oid value, even when friendly name is valid
-                // so it cannot be used for curves with no oid value such as curve25519
-                return !string.IsNullOrEmpty(Oid.FromFriendlyName(oidFriendlyName, OidGroup.PublicKeyAlgorithm).FriendlyName);
-            }
-            catch (Exception)
-            {
-                return false;
-            }
-        }
-
-        private static bool IsValueOrFriendlyNameValid(string friendlyNameOrValue)
-        {
-            if (string.IsNullOrEmpty(friendlyNameOrValue))
-            {
-                return false;
-            }
-
-            IntPtr key = Interop.Crypto.EcKeyCreateByOid(friendlyNameOrValue);
-            if (key != IntPtr.Zero)
-            {
-                Interop.Crypto.EcKeyDestroy(key);
-                return true;
-            }
-            return false;
-        }
     }
 
     public partial class ECDsaFactory
@@ -106,14 +35,3 @@ namespace System.Security.Cryptography.EcDsa.Tests
 
 }
 
-internal static partial class Interop
-{
-    internal static partial class Crypto
-    {
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcKeyCreateByOid")]
-        internal static extern System.IntPtr EcKeyCreateByOid(string oid);
-
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcKeyDestroy")]
-        internal static extern void EcKeyDestroy(System.IntPtr r);
-    }
-}

--- a/src/System.Security.Cryptography.Algorithms/tests/Resources/System.Security.Cryptography.Algorithms.Tests.rd.xml
+++ b/src/System.Security.Cryptography.Algorithms/tests/Resources/System.Security.Cryptography.Algorithms.Tests.rd.xml
@@ -1,0 +1,10 @@
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Library>
+    <!-- Needed because of [Theory] data that xunit reflects on for ToString() -->
+    <Type Name="System.Security.Cryptography.ECDsaCng" Dynamic="Required Public" />
+    <Type Name="System.Security.Cryptography.MD5" Dynamic="Required Public" />
+    <Type Name="System.Security.Cryptography.HMACMD5" Dynamic="Required Public" />
+  </Library>
+</Directives>
+
+

--- a/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
+++ b/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
@@ -131,9 +131,16 @@
     <Compile Include="Sha512Tests.cs" />
     <Compile Include="TripleDesProvider.cs" />
     <Compile Include="TripleDesTests.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
+    <Compile Include="DefaultECDsaProvider.Windows.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
+    <Compile Include="DefaultECDsaProvider.Unix.cs" />
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
+    <Folder Include="Common\Interop\Unix\" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)'=='netcoreapp'">
     <Compile Include="AesManagedTests.cs" />
@@ -218,7 +225,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Common\Interop\Unix\" />
+    <EmbeddedResource Include="Resources\$(AssemblyName).rd.xml" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
- More XUnit Reflection bandaids

- Don't embed Unix P/Invokes into Windows assemblies.
  .Net Native toolchain really hates that.