### PR TITLE
Use precise time in DiagnosticSource.StopActivity

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.DateTime.corefx.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.DateTime.corefx.cs
@@ -9,7 +9,7 @@ namespace System.Diagnostics
         /// <summary>
         /// Returns high resolution (~1 usec) current UTC DateTime.
         /// </summary>
-        private DateTime GetUtcNow()
+        internal static DateTime GetUtcNow()
         {
             // .NET Core CLR gives accurate UtcNow
             return DateTime.UtcNow;

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceActivity.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceActivity.cs
@@ -41,7 +41,7 @@
             // Stop sets the end time if it was unset, but we want it set before we issue the write
             // so we do it now.   
             if (activity.Duration == TimeSpan.Zero)
-                activity.SetEndTime(DateTime.UtcNow);
+                activity.SetEndTime(Activity.GetUtcNow());
             Write(activity.OperationName + ".Stop", args);
             activity.Stop();    // Resets Activity.Current (we want this after the Write)
         }

--- a/src/System.Diagnostics.DiagnosticSource/tests/ActivityDateTimeTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/ActivityDateTimeTests.cs
@@ -18,7 +18,7 @@ namespace System.Diagnostics.Tests
             
             sw.Stop();
 
-            Assert.True(activity.Duration.TotalMilliseconds > 1 && activity.Duration.TotalMilliseconds <= sw.ElapsedMilliseconds);
+            Assert.True(activity.Duration.TotalMilliseconds > 1 && activity.Duration <= sw.Elapsed);
         }
     }
 }

--- a/src/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
@@ -406,7 +406,12 @@ namespace System.Diagnostics.Tests
                     var activity = new Activity("activity");
 
                     // Test Activity.Start
+                    Stopwatch sw = Stopwatch.StartNew();
                     source.StartActivity(activity, arguments);
+
+                    // DateTime.UtcNow is not precise on some platforms, we check that StartTime of Activity is within 20ms from now
+                    Assert.True(Math.Abs((DateTime.UtcNow - observer.Activity.StartTimeUtc).TotalMilliseconds) <= 20);
+
                     Assert.Equal(activity.OperationName + ".Start", observer.EventName);
                     Assert.Equal(arguments, observer.EventObject);
 
@@ -423,13 +428,14 @@ namespace System.Diagnostics.Tests
 
                     // Test Activity.Stop
                     source.StopActivity(activity, arguments);
+                    sw.Stop();
                     Assert.Equal(activity.OperationName + ".Stop", observer.EventName);
                     Assert.Equal(arguments, observer.EventObject);
 
                     // Confirm that duration is set. 
                     Assert.NotNull(observer.Activity);
                     Assert.True(TimeSpan.Zero < observer.Activity.Duration);
-                    Assert.True(observer.Activity.StartTimeUtc + observer.Activity.Duration <= DateTime.UtcNow.AddTicks(1));
+                    Assert.True(observer.Activity.Duration <= sw.Elapsed);
                 } 
             }
         }


### PR DESCRIPTION
Address post-review comments from PR #18651:

1. `DiagnosticSource.StopActivity` used DateTime.UtcNow
2. wrong time will be returned if `GetUtcNow` is triggered during sync

/cc @cwe1ss @vancem 