### PR TITLE
[release/2.0.0] Remove duplicate TFM in runtime framework packages

### DIFF
--- a/pkg/frameworkPackage.targets
+++ b/pkg/frameworkPackage.targets
@@ -76,7 +76,7 @@
       
       <!-- Include lib -->
       <File Include="@(LibFile)">
-        <TargetPath Condition="'%(LibFile.TargetPath)' == '' ">$(LibFileTargetPath)$(TargetFramework)%(LibFile.SubFolder)</TargetPath>
+        <TargetPath Condition="'%(LibFile.TargetPath)' == '' ">$(LibFileTargetPath)%(LibFile.SubFolder)</TargetPath>
       </File>
 
       <File Include="@(NativeFile)">


### PR DESCRIPTION
In refactoring these targets for the desktop support package I broke the
targetpath for lib files.

Cherry-pick of 9f6c671268d1918e5da934334a7bbd1e9197b1c2