### PR TITLE
Remove fragile connection string parsing from Sql Named Pipes tests

### DIFF
--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlNamedPipesTest/SqlNamedPipesTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlNamedPipesTest/SqlNamedPipesTest.cs
@@ -34,24 +34,26 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(DataTestUtility.NpConnStr);
             builder.ConnectTimeout = 2;
 
+            string fakeServerName = Guid.NewGuid().ToString("N");
+
             // Using forward slashes
-            builder.DataSource = "np://NotARealServer/pipe/sql/query";
+            builder.DataSource = "np://" + fakeServerName + "/pipe/sql/query";
             OpenBadConnection<SqlException>(builder.ConnectionString, invalidConnStringError);
 
             // Without pipe token
-            builder.DataSource = @"np:\\NotARealServer\sql\query";
+            builder.DataSource = @"np:\\" + fakeServerName + @"\sql\query";
             OpenBadConnection<SqlException>(builder.ConnectionString, invalidConnStringError);
 
             // Without a pipe name
-            builder.DataSource = @"np:\\NotARealServer\pipe";
+            builder.DataSource = @"np:\\" + fakeServerName + @"\pipe";
             OpenBadConnection<SqlException>(builder.ConnectionString, invalidConnStringError);
 
             // Nothing after server
-            builder.DataSource = @"np:\\NotARealServer";
+            builder.DataSource = @"np:\\" + fakeServerName;
             OpenBadConnection<SqlException>(builder.ConnectionString, invalidConnStringError);
 
             // No leading slashes
-            builder.DataSource = @"np:NotARealServer\pipe\sql\query";
+            builder.DataSource = @"np:" + fakeServerName + @"\pipe\sql\query";
             OpenBadConnection<SqlException>(builder.ConnectionString, invalidConnStringError);
 
             // No server name

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlNamedPipesTest/SqlNamedPipesTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlNamedPipesTest/SqlNamedPipesTest.cs
@@ -29,7 +29,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [CheckConnStrSetupFact]
         public static void InvalidConnStringTest()
         {
-            const string invalidConnStringError = "A network-related or instance-specific error occurred while establishing a connection to SQL Server. The server was not found or was not accessible. Verify that the instance name is correct and that SQL Server is configured to allow remote connections. (provider: Named Pipes Provider, error: 25 - Connection string is not valid)";
+            string invalidConnStringError = SystemDataResourceManager.Instance.SNI_ERROR_25;
 
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(DataTestUtility.NpConnStr);
             builder.ConnectTimeout = 2;


### PR DESCRIPTION
Having connection string parsing in these tests added extra complexity for no benefit.