### PR TITLE
Rename src to sources in private packages

### DIFF
--- a/Tools-Override/FrameworkTargeting.targets
+++ b/Tools-Override/FrameworkTargeting.targets
@@ -291,9 +291,10 @@
       <_itemsToSave Include="@(_docFiles)"/>
       
       <!-- Include source files. -->
+      <!-- Here we use "sources" rather than "src" because MyGet treats packages with "src" as symbol packages  -->
       <_itemsToSave Condition="'@(Compile)' != ''" Include="@(Compile->'%(FullPath)')">
-        <TargetPath>src</TargetPath>
-        <TargetPath Condition="$([System.String]::Copy('%(FullPath)').StartsWith('$(ProjectDir)'))">src/$([System.String]::Copy('%(FullPath)').Substring($(_projectDirLength)).Replace('\', '/'))</TargetPath>
+        <TargetPath>sources</TargetPath>
+        <TargetPath Condition="$([System.String]::Copy('%(FullPath)').StartsWith('$(ProjectDir)'))">sources/$([System.String]::Copy('%(FullPath)').Substring($(_projectDirLength)).Replace('\', '/'))</TargetPath>
         <IsSourceCodeFile>true</IsSourceCodeFile>
       </_itemsToSave>
     </ItemGroup>


### PR DESCRIPTION
These packages are meant to contain both source and symbols but we need
to avoid triggering the typical convention for these (src folder) so
that myget doesn't treat them as symbol packages.