### PR TITLE
Add Exists check to RemoteExecutorConsoleApp

### DIFF
--- a/src/Common/tests/System/Diagnostics/RemoteExecutorTestBase.cs
+++ b/src/Common/tests/System/Diagnostics/RemoteExecutorTestBase.cs
@@ -135,7 +135,10 @@ namespace System.Diagnostics
 
             // If we need the host (if it exists), use it, otherwise target the console app directly.
             string testConsoleAppArgs = "\"" + a.FullName + "\" " + t.FullName + " " + method.Name + " " + string.Join(" ", args);
-            
+
+            if (!File.Exists(TestConsoleApp))
+                throw new IOException("RemoteExecutorConsoleApp test app isn't present in the test runtime directory.");
+
             if (IsFullFramework)
             {
                 psi.FileName = TestConsoleApp;

--- a/src/System.Runtime.Extensions/tests/System/AppDomainTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/AppDomainTests.cs
@@ -196,19 +196,19 @@ namespace System.Tests
         [Fact]
         public void ProcessExit_Called()
         {
-            System.IO.File.Delete("success.txt");
-            RemoteInvoke(() =>
+            string path = GetTestFilePath();
+            RemoteInvoke((pathToFile) =>
             {
                 EventHandler handler = (sender, e) => 
                 {
-                    System.IO.File.Create("success.txt");
+                    File.Create(pathToFile);
                 };
 
                 AppDomain.CurrentDomain.ProcessExit += handler;
                 return SuccessExitCode;
-            }).Dispose();
+            }, path).Dispose();
 
-            Assert.True(System.IO.File.Exists("success.txt"));
+            Assert.True(File.Exists(path));
         }
 
         [Fact]


### PR DESCRIPTION
Some tests are failing on Unix with an error that appears to be indicating that the RemoteExecutorConsoleApp.exe is missing. I'm adding an explicit check to confirm or deny that this is the case. It is also possible that the exe can go missing between the check passing and the process startup failing, but there's not much I can do about that other than ignore the SIGCHLD failures which I would prefer to not do except as a last resort.

Also modified a test to use a random file path.

@danmosemsft @stephentoub 

Helps to diagnose root cause of #16688