### PR TITLE
Skip DCJS_StringAsRoot on NetFx.

### DIFF
--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -221,6 +221,7 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Implemented in 4.7. and Xunit runner currently targets 4.6.1.")]
     public static void DCJS_StringAsRoot()
     {
         foreach (string value in new string[] { "abc", "  a b  ", null, "", " ", "Hello World! 漢 ñ" })


### PR DESCRIPTION
Test `DCJS_StringAsRoot ` was for a fix originally made on NetCore. Later we port the fix to Desktop (4.7 and above). As Xunit runner currently targets 4.6.1, the test fails on NetFx. The PR is to skip the test on netfx.

Fix #18723 
