### PR TITLE
Revert exception type

### DIFF
--- a/src/System.Runtime.Extensions/src/System/OperatingSystem.cs
+++ b/src/System.Runtime.Extensions/src/System/OperatingSystem.cs
@@ -23,7 +23,7 @@ namespace System
         {
             if (platform < PlatformID.Win32S || platform > PlatformID.MacOSX)
             {
-                throw new ArgumentOutOfRangeException(nameof(platform), platform, SR.Arg_EnumIllegalVal);
+                throw new ArgumentException(SR.Format(SR.Arg_EnumIllegalVal, platform), nameof(platform));
             }
 
             if (version == null)

--- a/src/System.Runtime.Extensions/tests/System/OperatingSystemTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/OperatingSystemTests.cs
@@ -34,8 +34,8 @@ namespace System.Tests
         [Fact]
         public static void Ctor_InvalidArgs_Throws()
         {
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("platform", () => new OperatingSystem((PlatformID)(-1), new Version(1, 2)));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("platform", () => new OperatingSystem((PlatformID)42, new Version(1, 2)));
+            AssertExtensions.Throws<ArgumentException>("platform", () => new OperatingSystem((PlatformID)(-1), new Version(1, 2)));
+            AssertExtensions.Throws<ArgumentException>("platform", () => new OperatingSystem((PlatformID)42, new Version(1, 2)));
             AssertExtensions.Throws<ArgumentNullException>("version", () => new OperatingSystem(PlatformID.Unix, null));
         }
 


### PR DESCRIPTION
Fix https://github.com/dotnet/corefx/issues/18822 by reverting AOORE to AE  to match desktop since there doesn't seem a great reason to prefer one over the other.

https://referencesource.microsoft.com/#mscorlib/system/operatingsystem.cs,45