### PR TITLE
Root cause System.Net.Http test failures on NETFX

### DIFF
--- a/src/Common/tests/System/Net/TestWebProxies.cs
+++ b/src/Common/tests/System/Net/TestWebProxies.cs
@@ -20,11 +20,4 @@ namespace System.Net.Test.Common
         public Uri GetProxy(Uri destination) => _uri;
         public bool IsBypassed(Uri host) => _bypass;
     }
-
-    internal sealed class PlatformNotSupportedWebProxy : IWebProxy
-    {
-        public ICredentials Credentials { get; set; }
-        public Uri GetProxy(Uri destination) { throw new PlatformNotSupportedException(); }
-        public bool IsBypassed(Uri host) { throw new PlatformNotSupportedException(); }
-    }
 }

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Net46.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Net46.cs
@@ -224,6 +224,14 @@ namespace System.Net.Http
 
             set
             {
+                if (value < 1)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(value),
+                        value,
+                        SR.Format(SR.net_http_value_must_be_greater_than, 0));
+                }
+
                 CheckDisposedOrStarted();
                 _maxConnectionsPerServer = value;
             }

--- a/src/System.Net.Http/tests/FunctionalTests/CancellationTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/CancellationTest.cs
@@ -62,7 +62,7 @@ namespace System.Net.Http.Functional.Tests
                     var stopwatch = Stopwatch.StartNew();
                     if (PlatformDetection.IsFullFramework)
                     {
-                        // .NET Framework throws WebException instead of OperationCancledException.
+                        // .NET Framework throws WebException instead of OperationCanceledException.
                         await Assert.ThrowsAnyAsync<WebException>(async () =>
                         {
                             Task<HttpResponseMessage> getResponse = client.GetAsync(url, HttpCompletionOption.ResponseContentRead, cancellationToken);

--- a/src/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
@@ -19,7 +19,7 @@ namespace System.Net.Http.Functional.Tests
 {
     using Configuration = System.Net.Test.Common.Configuration;
 
-    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17691")]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Core specific diagnostic test")]
     public class DiagnosticsTest : RemoteExecutorTestBase
     {
         [Fact]

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxConnectionsPerServer.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxConnectionsPerServer.cs
@@ -15,7 +15,6 @@ namespace System.Net.Http.Functional.Tests
 
     public class HttpClientHandler_MaxConnectionsPerServer_Test
     {
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17691")] // Difference in behavior
         [Fact]
         public void Default_ExpectedValue()
         {
@@ -25,7 +24,6 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17691")] // Difference in behavior
         [Theory]
         [InlineData(0)]
         [InlineData(-1)]

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -88,7 +88,6 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17691")] // Difference in behavior
         [Fact]
         public void MaxResponseContentBufferSize_Roundtrip_Equal()
         {
@@ -102,7 +101,6 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17691")] // Difference in behavior
         [Fact]
         public void MaxResponseContentBufferSize_OutOfRange_Throws()
         {
@@ -114,7 +112,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17691")] // Difference in behavior
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "no exception throw on netfx")]
         [Fact]
         public async Task MaxResponseContentBufferSize_TooSmallForContent_Throws()
         {


### PR DESCRIPTION
Finished investigation of failures on .NET Framework for
System.Net.Http.

Added specific NETFX test changes where necessary. Opened up additional
bugs for investigation.

Added missing parameter validation for HttpClientHandler.MaxConnectionsPerServer
for the net46 OOB. This matches .NET Core now.

Removed some test code that was incorrectly trying to do CredentialCache.Add()
with a 'basic' authtype and using DefaultCredentials. This is invalid and
throws exception on netfx. Added #18870.

Remove PlatformNotSupportedProxy test code. It was throwing an exception
on netfx and the purpose of it didn't seem to make sense in the one test
that was using it.

Fixes #17691.