### PR TITLE
Trap tests that start child processes on AOT.

### DIFF
--- a/src/Common/tests/System/Diagnostics/RemoteExecutorTestBase.cs
+++ b/src/Common/tests/System/Diagnostics/RemoteExecutorTestBase.cs
@@ -28,6 +28,8 @@ namespace System.Diagnostics
         /// <summary>Determines if we're running on the .NET Framework (rather than .NET Core).</summary>
         internal static bool IsFullFramework => RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
 
+        internal static bool IsNetNative => RuntimeInformation.FrameworkDescription.StartsWith(".NET Native", StringComparison.OrdinalIgnoreCase);
+
         /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
         /// <param name="method">The method to invoke.</param>
         /// <param name="options">Options to use for the invocation.</param>
@@ -140,6 +142,16 @@ namespace System.Diagnostics
             {
                 psi.FileName = TestConsoleApp;
                 psi.Arguments = testConsoleAppArgs;
+            }
+            else if (IsNetNative)
+            {
+                psi.FileName = TestConsoleApp;
+                psi.Arguments = testConsoleAppArgs;
+
+                // The test pipeline does not have the infrastructure to copy RemoteExecutorConsoleApp.exe to the test directly, let alone
+                // ILC it against whatever assembly it might be asked to load up. (Is UWP even allowed to spin up a process!?)
+                // Until, and unless that's fixed, throw an informative exception so as not to waste debugging time.
+                throw new Exception(".NET Native platforms cannot run tests that use RemoteExecutorTestBase.RemoteInvoke()");
             }
             else
             {


### PR DESCRIPTION
A number of tests use the corefx RemoteExecutorTestBase
helper to start child processes.

Since this helper has never heard of .NET Native,
it ends up through a series of accidents, reinvoking
xunit.console.netcore.exe recursively with a
command line that xunit.console.netcore.exe has
no clue of understanding.

We'll now properly detect this case and throw
an informative exception for future run-ins
with this.