### PR TITLE
Fix System.ComponentModel.Annotations test bug

### DIFF
--- a/src/System.ComponentModel.Annotations/tests/CompareAttributeTests.cs
+++ b/src/System.ComponentModel.Annotations/tests/CompareAttributeTests.cs
@@ -47,7 +47,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
         public static void Validate_Indexer_ThrowsTargetParameterCountException_Netfx()
         {
             CompareAttribute attribute = new CompareAttribute("Item");
-            Assert.Throws<ArgumentException>(() => attribute.Validate("b", s_context));
+            Assert.Throws<TargetParameterCountException>(() => attribute.Validate("b", s_context));
         }
 
         [Fact]


### PR DESCRIPTION
Looks like in: https://github.com/dotnet/corefx/pull/17874 this test was added but as it was a difference in behavior and it was copied over from the .Net Core one we missed to update the expected exception to what it actually throws, look at the test name.

Fixes: https://github.com/dotnet/corefx/issues/18542

cc: @danmosemsft @lajones @divega 