### PR TITLE
[release/2.0] Change default clang version to clang3.9 in cross build

### DIFF
--- a/cross/arm32_ci_script.sh
+++ b/cross/arm32_ci_script.sh
@@ -231,7 +231,7 @@ function cross_build_corefx_with_docker {
     fi
 
     # Cross building corefx with rootfs in Docker
-    __buildNativeCmd="/opt/corefx/build-native.sh -buildArch=$__buildArch -$__buildConfig -- cross $__verboseFlag clang3.9"
+    __buildNativeCmd="/opt/corefx/build-native.sh -buildArch=$__buildArch -$__buildConfig -- cross $__verboseFlag"
     if [ "$__buildArch" == "arm" ]; then
         __buildManagedCmd="./build-managed.sh -$__buildConfig -buildArch=$__buildArch -RuntimeOS=$__runtimeOS"
     else

--- a/cross/arm32_ci_script.sh
+++ b/cross/arm32_ci_script.sh
@@ -189,13 +189,13 @@ function cross_build_corefx_with_docker {
         # TODO: For arm, we are going to embed RootFS inside Docker image.
         case $__linuxCodeName in
         trusty)
-            __dockerImage=" microsoft/dotnet-buildtools-prereqs:ubuntu1404_cross_prereqs_v3"
+            __dockerImage=" microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-cross-0cd4667-20172211042239"
             __skipRootFS=1
             __dockerEnvironmentVariables="-e ROOTFS_DIR=/crossrootfs/arm"
             __runtimeOS="ubuntu.14.04"
         ;;
         xenial)
-            __dockerImage=" microsoft/dotnet-buildtools-prereqs:ubuntu1604_cross_prereqs_v3"
+            __dockerImage=" microsoft/dotnet-buildtools-prereqs:ubuntu-16.04-cross-ef0ac75-20175511035548"
             __skipRootFS=1
             __dockerEnvironmentVariables="-e ROOTFS_DIR=/crossrootfs/arm"
             __runtimeOS="ubuntu.16.04"
@@ -208,7 +208,7 @@ function cross_build_corefx_with_docker {
         # For armel Tizen, we are going to construct RootFS on the fly.
         case $__linuxCodeName in
         tizen)
-            __dockerImage=" t2wish/dotnetcore:ubuntu1404_cross_prereqs_v2"
+            __dockerImage=" t2wish/dotnetcore:ubuntu1404_cross_prereqs_v4"
             __runtimeOS="tizen.4.0.0"
         ;;
         *)
@@ -231,7 +231,7 @@ function cross_build_corefx_with_docker {
     fi
 
     # Cross building corefx with rootfs in Docker
-    __buildNativeCmd="/opt/corefx/build-native.sh -buildArch=$__buildArch -$__buildConfig -- cross $__verboseFlag"
+    __buildNativeCmd="/opt/corefx/build-native.sh -buildArch=$__buildArch -$__buildConfig -- cross $__verboseFlag clang3.9"
     if [ "$__buildArch" == "arm" ]; then
         __buildManagedCmd="./build-managed.sh -$__buildConfig -buildArch=$__buildArch -RuntimeOS=$__runtimeOS"
     else

--- a/cross/build-rootfs.sh
+++ b/cross/build-rootfs.sh
@@ -5,7 +5,7 @@ usage()
     echo "Usage: $0 [BuildArch] [LinuxCodeName] [--skipunmount]"
     echo "BuildArch can be: arm(default), armel, arm64, x86"
     echo "LinuxCodeName - optional, Code name for Linux, can be: trusty(default), vivid, wily, xenial. If BuildArch is armel, LinuxCodeName is jessie(default) or tizen."
-    echo "lldbx.y - optional, LLDB version, can be: lldb3.6(default), lldb3.8, no-lldb"
+    echo "lldbx.y - optional, LLDB version, can be: lldb3.6(default), lldb3.8, lldb3.9, no-lldb"
     echo "--skipunmount - optional, will skip the unmount of rootfs folder."
     exit 1
 }
@@ -69,6 +69,9 @@ for i in "$@" ; do
             ;;
         lldb3.8)
             __LLDB_Package="lldb-3.8-dev"
+            ;;
+        lldb3.9)
+            __LLDB_Package="lldb-3.9-dev"
             ;;
         no-lldb)
             unset __LLDB_Package

--- a/src/Native/Unix/CMakeLists.txt
+++ b/src/Native/Unix/CMakeLists.txt
@@ -90,7 +90,9 @@ if (UPPERCASE_CMAKE_BUILD_TYPE STREQUAL DEBUG)
       set(CMAKE_SHARED_LINKER_FLAGS_DEBUG "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} ${CLR_SANITIZE_LINK_FLAGS} -Wl,--gc-sections")
     endif ()
 elseif (UPPERCASE_CMAKE_BUILD_TYPE STREQUAL RELEASE)
-    if (CMAKE_SYSTEM_PROCESSOR STREQUAL armv7l AND DEFINED ENV{CROSSCOMPILE})
+    # Use O1 option when the clang version is smaller than 3.9
+    # Otherwise use O3 option in release build
+    if (CMAKE_SYSTEM_PROCESSOR STREQUAL armv7l AND DEFINED ENV{CROSSCOMPILE} AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.9)
         add_compile_options (-O1)
     else()
         add_compile_options (-O3)

--- a/src/Native/build-native.sh
+++ b/src/Native/build-native.sh
@@ -67,6 +67,14 @@ check_native_prereqs()
     # Check presence of CMake on the path
     hash cmake 2>/dev/null || { echo >&2 "Please install cmake before running this script"; exit 1; }
 
+
+    # Minimum required version of clang is version 3.9 for arm/armel cross build
+    if [[ $__CrossBuild == 1 && ("$__BuildArch" == "arm" || "$__BuildArch" == "armel") ]]; then
+        if ! [[ "$__ClangMajorVersion" -gt "3" || ( $__ClangMajorVersion == 3 && $__ClangMinorVersion == 9 ) ]]; then
+            echo "Please install clang3.9 or latest for arm/armel cross build"; exit 1;
+        fi
+    fi
+
     # Check for clang
     hash clang-$__ClangMajorVersion.$__ClangMinorVersion 2>/dev/null ||  hash clang$__ClangMajorVersion$__ClangMinorVersion 2>/dev/null ||  hash clang 2>/dev/null || { echo >&2 "Please install clang before running this script"; exit 1; }
 }
@@ -342,8 +350,13 @@ esac
 # Set the default clang version if not already set
 if [[ $__ClangMajorVersion == 0 && $__ClangMinorVersion == 0 ]]; then
     if [ $__CrossBuild == 1 ]; then
-        __ClangMajorVersion=3
-        __ClangMinorVersion=6
+        if [[ "$__BuildArch" == "arm" || "$__BuildArch" == "armel" ]]; then
+            __ClangMajorVersion=3
+            __ClangMinorVersion=9
+        else
+            __ClangMajorVersion=3
+            __ClangMinorVersion=6
+        fi
     else
         __ClangMajorVersion=3
         __ClangMinorVersion=5


### PR DESCRIPTION
If we use clang3.9 version in cross build, we can use -O3 option for optimizing.
Revert #15643 PR.

Related issue : #18256 