### PR TITLE
Fix OS test for netfx

### DIFF
--- a/src/System.Runtime.Extensions/tests/System/OperatingSystemTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/OperatingSystemTests.cs
@@ -34,8 +34,9 @@ namespace System.Tests
         [Fact]
         public static void Ctor_InvalidArgs_Throws()
         {
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("platform", () => new OperatingSystem((PlatformID)(-1), new Version(1, 2)));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("platform", () => new OperatingSystem((PlatformID)42, new Version(1, 2)));
+            // ArgumentException on full framework
+            AssertExtensions.Throws<ArgumentOutOfRangeException, ArgumentException>("platform", "platform", () => new OperatingSystem((PlatformID)(-1), new Version(1, 2)));
+            AssertExtensions.Throws<ArgumentOutOfRangeException, ArgumentException>("platform", "platform", () => new OperatingSystem((PlatformID)42, new Version(1, 2)));
             AssertExtensions.Throws<ArgumentNullException>("version", () => new OperatingSystem(PlatformID.Unix, null));
         }
 


### PR DESCRIPTION
Fix https://github.com/dotnet/corefx/issues/18822 to be tolerant of the base exception type thrown in full fx.

This is a bit ugly: i could also just disable the test for netfx.