### PR TITLE
S.L.Expressions: Consolidate pointer & byref test in ValidateType

### DIFF
--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/ExpressionUtils.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/ExpressionUtils.cs
@@ -164,7 +164,8 @@ namespace System.Dynamic.Utils
             {
                 pType = pType.GetElementType();
             }
-            TypeUtils.ValidateType(pType, methodParamName);
+
+            TypeUtils.ValidateType(pType, methodParamName, allowByRef: true, allowPointer: true);
             if (!TypeUtils.AreReferenceAssignable(pType, arguments.Type))
             {
                 if (!TryQuote(pType, ref arguments))

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
@@ -590,8 +590,8 @@ namespace System.Linq.Expressions
         {
             RequiresCanWrite(left, nameof(left));
             ExpressionUtils.RequiresCanRead(right, nameof(right));
-            TypeUtils.ValidateType(left.Type, nameof(left));
-            TypeUtils.ValidateType(right.Type, nameof(right));
+            TypeUtils.ValidateType(left.Type, nameof(left), allowByRef: true, allowPointer: true);
+            TypeUtils.ValidateType(right.Type, nameof(right), allowByRef: true, allowPointer: true);
             if (!TypeUtils.AreReferenceAssignable(left.Type, right.Type))
             {
                 throw Error.ExpressionTypeDoesNotMatchAssignment(right.Type, left.Type);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/CatchBlock.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/CatchBlock.cs
@@ -140,15 +140,6 @@ namespace System.Linq.Expressions
             if (variable == null)
             {
                 TypeUtils.ValidateType(type, nameof(type));
-                if (type.IsByRef)
-                {
-                    throw Error.TypeMustNotBeByRef(nameof(type));
-                }
-
-                if (type.IsPointer)
-                {
-                    throw Error.TypeMustNotBePointer(nameof(type));
-                }
             }
             else if (variable.IsByRef)
             {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ConstantExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ConstantExpression.cs
@@ -97,16 +97,6 @@ namespace System.Linq.Expressions
         {
             ContractUtils.RequiresNotNull(type, nameof(type));
             TypeUtils.ValidateType(type, nameof(type));
-            if (type.IsByRef)
-            {
-                throw Error.TypeMustNotBeByRef(nameof(type));
-            }
-
-            if (type.IsPointer)
-            {
-                throw Error.TypeMustNotBePointer(nameof(type));
-            }
-
             if (value == null)
             {
                 if (type == typeof(object))

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/DefaultExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/DefaultExpression.cs
@@ -66,16 +66,6 @@ namespace System.Linq.Expressions
         {
             ContractUtils.RequiresNotNull(type, nameof(type));
             TypeUtils.ValidateType(type, nameof(type));
-            if (type.IsByRef)
-            {
-                throw Error.TypeMustNotBeByRef(nameof(type));
-            }
-
-            if (type.IsPointer)
-            {
-                throw Error.TypeMustNotBePointer(nameof(type));
-            }
-
             return new DefaultExpression(type);
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/DynamicExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/DynamicExpression.cs
@@ -1271,7 +1271,7 @@ namespace System.Linq.Expressions
             ExpressionUtils.RequiresCanRead(arg, paramName, index);
             var type = arg.Type;
             ContractUtils.RequiresNotNull(type, nameof(type));
-            TypeUtils.ValidateType(type, nameof(type));
+            TypeUtils.ValidateType(type, nameof(type), allowByRef: true, allowPointer: true);
             if (type == typeof(void)) throw Error.ArgumentTypeCannotBeVoid();
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/GotoExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/GotoExpression.cs
@@ -347,15 +347,6 @@ namespace System.Linq.Expressions
                 if (type != null)
                 {
                     TypeUtils.ValidateType(type, nameof(type));
-                    if (type.IsByRef)
-                    {
-                        throw Error.TypeMustNotBeByRef(nameof(type));
-                    }
-
-                    if (type.IsPointer)
-                    {
-                        throw Error.TypeMustNotBePointer(nameof(type));
-                    }
                 }
             }
             else

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LabelTarget.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LabelTarget.cs
@@ -81,15 +81,6 @@ namespace System.Linq.Expressions
         {
             ContractUtils.RequiresNotNull(type, nameof(type));
             TypeUtils.ValidateType(type, nameof(type));
-            if (type.IsByRef)
-            {
-                throw Error.TypeMustNotBeByRef(nameof(type));
-            }
-
-            if (type.IsPointer)
-            {
-                throw Error.TypeMustNotBePointer(nameof(type));
-            }
             return new LabelTarget(type, name);
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
@@ -891,7 +891,7 @@ namespace System.Linq.Expressions
                 throw Error.LambdaTypeMustBeDerivedFromSystemDelegate(paramName);
             }
 
-            TypeUtils.ValidateType(delegateType, nameof(delegateType));
+            TypeUtils.ValidateType(delegateType, nameof(delegateType), allowByRef: true, allowPointer: true);
 
             MethodInfo mi;
             CacheDict<Type, MethodInfo> ldc = s_lambdaDelegateCache;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberMemberBinding.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberMemberBinding.cs
@@ -126,7 +126,7 @@ namespace System.Linq.Expressions
             }
 
             // Null paramName as there are several paths here with different parameter names at the API
-            TypeUtils.ValidateType(decType, null);
+            TypeUtils.ValidateType(decType, null, allowByRef: true, allowPointer: true);
             switch (member)
             {
                 case PropertyInfo pi:

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/NewArrayExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/NewArrayExpression.cs
@@ -137,16 +137,6 @@ namespace System.Linq.Expressions
             }
 
             TypeUtils.ValidateType(type, nameof(type));
-            if (type.IsByRef)
-            {
-                throw Error.TypeMustNotBeByRef(nameof(type));
-            }
-
-            if (type.IsPointer)
-            {
-                throw Error.TypeMustNotBePointer(nameof(type));
-            }
-
             ReadOnlyCollection<Expression> initializerList = initializers.ToReadOnly();
 
             Expression[] newList = null;
@@ -215,15 +205,6 @@ namespace System.Linq.Expressions
             }
 
             TypeUtils.ValidateType(type, nameof(type));
-            if (type.IsByRef)
-            {
-                throw Error.TypeMustNotBeByRef(nameof(type));
-            }
-
-            if (type.IsPointer)
-            {
-                throw Error.TypeMustNotBePointer(nameof(type));
-            }
 
             ReadOnlyCollection<Expression> boundsList = bounds.ToReadOnly();
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/NewExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/NewExpression.cs
@@ -135,7 +135,7 @@ namespace System.Linq.Expressions
         {
             ContractUtils.RequiresNotNull(constructor, nameof(constructor));
             ContractUtils.RequiresNotNull(constructor.DeclaringType, nameof(constructor) + "." + nameof(constructor.DeclaringType));
-            TypeUtils.ValidateType(constructor.DeclaringType, nameof(constructor));
+            TypeUtils.ValidateType(constructor.DeclaringType, nameof(constructor), allowByRef: true, allowPointer: true);
             ValidateConstructor(constructor, nameof(constructor));
             ReadOnlyCollection<Expression> argList = arguments.ToReadOnly();
             ValidateArgumentTypes(constructor, ExpressionType.New, ref argList, nameof(constructor));
@@ -154,7 +154,7 @@ namespace System.Linq.Expressions
         {
             ContractUtils.RequiresNotNull(constructor, nameof(constructor));
             ContractUtils.RequiresNotNull(constructor.DeclaringType, nameof(constructor) + "." + nameof(constructor.DeclaringType));
-            TypeUtils.ValidateType(constructor.DeclaringType, nameof(constructor));
+            TypeUtils.ValidateType(constructor.DeclaringType, nameof(constructor), allowByRef: true, allowPointer: true);
             ValidateConstructor(constructor, nameof(constructor));
             ReadOnlyCollection<MemberInfo> memberList = members.ToReadOnly();
             ReadOnlyCollection<Expression> argList = arguments.ToReadOnly();

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ParameterExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ParameterExpression.cs
@@ -176,8 +176,7 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="ParameterExpression"/> node with the specified name and type.</returns>
         public static ParameterExpression Parameter(Type type, string name)
         {
-            Validate(type);
-
+            Validate(type, allowByRef: true);
             bool byref = type.IsByRef;
             if (byref)
             {
@@ -195,29 +194,18 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="ParameterExpression"/> node with the specified name and type.</returns>
         public static ParameterExpression Variable(Type type, string name)
         {
-            Validate(type);
-
-            if (type.IsByRef)
-            {
-                throw Error.TypeMustNotBeByRef(nameof(type));
-            }
-
+            Validate(type, allowByRef: false);
             return ParameterExpression.Make(type, name, isByRef: false);
         }
 
-        private static void Validate(Type type)
+        private static void Validate(Type type, bool allowByRef)
         {
             ContractUtils.RequiresNotNull(type, nameof(type));
-            TypeUtils.ValidateType(type, nameof(type));
+            TypeUtils.ValidateType(type, nameof(type), allowByRef, allowPointer: false);
 
             if (type == typeof(void))
             {
                 throw Error.ArgumentCannotBeOfTypeVoid(nameof(type));
-            }
-
-            if (type.IsPointer)
-            {
-                throw Error.TypeMustNotBePointer(nameof(type));
             }
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
@@ -714,16 +714,6 @@ namespace System.Linq.Expressions
             ExpressionUtils.RequiresCanRead(expression, nameof(expression));
             ContractUtils.RequiresNotNull(type, nameof(type));
             TypeUtils.ValidateType(type, nameof(type));
-            if (type.IsByRef)
-            {
-                throw Error.TypeMustNotBeByRef(nameof(type));
-            }
-
-            if (type.IsPointer)
-            {
-                throw Error.TypeMustNotBePointer(nameof(type));
-            }
-
             if (type.IsValueType && !type.IsNullableType())
             {
                 throw Error.IncorrectTypeForTypeAs(type, nameof(type));
@@ -779,16 +769,6 @@ namespace System.Linq.Expressions
             ExpressionUtils.RequiresCanRead(expression, nameof(expression));
             ContractUtils.RequiresNotNull(type, nameof(type));
             TypeUtils.ValidateType(type, nameof(type));
-            if (type.IsByRef)
-            {
-                throw Error.TypeMustNotBeByRef(nameof(type));
-            }
-
-            if (type.IsPointer)
-            {
-                throw Error.TypeMustNotBePointer(nameof(type));
-            }
-
             if (method == null)
             {
                 if (expression.Type.HasIdentityPrimitiveOrNullableConversionTo(type) ||
@@ -829,16 +809,6 @@ namespace System.Linq.Expressions
             ExpressionUtils.RequiresCanRead(expression, nameof(expression));
             ContractUtils.RequiresNotNull(type, nameof(type));
             TypeUtils.ValidateType(type, nameof(type));
-            if (type.IsByRef)
-            {
-                throw Error.TypeMustNotBeByRef(nameof(type));
-            }
-
-            if (type.IsPointer)
-            {
-                throw Error.TypeMustNotBePointer(nameof(type));
-            }
-
             if (method == null)
             {
                 if (expression.Type.HasIdentityPrimitiveOrNullableConversionTo(type))
@@ -933,16 +903,6 @@ namespace System.Linq.Expressions
         {
             ContractUtils.RequiresNotNull(type, nameof(type));
             TypeUtils.ValidateType(type, nameof(type));
-            if (type.IsByRef)
-            {
-                throw Error.TypeMustNotBeByRef(nameof(type));
-            }
-
-            if (type.IsPointer)
-            {
-                throw Error.TypeMustNotBePointer(nameof(type));
-            }
-
             if (value != null)
             {
                 ExpressionUtils.RequiresCanRead(value, nameof(value));


### PR DESCRIPTION
The majority of calls to `ValidateType` happen along with tests that the type validated isn't a pointer or byref (in the other direction,all pointer checks and the majority of byref checks happen this way).

Make these checks part of `ValidateType` with an overload for the minority case where they aren't necessary (allowed or statically known not to be the case).