### PR TITLE
Fix IsolatedStorage difference in behavior and fix tests

### DIFF
--- a/src/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.cs
+++ b/src/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.cs
@@ -691,7 +691,7 @@ namespace System.IO.IsolatedStorage
             if (Disposed)
                 throw new ObjectDisposedException(null, SR.IsolatedStorage_StoreNotOpen);
 
-            if (_closed)
+            if (_closed || IsDeleted)
                 throw new InvalidOperationException(SR.IsolatedStorage_StoreNotOpen);
         }
 

--- a/src/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.cs
+++ b/src/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.cs
@@ -691,11 +691,6 @@ namespace System.IO.IsolatedStorage
             if (Disposed)
                 throw new ObjectDisposedException(null, SR.IsolatedStorage_StoreNotOpen);
 
-            if (IsDeleted)
-            {
-                throw new IsolatedStorageException(SR.IsolatedStorage_StoreNotOpen);
-            }
-
             if (_closed)
                 throw new InvalidOperationException(SR.IsolatedStorage_StoreNotOpen);
         }

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/CopyFileTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/CopyFileTests.cs
@@ -45,17 +45,17 @@ namespace System.IO.IsolatedStorage
         }
 
         [Fact]
-        public void CopyFile_ThrowsIsolatedStorageException()
+        public void CopyDeletedFile_ThrowsInvalidOperationException()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
             {
                 isf.Remove();
-                Assert.Throws<IsolatedStorageException>(() => isf.CopyFile("foo", "bar"));
+                Assert.Throws<InvalidOperationException>(() => isf.CopyFile("foo", "bar"));
             }
         }
 
         [Fact]
-        public void CopyFile_ThrowsInvalidOperationException()
+        public void CopyClosedFile_ThrowsInvalidOperationException()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
             {

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/CreateDirectoryTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/CreateDirectoryTests.cs
@@ -19,12 +19,12 @@ namespace System.IO.IsolatedStorage
         }
 
         [Fact]
-        public void CreateDirectory_ThrowsIsolatedStorageException()
+        public void CreateRemovedDirectory_ThrowsInvalidOperationException()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
             {
                 isf.Remove();
-                Assert.Throws<IsolatedStorageException>(() => isf.CreateDirectory("foo"));
+                Assert.Throws<InvalidOperationException>(() => isf.CreateDirectory("foo"));
             }
         }
 
@@ -40,7 +40,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Fact]
-        public void CreateDirectory_ThrowsInvalidOperationException()
+        public void CreateClosedDirectory_ThrowsInvalidOperationException()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
             {

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/CreateFileTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/CreateFileTests.cs
@@ -19,12 +19,12 @@ namespace System.IO.IsolatedStorage
         }
 
         [Fact]
-        public void CreateFile_ThrowsIsolatedStorageException()
+        public void CreateRemovedFile_ThrowsInvalidOperationException()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
             {
                 isf.Remove();
-                Assert.Throws<IsolatedStorageException>(() => isf.CreateFile("foo"));
+                Assert.Throws<InvalidOperationException>(() => isf.CreateFile("foo"));
             }
         }
 
@@ -40,7 +40,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Fact]
-        public void CreateFile_ThrowsInvalidOperationException()
+        public void CreateClosedFile_ThrowsInvalidOperationException()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
             {

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/DeleteDirectoryTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/DeleteDirectoryTests.cs
@@ -30,17 +30,17 @@ namespace System.IO.IsolatedStorage
         }
 
         [Fact]
-        public void DeleteDirectory_ThrowsIsolatedStorageException()
+        public void DeleteRemovedDirectory_ThrowsInvalidOperationException()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
             {
                 isf.Remove();
-                Assert.Throws<IsolatedStorageException>(() => isf.DeleteDirectory("foo"));
+                Assert.Throws<InvalidOperationException>(() => isf.DeleteDirectory("foo"));
             }
         }
 
         [Fact]
-        public void DeleteDirectory_ThrowsInvalidOperationException()
+        public void DeleteClosedDirectory_ThrowsInvalidOperationException()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
             {

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/DeleteFileTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/DeleteFileTests.cs
@@ -30,17 +30,17 @@ namespace System.IO.IsolatedStorage
         }
 
         [Fact]
-        public void DeleteFile_ThrowsIsolatedStorageException()
+        public void DeleteRemovedFile_ThrowsInvalidOperationException()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
             {
                 isf.Remove();
-                Assert.Throws<IsolatedStorageException>(() => isf.DeleteFile("foo"));
+                Assert.Throws<InvalidOperationException>(() => isf.DeleteFile("foo"));
             }
         }
 
         [Fact]
-        public void DeleteFile_ThrowsInvalidOperationException()
+        public void DeleteClosedFile_ThrowsInvalidOperationException()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
             {

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/DirectoryExistsTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/DirectoryExistsTests.cs
@@ -30,17 +30,17 @@ namespace System.IO.IsolatedStorage
         }
 
         [Fact]
-        public void DirectoryExists_ThrowsIsolatedStorageException()
+        public void DirectoryExists_Removed_ThrowsInvalidOperationException()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
             {
                 isf.Remove();
-                Assert.Throws<IsolatedStorageException>(() => isf.DirectoryExists("foo"));
+                Assert.Throws<InvalidOperationException>(() => isf.DirectoryExists("foo"));
             }
         }
 
         [Fact]
-        public void DirectoryExists_ThrowsInvalidOperationException()
+        public void DirectoryExists_Closed_ThrowsInvalidOperationException()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
             {

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/FileExistsTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/FileExistsTests.cs
@@ -30,17 +30,17 @@ namespace System.IO.IsolatedStorage
         }
 
         [Fact]
-        public void FileExists_ThrowsIsolatedStorageException()
+        public void FileExists_Removed_ThrowsInvalidOperationException()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
             {
                 isf.Remove();
-                Assert.Throws<IsolatedStorageException>(() => isf.FileExists("foo"));
+                Assert.Throws<InvalidOperationException>(() => isf.FileExists("foo"));
             }
         }
 
         [Fact]
-        public void FileExists_ThrowsInvalidOperationException()
+        public void FileExists_Closed_ThrowsInvalidOperationException()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
             {

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetCreationTimeTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetCreationTimeTests.cs
@@ -19,12 +19,12 @@ namespace System.IO.IsolatedStorage
         }
 
         [Fact]
-        public void GetCreationTime_ThrowsIsolatedStorageException()
+        public void GetCreationTime_Removed_ThrowsInvalidOperationException()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
             {
                 isf.Remove();
-                Assert.Throws<IsolatedStorageException>(() => isf.GetCreationTime("foo"));
+                Assert.Throws<InvalidOperationException>(() => isf.GetCreationTime("foo"));
             }
         }
 
@@ -40,7 +40,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Fact]
-        public void GetCreationTime_ThrowsInvalidOperationException()
+        public void GetCreationTime_Closed_ThrowsInvalidOperationException()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
             {

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetFileNamesTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetFileNamesTests.cs
@@ -32,17 +32,17 @@ namespace System.IO.IsolatedStorage
         }
 
         [Fact]
-        public void GetFileNames_ThrowsIsolatedStorageException()
+        public void GetFileNames_Deleted_ThrowsInvalidOperationException()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
             {
                 isf.Remove();
-                Assert.Throws<IsolatedStorageException>(() => isf.GetFileNames("foo"));
+                Assert.Throws<InvalidOperationException>(() => isf.GetFileNames("foo"));
             }
         }
 
         [Fact]
-        public void GetFileNames_ThrowsInvalidOperationException()
+        public void GetFileNames_Closed_ThrowsInvalidOperationException()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
             {

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetLastAccessTimeTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetLastAccessTimeTests.cs
@@ -19,12 +19,12 @@ namespace System.IO.IsolatedStorage
         }
 
         [Fact]
-        public void GetLastAccessTime_ThrowsIsolatedStorageException()
+        public void GetLastAccessTime_Removed_ThrowsInvalidOperationException()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
             {
                 isf.Remove();
-                Assert.Throws<IsolatedStorageException>(() => isf.GetLastAccessTime("foo"));
+                Assert.Throws<InvalidOperationException>(() => isf.GetLastAccessTime("foo"));
             }
         }
 
@@ -40,7 +40,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Fact]
-        public void GetLastAccessTime_ThrowsInvalidOperationException()
+        public void GetLastAccessTime_Closed_ThrowsInvalidOperationException()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
             {

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetLastWriteTimeTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetLastWriteTimeTests.cs
@@ -19,12 +19,12 @@ namespace System.IO.IsolatedStorage
         }
 
         [Fact]
-        public void GetLastWriteTime_ThrowsIsolatedStorageException()
+        public void GetLastWriteTime_Deleted_ThrowsInvalidOperationException()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
             {
                 isf.Remove();
-                Assert.Throws<IsolatedStorageException>(() => isf.GetLastWriteTime("foo"));
+                Assert.Throws<InvalidOperationException>(() => isf.GetLastWriteTime("foo"));
             }
         }
 
@@ -40,7 +40,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Fact]
-        public void GetLastWriteTime_ThrowsInvalidOperationException()
+        public void GetLastWriteTime_Closed_ThrowsInvalidOperationException()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
             {

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/MoveDirectoryTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/MoveDirectoryTests.cs
@@ -41,17 +41,17 @@ namespace System.IO.IsolatedStorage
         }
 
         [Fact]
-        public void MoveDirectory_ThrowsIsolatedStorageException()
+        public void MoveDirectory_Removed_ThrowsInvalidOperationException()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
             {
                 isf.Remove();
-                Assert.Throws<IsolatedStorageException>(() => isf.MoveDirectory("foo", "bar"));
+                Assert.Throws<InvalidOperationException>(() => isf.MoveDirectory("foo", "bar"));
             }
         }
 
         [Fact]
-        public void MoveDirectory_ThrowsInvalidOperationException()
+        public void MoveDirectory_Closed_ThrowsInvalidOperationException()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
             {

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/MoveFileTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/MoveFileTests.cs
@@ -42,17 +42,17 @@ namespace System.IO.IsolatedStorage
         }
 
         [Fact]
-        public void MoveFile_ThrowsIsolatedStorageException()
+        public void MoveFile_Deleted_ThrowsInvalidOperationException()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
             {
                 isf.Remove();
-                Assert.Throws<IsolatedStorageException>(() => isf.MoveFile("foo", "bar"));
+                Assert.Throws<InvalidOperationException>(() => isf.MoveFile("foo", "bar"));
             }
         }
 
         [Fact]
-        public void MoveFile_ThrowsInvalidOperationException()
+        public void MoveFile_Closed_ThrowsInvalidOperationException()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
             {

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/OpenFileTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/OpenFileTests.cs
@@ -21,14 +21,14 @@ namespace System.IO.IsolatedStorage
         }
 
         [Fact]
-        public void OpenFile_ThrowsIsolatedStorageException()
+        public void OpenFile_Deleted_ThrowsInvalidOperationException()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
             {
                 isf.Remove();
-                Assert.Throws<IsolatedStorageException>(() => isf.OpenFile("foo", FileMode.Create));
-                Assert.Throws<IsolatedStorageException>(() => isf.OpenFile("foo", FileMode.Create, FileAccess.ReadWrite));
-                Assert.Throws<IsolatedStorageException>(() => isf.OpenFile("foo", FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite));
+                Assert.Throws<InvalidOperationException>(() => isf.OpenFile("foo", FileMode.Create));
+                Assert.Throws<InvalidOperationException>(() => isf.OpenFile("foo", FileMode.Create, FileAccess.ReadWrite));
+                Assert.Throws<InvalidOperationException>(() => isf.OpenFile("foo", FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite));
             }
         }
 
@@ -46,7 +46,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Fact]
-        public void OpenFile_ThrowsInvalidOperationException()
+        public void OpenFile_Closed_ThrowsInvalidOperationException()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())
             {


### PR DESCRIPTION
IsolatedStorageFile had some difference in behavior in between .Net Core and desktop where in desktop all the operations over a file/directory would throw `InvalidOperationException` if the file/directory is closed (which is also true if the item is deleted) but in .Net Core we would do an extra check if the item is deleted and throw an `IsolatedStorageException`.

This makes desktop and core behave the same.

Fixes: https://github.com/dotnet/corefx/issues/18266
Fixes: https://github.com/dotnet/corefx/issues/18803

cc: @danmosemsft @JeremyKuhne @ianhays 
