### PR TITLE
Root cause PostScenarioTests (Http) test failures on NETFX

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -1249,7 +1249,7 @@ namespace System.Net.Http
                 // If the exception was due to the cancellation token being canceled, throw cancellation exception.
                 state.Tcs.TrySetCanceled(state.CancellationToken);
             }
-            else if (ex is WinHttpException || ex is IOException)
+            else if (ex is WinHttpException || ex is IOException || ex is InvalidOperationException)
             {
                 // Wrap expected exceptions as HttpRequestExceptions since this is considered an error during
                 // execution. All other exception types, including ArgumentExceptions and ProtocolViolationExceptions

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpHandlerTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpHandlerTest.cs
@@ -577,7 +577,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         }
 
         [Fact]
-        public async Task SendAsync_PostNoContentObjectWithChunkedEncodingHeader_ExpectInvalidOperationException()
+        public async Task SendAsync_PostNoContentObjectWithChunkedEncodingHeader_ExpectHttpRequestException()
         {
             var handler = new WinHttpHandler();
             using (var client = new HttpClient(handler))
@@ -587,7 +587,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
 
                 var request = new HttpRequestMessage(HttpMethod.Post, TestServer.FakeServerEndpoint);
 
-                await Assert.ThrowsAsync<InvalidOperationException>(() => client.SendAsync(request));
+                await Assert.ThrowsAsync<HttpRequestException>(() => client.SendAsync(request));
             }
         }
 

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
@@ -188,7 +188,7 @@ namespace System.Net.Http
                 }
                 else
                 {
-                    if (error is IOException || error is CurlException || error == null)
+                    if (error is InvalidOperationException || error is IOException || error is CurlException || error == null)
                     {
                         error = CreateHttpRequestException(error);
                     }


### PR DESCRIPTION
Fixed a test bug in PostAuthHelper which caused the wrong entity-body
semantics to get used during the test. This actually exposed a netfx
bug dealing with ambiguous semantics (Content-Length vs. chunked).

After fixing this test bug, it then exposed a product bug where we
leak an InvalidOperationException that isn't wrapped properly by an
HttpRequestException. The scenario that exposed this related to
POST'ing content that is non-rewindable and having to resubmit the
POST due to authentication challenges. This test was passing on
.NET Core because the test was written using the wrong assumptions.
It failed on .NET Framework which exposed the problem.

The InvalidOperationException comes from when a StreamContent's
SerializeToStreamAsync method is called and the content needs to be rewound.
If the content can't be rewound, then the exception is thrown with the
error message "The stream was already consumed. It cannot be read again."

Updated the WinHttpHandler and CurlHandler to wrap the InvalidOperationException
in an HttpRequestException. Updated the test accordingly.

Fixes #17621.