### PR TITLE
Fix Desktop test failures in System.Xml.RW.ReaderSettings.Tests

### DIFF
--- a/src/System.Private.Xml/tests/Readers/ReaderSettings/MaxSettings.cs
+++ b/src/System.Private.Xml/tests/Readers/ReaderSettings/MaxSettings.cs
@@ -12,7 +12,7 @@ namespace System.Xml.Tests
     [TestCase(Name = "MaxCharacters Settings", Desc = "MaxCharacters Settings")]
     public partial class TCMaxSettings : TCXMLReaderBaseGeneral
     {
-        private long _defaultCharsEnt = (long)1e7;  // By default, entity resolving is limited to 10 million characters (On full .NET the default used to be zero (=unlimited) as LegacyXmlSettings was enabled)
+        private long _defaultCharsEnt = (PlatformDetection.IsFullFramework)?0:(long)1e7;  // By default, entity resolving is limited to 10 million characters (On full .NET the default used to be zero (=unlimited) as LegacyXmlSettings was enabled)
         private long _defaultCharsDoc = 0;
         private long _maxVal = Int64.MaxValue;
         private long _bigVal = 100000;

--- a/src/System.Private.Xml/tests/Readers/ReaderSettings/System.Xml.RW.ReaderSettings.Tests.csproj
+++ b/src/System.Private.Xml/tests/Readers/ReaderSettings/System.Xml.RW.ReaderSettings.Tests.csproj
@@ -28,6 +28,9 @@
     <Compile Include="TCOneByteStream.cs" />
     <Compile Include="TCReaderSettings.cs" />
     <Compile Include="TCRSGeneric.cs" />
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>CommonTest\System\PlatformDetection.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(CommonTestPath)\System\Xml\BaseLibManaged\BaseLibManaged.csproj" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/18812. The failure was due to a behavior change between Desktop and Core, On Desktop, XmlReaderSettings used to read full framework registry keys to decide the default value of entity resolving limit. Default used to be 0 (=unlimited), but is 10 million characters now.
[The user can still override it with any value.] Limit should be ON by default - for most of the normal and valid XML documents you should not have problems with limits.

cc: @krwq @danmosemsft 