### PR TITLE
Emit a assembly graph when analyzing fx packages

### DIFF
--- a/pkg/frameworkPackage.targets
+++ b/pkg/frameworkPackage.targets
@@ -113,7 +113,8 @@
 
     <Message Importance="High" Text="Verifying closure of $(Id) %(ClosureFile.FileSet) assemblies" />
     <VerifyClosure Sources="@(_closureFileFiltered)"
-                   IgnoredReferences="@(IgnoredReference)" />
+                   IgnoredReferences="@(IgnoredReference)"
+                   DependencyGraphFilePath="$(PackageReportDir)$(Id)$(NuspecSuffix)-%(ClosureFile.FileSet).dgml" />
 
   </Target>
 


### PR DESCRIPTION
This will drop a dgml for each framework package when validating the assembly closure.

This is useful for understanding which assemblies can be removed from the framework package.

/cc @weshaggard @ianhays 