### PR TITLE
Disable System.IO.IsolatedStorage test for uap-aot.

### DIFF
--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/ContainsUnknownFilesTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/ContainsUnknownFilesTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage
 {
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
     public class ContainsUnknownFilesTests : IsoStorageTest
     {
         private static MethodInfo s_containsUnknownFilesMethod

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/CopyFileTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/CopyFileTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage
 {
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
     public class CopyFileTests : IsoStorageTest
     {
         [Fact]

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/CreateDirectoryTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/CreateDirectoryTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage
 {
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
     public class CreateDirectoryTests : IsoStorageTest
     {
         [Fact]

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/CreateFileTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/CreateFileTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage
 {
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
     public class CreateFileTests : IsoStorageTest
     {
         [Fact]

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/DeleteDirectoryTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/DeleteDirectoryTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage
 {
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
     public class DeleteDirectoryTests : IsoStorageTest
     {
         [Fact]

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/DeleteFileTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/DeleteFileTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage
 {
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
     public class DeleteFileTests : IsoStorageTest
     {
         [Fact]

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/DirectoryExistsTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/DirectoryExistsTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage
 {
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
     public class DirectoryExistsTests : IsoStorageTest
     {
         [Fact]

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/FileExistsTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/FileExistsTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage
 {
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
     public class FileExistsTests : IsoStorageTest
     {
         [Fact]

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetCreationTimeTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetCreationTimeTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage
 {
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
     public class GetCreationTimeTests : IsoStorageTest
     {
         [Fact]

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetFileNamesTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetFileNamesTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage
 {
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
     public class GetFileNamesTests : IsoStorageTest
     {
         [Fact]

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetLastAccessTimeTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetLastAccessTimeTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage
 {
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
     public class GetLastAccessTimeTests : IsoStorageTest
     {
         [Fact]

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetLastWriteTimeTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetLastWriteTimeTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage
 {
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
     public class GetLastWriteTimeTests : IsoStorageTest
     {
         [Fact]

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetStoreTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetStoreTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage
 {
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
     public class GetStoreTests : IsoStorageTest
     {
         private static MethodInfo s_verifyScopeMethod;

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/HelperTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/HelperTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage.Tests
 {
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
     public class HelperTests
     {
         [Fact]

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/IdentityTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/IdentityTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage
 {
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
     public class IdentityTests : IsoStorageTest
     {
         private class TestStorage : IsolatedStorage

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/IsoStorageTest.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/IsoStorageTest.cs
@@ -11,6 +11,7 @@ namespace System.IO.IsolatedStorage
     // We put the tests in the "Store collection" to get them to pick up the StoreTestsFixture. This will run the fixture
     // at the start and end of the collection, cleaning the test environment.
     [Collection("Store collection")]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
     public class IsoStorageTest
     {
         public static IEnumerable<object[]> ValidScopes

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/IsolatedStorageBaseClassTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/IsolatedStorageBaseClassTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 namespace System.IO.IsolatedStorage
 {
     // Test default IsolatedStorage base class behaviors
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
     public class IsolatedStorageBaseClassTests : IsoStorageTest
     {
         private class TestStorage : IsolatedStorage

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/MoveDirectoryTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/MoveDirectoryTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage
 {
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
     public class MoveDirectoryTests : IsoStorageTest
     {
         [Fact]

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/MoveFileTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/MoveFileTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage
 {
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
     public class MoveFileTests : IsoStorageTest
     {
         [Fact]

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/OpenFileTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/OpenFileTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage
 {
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
     public class OpenFileTests : IsoStorageTest
     {
         [Fact]

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/RemoveTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/RemoveTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage
 {
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
     public class RemoveTests : IsoStorageTest
     {
         [Fact]


### PR DESCRIPTION
Disabling since these tests need to be run from an appcontainer which the infrastructure
do not support. #18940 