### PR TITLE
Disable Aes test TestDecryptorReusability when quirk disabled or old netfx

### DIFF
--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/AES/DecryptorReusability.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/AES/DecryptorReusability.cs
@@ -10,13 +10,10 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
 
     public static class DecryptorReusabilty
     {
-        [Fact]
+        // See https://github.com/dotnet/corefx/issues/18903 for details
+        [ConditionalFact(nameof(ShouldDescriptorBeReusable))]
         public static void TestDecryptorReusability()
         {
-            // See https://github.com/dotnet/corefx/issues/18903 for details
-            if (!ShouldDescriptorBeReusable())
-                return;
-
             byte[] expectedPlainText = new byte[]
             {
                 0x14, 0x30, 0x71, 0xad, 0xed, 0x8e, 0x58, 0x84,

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/AES/DecryptorReusability.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/AES/DecryptorReusability.cs
@@ -11,7 +11,7 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
     public static class DecryptorReusabilty
     {
         // See https://github.com/dotnet/corefx/issues/18903 for details
-        [ConditionalFact(nameof(ShouldDescriptorBeReusable))]
+        [ConditionalFact(nameof(ShouldDecryptorBeReusable))]
         public static void TestDecryptorReusability()
         {
             byte[] expectedPlainText = new byte[]
@@ -68,7 +68,7 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
             }
         }
 
-        private static bool ShouldDescriptorBeReusable()
+        private static bool ShouldDecryptorBeReusable()
         {
             if (!PlatformDetection.IsFullFramework)
                 return true;

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/AES/DecryptorReusability.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/AES/DecryptorReusability.cs
@@ -13,6 +13,10 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
         [Fact]
         public static void TestDecryptorReusability()
         {
+            // See https://github.com/dotnet/corefx/issues/18903 for details
+            if (!ShouldDescriptorBeReusable())
+                return;
+
             byte[] expectedPlainText = new byte[]
             {
                 0x14, 0x30, 0x71, 0xad, 0xed, 0x8e, 0x58, 0x84,
@@ -65,6 +69,20 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
                     Assert.Equal(expectedPlainText, output2);
                 }
             }
+        }
+
+        private static bool ShouldDescriptorBeReusable()
+        {
+            if (!PlatformDetection.IsFullFramework)
+                return true;
+
+            bool doNotResetDecryptor;
+            if (AppContext.TryGetSwitch("Switch.System.Security.Cryptography.AesCryptoServiceProvider.DontCorrectlyResetDecryptor", out doNotResetDecryptor))
+            {
+                return !doNotResetDecryptor;
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/18903

I've manually tested the test is still being run on Core