### PR TITLE
Update XUnit Package Version

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -125,7 +125,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <XUnitPackageVersion>2.2.0-beta4-build3444</XUnitPackageVersion>
+    <XUnitPackageVersion>2.3.0-beta1-build3642</XUnitPackageVersion>
   </PropertyGroup>
 
   <!-- Set up dependencies on packages that aren't found in a BuildInfo. -->


### PR DESCRIPTION
While investigating https://github.com/dotnet/corefx/issues/18812, @safern and I realized that the runtime version for Full Framework is .NETFramework,Version=v4.5 instead of .NETFramework,Version=v4.5.2 which was expected. Turned out the XUnit package version had not been updated and we were running against 4.5. This should fix a bunch of Desktop test failures.

Closes:  https://github.com/dotnet/corefx/issues/18812

cc: @safern  @danmosemsft 