### PR TITLE
Enable testing using remote processes in uapaot

### DIFF
--- a/Tools-Override/RunnerTemplate.Windows.txt
+++ b/Tools-Override/RunnerTemplate.Windows.txt
@@ -12,10 +12,10 @@ echo Executing in %EXECUTION_DIR%
 
 :: ========================= BEGIN Test Execution ============================= 
 echo Running tests... Start time: %TIME%
-echo Command(s):
-[[TestRunCommandsEcho]]
 pushd %EXECUTION_DIR%
+echo on
 [[TestRunCommands]]
+@echo off
 popd
 echo Finished running tests.  End time=%TIME%, Exit code = %ERRORLEVEL%
 EXIT /B %ERRORLEVEL%

--- a/Tools-Override/tests.targets
+++ b/Tools-Override/tests.targets
@@ -229,13 +229,20 @@
     </PropertyGroup>
     
     <ItemGroup Condition="'$(UseDotNetNativeToolchain)' == 'true' AND '$(Performance)'!='true'" >
+      <TargetExecutableNames Include="xunit.console.netcore.exe"/>
+      <TargetExecutableNames Condition="'%(ProjectReference.Filename)' == 'RemoteExecutorConsoleApp'" Include="RemoteExecutorConsoleApp.exe"/>
       <IlcInputFolderContents Include="$(ILCFXInputFolder)/*" />
       <TestCommandLines Include="mklink /H %(IlcInputFolderContents.Filename)%(IlcInputFolderContents.Extension) $(_Runtime_Path)%(IlcInputFolderContents.Filename)%(IlcInputFolderContents.Extension)" />
       <TestCommandLines Include="copy /y $(_TestILCFolder)\default.rd.xml  %EXECUTION_DIR%" />
-      <TestCommandLines Include="call $(_TestILCFolder)\ilc.exe -ExeName xunit.console.netcore.exe -in %EXECUTION_DIR% -out %EXECUTION_DIR%\native -usedefaultpinvoke -buildtype $(ILCBuildType) -v diag" />
-      <TestCommandLines Include="set ILCERRORLEVEL=%ERRORLEVEL%" />
-      <TestCommandLines Include="if NOT [%ILCERRORLEVEL%] == [0] exit /b %ILCERRORLEVEL%" />
-      <TestCommandLines Include="copy /y $(_TestILCFolder)\CRT\vcruntime140_app.dll %EXECUTION_DIR%\native" />
+      <TestCommandLines Include="rmdir /S /Q %EXECUTION_DIR%int" />
+      <TestCommandLines Include="rmdir /S /Q %EXECUTION_DIR%native" />
+      <TestCommandLines Include="@(TargetExecutableNames -> '
+call %RUNTIME_PATH%\TestILC\ilc.exe -ExeName %(Identity) -in %EXECUTION_DIR% -out %EXECUTION_DIR%int\%(Identity)\ -usedefaultpinvoke -buildtype $(ILCBuildType) -v diag
+set ILCERRORLEVEL=%ERRORLEVEL%
+if NOT [%ILCERRORLEVEL%] == [0] exit /b %ILCERRORLEVEL%
+robocopy /S /NP %EXECUTION_DIR%int\%(Identity)\ %EXECUTION_DIR%native\
+')"/>
+      <TestCommandLines Include="copy /y $(_TestILCFolder)\CRT\vcruntime140_app.dll %EXECUTION_DIR%native" />
       <TestCommandLines Include="echo > %EXECUTION_DIR%\native\$(XunitTestAssembly)"/>
       <TestCommandLines Include="cd native"/>
       <PostExecutionTestCommandLines Include="type Xunit.Console.Output.txt" />

--- a/src/Common/tests/System/Diagnostics/RemoteExecutorTestBase.cs
+++ b/src/Common/tests/System/Diagnostics/RemoteExecutorTestBase.cs
@@ -143,27 +143,17 @@ namespace System.Diagnostics
             if (!File.Exists(TestConsoleApp))
                 throw new IOException("RemoteExecutorConsoleApp test app isn't present in the test runtime directory.");
 
-            if (IsFullFramework)
+            if (IsFullFramework || IsNetNative)
             {
                 psi.FileName = TestConsoleApp;
                 psi.Arguments = testConsoleAppArgs;
-            }
-            else if (IsNetNative)
-            {
-                psi.FileName = TestConsoleApp;
-                psi.Arguments = testConsoleAppArgs;
-
-                // The test pipeline does not have the infrastructure to copy RemoteExecutorConsoleApp.exe to the test directly, let alone
-                // ILC it against whatever assembly it might be asked to load up. (Is UWP even allowed to spin up a process!?)
-                // Until, and unless that's fixed, throw an informative exception so as not to waste debugging time.
-                throw new Exception(".NET Native platforms cannot run tests that use RemoteExecutorTestBase.RemoteInvoke()");
             }
             else
             {
                 psi.FileName = HostRunner;
                 psi.Arguments = TestConsoleApp + " " + testConsoleAppArgs;
             }
-         
+
             // Return the handle to the process, which may or not be started
             return new RemoteInvokeHandle(options.Start ?
                 Process.Start(psi) :


### PR DESCRIPTION
This change enables using the RemoteExecutorConsoleApp on AOT by
compiling each executable in the input directory and merging the
outputs.