### PR TITLE
Fix 2 failing IO tests.

### DIFF
--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.WaitForChanged.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.WaitForChanged.cs
@@ -125,6 +125,7 @@ namespace System.IO.Tests
         }
 
         [Theory]
+        [OuterLoop("This test has a longer than average timeout and may fail intermittently")]
         [InlineData(WatcherChangeTypes.Created)]
         [InlineData(WatcherChangeTypes.Deleted)]
         public void CreatedDeleted_Success(WatcherChangeTypes changeType)
@@ -134,7 +135,7 @@ namespace System.IO.Tests
             {
                 for (int i = 1; i <= DefaultAttemptsForExpectedEvent; i++)
                 {
-                    Task<WaitForChangedResult> t = Task.Run(() => fsw.WaitForChanged(changeType, WaitForExpectedEventTimeout));
+                    Task<WaitForChangedResult> t = Task.Run(() => fsw.WaitForChanged(changeType, LongWaitTimeout));
                     while (!t.IsCompleted)
                     {
                         string path = Path.Combine(testDirectory.Path, Path.GetRandomFileName());
@@ -164,6 +165,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [OuterLoop("This test has a longer than average timeout and may fail intermittently")]
         public void Changed_Success()
         {
             using (var testDirectory = new TempDirectory(GetTestFilePath()))
@@ -174,7 +176,7 @@ namespace System.IO.Tests
                     string name = Path.Combine(testDirectory.Path, Path.GetRandomFileName());
                     File.Create(name).Dispose();
 
-                    Task<WaitForChangedResult> t = Task.Run(() => fsw.WaitForChanged(WatcherChangeTypes.Changed, WaitForExpectedEventTimeout));
+                    Task<WaitForChangedResult> t = Task.Run(() => fsw.WaitForChanged(WatcherChangeTypes.Changed, LongWaitTimeout));
                     while (!t.IsCompleted)
                     {
                         File.AppendAllText(name, "text");
@@ -199,6 +201,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [OuterLoop("This test has a longer than average timeout and may fail intermittently")]
         public void Renamed_Success()
         {
             using (var testDirectory = new TempDirectory(GetTestFilePath()))
@@ -207,7 +210,7 @@ namespace System.IO.Tests
                 for (int i = 1; i <= DefaultAttemptsForExpectedEvent; i++)
                 {
                     Task<WaitForChangedResult> t = Task.Run(() =>
-                        fsw.WaitForChanged(WatcherChangeTypes.Renamed | WatcherChangeTypes.Created, WaitForExpectedEventTimeout)); // on some OSes, the renamed might come through as Deleted/Created
+                        fsw.WaitForChanged(WatcherChangeTypes.Renamed | WatcherChangeTypes.Created, LongWaitTimeout)); // on some OSes, the renamed might come through as Deleted/Created
 
                     string name = Path.Combine(testDirectory.Path, Path.GetRandomFileName());
                     File.Create(name).Dispose();

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
@@ -626,6 +626,7 @@ namespace System.IO.MemoryMappedFiles.Tests
         /// Test to validate we can create multiple concurrent read-only maps from the same file path.
         /// </summary>
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "On netfx, the MMF.CreateFromFile default FileShare is None. We intentionally changed it in netcoreapp.")]
         public void FileInUse_CreateFromFile_SucceedsWithReadOnly()
         {
             const int Capacity = 4096;

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
@@ -626,7 +626,7 @@ namespace System.IO.MemoryMappedFiles.Tests
         /// Test to validate we can create multiple concurrent read-only maps from the same file path.
         /// </summary>
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "On netfx, the MMF.CreateFromFile default FileShare is None. We intentionally changed it in netcoreapp.")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "On netfx, the MMF.CreateFromFile default FileShare is None. We intentionally changed it in netcoreapp in #6092.")]
         public void FileInUse_CreateFromFile_SucceedsWithReadOnly()
         {
             const int Capacity = 4096;


### PR DESCRIPTION
The MMF test is failing from a purposeful design change around the default FileShare being used in CreateFromFile. The FSW tests are failing intermittently from inconsistency so I'm reverting my recent change to move them to innerloop and reduce their wait time.

resolves https://github.com/dotnet/corefx/issues/18630
resolves https://github.com/dotnet/corefx/issues/17725

@safern @danmosemsft 