### PR TITLE
Allow previously not supported GetStore overloads that pass null.

### DIFF
--- a/src/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.cs
+++ b/src/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.cs
@@ -612,25 +612,25 @@ namespace System.IO.IsolatedStorage
         public static IsolatedStorageFile GetStore(IsolatedStorageScope scope, Type applicationEvidenceType)
         {
             // Scope MUST be Application
-            throw new PlatformNotSupportedException(SR.PlatformNotSupported_CAS); // https://github.com/dotnet/corefx/issues/10935
+            return (applicationEvidenceType == null) ? GetStore(scope) : throw new PlatformNotSupportedException(SR.PlatformNotSupported_CAS); // https://github.com/dotnet/corefx/issues/10935
         }
 
         public static IsolatedStorageFile GetStore(IsolatedStorageScope scope, object applicationIdentity)
         {
             // Scope MUST be Application
-            throw new PlatformNotSupportedException(SR.PlatformNotSupported_CAS); // https://github.com/dotnet/corefx/issues/10935
+            return (applicationIdentity == null) ? GetStore(scope) : throw new PlatformNotSupportedException(SR.PlatformNotSupported_CAS); // https://github.com/dotnet/corefx/issues/10935
         }
 
         public static IsolatedStorageFile GetStore(IsolatedStorageScope scope, Type domainEvidenceType, Type assemblyEvidenceType)
         {
             // Scope MUST NOT be Application (assembly is assumed otherwise)
-            throw new PlatformNotSupportedException(SR.PlatformNotSupported_CAS); // https://github.com/dotnet/corefx/issues/10935
+            return (domainEvidenceType == null && assemblyEvidenceType == null) ? GetStore(scope) : throw new PlatformNotSupportedException(SR.PlatformNotSupported_CAS); // https://github.com/dotnet/corefx/issues/10935
         }
 
         public static IsolatedStorageFile GetStore(IsolatedStorageScope scope, object domainIdentity, object assemblyIdentity)
         {
             // Scope MUST NOT be Application (assembly is assumed otherwise)
-            throw new PlatformNotSupportedException(SR.PlatformNotSupported_CAS); // https://github.com/dotnet/corefx/issues/10935
+            return (domainIdentity == null && assemblyIdentity == null) ? GetStore(scope) : throw new PlatformNotSupportedException(SR.PlatformNotSupported_CAS); // https://github.com/dotnet/corefx/issues/10935
         }
 
         // https://github.com/dotnet/corefx/issues/10935

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetStoreTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetStoreTests.cs
@@ -53,6 +53,11 @@ namespace System.IO.IsolatedStorage
         public void GetUserStoreForApplication()
         {
             var isf = IsolatedStorageFile.GetUserStoreForApplication();
+            VerifyApplicationStore(isf);
+        }
+
+        private void VerifyApplicationStore(IsolatedStorageFile isf)
+        {
             string root = isf.GetUserRootDirectory();
             Assert.EndsWith(@"AppFiles" + Path.DirectorySeparatorChar, root);
             Assert.True(Directory.Exists(root), "store root folder should exist");
@@ -84,6 +89,15 @@ namespace System.IO.IsolatedStorage
             Assert.Throws<PlatformNotSupportedException>(() => IsolatedStorageFile.GetStore(IsolatedStorageScope.User, typeof(object), typeof(object)));
             Assert.Throws<PlatformNotSupportedException>(() => IsolatedStorageFile.GetStore(IsolatedStorageScope.User, new object()));
             Assert.Throws<PlatformNotSupportedException>(() => IsolatedStorageFile.GetStore(IsolatedStorageScope.User, new object(), new object()));
+        }
+
+        [Fact]
+        public void GetStore_NullParamsAllowed()
+        {
+            VerifyApplicationStore(IsolatedStorageFile.GetStore(IsolatedStorageScope.User | IsolatedStorageScope.Application, (Type)null));
+            VerifyApplicationStore(IsolatedStorageFile.GetStore(IsolatedStorageScope.User | IsolatedStorageScope.Application, (Type)null, (Type)null));
+            VerifyApplicationStore(IsolatedStorageFile.GetStore(IsolatedStorageScope.User | IsolatedStorageScope.Application, (object)null));
+            VerifyApplicationStore(IsolatedStorageFile.GetStore(IsolatedStorageScope.User | IsolatedStorageScope.Application, (object)null, (object)null));
         }
 
         [Fact]


### PR DESCRIPTION
The GetStore overloads other than the IsoStorageScope throw PSNE for any input. This commit modifies them to check for null inputs and treat the method as equivalent to a 1-arg GetStore in that case.

resolves https://github.com/dotnet/corefx/issues/18706

@JeremyKuhne @billwert 