### PR TITLE
Fixed test under System.Diagnostics.Tracing

### DIFF
--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsManifestNegative.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsManifestNegative.cs
@@ -42,6 +42,7 @@ namespace BasicEventSourceTests
         /// For NuGet EventSources we validate both "runtime" and "validation" behavior
         /// </summary>
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full Framework doesn't have System.SR type which is used in this test.")]
         public void Test_GenerateManifest_InvalidEventSources()
         {
             TestUtilities.CheckNoEventSourcesRunning("Start");

--- a/src/System.Diagnostics.Tracing/tests/System.Diagnostics.Tracing.Tests.csproj
+++ b/src/System.Diagnostics.Tracing/tests/System.Diagnostics.Tracing.Tests.csproj
@@ -33,6 +33,9 @@
     <Compile Include="CustomEventSources\SimpleEventSource.cs" />
     <Compile Include="CustomEventSources\UseAbstractEventSource.cs" />
     <Compile Include="CustomEventSources\UseInterfaceEventSource.cs" />
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>CommonTest\System\PlatformDetection.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/18807

Fixed the test to get the actually resource string from Environment.GetResourceString via reflection on Desktop

cc: @danmosemsft @vancem 