### PR TITLE
Skip more System.Runtime.Tests on UWP/AOT

### DIFF
--- a/src/Common/tests/System/Collections/IEnumerable.Generic.Serialization.Tests.cs
+++ b/src/Common/tests/System/Collections/IEnumerable.Generic.Serialization.Tests.cs
@@ -3,10 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Runtime.Serialization.Formatters.Binary;
+using System.Runtime.Serialization.Formatters.Tests;
 using Xunit;
 
 namespace System.Collections.Tests
@@ -18,24 +15,18 @@ namespace System.Collections.Tests
         public void IGenericSharedAPI_SerializeDeserialize(int count)
         {
             IEnumerable<T> expected = GenericIEnumerableFactory(count);
-            var bf = new BinaryFormatter();
-            using (var ms = new MemoryStream())
-            {
-                bf.Serialize(ms, expected);
-                ms.Position = 0;
-                IEnumerable<T> actual = (IEnumerable<T>)bf.Deserialize(ms);
+            IEnumerable<T> actual = BinaryFormatterHelpers.Clone(expected);
 
-                if (Order == EnumerableOrder.Sequential)
-                {
-                    Assert.Equal(expected, actual);
-                }
-                else
-                {
-                    var expectedSet = new HashSet<T>(expected);
-                    var actualSet = new HashSet<T>(actual);
-                    Assert.Subset(expectedSet, actualSet);
-                    Assert.Subset(actualSet, expectedSet);
-                }
+            if (Order == EnumerableOrder.Sequential)
+            {
+                Assert.Equal(expected, actual);
+            }
+            else
+            {
+                var expectedSet = new HashSet<T>(expected);
+                var actualSet = new HashSet<T>(actual);
+                Assert.Subset(expectedSet, actualSet);
+                Assert.Subset(actualSet, expectedSet);
             }
         }
     }

--- a/src/Common/tests/System/Runtime/Serialization/Formatters/BinaryFormatterHelpers.cs
+++ b/src/Common/tests/System/Runtime/Serialization/Formatters/BinaryFormatterHelpers.cs
@@ -27,7 +27,19 @@ namespace System.Runtime.Serialization.Formatters.Tests
 			}
 		}
 
-		public static void AssertRoundtrips<T>(T expected, params Func<T, object>[] additionalGetters)
+        internal static Lazy<T> Clone<T>(Lazy<T> lazy)
+        {
+            // https://github.com/dotnet/corefx/issues/18942 - Binary serialization still WIP on AOT platforms.
+            if (RuntimeInformation.FrameworkDescription.StartsWith(".NET Native"))
+            {
+                T ignore = lazy.Value;
+                return lazy;
+            }
+
+            return Clone<Lazy<T>>(lazy);
+        }
+
+        public static void AssertRoundtrips<T>(T expected, params Func<T, object>[] additionalGetters)
 			where T : Exception
 		{
 			for (int i = 0; i < 2; i++)

--- a/src/System.Collections.Concurrent/tests/System.Collections.Concurrent.Tests.csproj
+++ b/src/System.Collections.Concurrent/tests/System.Collections.Concurrent.Tests.csproj
@@ -71,6 +71,9 @@
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
       <Link>CommonTest\System\PlatformDetection.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
+      <Link>System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
+    </Compile>
     <Compile Include="BlockingCollectionCancellationTests.cs" />
     <Compile Include="BlockingCollectionTests.cs" />
     <Compile Include="ConcurrentBagTests.cs" />

--- a/src/System.Collections/tests/System.Collections.Tests.csproj
+++ b/src/System.Collections/tests/System.Collections.Tests.csproj
@@ -77,6 +77,9 @@
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
       <Link>CommonTest\System\PlatformDetection.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
+      <Link>System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
+    </Compile>
     <!-- Generic tests -->
     <Compile Include="Generic\Dictionary\Dictionary.Generic.Tests.netcoreapp.cs"  Condition="'$(TargetGroup)' == 'netcoreapp'"/>
     <Compile Include="Generic\SortedSet\SortedSet.TreeSubSet.Tests.cs" />

--- a/src/System.Runtime/tests/System/Attributes.cs
+++ b/src/System.Runtime/tests/System/Attributes.cs
@@ -204,6 +204,7 @@ namespace System.Tests
     {
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "CustomAttributes on Modules not supported in UapAot")]
         public static void customAttributeCount()
         {
             List<CustomAttributeData> customAttributes =  typeof(GetCustomAttribute).Module.CustomAttributes.ToList();
@@ -373,6 +374,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "CustomAttributes on Modules not supported in UapAot")]
         public static void PositiveTest5()
         {
             Type clsType = typeof(GetCustomAttribute);
@@ -405,6 +407,7 @@ namespace System.Tests
 
         }
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "CustomAttributes on Modules not supported in UapAot")]
         public static void PositiveTest6()
         {
             Type clsType = typeof(GetCustomAttribute);

--- a/src/System.Runtime/tests/System/ExceptionTests.cs
+++ b/src/System.Runtime/tests/System/ExceptionTests.cs
@@ -19,7 +19,8 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void Exception_TargetSite()
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Exception.TargetSite always returns null on UapAot.")]
+        public static void Exception_TargetSite_Jit()
         {
             bool caught = false;
 
@@ -32,6 +33,26 @@ namespace System.Tests
                 caught = true;
 
                 Assert.Equal(MethodInfo.GetCurrentMethod(), ex.TargetSite);
+            }
+
+            Assert.True(caught);
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.UapAot, "Exception.TargetSite always returns null on UapAot.")]
+        public static void Exception_TargetSite_Aot()
+        {
+            bool caught = false;
+
+            try
+            {
+                throw new Exception();
+            }
+            catch (Exception ex)
+            {
+                caught = true;
+
+                Assert.Null(ex.TargetSite);
             }
 
             Assert.True(caught);

--- a/src/System.Runtime/tests/System/LazyTests.cs
+++ b/src/System.Runtime/tests/System/LazyTests.cs
@@ -359,12 +359,7 @@ namespace System.Tests
         [Fact]
         public static void Serialization_ValueType()
         {
-            var stream = new MemoryStream();
-            var formatter = new BinaryFormatter();
-            formatter.Serialize(stream, new Lazy<int>(() => 42));
-            stream.Seek(0, SeekOrigin.Begin);
-
-            var fortytwo = (Lazy<int>)formatter.Deserialize(stream);
+            Lazy<int> fortytwo = BinaryFormatterHelpers.Clone(new Lazy<int>(() => 42));
             Assert.True(fortytwo.IsValueCreated);
             Assert.Equal(fortytwo.Value, 42);
         }
@@ -372,13 +367,7 @@ namespace System.Tests
         [Fact]
         public static void Serialization_RefType()
         {
-            var stream = new MemoryStream();
-            var formatter = new BinaryFormatter();
-            formatter.Serialize(stream, new Lazy<string>(() => "42"));
-            stream.Seek(0, SeekOrigin.Begin);
-
-            var x = BinaryFormatterHelpers.Clone(new object());
-            var fortytwo = (Lazy<string>)formatter.Deserialize(stream);
+            Lazy<string> fortytwo = BinaryFormatterHelpers.Clone(new Lazy<string>(() => "42"));
             Assert.True(fortytwo.IsValueCreated);
             Assert.Equal(fortytwo.Value, "42");
         }

--- a/src/System.Runtime/tests/System/Reflection/AssemblyTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/AssemblyTests.cs
@@ -90,6 +90,7 @@ namespace System.Reflection.Tests
 
         [Theory]
         [MemberData(nameof(GetCallingAssembly_TestData))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "GetCallingAssembly() is not supported on UapAot")]
         public static void GetCallingAssembly(Assembly assembly1, Assembly assembly2, bool expected)
         {
             Assert.Equal(expected, assembly1.Equals(assembly2));
@@ -480,6 +481,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.CodeBase not supported on UapAot")]
         public static void Load_AssemblyNameWithCodeBase()
         {
             AssemblyName an = typeof(AssemblyTests).Assembly.GetName();

--- a/src/System.Runtime/tests/System/Reflection/ModuleTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/ModuleTests.cs
@@ -81,12 +81,14 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Module.FullyQualifiedName does not indicate file location on UwpAot")]
         public void FullyQualifiedName()
         {
             Assert.Equal(Assembly.GetExecutingAssembly().Location, Module.FullyQualifiedName);
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Module.Name does not indicate file location on UwpAot")]
         public void Name()
         {
             Assert.Equal("system.runtime.tests.dll", Module.Name, ignoreCase: true);
@@ -115,6 +117,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Module.ToString() does not indicate file location on UwpAot")]
         public void TestToString()
         {
             Assert.Equal("System.Runtime.Tests.dll", Module.ToString());

--- a/src/System.Runtime/tests/System/Runtime/ExceptionServices/HandleProcessCorruptedStateExceptions.cs
+++ b/src/System.Runtime/tests/System/Runtime/ExceptionServices/HandleProcessCorruptedStateExceptions.cs
@@ -17,9 +17,15 @@ namespace System.Runtime.ExceptionServices.Tests
         [DllImport("kernel32.dll")]
         static extern void RaiseException(uint dwExceptionCode, uint dwExceptionFlags, uint nNumberOfArguments, IntPtr lpArguments);
 
+        [DllImport("kernel32.dll")]
+        private static extern int SetErrorMode(int uMode);
+
+        private const int SEM_NOGPFAULTERRORBOX = 2;
+
         [HandleProcessCorruptedStateExceptions]
         static void CauseAVInNative()
         {
+            SetErrorMode(SEM_NOGPFAULTERRORBOX);
             try 
             {
                 RaiseException(0xC0000005, 0, 0, IntPtr.Zero);

--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -1676,7 +1676,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Join_ObjectArray_TestData))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp | TargetFrameworkMonikers.Uap)]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
         public static void Join_ObjectArray_WithNullIssue(string separator, object[] values, string expected)
         {
             string enumerableExpected = expected;

--- a/src/System.Runtime/tests/System/TypeTests.cs
+++ b/src/System.Runtime/tests/System/TypeTests.cs
@@ -314,6 +314,7 @@ namespace System.Tests
                              Type.GetType(name, false, ignore) :
                                  assem.GetType(name, false, ignore);
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.LoadFrom() is not supported on UapAot")]
         public static void GetTypeByName()
         {
             RemoteInvokeOptions options = new RemoteInvokeOptions();
@@ -340,6 +341,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.LoadFrom() is not supported on UapAot")]
         public static void GetTypeByNameTypeloadFailure()
         {
             RemoteInvokeOptions options = new RemoteInvokeOptions();
@@ -373,6 +375,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.LoadFrom() is not supported on UapAot")]
         public static void GetTypeByNameCaseSensitiveTypeloadFailure()
         {
             RemoteInvokeOptions options = new RemoteInvokeOptions();


### PR DESCRIPTION
Also, got tired of that processcorruptedstateexception
test popping up an error dialog on CoreCLR - fixed that
too.