### PR TITLE
Excluded uap from Microsoft.Win32.Registry.AccessControl test targets

### DIFF
--- a/src/Microsoft.Win32.Registry.AccessControl/tests/Configurations.props
+++ b/src/Microsoft.Win32.Registry.AccessControl/tests/Configurations.props
@@ -2,7 +2,8 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
-      netstandard-Windows_NT;;
+      netcoreapp-Windows_NT;
+      netfx-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.Win32.Registry.AccessControl/tests/Microsoft.Win32.Registry.AccessControl.Tests.csproj
+++ b/src/Microsoft.Win32.Registry.AccessControl/tests/Microsoft.Win32.Registry.AccessControl.Tests.csproj
@@ -4,8 +4,10 @@
   <PropertyGroup>
     <ProjectGuid>{C2B7761E-A4C0-4285-8B83-CC426A1494FA}</ProjectGuid>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="RegistryAclExtensionsTests.cs" />
   </ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/18982
Fixes https://github.com/dotnet/corefx/issues/18652