### PR TITLE
Make the OSX mutable store tests skip on OSStatus -61.

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/tests/X509StoreMutableTests.OSX.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X509StoreMutableTests.OSX.cs
@@ -10,7 +10,31 @@ namespace System.Security.Cryptography.X509Certificates.Tests
     [PlatformSpecific(TestPlatforms.OSX)]
     public static class X509StoreMutableTests_OSX
     {
-        [Fact]
+        public static bool PermissionsAllowStoreWrite => TestPermissions();
+
+        private static bool TestPermissions()
+        {
+            try
+            {
+                AddToStore_Exportable();
+            }
+            catch (CryptographicException e)
+            {
+                const int errSecWrPerm = -61;
+
+                if (e.HResult == errSecWrPerm)
+                {
+                    return false;
+                }
+            }
+            catch
+            {
+            }
+
+            return true;
+        }
+
+        [ConditionalFact(nameof(PermissionsAllowStoreWrite))]
         public static void PersistKeySet_OSX()
         {
             using (var store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
@@ -37,7 +61,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(PermissionsAllowStoreWrite))]
         public static void AddToStore_NonExportable_OSX()
         {
             using (var store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
@@ -57,7 +81,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(PermissionsAllowStoreWrite))]
         public static void AddToStore_Exportable()
         {
             using (var store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
@@ -78,7 +102,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(PermissionsAllowStoreWrite))]
         public static void AddToStoreTwice()
         {
             using (var store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
@@ -102,7 +126,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(PermissionsAllowStoreWrite))]
         public static void AddPrivateAfterPublic()
         {
             using (var store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
@@ -128,7 +152,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(PermissionsAllowStoreWrite))]
         public static void AddPublicAfterPrivate()
         {
             using (var store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
@@ -155,7 +179,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(PermissionsAllowStoreWrite))]
         public static void VerifyRemove()
         {
             using (var store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
@@ -175,7 +199,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(PermissionsAllowStoreWrite))]
         public static void RemovePublicDeletesPrivateKey()
         {
             using (var store = new X509Store(StoreName.My, StoreLocation.CurrentUser))

--- a/src/System.Security.Cryptography.X509Certificates/tests/X509StoreMutableTests.OSX.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X509StoreMutableTests.OSX.cs
@@ -10,7 +10,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
     [PlatformSpecific(TestPlatforms.OSX)]
     public static class X509StoreMutableTests_OSX
     {
-        public static bool PermissionsAllowStoreWrite => TestPermissions();
+        public static bool PermissionsAllowStoreWrite { get; } = TestPermissions();
 
         private static bool TestPermissions()
         {


### PR DESCRIPTION
Something about the hosting model in Helix is causing it to always fail with
errSecWrPerm (-61).  I can reproduce this problem by making ~/Library/Keychains
readonly (u-w); and I can produce other problems using ssh and
sudo, but I can't quite reproduce a hosting model problem which produces
errSecWrPerm.

So "run" one of the tests, and if it fails with CryptographicException(-61) then
don't run the tests.  If it fails for any other reason, run the tests to get the
telemetry.

Fixes #17422.