### PR TITLE
Cleanup AOT failures in System.Collections.*.Tests.dll

### DIFF
--- a/src/Common/tests/System/Collections/DebugView.Tests.cs
+++ b/src/Common/tests/System/Collections/DebugView.Tests.cs
@@ -33,6 +33,7 @@ namespace System.Collections.Tests
 
         [Theory]
         [MemberData(nameof(TestDebuggerAttributes_Inputs))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Cannot do DebuggerAttribute testing on UapAot: requires internal Reflection on framework types.")]
         public static void TestDebuggerAttributes(object obj)
         {
             DebuggerAttributes.ValidateDebuggerDisplayReferences(obj);
@@ -41,6 +42,7 @@ namespace System.Collections.Tests
 
         [Theory]
         [MemberData(nameof(TestDebuggerAttributes_Inputs))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Cannot do DebuggerAttribute testing on UapAot: requires internal Reflection on framework types.")]
         public static void TestDebuggerAttributes_Null(object obj)
         {
             Type proxyType = DebuggerAttributes.GetProxyType(obj);

--- a/src/Common/tests/System/Collections/IEnumerable.NonGeneric.Serialization.Tests.cs
+++ b/src/Common/tests/System/Collections/IEnumerable.NonGeneric.Serialization.Tests.cs
@@ -3,10 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.Serialization.Formatters.Binary;
+using System.Runtime.Serialization.Formatters.Tests;
 using Xunit;
 
 namespace System.Collections.Tests
@@ -25,26 +24,18 @@ namespace System.Collections.Tests
                 // using ListDictionary.Keys.
                 return;
             }
-            Assert.True(expected.GetType().GetTypeInfo().IsSerializable, "Expected IsSerializable");
 
-            var bf = new BinaryFormatter();
-            using (var ms = new MemoryStream())
+            IEnumerable actual = BinaryFormatterHelpers.Clone(expected);
+            if (Order == EnumerableOrder.Sequential)
             {
-                bf.Serialize(ms, expected);
-                ms.Position = 0;
-                IEnumerable actual = (IEnumerable)bf.Deserialize(ms);
-
-                if (Order == EnumerableOrder.Sequential)
-                {
-                    Assert.Equal(expected, actual);
-                }
-                else
-                {
-                    var expectedSet = new HashSet<object>(expected.Cast<object>());
-                    var actualSet = new HashSet<object>(actual.Cast<object>());
-                    Assert.Subset(expectedSet, actualSet);
-                    Assert.Subset(actualSet, expectedSet);
-                }
+                Assert.Equal(expected, actual);
+            }
+            else
+            {
+                var expectedSet = new HashSet<object>(expected.Cast<object>());
+                var actualSet = new HashSet<object>(actual.Cast<object>());
+                Assert.Subset(expectedSet, actualSet);
+                Assert.Subset(actualSet, expectedSet);
             }
         }
 

--- a/src/System.Collections.Concurrent/tests/BlockingCollectionTests.cs
+++ b/src/System.Collections.Concurrent/tests/BlockingCollectionTests.cs
@@ -170,6 +170,7 @@ namespace System.Collections.Concurrent.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Cannot do DebuggerAttribute testing on UapAot: requires internal Reflection on framework types.")]
         public static void TestDebuggerAttributes()
         {
             DebuggerAttributes.ValidateDebuggerDisplayReferences(new BlockingCollection<int>());

--- a/src/System.Collections.Concurrent/tests/ConcurrentDictionary/ConcurrentDictionaryTests.cs
+++ b/src/System.Collections.Concurrent/tests/ConcurrentDictionary/ConcurrentDictionaryTests.cs
@@ -539,6 +539,7 @@ namespace System.Collections.Concurrent.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Cannot do DebuggerAttribute testing on UapAot: requires internal Reflection on framework types.")]
         public static void TestDebuggerAttributes()
         {
             DebuggerAttributes.ValidateDebuggerDisplayReferences(new ConcurrentDictionary<string, int>());

--- a/src/System.Collections.Concurrent/tests/ProducerConsumerCollectionTests.cs
+++ b/src/System.Collections.Concurrent/tests/ProducerConsumerCollectionTests.cs
@@ -994,6 +994,7 @@ namespace System.Collections.Concurrent.Tests
         [Theory]
         [InlineData(0)]
         [InlineData(10)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Cannot do DebuggerAttribute testing on UapAot: requires internal Reflection on framework types.")]
         public void DebuggerAttributes_Success(int count)
         {
             IProducerConsumerCollection<int> c = CreateProducerConsumerCollection(count);
@@ -1002,6 +1003,7 @@ namespace System.Collections.Concurrent.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Cannot do DebuggerAttribute testing on UapAot: requires internal Reflection on framework types.")]
         public void DebuggerTypeProxy_Ctor_NullArgument_Throws()
         {
             IProducerConsumerCollection<int> c = CreateProducerConsumerCollection();

--- a/src/System.Collections.NonGeneric/tests/ArrayListTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayListTests.cs
@@ -80,6 +80,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Cannot do DebuggerAttribute testing on UapAot: requires internal Reflection on framework types.")]
         public static void DebuggerAttribute()
         {
             DebuggerAttributes.ValidateDebuggerDisplayReferences(new ArrayList());

--- a/src/System.Collections.NonGeneric/tests/HashtableTests.cs
+++ b/src/System.Collections.NonGeneric/tests/HashtableTests.cs
@@ -365,6 +365,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Cannot do DebuggerAttribute testing on UapAot: requires internal Reflection on framework types.")]
         public static void DebuggerAttribute()
         {
             DebuggerAttributes.ValidateDebuggerDisplayReferences(new Hashtable());

--- a/src/System.Collections.NonGeneric/tests/QueueTests.cs
+++ b/src/System.Collections.NonGeneric/tests/QueueTests.cs
@@ -93,6 +93,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Cannot do DebuggerAttribute testing on UapAot: requires internal Reflection on framework types.")]
         public static void DebuggerAttribute()
         {
             DebuggerAttributes.ValidateDebuggerDisplayReferences(new Queue());
@@ -111,6 +112,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Cannot do DebuggerAttribute testing on UapAot: requires internal Reflection on framework types.")]
         public static void DebuggerAttribute_NullQueue_ThrowsArgumentNullException()
         {
             bool threwNull = false;

--- a/src/System.Collections.NonGeneric/tests/SortedListTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedListTests.cs
@@ -212,12 +212,14 @@ namespace System.Collections.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Cannot do DebuggerAttribute testing on UapAot: requires internal Reflection on framework types.")]
         public static void DebuggerAttribute_Empty()
         {
             Assert.Equal("Count = 0", DebuggerAttributes.ValidateDebuggerDisplayReferences(new SortedList()));
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Cannot do DebuggerAttribute testing on UapAot: requires internal Reflection on framework types.")]
         public static void DebuggerAttribute_NormalList()
         {
             var list = new SortedList() { { "a", 1 }, { "b", 2 } };
@@ -228,6 +230,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Cannot do DebuggerAttribute testing on UapAot: requires internal Reflection on framework types.")]
         public static void DebuggerAttribute_SynchronizedList()
         {
             var list = SortedList.Synchronized(new SortedList() { { "a", 1 }, { "b", 2 } });
@@ -238,6 +241,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Cannot do DebuggerAttribute testing on UapAot: requires internal Reflection on framework types.")]
         public static void DebuggerAttribute_NullSortedList_ThrowsArgumentNullException()
         {
             bool threwNull = false;
@@ -254,6 +258,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "This test intentionally reflects on an internal member of SortedList. Cannot do that on UaoAot.")]
         public static void EnsureCapacity_NewCapacityLessThanMin_CapsToMaxArrayLength()
         {
             // A situation like this occurs for very large lengths of SortedList.

--- a/src/System.Collections.NonGeneric/tests/StackTests.cs
+++ b/src/System.Collections.NonGeneric/tests/StackTests.cs
@@ -71,6 +71,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Cannot do DebuggerAttribute testing on UapAot: requires internal Reflection on framework types.")]
         public static void DebuggerAttribute()
         {
             DebuggerAttributes.ValidateDebuggerDisplayReferences(new Stack());
@@ -89,6 +90,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Cannot do DebuggerAttribute testing on UapAot: requires internal Reflection on framework types.")]
         public static void DebuggerAttribute_NullStack_ThrowsArgumentNullException()
         {
             bool threwNull = false;

--- a/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
+++ b/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
@@ -30,6 +30,9 @@
     <Compile Include="$(CommonTestPath)\System\Collections\TestingTypes.cs">
       <Link>Common\System\Collections\TestingTypes.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
+      <Link>System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
+    </Compile>
     <Compile Include="ArrayListTests.cs" />
     <Compile Include="ArrayList\ArrayList.IList.Tests.cs" />
     <Compile Include="Hashtable\Hashtable.Values.Tests.cs" />

--- a/src/System.Collections.Specialized/tests/System.Collections.Specialized.Tests.csproj
+++ b/src/System.Collections.Specialized/tests/System.Collections.Specialized.Tests.csproj
@@ -36,6 +36,9 @@
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
       <Link>CommonTest\System\PlatformDetection.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
+      <Link>System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
+    </Compile>
     <Compile Include="BitVector32Tests.cs" />
     <Compile Include="Helpers.cs" />
     <Compile Include="HybridDictionary\HybridDictionary.AddTests.cs" />


### PR DESCRIPTION
(all except Immutable since another dev is already working
on that).

Marked the remaining DebuggerAttribute tests for SkipOnAot

Moved another common serialization test to the Clone
helper.

Removed an IsSerializable check that was attempting to
reflect on internal framework types (albeit returned through
public api.) Since BinaryFormatter will do the same check
a few steps later, this extra assert adds little value and no other
BinaryFormatterHelper client I've seen has this.