### PR TITLE
Remove List.Clear perf test which uses very large amounts of memory

### DIFF
--- a/src/System.Collections/tests/Performance/Perf.List.cs
+++ b/src/System.Collections/tests/Performance/Perf.List.cs
@@ -62,7 +62,6 @@ namespace System.Collections.Tests
         [Benchmark]
         [InlineData(1000)]
         [InlineData(10000)]
-        [InlineData(100000)]
         public void Clear(int size)
         {
             List<object> list = CreateList(size);


### PR DESCRIPTION
This could potentially be fixed in other ways, but we already have feedback from the performance team that we have too many redundant test cases for a lot of methods, and I think that applies here. We already have a couple of other test cases for `List.Clear` here that don't use 2 GB of memory.

Fixes: #18461 

@danmosemsft 