### PR TITLE
Re-enable some Principal tests

### DIFF
--- a/src/System.Security.Principal.Windows/tests/WellKnownSidTypeTests.cs
+++ b/src/System.Security.Principal.Windows/tests/WellKnownSidTypeTests.cs
@@ -8,8 +8,12 @@ using Xunit;
 
 public class WellKnownSidTypeTests
 {
-    [ActiveIssue(15436)]
-    [Theory]
+    public static bool AccountIsDomainJoined()
+    {
+        return WindowsIdentity.GetCurrent().Owner.AccountDomainSid != null;
+    }
+
+    [ConditionalTheory(nameof(AccountIsDomainJoined))]
     [InlineData(WellKnownSidType.NullSid)]
     [InlineData(WellKnownSidType.WorldSid)]
     [InlineData(WellKnownSidType.LocalSid)]

--- a/src/System.Security.Principal.Windows/tests/WellKnownSidTypeTests.cs
+++ b/src/System.Security.Principal.Windows/tests/WellKnownSidTypeTests.cs
@@ -10,7 +10,8 @@ public class WellKnownSidTypeTests
 {
     public static bool AccountIsDomainJoined()
     {
-        return WindowsIdentity.GetCurrent().Owner.AccountDomainSid != null;
+        using (var identity = WindowsIdentity.GetCurrent())
+            return identity.Owner.AccountDomainSid != null;
     }
 
     [ConditionalTheory(nameof(AccountIsDomainJoined))]
@@ -115,10 +116,13 @@ public class WellKnownSidTypeTests
     [InlineData(WellKnownSidType.WinCapabilityRemovableStorageSid)]
     public void CanCreateSecurityIdentifierFromWellKnownSidType(WellKnownSidType sidType)
     {
-        var currentDomainSid = WindowsIdentity.GetCurrent().Owner.AccountDomainSid;
-        var wellKnownSidInstance = new SecurityIdentifier(sidType, currentDomainSid);
+        using (var identity = WindowsIdentity.GetCurrent())
+        {
+            var currentDomainSid = identity.Owner.AccountDomainSid;
+            var wellKnownSidInstance = new SecurityIdentifier(sidType, currentDomainSid);
 
-        Assert.True(wellKnownSidInstance.IsWellKnown(sidType));
+            Assert.True(wellKnownSidInstance.IsWellKnown(sidType));
+        }
     }
 
     [Theory]


### PR DESCRIPTION
These tests are failing when run on an account that is not domain joined. This PR makes the Theory a ConditionalTheory based on whether we can get an AccountDomainSid so that these tests can be run and pass when not run as local admin.

resolves https://github.com/dotnet/corefx/issues/15436
resolves https://github.com/dotnet/corefx/issues/15421