### PR TITLE
Disable HttpListener WebSocket test on Windows 7

### DIFF
--- a/src/System.Net.HttpListener/tests/HttpListenerRequestTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerRequestTests.cs
@@ -186,7 +186,6 @@ namespace System.Net.Tests
             });
         }
 
-        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         [InlineData("Connection: ", false)]
         [InlineData("Connection: Connection\r\nUpgrade: ", false)]
         [InlineData("Connection: Test1\r\nUpgrade: Test2", false)]
@@ -195,6 +194,12 @@ namespace System.Net.Tests
         [InlineData("Unknown-Header: Test", false)]
         public async Task IsWebSocketRequest_GetProperty_ReturnsExpected(string webSocketString, bool expected)
         {
+            // Skip on Windows 7 or UAP platforms. WebSocket support is not present.
+            if (PlatformDetection.IsWindows7 || !PlatformDetection.IsNotOneCoreUAP)
+            {
+                return;
+            }
+
             await GetRequest("POST", "", new string[] { webSocketString }, (_, request) =>
             {
                 Assert.Equal(expected, request.IsWebSocketRequest);


### PR DESCRIPTION
HttpListener on Windows platforms requires "websocket.dll" native
component in order for WebSocket upgrade to work. And Windows platforms
before Windows 8 did not have that component.

Fixes #18906.