### PR TITLE
Adding rdxml to Serialization reflection only tests.

### DIFF
--- a/src/System.Runtime.Serialization.Json/tests/ReflectionOnly/Resources/System.Runtime.Serialization.Json.ReflectionOnly.Tests.rd.xml
+++ b/src/System.Runtime.Serialization.Json/tests/ReflectionOnly/Resources/System.Runtime.Serialization.Json.ReflectionOnly.Tests.rd.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Library Name="*System.Private.DataContractSerialization*">
+    <Assembly Name="System.Private.DataContractSerialization" Dynamic="Required All">
+    </Assembly>
+  </Library>
+</Directives>

--- a/src/System.Runtime.Serialization.Json/tests/ReflectionOnly/System.Runtime.Serialization.Json.ReflectionOnly.Tests.csproj
+++ b/src/System.Runtime.Serialization.Json/tests/ReflectionOnly/System.Runtime.Serialization.Json.ReflectionOnly.Tests.csproj
@@ -11,6 +11,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Release|AnyCPU'" />
+ 
   <ItemGroup>
     <Compile Include="$(TestSourceFolder)..\..\..\System.Runtime.Serialization.Xml\tests\Utils.cs" />
     <Compile Include="$(TestSourceFolder)..\..\..\System.Runtime.Serialization.Xml\tests\SerializationTypes.cs" />
@@ -22,6 +23,9 @@
   <ItemGroup Condition="'$(TargetGroup)' != 'uap'">
     <Compile Include="$(TestSourceFolder)..\DataContractJsonSerializer.CoreCLR.cs" />
     <Compile Include="$(TestSourceFolder)..\..\..\System.Runtime.Serialization.Xml\tests\SerializationTypes.CoreCLR.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'uap'">
+    <EmbeddedResource Include="$(MsBuildThisFileDirectory)Resources\$(AssemblyName).rd.xml" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime.Serialization.Xml/tests/ReflectionOnly/Resources/System.Runtime.Serialization.Xml.ReflectionOnly.Tests.rd.xml
+++ b/src/System.Runtime.Serialization.Xml/tests/ReflectionOnly/Resources/System.Runtime.Serialization.Xml.ReflectionOnly.Tests.rd.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Library Name="*System.Private.DataContractSerialization*">
+    <Assembly Name="System.Private.DataContractSerialization" Dynamic="Required All">
+    </Assembly>
+  </Library>
+</Directives>

--- a/src/System.Runtime.Serialization.Xml/tests/ReflectionOnly/System.Runtime.Serialization.Xml.ReflectionOnly.Tests.csproj
+++ b/src/System.Runtime.Serialization.Xml/tests/ReflectionOnly/System.Runtime.Serialization.Xml.ReflectionOnly.Tests.csproj
@@ -37,5 +37,8 @@
     <Compile Include="$(TestSourceFolder)..\SerializationTypes.CoreCLR.cs" />
     <Compile Include="$(TestSourceFolder)..\DataContractSerializer.CoreCLR.cs" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'uap'">
+    <EmbeddedResource Include="$(MsBuildThisFileDirectory)Resources\$(AssemblyName).rd.xml" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
The tests use internal types and methods that gets reduced away.rdxml ask ILC to keep all from assembly System.Private.DataContractSerialization. With this change  about 400+ tests will pass in ILC UWP runs.