### PR TITLE
Simplify X509Chain building with OpenSSL 

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509.cs
@@ -129,7 +129,11 @@ internal static partial class Interop
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreCtxInit")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern bool X509StoreCtxInit(SafeX509StoreCtxHandle ctx, SafeX509StoreHandle store, SafeX509Handle x509);
+        internal static extern bool X509StoreCtxInit(
+            SafeX509StoreCtxHandle ctx,
+            SafeX509StoreHandle store,
+            SafeX509Handle x509,
+            SafeX509StackHandle extraCerts);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509VerifyCert")]
         internal static extern int X509VerifyCert(SafeX509StoreCtxHandle ctx);

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.cpp
@@ -205,9 +205,9 @@ extern "C" void CryptoNative_X509StoreCtxDestroy(X509_STORE_CTX* v)
     }
 }
 
-extern "C" int32_t CryptoNative_X509StoreCtxInit(X509_STORE_CTX* ctx, X509_STORE* store, X509* x509)
+extern "C" int32_t CryptoNative_X509StoreCtxInit(X509_STORE_CTX* ctx, X509_STORE* store, X509* x509, X509Stack* extraStore)
 {
-    return X509_STORE_CTX_init(ctx, store, x509, nullptr);
+    return X509_STORE_CTX_init(ctx, store, x509, extraStore);
 }
 
 extern "C" int32_t CryptoNative_X509VerifyCert(X509_STORE_CTX* ctx)

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.h
@@ -219,7 +219,7 @@ extern "C" void CryptoNative_X509StoreCtxDestroy(X509_STORE_CTX* v);
 /*
 Shims the X509_STORE_CTX_init method.
 */
-extern "C" int32_t CryptoNative_X509StoreCtxInit(X509_STORE_CTX* ctx, X509_STORE* store, X509* x509);
+extern "C" int32_t CryptoNative_X509StoreCtxInit(X509_STORE_CTX* ctx, X509_STORE* store, X509* x509, X509Stack* extraStore);
 
 /*
 Shims the X509_verify_cert method.

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ChainPal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ChainPal.cs
@@ -66,7 +66,6 @@ namespace Internal.Cryptography.Pal
                 IChainPal chain = OpenSslX509ChainProcessor.BuildChain(
                     leaf,
                     candidates,
-                    downloaded,
                     systemTrusted,
                     applicationPolicy,
                     certificatePolicy,

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
@@ -37,7 +37,6 @@ namespace Internal.Cryptography.Pal
         public static IChainPal BuildChain(
             X509Certificate2 leaf,
             HashSet<X509Certificate2> candidates,
-            HashSet<X509Certificate2> downloaded,
             HashSet<X509Certificate2> systemTrusted,
             OidCollection applicationPolicy,
             OidCollection certificatePolicy,
@@ -57,9 +56,11 @@ namespace Internal.Cryptography.Pal
             // (If you need to think of it as an X509Store, it's a volatile memory store)
             using (SafeX509StoreHandle store = Interop.Crypto.X509StoreCreate())
             using (SafeX509StoreCtxHandle storeCtx = Interop.Crypto.X509StoreCtxCreate())
+            using (SafeX509StackHandle extraCerts = Interop.Crypto.NewX509Stack())
             {
                 Interop.Crypto.CheckValidOpenSslHandle(store);
                 Interop.Crypto.CheckValidOpenSslHandle(storeCtx);
+                Interop.Crypto.CheckValidOpenSslHandle(extraCerts);
 
                 bool lookupCrl = revocationMode != X509RevocationMode.NoCheck;
 
@@ -67,9 +68,15 @@ namespace Internal.Cryptography.Pal
                 {
                     OpenSslX509CertificateReader pal = (OpenSslX509CertificateReader)cert.Pal;
 
-                    if (!Interop.Crypto.X509StoreAddCert(store, pal.SafeHandle))
+                    using (SafeX509Handle handle = Interop.Crypto.X509UpRef(pal.SafeHandle))
                     {
-                        throw Interop.Crypto.CreateOpenSslCryptographicException();
+                        if (!Interop.Crypto.PushX509StackField(extraCerts, handle))
+                        {
+                            throw Interop.Crypto.CreateOpenSslCryptographicException();
+                        }
+
+                        // Ownership was transferred to the cert stack.
+                        handle.SetHandleAsInvalid();
                     }
 
                     if (lookupCrl)
@@ -95,9 +102,19 @@ namespace Internal.Cryptography.Pal
                     }
                 }
 
+                foreach (X509Certificate2 trustedCert in systemTrusted)
+                {
+                    OpenSslX509CertificateReader pal = (OpenSslX509CertificateReader)trustedCert.Pal;
+
+                    if (!Interop.Crypto.X509StoreAddCert(store, pal.SafeHandle))
+                    {
+                        throw Interop.Crypto.CreateOpenSslCryptographicException();
+                    }
+                }
+
                 SafeX509Handle leafHandle = ((OpenSslX509CertificateReader)leaf.Pal).SafeHandle;
 
-                if (!Interop.Crypto.X509StoreCtxInit(storeCtx, store, leafHandle))
+                if (!Interop.Crypto.X509StoreCtxInit(storeCtx, store, leafHandle, extraCerts))
                 {
                     throw Interop.Crypto.CreateOpenSslCryptographicException();
                 }
@@ -144,22 +161,6 @@ namespace Internal.Cryptography.Pal
 
                         // Duplicate the certificate handle
                         X509Certificate2 elementCert = new X509Certificate2(elementCertPtr);
-
-                        // If the last cert is self signed then it's the root cert, do any extra checks.
-                        if (i == maybeRootDepth && IsSelfSigned(elementCert))
-                        {
-                            // If the root certificate was downloaded or the system
-                            // doesn't trust it, it's untrusted.
-                            if (downloaded.Contains(elementCert) ||
-                                !systemTrusted.Contains(elementCert))
-                            {
-                                AddElementStatus(
-                                    Interop.Crypto.X509VerifyStatusCode.X509_V_ERR_CERT_UNTRUSTED,
-                                    status,
-                                    overallStatus);
-                            }
-                        }
-
                         elements[i] = new X509ChainElement(elementCert, status.ToArray(), "");
                     }
                 }
@@ -416,8 +417,6 @@ namespace Internal.Cryptography.Pal
                     extraStore,
                     userIntermediateCerts,
                     systemIntermediateCerts,
-                    userRootCerts,
-                    systemRootCerts,
                 };
 
                 while (toProcess.Count > 0)
@@ -629,7 +628,7 @@ namespace Internal.Cryptography.Pal
 
             internal int VerifyCallback(int ok, IntPtr ctx)
             {
-                if (ok < 0)
+                if (ok != 0)
                 {
                     return ok;
                 }


### PR DESCRIPTION
While looking into why some chain errors show on all certificates, vs just the ones where the problem originates, I ran across some information that would have simplified the work of building chains long ago.

By providing the candidates set (including the values from ChainPolicy.ExtraStore) and the trusted store (the union of the CurrentUser\Root and LocalMachine\Root stores) in separate collections OpenSSL will tell us when the root was trusted or not.  So we should do that, and get rid of our post-facto decision that says the root was not trusted after all.

The error codes getting copied in multiple positions was an artifact of the callback being called at the end with `ok=1`.  Most of the time the X509StoreCtxGetError value has been cleared to `X509_V_OK`, but some of them remain.  By only reading error codes when `ok=0` they're not only placed on the element where we first read them.

There's a fair body of tests which already verify LM\Root trust; and I manually verified behaviors with CU\Root.