### PR TITLE
Make RSASignaturePadding a required parameter for RSA certs

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/ref/System.Security.Cryptography.X509Certificates.cs
+++ b/src/System.Security.Cryptography.X509Certificates/ref/System.Security.Cryptography.X509Certificates.cs
@@ -21,10 +21,10 @@ namespace System.Security.Cryptography.X509Certificates
     public sealed partial class CertificateRequest
     {
         public CertificateRequest(System.Security.Cryptography.X509Certificates.X500DistinguishedName subjectName, System.Security.Cryptography.ECDsa key, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { }
-        public CertificateRequest(System.Security.Cryptography.X509Certificates.X500DistinguishedName subjectName, System.Security.Cryptography.RSA key, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { }
+        public CertificateRequest(System.Security.Cryptography.X509Certificates.X500DistinguishedName subjectName, System.Security.Cryptography.RSA key, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { }
         public CertificateRequest(System.Security.Cryptography.X509Certificates.X500DistinguishedName subjectName, System.Security.Cryptography.X509Certificates.PublicKey publicKey, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { }
         public CertificateRequest(string subjectName, System.Security.Cryptography.ECDsa key, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { }
-        public CertificateRequest(string subjectName, System.Security.Cryptography.RSA key, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { }
+        public CertificateRequest(string subjectName, System.Security.Cryptography.RSA key, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { }
         public System.Collections.ObjectModel.Collection<System.Security.Cryptography.X509Certificates.X509Extension> CertificateExtensions { get { throw null; } }
         public System.Security.Cryptography.HashAlgorithmName HashAlgorithm { get { throw null; } }
         public System.Security.Cryptography.X509Certificates.PublicKey PublicKey { get { throw null; } }

--- a/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
@@ -106,6 +106,9 @@
   <data name="Cryptography_Cert_AlreadyHasPrivateKey" xml:space="preserve">
     <value>The certificate already has an associated private key.</value>
   </data>
+  <data name="Cryptography_CertReq_AlgorithmMustMatch" xml:space="preserve">
+    <value>The issuer certificate public key algorithm ({0}) does not match the value for this certificate request ({1}), use the X509SignatureGenerator overload.</value>
+  </data>
   <data name="Cryptography_CertReq_DatesReversed" xml:space="preserve">
     <value>The provided notBefore value is later than the notAfter value.</value>
   </data>
@@ -120,6 +123,9 @@
   </data>
   <data name="Cryptography_CertReq_NoKeyProvided" xml:space="preserve">
     <value>This method cannot be used since no signing key was provided via a constructor, use an overload accepting an X509SignatureGenerator instead.</value>
+  </data>
+  <data name="Cryptography_CertReq_RSAPaddingRequired" xml:space="preserve">
+    <value>The issuer certificate uses an RSA key but no RSASignaturePadding was provided to a constructor. If one cannot be provided, use the X509SignatureGenerator overload.</value>
   </data>
   <data name="Cryptography_CSP_NoPrivateKey" xml:space="preserve">
     <value>Object contains only the public half of a key pair. A private key must also be provided.</value>

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/CertificateRequest.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/CertificateRequest.cs
@@ -17,6 +17,7 @@ namespace System.Security.Cryptography.X509Certificates
     {
         private readonly AsymmetricAlgorithm _key;
         private readonly X509SignatureGenerator _generator;
+        private readonly RSASignaturePadding _rsaPadding;
 
         /// <summary>
         /// The X.500 Distinguished Name to use as the Subject in a created certificate or certificate request.
@@ -112,8 +113,11 @@ namespace System.Security.Cryptography.X509Certificates
         /// <param name="hashAlgorithm">
         ///   The hash algorithm to use when signing the certificate or certificate request.
         /// </param>
+        /// <param name="padding">
+        ///   The RSA signature padding to apply if self-signing or being signed with an <see cref="X509Certificate2" />.
+        /// </param>
         /// <seealso cref="X500DistinguishedName(string)"/>
-        public CertificateRequest(string subjectName, RSA key, HashAlgorithmName hashAlgorithm)
+        public CertificateRequest(string subjectName, RSA key, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
         {
             if (subjectName == null)
                 throw new ArgumentNullException(nameof(subjectName));
@@ -121,11 +125,14 @@ namespace System.Security.Cryptography.X509Certificates
                 throw new ArgumentNullException(nameof(key));
             if (string.IsNullOrEmpty(hashAlgorithm.Name))
                 throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
+            if (padding == null)
+                throw new ArgumentNullException(nameof(padding));
 
             SubjectName = new X500DistinguishedName(subjectName);
 
             _key = key;
-            _generator = X509SignatureGenerator.CreateForRSA(key, RSASignaturePadding.Pkcs1);
+            _generator = X509SignatureGenerator.CreateForRSA(key, padding);
+            _rsaPadding = padding;
             PublicKey = _generator.PublicKey;
             HashAlgorithm = hashAlgorithm;
         }
@@ -143,7 +150,14 @@ namespace System.Security.Cryptography.X509Certificates
         /// <param name="hashAlgorithm">
         ///   The hash algorithm to use when signing the certificate or certificate request.
         /// </param>
-        public CertificateRequest(X500DistinguishedName subjectName, RSA key, HashAlgorithmName hashAlgorithm)
+        /// <param name="padding">
+        ///   The RSA signature padding to apply if self-signing or being signed with an <see cref="X509Certificate2" />.
+        /// </param>
+        public CertificateRequest(
+            X500DistinguishedName subjectName,
+            RSA key,
+            HashAlgorithmName hashAlgorithm,
+            RSASignaturePadding padding)
         {
             if (subjectName == null)
                 throw new ArgumentNullException(nameof(subjectName));
@@ -151,11 +165,14 @@ namespace System.Security.Cryptography.X509Certificates
                 throw new ArgumentNullException(nameof(key));
             if (string.IsNullOrEmpty(hashAlgorithm.Name))
                 throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
+            if (padding == null)
+                throw new ArgumentNullException(nameof(padding));
 
             SubjectName = subjectName;
 
             _key = key;
-            _generator = X509SignatureGenerator.CreateForRSA(key, RSASignaturePadding.Pkcs1);
+            _generator = X509SignatureGenerator.CreateForRSA(key, padding);
+            _rsaPadding = padding;
             PublicKey = _generator.PublicKey;
             HashAlgorithm = hashAlgorithm;
         }
@@ -354,6 +371,13 @@ namespace System.Security.Cryptography.X509Certificates
         ///   <paramref name="notAfter"/> represents a date and time before <paramref name="notBefore"/>.
         /// </exception>
         /// <exception cref="ArgumentException"><paramref name="serialNumber"/> is null or has length 0.</exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="issuerCertificate"/> has a different key algorithm than the requested certificate.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///   <paramref name="issuerCertificate"/> is an RSA certificate and this object was created via a constructor
+        ///   which does not accept a <see cref="RSASignaturePadding"/> value.
+        /// </exception>
         public X509Certificate2 Create(
             X509Certificate2 issuerCertificate,
             DateTimeOffset notBefore,
@@ -365,6 +389,16 @@ namespace System.Security.Cryptography.X509Certificates
             if (!issuerCertificate.HasPrivateKey)
                 throw new ArgumentException(SR.Cryptography_CertReq_IssuerRequiresPrivateKey, nameof(issuerCertificate));
 
+            if (issuerCertificate.PublicKey.Oid.Value != PublicKey.Oid.Value)
+            {
+                throw new ArgumentException(
+                    SR.Format(
+                        SR.Cryptography_CertReq_AlgorithmMustMatch,
+                        issuerCertificate.PublicKey.Oid.Value,
+                        PublicKey.Oid.Value),
+                    nameof(issuerCertificate));
+            }
+
             AsymmetricAlgorithm key = null;
             string keyAlgorithm = issuerCertificate.GetKeyAlgorithm();
             X509SignatureGenerator generator;
@@ -374,9 +408,14 @@ namespace System.Security.Cryptography.X509Certificates
                 switch (keyAlgorithm)
                 {
                     case Oids.RsaRsa:
+                        if (_rsaPadding == null)
+                        {
+                            throw new InvalidOperationException(SR.Cryptography_CertReq_RSAPaddingRequired);
+                        }
+
                         RSA rsa = issuerCertificate.GetRSAPrivateKey();
                         key = rsa;
-                        generator = X509SignatureGenerator.CreateForRSA(rsa, RSASignaturePadding.Pkcs1);
+                        generator = X509SignatureGenerator.CreateForRSA(rsa, _rsaPadding);
                         break;
                     case Oids.Ecc:
                         ECDsa ecdsa = issuerCertificate.GetECDsaPrivateKey();

--- a/src/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/CertificateRequestChainTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/CertificateRequestChainTests.cs
@@ -70,12 +70,28 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
             RSA rsa = key as RSA;
 
             if (rsa != null)
-                return new CertificateRequest(dn, rsa, hashAlgorithm);
+                return new CertificateRequest(dn, rsa, hashAlgorithm, RSASignaturePadding.Pkcs1);
 
             ECDsa ecdsa = key as ECDsa;
 
             if (ecdsa != null)
                 return new CertificateRequest(dn, ecdsa, hashAlgorithm);
+
+            throw new InvalidOperationException(
+                $"Had no handler for key of type {key?.GetType().FullName ?? "null"}");
+        }
+
+        private static X509SignatureGenerator OpenGenerator(AsymmetricAlgorithm key)
+        {
+            RSA rsa = key as RSA;
+
+            if (rsa != null)
+                return X509SignatureGenerator.CreateForRSA(rsa, RSASignaturePadding.Pkcs1);
+
+            ECDsa ecdsa = key as ECDsa;
+
+            if (ecdsa != null)
+                return X509SignatureGenerator.CreateForECDsa(ecdsa);
 
             throw new InvalidOperationException(
                 $"Had no handler for key of type {key?.GetType().FullName ?? "null"}");
@@ -219,6 +235,9 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
             leafRequest.CertificateExtensions.Add(
                 new X509EnhancedKeyUsageExtension(new OidCollection { new Oid("1.3.6.1.5.5.7.3.1") }, false));
 
+            X509SignatureGenerator rootGenerator = OpenGenerator(rootPrivKey);
+            X509SignatureGenerator intermed2Generator = OpenGenerator(intermed2PrivKey);
+
             X509Certificate2 rootCertWithKey = null;
             X509Certificate2 intermed1CertWithKey = null;
             X509Certificate2 intermed2CertWithKey = null;
@@ -248,8 +267,11 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                     rng.GetBytes(leafSerial, 2, leafSerial.Length - 2);
                 }
 
-                X509Certificate2 intermed1Tmp = intermed1Request.Create(rootCertWithKey, now, intermedEnd, intermed1Serial);
-                X509Certificate2 intermed2Tmp = intermed2Request.Create(rootCertWithKey, now, intermedEnd, intermed1Serial);
+                X509Certificate2 intermed1Tmp =
+                    intermed1Request.Create(rootCertWithKey.SubjectName, rootGenerator, now, intermedEnd, intermed1Serial);
+
+                X509Certificate2 intermed2Tmp =
+                    intermed2Request.Create(rootCertWithKey.SubjectName, rootGenerator, now, intermedEnd, intermed1Serial);
 
                 intermed1CertWithKey = CloneWithPrivateKey(intermed1Tmp, intermed1PrivKey);
                 intermed2CertWithKey = CloneWithPrivateKey(intermed2Tmp, intermed2PrivKey);
@@ -257,7 +279,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                 intermed1Tmp.Dispose();
                 intermed2Tmp.Dispose();
 
-                leafCert = leafRequest.Create(intermed2CertWithKey, now, leafEnd, leafSerial);
+                leafCert = leafRequest.Create(
+                    intermed2CertWithKey.SubjectName, intermed2Generator, now, leafEnd, leafSerial);
 
                 using (X509Chain chain = new X509Chain())
                 {

--- a/src/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/CertificateRequestUsageTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/CertificateRequestUsageTests.cs
@@ -28,7 +28,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                 CertificateRequest request = new CertificateRequest(
                     "CN=localhost, OU=.NET Framework (CoreFX), O=Microsoft Corporation, L=Redmond, S=Washington, C=US",
                     rsa,
-                    HashAlgorithmName.SHA256);
+                    HashAlgorithmName.SHA256,
+                    RSASignaturePadding.Pkcs1);
 
                 request.CertificateExtensions.Add(sanExtension);
 
@@ -69,7 +70,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
             {
                 rsa.ImportParameters(TestData.RsaBigExponentParams);
 
-                CertificateRequest request = new CertificateRequest(subject, rsa, HashAlgorithmName.SHA256);
+                var request = new CertificateRequest(subject, rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
                 request.CertificateExtensions.Add(skidExtension);
                 request.CertificateExtensions.Add(akidExtension);
                 request.CertificateExtensions.Add(basicConstraints);
@@ -122,7 +123,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
             using (RSA rsa = RSA.Create())
             {
                 SimpleSelfSign(
-                    new CertificateRequest("CN=localhost", rsa, HashAlgorithmName.SHA256),
+                    new CertificateRequest("CN=localhost", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1),
                     "1.2.840.113549.1.1.1");
             }
         }
@@ -185,7 +186,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                 CertificateRequest request = new CertificateRequest(
                     "CN=localhost, OU=.NET Framework (CoreFX), O=Microsoft Corporation, L=Redmond, S=Washington, C=US",
                     rsa,
-                    HashAlgorithmName.SHA256);
+                    HashAlgorithmName.SHA256,
+                    RSASignaturePadding.Pkcs1);
 
                 DateTimeOffset now = DateTimeOffset.UtcNow;
                 cert = request.CreateSelfSigned(now, now.AddDays(90));
@@ -356,7 +358,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                 CertificateRequest request = new CertificateRequest(
                     "CN=Double Extension Test",
                     rsa,
-                    HashAlgorithmName.SHA256);
+                    HashAlgorithmName.SHA256,
+                    RSASignaturePadding.Pkcs1);
 
                 request.CertificateExtensions.Add(
                     new X509BasicConstraintsExtension(true, false, 0, true));
@@ -441,6 +444,168 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
             if (CultureInfo.CurrentCulture.Name == "en-US")
             {
                 Assert.Contains("ASN1", exception.Message);
+            }
+        }
+
+        [Fact]
+        public static void ECDSA_Signing_RSA()
+        {
+            using (RSA rsa = RSA.Create())
+            using (ECDsa ecdsa = ECDsa.Create())
+            {
+                var request = new CertificateRequest(
+                    new X500DistinguishedName("CN=Test"),
+                    ecdsa,
+                    HashAlgorithmName.SHA256);
+
+                request.CertificateExtensions.Add(
+                    new X509BasicConstraintsExtension(true, false, 0, true));
+
+                DateTimeOffset now = DateTimeOffset.UtcNow;
+
+                using (X509Certificate2 cert = request.CreateSelfSigned(now, now.AddDays(1)))
+                {
+                    X509SignatureGenerator generator =
+                        X509SignatureGenerator.CreateForRSA(rsa, RSASignaturePadding.Pkcs1);
+
+                    request = new CertificateRequest(
+                        new X500DistinguishedName("CN=Leaf"),
+                        rsa,
+                        HashAlgorithmName.SHA256,
+                        RSASignaturePadding.Pkcs1);
+
+                    byte[] serialNumber = { 1, 1, 2, 3, 5, 8, 13 };
+
+                    Assert.Throws<ArgumentException>(
+                        () => request.Create(cert, now, now.AddHours(3), serialNumber));
+
+
+                    // Passes with the generator
+                    using (request.Create(cert.SubjectName, generator, now, now.AddHours(3), serialNumber))
+                    {
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public static void ECDSA_Signing_RSAPublicKey()
+        {
+            using (RSA rsa = RSA.Create())
+            using (ECDsa ecdsa = ECDsa.Create())
+            {
+                var request = new CertificateRequest(
+                    new X500DistinguishedName("CN=Test"),
+                    ecdsa,
+                    HashAlgorithmName.SHA256);
+
+                request.CertificateExtensions.Add(
+                    new X509BasicConstraintsExtension(true, false, 0, true));
+
+                DateTimeOffset now = DateTimeOffset.UtcNow;
+
+                using (X509Certificate2 cert = request.CreateSelfSigned(now, now.AddDays(1)))
+                {
+                    X509SignatureGenerator rsaGenerator =
+                        X509SignatureGenerator.CreateForRSA(rsa, RSASignaturePadding.Pkcs1);
+
+                    request = new CertificateRequest(
+                        new X500DistinguishedName("CN=Leaf"),
+                        rsaGenerator.PublicKey,
+                        HashAlgorithmName.SHA256);
+
+                    byte[] serialNumber = { 1, 1, 2, 3, 5, 8, 13 };
+
+                    Assert.Throws<ArgumentException>(
+                        () => request.Create(cert, now, now.AddHours(3), serialNumber));
+
+                    X509SignatureGenerator ecdsaGenerator =
+                        X509SignatureGenerator.CreateForECDsa(ecdsa);
+
+                    // Passes with the generator
+                    using (request.Create(cert.SubjectName, ecdsaGenerator, now, now.AddHours(3), serialNumber))
+                    {
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public static void RSA_Signing_ECDSA()
+        {
+            using (RSA rsa = RSA.Create())
+            using (ECDsa ecdsa = ECDsa.Create())
+            {
+                var request = new CertificateRequest(
+                    new X500DistinguishedName("CN=Test"),
+                    rsa,
+                    HashAlgorithmName.SHA256,
+                    RSASignaturePadding.Pkcs1);
+
+                request.CertificateExtensions.Add(
+                    new X509BasicConstraintsExtension(true, false, 0, true));
+
+                DateTimeOffset now = DateTimeOffset.UtcNow;
+
+                using (X509Certificate2 cert = request.CreateSelfSigned(now, now.AddDays(1)))
+                {
+                    request = new CertificateRequest(
+                        new X500DistinguishedName("CN=Leaf"),
+                        ecdsa,
+                        HashAlgorithmName.SHA256);
+
+                    byte[] serialNumber = { 1, 1, 2, 3, 5, 8, 13 };
+
+                    Assert.Throws<ArgumentException>(
+                        () => request.Create(cert, now, now.AddHours(3), serialNumber));
+
+                    X509SignatureGenerator generator =
+                        X509SignatureGenerator.CreateForRSA(rsa, RSASignaturePadding.Pkcs1);
+
+                    // Passes with the generator
+                    using (request.Create(cert.SubjectName, generator, now, now.AddHours(3), serialNumber))
+                    {
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public static void RSACertificateNoPaddingMode()
+        {
+            using (RSA rsa = RSA.Create())
+            {
+                var request = new CertificateRequest(
+                    new X500DistinguishedName("CN=Test"),
+                    rsa,
+                    HashAlgorithmName.SHA256,
+                    RSASignaturePadding.Pkcs1);
+
+                request.CertificateExtensions.Add(
+                    new X509BasicConstraintsExtension(true, false, 0, true));
+
+                DateTimeOffset now = DateTimeOffset.UtcNow;
+
+                using (X509Certificate2 cert = request.CreateSelfSigned(now, now.AddDays(1)))
+                {
+                    request = new CertificateRequest(
+                        new X500DistinguishedName("CN=Leaf"),
+                        cert.PublicKey,
+                        HashAlgorithmName.SHA256);
+
+                    byte[] serialNumber = { 1, 1, 2, 3, 5, 8, 13 };
+
+                    Assert.Throws<InvalidOperationException>(
+                        () => request.Create(cert, now, now.AddHours(3), serialNumber));
+
+                    X509SignatureGenerator generator =
+                        X509SignatureGenerator.CreateForRSA(rsa, RSASignaturePadding.Pkcs1);
+
+                    // Passes with the generator
+                    using (request.Create(cert.SubjectName, generator, now, now.AddHours(3), serialNumber))
+                    {
+                    }
+                }
             }
         }
 

--- a/src/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/PrivateKeyAssociationTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/PrivateKeyAssociationTests.cs
@@ -106,7 +106,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                 CertificateRequest request = new CertificateRequest(
                     $"CN={KeyName}-{provType}-{keyNumber}",
                     rsaCsp,
-                    hashAlgorithm);
+                    hashAlgorithm,
+                    RSASignaturePadding.Pkcs1);
 
                 DateTimeOffset now = DateTimeOffset.UtcNow;
 
@@ -121,7 +122,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                     request = new CertificateRequest(
                         $"CN={KeyName}-{provType}-{keyNumber}-again",
                         rsa,
-                        hashAlgorithm);
+                        hashAlgorithm,
+                        RSASignaturePadding.Pkcs1);
 
                     X509Certificate2 cert2 = request.Create(
                         request.SubjectName,
@@ -189,7 +191,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                     CertificateRequest request = new CertificateRequest(
                         $"CN={KeyName}",
                         rsaCng,
-                        HashAlgorithmName.SHA256);
+                        HashAlgorithmName.SHA256,
+                        RSASignaturePadding.Pkcs1);
 
                     DateTimeOffset now = DateTimeOffset.UtcNow;
 
@@ -228,7 +231,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                 CertificateRequest request = new CertificateRequest(
                     $"CN={nameof(ThirdPartyProvider_RSA)}",
                     rsaOther,
-                    hashAlgorithm);
+                    hashAlgorithm,
+                    RSASignaturePadding.Pkcs1);
 
                 byte[] signature;
                 byte[] data = request.SubjectName.RawData;


### PR DESCRIPTION
In the original API design we went back and forth on having a default for
RSASignaturePadding.  In the end we landed on convenience, and defaulted
it to Pkcs1 (v1.5) padding since that is the most widely supported.  Some
additional feedback was given that suggested that we really didn't want to do
that, after all, we had nicely made the digest algorithm a required parameter.

This change makes RSASignaturePadding a required parameter for creating
RSA certificates.  As a consequence the Create method which uses a
certificate now has more failure modes.

1) Hybrid algorithm signing is currently disallowed.

Either "RSA is special", or "you can only sign with the same algorithm so the
options make sense".  We are currently using the latter, though they're almost
identical given our current support matrix (2 algorithms).

2) Using Create(X509Certificate2) with .ctor(PublicKey) fails for RSA.

This one ended up being "RSA is special".  In this degenerate case we don't
have enough data to know if the signing key is using Pkcs1 or PSS, and NIST
guidance is to only use a single padding mode with an RSA private key; so
we can't make any assumptions.  (We can't even assume signed-with-Pkcs1
means signs-with-Pkcs1, unless it's self-signed)