### PR TITLE
Add Async flag to SqlClient NamedPipes' PipeStream to resolve an issue with connection hangs while using MARS over NP.

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNINpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNINpHandle.cs
@@ -46,7 +46,11 @@ namespace System.Data.SqlClient.SNI
 
             try
             {
-                _pipeStream = new NamedPipeClientStream(serverName, pipeName, PipeDirection.InOut, PipeOptions.WriteThrough, Security.Principal.TokenImpersonationLevel.None);
+                _pipeStream = new NamedPipeClientStream(
+                    serverName,
+                    pipeName,
+                    PipeDirection.InOut,
+                    PipeOptions.Asynchronous | PipeOptions.WriteThrough);
 
                 bool isInfiniteTimeOut = long.MaxValue == timerExpire;
                 if (isInfiniteTimeOut)

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/LocalDBTest/LocalDBTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/LocalDBTest/LocalDBTest.cs
@@ -13,10 +13,25 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [ConditionalFact(nameof(IsLocalDBEnvironmentSet))]
         public static void LocalDBConnectionTest()
         {
-            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder("server=(localdb)\\MSSQLLocalDB");
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(@"server=(localdb)\MSSQLLocalDB");
             builder.IntegratedSecurity = true;
             builder.ConnectTimeout = 2;
-            using (SqlConnection connection = new SqlConnection(builder.ConnectionString))
+            OpenConnection(builder.ConnectionString);
+        }
+
+        [ConditionalFact(nameof(IsLocalDBEnvironmentSet))]
+        public static void LocalDBMarsTest()
+        {
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(@"server=(localdb)\MSSQLLocalDB;");
+            builder.IntegratedSecurity = true;
+            builder.MultipleActiveResultSets = true;
+            builder.ConnectTimeout = 2;
+            OpenConnection(builder.ConnectionString);
+        }
+
+        private static void OpenConnection(string connString)
+        {
+            using (SqlConnection connection = new SqlConnection(connString))
             {
                 connection.Open();
                 using (SqlCommand command = new SqlCommand("SELECT @@SERVERNAME", connection))

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/MARSTest/MARSTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/MARSTest/MARSTest.cs
@@ -13,6 +13,24 @@ namespace System.Data.SqlClient.ManualTesting.Tests
     {
         private static readonly string _connStr = (new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr) { MultipleActiveResultSets = true }).ConnectionString;
 
+        [CheckConnStrSetupFact]
+        public static void NamedPipesMARSTest()
+        {
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(DataTestUtility.NpConnStr);
+            builder.MultipleActiveResultSets = true;
+            builder.ConnectTimeout = 5;
+
+            using (SqlConnection conn = new SqlConnection(builder.ConnectionString))
+            {
+                conn.Open();
+                using (SqlCommand command = new SqlCommand("SELECT @@SERVERNAME", conn))
+                {
+                    var result = command.ExecuteScalar();
+                    Assert.NotNull(result);
+                }
+            }
+        }
+
 #if DEBUG
         [CheckConnStrSetupFact]
         public static void MARSAsyncTimeoutTest()


### PR DESCRIPTION
Needed to add an Async flag to the NP PipeStream options. Without the async option, connection.Open() hangs forever while waiting on a sync write for sending the MARS SYN packet.