### PR TITLE
Skip Xml_TypeWithDateTimePropertyAsXmlTime on netfx.

### DIFF
--- a/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -117,7 +117,6 @@ public static partial class XmlSerializerTests
     }
 
     [Fact]
-    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "XmlCustomFormatter.FromTime is quirked, which causes behavior difference. See the method for more details.")]
     public static void Xml_TypeWithDateTimePropertyAsXmlTime()
     {
         DateTime localTime = new DateTime(549269870000L, DateTimeKind.Local);
@@ -140,11 +139,14 @@ string.Format(@"<?xml version=""1.0"" encoding=""utf-8""?>
             Value = new DateTime(549269870000L, DateTimeKind.Utc)
         };
 
-        TypeWithDateTimePropertyAsXmlTime utcTimeRoundTrip = SerializeAndDeserialize(utcTimeOjbect,
-@"<?xml version=""1.0"" encoding=""utf-8""?>
+        if (!PlatformDetection.IsFullFramework || PlatformDetection.IsNetfx462OrNewer())
+        {
+            TypeWithDateTimePropertyAsXmlTime utcTimeRoundTrip = SerializeAndDeserialize(utcTimeOjbect,
+    @"<?xml version=""1.0"" encoding=""utf-8""?>
 <TypeWithDateTimePropertyAsXmlTime xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">15:15:26.9870000Z</TypeWithDateTimePropertyAsXmlTime>");
 
-        Assert.StrictEqual(utcTimeOjbect.Value, utcTimeRoundTrip.Value);
+            Assert.StrictEqual(utcTimeOjbect.Value, utcTimeRoundTrip.Value);
+        }
     }
 
     [Fact]

--- a/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -117,6 +117,7 @@ public static partial class XmlSerializerTests
     }
 
     [Fact]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "XmlCustomFormatter.FromTime is quirked, which causes behavior difference. See the method for more details.")]
     public static void Xml_TypeWithDateTimePropertyAsXmlTime()
     {
         DateTime localTime = new DateTime(549269870000L, DateTimeKind.Local);


### PR DESCRIPTION
XmlCustomFormatter.FromTime is quirked, which causes the test to behavior differently on netfx and netcore. See [the method](https://github.com/dotnet/corefx/blob/63e70fa6b1bc6b7175467e0ad16cbbf4c44f8d83/src/System.Private.Xml/src/System/Xml/Serialization/Xmlcustomformatter.cs#L88) for more details.

Fix #18993