### PR TITLE
Add WinRT to SafeFileHandle converters

### DIFF
--- a/src/Common/src/System/IO/Win32Marshal.cs
+++ b/src/Common/src/System/IO/Win32Marshal.cs
@@ -99,11 +99,13 @@ namespace System.IO
         }
 
         /// <summary>
-        ///     Returns a HRESULT for the specified Win32 error code.
+        /// If not already an HRESULT, returns an HRESULT for the specified Win32 error code.
         /// </summary>
         internal static int MakeHRFromErrorCode(int errorCode)
         {
-            Debug.Assert((0xFFFF0000 & errorCode) == 0, "This is an HRESULT, not an error code!");
+            // Don't convert it if it is already an HRESULT
+            if ((0xFFFF0000 & errorCode) == 0)
+                return errorCode;
 
             return unchecked(((int)0x80070000) | errorCode);
         }

--- a/src/Common/src/System/IO/Win32Marshal.cs
+++ b/src/Common/src/System/IO/Win32Marshal.cs
@@ -104,7 +104,7 @@ namespace System.IO
         internal static int MakeHRFromErrorCode(int errorCode)
         {
             // Don't convert it if it is already an HRESULT
-            if ((0xFFFF0000 & errorCode) == 0)
+            if ((0xFFFF0000 & errorCode) != 0)
                 return errorCode;
 
             return unchecked(((int)0x80070000) | errorCode);

--- a/src/System.Runtime.WindowsRuntime/System.Runtime.WindowsRuntime.sln
+++ b/src/System.Runtime.WindowsRuntime/System.Runtime.WindowsRuntime.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26403.7
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.WindowsRuntime", "src\System.Runtime.WindowsRuntime.csproj", "{844A2A0B-4169-49C3-B367-AFDC4894E487}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -13,20 +13,56 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E89
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{6ABF965C-8997-4A43-8D10-425AC8614CCF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.WindowsRuntime.Tests", "tests\System.Runtime.WindowsRuntime.Tests.csproj", "{C4854B44-ABFE-4BB5-8F89-F35FE6201338}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
+		uapaot-Windows_NT-Debug|Any CPU = uapaot-Windows_NT-Debug|Any CPU
+		uapaot-Windows_NT-Release|Any CPU = uapaot-Windows_NT-Release|Any CPU
+		uap-Windows_NT-Debug|Any CPU = uap-Windows_NT-Debug|Any CPU
+		uap-Windows_NT-Release|Any CPU = uap-Windows_NT-Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{844A2A0B-4169-49C3-B367-AFDC4894E487}.Debug|Any CPU.ActiveCfg = uap-Windows_NT-Debug|Any CPU
 		{844A2A0B-4169-49C3-B367-AFDC4894E487}.Debug|Any CPU.Build.0 = uap-Windows_NT-Debug|Any CPU
 		{844A2A0B-4169-49C3-B367-AFDC4894E487}.Release|Any CPU.ActiveCfg = uap-Windows_NT-Release|Any CPU
 		{844A2A0B-4169-49C3-B367-AFDC4894E487}.Release|Any CPU.Build.0 = uap-Windows_NT-Release|Any CPU
+		{844A2A0B-4169-49C3-B367-AFDC4894E487}.uapaot-Windows_NT-Debug|Any CPU.ActiveCfg = uapaot-Windows_NT-Debug|Any CPU
+		{844A2A0B-4169-49C3-B367-AFDC4894E487}.uapaot-Windows_NT-Debug|Any CPU.Build.0 = uapaot-Windows_NT-Debug|Any CPU
+		{844A2A0B-4169-49C3-B367-AFDC4894E487}.uapaot-Windows_NT-Release|Any CPU.ActiveCfg = uapaot-Windows_NT-Release|Any CPU
+		{844A2A0B-4169-49C3-B367-AFDC4894E487}.uapaot-Windows_NT-Release|Any CPU.Build.0 = uapaot-Windows_NT-Release|Any CPU
+		{844A2A0B-4169-49C3-B367-AFDC4894E487}.uap-Windows_NT-Debug|Any CPU.ActiveCfg = uap-Windows_NT-Debug|Any CPU
+		{844A2A0B-4169-49C3-B367-AFDC4894E487}.uap-Windows_NT-Debug|Any CPU.Build.0 = uap-Windows_NT-Debug|Any CPU
+		{844A2A0B-4169-49C3-B367-AFDC4894E487}.uap-Windows_NT-Release|Any CPU.ActiveCfg = uap-Windows_NT-Release|Any CPU
+		{844A2A0B-4169-49C3-B367-AFDC4894E487}.uap-Windows_NT-Release|Any CPU.Build.0 = uap-Windows_NT-Release|Any CPU
 		{FDDA3E4A-B182-4CD1-B624-EBD72D8A05DA}.Debug|Any CPU.ActiveCfg = uap-Debug|Any CPU
 		{FDDA3E4A-B182-4CD1-B624-EBD72D8A05DA}.Debug|Any CPU.Build.0 = uap-Debug|Any CPU
 		{FDDA3E4A-B182-4CD1-B624-EBD72D8A05DA}.Release|Any CPU.ActiveCfg = uap-Release|Any CPU
 		{FDDA3E4A-B182-4CD1-B624-EBD72D8A05DA}.Release|Any CPU.Build.0 = uap-Release|Any CPU
+		{FDDA3E4A-B182-4CD1-B624-EBD72D8A05DA}.uapaot-Windows_NT-Debug|Any CPU.ActiveCfg = uap-Release|Any CPU
+		{FDDA3E4A-B182-4CD1-B624-EBD72D8A05DA}.uapaot-Windows_NT-Debug|Any CPU.Build.0 = uap-Release|Any CPU
+		{FDDA3E4A-B182-4CD1-B624-EBD72D8A05DA}.uapaot-Windows_NT-Release|Any CPU.ActiveCfg = uap-Release|Any CPU
+		{FDDA3E4A-B182-4CD1-B624-EBD72D8A05DA}.uapaot-Windows_NT-Release|Any CPU.Build.0 = uap-Release|Any CPU
+		{FDDA3E4A-B182-4CD1-B624-EBD72D8A05DA}.uap-Windows_NT-Debug|Any CPU.ActiveCfg = uap-Release|Any CPU
+		{FDDA3E4A-B182-4CD1-B624-EBD72D8A05DA}.uap-Windows_NT-Debug|Any CPU.Build.0 = uap-Release|Any CPU
+		{FDDA3E4A-B182-4CD1-B624-EBD72D8A05DA}.uap-Windows_NT-Release|Any CPU.ActiveCfg = uap-Release|Any CPU
+		{FDDA3E4A-B182-4CD1-B624-EBD72D8A05DA}.uap-Windows_NT-Release|Any CPU.Build.0 = uap-Release|Any CPU
+		{C4854B44-ABFE-4BB5-8F89-F35FE6201338}.Debug|Any CPU.ActiveCfg = uap-Windows_NT-Debug|Any CPU
+		{C4854B44-ABFE-4BB5-8F89-F35FE6201338}.Debug|Any CPU.Build.0 = uap-Windows_NT-Debug|Any CPU
+		{C4854B44-ABFE-4BB5-8F89-F35FE6201338}.Release|Any CPU.ActiveCfg = uapaot-Windows_NT-Release|Any CPU
+		{C4854B44-ABFE-4BB5-8F89-F35FE6201338}.Release|Any CPU.Build.0 = uapaot-Windows_NT-Release|Any CPU
+		{C4854B44-ABFE-4BB5-8F89-F35FE6201338}.uapaot-Windows_NT-Debug|Any CPU.ActiveCfg = uapaot-Windows_NT-Debug|Any CPU
+		{C4854B44-ABFE-4BB5-8F89-F35FE6201338}.uapaot-Windows_NT-Debug|Any CPU.Build.0 = uapaot-Windows_NT-Debug|Any CPU
+		{C4854B44-ABFE-4BB5-8F89-F35FE6201338}.uapaot-Windows_NT-Release|Any CPU.ActiveCfg = uapaot-Windows_NT-Release|Any CPU
+		{C4854B44-ABFE-4BB5-8F89-F35FE6201338}.uapaot-Windows_NT-Release|Any CPU.Build.0 = uapaot-Windows_NT-Release|Any CPU
+		{C4854B44-ABFE-4BB5-8F89-F35FE6201338}.uap-Windows_NT-Debug|Any CPU.ActiveCfg = uap-Windows_NT-Debug|Any CPU
+		{C4854B44-ABFE-4BB5-8F89-F35FE6201338}.uap-Windows_NT-Debug|Any CPU.Build.0 = uap-Windows_NT-Debug|Any CPU
+		{C4854B44-ABFE-4BB5-8F89-F35FE6201338}.uap-Windows_NT-Release|Any CPU.ActiveCfg = uap-Windows_NT-Release|Any CPU
+		{C4854B44-ABFE-4BB5-8F89-F35FE6201338}.uap-Windows_NT-Release|Any CPU.Build.0 = uap-Windows_NT-Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -34,5 +70,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{844A2A0B-4169-49C3-B367-AFDC4894E487} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{FDDA3E4A-B182-4CD1-B624-EBD72D8A05DA} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
+		{C4854B44-ABFE-4BB5-8F89-F35FE6201338} = {6ABF965C-8997-4A43-8D10-425AC8614CCF}
 	EndGlobalSection
 EndGlobal

--- a/src/System.Runtime.WindowsRuntime/System.Runtime.WindowsRuntime.sln
+++ b/src/System.Runtime.WindowsRuntime/System.Runtime.WindowsRuntime.sln
@@ -14,6 +14,9 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{6ABF965C-8997-4A43-8D10-425AC8614CCF}"
+	ProjectSection(SolutionItems) = preProject
+		tests\Configurations.props = tests\Configurations.props
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.WindowsRuntime.Tests", "tests\System.Runtime.WindowsRuntime.Tests.csproj", "{C4854B44-ABFE-4BB5-8F89-F35FE6201338}"
 EndProject
@@ -53,12 +56,12 @@ Global
 		{FDDA3E4A-B182-4CD1-B624-EBD72D8A05DA}.uap-Windows_NT-Release|Any CPU.Build.0 = uap-Release|Any CPU
 		{C4854B44-ABFE-4BB5-8F89-F35FE6201338}.Debug|Any CPU.ActiveCfg = uap-Windows_NT-Debug|Any CPU
 		{C4854B44-ABFE-4BB5-8F89-F35FE6201338}.Debug|Any CPU.Build.0 = uap-Windows_NT-Debug|Any CPU
-		{C4854B44-ABFE-4BB5-8F89-F35FE6201338}.Release|Any CPU.ActiveCfg = uapaot-Windows_NT-Release|Any CPU
-		{C4854B44-ABFE-4BB5-8F89-F35FE6201338}.Release|Any CPU.Build.0 = uapaot-Windows_NT-Release|Any CPU
-		{C4854B44-ABFE-4BB5-8F89-F35FE6201338}.uapaot-Windows_NT-Debug|Any CPU.ActiveCfg = uapaot-Windows_NT-Debug|Any CPU
-		{C4854B44-ABFE-4BB5-8F89-F35FE6201338}.uapaot-Windows_NT-Debug|Any CPU.Build.0 = uapaot-Windows_NT-Debug|Any CPU
-		{C4854B44-ABFE-4BB5-8F89-F35FE6201338}.uapaot-Windows_NT-Release|Any CPU.ActiveCfg = uapaot-Windows_NT-Release|Any CPU
-		{C4854B44-ABFE-4BB5-8F89-F35FE6201338}.uapaot-Windows_NT-Release|Any CPU.Build.0 = uapaot-Windows_NT-Release|Any CPU
+		{C4854B44-ABFE-4BB5-8F89-F35FE6201338}.Release|Any CPU.ActiveCfg = uap-Windows_NT-Release|Any CPU
+		{C4854B44-ABFE-4BB5-8F89-F35FE6201338}.Release|Any CPU.Build.0 = uap-Windows_NT-Release|Any CPU
+		{C4854B44-ABFE-4BB5-8F89-F35FE6201338}.uapaot-Windows_NT-Debug|Any CPU.ActiveCfg = uap-Windows_NT-Release|Any CPU
+		{C4854B44-ABFE-4BB5-8F89-F35FE6201338}.uapaot-Windows_NT-Debug|Any CPU.Build.0 = uap-Windows_NT-Release|Any CPU
+		{C4854B44-ABFE-4BB5-8F89-F35FE6201338}.uapaot-Windows_NT-Release|Any CPU.ActiveCfg = uap-Windows_NT-Release|Any CPU
+		{C4854B44-ABFE-4BB5-8F89-F35FE6201338}.uapaot-Windows_NT-Release|Any CPU.Build.0 = uap-Windows_NT-Release|Any CPU
 		{C4854B44-ABFE-4BB5-8F89-F35FE6201338}.uap-Windows_NT-Debug|Any CPU.ActiveCfg = uap-Windows_NT-Debug|Any CPU
 		{C4854B44-ABFE-4BB5-8F89-F35FE6201338}.uap-Windows_NT-Debug|Any CPU.Build.0 = uap-Windows_NT-Debug|Any CPU
 		{C4854B44-ABFE-4BB5-8F89-F35FE6201338}.uap-Windows_NT-Release|Any CPU.ActiveCfg = uap-Windows_NT-Release|Any CPU

--- a/src/System.Runtime.WindowsRuntime/ref/System.Runtime.WindowsRuntime.cs
+++ b/src/System.Runtime.WindowsRuntime/ref/System.Runtime.WindowsRuntime.cs
@@ -49,6 +49,25 @@ namespace System.IO
         public static global::System.Threading.Tasks.Task<global::System.IO.Stream> OpenStreamForWriteAsync(this global::Windows.Storage.IStorageFile windowsRuntimeFile) { throw null; }
         [global::System.CLSCompliantAttribute(false)]
         public static global::System.Threading.Tasks.Task<global::System.IO.Stream> OpenStreamForWriteAsync(this global::Windows.Storage.IStorageFolder rootDirectory, string relativePath, global::Windows.Storage.CreationCollisionOption creationCollisionOption) { throw null; }
+        [global::System.CLSCompliantAttribute(false)]
+        public static global::Microsoft.Win32.SafeHandles.SafeFileHandle CreateSafeFileHandle(
+            this global::Windows.Storage.IStorageFile windowsRuntimeFile,
+            global::System.IO.FileAccess access = global::System.IO.FileAccess.ReadWrite,
+            global::System.IO.FileShare share = global::System.IO.FileShare.Read,
+            global::System.IO.FileOptions options = global::System.IO.FileOptions.None) { throw null; }
+        [global::System.CLSCompliantAttribute(false)]
+        public static global::Microsoft.Win32.SafeHandles.SafeFileHandle CreateSafeFileHandle(
+            this global::Windows.Storage.IStorageFolder rootDirectory,
+            string relativePath,
+            global::System.IO.FileMode mode) { throw null; }
+        [global::System.CLSCompliantAttribute(false)]
+        public static global::Microsoft.Win32.SafeHandles.SafeFileHandle CreateSafeFileHandle(
+            this global::Windows.Storage.IStorageFolder rootDirectory,
+            string relativePath,
+            global::System.IO.FileMode mode,
+            global::System.IO.FileAccess access,
+            global::System.IO.FileShare share = global::System.IO.FileShare.Read,
+            global::System.IO.FileOptions options = global::System.IO.FileOptions.None) { throw null; }
     }
     [global::System.Security.SecurityCriticalAttribute]
     public static partial class WindowsRuntimeStreamExtensions

--- a/src/System.Runtime.WindowsRuntime/src/Resources/Strings.resx
+++ b/src/System.Runtime.WindowsRuntime/src/Resources/Strings.resx
@@ -235,4 +235,43 @@
   <data name="UnauthorizedAccess_InternalBuffer" xml:space="preserve">
     <value>MemoryStream's internal buffer cannot be accessed.</value>
   </data>
+  <data name="NotSupported_Inheritable" xml:space="preserve">
+    <value>Inheritable is not a supported option.</value>
+  </data>
+  <data name="NotSupported_Encrypted" xml:space="preserve">
+    <value>Encrypted is not a supported option.</value>
+  </data>
+  <data name="IO_FileNotFound" xml:space="preserve">
+    <value>Unable to find the specified file.</value>
+  </data>
+  <data name="IO_FileNotFound_FileName" xml:space="preserve">
+    <value>Could not find file '{0}'.</value>
+  </data>
+  <data name="IO_PathNotFound_NoPathName" xml:space="preserve">
+    <value>Could not find a part of the path.</value>
+  </data>
+  <data name="IO_PathNotFound_Path" xml:space="preserve">
+    <value>Could not find a part of the path '{0}'.</value>
+  </data>
+  <data name="UnauthorizedAccess_IODenied_NoPathName" xml:space="preserve">
+    <value>Access to the path is denied.</value>
+  </data>
+  <data name="UnauthorizedAccess_IODenied_Path" xml:space="preserve">
+    <value>Access to the path '{0}' is denied.</value>
+  </data>
+  <data name="IO_AlreadyExists_Name" xml:space="preserve">
+    <value>Cannot create '{0}' because a file or directory with the same name already exists.</value>
+  </data>
+  <data name="IO_PathTooLong" xml:space="preserve">
+    <value>The specified file name or path is too long, or a component of the specified path is too long.</value>
+  </data>
+  <data name="IO_SharingViolation_File" xml:space="preserve">
+    <value>The process cannot access the file '{0}' because it is being used by another process.</value>
+  </data>
+  <data name="IO_SharingViolation_NoFileName" xml:space="preserve">
+    <value>The process cannot access the file because it is being used by another process.</value>
+  </data>
+  <data name="IO_FileExists_Name" xml:space="preserve">
+    <value>The file '{0}' already exists.</value>
+  </data>
 </root>

--- a/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.csproj
+++ b/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.csproj
@@ -81,13 +81,28 @@
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.ResolveLocaleName.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.ResolveLocaleName.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.FormatMessage.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.FormatMessage.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.RoGetBufferMarshaler.cs">
       <Link>Common\Interop\Windows\mincore\Interop.RoGetBufferMarshaler.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Errors.cs">
+      <Link>Common\Interop\Windows\Interop.Errors.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\IO\Win32Marshal.cs">
+      <Link>Common\System\IO\Win32Marshal.cs</Link>
+    </Compile>
     <Compile Include="System\InternalHelpers.cs" />
+    <Compile Include="System\IO\HANDLE_ACCESS_OPTIONS.cs" />
+    <Compile Include="System\IO\HANDLE_CREATION_OPTIONS.cs" />
+    <Compile Include="System\IO\HANDLE_OPTIONS.cs" />
+    <Compile Include="System\IO\HANDLE_SHARING_OPTION.cs" />
+    <Compile Include="System\IO\IStorageFolderHandleAccess.cs" />
+    <Compile Include="System\IO\IStorageItemHandleAccess.cs" />
     <Compile Include="System\IO\NetFxToWinRtStreamAdapter.cs" />
     <Compile Include="System\IO\StreamOperationAsyncResult.cs" />
     <Compile Include="System\IO\StreamOperationsImplementation.cs" />

--- a/src/System.Runtime.WindowsRuntime/src/System/IO/HANDLE_ACCESS_OPTIONS.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/IO/HANDLE_ACCESS_OPTIONS.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.IO
+{
+    [Flags]
+    internal enum HANDLE_ACCESS_OPTIONS : uint
+    {
+        HAO_NONE = 0,
+        HAO_READ_ATTRIBUTES = 0x80,
+        HAO_READ = 0x120089,
+        HAO_WRITE = 0x120116,
+        HAO_DELETE = 0x10000,
+
+        // These are defined elsewhere, adding here for clarity
+        // on what the HANDLE_ACCESS_OPTIONS represent.
+
+        // DELETE               = 0x00010000,
+        READ_CONTROL = 0x00020000,
+        SYNCHRONIZE = 0x00100000,
+        FILE_READ_DATA = 0x00000001,
+        FILE_WRITE_DATA = 0x00000002,
+        FILE_APPEND_DATA = 0x00000004,
+        FILE_READ_EA = 0x00000008,
+        FILE_WRITE_EA = 0x00000010,
+        FILE_EXECUTE = 0x00000020,
+        // FILE_READ_ATTRIBUTES = 0x00000080,
+        FILE_WRITE_ATTRIBUTES = 0x00000100,
+    }
+}

--- a/src/System.Runtime.WindowsRuntime/src/System/IO/HANDLE_ACCESS_OPTIONS.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/IO/HANDLE_ACCESS_OPTIONS.cs
@@ -9,8 +9,10 @@ namespace System.IO
     {
         HAO_NONE = 0,
         HAO_READ_ATTRIBUTES = 0x80,
-        HAO_READ = 0x120089,
-        HAO_WRITE = 0x120116,
+        // 0x120089
+        HAO_READ = SYNCHRONIZE | READ_CONTROL | HAO_READ_ATTRIBUTES | FILE_READ_EA | FILE_READ_DATA,
+        // 0x120116
+        HAO_WRITE = SYNCHRONIZE | READ_CONTROL | FILE_WRITE_ATTRIBUTES | FILE_WRITE_EA | FILE_APPEND_DATA | FILE_WRITE_DATA,
         HAO_DELETE = 0x10000,
 
         // These are defined elsewhere, adding here for clarity

--- a/src/System.Runtime.WindowsRuntime/src/System/IO/HANDLE_CREATION_OPTIONS.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/IO/HANDLE_CREATION_OPTIONS.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.IO
+{
+    internal enum HANDLE_CREATION_OPTIONS : uint
+    {
+        HCO_CREATE_NEW = 0x1,
+        HCO_CREATE_ALWAYS = 0x2,
+        HCO_OPEN_EXISTING = 0x3,
+        HCO_OPEN_ALWAYS = 0x4,
+        HCO_TRUNCATE_EXISTING = 0x5,
+    }
+}

--- a/src/System.Runtime.WindowsRuntime/src/System/IO/HANDLE_OPTIONS.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/IO/HANDLE_OPTIONS.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.IO
+{
+    [Flags]
+    internal enum HANDLE_OPTIONS : uint
+    {
+        HO_NONE = 0,
+        HO_OPEN_REQUIRING_OPLOCK = 0x40000,
+        HO_DELETE_ON_CLOSE = 0x4000000,
+        HO_SEQUENTIAL_SCAN = 0x8000000,
+        HO_RANDOM_ACCESS = 0x10000000,
+        HO_NO_BUFFERING = 0x20000000,
+        HO_OVERLAPPED = 0x40000000,
+        HO_WRITE_THROUGH = 0x80000000
+    }
+}

--- a/src/System.Runtime.WindowsRuntime/src/System/IO/HANDLE_SHARING_OPTION.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/IO/HANDLE_SHARING_OPTION.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.IO
+{
+    [Flags]
+    internal enum HANDLE_SHARING_OPTIONS : uint
+    {
+        HSO_SHARE_NONE = 0,
+        HSO_SHARE_READ = 0x1,
+        HSO_SHARE_WRITE = 0x2,
+        HSO_SHARE_DELETE = 0x4
+    }
+}

--- a/src/System.Runtime.WindowsRuntime/src/System/IO/IStorageFolderHandleAccess.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/IO/IStorageFolderHandleAccess.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System.Runtime.InteropServices;
+
+namespace System.IO
+{
+    // Available in 14393 (RS1) and later
+    [ComImport]
+    [Guid("DF19938F-5462-48A0-BE65-D2A3271A08D6")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    internal interface IStorageFolderHandleAccess
+    {
+        [PreserveSig]
+        int Create(
+            [MarshalAs(UnmanagedType.LPWStr)] string fileName,
+            HANDLE_CREATION_OPTIONS creationOptions,
+            HANDLE_ACCESS_OPTIONS accessOptions,
+            HANDLE_SHARING_OPTIONS sharingOptions,
+            HANDLE_OPTIONS options,
+            IntPtr oplockBreakingHandler,
+            out SafeFileHandle interopHandle);
+    }
+}

--- a/src/System.Runtime.WindowsRuntime/src/System/IO/IStorageItemHandleAccess.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/IO/IStorageItemHandleAccess.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System.Runtime.InteropServices;
+
+namespace System.IO
+{
+    // Available in 14393 (RS1) and later
+    [ComImport]
+    [Guid("5CA296B2-2C25-4D22-B785-B885C8201E6A")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    internal interface IStorageItemHandleAccess
+    {
+        [PreserveSig]
+        int Create(
+            HANDLE_ACCESS_OPTIONS accessOptions,
+            HANDLE_SHARING_OPTIONS sharingOptions,
+            HANDLE_OPTIONS options,
+            IntPtr oplockBreakingHandler,
+            out SafeFileHandle interopHandle);
+    }
+}

--- a/src/System.Runtime.WindowsRuntime/src/System/IO/WindowsRuntimeStorageExtensions.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/IO/WindowsRuntimeStorageExtensions.cs
@@ -2,17 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
-using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading.Tasks;
+using Windows.Storage;
 using Windows.Storage.FileProperties;
 using Windows.Storage.Streams;
-using Windows.Storage;
 
 namespace System.IO
 {
@@ -21,26 +15,18 @@ namespace System.IO
     /// </summary>
     public static class WindowsRuntimeStorageExtensions
     {
-        #region Extensions on IStorageFile for retreaving a managed Stream
-
         [CLSCompliant(false)]
         public static Task<Stream> OpenStreamForReadAsync(this IStorageFile windowsRuntimeFile)
         {
             if (windowsRuntimeFile == null)
                 throw new ArgumentNullException(nameof(windowsRuntimeFile));
 
-            Contract.Ensures(Contract.Result<Task<Stream>>() != null);
-            Contract.EndContractBlock();
-
             return OpenStreamForReadAsyncCore(windowsRuntimeFile);
         }
-
 
         private static async Task<Stream> OpenStreamForReadAsyncCore(this IStorageFile windowsRuntimeFile)
         {
             Debug.Assert(windowsRuntimeFile != null);
-            Contract.Ensures(Contract.Result<Task<Stream>>() != null);
-            Contract.EndContractBlock();
 
             try
             {
@@ -57,26 +43,20 @@ namespace System.IO
             }
         }
 
-
         [CLSCompliant(false)]
         public static Task<Stream> OpenStreamForWriteAsync(this IStorageFile windowsRuntimeFile)
         {
             if (windowsRuntimeFile == null)
                 throw new ArgumentNullException(nameof(windowsRuntimeFile));
 
-            Contract.Ensures(Contract.Result<Task<Stream>>() != null);
-            Contract.EndContractBlock();
-
             return OpenStreamForWriteAsyncCore(windowsRuntimeFile, 0);
         }
 
 
-        private static async Task<Stream> OpenStreamForWriteAsyncCore(this IStorageFile windowsRuntimeFile, Int64 offset)
+        private static async Task<Stream> OpenStreamForWriteAsyncCore(this IStorageFile windowsRuntimeFile, long offset)
         {
             Debug.Assert(windowsRuntimeFile != null);
             Debug.Assert(offset >= 0);
-            Contract.Ensures(Contract.Result<Task<Stream>>() != null);
-            Contract.EndContractBlock();
 
             try
             {
@@ -94,13 +74,8 @@ namespace System.IO
             }
         }
 
-        #endregion Extensions on IStorageFile for retreaving a managed Stream
-
-
-        #region Extensions on IStorageFolder for retreaving a managed Stream
-
         [CLSCompliant(false)]
-        public static Task<Stream> OpenStreamForReadAsync(this IStorageFolder rootDirectory, String relativePath)
+        public static Task<Stream> OpenStreamForReadAsync(this IStorageFolder rootDirectory, string relativePath)
         {
             if (rootDirectory == null)
                 throw new ArgumentNullException(nameof(rootDirectory));
@@ -108,22 +83,16 @@ namespace System.IO
             if (relativePath == null)
                 throw new ArgumentNullException(nameof(relativePath));
 
-            if (String.IsNullOrWhiteSpace(relativePath))
+            if (string.IsNullOrWhiteSpace(relativePath))
                 throw new ArgumentException(SR.Argument_RelativePathMayNotBeWhitespaceOnly, nameof(relativePath));
-
-            Contract.Ensures(Contract.Result<Task<Stream>>() != null);
-            Contract.EndContractBlock();
 
             return OpenStreamForReadAsyncCore(rootDirectory, relativePath);
         }
 
-
-        private static async Task<Stream> OpenStreamForReadAsyncCore(this IStorageFolder rootDirectory, String relativePath)
+        private static async Task<Stream> OpenStreamForReadAsyncCore(this IStorageFolder rootDirectory, string relativePath)
         {
             Debug.Assert(rootDirectory != null);
-            Debug.Assert(!String.IsNullOrWhiteSpace(relativePath));
-            Contract.Ensures(Contract.Result<Task<Stream>>() != null);
-            Contract.EndContractBlock();
+            Debug.Assert(!string.IsNullOrWhiteSpace(relativePath));
 
             try
             {
@@ -141,9 +110,8 @@ namespace System.IO
             }
         }
 
-
         [CLSCompliant(false)]
-        public static Task<Stream> OpenStreamForWriteAsync(this IStorageFolder rootDirectory, String relativePath,
+        public static Task<Stream> OpenStreamForWriteAsync(this IStorageFolder rootDirectory, string relativePath,
                                                            CreationCollisionOption creationCollisionOption)
         {
             if (rootDirectory == null)
@@ -152,21 +120,18 @@ namespace System.IO
             if (relativePath == null)
                 throw new ArgumentNullException(nameof(relativePath));
 
-            if (String.IsNullOrWhiteSpace(relativePath))
+            if (string.IsNullOrWhiteSpace(relativePath))
                 throw new ArgumentException(SR.Argument_RelativePathMayNotBeWhitespaceOnly, nameof(relativePath));
-
-            Contract.Ensures(Contract.Result<Task<Stream>>() != null);
-            Contract.EndContractBlock();
 
             return OpenStreamForWriteAsyncCore(rootDirectory, relativePath, creationCollisionOption);
         }
 
 
-        private static async Task<Stream> OpenStreamForWriteAsyncCore(this IStorageFolder rootDirectory, String relativePath,
+        private static async Task<Stream> OpenStreamForWriteAsyncCore(this IStorageFolder rootDirectory, string relativePath,
                                                                       CreationCollisionOption creationCollisionOption)
         {
             Debug.Assert(rootDirectory != null);
-            Debug.Assert(!String.IsNullOrWhiteSpace(relativePath));
+            Debug.Assert(!string.IsNullOrWhiteSpace(relativePath));
 
             Debug.Assert(creationCollisionOption == CreationCollisionOption.FailIfExists
                                     || creationCollisionOption == CreationCollisionOption.GenerateUniqueName
@@ -176,16 +141,13 @@ namespace System.IO
                             + " policy about Append-On-OpenIfExists used in this method. Apparently a new enum value was added to the"
                             + " CreationCollisionOption type and we need to make sure that the policy still makes sense.");
 
-            Contract.Ensures(Contract.Result<Task<Stream>>() != null);
-            Contract.EndContractBlock();
-
             try
             {
                 // Open file and set up default options for opening it:
 
                 IStorageFile windowsRuntimeFile = await rootDirectory.CreateFileAsync(relativePath, creationCollisionOption)
                                                                      .AsTask().ConfigureAwait(continueOnCapturedContext: false);
-                Int64 offset = 0;
+                long offset = 0;
 
                 // If the specified creationCollisionOption was OpenIfExists, then we will try to APPEND, otherwise we will OVERWRITE:
 
@@ -193,11 +155,11 @@ namespace System.IO
                 {
                     BasicProperties fileProperties = await windowsRuntimeFile.GetBasicPropertiesAsync()
                                                            .AsTask().ConfigureAwait(continueOnCapturedContext: false);
-                    UInt64 fileSize = fileProperties.Size;
+                    ulong fileSize = fileProperties.Size;
 
-                    Debug.Assert(fileSize <= Int64.MaxValue, ".NET streams assume that file sizes are not larger than Int64.MaxValue,"
+                    Debug.Assert(fileSize <= long.MaxValue, ".NET streams assume that file sizes are not larger than Int64.MaxValue,"
                                                               + " so we are not supporting the situation where this is not the case.");
-                    offset = checked((Int64)fileSize);
+                    offset = checked((long)fileSize);
                 }
 
                 // Now open a file with the correct options:
@@ -212,9 +174,6 @@ namespace System.IO
                 return null;
             }
         }
-        #endregion Extensions on IStorageFolder for retreaving a managed Stream
+    }
+}
 
-    }  // class WindowsRuntimeStorageExtensions
-}  // namespace
-
-// WindowsRuntimeStorageExtensions.cs

--- a/src/System.Runtime.WindowsRuntime/src/System/IO/WindowsRuntimeStorageExtensions.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/IO/WindowsRuntimeStorageExtensions.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.Threading.Tasks;
+using Microsoft.Win32.SafeHandles;
 using Windows.Storage;
 using Windows.Storage.FileProperties;
 using Windows.Storage.Streams;
@@ -51,7 +52,6 @@ namespace System.IO
 
             return OpenStreamForWriteAsyncCore(windowsRuntimeFile, 0);
         }
-
 
         private static async Task<Stream> OpenStreamForWriteAsyncCore(this IStorageFile windowsRuntimeFile, long offset)
         {
@@ -173,6 +173,146 @@ namespace System.IO
                 WinRtIOHelper.NativeExceptionToIOExceptionInfo(ex).Throw();
                 return null;
             }
+        }
+
+        [CLSCompliant(false)]
+        public static SafeFileHandle CreateSafeFileHandle(
+            this IStorageFile windowsRuntimeFile,
+            FileAccess access = FileAccess.ReadWrite,
+            FileShare share = FileShare.Read,
+            FileOptions options = FileOptions.None)
+        {
+            if (windowsRuntimeFile == null)
+                throw new ArgumentNullException(nameof(windowsRuntimeFile));
+
+            HANDLE_ACCESS_OPTIONS accessOptions = FileAccessToHandleAccessOptions(access);
+            HANDLE_SHARING_OPTIONS sharingOptions = FileShareToHandleSharingOptions(share);
+            HANDLE_OPTIONS handleOptions = FileOptionsToHandleOptions(options);
+
+            IStorageItemHandleAccess handleAccess = ((object)windowsRuntimeFile) as IStorageItemHandleAccess;
+
+            if (handleAccess == null)
+                return null;
+
+            SafeFileHandle handle;
+
+            int result = handleAccess.Create(
+                accessOptions,
+                sharingOptions,
+                handleOptions,
+                IntPtr.Zero,
+                out handle);
+
+            if (result != 0)
+                throw Win32Marshal.GetExceptionForWin32Error(Win32Marshal.TryMakeWin32ErrorCodeFromHR(result), windowsRuntimeFile.Name);
+
+            return handle;
+        }
+
+        [CLSCompliant(false)]
+        public static SafeFileHandle CreateSafeFileHandle(
+            this IStorageFolder rootDirectory,
+            string relativePath,
+            FileMode mode)
+        {
+            return rootDirectory.CreateSafeFileHandle(relativePath, mode, (mode == FileMode.Append ? FileAccess.Write : FileAccess.ReadWrite));
+        }
+
+        [CLSCompliant(false)]
+        public static SafeFileHandle CreateSafeFileHandle(
+            this IStorageFolder rootDirectory,
+            string relativePath,
+            FileMode mode,
+            FileAccess access,
+            FileShare share = FileShare.Read,
+            FileOptions options = FileOptions.None)
+        {
+            if (rootDirectory == null)
+                throw new ArgumentNullException(nameof(rootDirectory));
+            if (relativePath == null)
+                throw new ArgumentNullException(nameof(relativePath));
+
+            HANDLE_CREATION_OPTIONS creationOptions = FileModeToCreationOptions(mode);
+            HANDLE_ACCESS_OPTIONS accessOptions = FileAccessToHandleAccessOptions(access);
+            HANDLE_SHARING_OPTIONS sharingOptions = FileShareToHandleSharingOptions(share);
+            HANDLE_OPTIONS handleOptions = FileOptionsToHandleOptions(options);
+
+            IStorageFolderHandleAccess handleAccess = ((object)rootDirectory) as IStorageFolderHandleAccess;
+
+            if (handleAccess == null)
+                return null;
+
+            SafeFileHandle handle;
+
+            int result = handleAccess.Create(
+                relativePath,
+                creationOptions,
+                accessOptions,
+                sharingOptions,
+                handleOptions,
+                IntPtr.Zero,
+                out handle);
+
+            if (result != 0)
+                throw Win32Marshal.GetExceptionForWin32Error(Win32Marshal.TryMakeWin32ErrorCodeFromHR(result), relativePath);
+
+            return handle;
+        }
+
+        private static HANDLE_ACCESS_OPTIONS FileAccessToHandleAccessOptions(FileAccess access)
+        {
+            switch (access)
+            {
+                case FileAccess.ReadWrite:
+                    return HANDLE_ACCESS_OPTIONS.HAO_READ | HANDLE_ACCESS_OPTIONS.HAO_WRITE;
+                case FileAccess.Read:
+                    return HANDLE_ACCESS_OPTIONS.HAO_READ;
+                case FileAccess.Write:
+                    return HANDLE_ACCESS_OPTIONS.HAO_WRITE;
+            }
+
+            throw new ArgumentOutOfRangeException(nameof(access));
+        }
+
+        private static HANDLE_SHARING_OPTIONS FileShareToHandleSharingOptions(FileShare share)
+        {
+            if ((share & FileShare.Inheritable) != 0)
+                throw new NotSupportedException(SR.NotSupported_Inheritable);
+            if (share < FileShare.None || share > (FileShare.ReadWrite | FileShare.Delete))
+                throw new ArgumentOutOfRangeException(nameof(share));
+
+            HANDLE_SHARING_OPTIONS sharingOptions = HANDLE_SHARING_OPTIONS.HSO_SHARE_NONE;
+            if ((share & FileShare.Read) != 0)
+                sharingOptions |= HANDLE_SHARING_OPTIONS.HSO_SHARE_READ;
+            if ((share & FileShare.Write) != 0)
+                sharingOptions |= HANDLE_SHARING_OPTIONS.HSO_SHARE_WRITE;
+            if ((share & FileShare.Delete) != 0)
+                sharingOptions |= HANDLE_SHARING_OPTIONS.HSO_SHARE_DELETE;
+
+            return sharingOptions;
+        }
+
+        private static HANDLE_OPTIONS FileOptionsToHandleOptions(FileOptions options)
+        {
+            if ((options & FileOptions.Encrypted) != 0)
+                throw new NotSupportedException(SR.NotSupported_Encrypted);
+            if (options != FileOptions.None && (options &
+                ~(FileOptions.WriteThrough | FileOptions.Asynchronous | FileOptions.RandomAccess | FileOptions.DeleteOnClose |
+                  FileOptions.SequentialScan | (FileOptions)0x20000000 /* NoBuffering */)) != 0)
+                throw new ArgumentOutOfRangeException(nameof(options));
+
+            return (HANDLE_OPTIONS)options;
+        }
+
+        private static HANDLE_CREATION_OPTIONS FileModeToCreationOptions(FileMode mode)
+        {
+            if (mode < FileMode.CreateNew || mode > FileMode.Append)
+                throw new ArgumentOutOfRangeException(nameof(mode));
+
+            if (mode == FileMode.Append)
+                return HANDLE_CREATION_OPTIONS.HCO_CREATE_ALWAYS;
+
+            return (HANDLE_CREATION_OPTIONS)mode;
         }
     }
 }

--- a/src/System.Runtime.WindowsRuntime/src/System/IO/WindowsRuntimeStorageExtensions.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/IO/WindowsRuntimeStorageExtensions.cs
@@ -271,7 +271,7 @@ namespace System.IO
                     return HANDLE_ACCESS_OPTIONS.HAO_WRITE;
             }
 
-            throw new ArgumentOutOfRangeException(nameof(access));
+            throw new ArgumentOutOfRangeException(nameof(access), access, null);
         }
 
         private static HANDLE_SHARING_OPTIONS FileShareToHandleSharingOptions(FileShare share)
@@ -279,7 +279,7 @@ namespace System.IO
             if ((share & FileShare.Inheritable) != 0)
                 throw new NotSupportedException(SR.NotSupported_Inheritable);
             if (share < FileShare.None || share > (FileShare.ReadWrite | FileShare.Delete))
-                throw new ArgumentOutOfRangeException(nameof(share));
+                throw new ArgumentOutOfRangeException(nameof(share), share, null);
 
             HANDLE_SHARING_OPTIONS sharingOptions = HANDLE_SHARING_OPTIONS.HSO_SHARE_NONE;
             if ((share & FileShare.Read) != 0)
@@ -299,7 +299,7 @@ namespace System.IO
             if (options != FileOptions.None && (options &
                 ~(FileOptions.WriteThrough | FileOptions.Asynchronous | FileOptions.RandomAccess | FileOptions.DeleteOnClose |
                   FileOptions.SequentialScan | (FileOptions)0x20000000 /* NoBuffering */)) != 0)
-                throw new ArgumentOutOfRangeException(nameof(options));
+                throw new ArgumentOutOfRangeException(nameof(options), options, null);
 
             return (HANDLE_OPTIONS)options;
         }
@@ -307,7 +307,7 @@ namespace System.IO
         private static HANDLE_CREATION_OPTIONS FileModeToCreationOptions(FileMode mode)
         {
             if (mode < FileMode.CreateNew || mode > FileMode.Append)
-                throw new ArgumentOutOfRangeException(nameof(mode));
+                throw new ArgumentOutOfRangeException(nameof(mode), mode, null);
 
             if (mode == FileMode.Append)
                 return HANDLE_CREATION_OPTIONS.HCO_CREATE_ALWAYS;

--- a/src/System.Runtime.WindowsRuntime/tests/Configurations.props
+++ b/src/System.Runtime.WindowsRuntime/tests/Configurations.props
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+      uap-Windows_NT;
+      uapaot-Windows_NT;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/src/System.Runtime.WindowsRuntime/tests/Configurations.props
+++ b/src/System.Runtime.WindowsRuntime/tests/Configurations.props
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <BuildConfigurations>
       uap-Windows_NT;
-      uapaot-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.WindowsRuntime/tests/System.Runtime.WindowsRuntime.Tests.csproj
+++ b/src/System.Runtime.WindowsRuntime/tests/System.Runtime.WindowsRuntime.Tests.csproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <ProjectGuid>{C4854B44-ABFE-4BB5-8F89-F35FE6201338}</ProjectGuid>
+    <TestCategories>InnerLoop;OuterLoop</TestCategories>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Windows_NT-Release|AnyCPU'" />
+  <ItemGroup>
+    <Compile Include="System\IO\StorageFileMock.cs" />
+    <Compile Include="System\IO\CreateSafeFileHandleTests.cs" />
+    <Compile Include="System\IO\StorageFolderMock.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Windows, Version=255.255.255.255, Culture=neutral, processorArchitecture=MSIL" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime.WindowsRuntime/tests/System.Runtime.WindowsRuntime.Tests.csproj
+++ b/src/System.Runtime.WindowsRuntime/tests/System.Runtime.WindowsRuntime.Tests.csproj
@@ -7,15 +7,13 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Windows_NT-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="System\IO\StorageFileMock.cs" />
     <Compile Include="System\IO\CreateSafeFileHandleTests.cs" />
     <Compile Include="System\IO\StorageFolderMock.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Windows, Version=255.255.255.255, Culture=neutral, processorArchitecture=MSIL" />
+    <Reference Include="Windows" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime.WindowsRuntime/tests/System/IO/CreateSafeFileHandleTests.cs
+++ b/src/System.Runtime.WindowsRuntime/tests/System/IO/CreateSafeFileHandleTests.cs
@@ -1,0 +1,249 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using Windows.Storage;
+using Xunit;
+
+namespace System.IO
+{
+    public class CreateSafeFileHandleTests
+    {
+        [Fact]
+        public void NullStorageFile_ThrowsArgumentNull()
+        {
+            IStorageFile file = null;
+            Assert.Equal(
+                "windowsRuntimeFile",
+                Assert.Throws<ArgumentNullException>(() => file.CreateSafeFileHandle()).ParamName);
+        }
+
+        [Fact]
+        public void FromStorageFile_BadAccessThrowsOutOfRange()
+        {
+            IStorageFile file = new StorageFileMock();
+            Assert.Equal(
+                "access",
+                Assert.Throws<ArgumentOutOfRangeException>(() => file.CreateSafeFileHandle((FileAccess)100)).ParamName);
+        }
+
+        [Fact]
+        public void FromStorageFile_BadSharingThrowsOutOfRange()
+        {
+            IStorageFile file = new StorageFileMock();
+            Assert.Equal(
+                "share",
+                Assert.Throws<ArgumentOutOfRangeException>(() => file.CreateSafeFileHandle(FileAccess.ReadWrite, (FileShare)100)).ParamName);
+        }
+
+        [Fact]
+        public void FromStorageFile_BadOptionsThrowsOutOfRange()
+        {
+            IStorageFile file = new StorageFileMock();
+            Assert.Equal(
+                "options",
+                Assert.Throws<ArgumentOutOfRangeException>(() => file.CreateSafeFileHandle(FileAccess.ReadWrite, FileShare.Read, (FileOptions)100)).ParamName);
+        }
+
+        [Fact]
+        public void FromStorageFile_InheritableThrowsNotSupported()
+        {
+            IStorageFile file = new StorageFileMock();
+            Assert.Throws<NotSupportedException>(() => file.CreateSafeFileHandle(FileAccess.ReadWrite, FileShare.Inheritable));
+        }
+
+        [Fact]
+        public void FromStorageFile_EncryptedThrowsNotSupported()
+        {
+            IStorageFile file = new StorageFileMock();
+            Assert.Throws<NotSupportedException>(() => file.CreateSafeFileHandle(FileAccess.ReadWrite, FileShare.Read, FileOptions.Encrypted));
+        }
+
+        [Fact]
+        public void FromStorageFile_NoInterfaceReturnsNull()
+        {
+            // If the provided IStorageFile object can't be cast to the COM interface needed it should return null
+            IStorageFile file = new StorageFileMock();
+            Assert.Null(file.CreateSafeFileHandle());
+        }
+
+        [Fact]
+        public void NullStorageFolder_ThrowsArgumentNull()
+        {
+            IStorageFolder folder = null;
+            Assert.Equal(
+                "rootDirectory",
+                Assert.Throws<ArgumentNullException>(() => folder.CreateSafeFileHandle("foo", FileMode.OpenOrCreate)).ParamName);
+        }
+
+        [Fact]
+        public void NullStorageFolder_ThrowsArgumentNull2()
+        {
+            IStorageFolder folder = null;
+            Assert.Equal(
+                "rootDirectory",
+                Assert.Throws<ArgumentNullException>(() => folder.CreateSafeFileHandle("foo", FileMode.OpenOrCreate, FileAccess.Write)).ParamName);
+        }
+
+        [Fact]
+        public void FromStorageFolder_BadModeThrowsOutOfRange()
+        {
+            IStorageFolder folder = new StorageFolderMock();
+            Assert.Equal(
+                "mode",
+                Assert.Throws<ArgumentOutOfRangeException>(() => folder.CreateSafeFileHandle("Foo", (FileMode)100)).ParamName);
+        }
+
+        [Fact]
+        public void FromStorageFolder_BadAccessThrowsOutOfRange()
+        {
+            IStorageFolder folder = new StorageFolderMock();
+            Assert.Equal(
+                "access",
+                Assert.Throws<ArgumentOutOfRangeException>(() => folder.CreateSafeFileHandle("Foo", FileMode.OpenOrCreate, (FileAccess)100)).ParamName);
+        }
+
+        [Fact]
+        public void FromStorageFolder_BadSharingThrowsOutOfRange()
+        {
+            IStorageFolder folder = new StorageFolderMock();
+            Assert.Equal(
+                "share",
+                Assert.Throws<ArgumentOutOfRangeException>(() => folder.CreateSafeFileHandle("Foo", FileMode.OpenOrCreate, FileAccess.ReadWrite, (FileShare)100)).ParamName);
+        }
+
+        [Fact]
+        public void FromStorageFolder_BadOptionsThrowsOutOfRange()
+        {
+            IStorageFolder folder = new StorageFolderMock();
+            Assert.Equal(
+                "options",
+                Assert.Throws<ArgumentOutOfRangeException>(() => folder.CreateSafeFileHandle("Foo", FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read, (FileOptions)100)).ParamName);
+        }
+
+        [Fact]
+        public void FromStorageFolder_InheritableThrowsNotSupported()
+        {
+            IStorageFolder folder = new StorageFolderMock();
+            Assert.Throws<NotSupportedException>(() => folder.CreateSafeFileHandle("Foo", FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Inheritable));
+        }
+
+        [Fact]
+        public void FromStorageFolder_EncryptedThrowsNotSupported()
+        {
+            IStorageFolder folder = new StorageFolderMock();
+            Assert.Throws<NotSupportedException>(() => folder.CreateSafeFileHandle("Foo", FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read, FileOptions.Encrypted));
+        }
+
+        [Fact]
+        public void FromStorageFolder_Basic()
+        {
+            StorageFolder folder = ApplicationData.Current.TemporaryFolder;
+            string filename = "FromStorageFolder_Basic_" + Path.GetRandomFileName();
+            SafeFileHandle handle = folder.CreateSafeFileHandle(filename, FileMode.CreateNew);
+            Assert.NotNull(handle);
+            Assert.False(handle.IsInvalid);
+            handle.Close();
+            File.Delete(Path.Combine(folder.Path, filename));
+        }
+
+        [Fact]
+        public void FromStorageFolder_SurfaceIOException()
+        {
+            StorageFolder folder = ApplicationData.Current.TemporaryFolder;
+            string filename = "FromStorageFolder_SurfaceIOException_" + Path.GetRandomFileName();
+            SafeFileHandle handle = folder.CreateSafeFileHandle(filename, FileMode.CreateNew);
+            Assert.NotNull(handle);
+            Assert.False(handle.IsInvalid);
+            handle.Close();
+            Assert.Contains(
+                filename,
+                Assert.Throws<IOException>(() => folder.CreateSafeFileHandle(filename, FileMode.CreateNew)).Message);
+            File.Delete(Path.Combine(folder.Path, filename));
+        }
+
+        [Fact]
+        public void FromStorageFolder_SurfaceNotFoundException()
+        {
+            StorageFolder folder = ApplicationData.Current.TemporaryFolder;
+            string filename = "FromStorageFolder_SurfaceNotFoundException_" + Path.GetRandomFileName();
+            Assert.Contains(
+                filename,
+                Assert.Throws<FileNotFoundException>(() => folder.CreateSafeFileHandle(filename, FileMode.Open)).Message);
+        }
+
+        [Fact]
+        public void FromStorageFolder_FileStream()
+        {
+            StorageFolder folder = ApplicationData.Current.TemporaryFolder;
+            string filename = "FromStorageFolder_FileStream_" + Path.GetRandomFileName();
+            SafeFileHandle handle = folder.CreateSafeFileHandle(filename, FileMode.CreateNew, FileAccess.ReadWrite);
+            Assert.NotNull(handle);
+            Assert.False(handle.IsInvalid);
+            using (FileStream fs = new FileStream(handle, FileAccess.ReadWrite))
+            {
+                byte[] data = { 0xDE, 0xAD, 0xBE, 0xEF };
+                fs.Write(data, 0, data.Length);
+                fs.Flush();
+                fs.Position = 0;
+                byte[] input = new byte[4];
+                Assert.Equal(4, fs.Read(input, 0, 4));
+                Assert.Equal(data, input);
+            }
+
+            File.Delete(Path.Combine(folder.Path, filename));
+        }
+
+        [Fact]
+        public void FromStorageFile_Basic()
+        {
+            StorageFolder folder = ApplicationData.Current.TemporaryFolder;
+            string filename = "FromStorageFile_Basic_" + Path.GetRandomFileName();
+            StorageFile file = folder.CreateFileAsync(filename, CreationCollisionOption.FailIfExists).AsTask().Result;
+            SafeFileHandle handle = file.CreateSafeFileHandle();
+            Assert.NotNull(handle);
+            Assert.False(handle.IsInvalid);
+            handle.Close();
+            file.DeleteAsync().AsTask().Wait();
+        }
+
+        [Fact]
+        public void FromStorageFile_FileStream()
+        {
+            StorageFolder folder = ApplicationData.Current.TemporaryFolder;
+            string filename = "FromStorageFile_FileStream_" + Path.GetRandomFileName();
+            StorageFile file = folder.CreateFileAsync(filename, CreationCollisionOption.FailIfExists).AsTask().Result;
+            SafeFileHandle handle = file.CreateSafeFileHandle();
+            Assert.NotNull(handle);
+            Assert.False(handle.IsInvalid);
+            using (FileStream fs = new FileStream(handle, FileAccess.ReadWrite))
+            {
+                byte[] data = { 0xAB, 0xBA, 0xCA, 0xDA, 0xBA };
+                fs.Write(data, 0, data.Length);
+                fs.Flush();
+                fs.Position = 0;
+                byte[] input = new byte[5];
+                Assert.Equal(5, fs.Read(input, 0, 5));
+                Assert.Equal(data, input);
+            }
+
+            file.DeleteAsync().AsTask().Wait();
+        }
+
+        [Fact]
+        public void FromStorageFile_SurfaceIOException()
+        {
+            StorageFolder folder = ApplicationData.Current.TemporaryFolder;
+            string filename = "FromStorageFile_SurfaceIOException_" + Path.GetRandomFileName();
+            StorageFile file = folder.CreateFileAsync(filename, CreationCollisionOption.FailIfExists).AsTask().Result;
+            SafeFileHandle handle = file.CreateSafeFileHandle(FileAccess.ReadWrite, FileShare.None);
+            Assert.Contains(
+                filename,
+                Assert.Throws<IOException>(() => file.CreateSafeFileHandle(FileAccess.ReadWrite, FileShare.None)).Message);
+
+            handle.Close();
+            file.DeleteAsync().AsTask().Wait();
+        }
+    }
+}

--- a/src/System.Runtime.WindowsRuntime/tests/System/IO/CreateSafeFileHandleTests.cs
+++ b/src/System.Runtime.WindowsRuntime/tests/System/IO/CreateSafeFileHandleTests.cs
@@ -14,36 +14,28 @@ namespace System.IO
         public void NullStorageFile_ThrowsArgumentNull()
         {
             IStorageFile file = null;
-            Assert.Equal(
-                "windowsRuntimeFile",
-                Assert.Throws<ArgumentNullException>(() => file.CreateSafeFileHandle()).ParamName);
+            Assert.Throws<ArgumentNullException>("windowsRuntimeFile", () => file.CreateSafeFileHandle());
         }
 
         [Fact]
         public void FromStorageFile_BadAccessThrowsOutOfRange()
         {
             IStorageFile file = new StorageFileMock();
-            Assert.Equal(
-                "access",
-                Assert.Throws<ArgumentOutOfRangeException>(() => file.CreateSafeFileHandle((FileAccess)100)).ParamName);
+            Assert.Throws<ArgumentOutOfRangeException>("access", () => file.CreateSafeFileHandle((FileAccess)100));
         }
 
         [Fact]
         public void FromStorageFile_BadSharingThrowsOutOfRange()
         {
             IStorageFile file = new StorageFileMock();
-            Assert.Equal(
-                "share",
-                Assert.Throws<ArgumentOutOfRangeException>(() => file.CreateSafeFileHandle(FileAccess.ReadWrite, (FileShare)100)).ParamName);
+            Assert.Throws<ArgumentOutOfRangeException>("share", () => file.CreateSafeFileHandle(FileAccess.ReadWrite, (FileShare)100));
         }
 
         [Fact]
         public void FromStorageFile_BadOptionsThrowsOutOfRange()
         {
             IStorageFile file = new StorageFileMock();
-            Assert.Equal(
-                "options",
-                Assert.Throws<ArgumentOutOfRangeException>(() => file.CreateSafeFileHandle(FileAccess.ReadWrite, FileShare.Read, (FileOptions)100)).ParamName);
+            Assert.Throws<ArgumentOutOfRangeException>("options", () => file.CreateSafeFileHandle(FileAccess.ReadWrite, FileShare.Read, (FileOptions)100));
         }
 
         [Fact]
@@ -72,54 +64,42 @@ namespace System.IO
         public void NullStorageFolder_ThrowsArgumentNull()
         {
             IStorageFolder folder = null;
-            Assert.Equal(
-                "rootDirectory",
-                Assert.Throws<ArgumentNullException>(() => folder.CreateSafeFileHandle("foo", FileMode.OpenOrCreate)).ParamName);
+            Assert.Throws<ArgumentNullException>("rootDirectory", () => folder.CreateSafeFileHandle("foo", FileMode.OpenOrCreate));
         }
 
         [Fact]
         public void NullStorageFolder_ThrowsArgumentNull2()
         {
             IStorageFolder folder = null;
-            Assert.Equal(
-                "rootDirectory",
-                Assert.Throws<ArgumentNullException>(() => folder.CreateSafeFileHandle("foo", FileMode.OpenOrCreate, FileAccess.Write)).ParamName);
+            Assert.Throws<ArgumentNullException>("rootDirectory", () => folder.CreateSafeFileHandle("foo", FileMode.OpenOrCreate, FileAccess.Write));
         }
 
         [Fact]
         public void FromStorageFolder_BadModeThrowsOutOfRange()
         {
             IStorageFolder folder = new StorageFolderMock();
-            Assert.Equal(
-                "mode",
-                Assert.Throws<ArgumentOutOfRangeException>(() => folder.CreateSafeFileHandle("Foo", (FileMode)100)).ParamName);
+            Assert.Throws<ArgumentOutOfRangeException>("mode", () => folder.CreateSafeFileHandle("Foo", (FileMode)100));
         }
 
         [Fact]
         public void FromStorageFolder_BadAccessThrowsOutOfRange()
         {
             IStorageFolder folder = new StorageFolderMock();
-            Assert.Equal(
-                "access",
-                Assert.Throws<ArgumentOutOfRangeException>(() => folder.CreateSafeFileHandle("Foo", FileMode.OpenOrCreate, (FileAccess)100)).ParamName);
+            Assert.Throws<ArgumentOutOfRangeException>("access", () => folder.CreateSafeFileHandle("Foo", FileMode.OpenOrCreate, (FileAccess)100));
         }
 
         [Fact]
         public void FromStorageFolder_BadSharingThrowsOutOfRange()
         {
             IStorageFolder folder = new StorageFolderMock();
-            Assert.Equal(
-                "share",
-                Assert.Throws<ArgumentOutOfRangeException>(() => folder.CreateSafeFileHandle("Foo", FileMode.OpenOrCreate, FileAccess.ReadWrite, (FileShare)100)).ParamName);
+            Assert.Throws<ArgumentOutOfRangeException>("share", () => folder.CreateSafeFileHandle("Foo", FileMode.OpenOrCreate, FileAccess.ReadWrite, (FileShare)100));
         }
 
         [Fact]
         public void FromStorageFolder_BadOptionsThrowsOutOfRange()
         {
             IStorageFolder folder = new StorageFolderMock();
-            Assert.Equal(
-                "options",
-                Assert.Throws<ArgumentOutOfRangeException>(() => folder.CreateSafeFileHandle("Foo", FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read, (FileOptions)100)).ParamName);
+            Assert.Throws<ArgumentOutOfRangeException>("options", () => folder.CreateSafeFileHandle("Foo", FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read, (FileOptions)100));
         }
 
         [Fact]
@@ -141,10 +121,11 @@ namespace System.IO
         {
             StorageFolder folder = ApplicationData.Current.TemporaryFolder;
             string filename = "FromStorageFolder_Basic_" + Path.GetRandomFileName();
-            SafeFileHandle handle = folder.CreateSafeFileHandle(filename, FileMode.CreateNew);
-            Assert.NotNull(handle);
-            Assert.False(handle.IsInvalid);
-            handle.Close();
+            using (SafeFileHandle handle = folder.CreateSafeFileHandle(filename, FileMode.CreateNew))
+            {
+                Assert.NotNull(handle);
+                Assert.False(handle.IsInvalid);
+            }
             File.Delete(Path.Combine(folder.Path, filename));
         }
 
@@ -153,10 +134,11 @@ namespace System.IO
         {
             StorageFolder folder = ApplicationData.Current.TemporaryFolder;
             string filename = "FromStorageFolder_SurfaceIOException_" + Path.GetRandomFileName();
-            SafeFileHandle handle = folder.CreateSafeFileHandle(filename, FileMode.CreateNew);
-            Assert.NotNull(handle);
-            Assert.False(handle.IsInvalid);
-            handle.Close();
+            using (SafeFileHandle handle = folder.CreateSafeFileHandle(filename, FileMode.CreateNew))
+            {
+                Assert.NotNull(handle);
+                Assert.False(handle.IsInvalid);
+            }
             Assert.Contains(
                 filename,
                 Assert.Throws<IOException>(() => folder.CreateSafeFileHandle(filename, FileMode.CreateNew)).Message);
@@ -201,10 +183,11 @@ namespace System.IO
             StorageFolder folder = ApplicationData.Current.TemporaryFolder;
             string filename = "FromStorageFile_Basic_" + Path.GetRandomFileName();
             StorageFile file = folder.CreateFileAsync(filename, CreationCollisionOption.FailIfExists).AsTask().Result;
-            SafeFileHandle handle = file.CreateSafeFileHandle();
-            Assert.NotNull(handle);
-            Assert.False(handle.IsInvalid);
-            handle.Close();
+            using (SafeFileHandle handle = file.CreateSafeFileHandle())
+            {
+                Assert.NotNull(handle);
+                Assert.False(handle.IsInvalid);
+            }
             file.DeleteAsync().AsTask().Wait();
         }
 
@@ -237,12 +220,13 @@ namespace System.IO
             StorageFolder folder = ApplicationData.Current.TemporaryFolder;
             string filename = "FromStorageFile_SurfaceIOException_" + Path.GetRandomFileName();
             StorageFile file = folder.CreateFileAsync(filename, CreationCollisionOption.FailIfExists).AsTask().Result;
-            SafeFileHandle handle = file.CreateSafeFileHandle(FileAccess.ReadWrite, FileShare.None);
-            Assert.Contains(
-                filename,
-                Assert.Throws<IOException>(() => file.CreateSafeFileHandle(FileAccess.ReadWrite, FileShare.None)).Message);
+            using (SafeFileHandle handle = file.CreateSafeFileHandle(FileAccess.ReadWrite, FileShare.None))
+            {
+                Assert.Contains(
+                    filename,
+                    Assert.Throws<IOException>(() => file.CreateSafeFileHandle(FileAccess.ReadWrite, FileShare.None)).Message);
+            }
 
-            handle.Close();
             file.DeleteAsync().AsTask().Wait();
         }
     }

--- a/src/System.Runtime.WindowsRuntime/tests/System/IO/StorageFileMock.cs
+++ b/src/System.Runtime.WindowsRuntime/tests/System/IO/StorageFileMock.cs
@@ -1,0 +1,116 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Windows.Foundation;
+using Windows.Storage;
+using Windows.Storage.FileProperties;
+using Windows.Storage.Streams;
+
+namespace System.IO
+{
+    internal class StorageFileMock : IStorageFile
+    {
+        public IAsyncOperation<IRandomAccessStream> OpenAsync(FileAccessMode accessMode)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAsyncOperation<StorageStreamTransaction> OpenTransactedWriteAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAsyncOperation<StorageFile> CopyAsync(IStorageFolder destinationFolder)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAsyncOperation<StorageFile> CopyAsync(IStorageFolder destinationFolder, string desiredNewName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAsyncOperation<StorageFile> CopyAsync(IStorageFolder destinationFolder, string desiredNewName, NameCollisionOption option)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAsyncAction CopyAndReplaceAsync(IStorageFile fileToReplace)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAsyncAction MoveAsync(IStorageFolder destinationFolder)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAsyncAction MoveAsync(IStorageFolder destinationFolder, string desiredNewName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAsyncAction MoveAsync(IStorageFolder destinationFolder, string desiredNewName, NameCollisionOption option)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAsyncAction MoveAndReplaceAsync(IStorageFile fileToReplace)
+        {
+            throw new NotImplementedException();
+        }
+
+        public string ContentType => throw new NotImplementedException();
+
+        public string FileType => throw new NotImplementedException();
+
+        public IAsyncAction RenameAsync(string desiredName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAsyncAction RenameAsync(string desiredName, NameCollisionOption option)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAsyncAction DeleteAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAsyncAction DeleteAsync(StorageDeleteOption option)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAsyncOperation<BasicProperties> GetBasicPropertiesAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsOfType(StorageItemTypes type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public global::Windows.Storage.FileAttributes Attributes => throw new NotImplementedException();
+
+        public DateTimeOffset DateCreated => throw new NotImplementedException();
+
+        public string Name => throw new NotImplementedException();
+
+        public string Path => throw new NotImplementedException();
+
+        public IAsyncOperation<IRandomAccessStreamWithContentType> OpenReadAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAsyncOperation<IInputStream> OpenSequentialReadAsync()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/System.Runtime.WindowsRuntime/tests/System/IO/StorageFolderMock.cs
+++ b/src/System.Runtime.WindowsRuntime/tests/System/IO/StorageFolderMock.cs
@@ -1,0 +1,102 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Windows.Foundation;
+using Windows.Storage;
+using Windows.Storage.FileProperties;
+
+namespace System.IO
+{
+    internal class StorageFolderMock : IStorageFolder
+    {
+        public IAsyncOperation<StorageFile> CreateFileAsync(string desiredName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAsyncOperation<StorageFile> CreateFileAsync(string desiredName, CreationCollisionOption options)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAsyncOperation<StorageFolder> CreateFolderAsync(string desiredName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAsyncOperation<StorageFolder> CreateFolderAsync(string desiredName, CreationCollisionOption options)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAsyncOperation<StorageFile> GetFileAsync(string name)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAsyncOperation<StorageFolder> GetFolderAsync(string name)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAsyncOperation<IStorageItem> GetItemAsync(string name)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAsyncOperation<IReadOnlyList<StorageFile>> GetFilesAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAsyncOperation<IReadOnlyList<StorageFolder>> GetFoldersAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAsyncOperation<IReadOnlyList<IStorageItem>> GetItemsAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAsyncAction RenameAsync(string desiredName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAsyncAction RenameAsync(string desiredName, NameCollisionOption option)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAsyncAction DeleteAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAsyncAction DeleteAsync(StorageDeleteOption option)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAsyncOperation<BasicProperties> GetBasicPropertiesAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsOfType(StorageItemTypes type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public global::Windows.Storage.FileAttributes Attributes => throw new NotImplementedException();
+
+        public DateTimeOffset DateCreated => throw new NotImplementedException();
+
+        public string Name => throw new NotImplementedException();
+
+        public string Path => throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
- Adds methods to create SafeFileHandle from IStorageFolder/IStorageFile
- Adds test project and tests to S.R.WindowsRuntime

This is the implementation of the API for #18759.

Note that these Windows APIs are simply helpers that allow getting brokered CreateFile2 access. The methods have additional context and some additional filtering and can broker, but they are effectively equivalent to calling CreateFile2 directly. One specific takeaway is that the handle is independent of the source IStorage item once created.