### PR TITLE
Remove SafeHandle marshaling from Send/ReceiveAsync operations

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.ReceiveMessage.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.ReceiveMessage.cs
@@ -11,6 +11,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ReceiveMessage")]
-        internal static extern unsafe Error ReceiveMessage(SafeHandle socket, MessageHeader* messageHeader, SocketFlags flags, long* received);
+        internal static extern unsafe Error ReceiveMessage(IntPtr socket, MessageHeader* messageHeader, SocketFlags flags, long* received);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.SendMessage.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SendMessage.cs
@@ -11,6 +11,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SendMessage")]
-        internal static extern unsafe Error SendMessage(SafeHandle socket, MessageHeader* messageHeader, SocketFlags flags, long* sent);
+        internal static extern unsafe Error SendMessage(IntPtr socket, MessageHeader* messageHeader, SocketFlags flags, long* sent);
     }
 }

--- a/src/Common/src/Interop/Windows/Winsock/Interop.WSARecv.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.WSARecv.cs
@@ -14,16 +14,6 @@ internal static partial class Interop
     {
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
         internal static unsafe extern SocketError WSARecv(
-            SafeCloseSocket socketHandle,
-            WSABuffer* buffer,
-            int bufferCount,
-            out int bytesTransferred,
-            ref SocketFlags socketFlags,
-            NativeOverlapped* overlapped,
-            IntPtr completionRoutine);
-
-        [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
-        internal static unsafe extern SocketError WSARecv(
             IntPtr socketHandle,
             WSABuffer* buffer,
             int bufferCount,
@@ -33,7 +23,7 @@ internal static partial class Interop
             IntPtr completionRoutine);
 
         internal static unsafe SocketError WSARecv(
-            SafeCloseSocket socketHandle,
+            IntPtr socketHandle,
             ref WSABuffer buffer,
             int bufferCount,
             out int bytesTransferred,
@@ -49,22 +39,6 @@ internal static partial class Interop
         }
 
         internal static unsafe SocketError WSARecv(
-            SafeCloseSocket socketHandle,
-            WSABuffer[] buffers,
-            int bufferCount,
-            out int bytesTransferred,
-            ref SocketFlags socketFlags,
-            NativeOverlapped* overlapped,
-            IntPtr completionRoutine)
-        {
-            Debug.Assert(buffers != null);
-            fixed (WSABuffer* buffersPtr = &buffers[0])
-            { 
-                return WSARecv(socketHandle, buffersPtr, bufferCount, out bytesTransferred, ref socketFlags, overlapped, completionRoutine);
-            }
-        }
-
-        internal static unsafe SocketError WSARecv(
             IntPtr socketHandle,
             WSABuffer[] buffers,
             int bufferCount,
@@ -73,7 +47,7 @@ internal static partial class Interop
             NativeOverlapped* overlapped,
             IntPtr completionRoutine)
         {
-            Debug.Assert(buffers != null);
+            Debug.Assert(buffers != null && buffers.Length > 0 );
             fixed (WSABuffer* buffersPtr = &buffers[0])
             {
                 return WSARecv(socketHandle, buffersPtr, bufferCount, out bytesTransferred, ref socketFlags, overlapped, completionRoutine);

--- a/src/Common/src/Interop/Windows/Winsock/Interop.WSARecvFrom.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.WSARecvFrom.cs
@@ -12,10 +12,9 @@ internal static partial class Interop
 {
     internal static partial class Winsock
     {
-
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
-        internal static unsafe extern SocketError WSARecvFrom(
-            SafeCloseSocket socketHandle,
+        private static unsafe extern SocketError WSARecvFrom(
+            IntPtr socketHandle,
             WSABuffer* buffers,
             int bufferCount,
             out int bytesTransferred,
@@ -26,7 +25,7 @@ internal static partial class Interop
             IntPtr completionRoutine);
 
         internal static unsafe SocketError WSARecvFrom(
-            SafeCloseSocket socketHandle,
+            IntPtr socketHandle,
             ref WSABuffer buffer,
             int bufferCount,
             out int bytesTransferred,
@@ -44,7 +43,7 @@ internal static partial class Interop
         }
 
         internal static unsafe SocketError WSARecvFrom(
-            SafeCloseSocket socketHandle,
+            IntPtr socketHandle,
             WSABuffer[] buffers,
             int bufferCount,
             out int bytesTransferred,
@@ -54,7 +53,7 @@ internal static partial class Interop
             NativeOverlapped* overlapped,
             IntPtr completionRoutine)
         {
-            Debug.Assert(buffers != null);
+            Debug.Assert(buffers != null && buffers.Length > 0);
             fixed (WSABuffer* buffersPtr = &buffers[0])
             {
                 return WSARecvFrom(socketHandle, buffersPtr, bufferCount, out bytesTransferred, ref socketFlags, socketAddressPointer, socketAddressSizePointer, overlapped, completionRoutine);

--- a/src/Common/src/Interop/Windows/Winsock/Interop.WSASend.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.WSASend.cs
@@ -14,16 +14,6 @@ internal static partial class Interop
     {
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
         internal static extern unsafe SocketError WSASend(
-            SafeCloseSocket socketHandle,
-            WSABuffer* buffers,
-            int bufferCount,
-            out int bytesTransferred,
-            SocketFlags socketFlags,
-            NativeOverlapped* overlapped,
-            IntPtr completionRoutine);
-
-        [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
-        internal static extern unsafe SocketError WSASend(
             IntPtr socketHandle,
             WSABuffer* buffers,
             int bufferCount,
@@ -33,7 +23,7 @@ internal static partial class Interop
             IntPtr completionRoutine);
 
         internal static unsafe SocketError WSASend(
-            SafeCloseSocket socketHandle,
+            IntPtr socketHandle,
             ref WSABuffer buffer,
             int bufferCount,
             out int bytesTransferred,
@@ -49,22 +39,6 @@ internal static partial class Interop
         }
 
         internal static unsafe SocketError WSASend(
-            SafeCloseSocket socketHandle,
-            WSABuffer[] buffers,
-            int bufferCount,
-            out int bytesTransferred,
-            SocketFlags socketFlags,
-            NativeOverlapped* overlapped,
-            IntPtr completionRoutine)
-        {
-            Debug.Assert(buffers != null);
-            fixed (WSABuffer* buffersPtr = &buffers[0])
-            {
-                return WSASend(socketHandle, buffersPtr, bufferCount, out bytesTransferred, socketFlags, overlapped, completionRoutine);
-            }
-        }
-
-        internal static unsafe SocketError WSASend(
             IntPtr socketHandle,
             WSABuffer[] buffers,
             int bufferCount,
@@ -73,7 +47,7 @@ internal static partial class Interop
             NativeOverlapped* overlapped,
             IntPtr completionRoutine)
         {
-            Debug.Assert(buffers != null);
+            Debug.Assert(buffers != null && buffers.Length > 0);
             fixed (WSABuffer* buffersPtr = &buffers[0])
             {
                 return WSASend(socketHandle, buffersPtr, bufferCount, out bytesTransferred, socketFlags, overlapped, completionRoutine);

--- a/src/Common/src/Interop/Windows/Winsock/Interop.WSASendTo.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.WSASendTo.cs
@@ -13,8 +13,8 @@ internal static partial class Interop
     internal static partial class Winsock
     {
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
-        internal static unsafe extern SocketError WSASendTo(
-            SafeCloseSocket socketHandle,
+        private static unsafe extern SocketError WSASendTo(
+            IntPtr socketHandle,
             WSABuffer* buffers,
             int bufferCount,
             out int bytesTransferred,
@@ -25,7 +25,7 @@ internal static partial class Interop
             IntPtr completionRoutine);
 
         internal static unsafe SocketError WSASendTo(
-            SafeCloseSocket socketHandle,
+            IntPtr socketHandle,
             ref WSABuffer buffer,
             int bufferCount,
             out int bytesTransferred,
@@ -43,7 +43,7 @@ internal static partial class Interop
         }
 
         internal static unsafe SocketError WSASendTo(
-            SafeCloseSocket socketHandle,
+            IntPtr socketHandle,
             WSABuffer[] buffers,
             int bufferCount,
             [Out] out int bytesTransferred,
@@ -53,7 +53,7 @@ internal static partial class Interop
             NativeOverlapped* overlapped,
             IntPtr completionRoutine)
         {
-            Debug.Assert(buffers != null);
+            Debug.Assert(buffers != null && buffers.Length > 0);
             fixed (WSABuffer* buffersPtr = &buffers[0])
             {
                 return WSASendTo(socketHandle, buffersPtr, bufferCount, out bytesTransferred, socketFlags, socketAddress, socketAddressSize, overlapped, completionRoutine);

--- a/src/Common/src/System/Net/SafeCloseSocket.cs
+++ b/src/Common/src/System/Net/SafeCloseSocket.cs
@@ -141,18 +141,15 @@ namespace System.Net.Sockets
 
             _released = true;
             InnerSafeCloseSocket innerSocket = _innerSocket == null ? null : Interlocked.Exchange<InnerSafeCloseSocket>(ref _innerSocket, null);
-            if (innerSocket != null)
-            {
+
 #if DEBUG
-                // On AppDomain unload we may still have pending Overlapped operations.
-                // ThreadPoolBoundHandle should handle this scenario by canceling them.
-                innerSocket.LogRemainingOperations();
+            // On AppDomain unload we may still have pending Overlapped operations.
+            // ThreadPoolBoundHandle should handle this scenario by canceling them.
+            innerSocket?.LogRemainingOperations();
 #endif
 
-                innerSocket.DangerousRelease();
-            }
-
             InnerReleaseHandle();
+            innerSocket?.DangerousRelease();
 
             return true;
         }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -1203,7 +1203,6 @@ namespace System.Net.Sockets
             ValidateBlockingMode();
             if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"SRC:{LocalEndPoint} DST:{RemoteEndPoint} size:{size}");
 
-            // This can throw ObjectDisposedException.
             int bytesTransferred;
             errorCode = SocketPal.Send(_handle, buffer, offset, size, socketFlags, out bytesTransferred);
 
@@ -1314,7 +1313,6 @@ namespace System.Net.Sockets
             EndPoint endPointSnapshot = remoteEP;
             Internals.SocketAddress socketAddress = SnapshotAndSerialize(ref endPointSnapshot);
 
-            // This can throw ObjectDisposedException.
             int bytesTransferred;
             SocketError errorCode = SocketPal.SendTo(_handle, buffer, offset, size, socketFlags, socketAddress.Buffer, socketAddress.Size, out bytesTransferred);
 
@@ -1686,7 +1684,6 @@ namespace System.Net.Sockets
             Internals.SocketAddress socketAddress = SnapshotAndSerialize(ref endPointSnapshot);
             Internals.SocketAddress socketAddressOriginal = IPEndPointExtensions.Serialize(endPointSnapshot);
 
-            // This can throw ObjectDisposedException.
             int bytesTransferred;
             SocketError errorCode = SocketPal.ReceiveFrom(_handle, buffer, offset, size, socketFlags, socketAddress.Buffer, ref socketAddress.InternalSize, out bytesTransferred);
 
@@ -1770,13 +1767,10 @@ namespace System.Net.Sockets
 
             int realOptionLength = 0;
 
-            //
             // IOControl is used for Windows-specific IOCTL operations.  If we need to add support for IOCTLs specific
             // to other platforms, we will likely need to add a new API, as the control codes may overlap with those 
             // from Windows.  Generally it would be preferable to add new methods/properties to abstract these across
             // platforms, however.
-            //
-            // This can throw ObjectDisposedException.
             SocketError errorCode = SocketPal.WindowsIoctl(_handle, ioControlCode, optionInValue, optionOutValue, out realOptionLength);
 
             if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Interop.Winsock.WSAIoctl returns errorCode:{errorCode}");
@@ -4513,7 +4507,6 @@ namespace System.Net.Sockets
         {
             if (NetEventSource.IsEnabled) NetEventSource.Enter(this, endPointSnapshot);
 
-            // This can throw ObjectDisposedException.
             SocketError errorCode = SocketPal.Connect(_handle, socketAddress.Buffer, socketAddress.Size);
 #if TRACE_VERBOSE
             if (NetEventSource.IsEnabled)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
@@ -301,7 +301,7 @@ namespace System.Net.Sockets
                 {
                     // Single buffer case.
                     socketError = Interop.Winsock.WSARecv(
-                        handle,
+                        handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
                         ref _wsaBuffer,
                         1,
                         out bytesTransferred,
@@ -313,7 +313,7 @@ namespace System.Net.Sockets
                 {
                     // Multi buffer case.
                     socketError = Interop.Winsock.WSARecv(
-                        handle,
+                        handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
                         _wsaBufferArray,
                         _bufferListInternal.Count,
                         out bytesTransferred,
@@ -321,6 +321,7 @@ namespace System.Net.Sockets
                         overlapped,
                         IntPtr.Zero);
                 }
+                GC.KeepAlive(handle); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
                 socketError = ProcessIOCPResult(socketError == SocketError.Success, bytesTransferred);
                 return socketError;
@@ -364,7 +365,7 @@ namespace System.Net.Sockets
                 if (_buffer != null)
                 {
                     socketError = Interop.Winsock.WSARecvFrom(
-                        handle,
+                        handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
                         ref _wsaBuffer,
                         1,
                         out bytesTransferred,
@@ -377,7 +378,7 @@ namespace System.Net.Sockets
                 else
                 {
                     socketError = Interop.Winsock.WSARecvFrom(
-                        handle,
+                        handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
                         _wsaBufferArray,
                         _bufferListInternal.Count,
                         out bytesTransferred,
@@ -387,6 +388,7 @@ namespace System.Net.Sockets
                         overlapped,
                         IntPtr.Zero);
                 }
+                GC.KeepAlive(handle); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
                 socketError = ProcessIOCPResult(socketError == SocketError.Success, bytesTransferred);
                 return socketError;
@@ -539,7 +541,7 @@ namespace System.Net.Sockets
                 {
                     // Single buffer case.
                     socketError = Interop.Winsock.WSASend(
-                        handle,
+                        handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
                         ref _wsaBuffer,
                         1,
                         out bytesTransferred,
@@ -551,7 +553,7 @@ namespace System.Net.Sockets
                 {
                     // Multi buffer case.
                     socketError = Interop.Winsock.WSASend(
-                        handle,
+                        handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
                         _wsaBufferArray,
                         _bufferListInternal.Count,
                         out bytesTransferred,
@@ -559,6 +561,7 @@ namespace System.Net.Sockets
                         overlapped,
                         IntPtr.Zero);
                 }
+                GC.KeepAlive(handle); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
                 socketError = ProcessIOCPResult(socketError == SocketError.Success, bytesTransferred);
                 return socketError;
@@ -713,7 +716,7 @@ namespace System.Net.Sockets
                 {
                     // Single buffer case.
                     socketError = Interop.Winsock.WSASendTo(
-                        handle,
+                        handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
                         ref _wsaBuffer,
                         1,
                         out bytesTransferred,
@@ -726,7 +729,7 @@ namespace System.Net.Sockets
                 else
                 {
                     socketError = Interop.Winsock.WSASendTo(
-                        handle,
+                        handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
                         _wsaBufferArray,
                         _bufferListInternal.Count,
                         out bytesTransferred,
@@ -736,6 +739,7 @@ namespace System.Net.Sockets
                         overlapped,
                         IntPtr.Zero);
                 }
+                GC.KeepAlive(handle); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
                 socketError = ProcessIOCPResult(socketError == SocketError.Success, bytesTransferred);
                 return socketError;

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -88,7 +88,13 @@ namespace System.Net.Sockets
                     IOVectorCount = 1
                 };
 
-                errno = Interop.Sys.ReceiveMessage(socket, &messageHeader, flags, &received);
+                errno = Interop.Sys.ReceiveMessage(
+                    socket.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
+                    &messageHeader,
+                    flags,
+                    &received);
+                GC.KeepAlive(socket); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
+
                 receivedFlags = messageHeader.Flags;
                 sockAddrLen = messageHeader.SocketAddressLen;
             }
@@ -128,7 +134,12 @@ namespace System.Net.Sockets
                 };
 
                 long bytesSent;
-                errno = Interop.Sys.SendMessage(socket, &messageHeader, flags, &bytesSent);
+                errno = Interop.Sys.SendMessage(
+                    socket.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
+                    &messageHeader,
+                    flags,
+                    &bytesSent);
+                GC.KeepAlive(socket); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
                 sent = checked((int)bytesSent);
             }
@@ -187,7 +198,12 @@ namespace System.Net.Sockets
                     };
 
                     long bytesSent;
-                    errno = Interop.Sys.SendMessage(socket, &messageHeader, flags, &bytesSent);
+                    errno = Interop.Sys.SendMessage(
+                        socket.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
+                        &messageHeader,
+                        flags,
+                        &bytesSent);
+                    GC.KeepAlive(socket); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
                     sent = checked((int)bytesSent);
                 }
@@ -305,7 +321,13 @@ namespace System.Net.Sockets
                         IOVectorCount = iovCount
                     };
 
-                    errno = Interop.Sys.ReceiveMessage(socket, &messageHeader, flags, &received);
+                    errno = Interop.Sys.ReceiveMessage(
+                        socket.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
+                        &messageHeader,
+                        flags,
+                        &received);
+                    GC.KeepAlive(socket); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
+
                     receivedFlags = messageHeader.Flags;
                     sockAddrLen = messageHeader.SocketAddressLen;
                 }
@@ -362,7 +384,13 @@ namespace System.Net.Sockets
                     ControlBufferLen = cmsgBufferLen
                 };
 
-                errno = Interop.Sys.ReceiveMessage(socket, &messageHeader, flags, &received);
+                errno = Interop.Sys.ReceiveMessage(
+                    socket.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
+                    &messageHeader,
+                    flags,
+                    &received);
+                GC.KeepAlive(socket); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
+
                 receivedFlags = messageHeader.Flags;
                 sockAddrLen = messageHeader.SocketAddressLen;
                 ipPacketInformation = GetIPPacketInformation(&messageHeader, isIPv4, isIPv6);
@@ -418,7 +446,13 @@ namespace System.Net.Sockets
                     };
 
                     long received;
-                    errno = Interop.Sys.ReceiveMessage(socket, &messageHeader, flags, &received);
+                    errno = Interop.Sys.ReceiveMessage(
+                        socket.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
+                        &messageHeader,
+                        flags,
+                        &received);
+                    GC.KeepAlive(socket); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
+
                     receivedFlags = messageHeader.Flags;
                     int sockAddrLen = messageHeader.SocketAddressLen;
                     ipPacketInformation = GetIPPacketInformation(&messageHeader, isIPv4, isIPv6);

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
@@ -140,7 +140,6 @@ namespace System.Net.Sockets
                     WSABuffers[i].Pointer = Marshal.UnsafeAddrOfPinnedArrayElement(buffer.Array, buffer.Offset);
                 }
 
-                // This may throw ObjectDisposedException.
                 unsafe
                 {
                     SocketError errorCode = Interop.Winsock.WSASend(
@@ -269,7 +268,6 @@ namespace System.Net.Sockets
                     WSABuffers[i].Pointer = Marshal.UnsafeAddrOfPinnedArrayElement(buffer.Array, buffer.Offset);
                 }
 
-                // This can throw ObjectDisposedException.
                 unsafe
                 {
                     SocketError errorCode = Interop.Winsock.WSARecv(
@@ -828,16 +826,16 @@ namespace System.Net.Sockets
             asyncResult.SetUnmanagedStructures(buffer, offset, count, null);
             try
             {
-                // This can throw ObjectDisposedException.
                 int bytesTransferred;
                 SocketError errorCode = Interop.Winsock.WSASend(
-                    handle,
+                    handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
                     ref asyncResult._singleBuffer,
                     1, // There is only ever 1 buffer being sent.
                     out bytesTransferred,
                     socketFlags,
                     asyncResult.DangerousOverlappedPointer, // SafeHandle was just created in SetUnmanagedStructures
                     IntPtr.Zero);
+                GC.KeepAlive(handle); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
                 return asyncResult.ProcessOverlappedResult(errorCode == SocketError.Success, bytesTransferred);
             }
@@ -854,16 +852,16 @@ namespace System.Net.Sockets
             asyncResult.SetUnmanagedStructures(buffers);
             try
             {
-                // This can throw ObjectDisposedException.
                 int bytesTransferred;
                 SocketError errorCode = Interop.Winsock.WSASend(
-                    handle,
+                    handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
                     asyncResult._wsaBuffers,
                     asyncResult._wsaBuffers.Length,
                     out bytesTransferred,
                     socketFlags,
                     asyncResult.DangerousOverlappedPointer, // SafeHandle was just created in SetUnmanagedStructures
                     IntPtr.Zero);
+                GC.KeepAlive(handle); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
                 return asyncResult.ProcessOverlappedResult(errorCode == SocketError.Success, bytesTransferred);
             }
@@ -937,7 +935,7 @@ namespace System.Net.Sockets
             {
                 int bytesTransferred;
                 SocketError errorCode = Interop.Winsock.WSASendTo(
-                    handle,
+                    handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
                     ref asyncResult._singleBuffer,
                     1, // There is only ever 1 buffer being sent.
                     out bytesTransferred,
@@ -946,6 +944,7 @@ namespace System.Net.Sockets
                     asyncResult.SocketAddress.Size,
                     asyncResult.DangerousOverlappedPointer, // SafeHandle was just created in SetUnmanagedStructures
                     IntPtr.Zero);
+                GC.KeepAlive(handle); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
                 return asyncResult.ProcessOverlappedResult(errorCode == SocketError.Success, bytesTransferred);
             }
@@ -962,16 +961,16 @@ namespace System.Net.Sockets
             asyncResult.SetUnmanagedStructures(buffer, offset, count, null);
             try
             {
-                // This can throw ObjectDisposedException.
                 int bytesTransferred;
                 SocketError errorCode = Interop.Winsock.WSARecv(
-                    handle,
+                    handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
                     ref asyncResult._singleBuffer,
                     1,
                     out bytesTransferred,
                     ref socketFlags,
                     asyncResult.DangerousOverlappedPointer, // SafeHandle was just created in SetUnmanagedStructures
                     IntPtr.Zero);
+                GC.KeepAlive(handle); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
                 return asyncResult.ProcessOverlappedResult(errorCode == SocketError.Success, bytesTransferred);
             }
@@ -988,16 +987,16 @@ namespace System.Net.Sockets
             asyncResult.SetUnmanagedStructures(buffers);
             try
             {
-                // This can throw ObjectDisposedException.
                 int bytesTransferred;
                 SocketError errorCode = Interop.Winsock.WSARecv(
-                    handle,
+                    handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
                     asyncResult._wsaBuffers,
                     asyncResult._wsaBuffers.Length,
                     out bytesTransferred,
                     ref socketFlags,
                     asyncResult.DangerousOverlappedPointer, // SafeHandle was just created in SetUnmanagedStructures
                     IntPtr.Zero);
+                GC.KeepAlive(handle); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
                 return asyncResult.ProcessOverlappedResult(errorCode == SocketError.Success, bytesTransferred);
             }
@@ -1016,7 +1015,7 @@ namespace System.Net.Sockets
             {
                 int bytesTransferred;
                 SocketError errorCode = Interop.Winsock.WSARecvFrom(
-                    handle,
+                    handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
                     ref asyncResult._singleBuffer,
                     1,
                     out bytesTransferred,
@@ -1025,6 +1024,7 @@ namespace System.Net.Sockets
                     asyncResult.GetSocketAddressSizePtr(),
                     asyncResult.DangerousOverlappedPointer, // SafeHandle was just created in SetUnmanagedStructures
                     IntPtr.Zero);
+                GC.KeepAlive(handle); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
                 return asyncResult.ProcessOverlappedResult(errorCode == SocketError.Success, bytesTransferred);
             }


### PR DESCRIPTION
In high-throughput situations with asynchronous operations on Sockets, the overhead involved in marshaling SafeHandles is showing up as a non-trivial cost, contributing upwards of 5% overhead to an end-to-end benchmark doing sends and receives on sockets.  While the SafeHandles help to avoid certain misuses, a) SafeHandle marshaling (and in particular the implicit use of DangerousAddRef/Release) already isn't being done for synchronous operations (presumably to enable operation cancelation by closing the handle concurrent with the operation), and it's only being done for asynchronous operations during the actual P/Invoke (and thus the SafeHandle isn't "protected" while the async operation is in flight).  The benefit of the protection isn't worth the cost.  This commit removes the marshaling for send/receive operations.

Anyone feel strongly for / against this change?

cc: @vancem, @geoffkizer, @jkotas, @davidsh, @cipop, @davidfowl 