### PR TITLE
LongPath generation fixed

### DIFF
--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -242,7 +242,6 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [ActiveIssue(11687)]
         [PlatformSpecific(TestPlatforms.Windows)]  // long directory path throws PathTooLongException
         public void DirectoryLongerThanMaxLongPath_ThrowsPathTooLongException()
         {

--- a/src/System.IO.FileSystem/tests/PortedCommon/IOServices.cs
+++ b/src/System.IO.FileSystem/tests/PortedCommon/IOServices.cs
@@ -111,13 +111,17 @@ internal class IOServices
 
         while (path.Length < characterCount)
         {
+            // Add directory seperator after each dir but not at the end of the path
             path.Append(Path.DirectorySeparatorChar);
-            if (path.Length == characterCount)
-                break;
 
             // Continue adding guids until the character count is hit
             string guid = Guid.NewGuid().ToString();
             path.Append(guid.Substring(0, Math.Min(characterCount - path.Length, guid.Length)));
+            if (path.Length + 1 == characterCount)
+            {
+                // If only one character is missing add a k!
+                path.Append('k');
+            }
             paths.Add(path.ToString());
         }
         Assert.Equal(path.Length, characterCount);


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/17536
Fixes https://github.com/dotnet/corefx/issues/11687

That issue was REALLY weird. Our CI bot username is "helixbot" and with that 8 characters the generated path always had a DirectorySeperator char as the last character. The problem is, putting that string into a Path.GetFullPath the DirectorySeperator gets removed and the path isn't too long anymore... 🐙 🗡 

That was also the reason why the tests didn't fail for most of us devs. Who would be brave enough to have a username with exactly 8 characters 🎃 