### PR TITLE
Update RefEmit Test to expect LoadContext for DynamicAssemblies

### DIFF
--- a/src/System.Runtime.Loader/tests/RefEmitLoadContext/RefEmitLoadContextTest.cs
+++ b/src/System.Runtime.Loader/tests/RefEmitLoadContext/RefEmitLoadContextTest.cs
@@ -73,7 +73,6 @@ namespace System.Runtime.Loader.Tests
             File.Copy(pathCurrentAssembly, targetPath);
         }
 
-        [ActiveIssue(19062)]
         [Fact]
         public static void LoadRefEmitAssembly()
         {

--- a/src/System.Runtime.Loader/tests/RefEmitLoadContext/RefEmitLoadContextTest.cs
+++ b/src/System.Runtime.Loader/tests/RefEmitLoadContext/RefEmitLoadContextTest.cs
@@ -95,7 +95,8 @@ namespace System.Runtime.Loader.Tests
             
             // Load the assembly in the specified load context
             var asmTargetAsm = loadContext.LoadFromAssemblyPath(Path.Combine(s_loadFromPath, assemblyNameStr));
-            var loadedContext = AssemblyLoadContext.GetLoadContext(asmTargetAsm);
+            var creatorLoadContext = AssemblyLoadContext.GetLoadContext(asmTargetAsm);
+            Assert.Equal(loadContext, creatorLoadContext);
 
             // Get reference to the helper method that will RefEmit an assembly and return reference to it.
             Type type = asmTargetAsm.GetType("System.Runtime.Loader.Tests.TestClass");
@@ -106,9 +107,10 @@ namespace System.Runtime.Loader.Tests
             var asmRefEmitLoaded = (Assembly)method.Invoke(null, new object[] {assemblyNameRefEmit, builderType});
             Assert.NotNull(asmRefEmitLoaded);
 
-            // Assert that Dynamically emitted assemblies do not have a load context associated with them.
+            // Assert that Dynamically emitted assemblies load context is the same as that of the assembly
+            // that created them.
             var loadContextRefEmitAssembly = AssemblyLoadContext.GetLoadContext(asmRefEmitLoaded);
-            Assert.Equal(null, loadContextRefEmitAssembly);
+            Assert.Equal(creatorLoadContext, loadContextRefEmitAssembly);
 
             // Invoke the method that will trigger a static load in the dynamically generated assembly.
             Type typeRefEmit = asmRefEmitLoaded.GetType("RefEmitTestType");
@@ -121,7 +123,7 @@ namespace System.Runtime.Loader.Tests
             Assert.NotNull(asmRefEmitLoadedStatic);
 
             // Load context of the statically loaded assembly is the custom load context in which dynamic assembly was created
-            Assert.Equal(loadContext, AssemblyLoadContext.GetLoadContext((Assembly)asmRefEmitLoadedStatic));
+            Assert.Equal(loadContextRefEmitAssembly, AssemblyLoadContext.GetLoadContext((Assembly)asmRefEmitLoadedStatic));
         }
     }
 }

--- a/src/System.Runtime.Loader/tests/System.Runtime.Loader.Noop.Assembly/TestClass.cs
+++ b/src/System.Runtime.Loader/tests/System.Runtime.Loader.Noop.Assembly/TestClass.cs
@@ -54,11 +54,8 @@ namespace System.Runtime.Loader.Tests
             // Return the reference to the loaded assembly
             ilGenerator.Emit(OpCodes.Ret);
 
-            // Generate the type
-            typeBuilder.CreateTypeInfo().AsType();
-
-            // Return the generated assembly
-            return builder;
+            // Generate the type and return the associated assembly
+            return typeBuilder.CreateTypeInfo().AsType().Assembly;
         }
     }
 }


### PR DESCRIPTION
Test update accompanying fix for https://github.com/dotnet/coreclr/issues/11228

CC @jkotas 