### PR TITLE
Disable SqlClient named pipes exception tests when targeted against Framework, since Core throws exceptions with different messages

### DIFF
--- a/src/System.Data.SqlClient/tests/FunctionalTests/ExceptionTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/ExceptionTest.cs
@@ -151,7 +151,12 @@ namespace System.Data.SqlClient.Tests
         private TException VerifyConnectionFailure<TException>(Action connectAction, string expectedExceptionMessage, Func<TException, bool> exVerifier) where TException : Exception
         {
             TException ex = Assert.Throws<TException>(connectAction);
-            Assert.Contains(expectedExceptionMessage, ex.Message);
+
+            // Some exception messages are different between Framework and Core
+            if(!PlatformDetection.IsFullFramework)
+            {
+                Assert.Contains(expectedExceptionMessage, ex.Message);
+            }
             Assert.True(exVerifier(ex), "FAILED Exception verifier failed on the exception.");
 
             return ex;

--- a/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
@@ -32,6 +32,9 @@
     <Compile Include="$(CommonTestPath)\System\IO\FileCleanupTestBase.cs">
       <Link>Common\System\IO\FileCleanupTestBase.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>Common\System\PlatformDetection.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tools\TDS\TDS.Servers\TDS.Servers.csproj">


### PR DESCRIPTION
Resolves failures in https://github.com/dotnet/corefx/issues/19039 and https://github.com/dotnet/corefx/pull/17566