### PR TITLE
Allow empty authType for ClaimsIdentity

### DIFF
--- a/src/System.Security.Claims/src/System/Security/Claims/ClaimsIdentity.cs
+++ b/src/System.Security.Claims/src/System/Security/Claims/ClaimsIdentity.cs
@@ -173,7 +173,7 @@ namespace System.Security.Claims
         {
             ClaimsIdentity claimsIdentity = identity as ClaimsIdentity;
 
-            _authenticationType = !string.IsNullOrWhiteSpace(authenticationType) ? authenticationType : (identity != null ? identity.AuthenticationType : null);
+            _authenticationType = (identity != null && string.IsNullOrEmpty(authenticationType)) ? identity.AuthenticationType : authenticationType;
             _nameClaimType = !string.IsNullOrEmpty(nameType) ? nameType : (claimsIdentity != null ? claimsIdentity._nameClaimType : DefaultNameClaimType);
             _roleClaimType = !string.IsNullOrEmpty(roleType) ? roleType : (claimsIdentity != null ? claimsIdentity._roleClaimType : DefaultRoleClaimType);
 

--- a/src/System.Security.Claims/tests/ClaimsIdentityTests.cs
+++ b/src/System.Security.Claims/tests/ClaimsIdentityTests.cs
@@ -33,7 +33,7 @@ namespace System.Security.Claims
         public void Ctor_AuthenticationType_Blank()
         {
             var id = new ClaimsIdentity("");
-            Assert.Null(id.AuthenticationType);
+            Assert.Equal(string.Empty, id.AuthenticationType);
             Assert.Null(id.Actor);
             Assert.Null(id.BootstrapContext);
             Assert.NotNull(id.Claims);
@@ -190,7 +190,7 @@ namespace System.Security.Claims
         public void Ctor_EnumerableClaimAuthNameRoleType_AllEmpty()
         {
             var id = new ClaimsIdentity(new Claim[0], "", "", "");
-            Assert.Null(id.AuthenticationType);
+            Assert.Equal(string.Empty, id.AuthenticationType);
             Assert.Null(id.Actor);
             Assert.Null(id.BootstrapContext);
             Assert.NotNull(id.Claims);
@@ -211,7 +211,7 @@ namespace System.Security.Claims
                     new Claim (ClaimsIdentity.DefaultNameClaimType, "claim_name_value"),
                 },
                        "", "", "");
-            Assert.Null(id.AuthenticationType);
+            Assert.Equal(string.Empty, id.AuthenticationType);
             Assert.Null(id.Actor);
             Assert.Null(id.BootstrapContext);
             Assert.NotNull(id.Claims);
@@ -264,7 +264,7 @@ namespace System.Security.Claims
         public void Ctor_IdentityEnumerableClaimAuthNameRoleType_IdentityNullRestEmpty()
         {
             var id = new ClaimsIdentity(null, new Claim[0], "", "", "");
-            Assert.Null(id.AuthenticationType);
+            Assert.Equal(string.Empty, id.AuthenticationType);
             Assert.Null(id.Actor);
             Assert.Null(id.BootstrapContext);
             Assert.NotNull(id.Claims);
@@ -287,7 +287,7 @@ namespace System.Security.Claims
                 },
                        "", "", "");
 
-            Assert.Null(id.AuthenticationType);
+            Assert.Equal(string.Empty, id.AuthenticationType);
             Assert.Null(id.Actor);
             Assert.Null(id.BootstrapContext);
             Assert.NotNull(id.Claims);


### PR DESCRIPTION
This looks like an unintentional change made in porting that introcued a discrepancy between netcoreapp and desktop behavior. On desktop, an empty string as the authenticationtype is allowed. On netcoreapp before this change, authType was set instead null.

resolves https://github.com/dotnet/corefx/issues/18814

After this change, all System.Security.Claims tests are passing on netfx and netcoreapp.

cc: @bartonjs @krwq 