### PR TITLE
Add more "Legacy" test cases for Complex class

### DIFF
--- a/src/System.Runtime.Numerics/tests/ComplexTests.cs
+++ b/src/System.Runtime.Numerics/tests/ComplexTests.cs
@@ -14,7 +14,7 @@ namespace System.Numerics.Tests
     {
         private static Random s_random = new Random(-55);
         private static bool Is64Bit => IntPtr.Size == 8;
-        
+
         public static readonly double[] s_validDoubleValues = new double[]
         {
             double.MinValue,
@@ -206,7 +206,7 @@ namespace System.Numerics.Tests
             var complex = new Complex(real, imaginary);
             VerifyRealImaginaryProperties(complex, real, imaginary);
         }
-        
+
         [Theory]
         [MemberData(nameof(Primitives_2_TestData))]
         [MemberData(nameof(Random_2_TestData))]
@@ -333,8 +333,10 @@ namespace System.Numerics.Tests
             VerifyRealImaginaryProperties(result, expectedReal, expectedImaginary);
         }
 
-        public static IEnumerable<object[]> ACos_Legacy_TestData ()
+        public static IEnumerable<object[]> ACos_Legacy_TestData()
         {
+            // These tests validate legacy .NET Framework behavior.
+
             // Boundary values
             yield return new object[] { double.MaxValue, 0, double.NaN, double.NaN };
             yield return new object[] { double.MinValue, 0, double.NaN, double.NaN };
@@ -351,7 +353,7 @@ namespace System.Numerics.Tests
             }
         }
 
-        [Theory, MemberData("ACos_Legacy_TestData")]
+        [Theory, MemberData(nameof(ACos_Legacy_TestData))]
         [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
         public static void ACos_Legacy(double real, double imaginary, double expectedReal, double expectedImaginary)
         {
@@ -435,7 +437,7 @@ namespace System.Numerics.Tests
             yield return new object[] { 0.0, double.NaN, double.NaN, double.NaN };
             yield return new object[] { double.PositiveInfinity, double.NaN, double.NaN, double.NaN };
             yield return new object[] { double.NaN, 1.0, double.NaN, double.NaN };
-            yield return new object[] { double.NaN, double.NegativeInfinity, double.NaN, double.NaN };            
+            yield return new object[] { double.NaN, double.NegativeInfinity, double.NaN, double.NaN };
         }
 
         [ActiveIssue(15455)]
@@ -450,6 +452,8 @@ namespace System.Numerics.Tests
 
         public static IEnumerable<object[]> ASin_Legacy_TestData()
         {
+            // These tests validate legacy .NET Framework behavior.
+
             // Boundary values
             yield return new object[] { double.MaxValue, 0, double.NaN, double.NaN };
             yield return new object[] { double.MinValue, 0, double.NaN, double.NaN };
@@ -466,7 +470,7 @@ namespace System.Numerics.Tests
             }
         }
 
-        [Theory, MemberData("ASin_Legacy_TestData")]
+        [Theory, MemberData(nameof(ASin_Legacy_TestData))]
         [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
         public static void ASin_Legacy(double real, double imaginary, double expectedReal, double expectedImaginary)
         {
@@ -517,7 +521,7 @@ namespace System.Numerics.Tests
             Complex result = Complex.Atan(complex);
             VerifyRealImaginaryProperties(result, expectedReal, expectedImaginary);
         }
-        
+
         [Theory]
         [MemberData(nameof(Primitives_2_TestData))]
         [MemberData(nameof(Boundaries_2_TestData))]
@@ -547,7 +551,7 @@ namespace System.Numerics.Tests
             Cos_Advanced(real, imaginary, expected.Real, expected.Imaginary);
         }
 
-        public static IEnumerable<object[]> Cos_Advanced_TestData()
+        public static IEnumerable<object[]> Cos_Advanced_TestData_Shared()
         {
             // Boundary values
             yield return new object[] { double.MaxValue, 0, Math.Cos(double.MaxValue), 0 };
@@ -555,9 +559,6 @@ namespace System.Numerics.Tests
 
             yield return new object[] { 0, double.MaxValue, double.PositiveInfinity, double.NaN };
             yield return new object[] { 0, double.MinValue, double.PositiveInfinity, double.NaN };
-
-            yield return new object[] { double.MaxValue, double.MaxValue, Math.Cos(double.MaxValue) * double.PositiveInfinity, Math.Cos(double.MaxValue) * double.PositiveInfinity };
-            yield return new object[] { double.MinValue, double.MinValue, Math.Cos(double.MaxValue) * double.PositiveInfinity, Math.Cos(double.MaxValue) * double.PositiveInfinity};
 
             // Invalid values
             foreach (double invalidReal in s_invalidDoubleValues)
@@ -582,13 +583,42 @@ namespace System.Numerics.Tests
             }
         }
 
-        [Theory, MemberData(nameof(Cos_Advanced_TestData))]
+        public static IEnumerable<object[]> Cos_Advanced_TestData()
+        {
+            yield return new object[] { double.MaxValue, double.MaxValue, Math.Cos(double.MaxValue) * double.PositiveInfinity, Math.Cos(double.MaxValue) * double.PositiveInfinity };
+            yield return new object[] { double.MinValue, double.MinValue, Math.Cos(double.MaxValue) * double.PositiveInfinity, Math.Cos(double.MaxValue) * double.PositiveInfinity };
+        }
+
+        [Theory]
+        [MemberData(nameof(Cos_Advanced_TestData_Shared))]
+        [MemberData(nameof(Cos_Advanced_TestData))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public static void Cos_Advanced(double real, double imaginary, double expectedReal, double expectedImaginary)
         {
             var complex = new Complex(real, imaginary);
             Complex result = Complex.Cos(complex);
             VerifyRealImaginaryProperties(result, expectedReal, expectedImaginary);
         }
+
+        public static IEnumerable<object[]> Cos_Legacy_TestData()
+        {
+            // These tests validate legacy .NET Framework behavior.
+
+            yield return new object[] { double.MaxValue, double.MaxValue, double.PositiveInfinity, double.NegativeInfinity };
+            yield return new object[] { double.MinValue, double.MinValue, double.NegativeInfinity, double.NegativeInfinity };
+        }
+
+        [Theory]
+        [MemberData(nameof(Cos_Advanced_TestData_Shared))]
+        [MemberData(nameof(Cos_Legacy_TestData))]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+        public static void Cos_Legacy(double real, double imaginary, double expectedReal, double expectedImaginary)
+        {
+            var complex = new Complex(real, imaginary);
+            Complex result = Complex.Cos(complex);
+            VerifyRealImaginaryProperties(result, expectedReal, expectedImaginary);
+        }
+
 
         [Theory]
         [MemberData(nameof(Primitives_2_TestData))]
@@ -603,7 +633,7 @@ namespace System.Numerics.Tests
             Cosh_Advanced(real, imaginary, expected.Real, expected.Imaginary);
         }
 
-        public static IEnumerable<object[]> Cosh_Advanced_TestData()
+        public static IEnumerable<object[]> Cosh_Advanced_TestData_Shared()
         {
             // Boundary values
             yield return new object[] { double.MaxValue, 0, double.PositiveInfinity, double.NaN };
@@ -611,9 +641,6 @@ namespace System.Numerics.Tests
 
             yield return new object[] { 0, double.MaxValue, Math.Cos(double.MaxValue), 0 };
             yield return new object[] { 0, double.MinValue, Math.Cos(double.MinValue), 0 };
-
-            yield return new object[] { double.MaxValue, double.MaxValue, Math.Cos(double.MaxValue) * double.PositiveInfinity, Math.Cos(double.MaxValue) * double.NegativeInfinity };
-            yield return new object[] { double.MinValue, double.MinValue, Math.Cos(double.MaxValue) * double.PositiveInfinity, Math.Cos(double.MaxValue) * double.NegativeInfinity };
 
             // Invalid values
             foreach (double invalidReal in s_invalidDoubleValues)
@@ -634,8 +661,36 @@ namespace System.Numerics.Tests
             }
         }
 
-        [Theory, MemberData(nameof(Cosh_Advanced_TestData))]
+        public static IEnumerable<object[]> Cosh_Advanced_TestData()
+        {
+            yield return new object[] { double.MaxValue, double.MaxValue, Math.Cos(double.MaxValue) * double.PositiveInfinity, Math.Cos(double.MaxValue) * double.NegativeInfinity };
+            yield return new object[] { double.MinValue, double.MinValue, Math.Cos(double.MaxValue) * double.PositiveInfinity, Math.Cos(double.MaxValue) * double.NegativeInfinity };
+        }
+
+        [Theory]
+        [MemberData(nameof(Cosh_Advanced_TestData_Shared))]
+        [MemberData(nameof(Cosh_Advanced_TestData))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public static void Cosh_Advanced(double real, double imaginary, double expectedReal, double expectedImaginary)
+        {
+            var complex = new Complex(real, imaginary);
+            Complex result = Complex.Cosh(complex);
+            VerifyRealImaginaryProperties(result, expectedReal, expectedImaginary);
+        }
+
+        public static IEnumerable<object[]> Cosh_Legacy_TestData()
+        {
+            // These tests validate legacy .NET Framework behavior.
+
+            yield return new object[] { double.MaxValue, double.MaxValue, double.PositiveInfinity, double.PositiveInfinity };
+            yield return new object[] { double.MinValue, double.MinValue, double.NegativeInfinity, double.PositiveInfinity };
+        }
+
+        [Theory]
+        [MemberData(nameof(Cosh_Advanced_TestData_Shared))]
+        [MemberData(nameof(Cosh_Legacy_TestData))]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+        public static void Cosh_Legacy(double real, double imaginary, double expectedReal, double expectedImaginary)
         {
             var complex = new Complex(real, imaginary);
             Complex result = Complex.Cosh(complex);
@@ -834,6 +889,7 @@ namespace System.Numerics.Tests
         [MemberData(nameof(Exp_TestData))]
         [MemberData(nameof(Primitives_2_TestData))]
         [MemberData(nameof(SmallRandom_2_TestData))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public static void Exp(double real, double imaginary)
         {
             Complex expected;
@@ -841,6 +897,45 @@ namespace System.Numerics.Tests
             if (real == double.MaxValue && imaginary == double.MaxValue)
             {
                 expected = new Complex(Math.Cos(double.MaxValue) * double.PositiveInfinity, Math.Cos(double.MaxValue) * double.NegativeInfinity);
+            }
+            else
+            {
+                // Verify with e(x+y) = e(x)*e(y) if xy == yx
+                var realComplex = new Complex(real, 0);
+                var imaginaryComplex = new Complex(0, imaginary);
+
+                Complex ri = realComplex * imaginaryComplex;
+                Complex ir = imaginaryComplex * realComplex;
+                if (!ri.Equals(ir))
+                {
+                    return;
+                }
+
+                Complex realExponential = Complex.Exp(realComplex);
+                Complex imaginaryExpontential = Complex.Exp(imaginaryComplex);
+                expected = realExponential * imaginaryExpontential;
+            }
+
+            var complex = new Complex(real, imaginary);
+            Complex result = Complex.Exp(complex);
+            VerifyRealImaginaryProperties(result, expected.Real, expected.Imaginary);
+        }
+
+        [Theory]
+        [MemberData(nameof(Exp_TestData))]
+        [MemberData(nameof(Primitives_2_TestData))]
+        [MemberData(nameof(SmallRandom_2_TestData))]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+        public static void Exp_Legacy(double real, double imaginary)
+        {
+            // This test validates legacy .NET Framework behavior.
+            // The behavior of Math.Cos(double.MaxValue) is different and thus affects the expected results here.
+
+            Complex expected;
+            // Special case the complex {double.MaxValue, double.MaxValue)
+            if (real == double.MaxValue && imaginary == double.MaxValue)
+            {
+                expected = new Complex(Math.Cos(double.MaxValue) * double.PositiveInfinity, double.PositiveInfinity);
             }
             else
             {
@@ -885,7 +980,7 @@ namespace System.Numerics.Tests
                     yield return new object[] { magnitude, phase };
                 }
             }
-            
+
             yield return new object[] { RandomPositiveDouble(), RandomPositivePhase() }; // First quadrant
             yield return new object[] { RandomNegativeDouble(), RandomPositivePhase() }; // Second quadrant
             yield return new object[] { RandomNegativeDouble(), RandomNegativePhase() }; // Third quadrant
@@ -1123,7 +1218,7 @@ namespace System.Numerics.Tests
             result = Complex.Multiply(left, right);
             VerifyRealImaginaryProperties(result, expectedReal, expectedImaginary);
         }
-        
+
         [Theory]
         [MemberData(nameof(Valid_2_TestData))]
         [MemberData(nameof(Random_2_TestData))]
@@ -1138,7 +1233,7 @@ namespace System.Numerics.Tests
             result = Complex.Negate(complex);
             VerifyRealImaginaryProperties(result, -complex.Real, -complex.Imaginary);
         }
-        
+
         [Theory]
         [MemberData(nameof(Boundaries_2_TestData))]
         [MemberData(nameof(Primitives_2_TestData))]
@@ -1191,7 +1286,7 @@ namespace System.Numerics.Tests
             VerifyPow_Complex_Complex(real, imaginary, 1, 0);
             VerifyPow_Complex_Complex(real, imaginary, 0, 1);
             VerifyPow_Complex_Complex(real, imaginary, 0, -1);
-            
+
             VerifyPow_Complex_Complex(real, imaginary, SmallRandomPositiveDouble(), SmallRandomPositiveDouble()); // First quadrant
             VerifyPow_Complex_Complex(real, imaginary, SmallRandomNegativeDouble(), SmallRandomPositiveDouble()); // Second quadrant
             VerifyPow_Complex_Complex(real, imaginary, SmallRandomNegativeDouble(), SmallRandomNegativeDouble()); // Third quadrant
@@ -1219,7 +1314,7 @@ namespace System.Numerics.Tests
             }
             VerifyRealImaginaryProperties(result, expectedReal, expectedImaginary);
         }
-        
+
         [Theory]
         [MemberData(nameof(Boundaries_2_TestData))]
         [MemberData(nameof(Primitives_2_TestData))]
@@ -1259,14 +1354,18 @@ namespace System.Numerics.Tests
 
         public static IEnumerable<object[]> Sin_Advanced_TestData()
         {
+            yield return new object[] { double.MaxValue, double.MaxValue, Math.Cos(double.MaxValue) * double.NegativeInfinity, Math.Cos(double.MaxValue) * double.PositiveInfinity };
+            yield return new object[] { double.MinValue, double.MinValue, Math.Cos(double.MaxValue) * double.PositiveInfinity, Math.Cos(double.MaxValue) * double.NegativeInfinity };
+        }
+
+        // Sin() test data for values which are shared across runtimes
+        public static IEnumerable<object[]> Sin_Advanced_TestData_Shared()
+        {
             yield return new object[] { double.MaxValue, 0, Math.Sin(double.MaxValue), 0 };
             yield return new object[] { double.MinValue, 0, Math.Sin(double.MinValue), 0 };
 
             yield return new object[] { 0, double.MaxValue, double.NaN, double.PositiveInfinity };
             yield return new object[] { 0, double.MinValue, double.NaN, double.NegativeInfinity };
-
-            yield return new object[] { double.MaxValue, double.MaxValue, Math.Cos(double.MaxValue) * double.NegativeInfinity, Math.Cos(double.MaxValue) * double.PositiveInfinity };
-            yield return new object[] { double.MinValue, double.MinValue, Math.Cos(double.MaxValue) * double.PositiveInfinity, Math.Cos(double.MaxValue) * double.NegativeInfinity };
 
             foreach (double invalidReal in s_invalidDoubleValues)
             {
@@ -1284,10 +1383,33 @@ namespace System.Numerics.Tests
                     yield return new object[] { invalidReal, invalidImaginary, double.NaN, double.NaN }; // Invalid real, invalid imaginary
                 }
             }
+
         }
 
-        [Theory, MemberData(nameof(Sin_Advanced_TestData))]
+        [Theory]
+        [MemberData(nameof(Sin_Advanced_TestData_Shared))]
+        [MemberData(nameof(Sin_Advanced_TestData))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public static void Sin_Advanced(double real, double imaginary, double expectedReal, double expectedImaginary)
+        {
+            var complex = new Complex(real, imaginary);
+            Complex result = Complex.Sin(complex);
+            VerifyRealImaginaryProperties(result, expectedReal, expectedImaginary);
+        }
+
+        public static IEnumerable<object[]> Sin_Legacy_TestData()
+        {
+            // These tests validate legacy .NET Framework behavior.
+
+            yield return new object[] { double.MaxValue, double.MaxValue, double.PositiveInfinity, double.PositiveInfinity};
+            yield return new object[] { double.MinValue, double.MinValue, double.NegativeInfinity, double.PositiveInfinity };
+        }
+
+        [Theory]
+        [MemberData(nameof(Sin_Advanced_TestData_Shared))]
+        [MemberData(nameof(Sin_Legacy_TestData))]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+        public static void Sin_Legacy(double real, double imaginary, double expectedReal, double expectedImaginary)
         {
             var complex = new Complex(real, imaginary);
             Complex result = Complex.Sin(complex);
@@ -1307,7 +1429,7 @@ namespace System.Numerics.Tests
             Sinh_Advanced(real, imaginary, expectedComplex.Real, expectedComplex.Imaginary);
         }
 
-        public static IEnumerable<object[]> Sinh_Advanced_TestData()
+        public static IEnumerable<object[]> Sinh_Advanced_TestData_Shared()
         {
             // Boundary values
             yield return new object[] { double.MaxValue, 0, double.PositiveInfinity, double.NaN };
@@ -1315,9 +1437,6 @@ namespace System.Numerics.Tests
 
             yield return new object[] { 0, double.MaxValue, 0, Math.Sin(double.MaxValue) };
             yield return new object[] { 0, double.MinValue, 0, Math.Sin(double.MinValue) };
-
-            yield return new object[] { double.MaxValue, double.MaxValue, Math.Cos(double.MaxValue) * double.PositiveInfinity, Math.Cos(double.MaxValue) * double.NegativeInfinity };
-            yield return new object[] { double.MinValue, double.MinValue, Math.Cos(double.MaxValue) * double.NegativeInfinity, Math.Cos(double.MaxValue) * double.PositiveInfinity };
 
             // Invalid values
             foreach (double invalidReal in s_invalidDoubleValues)
@@ -1338,13 +1457,42 @@ namespace System.Numerics.Tests
             }
         }
 
-        [Theory, MemberData(nameof(Sinh_Advanced_TestData))]
+        public static IEnumerable<object[]> Sinh_Advanced_TestData()
+        {
+            yield return new object[] { double.MaxValue, double.MaxValue, Math.Cos(double.MaxValue) * double.PositiveInfinity, Math.Cos(double.MaxValue) * double.NegativeInfinity };
+            yield return new object[] { double.MinValue, double.MinValue, Math.Cos(double.MaxValue) * double.NegativeInfinity, Math.Cos(double.MaxValue) * double.PositiveInfinity };
+        }
+
+        [Theory]
+        [MemberData(nameof(Sinh_Advanced_TestData_Shared))]
+        [MemberData(nameof(Sinh_Advanced_TestData))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public static void Sinh_Advanced(double real, double imaginary, double expectedReal, double expectedImaginary)
         {
             var complex = new Complex(real, imaginary);
             Complex result = Complex.Sinh(complex);
             VerifyRealImaginaryProperties(result, expectedReal, expectedImaginary);
         }
+
+        public static IEnumerable<object[]> Sinh_Legacy_TestData()
+        {
+            // These tests validate legacy .NET Framework behavior.
+
+            yield return new object[] { double.MaxValue, double.MaxValue, double.PositiveInfinity, double.PositiveInfinity };
+            yield return new object[] { double.MinValue, double.MinValue, double.PositiveInfinity, double.NegativeInfinity };
+        }
+
+        [Theory]
+        [MemberData(nameof(Sinh_Advanced_TestData_Shared))]
+        [MemberData(nameof(Sinh_Legacy_TestData))]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+        public static void Sinh_Legacy(double real, double imaginary, double expectedReal, double expectedImaginary)
+        {
+            var complex = new Complex(real, imaginary);
+            Complex result = Complex.Sinh(complex);
+            VerifyRealImaginaryProperties(result, expectedReal, expectedImaginary);
+        }
+
 
         public static IEnumerable<object[]> Subtract_TestData()
         {
@@ -1492,7 +1640,7 @@ namespace System.Numerics.Tests
 
         public static IEnumerable<object[]> Tan_Legacy_TestData()
         {
-            // These tests validate legacy .NET behavior.
+            // These tests validate legacy .NET Framework behavior.
 
             yield return new object[] { double.MaxValue, 0, Math.Sin(double.MaxValue) / Math.Cos(double.MaxValue), 0 };
             yield return new object[] { double.MinValue, 0, Math.Sin(double.MinValue) / Math.Cos(double.MinValue), 0 };


### PR DESCRIPTION
* These test cases validate legacy .NET Framework behavior, and only run there. Test cases which validate new, correct .NET Core behavior are now skipped on .NET Framework.
* Clean up some use of string literals instead of `nameof` in `MemberData` attributes.
* Add comments in all of the "Legacy_TestData" methods explaining that they are there for .NET Framework compat checks.
* Cleaned up some whitespace inconsistency in the file

I've done the following test runs: x86 + x64 .NET Core, x64 .NET Framework, all on Windows.