### PR TITLE
Fix SSL on Debian 9

### DIFF
--- a/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.cpp
@@ -25,6 +25,12 @@ bool OpenLibrary()
         libssl = dlopen("libssl.so.10", RTLD_LAZY);
     }
 
+    if (libssl == nullptr)
+    {
+        // Debian 9 has dropped support for SSLv3 and so they have bumped their soname
+        libssl = dlopen("libssl.so.1.0.2", RTLD_LAZY);
+    }
+
     return libssl != nullptr;
 }
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -280,7 +280,7 @@ int EC_POINT_set_affine_coordinates_GF2m(const EC_GROUP *group, EC_POINT *p,
     PER_FUNCTION_BLOCK(SSL_shutdown, true) \
     PER_FUNCTION_BLOCK(SSL_state, true) \
     PER_FUNCTION_BLOCK(SSLv23_method, true) \
-    PER_FUNCTION_BLOCK(SSLv3_method, true) \
+    PER_FUNCTION_BLOCK(SSLv3_method, false) \
     PER_FUNCTION_BLOCK(SSL_write, true) \
     PER_FUNCTION_BLOCK(TLSv1_1_method, true) \
     PER_FUNCTION_BLOCK(TLSv1_2_method, true) \

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -29,13 +29,15 @@ extern "C" const SSL_METHOD* CryptoNative_SslV2_3Method()
 
 extern "C" const SSL_METHOD* CryptoNative_SslV3Method()
 {
-#ifdef OPENSSL_NO_SSL3_METHOD
-    return nullptr;
-#else
-    const SSL_METHOD* method = SSLv3_method();
-    assert(method != nullptr);
-    return method;
+    const SSL_METHOD* method = nullptr;
+#ifndef OPENSSL_NO_SSL3_METHOD
+    if (API_EXISTS(SSLv3_method))
+    {
+        method = SSLv3_method();
+        assert(method != nullptr);
+    }
 #endif
+    return method;
 }
 
 extern "C" const SSL_METHOD* CryptoNative_TlsV1Method()


### PR DESCRIPTION
Debian 9 has dropped support for SSLv3 and so they have bumped their soname to
libssl.so.1.0.2.
This change adds lookup for that soname and also makes SSLv3_method optional.