### PR TITLE
Skip S.S.C.Rsa test when framework version is smaller than 462

### DIFF
--- a/src/Common/tests/System/PlatformDetection.cs
+++ b/src/Common/tests/System/PlatformDetection.cs
@@ -43,6 +43,15 @@ namespace System
 
         public static int WindowsVersion => GetWindowsVersion();
 
+        public static bool IsSmallerThan462
+        {
+            get
+            {
+                string description = RuntimeInformation.FrameworkDescription;
+                return IsFullFramework && !description.Contains("4.6.2") && !description.Contains("4.7");
+            }
+        }
+
         private static int s_isWinRT = -1;
 
         public static bool IsWinRT

--- a/src/Common/tests/System/PlatformDetection.cs
+++ b/src/Common/tests/System/PlatformDetection.cs
@@ -43,13 +43,31 @@ namespace System
 
         public static int WindowsVersion => GetWindowsVersion();
 
-        public static bool IsSmallerThan462
+        public static bool IsAtLeast462()
         {
-            get
+            if (!IsFullFramework)
             {
-                string description = RuntimeInformation.FrameworkDescription;
-                return IsFullFramework && !description.Contains("4.6.2") && !description.Contains("4.7");
+                return true;
             }
+
+            string[] descriptionArray = RuntimeInformation.FrameworkDescription.Split(' ');
+            if (descriptionArray.Length < 3)
+            {
+                return true;
+            }
+                
+            Version result;
+            Version net462 = new Version(4, 6, 2);
+            string runningVersion = descriptionArray[2];
+
+            // we could get a version with build number > 1 e.g 4.6.1375 but we only want to have 4.6.1
+            // since the first would be greater than 4.6.2
+            if (runningVersion.Length > 5)
+            {
+                runningVersion = runningVersion.Substring(0, 5);
+            }
+
+            return !Version.TryParse(runningVersion, out result) || result >= net462;
         }
 
         private static int s_isWinRT = -1;

--- a/src/Common/tests/System/PlatformDetection.cs
+++ b/src/Common/tests/System/PlatformDetection.cs
@@ -50,24 +50,30 @@ namespace System
                 return false;
             }
 
+            Version net462 = new Version(4, 6, 2);
+            Version runningVersion = GetFrameworkVersion();
+            return runningVersion != null && runningVersion >= net462;
+        }
+
+        public static Version GetFrameworkVersion()
+        {
             string[] descriptionArray = RuntimeInformation.FrameworkDescription.Split(' ');
             if (descriptionArray.Length < 3)
             {
-                return false;
+                return null;
             }
                 
-            Version result;
-            Version net462 = new Version(4, 6, 2);
             string runningVersion = descriptionArray[2];
 
             // we could get a version with build number > 1 e.g 4.6.1375 but we only want to have 4.6.1
-            // since the first would be greater than 4.6.2
+            // so that we get the actual Framework Version
             if (runningVersion.Length > 5)
             {
                 runningVersion = runningVersion.Substring(0, 5);
             }
 
-            return !Version.TryParse(runningVersion, out result) || result >= net462;
+            Version result;
+            return Version.TryParse(runningVersion, out result) ? result : null;
         }
 
         private static int s_isWinRT = -1;

--- a/src/Common/tests/System/PlatformDetection.cs
+++ b/src/Common/tests/System/PlatformDetection.cs
@@ -43,17 +43,17 @@ namespace System
 
         public static int WindowsVersion => GetWindowsVersion();
 
-        public static bool IsAtLeast462()
+        public static bool IsNetfx462OrNewer()
         {
             if (!IsFullFramework)
             {
-                return true;
+                return false;
             }
 
             string[] descriptionArray = RuntimeInformation.FrameworkDescription.Split(' ');
             if (descriptionArray.Length < 3)
             {
-                return true;
+                return false;
             }
                 
             Version result;

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
@@ -13,6 +13,11 @@ namespace System.Security.Cryptography.Rsa.Tests
         [Fact]
         public static void ExportAutoKey()
         {
+            if (PlatformDetection.IsSmallerThan462)
+            {
+                return;
+            }
+            
             RSAParameters privateParams;
             RSAParameters publicParams;
             int keySize;

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
@@ -10,14 +10,11 @@ namespace System.Security.Cryptography.Rsa.Tests
 {
     public partial class ImportExport
     {
-        [Fact]
+        private static bool IsAtLeast462 => PlatformDetection.IsAtLeast462();
+
+        [ConditionalFact(nameof(IsAtLeast462))]
         public static void ExportAutoKey()
         {
-            if (PlatformDetection.IsSmallerThan462)
-            {
-                return;
-            }
-            
             RSAParameters privateParams;
             RSAParameters publicParams;
             int keySize;

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
@@ -10,9 +10,9 @@ namespace System.Security.Cryptography.Rsa.Tests
 {
     public partial class ImportExport
     {
-        private static bool IsAtLeast462 => PlatformDetection.IsAtLeast462();
+        private static bool EphemeralKeysAreExportable => !PlatformDetection.IsFullFramework || PlatformDetection.IsNetfx462OrNewer();
 
-        [ConditionalFact(nameof(IsAtLeast462))]
+        [ConditionalFact(nameof(EphemeralKeysAreExportable))]
         public static void ExportAutoKey()
         {
             RSAParameters privateParams;

--- a/src/System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.csproj
+++ b/src/System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.csproj
@@ -23,6 +23,9 @@
     <Compile Include="$(CommonTestPath)\System\AssertExtensions.cs">
       <Link>Common\System\AssertExtensions.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>Common\System\PlatformDetection.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\ByteUtils.cs">
       <Link>CommonTest\System\Security\Cryptography\ByteUtils.cs</Link>
     </Compile>
@@ -64,9 +67,6 @@
     <Compile Include="RNGCryptoServiceProviderTests.cs" />
     <Compile Include="SHAxCryptoServiceProviderTests.cs" />
     <Compile Include="TripleDESCryptoServiceProviderTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
-      <Link>CommonTest\System\PlatformDetection.cs</Link>
-    </Compile>
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AsymmetricSignatureFormatter.cs">
       <Link>CommonTest\System\Security\Cryptography\AsymmetricSignatureFormatter.cs</Link>
     </Compile>

--- a/src/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
+++ b/src/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
@@ -19,6 +19,9 @@
     <Compile Include="$(CommonTestPath)\System\AssertExtensions.cs">
       <Link>Common\System\AssertExtensions.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>CommonTest\System\PlatformDetection.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\ByteUtils.cs">
       <Link>CommonTest\System\Security\Cryptography\ByteUtils.cs</Link>
     </Compile>


### PR DESCRIPTION
Fixes: #19041
Fixes: #19040

cc: @danmosemsft @ianhays @bartonjs 