### PR TITLE
Exclude flushing stream in SslOverTdsStream if the underlying stream is a PipeStream

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNINpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNINpHandle.cs
@@ -141,6 +141,9 @@ namespace System.Data.SqlClient.SNI
                     _pipeStream.Dispose();
                     _pipeStream = null;
                 }
+
+                //Release any references held by _stream.
+                _stream = null;
             }
         }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SslOverTdsStream.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SslOverTdsStream.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
+using System.IO.Pipes;
 
 namespace System.Data.SqlClient.SNI
 {
@@ -160,7 +161,12 @@ namespace System.Data.SqlClient.SNI
         /// </summary>
         public override void Flush()
         {
-            _stream.Flush();
+            // Can sometimes get Pipe broken errors from flushing a PipeStream.
+            // PipeStream.Flush() also doesn't do anything, anyway.
+            if (!(_stream is PipeStream))
+            {
+                _stream.Flush();
+            }
         }
 
         /// <summary>

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/LocalDBTest/LocalDBTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/LocalDBTest/LocalDBTest.cs
@@ -29,6 +29,15 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             OpenConnection(builder.ConnectionString);
         }
 
+        [ConditionalFact(nameof(IsLocalDBEnvironmentSet))]
+        public static void InvalidDBTest()
+        {
+            using (var connection = new SqlConnection(@"Data Source=(localdb)\MSSQLLOCALDB;Database=DOES_NOT_EXIST;Pooling=false;"))
+            {
+                DataTestUtility.AssertThrowsWrapper<SqlException>(() => connection.Open());
+            }
+        }
+
         private static void OpenConnection(string connString)
         {
             using (SqlConnection connection = new SqlConnection(connString))


### PR DESCRIPTION
Pipes can sometimes be disconnected when trying to flush, and PipeStream's flush doesn't actually flush any data.

Addresses https://github.com/dotnet/corefx/issues/19057