### PR TITLE
Stop disposing of request content in HttpClient

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/HttpClient.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClient.cs
@@ -463,7 +463,7 @@ namespace System.Net.Http
             }
             finally
             {
-                HandleFinishSendAsyncCleanup(request, cts, disposeCts);
+                HandleFinishSendAsyncCleanup(cts, disposeCts);
             }
         }
 
@@ -488,7 +488,7 @@ namespace System.Net.Http
             }
             finally
             {
-                HandleFinishSendAsyncCleanup(request, cts, disposeCts);
+                HandleFinishSendAsyncCleanup(cts, disposeCts);
             }
         }
 
@@ -505,22 +505,31 @@ namespace System.Net.Http
             }
         }
 
-        private void HandleFinishSendAsyncCleanup(HttpRequestMessage request, CancellationTokenSource cts, bool disposeCts)
+        private void HandleFinishSendAsyncCleanup(CancellationTokenSource cts, bool disposeCts)
         {
-            try
+            // Dispose of the CancellationTokenSource if it was created specially for this request
+            // rather than being used across multiple requests.
+            if (disposeCts)
             {
-                // When a request completes, dispose the request content so the user doesn't have to. This also
-                // helps ensure that a HttpContent object is only sent once using HttpClient (similar to HttpRequestMessages
-                // that can also be sent only once).
-                request.Content?.Dispose();
+                cts.Dispose();
             }
-            finally
-            {
-                if (disposeCts)
-                {
-                    cts.Dispose();
-                }
-            }
+
+            // This method used to also dispose of the request content, e.g.:
+            //     request.Content?.Dispose();
+            // This has multiple problems:
+            // 1. It prevents code from reusing request content objects for subsequent requests,
+            //    as disposing of the object likely invalidates it for further use.
+            // 2. It prevents the possibility of partial or full duplex communication, even if supported
+            //    by the handler, as the request content may still be in use even if the response
+            //    (or response headers) has been received.
+            // By changing this to not dispose of the request content, disposal may end up being
+            // left for the finalizer to handle, or the developer can explicitly dispose of the
+            // content when they're done with it.  But it allows request content to be reused,
+            // and more importantly it enables handlers that allow receiving of the response before
+            // fully sending the request.  Prior to this change, a handler like CurlHandler would
+            // fail trying to access certain sites, if the site sent its response before it had
+            // completely received the request: CurlHandler might then find that the request content
+            // was disposed of while it still needed to read from it.
         }
 
         public void CancelPendingRequests()

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -323,14 +323,14 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
-        public async Task SendAsync_RequestContentDisposed()
+        public async Task SendAsync_RequestContentNotDisposed()
         {
             var content = new ByteArrayContent(new byte[1]);
             using (var request = new HttpRequestMessage(HttpMethod.Get, CreateFakeUri()) { Content = content }) 
             using (var client = new HttpClient(new CustomResponseHandler((r, c) => Task.FromResult(new HttpResponseMessage()))))
             {
                 await client.SendAsync(request);
-                Assert.Throws<ObjectDisposedException>(() => { content.ReadAsStringAsync(); });
+                await content.ReadAsStringAsync(); // no exception
             }
         }
 


### PR DESCRIPTION
HttpClient on Unix fails for some sites, in cases where the site sends a response before it’s fully received the entirety of the request.  That’s because HttpClient has logic to Dispose of the request content once the Task returned from the handler’s SendAsync completes, and unlike WinHTTP, libcurl doesn’t require that the whole request be sent before any of the response is processed.  That means that CurlHandler may receive the response (or the response headers), complete the SendAsync task, but still be reading from the request content, which may then be disposed of by HttpClient while it’s still in use, causing potential corruption, exceptions, etc.

The Dispose behavior has other problems with it.  A more generalized version of the above is that it prevents handlers that want to support full duplex communication, since it essentially requires that the whole request be sent before the response is processed.  It also forces extra cost onto consuming code in some situations, as it means that the request content objects can’t be pooled and reused (since disposal typically invalidates objects for such a purpose, though in some cases a custom content could be developed to override and ignore Dispose).

A variety of approaches were explored to address this:
- Change CurlHandler to only complete the SendAsync Task when both the request has been fully sent and the appropriate portion of the response has been received.  This is problematic, though, as with the pull model employed by libcurl, we don’t know reliably when the request has been fully sent.
- Change the disposal to be handled by the handlers rather than by HttpClient.  This could help in that a handler like CurlHandler could simply defer disposal until libcurl tells it the “easy” operation is done.  But it has other downsides. Today code can use an HttpClientHandler without HttpClient, e.g. by using HttpMessageInvoker instead of HttpClient, in which case it bypasses this disposal logic (and other logic provided by the relatively thin HttpClient wrapper). If we were to move the disposal logic to the HttpClientHandler, now such code that was never having its request content disposed will start to, which is bad and exactly the opposite of what we want. It also causes problems for chains of handlers, e.g. if HttpClient is given a handler that wraps CurlHandler, and that handler expects to be able to look at the request content after the SendAsync Task from CurlHandler completes but before it itself completes its SendAsync Task. And while such a scenario may seem far fetched, we effectively have it in the bits today: the diagnostic handler that's used to pass details off to DiagnosticListeners is injected in the middle like this, and it does pass off the request content after the wrapped SendAsync Task completes... if a listener was expecting a non-disposed request content at that point, it would be sorely disappointed.
- Simply stop disposing.  The primary downside here is existing code that may have expected disposal to happen, e.g. if a StreamContent wrapping a FileStream isn't explicitly disposed of by the app code, cleanup of the FileStream will be left to its finalizer.

The least bad option is to simply stop disposing.  This PR makes that change.

Fixes https://github.com/dotnet/corefx/issues/9006
Fixes https://github.com/dotnet/corefx/issues/16259
Fixes https://github.com/dotnet/corefx/issues/1794
cc: @davidsh, @cipop, @geoffkizer, @Priya91, @davidfowl, @mikeharder