### PR TITLE
Disable HandleCountChange test for netfx

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -1194,6 +1194,7 @@ namespace System.Diagnostics.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Linux | TestPlatforms.Windows)]  // Expected process HandleCounts differs on OSX
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Handle count change is not reliable, but seems less robust on NETFX")]
         public void HandleCountChanges()
         {
             RemoteInvoke(() =>


### PR DESCRIPTION
Fix https://github.com/dotnet/corefx/issues/19076

This test is intrinsically unstable, but I'm not going to robustify it now (eg., by opening far more files) since it seems to be stable so far on Core. It doesn't seem particularly important to keep it for desktop. 