### PR TITLE
Set EnableDefaultItems=false in init-tools.msbuild

### DIFF
--- a/init-tools.msbuild
+++ b/init-tools.msbuild
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp1.0</TargetFramework>
+    <EnableDefaultItems>false</EnableDefaultItems>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
     <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)Tools/$(BuildToolsPackageVersion)</BaseIntermediateOutputPath>
   </PropertyGroup>


### PR DESCRIPTION
By default the new SDK will try to find all files automatically
by doing **\* inclusions. For our restore project we don't need
any of that so we turn it off.

See:
https://github.com/dotnet/sdk/blob/master/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.props for what it currently tries to find automatically.

cc @mmitche @mellinoe @ericstj this should fix the 30+ wait time we are seeing during Restore BuildTools step in CI. 