### PR TITLE
Add parameter validation for CredentialCache.Add

### DIFF
--- a/src/System.Net.Primitives/src/Resources/Strings.resx
+++ b/src/System.Net.Primitives/src/Resources/Strings.resx
@@ -103,6 +103,9 @@
   <data name="net_collection_readonly" xml:space="preserve">
     <value>The collection is read-only.</value>
   </data>
+  <data name="net_nodefaultcreds" xml:space="preserve">
+    <value>Default credentials cannot be supplied for the {0} authentication scheme.</value>
+  </data>
   <data name="InvalidOperation_EnumFailedVersion" xml:space="preserve">
     <value>Collection was modified after the enumerator was instantiated.</value>
   </data>

--- a/src/System.Net.Primitives/src/System.Net.Primitives.csproj
+++ b/src/System.Net.Primitives/src/System.Net.Primitives.csproj
@@ -77,6 +77,9 @@
     <Compile Include="$(CommonPath)\System\Net\SocketAddress.cs">
       <Link>Common\System\Net\SocketAddress.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Net\NegotiationInfoClass.cs">
+      <Link>Common\System\Net\NegotiationInfoClass.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Net\NetworkInformation\HostInformation.cs">
       <Link>Common\System\Net\NetworkInformation\HostInformation.cs</Link>
     </Compile>

--- a/src/System.Net.Primitives/src/System/Net/CredentialCache.cs
+++ b/src/System.Net.Primitives/src/System/Net/CredentialCache.cs
@@ -31,6 +31,15 @@ namespace System.Net
             {
                 throw new ArgumentNullException(nameof(authType));
             }
+            
+            if ((cred is SystemNetworkCredential)
+                && !((string.Compare(authType, NegotiationInfoClass.NTLM, StringComparison.OrdinalIgnoreCase)==0)
+                     || (string.Compare(authType, NegotiationInfoClass.Kerberos, StringComparison.OrdinalIgnoreCase)==0)
+                     || (string.Compare(authType, NegotiationInfoClass.Negotiate, StringComparison.OrdinalIgnoreCase)==0))
+                )
+            {
+                throw new ArgumentException(SR.Format(SR.net_nodefaultcreds, authType), "authType");
+            }
 
             ++_version;
 

--- a/src/System.Net.Primitives/src/System/Net/CredentialCache.cs
+++ b/src/System.Net.Primitives/src/System/Net/CredentialCache.cs
@@ -33,12 +33,12 @@ namespace System.Net
             }
             
             if ((cred is SystemNetworkCredential)
-                && !((string.Compare(authType, NegotiationInfoClass.NTLM, StringComparison.OrdinalIgnoreCase)==0)
-                     || (string.Compare(authType, NegotiationInfoClass.Kerberos, StringComparison.OrdinalIgnoreCase)==0)
-                     || (string.Compare(authType, NegotiationInfoClass.Negotiate, StringComparison.OrdinalIgnoreCase)==0))
+                && !((string.Equals(authType, NegotiationInfoClass.NTLM, StringComparison.OrdinalIgnoreCase))
+                     || (string.Equals(authType, NegotiationInfoClass.Kerberos, StringComparison.OrdinalIgnoreCase))
+                     || (string.Equals(authType, NegotiationInfoClass.Negotiate, StringComparison.OrdinalIgnoreCase)))
                 )
             {
-                throw new ArgumentException(SR.Format(SR.net_nodefaultcreds, authType), "authType");
+                throw new ArgumentException(SR.Format(SR.net_nodefaultcreds, authType), nameof(authType));
             }
 
             ++_version;
@@ -75,6 +75,15 @@ namespace System.Net
             if (port < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(port));
+            }
+            
+            if ((credential is SystemNetworkCredential)
+                && !((string.Equals(authenticationType, NegotiationInfoClass.NTLM, StringComparison.OrdinalIgnoreCase))
+                     || (string.Equals(authenticationType, NegotiationInfoClass.Kerberos, StringComparison.OrdinalIgnoreCase))
+                     || (string.Equals(authenticationType, NegotiationInfoClass.Negotiate, StringComparison.OrdinalIgnoreCase)))
+                )
+            {
+                throw new ArgumentException(SR.Format(SR.net_nodefaultcreds, authenticationType), nameof(authenticationType));
             }
 
             ++_version;

--- a/src/System.Net.Primitives/tests/FunctionalTests/CredentialCacheTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/CredentialCacheTest.cs
@@ -524,7 +524,7 @@ namespace System.Net.Primitives.Functional.Tests
         [Fact]
         public static void AddRemove_UriAuthenticationType_Success()
         {
-            NetworkCredential nc = credential1;
+            NetworkCredential nc = customCredential;
 
             CredentialCache cc = new CredentialCache();
             cc.Add(uriPrefix1, authenticationType1, nc);
@@ -538,7 +538,7 @@ namespace System.Net.Primitives.Functional.Tests
         [Fact]
         public static void AddRemove_HostPortAuthenticationType_Success()
         {
-            NetworkCredential nc = credential1;
+            NetworkCredential nc = customCredential;
 
             CredentialCache cc = new CredentialCache();
             cc.Add(host1, port1, authenticationType1, nc);

--- a/src/System.Net.Primitives/tests/FunctionalTests/CredentialCacheTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/CredentialCacheTest.cs
@@ -29,6 +29,7 @@ namespace System.Net.Primitives.Functional.Tests
         private static readonly string authenticationTypeBasic = "Basic";
         private static readonly string authenticationTypeDigest = "Digest";
 
+        private static readonly NetworkCredential customCredential = new NetworkCredential("username", "password");
         private static readonly NetworkCredential credential1 = new NetworkCredential("username1", "password");
         private static readonly NetworkCredential credential2 = new NetworkCredential("username2", "password");
         private static readonly NetworkCredential credential3 = new NetworkCredential("username3", "password");
@@ -104,11 +105,11 @@ namespace System.Net.Primitives.Functional.Tests
         public static IEnumerable<object[]> StandardAuthTypeWithNetworkCredential =>
             new[]
             {
-                new object[] {authenticationTypeNTLM, credential1},
-                new object[] {authenticationTypeKerberos, credential2},
-                new object[] {authenticationTypeNegotiate, credential3},
-                new object[] {authenticationTypeBasic, credential4},
-                new object[] {authenticationTypeDigest, credential5},
+                new object[] {authenticationTypeNTLM, customCredential},
+                new object[] {authenticationTypeKerberos, customCredential},
+                new object[] {authenticationTypeNegotiate, customCredential},
+                new object[] {authenticationTypeBasic, customCredential},
+                new object[] {authenticationTypeDigest, customCredential},
                 
                 new object[] {authenticationTypeNTLM, CredentialCache.DefaultNetworkCredentials as NetworkCredential},
                 new object[] {authenticationTypeKerberos, CredentialCache.DefaultNetworkCredentials as NetworkCredential},
@@ -127,11 +128,11 @@ namespace System.Net.Primitives.Functional.Tests
         public static IEnumerable<object[]> CustomAuthTypeWithCustomNetworkCredential =>
             new[]
             {
-                new object[] {authenticationType1, credential1},
-                new object[] {authenticationType1, credential2},
+                new object[] {authenticationType1, customCredential},
+                new object[] {authenticationType1, customCredential},
                 
-                new object[] {authenticationType2, credential1},
-                new object[] {authenticationType2, credential2},
+                new object[] {authenticationType2, customCredential},
+                new object[] {authenticationType2, customCredential},
             };
 
         [Fact]
@@ -445,20 +446,19 @@ namespace System.Net.Primitives.Functional.Tests
             
             CredentialCache cc = new CredentialCache();
             
-            // .Net Framework and .Net Core have different behaviors for Digest when default NetworkCredential is used.
+            // .NET Framework and .NET Core have different behaviors for Digest when default NetworkCredential is used.
             if (string.Equals(authType, authenticationTypeDigest, StringComparison.OrdinalIgnoreCase) && (nc == CredentialCache.DefaultNetworkCredentials))
             {
                 if (PlatformDetection.IsFullFramework)
                 {
-                    // In .Net framework, when authType == Digest, if WDigestAvailable == true, it will pass the validation.
+                    // In .NET Framework, when authType == Digest, if WDigestAvailable == true, it will pass the validation.
                     // if WDigestAvailable == false, it will throw ArgumentException.
-                    // In order to determine WDigestAvailable's value, we need to use a method in SSPIWrapper.cs
-                    // It's not good practice to expose low level code in test project, we will skip the test.
+                    // It is not possible to easily determine if Digest is supported or not on .NET Framework. So, we will skip the test.
                     return;
                 }
                 else
                 {
-                    // In .Net Core, WDigestAvailable will always be false (we don't support it).
+                    // In .NET Core, WDigestAvailable will always be false (we don't support it).
                     // It will always throw ArgumentException.
                     AssertExtensions.Throws<ArgumentException>("authType", () => cc.Add(uriPrefix1, authType, nc));
                     return;
@@ -490,20 +490,19 @@ namespace System.Net.Primitives.Functional.Tests
             
             CredentialCache cc = new CredentialCache();
             
-            // .Net Framework and .Net Core have different behaviors for Digest when default NetworkCredential is used.
+            // .NET Framework and .NET Core have different behaviors for Digest when default NetworkCredential is used.
             if (string.Equals(authType, authenticationTypeDigest, StringComparison.OrdinalIgnoreCase) && (nc == CredentialCache.DefaultNetworkCredentials))
             {
                 if (PlatformDetection.IsFullFramework)
                 {
-                    // In .Net framework, when authType == Digest, if WDigestAvailable == true, it will pass the validation.
+                    // In .NET Framework, when authType == Digest, if WDigestAvailable == true, it will pass the validation.
                     // if WDigestAvailable == false, it will throw ArgumentException.
-                    // In order to determine WDigestAvailable's value, we need to use a method in SSPIWrapper.cs
-                    // It's not good practice to expose low level code in test project, we will skip the test.
+                    // It is not possible to easily determine if Digest is supported or not on .NET Framework. So, we will skip the test.
                     return;
                 }
                 else
                 {
-                    // In .Net Core, WDigestAvailable will always be false (we don't support it).
+                    // In .NET Core, WDigestAvailable will always be false (we don't support it).
                     // It will always throw ArgumentException.
                     AssertExtensions.Throws<ArgumentException>("authenticationType", () => cc.Add(host1, port1, authType, nc));
                     return;

--- a/src/System.Net.Primitives/tests/FunctionalTests/CredentialCacheTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/CredentialCacheTest.cs
@@ -62,7 +62,6 @@ namespace System.Net.Primitives.Functional.Tests
 
             cc.Add(uriPrefix2, authenticationType1, credential3); count++;
             cc.Add(uriPrefix2, authenticationType2, credential4); count++;
-            
             return new CredentialCacheCount(cc, count);
         }
 

--- a/src/System.Net.Primitives/tests/FunctionalTests/CredentialCacheTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/CredentialCacheTest.cs
@@ -394,22 +394,17 @@ namespace System.Net.Primitives.Functional.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp | TargetFrameworkMonikers.Uap)]
-        public static void AddRemove_UriAuthenticationTypeDefaultCredentials_Success_net46()
+        public static void Add_DefaultCredentials_ThrowsArgumentException()
         {
             NetworkCredential nc = CredentialCache.DefaultNetworkCredentials as NetworkCredential;
             CredentialCache cc = new CredentialCache();
-
-            // The full framework throw System.ArgumentException with the message
-            // 'Default credentials cannot be supplied for the authenticationType1 authentication scheme.'
             AssertExtensions.Throws<ArgumentException>("authType", () => cc.Add(uriPrefix1, authenticationType1, nc));
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
-        public static void AddRemove_UriAuthenticationTypeDefaultCredentials_Success()
+        public static void AddRemove_UriAuthenticationType_Success()
         {
-            NetworkCredential nc = CredentialCache.DefaultNetworkCredentials as NetworkCredential;
+            NetworkCredential nc = credential1;
 
             CredentialCache cc = new CredentialCache();
             cc.Add(uriPrefix1, authenticationType1, nc);
@@ -421,10 +416,9 @@ namespace System.Net.Primitives.Functional.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
-        public static void AddRemove_HostPortAuthenticationTypeDefaultCredentials_Success()
+        public static void AddRemove_HostPortAuthenticationType_Success()
         {
-            NetworkCredential nc = CredentialCache.DefaultNetworkCredentials as NetworkCredential;
+            NetworkCredential nc = credential1;
 
             CredentialCache cc = new CredentialCache();
             cc.Add(host1, port1, authenticationType1, nc);

--- a/src/System.Net.Primitives/tests/FunctionalTests/CredentialCacheTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/CredentialCacheTest.cs
@@ -63,6 +63,7 @@ namespace System.Net.Primitives.Functional.Tests
 
             cc.Add(uriPrefix2, authenticationType1, credential3); count++;
             cc.Add(uriPrefix2, authenticationType2, credential4); count++;
+
             return new CredentialCacheCount(cc, count);
         }
 


### PR DESCRIPTION
Add parameter validation for CredentialCache.Add, and fix test cases.

Fix #18870 