### PR TITLE
Disable Perf_MemoryMappedFile.CreateNew test on macOS.

### DIFF
--- a/src/System.IO.MemoryMappedFiles/tests/Performance/Perf.MemoryMappedFile.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/Performance/Perf.MemoryMappedFile.cs
@@ -18,6 +18,7 @@ namespace System.IO.MemoryMappedFiles.Tests
         [InlineData(100000)]
         [InlineData(1000000)]
         [InlineData(10000000)]
+        [ActiveIssue(18463, TestPlatforms.OSX)] // Hits the max-open-file limit often on OSX.
         public void CreateNew(int capacity)
         {
             const int innerIterations = 1000;


### PR DESCRIPTION
This test opens a large number of files simultaneously, which trips the open-file limit on macOS.

@danmosemsft 