### PR TITLE
Validate framework package

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-2.0.0-prerelease-01528-02
+2.0.0-prerelease-01528-03

--- a/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.pkgproj
+++ b/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.pkgproj
@@ -27,6 +27,23 @@
     <ExcludeFromClosure Include="System.Drawing" />
     <ExcludeFromClosure Include="System.Net" />
     <ExcludeFromClosure Include="System.Transactions" />
+
+    <!-- Permit the following implementation-only assemblies -->
+    <ValidatePackageSuppression Condition="'$(PackageTargetRuntime)' != ''" Include="PermitInbox">
+      <Value>
+        Microsoft.VisualBasic;
+        Microsoft.Win32.Registry;
+        System.IO.FileSystem.AccessControl;
+        System.Private.DataContractSerialization;
+        System.Private.Uri;
+        System.Private.Xml;
+        System.Private.Xml.Linq;
+        System.Security.AccessControl;
+        System.Security.Cryptography.Cng;
+        System.Security.Cryptography.OpenSsl;
+        System.Security.Principal.Windows;
+      </Value>
+    </ValidatePackageSuppression>
   </ItemGroup>
   
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.pkgproj
+++ b/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.pkgproj
@@ -34,6 +34,30 @@
     <ExcludeFromClosure Include="System.Drawing" />
     <ExcludeFromClosure Include="System.Net" />
     <ExcludeFromClosure Include="System.Transactions" />
+
+    <!-- Permit the following implementation-only assemblies -->
+    <ValidatePackageSuppression Condition="'$(PackageTargetRuntime)' != ''" Include="PermitInbox">
+      <Value>
+        Microsoft.VisualBasic;
+        System.Diagnostics.DiagnosticSource;
+        System.Private.DataContractSerialization;
+        System.Private.Uri;
+        System.Private.Xml;
+        System.Private.Xml.Linq;
+        System.Reflection.Emit.ILGeneration;
+        System.Reflection.Emit.Lightweight;
+        System.Reflection.Emit;
+        System.Security.AccessControl;
+        System.Security.Cryptography.Cng;
+        System.Security.Principal.Windows;
+        System.Threading.Tasks.Extensions;
+      </Value>
+    </ValidatePackageSuppression>
+    <ValidatePackageSuppression Condition="'$(PackageTargetRuntime)' != '' AND '$(TargetGroup)' == 'uapaot'" Include="PermitInbox">
+      <Value>
+        System.Private.Reflection.Metadata.Ecma335;
+      </Value>
+    </ValidatePackageSuppression>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -785,11 +785,13 @@
     },
     "System.ComponentModel.DataAnnotations": {
       "InboxOn": {
+        "netcoreapp2.0": "4.0.0.0",
         "net45": "4.0.0.0",
         "portable46-net451+win81": "4.0.0.0",
         "portable45-net45+win8": "4.0.0.0",
         "monoandroid10": "Any",
         "monotouch10": "Any",
+        "uap10.1": "4.0.0.0",
         "win8": "4.0.0.0",
         "xamarinios10": "Any",
         "xamarinmac20": "Any",
@@ -2215,6 +2217,7 @@
     },
     "System.Net": {
       "InboxOn": {
+        "netcoreapp2.0": "4.0.0.0",
         "net45": "4.0.0.0",
         "portable45-net45+win8+wpa81": "4.0.0.0",
         "portable46-net451+win81+wpa81": "4.0.0.0",
@@ -2229,6 +2232,7 @@
         "portable46-wp81+wpa81": "3.9.0.0",
         "monoandroid10": "Any",
         "monotouch10": "Any",
+        "uap10.1": "4.0.0.0",
         "win8": "4.0.0.0",
         "wp8": "3.9.0.0",
         "wpa81": "4.0.0.0",
@@ -2346,6 +2350,7 @@
         "netcoreapp2.0": "4.0.0.0",
         "monoandroid10": "Any",
         "monotouch10": "Any",
+        "uap10.1": "4.0.0.0",
         "xamarinios10": "Any",
         "xamarinmac20": "Any",
         "xamarintvos10": "Any",
@@ -2357,6 +2362,7 @@
         "netcoreapp2.0": "4.0.0.0",
         "monoandroid10": "Any",
         "monotouch10": "Any",
+        "uap10.1": "4.0.0.0",
         "xamarinios10": "Any",
         "xamarinmac20": "Any",
         "xamarintvos10": "Any",
@@ -3127,7 +3133,8 @@
       "InboxOn": {
         "netcoreapp2.0": "4.1.0.0",
         "net461": "4.0.1.0",
-        "netstandard2.0": "4.0.1.0"
+        "netstandard2.0": "4.0.1.0",
+        "uap10.1": "4.1.0.0"
       },
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
@@ -3411,6 +3418,7 @@
         "netcoreapp2.0": "4.0.2.0",
         "monoandroid10": "Any",
         "monotouch10": "Any",
+        "uap10.1": "4.0.2.0",
         "xamarinios10": "Any",
         "xamarinmac20": "Any",
         "xamarintvos10": "Any",
@@ -4042,6 +4050,7 @@
         "netstandard2.0": "4.0.0.0",
         "monoandroid10": "Any",
         "monotouch10": "Any",
+        "uap10.1": "4.1.0.0",
         "xamarinios10": "Any",
         "xamarinmac20": "Any",
         "xamarintvos10": "Any",
@@ -4190,6 +4199,7 @@
     },
     "System.ServiceModel.Web": {
       "InboxOn": {
+        "netcoreapp2.0": "4.0.0.0",
         "net45": "4.0.0.0",
         "portable45-net45+win8+wpa81": "4.0.0.0",
         "portable46-net451+win81+wpa81": "4.0.0.0",
@@ -4204,6 +4214,7 @@
         "portable46-wp81+wpa81": "4.0.0.0",
         "monoandroid10": "Any",
         "monotouch10": "Any",
+        "uap10.1": "4.0.0.0",
         "win8": "4.0.0.0",
         "wp8": "2.0.5.0",
         "wpa81": "4.0.0.0",
@@ -4788,6 +4799,7 @@
     },
     "System.Windows": {
       "InboxOn": {
+        "netcoreapp2.0": "4.0.0.0",
         "net45": "4.0.0.0",
         "portable45-net45+win8+wpa81": "4.0.0.0",
         "portable46-net451+win81+wpa81": "4.0.0.0",
@@ -4802,6 +4814,7 @@
         "portable46-wp81+wpa81": "4.0.0.0",
         "monoandroid10": "Any",
         "monotouch10": "Any",
+        "uap10.1": "4.0.0.0",
         "win8": "4.0.0.0",
         "wp8": "2.0.6.0",
         "wpa81": "4.0.0.0",
@@ -4967,6 +4980,7 @@
     },
     "System.Xml.Serialization": {
       "InboxOn": {
+        "netcoreapp2.0": "4.0.0.0",
         "net45": "4.0.0.0",
         "portable45-net45+win8+wpa81": "4.0.0.0",
         "portable46-net451+win81+wpa81": "4.0.0.0",
@@ -4981,6 +4995,7 @@
         "portable46-wp81+wpa81": "4.0.0.0",
         "monoandroid10": "Any",
         "monotouch10": "Any",
+        "uap10.1": "4.0.0.0",
         "win8": "4.0.0.0",
         "wp8": "2.0.5.0",
         "wpa81": "4.0.0.0",
@@ -5045,6 +5060,7 @@
         "netstandard2.0": "4.0.1.0",
         "monoandroid10": "Any",
         "monotouch10": "Any",
+        "uap10.1": "4.1.0.0",
         "xamarinios10": "Any",
         "xamarinmac20": "Any",
         "xamarintvos10": "Any",

--- a/pkg/NETStandard.Library.NETFramework/NETStandard.Library.NETFramework.pkgproj
+++ b/pkg/NETStandard.Library.NETFramework/NETStandard.Library.NETFramework.pkgproj
@@ -13,6 +13,10 @@
 
     <IsFrameworkPackage>true</IsFrameworkPackage>
     <IncludeLibFiles>true</IncludeLibFiles>
+    
+    <!-- ValidatePackage doesn't evaluate our targets/props so it does 
+         not find any of the assets in this package -->
+    <SkipValidatePackage>true</SkipValidatePackage>
   </PropertyGroup>
   
   <ItemGroup>

--- a/pkg/frameworkPackage.targets
+++ b/pkg/frameworkPackage.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" InitialTargets="_CheckForFiles;IncludeFiles" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" InitialTargets="_CheckForFiles;IncludeFiles;SetValidateFramework" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
     <IsLineupPackage Condition="'$(PackageTargetRuntime)' == '' AND '$(IncludeLibFiles)' != 'true'">true</IsLineupPackage>
@@ -145,6 +145,16 @@
         <IsSymbolFile Condition="'%(Extension)' == '.pdb'">true</IsSymbolFile>
         <IsSymbolFile Condition="'$(SymbolFileExtension)' != '' AND'%(Extension)' == '$(SymbolFileExtension)'">true</IsSymbolFile>
       </File>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="SetValidateFramework">
+    <ItemGroup>
+      <!-- Update validation with locally authored RID list -->
+      <DefaultValidateFramework Remove="$(TargetFramework)"/>
+      <DefaultValidateFramework Include="$(TargetFramework)">
+        <RuntimeIDs>@(BuildRID)</RuntimeIDs>
+      </DefaultValidateFramework>
     </ItemGroup>
   </Target>
 </Project>

--- a/pkg/frameworkPackage.targets
+++ b/pkg/frameworkPackage.targets
@@ -5,10 +5,6 @@
     <IsLineupPackage Condition="'$(PackageTargetRuntime)' == '' AND '$(IncludeLibFiles)' != 'true'">true</IsLineupPackage>
     <PreventImplementationReference Condition="'$(PackageTargetRuntime)' != ''">true</PreventImplementationReference>
 
-    <!-- these packages don't follow the patterns expected by package validation -->
-    <SkipPackageFileCheck>true</SkipPackageFileCheck>
-    <SkipValidatePackage>true</SkipValidatePackage>
-
     <NETStandardVersion Condition="'$(NETStandardVersion)' == ''">2.0</NETStandardVersion>
     <NETStandardPackageRefPath Condition="'$(NETStandardPackageRefPath)' == ''">$(PackagesDir)$(NETStandardPackageId.ToLower())\$(NETStandardPackageVersion)\build\netstandard$(NETStandardVersion)\ref</NETStandardPackageRefPath>
 


### PR DESCRIPTION
Adds validation for our framework packages and marks suppresses errors.

With this change we can ensure our packageIndex remains in sync with the actual framework packages.  It also forces us to add exceptions when we have implementation-only assemblies.

@weshaggard please review the index and exceptions to make sure they match your expectations.

