### PR TITLE
Perf improvements to StreamWriter with perf tests

### DIFF
--- a/src/System.Runtime.Extensions/src/System/IO/StreamWriter.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/StreamWriter.cs
@@ -334,26 +334,45 @@ namespace System.IO
 
             CheckAsyncTaskInProgress();
 
-            int index = 0;
             int count = buffer.Length;
-            while (count > 0)
+			
+            // Threshold of 4 was chosen after running perf tests
+            if (count <= 4)
             {
-                if (_charPos == _charLen)
+                for (int i = 0; i < count; i++)
                 {
-                    Flush(false, false);
-                }
+                    if (_charPos == _charLen)
+                    {
+                        Flush(false, false);
+                    }
 
-                int n = _charLen - _charPos;
-                if (n > count)
+                    Debug.Assert(_charLen - _charPos > 0, "StreamWriter::Write(char[]) isn't making progress!  This is most likely a race in user code.");
+                    _charBuffer[_charPos] = buffer[i];
+                    _charPos++;
+                }
+            }
+            else
+            {
+                int index = 0;
+                while (count > 0)
                 {
-                    n = count;
-                }
+                    if (_charPos == _charLen)
+                    {
+                        Flush(false, false);
+                    }
 
-                Debug.Assert(n > 0, "StreamWriter::Write(char[]) isn't making progress!  This is most likely a race in user code.");
-                Buffer.BlockCopy(buffer, index * sizeof(char), _charBuffer, _charPos * sizeof(char), n * sizeof(char));
-                _charPos += n;
-                index += n;
-                count -= n;
+                    int n = _charLen - _charPos;
+                    if (n > count)
+                    {
+                        n = count;
+                    }
+
+                    Debug.Assert(n > 0, "StreamWriter::Write(char[]) isn't making progress!  This is most likely a race in user code.");
+                    Buffer.BlockCopy(buffer, index * sizeof(char), _charBuffer, _charPos * sizeof(char), n * sizeof(char));
+                    _charPos += n;
+                    index += n;
+                    count -= n;
+                }
             }
 
             if (_autoFlush)
@@ -383,24 +402,44 @@ namespace System.IO
 
             CheckAsyncTaskInProgress();
 
-            while (count > 0)
+            // Threshold of 4 was chosen after running perf tests
+            if (count <= 4)
             {
-                if (_charPos == _charLen)
+                while (count > 0)
                 {
-                    Flush(false, false);
-                }
+                    if (_charPos == _charLen)
+                    {
+                        Flush(false, false);
+                    }
 
-                int n = _charLen - _charPos;
-                if (n > count)
+                    Debug.Assert(_charLen - _charPos > 0, "StreamWriter::Write(char[]) isn't making progress!  This is most likely a race in user code.");
+                    _charBuffer[_charPos] = buffer[index];
+                    _charPos++;
+                    index++;
+                    count--;
+                }
+            }
+            else
+            {
+                while (count > 0)
                 {
-                    n = count;
-                }
+                    if (_charPos == _charLen)
+                    {
+                        Flush(false, false);
+                    }
 
-                Debug.Assert(n > 0, "StreamWriter::Write(char[], int, int) isn't making progress!  This is most likely a race condition in user code.");
-                Buffer.BlockCopy(buffer, index * sizeof(char), _charBuffer, _charPos * sizeof(char), n * sizeof(char));
-                _charPos += n;
-                index += n;
-                count -= n;
+                    int n = _charLen - _charPos;
+                    if (n > count)
+                    {
+                        n = count;
+                    }
+
+                    Debug.Assert(n > 0, "StreamWriter::Write(char[], int, int) isn't making progress!  This is most likely a race condition in user code.");
+                    Buffer.BlockCopy(buffer, index * sizeof(char), _charBuffer, _charPos * sizeof(char), n * sizeof(char));
+                    _charPos += n;
+                    index += n;
+                    count -= n;
+                }
             }
 
             if (_autoFlush)
@@ -419,25 +458,44 @@ namespace System.IO
             CheckAsyncTaskInProgress();
 
             int count = value.Length;
-            int index = 0;
-            while (count > 0)
+
+            // Threshold of 4 was chosen after running perf tests
+            if (count <= 4)
             {
-                if (_charPos == _charLen)
+                for (int i = 0; i < count; i++)
                 {
-                    Flush(false, false);
-                }
+                    if (_charPos == _charLen)
+                    {
+                        Flush(false, false);
+                    }
 
-                int n = _charLen - _charPos;
-                if (n > count)
+                    Debug.Assert(_charLen - _charPos > 0, "StreamWriter::Write(String) isn't making progress!  This is most likely a race condition in user code.");
+                    _charBuffer[_charPos] = value[i];
+                    _charPos++;
+                }
+            }
+            else
+            {
+                int index = 0;
+                while (count > 0)
                 {
-                    n = count;
-                }
+                    if (_charPos == _charLen)
+                    {
+                        Flush(false, false);
+                    }
 
-                Debug.Assert(n > 0, "StreamWriter::Write(String) isn't making progress!  This is most likely a race condition in user code.");
-                value.CopyTo(index, _charBuffer, _charPos, n);
-                _charPos += n;
-                index += n;
-                count -= n;
+                    int n = _charLen - _charPos;
+                    if (n > count)
+                    {
+                        n = count;
+                    }
+
+                    Debug.Assert(n > 0, "StreamWriter::Write(String) isn't making progress!  This is most likely a race condition in user code.");
+                    value.CopyTo(index, _charBuffer, _charPos, n);
+                    _charPos += n;
+                    index += n;
+                    count -= n;
+                }
             }
 
             if (_autoFlush)

--- a/src/System.Runtime.Extensions/src/System/IO/StreamWriter.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/StreamWriter.cs
@@ -334,12 +334,10 @@ namespace System.IO
 
             CheckAsyncTaskInProgress();
 
-            int count = buffer.Length;
-			
             // Threshold of 4 was chosen after running perf tests
-            if (count <= 4)
+            if (buffer.Length <= 4)
             {
-                for (int i = 0; i < count; i++)
+                for (int i = 0; i < buffer.Length; i++)
                 {
                     if (_charPos == _charLen)
                     {
@@ -353,6 +351,8 @@ namespace System.IO
             }
             else
             {
+                int count = buffer.Length;
+
                 int index = 0;
                 while (count > 0)
                 {

--- a/src/System.Runtime.Extensions/tests/Performance/Perf.StreamWriter.cs
+++ b/src/System.Runtime.Extensions/tests/Performance/Perf.StreamWriter.cs
@@ -17,7 +17,7 @@ namespace System.IO.Tests
         private const int DefaultStreamWriterBufferSize = 1024; // Same as StreamWriter internal default
 
         [Benchmark]
-        [MemberData(nameof(WriteMemberData))]
+        [MemberData(nameof(WriteLengthMemberData))]
         public void WriteCharArray(int writeLength)
         {
             char[] buffer = new string('a', writeLength).ToCharArray();
@@ -47,7 +47,7 @@ namespace System.IO.Tests
         }
 
         [Benchmark]
-        [MemberData(nameof(WriteMemberData))]
+        [MemberData(nameof(WriteLengthMemberData))]
         public void WritePartialCharArray(int writeLength)
         {
             char[] buffer = new string('a', writeLength + 10).ToCharArray();
@@ -77,7 +77,7 @@ namespace System.IO.Tests
         }
 
         [Benchmark]
-        [MemberData(nameof(WriteMemberData))]
+        [MemberData(nameof(WriteLengthMemberData))]
         public void WriteString(int writeLength)
         {
             string value = new string('a', writeLength);
@@ -106,13 +106,9 @@ namespace System.IO.Tests
             }
         }
 
-        public static IEnumerable<object[]> WriteMemberData()
+        public static IEnumerable<object[]> WriteLengthMemberData()
         {
-            for (int i = 2; i <= 10; i++)
-            {
-                yield return new object[] { i };
-            }
-
+            yield return new object[] { 2 };
             yield return new object[] { 100 };
         }
     }

--- a/src/System.Runtime.Extensions/tests/Performance/Perf.StreamWriter.cs
+++ b/src/System.Runtime.Extensions/tests/Performance/Perf.StreamWriter.cs
@@ -1,0 +1,119 @@
+﻿// Licensed to the.NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Microsoft.Xunit.Performance;
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public class Perf_StreamWriter
+    {
+        private const int MemoryStreamSize = 32768;
+        private const int TotalWriteCount = 16777216; // 2^24 - should yield around 300ms runs
+        private const int DefaultStreamWriterBufferSize = 1024; // Same as StreamWriter internal default
+
+        [Benchmark]
+        [MemberData(nameof(WriteMemberData))]
+        public void WriteCharArray(int writeLength)
+        {
+            char[] buffer = new string('a', writeLength).ToCharArray();
+            int innerIterations = MemoryStreamSize / writeLength;
+            int outerIteration = TotalWriteCount / innerIterations;
+            using (var stream = new MemoryStream(MemoryStreamSize))
+            {
+                using (var writer = new StreamWriter(stream, new UTF8Encoding(false, true), DefaultStreamWriterBufferSize, true))
+                {
+                    foreach (var iteration in Benchmark.Iterations)
+                    {
+                        using (iteration.StartMeasurement())
+                        {
+                            for (int i = 0; i < outerIteration; i++)
+                            {
+                                for (int j = 0; j < innerIterations; j++)
+                                {
+                                    writer.Write(buffer);
+                                }
+                                writer.Flush();
+                                stream.Position = 0;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        [Benchmark]
+        [MemberData(nameof(WriteMemberData))]
+        public void WritePartialCharArray(int writeLength)
+        {
+            char[] buffer = new string('a', writeLength + 10).ToCharArray();
+            int innerIterations = MemoryStreamSize / writeLength;
+            int outerIteration = TotalWriteCount / innerIterations;
+            using (var stream = new MemoryStream(MemoryStreamSize))
+            {
+                using (var writer = new StreamWriter(stream, new UTF8Encoding(false, true), DefaultStreamWriterBufferSize, true))
+                {
+                    foreach (var iteration in Benchmark.Iterations)
+                    {
+                        using (iteration.StartMeasurement())
+                        {
+                            for (int i = 0; i < outerIteration; i++)
+                            {
+                                for (int j = 0; j < innerIterations; j++)
+                                {
+                                    writer.Write(buffer, 10, writeLength);
+                                }
+                                writer.Flush();
+                                stream.Position = 0;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        [Benchmark]
+        [MemberData(nameof(WriteMemberData))]
+        public void WriteString(int writeLength)
+        {
+            string value = new string('a', writeLength);
+            int innerIterations = MemoryStreamSize / writeLength;
+            int outerIteration = TotalWriteCount / innerIterations;
+            using (var stream = new MemoryStream(MemoryStreamSize))
+            {
+                using (var writer = new StreamWriter(stream, new UTF8Encoding(false, true), DefaultStreamWriterBufferSize, true))
+                {
+                    foreach (var iteration in Benchmark.Iterations)
+                    {
+                        using (iteration.StartMeasurement())
+                        {
+                            for (int i = 0; i < outerIteration; i++)
+                            {
+                                for (int j = 0; j < innerIterations; j++)
+                                {
+                                    writer.Write(value);
+                                }
+                                writer.Flush();
+                                stream.Position = 0;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        public static IEnumerable<object[]> WriteMemberData()
+        {
+            for (int i = 2; i <= 10; i++)
+            {
+                yield return new object[] { i };
+            }
+
+            yield return new object[] { 100 };
+        }
+    }
+}

--- a/src/System.Runtime.Extensions/tests/Performance/System.Runtime.Extensions.Performance.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/Performance/System.Runtime.Extensions.Performance.Tests.csproj
@@ -13,6 +13,7 @@
     <Compile Include="Perf.Environment.cs" />
     <Compile Include="Perf.Path.cs" />
     <Compile Include="Perf.Random.cs" />
+    <Compile Include="Perf.StreamWriter.cs" />
     <Compile Include="$(CommonTestPath)\System\PerfUtils.cs">
       <Link>Common\System\PerfUtils.cs</Link>
     </Compile>


### PR DESCRIPTION
StreamWriter Write multi character methods are inefficient when writing a small number of characters. This leads to the situation where the two calls to StreamWriter when doing this:
```csharp
    _streamWriter.Write('<');
    _streamWriter.Write('/');
```
runs significantly faster than the one call to StreamWriter when doing this:
```csharp
    char[] chars = new char[] { '<', '/'};
    _streamWriter.Write(chars);
```
This is because Buffer.BlockCopy is always used with char arrays which is more expensive than a simple one char at a time array assignment in a loop. This is more expensive to the point that the overhead of an extra method call costs significantly less. When using the overload which takes a string, a similar issue occurs with a call to string.CopyTo.
Here are the perf results before and after the change:

| Test | Baseline Avg | Change Avg | % Diff |
| --- | --- | --- | --- |
| WriteCharArray(writeLength: 10) | 317.7133995 | 315.3404692 | 0.75% |
| WriteCharArray(writeLength: 100) | 1042.793872 | 1022.39794 | 1.96% |
| WriteCharArray(writeLength: 2) | 258.3788186 | 152.7016172 | 40.90% |
| WriteCharArray(writeLength: 3) | 265.1405325 | 163.8113327 | 38.22% |
| WriteCharArray(writeLength: 4) | 270.9672665 | 199.7605459 | 26.28% |
| WriteCharArray(writeLength: 5) | 272.7933884 | 268.0367705 | 1.74% |
| WriteCharArray(writeLength: 6) | 275.7948424 | 272.662552 | 1.14% |
| WriteCharArray(writeLength: 7) | 286.0221257 | 287.7501426 | -0.60% |
| WriteCharArray(writeLength: 8) | 286.0322753 | 292.7262179 | -2.34% |
| WriteCharArray(writeLength: 9) | 310.2990805 | 300.8100611 | 3.06% |
| WritePartialCharArray(writeLength: 10) | 320.8516534 | 306.7162235 | 4.41% |
| WritePartialCharArray(writeLength: 100) | 992.9288187 | 989.0454886 | 0.39% |
| WritePartialCharArray(writeLength: 2) | 274.1539188 | 161.9795985 | 40.92% |
| WritePartialCharArray(writeLength: 3) | 272.7907888 | 187.373916 | 31.31% |
| WritePartialCharArray(writeLength: 4) | 271.060147 | 218.1671762 | 19.51% |
| WritePartialCharArray(writeLength: 5) | 279.3890399 | 285.6314942 | -2.23% |
| WritePartialCharArray(writeLength: 6) | 284.7554306 | 298.942551 | -4.98% |
| WritePartialCharArray(writeLength: 7) | 301.1510832 | 304.8441162 | -1.23% |
| WritePartialCharArray(writeLength: 8) | 307.0650737 | 313.7156342 | -2.17% |
| WritePartialCharArray(writeLength: 9) | 296.8718112 | 308.0524504 | -3.77% |
| WriteString(writeLength: 10) | 282.8297979 | 283.8806133 | -0.37% |
| WriteString(writeLength: 100) | 1015.825361 | 969.9482392 | 4.52% |
| WriteString(writeLength: 2) | 229.6652552 | 156.3140115 | 31.94% |
| WriteString(writeLength: 3) | 239.3874726 | 174.3450671 | 27.17% |
| WriteString(writeLength: 4) | 245.0068201 | 199.1682472 | 18.71% |
| WriteString(writeLength: 5) | 255.5878577 | 244.4042087 | 4.38% |
| WriteString(writeLength: 6) | 246.6323967 | 244.8518418 | 0.72% |
| WriteString(writeLength: 7) | 272.074129 | 261.9257195 | 3.73% |
| WriteString(writeLength: 8) | 277.286225 | 266.4553122 | 3.91% |
| WriteString(writeLength: 9) | 281.5565211 | 277.8713811 | 1.31% |
