### PR TITLE
Increase VSTS Symbol expiration to 30 day default

### DIFF
--- a/buildpipeline/DotNet-Trusted-Publish-Symbols.json
+++ b/buildpipeline/DotNet-Trusted-Publish-Symbols.json
@@ -78,7 +78,7 @@
         "assemblyPath": "",
         "toLowerCase": "true",
         "detailedLog": "true",
-        "expirationInDays": "1",
+        "expirationInDays": "30",
         "usePat": "false"
       }
     }


### PR DESCRIPTION
skip ci please

I accidentally had expiration set to 1 day in https://github.com/dotnet/corefx/pull/18350, I think for debug purposes. This PR sets it to 30. 30 is the default, but I hard-coded it in case the default changes.

Realized I used 1 when porting this to CoreCLR/master in https://github.com/dotnet/coreclr/pull/11300.