### PR TITLE
Remove a few PNSEs from HttpListener

### DIFF
--- a/src/System.Net.HttpListener/src/System/Net/Managed/HttpListener.Managed.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/HttpListener.Managed.cs
@@ -27,7 +27,8 @@ namespace System.Net
         {
             get
             {
-                throw new PlatformNotSupportedException();
+                CheckDisposed();
+                return _timeoutManager;
             }
         }
 

--- a/src/System.Net.HttpListener/src/System/Net/Managed/HttpListenerTimeoutManager.Managed.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/HttpListenerTimeoutManager.Managed.cs
@@ -6,77 +6,84 @@ namespace System.Net
 {
     public class HttpListenerTimeoutManager
     {
-        internal HttpListenerTimeoutManager(HttpListener listener) { }
+        private TimeSpan _drainEntityBody = TimeSpan.Zero;
+        private TimeSpan _idleConnection = TimeSpan.Zero;
 
-        public TimeSpan EntityBody
-        {
-            get
-            {
-                throw new PlatformNotSupportedException();
-            }
-            set
-            {
-                throw new PlatformNotSupportedException();
-            }
-        }
+        internal HttpListenerTimeoutManager(HttpListener listener) { }
 
         public TimeSpan DrainEntityBody
         {
-            get
-            {
-                throw new PlatformNotSupportedException();
-            }
+            get => _drainEntityBody;
             set
             {
-                throw new PlatformNotSupportedException();
-            }
-        }
-
-        public TimeSpan RequestQueue
-        {
-            get
-            {
-                throw new PlatformNotSupportedException();
-            }
-            set
-            {
-                throw new PlatformNotSupportedException();
+                // Managed implementation currently doesn't pool connections,
+                // so this is a nop other than roundtripping the value.
+                ValidateTimeout(value);
+                _drainEntityBody = value;
             }
         }
 
         public TimeSpan IdleConnection
         {
-            get
-            {
-                throw new PlatformNotSupportedException();
-            }
+            get => _idleConnection;
             set
             {
-                throw new PlatformNotSupportedException();
+                // Managed implementation currently doesn't pool connections,
+                // so this is a nop other than roundtripping the value.
+                ValidateTimeout(value);
+                _idleConnection = value;
+            }
+        }
+
+        public TimeSpan EntityBody
+        {
+            get => TimeSpan.Zero;
+            set
+            {
+                ValidateTimeout(value);
+                throw new PlatformNotSupportedException(); // low usage, not currently implemented
             }
         }
 
         public TimeSpan HeaderWait
         {
-            get
-            {
-                throw new PlatformNotSupportedException();
-            }
+            get => TimeSpan.Zero;
             set
             {
-                throw new PlatformNotSupportedException();
+                ValidateTimeout(value);
+                throw new PlatformNotSupportedException(); // low usage, not currently implemented
             }
         }
 
         public long MinSendBytesPerSecond
         {
-            get
-            {
-                throw new PlatformNotSupportedException();
-            }
+            get => 0;
             set
             {
-                throw new PlatformNotSupportedException();
+                if (value < 0 || value > uint.MaxValue)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+                throw new PlatformNotSupportedException(); // low usage, not currently implemented
+            }
+        }
+
+        public TimeSpan RequestQueue
+        {
+            get => TimeSpan.Zero;
+            set
+            {
+                ValidateTimeout(value);
+                throw new PlatformNotSupportedException(); // low usage, not currently implemented
+            }
+        }
+
+        private void ValidateTimeout(TimeSpan value)
+        {
+            long timeoutValue = Convert.ToInt64(value.TotalSeconds);
+            if (timeoutValue < 0 || timeoutValue > ushort.MaxValue)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value));
             }
         }
     }

--- a/src/System.Net.HttpListener/tests/HttpListenerTimeoutManagerTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerTimeoutManagerTests.cs
@@ -8,6 +8,36 @@ using Xunit;
 
 namespace System.Net.Tests
 {
+    public class HttpListenerTimeoutManagerTests
+    {
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
+        [InlineData(-1)]
+        [InlineData((long)uint.MaxValue + 1)]
+        public void MinSendBytesPerSecond_NotUInt_ThrowsArgumentOutOfRangeException(long value)
+        {
+            using (var listener = new HttpListener())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>("value", () => listener.TimeoutManager.MinSendBytesPerSecond = value);
+            }
+        }
+
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
+        [InlineData(-1)]
+        [InlineData((uint)ushort.MaxValue + 1)]
+        public void TimeoutValue_NotUShort_ThrowsArgumentOutOfRangeException(long totalSeconds)
+        {
+            using (var listener = new HttpListener())
+            {
+                TimeSpan timeSpan = TimeSpan.FromSeconds(totalSeconds);
+                Assert.Throws<ArgumentOutOfRangeException>("value", () => listener.TimeoutManager.EntityBody = timeSpan);
+                Assert.Throws<ArgumentOutOfRangeException>("value", () => listener.TimeoutManager.DrainEntityBody = timeSpan);
+                Assert.Throws<ArgumentOutOfRangeException>("value", () => listener.TimeoutManager.RequestQueue = timeSpan);
+                Assert.Throws<ArgumentOutOfRangeException>("value", () => listener.TimeoutManager.IdleConnection = timeSpan);
+                Assert.Throws<ArgumentOutOfRangeException>("value", () => listener.TimeoutManager.HeaderWait = timeSpan);
+            }
+        }
+    }
+
     [PlatformSpecific(TestPlatforms.Windows)]
     public class HttpListenerTimeoutManagerWindowsTests : IDisposable
     {
@@ -337,32 +367,6 @@ namespace System.Net.Tests
             }
         }
 
-        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
-        [InlineData(-1)]
-        [InlineData((long)uint.MaxValue + 1)]
-        public void MinSendBytesPerSecond_NotUInt_ThrowsArgumentOutOfRangeException(long value)
-        {
-            using (var listener = new HttpListener())
-            {
-                Assert.Throws<ArgumentOutOfRangeException>("value", () => listener.TimeoutManager.MinSendBytesPerSecond = value);
-            }
-        }
-
-        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
-        [InlineData(-1)]
-        [InlineData((uint)ushort.MaxValue + 1)]
-        public void TimeoutValue_NotUShort_ThrowsArgumentOutOfRangeException(long totalSeconds)
-        {
-            using (var listener = new HttpListener())
-            {
-                TimeSpan timeSpan = TimeSpan.FromSeconds(totalSeconds);
-                Assert.Throws<ArgumentOutOfRangeException>("value", () => listener.TimeoutManager.EntityBody = timeSpan);
-                Assert.Throws<ArgumentOutOfRangeException>("value", () => listener.TimeoutManager.DrainEntityBody = timeSpan);
-                Assert.Throws<ArgumentOutOfRangeException>("value", () => listener.TimeoutManager.RequestQueue = timeSpan);
-                Assert.Throws<ArgumentOutOfRangeException>("value", () => listener.TimeoutManager.IdleConnection = timeSpan);
-                Assert.Throws<ArgumentOutOfRangeException>("value", () => listener.TimeoutManager.HeaderWait = timeSpan);
-            }
-        }
 
         [Theory]
         [InlineData(1.3, 1)]
@@ -391,11 +395,59 @@ namespace System.Net.Tests
     public class HttpListenerTimeoutManagerUnixTests
     {
         [Fact]
-        public void TimeoutManager_GetUnix_ThrowsPlatformNotSupportedException()
+        public void Properties_DefaultValues()
         {
             using (var listener = new HttpListener())
             {
-                Assert.Throws<PlatformNotSupportedException>(() => listener.TimeoutManager);
+                HttpListenerTimeoutManager m = listener.TimeoutManager;
+                Assert.NotNull(m);
+                Assert.Equal(TimeSpan.Zero, m.DrainEntityBody);
+                Assert.Equal(TimeSpan.Zero, m.EntityBody);
+                Assert.Equal(TimeSpan.Zero, m.HeaderWait);
+                Assert.Equal(TimeSpan.Zero, m.IdleConnection);
+                Assert.Equal(0, m.MinSendBytesPerSecond);
+                Assert.Equal(TimeSpan.Zero, m.RequestQueue);
+            }
+        }
+
+        [Fact]
+        public void UnsupportedProperties_Throw()
+        {
+            using (var listener = new HttpListener())
+            {
+                HttpListenerTimeoutManager m = listener.TimeoutManager;
+                Assert.Throws<PlatformNotSupportedException>(() => m.EntityBody = TimeSpan.Zero);
+                Assert.Throws<PlatformNotSupportedException>(() => m.HeaderWait = TimeSpan.Zero);
+                Assert.Throws<PlatformNotSupportedException>(() => m.MinSendBytesPerSecond = 0);
+                Assert.Throws<PlatformNotSupportedException>(() => m.RequestQueue = TimeSpan.Zero);
+            }
+        }
+
+        [Fact]
+        public void DrainEntityBody_Roundtrips()
+        {
+            using (var listener = new HttpListener())
+            {
+                HttpListenerTimeoutManager m = listener.TimeoutManager;
+                Assert.Equal(TimeSpan.Zero, m.DrainEntityBody);
+
+                TimeSpan value = TimeSpan.FromSeconds(123);
+                m.DrainEntityBody = value;
+                Assert.Equal(value, m.DrainEntityBody);
+            }
+        }
+
+        [Fact]
+        public void IdleConnection_Roundtrips()
+        {
+            using (var listener = new HttpListener())
+            {
+                HttpListenerTimeoutManager m = listener.TimeoutManager;
+                Assert.Equal(TimeSpan.Zero, m.IdleConnection);
+
+                TimeSpan value = TimeSpan.FromSeconds(123);
+                m.IdleConnection = value;
+                Assert.Equal(value, m.IdleConnection);
             }
         }
     }


### PR DESCRIPTION
- Make HttpListener.TimeoutManager return a valid instance
- Make HttpListenerTimeoutManager.DrainEntityBody and IdleConnection validate arguments and roundtrip, as we can implicitly "respect" them due to them being about connection pooling and the managed implementation not doing any.
- Make EntityBody, HeaderWait, MinSendBytesPerSecond, and RequestQueue getters all return the same default value as desktop
- Make EntityBody, HeaderWait, MinSendBytesPerSecond, and RequestQueue setters all do argument validation prior to throwing a PNSE

Closes https://github.com/dotnet/corefx/issues/17977
cc: @davidsh, @danmosemsft, @Priya91 