### PR TITLE
Add support for RSA-PSS to cert creation.

### DIFF
--- a/src/Common/src/System/Security/Cryptography/DerEncoder.cs
+++ b/src/Common/src/System/Security/Cryptography/DerEncoder.cs
@@ -116,6 +116,23 @@ namespace System.Security.Cryptography
         /// <summary>
         /// Encode the segments { tag, length, value } of an unsigned integer.
         /// </summary>
+        /// <param name="value">The value to encode.</param>
+        /// <returns>The encoded segments { tag, length, value }</returns>
+        internal static byte[][] SegmentedEncodeUnsignedInteger(uint value)
+        {
+            byte[] bytes = BitConverter.GetBytes(value);
+
+            if (BitConverter.IsLittleEndian)
+            {
+                Array.Reverse(bytes);
+            }
+
+            return SegmentedEncodeUnsignedInteger(bytes);
+        }
+
+        /// <summary>
+        /// Encode the segments { tag, length, value } of an unsigned integer.
+        /// </summary>
         /// <param name="bigEndianBytes">The value to encode, in big integer representation.</param>
         /// <returns>The encoded segments { tag, length, value }</returns>
         internal static byte[][] SegmentedEncodeUnsignedInteger(byte[] bigEndianBytes)

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Oids.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Oids.cs
@@ -25,6 +25,9 @@ namespace Internal.Cryptography
         public const string CertPolicyConstraints       = "2.5.29.36";
         public const string EnhancedKeyUsage            = "2.5.29.37";
         public const string InhibitAnyPolicyExtension   = "2.5.29.54";
+        public const string Sha256                      = "2.16.840.1.101.3.4.2.1";
+        public const string Sha384                      = "2.16.840.1.101.3.4.2.2";
+        public const string Sha512                      = "2.16.840.1.101.3.4.2.3";
         public const string EccCurveSecp384r1           = "1.3.132.0.34";
         public const string EccCurveSecp521r1           = "1.3.132.0.35";
         public const string Ecc                         = "1.2.840.10045.2.1";
@@ -33,6 +36,8 @@ namespace Internal.Cryptography
         public const string ECDsaSha384                 = "1.2.840.10045.4.3.3";
         public const string ECDsaSha512                 = "1.2.840.10045.4.3.4";
         public const string RsaRsa                      = "1.2.840.113549.1.1.1";
+        public const string Mgf1                        = "1.2.840.113549.1.1.8";
+        public const string RsaSsaPss                   = "1.2.840.113549.1.1.10";
         public const string RsaPkcs1Sha256              = "1.2.840.113549.1.1.11";
         public const string RsaPkcs1Sha384              = "1.2.840.113549.1.1.12";
         public const string RsaPkcs1Sha512              = "1.2.840.113549.1.1.13";

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -52,6 +52,7 @@
     <Compile Include="System\Security\Cryptography\X509Certificates\PublicKey.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\RSACertificateExtensions.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\RSAPkcs1X509SignatureGenerator.cs" />
+    <Compile Include="System\Security\Cryptography\X509Certificates\RSAPssX509SignatureGenerator.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\StoreLocation.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\StoreName.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\SubjectAlternativeNameBuilder.cs" />

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/RSAPkcs1X509SignatureGenerator.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/RSAPkcs1X509SignatureGenerator.cs
@@ -25,7 +25,12 @@ namespace System.Security.Cryptography.X509Certificates
 
         protected override PublicKey BuildPublicKey()
         {
-            RSAParameters parameters = _key.ExportParameters(false);
+            return BuildPublicKey(_key);
+        }
+
+        internal static PublicKey BuildPublicKey(RSA rsa)
+        {
+            RSAParameters parameters = rsa.ExportParameters(false);
 
             byte[] rsaPublicKey = DerEncoder.ConstructSequence(
                 DerEncoder.SegmentedEncodeUnsignedInteger(parameters.Modulus),

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/RSAPssX509SignatureGenerator.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/RSAPssX509SignatureGenerator.cs
@@ -1,0 +1,126 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using Internal.Cryptography;
+
+namespace System.Security.Cryptography.X509Certificates
+{
+    internal sealed class RSAPssX509SignatureGenerator : X509SignatureGenerator
+    {
+        private readonly RSA _key;
+        private readonly RSASignaturePadding _padding;
+
+        internal RSAPssX509SignatureGenerator(RSA key, RSASignaturePadding padding)
+        {
+            Debug.Assert(key != null);
+            Debug.Assert(padding != null);
+            Debug.Assert(padding.Mode == RSASignaturePaddingMode.Pss);
+
+            // Currently we don't accept options in PSS mode, but we could, so store the padding here.
+            _key = key;
+            _padding = padding;
+        }
+
+        public override byte[] GetSignatureAlgorithmIdentifier(HashAlgorithmName hashAlgorithm)
+        {
+            // If we ever support options in PSS (like MGF-2, if such an MGF is ever invented)
+            // Or, more reasonably, supporting a custom value for the salt size.
+            if (_padding != RSASignaturePadding.Pss)
+            {
+                throw new CryptographicException(SR.Cryptography_InvalidPaddingMode);
+            }
+
+            uint cbSalt;
+            string digestOid;
+
+            if (hashAlgorithm == HashAlgorithmName.SHA256)
+            {
+                cbSalt = 256 / 8;
+                digestOid = Oids.Sha256;
+            }
+            else if (hashAlgorithm == HashAlgorithmName.SHA384)
+            {
+                cbSalt = 384 / 8;
+                digestOid = Oids.Sha384;
+            }
+            else if (hashAlgorithm == HashAlgorithmName.SHA512)
+            {
+                cbSalt = 512 / 8;
+                digestOid = Oids.Sha512;
+            }
+            else
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(hashAlgorithm),
+                    hashAlgorithm,
+                    SR.Format(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithm.Name));
+            }
+
+            // RSASSA-PSS-params comes from RFC 4055, section 3.1:
+            // https://tools.ietf.org/html/rfc4055#section-3.1
+            //
+            // RSASSA-PSS-params  ::=  SEQUENCE  {
+            //   hashAlgorithm      [0] HashAlgorithm DEFAULT sha1Identifier,
+            //   maskGenAlgorithm   [1] MaskGenAlgorithm DEFAULT mgf1SHA1Identifier,
+            //   saltLength         [2] INTEGER DEFAULT 20,
+            //   trailerField       [3] INTEGER DEFAULT 1  }
+            //
+            // mgf1SHA1Identifier  AlgorithmIdentifier  ::= { id-mgf1, sha1Identifier }
+            // sha1Identifier  AlgorithmIdentifier  ::=  { id-sha1, NULL }
+            // (and similar for SHA256/384/512)
+            //
+            // RFC 5754 says that the NULL for SHA2 (256/384/512) MUST be omitted
+            // (https://tools.ietf.org/html/rfc5754#section-2) (and that you MUST
+            // be able to read it even if someone wrote it down)
+
+            // Since we
+            //  * don't support SHA-1 in this class
+            //  * only support MGF-1
+            //  * don't support the MGF PRF being different than hashAlgorithm
+            //  * use saltLength==hashLength
+            //  * don't allow custom trailer
+            // we don't have to worry about any of the DEFAULTs. (specify, specify, specify, omit).
+
+            byte[][] hashAlgorithmAlgId = DerEncoder.ConstructSegmentedSequence(
+                DerEncoder.SegmentedEncodeOid(digestOid));
+
+            byte[][] hashAlgorithmField = DerEncoder.ConstructSegmentedSequence(hashAlgorithmAlgId);
+            hashAlgorithmField[0][0] = DerSequenceReader.ContextSpecificConstructedTag0;
+
+            byte[][] maskGenField = DerEncoder.ConstructSegmentedSequence(
+                DerEncoder.ConstructSegmentedSequence(
+                    DerEncoder.SegmentedEncodeOid(Oids.Mgf1),
+                    hashAlgorithmAlgId));
+            maskGenField[0][0] = DerSequenceReader.ContextSpecificConstructedTag1;
+
+            byte[][] saltLengthField = DerEncoder.ConstructSegmentedSequence(
+                DerEncoder.SegmentedEncodeUnsignedInteger(cbSalt));
+            saltLengthField[0][0] = DerSequenceReader.ContextSpecificConstructedTag2;
+
+            return DerEncoder.ConstructSequence(
+                DerEncoder.SegmentedEncodeOid(Oids.RsaSsaPss),
+                // RSASSA-PSS-params
+                DerEncoder.ConstructSegmentedSequence(
+                    hashAlgorithmField,
+                    maskGenField,
+                    saltLengthField));
+        }
+
+        public override byte[] SignData(byte[] data, HashAlgorithmName hashAlgorithm)
+        {
+            return _key.SignData(data, hashAlgorithm, _padding);
+        }
+
+        protected override PublicKey BuildPublicKey()
+        {
+            // RFC 4055 (https://tools.ietf.org/html/rfc4055) recommends using a different
+            // key format for 'PSS keys'.  RFC 5756 (https://tools.ietf.org/html/rfc5756) says
+            // that almost no one did that, and that it goes against the general guidance of
+            // SubjectPublicKeyInfo, so RSA keys should use the existing form always and the
+            // PSS-specific key algorithm ID is deprecated (as a key ID).
+            return RSAPkcs1X509SignatureGenerator.BuildPublicKey(_key);
+        }
+    }
+}

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509SignatureGenerator.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509SignatureGenerator.cs
@@ -37,9 +37,13 @@ namespace System.Security.Cryptography.X509Certificates
         {
             if (key == null)
                 throw new ArgumentNullException(nameof(key));
+            if (signaturePadding == null)
+                throw new ArgumentNullException(nameof(signaturePadding));
 
             if (signaturePadding == RSASignaturePadding.Pkcs1)
                 return new RSAPkcs1X509SignatureGenerator(key);
+            if (signaturePadding.Mode == RSASignaturePaddingMode.Pss)
+                return new RSAPssX509SignatureGenerator(key, signaturePadding);
 
             throw new ArgumentException(SR.Cryptography_InvalidPaddingMode);
         }

--- a/src/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/CertificateRequestChainTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/CertificateRequestChainTests.cs
@@ -9,6 +9,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
 {
     public static class CertificateRequestChainTests
     {
+        public static bool PlatformSupportsPss { get; } = DetectPssSupport();
+
         [Fact]
         public static void CreateChain_ECC()
         {
@@ -323,6 +325,86 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                 intermed1CertWithKey?.Dispose();
                 rootCertWithKey?.Dispose();
             }
+        }
+
+        [ConditionalFact(nameof(PlatformSupportsPss))]
+        public static void CreateChain_RSAPSS()
+        {
+            using (RSA rootKey = RSA.Create())
+            using (RSA intermedKey = RSA.Create())
+            using (RSA leafKey = RSA.Create(TestData.RsaBigExponentParams))
+            {
+                X509Certificate2 rootCertWithKey = null;
+                X509Certificate2 intermedCertWithKey = null;
+                X509Certificate2 leafCert = null;
+                CertificateRequest request;
+
+                RSASignaturePadding padding = RSASignaturePadding.Pss;
+
+                DateTimeOffset notBefore = DateTimeOffset.UtcNow;
+                DateTimeOffset notAfter = notBefore.AddHours(1);
+
+                try
+                {
+                    request = new CertificateRequest("CN=Root", rootKey, HashAlgorithmName.SHA512, padding);
+                    request.CertificateExtensions.Add(
+                        new X509BasicConstraintsExtension(true, false, 0, true));
+
+                    rootCertWithKey = request.CreateSelfSigned(notBefore, notAfter);
+
+                    byte[] intermedSerial = { 1, 2, 3, 5, 7, 11, 13 };
+
+                    request = new CertificateRequest("CN=Intermediate", intermedKey, HashAlgorithmName.SHA384, padding);
+                    request.CertificateExtensions.Add(
+                        new X509BasicConstraintsExtension(true, true, 1, true));
+
+                    X509Certificate2 intermedPublic = request.Create(rootCertWithKey, notBefore, notAfter, intermedSerial);
+                    intermedCertWithKey = intermedPublic.CopyWithPrivateKey(intermedKey);
+                    intermedPublic.Dispose();
+
+                    request = new CertificateRequest("CN=Leaf", leafKey, HashAlgorithmName.SHA256, padding);
+                    request.CertificateExtensions.Add(
+                        new X509BasicConstraintsExtension(false, false, 0, true));
+
+                    byte[] leafSerial = { 1, 1, 2, 6, 12, 60, 60, };
+
+                    leafCert = request.Create(intermedCertWithKey, notBefore, notAfter, leafSerial);
+
+                    using (X509Chain chain = new X509Chain())
+                    {
+                        chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+                        chain.ChainPolicy.VerificationFlags = X509VerificationFlags.AllowUnknownCertificateAuthority;
+                        chain.ChainPolicy.ExtraStore.Add(intermedCertWithKey);
+                        chain.ChainPolicy.ExtraStore.Add(rootCertWithKey);
+
+                        RunChain(chain, leafCert, true, "Chain build");
+                    }
+                }
+                finally
+                {
+                    leafCert?.Dispose();
+                    intermedCertWithKey?.Dispose();
+                    rootCertWithKey?.Dispose();
+                }
+            }
+        }
+
+        private static bool DetectPssSupport()
+        {
+            using (X509Certificate2 cert = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword))
+            using (RSA rsa = cert.GetRSAPrivateKey())
+            {
+                try
+                {
+                    rsa.SignData(Array.Empty<byte>(), HashAlgorithmName.SHA256, RSASignaturePadding.Pss);
+                }
+                catch (CryptographicException)
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
     }
 }

--- a/src/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/RSAPssX509SignatureGeneratorTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/RSAPssX509SignatureGeneratorTests.cs
@@ -1,0 +1,177 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Test.Cryptography;
+using Xunit;
+
+namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreation
+{
+    public static class RSAPssX509SignatureGeneratorTests
+    {
+        [Fact]
+        public static void RsaPssSignatureGeneratorCtor_Exceptions()
+        {
+            Assert.Throws<ArgumentNullException>(
+                "key",
+                () => X509SignatureGenerator.CreateForRSA(null, RSASignaturePadding.Pss));
+        }
+
+        [Fact]
+        public static void PublicKeyEncoding()
+        {
+            using (RSA rsa = RSA.Create())
+            {
+                rsa.ImportParameters(TestData.RsaBigExponentParams);
+
+                X509SignatureGenerator signatureGenerator = X509SignatureGenerator.CreateForRSA(rsa, RSASignaturePadding.Pss);
+                PublicKey publicKey = signatureGenerator.PublicKey;
+
+                // Irrespective of what the current key thinks, the PublicKey value we encode for RSA will always write
+                // DER-NULL parameters, by the guidance of RFC 3447:
+                //
+                //    The object identifier rsaEncryption identifies RSA public and private
+                //    keys as defined in Appendices A.1.1 and A.1.2.  The parameters field
+                //    associated with this OID in a value of type AlgorithmIdentifier shall
+                //    have a value of type NULL.
+                Assert.Equal(new byte[] { 5, 0 }, publicKey.EncodedParameters.RawData);
+
+                string expectedKeyHex =
+                    // SEQUENCE
+                    "3082010C" +
+                    //   INTEGER (modulus)
+                    "0282010100" + TestData.RsaBigExponentParams.Modulus.ByteArrayToHex() +
+                    //   INTEGER (exponent)
+                    "0205" + TestData.RsaBigExponentParams.Exponent.ByteArrayToHex();
+
+                Assert.Equal(expectedKeyHex, publicKey.EncodedKeyValue.RawData.ByteArrayToHex());
+
+                const string rsaEncryptionOid = "1.2.840.113549.1.1.1";
+                Assert.Equal(rsaEncryptionOid, publicKey.Oid.Value);
+                Assert.Equal(rsaEncryptionOid, publicKey.EncodedParameters.Oid.Value);
+                Assert.Equal(rsaEncryptionOid, publicKey.EncodedKeyValue.Oid.Value);
+
+                PublicKey publicKey2 = signatureGenerator.PublicKey;
+                Assert.Same(publicKey, publicKey2);
+            }
+        }
+
+        [Theory]
+        [InlineData("SHA256")]
+        [InlineData("SHA384")]
+        [InlineData("SHA512")]
+        public static void SignatureAlgorithm_StableNotSame(string hashAlgorithmName)
+        {
+            using (RSA rsa = RSA.Create())
+            {
+                RSAParameters parameters = TestData.RsaBigExponentParams;
+                rsa.ImportParameters(parameters);
+
+                var signatureGenerator = X509SignatureGenerator.CreateForRSA(rsa, RSASignaturePadding.Pss);
+
+                HashAlgorithmName hashAlgorithm = new HashAlgorithmName(hashAlgorithmName);
+
+                byte[] sigAlg = signatureGenerator.GetSignatureAlgorithmIdentifier(hashAlgorithm);
+                byte[] sigAlg2 = signatureGenerator.GetSignatureAlgorithmIdentifier(hashAlgorithm);
+
+                Assert.NotSame(sigAlg, sigAlg2);
+                Assert.Equal(sigAlg, sigAlg2);
+            }
+        }
+
+        [Theory]
+        [InlineData("MD5")]
+        [InlineData("SHA1")]
+        [InlineData("Potato")]
+        public static void SignatureAlgorithm_NotSupported(string hashAlgorithmName)
+        {
+            using (RSA rsa = RSA.Create())
+            {
+                RSAParameters parameters = TestData.RsaBigExponentParams;
+                rsa.ImportParameters(parameters);
+
+                var signatureGenerator = X509SignatureGenerator.CreateForRSA(rsa, RSASignaturePadding.Pss);
+
+                HashAlgorithmName hashAlgorithm = new HashAlgorithmName(hashAlgorithmName);
+
+                Assert.Throws<ArgumentOutOfRangeException>(
+                    "hashAlgorithm",
+                    () => signatureGenerator.GetSignatureAlgorithmIdentifier(hashAlgorithm));
+            }
+        }
+
+        [Theory]
+        [InlineData("SHA256")]
+        [InlineData("SHA384")]
+        [InlineData("SHA512")]
+        public static void SignatureAlgorithm_Encoding(string hashAlgorithmName)
+        {
+
+            // PSS-MGF1-with-SHA-2-* end up differing in only three bytes:
+            // 1) hashAlgorithm.algorithmId's last byte
+            // 2) mgf.parameters.algorithmId's last byte
+            // 3) saltLen.
+
+            byte lastOidByte;
+            byte saltLenByte;
+
+            switch (hashAlgorithmName)
+            {
+                case "SHA256":
+                    lastOidByte = 0x01;
+                    saltLenByte = 256 / 8;
+                    break;
+                case "SHA384":
+                    lastOidByte = 0x02;
+                    saltLenByte = 384 / 8;
+                    break;
+                case "SHA512":
+                    lastOidByte = 0x03;
+                    saltLenByte = 512 / 8;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(hashAlgorithmName));
+            }
+
+            string expectedHex =
+                // SEQUENCE (AlgorithmIdentifier)
+                "303D" +
+                    // OBJECT IDENTIFIER (AlgorithmIdentifier.algorithm == Oids.RsaSsaPss)
+                    "06092A864886F70D01010A" +
+                    // SEQUENCE (AlgorithmIdentifier.params == RSASSA-PSS-params)
+                    "3030" +
+                        // CONSTRUCTED CONTEXT SPECIFIC 0 (params.hashAlgorithm)
+                        "A00D" +
+                            // SEQUENCE (AlgorithmIdentifier)
+                            "300B" +
+                                // OBJECT IDENTIFIER (params.hashAlgorithm.algorithm)
+                                "06096086480165030402" + lastOidByte.ToString("X2") +
+                        // CONSTRUCTED CONTEXT SPECIFIC 1 (params.maskGenAlgorithm)
+                        "A11A" +
+                            // SEQUENCE (MaskGenAlgorithm)
+                            "3018" +
+                                // OBJECT IDENTIFIER (MaskGenAlgorithm.algorithm == Oids.Mgf1)
+                                "06092A864886F70D010108" +
+                                // SEQUENCE (MaskGenAlgorithm.params)
+                                "300B" +
+                                    // OBJECT IDENTIFIER (MGF PRF == same hash algorithm as above)
+                                    "06096086480165030402" + lastOidByte.ToString("X2") +
+                        // CONSTRUCTED CONTEXT SPECIFIC 2 (params.saltLength)
+                        "A203" +
+                            // INTEGER (saltLength == size of hash)
+                            "0201" + saltLenByte.ToString("X2");
+
+            using (RSA rsa = RSA.Create())
+            {
+                RSAParameters parameters = TestData.RsaBigExponentParams;
+                rsa.ImportParameters(parameters);
+
+                HashAlgorithmName hashAlgorithm = new HashAlgorithmName(hashAlgorithmName);
+                var signatureGenerator = X509SignatureGenerator.CreateForRSA(rsa, RSASignaturePadding.Pss);
+                byte[] sigAlg = signatureGenerator.GetSignatureAlgorithmIdentifier(hashAlgorithm);
+
+                Assert.Equal(expectedHex, sigAlg.ByteArrayToHex());
+            }
+        }
+    }
+}

--- a/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
@@ -22,6 +22,7 @@
     <Compile Include="CertificateCreation\ECDsaX509SignatureGeneratorTests.cs" />
     <Compile Include="CertificateCreation\PrivateKeyAssociationTests.cs" />
     <Compile Include="CertificateCreation\RSAPkcs1X509SignatureGeneratorTests.cs" />
+    <Compile Include="CertificateCreation\RSAPssX509SignatureGeneratorTests.cs" />
     <Compile Include="CertificateCreation\SubjectAltNameBuilderTests.cs" />
     <Compile Include="CertTests.cs" />
     <Compile Include="ChainHolder.cs" />


### PR DESCRIPTION
Encodes RSA-PSS SubjectPublicKeyInfo according to RFC 5756 and the
SignatureAlgorithm value according to RFC 4055.

PSS certificate creation still relies on the underlying key ability to compute the
PSS signature.