### PR TITLE
Add native error codes and messages to managed SNI Named Pipe disconnect errors, so as to match native SNI behavior.

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNINpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNINpHandle.cs
@@ -162,7 +162,7 @@ namespace System.Data.SqlClient.SNI
                     if (packet.Length == 0)
                     {
                         var e = new Win32Exception();
-                        ReportErrorAndReleasePacket(packet, (uint)e.NativeErrorCode, 0, e.Message);
+                        return ReportErrorAndReleasePacket(packet, (uint)e.NativeErrorCode, 0, e.Message);
                     }
                 }
                 catch (ObjectDisposedException ode)

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNINpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNINpHandle.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
 using System.IO;
 using System.IO.Pipes;
 using System.Net.Security;
@@ -160,7 +161,8 @@ namespace System.Data.SqlClient.SNI
 
                     if (packet.Length == 0)
                     {
-                        return ReportErrorAndReleasePacket(packet, 0, SNICommon.ConnTerminatedError, string.Empty);
+                        var e = new Win32Exception();
+                        ReportErrorAndReleasePacket(packet, (uint)e.NativeErrorCode, 0, e.Message);
                     }
                 }
                 catch (ObjectDisposedException ode)

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Net;
@@ -440,7 +441,8 @@ namespace System.Data.SqlClient.SNI
 
                     if (packet.Length == 0)
                     {
-                        return ReportErrorAndReleasePacket(packet, 0, SNICommon.ConnTerminatedError, string.Empty);
+                        var e = new Win32Exception();
+                        ReportErrorAndReleasePacket(packet, (uint)e.NativeErrorCode, 0, e.Message);
                     }
 
                     return TdsEnums.SNI_SUCCESS;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -442,7 +442,7 @@ namespace System.Data.SqlClient.SNI
                     if (packet.Length == 0)
                     {
                         var e = new Win32Exception();
-                        ReportErrorAndReleasePacket(packet, (uint)e.NativeErrorCode, 0, e.Message);
+                        return ReportErrorAndReleasePacket(packet, (uint)e.NativeErrorCode, 0, e.Message);
                     }
 
                     return TdsEnums.SNI_SUCCESS;


### PR DESCRIPTION
Resolves some of the issues seen in https://github.com/dotnet/corefx/issues/19057