### PR TITLE
Remove dead code from System.Collections

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/SortedDictionary.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedDictionary.cs
@@ -965,10 +965,6 @@ namespace System.Collections.Generic
 
         public TreeSet(IComparer<T> comparer) : base(comparer) { }
 
-        public TreeSet(ICollection<T> collection) : base(collection) { }
-
-        public TreeSet(ICollection<T> collection, IComparer<T> comparer) : base(collection, comparer) { }
-
         public TreeSet(SerializationInfo siInfo, StreamingContext context) : base(siInfo, context) { }
 
         internal override bool AddIfNotPresent(T item)


### PR DESCRIPTION
Didn't see the pull from @Olafski for #17905. Found two constuctors that could be removed. Rest of the code is indeed used. 