### PR TITLE
Modified test to use GetTempFileName

### DIFF
--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -3092,7 +3092,7 @@ public static partial class DataContractSerializerTests
     [Fact]
     public static void DCS_FileStreamSurrogate()
     {
-        using(var testFile = TempFile.Create())
+        using (var testFile = TempFile.Create())
         {
             const string TestFileData = "Some data for data contract surrogate test";
 
@@ -3104,10 +3104,10 @@ public static partial class DataContractSerializerTests
             byte[] serializedStream;
 
             // Serialize the stream
-            using (MyFileStream stream1 = new MyFileStream(testFile.Path))
+            using (var stream1 = new MyFileStream(testFile.Path))
             {
                 stream1.WriteLine(TestFileData);
-                using (MemoryStream memoryStream = new MemoryStream())
+                using (var memoryStream = new MemoryStream())
                 {
                     dcs.WriteObject(memoryStream, stream1);
                     serializedStream = memoryStream.ToArray();
@@ -3115,9 +3115,9 @@ public static partial class DataContractSerializerTests
             }
 
             // Deserialize the stream
-            using (MemoryStream stream = new MemoryStream(serializedStream))
+            using (var stream = new MemoryStream(serializedStream))
             {
-                using (MyFileStream stream2 = (MyFileStream)dcs.ReadObject(stream))
+                using (var stream2 = (MyFileStream)dcs.ReadObject(stream))
                 {
                     string fileData = stream2.ReadLine();
                     Assert.StrictEqual(TestFileData, fileData);

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -3092,7 +3092,7 @@ public static partial class DataContractSerializerTests
     [Fact]
     public static void DCS_FileStreamSurrogate()
     {
-        const string TestFileName = "Test.txt";
+        string TestFileName = Path.GetTempFileName();
         const string TestFileData = "Some data for data contract surrogate test";
 
         // Create the serializer and specify the surrogate

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -3092,9 +3092,7 @@ public static partial class DataContractSerializerTests
     [Fact]
     public static void DCS_FileStreamSurrogate()
     {
-        string testFileName = Path.GetTempFileName();
-
-        try 
+        using(var testFile = TempFile.Create())
         {
             const string TestFileData = "Some data for data contract surrogate test";
 
@@ -3106,7 +3104,7 @@ public static partial class DataContractSerializerTests
             byte[] serializedStream;
 
             // Serialize the stream
-            using (MyFileStream stream1 = new MyFileStream(testFileName))
+            using (MyFileStream stream1 = new MyFileStream(testFile.Path))
             {
                 stream1.WriteLine(TestFileData);
                 using (MemoryStream memoryStream = new MemoryStream())
@@ -3125,10 +3123,6 @@ public static partial class DataContractSerializerTests
                     Assert.StrictEqual(TestFileData, fileData);
                 }
             }
-        }
-        finally 
-        {                
-            File.Delete(testFileName);
         }
     }
 

--- a/src/System.Runtime.Serialization.Xml/tests/ReflectionOnly/System.Runtime.Serialization.Xml.ReflectionOnly.Tests.csproj
+++ b/src/System.Runtime.Serialization.Xml/tests/ReflectionOnly/System.Runtime.Serialization.Xml.ReflectionOnly.Tests.csproj
@@ -31,6 +31,9 @@
     <Compile Include="$(TestSourceFolder)..\SerializationTestTypes\ObjRefSample.cs">
       <Link>SerializationTestTypes\ObjRefSample.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\IO\TempFile.cs">
+      <Link>Common\System\IO\TempFile.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'uap'">
     <Compile Include="$(TestSourceFolder)..\SerializationTypes.CoreCLR.cs" />

--- a/src/System.Runtime.Serialization.Xml/tests/ReflectionOnly/System.Runtime.Serialization.Xml.ReflectionOnly.Tests.csproj
+++ b/src/System.Runtime.Serialization.Xml/tests/ReflectionOnly/System.Runtime.Serialization.Xml.ReflectionOnly.Tests.csproj
@@ -25,14 +25,14 @@
     <Compile Include="$(TestSourceFolder)..\SerializationTestTypes\DCRSampleType.cs" />
     <Compile Include="$(TestSourceFolder)..\SerializationTestTypes\DCRTypeLibrary.cs" />
     <Compile Include="$(TestSourceFolder)..\SerializationTestTypes\Primitives.cs" />
+    <Compile Include="$(CommonTestPath)\System\IO\TempFile.cs">
+      <Link>Common\System\IO\TempFile.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
       <Link>CommonTest\System\PlatformDetection.cs</Link>
     </Compile>
     <Compile Include="$(TestSourceFolder)..\SerializationTestTypes\ObjRefSample.cs">
       <Link>SerializationTestTypes\ObjRefSample.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\TempFile.cs">
-      <Link>Common\System\IO\TempFile.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'uap'">

--- a/src/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.csproj
+++ b/src/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.csproj
@@ -24,11 +24,11 @@
     <Compile Include="$(TestSourceFolder)SerializationTestTypes\DCRSampleType.cs" />
     <Compile Include="$(TestSourceFolder)SerializationTestTypes\DCRTypeLibrary.cs" />
     <Compile Include="$(TestSourceFolder)SerializationTestTypes\Primitives.cs" />
-    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
-      <Link>CommonTest\System\PlatformDetection.cs</Link>
-    </Compile>
     <Compile Include="$(CommonTestPath)\System\IO\TempFile.cs">
       <Link>Common\System\IO\TempFile.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>CommonTest\System\PlatformDetection.cs</Link>
     </Compile>
     <Compile Include="$(TestSourceFolder)SerializationTestTypes\ObjRefSample.cs" />
   </ItemGroup>

--- a/src/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.csproj
+++ b/src/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.csproj
@@ -28,7 +28,7 @@
       <Link>CommonTest\System\PlatformDetection.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)\System\IO\TempFile.cs">
-      <Link>CommonTest\System\IO\TempFile.cs</Link>
+      <Link>Common\System\IO\TempFile.cs</Link>
     </Compile>
     <Compile Include="$(TestSourceFolder)SerializationTestTypes\ObjRefSample.cs" />
   </ItemGroup>

--- a/src/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.csproj
+++ b/src/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.csproj
@@ -27,6 +27,9 @@
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
       <Link>CommonTest\System\PlatformDetection.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\IO\TempFile.cs">
+      <Link>CommonTest\System\IO\TempFile.cs</Link>
+    </Compile>
     <Compile Include="$(TestSourceFolder)SerializationTestTypes\ObjRefSample.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'uap'">


### PR DESCRIPTION
As discussed in #19095 the test should be modified to use an actual temp file path.
This also means it's no longer a const though.