### PR TITLE
Removed dead code from Security.Cryptography.X509Certificates for issue #17905.

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Helpers.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Helpers.cs
@@ -150,14 +150,6 @@ namespace Internal.Cryptography
         {
             return (year >= calendar.GetYear(calendar.MinSupportedDateTime) && year <= calendar.GetYear(calendar.MaxSupportedDateTime));
         }
-
-        internal static void DisposeAll(this IEnumerable<IDisposable> disposables)
-        {
-            foreach (IDisposable disposable in disposables)
-            {
-                disposable.Dispose();
-            }
-        }
     }
 
     internal struct PinAndClear : IDisposable

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Helpers.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Helpers.cs
@@ -150,6 +150,14 @@ namespace Internal.Cryptography
         {
             return (year >= calendar.GetYear(calendar.MinSupportedDateTime) && year <= calendar.GetYear(calendar.MaxSupportedDateTime));
         }
+
+        internal static void DisposeAll(this IEnumerable<IDisposable> disposables)
+        {
+            foreach (IDisposable disposable in disposables)
+            {
+                disposable.Dispose();
+            }
+        }
     }
 
     internal struct PinAndClear : IDisposable

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Primitives.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Primitives.cs
@@ -401,22 +401,7 @@ namespace Internal.Cryptography.Pal.Native
         EXPORT_PRIVATE_KEYS                   = 0x00000004,
         None                                  = 0x00000000,
     }
-
-    internal enum KeyContextSpec : uint
-    {
-        AT_KEYEXCHANGE = 1,
-        AT_SIGNATURE = 2,
-        CERT_NCRYPT_KEY_SPEC = 0xFFFFFFFF,
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    internal struct CERT_KEY_CONTEXT
-    {
-        public int cbSize;
-        public IntPtr hProvOrNcryptKey;
-        public KeyContextSpec dwKeySpec;
-    }
-
+    
     [StructLayout(LayoutKind.Sequential)]
     internal unsafe struct CRYPT_KEY_PROV_INFO
     {
@@ -565,15 +550,6 @@ namespace Internal.Cryptography.Pal.Native
     {
         DSS_MAGIC = 0x31535344,
     }
-
-    [StructLayout(LayoutKind.Sequential)]
-    internal struct BLOBHEADER
-    {
-        public byte bType;
-        public byte bVersion;
-        public short reserved;
-        public uint aiKeyAlg;
-    };
 
     [StructLayout(LayoutKind.Sequential)]
     internal unsafe struct CERT_BASIC_CONSTRAINTS_INFO


### PR DESCRIPTION
Removed dead code from Security Cryptography X509Certificates for issue #17905.