### PR TITLE
Validate input parameters for HttpWebRequest requeststream Write calls

### DIFF
--- a/src/System.Net.Requests/src/Resources/Strings.resx
+++ b/src/System.Net.Requests/src/Resources/Strings.resx
@@ -265,4 +265,7 @@
   <data name="net_ftpstatuscode_ActionNotTakenFilenameNotAllowed" xml:space="preserve">
     <value>File name not allowed</value>
   </data>
+  <data name="net_readonlystream" xml:space="preserve">
+    <value>The stream does not support writing.</value>
+  </data>
 </root>

--- a/src/System.Net.Requests/src/Resources/Strings.resx
+++ b/src/System.Net.Requests/src/Resources/Strings.resx
@@ -265,7 +265,4 @@
   <data name="net_ftpstatuscode_ActionNotTakenFilenameNotAllowed" xml:space="preserve">
     <value>File name not allowed</value>
   </data>
-  <data name="net_readonlystream" xml:space="preserve">
-    <value>The stream does not support writing.</value>
-  </data>
 </root>

--- a/src/System.Net.Requests/src/System/Net/RequestStream.cs
+++ b/src/System.Net.Requests/src/System/Net/RequestStream.cs
@@ -99,16 +99,52 @@ namespace System.Net
 
         public override void Write(byte[] buffer, int offset, int count)
         {
+            if (buffer == null)
+            {
+                throw new ArgumentNullException(nameof(buffer));
+            }
+            if (offset < 0 || offset > buffer.Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(offset));
+            }
+            if (count < 0 || count > (buffer.Length - offset))
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
             _buffer.Write(buffer, offset, count);
         }
 
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
+            if (buffer == null)
+            {
+                throw new ArgumentNullException(nameof(buffer));
+            }
+            if (offset < 0 || offset > buffer.Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(offset));
+            }
+            if (count < 0 || count > (buffer.Length - offset))
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
             return _buffer.WriteAsync(buffer, offset, count, cancellationToken);
         }
 
         public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback asyncCallback, object asyncState)
         {
+            if (buffer == null)
+            {
+                throw new ArgumentNullException(nameof(buffer));
+            }
+            if (offset < 0 || offset > buffer.Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(offset));
+            }
+            if (count < 0 || count > (buffer.Length - offset))
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
             return _buffer.BeginWrite(buffer, offset, count, asyncCallback, asyncState);
         }
 

--- a/src/System.Net.Requests/tests/RequestStreamTest.cs
+++ b/src/System.Net.Requests/tests/RequestStreamTest.cs
@@ -40,7 +40,7 @@ namespace System.Net.Tests
         {
             using (Stream stream = GetRequestStream())
             {
-                Assert.Throws<ArgumentOutOfRangeException>("count", () => stream.Write(buffer, 0, -1));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("count", "size", () => stream.Write(buffer, 0, -1));
             }
         }
 
@@ -49,7 +49,7 @@ namespace System.Net.Tests
         {
             using (Stream stream = GetRequestStream())
             {
-                Assert.Throws<ArgumentOutOfRangeException>("count", () => stream.Write(buffer, 0, buffer.Length + 1));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("count", "size", () => stream.Write(buffer, 0, buffer.Length + 1));
             }
         }
 
@@ -89,7 +89,7 @@ namespace System.Net.Tests
         {
             using (Stream stream = GetRequestStream())
             {
-                Assert.Throws<ArgumentOutOfRangeException>("count", () => { Task t = stream.WriteAsync(buffer, 0, -1); });
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("count", "size", () => { Task t = stream.WriteAsync(buffer, 0, -1); });
             }
         }
 
@@ -98,7 +98,7 @@ namespace System.Net.Tests
         {
             using (Stream stream = GetRequestStream())
             {
-                Assert.Throws<ArgumentOutOfRangeException>("count", () => { Task t = stream.WriteAsync(buffer, 0, buffer.Length + 1); });
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("count", "size", () => { Task t = stream.WriteAsync(buffer, 0, buffer.Length + 1); });
             }
         }
 
@@ -160,7 +160,7 @@ namespace System.Net.Tests
         {
             using (Stream stream = GetRequestStream())
             {
-                Assert.Throws<ArgumentOutOfRangeException>("count", () => stream.BeginWrite(buffer, 0, -1, null, null));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("count", "size", () => stream.BeginWrite(buffer, 0, -1, null, null));
             }
         }
 
@@ -169,7 +169,7 @@ namespace System.Net.Tests
         {
             using (Stream stream = GetRequestStream())
             {
-                Assert.Throws<ArgumentOutOfRangeException>("count", () => stream.BeginWrite(buffer, 0, buffer.Length + 1, null, null));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("count", "size", () => stream.BeginWrite(buffer, 0, buffer.Length + 1, null, null));
             }
         }
 

--- a/src/System.Net.Requests/tests/RequestStreamTest.cs
+++ b/src/System.Net.Requests/tests/RequestStreamTest.cs
@@ -15,6 +15,57 @@ namespace System.Net.Tests
     {
         readonly byte[] buffer = new byte[1];
 
+        #region Write
+
+        [Fact]
+        public void Write_BufferIsNull_ThrowsArgumentNullException()
+        {
+            using (Stream stream = GetRequestStream())
+            {
+                Assert.Throws<ArgumentNullException>(() => stream.Write(null, 0, 1));
+            }
+        }
+
+        [Fact]
+        public void Write_OffsetIsNegative_ThrowsArgumentOutOfRangeException()
+        {
+            using (Stream stream = GetRequestStream())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => stream.Write(buffer, -1, buffer.Length));
+            }
+        }
+
+        [Fact]
+        public void Write_CountIsNegative_ThrowsArgumentOutOfRangeException()
+        {
+            using (Stream stream = GetRequestStream())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => stream.Write(buffer, 0, -1));
+            }
+        }
+
+        [Fact]
+        public void Write_OffsetPlusCountExceedsBufferLength_ThrowsArgumentException()
+        {
+            using (Stream stream = GetRequestStream())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => stream.Write(buffer, 0, buffer.Length + 1));
+            }
+        }
+
+        [Fact]
+        public void Write_OffsetPlusCountMaxValueExceedsBufferLength_Throws()
+        {
+            using (Stream stream = GetRequestStream())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => stream.Write(buffer, int.MaxValue, int.MaxValue));
+            }
+        }
+
+        #endregion
+
+        #region WriteAsync
+
         [Fact]
         public void WriteAsync_BufferIsNull_ThrowsArgumentNullException()
         {
@@ -47,19 +98,7 @@ namespace System.Net.Tests
         {
             using (Stream stream = GetRequestStream())
             {
-                // TODO: #18787
-                if (PlatformDetection.IsFullFramework)
-                {
-                    // In .NET Framework, the request stream is a System.Net.ConnectStream
-                    // which throws ArgumentOutOfRangeException in this case.
-                    Assert.Throws<ArgumentOutOfRangeException>(() => { Task t = stream.WriteAsync(buffer, 0, buffer.Length+1); });
-                }
-                else
-                {
-                    // In .NET Core, the request stream is a System.IO.MemoryStream
-                    // which throws ArgumentException in this case.
-                    Assert.Throws<ArgumentException>(() => { Task t = stream.WriteAsync(buffer, 0, buffer.Length+1); });
-                }
+                Assert.Throws<ArgumentOutOfRangeException>(() => { Task t = stream.WriteAsync(buffer, 0, buffer.Length + 1); });
             }
         }
 
@@ -68,20 +107,7 @@ namespace System.Net.Tests
         {
             using (Stream stream = GetRequestStream())
             {
-                // TODO: #18787
-                if (PlatformDetection.IsFullFramework)
-                {
-                    // In .NET Framework, the request stream is a System.Net.ConnectStream
-                    // which throws ArgumentOutOfRangeException in this case.
-                    Assert.Throws<ArgumentOutOfRangeException>(() => { Task t = stream.WriteAsync(buffer, int.MaxValue, int.MaxValue); });
-
-                }
-                else
-                {
-                    // In .NET Core, the request stream is a System.IO.MemoryStream
-                    // which throws ArgumentException in this case.
-                    Assert.Throws<ArgumentException>(() => { Task t = stream.WriteAsync(buffer, int.MaxValue, int.MaxValue); });
-                }
+                Assert.Throws<ArgumentOutOfRangeException>(() => { Task t = stream.WriteAsync(buffer, int.MaxValue, int.MaxValue); });
             }
         }
 
@@ -106,6 +132,77 @@ namespace System.Net.Tests
                 Assert.True(t.IsCanceled);
             }
         }
+
+        #endregion
+
+        #region BeginWrite
+
+        private IAsyncResult BeginWriteWrapper(Stream stream, byte[] buffer, int offset, int count)
+        {
+            AsyncCallback callback = null;
+            object state = new object();
+            IAsyncResult result = stream.BeginWrite(buffer, offset, count, callback, state);
+            stream.EndWrite(result);
+
+            return result;
+        }
+
+        [Fact]
+        public void BeginWriteAsync_BufferIsNull_ThrowsArgumentNullException()
+        {
+            using (Stream stream = GetRequestStream())
+            {
+                Assert.Throws<ArgumentNullException>(() => BeginWriteWrapper(stream, null, 0, 1));
+            }
+        }
+
+        [Fact]
+        public void BeginWriteAsync_OffsetIsNegative_ThrowsArgumentOutOfRangeException()
+        {
+            using (Stream stream = GetRequestStream())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => BeginWriteWrapper(stream, buffer, -1, buffer.Length));
+            }
+        }
+
+        [Fact]
+        public void BeginWriteAsync_CountIsNegative_ThrowsArgumentOutOfRangeException()
+        {
+            using (Stream stream = GetRequestStream())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => BeginWriteWrapper(stream, buffer, 0, -1));
+            }
+        }
+
+        [Fact]
+        public void BeginWriteAsync_OffsetPlusCountExceedsBufferLength_ThrowsArgumentException()
+        {
+            using (Stream stream = GetRequestStream())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => BeginWriteWrapper(stream, buffer, 0, buffer.Length + 1));
+            }
+        }
+
+        [Fact]
+        public void BeginWriteAsync_OffsetPlusCountMaxValueExceedsBufferLength_Throws()
+        {
+            using (Stream stream = GetRequestStream())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => BeginWriteWrapper(stream, buffer, int.MaxValue, int.MaxValue));
+            }
+        }
+
+        [Fact]
+        public void BeginWriteAsync_ValidParameters_TaskRanToCompletion()
+        {
+            using (Stream stream = GetRequestStream())
+            {
+                IAsyncResult result = BeginWriteWrapper(stream, buffer, 0, buffer.Length);
+                Assert.True(result.IsCompleted);
+            }
+        }
+
+        #endregion
 
         [Fact]
         public void FlushAsync_TaskRanToCompletion()

--- a/src/System.Net.Requests/tests/RequestStreamTest.cs
+++ b/src/System.Net.Requests/tests/RequestStreamTest.cs
@@ -22,7 +22,7 @@ namespace System.Net.Tests
         {
             using (Stream stream = GetRequestStream())
             {
-                Assert.Throws<ArgumentNullException>(() => stream.Write(null, 0, 1));
+                Assert.Throws<ArgumentNullException>("buffer", () => stream.Write(null, 0, 1));
             }
         }
 
@@ -31,7 +31,7 @@ namespace System.Net.Tests
         {
             using (Stream stream = GetRequestStream())
             {
-                Assert.Throws<ArgumentOutOfRangeException>(() => stream.Write(buffer, -1, buffer.Length));
+                Assert.Throws<ArgumentOutOfRangeException>("offset", () => stream.Write(buffer, -1, buffer.Length));
             }
         }
 
@@ -40,7 +40,7 @@ namespace System.Net.Tests
         {
             using (Stream stream = GetRequestStream())
             {
-                Assert.Throws<ArgumentOutOfRangeException>(() => stream.Write(buffer, 0, -1));
+                Assert.Throws<ArgumentOutOfRangeException>("count", () => stream.Write(buffer, 0, -1));
             }
         }
 
@@ -49,7 +49,7 @@ namespace System.Net.Tests
         {
             using (Stream stream = GetRequestStream())
             {
-                Assert.Throws<ArgumentOutOfRangeException>(() => stream.Write(buffer, 0, buffer.Length + 1));
+                Assert.Throws<ArgumentOutOfRangeException>("count", () => stream.Write(buffer, 0, buffer.Length + 1));
             }
         }
 
@@ -58,7 +58,7 @@ namespace System.Net.Tests
         {
             using (Stream stream = GetRequestStream())
             {
-                Assert.Throws<ArgumentOutOfRangeException>(() => stream.Write(buffer, int.MaxValue, int.MaxValue));
+                Assert.Throws<ArgumentOutOfRangeException>("offset", () => stream.Write(buffer, int.MaxValue, int.MaxValue));
             }
         }
 
@@ -71,7 +71,7 @@ namespace System.Net.Tests
         {
             using (Stream stream = GetRequestStream())
             {
-                Assert.Throws<ArgumentNullException>(() => { Task t = stream.WriteAsync(null, 0, 1); });
+                Assert.Throws<ArgumentNullException>("buffer", () => { Task t = stream.WriteAsync(null, 0, 1); });
             }
         }
 
@@ -80,7 +80,7 @@ namespace System.Net.Tests
         {
             using (Stream stream = GetRequestStream())
             {
-                Assert.Throws<ArgumentOutOfRangeException>(() => { Task t = stream.WriteAsync(buffer, -1, buffer.Length); });
+                Assert.Throws<ArgumentOutOfRangeException>("offset", () => { Task t = stream.WriteAsync(buffer, -1, buffer.Length); });
             }
         }
 
@@ -89,7 +89,7 @@ namespace System.Net.Tests
         {
             using (Stream stream = GetRequestStream())
             {
-                Assert.Throws<ArgumentOutOfRangeException>(() => { Task t = stream.WriteAsync(buffer, 0, -1); });
+                Assert.Throws<ArgumentOutOfRangeException>("count", () => { Task t = stream.WriteAsync(buffer, 0, -1); });
             }
         }
 
@@ -98,7 +98,7 @@ namespace System.Net.Tests
         {
             using (Stream stream = GetRequestStream())
             {
-                Assert.Throws<ArgumentOutOfRangeException>(() => { Task t = stream.WriteAsync(buffer, 0, buffer.Length + 1); });
+                Assert.Throws<ArgumentOutOfRangeException>("count", () => { Task t = stream.WriteAsync(buffer, 0, buffer.Length + 1); });
             }
         }
 
@@ -107,7 +107,7 @@ namespace System.Net.Tests
         {
             using (Stream stream = GetRequestStream())
             {
-                Assert.Throws<ArgumentOutOfRangeException>(() => { Task t = stream.WriteAsync(buffer, int.MaxValue, int.MaxValue); });
+                Assert.Throws<ArgumentOutOfRangeException>("offset", () => { Task t = stream.WriteAsync(buffer, int.MaxValue, int.MaxValue); });
             }
         }
 
@@ -137,22 +137,12 @@ namespace System.Net.Tests
 
         #region BeginWrite
 
-        private IAsyncResult BeginWriteWrapper(Stream stream, byte[] buffer, int offset, int count)
-        {
-            AsyncCallback callback = null;
-            object state = new object();
-            IAsyncResult result = stream.BeginWrite(buffer, offset, count, callback, state);
-            stream.EndWrite(result);
-
-            return result;
-        }
-
         [Fact]
         public void BeginWriteAsync_BufferIsNull_ThrowsArgumentNullException()
         {
             using (Stream stream = GetRequestStream())
             {
-                Assert.Throws<ArgumentNullException>(() => BeginWriteWrapper(stream, null, 0, 1));
+                Assert.Throws<ArgumentNullException>("buffer", () => stream.BeginWrite(null, 0, 1, null, null));
             }
         }
 
@@ -161,7 +151,7 @@ namespace System.Net.Tests
         {
             using (Stream stream = GetRequestStream())
             {
-                Assert.Throws<ArgumentOutOfRangeException>(() => BeginWriteWrapper(stream, buffer, -1, buffer.Length));
+                Assert.Throws<ArgumentOutOfRangeException>("offset", () => stream.BeginWrite(buffer, -1, buffer.Length, null, null));
             }
         }
 
@@ -170,7 +160,7 @@ namespace System.Net.Tests
         {
             using (Stream stream = GetRequestStream())
             {
-                Assert.Throws<ArgumentOutOfRangeException>(() => BeginWriteWrapper(stream, buffer, 0, -1));
+                Assert.Throws<ArgumentOutOfRangeException>("count", () => stream.BeginWrite(buffer, 0, -1, null, null));
             }
         }
 
@@ -179,7 +169,7 @@ namespace System.Net.Tests
         {
             using (Stream stream = GetRequestStream())
             {
-                Assert.Throws<ArgumentOutOfRangeException>(() => BeginWriteWrapper(stream, buffer, 0, buffer.Length + 1));
+                Assert.Throws<ArgumentOutOfRangeException>("count", () => stream.BeginWrite(buffer, 0, buffer.Length + 1, null, null));
             }
         }
 
@@ -188,7 +178,7 @@ namespace System.Net.Tests
         {
             using (Stream stream = GetRequestStream())
             {
-                Assert.Throws<ArgumentOutOfRangeException>(() => BeginWriteWrapper(stream, buffer, int.MaxValue, int.MaxValue));
+                Assert.Throws<ArgumentOutOfRangeException>("offset", () => stream.BeginWrite(buffer, int.MaxValue, int.MaxValue, null, null));
             }
         }
 
@@ -197,7 +187,9 @@ namespace System.Net.Tests
         {
             using (Stream stream = GetRequestStream())
             {
-                IAsyncResult result = BeginWriteWrapper(stream, buffer, 0, buffer.Length);
+                object state = new object();
+                IAsyncResult result = stream.BeginWrite(buffer, 0, buffer.Length, null, state);
+                stream.EndWrite(result);
                 Assert.True(result.IsCompleted);
             }
         }


### PR DESCRIPTION
Validate the input parameters for Write* calls before hitting the underlying MemoryStream calls which throw exceptions different than expected ones.

Fixes #18787 

@davidsh  Kindly review.

Thanks,
Mandar