### PR TITLE
Fix WaitHandle.WaitAll test on desktop

### DIFF
--- a/src/System.Threading/tests/ManualResetEventTests.cs
+++ b/src/System.Threading/tests/ManualResetEventTests.cs
@@ -52,7 +52,7 @@ namespace System.Threading.Tests
             }
             Assert.True(t.Result);
 
-            Assert.True(WaitHandle.WaitAll(handles, 0));
+            Assert.True(Task.Run(() => WaitHandle.WaitAll(handles, 0)).Result); // Task.Run used to ensure MTA thread (necessary for desktop)
         }
 
         [Fact]


### PR DESCRIPTION
xunit ends up using an STA thread for some (not all) test executions in the desktop runner.  This breaks a WaitHandle.WaitAll test, as WaitAll can't be used from STA threads.  This commit just makes sure that the WaitAll call is done from an MTA thread.

Fixes https://github.com/dotnet/corefx/issues/19156
cc: @danmosemsft, @kouvel 
