### PR TITLE
Fix "Too many open files" in MMF perf test

### DIFF
--- a/src/System.IO.MemoryMappedFiles/tests/Performance/Perf.MemoryMappedFile.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/Performance/Perf.MemoryMappedFile.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.IO;
 using Microsoft.Xunit.Performance;
 using Xunit;
 
@@ -18,18 +17,14 @@ namespace System.IO.MemoryMappedFiles.Tests
         [InlineData(100000)]
         [InlineData(1000000)]
         [InlineData(10000000)]
-        [ActiveIssue(18463, TestPlatforms.OSX)] // Hits the max-open-file limit often on OSX.
         public void CreateNew(int capacity)
         {
-            const int innerIterations = 1000;
-            MemoryMappedFile[] files = new MemoryMappedFile[innerIterations];
+            const int InnerIterations = 1000;
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
-                    for (int i = 0; i < innerIterations; i++)
-                        files[i] = MemoryMappedFile.CreateNew(null, capacity);
-                for (int i = 0; i < innerIterations; i++)
-                    files[i].Dispose();
+                    for (int i = 0; i < InnerIterations; i++)
+                        MemoryMappedFile.CreateNew(null, capacity).Dispose();
             }
         }
 
@@ -48,24 +43,6 @@ namespace System.IO.MemoryMappedFiles.Tests
                 using (MemoryMappedFile mmfile = MemoryMappedFile.CreateFromFile(file.Path))
                 using (mmfile.CreateViewAccessor(capacity / 4, capacity / 2))
                 { }
-        }
-
-        [Benchmark]
-        [InlineData(10000)]
-        [InlineData(100000)]
-        [InlineData(1000000)]
-        public void Dispose(int capacity)
-        {
-            const int innerIterations = 1000;
-            MemoryMappedFile[] files = new MemoryMappedFile[innerIterations];
-            foreach (var iteration in Benchmark.Iterations)
-            {
-                for (int i = 0; i < innerIterations; i++)
-                    files[i] = MemoryMappedFile.CreateNew(null, capacity);
-                using (iteration.StartMeasurement())
-                    for (int i = 0; i < innerIterations; i++)
-                        files[i].Dispose();
-            }
         }
     }
 }


### PR DESCRIPTION
The test is attempting to time the performance of CreateNew separate from Dispose, but they should only ever be used 1:1 as part of the lifecycle of the MMF, so there isn't a need to measure the performance of these separately (if there's ever an issue, we can dive into understanding where exactly it's coming from).  And it's the attempt to measure them separately that's resulting in these "too many open file" errors on macOS, due to needing to keep a bunch of MMFs open so that we don't measure the Dispose time as part of the benchmark.  This commit just collapses them.

Fixes https://github.com/dotnet/corefx/issues/18463
cc: @mellinoe, @danmosemsft 