### PR TITLE
Ignore PDB age when opening Portable PDB

### DIFF
--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/DebugDirectory/DebugDirectoryBuilder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/DebugDirectory/DebugDirectoryBuilder.cs
@@ -66,7 +66,7 @@ namespace System.Reflection.PortableExecutable
         /// <exception cref="ArgumentException"><paramref name="pdbPath"/> contains NUL character.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="age"/> is less than 1.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="portablePdbVersion"/> is smaller than 0x0100.</exception>
-        public void AddCodeViewEntry(
+        internal void AddCodeViewEntry(
             string pdbPath,
             BlobContentId pdbContentId,
             ushort portablePdbVersion,

--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/DebugDirectory/DebugDirectoryBuilder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/DebugDirectory/DebugDirectoryBuilder.cs
@@ -52,9 +52,34 @@ namespace System.Reflection.PortableExecutable
             BlobContentId pdbContentId,
             ushort portablePdbVersion)
         {
+            AddCodeViewEntry(pdbPath, pdbContentId, portablePdbVersion, age: 1);
+        }
+
+        /// <summary>
+        /// Adds a CodeView entry.
+        /// </summary>
+        /// <param name="pdbPath">Path to the PDB. Shall not be empty.</param>
+        /// <param name="pdbContentId">Unique id of the PDB content.</param>
+        /// <param name="portablePdbVersion">Version of Portable PDB format (e.g. 0x0100 for 1.0), or 0 if the PDB is not portable.</param>
+        /// <param name="age">Age (iteration) of the PDB. Shall be 1 for Portable PDBs.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="pdbPath"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="pdbPath"/> contains NUL character.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="age"/> is less than 1.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="portablePdbVersion"/> is smaller than 0x0100.</exception>
+        public void AddCodeViewEntry(
+            string pdbPath,
+            BlobContentId pdbContentId,
+            ushort portablePdbVersion,
+            int age)
+        {
             if (pdbPath == null)
             {
                 Throw.ArgumentNull(nameof(pdbPath));
+            }
+
+            if (age < 1)
+            {
+                Throw.ArgumentOutOfRange(nameof(age));
             }
 
             // We allow NUL characters to allow for padding for backward compat purposes.
@@ -68,7 +93,7 @@ namespace System.Reflection.PortableExecutable
                 Throw.ArgumentOutOfRange(nameof(portablePdbVersion));
             }
 
-            int dataSize = WriteCodeViewData(_dataBuilder, pdbPath, pdbContentId.Guid);
+            int dataSize = WriteCodeViewData(_dataBuilder, pdbPath, pdbContentId.Guid, age);
             
             AddEntry(
                 type: DebugDirectoryEntryType.CodeView,
@@ -85,7 +110,7 @@ namespace System.Reflection.PortableExecutable
             AddEntry(type: DebugDirectoryEntryType.Reproducible, version: 0, stamp: 0);
         }
 
-        private static int WriteCodeViewData(BlobBuilder builder, string pdbPath, Guid pdbGuid)
+        private static int WriteCodeViewData(BlobBuilder builder, string pdbPath, Guid pdbGuid, int age)
         {
             int start = builder.Count;
 
@@ -98,7 +123,7 @@ namespace System.Reflection.PortableExecutable
             builder.WriteGuid(pdbGuid);
 
             // age
-            builder.WriteUInt32(1);
+            builder.WriteInt32(age);
 
             // UTF-8 encoded zero-terminated path to PDB
             int pathStart = builder.Count;

--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEReader.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEReader.cs
@@ -736,12 +736,6 @@ namespace System.Reflection.PortableExecutable
                 return false;
             }
 
-            if (data.Age != 1)
-            {
-                // not a portable code view:
-                return false;
-            }
-
             var id = new BlobContentId(data.Guid, codeViewEntry.Stamp);
            
             // The interpretation os the path in the CodeView needs to be platform agnostic,

--- a/src/System.Reflection.Metadata/tests/PortableExecutable/DebugDirectoryBuilderTests.cs
+++ b/src/System.Reflection.Metadata/tests/PortableExecutable/DebugDirectoryBuilderTests.cs
@@ -32,7 +32,11 @@ namespace System.Reflection.PortableExecutable.Tests
             Assert.Throws<ArgumentException>(() => builder.AddCodeViewEntry("", default(BlobContentId), 0x0100));
             Assert.Throws<ArgumentException>(() => builder.AddCodeViewEntry("\0", default(BlobContentId), 0x0100));
             Assert.Throws<ArgumentException>(() => builder.AddCodeViewEntry("\0xx", default(BlobContentId), 0x0100));
+            Assert.Throws<ArgumentOutOfRangeException>(() => builder.AddCodeViewEntry("xx", default(BlobContentId), 0x0100, int.MinValue));
+            Assert.Throws<ArgumentOutOfRangeException>(() => builder.AddCodeViewEntry("xx", default(BlobContentId), 0x0100, -1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => builder.AddCodeViewEntry("xx", default(BlobContentId), 0x0100, 0));
             builder.AddCodeViewEntry("foo\0", default(BlobContentId), 0x0100);
+            builder.AddCodeViewEntry("baz\0", default(BlobContentId), 0x0100, int.MaxValue);
             Assert.Throws<ArgumentNullException>(() => builder.AddCodeViewEntry(null, default(BlobContentId), 0x0100));
             builder.AddCodeViewEntry("foo", default(BlobContentId), 0);
             Assert.Throws<ArgumentOutOfRangeException>(() => builder.AddCodeViewEntry("foo", default(BlobContentId), 0x0001));
@@ -99,7 +103,7 @@ namespace System.Reflection.PortableExecutable.Tests
         {
             var b = new DebugDirectoryBuilder();
             var id = new BlobContentId(new Guid("3C88E66E-E0B9-4508-9290-11E0DB51A1C5"), 0x12345678);
-            b.AddCodeViewEntry("foo.pdb" + new string('\0', 260 - "foo.pdb".Length - 1), id, 0xABCD);
+            b.AddCodeViewEntry("foo.pdb" + new string('\0', 260 - "foo.pdb".Length - 1), id, 0xABCD, 0x99);
 
             var blob = new BlobBuilder();
             b.Serialize(blob, new SectionLocation(0x1000, 0x2000), 0x50);
@@ -117,7 +121,7 @@ namespace System.Reflection.PortableExecutable.Tests
                 // data
                 (byte)'R', (byte)'S', (byte)'D', (byte)'S',
                 0x6E, 0xE6, 0x88, 0x3C, 0xB9, 0xE0, 0x08, 0x45, 0x92, 0x90, 0x11, 0xE0, 0xDB, 0x51, 0xA1, 0xC5, // GUID
-                0x01, 0x00, 0x00, 0x00, // age
+                0x99, 0x00, 0x00, 0x00, // age
                 (byte)'f', (byte)'o', (byte)'o', (byte)'.', (byte)'p', (byte)'d', (byte)'b', 0x00, // path
                 // path padding:
                 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 

--- a/src/System.Reflection.Metadata/tests/PortableExecutable/PEReaderTests.cs
+++ b/src/System.Reflection.Metadata/tests/PortableExecutable/PEReaderTests.cs
@@ -505,7 +505,7 @@ namespace System.Reflection.PortableExecutable.Tests
             var ddBuilder = new DebugDirectoryBuilder();
             ddBuilder.AddCodeViewEntry(@"/a/b/a.pdb", id, portablePdbVersion: 0);
             ddBuilder.AddReproducibleEntry();
-            ddBuilder.AddCodeViewEntry(@"/a/b/c.pdb", id, portablePdbVersion: 0x0100);
+            ddBuilder.AddCodeViewEntry(@"/a/b/c.pdb", id, portablePdbVersion: 0x0100, age: 0x1234);
             ddBuilder.AddCodeViewEntry(@"/a/b/d.pdb", id, portablePdbVersion: 0x0100);
 
             var peStream = new MemoryStream(TestBuilders.BuildPEWithDebugDirectory(ddBuilder));


### PR DESCRIPTION
A couple of changes:
- Ignore the value of Age when checking for Portable PDB CodeView entry. The value is always 1 when the Portable PDB is built by Roslyn compiler, however when a Windows PDB that has been post-processed by a custom tool is converted to a Portable PDB the age might be > 1. Allow such converted PDB to be open.

