### PR TITLE
Fix assembly name test

### DIFF
--- a/src/System.Reflection/tests/AssemblyNameTests.cs
+++ b/src/System.Reflection/tests/AssemblyNameTests.cs
@@ -27,10 +27,9 @@ namespace System.Reflection.Tests
         public static IEnumerable<object[]> Names_TestData()
         {
             yield return new object[] { "name", "name" };
-            yield return new object[] { "NAME", "NAME" };
             yield return new object[] { "name with spaces", "name with spaces" };
             yield return new object[] { "\uD800\uDC00", "\uD800\uDC00" };
-            yield return new object[] { "привет", "привет" };
+            yield return new object[] { "\u043F\u0440\u0438\u0432\u0435\u0442", "\u043F\u0440\u0438\u0432\u0435\u0442" };
         }
 
         [Fact]

--- a/src/System.Reflection/tests/AssemblyNameTests.cs
+++ b/src/System.Reflection/tests/AssemblyNameTests.cs
@@ -27,6 +27,7 @@ namespace System.Reflection.Tests
         public static IEnumerable<object[]> Names_TestData()
         {
             yield return new object[] { "name", "name" };
+            yield return new object[] { "NAME", "NAME" };
             yield return new object[] { "name with spaces", "name with spaces" };
             yield return new object[] { "\uD800\uDC00", "\uD800\uDC00" };
             yield return new object[] { "\u043F\u0440\u0438\u0432\u0435\u0442", "\u043F\u0440\u0438\u0432\u0435\u0442" };
@@ -45,7 +46,7 @@ namespace System.Reflection.Tests
         public void Ctor_String(string name, string expectedName)
         {
             AssemblyName assemblyName = new AssemblyName(name);
-            Assert.Equal(expectedName, assemblyName.Name);
+            Assert.Equal(expectedName.ToLowerInvariant(), assemblyName.Name.ToLowerInvariant());
             Assert.Equal(ProcessorArchitecture.None, assemblyName.ProcessorArchitecture);
         }
 

--- a/src/System.Reflection/tests/AssemblyNameTests.cs
+++ b/src/System.Reflection/tests/AssemblyNameTests.cs
@@ -263,7 +263,9 @@ namespace System.Reflection.Tests
 
             string expected = "MyAssemblyName, Version=" + versionString;
             string extended = expected + ", Culture=neutral, PublicKeyToken=null";
-            Assert.True(assemblyName.FullName == expected || assemblyName.FullName == extended);
+
+            Assert.True(assemblyName.FullName == expected || assemblyName.FullName == extended,
+                        $"Expected\n{assemblyName.FullName} == {expected}\nor\n{assemblyName.FullName} == {extended}");
         }
 
         [Fact]

--- a/src/System.Reflection/tests/AssemblyTests.cs
+++ b/src/System.Reflection/tests/AssemblyTests.cs
@@ -118,6 +118,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "On desktop, XUnit hosts in an appdomain in such a way that GetEntryAssembly() returns null")]
         public void GetEntryAssembly()
         {
             Assert.NotNull(Assembly.GetEntryAssembly());

--- a/src/System.Runtime/tests/System/Reflection/AssemblyTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/AssemblyTests.cs
@@ -335,13 +335,6 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, ".NET Core fixed a bug where LoadFile(null) throws a NullReferenceException")]
-        public static void LoadFile_NullPath_Netfx_ThrowsNullReferenceException()
-        {
-            Assert.Throws<NullReferenceException>(() => Assembly.LoadFile(null));
-        }
-
-        [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.LoadFile() not supported on UapAot")]
         public static void LoadFile_NoSuchPath_ThrowsArgumentException()
         {


### PR DESCRIPTION
Fix https://github.com/dotnet/corefx/issues/18311
Fix https://github.com/dotnet/corefx/issues/18710

According to @AtsushiKan in desktop, fusion will cache names case-insensitively. Core apparently does not. This does not seem worth protecting: removing test.

Also changing another line to unicode escapes per guidelines

Also fix unfiled test failure caused by GetEntryAssembly() returning null in desktop xunit as noted here https://github.com/Microsoft/vstest/issues/649

Fix https://github.com/dotnet/corefx/issues/18809 by removing the test. Older versions of desktop throw ANE, newer ones throw NRE. Not worth accommodating.