### PR TITLE
Fix DispatchProxy AV when using generic type parameters on methods

### DIFF
--- a/src/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
+++ b/src/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
@@ -781,7 +781,7 @@ namespace System.Reflection
                 }
                 else if (targetTypeInfo.IsAssignableFrom(sourceTypeInfo))
                 {
-                    if (sourceTypeInfo.IsValueType)
+                    if (sourceTypeInfo.IsValueType || source.IsGenericParameter)
                     {
                         if (isAddress)
                             Ldind(il, source);
@@ -793,8 +793,6 @@ namespace System.Reflection
                     Debug.Assert(sourceTypeInfo.IsAssignableFrom(targetTypeInfo) || targetTypeInfo.IsInterface || sourceTypeInfo.IsInterface);
                     if (target.IsGenericParameter)
                     {
-                        // T GetProperty<T>() where T : class;
-                        Debug.Assert(targetTypeInfo.GenericParameterAttributes == GenericParameterAttributes.ReferenceTypeConstraint);
                         il.Emit(OpCodes.Unbox_Any, target);
                     }
                     else

--- a/src/System.Reflection.DispatchProxy/tests/DispatchProxyTests.cs
+++ b/src/System.Reflection.DispatchProxy/tests/DispatchProxyTests.cs
@@ -495,5 +495,33 @@ namespace DispatchProxyTests
             PropertyInfo propertyInfo = proxy.GetType().GetTypeInfo().GetDeclaredProperty("Item");
             Assert.NotNull(propertyInfo);
         }
+
+        static void testGenericMethodRoundTrip<T>(T testValue)
+        {
+            var proxy = DispatchProxy.Create<TypeType_GenericMethod, TestDispatchProxy>();
+            ((TestDispatchProxy)proxy).CallOnInvoke = (mi, a) =>
+            {
+                Assert.True(mi.IsGenericMethod);
+                Assert.False(mi.IsGenericMethodDefinition);
+                Assert.Equal(1, mi.GetParameters().Length);
+                Assert.Equal(typeof(T), mi.GetParameters()[0].ParameterType);
+                Assert.Equal(typeof(T), mi.ReturnType);
+                return a[0];
+            };
+            Assert.Equal(proxy.Echo(testValue), testValue);
+        }
+
+        [Fact]
+        public static void Invoke_Generic_Method()
+        {
+            //string
+            testGenericMethodRoundTrip("asdf");
+            //reference type
+            testGenericMethodRoundTrip(new Version(1, 0, 0, 0));
+            //value type
+            testGenericMethodRoundTrip(42);
+            //enum type
+            testGenericMethodRoundTrip(DayOfWeek.Monday);
+        }
     }
 }

--- a/src/System.Reflection.DispatchProxy/tests/TestTypes.cs
+++ b/src/System.Reflection.DispatchProxy/tests/TestTypes.cs
@@ -80,6 +80,11 @@ internal interface TestType_PublicInterfaceService_Implements_Internal : TestTyp
     string Echo2(string message);
 }
 
+public interface TypeType_GenericMethod
+{
+    T Echo<T>(T messages);
+}
+
 // Negative -- demonstrates trying to use a class for the interface type for the proxy
 public class TestType_ConcreteClass
 {


### PR DESCRIPTION
For return types, an assert is triggered in debug mode.

For parameters, an `ExecutionEngineException` is triggered at run time on x64 Windows when a proxied method has a generic-typed parameter and a value type is passed. The lack of an `box` instruction causes an AV in JIT_Stelem_Ref when it tries to treat the value type as an `Object*` .

I added some tests that trigger the problem too.