### PR TITLE
Implement CryptoConfig.AddOID and AddAlgorithm

### DIFF
--- a/src/System.Security.Cryptography.Algorithms/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Algorithms/src/Resources/Strings.resx
@@ -238,4 +238,10 @@
   <data name="NotSupported_SubclassOverride" xml:space="preserve">
     <value>Method not supported. Derived class must override.</value>
   </data>
+  <data name="Cryptography_AlgorithmTypesMustBeVisible" xml:space="preserve">
+    <value>Algorithms added to CryptoConfig must be accessable from outside their assembly.</value>
+  </data>
+  <data name="Cryptography_AddNullOrEmptyName" xml:space="preserve">
+    <value>CryptoConfig cannot add a mapping for a null or empty name.</value>
+  </data>
 </root>

--- a/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -489,10 +489,10 @@
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation" />
     <Reference Include="System.Security.Cryptography.Encoding" />
     <Reference Include="System.Security.Cryptography.Primitives" />
+    <Reference Include="System.Threading" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
     <Reference Include="System.Runtime.Numerics" />
-    <Reference Include="System.Threading" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netfx'">
     <Reference Include="mscorlib" />

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/CryptoConfig.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/CryptoConfig.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Reflection;
-using System.Threading;
 
 namespace System.Security.Cryptography
 {
@@ -41,16 +40,7 @@ namespace System.Security.Cryptography
         public static bool AllowOnlyFipsAlgorithms => false;
 
         // Private object for locking instead of locking on a public type for SQL reliability work.
-        private static Object s_InternalSyncObject;
-        private static Object InternalSyncObject {
-            get {
-                if (s_InternalSyncObject == null) {
-                    Object o = new Object();
-                    Interlocked.CompareExchange(ref s_InternalSyncObject, o, null);
-                }
-                return s_InternalSyncObject;
-            }
-        }
+        private static Object s_InternalSyncObject = new Object();
 
         private static Dictionary<string, string> DefaultOidHT
         {
@@ -309,15 +299,19 @@ namespace System.Security.Cryptography
  
             // Pre-check the algorithm names for validity so that we don't add a few of the names and then
             // throw an exception if we find an invalid name partway through the list.
-            foreach (string name in algorithmNames) {
-                if (String.IsNullOrEmpty(name)) {
+            foreach (string name in algorithmNames)
+            {
+                if (String.IsNullOrEmpty(name))
+                {
                     throw new ArgumentException(SR.Cryptography_AddNullOrEmptyName);
                 }
             }
  
             // Everything looks valid, so we're safe to take the table lock and add the name mappings.
-            lock (InternalSyncObject) {
-                foreach (string name in algorithmNames) {
+            lock (s_InternalSyncObject)
+            {
+                foreach (string name in algorithmNames)
+                {
                     appNameHT[name] = algorithm;
                 }
             }
@@ -330,9 +324,11 @@ namespace System.Security.Cryptography
 
             Type retvalType = null;
             
-            // Check to see if we have an applicaiton defined mapping
-            lock (InternalSyncObject) {
-                if (!appNameHT.TryGetValue(name, out retvalType)) {
+            // Check to see if we have an application defined mapping
+            lock (s_InternalSyncObject)
+            {
+                if (!appNameHT.TryGetValue(name, out retvalType))
+                {
                     retvalType = null;
                 }
             }
@@ -443,24 +439,28 @@ namespace System.Security.Cryptography
         public static void AddOID(string oid, params string[] names)
         {
             if (oid == null)
-                throw new ArgumentNullException("oid");
+                throw new ArgumentNullException(nameof(oid));
             if (names == null)
-                throw new ArgumentNullException("names");
+                throw new ArgumentNullException(nameof(names));
  
             string[] oidNames = new string[names.Length];
             Array.Copy(names, oidNames, oidNames.Length);
  
             // Pre-check the input names for validity, so that we don't add a few of the names and throw an
             // exception if an invalid name is found further down the array. 
-            foreach (string name in oidNames) {
-                if (String.IsNullOrEmpty(name)) {
+            foreach (string name in oidNames)
+            {
+                if (String.IsNullOrEmpty(name))
+                {
                     throw new ArgumentException(SR.Cryptography_AddNullOrEmptyName);
                 }
             }
  
             // Everything is valid, so we're good to lock the hash table and add the application mappings
-            lock (InternalSyncObject) {
-                foreach (string name in oidNames) {
+            lock (s_InternalSyncObject)
+            {
+                foreach (string name in oidNames)
+                {
                     appOidHT[name] = oid;
                 }
             }
@@ -474,8 +474,10 @@ namespace System.Security.Cryptography
             string oidName;
             
             // Check to see if we have an application defined mapping
-            lock (InternalSyncObject) {
-                if (!appOidHT.TryGetValue(name, out oidName)) {
+            lock (s_InternalSyncObject)
+            {
+                if (!appOidHT.TryGetValue(name, out oidName))
+                {
                     oidName = null;
                 }
             }

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/CryptoConfig.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/CryptoConfig.cs
@@ -329,12 +329,19 @@ namespace System.Security.Cryptography
                 throw new ArgumentNullException(nameof(name));
 
             Type retvalType = null;
+            
+            // Check to see if we have an applicaiton defined mapping
+            lock (InternalSyncObject) {
+                if (!appNameHT.TryGetValue(name, out retvalType)) {
+                    retvalType = null;
+                }
+            }
 
             // We allow the default table to Types and Strings
             // Types get used for types in .Algorithms assembly.
             // strings get used for delay-loaded stuff in other assemblies such as .Csp.
             object retvalObj;
-            if (DefaultNameHT.TryGetValue(name, out retvalObj))
+            if (retvalType == null && DefaultNameHT.TryGetValue(name, out retvalObj))
             {
                 if (retvalObj is Type)
                 {
@@ -465,7 +472,15 @@ namespace System.Security.Cryptography
                 throw new ArgumentNullException(nameof(name));
 
             string oidName;
-            if (!DefaultOidHT.TryGetValue(name, out oidName))
+            
+            // Check to see if we have an application defined mapping
+            lock (InternalSyncObject) {
+                if (!appOidHT.TryGetValue(name, out oidName)) {
+                    oidName = null;
+                }
+            }
+
+            if (string.IsNullOrEmpty(oidName) && !DefaultOidHT.TryGetValue(name, out oidName))
             {
                 try
                 {

--- a/src/System.Security.Cryptography.Algorithms/tests/CryptoConfigTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/CryptoConfigTests.cs
@@ -20,15 +20,53 @@ namespace System.Security.Cryptography.CryptoConfigTests
         }
 
         [Fact]
-        public static void AddOID_NotSupported()
+        public static void AddOID_MapNameToOID_ReturnsMapped()
         {
-            Assert.Throws<PlatformNotSupportedException>(() => CryptoConfig.AddOID(string.Empty, string.Empty));
+            CryptoConfig.AddOID("1.3.14.3.2.28", "SHAFancy");
+            Assert.Equal("1.3.14.3.2.28", CryptoConfig.MapNameToOID("SHAFancy"));
         }
 
         [Fact]
-        public static void AddAlgorithm_NotSupported()
+        public static void AddOID_EmptyString_Throws()
         {
-            Assert.Throws<PlatformNotSupportedException>(() => CryptoConfig.AddAlgorithm(typeof(CryptoConfigTests), string.Empty));
+            Assert.Throws<ArgumentException>(() => CryptoConfig.AddOID(string.Empty, string.Empty));
+        }
+
+        [Fact]
+        public static void AddOID_NullOid_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => CryptoConfig.AddOID(null, string.Empty));
+        }
+
+        [Fact]
+        public static void AddOID_NullNames_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => CryptoConfig.AddOID(string.Empty, null));
+        }
+
+        [Fact]
+        public static void AddAlgorithm_CreateFromName_ReturnsMapped()
+        {
+            CryptoConfig.AddAlgorithm(typeof(AesCryptoServiceProvider), "AESFancy");
+            Assert.Equal(typeof(AesCryptoServiceProvider).FullName, CryptoConfig.CreateFromName("AESFancy").GetType().FullName);
+        }
+
+        [Fact]
+        public static void AddAlgorithm_EmptyString_Throws()
+        {
+            Assert.Throws<ArgumentException>(() => CryptoConfig.AddAlgorithm(typeof(CryptoConfigTests), string.Empty));
+        }
+
+        [Fact]
+        public static void AddAlgorithm_NullAlgorithm_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => CryptoConfig.AddAlgorithm(null, string.Empty));
+        }
+
+        [Fact]
+        public static void AddAlgorithm_NullNames_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => CryptoConfig.AddAlgorithm(typeof(CryptoConfigTests), null));
         }
 
         [Fact]

--- a/src/System.Security.Cryptography.Algorithms/tests/CryptoConfigTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/CryptoConfigTests.cs
@@ -29,19 +29,25 @@ namespace System.Security.Cryptography.CryptoConfigTests
         [Fact]
         public static void AddOID_EmptyString_Throws()
         {
-            Assert.Throws<ArgumentException>(() => CryptoConfig.AddOID(string.Empty, string.Empty));
+            Assert.Throws<ArgumentException>(null, () => CryptoConfig.AddOID(string.Empty, string.Empty));
+        }
+
+        [Fact]
+        public static void AddOID_EmptyNamesArray()
+        {
+            CryptoConfig.AddOID("1.3.14.3.2.28", new string[0]);
         }
 
         [Fact]
         public static void AddOID_NullOid_Throws()
         {
-            Assert.Throws<ArgumentNullException>(() => CryptoConfig.AddOID(null, string.Empty));
+            Assert.Throws<ArgumentNullException>("oid", () => CryptoConfig.AddOID(null, string.Empty));
         }
 
         [Fact]
         public static void AddOID_NullNames_Throws()
         {
-            Assert.Throws<ArgumentNullException>(() => CryptoConfig.AddOID(string.Empty, null));
+            Assert.Throws<ArgumentNullException>("names", () => CryptoConfig.AddOID(string.Empty, null));
         }
 
         [Fact]
@@ -52,21 +58,31 @@ namespace System.Security.Cryptography.CryptoConfigTests
         }
 
         [Fact]
+        public static void AddAlgorithm_NonVisibleType()
+        {
+            Assert.Throws<ArgumentException>("algorithm", () => CryptoConfig.AddAlgorithm(typeof(AESFancy), "AESFancy"));
+        }
+
+        private class AESFancy
+        {
+        }
+
+        [Fact]
         public static void AddAlgorithm_EmptyString_Throws()
         {
-            Assert.Throws<ArgumentException>(() => CryptoConfig.AddAlgorithm(typeof(CryptoConfigTests), string.Empty));
+            Assert.Throws<ArgumentException>(null, () => CryptoConfig.AddAlgorithm(typeof(CryptoConfigTests), string.Empty));
         }
 
         [Fact]
         public static void AddAlgorithm_NullAlgorithm_Throws()
         {
-            Assert.Throws<ArgumentNullException>(() => CryptoConfig.AddAlgorithm(null, string.Empty));
+            Assert.Throws<ArgumentNullException>("algorithm", () => CryptoConfig.AddAlgorithm(null, string.Empty));
         }
 
         [Fact]
         public static void AddAlgorithm_NullNames_Throws()
         {
-            Assert.Throws<ArgumentNullException>(() => CryptoConfig.AddAlgorithm(typeof(CryptoConfigTests), null));
+            Assert.Throws<ArgumentNullException>("names", () => CryptoConfig.AddAlgorithm(typeof(CryptoConfigTests), null));
         }
 
         [Fact]

--- a/src/System.Security.Cryptography.Algorithms/tests/CryptoConfigTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/CryptoConfigTests.cs
@@ -36,6 +36,7 @@ namespace System.Security.Cryptography.CryptoConfigTests
         public static void AddOID_EmptyNamesArray()
         {
             CryptoConfig.AddOID("1.3.14.3.2.28", new string[0]);
+            // There is no verifiable behavior in this case. We only check that we don't throw.
         }
 
         [Fact]
@@ -71,6 +72,13 @@ namespace System.Security.Cryptography.CryptoConfigTests
         public static void AddAlgorithm_EmptyString_Throws()
         {
             Assert.Throws<ArgumentException>(null, () => CryptoConfig.AddAlgorithm(typeof(CryptoConfigTests), string.Empty));
+        }
+
+        [Fact]
+        public static void AddAlgorithm_EmptyNamesArray()
+        {
+            CryptoConfig.AddAlgorithm(typeof(AesCryptoServiceProvider), new string[0]);
+            // There is no verifiable behavior in this case. We only check that we don't throw.
         }
 
         [Fact]


### PR DESCRIPTION
This PR implements two methods on the CryptoConfig class that threw PNSE's previously. These are AddOID and AddAlgorithm respectively, which allow application specific mappings.

Fixes #18892