### PR TITLE
Modifying the SNI identity package to pick up the new SNI package names.

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -29,7 +29,7 @@
     <NETStandardPackageVersion>2.0.0-preview1-25228-01</NETStandardPackageVersion>
     <NETStandardPackageId>NETStandard.Library</NETStandardPackageId>
     <!-- Use the SNI runtime package -->
-    <SniPackageVersion>4.4.0-beta-25007-02</SniPackageVersion>
+    <SniPackageVersion>4.4.0-preview1-25301-01</SniPackageVersion>
   </PropertyGroup>
 
   <!-- Full package version strings that are used in other parts of the build. -->

--- a/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/runtime.native.System.Data.SqlClient.sni.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/runtime.native.System.Data.SqlClient.sni.pkgproj
@@ -6,13 +6,13 @@
     <SkipValidatePackage>true</SkipValidatePackage>
   </PropertyGroup>
   <ItemGroup>
-    <Dependency Include="runtime.win7-x64.runtime.native.System.Data.SqlClient.sni">
+    <Dependency Include="runtime.win-x64.runtime.native.System.Data.SqlClient.sni">
       <Version>$(SniPackageVersion)</Version>
     </Dependency>
-    <Dependency Include="runtime.win7-x86.runtime.native.System.Data.SqlClient.sni">
+    <Dependency Include="runtime.win-x86.runtime.native.System.Data.SqlClient.sni">
       <Version>$(SniPackageVersion)</Version>
     </Dependency>
-    <Dependency Include="runtime.win10-arm64.runtime.native.System.Data.SqlClient.sni">
+    <Dependency Include="runtime.win-arm64.runtime.native.System.Data.SqlClient.sni">
       <Version>$(SniPackageVersion)</Version>
     </Dependency>
   </ItemGroup>


### PR DESCRIPTION
Addresses https://github.com/dotnet/corefx/issues/19154

SNI supports RIDs win-{arch} 
This led to package changes for preview1. The updated packages on myget are 
runtime.win-x86.runtime.native.System.Data.SqlClient.sni.4.4.0-preview1-25301-01.nupkg
runtime.win-x64.runtime.native.System.Data.SqlClient.sni.4.4.0-preview1-25301-01.nupkg
runtime.win-arm64.runtime.native.System.Data.SqlClient.sni.4.4.0-preview1-25301-01.nupkg

