### PR TITLE
Handle some Crypto desktop inconsistencies.

### DIFF
--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/AES/AesContractTests.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/AES/AesContractTests.cs
@@ -195,6 +195,7 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "In NetFX AesCryptoServiceProvider requires a set key and throws otherwise. See #19023.")]
         public static void ValidateDecryptorProperties()
         {
             using (Aes aes = AesFactory.Create())

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
@@ -251,7 +251,7 @@ namespace System.Security.Cryptography.Rsa.Tests
                 if (rsa is RSACng && PlatformDetection.IsFullFramework)
                     Assert.Throws<ArgumentException>(() => rsa.ImportParameters(imported));
                 else
-                    Assert.Throws<CryptographicException>(() => rsa.ImportParameters(imported));
+                    Assert.ThrowsAny<CryptographicException>(() => rsa.ImportParameters(imported));
             }
         }
 
@@ -268,7 +268,7 @@ namespace System.Security.Cryptography.Rsa.Tests
                 if (rsa is RSACng && PlatformDetection.IsFullFramework)
                     Assert.Throws<ArgumentException>(() => rsa.ImportParameters(imported));
                 else
-                    Assert.Throws<CryptographicException>(() => rsa.ImportParameters(imported));
+                    Assert.ThrowsAny<CryptographicException>(() => rsa.ImportParameters(imported));
             }
         }
 

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
@@ -248,7 +248,10 @@ namespace System.Security.Cryptography.Rsa.Tests
 
             using (RSA rsa = RSAFactory.Create())
             {
-                Assert.ThrowsAny<CryptographicException>(() => rsa.ImportParameters(imported));
+                if (rsa is RSACng && PlatformDetection.IsFullFramework)
+                    Assert.Throws<ArgumentException>(() => rsa.ImportParameters(imported));
+                else
+                    Assert.Throws<CryptographicException>(() => rsa.ImportParameters(imported));
             }
         }
 
@@ -262,7 +265,10 @@ namespace System.Security.Cryptography.Rsa.Tests
 
             using (RSA rsa = RSAFactory.Create())
             {
-                Assert.ThrowsAny<CryptographicException>(() => rsa.ImportParameters(imported));
+                if (rsa is RSACng && PlatformDetection.IsFullFramework)
+                    Assert.Throws<ArgumentException>(() => rsa.ImportParameters(imported));
+                else
+                    Assert.Throws<CryptographicException>(() => rsa.ImportParameters(imported));
             }
         }
 

--- a/src/System.Security.Cryptography.Algorithms/tests/DefaultRSAProvider.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/DefaultRSAProvider.cs
@@ -51,7 +51,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         public bool SupportsSha2Oaep
         {
             // Currently only RSACng does, which is the default provider on Windows.
-            get { return RuntimeInformation.IsOSPlatform(OSPlatform.Windows); }
+            get { return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !(Create() is RSACryptoServiceProvider); }
         }
     }
 

--- a/src/System.Security.Cryptography.Algorithms/tests/InvalidUsageTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/InvalidUsageTests.cs
@@ -24,6 +24,7 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetFX throws a CryptoException because it lacks boundary checking in the Stream overload. See #19092.")]
         public void InvalidHashCoreArgumentsFromStream()
         {
             using (SHA1 sha1 = SHA1.Create())

--- a/src/System.Security.Cryptography.Algorithms/tests/RSACreateTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/RSACreateTests.cs
@@ -75,7 +75,10 @@ namespace System.Security.Cryptography.Algorithms.Tests
             RSAParameters parameters = TestData.RSA1032Parameters;
             parameters.Exponent = null;
 
-            Assert.Throws<CryptographicException>(() => RSA.Create(parameters));
+            if (RSA.Create() is RSACng && PlatformDetection.IsFullFramework)
+                Assert.Throws<ArgumentException>(() => RSA.Create(parameters));
+            else
+                Assert.Throws<CryptographicException>(() => RSA.Create(parameters));
         }
     }
 }


### PR DESCRIPTION
- RSACng ImportParameters was throwing a CryptoException for null Exponent/Modulus. On NetFX RSACng throws an ArgumentException. The tests were modified to expect CryptoException when the RSA is not full framework and the RSA is not RSACng
- Skip the `ValidateDecryptorProperties` test on netfx because it throws a CryptoException when there isn't a key set before doing the test validation.
- `RSACryptoServiceProvider` doesn't support SHA20aep, so the `DefaultRSAProvider` test helper was modified to return false for `SupportsSha20aep` when the RSA created by the factory is an `RSACryptoServiceProvider`.
- `InvalidHashCoreArgumentsFromStream` is skipped on netfx. Netfx doesn't do argument boundary checking for stream input in ComputeHash which was fixed in netcoreapp.

resolves https://github.com/dotnet/corefx/issues/19042
resolves https://github.com/dotnet/corefx/issues/19023
resolves https://github.com/dotnet/corefx/issues/19092

cc: @bartonjs 