### PR TITLE
Make ECDsa.Create(ECCurve(.IsExplicit)) work on Windows.

### DIFF
--- a/src/Common/src/System/Security/Cryptography/ECDsaCng.cs
+++ b/src/Common/src/System/Security/Cryptography/ECDsaCng.cs
@@ -21,11 +21,7 @@ namespace System.Security.Cryptography
             /// <exception cref="PlatformNotSupportedException">if <paramref name="curve" /> does not contain an Oid with a FriendlyName.</exception>
             public ECDsaCng(ECCurve curve)
             {
-                // FriendlyName is required; an attempt was already made to default it in ECCurve
-                if (string.IsNullOrEmpty(curve.Oid.FriendlyName))
-                    throw new PlatformNotSupportedException(string.Format(SR.Cryptography_InvalidCurveOid, curve.Oid.Value.ToString()));
-
-                // Named curves generate the key immediately
+                // Specified curves generate the key immediately
                 GenerateKey(curve);
             }
 

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/EC/CurveDef.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/EC/CurveDef.cs
@@ -13,13 +13,16 @@ namespace System.Security.Cryptography.EcDsa.Tests
         public int KeySize;
         public bool IncludePrivate;
         public bool RequiredOnPlatform;
+        public string DisplayName;
 
         public bool IsCurveValidOnPlatform
         {
             get
             {
                 // Assume curve is valid if required; tests will fail if not present
-                return RequiredOnPlatform || ECDsaFactory.IsCurveValid(Curve.Oid);
+                return RequiredOnPlatform ||
+                    (Curve.IsNamed && ECDsaFactory.IsCurveValid(Curve.Oid)) ||
+                    (Curve.IsExplicit && ECDsaFactory.ExplicitCurvesSupported);
             }
         }
 
@@ -36,6 +39,24 @@ namespace System.Security.Cryptography.EcDsa.Tests
             }
 
             return false;
+        }
+
+        public override string ToString()
+        {
+            if (Curve.IsNamed)
+                return $"CurveDef Named:({Curve.Oid.Value ?? "(null)"}, {Curve.Oid.FriendlyName ?? "(null)"})";
+
+            if (Curve.IsExplicit)
+            {
+                if (string.IsNullOrEmpty(DisplayName))
+                {
+                    return $"CurveDef Explicit:{Curve.CurveType} - {(Curve.Prime ?? Curve.Polynomial)?.Length}-byte descriptor";
+                }
+
+                return $"CurveDef Explicit:{Curve.CurveType} - {DisplayName}";
+            }
+
+            return "CurveDef (Unknown, edit ToString)";
         }
 #endif
     }

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaImportExport.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaImportExport.cs
@@ -16,8 +16,9 @@ namespace System.Security.Cryptography.EcDsa.Tests
             ECParameters privateParams;
             ECParameters publicParams;
 
-            using (ECDsa ecdsa = ECDsa.Create(toImport))
+            using (ECDsa ecdsa = ECDsaFactory.Create())
             {
+                ecdsa.ImportParameters(toImport);
                 privateParams = ecdsa.ExportParameters(true);
                 publicParams = ecdsa.ExportParameters(false);
             }
@@ -32,6 +33,9 @@ namespace System.Security.Cryptography.EcDsa.Tests
         [MemberData(nameof(TestCurvesFull))]
         public static void TestNamedCurves(CurveDef curveDef)
         {
+            if (!curveDef.Curve.IsNamed)
+                return;
+
             using (ECDsa ec1 = ECDsaFactory.Create(curveDef.Curve))
             {
                 ECParameters param1 = ec1.ExportParameters(curveDef.IncludePrivate);
@@ -51,6 +55,9 @@ namespace System.Security.Cryptography.EcDsa.Tests
         [Theory, MemberData(nameof(TestInvalidCurves))]
         public static void TestNamedCurvesNegative(CurveDef curveDef)
         {
+            if (!curveDef.Curve.IsNamed)
+                return;
+
             // An exception may be thrown during Create() if the Oid is bad, or later during native calls
             Assert.Throws<PlatformNotSupportedException>(() => ECDsaFactory.Create(curveDef.Curve).ExportParameters(false));
         }
@@ -261,11 +268,12 @@ namespace System.Security.Cryptography.EcDsa.Tests
         private static void VerifyNamedCurve(ECParameters parameters, ECDsa ec, int keySize, bool includePrivate)
         {
             parameters.Validate();
-            Assert.True(parameters.Curve.IsNamed);
+            Assert.True(parameters.Curve.IsNamed, "parameters.Curve.IsNamed");
             Assert.Equal(keySize, ec.KeySize);
             Assert.True(
                 includePrivate && parameters.D.Length > 0 ||
-                !includePrivate && parameters.D == null);
+                !includePrivate && parameters.D == null,
+                "Private key is " + (includePrivate ? "present" : "absent"));
 
             if (includePrivate)
                 ec.Exercise();
@@ -280,7 +288,6 @@ namespace System.Security.Cryptography.EcDsa.Tests
         {
             Assert.True(parameters.Curve.IsExplicit);
             ECCurve curve = parameters.Curve;
-
 
             Assert.True(curveDef.IsCurveTypeEqual(curve.CurveType));
             Assert.True(

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTests.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTests.cs
@@ -73,7 +73,8 @@ namespace System.Security.Cryptography.EcDsa.Tests
                     // Specify different curve than current
                     if (param.Curve.IsPrime)
                     {
-                        if (curveDef.Curve.Oid.FriendlyName != ECCurve.NamedCurves.nistP256.Oid.FriendlyName)
+                        if (curveDef.Curve.IsNamed &&
+                            curveDef.Curve.Oid.FriendlyName != ECCurve.NamedCurves.nistP256.Oid.FriendlyName)
                         {
                             // Specify different curve (nistP256) by explicit value
                             newEc.GenerateKey(ECCurve.NamedCurves.nistP256);
@@ -185,6 +186,9 @@ namespace System.Security.Cryptography.EcDsa.Tests
         [MemberData(nameof(TestCurves))]
         public void TestChangeFromNamedCurveToKeySize(CurveDef curveDef)
         {
+            if (!curveDef.Curve.IsNamed)
+                return;
+
             using (ECDsa ec = ECDsaFactory.Create(curveDef.Curve))
             {
                 ECParameters param = ec.ExportParameters(false);

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTestsBase.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTestsBase.cs
@@ -154,6 +154,13 @@ namespace System.Security.Cryptography.EcDsa.Tests
                     KeySize = 160,
                     CurveType = ECCurve.ECCurveType.PrimeShortWeierstrass,
                 };
+                yield return new CurveDef
+                {
+                    Curve = ECDsaTestData.GetNistP256ExplicitCurve(),
+                    KeySize = 256,
+                    CurveType = ECCurve.ECCurveType.PrimeShortWeierstrass,
+                    DisplayName = "NIST P-256",
+                };
             }
         }
 

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDsaCng.Key.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDsaCng.Key.cs
@@ -82,6 +82,9 @@ namespace System.Security.Cryptography
 
                 if (curve.IsNamed)
                 {
+                    if (string.IsNullOrEmpty(curve.Oid.FriendlyName))
+                        throw new PlatformNotSupportedException(string.Format(SR.Cryptography_InvalidCurveOid, curve.Oid.Value));
+
                     // Map curve name to algorithm to support pre-Win10 curves
                     algorithm = ECCng.EcdsaCurveNameToAlgorithm(curve.Oid.FriendlyName);
                     if (IsECNamedCurve(algorithm))

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/ECDsaCng.Key.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/ECDsaCng.Key.cs
@@ -46,6 +46,9 @@ namespace System.Security.Cryptography
 
             if (curve.IsNamed)
             {
+                if (string.IsNullOrEmpty(curve.Oid.FriendlyName))
+                    throw new PlatformNotSupportedException(string.Format(SR.Cryptography_InvalidCurveOid, curve.Oid.Value));
+
                 // Map curve name to algorithm to support pre-Win10 curves
                 CngAlgorithm alg = CngKey.EcdsaCurveNameToAlgorithm(curve.Oid.FriendlyName);
                 if (CngKey.IsECNamedCurve(alg.Algorithm))


### PR DESCRIPTION
ECDsa.Create(ECCurve) had a check which rightly belonged in GenerateKey
behind an IsNamed check.  Moved that check to where it belonged, and added
an Explicit (PrimeShortWeierstrass) test to the big create matrix.

Adding the test resulted in debugging several tests which were assuming IsNamed.
The extra debugging data seemed generally applicable, so it remains.

Fixes the `NullReferenceException` reported in #19168.