### PR TITLE
Change SkipOnTargetFramework for Issue 18052

### DIFF
--- a/src/System.Runtime/tests/System/GuidTests.cs
+++ b/src/System.Runtime/tests/System/GuidTests.cs
@@ -161,7 +161,7 @@ namespace System.Tests
         }
 
         [Theory]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp, "The coreclr fixed a bug where Guid.TryParse throws a format or overflow exception (https://github.com/dotnet/corefx/issues/6316)")]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "The coreclr fixed a bug where Guid.TryParse throws a format or overflow exception (https://github.com/dotnet/corefx/issues/6316)")]
         [MemberData(nameof(GuidStrings_TryParseThrows_TestData))]
         public static void Parse_Invalid_Netfx(string input, Type exceptionType)
         {


### PR DESCRIPTION
Change
 [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp, "The coreclr fixed a bug where Guid.TryParse throws a format or overflow exception (https://github.com/dotnet/corefx/issues/6316)")] 

to
 [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework,"The coreclr fixed a bug where Guid.TryParse throws a format or overflow exception (https://github.com/dotnet/corefx/issues/6316)")] 

for method Parse_Invalid_Netfx() in GuidTests.cs under System.Runtime.Tests.
