### PR TITLE
lowercase another assembly name

### DIFF
--- a/src/System.Reflection/tests/AssemblyNameTests.cs
+++ b/src/System.Reflection/tests/AssemblyNameTests.cs
@@ -184,8 +184,11 @@ namespace System.Reflection.Tests
         {
             AssemblyName assemblyName = new AssemblyName(name);
 
-            string extended = $"{expectedName}, Culture=neutral, PublicKeyToken=null";
-            Assert.True(assemblyName.FullName == expectedName || assemblyName.FullName == extended);
+            expectedName = expectedName.ToLowerInvariant();
+            string extended = $"{expectedName}, Culture=neutral, PublicKeyToken=null".ToLowerInvariant();
+            string afn = assemblyName.FullName.ToLowerInvariant();
+
+            Assert.True(afn == expectedName || afn == extended, $"Expected\n{afn} == {expectedName}\nor\n{afn} == {extended}");
         }
 
         [Fact]


### PR DESCRIPTION
Akin to https://github.com/dotnet/corefx/pull/19178 .. the initial casing is persisted so we don't guarantee casing matches. Not sure why I didn't see this last time.