### PR TITLE
Enable Environment.Exit tests.

### DIFF
--- a/external/runtime/runtime.depproj
+++ b/external/runtime/runtime.depproj
@@ -37,10 +37,10 @@
       <Version>4.4.0-$(CoreFxExpectedPrerelease)</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.DotNetHost">
-      <Version>1.2.0-beta-001259-00</Version>
+      <Version>2.0.0-preview2-25310-02</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.DotNetHostPolicy">
-      <Version>1.2.0-beta-001259-00</Version>
+      <Version>2.0.0-preview2-25310-02</Version>
     </PackageReference>
   </ItemGroup>
 

--- a/src/System.Runtime.Extensions/tests/System/Environment.Exit.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.Exit.cs
@@ -59,15 +59,15 @@ namespace System.Tests
 
             const string AppName = "VoidMainWithExitCodeApp.exe";
             var psi = new ProcessStartInfo();
-            if (File.Exists(HostRunner))
-            {
-                psi.FileName = HostRunner;
-                psi.Arguments = $"{AppName} {expectedExitCode} {mode}";
-            }
-            else
+            if (IsFullFramework || IsNetNative)
             {
                 psi.FileName = AppName;
                 psi.Arguments = $"{expectedExitCode} {mode}";
+            }
+            else
+            {
+                psi.FileName = HostRunner;
+                psi.Arguments = $"{AppName} {expectedExitCode} {mode}";
             }
 
             using (Process p = Process.Start(psi))

--- a/src/System.Runtime.Extensions/tests/System/Environment.Exit.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.Exit.cs
@@ -49,7 +49,6 @@ namespace System.Tests
             Environment.ExitCode = 0; // in case the test host has a void returning Main
         }
 
-        [ActiveIssue("https://github.com/dotnet/coreclr/issues/6206")]
         [Theory]
         [InlineData(1)] // setting ExitCode and exiting Main
         [InlineData(2)] // setting ExitCode both from Main and from an Unloading event handler.

--- a/src/System.Runtime.Extensions/tests/VoidMainWithExitCodeApp/VoidMainWithExitCodeApp.csproj
+++ b/src/System.Runtime.Extensions/tests/VoidMainWithExitCodeApp/VoidMainWithExitCodeApp.csproj
@@ -17,6 +17,9 @@
     <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAssemblyAttribute.cs">
       <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAssemblyAttribute.cs</Link>
     </Compile>
+    <Content Include="VoidMainWithExitCodeApp.runtimeconfig.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime.Extensions/tests/VoidMainWithExitCodeApp/VoidMainWithExitCodeApp.csproj
+++ b/src/System.Runtime.Extensions/tests/VoidMainWithExitCodeApp/VoidMainWithExitCodeApp.csproj
@@ -20,6 +20,9 @@
     <Content Include="VoidMainWithExitCodeApp.runtimeconfig.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="VoidMainWithExitCodeApp.exe.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime.Extensions/tests/VoidMainWithExitCodeApp/VoidMainWithExitCodeApp.exe.config
+++ b/src/System.Runtime.Extensions/tests/VoidMainWithExitCodeApp/VoidMainWithExitCodeApp.exe.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <developmentMode developerInstallation="true" />
+  </runtime>
+</configuration>

--- a/src/System.Runtime.Extensions/tests/VoidMainWithExitCodeApp/VoidMainWithExitCodeApp.runtimeconfig.json
+++ b/src/System.Runtime.Extensions/tests/VoidMainWithExitCodeApp/VoidMainWithExitCodeApp.runtimeconfig.json
@@ -1,0 +1,8 @@
+{
+	"runtimeOptions": {
+		"framework": {
+			"name": "Microsoft.NETCore.App",
+			"version": "9.9.9"
+		}
+	}
+}


### PR DESCRIPTION
Since Environment.Exit bug has been fixed in both coreclr and core-setup, this PR enables the tests in corefx repo.

Related issue:
https://github.com/dotnet/coreclr/issues/6206#issuecomment-295339778
https://github.com/dotnet/core-setup/issues/2050

Fix #18776