### PR TITLE
Add missing usings in CopyWithPrivateKey

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/DSACertificateExtensions.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/DSACertificateExtensions.cs
@@ -39,20 +39,21 @@ namespace System.Security.Cryptography.X509Certificates
             if (certificate.HasPrivateKey)
                 throw new InvalidOperationException(SR.Cryptography_Cert_AlreadyHasPrivateKey);
 
-            DSA publicKey = GetDSAPublicKey(certificate);
-
-            if (publicKey == null)
-                throw new ArgumentException(SR.Cryptography_PrivateKey_WrongAlgorithm);
-
-            DSAParameters currentParameters = publicKey.ExportParameters(false);
-            DSAParameters newParameters = privateKey.ExportParameters(false);
-
-            if (!currentParameters.G.ContentsEqual(newParameters.G) ||
-                !currentParameters.P.ContentsEqual(newParameters.P) ||
-                !currentParameters.Q.ContentsEqual(newParameters.Q) ||
-                !currentParameters.Y.ContentsEqual(newParameters.Y))
+            using (DSA publicKey = GetDSAPublicKey(certificate))
             {
-                throw new ArgumentException(SR.Cryptography_PrivateKey_DoesNotMatch, nameof(privateKey));
+                if (publicKey == null)
+                    throw new ArgumentException(SR.Cryptography_PrivateKey_WrongAlgorithm);
+
+                DSAParameters currentParameters = publicKey.ExportParameters(false);
+                DSAParameters newParameters = privateKey.ExportParameters(false);
+
+                if (!currentParameters.G.ContentsEqual(newParameters.G) ||
+                    !currentParameters.P.ContentsEqual(newParameters.P) ||
+                    !currentParameters.Q.ContentsEqual(newParameters.Q) ||
+                    !currentParameters.Y.ContentsEqual(newParameters.Y))
+                {
+                    throw new ArgumentException(SR.Cryptography_PrivateKey_DoesNotMatch, nameof(privateKey));
+                }
             }
 
             ICertificatePal pal = certificate.Pal.CopyWithPrivateKey(privateKey);

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/ECDsaCertificateExtensions.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/ECDsaCertificateExtensions.cs
@@ -40,14 +40,15 @@ namespace System.Security.Cryptography.X509Certificates
             if (certificate.HasPrivateKey)
                 throw new InvalidOperationException(SR.Cryptography_Cert_AlreadyHasPrivateKey);
 
-            ECDsa publicKey = GetECDsaPublicKey(certificate);
-
-            if (publicKey == null)
-                throw new ArgumentException(SR.Cryptography_PrivateKey_WrongAlgorithm);
-
-            if (!IsSameKey(publicKey, privateKey))
+            using (ECDsa publicKey = GetECDsaPublicKey(certificate))
             {
-                throw new ArgumentException(SR.Cryptography_PrivateKey_DoesNotMatch, nameof(privateKey));
+                if (publicKey == null)
+                    throw new ArgumentException(SR.Cryptography_PrivateKey_WrongAlgorithm);
+
+                if (!IsSameKey(publicKey, privateKey))
+                {
+                    throw new ArgumentException(SR.Cryptography_PrivateKey_DoesNotMatch, nameof(privateKey));
+                }
             }
 
             ICertificatePal pal = certificate.Pal.CopyWithPrivateKey(privateKey);

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/RSACertificateExtensions.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/RSACertificateExtensions.cs
@@ -39,18 +39,19 @@ namespace System.Security.Cryptography.X509Certificates
             if (certificate.HasPrivateKey)
                 throw new InvalidOperationException(SR.Cryptography_Cert_AlreadyHasPrivateKey);
 
-            RSA publicKey = GetRSAPublicKey(certificate);
-
-            if (publicKey == null)
-                throw new ArgumentException(SR.Cryptography_PrivateKey_WrongAlgorithm);
-
-            RSAParameters currentParameters = publicKey.ExportParameters(false);
-            RSAParameters newParameters = privateKey.ExportParameters(false);
-
-            if (!currentParameters.Modulus.ContentsEqual(newParameters.Modulus) ||
-                !currentParameters.Exponent.ContentsEqual(newParameters.Exponent))
+            using (RSA publicKey = GetRSAPublicKey(certificate))
             {
-                throw new ArgumentException(SR.Cryptography_PrivateKey_DoesNotMatch, nameof(privateKey));
+                if (publicKey == null)
+                    throw new ArgumentException(SR.Cryptography_PrivateKey_WrongAlgorithm);
+
+                RSAParameters currentParameters = publicKey.ExportParameters(false);
+                RSAParameters newParameters = privateKey.ExportParameters(false);
+
+                if (!currentParameters.Modulus.ContentsEqual(newParameters.Modulus) ||
+                    !currentParameters.Exponent.ContentsEqual(newParameters.Exponent))
+                {
+                    throw new ArgumentException(SR.Cryptography_PrivateKey_DoesNotMatch, nameof(privateKey));
+                }
             }
 
             ICertificatePal pal = certificate.Pal.CopyWithPrivateKey(privateKey);


### PR DESCRIPTION
All three overloads of CopyWithPrivateKey created a public key object and
let it die off to the GC/Finalizer.  This adds the usings that should have been
there the whole time.