### PR TITLE
Fix Async DeflateStream tests for netfx

### DIFF
--- a/src/System.IO.Compression/tests/DeflateStreamTests.cs
+++ b/src/System.IO.Compression/tests/DeflateStreamTests.cs
@@ -833,6 +833,11 @@ namespace System.IO.Compression.Tests
             isSync = sync;
         }
 
+        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state) => TaskToApm.Begin(ReadAsync(buffer, offset, count), callback, state);
+        public override int EndRead(IAsyncResult asyncResult) => TaskToApm.End<int>(asyncResult);
+        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state) => TaskToApm.Begin(WriteAsync(buffer, offset, count), callback, state);
+        public override void EndWrite(IAsyncResult asyncResult) => TaskToApm.End(asyncResult);
+
         public override async Task<int> ReadAsync(byte[] array, int offset, int count, CancellationToken cancellationToken)
         {
             ReadHit = true;

--- a/src/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
+++ b/src/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
@@ -48,6 +48,9 @@
     <Compile Include="$(CommonTestPath)\System\IO\Compression\ZipTestHelper.cs">
       <Link>Common\System\IO\Compression\ZipTestHelper.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Threading\Tasks\TaskToApm.cs">
+      <Link>Common\System\Threading\Tasks\TaskToApm.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
       <Compile Include="ZipArchive\zip_netcoreappTests.cs" />


### PR DESCRIPTION
On NetFX the async Write and Read methods call Stream's versions which wrap around the underlying stream's non-sync Read and Write methods. In netcoreapp this was fixed to have the underlying stream's async methods called instead. I modified the overlap tests to accomodate the netfx style.

resolves https://github.com/dotnet/corefx/issues/18263