### PR TITLE
Fix 96 failing tests in S.L.Expressions.Tests

### DIFF
--- a/src/System.Linq.Expressions/tests/DelegateType/DelegateCreationTests.cs
+++ b/src/System.Linq.Expressions/tests/DelegateType/DelegateCreationTests.cs
@@ -26,7 +26,7 @@ namespace System.Linq.Expressions.Tests
         {
             for (int i = 1; i <= (includesReturnType ? 17 : 16); ++i)
             {
-                yield return new object[] { Enumerable.Repeat(typeof(List<>), i).ToArray() };
+                yield return new object[] { Enumerable.Repeat(typeof(List<>).MakeGenericType(typeof(List<>).GetGenericArguments()), i).ToArray() };
             }
         }
 


### PR DESCRIPTION
This subclass of tests was trying to instantiate
a generic type over a generic type definition (List<>). On
the full framework, this nonsensical request is allowed -
presumably because of another desktop quirk: the Type
representation for List<> (the type definition) is identical
to that of List<T> (List<> instantiated using its own generic
parameter as the type argument.)

.NET Native chose to evolve itself past
this way back in the days of .NETCore 1.0
(keeping the old behavior would have caused
many problems using the .NET Core Reflection
subset api) and we've yet to find a real world
reason to reintroduce it.

The fix is for the test to create
an actual generic instantiation instead
of relying on the desktop quirk. (Also
switching to a test-defined type to
sidestep more rd.xml issues.)

There's a separate fix out for
MakeGenericType() on .Net Native to
do this transformation, but that
alone isn't sufficient to fix this particular
test (as it's also doing comparisons
on th type afterward.)