### PR TITLE
Clean up X509Certificates test conditions

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
@@ -11,10 +11,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 {
     public static class ChainTests
     {
-        // #9293: Our Fedora and Ubuntu CI machines use NTFS for "tmphome", which causes our filesystem permissions checks to fail.
-        internal static bool IsReliableInCI { get; } =
-            !PlatformDetection.IsFedora &&
-            (!PlatformDetection.IsUbuntu || PlatformDetection.IsUbuntu1404);
+        internal static bool CanModifyStores { get; } = TestEnvironmentConfiguration.CanModifyStores;
 
         private static bool TrustsMicrosoftDotComRoot
         {
@@ -125,7 +122,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [PlatformSpecific(TestPlatforms.AnyUnix)]
-        [ConditionalFact(nameof(IsReliableInCI))]
+        [ConditionalFact(nameof(CanModifyStores))]
         public static void VerifyChainFromHandle_Unix()
         {
             using (var microsoftDotCom = new X509Certificate2(TestData.MicrosoftDotComSslCertBytes))
@@ -414,7 +411,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
-        [ConditionalFact(nameof(TrustsMicrosoftDotComRoot), nameof(IsReliableInCI))]
+        [ConditionalFact(nameof(TrustsMicrosoftDotComRoot), nameof(CanModifyStores))]
         [OuterLoop(/* Modifies user certificate store */)]
         public static void BuildChain_MicrosoftDotCom_WithRootCertInUserAndSystemRootCertStores()
         {

--- a/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
@@ -44,6 +44,7 @@
     <Compile Include="PublicKeyTests.cs" />
     <Compile Include="RSAOther.cs" />
     <Compile Include="TestData.cs" />
+    <Compile Include="TestEnvironmentConfiguration.cs" />
     <Compile Include="X500DistinguishedNameEncodingTests.cs" />
     <Compile Include="X500DistinguishedNameTests.cs" />
     <Compile Include="X509StoreMutableTests.OSX.cs" />
@@ -78,12 +79,22 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetPwUid.cs">
       <Link>Common\Interop\Unix\Interop.GetPwUid.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.FChMod.cs">
+      <Link>Common\Interop\Unix\System.Native\Interop.FChMod.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Permissions.cs">
+      <Link>Common\Interop\Unix\System.Native\Interop.Permissions.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Stat.cs">
+      <Link>Common\Interop\Unix\System.Native\Interop.Stat.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\IO\PersistedFiles.Unix.cs">
       <Link>Common\System\IO\PersistedFiles.Unix.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\IO\PersistedFiles.Names.Unix.cs">
       <Link>Common\System\IO\PersistedFiles.Names.Unix.cs</Link>
     </Compile>
+    <Compile Include="TestEnvironmentConfiguration.Unix.cs" />
   </ItemGroup>
   <ItemGroup>
     <SupplementalTestData Include="$(PackagesDir)system.security.cryptography.x509certificates.testdata\1.0.2-prerelease\content\**\*.*" />

--- a/src/System.Security.Cryptography.X509Certificates/tests/TestEnvironmentConfiguration.Unix.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/TestEnvironmentConfiguration.Unix.cs
@@ -1,0 +1,111 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+
+namespace System.Security.Cryptography.X509Certificates.Tests
+{
+    internal static partial class TestEnvironmentConfiguration
+    {
+        static partial void DetermineCanModifyStores(ref bool canModify)
+        {
+            try
+            {
+                canModify = DetermineCanModifyStores();
+            }
+            catch
+            {
+                // This is a little counterintuitive. If the capability probe fails,
+                // assert that the feature works.  Then we'll hopefully get diagnosable
+                // errors out of the test failures.
+                canModify = true;
+            }
+        }
+
+        private static bool DetermineCanModifyStores()
+        {
+            // Check the directory permissions and whether the filesystem supports chmod.
+            // The only real expected failure from this method is that at the very end
+            // `stat.Mode == mode` will fail, because fuseblk (NTFS) returns success on chmod,
+            // but is a no-op.
+
+            uint userId = Interop.Sys.GetEUid();
+            string certStoresFeaturePath = PersistedFiles.GetUserFeatureDirectory("cryptography", "x509stores");
+
+            Directory.CreateDirectory(certStoresFeaturePath);
+
+            // Check directory permissions:
+
+            Interop.Sys.FileStatus dirStat;
+            if (Interop.Sys.Stat(certStoresFeaturePath, out dirStat) != 0)
+            {
+                return false;
+            }
+
+            if (dirStat.Uid != userId)
+            {
+                return false;
+            }
+
+            if ((dirStat.Mode & (int)Interop.Sys.Permissions.S_IRWXU) != (int)Interop.Sys.Permissions.S_IRWXU)
+            {
+                return false;
+            }
+
+            string probeFilename =
+                Path.Combine(certStoresFeaturePath, $"{Guid.NewGuid().ToString("N")}.chmod");
+
+            try
+            {
+                using (FileStream stream = new FileStream(probeFilename, FileMode.Create))
+                {
+                    Interop.Sys.FileStatus stat;
+                    if (Interop.Sys.FStat(stream.SafeFileHandle, out stat) != 0)
+                    {
+                        return false;
+                    }
+
+                    if (stat.Uid != userId)
+                    {
+                        return false;
+                    }
+
+                    // The product code here has a lot of stuff it does.
+                    // This capabilities probe will just check that chmod works.
+                    int mode = stat.Mode;
+
+                    // Flip all of the O bits.
+                    mode ^= (int)Interop.Sys.Permissions.S_IRWXO;
+
+                    if (Interop.Sys.FChMod(stream.SafeFileHandle, mode) < 0)
+                    {
+                        return false;
+                    }
+
+                    // Verify the chmod applied.
+                    if (Interop.Sys.FStat(stream.SafeFileHandle, out stat) != 0)
+                    {
+                        return false;
+                    }
+
+                    // On fuseblk (NTFS) this will return false, because the fchmod
+                    // call returned success without being able to actually apply
+                    // mode-bits.
+                    return stat.Mode == mode;
+                }
+            }
+            finally
+            {
+                try
+                {
+                    File.Delete(probeFilename);
+                }
+                catch
+                {
+                    // Ignore any failure on delete.
+                }
+            }
+        }
+    }
+}

--- a/src/System.Security.Cryptography.X509Certificates/tests/TestEnvironmentConfiguration.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/TestEnvironmentConfiguration.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Cryptography.X509Certificates.Tests
+{
+    internal static partial class TestEnvironmentConfiguration
+    {
+        internal static bool CanModifyStores { get; }
+
+        internal static bool RunManualTests { get; } =
+            !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CRYPTOGRAPHY_MANUAL_TESTS"));
+
+        static TestEnvironmentConfiguration()
+        {
+            bool canModifyStores = true;
+            DetermineCanModifyStores(ref canModifyStores);
+            CanModifyStores = canModifyStores;
+        }
+
+        static partial void DetermineCanModifyStores(ref bool canModify);
+    }
+}

--- a/src/System.Security.Cryptography.X509Certificates/tests/X509FilesystemTests.Unix.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X509FilesystemTests.Unix.cs
@@ -15,12 +15,14 @@ namespace System.Security.Cryptography.X509Certificates.Tests
     [Collection("X509Filesystem")]
     public static class X509FilesystemTests
     {
-        // #9293: Our Fedora and Ubuntu1610 CI machines use NTFS for "tmphome", which causes our filesystem permissions checks to fail.
-        private static bool IsReliableInCI { get; } = ChainTests.IsReliableInCI;
+        private static bool CanModifyStores { get; } = TestEnvironmentConfiguration.CanModifyStores;
+        private static bool RunManualTests { get; } = TestEnvironmentConfiguration.RunManualTests;
 
-        [ActiveIssue(12833, TestPlatforms.AnyUnix)]
-        [Fact]
         [OuterLoop]
+        // This test is a bit too flaky to be on in the normal run, even for OuterLoop.
+        // It can fail due to networking problems, and due to the filesystem interactions it doesn't
+        // have strong isolation from other tests (even in different processes).
+        [ConditionalFact(nameof(RunManualTests))]
         public static void VerifyCrlCache()
         {
             string crlDirectory = PersistedFiles.GetUserFeatureDirectory("cryptography", "crls");
@@ -124,7 +126,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 });
         }
 
-        [ConditionalFact(nameof(IsReliableInCI))]
+        [ConditionalFact(nameof(CanModifyStores))]
         [OuterLoop(/* Alters user/machine state */)]
         private static void X509Store_AddOne()
         {
@@ -155,7 +157,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 });
         }
 
-        [ConditionalFact(nameof(IsReliableInCI))]
+        [ConditionalFact(nameof(CanModifyStores))]
         [OuterLoop(/* Alters user/machine state */)]
         private static void X509Store_AddOneAfterUpgrade()
         {
@@ -195,7 +197,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 });
         }
 
-        [ConditionalFact(nameof(IsReliableInCI))]
+        [ConditionalFact(nameof(CanModifyStores))]
         [OuterLoop(/* Alters user/machine state */)]
         private static void X509Store_DowngradePermissions()
         {
@@ -218,7 +220,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 });
         }
 
-        [ConditionalFact(nameof(IsReliableInCI))]
+        [ConditionalFact(nameof(CanModifyStores))]
         [OuterLoop(/* Alters user/machine state */)]
         private static void X509Store_AddAfterDispose()
         {
@@ -241,7 +243,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 });
         }
 
-        [ConditionalFact(nameof(IsReliableInCI))]
+        [ConditionalFact(nameof(CanModifyStores))]
         [OuterLoop(/* Alters user/machine state */)]
         private static void X509Store_AddAndClear()
         {
@@ -265,7 +267,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 });
         }
 
-        [ConditionalFact(nameof(IsReliableInCI))]
+        [ConditionalFact(nameof(CanModifyStores))]
         [OuterLoop(/* Alters user/machine state */)]
         private static void X509Store_AddDuplicate()
         {
@@ -287,7 +289,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 });
         }
 
-        [ConditionalFact(nameof(IsReliableInCI))]
+        [ConditionalFact(nameof(CanModifyStores))]
         [OuterLoop(/* Alters user/machine state */)]
         private static void X509Store_AddTwo()
         {
@@ -318,7 +320,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 });
         }
 
-        [ConditionalFact(nameof(IsReliableInCI))]
+        [ConditionalFact(nameof(CanModifyStores))]
         [OuterLoop(/* Alters user/machine state */)]
         private static void X509Store_AddTwo_UpgradePrivateKey()
         {
@@ -380,7 +382,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 });
         }
 
-        [ConditionalFact(nameof(IsReliableInCI))]
+        [ConditionalFact(nameof(CanModifyStores))]
         [OuterLoop(/* Alters user/machine state */)]
         private static void X509Store_AddTwo_UpgradePrivateKey_NoDowngrade()
         {
@@ -440,7 +442,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 });
         }
 
-        [ConditionalFact(nameof(IsReliableInCI))]
+        [ConditionalFact(nameof(CanModifyStores))]
         [OuterLoop(/* Alters user/machine state */)]
         private static void X509Store_DistinctCollections()
         {
@@ -481,7 +483,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 });
         }
 
-        [ConditionalFact(nameof(IsReliableInCI))]
+        [ConditionalFact(nameof(CanModifyStores))]
         [OuterLoop(/* Alters user/machine state */)]
         private static void X509Store_Add4_Remove1()
         {
@@ -530,7 +532,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 });
         }
 
-        [ConditionalTheory(nameof(IsReliableInCI))]
+        [ConditionalTheory(nameof(CanModifyStores))]
         [OuterLoop(/* Alters user/machine state */)]
         [InlineData(false)]
         [InlineData(true)]
@@ -577,7 +579,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 });
         }
 
-        [ConditionalFact(nameof(IsReliableInCI))]
+        [ConditionalFact(nameof(CanModifyStores))]
         [OuterLoop( /* Alters user/machine state */)]
         private static void X509Store_FiltersDuplicateOnLoad()
         {


### PR DESCRIPTION
A hacky capability, `IsReliableInCI`, was created to overcome test failures during
the final days of .NET Core 1.0 when a new configuration came online with a
CI tmphome on a fuseblk (NTFS) volume instead of an EXT volume. The
infrastructure bug has survived longer than anticipated and the capability is
continually updated as new configurations encounter the problem.

The capability is very loosely structured, and that is costing us test coverage.
Our Helix machines are believed to not have the same limitation, so they
could run the tests.  A private Ubuntu 16.04 stock machine won't have the
limitations, and could run the tests.  Only in our CI system does it actually fail.

This change introduces a new class, TestEnvironmentConfiguration, which
has a partial method to determine the baseline chmod requirements of the
persisted files store to assess that the tests won't make sense to run, and the
`IsReliableInCI` condition has been renamed to `CanModifyStores`.

In order to not have TestEnvironmentConfiguration be a one-trick-pony the
change also introduces a `RunManualTests` value to allow for those tests
which are not even OuterLoop-reliable to be opted into. Painting a method
as a manual test is hoped to not be a very common occurrence, but it is
occasionally valueable to indicate that a test is present, but not running.