### PR TITLE
Re-enable managed SNI by default in SqlClient

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectFactory.Windows.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectFactory.Windows.cs
@@ -13,13 +13,9 @@ namespace System.Data.SqlClient
 
         public static readonly TdsParserStateObjectFactory Singleton = new TdsParserStateObjectFactory();
 
-
-        // Temporary disabling App Context switching for managed SNI.
         // If the appcontext switch is set then Use Managed SNI based on the value. Otherwise Managed SNI should always be used.
-        //private static bool shouldUseLegacyNetorking;
-        //public static bool UseManagedSNI { get; } = AppContext.TryGetSwitch(UseLegacyNetworkingOnWindows, out shouldUseLegacyNetorking) ? !shouldUseLegacyNetorking : true;
-
-        public static bool UseManagedSNI { get; } = false;
+        private static bool shouldUseLegacyNetorking;
+        public static bool UseManagedSNI { get; } = AppContext.TryGetSwitch(UseLegacyNetworkingOnWindows, out shouldUseLegacyNetorking) ? !shouldUseLegacyNetorking : true;
 
         public EncryptionOptions EncryptionOptions
         {


### PR DESCRIPTION
EntityFramework test failures in https://github.com/dotnet/corefx/issues/19057 have been resolved (aside from occasional command timeouts), so re-enabling SqlClient managed SNI by default in master
