### PR TITLE
    Adding a test for dynamic calls through InternalsVisibleTo. (Bug:dotnet/coreclr#7103)

### DIFF
--- a/src/Microsoft.CSharp/tests/RuntimeBinderTests.cs
+++ b/src/Microsoft.CSharp/tests/RuntimeBinderTests.cs
@@ -3,7 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.CompilerServices;
 using Xunit;
+
+// IVT to "Microsoft.CSharp.RuntimeBinder.Binder", just to use IVT in a test (see: InternalsVisibleToTest below)
+[assembly: InternalsVisibleTo("Microsoft.CSharp, PublicKey = 002400000480000094000000060200000024000052534131000400000100010007D1FA57C4AED9F0A32E84AA0FAEFD0DE9E8FD6AEC8F87FB03766C834C99921EB23BE79AD9D5DCC1DD9AD236132102900B723CF980957FC4E177108FC607774F29E8320E92EA05ECE4E821C0A5EFE8F1645C4C0C93C1AB99285D622CAA652C1DFAD63D745D6F2DE5F17E5EAF0FC4963D261C8A12436518206DC093344D5AD293")]
 
 namespace Microsoft.CSharp.RuntimeBinder.Tests
 {
@@ -51,5 +55,60 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
             h.Assign(2);
             Assert.Equal(2, h.Value<int>());
         }
+
+        private static class MySite
+        {
+            public static CallSite<Action<CallSite, object>> mySite;
+        }
+
+        public class Class1
+        {
+            public static string Result = null;
+
+            internal void Foo()
+            {
+                Result += "CALLED";
+            }
+        }
+
+        // https://github.com/dotnet/coreclr/issues/7103
+        [Fact]
+        public void InternalsVisibleToTest()
+        {
+            Class1 typed = new Class1();
+
+            // make a callsite as if it is contained inside "Microsoft.CSharp.RuntimeBinder.RuntimeBinderException"
+            MySite.mySite = CallSite<Action<CallSite, object>>.Create(Microsoft.CSharp.RuntimeBinder.Binder.InvokeMember(
+                CSharpBinderFlags.ResultDiscarded,
+                "Foo",
+                null,
+                typeof(Microsoft.CSharp.RuntimeBinder.RuntimeBinderException),
+                new CSharpArgumentInfo[]
+                {
+                    CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)
+                }));
+
+            MySite.mySite.Target(MySite.mySite, typed);
+
+            // call should suceed becasue of the IVT to Microsoft.CSharp
+            Assert.Equal("CALLED", Class1.Result);
+
+            // make a callsite as if it is contained inside "System.Exception"
+            MySite.mySite = CallSite<Action<CallSite, object>>.Create(Microsoft.CSharp.RuntimeBinder.Binder.InvokeMember(
+                CSharpBinderFlags.ResultDiscarded,
+                "Foo",
+                null,
+                typeof(System.Exception),
+                new CSharpArgumentInfo[]
+                {
+                    CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)
+                }));
+
+            // call should fail because "Foo" is internal to the calling context.
+            Assert.Throws<Microsoft.CSharp.RuntimeBinder.RuntimeBinderException>(
+                                                            () => MySite.mySite.Target(MySite.mySite, typed)
+                                                         );
+        }
+
     }
 }


### PR DESCRIPTION
It appears that the bug has been fixed   
(most likely by https://github.com/dotnet/corefx/commit/501c2632493796ba50b43ec06d2e930cd556fc23)

Closes:https://github.com/dotnet/coreclr/issues/7103