### PR TITLE
System.Globalization.Calendars - fix Random instances shared across threads

### DIFF
--- a/src/System.Globalization.Calendars/tests/GregorianCalendar/GregorianCalendarIsLeapDay.cs
+++ b/src/System.Globalization.Calendars/tests/GregorianCalendar/GregorianCalendarIsLeapDay.cs
@@ -11,8 +11,6 @@ namespace System.Globalization.Tests
 {
     public class GregorianCalendarIsLeapDay
     {
-        private static readonly RandomDataGenerator s_randomDataGenerator = new RandomDataGenerator();
-
         public static IEnumerable<object[]> IsLeapDay_TestData()
         {
             int randomYear = RandomYear();

--- a/src/System.Globalization.Calendars/tests/GregorianCalendar/GregorianCalendarTests.Utilities.cs
+++ b/src/System.Globalization.Calendars/tests/GregorianCalendar/GregorianCalendarTests.Utilities.cs
@@ -7,19 +7,9 @@ namespace System.Globalization.Tests
     public class GregorianCalendarTestUtilities
     {
         [ThreadStatic]
-        private static RandomDataGenerator s_randomDataGenerator;
+        private static RandomDataGenerator t_randomDataGenerator;
 
-        private static RandomDataGenerator RandomDataGenerator
-        {
-            get
-            {
-                if (s_randomDataGenerator == null)
-                {
-                    s_randomDataGenerator = new RandomDataGenerator();
-                }
-                return s_randomDataGenerator;
-            }
-        }
+        private static RandomDataGenerator Generator => t_randomDataGenerator ?? (t_randomDataGenerator = new RandomDataGenerator());
 
         private static readonly Calendar s_calendar = new GregorianCalendar(GregorianCalendarTypes.USEnglish);
 
@@ -35,7 +25,7 @@ namespace System.Globalization.Tests
         {
             int maxYear = s_calendar.MaxSupportedDateTime.Year;
             int minYear = s_calendar.MinSupportedDateTime.Year;
-            return minYear + RandomDataGenerator.GetInt32(-55) % (maxYear + 1 - minYear);
+            return minYear + Generator.GetInt32(-55) % (maxYear + 1 - minYear);
         }
 
         public static int RandomLeapYear()
@@ -64,7 +54,7 @@ namespace System.Globalization.Tests
             return randomYear;
         }
 
-        public static int RandomMonth() => RandomDataGenerator.GetInt32(-55) % 12 + 1;
+        public static int RandomMonth() => Generator.GetInt32(-55) % 12 + 1;
 
         public static int RandomMonthNotFebruary()
         {
@@ -76,9 +66,9 @@ namespace System.Globalization.Tests
             return randomMonthNotFebruary;
         }
 
-        public static int RandomLeapYearDay(int month) => RandomDataGenerator.GetInt32(-55) % s_daysInMonthInLeapYear[month] + 1;
+        public static int RandomLeapYearDay(int month) => Generator.GetInt32(-55) % s_daysInMonthInLeapYear[month] + 1;
 
-        public static int RandomCommonYearDay(int month) => RandomDataGenerator.GetInt32(-55) % s_daysInMonthInCommonYear[month] + 1;
+        public static int RandomCommonYearDay(int month) => Generator.GetInt32(-55) % s_daysInMonthInCommonYear[month] + 1;
 
         public static int RandomDay(int year, int month)
         {

--- a/src/System.Globalization.Calendars/tests/GregorianCalendar/GregorianCalendarTests.Utilities.cs
+++ b/src/System.Globalization.Calendars/tests/GregorianCalendar/GregorianCalendarTests.Utilities.cs
@@ -9,7 +9,7 @@ namespace System.Globalization.Tests
         [ThreadStatic]
         private static RandomDataGenerator s_randomDataGenerator;
 
-        private static RandomDataGenerator RDG
+        private static RandomDataGenerator RandomDataGenerator
         {
             get
             {
@@ -35,7 +35,7 @@ namespace System.Globalization.Tests
         {
             int maxYear = s_calendar.MaxSupportedDateTime.Year;
             int minYear = s_calendar.MinSupportedDateTime.Year;
-            return minYear + RDG.GetInt32(-55) % (maxYear + 1 - minYear);
+            return minYear + RandomDataGenerator.GetInt32(-55) % (maxYear + 1 - minYear);
         }
 
         public static int RandomLeapYear()
@@ -64,7 +64,7 @@ namespace System.Globalization.Tests
             return randomYear;
         }
 
-        public static int RandomMonth() => RDG.GetInt32(-55) % 12 + 1;
+        public static int RandomMonth() => RandomDataGenerator.GetInt32(-55) % 12 + 1;
 
         public static int RandomMonthNotFebruary()
         {
@@ -76,9 +76,9 @@ namespace System.Globalization.Tests
             return randomMonthNotFebruary;
         }
 
-        public static int RandomLeapYearDay(int month) => RDG.GetInt32(-55) % s_daysInMonthInLeapYear[month] + 1;
+        public static int RandomLeapYearDay(int month) => RandomDataGenerator.GetInt32(-55) % s_daysInMonthInLeapYear[month] + 1;
 
-        public static int RandomCommonYearDay(int month) => RDG.GetInt32(-55) % s_daysInMonthInCommonYear[month] + 1;
+        public static int RandomCommonYearDay(int month) => RandomDataGenerator.GetInt32(-55) % s_daysInMonthInCommonYear[month] + 1;
 
         public static int RandomDay(int year, int month)
         {

--- a/src/System.Globalization.Calendars/tests/GregorianCalendar/GregorianCalendarTests.Utilities.cs
+++ b/src/System.Globalization.Calendars/tests/GregorianCalendar/GregorianCalendarTests.Utilities.cs
@@ -6,7 +6,21 @@ namespace System.Globalization.Tests
 {
     public class GregorianCalendarTestUtilities
     {
-        private static readonly RandomDataGenerator s_randomDataGenerator = new RandomDataGenerator();
+        [ThreadStatic]
+        private static RandomDataGenerator s_randomDataGenerator;
+
+        private static RandomDataGenerator RDG
+        {
+            get
+            {
+                if (s_randomDataGenerator == null)
+                {
+                    s_randomDataGenerator = new RandomDataGenerator();
+                }
+                return s_randomDataGenerator;
+            }
+        }
+
         private static readonly Calendar s_calendar = new GregorianCalendar(GregorianCalendarTypes.USEnglish);
 
         private static readonly int[] s_daysInMonthInLeapYear = { 0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
@@ -21,7 +35,7 @@ namespace System.Globalization.Tests
         {
             int maxYear = s_calendar.MaxSupportedDateTime.Year;
             int minYear = s_calendar.MinSupportedDateTime.Year;
-            return minYear + s_randomDataGenerator.GetInt32(-55) % (maxYear + 1 - minYear);
+            return minYear + RDG.GetInt32(-55) % (maxYear + 1 - minYear);
         }
 
         public static int RandomLeapYear()
@@ -50,9 +64,9 @@ namespace System.Globalization.Tests
             return randomYear;
         }
 
-		public static int RandomMonth() => s_randomDataGenerator.GetInt32(-55) % 12 + 1;
+        public static int RandomMonth() => RDG.GetInt32(-55) % 12 + 1;
 
-		public static int RandomMonthNotFebruary()
+        public static int RandomMonthNotFebruary()
         {
             int randomMonthNotFebruary;
             do
@@ -62,8 +76,9 @@ namespace System.Globalization.Tests
             return randomMonthNotFebruary;
         }
 
-        public static int RandomLeapYearDay(int month) => s_randomDataGenerator.GetInt32(-55) % s_daysInMonthInLeapYear[month] + 1;
-        public static int RandomCommonYearDay(int month) => s_randomDataGenerator.GetInt32(-55) % s_daysInMonthInCommonYear[month] + 1;
+        public static int RandomLeapYearDay(int month) => RDG.GetInt32(-55) % s_daysInMonthInLeapYear[month] + 1;
+
+        public static int RandomCommonYearDay(int month) => RDG.GetInt32(-55) % s_daysInMonthInCommonYear[month] + 1;
 
         public static int RandomDay(int year, int month)
         {

--- a/src/System.Globalization.Calendars/tests/TaiwanCalendar/TaiwanCalendarIsLeapDay.cs
+++ b/src/System.Globalization.Calendars/tests/TaiwanCalendar/TaiwanCalendarIsLeapDay.cs
@@ -11,12 +11,10 @@ namespace System.Globalization.Tests
     {
         public static IEnumerable<object[]> IsLeapDay_TestData()
         {
-            int randomYear = TaiwanCalendarUtilities.RandomYear();
-            int radomMonth = TaiwanCalendarUtilities.RandomMonth();
-            int randomDay = TaiwanCalendarUtilities.RandomDay(randomYear, radomMonth);
-            yield return new object[] { randomYear, radomMonth, randomDay, false };
-
+            yield return new object[] { 2000 - 1911, 2, 28, false };
             yield return new object[] { 2000 - 1911, 2, 29, true };
+            yield return new object[] { 2000 - 1911, 3, 1, false };
+            yield return new object[] { 2001 - 1911, 2, 28, false };
         }
 
         [Theory]

--- a/src/System.Globalization.Calendars/tests/TaiwanCalendar/TaiwanCalendarUtilities.cs
+++ b/src/System.Globalization.Calendars/tests/TaiwanCalendar/TaiwanCalendarUtilities.cs
@@ -9,7 +9,7 @@ namespace System.Globalization.Tests
         [ThreadStatic]
         private static RandomDataGenerator s_randomDataGenerator;
 
-        private static RandomDataGenerator RDG
+        private static RandomDataGenerator RandomDataGenerator
         {
             get
             {
@@ -36,20 +36,20 @@ namespace System.Globalization.Tests
             TaiwanCalendar calendar = new TaiwanCalendar();
             int maxYear = calendar.MaxSupportedDateTime.Year;
             int minYear = calendar.MinSupportedDateTime.Year;
-            return minYear + RDG.GetInt32(-55) % (maxYear - 1911 + 1 - minYear);
+            return minYear + RandomDataGenerator.GetInt32(-55) % (maxYear - 1911 + 1 - minYear);
         }
 
-        public static int RandomMonth() => RDG.GetInt32(-55) % 12 + 1;
+        public static int RandomMonth() => RandomDataGenerator.GetInt32(-55) % 12 + 1;
 
         public static int RandomDay(int year, int month)
         {
             if (new TaiwanCalendar().IsLeapYear(year))
             {
-                return RDG.GetInt32(-55) % s_daysPerMonthLeapYear[month] + 1;
+                return RandomDataGenerator.GetInt32(-55) % s_daysPerMonthLeapYear[month] + 1;
             }
             else
             {
-                return RDG.GetInt32(-55) % s_daysPerMonthCommonYear[month] + 1;
+                return RandomDataGenerator.GetInt32(-55) % s_daysPerMonthCommonYear[month] + 1;
             }
         }
 

--- a/src/System.Globalization.Calendars/tests/TaiwanCalendar/TaiwanCalendarUtilities.cs
+++ b/src/System.Globalization.Calendars/tests/TaiwanCalendar/TaiwanCalendarUtilities.cs
@@ -7,19 +7,9 @@ namespace System.Globalization.Tests
     public static class TaiwanCalendarUtilities
     {
         [ThreadStatic]
-        private static RandomDataGenerator s_randomDataGenerator;
+        private static RandomDataGenerator t_randomDataGenerator;
 
-        private static RandomDataGenerator RandomDataGenerator
-        {
-            get
-            {
-                if (s_randomDataGenerator == null)
-                {
-                    s_randomDataGenerator = new RandomDataGenerator();
-                }
-                return s_randomDataGenerator;
-            }
-        }
+        private static RandomDataGenerator Generator => t_randomDataGenerator ?? (t_randomDataGenerator = new RandomDataGenerator());
 
         private static readonly int[] s_daysPerMonthLeapYear = new int[]
         {
@@ -36,20 +26,20 @@ namespace System.Globalization.Tests
             TaiwanCalendar calendar = new TaiwanCalendar();
             int maxYear = calendar.MaxSupportedDateTime.Year;
             int minYear = calendar.MinSupportedDateTime.Year;
-            return minYear + RandomDataGenerator.GetInt32(-55) % (maxYear - 1911 + 1 - minYear);
+            return minYear + Generator.GetInt32(-55) % (maxYear - 1911 + 1 - minYear);
         }
 
-        public static int RandomMonth() => RandomDataGenerator.GetInt32(-55) % 12 + 1;
+        public static int RandomMonth() => Generator.GetInt32(-55) % 12 + 1;
 
         public static int RandomDay(int year, int month)
         {
             if (new TaiwanCalendar().IsLeapYear(year))
             {
-                return RandomDataGenerator.GetInt32(-55) % s_daysPerMonthLeapYear[month] + 1;
+                return Generator.GetInt32(-55) % s_daysPerMonthLeapYear[month] + 1;
             }
             else
             {
-                return RandomDataGenerator.GetInt32(-55) % s_daysPerMonthCommonYear[month] + 1;
+                return Generator.GetInt32(-55) % s_daysPerMonthCommonYear[month] + 1;
             }
         }
 

--- a/src/System.Globalization.Calendars/tests/TaiwanCalendar/TaiwanCalendarUtilities.cs
+++ b/src/System.Globalization.Calendars/tests/TaiwanCalendar/TaiwanCalendarUtilities.cs
@@ -6,7 +6,20 @@ namespace System.Globalization.Tests
 {
     public static class TaiwanCalendarUtilities
     {
-        private static readonly RandomDataGenerator s_randomDataGenerator = new RandomDataGenerator();
+        [ThreadStatic]
+        private static RandomDataGenerator s_randomDataGenerator;
+
+        private static RandomDataGenerator RDG
+        {
+            get
+            {
+                if (s_randomDataGenerator == null)
+                {
+                    s_randomDataGenerator = new RandomDataGenerator();
+                }
+                return s_randomDataGenerator;
+            }
+        }
 
         private static readonly int[] s_daysPerMonthLeapYear = new int[]
         {
@@ -21,20 +34,22 @@ namespace System.Globalization.Tests
         public static int RandomYear()
         {
             TaiwanCalendar calendar = new TaiwanCalendar();
-            return new Random(-55).Next(calendar.MinSupportedDateTime.Year, calendar.MaxSupportedDateTime.Year - 1911);
+            int maxYear = calendar.MaxSupportedDateTime.Year;
+            int minYear = calendar.MinSupportedDateTime.Year;
+            return minYear + RDG.GetInt32(-55) % (maxYear - 1911 + 1 - minYear);
         }
 
-        public static int RandomMonth() => new Random(-55).Next(1, 12);
+        public static int RandomMonth() => RDG.GetInt32(-55) % 12 + 1;
 
         public static int RandomDay(int year, int month)
         {
             if (new TaiwanCalendar().IsLeapYear(year))
             {
-                return new Random(-55).Next(1, s_daysPerMonthLeapYear[month] + 1);
+                return RDG.GetInt32(-55) % s_daysPerMonthLeapYear[month] + 1;
             }
             else
             {
-                return new Random(-55).Next(1, s_daysPerMonthCommonYear[month] + 1);
+                return RDG.GetInt32(-55) % s_daysPerMonthCommonYear[month] + 1;
             }
         }
 


### PR DESCRIPTION
Remove sharing of RandomDataGenerators betwen threads.
Also, the Taiwanese utilities would generate the same year/month/day every call, almost certainly not what was intended.