### PR TITLE
Fix threading test for Nano to not expect STA

### DIFF
--- a/src/Common/tests/System/PlatformDetection.cs
+++ b/src/Common/tests/System/PlatformDetection.cs
@@ -28,16 +28,14 @@ namespace System
         public static bool IsNetBSD => RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD"));
         public static bool IsOpenSUSE => IsDistroAndVersion("opensuse");
         public static bool IsUbuntu => IsDistroAndVersion("ubuntu");
-        public static bool IsNotWindowsNanoServer => (!IsWindows ||
-            File.Exists(Path.Combine(Environment.GetEnvironmentVariable("windir"), "regedit.exe")));
+        public static bool IsWindowsNanoServer => (IsWindows && !File.Exists(Path.Combine(Environment.GetEnvironmentVariable("windir"), "regedit.exe")));
+        public static bool IsNotWindowsNanoServer => !IsWindowsNanoServer;
         public static bool IsWindows10Version1607OrGreater => IsWindows &&
             GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 14393;
         public static bool IsWindows10Version1703OrGreater => IsWindows &&
             GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 15063;
-        // Windows OneCoreUAP SKU doesn't have httpapi.dll
-        public static bool HasHttpApi => (IsWindows &&
-            File.Exists(Path.Combine(Environment.GetEnvironmentVariable("windir"), "System32", "httpapi.dll")));
 
+        // Windows OneCoreUAP SKU doesn't have httpapi.dll
         public static bool IsNotOneCoreUAP => (!IsWindows || 
             File.Exists(Path.Combine(Environment.GetEnvironmentVariable("windir"), "System32", "httpapi.dll")));
 

--- a/src/System.Threading.Thread/tests/System.Threading.Thread.Tests.csproj
+++ b/src/System.Threading.Thread/tests/System.Threading.Thread.Tests.csproj
@@ -15,6 +15,9 @@
     <Compile Include="ThreadTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>Common\System\PlatformDetection.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Threading\ThreadTestHelpers.cs">
       <Link>CommonTest\System\Threading\ThreadPoolHelpers.cs</Link>
     </Compile>

--- a/src/System.Threading.Thread/tests/ThreadTests.cs
+++ b/src/System.Threading.Thread/tests/ThreadTests.cs
@@ -178,7 +178,17 @@ namespace System.Threading.Threads.Tests
             Assert.Equal(ApartmentState.STA, getApartmentState(t));
             t.Start();
             Assert.True(t.Join(UnexpectedTimeoutMilliseconds));
-            Assert.Equal(ApartmentState.STA, apartmentStateInThread);
+
+            if (PlatformDetection.IsWindowsNanoServer)
+            {
+                // Nano server threads are always MTA. If you set the thread to STA
+                // it will read back as STA but when the thread starts it will read back as MTA.
+                Assert.Equal(ApartmentState.MTA, apartmentStateInThread);
+            }
+            else
+            {
+                Assert.Equal(ApartmentState.STA, apartmentStateInThread);
+            }
         }
 
         [Theory]


### PR DESCRIPTION
Fix https://github.com/dotnet/corefx/issues/19222

Threads on Nano always run at MTA. If you set apartment state to STA, the value will read back, but once you start the thread, it will return the truth: MTA.

The platformdetection change is just ripped off my other current PR unchanged.