### PR TITLE
Enable building on older Linux distros

### DIFF
--- a/src/Native/Unix/Common/pal_config.h.in
+++ b/src/Native/Unix/Common/pal_config.h.in
@@ -37,6 +37,7 @@
 #cmakedefine01 HAVE_FCOPYFILE
 #cmakedefine01 HAVE_GETHOSTBYNAME_R
 #cmakedefine01 HAVE_GETHOSTBYADDR_R
+#cmakedefine01 HAVE_GETNAMEINFO_SIGNED_FLAGS
 #cmakedefine01 HAVE_GETPEEREID
 #cmakedefine01 HAVE_SUPPORT_FOR_DUAL_MODE_IPV4_PACKET_INFO
 #cmakedefine01 HAVE_THREAD_SAFE_GETHOSTBYNAME_AND_GETHOSTBYADDR
@@ -78,6 +79,7 @@
 #cmakedefine01 IPV6MR_INTERFACE_UNSIGNED
 #cmakedefine01 BIND_ADDRLEN_UNSIGNED
 #cmakedefine01 INOTIFY_RM_WATCH_WD_UNSIGNED
+#cmakedefine01 HAVE_IN_EXCL_UNLINK
 
 // Mac OS X has stat64, but it is deprecated since plain stat now
 // provides the same 64-bit aware struct when targeting OS X > 10.5

--- a/src/Native/Unix/System.Native/pal_io.cpp
+++ b/src/Native/Unix/System.Native/pal_io.cpp
@@ -134,9 +134,11 @@ static_assert(PAL_IN_Q_OVERFLOW == IN_Q_OVERFLOW, "");
 static_assert(PAL_IN_IGNORED == IN_IGNORED, "");
 static_assert(PAL_IN_ONLYDIR == IN_ONLYDIR, "");
 static_assert(PAL_IN_DONT_FOLLOW == IN_DONT_FOLLOW, "");
+#if HAVE_IN_EXCL_UNLINK
 static_assert(PAL_IN_EXCL_UNLINK == IN_EXCL_UNLINK, "");
+#endif // HAVE_IN_EXCL_UNLINK
 static_assert(PAL_IN_ISDIR == IN_ISDIR, "");
-#endif
+#endif // HAVE_INOTIFY
 
 static void ConvertFileStatus(const struct stat_& src, FileStatus* dst)
 {
@@ -1220,6 +1222,9 @@ extern "C" int32_t SystemNative_INotifyAddWatch(intptr_t fd, const char* pathNam
     assert(pathName != nullptr);
 
 #if HAVE_INOTIFY
+#if !HAVE_IN_EXCL_UNLINK
+    mask &= ~static_cast<uint32_t>(PAL_IN_EXCL_UNLINK);
+#endif
     return inotify_add_watch(ToFileDescriptor(fd), pathName, mask);
 #else
     (void)fd, (void)pathName, (void)mask;

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -199,6 +199,7 @@ check_cxx_source_compiles(
     {
         char buffer[1];
         char* c = strerror_r(0, buffer, 0);
+        return 0;
     }
     "
     HAVE_GNU_STRERROR_R)
@@ -246,7 +247,7 @@ check_struct_has_member(
 check_cxx_source_compiles(
     "
     #include <sys/sendfile.h>
-    int main() { int i = sendfile(0, 0, 0, 0); }
+    int main() { int i = sendfile(0, 0, 0, 0); return 0; }
     "
     HAVE_SENDFILE_4)
 
@@ -256,7 +257,7 @@ check_cxx_source_compiles(
     #include <sys/types.h>
     #include <sys/socket.h>
     #include <sys/uio.h>
-    int main() { int i = sendfile(0, 0, 0, NULL, NULL, 0); }
+    int main() { int i = sendfile(0, 0, 0, NULL, NULL, 0); return 0; }
     "
     HAVE_SENDFILE_6)
 
@@ -600,7 +601,7 @@ set (CMAKE_REQUIRED_FLAGS "-Werror -Weverything")
 check_cxx_source_compiles(
     "
     #include <unistd.h>
-    int main() { size_t namelen = 20; char name[20]; getdomainname(name, namelen); }
+    int main() { size_t namelen = 20; char name[20]; getdomainname(name, namelen); return 0; }
     "
     HAVE_GETDOMAINNAME_SIZET
 )
@@ -628,21 +629,21 @@ endif()
 check_cxx_source_compiles(
     "
     #include <curl/multi.h>
-    int main() { int i = CURLM_ADDED_ALREADY; }
+    int main() { int i = CURLM_ADDED_ALREADY; return 0; }
     "
     HAVE_CURLM_ADDED_ALREADY)
 
 check_cxx_source_compiles(
     "
     #include <curl/multi.h>
-    int main() { int i = CURL_HTTP_VERSION_2_0; }
+    int main() { int i = CURL_HTTP_VERSION_2_0; return 0; }
     "
     HAVE_CURL_HTTP_VERSION_2_0)
 
 check_cxx_source_compiles(
     "
     #include <curl/multi.h>
-    int main() { int i = CURLPIPE_MULTIPLEX; }
+    int main() { int i = CURLPIPE_MULTIPLEX; return 0; }
     "
     HAVE_CURLPIPE_MULTIPLEX)
 
@@ -654,6 +655,7 @@ check_cxx_source_compiles(
         int i = CURL_SSLVERSION_TLSv1_0;
         i = CURL_SSLVERSION_TLSv1_1;
         i = CURL_SSLVERSION_TLSv1_2;
+        return 0;
     }
     "
     HAVE_CURL_SSLVERSION_TLSv1_012)
@@ -700,7 +702,7 @@ if (HAVE_CRT_EXTERNS_H)
     check_cxx_source_compiles(
     "
     #include <crt_externs.h>
-    int main() { char** e = *(_NSGetEnviron()); }
+    int main() { char** e = *(_NSGetEnviron()); return 0; }
     "
     HAVE_NSGETENVIRON)
 endif()
@@ -712,7 +714,8 @@ check_cxx_source_compiles(
     #include <sys/inotify.h>
     int main()
     {
-        uint32_t mask = IN_EXCL_UNLINK;   
+        uint32_t mask = IN_EXCL_UNLINK;
+        return 0;
     }
     "
     HAVE_IN_EXCL_UNLINK)


### PR DESCRIPTION
This change enables building of corefx native parts on older
Linux distros that don't support IN_EXCL_UNLINK, where the
getnameinfo's last parameter (flags) is unsigned int instead
of int, EPOLLET constant is int and in_pktinfo and struct ip_mreqn
presence detection during build using the check_type_size
doesn't work.