### PR TITLE
Add repo name explicitly to symbol publish leg

### DIFF
--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -972,6 +972,7 @@
         {
           "Name": "DotNet-Trusted-Publish-Symbols",
           "Parameters": {
+            "PB_VsoRepositoryName": "DotNet-CoreFX-Trusted"
           },
           "ReportingParameters": {
             "TaskName": "Symbol Publish",


### PR DESCRIPTION
skip ci please

`DotNet-CoreFX-Trusted` is the same as the default value specified in the build leg's checked-in json, but it seems that setting it manually might be necessary because the symbol leg broke while the package publish leg didn't. The goal of the workaround is to make DotNet-Trusted-Publish-Symbols work at least as well as DotNet-Trusted-Publish.

/cc @chcosta 