### PR TITLE
Get rid of ParamName failures in S.L.Expressions.Test

### DIFF
--- a/src/System.Linq.Expressions/tests/Array/ArrayArrayIndexTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayArrayIndexTests.cs
@@ -2682,7 +2682,7 @@ namespace System.Linq.Expressions.Tests
         public static void ArrayIndexNullArray()
         {
             AssertExtensions.Throws<ArgumentNullException>("array", () => Expression.ArrayIndex(null));
-            Assert.Throws<ArgumentNullException>(
+            AssertExtensions.Throws<ArgumentNullException>(
                 "array", () => Expression.ArrayIndex(null, Enumerable.Empty<Expression>()));
         }
 
@@ -2699,8 +2699,8 @@ namespace System.Linq.Expressions.Tests
         public static void ArrayIndexWrongRank()
         {
             Expression array = Expression.Constant(new[,] { { 1, 2 }, { 2, 1 } });
-            Assert.Throws<ArgumentException>(null, () => Expression.ArrayIndex(array, new[] { Expression.Constant(2) }));
-            Assert.Throws<ArgumentException>(null, () =>
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.ArrayIndex(array, new[] { Expression.Constant(2) }));
+            AssertExtensions.Throws<ArgumentException>(null, () =>
                 Expression.ArrayIndex(array, Expression.Constant(2), Expression.Constant(1), Expression.Constant(2)));
         }
 

--- a/src/System.Linq.Expressions/tests/Array/ArrayIndexTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayIndexTests.cs
@@ -2745,7 +2745,7 @@ namespace System.Linq.Expressions.Tests
         public static void ArrayIndexWrongRank()
         {
             Expression array = Expression.Constant(new[,] { { 1, 2 }, { 2, 1 } });
-            Assert.Throws<ArgumentException>(null, () => Expression.ArrayIndex(array, Expression.Constant(2)));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.ArrayIndex(array, Expression.Constant(2)));
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryAddTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryAddTests.cs
@@ -487,7 +487,7 @@ namespace System.Linq.Expressions.Tests
             Expression exp = Expression.Add(Expression.Constant(0), Expression.Constant(0));
             Assert.False(exp.CanReduce);
             Assert.Same(exp, exp.Reduce());
-            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
         [Fact]
@@ -496,7 +496,7 @@ namespace System.Linq.Expressions.Tests
             Expression exp = Expression.AddChecked(Expression.Constant(0), Expression.Constant(0));
             Assert.False(exp.CanReduce);
             Assert.Same(exp, exp.Reduce());
-            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryDivideTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryDivideTests.cs
@@ -347,7 +347,7 @@ namespace System.Linq.Expressions.Tests
             Expression exp = Expression.Divide(Expression.Constant(0), Expression.Constant(0));
             Assert.False(exp.CanReduce);
             Assert.Same(exp, exp.Reduce());
-            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryModuloTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryModuloTests.cs
@@ -347,7 +347,7 @@ namespace System.Linq.Expressions.Tests
             Expression exp = Expression.Modulo(Expression.Constant(0), Expression.Constant(0));
             Assert.False(exp.CanReduce);
             Assert.Same(exp, exp.Reduce());
-            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryMultiplyTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryMultiplyTests.cs
@@ -495,7 +495,7 @@ namespace System.Linq.Expressions.Tests
             Expression exp = Expression.Multiply(Expression.Constant(0), Expression.Constant(0));
             Assert.False(exp.CanReduce);
             Assert.Same(exp, exp.Reduce());
-            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
         [Fact]
@@ -504,7 +504,7 @@ namespace System.Linq.Expressions.Tests
             Expression exp = Expression.MultiplyChecked(Expression.Constant(0), Expression.Constant(0));
             Assert.False(exp.CanReduce);
             Assert.Same(exp, exp.Reduce());
-            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryShiftTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryShiftTests.cs
@@ -1008,7 +1008,7 @@ namespace System.Linq.Expressions.Tests
             Expression exp = Expression.LeftShift(Expression.Constant(0), Expression.Constant(0));
             Assert.False(exp.CanReduce);
             Assert.Same(exp, exp.Reduce());
-            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
         [Fact]
@@ -1017,7 +1017,7 @@ namespace System.Linq.Expressions.Tests
             Expression exp = Expression.RightShift(Expression.Constant(0), Expression.Constant(0));
             Assert.False(exp.CanReduce);
             Assert.Same(exp, exp.Reduce());
-            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinarySubtractTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinarySubtractTests.cs
@@ -516,7 +516,7 @@ namespace System.Linq.Expressions.Tests
             Expression exp = Expression.Subtract(Expression.Constant(0), Expression.Constant(0));
             Assert.False(exp.CanReduce);
             Assert.Same(exp, exp.Reduce());
-            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
         [Fact]
@@ -525,7 +525,7 @@ namespace System.Linq.Expressions.Tests
             Expression exp = Expression.SubtractChecked(Expression.Constant(0), Expression.Constant(0));
             Assert.False(exp.CanReduce);
             Assert.Same(exp, exp.Reduce());
-            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/Assign.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/Assign.cs
@@ -210,7 +210,7 @@ namespace System.Linq.Expressions.Tests
             Expression exp = Expression.Assign(Expression.Variable(typeof(int)), Expression.Constant(0));
             Assert.False(exp.CanReduce);
             Assert.Same(exp, exp.Reduce());
-            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
         [Fact]
@@ -234,7 +234,7 @@ namespace System.Linq.Expressions.Tests
         [InlineData(typeof(BaseClass), 1, typeof(int))]
         public void MismatchTypes(Type variableType, object constantValue, Type constantType)
         {
-            Assert.Throws<ArgumentException>(null, () => Expression.Assign(Expression.Variable(variableType), Expression.Constant(constantValue, constantType)));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Assign(Expression.Variable(variableType), Expression.Constant(constantValue, constantType)));
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/OpAssign.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/OpAssign.cs
@@ -472,7 +472,7 @@ namespace System.Linq.Expressions.Tests
             var lhs = Expression.Parameter(typeof(int));
             var rhs = Expression.Constant(25);
             MethodInfo meth = GetType().GetMethod(nameof(FiftyNinthBear));
-            Assert.Throws<ArgumentException>(
+            AssertExtensions.Throws<ArgumentException>(
                 "conversion", () => Expression.MakeBinary(type, lhs, rhs, false, meth, conversion));
         }
 
@@ -519,7 +519,7 @@ namespace System.Linq.Expressions.Tests
         {
             var lhs = Expression.Parameter(typeof(AddsToSomethingElse));
             var rhs = Expression.Constant(new AddsToSomethingElse(3));
-            Assert.Throws<ArgumentException>(null, () => Expression.AddAssign(lhs, rhs));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.AddAssign(lhs, rhs));
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryAndTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryAndTests.cs
@@ -230,7 +230,7 @@ namespace System.Linq.Expressions.Tests
             Expression exp = Expression.And(Expression.Constant(0), Expression.Constant(0));
             Assert.False(exp.CanReduce);
             Assert.Same(exp, exp.Reduce());
-            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryExclusiveOrTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryExclusiveOrTests.cs
@@ -230,7 +230,7 @@ namespace System.Linq.Expressions.Tests
             Expression exp = Expression.ExclusiveOr(Expression.Constant(0), Expression.Constant(0));
             Assert.False(exp.CanReduce);
             Assert.Same(exp, exp.Reduce());
-            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryOrTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryOrTests.cs
@@ -230,7 +230,7 @@ namespace System.Linq.Expressions.Tests
             Expression exp = Expression.Or(Expression.Constant(0), Expression.Constant(0));
             Assert.False(exp.CanReduce);
             Assert.Same(exp, exp.Reduce());
-            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryCoalesceTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryCoalesceTests.cs
@@ -318,7 +318,7 @@ namespace System.Linq.Expressions.Tests
             Expression exp = Expression.Coalesce(Expression.Constant(0, typeof(int?)), Expression.Constant(0));
             Assert.False(exp.CanReduce);
             Assert.Same(exp, exp.Reduce());
-            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
         [Fact]
@@ -393,7 +393,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void RightLeft_NonEquivilentTypes_ThrowsArgumentException()
         {
-            Assert.Throws<ArgumentException>(null, () => Expression.Coalesce(Expression.Constant("abc"), Expression.Constant(5)));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Coalesce(Expression.Constant("abc"), Expression.Constant(5)));
         }
 
         public delegate void VoidDelegate();

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/CompareTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/CompareTests.cs
@@ -115,7 +115,7 @@ namespace System.Linq.Expressions.Tests
             Expression exp = Expression.GreaterThanOrEqual(Expression.Constant(0), Expression.Constant(0));
             Assert.False(exp.CanReduce);
             Assert.Same(exp, exp.Reduce());
-            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
         [Fact]
@@ -124,7 +124,7 @@ namespace System.Linq.Expressions.Tests
             Expression exp = Expression.GreaterThan(Expression.Constant(0), Expression.Constant(0));
             Assert.False(exp.CanReduce);
             Assert.Same(exp, exp.Reduce());
-            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
         [Fact]
@@ -133,7 +133,7 @@ namespace System.Linq.Expressions.Tests
             Expression exp = Expression.LessThanOrEqual(Expression.Constant(0), Expression.Constant(0));
             Assert.False(exp.CanReduce);
             Assert.Same(exp, exp.Reduce());
-            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
         [Fact]
@@ -142,7 +142,7 @@ namespace System.Linq.Expressions.Tests
             Expression exp = Expression.LessThan(Expression.Constant(0), Expression.Constant(0));
             Assert.False(exp.CanReduce);
             Assert.Same(exp, exp.Reduce());
-            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/EqualNotEqualTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/EqualNotEqualTests.cs
@@ -117,7 +117,7 @@ namespace System.Linq.Expressions.Tests
             Expression exp = Expression.Equal(Expression.Constant(0), Expression.Constant(0));
             Assert.False(exp.CanReduce);
             Assert.Same(exp, exp.Reduce());
-            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
         [Fact]
@@ -126,7 +126,7 @@ namespace System.Linq.Expressions.Tests
             Expression exp = Expression.NotEqual(Expression.Constant(0), Expression.Constant(0));
             Assert.False(exp.CanReduce);
             Assert.Same(exp, exp.Reduce());
-            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Logical/BinaryLogicalTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Logical/BinaryLogicalTests.cs
@@ -253,7 +253,7 @@ namespace System.Linq.Expressions.Tests
             Expression exp = Expression.AndAlso(Expression.Constant(true), Expression.Constant(false));
             Assert.False(exp.CanReduce);
             Assert.Same(exp, exp.Reduce());
-            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
         [Fact]
@@ -262,7 +262,7 @@ namespace System.Linq.Expressions.Tests
             Expression exp = Expression.OrElse(Expression.Constant(true), Expression.Constant(false));
             Assert.False(exp.CanReduce);
             Assert.Same(exp, exp.Reduce());
-            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
         [Fact]
@@ -354,24 +354,24 @@ namespace System.Linq.Expressions.Tests
         public static void MethodParametersNotEqual_ThrowsArgumentException()
         {
             MethodInfo method = typeof(NonGenericClass).GetMethod(nameof(NonGenericClass.StaticIntMethod2Invalid1));
-            Assert.Throws<ArgumentException>(null, () => Expression.AndAlso(Expression.Constant(5), Expression.Constant("abc"), method));
-            Assert.Throws<ArgumentException>(null, () => Expression.OrElse(Expression.Constant(5), Expression.Constant("abc"), method));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.AndAlso(Expression.Constant(5), Expression.Constant("abc"), method));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.OrElse(Expression.Constant(5), Expression.Constant("abc"), method));
         }
 
         [Fact]
         public static void Method_ReturnTypeNotEqualToParameterTypes_ThrowsArgumentException()
         {
             MethodInfo method = typeof(NonGenericClass).GetMethod(nameof(NonGenericClass.StaticIntMethod2Invalid2));
-            Assert.Throws<ArgumentException>(null, () => Expression.AndAlso(Expression.Constant(5), Expression.Constant(5), method));
-            Assert.Throws<ArgumentException>(null, () => Expression.OrElse(Expression.Constant(5), Expression.Constant(5), method));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.AndAlso(Expression.Constant(5), Expression.Constant(5), method));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.OrElse(Expression.Constant(5), Expression.Constant(5), method));
         }
 
         [Fact]
         public static void MethodDeclaringTypeHasNoTrueFalseOperator_ThrowsArgumentException()
         {
             MethodInfo method = typeof(NonGenericClass).GetMethod(nameof(NonGenericClass.StaticIntMethod2Valid));
-            Assert.Throws<ArgumentException>(null, () => Expression.AndAlso(Expression.Constant(5), Expression.Constant(5), method));
-            Assert.Throws<ArgumentException>(null, () => Expression.OrElse(Expression.Constant(5), Expression.Constant(5), method));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.AndAlso(Expression.Constant(5), Expression.Constant(5), method));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.OrElse(Expression.Constant(5), Expression.Constant(5), method));
         }
 
 #if FEATURE_COMPILE
@@ -497,7 +497,7 @@ namespace System.Linq.Expressions.Tests
             Type createdType = type.CreateTypeInfo();
             object obj = Activator.CreateInstance(createdType);
 
-            Assert.Throws<ArgumentException>(null, () => Expression.AndAlso(Expression.Constant(obj), Expression.Constant(obj)));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.AndAlso(Expression.Constant(obj), Expression.Constant(obj)));
         }
 
         [Fact]
@@ -510,7 +510,7 @@ namespace System.Linq.Expressions.Tests
             Type createdType = type.CreateTypeInfo();
             object obj = Activator.CreateInstance(createdType);
 
-            Assert.Throws<ArgumentException>(null, () => Expression.OrElse(Expression.Constant(obj), Expression.Constant(obj)));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.OrElse(Expression.Constant(obj), Expression.Constant(obj)));
         }
 
         public static IEnumerable<object[]> Operator_IncorrectMethod_TestData()
@@ -547,8 +547,8 @@ namespace System.Linq.Expressions.Tests
             object obj = Activator.CreateInstance(createdType);
             MethodInfo createdMethod = createdType.GetMethod("Method");
 
-            Assert.Throws<ArgumentException>(null, () => Expression.AndAlso(Expression.Constant(obj), Expression.Constant(obj), createdMethod));
-            Assert.Throws<ArgumentException>(null, () => Expression.OrElse(Expression.Constant(obj), Expression.Constant(obj), createdMethod));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.AndAlso(Expression.Constant(obj), Expression.Constant(obj), createdMethod));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.OrElse(Expression.Constant(obj), Expression.Constant(obj), createdMethod));
         }
 
         [Theory]
@@ -568,8 +568,8 @@ namespace System.Linq.Expressions.Tests
             object obj = Activator.CreateInstance(createdType);
             MethodInfo createdMethod = createdType.GetMethod("Method");
 
-            Assert.Throws<ArgumentException>(null, () => Expression.AndAlso(Expression.Constant(obj), Expression.Constant(obj), createdMethod));
-            Assert.Throws<ArgumentException>(null, () => Expression.OrElse(Expression.Constant(obj), Expression.Constant(obj), createdMethod));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.AndAlso(Expression.Constant(obj), Expression.Constant(obj), createdMethod));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.OrElse(Expression.Constant(obj), Expression.Constant(obj), createdMethod));
         }
 
         [Theory]
@@ -588,7 +588,7 @@ namespace System.Linq.Expressions.Tests
             TypeInfo createdType = builder.CreateTypeInfo();
             object obj = Activator.CreateInstance(createdType);
 
-            Assert.Throws<ArgumentException>(null, () => Expression.AndAlso(Expression.Constant(obj), Expression.Constant(obj)));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.AndAlso(Expression.Constant(obj), Expression.Constant(obj)));
         }
 
         [Theory]
@@ -607,7 +607,7 @@ namespace System.Linq.Expressions.Tests
             TypeInfo createdType = builder.CreateTypeInfo();
             object obj = Activator.CreateInstance(createdType);
 
-            Assert.Throws<ArgumentException>(null, () => Expression.OrElse(Expression.Constant(obj), Expression.Constant(obj)));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.OrElse(Expression.Constant(obj), Expression.Constant(obj)));
         }
 
         [Theory]
@@ -629,8 +629,8 @@ namespace System.Linq.Expressions.Tests
             object obj = Activator.CreateInstance(createdType);
             MethodInfo createdMethod = createdType.GetMethod("Method");
 
-            Assert.Throws<ArgumentException>(null, () => Expression.AndAlso(Expression.Constant(obj), Expression.Constant(obj), createdMethod));
-            Assert.Throws<ArgumentException>(null, () => Expression.OrElse(Expression.Constant(obj), Expression.Constant(obj), createdMethod));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.AndAlso(Expression.Constant(obj), Expression.Constant(obj), createdMethod));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.OrElse(Expression.Constant(obj), Expression.Constant(obj), createdMethod));
         }
 
         [Theory]
@@ -650,7 +650,7 @@ namespace System.Linq.Expressions.Tests
 
             TypeInfo createdType = builder.CreateTypeInfo();
             object obj = Activator.CreateInstance(createdType);
-            Assert.Throws<ArgumentException>(null, () => Expression.AndAlso(Expression.Constant(obj), Expression.Constant(obj)));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.AndAlso(Expression.Constant(obj), Expression.Constant(obj)));
         }
 
         [Theory]
@@ -670,7 +670,7 @@ namespace System.Linq.Expressions.Tests
 
             TypeInfo createdType = builder.CreateTypeInfo();
             object obj = Activator.CreateInstance(createdType);
-            Assert.Throws<ArgumentException>(null, () => Expression.OrElse(Expression.Constant(obj), Expression.Constant(obj)));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.OrElse(Expression.Constant(obj), Expression.Constant(obj)));
         }
 
         [Fact]
@@ -736,8 +736,8 @@ namespace System.Linq.Expressions.Tests
         public static void ImplicitConversionToBool_ThrowsArgumentException()
         {
             MethodInfo method = typeof(ClassWithImplicitBoolOperator).GetMethod(nameof(ClassWithImplicitBoolOperator.ConversionMethod));
-            Assert.Throws<ArgumentException>(null, () => Expression.AndAlso(Expression.Constant(new ClassWithImplicitBoolOperator()), Expression.Constant(new ClassWithImplicitBoolOperator()), method));
-            Assert.Throws<ArgumentException>(null, () => Expression.OrElse(Expression.Constant(new ClassWithImplicitBoolOperator()), Expression.Constant(new ClassWithImplicitBoolOperator()), method));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.AndAlso(Expression.Constant(new ClassWithImplicitBoolOperator()), Expression.Constant(new ClassWithImplicitBoolOperator()), method));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.OrElse(Expression.Constant(new ClassWithImplicitBoolOperator()), Expression.Constant(new ClassWithImplicitBoolOperator()), method));
         }
 
         [Theory]

--- a/src/System.Linq.Expressions/tests/BinaryOperators/ReferenceComparison/ReferenceEqual.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/ReferenceComparison/ReferenceEqual.cs
@@ -144,7 +144,7 @@ namespace System.Linq.Expressions.Tests
             Expression exp = Expression.ReferenceEqual(Expression.Constant(""), Expression.Constant(""));
             Assert.False(exp.CanReduce);
             Assert.Same(exp, exp.Reduce());
-            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/BinaryOperators/ReferenceComparison/ReferenceNotEqual.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/ReferenceComparison/ReferenceNotEqual.cs
@@ -144,7 +144,7 @@ namespace System.Linq.Expressions.Tests
             Expression exp = Expression.ReferenceNotEqual(Expression.Constant(""), Expression.Constant(""));
             Assert.False(exp.CanReduce);
             Assert.Same(exp, exp.Reduce());
-            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/Block/BlockTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/BlockTests.cs
@@ -179,7 +179,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void EmptyBlockWrongExplicitType()
         {
-            Assert.Throws<ArgumentException>(null, () => Expression.Block(typeof(int)));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Block(typeof(int)));
         }
 
         [Theory]
@@ -207,7 +207,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void EmptyScopeExplicitWrongType()
         {
-            Assert.Throws<ArgumentException>(null, () => Expression.Block(
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Block(
                 typeof(int),
                 new[] { Expression.Parameter(typeof(int), "x") },
                 new Expression[0]));

--- a/src/System.Linq.Expressions/tests/Block/NoParameterBlockTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/NoParameterBlockTests.cs
@@ -213,12 +213,12 @@ namespace System.Linq.Expressions.Tests
             {
                 Expression[] expressions = expressionList.ToArray();
                 expressions[i] = null;
-                Assert.Throws<ArgumentNullException>($"expressions[{i}]", () => Expression.Block(expressions));
-                Assert.Throws<ArgumentNullException>($"expressions[{i}]", () => Expression.Block(expressions.Skip(0)));
-                Assert.Throws<ArgumentNullException>($"expressions[{i}]", () => Expression.Block(typeof(int), expressions));
-                Assert.Throws<ArgumentNullException>($"expressions[{i}]", () => Expression.Block(typeof(int), expressions.Skip(0)));
-                Assert.Throws<ArgumentNullException>($"expressions[{i}]", () => Expression.Block(typeof(int), null, expressions));
-                Assert.Throws<ArgumentNullException>($"expressions[{i}]", () => Expression.Block(typeof(int), null, expressions.Skip(0)));
+                AssertExtensions.Throws<ArgumentNullException>($"expressions[{i}]", () => Expression.Block(expressions));
+                AssertExtensions.Throws<ArgumentNullException>($"expressions[{i}]", () => Expression.Block(expressions.Skip(0)));
+                AssertExtensions.Throws<ArgumentNullException>($"expressions[{i}]", () => Expression.Block(typeof(int), expressions));
+                AssertExtensions.Throws<ArgumentNullException>($"expressions[{i}]", () => Expression.Block(typeof(int), expressions.Skip(0)));
+                AssertExtensions.Throws<ArgumentNullException>($"expressions[{i}]", () => Expression.Block(typeof(int), null, expressions));
+                AssertExtensions.Throws<ArgumentNullException>($"expressions[{i}]", () => Expression.Block(typeof(int), null, expressions.Skip(0)));
             }
         }
 
@@ -231,12 +231,12 @@ namespace System.Linq.Expressions.Tests
             {
                 Expression[] expressions = expressionList.ToArray();
                 expressions[i] = UnreadableExpression;
-                Assert.Throws<ArgumentException>($"expressions[{i}]", () => Expression.Block(expressions));
-                Assert.Throws<ArgumentException>($"expressions[{i}]", () => Expression.Block(expressions.Skip(0)));
-                Assert.Throws<ArgumentException>($"expressions[{i}]", () => Expression.Block(typeof(int), expressions));
-                Assert.Throws<ArgumentException>($"expressions[{i}]", () => Expression.Block(typeof(int), expressions.Skip(0)));
-                Assert.Throws<ArgumentException>($"expressions[{i}]", () => Expression.Block(typeof(int), null, expressions));
-                Assert.Throws<ArgumentException>($"expressions[{i}]", () => Expression.Block(typeof(int), null, expressions.Skip(0)));
+                AssertExtensions.Throws<ArgumentException>($"expressions[{i}]", () => Expression.Block(expressions));
+                AssertExtensions.Throws<ArgumentException>($"expressions[{i}]", () => Expression.Block(expressions.Skip(0)));
+                AssertExtensions.Throws<ArgumentException>($"expressions[{i}]", () => Expression.Block(typeof(int), expressions));
+                AssertExtensions.Throws<ArgumentException>($"expressions[{i}]", () => Expression.Block(typeof(int), expressions.Skip(0)));
+                AssertExtensions.Throws<ArgumentException>($"expressions[{i}]", () => Expression.Block(typeof(int), null, expressions));
+                AssertExtensions.Throws<ArgumentException>($"expressions[{i}]", () => Expression.Block(typeof(int), null, expressions.Skip(0)));
             }
         }
 
@@ -259,8 +259,8 @@ namespace System.Linq.Expressions.Tests
         {
             ConstantExpression constant = Expression.Constant(0);
             IEnumerable<Expression> expressions = PadBlock(blockSize - 1, Expression.Constant(0));
-            Assert.Throws<ArgumentException>(null, () => Expression.Block(typeof(string), expressions));
-            Assert.Throws<ArgumentException>(null, (() => Expression.Block(typeof(string), expressions.ToArray())));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Block(typeof(string), expressions));
+            AssertExtensions.Throws<ArgumentException>(null, (() => Expression.Block(typeof(string), expressions.ToArray())));
         }
 
         [Theory]
@@ -275,8 +275,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void EmptyBlockWithNonVoidTypeNotAllowed()
         {
-            Assert.Throws<ArgumentException>(null, () => Expression.Block(typeof(int)));
-            Assert.Throws<ArgumentException>(null, () => Expression.Block(typeof(int), Enumerable.Empty<Expression>()));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Block(typeof(int)));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Block(typeof(int), Enumerable.Empty<Expression>()));
         }
 
         [Theory]

--- a/src/System.Linq.Expressions/tests/Block/ParameterBlockTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/ParameterBlockTests.cs
@@ -75,10 +75,10 @@ namespace System.Linq.Expressions.Tests
             {
                 Expression[] expressions = expressionList.ToArray();
                 expressions[i] = null;
-                Assert.Throws<ArgumentNullException>($"expressions[{i}]", () => Expression.Block(SingleParameter, expressions));
-                Assert.Throws<ArgumentNullException>($"expressions[{i}]", () => Expression.Block(SingleParameter, expressions.Skip(0)));
-                Assert.Throws<ArgumentNullException>($"expressions[{i}]", () => Expression.Block(typeof(int), SingleParameter, expressions));
-                Assert.Throws<ArgumentNullException>($"expressions[{i}]", () => Expression.Block(typeof(int), SingleParameter, expressions.Skip(0)));
+                AssertExtensions.Throws<ArgumentNullException>($"expressions[{i}]", () => Expression.Block(SingleParameter, expressions));
+                AssertExtensions.Throws<ArgumentNullException>($"expressions[{i}]", () => Expression.Block(SingleParameter, expressions.Skip(0)));
+                AssertExtensions.Throws<ArgumentNullException>($"expressions[{i}]", () => Expression.Block(typeof(int), SingleParameter, expressions));
+                AssertExtensions.Throws<ArgumentNullException>($"expressions[{i}]", () => Expression.Block(typeof(int), SingleParameter, expressions.Skip(0)));
             }
         }
 
@@ -91,10 +91,10 @@ namespace System.Linq.Expressions.Tests
             {
                 Expression[] expressions = expressionList.ToArray();
                 expressions[i] = UnreadableExpression;
-                Assert.Throws<ArgumentException>($"expressions[{i}]", () => Expression.Block(SingleParameter, expressions));
-                Assert.Throws<ArgumentException>($"expressions[{i}]", () => Expression.Block(SingleParameter, expressions.Skip(0)));
-                Assert.Throws<ArgumentException>($"expressions[{i}]", () => Expression.Block(typeof(int), SingleParameter, expressions));
-                Assert.Throws<ArgumentException>($"expressions[{i}]", () => Expression.Block(typeof(int), SingleParameter, expressions.Skip(0)));
+                AssertExtensions.Throws<ArgumentException>($"expressions[{i}]", () => Expression.Block(SingleParameter, expressions));
+                AssertExtensions.Throws<ArgumentException>($"expressions[{i}]", () => Expression.Block(SingleParameter, expressions.Skip(0)));
+                AssertExtensions.Throws<ArgumentException>($"expressions[{i}]", () => Expression.Block(typeof(int), SingleParameter, expressions));
+                AssertExtensions.Throws<ArgumentException>($"expressions[{i}]", () => Expression.Block(typeof(int), SingleParameter, expressions.Skip(0)));
             }
         }
 
@@ -117,8 +117,8 @@ namespace System.Linq.Expressions.Tests
         {
             ConstantExpression constant = Expression.Constant(0);
             IEnumerable<Expression> expressions = PadBlock(blockSize - 1, Expression.Constant(0));
-            Assert.Throws<ArgumentException>(null, () => Expression.Block(typeof(string), SingleParameter, expressions));
-            Assert.Throws<ArgumentException>(null, () => Expression.Block(typeof(string), SingleParameter, expressions.ToArray()));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Block(typeof(string), SingleParameter, expressions));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Block(typeof(string), SingleParameter, expressions.ToArray()));
         }
 
         [Theory]
@@ -149,8 +149,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void EmptyBlockWithParametersAndNonVoidTypeNotAllowed()
         {
-            Assert.Throws<ArgumentException>(null, () => Expression.Block(typeof(int), SingleParameter));
-            Assert.Throws<ArgumentException>(null, () => Expression.Block(typeof(int), SingleParameter, Enumerable.Empty<Expression>()));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Block(typeof(int), SingleParameter));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Block(typeof(int), SingleParameter, Enumerable.Empty<Expression>()));
         }
 
         [Theory]

--- a/src/System.Linq.Expressions/tests/Call/CallTests.cs
+++ b/src/System.Linq.Expressions/tests/Call/CallTests.cs
@@ -335,26 +335,26 @@ namespace System.Linq.Expressions.Tests
         [MemberData(nameof(Method_DoesntBelongToInstance_TestData))]
         public static void Method_DoesntBelongToInstance_ThrowsArgumentException(Expression instance, MethodInfo method)
         {
-            Assert.Throws<ArgumentException>(null, () => Expression.Call(instance, method));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Call(instance, method));
         }
 
         [Fact]
         public static void InstanceMethod_NullInstance_ThrowsArgumentException()
         {
             MethodInfo method = typeof(NonGenericClass).GetMethod(nameof(NonGenericClass.InstanceMethod));
-            Assert.Throws<ArgumentException>(null, () => Expression.Call(method, s_valid));
-            Assert.Throws<ArgumentException>(null, () => Expression.Call(method, s_valid, s_valid));
-            Assert.Throws<ArgumentException>(null, () => Expression.Call(method, s_valid, s_valid, s_valid));
-            Assert.Throws<ArgumentException>(null, () => Expression.Call(method, s_valid, s_valid, s_valid, s_valid));
-            Assert.Throws<ArgumentException>(null, () => Expression.Call(method, s_valid, s_valid, s_valid, s_valid, s_valid));
-            Assert.Throws<ArgumentException>(null, () => Expression.Call(method, new Expression[0]));
-            Assert.Throws<ArgumentException>(null, () => Expression.Call(method, (IEnumerable<Expression>)new Expression[0]));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Call(method, s_valid));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Call(method, s_valid, s_valid));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Call(method, s_valid, s_valid, s_valid));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Call(method, s_valid, s_valid, s_valid, s_valid));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Call(method, s_valid, s_valid, s_valid, s_valid, s_valid));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Call(method, new Expression[0]));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Call(method, (IEnumerable<Expression>)new Expression[0]));
 
-            Assert.Throws<ArgumentException>(null, () => Expression.Call(null, method, s_valid));
-            Assert.Throws<ArgumentException>(null, () => Expression.Call(null, method, s_valid, s_valid));
-            Assert.Throws<ArgumentException>(null, () => Expression.Call(null, method, s_valid, s_valid, s_valid));
-            Assert.Throws<ArgumentException>(null, () => Expression.Call(null, method, new Expression[0]));
-            Assert.Throws<ArgumentException>(null, () => Expression.Call(null, method, (IEnumerable<Expression>)new Expression[0]));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Call(null, method, s_valid));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Call(null, method, s_valid, s_valid));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Call(null, method, s_valid, s_valid, s_valid));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Call(null, method, new Expression[0]));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Call(null, method, (IEnumerable<Expression>)new Expression[0]));
         }
 
         [Fact]
@@ -362,11 +362,11 @@ namespace System.Linq.Expressions.Tests
         {
             Expression instance = Expression.Constant(new NonGenericClass());
             MethodInfo method = typeof(NonGenericClass).GetMethod(nameof(NonGenericClass.StaticMethod));
-            Assert.Throws<ArgumentException>(null, () => Expression.Call(instance, method, s_valid));
-            Assert.Throws<ArgumentException>(null, () => Expression.Call(instance, method, s_valid, s_valid));
-            Assert.Throws<ArgumentException>(null, () => Expression.Call(instance, method, s_valid, s_valid, s_valid));
-            Assert.Throws<ArgumentException>(null, () => Expression.Call(instance, method, new Expression[0]));
-            Assert.Throws<ArgumentException>(null, () => Expression.Call(instance, method, (IEnumerable<Expression>)new Expression[0]));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Call(instance, method, s_valid));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Call(instance, method, s_valid, s_valid));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Call(instance, method, s_valid, s_valid, s_valid));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Call(instance, method, new Expression[0]));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Call(instance, method, (IEnumerable<Expression>)new Expression[0]));
         }
 
         public static IEnumerable<object[]> InvalidArg_TestData()
@@ -433,7 +433,10 @@ namespace System.Linq.Expressions.Tests
         private static void AssertArgumentException(Action action, Type exceptionType, string paramName)
         {
             ArgumentException ex = (ArgumentException)Assert.Throws(exceptionType, action);
-            Assert.Equal(paramName, ex.ParamName);
+            if (!PlatformDetection.IsNetNative) // The .NET Native toolchain optimizes away exception ParamNames
+            {
+                Assert.Equal(paramName, ex.ParamName);
+            }
         }
 
         [Theory]
@@ -526,8 +529,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void MethodName_TypeArgsDontMatchConstraints_ThrowsArgumentException()
         {
-            Assert.Throws<ArgumentException>(null, () => Expression.Call(Expression.Constant(new NonGenericClass()), nameof(NonGenericClass.ConstrainedInstanceMethod), new Type[] { typeof(object) }));
-            Assert.Throws<ArgumentException>(null, () => Expression.Call(typeof(NonGenericClass), nameof(NonGenericClass.ConstrainedStaticMethod), new Type[] { typeof(object) }));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Call(Expression.Constant(new NonGenericClass()), nameof(NonGenericClass.ConstrainedInstanceMethod), new Type[] { typeof(object) }));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Call(typeof(NonGenericClass), nameof(NonGenericClass.ConstrainedStaticMethod), new Type[] { typeof(object) }));
         }
 
         [Fact]
@@ -540,8 +543,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void MethodName_TypeArgsHasNullValue_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(null, () => Expression.Call(Expression.Constant(new NonGenericClass()), nameof(NonGenericClass.GenericInstanceMethod), new Type[] { null }));
-            Assert.Throws<ArgumentNullException>(null, () => Expression.Call(typeof(NonGenericClass), nameof(NonGenericClass.GenericStaticMethod), new Type[] { null }));
+            AssertExtensions.Throws<ArgumentNullException>(null, () => Expression.Call(Expression.Constant(new NonGenericClass()), nameof(NonGenericClass.GenericInstanceMethod), new Type[] { null }));
+            AssertExtensions.Throws<ArgumentNullException>(null, () => Expression.Call(typeof(NonGenericClass), nameof(NonGenericClass.GenericStaticMethod), new Type[] { null }));
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/Cast/AsTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/AsTests.cs
@@ -872,14 +872,14 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void PointerType()
         {
-            Assert.Throws<ArgumentException>(
+            AssertExtensions.Throws<ArgumentException>(
                 "type", () => Expression.TypeAs(Expression.Constant(""), typeof(int).MakePointerType()));
         }
 
         [Fact]
         public static void ByRefType()
         {
-            Assert.Throws<ArgumentException>(
+            AssertExtensions.Throws<ArgumentException>(
                 "type", () => Expression.TypeAs(Expression.Constant(""), typeof(string).MakeByRefType()));
         }
 

--- a/src/System.Linq.Expressions/tests/Conditional/ConditionalTests.cs
+++ b/src/System.Linq.Expressions/tests/Conditional/ConditionalTests.cs
@@ -121,21 +121,21 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void IncompatibleImplicitTypes()
         {
-            Assert.Throws<ArgumentException>(null, () => Expression.Condition(Expression.Constant(true), Expression.Constant(0), Expression.Constant(0L)));
-            Assert.Throws<ArgumentException>(null, () => Expression.Condition(Expression.Constant(true), Expression.Constant(0L), Expression.Constant(0)));
-            Assert.Throws<ArgumentException>(null, () => Expression.Condition(Expression.Constant(true), Expression.Constant("hello"), Expression.Constant(new object())));
-            Assert.Throws<ArgumentException>(null, () => Expression.Condition(Expression.Constant(true), Expression.Constant(new object()), Expression.Constant("hello")));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Condition(Expression.Constant(true), Expression.Constant(0), Expression.Constant(0L)));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Condition(Expression.Constant(true), Expression.Constant(0L), Expression.Constant(0)));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Condition(Expression.Constant(true), Expression.Constant("hello"), Expression.Constant(new object())));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Condition(Expression.Constant(true), Expression.Constant(new object()), Expression.Constant("hello")));
         }
 
         [Fact]
         public void IncompatibleExplicitTypes()
         {
-            Assert.Throws<ArgumentException>(null, () => Expression.Condition(Expression.Constant(true), Expression.Constant(0), Expression.Constant(0L), typeof(int)));
-            Assert.Throws<ArgumentException>(null, () => Expression.Condition(Expression.Constant(true), Expression.Constant(0L), Expression.Constant(0), typeof(int)));
-            Assert.Throws<ArgumentException>(null, () => Expression.Condition(Expression.Constant(true), Expression.Constant(0), Expression.Constant(0L), typeof(long)));
-            Assert.Throws<ArgumentException>(null, () => Expression.Condition(Expression.Constant(true), Expression.Constant(0L), Expression.Constant(0), typeof(long)));
-            Assert.Throws<ArgumentException>(null, () => Expression.Condition(Expression.Constant(true), Expression.Constant(0), Expression.Constant("hello"), typeof(object)));
-            Assert.Throws<ArgumentException>(null, () => Expression.Condition(Expression.Constant(true), Expression.Constant("hello"), Expression.Constant(0), typeof(object)));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Condition(Expression.Constant(true), Expression.Constant(0), Expression.Constant(0L), typeof(int)));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Condition(Expression.Constant(true), Expression.Constant(0L), Expression.Constant(0), typeof(int)));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Condition(Expression.Constant(true), Expression.Constant(0), Expression.Constant(0L), typeof(long)));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Condition(Expression.Constant(true), Expression.Constant(0L), Expression.Constant(0), typeof(long)));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Condition(Expression.Constant(true), Expression.Constant(0), Expression.Constant("hello"), typeof(object)));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Condition(Expression.Constant(true), Expression.Constant("hello"), Expression.Constant(0), typeof(object)));
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]

--- a/src/System.Linq.Expressions/tests/Constant/ConstantTests.cs
+++ b/src/System.Linq.Expressions/tests/Constant/ConstantTests.cs
@@ -956,13 +956,13 @@ namespace System.Linq.Expressions.Tests
         public static void InvalidTypeValueType()
         {
             // implicit cast, but not reference assignable.
-            Assert.Throws<ArgumentException>(null, () => Expression.Constant(0, typeof(long)));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Constant(0, typeof(long)));
         }
 
         [Fact]
         public static void InvalidTypeReferenceType()
         {
-            Assert.Throws<ArgumentException>(null, () => Expression.Constant("hello", typeof(Expression)));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Constant("hello", typeof(Expression)));
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/DebugInfo/DebugInfoExpressionTests.cs
+++ b/src/System.Linq.Expressions/tests/DebugInfo/DebugInfoExpressionTests.cs
@@ -33,8 +33,8 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentOutOfRangeException>("endLine", () => Expression.DebugInfo(document, 1, 1, 0, 1));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("endColumn", () => Expression.DebugInfo(document, 1, 1, 1, 0));
 
-            Assert.Throws<ArgumentException>(null, () => Expression.DebugInfo(document, 10, 1, 1, 1));
-            Assert.Throws<ArgumentException>(null, () => Expression.DebugInfo(document, 1, 10, 1, 1));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.DebugInfo(document, 10, 1, 1, 1));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.DebugInfo(document, 1, 10, 1, 1));
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/DebuggerTypeProxy/ExpressionDebuggerTypeProxyTests.cs
+++ b/src/System.Linq.Expressions/tests/DebuggerTypeProxy/ExpressionDebuggerTypeProxyTests.cs
@@ -161,9 +161,12 @@ namespace System.Linq.Expressions.Tests
             Type type = sourceObject.GetType();
             Type viewType = GetDebugViewType(type);
             ConstructorInfo ctor = viewType.GetConstructors().Single();
-            TargetInvocationException tie = Assert.Throws<TargetInvocationException>(() => ctor.Invoke(new object[] {null}));
+            TargetInvocationException tie = Assert.Throws<TargetInvocationException>(() => ctor.Invoke(new object[] { null }));
             ArgumentNullException ane = (ArgumentNullException)tie.InnerException;
-            Assert.Equal(ctor.GetParameters()[0].Name, ane.ParamName);
+            if (!PlatformDetection.IsNetNative) // The .NET Native toolchain optimizes away exception ParamNames
+            {
+                Assert.Equal(ctor.GetParameters()[0].Name, ane.ParamName);
+            }
         }
 
         private static IEnumerable<object[]> OnePerType()

--- a/src/System.Linq.Expressions/tests/Dynamic/BindingRestrictionsProxyTests.cs
+++ b/src/System.Linq.Expressions/tests/Dynamic/BindingRestrictionsProxyTests.cs
@@ -176,7 +176,10 @@ namespace System.Dynamic.Tests
         {
             TargetInvocationException tie = Assert.Throws<TargetInvocationException>(() => BindingRestrictionsProxyCtor.Invoke(new object[] {null}));
             ArgumentNullException ane = (ArgumentNullException)tie.InnerException;
-            Assert.Equal("node", ane.ParamName);
+            if (!PlatformDetection.IsNetNative) // The .NET Native toolchain optimizes away exception ParamNames
+            {
+                Assert.Equal("node", ane.ParamName);
+            }
         }
     }
 }

--- a/src/System.Linq.Expressions/tests/Dynamic/BindingRestrictionsTests.cs
+++ b/src/System.Linq.Expressions/tests/Dynamic/BindingRestrictionsTests.cs
@@ -75,16 +75,16 @@ namespace System.Dynamic.Tests
         [Fact]
         public void ExpressionRestrictionFromNonBooleanExpression()
         {
-            Assert.Throws<ArgumentException>(
+            AssertExtensions.Throws<ArgumentException>(
                 "expression", () => BindingRestrictions.GetExpressionRestriction(Expression.Empty()));
-            Assert.Throws<ArgumentException>(
+            AssertExtensions.Throws<ArgumentException>(
                 "expression", () => BindingRestrictions.GetExpressionRestriction(Expression.Constant("")));
         }
 
         [Fact]
         public void InstanceRestrictionFromNull()
         {
-            Assert.Throws<ArgumentNullException>(
+            AssertExtensions.Throws<ArgumentNullException>(
                 "expression", () => BindingRestrictions.GetInstanceRestriction(null, new object()));
         }
 

--- a/src/System.Linq.Expressions/tests/Dynamic/CallInfoTests.cs
+++ b/src/System.Linq.Expressions/tests/Dynamic/CallInfoTests.cs
@@ -23,14 +23,14 @@ namespace System.Dynamic.Tests
         [InlineData(2, new string[] { "foo", "bar", "baz", "quux", "quuux" })]
         public void Ctor_CountLessThanArgNamesCount_ThrowsArgumentException(int argCount, string[] argNames)
         {
-            Assert.Throws<ArgumentException>(null, () => new CallInfo(argCount, argNames));
+            AssertExtensions.Throws<ArgumentException>(null, () => new CallInfo(argCount, argNames));
         }
 
         [Fact]
         public void Ctor_NullItemInArgNames_ThrowsArgumentNullException()
         {
             AssertExtensions.Throws<ArgumentNullException>("argNames[1]", () => new CallInfo(3, "foo", null, "bar"));
-            Assert.Throws<ArgumentNullException>(
+            AssertExtensions.Throws<ArgumentNullException>(
                 "argNames[0]", () => new CallInfo(3, Enumerable.Repeat(default(string), 2)));
         }
 

--- a/src/System.Linq.Expressions/tests/Dynamic/ExpandoObjectProxyTests.cs
+++ b/src/System.Linq.Expressions/tests/Dynamic/ExpandoObjectProxyTests.cs
@@ -111,7 +111,10 @@ namespace System.Dynamic.Tests
             ConstructorInfo constructor = debugViewType.GetConstructors().Single();
             TargetInvocationException tie = Assert.Throws<TargetInvocationException>(() => constructor.Invoke(new object[] {null}));
             var ane = (ArgumentNullException)tie.InnerException;
-            Assert.Equal("collection", ane.ParamName);
+            if (!PlatformDetection.IsNetNative) // The .NET Native toolchain optimizes away exception ParamNames
+            {
+                Assert.Equal("collection", ane.ParamName);
+            }
         }
     }
 }

--- a/src/System.Linq.Expressions/tests/Dynamic/InvokeMemberBindingTests.cs
+++ b/src/System.Linq.Expressions/tests/Dynamic/InvokeMemberBindingTests.cs
@@ -143,14 +143,14 @@ namespace System.Dynamic.Tests
         public void NullName()
         {
             CallInfo info = new CallInfo(0);
-            Assert.Throws<ArgumentNullException>(
+            AssertExtensions.Throws<ArgumentNullException>(
                 "name", () => new MinimumOverrideInvokeMemberBinding(null, false, info));
         }
 
         [Fact]
         public void NullCallInfo()
         {
-            Assert.Throws<ArgumentNullException>(
+            AssertExtensions.Throws<ArgumentNullException>(
                 "callInfo", () => new MinimumOverrideInvokeMemberBinding("Name", false, null));
         }
 

--- a/src/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
+++ b/src/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
@@ -81,7 +81,7 @@ namespace System.Linq.Expressions.Tests
         public void GenericThrowType()
         {
             Type listType = typeof(List<>);
-            Assert.Throws<ArgumentException>(
+            AssertExtensions.Throws<ArgumentException>(
                 "type", () => Expression.Throw(Expression.Constant(new TestException()), listType));
             AssertExtensions.Throws<ArgumentException>("type", () => Expression.Rethrow(listType));
         }
@@ -91,7 +91,7 @@ namespace System.Linq.Expressions.Tests
         {
             Type listType = typeof(List<>);
             Type listListListType = listType.MakeGenericType(listType.MakeGenericType(listType));
-            Assert.Throws<ArgumentException>(
+            AssertExtensions.Throws<ArgumentException>(
                 "type", () => Expression.Throw(Expression.Constant(new TestException()), listListListType));
             AssertExtensions.Throws<ArgumentException>("type", () => Expression.Rethrow(listListListType));
         }
@@ -100,7 +100,7 @@ namespace System.Linq.Expressions.Tests
         public void PointerThrowType()
         {
             Type pointer = typeof(int).MakeByRefType();
-            Assert.Throws<ArgumentException>(
+            AssertExtensions.Throws<ArgumentException>(
                 "type", () => Expression.Throw(Expression.Constant(new TestException()), pointer));
             AssertExtensions.Throws<ArgumentException>("type", () => Expression.Rethrow(pointer));
         }
@@ -109,7 +109,7 @@ namespace System.Linq.Expressions.Tests
         public void ByRefThrowType()
         {
             Type byRefType = typeof(int).MakeByRefType();
-            Assert.Throws<ArgumentException>(
+            AssertExtensions.Throws<ArgumentException>(
                 "type", () => Expression.Throw(Expression.Constant(new TestException()), byRefType));
             AssertExtensions.Throws<ArgumentException>("type", () => Expression.Rethrow(byRefType));
         }
@@ -366,7 +366,7 @@ namespace System.Linq.Expressions.Tests
             UnaryExpression throwExp = Expression.Throw(Expression.Constant(new TestException()));
             Assert.False(throwExp.CanReduce);
             Assert.Same(throwExp, throwExp.Reduce());
-            Assert.Throws<ArgumentException>(null, () => throwExp.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => throwExp.ReduceAndCheck());
         }
 
         [Fact]
@@ -375,7 +375,7 @@ namespace System.Linq.Expressions.Tests
             TryExpression tryExp = Expression.TryFault(Expression.Empty(), Expression.Empty());
             Assert.False(tryExp.CanReduce);
             Assert.Same(tryExp, tryExp.Reduce());
-            Assert.Throws<ArgumentException>(null, () => tryExp.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => tryExp.ReduceAndCheck());
         }
 
         [Fact]
@@ -398,7 +398,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void MustHaveCatchFinallyOrFault()
         {
-            Assert.Throws<ArgumentException>(null, () => Expression.MakeTry(typeof(int), Expression.Constant(1), null, null, null));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.MakeTry(typeof(int), Expression.Constant(1), null, null, null));
         }
 
         [Fact]
@@ -1202,19 +1202,19 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void NonAssignableTryAndCatchTypes()
         {
-            Assert.Throws<ArgumentException>(null, () => Expression.TryCatch(Expression.Constant(new Uri("http://example.net/")), Expression.Catch(typeof(Exception), Expression.Constant("hello"))));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.TryCatch(Expression.Constant(new Uri("http://example.net/")), Expression.Catch(typeof(Exception), Expression.Constant("hello"))));
         }
 
         [Fact]
         public void BodyTypeNotAssignableToTryType()
         {
-            Assert.Throws<ArgumentException>(null, () => Expression.MakeTry(typeof(int), Expression.Constant("hello"), Expression.Empty(), null, null));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.MakeTry(typeof(int), Expression.Constant("hello"), Expression.Empty(), null, null));
         }
 
         [Fact]
         public void CatchTypeNotAssignableToTryType()
         {
-            Assert.Throws<ArgumentException>(null, () => Expression.MakeTry(typeof(int), Expression.Constant(2), null, null, new[] { Expression.Catch(typeof(InvalidCastException), Expression.Constant("")) }));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.MakeTry(typeof(int), Expression.Constant(2), null, null, new[] { Expression.Catch(typeof(InvalidCastException), Expression.Constant("")) }));
         }
 
         [Theory]

--- a/src/System.Linq.Expressions/tests/ExpressionTests.cs
+++ b/src/System.Linq.Expressions/tests/ExpressionTests.cs
@@ -201,7 +201,7 @@ namespace System.Linq.Expressions.Tests
         public void VisitChildrenThrowsAsNotReducible()
         {
             var exp = new IncompleteExpressionOverride();
-            Assert.Throws<ArgumentException>(null, () => exp.VisitChildren());
+            AssertExtensions.Throws<ArgumentException>(null, () => exp.VisitChildren());
         }
 
         [Fact]
@@ -221,42 +221,42 @@ namespace System.Linq.Expressions.Tests
         public void ReduceAndCheckThrowsByDefault()
         {
             var exp = new IncompleteExpressionOverride();
-            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
         [Fact]
         public void ReduceExtensionsThrowsByDefault()
         {
             var exp = new IncompleteExpressionOverride();
-            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
         [Fact]
         public void IfClaimCanReduceMustReduce()
         {
             var exp = new ClaimedReducibleOverride();
-            Assert.Throws<ArgumentException>(null, () => exp.Reduce());
+            AssertExtensions.Throws<ArgumentException>(null, () => exp.Reduce());
         }
 
         [Fact]
         public void ReduceAndCheckThrowOnReduceToSame()
         {
             var exp = new ReducesToSame();
-            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
         [Fact]
         public void ReduceAndCheckThrowOnReduceToNull()
         {
             var exp = new ReducesToNull();
-            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
         [Fact]
         public void ReduceAndCheckThrowOnReducedTypeNotAssignable()
         {
             var exp = new ReducesToLongTyped();
-            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
 #pragma warning disable 0169, 0414 // Accessed through reflection.
@@ -375,14 +375,14 @@ namespace System.Linq.Expressions.Tests
         public void CompileIrreduciebleExtension(bool useInterpreter)
         {
             Expression<Action> exp = Expression.Lambda<Action>(new IrreducibleWithTypeAndNodeType());
-            Assert.Throws<ArgumentException>(null, () => exp.Compile(useInterpreter));
+            AssertExtensions.Throws<ArgumentException>(null, () => exp.Compile(useInterpreter));
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
         public void CompileIrreduciebleStrangeNodeTypeExtension(bool useInterpreter)
         {
             Expression<Action> exp = Expression.Lambda<Action>(new IrreduceibleWithTypeAndStrangeNodeType());
-            Assert.Throws<ArgumentException>(null, () => exp.Compile(useInterpreter));
+            AssertExtensions.Throws<ArgumentException>(null, () => exp.Compile(useInterpreter));
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]

--- a/src/System.Linq.Expressions/tests/Goto/Break.cs
+++ b/src/System.Linq.Expressions/tests/Goto/Break.cs
@@ -135,7 +135,7 @@ namespace System.Linq.Expressions.Tests
         [MemberData(nameof(NonObjectAssignableConstantValueData))]
         public void CannotAssignValueTypesToObject(object value)
         {
-            Assert.Throws<ArgumentException>(null, () => Expression.Break(Expression.Label(typeof(object)), Expression.Constant(value)));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Break(Expression.Label(typeof(object)), Expression.Constant(value)));
         }
 
         [Theory]

--- a/src/System.Linq.Expressions/tests/Goto/Goto.cs
+++ b/src/System.Linq.Expressions/tests/Goto/Goto.cs
@@ -135,7 +135,7 @@ namespace System.Linq.Expressions.Tests
         [MemberData(nameof(NonObjectAssignableConstantValueData))]
         public void CannotAssignValueTypesToObject(object value)
         {
-            Assert.Throws<ArgumentException>(null, () => Expression.Goto(Expression.Label(typeof(object)), Expression.Constant(value)));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Goto(Expression.Label(typeof(object)), Expression.Constant(value)));
         }
 
         [Theory]

--- a/src/System.Linq.Expressions/tests/Goto/MakeGoto.cs
+++ b/src/System.Linq.Expressions/tests/Goto/MakeGoto.cs
@@ -16,7 +16,7 @@ namespace System.Linq.Expressions.Tests
         [MemberData(nameof(GotoTypes))]
         public void OpenGenericType(GotoExpressionKind kind)
         {
-            Assert.Throws<ArgumentException>(
+            AssertExtensions.Throws<ArgumentException>(
                 "type", () => Expression.MakeGoto(kind, Expression.Label(typeof(void)), null, typeof(List<>)));
         }
 
@@ -24,9 +24,9 @@ namespace System.Linq.Expressions.Tests
         [MemberData(nameof(GotoTypes))]
         public static void TypeContainsGenericParameters(GotoExpressionKind kind)
         {
-            Assert.Throws<ArgumentException>(
+            AssertExtensions.Throws<ArgumentException>(
                 "type", () => Expression.MakeGoto(kind, Expression.Label(typeof(void)), null, typeof(List<>.Enumerator)));
-            Assert.Throws<ArgumentException>(
+            AssertExtensions.Throws<ArgumentException>(
                 "type",
                 () =>
                     Expression.MakeGoto(
@@ -37,7 +37,7 @@ namespace System.Linq.Expressions.Tests
         [MemberData(nameof(GotoTypes))]
         public void PointerType(GotoExpressionKind kind)
         {
-            Assert.Throws<ArgumentException>(
+            AssertExtensions.Throws<ArgumentException>(
                 "type",
                 () => Expression.MakeGoto(kind, Expression.Label(typeof(void)), null, typeof(int).MakePointerType()));
         }
@@ -46,7 +46,7 @@ namespace System.Linq.Expressions.Tests
         [MemberData(nameof(GotoTypes))]
         public void ByRefType(GotoExpressionKind kind)
         {
-            Assert.Throws<ArgumentException>(
+            AssertExtensions.Throws<ArgumentException>(
                 "type",
                 () => Expression.MakeGoto(kind, Expression.Label(typeof(void)), null, typeof(int).MakeByRefType()));
         }

--- a/src/System.Linq.Expressions/tests/Goto/Return.cs
+++ b/src/System.Linq.Expressions/tests/Goto/Return.cs
@@ -135,7 +135,7 @@ namespace System.Linq.Expressions.Tests
         [MemberData(nameof(NonObjectAssignableConstantValueData))]
         public void CannotAssignValueTypesToObject(object value)
         {
-            Assert.Throws<ArgumentException>(null, () => Expression.Return(Expression.Label(typeof(object)), Expression.Constant(value)));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Return(Expression.Label(typeof(object)), Expression.Constant(value)));
         }
 
         [Theory]

--- a/src/System.Linq.Expressions/tests/Label/LabelTests.cs
+++ b/src/System.Linq.Expressions/tests/Label/LabelTests.cs
@@ -45,7 +45,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void DefaultMustMatchLabelType()
         {
-            Assert.Throws<ArgumentException>(null, () => Expression.Label(Expression.Label(typeof(int)), Expression.Constant("hello")));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Label(Expression.Label(typeof(int)), Expression.Constant("hello")));
         }
 
         [Fact]
@@ -57,7 +57,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void AssignableOnlyReferenceAssignableNotImplicitConversion()
         {
-            Assert.Throws<ArgumentException>(null, () => Expression.Label(Expression.Label(typeof(long)), Expression.Constant(0)));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Label(Expression.Label(typeof(long)), Expression.Constant(0)));
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
@@ -334,34 +334,34 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void IncorrectArgumentCount()
         {
-            Assert.Throws<ArgumentException>(null,
+            AssertExtensions.Throws<ArgumentException>(null,
                 () => Expression.Lambda<Action>(Expression.Empty(), Expression.Parameter(typeof(int))));
-            Assert.Throws<ArgumentException>(null,
+            AssertExtensions.Throws<ArgumentException>(null,
                 () => Expression.Lambda<Action<int, int>>(Expression.Empty(), "nullary or binary?", Enumerable.Empty<ParameterExpression>()));
-            Assert.Throws<ArgumentException>(null,
+            AssertExtensions.Throws<ArgumentException>(null,
                 () => Expression.Lambda<Func<int>>(Expression.Constant(1), Expression.Parameter(typeof(int))));
-            Assert.Throws<ArgumentException>(null,
+            AssertExtensions.Throws<ArgumentException>(null,
                 () => Expression.Lambda<Func<int, int, int>>(Expression.Constant(1), "nullary or binary?", Enumerable.Empty<ParameterExpression>()));
-            Assert.Throws<ArgumentException>(null,
+            AssertExtensions.Throws<ArgumentException>(null,
                 () => Expression.Lambda(typeof(Action), Expression.Empty(), Expression.Parameter(typeof(int))));
-            Assert.Throws<ArgumentException>(null,
+            AssertExtensions.Throws<ArgumentException>(null,
                 () => Expression.Lambda(typeof(Func<int, int, int>), Expression.Constant(1), "nullary or binary?", Enumerable.Empty<ParameterExpression>()));
         }
 
         [Fact]
         public void ByRefParameterForValueDelegateParameter()
         {
-            Assert.Throws<ArgumentException>(null,
+            AssertExtensions.Throws<ArgumentException>(null,
                 () => Expression.Lambda<Action<int>>(Expression.Empty(), Expression.Parameter(typeof(int).MakeByRefType())));
-            Assert.Throws<ArgumentException>(null,
+            AssertExtensions.Throws<ArgumentException>(null,
                 () => Expression.Lambda<Func<int, bool, int, string>>(
                     Expression.Constant(""),
                     Expression.Parameter(typeof(int)),
                     Expression.Parameter(typeof(bool).MakeByRefType()),
                     Expression.Parameter(typeof(int))));
-            Assert.Throws<ArgumentException>(null,
+            AssertExtensions.Throws<ArgumentException>(null,
                 () => Expression.Lambda(typeof(Action<int>), Expression.Empty(), Expression.Parameter(typeof(int).MakeByRefType())));
-            Assert.Throws<ArgumentException>(null,
+            AssertExtensions.Throws<ArgumentException>(null,
                 () => Expression.Lambda(
                     typeof(Func<int, bool, int, string>),
                     Expression.Constant(""),
@@ -388,8 +388,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void IncorrectReturnTypes()
         {
-            Assert.Throws<ArgumentException>(null, () => Expression.Lambda<Func<int>>(Expression.Constant(typeof(long))));
-            Assert.Throws<ArgumentException>(null, () => Expression.Lambda(typeof(Func<int>), Expression.Constant(typeof(long))));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Lambda<Func<int>>(Expression.Constant(typeof(long))));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Lambda(typeof(Func<int>), Expression.Constant(typeof(long))));
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]

--- a/src/System.Linq.Expressions/tests/ListInit/ListInitExpressionTests.cs
+++ b/src/System.Linq.Expressions/tests/ListInit/ListInitExpressionTests.cs
@@ -163,7 +163,7 @@ namespace System.Linq.Expressions.Tests
             // This logically includes cases of methods of open generic types, since the NewExpression cannot be of such a type.
             NewExpression newExp = Expression.New(typeof(List<int>));
             MethodInfo adder = typeof(HashSet<int>).GetMethod(nameof(HashSet<int>.Add));
-            Assert.Throws<ArgumentException>(null, () => Expression.ListInit(newExp, adder, Expression.Constant(0)));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.ListInit(newExp, adder, Expression.Constant(0)));
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/Loop/LoopTests.cs
+++ b/src/System.Linq.Expressions/tests/Loop/LoopTests.cs
@@ -254,7 +254,7 @@ namespace System.Linq.Expressions.Tests
             LoopExpression loop = Expression.Loop(Expression.Empty(), Expression.Label(), Expression.Label());
             Assert.False(loop.CanReduce);
             Assert.Same(loop, loop.Reduce());
-            Assert.Throws<ArgumentException>(null, () => loop.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => loop.ReduceAndCheck());
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
+++ b/src/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
@@ -281,17 +281,17 @@ namespace System.Linq.Expressions.Tests
         {
             Expression expression = Expression.Constant(new PC());
 
-            Assert.Throws<ArgumentException>(null, () => Expression.Field(expression, typeof(FC), nameof(FC.II)));
-            Assert.Throws<ArgumentException>(null, () => Expression.Field(expression, typeof(FC).GetField(nameof(FC.II))));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Field(expression, typeof(FC), nameof(FC.II)));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Field(expression, typeof(FC).GetField(nameof(FC.II))));
 
-            Assert.Throws<ArgumentException>(null, () => Expression.MakeMemberAccess(expression, typeof(FC).GetField(nameof(FC.II))));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.MakeMemberAccess(expression, typeof(FC).GetField(nameof(FC.II))));
         }
 
         [Fact]
         public static void Field_NoSuchFieldName_ThrowsArgumentException()
         {
-            Assert.Throws<ArgumentException>(null, () => Expression.Field(Expression.Constant(new FC()), "NoSuchField"));
-            Assert.Throws<ArgumentException>(null, () => Expression.Field(Expression.Constant(new FC()), typeof(FC), "NoSuchField"));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Field(Expression.Constant(new FC()), "NoSuchField"));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Field(Expression.Constant(new FC()), typeof(FC), "NoSuchField"));
         }
 
         [Theory]

--- a/src/System.Linq.Expressions/tests/MemberInit/BindTests.cs
+++ b/src/System.Linq.Expressions/tests/MemberInit/BindTests.cs
@@ -91,8 +91,8 @@ namespace System.Linq.Expressions.Tests
         {
             MemberInfo member = typeof(PropertyAndFields).GetMember(nameof(PropertyAndFields.StringProperty))[0];
             PropertyInfo property = typeof(PropertyAndFields).GetProperty(nameof(PropertyAndFields.StringProperty));
-            Assert.Throws<ArgumentException>(null, () => Expression.Bind(member, Expression.Constant(0)));
-            Assert.Throws<ArgumentException>(null, () => Expression.Bind(property, Expression.Constant(0)));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Bind(member, Expression.Constant(0)));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Bind(property, Expression.Constant(0)));
         }
 
         [Fact]
@@ -100,8 +100,8 @@ namespace System.Linq.Expressions.Tests
         {
             MemberInfo member = typeof(Unreadable<>).GetMember("WriteOnly")[0];
             PropertyInfo property = typeof(Unreadable<>).GetProperty("WriteOnly");
-            Assert.Throws<ArgumentException>(null, () => Expression.Bind(member, Expression.Constant(0)));
-            Assert.Throws<ArgumentException>(null, () => Expression.Bind(property, Expression.Constant(0)));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Bind(member, Expression.Constant(0)));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Bind(property, Expression.Constant(0)));
         }
 
         [Fact]
@@ -109,8 +109,8 @@ namespace System.Linq.Expressions.Tests
         {
             MemberInfo member = typeof(GenericType<>).GetMember(nameof(GenericType<int>.AlwaysInt32))[0];
             PropertyInfo property = typeof(GenericType<>).GetProperty(nameof(GenericType<int>.AlwaysInt32));
-            Assert.Throws<ArgumentException>(null, () => Expression.Bind(member, Expression.Constant(0)));
-            Assert.Throws<ArgumentException>(null, () => Expression.Bind(property, Expression.Constant(0)));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Bind(member, Expression.Constant(0)));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Bind(property, Expression.Constant(0)));
         }
 
         [Fact]
@@ -296,7 +296,7 @@ namespace System.Linq.Expressions.Tests
         [Theory, MemberData(nameof(BogusBindings))]
         public void BogusBindingType(MemberBinding binding)
         {
-            Assert.Throws<ArgumentException>("bindings[0]", () => Expression.MemberInit(Expression.New(typeof(PropertyAndFields)), binding));
+            AssertExtensions.Throws<ArgumentException>("bindings[0]", () => Expression.MemberInit(Expression.New(typeof(PropertyAndFields)), binding));
         }
 
 #if FEATURE_COMPILE

--- a/src/System.Linq.Expressions/tests/MemberInit/ListBindTests.cs
+++ b/src/System.Linq.Expressions/tests/MemberInit/ListBindTests.cs
@@ -281,14 +281,14 @@ namespace System.Linq.Expressions.Tests
             PropertyInfo property = typeof(ListWrapper<>).GetProperty(nameof(ListWrapper<int>.ListProperty));
             FieldInfo field = typeof(ListWrapper<>).GetField(nameof(ListWrapper<int>.ListField));
             MethodInfo method = property.GetMethod;
-            Assert.Throws<ArgumentException>(null, () => Expression.ListBind(member, Enumerable.Empty<ElementInit>()));
-            Assert.Throws<ArgumentException>(null, () => Expression.ListBind(member));
-            Assert.Throws<ArgumentException>(null, () => Expression.ListBind(property, Enumerable.Empty<ElementInit>()));
-            Assert.Throws<ArgumentException>(null, () => Expression.ListBind(property));
-            Assert.Throws<ArgumentException>(null, () => Expression.ListBind(field, Enumerable.Empty<ElementInit>()));
-            Assert.Throws<ArgumentException>(null, () => Expression.ListBind(field));
-            Assert.Throws<ArgumentException>(null, () => Expression.ListBind(method, Enumerable.Empty<ElementInit>()));
-            Assert.Throws<ArgumentException>(null, () => Expression.ListBind(method));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.ListBind(member, Enumerable.Empty<ElementInit>()));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.ListBind(member));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.ListBind(property, Enumerable.Empty<ElementInit>()));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.ListBind(property));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.ListBind(field, Enumerable.Empty<ElementInit>()));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.ListBind(field));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.ListBind(method, Enumerable.Empty<ElementInit>()));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.ListBind(method));
         }
 
 #if FEATURE_COMPILE

--- a/src/System.Linq.Expressions/tests/New/NewTests.cs
+++ b/src/System.Linq.Expressions/tests/New/NewTests.cs
@@ -319,13 +319,13 @@ namespace System.Linq.Expressions.Tests
         {
             if (expressions.Length == 0)
             {
-                Assert.Throws<ArgumentException>(null, () => Expression.New(constructor));
+                AssertExtensions.Throws<ArgumentException>(null, () => Expression.New(constructor));
             }
-            Assert.Throws<ArgumentException>(null, () => Expression.New(constructor, expressions));
-            Assert.Throws<ArgumentException>(null, () => Expression.New(constructor, (IEnumerable<Expression>)expressions));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.New(constructor, expressions));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.New(constructor, (IEnumerable<Expression>)expressions));
 
-            Assert.Throws<ArgumentException>(null, () => Expression.New(constructor, expressions, new MemberInfo[expressions.Length]));
-            Assert.Throws<ArgumentException>(null, () => Expression.New(constructor, expressions, (IEnumerable<MemberInfo>)new MemberInfo[expressions.Length]));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.New(constructor, expressions, new MemberInfo[expressions.Length]));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.New(constructor, expressions, (IEnumerable<MemberInfo>)new MemberInfo[expressions.Length]));
         }
 
         [Fact]
@@ -366,8 +366,8 @@ namespace System.Linq.Expressions.Tests
         [MemberData(nameof(ArgumentsAndMembers_DifferentLengths_TestData))]
         public static void ArgumentsAndMembers_DifferentLengths_ThrowsArgumentException(ConstructorInfo constructor, Expression[] arguments, MemberInfo[] members)
         {
-            Assert.Throws<ArgumentException>(null, () => Expression.New(constructor, arguments, members));
-            Assert.Throws<ArgumentException>(null, () => Expression.New(constructor, arguments, (IEnumerable<MemberInfo>)members));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.New(constructor, arguments, members));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.New(constructor, arguments, (IEnumerable<MemberInfo>)members));
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
+++ b/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
@@ -160,7 +160,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ConstantNullWithValueTypeIsInvalid()
         {
-            Assert.Throws<ArgumentException>(null, () => Expression.Constant(null, typeof(int)));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Constant(null, typeof(int)));
         }
 
         [Fact]
@@ -718,7 +718,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(f2().Value.Name, "lhs");
 
             ConstantExpression constant = Expression.Constant(1.0, typeof(double));
-            Assert.Throws<ArgumentException>(null, () => Expression.Lambda<Func<double?>>(constant, null));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Lambda<Func<double?>>(constant, null));
         }
 
         public static int GetBound()

--- a/src/System.Linq.Expressions/tests/Switch/SwitchTests.cs
+++ b/src/System.Linq.Expressions/tests/Switch/SwitchTests.cs
@@ -513,10 +513,10 @@ namespace System.Linq.Expressions.Tests
         {
             Func<string, int, bool> isLength = (x, y) => (x?.Length).GetValueOrDefault() == y;
             MethodInfo comparer = isLength.GetMethodInfo();
-            Assert.Throws<ArgumentException>(null, () => Expression.Switch(Expression.Constant(0), Expression.Empty(), comparer));
-            Assert.Throws<ArgumentException>(null, () => Expression.Switch(Expression.Constant(0), Expression.Empty(), comparer, Enumerable.Empty<SwitchCase>()));
-            Assert.Throws<ArgumentException>(null, () => Expression.Switch(typeof(int), Expression.Constant(0), Expression.Constant(1), comparer));
-            Assert.Throws<ArgumentException>(null, () => Expression.Switch(typeof(int), Expression.Constant(0), Expression.Constant(1), comparer, Enumerable.Empty<SwitchCase>()));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Switch(Expression.Constant(0), Expression.Empty(), comparer));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Switch(Expression.Constant(0), Expression.Empty(), comparer, Enumerable.Empty<SwitchCase>()));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Switch(typeof(int), Expression.Constant(0), Expression.Constant(1), comparer));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Switch(typeof(int), Expression.Constant(0), Expression.Constant(1), comparer, Enumerable.Empty<SwitchCase>()));
         }
 
         [Fact]
@@ -524,8 +524,8 @@ namespace System.Linq.Expressions.Tests
         {
             Func<int, string, bool> isLength = (x, y) => (y?.Length).GetValueOrDefault() == x;
             MethodInfo comparer = isLength.GetMethodInfo();
-            Assert.Throws<ArgumentException>(null, () => Expression.Switch(Expression.Constant(0), Expression.Empty(), comparer, Expression.SwitchCase(Expression.Empty(), Expression.Constant(0))));
-            Assert.Throws<ArgumentException>(null, () => Expression.Switch(Expression.Constant(0), Expression.Empty(), comparer, Enumerable.Repeat(Expression.SwitchCase(Expression.Empty(), Expression.Constant(0)), 1)));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Switch(Expression.Constant(0), Expression.Empty(), comparer, Expression.SwitchCase(Expression.Empty(), Expression.Constant(0))));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.Switch(Expression.Constant(0), Expression.Empty(), comparer, Enumerable.Repeat(Expression.SwitchCase(Expression.Empty(), Expression.Constant(0)), 1)));
             AssertExtensions.Throws<ArgumentException>("cases", () => Expression.Switch(typeof(int), Expression.Constant(0), Expression.Constant(1), comparer, Expression.SwitchCase(Expression.Empty(), Expression.Constant(0))));
             AssertExtensions.Throws<ArgumentException>("cases", () => Expression.Switch(typeof(int), Expression.Constant(0), Expression.Constant(1), comparer, Enumerable.Repeat(Expression.SwitchCase(Expression.Empty(), Expression.Constant(0)), 1)));
         }
@@ -542,7 +542,7 @@ namespace System.Linq.Expressions.Tests
             Expression defaultExp = Expression.Constant(0);
             SwitchCase switchCase = Expression.SwitchCase(Expression.Constant(1), Expression.Constant(2));
             MethodInfo method = typeof(GenClass<>).GetMethod(nameof(GenClass<int>.WithinTwo), BindingFlags.Static | BindingFlags.Public);
-            Assert.Throws<ArgumentException>(
+            AssertExtensions.Throws<ArgumentException>(
                 "comparison", () => Expression.Switch(switchVal, defaultExp, method, switchCase));
         }
 
@@ -568,7 +568,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void LeftLiftedCall()
         {
-            Assert.Throws<ArgumentException>(null, () =>
+            AssertExtensions.Throws<ArgumentException>(null, () =>
                 Expression.Switch(
                     Expression.Constant(30, typeof(int?)),
                     Expression.Constant(0),

--- a/src/System.Linq.Expressions/tests/TypeBinary/TypeEqual.cs
+++ b/src/System.Linq.Expressions/tests/TypeBinary/TypeEqual.cs
@@ -53,7 +53,7 @@ namespace System.Linq.Expressions.Tests
             Expression exp = Expression.TypeIs(Expression.Constant(0), typeof(int));
             Assert.False(exp.CanReduce);
             Assert.Same(exp, exp.Reduce());
-            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
         [Theory]

--- a/src/System.Linq.Expressions/tests/TypeBinary/TypeIs.cs
+++ b/src/System.Linq.Expressions/tests/TypeBinary/TypeIs.cs
@@ -53,7 +53,7 @@ namespace System.Linq.Expressions.Tests
             Expression exp = Expression.TypeIs(Expression.Constant(0), typeof(int));
             Assert.False(exp.CanReduce);
             Assert.Same(exp, exp.Reduce());
-            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
         [Theory]

--- a/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PostDecrementAssignTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PostDecrementAssignTests.cs
@@ -186,7 +186,7 @@ namespace System.Linq.Expressions.Tests
         {
             Expression variable = Expression.Variable(typeof(int));
             MethodInfo method = typeof(IncDecAssignTests).GetTypeInfo().GetDeclaredMethod("GetString");
-            Assert.Throws<ArgumentException>(null, () => Expression.PostDecrementAssign(variable, method));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.PostDecrementAssign(variable, method));
         }
 
         [Theory]

--- a/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PostIncrementAssignTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PostIncrementAssignTests.cs
@@ -186,7 +186,7 @@ namespace System.Linq.Expressions.Tests
         {
             Expression variable = Expression.Variable(typeof(int));
             MethodInfo method = typeof(IncDecAssignTests).GetTypeInfo().GetDeclaredMethod("GetString");
-            Assert.Throws<ArgumentException>(null, () => Expression.PostIncrementAssign(variable, method));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.PostIncrementAssign(variable, method));
         }
 
         [Theory]

--- a/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PreDecrementAssignTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PreDecrementAssignTests.cs
@@ -186,7 +186,7 @@ namespace System.Linq.Expressions.Tests
         {
             Expression variable = Expression.Variable(typeof(int));
             MethodInfo method = typeof(IncDecAssignTests).GetTypeInfo().GetDeclaredMethod("GetString");
-            Assert.Throws<ArgumentException>(null, () => Expression.PreDecrementAssign(variable, method));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.PreDecrementAssign(variable, method));
         }
 
         [Theory]

--- a/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PreIncrementAssignTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PreIncrementAssignTests.cs
@@ -186,7 +186,7 @@ namespace System.Linq.Expressions.Tests
         {
             Expression variable = Expression.Variable(typeof(int));
             MethodInfo method = typeof(IncDecAssignTests).GetTypeInfo().GetDeclaredMethod("GetString");
-            Assert.Throws<ArgumentException>(null, () => Expression.PreIncrementAssign(variable, method));
+            AssertExtensions.Throws<ArgumentException>(null, () => Expression.PreIncrementAssign(variable, method));
         }
 
         [Theory]

--- a/src/System.Linq.Expressions/tests/Unary/UnboxTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnboxTests.cs
@@ -181,7 +181,7 @@ namespace System.Linq.Expressions.Tests
             Expression unbox = Expression.Unbox(Expression.Constant(0, typeof(object)), typeof(int));
             Assert.False(unbox.CanReduce);
             Assert.Same(unbox, unbox.Reduce());
-            Assert.Throws<ArgumentException>(null, () => unbox.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => unbox.ReduceAndCheck());
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/Variables/ParameterTests.cs
+++ b/src/System.Linq.Expressions/tests/Variables/ParameterTests.cs
@@ -299,7 +299,7 @@ namespace System.Linq.Expressions.Tests
             ParameterExpression param = Expression.Parameter(typeof(int));
             Assert.False(param.CanReduce);
             Assert.Same(param, param.Reduce());
-            Assert.Throws<ArgumentException>(null, () => param.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => param.ReduceAndCheck());
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/Variables/RuntimeVariablesTests.cs
+++ b/src/System.Linq.Expressions/tests/Variables/RuntimeVariablesTests.cs
@@ -156,7 +156,7 @@ namespace System.Linq.Expressions.Tests
             RuntimeVariablesExpression vars = Expression.RuntimeVariables(Expression.Variable(typeof(int)));
             Assert.False(vars.CanReduce);
             Assert.Same(vars, vars.Reduce());
-            Assert.Throws<ArgumentException>(null, () => vars.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => vars.ReduceAndCheck());
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/Variables/VariableTests.cs
+++ b/src/System.Linq.Expressions/tests/Variables/VariableTests.cs
@@ -96,7 +96,7 @@ namespace System.Linq.Expressions.Tests
             ParameterExpression variable = Expression.Variable(typeof(int));
             Assert.False(variable.CanReduce);
             Assert.Same(variable, variable.Reduce());
-            Assert.Throws<ArgumentException>(null, () => variable.ReduceAndCheck());
+            AssertExtensions.Throws<ArgumentException>(null, () => variable.ReduceAndCheck());
         }
 
         [Theory]


### PR DESCRIPTION
All remaining test failures now repro in /buildType:chk.