### PR TITLE
Remove invalid assert in Console encoding test on Unix

### DIFF
--- a/src/System.Console/tests/ConsoleEncoding.cs
+++ b/src/System.Console/tests/ConsoleEncoding.cs
@@ -107,7 +107,14 @@ public partial class ConsoleEncoding : RemoteExecutorTestBase
             Console.InputEncoding = Encoding.ASCII;
             Assert.Equal(Encoding.ASCII, Console.InputEncoding);
 
-            Assert.NotSame(inReader, Console.In);
+            if (PlatformDetection.IsWindows)
+            {
+                // Console.set_InputEncoding is effectively a nop on Unix,
+                // so although the reader accessed by Console.In will be reset,
+                // it'll be re-initialized on re-access to the same singleton,
+                // (assuming input isn't redirected).
+                Assert.NotSame(inReader, Console.In);
+            }
 
             return SuccessExitCode;
         }).Dispose();


### PR DESCRIPTION
This test is invalid on Unix if input isn't redirected; that's why it's passing in CI but failing when run locally.

Fixes https://github.com/dotnet/corefx/issues/18726
cc: @ianhays