### PR TITLE
S.L.Expressions.Tests.dll at 0 failures.

### DIFF
--- a/src/System.Linq.Expressions/src/Resources/System.Linq.Expressions.rd.xml
+++ b/src/System.Linq.Expressions/src/Resources/System.Linq.Expressions.rd.xml
@@ -140,6 +140,28 @@
           <Method Name="op_Implicit" Dynamic="Required"/>
           <Method Name="op_Explicit" Dynamic="Required"/>
         </Type>
+        <Type Name="IDisposable">
+          <Method Name="Dispose" Dynamic="Required"/>
+        </Type>
+        <Type Name="Math">
+          <Method Name="Pow" Dynamic="Required"/>
+        </Type>
+      </Namespace>
+      <Namespace Name="System.Collections">
+        <Type Name="IEnumerator">
+           <Method Name="MoveNext" Dynamic="Required"/>
+        </Type>
+      </Namespace>
+      <Namespace Name="System.Collections.Generic">
+        <Type Name="IEnumerable&lt;&gt;" Dynamic="Required">
+           <Method Name="GetEnumerator" Dynamic="Required"/>
+        </Type>
+        <Type Name="IEnumerator&lt;&gt;">
+           <Property Name="Current" Dynamic="Required"/>
+        </Type>
+      </Namespace>
+      <Namespace Name="System.Runtime.CompilerServices">
+        <Type Name="RuntimeWrappedException" Dynamic="Required All" Activate="Required All" />
       </Namespace>
     </Assembly>
     <Assembly Name="System.Runtime">

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
@@ -776,8 +776,10 @@ namespace System.Linq.Expressions.Interpreter
         {
             ConstructorInfo ctor = _runtimeWrappedExceptionCtor
                 ?? (_runtimeWrappedExceptionCtor = typeof(RuntimeWrappedException)
-                .GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic)
-                .First(c => c.GetParametersCached().Length == 1));
+                .GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.ExactBinding, 
+                                null, 
+                                new Type[] { typeof(object) }, 
+                                null));
             return (RuntimeWrappedException)ctor.Invoke(new [] {thrown});
         }
     }

--- a/src/System.Linq.Expressions/tests/Block/BlockFactoryTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/BlockFactoryTests.cs
@@ -129,7 +129,10 @@ namespace System.Linq.Expressions.Tests
 
         private static void AssertBlock(int n, object obj)
         {
-            AssertTypeName("Block" + n, obj);
+            if (!PlatformDetection.IsNetNative)  // .Net Native blocks internal framework reflection.
+            {
+                AssertTypeName("Block" + n, obj);
+            }
         }
 
         private static void AssertTypeName(string expected, object obj)

--- a/src/System.Linq.Expressions/tests/Call/CallFactoryTests.cs
+++ b/src/System.Linq.Expressions/tests/Call/CallFactoryTests.cs
@@ -54,7 +54,10 @@ namespace System.Linq.Expressions.Tests
 
             MethodCallExpression expr = Expression.Call(obj, typeof(MS).GetMethod("I" + N), args);
 
-            Assert.Equal("InstanceMethodCallExpressionN", expr.GetType().Name);
+            if (!PlatformDetection.IsNetNative) // .Net Native blocks internal framework reflection.
+            {
+                Assert.Equal("InstanceMethodCallExpressionN", expr.GetType().Name);
+            }
 
             Assert.Same(obj, expr.Object);
 
@@ -159,7 +162,10 @@ namespace System.Linq.Expressions.Tests
 
             MethodCallExpression expr = Expression.Call(typeof(MS).GetMethod("S" + N), args);
 
-            Assert.Equal("MethodCallExpressionN", expr.GetType().Name);
+            if (!PlatformDetection.IsNetNative) // .Net Native blocks internal framework reflection.
+            {
+                Assert.Equal("MethodCallExpressionN", expr.GetType().Name);
+            }
 
             Assert.Equal(N, expr.ArgumentCount);
             for (var i = 0; i < N; i++)
@@ -309,12 +315,18 @@ namespace System.Linq.Expressions.Tests
 
         private static void AssertStaticMethodCall(int n, object obj)
         {
-            AssertTypeName("MethodCallExpression" + n, obj);
+            if (!PlatformDetection.IsNetNative)  // .Net Native blocks internal framework reflection.
+            {
+                AssertTypeName("MethodCallExpression" + n, obj);
+            }
         }
 
         private static void AssertInstanceMethodCall(int n, object obj)
         {
-            AssertTypeName("InstanceMethodCallExpression" + n, obj);
+            if (!PlatformDetection.IsNetNative)  // .Net Native blocks internal framework reflection.
+            {
+                AssertTypeName("InstanceMethodCallExpression" + n, obj);
+            }
         }
 
         private static void AssertTypeName(string expected, object obj)

--- a/src/System.Linq.Expressions/tests/Convert/ConvertTests.cs
+++ b/src/System.Linq.Expressions/tests/Convert/ConvertTests.cs
@@ -16808,8 +16808,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(5, x); // Refness is lost on lifting.
         }
 
-        [Theory, InlineData(false)]
-        public static void CustomConversionNotStandardNameFromByRef(bool useInterpreter)
+        private static void CustomConversionNotStandardNameFromByRef(bool useInterpreter)
         {
             var param = Expression.Parameter(typeof(int).MakeByRefType());
             MethodInfo method = typeof(CustomConversions).GetMethod(nameof(CustomConversions.ConvertFromRefInt));
@@ -16824,8 +16823,16 @@ namespace System.Linq.Expressions.Tests
         [Fact, ActiveIssue(18445)]
         public static void CustomConversionNotStandardNameFromByRefInterpreter()
         {
-            CustomConversionNotStandardNameFromByRef(true);
+            CustomConversionNotStandardNameFromByRef(useInterpreter: true);
         }
+
+#if FEATURE_COMPILE
+        [Fact]
+        public static void CustomConversionNotStandardNameFromByRefCompiler()
+        {
+            CustomConversionNotStandardNameFromByRef(useInterpreter: false);
+        }
+#endif
 
         [Fact]
         public static void CustomConversionNotStandardNameToWrongType()

--- a/src/System.Linq.Expressions/tests/DynamicExpression/DynamicExpressionTests.cs
+++ b/src/System.Linq.Expressions/tests/DynamicExpression/DynamicExpressionTests.cs
@@ -20,6 +20,7 @@ namespace System.Linq.Expressions.Tests
             => Enumerable.Range(1, 6).SelectMany(i => Types, (i, t) => new object[] { i, t });
 
         [Theory, MemberData(nameof(SizesAndSuffixes))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Internal framework reflection not supported on UapAot.")]
         public void AritySpecialisedUsedWhenPossible(int size, string nameSuffix)
         {
             CallSiteBinder binder = Binder.GetMember(
@@ -42,6 +43,7 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Theory, MemberData(nameof(SizesAndSuffixes))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Internal framework reflection not supported on UapAot.")]
         public void TypedAritySpecialisedUsedWhenPossible(int size, string nameSuffix)
         {
             CallSiteBinder binder = Binder.GetMember(

--- a/src/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
+++ b/src/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
@@ -39,9 +39,10 @@ namespace System.Linq.Expressions.Tests
         {
             return
                 (RuntimeWrappedException)
-                    typeof(RuntimeWrappedException).GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic)
-                        .First(c => c.GetParameters().Length == 1)
-                        .Invoke(new[] {inner});
+                    typeof(RuntimeWrappedException).GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.ExactBinding,
+                                                                   null,
+                                                                   new Type[] { typeof(object) },
+                                                                   null).Invoke(new[] {inner});
         }
 
         [Theory]
@@ -1008,7 +1009,11 @@ namespace System.Linq.Expressions.Tests
                 )
             );
             Expression<Func<int>> lambda = Expression.Lambda<Func<int>>(tryExp);
+#if FEATURE_COMPILE
             Assert.Throws<InvalidOperationException>(() => lambda.Compile(false));
+#else
+            lambda.Compile(true);
+#endif
         }
 
         [Theory, InlineData(true)]

--- a/src/System.Linq.Expressions/tests/HelperTypes.cs
+++ b/src/System.Linq.Expressions/tests/HelperTypes.cs
@@ -249,10 +249,10 @@ namespace System.Linq.Expressions.Tests
     {
         private static readonly IEnumerable<object[]> Booleans = new[]
         {
-            new object[] {false},
 #if FEATURE_COMPILE && FEATURE_INTERPRET
-            new object[] {true}
+            new object[] {false},
 #endif
+            new object[] {true},
         };
 
         public IEnumerator<object[]> GetEnumerator() => Booleans.GetEnumerator();

--- a/src/System.Linq.Expressions/tests/Invoke/InvokeFactoryTests.cs
+++ b/src/System.Linq.Expressions/tests/Invoke/InvokeFactoryTests.cs
@@ -100,7 +100,10 @@ namespace System.Linq.Expressions.Tests
 
         private static void AssertInvocation(int n, object obj)
         {
-            AssertTypeName("InvocationExpression" + n, obj);
+            if (!PlatformDetection.IsNetNative)  // .Net Native blocks internal framework reflection.
+            {
+                AssertTypeName("InvocationExpression" + n, obj);
+            }
         }
 
         private static void AssertTypeName(string expected, object obj)

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
@@ -269,6 +269,9 @@ namespace System.Linq.Expressions.Tests
                 double, double, double, double,
                 bool>), exp.Type);
 
+#if FEATURE_COMPILE
+            // From this point on, the tests require FEATURE_COMPILE (RefEmit) support as SLE needs to create delegate types on the fly. 
+            // You can't instantiate Func<> over 20 arguments or over byrefs.
             ParameterExpression[] paramList = Enumerable.Range(0, 20).Select(_ => Expression.Variable(typeof(int))).ToArray();
             exp = Expression.Lambda(
                 Expression.Constant(0),
@@ -300,6 +303,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(1, delMethod.GetParameters().Length);
             Assert.Equal(typeof(int).MakeByRefType(), delMethod.GetParameters()[0].ParameterType);
             Assert.Same(delType, Expression.Lambda(Expression.Constant(3L), Expression.Parameter(typeof(int).MakeByRefType())).Type);
+#endif //FEATURE_COMPILE
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/New/NewWithByRefParameterTests.cs
+++ b/src/System.Linq.Expressions/tests/New/NewWithByRefParameterTests.cs
@@ -53,8 +53,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(16, y);
         }
 
-        [Theory, InlineData(false)]
-        public void CreateByRefAliasing(bool useInterpreter)
+        private void CreateByRefAliasing(bool useInterpreter)
         {
             ParameterExpression pX = Expression.Parameter(typeof(int).MakeByRefType());
             ParameterExpression pY = Expression.Parameter(typeof(int).MakeByRefType());
@@ -69,8 +68,16 @@ namespace System.Linq.Expressions.Tests
         [Fact, ActiveIssue(13458)]
         public void CreateByRefAliasingInterpreted()
         {
-            CreateByRefAliasing(true);
+            CreateByRefAliasing(useInterpreter: true);
         }
+
+#if FEATURE_COMPILE
+        [Fact]
+        public void CreateByRefAliasingCompiled()
+        {
+            CreateByRefAliasing(useInterpreter: false);
+        }
+#endif
 
         [Theory, ClassData(typeof(CompilationTypes))]
         public void CreateByRefReferencingReadonly(bool useInterpreter)

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -125,7 +125,6 @@
     <Compile Include="DelegateType\GetDelegateTypeTests.cs" />
     <Compile Include="DynamicExpression\DynamicExpressionTests.cs" />
     <Compile Include="Dynamic\BinaryOperationTests.cs" />
-    <Compile Include="Dynamic\BindingRestrictionsProxyTests.cs" />
     <Compile Include="Dynamic\BindingRestrictionsTests.cs" />
     <Compile Include="Dynamic\CallInfoTests.cs" />
     <Compile Include="Dynamic\CallSiteBinderDefaultBehaviourTests.cs" />
@@ -133,7 +132,6 @@
     <Compile Include="Dynamic\ConvertBinderTests.cs" />
     <Compile Include="Dynamic\DynamicObjectTests.cs" />
     <Compile Include="Dynamic\DynamicObjectDefaultBehaviorTests.cs" />
-    <Compile Include="Dynamic\ExpandoObjectProxyTests.cs" />
     <Compile Include="Dynamic\ExpandoObjectTests.cs" />
     <Compile Include="Dynamic\GetIndexBinderTests.cs" />
     <Compile Include="Dynamic\GetMemberBinderTests.cs" />
@@ -292,6 +290,8 @@
   <ItemGroup  Condition="'$(TargetGroup)'!='uapaot'">
     <Compile Include="DebugViewTests.cs" />
     <Compile Include="DebuggerTypeProxy\ExpressionDebuggerTypeProxyTests.cs" />
+    <Compile Include="Dynamic\BindingRestrictionsProxyTests.cs" />
+    <Compile Include="Dynamic\ExpandoObjectProxyTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ReferenceFromRuntime Include="xunit.execution.dotnet" />


### PR DESCRIPTION
Background:

  Expressions can be compiled into delegates using one of
  two strategies: interpreted and compiled (requires RefEmit).

  Expression<>.Compile() takes a boolean parameter
  named "preferInterpretation" that lets the app choose the
  strategy.

  UapAOT uses a special build of S.L.E. that compilation
  disabled. (FEATURE_COMPILE not defined). On these builds,
  the Compile() method ignores the preferInterpretation parameter
  (always behaves as if you passed "true").

  S.L.E.Tests also has a compile-disabled build that Aot uses
  (FEATURE_COMPILE not defined).

  Most of the remaining test failures were due to tests that
  were still inadventently testing for compile-specific behaviors.

  Some interpreter-specific behaviors:

   PNSE if you try to compile a lambda with byref, pointer
   or more than 17 parameters. (SLE can't whip up a Func<>
   or Action<> instantiation in those cases so it has to
   use RefEmit to create a custom delegate type on the fly.)

   Known problems (with ActiveIssues) regarding byref parameters.

Additional fixes:

  Disabled more DebuggerProxyType tests that were hiding inside
  filenames that didn't yell out "I'm a debugger attribute test."

  More rd.xml slogging for system types that SLE is known to
  reflect on.

  Modified GetMethod strategy for RuntimeWrappedException's
  non-api constructor (in .Net Native, it's now public
  to satisify the white-list gate guard's requirements.)