### PR TITLE
Add type forwarders for newly added IsByRefLikeAttribute in System.Runtime.CompilerServices

### DIFF
--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -6500,6 +6500,12 @@ namespace System.Runtime.CompilerServices
     {
         public IsReadOnlyAttribute() { }
     }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    [AttributeUsage(AttributeTargets.Struct)]
+    public sealed class IsByRefLikeAttribute : Attribute
+    {
+        public IsByRefLikeAttribute() { }
+    }
     public sealed partial class RuntimeWrappedException : System.Exception
     {
         internal RuntimeWrappedException() { }


### PR DESCRIPTION
Add type forwarders for newly added IsByRefLikeAttribute in System.Runtime.CompilerServices

IsByRefLikeAttribute has been added to dotnet/coreclr and PR is pending for dotnet/corert.
(see: https://github.com/dotnet/corert/pull/3502)

cc @jcouv @jkotas