### PR TITLE
Re-enabling tests and adding workaround for a known Windows bug.

### DIFF
--- a/src/Common/tests/System/Net/Configuration.Certificates.cs
+++ b/src/Common/tests/System/Net/Configuration.Certificates.cs
@@ -7,7 +7,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
-
+using System.Threading;
 using Xunit;
 
 namespace System.Net.Test.Common
@@ -18,6 +18,8 @@ namespace System.Net.Test.Common
         {
             private const string CertificatePassword = "testcertificate";
             private const string TestDataFolder = "TestData";
+            private static Mutex m = new Mutex(false, "Global\\CoreFXTest.Configuration.Certificates.LoadPfxCertificate");
+            private const int MutexTimeout = 5 * 1000;
 
             public static X509Certificate2 GetServerCertificate() => GetCertWithPrivateKey(GetServerCertificateCollection());
 
@@ -29,8 +31,15 @@ namespace System.Net.Test.Common
 
             private static X509Certificate2Collection GetCertificateCollection(string certificateFileName)
             {
+                // On Windows, .Net Core applications should not import PFX files in parallel to avoid a known system-level race condition.
+                // This bug results in corrupting the X509Certificate2 certificate state.
+                Assert.True(m.WaitOne(MutexTimeout), "Cannot acquire the global certificate mutex.");
+
                 var certCollection = new X509Certificate2Collection();
                 certCollection.Import(Path.Combine(TestDataFolder, certificateFileName), CertificatePassword, X509KeyStorageFlags.DefaultKeySet);
+
+                m.ReleaseMutex();
+
                 return certCollection;
             }
 

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
@@ -402,8 +402,9 @@ namespace System.Net.Security
                     return SSPIWrapper.AcquireCredentialsHandle(GlobalSSPI.SSPISecureChannel, SecurityPackage, credUsage, secureCredential);
                 });
             }
-            catch
+            catch(Exception ex)
             {
+                Debug.Fail("AcquireCredentialsHandle failed.", ex.ToString());
                 return SSPIWrapper.AcquireCredentialsHandle(GlobalSSPI.SSPISecureChannel, SecurityPackage, credUsage, secureCredential);
             }
         }

--- a/src/System.Net.Security/tests/FunctionalTests/LoggingTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/LoggingTest.cs
@@ -26,7 +26,6 @@ namespace System.Net.Security.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core")]
-        [ActiveIssue(16516, TestPlatforms.Windows)]
         public void EventSource_EventsRaisedAsExpected()
         {
             RemoteInvoke(() =>

--- a/src/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
@@ -37,7 +37,6 @@ namespace System.Net.Security.Tests
 
         [Theory]
         [ClassData(typeof(SslProtocolSupport.SupportedSslProtocolsTestData))]
-        [ActiveIssue(16516, TestPlatforms.Windows)]
         public async Task ServerAsyncAuthenticate_EachSupportedProtocol_Success(SslProtocols protocol)
         {
             await ServerAsyncSslHelper(protocol, protocol);
@@ -45,7 +44,6 @@ namespace System.Net.Security.Tests
 
         [Theory]
         [ClassData(typeof(SslProtocolSupport.UnsupportedSslProtocolsTestData))]
-        [ActiveIssue(16516, TestPlatforms.Windows)]
         public async Task ServerAsyncAuthenticate_EachServerUnsupportedProtocol_Fail(SslProtocols protocol)
         {
             await Assert.ThrowsAsync<NotSupportedException>(() =>
@@ -59,7 +57,6 @@ namespace System.Net.Security.Tests
 
         [Theory]
         [MemberData(nameof(ProtocolMismatchData))]
-        [ActiveIssue(16516, TestPlatforms.Windows)]
         public async Task ServerAsyncAuthenticate_MismatchProtocols_Fails(
             SslProtocols serverProtocol,
             SslProtocols clientProtocol,
@@ -77,7 +74,6 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
-        [ActiveIssue(16516, TestPlatforms.Windows)]
         public async Task ServerAsyncAuthenticate_UnsupportedAllServer_Fail()
         {
             await Assert.ThrowsAsync<NotSupportedException>(() =>
@@ -91,7 +87,6 @@ namespace System.Net.Security.Tests
 
         [Theory]
         [ClassData(typeof(SslProtocolSupport.SupportedSslProtocolsTestData))]
-        [ActiveIssue(16516, TestPlatforms.Windows)]
         public async Task ServerAsyncAuthenticate_AllClientVsIndividualServerSupportedProtocols_Success(
             SslProtocols serverProtocol)
         {

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamAlertsTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamAlertsTest.cs
@@ -23,7 +23,6 @@ namespace System.Net.Security.Tests
 
         [Fact]
         [ActiveIssue(12319, TestPlatforms.AnyUnix)]
-        [ActiveIssue(16516, TestPlatforms.Windows)]
         public async Task SslStream_StreamToStream_HandshakeAlert_Ok()
         {
             VirtualNetwork network = new VirtualNetwork();
@@ -58,7 +57,6 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
-        [ActiveIssue(16516, TestPlatforms.Windows)]
         public async Task SslStream_StreamToStream_ServerInitiatedCloseNotify_Ok()
         {
             VirtualNetwork network = new VirtualNetwork();
@@ -91,7 +89,6 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
-        [ActiveIssue(16516, TestPlatforms.Windows)]
         public async Task SslStream_StreamToStream_ClientInitiatedCloseNotify_Ok()
         {
             VirtualNetwork network = new VirtualNetwork();
@@ -124,7 +121,6 @@ namespace System.Net.Security.Tests
         }
         
         [Fact]
-        [ActiveIssue(16516, TestPlatforms.Windows)]
         public async Task SslStream_StreamToStream_DataAfterShutdown_Fail()
         {
             VirtualNetwork network = new VirtualNetwork();

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -17,7 +17,6 @@ namespace System.Net.Security.Tests
     public class SslStreamNetworkStreamTest
     {
         [Fact]
-        [ActiveIssue(16516, TestPlatforms.Windows)]
         public async Task SslStream_SendReceiveOverNetworkStream_Ok()
         {
             TcpListener listener = new TcpListener(IPAddress.Loopback, 0);

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamSchSendAuxRecordTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamSchSendAuxRecordTest.cs
@@ -26,7 +26,6 @@ namespace System.Net.Security.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]
-        [ActiveIssue(16516, TestPlatforms.Windows)]
         public async Task SslStream_ClientAndServerUsesAuxRecord_Ok()
         {
             X509Certificate2 serverCert = Configuration.Certificates.GetServerCertificate();

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
@@ -23,7 +23,6 @@ namespace System.Net.Security.Tests
         protected abstract bool DoHandshake(SslStream clientSslStream, SslStream serverSslStream);
 
         [Fact]
-        [ActiveIssue(16516, TestPlatforms.Windows)]
         public void SslStream_StreamToStream_Authentication_Success()
         {
             VirtualNetwork network = new VirtualNetwork();
@@ -229,7 +228,6 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
-        [ActiveIssue(16516, TestPlatforms.Windows)]
         public void SslStream_StreamToStream_Write_ReadByte_Success()
         {
             VirtualNetwork network = new VirtualNetwork();


### PR DESCRIPTION
Potential fix for #16516.

A Windows-OS bug may corrupt the X509Certificate KeyStore if multiple processes/threads import the same PFX. A global mutex should prevent this from happening in our tests.