### PR TITLE
fixed isolation level leak on connection disposed

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlTransaction.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlTransaction.cs
@@ -160,6 +160,8 @@ namespace System.Data.SqlClient
 
         protected override void Dispose(bool disposing)
         {
+            this._connection.CurrentTransaction = null;
+
             if (disposing)
             {
                 if (!IsZombied && !IsYukonPartialZombie)

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/TransactionTest/IsolationLevelCleanUpTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/TransactionTest/IsolationLevelCleanUpTest.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Data.SqlClient;
+using System.Data.SqlClient.ManualTesting.Tests;
+using Xunit;
+
+namespace SQL.TransactionTest
+{
+    public class IsolationLevelCleanUpTest
+    {
+        [CheckConnStrSetupFact]
+        public static void TestIsolationLevelCleanUpOnClose()
+        {
+            Console.WriteLine("TestIsolationLevelCleanUpOnClose Test");
+
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr);
+            builder.Pooling = true;
+
+            SqlConnection conn = new SqlConnection(builder.ConnectionString);
+            conn.Open();
+            conn.BeginTransaction(System.Data.IsolationLevel.Serializable).Dispose();
+            conn.Close();
+            conn.Open();
+            string currentIsolationLevel = GetCurrentIsolationLevel(conn);
+            conn.Dispose();
+
+            Assert.True("ReadCommitted".Equals(currentIsolationLevel));
+        }
+
+        private static string GetCurrentIsolationLevel(SqlConnection conn, SqlTransaction transaction = null)
+        {
+            var cmd = conn.CreateCommand();
+            cmd.Transaction = transaction;
+            cmd.CommandText = @"SELECT CASE transaction_isolation_level 
+						WHEN 0 THEN 'Unspecified' 
+						WHEN 1 THEN 'ReadUncommitted' 
+						WHEN 2 THEN 'ReadCommitted' 
+						WHEN 3 THEN 'Repeatable' 
+						WHEN 4 THEN 'Serializable' 
+						WHEN 5 THEN 'Snapshot' END AS TRANSACTION_ISOLATION_LEVEL 
+						FROM sys.dm_exec_sessions 
+						where session_id = @@SPID";
+            string isolationLevel = cmd.ExecuteScalar().ToString();
+            return isolationLevel;
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/TransactionTest/IsolationLevelCleanUpTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/TransactionTest/IsolationLevelCleanUpTest.cs
@@ -10,8 +10,6 @@ namespace SQL.TransactionTest
         [CheckConnStrSetupFact]
         public static void TestIsolationLevelCleanUpOnClose()
         {
-            Console.WriteLine("TestIsolationLevelCleanUpOnClose Test");
-
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr);
             builder.Pooling = true;
 

--- a/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
@@ -97,6 +97,7 @@
     <Compile Include="SQL\RandomStressTest\RandomStressTest.cs" />
     <Compile Include="SQL\SplitPacketTest\SplitPacketTest.cs" />
     <Compile Include="SQL\TransactionTest\TransactionTest.cs" />
+	<Compile Include="SQL\TransactionTest\IsolationLevelCleanUpTest.cs" />
     <Compile Include="SQL\WeakRefTest\WeakRefTest.cs" />
     <Compile Include="SQL\WeakRefTestYukonSpecific\WeakRefTestYukonSpecific.cs" />
     <Compile Include="XUnitAssemblyAttributes.cs" />

--- a/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
@@ -97,7 +97,7 @@
     <Compile Include="SQL\RandomStressTest\RandomStressTest.cs" />
     <Compile Include="SQL\SplitPacketTest\SplitPacketTest.cs" />
     <Compile Include="SQL\TransactionTest\TransactionTest.cs" />
-	<Compile Include="SQL\TransactionTest\IsolationLevelCleanUpTest.cs" />
+    <Compile Include="SQL\TransactionTest\IsolationLevelCleanUpTest.cs" />
     <Compile Include="SQL\WeakRefTest\WeakRefTest.cs" />
     <Compile Include="SQL\WeakRefTestYukonSpecific\WeakRefTestYukonSpecific.cs" />
     <Compile Include="XUnitAssemblyAttributes.cs" />


### PR DESCRIPTION
Currently, isolation level setting is not cleared out when connection moves back to pool, and connection keeps isolation level value of previous session. This can cause problem because default isolation level `ReadCommitted` is expected for fresh connection object. This fix resets isolation level to default when pooled connection is closed. This fix is for https://github.com/dotnet/corefx/issues/18277