### PR TITLE
Remove some assemblies from some OS shared frameworks

### DIFF
--- a/src/Microsoft.Win32.Registry/dir.props
+++ b/src/Microsoft.Win32.Registry/dir.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
-    <IsNETCoreApp>true</IsNETCoreApp>
+    <IsNETCoreApp Condition="'$(OSGroup)' == 'Windows_NT'">true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.FileSystem.AccessControl/dir.props
+++ b/src/System.IO.FileSystem.AccessControl/dir.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
-    <IsNETCoreApp>true</IsNETCoreApp>
+    <IsNETCoreApp Condition="'$(OSGroup)' == 'Windows_NT'">true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.AccessControl/dir.props
+++ b/src/System.Security.AccessControl/dir.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
-    <IsNETCoreApp>true</IsNETCoreApp>
+    <IsNETCoreApp Condition="'$(OSGroup)' == 'Windows_NT'">true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>
     <IsUAP>true</IsUAP>
     <ISUAPRef>false</ISUAPRef>

--- a/src/System.Security.Cryptography.Cng/dir.props
+++ b/src/System.Security.Cryptography.Cng/dir.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <AssemblyVersion>4.3.0.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
-    <IsNETCoreApp>true</IsNETCoreApp>
+    <IsNETCoreApp Condition="'$(OSGroup)' == 'Windows_NT'">true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>
     <IsUAP>true</IsUAP>
     <IsUAPRef>false</IsUAPRef>

--- a/src/System.Security.Cryptography.OpenSsl/dir.props
+++ b/src/System.Security.Cryptography.OpenSsl/dir.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
-    <IsNETCoreApp>true</IsNETCoreApp>
+    <IsNETCoreApp Condition="'$(OSGroup)' == 'Unix'">true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Principal.Windows/dir.props
+++ b/src/System.Security.Principal.Windows/dir.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
-    <IsNETCoreApp>true</IsNETCoreApp>
+    <IsNETCoreApp Condition="'$(OSGroup)' == 'Windows_NT'">true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>
     <IsUAP>true</IsUAP>
     <IsUAPRef>false</IsUAPRef>


### PR DESCRIPTION
A number of assemblies are only needed for implementation closure
on some OS's so for those lets only include them on the OS that
needs them.

Contributes to https://github.com/dotnet/corefx/issues/16912. 

PTAL @ericstj 