### PR TITLE
Implement close_notify alert on ShutdownAsync on Linux.

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -83,6 +83,9 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslShutdown")]
         internal static extern int SslShutdown(IntPtr ssl);
 
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslShutdown")]
+        internal static extern int SslShutdown(SafeSslHandle ssl);
+
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslSetBio")]
         internal static extern void SslSetBio(SafeSslHandle ssl, SafeBioHandle rbio, SafeBioHandle wbio);
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -246,6 +246,7 @@ int EC_POINT_set_affine_coordinates_GF2m(const EC_GROUP *group, EC_POINT *p,
     PER_FUNCTION_BLOCK(sk_value, true) \
     PER_FUNCTION_BLOCK(SSL_CIPHER_description, true) \
     PER_FUNCTION_BLOCK(SSL_ctrl, true) \
+    PER_FUNCTION_BLOCK(SSL_set_quiet_shutdown, true) \
     PER_FUNCTION_BLOCK(SSL_CTX_check_private_key, true) \
     PER_FUNCTION_BLOCK(SSL_CTX_ctrl, true) \
     PER_FUNCTION_BLOCK(SSL_CTX_free, true) \
@@ -535,6 +536,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define sk_value sk_value_ptr
 #define SSL_CIPHER_description SSL_CIPHER_description_ptr
 #define SSL_ctrl SSL_ctrl_ptr
+#define SSL_set_quiet_shutdown SSL_set_quiet_shutdown_ptr
 #define SSL_CTX_check_private_key SSL_CTX_check_private_key_ptr
 #define SSL_CTX_ctrl SSL_CTX_ctrl_ptr
 #define SSL_CTX_free SSL_CTX_free_ptr

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -482,6 +482,11 @@ extern "C" void CryptoNative_SslCtxSetQuietShutdown(SSL_CTX* ctx)
     SSL_CTX_set_quiet_shutdown(ctx, 1);
 }
 
+extern "C" void CryptoNative_SslSetQuietShutdown(SSL* ssl, int mode)
+{
+    SSL_set_quiet_shutdown(ssl, mode);
+}
+
 extern "C" X509NameStack* CryptoNative_SslGetClientCAList(SSL* ssl)
 {
     return SSL_get_client_CA_list(ssl);

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.h
@@ -332,6 +332,11 @@ Shims the SSL_CTX_set_quiet_shutdown method.
 extern "C" void CryptoNative_SslCtxSetQuietShutdown(SSL_CTX* ctx);
 
 /*
+Shims the SSL_set_quiet_shutdown method.
+*/
+extern "C" void CryptoNative_SslSetQuietShutdown(SSL* ctx, int mode);
+
+/*
 Shims the SSL_get_client_CA_list method.
 
 Returns the list of CA names explicity set.

--- a/src/System.Net.Security/src/System/Net/Security/SslState.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslState.cs
@@ -737,9 +737,7 @@ namespace System.Net.Security
                     KeyExchangeStrength);
             }
         }
-        //
-        //
-        //
+
         internal void InternalEndProcessAuthentication(LazyAsyncResult lazyResult)
         {
             // No "artificial" timeouts implemented so far, InnerStream controls that.

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
@@ -193,18 +193,17 @@ namespace System.Net.Security
             // Unset the quiet shutdown option initially configured.
             Interop.Ssl.SslSetQuietShutdown(sslContext.SslContext, 0);
 
-            IntPtr sslHandle = sslContext.SslContext.DangerousGetHandle();
-            int status = Interop.Ssl.SslShutdown(sslHandle);
+            int status = Interop.Ssl.SslShutdown(sslContext.SslContext);
             if (status == 0)
             {
                 // Call SSL_shutdown again for a bi-directional shutdown.
-                status = Interop.Ssl.SslShutdown(sslHandle);
+                status = Interop.Ssl.SslShutdown(sslContext.SslContext);
             }
 
             if (status == 1)
                 return new SecurityStatusPal(SecurityStatusPalErrorCode.OK);
 
-            Interop.Ssl.SslErrorCode code = Interop.Ssl.SslGetError(sslHandle, status);
+            Interop.Ssl.SslErrorCode code = Interop.Ssl.SslGetError(sslContext.SslContext, status);
             if (code == Interop.Ssl.SslErrorCode.SSL_ERROR_WANT_READ ||
                 code == Interop.Ssl.SslErrorCode.SSL_ERROR_WANT_WRITE)
             {

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamAlertsTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamAlertsTest.cs
@@ -58,7 +58,6 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
-        [ActiveIssue(12319, TestPlatforms.AnyUnix)]
         [ActiveIssue(16516, TestPlatforms.Windows)]
         public async Task SslStream_StreamToStream_ServerInitiatedCloseNotify_Ok()
         {
@@ -92,7 +91,6 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
-        [ActiveIssue(12319, TestPlatforms.AnyUnix)]
         [ActiveIssue(16516, TestPlatforms.Windows)]
         public async Task SslStream_StreamToStream_ClientInitiatedCloseNotify_Ok()
         {
@@ -126,7 +124,6 @@ namespace System.Net.Security.Tests
         }
         
         [Fact]
-        [ActiveIssue(12319, TestPlatforms.AnyUnix)]
         [ActiveIssue(16516, TestPlatforms.Windows)]
         public async Task SslStream_StreamToStream_DataAfterShutdown_Fail()
         {


### PR DESCRIPTION
implements close_notify in #12319, the other part of implementing alerts requires changing the structure of pal on Unix. For now, returning the same behavior as on OSX.

cc @bartonjs @stephentoub @geoffkizer  @davidsh @CIPop @karelz 