### PR TITLE
Surface System.Type.IsVariableBoundArray

### DIFF
--- a/src/System.Reflection.Emit/ref/System.Reflection.Emit.cs
+++ b/src/System.Reflection.Emit/ref/System.Reflection.Emit.cs
@@ -110,6 +110,7 @@ namespace System.Reflection.Emit
         protected override bool IsPointerImpl() { throw null; }
         protected override bool IsPrimitiveImpl() { throw null; }
         public override bool IsSZArray { get { throw null; } }
+        public override bool IsVariableBoundArray { get { throw null; } }
         protected override bool IsValueTypeImpl() { throw null; }
         public override System.Type MakeArrayType() { throw null; }
         public override System.Type MakeArrayType(int rank) { throw null; }
@@ -208,6 +209,7 @@ namespace System.Reflection.Emit
         protected override bool IsPrimitiveImpl() { throw null; }
         public override bool IsSubclassOf(System.Type c) { throw null; }
         public override bool IsSZArray { get { throw null; } }
+        public override bool IsVariableBoundArray { get { throw null; } }
         protected override bool IsValueTypeImpl() { throw null; }
         public override System.Type MakeArrayType() { throw null; }
         public override System.Type MakeArrayType(int rank) { throw null; }
@@ -415,6 +417,7 @@ namespace System.Reflection.Emit
         protected override bool IsPrimitiveImpl() { throw null; }
         public override bool IsSubclassOf(System.Type c) { throw null; }
         public override bool IsSZArray { get { throw null; } }
+        public override bool IsVariableBoundArray { get { throw null; } }
         public override System.Type MakeArrayType() { throw null; }
         public override System.Type MakeArrayType(int rank) { throw null; }
         public override System.Type MakeByRefType() { throw null; }

--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -2634,7 +2634,7 @@ namespace System
         public virtual bool IsSerializable { get { throw null; } }
         public bool IsSpecialName { get { throw null; } }
         public virtual bool IsSZArray { get { throw null; } }
-        public bool IsVariableBoundArray { get { throw null; } }
+        public virtual bool IsVariableBoundArray { get { throw null; } }
         public bool IsUnicodeClass { get { throw null; } }
         public bool IsValueType { get { throw null; } }
         public bool IsVisible { get { throw null; } }
@@ -6137,6 +6137,7 @@ namespace System.Reflection
         protected override bool IsCOMObjectImpl() { throw null; }
         public override bool IsConstructedGenericType { get { throw null; } }
         public override bool IsSZArray { get { throw null; } }
+        public override bool IsVariableBoundArray { get { throw null; } }
         public override System.Type GetElementType() { throw null; }
         protected override bool HasElementTypeImpl() { throw null; }
         public override System.Type UnderlyingSystemType { get { throw null; } }

--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -2634,6 +2634,7 @@ namespace System
         public virtual bool IsSerializable { get { throw null; } }
         public bool IsSpecialName { get { throw null; } }
         public virtual bool IsSZArray { get { throw null; } }
+        public bool IsVariableBoundArray { get { throw null; } }
         public bool IsUnicodeClass { get { throw null; } }
         public bool IsValueType { get { throw null; } }
         public bool IsVisible { get { throw null; } }

--- a/src/System.Runtime/tests/System/Reflection/TypeDelegatorTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/Reflection/TypeDelegatorTests.netcoreapp.cs
@@ -1,40 +1,113 @@
 using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace System.Reflection.Tests
 {
     public class TypeDelegatorNetcoreTests
     {
-        private static IEnumerable<object[]> SZArrayOrNotTypes()
+        private static readonly IEnumerable<Type> NonArrayBaseTypes = new Type[]
+         {
+            typeof(int),
+            typeof(void),
+            typeof(int*),
+            typeof(Outside),
+            typeof(Outside<>),
+            typeof(Outside<>).GetTypeInfo().GenericTypeParameters[0],
+            Type.GetTypeFromCLSID(default(Guid)),
+            new object().GetType().GetType()
+         };
+
+        [Fact]
+        public void IsSZArray_FalseForNonArrayTypes()
         {
-            yield return new object[] { typeof(int[]), true };
-            yield return new object[] { typeof(string[]), true };
-            yield return new object[] { typeof(void), false };
-            yield return new object[] { typeof(int), false };
-            yield return new object[] { typeof(int[]).MakeByRefType(), false };
-            yield return new object[] { typeof(int[,]), false };
-            yield return new object[] { typeof(TypeInfoTests), false };
-            yield return new object[] { Array.CreateInstance(typeof(int), new[] { 2 }, new[] { -1 }).GetType(), false };
-            yield return new object[] { Array.CreateInstance(typeof(int), new[] { 2 }, new[] { 1 }).GetType(), false };
-            yield return new object[] { Array.CreateInstance(typeof(int), new[] { 2 }, new[] { 0 }).GetType(), true };
-            yield return new object[] { typeof(int[][]), true };
-            yield return new object[] { Type.GetType("System.Int32[]"), true };
-            yield return new object[] { Type.GetType("System.Int32[*]"), false };
-            yield return new object[] { Type.GetType("System.Int32"), false };
-            yield return new object[] { typeof(int).MakeArrayType(), true };
-            yield return new object[] { typeof(int).MakeArrayType(1), false };
-            yield return new object[] { typeof(int).MakeArrayType().MakeArrayType(), true };
-            yield return new object[] { typeof(int).MakeArrayType(2), false };
-            yield return new object[] { typeof(Outside<int>.Inside<string>), false };
-            yield return new object[] { typeof(Outside<int>.Inside<string>[]), true };
-            yield return new object[] { typeof(Outside<int>.Inside<string>[,]), false };
-            yield return new object[] { Array.CreateInstance(typeof(Outside<int>.Inside<string>), new[] { 2 }, new[] { -1 }).GetType(), false };
+            foreach (Type type in NonArrayBaseTypes)
+            {
+                Assert.False(new TypeDelegator(type).IsSZArray);
+            }
         }
 
-        [Theory, MemberData(nameof(SZArrayOrNotTypes))]
-        public void IsSZArray(Type type, bool expected)
+        [Fact]
+        public void IsSZArray_TrueForSZArrayTypes()
         {
-            Assert.Equal(expected, new TypeDelegator(type).IsSZArray);
+            foreach (Type type in NonArrayBaseTypes.Select(nonArrayBaseType => nonArrayBaseType.MakeArrayType()))
+            {
+                Assert.True(new TypeDelegator(type).IsSZArray);
+            }
+        }
+
+        [Fact]
+        public void IsSZArray_FalseForVariableBoundArrayTypes()
+        {
+            foreach (Type type in NonArrayBaseTypes.Select(nonArrayBaseType => nonArrayBaseType.MakeArrayType(1)))
+            {
+                Assert.False(new TypeDelegator(type).IsSZArray);
+            }
+        }
+
+        [Fact]
+        public void IsSZArray_FalseForNonArrayByRefType()
+        {
+            Assert.False(new TypeDelegator(typeof(int).MakeByRefType()).IsSZArray);
+        }
+
+        [Fact]
+        public void IsSZArray_FalseForByRefSZArrayType()
+        {
+            Assert.False(new TypeDelegator(typeof(int[]).MakeByRefType()).IsSZArray);
+        }
+
+
+        [Fact]
+        public void IsSZArray_FalseForByRefVariableArrayType()
+        {
+            Assert.False(new TypeDelegator(typeof(int[,]).MakeByRefType()).IsSZArray);
+        }
+
+        [Fact]
+        public void IsVariableBoundArray_FalseForNonArrayTypes()
+        {
+            foreach (Type type in NonArrayBaseTypes)
+            {
+                Assert.False(new TypeDelegator(type).IsVariableBoundArray);
+            }
+        }
+
+        [Fact]
+        public void IsVariableBoundArray_FalseForSZArrayTypes()
+        {
+            foreach (Type type in NonArrayBaseTypes.Select(nonArrayBaseType => nonArrayBaseType.MakeArrayType()))
+            {
+                Assert.False(new TypeDelegator(type).IsVariableBoundArray);
+            }
+        }
+
+        [Fact]
+        public void IsVariableBoundArray_TrueForVariableBoundArrayTypes()
+        {
+            foreach (Type type in NonArrayBaseTypes.Select(nonArrayBaseType => nonArrayBaseType.MakeArrayType(1)))
+            {
+                Assert.True(new TypeDelegator(type).IsVariableBoundArray);
+            }
+        }
+
+        [Fact]
+        public void IsVariableBoundArray_FalseForNonArrayByRefType()
+        {
+            Assert.False(new TypeDelegator(typeof(int).MakeByRefType()).IsVariableBoundArray);
+        }
+
+        [Fact]
+        public void IsVariableBoundArray_FalseForByRefSZArrayType()
+        {
+            Assert.False(new TypeDelegator(typeof(int[]).MakeByRefType()).IsVariableBoundArray);
+        }
+
+
+        [Fact]
+        public void IsVariableBoundArray_FalseForByRefVariableArrayType()
+        {
+            Assert.False(new TypeDelegator(typeof(int[,]).MakeByRefType()).IsVariableBoundArray);
         }
     }
 }

--- a/src/System.Runtime/tests/System/Reflection/TypeDelegatorTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/Reflection/TypeDelegatorTests.netcoreapp.cs
@@ -1,113 +1,40 @@
 using System.Collections.Generic;
-using System.Linq;
 using Xunit;
 
 namespace System.Reflection.Tests
 {
     public class TypeDelegatorNetcoreTests
     {
-        private static readonly IEnumerable<Type> NonArrayBaseTypes = new Type[]
-         {
-            typeof(int),
-            typeof(void),
-            typeof(int*),
-            typeof(Outside),
-            typeof(Outside<>),
-            typeof(Outside<>).GetTypeInfo().GenericTypeParameters[0],
-            Type.GetTypeFromCLSID(default(Guid)),
-            new object().GetType().GetType()
-         };
-
-        [Fact]
-        public void IsSZArray_FalseForNonArrayTypes()
+        private static IEnumerable<object[]> SZArrayOrNotTypes()
         {
-            foreach (Type type in NonArrayBaseTypes)
-            {
-                Assert.False(new TypeDelegator(type).IsSZArray);
-            }
+            yield return new object[] { typeof(int[]), true };
+            yield return new object[] { typeof(string[]), true };
+            yield return new object[] { typeof(void), false };
+            yield return new object[] { typeof(int), false };
+            yield return new object[] { typeof(int[]).MakeByRefType(), false };
+            yield return new object[] { typeof(int[,]), false };
+            yield return new object[] { typeof(TypeInfoTests), false };
+            yield return new object[] { Array.CreateInstance(typeof(int), new[] { 2 }, new[] { -1 }).GetType(), false };
+            yield return new object[] { Array.CreateInstance(typeof(int), new[] { 2 }, new[] { 1 }).GetType(), false };
+            yield return new object[] { Array.CreateInstance(typeof(int), new[] { 2 }, new[] { 0 }).GetType(), true };
+            yield return new object[] { typeof(int[][]), true };
+            yield return new object[] { Type.GetType("System.Int32[]"), true };
+            yield return new object[] { Type.GetType("System.Int32[*]"), false };
+            yield return new object[] { Type.GetType("System.Int32"), false };
+            yield return new object[] { typeof(int).MakeArrayType(), true };
+            yield return new object[] { typeof(int).MakeArrayType(1), false };
+            yield return new object[] { typeof(int).MakeArrayType().MakeArrayType(), true };
+            yield return new object[] { typeof(int).MakeArrayType(2), false };
+            yield return new object[] { typeof(Outside<int>.Inside<string>), false };
+            yield return new object[] { typeof(Outside<int>.Inside<string>[]), true };
+            yield return new object[] { typeof(Outside<int>.Inside<string>[,]), false };
+            yield return new object[] { Array.CreateInstance(typeof(Outside<int>.Inside<string>), new[] { 2 }, new[] { -1 }).GetType(), false };
         }
 
-        [Fact]
-        public void IsSZArray_TrueForSZArrayTypes()
+        [Theory, MemberData(nameof(SZArrayOrNotTypes))]
+        public void IsSZArray(Type type, bool expected)
         {
-            foreach (Type type in NonArrayBaseTypes.Select(nonArrayBaseType => nonArrayBaseType.MakeArrayType()))
-            {
-                Assert.True(new TypeDelegator(type).IsSZArray);
-            }
-        }
-
-        [Fact]
-        public void IsSZArray_FalseForVariableBoundArrayTypes()
-        {
-            foreach (Type type in NonArrayBaseTypes.Select(nonArrayBaseType => nonArrayBaseType.MakeArrayType(1)))
-            {
-                Assert.False(new TypeDelegator(type).IsSZArray);
-            }
-        }
-
-        [Fact]
-        public void IsSZArray_FalseForNonArrayByRefType()
-        {
-            Assert.False(new TypeDelegator(typeof(int).MakeByRefType()).IsSZArray);
-        }
-
-        [Fact]
-        public void IsSZArray_FalseForByRefSZArrayType()
-        {
-            Assert.False(new TypeDelegator(typeof(int[]).MakeByRefType()).IsSZArray);
-        }
-
-
-        [Fact]
-        public void IsSZArray_FalseForByRefVariableArrayType()
-        {
-            Assert.False(new TypeDelegator(typeof(int[,]).MakeByRefType()).IsSZArray);
-        }
-
-        [Fact]
-        public void IsVariableBoundArray_FalseForNonArrayTypes()
-        {
-            foreach (Type type in NonArrayBaseTypes)
-            {
-                Assert.False(new TypeDelegator(type).IsVariableBoundArray);
-            }
-        }
-
-        [Fact]
-        public void IsVariableBoundArray_FalseForSZArrayTypes()
-        {
-            foreach (Type type in NonArrayBaseTypes.Select(nonArrayBaseType => nonArrayBaseType.MakeArrayType()))
-            {
-                Assert.False(new TypeDelegator(type).IsVariableBoundArray);
-            }
-        }
-
-        [Fact]
-        public void IsVariableBoundArray_TrueForVariableBoundArrayTypes()
-        {
-            foreach (Type type in NonArrayBaseTypes.Select(nonArrayBaseType => nonArrayBaseType.MakeArrayType(1)))
-            {
-                Assert.True(new TypeDelegator(type).IsVariableBoundArray);
-            }
-        }
-
-        [Fact]
-        public void IsVariableBoundArray_FalseForNonArrayByRefType()
-        {
-            Assert.False(new TypeDelegator(typeof(int).MakeByRefType()).IsVariableBoundArray);
-        }
-
-        [Fact]
-        public void IsVariableBoundArray_FalseForByRefSZArrayType()
-        {
-            Assert.False(new TypeDelegator(typeof(int[]).MakeByRefType()).IsVariableBoundArray);
-        }
-
-
-        [Fact]
-        public void IsVariableBoundArray_FalseForByRefVariableArrayType()
-        {
-            Assert.False(new TypeDelegator(typeof(int[,]).MakeByRefType()).IsVariableBoundArray);
+            Assert.Equal(expected, new TypeDelegator(type).IsSZArray);
         }
     }
 }

--- a/src/System.Runtime/tests/System/TypeTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/TypeTests.netcoreapp.cs
@@ -18,7 +18,7 @@ namespace System.Tests
             Type.GetTypeFromCLSID(default(Guid)),
             new object().GetType().GetType()
         };
-        
+
         [Fact]
         public void IsSZArray_FalseForNonArrayTypes()
         {
@@ -47,6 +47,25 @@ namespace System.Tests
         }
 
         [Fact]
+        public void IsSZArray_FalseForNonArrayByRefType()
+        {
+            Assert.False(typeof(int).MakeByRefType().IsSZArray);
+        }
+
+        [Fact]
+        public void IsSZArray_FalseForByRefSZArrayType()
+        {
+            Assert.False(typeof(int[]).MakeByRefType().IsSZArray);
+        }
+
+
+        [Fact]
+        public void IsSZArray_FalseForByRefVariableArrayType()
+        {
+            Assert.False(typeof(int[,]).MakeByRefType().IsSZArray);
+        }
+
+        [Fact]
         public void IsVariableBoundArray_FalseForNonArrayTypes()
         {
             foreach (Type type in NonArrayBaseTypes)
@@ -71,6 +90,25 @@ namespace System.Tests
             {
                 Assert.True(type.IsVariableBoundArray);
             }
+        }
+
+        [Fact]
+        public void IsVariableBoundArray_FalseForNonArrayByRefType()
+        {
+            Assert.False(typeof(int).MakeByRefType().IsVariableBoundArray);
+        }
+
+        [Fact]
+        public void IsVariableBoundArray_FalseForByRefSZArrayType()
+        {
+            Assert.False(typeof(int[]).MakeByRefType().IsVariableBoundArray);
+        }
+
+
+        [Fact]
+        public void IsVariableBoundArray_FalseForByRefVariableArrayType()
+        {
+            Assert.False(typeof(int[,]).MakeByRefType().IsVariableBoundArray);
         }
     }
 }

--- a/src/System.Runtime/tests/System/TypeTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/TypeTests.netcoreapp.cs
@@ -7,18 +7,27 @@ namespace System.Tests
 {
     public class TypeTestsNetcore
     {
-        private static readonly IEnumerable<Type> NonArrayBaseTypes = new Type[]
-        {
-            typeof(int),
-            typeof(void),
-            typeof(int*),
-            typeof(Outside),
-            typeof(Outside<>),
-            typeof(Outside<>).GetTypeInfo().GenericTypeParameters[0],
-            Type.GetTypeFromCLSID(default(Guid)),
-            new object().GetType().GetType()
-        };
+        private static readonly IList<Type> NonArrayBaseTypes;
 
+        static TypeTestsNetcore()
+        {
+            NonArrayBaseTypes = new List<Type>()
+            {
+                typeof(int),
+                typeof(void),
+                typeof(int*),
+                typeof(Outside),
+                typeof(Outside<>),
+                typeof(Outside<>).GetTypeInfo().GenericTypeParameters[0],
+                new object().GetType().GetType()
+            };
+
+            if (PlatformDetection.IsWindows)
+            {
+                NonArrayBaseTypes.Add(Type.GetTypeFromCLSID(default(Guid)));
+            }
+        }
+        
         [Fact]
         public void IsSZArray_FalseForNonArrayTypes()
         {

--- a/src/System.Runtime/tests/System/TypeTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/TypeTests.netcoreapp.cs
@@ -36,5 +36,42 @@ namespace System.Tests
         {
             Assert.Equal(expected, type.IsSZArray);
         }
+
+        private static IEnumerable<object[]> VariableBoundArrayOrNotTypes()
+        {
+            // Not arrays
+            yield return new object[] { typeof(void), false };
+            yield return new object[] { typeof(int), false };
+            yield return new object[] { typeof(int[]).MakeByRefType(), false };
+            yield return new object[] { typeof(TypeTests), false };
+            yield return new object[] { Type.GetType("System.Int32"), false };
+            yield return new object[] { typeof(Outside<int>.Inside<string>), false };
+
+            // Arrays, but SZ arrays
+            yield return new object[] { Type.GetType("System.Int32[]"), false };
+            yield return new object[] { typeof(int[]), false };
+            yield return new object[] { typeof(string[]), false };
+            yield return new object[] { Array.CreateInstance(typeof(int), new[] { 2 }, new[] { 0 }).GetType(), false };
+            yield return new object[] { typeof(int[][]), false };
+            yield return new object[] { typeof(int).MakeArrayType(), false };
+            yield return new object[] { typeof(int).MakeArrayType().MakeArrayType(), false };
+            yield return new object[] { typeof(Outside<int>.Inside<string>[]), false };
+
+            // Variable bound arrays
+            yield return new object[] { typeof(int[,]), true };
+            yield return new object[] { Array.CreateInstance(typeof(int), new[] { 2 }, new[] { -1 }).GetType(), true };
+            yield return new object[] { Array.CreateInstance(typeof(int), new[] { 2 }, new[] { 1 }).GetType(), true };
+            yield return new object[] { typeof(int).MakeArrayType(1), true };
+            yield return new object[] { typeof(int).MakeArrayType(2), true };
+            yield return new object[] { typeof(Outside<int>.Inside<string>[,]), true };
+            yield return new object[] { Array.CreateInstance(typeof(Outside<int>.Inside<string>), new[] { 2 }, new[] { -1 }).GetType(), true };
+            yield return new object[] { Type.GetType("System.Int32[*]"), true };
+        }
+
+        [Theory, MemberData(nameof(VariableBoundArrayOrNotTypes))]
+        public void IsVariableBoundArray(Type type, bool expected)
+        {
+            Assert.Equal(expected, type.IsVariableBoundArray);
+        }
     }
 }

--- a/src/System.Runtime/tests/System/TypeTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/TypeTests.netcoreapp.cs
@@ -22,7 +22,7 @@ namespace System.Tests
         [Fact]
         public void IsSZArray_FalseForNonArrayTypes()
         {
-            foreach (var type in NonArrayBaseTypes)
+            foreach (Type type in NonArrayBaseTypes)
             {
                 Assert.False(type.IsSZArray);
             }
@@ -31,7 +31,7 @@ namespace System.Tests
         [Fact]
         public void IsSZArray_TrueForSZArrayTypes()
         {
-            foreach (var type in NonArrayBaseTypes.Select(nonArrayBaseType => nonArrayBaseType.MakeArrayType()))
+            foreach (Type type in NonArrayBaseTypes.Select(nonArrayBaseType => nonArrayBaseType.MakeArrayType()))
             {
                 Assert.True(type.IsSZArray);
             }
@@ -40,7 +40,7 @@ namespace System.Tests
         [Fact]
         public void IsSZArray_FalseForVariableBoundArrayTypes()
         {
-            foreach (var type in NonArrayBaseTypes.Select(nonArrayBaseType => nonArrayBaseType.MakeArrayType(1)))
+            foreach (Type type in NonArrayBaseTypes.Select(nonArrayBaseType => nonArrayBaseType.MakeArrayType(1)))
             {
                 Assert.False(type.IsSZArray);
             }
@@ -49,7 +49,7 @@ namespace System.Tests
         [Fact]
         public void IsVariableBoundArray_FalseForNonArrayTypes()
         {
-            foreach (var type in NonArrayBaseTypes)
+            foreach (Type type in NonArrayBaseTypes)
             {
                 Assert.False(type.IsVariableBoundArray);
             }
@@ -58,7 +58,7 @@ namespace System.Tests
         [Fact]
         public void IsVariableBoundArray_FalseForSZArrayTypes()
         {
-            foreach (var type in NonArrayBaseTypes.Select(nonArrayBaseType => nonArrayBaseType.MakeArrayType()))
+            foreach (Type type in NonArrayBaseTypes.Select(nonArrayBaseType => nonArrayBaseType.MakeArrayType()))
             {
                 Assert.False(type.IsVariableBoundArray);
             }
@@ -67,7 +67,7 @@ namespace System.Tests
         [Fact]
         public void IsVariableBoundArray_TrueForVariableBoundArrayTypes()
         {
-            foreach (var type in NonArrayBaseTypes.Select(nonArrayBaseType => nonArrayBaseType.MakeArrayType(1)))
+            foreach (Type type in NonArrayBaseTypes.Select(nonArrayBaseType => nonArrayBaseType.MakeArrayType(1)))
             {
                 Assert.True(type.IsVariableBoundArray);
             }


### PR DESCRIPTION
@karelz @stephentoub @AtsushiKan 

This PR resolves #16836 

NB unlike IsSZArray, I've not declared IsVariableBoundArray as virtual. My reasoning is that since the TypeInfo stuff is going away, this shouldn't need to be overridden. 