### PR TITLE
Disable Failed test for issue 18831.

### DIFF
--- a/src/System.Configuration.ConfigurationManager/tests/Mono/ConfigurationManagerTest.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/Mono/ConfigurationManagerTest.cs
@@ -130,6 +130,7 @@ namespace MonoTests.System.Configuration
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18831")]
         public void exePath_UserLevelNone()
         {
             string name = TestUtil.ThisApplicationPath;


### PR DESCRIPTION
Add [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18831")]

For exePath_UserLevelNone

in ConfigurationManagerTest.cs under MonoTests.System.Configuration

cc: @danmosemsft @safern 