### PR TITLE
Disable failed test for issue 18810.

### DIFF
--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/XmlSystemPathResolverTests.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/XmlSystemPathResolverTests.cs
@@ -75,6 +75,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18810")]
         public static void TestResolveInvalidPaths()
         {
             AssertInvalidPath(null);


### PR DESCRIPTION
Add [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18810")]
For TestResolveInvalidPaths()

in XmlSystemPathResolverTests.cs under System.Xml.Tests

cc: @danmosemsft @safern 