### PR TITLE
Dsiable failed test for issue 18808.

### DIFF
--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsManifestGeneration.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsManifestGeneration.cs
@@ -25,6 +25,7 @@ namespace BasicEventSourceTests
         /// EventSource would fail when an EventSource was named "EventSource".
         /// </summary>
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18808")]
         public void Test_EventSource_NamedEventSource()
         {
             using (var es = new SdtEventSources.DontPollute.EventSource())


### PR DESCRIPTION
Add [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18808")]
For Test_EventSource_NamedEventSource()

in TestsManifestGeneration.cs under BasicEventSourceTests

cc: @danmosemsft @safern 