### PR TITLE
Disable failed tests for issue 18806.

### DIFF
--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWriteEvent.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWriteEvent.cs
@@ -39,6 +39,7 @@ namespace BasicEventSourceTests
         /// Tests bTraceListener path. 
         /// </summary>
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18806")]
         public void Test_WriteEvent_Manifest_EventListener()
         {
             using (var listener = new EventListenerListener())
@@ -52,6 +53,7 @@ namespace BasicEventSourceTests
         /// Tests bTraceListener path using events instead of virtual callbacks. 
         /// </summary>
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18806")]
         public void Test_WriteEvent_Manifest_EventListener_UseEvents()
         {
             Test_WriteEvent(new EventListenerListener(true), false);
@@ -75,6 +77,7 @@ namespace BasicEventSourceTests
         /// Tests both the ETW and TraceListener paths. 
         /// </summary>
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18806")]
         public void Test_WriteEvent_SelfDescribing_EventListener()
         {
             using (var listener = new EventListenerListener())
@@ -89,6 +92,7 @@ namespace BasicEventSourceTests
         /// instead of virtual callbacks. 
         /// </summary>
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18806")]
         public void Test_WriteEvent_SelfDescribing_EventListener_UseEvents()
         {
             Test_WriteEvent(new EventListenerListener(true), true);


### PR DESCRIPTION
Add [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18806")]
For:
BasicEventSourceTests.TestsWriteEvent.Test_WriteEvent_Manifest_EventListener
 BasicEventSourceTests.TestsWriteEvent.Test_WriteEvent_SelfDescribing_EventListener
 BasicEventSourceTests.TestsWriteEvent.Test_WriteEvent_SelfDescribing_EventListener_UseEvents
 BasicEventSourceTests.TestsWriteEvent.Test_WriteEvent_Manifest_EventListener_UseEvents

cc: @danmosemsft @safern 