### PR TITLE
Fix marshaling-related ArgumentException in ExpandEnvironmentVariablesCore

### DIFF
--- a/src/System.Runtime.Extensions/src/System/Environment.Win32.cs
+++ b/src/System.Runtime.Extensions/src/System/Environment.Win32.cs
@@ -3,9 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Internal.Runtime.Augments;
-using Microsoft.Win32;
-using System.Collections;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -33,8 +30,8 @@ namespace System
             while (size > currentSize)
             {
                 currentSize = size;
-                result.Capacity = currentSize;
                 result.Length = 0;
+                result.Capacity = currentSize;
 
                 size = Interop.Kernel32.ExpandEnvironmentStringsW(name, result, currentSize);
                 if (size == 0)

--- a/src/System.Runtime.Extensions/tests/System/Environment.ExpandEnvironmentVariables.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.ExpandEnvironmentVariables.cs
@@ -54,10 +54,15 @@ namespace System.Tests
             Assert.Equal(unexpanded, Environment.ExpandEnvironmentVariables(unexpanded));
         }
 
-        [Fact]
-        public void StringWithNoEnvironmentVariablesGoesThroughUnchnaged()
+        [Theory]
+        [InlineData("Hello World")]
+        [InlineData("C:\\J\\workspace\\debug_windows---bc3c3f12\\artifacts\\win81-x86\\stage2\\sdk\\2.0.0-preview1-005938\\Extensions")] // longer than 100 chars, a magic number in the impl
+        public void StringWithNoEnvironmentVariablesGoesThroughUnchanged(string value)
         {
-            Assert.Equal("Hello World", Environment.ExpandEnvironmentVariables("Hello World"));
+            for (int i = 0; i < 2; i++) // invoke multiple times to exercise StringBuilder reuse path
+            {
+                Assert.Equal(value, Environment.ExpandEnvironmentVariables(value));
+            }
         }
 
         [Fact]


### PR DESCRIPTION
This bug requires a certain pattern of inputs and calls to manifest, e.g.
- StringBuilderCache contains a StringBuilder with Capacity == N, where N > 100
- Call ExpandEnvironmentVariablesCore on 32-bit with a string (no quoted regions) of length M > 100 && M < N

The ExpandEnvironmentVariablesCore implementation will acquire a StringBuilder of at least length 100, tracking the requested size of 100 in "currentSize" rather than the actual capacity it gets back.  Then it will make an initial call to ExpandEnvironmentStringsW with the StringBuilder and the tracked currentSize.  The length will be insufficient, so the Win32 call will fail and return the required size.  But the runtime marshaling for the StringBuilder doesn't know it failed, so it dutifully marshals back the results of the call, and in doing so, ends up increasing the capacity of the StringBuilder and, importantly, increasing its Length, such that the Length is now larger than both the required size and currentSize.  It will then try to increase the capacity of the builder to the required size, but the length and capacity are already longer than that, and the call to set the Capacity will throw due to it being perceived as losing data.

The short-term fix is simple: just clear the builder before rather than after changing its capacity.  A better longer-term fix is to stop using StringBuilder entirely; it adds overhead for little benefit.

Fixes https://github.com/dotnet/corefx/issues/19354
cc: @JeremyKuhne 