### PR TITLE
Skip DualMode localhost tests when it's not

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/DnsEndPointTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DnsEndPointTest.cs
@@ -10,18 +10,8 @@ using Xunit.Abstractions;
 
 namespace System.Net.Sockets.Tests
 {
-    public class DnsEndPointTest
+    public class DnsEndPointTest : DualModeBase
     {
-        // Port 8 is unassigned as per https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.txt
-        private const int UnusedPort = 8;
-
-        private readonly ITestOutputHelper _log;
-
-        public DnsEndPointTest(ITestOutputHelper output)
-        {
-            _log = TestLogging.GetInstance();
-        }
-
         private void OnConnectAsyncCompleted(object sender, SocketAsyncEventArgs args)
         {
             ManualResetEvent complete = (ManualResetEvent)args.UserToken;
@@ -312,12 +302,11 @@ namespace System.Net.Sockets.Tests
         }
 
         [OuterLoop] // TODO: Issue #11345
-        [Theory]
+        [ConditionalTheory(nameof(LocalhostIsBothIPv4AndIPv6))]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
         [Trait("IPv4", "true")]
         [Trait("IPv6", "true")]
-        [ActiveIssue(4002, TestPlatforms.AnyUnix)]
         public void Socket_StaticConnectAsync_Success(SocketImplementationType type)
         {
             Assert.True(Capability.IPv4Support() && Capability.IPv6Support());

--- a/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
 using System.Net.Test.Common;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -302,9 +303,8 @@ namespace System.Net.Sockets.Tests
     [Trait("IPv6", "true")]
     public class DualModeConnectToHostString : DualModeBase
     {
-        [Theory]
+        [ConditionalTheory(nameof(LocalhostIsBothIPv4AndIPv6))]
         [MemberData(nameof(DualMode_Connect_IPAddress_DualMode_Data))]
-        [ActiveIssue(4002, TestPlatforms.AnyUnix)]
         public void DualModeConnect_LoopbackDnsToHost_Helper(IPAddress listenOn, bool dualModeServer)
         {
             int port;
@@ -321,9 +321,8 @@ namespace System.Net.Sockets.Tests
     [Trait("IPv6", "true")]
     public class DualModeConnectToDnsEndPoint : DualModeBase
     {
-        [Theory]
+        [ConditionalTheory(nameof(LocalhostIsBothIPv4AndIPv6))]
         [MemberData(nameof(DualMode_Connect_IPAddress_DualMode_Data))]
-        [ActiveIssue(4002, TestPlatforms.AnyUnix)]
         public void DualModeConnect_DnsEndPointToHost_Helper(IPAddress listenOn, bool dualModeServer)
         {
             int port;
@@ -614,9 +613,8 @@ namespace System.Net.Sockets.Tests
             });
         }
 
-        [Theory]
+        [ConditionalTheory(nameof(LocalhostIsBothIPv4AndIPv6))]
         [MemberData(nameof(DualMode_Connect_IPAddress_DualMode_Data))]
-        [ActiveIssue(4002, TestPlatforms.AnyUnix)]
         public void DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress listenOn, bool dualModeServer)
         {
             int port;
@@ -640,9 +638,8 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory(nameof(LocalhostIsBothIPv4AndIPv6))]
         [MemberData(nameof(DualMode_Connect_IPAddress_DualMode_Data))]
-        [ActiveIssue(4002, TestPlatforms.AnyUnix)]
         public void DualModeConnectAsync_Static_DnsEndPointToHost_Helper(IPAddress listenOn, bool dualModeServer)
         {
             int port;
@@ -2445,6 +2442,21 @@ namespace System.Net.Sockets.Tests
         {
             _log = TestLogging.GetInstance();
             Assert.True(Capability.IPv4Support() && Capability.IPv6Support());
+        }
+
+        public static bool LocalhostIsBothIPv4AndIPv6 { get; } = GetLocalhostIsBothIPv4AndIPv6();
+
+        private static bool GetLocalhostIsBothIPv4AndIPv6()
+        {
+            try
+            {
+                IPAddress[] addresses = Dns.GetHostAddresses("localhost");
+                return
+                    addresses.Any(ip => ip.AddressFamily == AddressFamily.InterNetwork) &&
+                    addresses.Any(ip => ip.AddressFamily == AddressFamily.InterNetworkV6);
+            }
+            catch { }
+            return false;
         }
 
         protected static void AssertDualModeEnabled(Socket socket, IPAddress listenOn)


### PR DESCRIPTION
Several DualMode tests assume that "localhost" maps to both IPv4 and IPv6 addresses, either because the test is verifying that a DualMode socket (such as one used by Socket.ConnectAsync) is able to connect to both IPv4 and IPv6 endpoints, or because the test is verifying that a DualMode socket listening at a given address can accept both IPv4 and IPv6 connections.  but "localhost" doesn't always map to both IPv4 and IPv6.  Change the tests to be conditional to only run when that assumption holds.

Fixes https://github.com/dotnet/corefx/issues/4002
cc: @steveharter, @davidsh, @geoffkizer 