### PR TITLE
Restore shared framework packages and get tests compiling against it

### DIFF
--- a/SharedFrameworkValidation.cmd
+++ b/SharedFrameworkValidation.cmd
@@ -1,0 +1,9 @@
+@if not defined _echo @echo off
+setlocal
+
+call %~dp0sync.cmd
+if NOT [%ERRORLEVEL%]==[0] exit /b 1
+call %~dp0build-managed.cmd -Project:%~dp0src\SharedFrameworkValidation\SharedFrameworkValidation.proj -- /t:ReBuild
+if NOT [%ERRORLEVEL%]==[0] exit /b 1
+call %~dp0build-tests.cmd -SkipTests -- /p:RefPath=%~dp0bin\ref\SharedFrameworkValidation /p:RunningSharedFrameworkValidation=true /p:RuntimePath=%~dp0bin\runtime\SharedFrameworkValidation\
+exit /b %ERRORLEVEL%

--- a/src/SharedFrameworkValidation/RestoreSDKProject/Dummy.cs
+++ b/src/SharedFrameworkValidation/RestoreSDKProject/Dummy.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace Dummy
+{
+    public class DummyClass
+    {
+    }
+}

--- a/src/SharedFrameworkValidation/RestoreSDKProject/RestoreSDKProject.csproj
+++ b/src/SharedFrameworkValidation/RestoreSDKProject/RestoreSDKProject.csproj
@@ -1,0 +1,64 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <RuntimeFrameworkVersion>$(_RuntimeFrameworkVersion)</RuntimeFrameworkVersion>
+    <CoreFxPackageVersion>4.4.0-$(CoreFxExpectedPrerelease)</CoreFxPackageVersion>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="$(CoreFxPackageVersion)" />
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="2.0.0-$(CoreFxExpectedPrerelease)" />
+    <PackageReference Include="Microsoft.NETCore.Targets" Version="2.0.0-$(CoreFxExpectedPrerelease)" />
+    <PackageReference Include="Microsoft.VisualBasic" Version="10.2.0-$(CoreFxExpectedPrerelease)" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="$(CoreFxPackageVersion)" />
+    <PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="$(CoreFxPackageVersion)" />
+    <PackageReference Include="Microsoft.XmlSerializer.Generator" Version="1.0.0-$(CoreFxExpectedPrerelease)" />
+    <PackageReference Include="System.Buffers" Version="$(CoreFxPackageVersion)" />
+    <PackageReference Include="System.CodeDom" Version="$(CoreFxPackageVersion)" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.4.0-$(CoreFxExpectedPrerelease)" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="$(CoreFxPackageVersion)" />
+    <PackageReference Include="System.Composition" Version="1.1.0-$(CoreFxExpectedPrerelease)" />
+    <PackageReference Include="System.Composition.AttributedModel" Version="1.1.0-$(CoreFxExpectedPrerelease)" />
+    <PackageReference Include="System.Composition.Convention" Version="1.1.0-$(CoreFxExpectedPrerelease)" />
+    <PackageReference Include="System.Composition.Hosting" Version="1.1.0-$(CoreFxExpectedPrerelease)" />
+    <PackageReference Include="System.Composition.Runtime" Version="1.1.0-$(CoreFxExpectedPrerelease)" />
+    <PackageReference Include="System.Composition.TypedParts" Version="1.1.0-$(CoreFxExpectedPrerelease)" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(CoreFxPackageVersion)" />
+    <PackageReference Include="System.Data.SqlClient" Version="$(CoreFxPackageVersion)" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(CoreFxPackageVersion)" />
+    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="$(CoreFxPackageVersion)" />
+    <PackageReference Include="System.IO.Packaging" Version="$(CoreFxPackageVersion)" />
+    <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(CoreFxPackageVersion)" />
+    <PackageReference Include="System.IO.Ports" Version="$(CoreFxPackageVersion)" />
+    <PackageReference Include="System.Json" Version="$(CoreFxPackageVersion)" />
+    <PackageReference Include="System.Memory" Version="$(CoreFxPackageVersion)" />
+    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="$(CoreFxPackageVersion)" />
+    <PackageReference Include="System.Numerics.Vectors" Version="$(CoreFxPackageVersion)" />
+    <PackageReference Include="System.Reflection.DispatchProxy" Version="$(CoreFxPackageVersion)" />
+    <PackageReference Include="System.Reflection.Metadata" Version="1.5.0-$(CoreFxExpectedPrerelease)" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="$(CoreFxPackageVersion)" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(CoreFxPackageVersion)" />
+    <PackageReference Include="System.Security.AccessControl" Version="$(CoreFxPackageVersion)" />
+    <PackageReference Include="System.Security.Cryptography.Cng" Version="$(CoreFxPackageVersion)" />
+    <PackageReference Include="System.Security.Cryptography.OpenSsl" Version="$(CoreFxPackageVersion)" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="$(CoreFxPackageVersion)" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="$(CoreFxPackageVersion)" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(CoreFxPackageVersion)" />
+    <PackageReference Include="System.Security.Permissions" Version="$(CoreFxPackageVersion)" />
+    <PackageReference Include="System.Security.Principal.Windows" Version="$(CoreFxPackageVersion)" />
+    <PackageReference Include="System.ServiceProcess.ServiceController" Version="$(CoreFxPackageVersion)" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="$(CoreFxPackageVersion)" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="$(CoreFxPackageVersion)" />
+    <PackageReference Include="System.Threading.AccessControl" Version="$(CoreFxPackageVersion)" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.8.0-$(CoreFxExpectedPrerelease)" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="$(CoreFxPackageVersion)" />
+    <PackageReference Include="System.ValueTuple" Version="$(CoreFxPackageVersion)" />
+  </ItemGroup>
+
+  <Target Name="BinPlaceMetaPackageRef" BeforeTargets="CoreCompile">
+    <Copy SourceFiles="%(ReferencePath.Identity)" DestinationFolder="$(_MetaPackageDestinationFolder)" />
+  </Target>
+
+</Project>

--- a/src/SharedFrameworkValidation/SharedFrameworkValidation.proj
+++ b/src/SharedFrameworkValidation/SharedFrameworkValidation.proj
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <SharedFrameworkValidationRefPath>$(RefRootPath)SharedFrameworkValidation</SharedFrameworkValidationRefPath>
+    <SharedFrameworkValidationRuntimePath>$(BinDir)runtime/SharedFrameworkValidation</SharedFrameworkValidationRuntimePath>
+  </PropertyGroup>
+
+  <Target Name="RestorePackagesProject">
+    <PropertyGroup>
+      <_RuntimeFrameworkVersion>2.0.0-preview2-25303-01</_RuntimeFrameworkVersion>
+      <_RestorePackagesCommand>"$(DotnetToolCommand)" restore $(MSBuildThisFileDirectory)\RestoreSDKProject\RestoreSDKProject.csproj /p:_RuntimeFrameworkVersion=$(_RuntimeFrameworkVersion) /p:CoreFxExpectedPrerelease=$(CoreFxExpectedPrerelease)</_RestorePackagesCommand>
+    </PropertyGroup>
+    <Exec Command="$(_RestorePackagesCommand)" />
+  </Target>
+
+  <Target Name="BuildPackagesProject">
+    <PropertyGroup>
+      <_BuildPackagesProjectCommand>"$(DotnetToolCommand)" build $(MSBuildThisFileDirectory)\RestoreSDKProject\RestoreSDKProject.csproj /p:_MetaPackageDestinationFolder=$(SharedFrameworkValidationRefPath)</_BuildPackagesProjectCommand>
+    </PropertyGroup>
+    <Exec Command="$(_BuildPackagesProjectCommand)" />
+  </Target>
+
+  <Target Name="PublishPackagesProject">
+    <PropertyGroup>
+      <_PublishPackagesProjectCommand>"$(DotnetToolCommand)" publish $(MSBuildThisFileDirectory)\RestoreSDKProject\RestoreSDKProject.csproj /p:_MetaPackageDestinationFolder=$(SharedFrameworkValidationRefPath) -f netcoreapp2.0 -r win-x64 -o $(SharedFrameworkValidationRuntimePath)</_PublishPackagesProjectCommand>
+    </PropertyGroup>
+    <Exec Command="$(_PublishPackagesProjectCommand)" />
+  </Target>
+
+  <Target Name="CopyXunitAssemblies">
+    <ItemGroup>
+      <XunitAssemblies Include="$(BinDir)runtime/$(BuildConfiguration)/xunit*.dll" />
+      <XunitAssemblies Include="$(BinDir)runtime/$(BuildConfiguration)/xunit.console.netcore.exe" />
+      <XunitAssemblies Include="$(BinDir)runtime/$(BuildConfiguration)/Newtonsoft.Json.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="%(XunitAssemblies.Identity)" DestinationFolder="$(SharedFrameworkValidationRuntimePath)" />
+  </Target>
+
+  <Target Name="Build" DependsOnTargets="RestorePackagesProject;BuildPackagesProject;PublishPackagesProject;CopyXunitAssemblies" />
+  <Target Name="Clean">
+    <RemoveDir Directories="$(MSBuildThisFileDirectory)RestoreSDKProject\obj;$(MSBuildThisFileDirectory)RestoreSDKProject\bin;$(SharedFrameworkValidationRefPath);$(SharedFrameworkValidationRuntimePath)" />
+  </Target>
+  <Target Name="Rebuild" DependsOnTargets="Clean;Build" />
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/tests.builds
+++ b/src/tests.builds
@@ -6,6 +6,13 @@
     <GenerateCodeCoverageReportForAll>true</GenerateCodeCoverageReportForAll>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(RunningSharedFrameworkValidation)'=='true'">
+    <TestProjectExclusions Include="$(MSBuildThisFileDirectory)*\tests\**\System.Data.Odbc.Tests.csproj" />
+    <TestProjectExclusions Include="$(MSBuildThisFileDirectory)*\tests\**\System.IO.Pipes.Tests.csproj" />
+    <TestProjectExclusions Include="$(MSBuildThisFileDirectory)*\tests\**\Microsoft.XmlSerializer.Generator.Tests.csproj" />
+    <TestProjectExclusions Include="$(MSBuildThisFileDirectory)*\tests\**\System.Reflection.Context.Tests.csproj" />
+  </ItemGroup>
+
   <!-- For UAP we are using an APPX that is registered with a unique ID. Because of that we need to run tests sequentially -->
   <PropertyGroup Condition="'$(BuildingUAPVertical)'=='true' and '$(SkipTests)' != 'true' " >
     <SerializeProjects>true</SerializeProjects>


### PR DESCRIPTION
Progress towards #18083 

cc: @weshaggard @ericstj @danmosemsft 

This is the initial step for automating the validation of the shared framework. This PR will take care of restoring shared framework + OOB packages using an SDK project and the CLI, and then compiling all of the tests against this shared framework. There are two more steps to be taken in order to get tests running on this shared framework which I will outline bellow.

Steps to run tests on a restored shared framework for validation:
 - [X] Restore shared framework (+ other OOB packages) using an SDK project
 - [X] Compile tests against the assemblies restored in step 1.
 - [ ] Run a git command in order to checkout the version of corefx that matches the SHA used to build assemblies restored in step 1.
 - [ ] Run Tests against the shared framework restored in step 1.

Steps to run ApiCompat on a restored shared framework for validation:
 - [X] Restore required packages containing ref assemblies in order to do the validation.
 - [ ] Restore all RID packages containing runtime assemblies for validation. (This PR only restores one RID)
 - [ ] Run ApiCompat for the desired configurations.