### PR TITLE
Source init-tools rather than execute

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
 __scriptpath=$(cd "$(dirname "$0")"; pwd -P)
+
+# Source the init-tools.sh script rather than execute in order to preserve ulimit values in child-processes. https://github.com/dotnet/corefx/issues/19152
 . $__scriptpath/init-tools.sh
 
 __toolRuntime=$__scriptpath/Tools

--- a/run.sh
+++ b/run.sh
@@ -1,10 +1,7 @@
 #!/usr/bin/env bash
 
 __scriptpath=$(cd "$(dirname "$0")"; pwd -P)
-$__scriptpath/init-tools.sh
-if [ $? -ne 0 ]; then
-    exit 1
-fi
+. $__scriptpath/init-tools.sh
 
 __toolRuntime=$__scriptpath/Tools
 __dotnet=$__toolRuntime/dotnetcli/dotnet


### PR DESCRIPTION
Sourcing init-tools.sh rather than executing it, prevents it from spawning a new process. The ulimit that's set is only valid for the sub-process which means that it's parent won't be affected by it which results in build failures as mentioned in #19152.

Sourcing it also means we no longer have to catch the exit code.