### PR TITLE
System.Globalization.Tests now at 3 failures.

### DIFF
--- a/src/System.Globalization/tests/CharUnicodeInfo/CharUnicodeInfoTests.cs
+++ b/src/System.Globalization/tests/CharUnicodeInfo/CharUnicodeInfoTests.cs
@@ -89,13 +89,7 @@ namespace System.Globalization.Tests
         }
 
         [Theory]
-        [InlineData("aA1!", new double[] { -1, -1, 1, -1 })]
-        // Numeric surrogate (CUNEIFORM NUMERIC SIGN FIVE BAN2 VARIANT FORM)
-        [InlineData("\uD809\uDC55", new double[] { 5, -1 })]
-        [InlineData("a\uD809\uDC55a", new double[] { -1, 5, -1 , -1 })]
-        // Non-numeric surrogate (CUNEIFORM SIGN ZU5 TIMES A)
-        [InlineData("\uD808\uDF6C", new double[] { -1, -1 })]
-        [InlineData("a\uD808\uDF6Ca", new double[] { -1, -1, -1, -1 })]
+        [MemberData(nameof(s_GetNumericValueData))]
         public void GetNumericValue(string s, double[] expected)
         {
             for (int i = 0; i < expected.Length; i++)
@@ -103,6 +97,17 @@ namespace System.Globalization.Tests
                 Assert.Equal(expected[i], CharUnicodeInfo.GetNumericValue(s, i));
             }
         }
+
+        public static readonly object[][] s_GetNumericValueData =
+        {
+            new object[] {"aA1!", new double[] { -1, -1, 1, -1 }},
+            // Numeric surrogate (CUNEIFORM NUMERIC SIGN FIVE BAN2 VARIANT FORM)
+            new object[] {"\uD809\uDC55", new double[] { 5, -1 }},
+            new object[] {"a\uD809\uDC55a", new double[] { -1, 5, -1 , -1 }},
+            // Numeric surrogate (CUNEIFORM NUMERIC SIGN FIVE BAN2 VARIANT FORM)
+            new object[] {"\uD808\uDF6C", new double[] { -1, -1 }},
+            new object[] {"a\uD808\uDF6Ca", new double[] { -1, -1, -1, -1 }},
+        };
 
         [Fact]
         public void GetNumericValue_Invalid()

--- a/src/System.Globalization/tests/CultureInfo/CultureInfoAll.cs
+++ b/src/System.Globalization/tests/CultureInfo/CultureInfoAll.cs
@@ -631,15 +631,15 @@ namespace System.Globalization.Tests
         [Fact]
         public void CultureNotFoundExceptionTest()
         {
-            Assert.Throws<CultureNotFoundException>("name", () => new CultureInfo("!@#$%^&*()"));
-            Assert.Throws<CultureNotFoundException>("name", () => new CultureInfo("This is invalid culture"));
-            Assert.Throws<CultureNotFoundException>("name", () => new CultureInfo("longCulture" + new string('a', 100)));
-            Assert.Throws<CultureNotFoundException>("culture", () => new CultureInfo(0x1000));
+            AssertExtensions.Throws<CultureNotFoundException>("name", () => new CultureInfo("!@#$%^&*()"));
+            AssertExtensions.Throws<CultureNotFoundException>("name", () => new CultureInfo("This is invalid culture"));
+            AssertExtensions.Throws<CultureNotFoundException>("name", () => new CultureInfo("longCulture" + new string('a', 100)));
+            AssertExtensions.Throws<CultureNotFoundException>("culture", () => new CultureInfo(0x1000));
 
-            CultureNotFoundException e = Assert.Throws<CultureNotFoundException>("name", () => new CultureInfo("This is invalid culture"));
+            CultureNotFoundException e = AssertExtensions.Throws<CultureNotFoundException>("name", () => new CultureInfo("This is invalid culture"));
             Assert.Equal("This is invalid culture", e.InvalidCultureName);
 
-            e = Assert.Throws<CultureNotFoundException>("culture", () => new CultureInfo(0x1000));
+            e = AssertExtensions.Throws<CultureNotFoundException>("culture", () => new CultureInfo(0x1000));
             Assert.Equal(0x1000, e.InvalidCultureId);
         }
     }


### PR DESCRIPTION
Moved some unicode strings out of InlineData to
work around TFS 430084 (.Net Native mangling
Unicode strings in custom attributes.)

More .ParamName checking disabled. This test
still fails because we optimize away
the InvalidCultureName property. Not sure
if we want to define that as intended behavior
so leaving it alone for the time being.