### PR TITLE
Add Path.cs performance tests.

### DIFF
--- a/src/Common/tests/System/PerfUtils.cs
+++ b/src/Common/tests/System/PerfUtils.cs
@@ -4,6 +4,7 @@
 
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace System
 {
@@ -31,14 +32,27 @@ namespace System
         }
 
         /// <summary>
-        /// Helper method to create a string containing a number of random
+        /// Helper method to create a string containing a number of 
         /// characters equal to the specified length
         /// </summary>
         public string CreateString(int length)
         {
-            byte[] bytes = new byte[length];
-            _rand.NextBytes(bytes);
-            return Convert.ToBase64String(bytes);
+            char[] str = new char[length];
+
+            for (int i = 0; i < str.Length; i++)
+            {
+                // Add path separator so folders aren't too long.
+                if (i%20 == 0)
+                {
+                    str[i] = '\\';
+                }
+                else
+                {
+                    str[i] = 'a';
+                }
+            }
+
+            return new string(str);
         }
 
         /// <summary>Gets a test file full path that is associated with the call site.</summary>

--- a/src/Common/tests/System/PerfUtils.cs
+++ b/src/Common/tests/System/PerfUtils.cs
@@ -44,7 +44,7 @@ namespace System
                 // Add path separator so folders aren't too long.
                 if (i%20 == 0)
                 {
-                    str[i] = '\\';
+                    str[i] = Path.DirectorySeparatorChar;
                 }
                 else
                 {

--- a/src/System.Runtime.Extensions/tests/Performance/Perf.Path.cs
+++ b/src/System.Runtime.Extensions/tests/Performance/Perf.Path.cs
@@ -62,5 +62,169 @@ namespace System.IO.Tests
                         Path.GetDirectoryName(testPath); Path.GetDirectoryName(testPath); Path.GetDirectoryName(testPath);
                     }
         }
+
+        [Benchmark]
+        [InlineData(10000)]
+        [InlineData(20000)]
+        [InlineData(30000)]
+        public void ChangeExtension(int innerIterations)
+        {
+            PerfUtils utils = new PerfUtils();
+            string testPath = utils.GetTestFilePath();
+            string extension = utils.CreateString(4);
+
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i < innerIterations; i++)
+                    {
+                        Path.ChangeExtension(testPath, extension); Path.ChangeExtension(testPath, extension); Path.ChangeExtension(testPath, extension);
+                        Path.ChangeExtension(testPath, extension); Path.ChangeExtension(testPath, extension); Path.ChangeExtension(testPath, extension);
+                        Path.ChangeExtension(testPath, extension); Path.ChangeExtension(testPath, extension); Path.ChangeExtension(testPath, extension);
+                    }
+        }
+
+        [Benchmark]
+        [InlineData(10000)]
+        [InlineData(20000)]
+        [InlineData(30000)]
+        public void GetExtension(int innerIterations)
+        {
+            PerfUtils utils = new PerfUtils();
+            string testPath = utils.GetTestFilePath();
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i < innerIterations; i++)
+                    {
+                        Path.GetExtension(testPath); Path.GetExtension(testPath); Path.GetExtension(testPath);
+                        Path.GetExtension(testPath); Path.GetExtension(testPath); Path.GetExtension(testPath);
+                        Path.GetExtension(testPath); Path.GetExtension(testPath); Path.GetExtension(testPath);
+                    }
+        }
+
+        [Benchmark]
+        [InlineData(10000)]
+        [InlineData(20000)]
+        [InlineData(30000)]
+        public void GetFileNameWithoutExtension(int innerIterations)
+        {
+            PerfUtils utils = new PerfUtils();
+            string testPath = utils.GetTestFilePath();
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i < innerIterations; i++)
+                    {
+                        Path.GetFileNameWithoutExtension(testPath); Path.GetFileNameWithoutExtension(testPath); Path.GetFileNameWithoutExtension(testPath);
+                        Path.GetFileNameWithoutExtension(testPath); Path.GetFileNameWithoutExtension(testPath); Path.GetFileNameWithoutExtension(testPath);
+                        Path.GetFileNameWithoutExtension(testPath); Path.GetFileNameWithoutExtension(testPath); Path.GetFileNameWithoutExtension(testPath);
+                    }
+        }
+
+        [Benchmark]
+        [InlineData(10000)]
+        [InlineData(20000)]
+        [InlineData(30000)]
+        public void GetFullPath(int innerIterations)
+        {
+            PerfUtils utils = new PerfUtils();
+            string testPath = utils.GetTestFilePath();
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i < innerIterations; i++)
+                    {
+                        Path.GetFullPath(testPath); Path.GetFullPath(testPath); Path.GetFullPath(testPath);
+                        Path.GetFullPath(testPath); Path.GetFullPath(testPath); Path.GetFullPath(testPath);
+                        Path.GetFullPath(testPath); Path.GetFullPath(testPath); Path.GetFullPath(testPath);
+                    }
+        }
+
+        [Benchmark]
+        [InlineData(10000)]
+        [InlineData(20000)]
+        [InlineData(30000)]
+        public void GetPathRoot(int innerIterations)
+        {
+            PerfUtils utils = new PerfUtils();
+            string testPath = utils.GetTestFilePath();
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i < innerIterations; i++)
+                    {
+                        Path.GetPathRoot(testPath); Path.GetPathRoot(testPath); Path.GetPathRoot(testPath);
+                        Path.GetPathRoot(testPath); Path.GetPathRoot(testPath); Path.GetPathRoot(testPath);
+                        Path.GetPathRoot(testPath); Path.GetPathRoot(testPath); Path.GetPathRoot(testPath);
+                    }
+        }
+
+        [Benchmark]
+        [InlineData(10000)]
+        [InlineData(20000)]
+        [InlineData(30000)]
+        public void GetRandomFileName(int innerIterations)
+        {
+            PerfUtils utils = new PerfUtils();
+            string testPath = utils.GetTestFilePath();
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i < innerIterations; i++)
+                    {
+                        Path.GetRandomFileName(); Path.GetRandomFileName(); Path.GetRandomFileName();
+                        Path.GetRandomFileName(); Path.GetRandomFileName(); Path.GetRandomFileName();
+                        Path.GetRandomFileName(); Path.GetRandomFileName(); Path.GetRandomFileName();
+                    }
+        }
+
+        [Benchmark]
+        [InlineData(10000)]
+        [InlineData(20000)]
+        [InlineData(30000)]
+        public void GetTempPath(int innerIterations)
+        {
+            PerfUtils utils = new PerfUtils();
+            string testPath = utils.GetTestFilePath();
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i < innerIterations; i++)
+                    {
+                        Path.GetTempPath(); Path.GetTempPath(); Path.GetTempPath();
+                        Path.GetTempPath(); Path.GetTempPath(); Path.GetTempPath();
+                        Path.GetTempPath(); Path.GetTempPath(); Path.GetTempPath();
+                    }
+        }
+
+        [Benchmark]
+        [InlineData(10000)]
+        [InlineData(20000)]
+        [InlineData(30000)]
+        public void HasExtension(int innerIterations)
+        {
+            PerfUtils utils = new PerfUtils();
+            string testPath = utils.GetTestFilePath();
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i < innerIterations; i++)
+                    {
+                        Path.HasExtension(testPath); Path.HasExtension(testPath); Path.HasExtension(testPath);
+                        Path.HasExtension(testPath); Path.HasExtension(testPath); Path.HasExtension(testPath);
+                        Path.HasExtension(testPath); Path.HasExtension(testPath); Path.HasExtension(testPath);
+                    }
+        }
+
+        [Benchmark]
+        [InlineData(10000)]
+        [InlineData(20000)]
+        [InlineData(30000)]
+        public void IsPathRooted(int innerIterations)
+        {
+            PerfUtils utils = new PerfUtils();
+            string testPath = utils.GetTestFilePath();
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i < innerIterations; i++)
+                    {
+                        Path.IsPathRooted(testPath); Path.IsPathRooted(testPath); Path.IsPathRooted(testPath);
+                        Path.IsPathRooted(testPath); Path.IsPathRooted(testPath); Path.IsPathRooted(testPath);
+                        Path.IsPathRooted(testPath); Path.IsPathRooted(testPath); Path.IsPathRooted(testPath);
+                    }
+        }
     }
 }

--- a/src/System.Runtime.Extensions/tests/Performance/Perf.Path.cs
+++ b/src/System.Runtime.Extensions/tests/Performance/Perf.Path.cs
@@ -123,10 +123,46 @@ namespace System.IO.Tests
         [InlineData(10000)]
         [InlineData(20000)]
         [InlineData(30000)]
-        public void GetFullPath(int innerIterations)
+        public void GetFullPathForLegacyLength(int innerIterations)
         {
             PerfUtils utils = new PerfUtils();
-            string testPath = utils.GetTestFilePath();
+            string testPath = utils.CreateString(length: 200);
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i < innerIterations; i++)
+                    {
+                        Path.GetFullPath(testPath); Path.GetFullPath(testPath); Path.GetFullPath(testPath);
+                        Path.GetFullPath(testPath); Path.GetFullPath(testPath); Path.GetFullPath(testPath);
+                        Path.GetFullPath(testPath); Path.GetFullPath(testPath); Path.GetFullPath(testPath);
+                    }
+        }
+
+        [Benchmark]
+        [InlineData(10000)]
+        [InlineData(20000)]
+        [InlineData(30000)]
+        public void GetFullPathForTypicalLongPath(int innerIterations)
+        {
+            PerfUtils utils = new PerfUtils();
+            string testPath = utils.CreateString(length: 500);
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i < innerIterations; i++)
+                    {
+                        Path.GetFullPath(testPath); Path.GetFullPath(testPath); Path.GetFullPath(testPath);
+                        Path.GetFullPath(testPath); Path.GetFullPath(testPath); Path.GetFullPath(testPath);
+                        Path.GetFullPath(testPath); Path.GetFullPath(testPath); Path.GetFullPath(testPath);
+                    }
+        }
+
+        [Benchmark]
+        [InlineData(10000)]
+        [InlineData(20000)]
+        [InlineData(30000)]
+        public void GetFullPathForReallyLongPath(int innerIterations)
+        {
+            PerfUtils utils = new PerfUtils();
+            string testPath = utils.CreateString(length: 1000);
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
                     for (int i = 0; i < innerIterations; i++)


### PR DESCRIPTION
Add performance tests for Path.cs

This is based on #18765

@mellinoe @karelz 

I had two questions:

1. Why do the perf tests run with 9 calls to the method inside the loop?
2. How do you decide the number of inner iterations? AKA doing 20k vs 10k and 20k and 30k?

I did not add tests for:

AltDirectorySeparatorChar
DirectorySeparatorChar
InvalidPathChars
PathSeparator
VolumeSeparatorChar
GetInvalidFileNameChars
GetInvalidPathChars
GetTempFileName
GetRelativePath