### PR TITLE
Fix missing System.Diagnostics.StackTrace.StackTraceSymbols class

### DIFF
--- a/src/System.Diagnostics.StackTrace/src/ILLinkTrim.xml
+++ b/src/System.Diagnostics.StackTrace/src/ILLinkTrim.xml
@@ -1,0 +1,7 @@
+<linker>
+  <assembly fullname="System.Diagnostics.StackTrace">
+    <!-- used by System.Private.CoreLib StackTrace code to load portable pdbs for the runtime diagnostic stack trace to get source/line info -->
+    <type fullname="System.Diagnostics.StackTraceSymbols" required="true" />
+  </assembly>
+</linker>
+


### PR DESCRIPTION
Add ILLinkTrim.xml to keep illink from removing it.

Issue #19319