### PR TITLE
Surface Type.IsTypeDefinition and tests

### DIFF
--- a/src/System.Reflection.Emit/ref/System.Reflection.Emit.cs
+++ b/src/System.Reflection.Emit/ref/System.Reflection.Emit.cs
@@ -109,6 +109,7 @@ namespace System.Reflection.Emit
         public override bool IsDefined(System.Type attributeType, bool inherit) { throw null; }
         protected override bool IsPointerImpl() { throw null; }
         protected override bool IsPrimitiveImpl() { throw null; }
+        public override bool IsTypeDefinition { get { throw null; } }
         public override bool IsSZArray { get { throw null; } }
         public override bool IsVariableBoundArray { get { throw null; } }
         protected override bool IsValueTypeImpl() { throw null; }
@@ -208,6 +209,7 @@ namespace System.Reflection.Emit
         protected override bool IsPointerImpl() { throw null; }
         protected override bool IsPrimitiveImpl() { throw null; }
         public override bool IsSubclassOf(System.Type c) { throw null; }
+        public override bool IsTypeDefinition { get { throw null; } }
         public override bool IsSZArray { get { throw null; } }
         public override bool IsVariableBoundArray { get { throw null; } }
         protected override bool IsValueTypeImpl() { throw null; }
@@ -416,6 +418,7 @@ namespace System.Reflection.Emit
         protected override bool IsPointerImpl() { throw null; }
         protected override bool IsPrimitiveImpl() { throw null; }
         public override bool IsSubclassOf(System.Type c) { throw null; }
+        public override bool IsTypeDefinition { get { throw null; } }
         public override bool IsSZArray { get { throw null; } }
         public override bool IsVariableBoundArray { get { throw null; } }
         public override System.Type MakeArrayType() { throw null; }

--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -2633,6 +2633,7 @@ namespace System
         public virtual bool IsSecurityTransparent { get { throw null; } }
         public virtual bool IsSerializable { get { throw null; } }
         public bool IsSpecialName { get { throw null; } }
+        public virtual bool IsTypeDefinition { get { throw null; } }
         public virtual bool IsSZArray { get { throw null; } }
         public virtual bool IsVariableBoundArray { get { throw null; } }
         public bool IsUnicodeClass { get { throw null; } }
@@ -6136,6 +6137,7 @@ namespace System.Reflection
         protected override bool IsValueTypeImpl() { throw null; }
         protected override bool IsCOMObjectImpl() { throw null; }
         public override bool IsConstructedGenericType { get { throw null; } }
+        public override bool IsTypeDefinition { get { throw null; } }
         public override bool IsSZArray { get { throw null; } }
         public override bool IsVariableBoundArray { get { throw null; } }
         public override System.Type GetElementType() { throw null; }

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -120,6 +120,9 @@
       <Link>Common\System\PlatformDetection.cs</Link>
     </Compile>
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp' or '$(TargetGroup)' == 'uapaot'">
+    <Compile Include="System\TypeTests.netcoreapp.cs" />
+  </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
     <Compile Include="ArrayTests.netcoreapp.cs" />
     <Compile Include="Helpers.netcoreapp.cs" />
@@ -142,7 +145,6 @@
     <Compile Include="System\UIntPtrTests.netcoreapp.cs" />
     <Compile Include="System\ComponentModel\DefaultValueAttributeTests.netcoreapp.cs" />
     <Compile Include="System\TypedReferenceTests.cs" />
-    <Compile Include="System\TypeTests.netcoreapp.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'netcoreapp'">
     <Compile Include="System\StringSplitExtensions.cs" />

--- a/src/System.Runtime/tests/System/TypeTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/TypeTests.netcoreapp.cs
@@ -153,6 +153,24 @@ namespace System.Tests
             Assert.False(type.IsTypeDefinition);
         }
 
+        // In the unlikely event we ever add new values to the CorElementType enumeration, CoreCLR will probably miss it because of the way IsTypeDefinition
+        // works. It's likely that such a type will live in the core assembly so to improve our chances of catching this situation, test IsTypeDefinition
+        // on every type exposed out of that assembly.
+        //
+        // Skipping this on .Net Native because:
+        //  - We really don't want to opt in all the metadata in System.Private.CoreLib
+        //  - The .Net Native implementation of IsTypeDefinition is not the one that works by enumerating selected values off CorElementType.
+        //    It has much less need of a test like this.
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)]
+        public void IsTypeDefinition_AllDefinedTypesInCoreAssembly()
+        {
+            foreach (Type type in typeof(object).Assembly.DefinedTypes)
+            {
+                Assert.True(type.IsTypeDefinition, "IsTypeDefinition expected to be true for type " + type);
+            }
+        }
+
         public static IEnumerable<object[]> DefinedTypes
         {
             get

--- a/src/System.Runtime/tests/System/TypeTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/TypeTests.netcoreapp.cs
@@ -17,17 +17,20 @@ namespace System.Tests
                 typeof(void),
                 typeof(int*),
                 typeof(Outside),
-                typeof(Outside<>),
+                typeof(Outside<int>),
                 typeof(Outside<>).GetTypeInfo().GenericTypeParameters[0],
                 new object().GetType().GetType()
             };
 
             if (PlatformDetection.IsWindows)
             {
-                NonArrayBaseTypes.Add(Type.GetTypeFromCLSID(default(Guid)));
+                if (!PlatformDetection.IsNetNative)  // .Net Native - MakeArrayType() of these magic types throws exception: (https://github.com/dotnet/corert/issues/3522)
+                {
+                    NonArrayBaseTypes.Add(Type.GetTypeFromCLSID(default(Guid)));
+                }
             }
         }
-        
+
         [Fact]
         public void IsSZArray_FalseForNonArrayTypes()
         {
@@ -49,7 +52,15 @@ namespace System.Tests
         [Fact]
         public void IsSZArray_FalseForVariableBoundArrayTypes()
         {
-            foreach (Type type in NonArrayBaseTypes.Select(nonArrayBaseType => nonArrayBaseType.MakeArrayType(1)))
+            if (!PlatformDetection.IsNetNative) // Multidim arrays of rank 1 not supported on UapAot: https://github.com/dotnet/corert/issues/3331
+            {
+                foreach (Type type in NonArrayBaseTypes.Select(nonArrayBaseType => nonArrayBaseType.MakeArrayType(1)))
+                {
+                    Assert.False(type.IsSZArray);
+                }
+            }
+
+            foreach (Type type in NonArrayBaseTypes.Select(nonArrayBaseType => nonArrayBaseType.MakeArrayType(2)))
             {
                 Assert.False(type.IsSZArray);
             }
@@ -95,7 +106,15 @@ namespace System.Tests
         [Fact]
         public void IsVariableBoundArray_TrueForVariableBoundArrayTypes()
         {
-            foreach (Type type in NonArrayBaseTypes.Select(nonArrayBaseType => nonArrayBaseType.MakeArrayType(1)))
+            if (!PlatformDetection.IsNetNative) // Multidim arrays of rank 1 not supported on UapAot: https://github.com/dotnet/corert/issues/3331
+            {
+                foreach (Type type in NonArrayBaseTypes.Select(nonArrayBaseType => nonArrayBaseType.MakeArrayType(1)))
+                {
+                    Assert.True(type.IsVariableBoundArray);
+                }
+            }
+
+            foreach (Type type in NonArrayBaseTypes.Select(nonArrayBaseType => nonArrayBaseType.MakeArrayType(2)))
             {
                 Assert.True(type.IsVariableBoundArray);
             }
@@ -118,6 +137,58 @@ namespace System.Tests
         public void IsVariableBoundArray_FalseForByRefVariableArrayType()
         {
             Assert.False(typeof(int[,]).MakeByRefType().IsVariableBoundArray);
+        }
+
+        [Theory]
+        [MemberData(nameof(DefinedTypes))]
+        public void IsTypeDefinition_True(Type type)
+        {
+            Assert.True(type.IsTypeDefinition);
+        }
+
+        [Theory]
+        [MemberData(nameof(NotDefinedTypes))]
+        public void IsTypeDefinition_False(Type type)
+        {
+            Assert.False(type.IsTypeDefinition);
+        }
+
+        public static IEnumerable<object[]> DefinedTypes
+        {
+            get
+            {
+                yield return new object[] { typeof(void) };
+                yield return new object[] { typeof(int) };
+                yield return new object[] { typeof(Outside) };
+                yield return new object[] { typeof(Outside.Inside) };
+                yield return new object[] { typeof(Outside<>) };
+                yield return new object[] { typeof(IEnumerable<>) };
+                yield return new object[] { 3.GetType().GetType() };  // This yields a reflection-blocked type on .Net Native - which is implemented separately
+
+                if (PlatformDetection.IsWindows)
+                    yield return new object[] { Type.GetTypeFromCLSID(default(Guid)) };
+            }
+        }
+
+        public static IEnumerable<object[]> NotDefinedTypes
+        {
+            get
+            {
+                Type theT = typeof(Outside<>).GetTypeInfo().GenericTypeParameters[0];
+
+                yield return new object[] { typeof(int[]) };
+                yield return new object[] { theT.MakeArrayType(1) }; // Using an open type as element type gets around .Net Native nonsupport of rank-1 multidim arrays 
+                yield return new object[] { typeof(int[,]) };
+
+                yield return new object[] { typeof(int).MakeByRefType() };
+
+                yield return new object[] { typeof(int).MakePointerType() };
+
+                yield return new object[] { typeof(Outside<int>) };
+                yield return new object[] { typeof(Outside<int>.Inside<int>) };
+
+                yield return new object[] { theT };
+            }
         }
     }
 }


### PR DESCRIPTION
Close https://github.com/dotnet/corefx/issues/17345

This also enables the IsSZArray and IsVariableBoundsArray
tests on .Net Native.

- Don't let test call MakeArrayType() on a generic type
  definition (.Net Native doesn't allow that loophole.)

- Don't let test call create rank-1 multidim arrays
  on .Net Native. Add a rank-2 test to compensate
  (and provide extra coverage on CoreCLR.)