### PR TITLE
Use ReferenceEquals instead of Delegate.op_Equality for sentinel checks

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/NetworkStream.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/NetworkStream.cs
@@ -922,7 +922,8 @@ namespace System.Net.Sockets
             /// <summary>Queues the provided continuation to be executed once the operation has completed.</summary>
             public void OnCompleted(Action continuation)
             {
-                if (_continuation == s_completedSentinel || Interlocked.CompareExchange(ref _continuation, continuation, null) == s_completedSentinel)
+                if (ReferenceEquals(_continuation, s_completedSentinel) ||
+                    ReferenceEquals(Interlocked.CompareExchange(ref _continuation, continuation, null), s_completedSentinel))
                 {
                     Task.Run(continuation);
                 }


### PR DESCRIPTION
The reference equality check is more efficient than `Delegate.op_Equality`.

cc: @stephentoub, @davidsh, @CIPop, @Priya91