### PR TITLE
Add SEC_E_DOWNGRADE_DETECTED to error table

### DIFF
--- a/src/Common/src/Interop/Windows/SChannel/Interop.SECURITY_STATUS.cs
+++ b/src/Common/src/Interop/Windows/SChannel/Interop.SECURITY_STATUS.cs
@@ -47,7 +47,8 @@ internal static partial class Interop
         SecurityQosFailed = unchecked((int)0x80090332),
         SmartcardLogonRequired = unchecked((int)0x8009033E),
         UnsupportedPreauth = unchecked((int)0x80090343),
-        BadBinding = unchecked((int)0x80090346)
+        BadBinding = unchecked((int)0x80090346),
+        DowngradeDetected = unchecked((int)0x80090350)
     }
 
 #if TRACE_VERBOSE
@@ -155,6 +156,7 @@ internal static partial class Interop
                 case 0x80090346: return "SEC_E_BAD_BINDINGS";
                 case 0x80090347: return "SEC_E_MULTIPLE_ACCOUNTS";
                 case 0x80090348: return "SEC_E_NO_KERB_KEY";
+                case 0x80090350: return "SEC_E_DOWNGRADE_DETECTED";
                 case 0x80091001: return "CRYPT_E_MSG_ERROR";
                 case 0x80091002: return "CRYPT_E_UNKNOWN_ALGO";
                 case 0x80091003: return "CRYPT_E_OID_FORMAT";

--- a/src/Common/src/System/Net/SecurityStatusAdapterPal.Windows.cs
+++ b/src/Common/src/System/Net/SecurityStatusAdapterPal.Windows.cs
@@ -25,21 +25,23 @@ namespace System.Net
             { Interop.SECURITY_STATUS.BadBinding, SecurityStatusPalErrorCode.BadBinding },
             { Interop.SECURITY_STATUS.BufferNotEnough, SecurityStatusPalErrorCode.BufferNotEnough },
             { Interop.SECURITY_STATUS.CannotInstall, SecurityStatusPalErrorCode.CannotInstall },
+            { Interop.SECURITY_STATUS.CannotPack, SecurityStatusPalErrorCode.CannotPack },
             { Interop.SECURITY_STATUS.CertExpired, SecurityStatusPalErrorCode.CertExpired },
             { Interop.SECURITY_STATUS.CertUnknown, SecurityStatusPalErrorCode.CertUnknown },
             { Interop.SECURITY_STATUS.CompAndContinue, SecurityStatusPalErrorCode.CompAndContinue },
             { Interop.SECURITY_STATUS.CompleteNeeded, SecurityStatusPalErrorCode.CompleteNeeded },
             { Interop.SECURITY_STATUS.ContextExpired, SecurityStatusPalErrorCode.ContextExpired },
-            { Interop.SECURITY_STATUS.CredentialsNeeded, SecurityStatusPalErrorCode.CredentialsNeeded },
             { Interop.SECURITY_STATUS.ContinueNeeded, SecurityStatusPalErrorCode.ContinueNeeded },
+            { Interop.SECURITY_STATUS.CredentialsNeeded, SecurityStatusPalErrorCode.CredentialsNeeded },
+            { Interop.SECURITY_STATUS.DowngradeDetected, SecurityStatusPalErrorCode.DowngradeDetected },
             { Interop.SECURITY_STATUS.IllegalMessage, SecurityStatusPalErrorCode.IllegalMessage },
-            { Interop.SECURITY_STATUS.CannotPack, SecurityStatusPalErrorCode.CannotPack },
             { Interop.SECURITY_STATUS.IncompleteCredentials, SecurityStatusPalErrorCode.IncompleteCredentials },
             { Interop.SECURITY_STATUS.IncompleteMessage, SecurityStatusPalErrorCode.IncompleteMessage },
             { Interop.SECURITY_STATUS.InternalError, SecurityStatusPalErrorCode.InternalError },
             { Interop.SECURITY_STATUS.InvalidHandle, SecurityStatusPalErrorCode.InvalidHandle },
             { Interop.SECURITY_STATUS.InvalidToken, SecurityStatusPalErrorCode.InvalidToken },
             { Interop.SECURITY_STATUS.LogonDenied, SecurityStatusPalErrorCode.LogonDenied },
+            { Interop.SECURITY_STATUS.MessageAltered, SecurityStatusPalErrorCode.MessageAltered },
             { Interop.SECURITY_STATUS.NoAuthenticatingAuthority, SecurityStatusPalErrorCode.NoAuthenticatingAuthority },
             { Interop.SECURITY_STATUS.NoImpersonation, SecurityStatusPalErrorCode.NoImpersonation },
             { Interop.SECURITY_STATUS.NoCredentials, SecurityStatusPalErrorCode.NoCredentials },
@@ -48,7 +50,6 @@ namespace System.Net
             { Interop.SECURITY_STATUS.OutOfMemory, SecurityStatusPalErrorCode.OutOfMemory },
             { Interop.SECURITY_STATUS.OutOfSequence, SecurityStatusPalErrorCode.OutOfSequence },
             { Interop.SECURITY_STATUS.PackageNotFound, SecurityStatusPalErrorCode.PackageNotFound },
-            { Interop.SECURITY_STATUS.MessageAltered, SecurityStatusPalErrorCode.MessageAltered },
             { Interop.SECURITY_STATUS.QopNotSupported, SecurityStatusPalErrorCode.QopNotSupported },
             { Interop.SECURITY_STATUS.Renegotiate, SecurityStatusPalErrorCode.Renegotiate },
             { Interop.SECURITY_STATUS.SecurityQosFailed, SecurityStatusPalErrorCode.SecurityQosFailed },
@@ -59,8 +60,7 @@ namespace System.Net
             { Interop.SECURITY_STATUS.UnsupportedPreauth, SecurityStatusPalErrorCode.UnsupportedPreauth },
             { Interop.SECURITY_STATUS.Unsupported, SecurityStatusPalErrorCode.Unsupported },
             { Interop.SECURITY_STATUS.UntrustedRoot, SecurityStatusPalErrorCode.UntrustedRoot },
-            { Interop.SECURITY_STATUS.WrongPrincipal, SecurityStatusPalErrorCode.WrongPrincipal },
-            { Interop.SECURITY_STATUS.DowngradeDetected, SecurityStatusPalErrorCode.DowngradeDetected }
+            { Interop.SECURITY_STATUS.WrongPrincipal, SecurityStatusPalErrorCode.WrongPrincipal }
         };
 
         internal static SecurityStatusPal GetSecurityStatusPalFromNativeInt(int win32SecurityStatus)

--- a/src/Common/src/System/Net/SecurityStatusAdapterPal.Windows.cs
+++ b/src/Common/src/System/Net/SecurityStatusAdapterPal.Windows.cs
@@ -10,7 +10,7 @@ namespace System.Net
 {
     internal static class SecurityStatusAdapterPal
     {
-        private const int StatusDictionarySize = 39;
+        private const int StatusDictionarySize = 40;
 
 #if DEBUG
         static SecurityStatusAdapterPal()
@@ -59,7 +59,8 @@ namespace System.Net
             { Interop.SECURITY_STATUS.UnsupportedPreauth, SecurityStatusPalErrorCode.UnsupportedPreauth },
             { Interop.SECURITY_STATUS.Unsupported, SecurityStatusPalErrorCode.Unsupported },
             { Interop.SECURITY_STATUS.UntrustedRoot, SecurityStatusPalErrorCode.UntrustedRoot },
-            { Interop.SECURITY_STATUS.WrongPrincipal, SecurityStatusPalErrorCode.WrongPrincipal }
+            { Interop.SECURITY_STATUS.WrongPrincipal, SecurityStatusPalErrorCode.WrongPrincipal },
+            { Interop.SECURITY_STATUS.DowngradeDetected, SecurityStatusPalErrorCode.DowngradeDetected }
         };
 
         internal static SecurityStatusPal GetSecurityStatusPalFromNativeInt(int win32SecurityStatus)

--- a/src/Common/src/System/Net/SecurityStatusPal.cs
+++ b/src/Common/src/System/Net/SecurityStatusPal.cs
@@ -66,6 +66,7 @@ namespace System.Net
         SecurityQosFailed,
         SmartcardLogonRequired,
         UnsupportedPreauth,
-        BadBinding
+        BadBinding,
+        DowngradeDetected
     }
 }


### PR DESCRIPTION
See detailed analysis here: https://github.com/dotnet/corefx/issues/11708#issuecomment-299325869

After I made modification and build on my machine, I used VS to debug into InitializeSecurityContext() and change the return error code to SEC_E_DOWNGRADE_DETECTED. The behavior matches in .NET Framework (cc: @davidsh )
![capture](https://cloud.githubusercontent.com/assets/8537784/25728873/ada21dec-30e6-11e7-8a93-aa386f0f516a.PNG)

Fix #11708 