### PR TITLE
Fix most of S.S.Cryptography.Xml desktop failures

### DIFF
--- a/src/System.Security.Cryptography.Xml/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Xml/src/Resources/Strings.resx
@@ -1,5 +1,64 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -108,6 +167,9 @@
   </data>
   <data name="Cryptography_Xml_InvalidSignatureLength2" xml:space="preserve">
     <value>The length in bits of the signature with a MAC should be a multiple of 8.</value>
+  </data>
+  <data name="Cryptography_Xml_InvalidX509IssuerSerialNumber" xml:space="preserve">
+    <value>X509 issuer serial number is invalid.</value>
   </data>
   <data name="Cryptography_Xml_KeyInfoRequired" xml:space="preserve">
     <value>A KeyInfo element is required to check the signature.</value>

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/KeyInfoX509Data.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/KeyInfoX509Data.cs
@@ -156,14 +156,14 @@ namespace System.Security.Cryptography.Xml
         public void AddIssuerSerial(string issuerName, string serialNumber)
         {
             if (string.IsNullOrEmpty(issuerName))
-                throw new ArgumentException(nameof(issuerName));
+                throw new ArgumentException(SR.Arg_EmptyOrNullString, nameof(issuerName));
 
             if (string.IsNullOrEmpty(serialNumber))
-                throw new ArgumentException(nameof(serialNumber));
+                throw new ArgumentException(SR.Arg_EmptyOrNullString, nameof(serialNumber));
 
             BigInteger h;
             if (!BigInteger.TryParse(serialNumber, NumberStyles.AllowHexSpecifier, NumberFormatInfo.CurrentInfo, out h))
-                throw new ArgumentException(nameof(serialNumber));
+                throw new ArgumentException(SR.Cryptography_Xml_InvalidX509IssuerSerialNumber, nameof(serialNumber));
 
             if (_issuerSerials == null)
                 _issuerSerials = new ArrayList();

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/KeyInfoX509Data.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/KeyInfoX509Data.cs
@@ -155,7 +155,16 @@ namespace System.Security.Cryptography.Xml
 
         public void AddIssuerSerial(string issuerName, string serialNumber)
         {
-            BigInteger h = BigInteger.Parse(serialNumber, NumberStyles.AllowHexSpecifier);
+            if (string.IsNullOrEmpty(issuerName))
+                throw new ArgumentException(nameof(issuerName));
+
+            if (string.IsNullOrEmpty(serialNumber))
+                throw new ArgumentException(nameof(serialNumber));
+
+            BigInteger h;
+            if (!BigInteger.TryParse(serialNumber, NumberStyles.AllowHexSpecifier, NumberFormatInfo.CurrentInfo, out h))
+                throw new ArgumentException(nameof(serialNumber));
+
             if (_issuerSerials == null)
                 _issuerSerials = new ArrayList();
             _issuerSerials.Add(new X509IssuerSerial(issuerName, h.ToString()));

--- a/src/System.Security.Cryptography.Xml/tests/EncryptionMethodTests.cs
+++ b/src/System.Security.Cryptography.Xml/tests/EncryptionMethodTests.cs
@@ -45,7 +45,7 @@ namespace System.Security.Cryptography.Xml.Tests
         public void KeySize_SetNegativeValue_ThrowsArgumentOutOfRangeException(int value)
         {
             EncryptionMethod method = new EncryptionMethod();
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => method.KeySize = value);
+            Assert.Throws<ArgumentOutOfRangeException>(() => method.KeySize = value);
         }
 
         [Theory]

--- a/src/System.Security.Cryptography.Xml/tests/EncryptionMethodTests.cs
+++ b/src/System.Security.Cryptography.Xml/tests/EncryptionMethodTests.cs
@@ -45,7 +45,10 @@ namespace System.Security.Cryptography.Xml.Tests
         public void KeySize_SetNegativeValue_ThrowsArgumentOutOfRangeException(int value)
         {
             EncryptionMethod method = new EncryptionMethod();
-            Assert.Throws<ArgumentOutOfRangeException>(() => method.KeySize = value);
+            if (PlatformDetection.IsFullFramework)
+                Assert.Throws<ArgumentOutOfRangeException>("The key size should be a non negative integer.", () => method.KeySize = value);
+            else
+                Assert.Throws<ArgumentOutOfRangeException>("value", () => method.KeySize = value);
         }
 
         [Theory]

--- a/src/System.Security.Cryptography.Xml/tests/KeyInfoX509DataTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/KeyInfoX509DataTest.cs
@@ -144,18 +144,26 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
-        public void AddIssuerSerial_Null_Serial()
+        public void AddIssuerSerial_Issuer_Null()
         {
             KeyInfoX509Data data = new KeyInfoX509Data();
-            Assert.Throws<ArgumentException>(() => data.AddIssuerSerial(null, "serial"));
+            Assert.Throws<ArgumentException>("issuerName", () => data.AddIssuerSerial(null, "serial"));
         }
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "https://github.com/dotnet/corefx/issues/18690")]
-        public void AddIssuerSerial_Issuer_Null()
+        public void AddIssuerSerial_Null_Serial()
         {
             KeyInfoX509Data data = new KeyInfoX509Data();
-            Assert.Throws<ArgumentException>(() => data.AddIssuerSerial("issuer", null));
+            Assert.Throws<ArgumentException>("serialNumber", () => data.AddIssuerSerial("issuer", null));
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "https://github.com/dotnet/corefx/issues/18690")]
+        public void AddIssuerSerial_Invalid_Serial()
+        {
+            KeyInfoX509Data data = new KeyInfoX509Data();
+            Assert.Throws<ArgumentException>("serialNumber", () => data.AddIssuerSerial("issuer", "NotANumber"));
         }
 
         [Fact]

--- a/src/System.Security.Cryptography.Xml/tests/KeyInfoX509DataTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/KeyInfoX509DataTest.cs
@@ -147,14 +147,15 @@ namespace System.Security.Cryptography.Xml.Tests
         public void AddIssuerSerial_Null_Serial()
         {
             KeyInfoX509Data data = new KeyInfoX509Data();
-            Assert.Throws<FormatException>(() => data.AddIssuerSerial(null, "serial"));
+            Assert.Throws<ArgumentException>(() => data.AddIssuerSerial(null, "serial"));
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "https://github.com/dotnet/corefx/issues/18690")]
         public void AddIssuerSerial_Issuer_Null()
         {
             KeyInfoX509Data data = new KeyInfoX509Data();
-            Assert.Throws<ArgumentNullException>(() => data.AddIssuerSerial("issuer", null));
+            Assert.Throws<ArgumentException>(() => data.AddIssuerSerial("issuer", null));
         }
 
         [Fact]

--- a/src/System.Security.Cryptography.Xml/tests/RSAKeyValueTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/RSAKeyValueTest.cs
@@ -96,7 +96,16 @@ namespace System.Security.Cryptography.Xml.Tests
             xmlDocument.LoadXml(xml);
 
             RSAKeyValue rsa = new RSAKeyValue();
-            Assert.Throws<CryptographicException>(() => rsa.LoadXml(xmlDocument.DocumentElement));
+
+            // FormatException exception because desktop does not
+            // check if Convert.FromBase64String throws
+            // Related to: https://github.com/dotnet/corefx/issues/18690
+            try
+            {
+                rsa.LoadXml(xmlDocument.DocumentElement);
+            }
+            catch (CryptographicException) { }
+            catch (FormatException) when (PlatformDetection.IsFullFramework) { }
         }
 
         private static object[][] LoadXml_InvalidXml_Source()

--- a/src/System.Security.Cryptography.Xml/tests/ReferenceTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/ReferenceTest.cs
@@ -43,7 +43,12 @@ namespace System.Security.Cryptography.Xml.Tests
         public void Ctor_Uri(string uri)
         {
             Reference reference = new Reference(uri);
-            Assert.Equal("http://www.w3.org/2001/04/xmlenc#sha256", reference.DigestMethod);
+
+            if (PlatformDetection.IsFullFramework)
+                Assert.Equal("http://www.w3.org/2000/09/xmldsig#sha1", reference.DigestMethod);
+            else
+                Assert.Equal("http://www.w3.org/2001/04/xmlenc#sha256", reference.DigestMethod);
+
             Assert.Null(reference.DigestValue);
             Assert.Null(reference.Id);
             Assert.Null(reference.Type);
@@ -61,7 +66,11 @@ namespace System.Security.Cryptography.Xml.Tests
             using (MemoryStream memoryStream = data != null ? new MemoryStream(Encoding.UTF8.GetBytes(data)) : null)
             {
                 Reference reference = new Reference(memoryStream);
-                Assert.Equal("http://www.w3.org/2001/04/xmlenc#sha256", reference.DigestMethod);
+                if (PlatformDetection.IsFullFramework)
+                    Assert.Equal("http://www.w3.org/2000/09/xmldsig#sha1", reference.DigestMethod);
+                else
+                    Assert.Equal("http://www.w3.org/2001/04/xmlenc#sha256", reference.DigestMethod);
+
                 Assert.Null(reference.DigestValue);
                 Assert.Null(reference.Id);
                 Assert.Null(reference.Type);

--- a/src/System.Security.Cryptography.Xml/tests/SignedXmlTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/SignedXmlTest.cs
@@ -1574,7 +1574,7 @@ namespace System.Security.Cryptography.Xml.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "https://github.com/dotnet/corefx/issues/18690")]
-        public void SignedXmlUsesSha256ByDefault()
+        public void CoreFxSignedXmlUsesSha256ByDefault()
         {
             const string expectedSignatureMethod = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
             const string expectedDigestMethod = "http://www.w3.org/2001/04/xmlenc#sha256";
@@ -1583,7 +1583,7 @@ namespace System.Security.Cryptography.Xml.Tests
 
         [Fact]
         [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "https://github.com/dotnet/corefx/issues/18690")]
-        public void SignedXmlUsesSha1ByDefault()
+        public void NetFxSignedXmlUsesSha1ByDefault()
         {
             const string expectedSignatureMethod = "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
             const string expectedDigestMethod = "http://www.w3.org/2000/09/xmldsig#sha1";

--- a/src/System.Security.Cryptography.Xml/tests/SignedXmlTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/SignedXmlTest.cs
@@ -1256,8 +1256,12 @@ namespace System.Security.Cryptography.Xml.Tests
             SignedXml sign = new SignedXml(doc);
             sign.LoadXml(doc.DocumentElement["Signature"]);
 
-            // verify MS-generated signature
-            Assert.False(sign.CheckSignature(new HMACSHA256(badKey)));
+            // https://github.com/dotnet/corefx/issues/18690
+            if (!PlatformDetection.IsFullFramework)
+            {
+                Assert.False(sign.CheckSignature(new HMACSHA256(badKey)));
+            }
+
             Assert.True(sign.CheckSignature(new HMACSHA256(emptyHmacKey)));
         }
 
@@ -1288,8 +1292,12 @@ namespace System.Security.Cryptography.Xml.Tests
             SignedXml sign = new SignedXml(doc);
             sign.LoadXml(doc.DocumentElement["Signature"]);
 
-            // verify MS-generated signature
-            Assert.False(sign.CheckSignature(new HMACSHA512(badKey)));
+            // https://github.com/dotnet/corefx/issues/18690
+            if (!PlatformDetection.IsFullFramework)
+            {
+                Assert.False(sign.CheckSignature(new HMACSHA512(badKey)));
+            }
+
             Assert.True(sign.CheckSignature(new HMACSHA512(emptyHmacKey)));
         }
 
@@ -1323,8 +1331,12 @@ namespace System.Security.Cryptography.Xml.Tests
             SignedXml sign = new SignedXml(doc);
             sign.LoadXml(doc.DocumentElement["Signature"]);
 
-            // verify MS-generated signature
-            Assert.False(sign.CheckSignature(new HMACSHA384(badKey)));
+            // https://github.com/dotnet/corefx/issues/18690
+            if (!PlatformDetection.IsFullFramework)
+            {
+                Assert.False(sign.CheckSignature(new HMACSHA384(badKey)));
+            }
+
             Assert.True(sign.CheckSignature(new HMACSHA384(emptyHmacKey)));
         }
 
@@ -1358,8 +1370,12 @@ namespace System.Security.Cryptography.Xml.Tests
             SignedXml sign = new SignedXml(doc);
             sign.LoadXml(doc.DocumentElement["Signature"]);
 
-            // verify MS-generated signature
-            Assert.False(sign.CheckSignature(new HMACMD5(badKey)));
+            // https://github.com/dotnet/corefx/issues/18690
+            if (!PlatformDetection.IsFullFramework)
+            {
+                Assert.False(sign.CheckSignature(new HMACMD5(badKey)));
+            }
+
             Assert.True(sign.CheckSignature(new HMACMD5(emptyHmacKey)));
         }
 

--- a/src/System.Security.Cryptography.Xml/tests/SignedXmlTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/SignedXmlTest.cs
@@ -188,7 +188,12 @@ namespace System.Security.Cryptography.Xml.Tests
             signedXml.ComputeSignature();
 
             Assert.Null(signedXml.SigningKeyName);
-            Assert.Equal("http://www.w3.org/2001/04/xmldsig-more#rsa-sha256", signedXml.SignatureMethod);
+
+            if (PlatformDetection.IsFullFramework)
+                Assert.Equal("http://www.w3.org/2000/09/xmldsig#rsa-sha1", signedXml.SignatureMethod);
+            else
+                Assert.Equal("http://www.w3.org/2001/04/xmldsig-more#rsa-sha256", signedXml.SignatureMethod);
+
             Assert.Equal(key.KeySize / 8, signedXml.SignatureValue.Length);
             Assert.Null(signedXml.SigningKeyName);
 
@@ -1568,11 +1573,25 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "https://github.com/dotnet/corefx/issues/18690")]
         public void SignedXmlUsesSha256ByDefault()
         {
             const string expectedSignatureMethod = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
             const string expectedDigestMethod = "http://www.w3.org/2001/04/xmlenc#sha256";
+            ValidateSignedXmlDefaultHashAlgorithms(expectedSignatureMethod, expectedDigestMethod);
+        }
 
+        [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "https://github.com/dotnet/corefx/issues/18690")]
+        public void SignedXmlUsesSha1ByDefault()
+        {
+            const string expectedSignatureMethod = "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
+            const string expectedDigestMethod = "http://www.w3.org/2000/09/xmldsig#sha1";
+            ValidateSignedXmlDefaultHashAlgorithms(expectedSignatureMethod, expectedDigestMethod);
+        }
+
+        private void ValidateSignedXmlDefaultHashAlgorithms(string expectedSignatureMethod, string expectedDigestMethod)
+        {
             const string xml = @"<?xml version=""1.0""?>
 <example>
 <test>some text node</test>

--- a/src/System.Security.Cryptography.Xml/tests/System.Security.Cryptography.Xml.Tests.csproj
+++ b/src/System.Security.Cryptography.Xml/tests/System.Security.Cryptography.Xml.Tests.csproj
@@ -56,6 +56,9 @@
     <Compile Include="$(CommonTestPath)\System\AssertExtensions.cs">
       <Link>Common\System\AssertExtensions.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>Common\System\PlatformDetection.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="EncryptedXmlSample3.xml" />

--- a/src/System.Security.Cryptography.Xml/tests/XmlDecryptionTransformTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/XmlDecryptionTransformTest.cs
@@ -134,6 +134,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "https://github.com/dotnet/corefx/issues/18690")]
         public void LoadStreamInput_CorrectXml()
         {
             XmlDocument doc = new XmlDocument();
@@ -166,6 +167,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "https://github.com/dotnet/corefx/issues/18690")]
         public void GetOutput_XmlNoEncryptedData()
         {
             XmlDocument doc = new XmlDocument();
@@ -179,6 +181,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "https://github.com/dotnet/corefx/issues/18690")]
         public void GetOutput_XmlWithEncryptedData()
         {
             XmlDocument doc = new XmlDocument();
@@ -192,6 +195,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "https://github.com/dotnet/corefx/issues/18690")]
         public void GetOutput_XmlWithEncryptedDataInRoot()
         {
             XmlDocument doc = new XmlDocument();
@@ -205,6 +209,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "https://github.com/dotnet/corefx/issues/18690")]
         public void GetOutput_XmlWithEncryptedDataAndExcept()
         {
             XmlDocument doc = new XmlDocument();

--- a/src/System.Security.Cryptography.Xml/tests/XmlDecryptionTransformTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/XmlDecryptionTransformTest.cs
@@ -134,7 +134,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "https://github.com/dotnet/corefx/issues/18690")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "https://github.com/dotnet/corefx/issues/16798")]
         public void LoadStreamInput_CorrectXml()
         {
             XmlDocument doc = new XmlDocument();

--- a/src/System.Security.Cryptography.Xml/tests/XmlDecryptionTransformTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/XmlDecryptionTransformTest.cs
@@ -167,7 +167,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "https://github.com/dotnet/corefx/issues/18690")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "https://github.com/dotnet/corefx/issues/16798")]
         public void GetOutput_XmlNoEncryptedData()
         {
             XmlDocument doc = new XmlDocument();
@@ -181,7 +181,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "https://github.com/dotnet/corefx/issues/18690")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "https://github.com/dotnet/corefx/issues/16798")]
         public void GetOutput_XmlWithEncryptedData()
         {
             XmlDocument doc = new XmlDocument();
@@ -195,7 +195,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "https://github.com/dotnet/corefx/issues/18690")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "https://github.com/dotnet/corefx/issues/16798")]
         public void GetOutput_XmlWithEncryptedDataInRoot()
         {
             XmlDocument doc = new XmlDocument();
@@ -209,7 +209,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "https://github.com/dotnet/corefx/issues/18690")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "https://github.com/dotnet/corefx/issues/16798")]
         public void GetOutput_XmlWithEncryptedDataAndExcept()
         {
             XmlDocument doc = new XmlDocument();

--- a/src/System.Security.Cryptography.Xml/tests/XmlLicenseTransformTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/XmlLicenseTransformTest.cs
@@ -132,7 +132,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "https://github.com/dotnet/corefx/issues/18690")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "https://github.com/dotnet/corefx/issues/19410")]
         public void ValidLicense()
         {
             XmlDocument doc = GetDocumentFromResource("System.Security.Cryptography.Xml.Tests.XmlLicenseSample.xml");

--- a/src/System.Security.Cryptography.Xml/tests/XmlLicenseTransformTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/XmlLicenseTransformTest.cs
@@ -132,6 +132,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "https://github.com/dotnet/corefx/issues/18690")]
         public void ValidLicense()
         {
             XmlDocument doc = GetDocumentFromResource("System.Security.Cryptography.Xml.Tests.XmlLicenseSample.xml");


### PR DESCRIPTION
- one product bug found (wrong exception being thrown)
- one test still failing https://github.com/dotnet/corefx/issues/19272

Fixes 20+ test failures.

Updated: https://github.com/dotnet/corefx/issues/18690

Fixes issues:
https://github.com/dotnet/corefx/issues/19275
https://github.com/dotnet/corefx/issues/19274
https://github.com/dotnet/corefx/issues/19273
https://github.com/dotnet/corefx/issues/19271
https://github.com/dotnet/corefx/issues/19270
https://github.com/dotnet/corefx/issues/19268
https://github.com/dotnet/corefx/issues/19267
https://github.com/dotnet/corefx/issues/19264
https://github.com/dotnet/corefx/issues/19263