### PR TITLE
Add note to build -release before running perf tests.

### DIFF
--- a/Documentation/project-docs/performance-tests.md
+++ b/Documentation/project-docs/performance-tests.md
@@ -22,6 +22,8 @@ Running the tests
 ### Windows
 Performance test files (if present) are stored within a library's ```tests/Performance``` directory and contain test methods that are all marked with a perf-specific *Benchmark* attribute. The performance tests will only be run if the ```performance``` property is set to ```true```.
 
+Before running the performance tests you must run ```build -release``` from the root folder.
+
 To build and run the tests using msbuild for a project, run ```msbuild /t:BuildAndTest /p:Performance=true /p:ConfigurationGroup=Release /p:TargetOS=Windows_NT``` from the Performance directory with Admin privileges. If the v5.0 assemblies aren't installed on your system, an error will be raised and no tests will be run.
 
 Note: Because build.cmd runs tests concurrently, it's not recommended that you execute the perf tests using it.


### PR DESCRIPTION
Add documentation note to build -release before running perf tests.

@DrewScoggins 

This is a follow up ticket for an issue found in #19158.