### PR TITLE
Enable Canonicalization on NetCore

### DIFF
--- a/src/System.Private.DataContractSerialization/src/Resources/Strings.resx
+++ b/src/System.Private.DataContractSerialization/src/Resources/Strings.resx
@@ -1111,4 +1111,19 @@
   <data name="FactoryTypeNotISerializable" xml:space="preserve">
     <value>Factory type '{0}' for ISerializable type '{1}' must also be ISerializable.</value>
   </data>
+  <data name="XmlCanonicalizationStarted" xml:space="preserve">
+    <value>Canonicalization already started.</value>
+  </data>
+
+  <data name="XmlCanonicalizationNotStarted" xml:space="preserve">
+    <value>Canonicalization not started.</value>
+  </data>
+
+  <data name="CombinedPrefixNSLength" xml:space="preserve">
+    <value>The combined length of the prefix and namespace must not be greater than {0}.</value>
+  </data>
+
+  <data name="InvalidInclusivePrefixListCollection" xml:space="preserve">
+    <value>The inclusive namespace prefix collection cannot contain null as one of the items.</value>
+  </data>
 </root>

--- a/src/System.Private.DataContractSerialization/src/System.Private.DataContractSerialization.csproj
+++ b/src/System.Private.DataContractSerialization/src/System.Private.DataContractSerialization.csproj
@@ -53,7 +53,7 @@
     <Compile Include="$(RuntimeSerializationSources)\Globals.cs" />
     <Compile Include="$(RuntimeSerializationSources)\GenericParameterDataContract.cs" />
     <Compile Include="$(RuntimeSerializationSources)\HybridObjectCache.cs" />
-    <Compile Include="$(RuntimeSerializationSources)\InvalidDataContract.cs"  Condition="'$(TargetGroup)' == 'uapaot'" />
+    <Compile Include="$(RuntimeSerializationSources)\InvalidDataContract.cs" Condition="'$(TargetGroup)' == 'uapaot'" />
     <Compile Include="$(RuntimeSerializationSources)\ObjectToIdCache.cs" />
     <Compile Include="$(RuntimeSerializationSources)\ObjectReferenceStack.cs" />
     <Compile Include="$(RuntimeSerializationSources)\PrimitiveDataContract.cs" />
@@ -162,6 +162,8 @@
     <Compile Include="System\Runtime\Serialization\XsdDataContractExporter.cs" />
     <Compile Include="System\Runtime\Serialization\SurrogateDataContract.cs" />
     <Compile Include="System\Xml\IFragmentCapableXmlDictionaryWriter.cs" />
+    <Compile Include="System\Xml\XmlCanonicalWriter.cs" />
+    <Compile Include="System\Xml\XmlSigningNodeWriter.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)'=='uapaot'">
     <EmbeddedResource Include="$(MsBuildThisFileDirectory)Resources\$(AssemblyName).rd.xml" />

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlJsonReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlJsonReader.cs
@@ -1689,6 +1689,11 @@ namespace System.Runtime.Serialization.Json
             return sb.ToString();
         }
 
+        protected override XmlSigningNodeWriter CreateSigningNodeWriter()
+        {
+            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(SR.Format(SR.JsonMethodNotSupported, "CreateSigningNodeWriter")));
+        }
+
         private static class CharType
         {
             public const byte FirstName = 0x01;

--- a/src/System.Private.DataContractSerialization/src/System/Xml/ValueHandle.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/ValueHandle.cs
@@ -562,6 +562,55 @@ namespace System.Xml
             return true;
         }
 
+        public void Sign(XmlSigningNodeWriter writer)
+        {
+            switch (_type)
+            {
+                case ValueHandleType.Int8:
+                case ValueHandleType.Int16:
+                case ValueHandleType.Int32:
+                    writer.WriteInt32Text(ToInt());
+                    break;
+                case ValueHandleType.Int64:
+                    writer.WriteInt64Text(GetInt64());
+                    break;
+                case ValueHandleType.UInt64:
+                    writer.WriteUInt64Text(GetUInt64());
+                    break;
+                case ValueHandleType.Single:
+                    writer.WriteFloatText(GetSingle());
+                    break;
+                case ValueHandleType.Double:
+                    writer.WriteDoubleText(GetDouble());
+                    break;
+                case ValueHandleType.Decimal:
+                    writer.WriteDecimalText(GetDecimal());
+                    break;
+                case ValueHandleType.DateTime:
+                    writer.WriteDateTimeText(ToDateTime());
+                    break;
+                case ValueHandleType.Empty:
+                    break;
+                case ValueHandleType.UTF8:
+                    writer.WriteEscapedText(_bufferReader.Buffer, _offset, _length);
+                    break;
+                case ValueHandleType.Base64:
+                    writer.WriteBase64Text(_bufferReader.Buffer, 0, _bufferReader.Buffer, _offset, _length);
+                    break;
+                case ValueHandleType.UniqueId:
+                    writer.WriteUniqueIdText(ToUniqueId());
+                    break;
+                case ValueHandleType.Guid:
+                    writer.WriteGuidText(ToGuid());
+                    break;
+                case ValueHandleType.TimeSpan:
+                    writer.WriteTimeSpanText(ToTimeSpan());
+                    break;
+                default:
+                    writer.WriteEscapedText(GetString());
+                    break;
+            }
+        }
 
         public object[] ToList()
         {

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryReader.cs
@@ -183,7 +183,7 @@ namespace System.Xml
 
         private bool CanOptimizeReadElementContent()
         {
-            return (_arrayState == ArrayState.None);
+            return (_arrayState == ArrayState.None && !Signing);
         }
 
         public override float ReadElementContentAsFloat()
@@ -364,6 +364,8 @@ namespace System.Xml
         {
             if (this.Node.ReadState == ReadState.Closed)
                 return false;
+
+            SignNode();
             if (_isTextWithEndElement)
             {
                 _isTextWithEndElement = false;
@@ -1204,12 +1206,12 @@ namespace System.Xml
 
         private bool IsStartArray(string localName, string namespaceUri, XmlBinaryNodeType nodeType)
         {
-            return IsStartElement(localName, namespaceUri) && _arrayState == ArrayState.Element && _arrayNodeType == nodeType;
+            return IsStartElement(localName, namespaceUri) && _arrayState == ArrayState.Element && _arrayNodeType == nodeType && !Signing;
         }
 
         private bool IsStartArray(XmlDictionaryString localName, XmlDictionaryString namespaceUri, XmlBinaryNodeType nodeType)
         {
-            return IsStartElement(localName, namespaceUri) && _arrayState == ArrayState.Element && _arrayNodeType == nodeType;
+            return IsStartElement(localName, namespaceUri) && _arrayState == ArrayState.Element && _arrayNodeType == nodeType && !Signing;
         }
 
         private void CheckArray(Array array, int offset, int count)
@@ -1494,6 +1496,11 @@ namespace System.Xml
             None,
             Element,
             Content
+        }
+
+        protected override XmlSigningNodeWriter CreateSigningNodeWriter()
+        {
+            return new XmlSigningNodeWriter(false);
         }
     }
 }

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryWriter.cs
@@ -1086,6 +1086,10 @@ namespace System.Xml
             SetOutput(_writer);
         }
 
+        protected override XmlSigningNodeWriter CreateSigningNodeWriter()
+        {
+            return new XmlSigningNodeWriter(false);
+        }
 
         protected override void WriteTextNode(XmlDictionaryReader reader, bool attribute)
         {

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlCanonicalWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlCanonicalWriter.cs
@@ -1,0 +1,1017 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.IO;
+using System.Runtime;
+using System.Runtime.Serialization;
+using System.Text;
+
+
+namespace System.Xml
+{
+    internal sealed class XmlCanonicalWriter
+    {
+        private XmlUTF8NodeWriter _writer;
+        private MemoryStream _elementStream;
+        private byte[] _elementBuffer;
+        private XmlUTF8NodeWriter _elementWriter;
+        private bool _inStartElement;
+        private int _depth;
+        private Scope[] _scopes;
+        private int _xmlnsAttributeCount;
+        private XmlnsAttribute[] _xmlnsAttributes;
+        private int _attributeCount;
+        private Attribute[] _attributes;
+        private Attribute _attribute;
+        private Element _element;
+        private byte[] _xmlnsBuffer;
+        private int _xmlnsOffset;
+        private const int maxBytesPerChar = 3;
+        private int _xmlnsStartOffset;
+        private bool _includeComments;
+        private string[] _inclusivePrefixes;
+        private const string xmlnsNamespace = "http://www.w3.org/2000/xmlns/";
+
+        private static readonly bool[] s_isEscapedAttributeChar = new bool[]
+        {
+            true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, // All
+            true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
+            false, false, true, false, false, false, true, false, false, false, false, false, false, false, false, false, // '"', '&'
+            false, false, false, false, false, false, false, false, false, false, false, false, true, false, false, false  // '<'
+        };
+        private static readonly bool[] s_isEscapedElementChar = new bool[]
+        {
+            true, true, true, true, true, true, true, true, true, false, false, true, true, true, true, true, // All but 0x09, 0x0A
+            true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
+            false, false, false, false, false, false, true, false, false, false, false, false, false, false, false, false, // '&'
+            false, false, false, false, false, false, false, false, false, false, false, false, true, false, true, false  // '<', '>'
+        };
+
+        public XmlCanonicalWriter()
+        {
+        }
+
+        public void SetOutput(Stream stream, bool includeComments, string[] inclusivePrefixes)
+        {
+            if (stream == null)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("stream");
+
+            if (_writer == null)
+            {
+                _writer = new XmlUTF8NodeWriter(s_isEscapedAttributeChar, s_isEscapedElementChar);
+            }
+            _writer.SetOutput(stream, false, null);
+
+            if (_elementStream == null)
+            {
+                _elementStream = new MemoryStream();
+            }
+
+            if (_elementWriter == null)
+            {
+                _elementWriter = new XmlUTF8NodeWriter(s_isEscapedAttributeChar, s_isEscapedElementChar);
+            }
+            _elementWriter.SetOutput(_elementStream, false, null);
+
+            if (_xmlnsAttributes == null)
+            {
+                _xmlnsAttributeCount = 0;
+                _xmlnsOffset = 0;
+                WriteXmlnsAttribute("xml", "http://www.w3.org/XML/1998/namespace");
+                WriteXmlnsAttribute("xmlns", xmlnsNamespace);
+                WriteXmlnsAttribute(string.Empty, string.Empty);
+                _xmlnsStartOffset = _xmlnsOffset;
+                for (int i = 0; i < 3; i++)
+                {
+                    _xmlnsAttributes[i].referred = true;
+                }
+            }
+            else
+            {
+                _xmlnsAttributeCount = 3;
+                _xmlnsOffset = _xmlnsStartOffset;
+            }
+
+            _depth = 0;
+            _inStartElement = false;
+            _includeComments = includeComments;
+            _inclusivePrefixes = null;
+            if (inclusivePrefixes != null)
+            {
+                _inclusivePrefixes = new string[inclusivePrefixes.Length];
+                for (int i = 0; i < inclusivePrefixes.Length; ++i)
+                {
+                    if (inclusivePrefixes[i] == null)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(SR.Format(SR.InvalidInclusivePrefixListCollection));
+                    }
+                    _inclusivePrefixes[i] = inclusivePrefixes[i];
+                }
+            }
+        }
+
+        public void Flush()
+        {
+            ThrowIfClosed();
+            _writer.Flush();
+        }
+
+        public void Close()
+        {
+            if (_writer != null)
+                _writer.Close();
+            if (_elementWriter != null)
+                _elementWriter.Close();
+            if (_elementStream != null && _elementStream.Length > 512)
+                _elementStream = null;
+            _elementBuffer = null;
+            if (_scopes != null && _scopes.Length > 16)
+                _scopes = null;
+            if (_attributes != null && _attributes.Length > 16)
+                _attributes = null;
+            if (_xmlnsBuffer != null && _xmlnsBuffer.Length > 1024)
+            {
+                _xmlnsAttributes = null;
+                _xmlnsBuffer = null;
+            }
+            _inclusivePrefixes = null;
+        }
+
+        public void WriteDeclaration()
+        {
+        }
+
+        public void WriteComment(string value)
+        {
+            if (value == null)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("value");
+            ThrowIfClosed();
+            if (_includeComments)
+            {
+                _writer.WriteComment(value);
+            }
+        }
+
+
+        private void StartElement()
+        {
+            if (_scopes == null)
+            {
+                _scopes = new Scope[4];
+            }
+            else if (_depth == _scopes.Length)
+            {
+                Scope[] newScopes = new Scope[_depth * 2];
+                Array.Copy(_scopes, newScopes, _depth);
+                _scopes = newScopes;
+            }
+            _scopes[_depth].xmlnsAttributeCount = _xmlnsAttributeCount;
+            _scopes[_depth].xmlnsOffset = _xmlnsOffset;
+            _depth++;
+            _inStartElement = true;
+            _attributeCount = 0;
+            _elementStream.Position = 0;
+        }
+
+        private void EndElement()
+        {
+            _depth--;
+            _xmlnsAttributeCount = _scopes[_depth].xmlnsAttributeCount;
+            _xmlnsOffset = _scopes[_depth].xmlnsOffset;
+        }
+
+        public void WriteStartElement(string prefix, string localName)
+        {
+            if (prefix == null)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("prefix");
+            if (localName == null)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("localName");
+            ThrowIfClosed();
+            bool isRootElement = (_depth == 0);
+
+            StartElement();
+            _element.prefixOffset = _elementWriter.Position + 1;
+            _element.prefixLength = Encoding.UTF8.GetByteCount(prefix);
+            _element.localNameOffset = _element.prefixOffset + _element.prefixLength + (_element.prefixLength != 0 ? 1 : 0);
+            _element.localNameLength = Encoding.UTF8.GetByteCount(localName);
+            _elementWriter.WriteStartElement(prefix, localName);
+
+            // If we have a inclusivenamespace prefix list and the namespace declaration is in the 
+            // outer context, then Add it to the root element.
+            if (isRootElement && (_inclusivePrefixes != null))
+            {
+                // Scan through all the namespace declarations in the outer scope.
+                for (int i = 0; i < _scopes[0].xmlnsAttributeCount; ++i)
+                {
+                    if (IsInclusivePrefix(ref _xmlnsAttributes[i]))
+                    {
+                        XmlnsAttribute attribute = _xmlnsAttributes[i];
+                        AddXmlnsAttribute(ref attribute);
+                    }
+                }
+            }
+        }
+
+        public void WriteStartElement(byte[] prefixBuffer, int prefixOffset, int prefixLength, byte[] localNameBuffer, int localNameOffset, int localNameLength)
+        {
+            if (prefixBuffer == null)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("prefixBuffer"));
+            if (prefixOffset < 0)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("prefixOffset", SR.Format(SR.ValueMustBeNonNegative)));
+            if (prefixOffset > prefixBuffer.Length)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("prefixOffset", SR.Format(SR.OffsetExceedsBufferSize, prefixBuffer.Length)));
+            if (prefixLength < 0)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("prefixLength", SR.Format(SR.ValueMustBeNonNegative)));
+            if (prefixLength > prefixBuffer.Length - prefixOffset)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("prefixLength", SR.Format(SR.SizeExceedsRemainingBufferSpace, prefixBuffer.Length - prefixOffset)));
+
+            if (localNameBuffer == null)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("localNameBuffer"));
+            if (localNameOffset < 0)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("localNameOffset", SR.Format(SR.ValueMustBeNonNegative)));
+            if (localNameOffset > localNameBuffer.Length)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("localNameOffset", SR.Format(SR.OffsetExceedsBufferSize, localNameBuffer.Length)));
+            if (localNameLength < 0)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("localNameLength", SR.Format(SR.ValueMustBeNonNegative)));
+            if (localNameLength > localNameBuffer.Length - localNameOffset)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("localNameLength", SR.Format(SR.SizeExceedsRemainingBufferSpace, localNameBuffer.Length - localNameOffset)));
+            ThrowIfClosed();
+            bool isRootElement = (_depth == 0);
+
+            StartElement();
+            _element.prefixOffset = _elementWriter.Position + 1;
+            _element.prefixLength = prefixLength;
+            _element.localNameOffset = _element.prefixOffset + prefixLength + (prefixLength != 0 ? 1 : 0);
+            _element.localNameLength = localNameLength;
+            _elementWriter.WriteStartElement(prefixBuffer, prefixOffset, prefixLength, localNameBuffer, localNameOffset, localNameLength);
+
+            // If we have a inclusivenamespace prefix list and the namespace declaration is in the 
+            // outer context, then Add it to the root element.
+            if (isRootElement && (_inclusivePrefixes != null))
+            {
+                // Scan through all the namespace declarations in the outer scope.
+                for (int i = 0; i < _scopes[0].xmlnsAttributeCount; ++i)
+                {
+                    if (IsInclusivePrefix(ref _xmlnsAttributes[i]))
+                    {
+                        XmlnsAttribute attribute = _xmlnsAttributes[i];
+                        AddXmlnsAttribute(ref attribute);
+                    }
+                }
+            }
+        }
+
+        private bool IsInclusivePrefix(ref XmlnsAttribute xmlnsAttribute)
+        {
+            for (int i = 0; i < _inclusivePrefixes.Length; ++i)
+            {
+                if (_inclusivePrefixes[i].Length == xmlnsAttribute.prefixLength)
+                {
+                    if (String.Compare(Encoding.UTF8.GetString(_xmlnsBuffer, xmlnsAttribute.prefixOffset, xmlnsAttribute.prefixLength), _inclusivePrefixes[i], StringComparison.Ordinal) == 0)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        public void WriteEndStartElement(bool isEmpty)
+        {
+            ThrowIfClosed();
+            _elementWriter.Flush();
+            _elementBuffer = _elementStream.GetBuffer();
+            _inStartElement = false;
+            ResolvePrefixes();
+            _writer.WriteStartElement(_elementBuffer, _element.prefixOffset, _element.prefixLength, _elementBuffer, _element.localNameOffset, _element.localNameLength);
+            for (int i = _scopes[_depth - 1].xmlnsAttributeCount; i < _xmlnsAttributeCount; i++)
+            {
+                // Check if this prefix with the same namespace has already been rendered.
+                int j = i - 1;
+                bool alreadyReferred = false;
+                while (j >= 0)
+                {
+                    if (Equals(_xmlnsBuffer, _xmlnsAttributes[i].prefixOffset, _xmlnsAttributes[i].prefixLength, _xmlnsBuffer, _xmlnsAttributes[j].prefixOffset, _xmlnsAttributes[j].prefixLength))
+                    {
+                        // Check if the namespace is also equal.
+                        if (Equals(_xmlnsBuffer, _xmlnsAttributes[i].nsOffset, _xmlnsAttributes[i].nsLength, _xmlnsBuffer, _xmlnsAttributes[j].nsOffset, _xmlnsAttributes[j].nsLength))
+                        {
+                            // We have found the prefix with the same namespace occur before. See if this has been
+                            // referred.
+                            if (_xmlnsAttributes[j].referred)
+                            {
+                                // This has been referred previously. So we don't have 
+                                // to output the namespace again.
+                                alreadyReferred = true;
+                                break;
+                            }
+                        }
+                        else
+                        {
+                            // The prefix is the same, but the namespace value has changed. So we have to 
+                            // output this namespace.
+                            break;
+                        }
+                    }
+                    --j;
+                }
+
+                if (!alreadyReferred)
+                {
+                    WriteXmlnsAttribute(ref _xmlnsAttributes[i]);
+                }
+            }
+            if (_attributeCount > 0)
+            {
+                if (_attributeCount > 1)
+                {
+                    SortAttributes();
+                }
+
+                for (int i = 0; i < _attributeCount; i++)
+                {
+                    _writer.WriteText(_elementBuffer, _attributes[i].offset, _attributes[i].length);
+                }
+            }
+            _writer.WriteEndStartElement(false);
+            if (isEmpty)
+            {
+                _writer.WriteEndElement(_elementBuffer, _element.prefixOffset, _element.prefixLength, _elementBuffer, _element.localNameOffset, _element.localNameLength);
+                EndElement();
+            }
+            _elementBuffer = null;
+        }
+
+        public void WriteEndElement(string prefix, string localName)
+        {
+            if (prefix == null)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("prefix");
+            if (localName == null)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("localName");
+            ThrowIfClosed();
+            _writer.WriteEndElement(prefix, localName);
+            EndElement();
+        }
+
+        private void EnsureXmlnsBuffer(int byteCount)
+        {
+            if (_xmlnsBuffer == null)
+            {
+                _xmlnsBuffer = new byte[Math.Max(byteCount, 128)];
+            }
+            else if (_xmlnsOffset + byteCount > _xmlnsBuffer.Length)
+            {
+                byte[] newBuffer = new byte[Math.Max(_xmlnsOffset + byteCount, _xmlnsBuffer.Length * 2)];
+                Buffer.BlockCopy(_xmlnsBuffer, 0, newBuffer, 0, _xmlnsOffset);
+                _xmlnsBuffer = newBuffer;
+            }
+        }
+
+        public void WriteXmlnsAttribute(string prefix, string ns)
+        {
+            if (prefix == null)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("prefix");
+            if (ns == null)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("ns");
+            ThrowIfClosed();
+            if (prefix.Length > int.MaxValue - ns.Length)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("ns", SR.Format(SR.CombinedPrefixNSLength, int.MaxValue / maxBytesPerChar)));
+            int totalLength = prefix.Length + ns.Length;
+            if (totalLength > int.MaxValue / maxBytesPerChar)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("ns", SR.Format(SR.CombinedPrefixNSLength, int.MaxValue / maxBytesPerChar)));
+            EnsureXmlnsBuffer(totalLength * maxBytesPerChar);
+            XmlnsAttribute xmlnsAttribute;
+            xmlnsAttribute.prefixOffset = _xmlnsOffset;
+            xmlnsAttribute.prefixLength = Encoding.UTF8.GetBytes(prefix, 0, prefix.Length, _xmlnsBuffer, _xmlnsOffset);
+            _xmlnsOffset += xmlnsAttribute.prefixLength;
+            xmlnsAttribute.nsOffset = _xmlnsOffset;
+            xmlnsAttribute.nsLength = Encoding.UTF8.GetBytes(ns, 0, ns.Length, _xmlnsBuffer, _xmlnsOffset);
+            _xmlnsOffset += xmlnsAttribute.nsLength;
+            xmlnsAttribute.referred = false;
+            AddXmlnsAttribute(ref xmlnsAttribute);
+        }
+
+        public void WriteXmlnsAttribute(byte[] prefixBuffer, int prefixOffset, int prefixLength, byte[] nsBuffer, int nsOffset, int nsLength)
+        {
+            if (prefixBuffer == null)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("prefixBuffer"));
+            if (prefixOffset < 0)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("prefixOffset", SR.Format(SR.ValueMustBeNonNegative)));
+            if (prefixOffset > prefixBuffer.Length)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("prefixOffset", SR.Format(SR.OffsetExceedsBufferSize, prefixBuffer.Length)));
+            if (prefixLength < 0)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("prefixLength", SR.Format(SR.ValueMustBeNonNegative)));
+            if (prefixLength > prefixBuffer.Length - prefixOffset)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("prefixLength", SR.Format(SR.SizeExceedsRemainingBufferSpace, prefixBuffer.Length - prefixOffset)));
+
+            if (nsBuffer == null)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("nsBuffer"));
+            if (nsOffset < 0)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("nsOffset", SR.Format(SR.ValueMustBeNonNegative)));
+            if (nsOffset > nsBuffer.Length)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("nsOffset", SR.Format(SR.OffsetExceedsBufferSize, nsBuffer.Length)));
+            if (nsLength < 0)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("nsLength", SR.Format(SR.ValueMustBeNonNegative)));
+            if (nsLength > nsBuffer.Length - nsOffset)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("nsLength", SR.Format(SR.SizeExceedsRemainingBufferSpace, nsBuffer.Length - nsOffset)));
+            ThrowIfClosed();
+            if (prefixLength > int.MaxValue - nsLength)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("nsLength", SR.Format(SR.CombinedPrefixNSLength, int.MaxValue)));
+            EnsureXmlnsBuffer(prefixLength + nsLength);
+            XmlnsAttribute xmlnsAttribute;
+            xmlnsAttribute.prefixOffset = _xmlnsOffset;
+            xmlnsAttribute.prefixLength = prefixLength;
+            Buffer.BlockCopy(prefixBuffer, prefixOffset, _xmlnsBuffer, _xmlnsOffset, prefixLength);
+            _xmlnsOffset += prefixLength;
+            xmlnsAttribute.nsOffset = _xmlnsOffset;
+            xmlnsAttribute.nsLength = nsLength;
+            Buffer.BlockCopy(nsBuffer, nsOffset, _xmlnsBuffer, _xmlnsOffset, nsLength);
+            _xmlnsOffset += nsLength;
+            xmlnsAttribute.referred = false;
+            AddXmlnsAttribute(ref xmlnsAttribute);
+        }
+
+        public void WriteStartAttribute(string prefix, string localName)
+        {
+            if (prefix == null)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("prefix");
+            if (localName == null)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("localName");
+            ThrowIfClosed();
+            _attribute.offset = _elementWriter.Position;
+            _attribute.length = 0;
+            _attribute.prefixOffset = _attribute.offset + 1; // WriteStartAttribute emits a space
+            _attribute.prefixLength = Encoding.UTF8.GetByteCount(prefix);
+            _attribute.localNameOffset = _attribute.prefixOffset + _attribute.prefixLength + (_attribute.prefixLength != 0 ? 1 : 0);
+            _attribute.localNameLength = Encoding.UTF8.GetByteCount(localName);
+            _attribute.nsOffset = 0;
+            _attribute.nsLength = 0;
+            _elementWriter.WriteStartAttribute(prefix, localName);
+        }
+
+        public void WriteStartAttribute(byte[] prefixBuffer, int prefixOffset, int prefixLength, byte[] localNameBuffer, int localNameOffset, int localNameLength)
+        {
+            if (prefixBuffer == null)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("prefixBuffer"));
+            if (prefixOffset < 0)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("prefixOffset", SR.Format(SR.ValueMustBeNonNegative)));
+            if (prefixOffset > prefixBuffer.Length)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("prefixOffset", SR.Format(SR.OffsetExceedsBufferSize, prefixBuffer.Length)));
+            if (prefixLength < 0)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("prefixLength", SR.Format(SR.ValueMustBeNonNegative)));
+            if (prefixLength > prefixBuffer.Length - prefixOffset)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("prefixLength", SR.Format(SR.SizeExceedsRemainingBufferSpace, prefixBuffer.Length - prefixOffset)));
+
+            if (localNameBuffer == null)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("localNameBuffer"));
+            if (localNameOffset < 0)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("localNameOffset", SR.Format(SR.ValueMustBeNonNegative)));
+            if (localNameOffset > localNameBuffer.Length)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("localNameOffset", SR.Format(SR.OffsetExceedsBufferSize, localNameBuffer.Length)));
+            if (localNameLength < 0)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("localNameLength", SR.Format(SR.ValueMustBeNonNegative)));
+            if (localNameLength > localNameBuffer.Length - localNameOffset)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("localNameLength", SR.Format(SR.SizeExceedsRemainingBufferSpace, localNameBuffer.Length - localNameOffset)));
+            ThrowIfClosed();
+            _attribute.offset = _elementWriter.Position;
+            _attribute.length = 0;
+            _attribute.prefixOffset = _attribute.offset + 1; // WriteStartAttribute emits a space
+            _attribute.prefixLength = prefixLength;
+            _attribute.localNameOffset = _attribute.prefixOffset + prefixLength + (prefixLength != 0 ? 1 : 0);
+            _attribute.localNameLength = localNameLength;
+            _attribute.nsOffset = 0;
+            _attribute.nsLength = 0;
+            _elementWriter.WriteStartAttribute(prefixBuffer, prefixOffset, prefixLength, localNameBuffer, localNameOffset, localNameLength);
+        }
+
+        public void WriteEndAttribute()
+        {
+            ThrowIfClosed();
+            _elementWriter.WriteEndAttribute();
+            _attribute.length = _elementWriter.Position - _attribute.offset;
+            AddAttribute(ref _attribute);
+        }
+
+        public void WriteCharEntity(int ch)
+        {
+            ThrowIfClosed();
+            if (ch <= char.MaxValue)
+            {
+                char[] chars = new char[1] { (char)ch };
+                WriteEscapedText(chars, 0, 1);
+            }
+            else
+            {
+                WriteText(ch);
+            }
+        }
+
+        public void WriteEscapedText(string value)
+        {
+            if (value == null)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("value");
+            ThrowIfClosed();
+            // Skip all white spaces before the start of root element.
+            if (_depth > 0)
+            {
+                if (_inStartElement)
+                {
+                    _elementWriter.WriteEscapedText(value);
+                }
+                else
+                {
+                    _writer.WriteEscapedText(value);
+                }
+            }
+        }
+
+        public void WriteEscapedText(byte[] chars, int offset, int count)
+        {
+            if (chars == null)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("chars"));
+            if (offset < 0)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("offset", SR.Format(SR.ValueMustBeNonNegative)));
+            if (offset > chars.Length)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("offset", SR.Format(SR.OffsetExceedsBufferSize, chars.Length)));
+            if (count < 0)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("count", SR.Format(SR.ValueMustBeNonNegative)));
+            if (count > chars.Length - offset)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("count", SR.Format(SR.SizeExceedsRemainingBufferSpace, chars.Length - offset)));
+            ThrowIfClosed();
+            // Skip all white spaces before the start of root element.
+            if (_depth > 0)
+            {
+                if (_inStartElement)
+                {
+                    _elementWriter.WriteEscapedText(chars, offset, count);
+                }
+                else
+                {
+                    _writer.WriteEscapedText(chars, offset, count);
+                }
+            }
+        }
+
+        public void WriteEscapedText(char[] chars, int offset, int count)
+        {
+            ThrowIfClosed();
+            // Skip all white spaces before the start of root element.
+            if (_depth > 0)
+            {
+                if (_inStartElement)
+                {
+                    _elementWriter.WriteEscapedText(chars, offset, count);
+                }
+                else
+                {
+                    _writer.WriteEscapedText(chars, offset, count);
+                }
+            }
+        }
+
+#if OLDWRITER
+        unsafe internal void WriteText(char* chars, int charCount)
+        {
+            ThrowIfClosed();
+            if (inStartElement)
+            {
+                elementWriter.WriteText(chars, charCount);
+            }
+            else
+            {
+                writer.WriteText(chars, charCount);
+            }
+        }
+        unsafe internal void WriteEscapedText(char* chars, int count)
+        {
+            ThrowIfClosed();
+            // Skip all white spaces before the start of root element.
+            if (this.depth > 0)
+            {
+                if (inStartElement)
+                {
+                    elementWriter.WriteEscapedText(chars, count);
+                }
+                else
+                {
+                    writer.WriteEscapedText(chars, count);
+                }
+            }
+        }
+#endif
+
+        public void WriteText(int ch)
+        {
+            ThrowIfClosed();
+            if (_inStartElement)
+            {
+                _elementWriter.WriteText(ch);
+            }
+            else
+            {
+                _writer.WriteText(ch);
+            }
+        }
+
+        public void WriteText(byte[] chars, int offset, int count)
+        {
+            ThrowIfClosed();
+            if (chars == null)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("chars"));
+            if (offset < 0)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("offset", SR.Format(SR.ValueMustBeNonNegative)));
+            if (offset > chars.Length)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("offset", SR.Format(SR.OffsetExceedsBufferSize, chars.Length)));
+            if (count < 0)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("count", SR.Format(SR.ValueMustBeNonNegative)));
+            if (count > chars.Length - offset)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("count", SR.Format(SR.SizeExceedsRemainingBufferSpace, chars.Length - offset)));
+            if (_inStartElement)
+            {
+                _elementWriter.WriteText(chars, offset, count);
+            }
+            else
+            {
+                _writer.WriteText(chars, offset, count);
+            }
+        }
+
+        public void WriteText(string value)
+        {
+            if (value == null)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("value"));
+            if (value.Length > 0)
+            {
+                if (_inStartElement)
+                {
+                    _elementWriter.WriteText(value);
+                }
+                else
+                {
+                    _writer.WriteText(value);
+                }
+            }
+        }
+
+        public void WriteText(char[] chars, int offset, int count)
+        {
+            ThrowIfClosed();
+            if (chars == null)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("chars"));
+            if (offset < 0)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("offset", SR.Format(SR.ValueMustBeNonNegative)));
+            if (offset > chars.Length)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("offset", SR.Format(SR.OffsetExceedsBufferSize, chars.Length)));
+            if (count < 0)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("count", SR.Format(SR.ValueMustBeNonNegative)));
+            if (count > chars.Length - offset)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("count", SR.Format(SR.SizeExceedsRemainingBufferSpace, chars.Length - offset)));
+            if (_inStartElement)
+            {
+                _elementWriter.WriteText(chars, offset, count);
+            }
+            else
+            {
+                _writer.WriteText(chars, offset, count);
+            }
+        }
+
+        private void ThrowIfClosed()
+        {
+            if (_writer == null)
+                ThrowClosed();
+        }
+
+        private void ThrowClosed()
+        {
+            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ObjectDisposedException(this.GetType().ToString()));
+        }
+
+        private void WriteXmlnsAttribute(ref XmlnsAttribute xmlnsAttribute)
+        {
+            if (xmlnsAttribute.referred)
+            {
+                _writer.WriteXmlnsAttribute(_xmlnsBuffer, xmlnsAttribute.prefixOffset, xmlnsAttribute.prefixLength, _xmlnsBuffer, xmlnsAttribute.nsOffset, xmlnsAttribute.nsLength);
+            }
+        }
+
+        private void SortAttributes()
+        {
+            if (_attributeCount < 16)
+            {
+                for (int i = 0; i < _attributeCount - 1; i++)
+                {
+                    int attributeMin = i;
+                    for (int j = i + 1; j < _attributeCount; j++)
+                    {
+                        if (Compare(ref _attributes[j], ref _attributes[attributeMin]) < 0)
+                        {
+                            attributeMin = j;
+                        }
+                    }
+
+                    if (attributeMin != i)
+                    {
+                        Attribute temp = _attributes[i];
+                        _attributes[i] = _attributes[attributeMin];
+                        _attributes[attributeMin] = temp;
+                    }
+                }
+            }
+            else
+            {
+                new AttributeSorter(this).Sort();
+            }
+        }
+
+        private void AddAttribute(ref Attribute attribute)
+        {
+            if (_attributes == null)
+            {
+                _attributes = new Attribute[4];
+            }
+            else if (_attributeCount == _attributes.Length)
+            {
+                Attribute[] newAttributes = new Attribute[_attributeCount * 2];
+                Array.Copy(_attributes, newAttributes, _attributeCount);
+                _attributes = newAttributes;
+            }
+
+            _attributes[_attributeCount] = attribute;
+            _attributeCount++;
+        }
+
+        private void AddXmlnsAttribute(ref XmlnsAttribute xmlnsAttribute)
+        {
+            //            Console.WriteLine("{0}={1}", Encoding.UTF8.GetString(xmlnsBuffer, xmlnsAttribute.prefixOffset, xmlnsAttribute.prefixLength), 
+            //                                Encoding.UTF8.GetString(xmlnsBuffer, xmlnsAttribute.nsOffset, xmlnsAttribute.nsLength));
+
+            if (_xmlnsAttributes == null)
+            {
+                _xmlnsAttributes = new XmlnsAttribute[4];
+            }
+            else if (_xmlnsAttributes.Length == _xmlnsAttributeCount)
+            {
+                XmlnsAttribute[] newXmlnsAttributes = new XmlnsAttribute[_xmlnsAttributeCount * 2];
+                Array.Copy(_xmlnsAttributes, newXmlnsAttributes, _xmlnsAttributeCount);
+                _xmlnsAttributes = newXmlnsAttributes;
+            }
+
+            // If the prefix is in the inclusive prefix list, then mark it as 
+            // to be rendered. Depth 0 is outer context and those can be ignored
+            // for now.
+            if ((_depth > 0) && (_inclusivePrefixes != null))
+            {
+                if (IsInclusivePrefix(ref xmlnsAttribute))
+                {
+                    xmlnsAttribute.referred = true;
+                }
+            }
+
+            if (_depth == 0)
+            {
+                // XmlnsAttributes at depth 0 are the outer context.  They don't need to be sorted.
+                _xmlnsAttributes[_xmlnsAttributeCount++] = xmlnsAttribute;
+            }
+            else
+            {
+                // Sort the xmlns xmlnsAttribute
+                int xmlnsAttributeIndex = _scopes[_depth - 1].xmlnsAttributeCount;
+                bool isNewPrefix = true;
+                while (xmlnsAttributeIndex < _xmlnsAttributeCount)
+                {
+                    int result = Compare(ref xmlnsAttribute, ref _xmlnsAttributes[xmlnsAttributeIndex]);
+                    if (result > 0)
+                    {
+                        xmlnsAttributeIndex++;
+                    }
+                    else if (result == 0)
+                    {
+                        // We already have the same prefix at this scope. So let's
+                        // just replace the old one with the new.
+                        _xmlnsAttributes[xmlnsAttributeIndex] = xmlnsAttribute;
+                        isNewPrefix = false;
+                        break;
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+
+                if (isNewPrefix)
+                {
+                    Array.Copy(_xmlnsAttributes, xmlnsAttributeIndex, _xmlnsAttributes, xmlnsAttributeIndex + 1, _xmlnsAttributeCount - xmlnsAttributeIndex);
+                    _xmlnsAttributes[xmlnsAttributeIndex] = xmlnsAttribute;
+                    _xmlnsAttributeCount++;
+                }
+            }
+        }
+
+        private void ResolvePrefix(int prefixOffset, int prefixLength, out int nsOffset, out int nsLength)
+        {
+            int xmlnsAttributeMin = _scopes[_depth - 1].xmlnsAttributeCount;
+
+            // Lookup the attribute; it has to be there.  The decls are in sorted order
+            // so we could do a binary search.
+            int j = _xmlnsAttributeCount - 1;
+            while (!Equals(_elementBuffer, prefixOffset, prefixLength,
+                           _xmlnsBuffer, _xmlnsAttributes[j].prefixOffset, _xmlnsAttributes[j].prefixLength))
+            {
+                j--;
+            }
+
+            nsOffset = _xmlnsAttributes[j].nsOffset;
+            nsLength = _xmlnsAttributes[j].nsLength;
+
+            if (j < xmlnsAttributeMin)
+            {
+                // If the xmlns decl isn't at this scope, see if we need to copy it down
+                if (!_xmlnsAttributes[j].referred)
+                {
+                    XmlnsAttribute xmlnsAttribute = _xmlnsAttributes[j];
+                    xmlnsAttribute.referred = true;
+
+                    // This inserts the xmlns attribute in sorted order, so j is no longer valid
+                    AddXmlnsAttribute(ref xmlnsAttribute);
+                }
+            }
+            else
+            {
+                // Found at this scope, indicate we need to emit it
+                _xmlnsAttributes[j].referred = true;
+            }
+        }
+
+        private void ResolvePrefix(ref Attribute attribute)
+        {
+            if (attribute.prefixLength != 0)
+            {
+                ResolvePrefix(attribute.prefixOffset, attribute.prefixLength, out attribute.nsOffset, out attribute.nsLength);
+            }
+            else
+            {
+                // These should've been set when we added the prefix
+                Fx.Assert(attribute.nsOffset == 0 && attribute.nsLength == 0, "");
+            }
+        }
+
+        private void ResolvePrefixes()
+        {
+            int nsOffset;
+            int nsLength;
+            ResolvePrefix(_element.prefixOffset, _element.prefixLength, out nsOffset, out nsLength);
+
+            for (int i = 0; i < _attributeCount; i++)
+            {
+                ResolvePrefix(ref _attributes[i]);
+            }
+        }
+
+        private int Compare(ref XmlnsAttribute xmlnsAttribute1, ref XmlnsAttribute xmlnsAttribute2)
+        {
+            return Compare(_xmlnsBuffer,
+                           xmlnsAttribute1.prefixOffset, xmlnsAttribute1.prefixLength,
+                           xmlnsAttribute2.prefixOffset, xmlnsAttribute2.prefixLength);
+        }
+
+        private int Compare(ref Attribute attribute1, ref Attribute attribute2)
+        {
+            int s = Compare(_xmlnsBuffer,
+                            attribute1.nsOffset, attribute1.nsLength,
+                            attribute2.nsOffset, attribute2.nsLength);
+
+            if (s == 0)
+            {
+                s = Compare(_elementBuffer,
+                            attribute1.localNameOffset, attribute1.localNameLength,
+                            attribute2.localNameOffset, attribute2.localNameLength);
+            }
+
+            return s;
+        }
+
+        private int Compare(byte[] buffer, int offset1, int length1, int offset2, int length2)
+        {
+            if (offset1 == offset2)
+            {
+                return length1 - length2;
+            }
+
+            return Compare(buffer, offset1, length1, buffer, offset2, length2);
+        }
+
+        private int Compare(byte[] buffer1, int offset1, int length1, byte[] buffer2, int offset2, int length2)
+        {
+            //            Console.WriteLine("Compare: \"{0}\", \"{1}\"", Encoding.UTF8.GetString(sourceBuffer, offset1, length1), Encoding.UTF8.GetString(sourceBuffer, offset2, length2));
+
+            int length = Math.Min(length1, length2);
+
+            int s = 0;
+            for (int i = 0; i < length && s == 0; i++)
+            {
+                s = buffer1[offset1 + i] - buffer2[offset2 + i];
+            }
+
+            if (s == 0)
+            {
+                s = length1 - length2;
+            }
+
+            return s;
+        }
+
+        private bool Equals(byte[] buffer1, int offset1, int length1, byte[] buffer2, int offset2, int length2)
+        {
+            //            Console.WriteLine("Equals: \"{0}\", \"{1}\"", Encoding.UTF8.GetString(buffer1, offset1, length1), Encoding.UTF8.GetString(buffer2, offset2, length2));
+
+            if (length1 != length2)
+                return false;
+
+            for (int i = 0; i < length1; i++)
+            {
+                if (buffer1[offset1 + i] != buffer2[offset2 + i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private class AttributeSorter : IComparer
+        {
+            private XmlCanonicalWriter _writer;
+
+            public AttributeSorter(XmlCanonicalWriter writer)
+            {
+                _writer = writer;
+            }
+
+            public void Sort()
+            {
+                object[] indeces = new object[_writer._attributeCount];
+
+                for (int i = 0; i < indeces.Length; i++)
+                {
+                    indeces[i] = i;
+                }
+
+                Array.Sort(indeces, this);
+
+                Attribute[] attributes = new Attribute[_writer._attributes.Length];
+                for (int i = 0; i < indeces.Length; i++)
+                {
+                    attributes[i] = _writer._attributes[(int)indeces[i]];
+                }
+
+                _writer._attributes = attributes;
+            }
+
+            public int Compare(object obj1, object obj2)
+            {
+                int attributeIndex1 = (int)obj1;
+                int attributeIndex2 = (int)obj2;
+                return _writer.Compare(ref _writer._attributes[attributeIndex1], ref _writer._attributes[attributeIndex2]);
+            }
+        }
+
+        private struct Scope
+        {
+            public int xmlnsAttributeCount;
+            public int xmlnsOffset;
+        }
+
+        private struct Element
+        {
+            public int prefixOffset;
+            public int prefixLength;
+            public int localNameOffset;
+            public int localNameLength;
+        }
+
+        private struct Attribute
+        {
+            public int prefixOffset;
+            public int prefixLength;
+            public int localNameOffset;
+            public int localNameLength;
+            public int nsOffset;
+            public int nsLength;
+            public int offset;
+            public int length;
+        }
+
+        private struct XmlnsAttribute
+        {
+            public int prefixOffset;
+            public int prefixLength;
+            public int nsOffset;
+            public int nsLength;
+            public bool referred;
+        }
+    }
+}

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlNodeWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlNodeWriter.cs
@@ -15,6 +15,18 @@ namespace System.Xml
 {
     internal abstract class XmlNodeWriter
     {
+        private static XmlNodeWriter s_nullNodeWriter;
+
+        static public XmlNodeWriter Null
+        {
+            get
+            {
+                if (s_nullNodeWriter == null)
+                    s_nullNodeWriter = new XmlNullNodeWriter();
+                return s_nullNodeWriter;
+            }
+        }
+
         public abstract void Flush();
         public virtual Task FlushAsync()
         {
@@ -94,5 +106,52 @@ namespace System.Xml
             throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(NotImplemented.ByDesign);
         }
         public abstract void WriteQualifiedName(string prefix, XmlDictionaryString localName);
+
+        private class XmlNullNodeWriter : XmlNodeWriter
+        {
+            public override void Flush() { }
+            public override void Close() { }
+            public override void WriteDeclaration() { }
+            public override void WriteComment(string text) { }
+            public override void WriteCData(string text) { }
+            public override void WriteStartElement(string prefix, string localName) { }
+            public override void WriteStartElement(byte[] prefixBuffer, int prefixOffset, int prefixLength, byte[] localNameBuffer, int localNameOffset, int localNameLength) { }
+            public override void WriteStartElement(string prefix, XmlDictionaryString localName) { }
+            public override void WriteEndStartElement(bool isEmpty) { }
+            public override void WriteEndElement(string prefix, string localName) { }
+            public override void WriteEndElement(byte[] prefixBuffer, int prefixOffset, int prefixLength, byte[] localNameBuffer, int localNameOffset, int localNameLength) { }
+            public override void WriteXmlnsAttribute(string prefix, string ns) { }
+            public override void WriteXmlnsAttribute(byte[] prefixBuffer, int prefixOffset, int prefixLength, byte[] nsBuffer, int nsOffset, int nsLength) { }
+            public override void WriteXmlnsAttribute(string prefix, XmlDictionaryString ns) { }
+            public override void WriteStartAttribute(string prefix, string localName) { }
+            public override void WriteStartAttribute(byte[] prefixBuffer, int prefixOffset, int prefixLength, byte[] localNameBuffer, int localNameOffset, int localNameLength) { }
+            public override void WriteStartAttribute(string prefix, XmlDictionaryString localName) { }
+            public override void WriteEndAttribute() { }
+            public override void WriteCharEntity(int ch) { }
+            public override void WriteEscapedText(string value) { }
+            public override void WriteEscapedText(XmlDictionaryString value) { }
+            public override void WriteEscapedText(char[] chars, int offset, int count) { }
+            public override void WriteEscapedText(byte[] buffer, int offset, int count) { }
+            public override void WriteText(string value) { }
+            public override void WriteText(XmlDictionaryString value) { }
+            public override void WriteText(char[] chars, int offset, int count) { }
+            public override void WriteText(byte[] buffer, int offset, int count) { }
+            public override void WriteInt32Text(int value) { }
+            public override void WriteInt64Text(Int64 value) { }
+            public override void WriteBoolText(bool value) { }
+            public override void WriteUInt64Text(UInt64 value) { }
+            public override void WriteFloatText(float value) { }
+            public override void WriteDoubleText(double value) { }
+            public override void WriteDecimalText(decimal value) { }
+            public override void WriteDateTimeText(DateTime value) { }
+            public override void WriteUniqueIdText(UniqueId value) { }
+            public override void WriteTimeSpanText(TimeSpan value) { }
+            public override void WriteGuidText(Guid value) { }
+            public override void WriteStartListText() { }
+            public override void WriteListSeparator() { }
+            public override void WriteEndListText() { }
+            public override void WriteBase64Text(byte[] trailBuffer, int trailCount, byte[] buffer, int offset, int count) { }
+            public override void WriteQualifiedName(string prefix, XmlDictionaryString localName) { }
+        }
     }
 }

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlSigningNodeWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlSigningNodeWriter.cs
@@ -1,0 +1,389 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Text;
+
+namespace System.Xml
+{
+    internal class XmlSigningNodeWriter : XmlNodeWriter
+    {
+        private XmlNodeWriter _writer;
+        private XmlCanonicalWriter _signingWriter;
+        private byte[] _chars;
+        private byte[] _base64Chars;
+        private bool _text;
+
+        public XmlSigningNodeWriter(bool text)
+        {
+            _text = text;
+        }
+
+        public void SetOutput(XmlNodeWriter writer, Stream stream, bool includeComments, string[] inclusivePrefixes)
+        {
+            _writer = writer;
+            if (_signingWriter == null)
+                _signingWriter = new XmlCanonicalWriter();
+            _signingWriter.SetOutput(stream, includeComments, inclusivePrefixes);
+            _chars = new byte[XmlConverter.MaxPrimitiveChars];
+            _base64Chars = null;
+        }
+
+        public XmlNodeWriter NodeWriter
+        {
+            get
+            {
+                return _writer;
+            }
+            set
+            {
+                _writer = value;
+            }
+        }
+
+        public XmlCanonicalWriter CanonicalWriter
+        {
+            get
+            {
+                return _signingWriter;
+            }
+        }
+
+        public override void Flush()
+        {
+            _writer.Flush();
+            _signingWriter.Flush();
+        }
+
+        public override void Close()
+        {
+            _writer.Close();
+            _signingWriter.Close();
+        }
+
+        public override void WriteDeclaration()
+        {
+            _writer.WriteDeclaration();
+            _signingWriter.WriteDeclaration();
+        }
+
+        public override void WriteComment(string text)
+        {
+            _writer.WriteComment(text);
+            _signingWriter.WriteComment(text);
+        }
+
+        public override void WriteCData(string text)
+        {
+            _writer.WriteCData(text);
+            _signingWriter.WriteEscapedText(text);
+        }
+
+        public override void WriteStartElement(string prefix, string localName)
+        {
+            _writer.WriteStartElement(prefix, localName);
+            _signingWriter.WriteStartElement(prefix, localName);
+        }
+
+        public override void WriteStartElement(byte[] prefixBuffer, int prefixOffset, int prefixLength,
+                                               byte[] localNameBuffer, int localNameOffset, int localNameLength)
+        {
+            _writer.WriteStartElement(prefixBuffer, prefixOffset, prefixLength, localNameBuffer, localNameOffset, localNameLength);
+            _signingWriter.WriteStartElement(prefixBuffer, prefixOffset, prefixLength, localNameBuffer, localNameOffset, localNameLength);
+        }
+
+        public override void WriteStartElement(string prefix, XmlDictionaryString localName)
+        {
+            _writer.WriteStartElement(prefix, localName);
+            _signingWriter.WriteStartElement(prefix, localName.Value);
+        }
+
+        public override void WriteEndStartElement(bool isEmpty)
+        {
+            _writer.WriteEndStartElement(isEmpty);
+            _signingWriter.WriteEndStartElement(isEmpty);
+        }
+
+        public override void WriteEndElement(string prefix, string localName)
+        {
+            _writer.WriteEndElement(prefix, localName);
+            _signingWriter.WriteEndElement(prefix, localName);
+        }
+
+        public override void WriteXmlnsAttribute(string prefix, string ns)
+        {
+            _writer.WriteXmlnsAttribute(prefix, ns);
+            _signingWriter.WriteXmlnsAttribute(prefix, ns);
+        }
+
+        public override void WriteXmlnsAttribute(byte[] prefixBuffer, int prefixOffset, int prefixLength,
+                                                 byte[] nsBuffer, int nsOffset, int nsLength)
+        {
+            _writer.WriteXmlnsAttribute(prefixBuffer, prefixOffset, prefixLength, nsBuffer, nsOffset, nsLength);
+            _signingWriter.WriteXmlnsAttribute(prefixBuffer, prefixOffset, prefixLength, nsBuffer, nsOffset, nsLength);
+        }
+
+        public override void WriteXmlnsAttribute(string prefix, XmlDictionaryString ns)
+        {
+            _writer.WriteXmlnsAttribute(prefix, ns);
+            _signingWriter.WriteXmlnsAttribute(prefix, ns.Value);
+        }
+
+        public override void WriteStartAttribute(string prefix, string localName)
+        {
+            _writer.WriteStartAttribute(prefix, localName);
+            _signingWriter.WriteStartAttribute(prefix, localName);
+        }
+
+        public override void WriteStartAttribute(byte[] prefixBuffer, int prefixOffset, int prefixLength,
+                                                 byte[] localNameBuffer, int localNameOffset, int localNameLength)
+        {
+            _writer.WriteStartAttribute(prefixBuffer, prefixOffset, prefixLength, localNameBuffer, localNameOffset, localNameLength);
+            _signingWriter.WriteStartAttribute(prefixBuffer, prefixOffset, prefixLength, localNameBuffer, localNameOffset, localNameLength);
+        }
+
+        public override void WriteStartAttribute(string prefix, XmlDictionaryString localName)
+        {
+            _writer.WriteStartAttribute(prefix, localName);
+            _signingWriter.WriteStartAttribute(prefix, localName.Value);
+        }
+
+        public override void WriteEndAttribute()
+        {
+            _writer.WriteEndAttribute();
+            _signingWriter.WriteEndAttribute();
+        }
+
+        public override void WriteCharEntity(int ch)
+        {
+            _writer.WriteCharEntity(ch);
+            _signingWriter.WriteCharEntity(ch);
+        }
+
+        public override void WriteEscapedText(string value)
+        {
+            _writer.WriteEscapedText(value);
+            _signingWriter.WriteEscapedText(value);
+        }
+
+        public override void WriteEscapedText(char[] chars, int offset, int count)
+        {
+            _writer.WriteEscapedText(chars, offset, count);
+            _signingWriter.WriteEscapedText(chars, offset, count);
+        }
+
+        public override void WriteEscapedText(XmlDictionaryString value)
+        {
+            _writer.WriteEscapedText(value);
+            _signingWriter.WriteEscapedText(value.Value);
+        }
+
+        public override void WriteEscapedText(byte[] chars, int offset, int count)
+        {
+            _writer.WriteEscapedText(chars, offset, count);
+            _signingWriter.WriteEscapedText(chars, offset, count);
+        }
+
+        public override void WriteText(string value)
+        {
+            _writer.WriteText(value);
+            _signingWriter.WriteText(value);
+        }
+
+        public override void WriteText(char[] chars, int offset, int count)
+        {
+            _writer.WriteText(chars, offset, count);
+            _signingWriter.WriteText(chars, offset, count);
+        }
+
+        public override void WriteText(byte[] chars, int offset, int count)
+        {
+            _writer.WriteText(chars, offset, count);
+            _signingWriter.WriteText(chars, offset, count);
+        }
+
+        public override void WriteText(XmlDictionaryString value)
+        {
+            _writer.WriteText(value);
+            _signingWriter.WriteText(value.Value);
+        }
+
+        public override void WriteInt32Text(int value)
+        {
+            int count = XmlConverter.ToChars(value, _chars, 0);
+            if (_text)
+                _writer.WriteText(_chars, 0, count);
+            else
+                _writer.WriteInt32Text(value);
+            _signingWriter.WriteText(_chars, 0, count);
+        }
+
+        public override void WriteInt64Text(Int64 value)
+        {
+            int count = XmlConverter.ToChars(value, _chars, 0);
+            if (_text)
+                _writer.WriteText(_chars, 0, count);
+            else
+                _writer.WriteInt64Text(value);
+            _signingWriter.WriteText(_chars, 0, count);
+        }
+
+        public override void WriteBoolText(bool value)
+        {
+            int count = XmlConverter.ToChars(value, _chars, 0);
+            if (_text)
+                _writer.WriteText(_chars, 0, count);
+            else
+                _writer.WriteBoolText(value);
+            _signingWriter.WriteText(_chars, 0, count);
+        }
+
+        public override void WriteUInt64Text(UInt64 value)
+        {
+            int count = XmlConverter.ToChars(value, _chars, 0);
+            if (_text)
+                _writer.WriteText(_chars, 0, count);
+            else
+                _writer.WriteUInt64Text(value);
+            _signingWriter.WriteText(_chars, 0, count);
+        }
+
+        public override void WriteFloatText(float value)
+        {
+            int count = XmlConverter.ToChars(value, _chars, 0);
+            if (_text)
+                _writer.WriteText(_chars, 0, count);
+            else
+                _writer.WriteFloatText(value);
+            _signingWriter.WriteText(_chars, 0, count);
+        }
+
+        public override void WriteDoubleText(double value)
+        {
+            int count = XmlConverter.ToChars(value, _chars, 0);
+            if (_text)
+                _writer.WriteText(_chars, 0, count);
+            else
+                _writer.WriteDoubleText(value);
+            _signingWriter.WriteText(_chars, 0, count);
+        }
+
+        public override void WriteDecimalText(decimal value)
+        {
+            int count = XmlConverter.ToChars(value, _chars, 0);
+            if (_text)
+                _writer.WriteText(_chars, 0, count);
+            else
+                _writer.WriteDecimalText(value);
+            _signingWriter.WriteText(_chars, 0, count);
+        }
+
+        public override void WriteDateTimeText(DateTime value)
+        {
+            int count = XmlConverter.ToChars(value, _chars, 0);
+            if (_text)
+                _writer.WriteText(_chars, 0, count);
+            else
+                _writer.WriteDateTimeText(value);
+            _signingWriter.WriteText(_chars, 0, count);
+        }
+
+        public override void WriteUniqueIdText(UniqueId value)
+        {
+            string s = XmlConverter.ToString(value);
+            if (_text)
+                _writer.WriteText(s);
+            else
+                _writer.WriteUniqueIdText(value);
+            _signingWriter.WriteText(s);
+        }
+
+        public override void WriteTimeSpanText(TimeSpan value)
+        {
+            string s = XmlConverter.ToString(value);
+            if (_text)
+                _writer.WriteText(s);
+            else
+                _writer.WriteTimeSpanText(value);
+            _signingWriter.WriteText(s);
+        }
+
+        public override void WriteGuidText(Guid value)
+        {
+            string s = XmlConverter.ToString(value);
+            if (_text)
+                _writer.WriteText(s);
+            else
+                _writer.WriteGuidText(value);
+            _signingWriter.WriteText(s);
+        }
+
+        public override void WriteStartListText()
+        {
+            _writer.WriteStartListText();
+        }
+
+        public override void WriteListSeparator()
+        {
+            _writer.WriteListSeparator();
+            _signingWriter.WriteText(' ');
+        }
+
+        public override void WriteEndListText()
+        {
+            _writer.WriteEndListText();
+        }
+
+        public override void WriteBase64Text(byte[] trailBytes, int trailByteCount, byte[] buffer, int offset, int count)
+        {
+            if (trailByteCount > 0)
+                WriteBase64Text(trailBytes, 0, trailByteCount);
+            WriteBase64Text(buffer, offset, count);
+            if (!_text)
+            {
+                _writer.WriteBase64Text(trailBytes, trailByteCount, buffer, offset, count);
+            }
+        }
+
+        private void WriteBase64Text(byte[] buffer, int offset, int count)
+        {
+            if (_base64Chars == null)
+                _base64Chars = new byte[512];
+            Base64Encoding encoding = XmlConverter.Base64Encoding;
+            while (count >= 3)
+            {
+                int byteCount = Math.Min(_base64Chars.Length / 4 * 3, count - count % 3);
+                int charCount = byteCount / 3 * 4;
+                encoding.GetChars(buffer, offset, byteCount, _base64Chars, 0);
+                _signingWriter.WriteText(_base64Chars, 0, charCount);
+                if (_text)
+                {
+                    _writer.WriteText(_base64Chars, 0, charCount);
+                }
+                offset += byteCount;
+                count -= byteCount;
+            }
+            if (count > 0)
+            {
+                encoding.GetChars(buffer, offset, count, _base64Chars, 0);
+                _signingWriter.WriteText(_base64Chars, 0, 4);
+                if (_text)
+                {
+                    _writer.WriteText(_base64Chars, 0, 4);
+                }
+            }
+        }
+
+        public override void WriteQualifiedName(string prefix, XmlDictionaryString localName)
+        {
+            _writer.WriteQualifiedName(prefix, localName);
+            if (prefix.Length != 0)
+            {
+                _signingWriter.WriteText(prefix);
+                _signingWriter.WriteText(":");
+            }
+            _signingWriter.WriteText(localName.Value);
+        }
+    }
+}

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlUTF8TextReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlUTF8TextReader.cs
@@ -1256,11 +1256,11 @@ namespace System.Xml
                 buffer = BufferReader.GetBuffer(out offset, out offsetMax);
                 if (hasLeadingByteOf0xEF)
                 {
-                    length = ReadTextAndWatchForInvalidCharacters(buffer, offset, offsetMax); 
+                    length = ReadTextAndWatchForInvalidCharacters(buffer, offset, offsetMax);
                 }
                 else
                 {
-                    length = ReadText(buffer, offset, offsetMax); 
+                    length = ReadText(buffer, offset, offsetMax);
                 }
             }
             else
@@ -1268,7 +1268,7 @@ namespace System.Xml
                 buffer = BufferReader.GetBuffer(MaxTextChunk, out offset, out offsetMax);
                 if (hasLeadingByteOf0xEF)
                 {
-                    length = ReadTextAndWatchForInvalidCharacters(buffer, offset, offsetMax); 
+                    length = ReadTextAndWatchForInvalidCharacters(buffer, offset, offsetMax);
                 }
                 else
                 {
@@ -1309,6 +1309,7 @@ namespace System.Xml
                 MoveToElement();
             }
 
+            SignNode();
             if (this.Node.ExitScope)
             {
                 ExitScope();
@@ -1397,6 +1398,11 @@ namespace System.Xml
                 XmlExceptionHelper.ThrowInvalidXml(this, ch);
             }
             return true;
+        }
+
+        protected override XmlSigningNodeWriter CreateSigningNodeWriter()
+        {
+            return new XmlSigningNodeWriter(true);
         }
 
         public bool HasLineInfo()

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlUTF8TextWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlUTF8TextWriter.cs
@@ -35,6 +35,11 @@ namespace System.Xml
             _writer.SetOutput(stream, ownsStream, encoding);
             SetOutput(_writer);
         }
+
+        protected override XmlSigningNodeWriter CreateSigningNodeWriter()
+        {
+            return new XmlSigningNodeWriter(true);
+        }
     }
 
     internal class XmlUTF8NodeWriter : XmlStreamNodeWriter

--- a/src/System.Runtime.Serialization.Xml/tests/Canonicalization/XmlCanonicalizationTest.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/Canonicalization/XmlCanonicalizationTest.cs
@@ -18,7 +18,6 @@ namespace System.Runtime.Serialization.Xml.Canonicalization.Tests
             TestConfigHelper.LoadAllTests(@"TestsConfig.xml");
         }
 
-        [ActiveIssue(18910)]
         [Fact]
         public static void C14NWriterNegativeTests()
         {
@@ -78,7 +77,6 @@ namespace System.Runtime.Serialization.Xml.Canonicalization.Tests
             }
         }
 
-        [ActiveIssue(18910)]
         [Fact]
         public static void TestC14NInclusivePrefixes()
         {
@@ -164,7 +162,6 @@ namespace System.Runtime.Serialization.Xml.Canonicalization.Tests
             }
         }
 
-        [ActiveIssue(18910)]
         [Fact]
         public static void ReaderWriter_C14N_DifferentReadersWriters()
         {

--- a/src/System.Runtime.Serialization.Xml/tests/Canonicalization/XmlCanonicalizationTest.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/Canonicalization/XmlCanonicalizationTest.cs
@@ -188,9 +188,9 @@ namespace System.Runtime.Serialization.Xml.Canonicalization.Tests
                         string rwTypeStr = input.Arguments[0].Value;
                         ReaderWriterFactory.ReaderWriterType rwType = (ReaderWriterFactory.ReaderWriterType)Enum.Parse(typeof(ReaderWriterFactory.ReaderWriterType), rwTypeStr, true);
                         Encoding encoding = Encoding.GetEncoding((string)input.Arguments[1].Value);
-                        string sampleXmlFileName = @"baselines\" + input2.Arguments[0].Value;
+                        string sampleXmlFileName = Path.Combine("baselines", input2.Arguments[0].Value);
                         bool mustSupportV14N = input.Arguments[2].Value == "true";
-                        string baselineFileName = @"baselines\" + input2.Arguments[1].Value;
+                        string baselineFileName = Path.Combine("baselines", input2.Arguments[1].Value);
 
                         bool testWithComments = input3.Arguments[0].Value == "true";
 
@@ -253,13 +253,13 @@ namespace System.Runtime.Serialization.Xml.Canonicalization.Tests
             foreach (var input in params4.Inputs)
             {
                 count++;
-                string sampleXmlFileName = @"baselines\" + input.Arguments[3].Value;
+                string sampleXmlFileName = Path.Combine("baselines", input.Arguments[3].Value);
                 string rwTypeStr = input.Arguments[0].Value;
                 ReaderWriterFactory.ReaderWriterType rwType = (ReaderWriterFactory.ReaderWriterType)Enum.Parse(typeof(ReaderWriterFactory.ReaderWriterType), rwTypeStr, true);
                 Encoding encoding = Encoding.GetEncoding((string)input.Arguments[1].Value);
 
                 bool mustSupportV14N = input.Arguments[2].Value == "true";
-                string baselineFileName = @"baselines\ReaderWriter_C14N_BaselineXML_OnlyLF.xml";
+                string baselineFileName = Path.Combine("baselines", "ReaderWriter_C14N_BaselineXML_OnlyLF.xml");
 
                 XmlDocument xmlDoc = new XmlDocument();
                 xmlDoc.PreserveWhitespace = true;


### PR DESCRIPTION
The PR ports the implementation for `StartCanonicalization` and `EndCanonicalization` from full framework to NetCore.

I verified that the tests being added by https://github.com/dotnet/corefx/pull/18911 passed with this fix.

Fix #18910.