### PR TITLE
Disable failed test for 19340.

### DIFF
--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/TypeUtilTests.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/TypeUtilTests.cs
@@ -37,6 +37,7 @@ namespace System.ConfigurationTests
             InlineData("System.Collections.Specialized.StringCollection", typeof(StringCollection))
             InlineData("System.Collections.Specialized.NameValueCollection", typeof(NameValueCollection))
             ]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #19340")]
         public void GetType_NoAssemblyQualifcation(string typeString, Type expectedType)
         {
             Assert.Equal(expectedType, TypeUtil.GetType(typeString, throwOnError: false));


### PR DESCRIPTION
Add [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #19340")]

For GetType_NoAssemblyQualifcation()

in TypeUtilTests.cs under  System.ConfigurationTests

cc: @danmosemsft @safern 