### PR TITLE
Disable failed tests for issue 18805.

### DIFF
--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsUserErrors.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsUserErrors.cs
@@ -62,6 +62,7 @@ namespace BasicEventSourceTests
         /// Test the 
         /// </summary>
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18805")]
         public void Test_BadEventSource_MismatchedIds()
         {
 #if USE_ETW // TODO: Enable when TraceEvent is available on CoreCLR. GitHub issue #4864.

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWrite.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWrite.cs
@@ -39,6 +39,7 @@ namespace BasicEventSourceTests
         /// Tests the EventListener code path
         /// </summary>
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18805")]
         public void Test_Write_T_EventListener()
         {
             using (var listener = new EventListenerListener())
@@ -52,6 +53,7 @@ namespace BasicEventSourceTests
         /// Tests the EventListener code path using events instead of virtual callbacks.
         /// </summary>
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18805")]
         public void Test_Write_T_EventListener_UseEvents()
         {
             Test_Write_T(new EventListenerListener(true));


### PR DESCRIPTION
Add [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18805")]

for:
BasicEventSourceTests.TestsWrite.Test_Write_T_EventListener
 BasicEventSourceTests.TestsWrite.Test_Write_T_EventListener_UseEvents
 BasicEventSourceTests.TestsUserErrors.Test_BadEventSource_MismatchedIds

cc: @danmosemsft @safern 