### PR TITLE
Disable failed test for issue 18312.

### DIFF
--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -1883,6 +1883,7 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18312")]
     public static void DCS_ReadOnlyDictionary()
     {
         var dict = new Dictionary<string, int>();


### PR DESCRIPTION
Add [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18312")]

for: DCS_ReadOnlyDictionary()

cc: @danmosemsft @safern 