### PR TITLE
Disable failed tests for issue 18269.

### DIFF
--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetStoreTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetStoreTests.cs
@@ -101,6 +101,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18269")]
         public void GetEnumerator_NoOp()
         {
             IEnumerator e = IsolatedStorageFile.GetEnumerator(IsolatedStorageScope.Assembly);
@@ -111,6 +112,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18269")]
         public void GetEnumerator_ThrowsForCurrent()
         {
             IEnumerator e = IsolatedStorageFile.GetEnumerator(IsolatedStorageScope.Assembly);


### PR DESCRIPTION
Add [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18269")]

for:
GetEnumerator_NoOp()
GetEnumerator_ThrowsForCurrent()

cc: @danmosemsft @safern 