### PR TITLE
Fix testILC package dependency now that we have RID on package name

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -12,8 +12,8 @@
     <CoreFxCurrentRef>1ec7eb334c406a82a41c020e73ff1717a0e90f92</CoreFxCurrentRef>
     <CoreClrCurrentRef>ccf03e3ac9788a503bae623ca6b765224656a586</CoreClrCurrentRef>
     <ExternalCurrentRef>1ec7eb334c406a82a41c020e73ff1717a0e90f92</ExternalCurrentRef>
-    <ProjectNTfsCurrentRef>1ec7eb334c406a82a41c020e73ff1717a0e90f92</ProjectNTfsCurrentRef>
-    <ProjectNTfsTestILCCurrentRef>1ec7eb334c406a82a41c020e73ff1717a0e90f92</ProjectNTfsTestILCCurrentRef>
+    <ProjectNTfsCurrentRef>2fec23caa2e720ba53500a8edac9093cf5d8c354</ProjectNTfsCurrentRef>
+    <ProjectNTfsTestILCCurrentRef>2fec23caa2e720ba53500a8edac9093cf5d8c354</ProjectNTfsTestILCCurrentRef>
     <SniCurrentRef>ca04b94304beb477534b4fa0d6080089c21a0284</SniCurrentRef>
     <StandardCurrentRef>1ec7eb334c406a82a41c020e73ff1717a0e90f92</StandardCurrentRef>
   </PropertyGroup>
@@ -23,9 +23,9 @@
     <CoreFxExpectedPrerelease>preview2-25304-02</CoreFxExpectedPrerelease>
     <CoreClrExpectedPrerelease>preview2-25304-02</CoreClrExpectedPrerelease>
     <ExternalExpectedPrerelease>beta-25304-00</ExternalExpectedPrerelease>
-    <ProjectNTfsExpectedPrerelease>beta-25304-01</ProjectNTfsExpectedPrerelease>
-    <ProjectNTfsTestILCExpectedPrerelease>beta-25304-01</ProjectNTfsTestILCExpectedPrerelease>
-    <ProjectNTfsTestILCPackageVersion>1.0.0-beta-25304-01</ProjectNTfsTestILCPackageVersion>
+    <ProjectNTfsExpectedPrerelease>beta-25305-00</ProjectNTfsExpectedPrerelease>
+    <ProjectNTfsTestILCExpectedPrerelease>beta-25305-00</ProjectNTfsTestILCExpectedPrerelease>
+    <ProjectNTfsTestILCPackageVersion>1.0.0-beta-25305-00</ProjectNTfsTestILCPackageVersion>
     <NETStandardPackageVersion>2.0.0-preview2-25304-01</NETStandardPackageVersion>
     <NETStandardPackageId>NETStandard.Library</NETStandardPackageId>
     <!-- Use the SNI runtime package -->
@@ -114,7 +114,7 @@
     <XmlUpdateStep Include="ProjectNTfsTestILC">
       <Path>$(MSBuildThisFileFullPath)</Path>
       <ElementName>ProjectNTfsTestILCPackageVersion</ElementName>
-      <PackageId>TestILCNugetPackageForCoreFX</PackageId>
+      <PackageId>TestILC.amd64ret</PackageId>
     </XmlUpdateStep>
     <XmlUpdateStep Include="Sni">
       <Path>$(MSBuildThisFileFullPath)</Path>

--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -140,7 +140,10 @@
           AfterTargets="RestorePackages"
           Condition="'$(TargetGroup)' == 'uapaot'">
     <PropertyGroup>
-      <TestILCToolsPackageName>TestILCNugetPackageForCoreFX</TestILCToolsPackageName>
+      <TestILCToolsPackageName>TestILC</TestILCToolsPackageName>
+      <TestILCToolsPackageName Condition="'$(ArchGroup)' == 'x64'">$(TestILCToolsPackageName).amd64ret</TestILCToolsPackageName>
+      <TestILCToolsPackageName Condition="'$(ArchGroup)' == 'x86'">$(TestILCToolsPackageName).x86ret</TestILCToolsPackageName>
+      <TestILCToolsPackageName Condition="'$(ArchGroup)' == 'arm'">$(TestILCToolsPackageName).armret</TestILCToolsPackageName>
       <TestILCFolder Condition="'$(TestILCFolder)' == ''">$(PackagesDir)$(TestILCToolsPackageName)\$(ProjectNTfsTestILCPackageVersion)\TestILC</TestILCFolder>
       <TestILCFolder>$(TestILCFolder.Replace('/', '\'))</TestILCFolder>
     </PropertyGroup>

--- a/external/test-runtime/optional.json
+++ b/external/test-runtime/optional.json
@@ -4,7 +4,9 @@
       "dependencies": {
         "Microsoft.DotNet.IBCMerge": "4.6.0-alpha-00001",
         "Microsoft.DotNet.UAP.TestTools": "1.0.2",
-        "TestILCNugetPackageForCoreFX": "1.0.0-beta-25304-01"
+        "TestILC.amd64ret": "1.0.0-beta-25305-00",
+        "TestILC.armret": "1.0.0-beta-25305-00",
+        "TestILC.x86ret": "1.0.0-beta-25305-00"
       }
     }
   }


### PR DESCRIPTION
cc: @dagood @weshaggard @MattGal 

Yesterday we started to push TestILC packages for x86 and arm to our private feed, which required a change in the name of the package. These changes will fix that and also pick the right one to copy into the testhost folder.