### PR TITLE
Fix AutoResetEvent WaitHandle.WaitAll test on desktop

### DIFF
--- a/src/System.Threading/tests/AutoResetEventTests.cs
+++ b/src/System.Threading/tests/AutoResetEventTests.cs
@@ -59,7 +59,7 @@ namespace System.Threading.Tests
             }
             Assert.True(t.Result);
 
-            Assert.False(WaitHandle.WaitAll(handles, 0));
+            Assert.False(Task.Run(() => WaitHandle.WaitAll(handles, 0)).Result); // Task.Run used to ensure MTA thread (necessary for desktop)
         }
 
         [Fact]


### PR DESCRIPTION
Same as https://github.com/dotnet/corefx/pull/19172, but for an identical AutoResetEvent instead of ManualResetEvent test.

Fixes https://github.com/dotnet/corefx/issues/19389