### PR TITLE
Clear out user/machine package folders & sources.

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <!-- Don't use any higher level config files.
+       Our builds need to be isolated from user/machine state -->
+  <fallbackPackageFolders>
+    <clear />
+  </fallbackPackageFolders>
+  <packageSources>
+    <clear/>
+  </packageSources>
+</configuration>


### PR DESCRIPTION
We don't want our builds relying on any user or machine state for packages.

This is placed higher than src/NuGet.config because it also must apply to external.

The latest CLIs write the fallbackPackageFolders entry to the user's nuget.config: https://github.com/dotnet/cli/commit/a46237784eea57edb6f341b898a86065bfc5ff62
/cc @livarcocc 

This breaks our assumption that we'll always restore packages from the feed (needed for stabilization during release) and they'll always be placed in the repo's packages folder (needed for package harvesting and other places where we access packages outside of the NuGet/SDK targets).

I've noticed this cause two types of build breaks for us:
1. Some repo downloaded and ran a new CLI on a machine, that CLI registered a fallback packages folder to the repo's path, that repo was deleted once build was complete, another repo failed to restore because of the stale fallbackPackagesFolder entry.
2. A fallback packages folder was written, restore didn't populate the local packages folder for corefx and it failed during packaging because packages weren't restored (for harvesting) in the local packages folder.

To insulate ourselves from this user/machine state we make sure to place a nuget.config in the root that clears those settings.

I'm also going to look into turning off this behavior for the CLI.

/cc @weshaggard @Petermarcu 
