### PR TITLE
Add tests for UMS PositionPointer overflowing

### DIFF
--- a/src/System.IO.UnmanagedMemoryStream/tests/UmsSecurityTest.cs
+++ b/src/System.IO.UnmanagedMemoryStream/tests/UmsSecurityTest.cs
@@ -27,8 +27,6 @@ public class UmsSecurityTests
                         stream.PositionPointer = stream.PositionPointer - 1;
                     });
 
-                    Assert.Throws<ArgumentOutOfRangeException>(() => stream.PositionPointer = (byte*)ulong.MaxValue);
-
                     // Make sure that moving later than the length can be done but then
                     // fails appropriately during reads and writes, and that the stream's
                     // data is still intact after the fact
@@ -49,6 +47,8 @@ public class UmsSecurityTests
             {
                 ums.PositionPointer = (byte*)0xF0000000;
                 Assert.Equal(0xB0000000, ums.Position);
+
+                Assert.Throws<ArgumentOutOfRangeException>(() => ums.PositionPointer = (byte*)ulong.MaxValue);
             }
         }
     }

--- a/src/System.IO.UnmanagedMemoryStream/tests/UmsSecurityTest.cs
+++ b/src/System.IO.UnmanagedMemoryStream/tests/UmsSecurityTest.cs
@@ -39,6 +39,7 @@ public class UmsSecurityTests
     }
 
     [Fact]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetFX allows a negative Position following some PositionPointer overflowing inputs. See dotnet/coreclr#11376.")]
     public static void OverflowPositionPointer()
     {
         unsafe

--- a/src/System.IO.UnmanagedMemoryStream/tests/UmsSecurityTest.cs
+++ b/src/System.IO.UnmanagedMemoryStream/tests/UmsSecurityTest.cs
@@ -27,6 +27,8 @@ public class UmsSecurityTests
                         stream.PositionPointer = stream.PositionPointer - 1;
                     });
 
+                    Assert.Throws<ArgumentOutOfRangeException>(() => stream.PositionPointer = (byte*)ulong.MaxValue);
+
                     // Make sure that moving later than the length can be done but then
                     // fails appropriately during reads and writes, and that the stream's
                     // data is still intact after the fact
@@ -35,6 +37,19 @@ public class UmsSecurityTests
                     CheckStreamIntegrity(stream, data);
                 }
             } // fixed
+        }
+    }
+
+    [Fact]
+    public static void OverflowPositionPointer()
+    {
+        unsafe
+        {
+            using (var ums = new UnmanagedMemoryStream((byte*)0x40000000, 0xB8000000))
+            {
+                ums.PositionPointer = (byte*)0xF0000000;
+                Assert.Equal(0xB0000000, ums.Position);
+            }
         }
     }
 

--- a/src/System.IO.UnmanagedMemoryStream/tests/UmsWrite.cs
+++ b/src/System.IO.UnmanagedMemoryStream/tests/UmsWrite.cs
@@ -109,18 +109,10 @@ namespace System.IO.Tests
                 UnmanagedMemoryStream stream = manager.Stream;
                 UmsTests.WriteUmsInvariants(stream);
 
-                if (IntPtr.Size == 4)
-                {
-                    stream.Position = long.MaxValue;
-                    stream.Position = int.MaxValue;
-                }
-                else
-                {
-                    stream.Position = long.MaxValue;
-                    var bytes = new byte[3];
-                    Assert.Throws<IOException>(() => stream.Write(bytes, 0, bytes.Length));
-                    Assert.Throws<IOException>(() => stream.WriteByte(1));
-                }
+                stream.Position = long.MaxValue;
+                var bytes = new byte[3];
+                Assert.Throws<IOException>(() => stream.Write(bytes, 0, bytes.Length));
+                Assert.Throws<IOException>(() => stream.WriteByte(1));
             }
         }
 

--- a/src/System.IO.UnmanagedMemoryStream/tests/UmsWrite.cs
+++ b/src/System.IO.UnmanagedMemoryStream/tests/UmsWrite.cs
@@ -111,7 +111,7 @@ namespace System.IO.Tests
 
                 if (IntPtr.Size == 4)
                 {
-                    Assert.Throws<ArgumentOutOfRangeException>(() => stream.Position = long.MaxValue);
+                    stream.Position = long.MaxValue;
                     stream.Position = int.MaxValue;
                 }
                 else


### PR DESCRIPTION
Adds some tests for https://github.com/dotnet/coreclr/pull/11376 which resolved https://github.com/dotnet/coreclr/issues/11199.

Requires a new version of coreclr for the tests to pass.

cc: @jkotas 