### PR TITLE
Ignore lack of CURLMOPT_MAX_HOST_CONNECTIONS in CurlHandler

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxConnectionsPerServer.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxConnectionsPerServer.cs
@@ -62,16 +62,7 @@ namespace System.Net.Http.Functional.Tests
             using (var handler = new HttpClientHandler())
             using (var client = new HttpClient(handler))
             {
-                try
-                {
-                    handler.MaxConnectionsPerServer = 1;
-                }
-                catch (PlatformNotSupportedException)
-                {
-                    // Some older libcurls used in some of our Linux CI systems don't support this
-                    Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Linux));
-                }
-
+                handler.MaxConnectionsPerServer = 1;
                 await Task.WhenAll(
                     from i in Enumerable.Range(0, 5)
                     select client.GetAsync(Configuration.Http.RemoteEchoServer));


### PR DESCRIPTION
Versions before 7.30 don't have this option.  Previously we would throw a PlatformNotSupportedException.  As devs would generally use an option of this type to increase the limit (since historically such a limit was 2 or 10 in the .NET Framework) rather than decrease it, and since it's already effectively infinite by default in .NET Core, with this commit, now we just ignore it.  This helps to avoid PNSEs on the few platforms that still ship with too old a version of libcurl.

Fixes https://github.com/dotnet/corefx/issues/14614
cc: @geoffkizer, @Priya91, @davidsh