### PR TITLE
Fix spurious EventSource test failures due to framework sources

### DIFF
--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestUtilities.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestUtilities.cs
@@ -22,9 +22,11 @@ namespace BasicEventSourceTests
             string eventSourceNames = "";
             foreach (var eventSource in EventSource.GetSources())
             {
-                if (eventSource.Name != "System.Threading.Tasks.TplEventSource"
-                   && eventSource.Name != "System.Diagnostics.Eventing.FrameworkEventSource"
-                   && eventSource.Name != "System.Buffers.ArrayPoolEventSource")
+                // Exempt sources built in to the framework that might be used by types involved in the tests
+                if (eventSource.Name != "System.Threading.Tasks.TplEventSource" &&
+                    eventSource.Name != "System.Diagnostics.Eventing.FrameworkEventSource" &&
+                    eventSource.Name != "System.Buffers.ArrayPoolEventSource" &&
+                    eventSource.Name != "System.Threading.SynchronizationEventSource")
                 {
                     eventSourceNames += eventSource.Name + " ";
                 }

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsUserErrors.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsUserErrors.cs
@@ -62,7 +62,6 @@ namespace BasicEventSourceTests
         /// Test the 
         /// </summary>
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18805")]
         public void Test_BadEventSource_MismatchedIds()
         {
 #if USE_ETW // TODO: Enable when TraceEvent is available on CoreCLR. GitHub issue #4864.

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWrite.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWrite.cs
@@ -39,7 +39,6 @@ namespace BasicEventSourceTests
         /// Tests the EventListener code path
         /// </summary>
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18805")]
         public void Test_Write_T_EventListener()
         {
             using (var listener = new EventListenerListener())
@@ -53,7 +52,6 @@ namespace BasicEventSourceTests
         /// Tests the EventListener code path using events instead of virtual callbacks.
         /// </summary>
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18805")]
         public void Test_Write_T_EventListener_UseEvents()
         {
             Test_Write_T(new EventListenerListener(true));


### PR DESCRIPTION
Some of the EventSource tests check to verify that EventSources have been properly shutdown and can no longer be found in EventSource.GetSources.  But the framework itself has several event sources used by core types, and if the tests end up using these types, those sources can end up triggering a failure.  As such, the test exempts known framework sources, but it missed SynchronizationEventSource (used by types like SpinWait).  This just adds it to the list of sources to exempt.

Fixes https://github.com/dotnet/corefx/issues/18805
cc: @vancem, @brianrob 