### PR TITLE
Fix svc test for nano

### DIFF
--- a/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/SafeServiceControllerTests.cs
+++ b/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/SafeServiceControllerTests.cs
@@ -27,7 +27,7 @@ namespace System.ServiceProcess.Tests
                     case KeyIsoSvcName:
                         foundKeyIsoSvc = true;
                         Assert.False(string.IsNullOrEmpty(service.DisplayName), "string.IsNullOrEmpty(KeyIso.DisplayName)");
-                        Assert.True(service.CanStop, "KeyIso.CanStop");
+                        Assert.Equal(PlatformDetection.IsNotWindowsNanoServer, service.CanStop);
                         Assert.False(service.CanPauseAndContinue, "KeyIso.CanPauseAndContinue");
                         Assert.False(service.CanShutdown, "KeyIso.CanShutdown");
                         Assert.Equal(ServiceType.Win32ShareProcess, service.ServiceType);
@@ -41,6 +41,11 @@ namespace System.ServiceProcess.Tests
                         Assert.False(service.CanShutdown, "SamSs.CanShutdown");
                         Assert.Equal(ServiceType.Win32ShareProcess, service.ServiceType);
                         Assert.Equal(ServiceStartMode.Automatic, service.StartType);
+                        break;
+                    case "EVENTLOG":
+                        Assert.False(string.IsNullOrEmpty(service.DisplayName), "string.IsNullOrEmpty(EventLog.DisplayName)");
+                        Assert.True(service.CanStop, "EventLog.CanStop");
+                        Assert.True(service.CanShutdown, "EventLog.CanShutdown");
                         break;
                     default:
                         foundOtherSvc = true;

--- a/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/System.ServiceProcess.ServiceController.Tests.csproj
+++ b/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/System.ServiceProcess.ServiceController.Tests.csproj
@@ -13,6 +13,9 @@
     <Compile Include="$(CommonTestPath)\System\AssertExtensions.cs">
       <Link>Common\System\AssertExtensions.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>CommonTest\System\PlatformDetection.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)'=='true' AND '$(Platform)'!='arm64'">
     <ProjectReference Include="..\System.ServiceProcess.ServiceController.TestNativeService\System.ServiceProcess.ServiceController.TestNativeService.vcxproj">


### PR DESCRIPTION
Fix https://github.com/dotnet/corefx/issues/19223

On Nano, the keysvc test returns false for CanStop.
Threw in another service which should return true for CanStop for every OS