### PR TITLE
Fix EnumConverter porting bug around ArrayList

### DIFF
--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EnumConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EnumConverter.cs
@@ -228,11 +228,11 @@ namespace System.ComponentModel
                 Type reflectType = TypeDescriptor.GetReflectionType(EnumType) ?? EnumType;
 
                 FieldInfo[] fields = reflectType.GetFields(BindingFlags.Public | BindingFlags.Static);
-                List<object> objValues = null;
+                ArrayList objValues = null;
 
                 if (fields != null && fields.Length > 0)
                 {
-                    objValues = new List<object>(fields.Length);
+                    objValues = new ArrayList(fields.Length);
                 }
 
                 if (objValues != null)
@@ -271,7 +271,7 @@ namespace System.ComponentModel
                     IComparer comparer = Comparer;
                     if (comparer != null)
                     {
-                        objValues.Sort((IComparer<object>) comparer);
+                        objValues.Sort(comparer);
                     }
                 }
 

--- a/src/System.ComponentModel.TypeConverter/tests/EnumConverterTest.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/EnumConverterTest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Globalization;
+using System.Linq;
 using Xunit;
 
 namespace System.ComponentModel.Tests
@@ -95,6 +96,15 @@ namespace System.ComponentModel.Tests
 
             Assert.Throws<ArgumentException>(
                 () => new EnumConverter(typeof(Enum)).ConvertTo(TypeConverterTests.s_context, null, SomeFlagsEnum.Option1, typeof(string)));
+        }
+
+        [Fact]
+        public static void GetStandardValues_Succeeds()
+        {
+            var converter = new EnumConverter(typeof(SomeEnum));
+            SomeEnum[] standardValues = converter.GetStandardValues().Cast<SomeEnum>().ToArray();
+            Assert.Equal(Enum.GetNames(typeof(SomeEnum)).Length, standardValues.Length);
+            Assert.All(Enum.GetValues(typeof(SomeEnum)).Cast<SomeEnum>(), value => Assert.Contains(value, standardValues));
         }
 
         private static void VerifyArraysEqual<T>(T[] expected, object actual)


### PR DESCRIPTION
EnumConverter.GetStandardValues switched from using `ArrayList` to `List<object>` when it was ported to .NET Core.  But it performs sorting using the non-generic IComparer, which `List<object>` doesn't have APIs for.  Rather than trying to work around the difference, it makes sense to just revert to using ArrayList.

Fixes https://github.com/dotnet/corefx/issues/19461
cc: @safern