### PR TITLE
Disable two System.Net.Security tests on desktop

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
@@ -42,6 +42,7 @@ namespace System.Net.Security.Tests
             await ServerAsyncSslHelper(protocol, protocol);
         }
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "These protocols are explicitly disabled on .NET Core but still supported on .NET Framework.")] 
         [Theory]
         [ClassData(typeof(SslProtocolSupport.UnsupportedSslProtocolsTestData))]
         public async Task ServerAsyncAuthenticate_EachServerUnsupportedProtocol_Fail(SslProtocols protocol)
@@ -73,6 +74,7 @@ namespace System.Net.Security.Tests
                 });
         }
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "These protocols are explicitly disabled on .NET Core but still supported on .NET Framework.")] 
         [Fact]
         public async Task ServerAsyncAuthenticate_UnsupportedAllServer_Fail()
         {


### PR DESCRIPTION
These tests are .NET Core-specific, as they're verifying that protocols that have been explicitly made unsupported for security reasons fail appropriately, but they're still supported on desktop.

Fixes https://github.com/dotnet/corefx/issues/19456
Fixes https://github.com/dotnet/corefx/issues/19458
cc: @cipop, @davidsh, @safern