### PR TITLE
Re-enable System.Dynamic.Runtime test

### DIFF
--- a/src/System.Dynamic.Runtime/tests/Dynamic.Simple/VarianceTest.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Simple/VarianceTest.cs
@@ -19,7 +19,6 @@ namespace SampleDynamicTests
         private delegate T Create<out T>();
 
         [Fact]
-        [ActiveIssue(16748)]
         public static void VarianceTest_RunTest()
         {
             dynamic d1 = (Create<Tiger>)(() => new Tiger());


### PR DESCRIPTION
The test passes on both desktop and core.  It shouldn't be disabled.
Closes https://github.com/dotnet/corefx/issues/16748
cc: @VSadov 