### PR TITLE
Avoid file collisions with temporary test files

### DIFF
--- a/src/Common/tests/System/IO/FileCleanupTestBase.cs
+++ b/src/Common/tests/System/IO/FileCleanupTestBase.cs
@@ -78,6 +78,11 @@ namespace System.IO
         /// <param name="memberName">The member name of the function calling this method.</param>
         /// <param name="lineNumber">The line number of the function calling this method.</param>
         protected string GetTestFileName(int? index = null, [CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0) =>
-            string.Format(index.HasValue ? "{0}_{1}_{2}" : "{0}_{1}", memberName ?? "TestBase", lineNumber, index.GetValueOrDefault());
+            string.Format(
+                index.HasValue ? "{0}_{1}_{2}_{3}" : "{0}_{1}_{3}",
+                memberName ?? "TestBase",
+                lineNumber,
+                index.GetValueOrDefault(),
+                Guid.NewGuid().ToString("N").Substring(0, 8)); // randomness to avoid collisions between derived test classes using same base method concurrently
     }
 }

--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
@@ -388,19 +388,19 @@ namespace System.IO.Tests
         {
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
             string testBase = GetTestFileName();
-            testDir.CreateSubdirectory(testBase + "aBBb");
-            testDir.CreateSubdirectory(testBase + "aBBB");
+            testDir.CreateSubdirectory(testBase + "yZZz");
+            testDir.CreateSubdirectory(testBase + "yZZZ");
 
-            File.Create(Path.Combine(testDir.FullName, testBase + "AAAA")).Dispose();
-            File.Create(Path.Combine(testDir.FullName, testBase + "aAAa")).Dispose();
+            File.Create(Path.Combine(testDir.FullName, testBase + "YYYY")).Dispose();
+            File.Create(Path.Combine(testDir.FullName, testBase + "yYYy")).Dispose();
 
             if (TestDirectories)
             {
-                Assert.Equal(1, GetEntries(testDir.FullName, "*BB*").Length);
+                Assert.Equal(1, GetEntries(testDir.FullName, "*ZZ*").Length);
             }
             if (TestFiles)
             {
-                Assert.Equal(1, GetEntries(testDir.FullName, "*AA*").Length);
+                Assert.Equal(1, GetEntries(testDir.FullName, "*YY*").Length);
             }
         }
 


### PR DESCRIPTION
In some of our test suites, we use a pattern where a base class contains the core test logic and then derived classes override various members in those base classes to customize the actual tests.  xunit then runs the base methods for each of the derived types.

Since xunit by default parallelizes inter-class, meaning it won't parallelize tests on the same class but will on different classes, tests on the base class may run in parallel with themselves, though, when actually being run for different concrete derived types.  This is problematic when the tests pick temporary file names based on the test itself, e.g. using the FileCleanupTestBase helper that derives a temporary file name from the current member name, line number, etc.

To avoid such conflicts, this changes adds a random identifier into each such temporary file name.

Fixes https://github.com/dotnet/corefx/issues/12993
cc: @ianhays, @JeremyKuhne 