### PR TITLE
CoreFX on ILC tests burndown

### DIFF
--- a/src/System.Reflection/tests/ParameterInfoTests.cs
+++ b/src/System.Reflection/tests/ParameterInfoTests.cs
@@ -151,10 +151,7 @@ namespace System.Reflection.Tests
         }
 
         [Theory]
-        [InlineData(typeof(OptionalAttribute))]
-        [InlineData(typeof(MarshalAsAttribute))]
-        [InlineData(typeof(OutAttribute))]
-        [InlineData(typeof(InAttribute))]
+        [MemberData(nameof(s_CustomAttributesTestData))]
         public void CustomAttributesTest(Type attrType)
         {
             ParameterInfo parameterInfo = GetParameterInfo(typeof(ParameterInfoMetadata), "MethodWithOptionalDefaultOutInMarshalParam", 0);
@@ -170,6 +167,20 @@ namespace System.Reflection.Tests
             Assert.NotNull(prov.GetCustomAttributes(true).SingleOrDefault(a => a.GetType().Equals(attrType)));
             Assert.True(prov.IsDefined(attrType, false));
             Assert.True(prov.IsDefined(attrType, true));
+        }
+
+        public static IEnumerable<object[]> s_CustomAttributesTestData
+        {
+            get
+            {
+                yield return new object[] { typeof(OptionalAttribute) };
+                yield return new object[] { typeof(OutAttribute) };
+                yield return new object[] { typeof(InAttribute) };
+                if (!PlatformDetection.IsNetNative) // Native Metadata format does not expose FieldMarshal info: https://github.com/dotnet/corert/issues/3366
+                {
+                    yield return new object[] { typeof(MarshalAsAttribute) };
+                }
+            }
         }
 
         [Theory]

--- a/src/System.Reflection/tests/System.Reflection.Tests.csproj
+++ b/src/System.Reflection/tests/System.Reflection.Tests.csproj
@@ -26,6 +26,11 @@
     <Compile Include="ExceptionTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>Common\System\PlatformDetection.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="Resources\EmbeddedImage.png">
       <LogicalName>EmbeddedImage.png</LogicalName>
     </EmbeddedResource>

--- a/src/System.Runtime/tests/System/Reflection/CustomAttributeDataTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/CustomAttributeDataTests.cs
@@ -136,7 +136,7 @@ namespace System.Reflection.Tests
             {
                 if (cad.AttributeType == typeof(MyAttribute))
                 {
-                    Assert.Equal("[System.Reflection.Tests.CustomAttributeDataTests+MyAttribute((Int32)3)]", cad.ToString());
+                    Assert.NotNull(cad.ToString());
                     return;
                 }
             }

--- a/src/System.Runtime/tests/System/TypeTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/TypeTests.netcoreapp.cs
@@ -24,10 +24,7 @@ namespace System.Tests
 
             if (PlatformDetection.IsWindows)
             {
-                if (!PlatformDetection.IsNetNative)  // .Net Native - MakeArrayType() of these magic types throws exception: (https://github.com/dotnet/corert/issues/3522)
-                {
-                    NonArrayBaseTypes.Add(Type.GetTypeFromCLSID(default(Guid)));
-                }
+                NonArrayBaseTypes.Add(Type.GetTypeFromCLSID(default(Guid)));
             }
         }
 


### PR DESCRIPTION
Getting down to 1-bucket items here...

- Disabled MarshalAs custom attribute test
  (not implemented on .Net Native)

- Reenabled GetTypeFromCLSID() data item
  (restored on .Net Native)

- Avoid testing contents of ToString()
  (.Net Native ToString() simplifies the type name
  in order to avoid excess metadata probing.)