### PR TITLE
Fix Mono bug #52508 in HttpListener when doing multiple Https request.

### DIFF
--- a/src/System.Net.HttpListener/src/System/Net/Managed/HttpConnection.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/HttpConnection.cs
@@ -103,6 +103,9 @@ namespace System.Net
             }
 
             _timer = new Timer(OnTimeout, null, Timeout.Infinite, Timeout.Infinite);
+            if (_sslStream != null) {
+                _sslStream.AuthenticateAsServer (_cert, true, (SslProtocols)ServicePointManager.SecurityProtocol, false);
+            }
             Init();
         }
 
@@ -118,11 +121,6 @@ namespace System.Net
 
         private void Init()
         {
-            if (_sslStream != null)
-            {
-                _sslStream.AuthenticateAsServer(_cert, true, (SslProtocols)ServicePointManager.SecurityProtocol, false);
-            }
-
             _contextBound = false;
             _requestStream = null;
             _responseStream = null;


### PR DESCRIPTION
Move the call to SslStream.AuthenticateAsServer() into the constructor because
we don't want to call it again when Init() is called from Close().