### PR TITLE
Mono-specific HttpListener additions.

### DIFF
--- a/src/System.Net.HttpListener/src/System.Net.HttpListener.csproj
+++ b/src/System.Net.HttpListener/src/System.Net.HttpListener.csproj
@@ -329,6 +329,7 @@
     <Compile Include="System\Net\Managed\ListenerPrefix.cs" />
     <Compile Include="System\Net\Managed\HttpRequestStream.Managed.cs" />
     <Compile Include="System\Net\Managed\HttpListener.Managed.cs" />
+    <Compile Include="System\Net\Managed\HttpListener.Certificates.cs" />
     <Compile Include="System\Net\Managed\HttpListenerContext.Managed.cs" />
     <Compile Include="System\Net\Managed\HttpListenerRequest.Managed.cs" />
     <Compile Include="System\Net\Managed\HttpListenerResponse.Managed.cs" />

--- a/src/System.Net.HttpListener/src/System/Net/Managed/HttpConnection.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/HttpConnection.cs
@@ -116,6 +116,11 @@ namespace System.Net
             get { return _clientCert; }
         }
 
+        internal SslStream SslStream
+        {
+            get { return _sslStream; }
+        }
+
         private void Init()
         {
             if (_sslStream != null)

--- a/src/System.Net.HttpListener/src/System/Net/Managed/HttpEndPointListener.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/HttpEndPointListener.cs
@@ -55,12 +55,7 @@ namespace System.Net
             if (secure)
             {
                 _secure = secure;
-                // TODO #14691: Implement functionality to read SSL certificate.
-#if MONO
                 _cert = _listener.LoadCertificateAndKey (addr, port);
-#else
-                _cert = null;
-#endif
             }
 
             _endpoint = new IPEndPoint(addr, port);

--- a/src/System.Net.HttpListener/src/System/Net/Managed/HttpEndPointListener.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/HttpEndPointListener.cs
@@ -56,7 +56,11 @@ namespace System.Net
             {
                 _secure = secure;
                 // TODO #14691: Implement functionality to read SSL certificate.
+#if MONO
+                _cert = _listener.LoadCertificateAndKey (addr, port);
+#else
                 _cert = null;
+#endif
             }
 
             _endpoint = new IPEndPoint(addr, port);

--- a/src/System.Net.HttpListener/src/System/Net/Managed/HttpListener.Certificates.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/HttpListener.Certificates.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
 
 namespace System.Net
 {

--- a/src/System.Net.HttpListener/src/System/Net/Managed/HttpListener.Certificates.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/HttpListener.Certificates.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Security;
+
+namespace System.Net
+{
+    partial class HttpListener
+    {
+        internal SslStream CreateSslStream(Stream innerStream, bool ownsStream, RemoteCertificateValidationCallback callback)
+        {
+            return new SslStream(innerStream, ownsStream, callback);
+        }
+
+        internal X509Certificate LoadCertificateAndKey(IPAddress addr, int port)
+        {
+            // TODO #14691: Implement functionality to read SSL certificate.
+            return null;
+        }
+    }
+}

--- a/src/System.Net.HttpListener/src/System/Net/Managed/HttpListener.Managed.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/HttpListener.Managed.cs
@@ -18,10 +18,13 @@ namespace System.Net
         private List<ListenerAsyncResult> _asyncWaitQueue = new List<ListenerAsyncResult>();
         private Dictionary<HttpConnection, HttpConnection> _connections = new Dictionary<HttpConnection, HttpConnection>();
 
+#if !MONO
+        // We have a custom version of this method.
         internal SslStream CreateSslStream(Stream innerStream, bool ownsStream, RemoteCertificateValidationCallback callback)
         {
             return new SslStream(innerStream, ownsStream, callback);
         }
+#endif
 
         public HttpListenerTimeoutManager TimeoutManager
         {

--- a/src/System.Net.HttpListener/src/System/Net/Managed/HttpListener.Managed.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/HttpListener.Managed.cs
@@ -18,14 +18,6 @@ namespace System.Net
         private List<ListenerAsyncResult> _asyncWaitQueue = new List<ListenerAsyncResult>();
         private Dictionary<HttpConnection, HttpConnection> _connections = new Dictionary<HttpConnection, HttpConnection>();
 
-#if !MONO
-        // We have a custom version of this method.
-        internal SslStream CreateSslStream(Stream innerStream, bool ownsStream, RemoteCertificateValidationCallback callback)
-        {
-            return new SslStream(innerStream, ownsStream, callback);
-        }
-#endif
-
         public HttpListenerTimeoutManager TimeoutManager
         {
             get


### PR DESCRIPTION
* Move HttpListener.CreateSslStream() into new partial class.

* Add new internal HttpListener.LoadCertificateAndKey() and call it from HttpEndPointListener's .ctor.