### PR TITLE
Solve System.Net.Sockets tests crash

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
@@ -101,7 +101,6 @@ namespace System.Net.Sockets.Tests
         public void SendFile_Synchronous(IPAddress listenAt, bool sendPreAndPostBuffers, int bytesToSend)
         {
             const int ListenBacklog = 1;
-            const int LingerTime = 10;
             const int TestTimeout = 30000;
 
             // Create file to send
@@ -153,7 +152,6 @@ namespace System.Net.Sockets.Tests
             {
                 client.SendFile(filename, preBuffer, postBuffer, TransmitFileOptions.UseDefaultWorkerThread);
 
-                client.LingerState = new LingerOption(true, LingerTime);
                 client.Shutdown(SocketShutdown.Send);
             }
 

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
@@ -154,6 +154,7 @@ namespace System.Net.Sockets.Tests
                 client.SendFile(filename, preBuffer, postBuffer, TransmitFileOptions.UseDefaultWorkerThread);
 
                 client.LingerState = new LingerOption(true, LingerTime);
+                client.Shutdown(SocketShutdown.Send);
             }
 
             Assert.True(serverThread.Join(TestTimeout), "Completed within allowed time");


### PR DESCRIPTION
I can reproduce the crash on my dev machine, explanation of the crash is here: https://github.com/dotnet/corefx/issues/13114#issuecomment-290554256. Client use RST to close the connection instead of FIN.

Shutdown() socket before dispose() will fix this test crash.

Fix #19428 