### PR TITLE
Fix UMS 32bit PositionPointer test.

### DIFF
--- a/src/System.IO.UnmanagedMemoryStream/tests/UmsSecurityTest.cs
+++ b/src/System.IO.UnmanagedMemoryStream/tests/UmsSecurityTest.cs
@@ -38,7 +38,6 @@ public class UmsSecurityTests
         }
     }
 
-    [ActiveIssue(19444)]
     [Fact]
     [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetFX allows a negative Position following some PositionPointer overflowing inputs. See dotnet/coreclr#11376.")]
     public static void OverflowPositionPointer()
@@ -50,7 +49,15 @@ public class UmsSecurityTests
                 ums.PositionPointer = (byte*)0xF0000000;
                 Assert.Equal(0xB0000000, ums.Position);
 
-                Assert.Throws<ArgumentOutOfRangeException>(() => ums.PositionPointer = (byte*)ulong.MaxValue);
+                if (IntPtr.Size == 4)
+                {
+                    ums.PositionPointer = (byte*)ulong.MaxValue;
+                    Assert.Equal(uint.MaxValue - 0x40000000, ums.Position);
+                }
+                else
+                {
+                    Assert.Throws<ArgumentOutOfRangeException>(() => ums.PositionPointer = (byte*)ulong.MaxValue);
+                }
             }
         }
     }


### PR DESCRIPTION
The purpose of the test is to make the PositionPointer setter cast ulong.MaxValue to a long, producing -1 which will always be less than the UMS pointer so the final newPosition will be negative. On a 32 bit system where the pointer length is 4, the max value passable to the PositionPointer setter is uint.MaxValue. So in the test when we cast a value greater than uint.MaxValue to the 4-byte byte* we only get the uint.MaxValue bytes. Since casting a 4-byte pointer to a long will never result in overflow, the AOoRE can never be hit.

resolves https://github.com/dotnet/corefx/issues/19444
related to https://github.com/dotnet/corefx/pull/19412

cc: @jkotas @stephentoub 