### PR TITLE
Block opening the Disallowed X509Store on Linux

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/StorePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/StorePal.cs
@@ -136,11 +136,18 @@ namespace Internal.Cryptography.Pal
 
         public static IStorePal FromSystemStore(string storeName, StoreLocation storeLocation, OpenFlags openFlags)
         {
-            if (storeLocation != StoreLocation.LocalMachine)
+            if (storeLocation == StoreLocation.CurrentUser)
             {
+                if (X509Store.DisallowedStoreName.Equals(storeName, StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new PlatformNotSupportedException(SR.Cryptography_Unix_X509_NoDisallowedStore);
+                }
+
                 return new DirectoryBasedStoreProvider(storeName, openFlags);
             }
 
+            Debug.Assert(storeLocation == StoreLocation.LocalMachine);
+            
             if ((openFlags & OpenFlags.ReadWrite) == OpenFlags.ReadWrite)
             {
                 throw new PlatformNotSupportedException(SR.Cryptography_Unix_X509_MachineStoresReadOnly);
@@ -160,12 +167,12 @@ namespace Internal.Cryptography.Pal
                 }
             }
 
-            if (StringComparer.Ordinal.Equals("Root", storeName))
+            if (X509Store.RootStoreName.Equals(storeName, StringComparison.OrdinalIgnoreCase))
             {
                 return s_machineRootStore;
             }
 
-            if (StringComparer.Ordinal.Equals("CA", storeName))
+            if (X509Store.IntermediateCAStoreName.Equals(storeName, StringComparison.OrdinalIgnoreCase))
             {
                 return s_machineIntermediateStore;
             }

--- a/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
@@ -193,6 +193,9 @@
   <data name="Cryptography_Unix_X509_MachineStoresRootOnly" xml:space="preserve">
     <value>Unix LocalMachine X509Store is limited to the Root and CertificateAuthority stores.</value>
   </data>
+  <data name="Cryptography_Unix_X509_NoDisallowedStore" xml:space="preserve">
+    <value>The Disallowed store is not supported on this platform.</value>
+  </data>
   <data name="Cryptography_Unix_X509_PropertyNotSettable" xml:space="preserve">
       <value>The {0} value cannot be set on Unix.</value>
   </data>

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Store.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Store.cs
@@ -10,6 +10,10 @@ namespace System.Security.Cryptography.X509Certificates
 {
     public sealed class X509Store : IDisposable
     {
+        internal const string RootStoreName = "Root";
+        internal const string IntermediateCAStoreName = "CA";
+        internal const string DisallowedStoreName = "Disallowed";
+
         private IStorePal _storePal;
 
         public X509Store()
@@ -46,16 +50,16 @@ namespace System.Security.Cryptography.X509Certificates
                     Name = "AuthRoot";
                     break;
                 case StoreName.CertificateAuthority:
-                    Name = "CA";
+                    Name = IntermediateCAStoreName;
                     break;
                 case StoreName.Disallowed:
-                    Name = "Disallowed";
+                    Name = DisallowedStoreName;
                     break;
                 case StoreName.My:
                     Name = "My";
                     break;
                 case StoreName.Root:
-                    Name = "Root";
+                    Name = RootStoreName;
                     break;
                 case StoreName.TrustedPeople:
                     Name = "TrustedPeople";


### PR DESCRIPTION
On Linux we don't use the Disallowed store for making (anti-)trust decisions, but
since we didn't go out of our way to block it a user can reference it either by
name or the StoreName enum and we'll happily create a store of that name, it
just won't do what the user expects.

So we should throw if they try to open the store, so we're not construed as
implicitly making promises that we don't follow through on.