### PR TITLE
Replace test shared framework with the runtime packages

### DIFF
--- a/SharedFrameworkValidation.cmd
+++ b/SharedFrameworkValidation.cmd
@@ -5,5 +5,5 @@ call %~dp0sync.cmd
 if NOT [%ERRORLEVEL%]==[0] exit /b 1
 call %~dp0build-managed.cmd -Project:%~dp0src\SharedFrameworkValidation\SharedFrameworkValidation.proj -- /t:ReBuild
 if NOT [%ERRORLEVEL%]==[0] exit /b 1
-call %~dp0build-tests.cmd -SkipTests -- /p:RefPath=%~dp0bin\ref\SharedFrameworkValidation /p:RunningSharedFrameworkValidation=true /p:RuntimePath=%~dp0bin\runtime\SharedFrameworkValidation\
+call %~dp0build-tests.cmd -- /p:RefPath=%~dp0bin\ref\SharedFrameworkValidation /p:RunningSharedFrameworkValidation=true /p:RuntimePath=%~dp0bin\runtime\SharedFrameworkValidation\
 exit /b %ERRORLEVEL%

--- a/src/SharedFrameworkValidation/SharedFrameworkValidation.proj
+++ b/src/SharedFrameworkValidation/SharedFrameworkValidation.proj
@@ -37,7 +37,37 @@
     <Copy SourceFiles="%(XunitAssemblies.Identity)" DestinationFolder="$(SharedFrameworkValidationRuntimePath)" />
   </Target>
 
-  <Target Name="Build" DependsOnTargets="RestorePackagesProject;BuildPackagesProject;PublishPackagesProject;CopyXunitAssemblies" />
+  <Target Name="ReplaceTestingSharedFrameworkWithRestoredPackages">
+    <!-- Deleting the contents of the test shared framework since it will be replaced. -->
+    <ItemGroup>
+      <_FilesToDelete Include="$(NETCoreAppTestSharedFrameworkPath)\*.*" />
+    </ItemGroup>
+    <Delete Files="@(_FilesToDelete)" />
+
+    <ItemGroup>
+      <_FilesToCopy Include="$(SharedFrameworkValidationRuntimePath)\*.*" />
+    </ItemGroup>
+    <Copy SourceFiles="%(_FilesToCopy.Identity)" DestinationFolder="$(NETCoreAppTestSharedFrameworkPath)" />
+  </Target>
+
+  <Target Name="GenerateTestSharedFrameworkDepsFile">
+    <MSBuild Targets="GenerateTestSharedFrameworkDepsFile"
+             Projects="$(MSBuildThisFileDirectory)\..\src.builds"
+             ContinueOnError="ErrorAndStop" />
+  </Target>
+
+  <PropertyGroup>
+    <BuildDependsOn>
+      RestorePackagesProject;
+      BuildPackagesProject;
+      PublishPackagesProject;
+      CopyXunitAssemblies;
+      ReplaceTestingSharedFrameworkWithRestoredPackages;
+      GenerateTestSharedFrameworkDepsFile;
+    </BuildDependsOn>
+  </PropertyGroup>
+
+  <Target Name="Build" DependsOnTargets="$(BuildDependsOn)" />
   <Target Name="Clean">
     <RemoveDir Directories="$(MSBuildThisFileDirectory)RestoreSDKProject\obj;$(MSBuildThisFileDirectory)RestoreSDKProject\bin;$(SharedFrameworkValidationRefPath);$(SharedFrameworkValidationRuntimePath)" />
   </Target>


### PR DESCRIPTION
Progress towards #18083 
cc: @weshaggard @ericstj @danmosemsft 

Using the runtime packages that were restored as the shared framework that the tests will run against. After this is in, the last pieces missing would be:

1. Find a form to get the right hash of corefx in order to match the test source with the packages that were restored.
2. Run the different ApiCompat runs that we care about with what we restored.