### PR TITLE
Whether serializer can deserialize different datetime formats on any OS

### DIFF
--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -2654,6 +2654,22 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
+    public static void DCJS_DeserializeDateTimeForDifferentFormats()
+    {
+        var jsonTypes = new JsonTypes();
+        var dcjsSettings = new DataContractJsonSerializerSettings()
+        {
+            DateTimeFormat = jsonTypes.DTF_hmsFt,
+            UseSimpleDictionaryFormat = true,
+            EmitTypeInformation = EmitTypeInformation.AsNeeded,
+            KnownTypes = new List<Type>()
+        };
+        var value1 = DeserializeString<DateTime>("\"03:58:32.00 a.m.\"", true, dcjsSettings);
+        var value2 = DeserializeString<DateTime>("\"03:58:32.00 a. m.\"", true, dcjsSettings);
+        Assert.Equal(value1, value2);
+    }
+
+    [Fact]
     public static void DCJS_VerifyDictionaryTypes()
     {
         var dcjsSettings = new DataContractJsonSerializerSettings()


### PR DESCRIPTION
@shmao
According to the results that serializer can't deserialize both formats on our test OS