### PR TITLE
Enable Environment.Exit tests and update DotNetHost and DotNetHostPolicy versions

### DIFF
--- a/external/runtime/runtime.depproj
+++ b/external/runtime/runtime.depproj
@@ -37,10 +37,10 @@
       <Version>4.4.0-$(CoreFxExpectedPrerelease)</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.DotNetHost">
-      <Version>1.2.0-beta-001259-00</Version>
+      <Version>2.0.0-preview2-002093-00</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.DotNetHostPolicy">
-      <Version>1.2.0-beta-001259-00</Version>
+      <Version>2.0.0-preview2-002093-00</Version>
     </PackageReference>
   </ItemGroup>
 

--- a/src/System.Runtime.Extensions/tests/System/Environment.Exit.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.Exit.cs
@@ -49,7 +49,6 @@ namespace System.Tests
             Environment.ExitCode = 0; // in case the test host has a void returning Main
         }
 
-        [ActiveIssue("https://github.com/dotnet/coreclr/issues/6206")]
         [Theory]
         [InlineData(1)] // setting ExitCode and exiting Main
         [InlineData(2)] // setting ExitCode both from Main and from an Unloading event handler.


### PR DESCRIPTION
Related: https://github.com/dotnet/corefx/pull/19232
As I can't push into mazons PR I try it here.
