### PR TITLE
Enable System.Net.Requests.Tests to run in parallel again

### DIFF
--- a/src/System.Net.Requests/tests/AssemblyInfo.cs
+++ b/src/System.Net.Requests/tests/AssemblyInfo.cs
@@ -1,9 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-using Xunit;
-
-// We have to run them with no parallelism because ServicePointManager.DefaultConnectionLimit is left as 2 in netfx and when they are running in parallel
-// it leaves too many connections open at once which causes tests to hang since they are not able to get a new HttpWebRequest connection opened.
-[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly, DisableTestParallelization = true, MaxParallelThreads = 1)]

--- a/src/System.Net.Requests/tests/AuthenticationManagerTest.cs
+++ b/src/System.Net.Requests/tests/AuthenticationManagerTest.cs
@@ -3,14 +3,14 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections;
-using System.Net.Security;
+using System.Diagnostics;
 using Xunit;
 
 #pragma warning disable CS0618 // obsolete warnings
 
 namespace System.Net.Tests
 {
-    public class AuthenticationManagerTest
+    public class AuthenticationManagerTest : RemoteExecutorTestBase
     {
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "AuthenticationManager supported on NETFX")]
         [Fact]
@@ -29,11 +29,30 @@ namespace System.Net.Tests
         [Fact]
         public void Register_Unregister_ModuleCountUnchanged()
         {
-            int initialCount = GetModuleCount();
-            IAuthenticationModule module = new CustomModule();
-            AuthenticationManager.Register(module);
-            AuthenticationManager.Unregister(module);
-            Assert.Equal(initialCount, GetModuleCount());
+            RemoteInvoke(() =>
+            {
+                int initialCount = GetModuleCount();
+                IAuthenticationModule module = new CustomModule();
+                AuthenticationManager.Register(module);
+                AuthenticationManager.Unregister(module);
+                Assert.Equal(initialCount, GetModuleCount());
+
+                return SuccessExitCode;
+            }).Dispose();           
+        }
+
+        public void Register_UnregisterByScheme_ModuleCountUnchanged()
+        {
+            RemoteInvoke(() =>
+            {
+                int initialCount = GetModuleCount();
+                IAuthenticationModule module = new CustomModule();
+                AuthenticationManager.Register(module);
+                AuthenticationManager.Unregister("custom");
+                Assert.Equal(initialCount, GetModuleCount());
+
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         public void Register_UnregisterByScheme_ModuleCountUnchanged()
@@ -59,12 +78,17 @@ namespace System.Net.Tests
         {
             Assert.Null(AuthenticationManager.CredentialPolicy);
 
-            ICredentialPolicy cp = new DummyCredentialPolicy();
-            AuthenticationManager.CredentialPolicy = cp;
-            Assert.Same(cp, AuthenticationManager.CredentialPolicy);
+            RemoteInvoke(() =>
+            {
+                ICredentialPolicy cp = new DummyCredentialPolicy();
+                AuthenticationManager.CredentialPolicy = cp;
+                Assert.Same(cp, AuthenticationManager.CredentialPolicy);
 
-            AuthenticationManager.CredentialPolicy = null;
-            Assert.Null(AuthenticationManager.CredentialPolicy);
+                AuthenticationManager.CredentialPolicy = null;
+                Assert.Null(AuthenticationManager.CredentialPolicy);
+
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         [Fact]
@@ -74,13 +98,18 @@ namespace System.Net.Tests
             Assert.Empty(AuthenticationManager.CustomTargetNameDictionary);
             Assert.Same(AuthenticationManager.CustomTargetNameDictionary, AuthenticationManager.CustomTargetNameDictionary);
 
-            string theKey = "http://www.contoso.com";
-            string theValue = "HTTP/www.contoso.com"; 
-            AuthenticationManager.CustomTargetNameDictionary.Add(theKey, theValue);
-            Assert.Equal(theValue, AuthenticationManager.CustomTargetNameDictionary[theKey]);
+            RemoteInvoke(() =>
+            {
+                string theKey = "http://www.contoso.com";
+                string theValue = "HTTP/www.contoso.com";
+                AuthenticationManager.CustomTargetNameDictionary.Add(theKey, theValue);
+                Assert.Equal(theValue, AuthenticationManager.CustomTargetNameDictionary[theKey]);
 
-            AuthenticationManager.CustomTargetNameDictionary.Clear();
-            Assert.Equal(0, AuthenticationManager.CustomTargetNameDictionary.Count);
+                AuthenticationManager.CustomTargetNameDictionary.Clear();
+                Assert.Equal(0, AuthenticationManager.CustomTargetNameDictionary.Count);
+
+                return SuccessExitCode;
+            }).Dispose();            
         }
 
         private int GetModuleCount()
@@ -125,6 +154,5 @@ namespace System.Net.Tests
                 throw new NotImplementedException();
             }
         }    
-    }
-    
+    }    
 }

--- a/src/System.Net.Requests/tests/AuthenticationManagerTest.cs
+++ b/src/System.Net.Requests/tests/AuthenticationManagerTest.cs
@@ -55,15 +55,6 @@ namespace System.Net.Tests
             }).Dispose();
         }
 
-        public void Register_UnregisterByScheme_ModuleCountUnchanged()
-        {
-            int initialCount = GetModuleCount();
-            IAuthenticationModule module = new CustomModule();
-            AuthenticationManager.Register(module);
-            AuthenticationManager.Unregister("custom");
-            Assert.Equal(initialCount, GetModuleCount());
-        }
-
         [Fact]
         public void RegisteredModules_DefaultCount_ExpectedValue()
         {
@@ -112,7 +103,7 @@ namespace System.Net.Tests
             }).Dispose();            
         }
 
-        private int GetModuleCount()
+        private static int GetModuleCount()
         {
             int count = 0;
             IEnumerator modules = AuthenticationManager.RegisteredModules;

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -620,8 +620,8 @@ namespace System.Net.Tests
             }).Dispose();
         }
 
-        [Theory, MemberData(nameof(EchoServers))]
-        public void DefaultMaximumErrorResponseLength_SetAndGetLength_ValuesMatch(Uri remoteServer)
+        [Fact]
+        public void DefaultMaximumErrorResponseLength_SetAndGetLength_ValuesMatch()
         {
             RemoteInvoke(() =>
             {
@@ -642,8 +642,8 @@ namespace System.Net.Tests
             }).Dispose();
         }
 
-        [Theory, MemberData(nameof(EchoServers))]
-        public void DefaultCachePolicy_SetAndGetPolicyReload_ValuesMatch(Uri remoteServer)
+        [Fact]
+        public void DefaultCachePolicy_SetAndGetPolicyReload_ValuesMatch()
         {
             RemoteInvoke(() =>
             {

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -598,8 +598,8 @@ namespace System.Net.Tests
             Assert.Throws<ArgumentException>("value", () => request.Expect = "100-continue");
         }
 
-        [Theory, MemberData(nameof(EchoServers))]
-        public void DefaultMaximumResponseHeadersLength_SetAndGetLength_ValuesMatch(Uri remoteServer)
+        [Fact]
+        public void DefaultMaximumResponseHeadersLength_SetAndGetLength_ValuesMatch()
         {
             RemoteInvoke(() =>
             {

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -29,13 +29,10 @@ namespace System.Net.Tests
         public HttpWebRequestTest(ITestOutputHelper output)
         {
             _output = output;
-            if (PlatformDetection.IsFullFramework)
-            {
-                // On .NET Framework, the default limit for connections/server is very low (2). 
-                // On .NET Core, the default limit is higher. Since these tests run in parallel,
-                // the limit needs to be increased to avoid timeouts when running the tests.
-                System.Net.ServicePointManager.DefaultConnectionLimit = int.MaxValue;
-            }
+            // On .NET Framework, the default limit for connections/server is very low (2). 
+            // On .NET Core, the default limit is higher. Since these tests run in parallel,
+            // the limit needs to be increased to avoid timeouts when running the tests.
+            System.Net.ServicePointManager.DefaultConnectionLimit = int.MaxValue;
         }
 
         [Theory, MemberData(nameof(EchoServers))]
@@ -140,6 +137,7 @@ namespace System.Net.Tests
         }
 
         [Theory, MemberData(nameof(EchoServers))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #19466")] // Sometimes it timesout
         public void ContentLength_SetAfterRequestSubmitted_ThrowsInvalidOperationException(Uri remoteServer)
         {
             HttpWebRequest request = WebRequest.CreateHttp(remoteServer);

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -29,10 +29,13 @@ namespace System.Net.Tests
         public HttpWebRequestTest(ITestOutputHelper output)
         {
             _output = output;
-            // On .NET Framework, the default limit for connections/server is very low (2). 
-            // On .NET Core, the default limit is higher. Since these tests run in parallel,
-            // the limit needs to be increased to avoid timeouts when running the tests.
-            System.Net.ServicePointManager.DefaultConnectionLimit = int.MaxValue;
+            if (PlatformDetection.IsFullFramework)
+            {
+                // On .NET Framework, the default limit for connections/server is very low (2). 
+                // On .NET Core, the default limit is higher. Since these tests run in parallel,
+                // the limit needs to be increased to avoid timeouts when running the tests.
+                System.Net.ServicePointManager.DefaultConnectionLimit = int.MaxValue;
+            }
         }
 
         [Theory, MemberData(nameof(EchoServers))]

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -137,7 +137,6 @@ namespace System.Net.Tests
         }
 
         [Theory, MemberData(nameof(EchoServers))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #19466")] // Sometimes it timesout
         public void ContentLength_SetAfterRequestSubmitted_ThrowsInvalidOperationException(Uri remoteServer)
         {
             HttpWebRequest request = WebRequest.CreateHttp(remoteServer);

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Net.Cache;
 using System.Net.Http;
-using System.Net.Sockets;
 using System.Net.Test.Common;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Text;
@@ -17,7 +16,7 @@ using Xunit.Abstractions;
 
 namespace System.Net.Tests
 {
-    public partial class HttpWebRequestTest
+    public partial class HttpWebRequestTest : RemoteExecutorTestBase
     {
         private const string RequestBody = "This is data to POST.";
         private readonly byte[] _requestBodyBytes = Encoding.UTF8.GetBytes(RequestBody);
@@ -526,8 +525,7 @@ namespace System.Net.Tests
         [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp, "ConnectionGroupName isn't implemented in Core")]
         public void ConnectionGroupName_SetAndGetGroup_ValuesMatch(Uri remoteServer)
         {
-            HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
-            
+            HttpWebRequest request = WebRequest.CreateHttp(remoteServer);            
 
             if (!PlatformDetection.IsFullFramework)
             {
@@ -603,52 +601,67 @@ namespace System.Net.Tests
         [Theory, MemberData(nameof(EchoServers))]
         public void DefaultMaximumResponseHeadersLength_SetAndGetLength_ValuesMatch(Uri remoteServer)
         {
-            int defaultMaximumResponseHeadersLength = HttpWebRequest.DefaultMaximumResponseHeadersLength;
-            const int NewDefaultMaximumResponseHeadersLength = 255;
+            RemoteInvoke(() =>
+            {
+                int defaultMaximumResponseHeadersLength = HttpWebRequest.DefaultMaximumResponseHeadersLength;
+                const int NewDefaultMaximumResponseHeadersLength = 255;
 
-            try
-            {
-                HttpWebRequest.DefaultMaximumResponseHeadersLength = NewDefaultMaximumResponseHeadersLength;
-                Assert.Equal(NewDefaultMaximumResponseHeadersLength, HttpWebRequest.DefaultMaximumResponseHeadersLength);
-            }
-            finally
-            {
-                HttpWebRequest.DefaultMaximumResponseHeadersLength = defaultMaximumResponseHeadersLength;
-            }
+                try
+                {
+                    HttpWebRequest.DefaultMaximumResponseHeadersLength = NewDefaultMaximumResponseHeadersLength;
+                    Assert.Equal(NewDefaultMaximumResponseHeadersLength, HttpWebRequest.DefaultMaximumResponseHeadersLength);
+                }
+                finally
+                {
+                    HttpWebRequest.DefaultMaximumResponseHeadersLength = defaultMaximumResponseHeadersLength;
+                }
+
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         [Theory, MemberData(nameof(EchoServers))]
         public void DefaultMaximumErrorResponseLength_SetAndGetLength_ValuesMatch(Uri remoteServer)
         {
-            int defaultMaximumErrorsResponseLength = HttpWebRequest.DefaultMaximumErrorResponseLength;
-            const int NewDefaultMaximumErrorsResponseLength = 255;
+            RemoteInvoke(() =>
+            {
+                int defaultMaximumErrorsResponseLength = HttpWebRequest.DefaultMaximumErrorResponseLength;
+                const int NewDefaultMaximumErrorsResponseLength = 255;
 
-            try
-            {
-                HttpWebRequest.DefaultMaximumErrorResponseLength = NewDefaultMaximumErrorsResponseLength;
-                Assert.Equal(NewDefaultMaximumErrorsResponseLength, HttpWebRequest.DefaultMaximumErrorResponseLength);
-            }
-            finally
-            {
-                HttpWebRequest.DefaultMaximumErrorResponseLength = defaultMaximumErrorsResponseLength;
-            }
+                try
+                {
+                    HttpWebRequest.DefaultMaximumErrorResponseLength = NewDefaultMaximumErrorsResponseLength;
+                    Assert.Equal(NewDefaultMaximumErrorsResponseLength, HttpWebRequest.DefaultMaximumErrorResponseLength);
+                }
+                finally
+                {
+                    HttpWebRequest.DefaultMaximumErrorResponseLength = defaultMaximumErrorsResponseLength;
+                }
+
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         [Theory, MemberData(nameof(EchoServers))]
         public void DefaultCachePolicy_SetAndGetPolicyReload_ValuesMatch(Uri remoteServer)
         {
-            RequestCachePolicy requestCachePolicy = HttpWebRequest.DefaultCachePolicy;
+            RemoteInvoke(() =>
+            {
+                RequestCachePolicy requestCachePolicy = HttpWebRequest.DefaultCachePolicy;
 
-            try
-            {
-                RequestCachePolicy newRequestCachePolicy = new RequestCachePolicy(RequestCacheLevel.Reload);
-                HttpWebRequest.DefaultCachePolicy = newRequestCachePolicy;
-                Assert.Equal(newRequestCachePolicy.Level, HttpWebRequest.DefaultCachePolicy.Level);
-            }
-            finally
-            {
-                HttpWebRequest.DefaultCachePolicy = requestCachePolicy;
-            }
+                try
+                {
+                    RequestCachePolicy newRequestCachePolicy = new RequestCachePolicy(RequestCacheLevel.Reload);
+                    HttpWebRequest.DefaultCachePolicy = newRequestCachePolicy;
+                    Assert.Equal(newRequestCachePolicy.Level, HttpWebRequest.DefaultCachePolicy.Level);
+                }
+                finally
+                {
+                    HttpWebRequest.DefaultCachePolicy = requestCachePolicy;
+                }
+
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         [Theory, MemberData(nameof(EchoServers))]
@@ -966,6 +979,7 @@ namespace System.Net.Tests
         {
             HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
             request.Method = HttpMethod.Get.Method;
+
             using (WebResponse response = await request.GetResponseAsync())
             using (Stream myStream = response.GetResponseStream())
             {
@@ -974,8 +988,7 @@ namespace System.Net.Tests
                 {
                     string strContent = sr.ReadToEnd();
                     Assert.True(strContent.Contains("\"Host\": \"" + System.Net.Test.Common.Configuration.Http.Host + "\""));
-                }
-                
+                }                
             }
         }
 
@@ -1037,7 +1050,6 @@ namespace System.Net.Tests
             HttpWebRequest request = WebRequest.CreateHttp(serverUrl);
             WebException ex = Assert.Throws<WebException>(() => request.GetResponseAsync().GetAwaiter().GetResult());
             Assert.Equal(WebExceptionStatus.NameResolutionFailure, ex.Status);
-
         }
 
         public static object[][] StatusCodeServers = {
@@ -1049,10 +1061,8 @@ namespace System.Net.Tests
         public async Task GetResponseAsync_ResourceNotFound_ThrowsWebException(Uri remoteServer)
         {
             HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
-
             WebException ex = await Assert.ThrowsAsync<WebException>(() => request.GetResponseAsync());
             Assert.Equal(WebExceptionStatus.ProtocolError, ex.Status);
-
         }
 
         [Theory, MemberData(nameof(EchoServers))]


### PR DESCRIPTION
In helix the timeout is to small that the tests where timing out when running not in parallel. Parallelization was disabled to avoid hangs due to ServicePointManager.DefaultConnectionLimit small limit in Desktop, but we already take care of that by setting it to int.MaxValue, so we can enable paralellization again to avoid time out issues.

The errors we where getting where like this one: 
```
2017-05-09 06:09:40,006: INFO: proc(54): run_and_log_output: Output: xUnit.net Console Runner (64-bit Desktop .NET 4.0.30319.42000)
2017-05-09 06:09:40,131: INFO: proc(54): run_and_log_output: Output:   Discovering: System.Net.Requests.Tests
2017-05-09 06:09:40,334: INFO: proc(54): run_and_log_output: Output:   Discovered:  System.Net.Requests.Tests
2017-05-09 06:09:40,349: INFO: proc(54): run_and_log_output: Output:   Starting:    System.Net.Requests.Tests
2017-05-09 06:11:42,687: INFO: proc(54): run_and_log_output: Output:     System.Net.Tests.HttpWebRequestTest.ContentLength_SetAfterRequestSubmitted_ThrowsInvalidOperationException(remoteServer: http://corefx-net.cloudapp.net/Echo.ashx) [FAIL]
2017-05-09 06:11:42,687: INFO: proc(54): run_and_log_output: Output:       System.Net.WebException : The operation has timed out
2017-05-09 06:11:42,701: INFO: proc(54): run_and_log_output: Output:       Stack Trace:
2017-05-09 06:11:42,701: INFO: proc(54): run_and_log_output: Output:            at System.Net.HttpWebRequest.GetResponse()
2017-05-09 06:11:42,701: INFO: proc(54): run_and_log_output: Output:         D:\repos\corefx\src\System.Net.Requests\tests\HttpWebRequestTest.cs(146,0): at System.Net.Tests.HttpWebRequestTest.ContentLength_SetAfterRequestSubmitted_ThrowsInvalidOperationException(Uri remoteServer)
```

Sometimes it wouldn't even show a test failure, it would just not finish running.

cc: @danmosemsft 