### PR TITLE
Fix sharing violations caused by FileShare.Inherited

### DIFF
--- a/src/System.IO.FileSystem/tests/File/Open.cs
+++ b/src/System.IO.FileSystem/tests/File/Open.cs
@@ -32,12 +32,12 @@ namespace System.IO.Tests
     {
         protected override FileStream CreateFileStream(string path, FileMode mode)
         {
-            return File.Open(path, mode, mode == FileMode.Append ? FileAccess.Write : FileAccess.ReadWrite, FileShare.ReadWrite | FileShare.Delete | FileShare.Inheritable);
+            return File.Open(path, mode, mode == FileMode.Append ? FileAccess.Write : FileAccess.ReadWrite, FileShare.ReadWrite | FileShare.Delete);
         }
 
         protected override FileStream CreateFileStream(string path, FileMode mode, FileAccess access)
         {
-            return File.Open(path, mode, access, FileShare.ReadWrite | FileShare.Delete | FileShare.Inheritable);
+            return File.Open(path, mode, access, FileShare.ReadWrite | FileShare.Delete);
         }
 
         protected override FileStream CreateFileStream(string path, FileMode mode, FileAccess access, FileShare share)

--- a/src/System.IO.FileSystem/tests/FileInfo/Open.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/Open.cs
@@ -65,12 +65,12 @@ namespace System.IO.Tests
     {
         protected override FileStream CreateFileStream(string path, FileMode mode)
         {
-            return new FileInfo(path).Open(mode, mode == FileMode.Append ? FileAccess.Write : FileAccess.ReadWrite, FileShare.ReadWrite | FileShare.Delete | FileShare.Inheritable);
+            return new FileInfo(path).Open(mode, mode == FileMode.Append ? FileAccess.Write : FileAccess.ReadWrite, FileShare.ReadWrite | FileShare.Delete);
         }
 
         protected override FileStream CreateFileStream(string path, FileMode mode, FileAccess access)
         {
-            return new FileInfo(path).Open(mode, access, FileShare.ReadWrite | FileShare.Delete | FileShare.Inheritable);
+            return new FileInfo(path).Open(mode, access, FileShare.ReadWrite | FileShare.Delete);
         }
 
         protected override FileStream CreateFileStream(string path, FileMode mode, FileAccess access, FileShare share)

--- a/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm.cs
@@ -2,13 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.IO;
+using System.Diagnostics;
 using Xunit;
 
 namespace System.IO.Tests
 {
-    public class FileStream_ctor_str_fm : FileSystemTest
+    public class FileStream_ctor_str_fm : RemoteExecutorTestBase
     {
         protected virtual FileStream CreateFileStream(string path, FileMode mode)
         {


### PR DESCRIPTION
The FileShareOpen test has been failing sporadically with sharing violations.  It turns out the problem has to do with FileShare.Inheritable being included in the list of FileShare values to test.  If another test in the same process concurrently spawns a process while a FileShare.Inheritable file is open, that file's handle will be inherited into the child process, which will in turn keep the file in use for longer than the test expects.  When it then tries to re-open the file, it may encounter a sharing violation if the subsequent open is incompatible with the previous one's FileShare.

(The second commit contains the fix.  The first contains some additional tracing that I initially added to help with diagnosis, but in the end procmon was the best debugging tool.)

Fixes https://github.com/dotnet/corefx/issues/12993
cc: @ianhays 