### PR TITLE
Disable newly added HttpListener test failing in CI

### DIFF
--- a/src/System.Net.HttpListener/tests/HttpListenerPrefixCollectionTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerPrefixCollectionTests.cs
@@ -252,6 +252,7 @@ namespace System.Net.Tests
             yield return new object[] { "http://\\/" };
         }
 
+        [ActiveIssue(19526)]
         [Theory]
         [MemberData(nameof(InvalidPrefix_TestData))]
         public void Add_InvalidPrefixNotStarted_ThrowsHttpListenerExceptionOnStart(string uriPrefix)


### PR DESCRIPTION
https://github.com/dotnet/corefx/issues/19526