### PR TITLE
Fix more CoreFx tests on ILC

### DIFF
--- a/src/System.Runtime/tests/System/EnumTests.cs
+++ b/src/System.Runtime/tests/System/EnumTests.cs
@@ -141,7 +141,7 @@ namespace System.Tests
             yield return new object[] { typeof(SimpleEnum), "1,Blue", false, typeof(ArgumentException) };
             yield return new object[] { typeof(SimpleEnum), "Blue,1", false, typeof(ArgumentException) };
             yield return new object[] { typeof(SimpleEnum), "Blue, 1", false, typeof(ArgumentException) };
-            yield return new object[] { typeof(SimpleEnum), "2147483649", false, typeof(ArgumentException) };
+            yield return new object[] { typeof(SimpleEnum), "2147483649", false, typeof(OverflowException) };
             yield return new object[] { typeof(SimpleEnum), "2147483648", false, typeof(OverflowException) };
 
 #if netcoreapp

--- a/src/System.Runtime/tests/System/HandleTests.cs
+++ b/src/System.Runtime/tests/System/HandleTests.cs
@@ -22,21 +22,16 @@ public static class HandleTests
     [Fact]
     public static void  RuntimeMethodHandleTest()
     {
-        MethodInfo minfo = typeof( Co6006LateBoundDelegate).GetMethod( "Method1" );
-        RuntimeMethodHandle rmh = minfo.MethodHandle;
-        Assert.True(rmh.Value != null);
-        Assert.True(rmh.GetFunctionPointer() != null);
-        Object [] args = new Object[] { null, rmh.GetFunctionPointer() };
-        MyDelegate dg = (MyDelegate)Activator.CreateInstance( typeof( MyDelegate ), args );
-        dg();
-        Assert.True(Co6006LateBoundDelegate.iInvokeCount == 1);
+        MethodInfo mi1 = typeof(Base).GetMethod(nameof(Base.MyMethod));
+        MethodInfo mi2 = (MethodInfo)MethodBase.GetMethodFromHandle(mi1.MethodHandle);
+        Assert.Equal(mi1, mi2);
     }
 
     [Fact]
     public static void  GenericMethodRuntimeMethodHandleTest()
     {
         // Make sure uninstantiated generic method has a valid handle
-        MethodInfo mi1 = typeof(Base).GetMethod("GenericMethod");
+        MethodInfo mi1 = typeof(Base).GetMethod(nameof(Base.GenericMethod));
         MethodInfo mi2 = (MethodInfo)MethodBase.GetMethodFromHandle(mi1.MethodHandle);
         Assert.Equal(mi1, mi2);
     }
@@ -60,21 +55,12 @@ public static class HandleTests
         public int MyProperty1 { get; private set; }
         public int MyProperty2 { private get; set; }
 
+        public static void MyMethod() { }
+
         public static void GenericMethod<T>() { }
     }
 
     private class Derived : Base
     {
     }
-
-    delegate void MyDelegate();
-    public class Co6006LateBoundDelegate
-    {
-        public static int iInvokeCount = 0;
-        public static void Method1()
-        {
-            iInvokeCount++;
-        }
-    }
-
 }


### PR DESCRIPTION
- RuntimeMethodHandle test was going off the
  reservation to test some private Delegator
  constructor functionality that we don't
  even expose in the reference assemblies,
  let alone CoreRT.

  Change it back to testing RuntimeMethodHandle.

- Q: When is 2147483649 not 2147483649?

  A: When there's a hidden Unicode character
     embedded at the start that neither cut-paste
     nor any differ I've found (including
     GitHub's) picks up.

  Removing it.