### PR TITLE
Cleaning up dead code in System.Net.Mail

### DIFF
--- a/src/Common/src/System/Net/TlsStream.cs
+++ b/src/Common/src/System/Net/TlsStream.cs
@@ -16,11 +16,6 @@ namespace System.Net
         private string _host;
         private X509CertificateCollection _clientCertificates;
 
-        public TlsStream(NetworkStream stream, Socket socket) : base(socket)
-        {
-            _sslStream = new SslStream(stream);
-        }
-
         public TlsStream(NetworkStream stream, Socket socket, string host, X509CertificateCollection clientCertificates) : base(socket)
         {
             _sslStream = new SslStream(stream, false, ServicePointManager.ServerCertificateValidationCallback);

--- a/src/System.Net.Mail/src/Resources/Strings.resx
+++ b/src/System.Net.Mail/src/Resources/Strings.resx
@@ -77,30 +77,6 @@
   <data name="event_OperationReturnedSomething" xml:space="preserve">
     <value>{0} returned {1}.</value>
   </data>
-  <data name="net_context_buffer_too_small" xml:space="preserve">
-    <value>Insufficient buffer space. Required: {0} Actual: {1}.</value>
-  </data>
-  <data name="net_gssapi_operation_failed_detailed" xml:space="preserve">
-    <value>GSSAPI operation failed with error - {0} ({1}).</value>
-  </data>
-  <data name="net_gssapi_operation_failed" xml:space="preserve">
-    <value>GSSAPI operation failed with status: {0} (Minor status: {1}).</value>
-  </data>
-  <data name="net_nego_channel_binding_not_supported" xml:space="preserve">
-    <value>No support for channel binding on operating systems other than Windows.</value>
-  </data>
-  <data name="net_ntlm_not_possible_default_cred" xml:space="preserve">
-    <value>NTLM authentication is not possible with default credentials on this platform.</value>
-  </data>
-  <data name="net_nego_not_supported_empty_target_with_defaultcreds" xml:space="preserve">
-    <value>Target name should be non empty if default credentials are passed.</value>
-  </data>
-  <data name="net_nego_server_not_supported" xml:space="preserve">
-    <value>Server implementation is not supported</value>
-  </data>
-  <data name="net_nego_protection_level_not_supported" xml:space="preserve">
-    <value>Requested protection level is not supported with the gssapi implementation currently installed.</value>
-  </data>
   <data name="SSPIInvalidHandleType" xml:space="preserve">
     <value>'{0}' is not a supported handle type.</value>
   </data>
@@ -209,9 +185,6 @@
   <data name="SmtpMailboxBusy" xml:space="preserve">
     <value>Mailbox unavailable.</value>
   </data>
-  <data name="net_securityprotocolnotsupported" xml:space="preserve">
-    <value>The requested security protocol is not supported.</value>
-  </data>
   <data name="SmtpMailboxNameNotAllowed" xml:space="preserve">
     <value>Mailbox name not allowed.</value>
   </data>
@@ -290,9 +263,6 @@
   <data name="WriteNotSupported" xml:space="preserve">
     <value>Writing is not supported on this stream.</value>
   </data>
-  <data name="net_perm_target" xml:space="preserve">
-    <value>Cannot cast target permission type.</value>
-  </data>
   <data name="MailAddressInvalidFormat" xml:space="preserve">
     <value>The specified string is not in the form required for an e-mail address.</value>
   </data>
@@ -308,17 +278,7 @@
   <data name="SmtpEhloResponseInvalid" xml:space="preserve">
     <value>The server returned an invalid response to the EHLO command.</value>
   </data>
-  <data name="net_not_ipermission" xml:space="preserve">
-    <value>Specified value does not contain 'IPermission' as its tag.</value>
-  </data>
-  <data name="net_no_classname" xml:space="preserve">
     <value>Specified value does not contain a 'class' attribute.</value>
-  </data>
-  <data name="net_no_typename" xml:space="preserve">
-    <value>The value class attribute is not valid.</value>
-  </data>
-  <data name="net_perm_invalid_val_in_element" xml:space="preserve">
-    <value>The '{0}' element contains one or more invalid values.</value>
   </data>
   <data name="net_io_readfailure" xml:space="preserve">
     <value>Unable to read data from the transport connection: {0}.</value>

--- a/src/System.Net.Mail/src/Resources/Strings.resx
+++ b/src/System.Net.Mail/src/Resources/Strings.resx
@@ -77,6 +77,30 @@
   <data name="event_OperationReturnedSomething" xml:space="preserve">
     <value>{0} returned {1}.</value>
   </data>
+  <data name="net_context_buffer_too_small" xml:space="preserve">
+    <value>Insufficient buffer space. Required: {0} Actual: {1}.</value>
+  </data>
+  <data name="net_gssapi_operation_failed_detailed" xml:space="preserve">
+    <value>GSSAPI operation failed with error - {0} ({1}).</value>
+  </data>
+  <data name="net_gssapi_operation_failed" xml:space="preserve">
+    <value>GSSAPI operation failed with status: {0} (Minor status: {1}).</value>
+  </data>
+  <data name="net_nego_channel_binding_not_supported" xml:space="preserve">
+    <value>No support for channel binding on operating systems other than Windows.</value>
+  </data>
+  <data name="net_ntlm_not_possible_default_cred" xml:space="preserve">
+    <value>NTLM authentication is not possible with default credentials on this platform.</value>
+  </data>
+  <data name="net_nego_not_supported_empty_target_with_defaultcreds" xml:space="preserve">
+    <value>Target name should be non empty if default credentials are passed.</value>
+  </data>
+  <data name="net_nego_server_not_supported" xml:space="preserve">
+    <value>Server implementation is not supported</value>
+  </data>
+  <data name="net_nego_protection_level_not_supported" xml:space="preserve">
+    <value>Requested protection level is not supported with the gssapi implementation currently installed.</value>
+  </data>
   <data name="SSPIInvalidHandleType" xml:space="preserve">
     <value>'{0}' is not a supported handle type.</value>
   </data>
@@ -185,6 +209,9 @@
   <data name="SmtpMailboxBusy" xml:space="preserve">
     <value>Mailbox unavailable.</value>
   </data>
+  <data name="net_securityprotocolnotsupported" xml:space="preserve">
+    <value>The requested security protocol is not supported.</value>
+  </data>
   <data name="SmtpMailboxNameNotAllowed" xml:space="preserve">
     <value>Mailbox name not allowed.</value>
   </data>
@@ -277,8 +304,6 @@
   </data>
   <data name="SmtpEhloResponseInvalid" xml:space="preserve">
     <value>The server returned an invalid response to the EHLO command.</value>
-  </data>
-    <value>Specified value does not contain a 'class' attribute.</value>
   </data>
   <data name="net_io_readfailure" xml:space="preserve">
     <value>Unable to read data from the transport connection: {0}.</value>

--- a/src/System.Net.Mail/src/System/Net/Base64Stream.cs
+++ b/src/System.Net.Mail/src/System/Net/Base64Stream.cs
@@ -55,12 +55,6 @@ namespace System.Net
             _lineLength = writeStateInfo.MaxLineLength;
         }
 
-        internal Base64Stream(Stream stream, int lineLength) : base(stream)
-        {
-            _lineLength = lineLength;
-            _writeState = new Base64WriteStateInfo();
-        }
-
         internal Base64Stream(Base64WriteStateInfo writeStateInfo) : base(new MemoryStream())
         {
             _lineLength = writeStateInfo.MaxLineLength;

--- a/src/System.Net.Mail/src/System/Net/BufferedReadStream.cs
+++ b/src/System.Net.Mail/src/System/Net/BufferedReadStream.cs
@@ -158,60 +158,6 @@ namespace System.Net
             Buffer.BlockCopy(buffer, offset, _storedBuffer, _storedOffset, count);
         }
 
-        // adds additional content to the end of the buffer
-        // so the layout of the storedBuffer will be
-        // <existingBuffer><buffer>
-        // after calling append
-        internal void Append(byte[] buffer, int offset, int count)
-        {
-            if (count == 0)
-                return;
-
-            int newBufferPosition;
-            if (_storedOffset == _storedLength)
-            {
-                if (_storedBuffer == null || _storedBuffer.Length < count)
-                {
-                    _storedBuffer = new byte[count];
-                }
-                _storedOffset = 0;
-                _storedLength = count;
-                newBufferPosition = 0;
-            }
-            else
-            {
-                // if there's room to just insert after existing data
-                if (count <= _storedBuffer.Length - _storedLength)
-                {
-                    //no preperation necessary
-                    newBufferPosition = _storedLength;
-                    _storedLength += count;
-                }
-                // if there's room in the buffer but need to shift things over
-                else if (count <= _storedBuffer.Length - _storedLength + _storedOffset)
-                {
-                    Buffer.BlockCopy(_storedBuffer, _storedOffset, _storedBuffer, 0, _storedLength - _storedOffset);
-                    newBufferPosition = _storedLength - _storedOffset;
-                    _storedOffset = 0;
-                    _storedLength = count + newBufferPosition;
-                }
-                else
-                {
-                    // the buffer is too small
-                    // allocate new buffer
-                    byte[] newBuffer = new byte[count + _storedLength - _storedOffset];
-                    // and prepopulate the remaining content of the original buffer
-                    Buffer.BlockCopy(_storedBuffer, _storedOffset, newBuffer, 0, _storedLength - _storedOffset);
-                    newBufferPosition = _storedLength - _storedOffset;
-                    _storedOffset = 0;
-                    _storedLength = count + newBufferPosition;
-                    _storedBuffer = newBuffer;
-                }
-            }
-
-            Buffer.BlockCopy(buffer, offset, _storedBuffer, newBufferPosition, count);
-        }
-
         private class ReadAsyncResult : LazyAsyncResult
         {
             private BufferedReadStream _parent;

--- a/src/System.Net.Mail/src/System/Net/DelegatedStream.cs
+++ b/src/System.Net.Mail/src/System/Net/DelegatedStream.cs
@@ -14,9 +14,6 @@ namespace System.Net
         private readonly Stream _stream;
         private readonly NetworkStream _netStream;
 
-        protected DelegatedStream()
-        {
-        }
         protected DelegatedStream(Stream stream)
         {
             if (stream == null)

--- a/src/System.Net.Mail/src/System/Net/Mail/MailHeaderInfo.cs
+++ b/src/System.Net.Mail/src/System/Net/Mail/MailHeaderInfo.cs
@@ -107,12 +107,6 @@ namespace System.Net.Mail
             return s_headerDictionary.TryGetValue(name, out id) ? (MailHeaderID)id : MailHeaderID.Unknown;
         }
 
-        internal static bool IsWellKnown(string name)
-        {
-            int dummy;
-            return s_headerDictionary.TryGetValue(name, out dummy);
-        }
-
         internal static bool IsUserSettable(string name)
         {
             //values not in the list of well-known headers are always user-settable
@@ -130,12 +124,6 @@ namespace System.Net.Mail
         {
             int index;
             return s_headerDictionary.TryGetValue(name, out index) ? s_headerInfo[index].NormalizedName : name;
-        }
-
-        internal static bool IsMatch(string name, MailHeaderID header)
-        {
-            int index;
-            return s_headerDictionary.TryGetValue(name, out index) && (MailHeaderID)index == header;
         }
 
         internal static bool AllowsUnicode(string name)

--- a/src/System.Net.Mail/src/System/Net/Mail/SmtpConnection.cs
+++ b/src/System.Net.Mail/src/System/Net/Mail/SmtpConnection.cs
@@ -413,41 +413,6 @@ namespace System.Net.Mail
                 _outerResult = outerResult;
             }
 
-            private static void ConnectionCreatedCallback(object request, object state)
-            {
-                if (NetEventSource.IsEnabled) NetEventSource.Enter(null, request);
-                ConnectAndHandshakeAsyncResult ConnectAndHandshakeAsyncResult = (ConnectAndHandshakeAsyncResult)request;
-                if (state is Exception)
-                {
-                    ConnectAndHandshakeAsyncResult.InvokeCallback((Exception)state);
-                    return;
-                }
-
-                try
-                {
-                    lock (ConnectAndHandshakeAsyncResult._connection)
-                    {
-                        //if we were cancelled while getting the connection, we should close and return
-                        if (ConnectAndHandshakeAsyncResult._connection._isClosed)
-                        {
-                            ConnectAndHandshakeAsyncResult._connection.ReleaseConnection();
-                            if (NetEventSource.IsEnabled) NetEventSource.Info(null, $"Connect was aborted: {request}");
-                            ConnectAndHandshakeAsyncResult.InvokeCallback(null);
-                            return;
-                        }
-                    }
-
-                    ConnectAndHandshakeAsyncResult.Handshake();
-                }
-                catch (Exception e)
-                {
-                    ConnectAndHandshakeAsyncResult.InvokeCallback(e);
-                }
-
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(null, request);
-            }
-
-
             internal static void End(IAsyncResult result)
             {
                 ConnectAndHandshakeAsyncResult thisPtr = (ConnectAndHandshakeAsyncResult)result;

--- a/src/System.Net.Mail/src/System/Net/Mime/EncodedStreamFactory.cs
+++ b/src/System.Net.Mail/src/System/Net/Mime/EncodedStreamFactory.cs
@@ -18,29 +18,6 @@ namespace System.Net.Mime
         //default buffer size for encoder
         private const int InitialBufferSize = 1024;
 
-        //get a raw encoder, not for use with header encoding
-        internal IEncodableStream GetEncoder(TransferEncoding encoding, Stream stream)
-        {
-            //raw encoder
-            if (encoding == TransferEncoding.Base64)
-            {
-                return new Base64Stream(stream, new Base64WriteStateInfo());
-            }
-
-            //return a QuotedPrintable stream because this is not being used for header encoding
-            if (encoding == TransferEncoding.QuotedPrintable)
-            {
-                return new QuotedPrintableStream(stream, true);
-            }
-
-            if (encoding == TransferEncoding.SevenBit || encoding == TransferEncoding.EightBit)
-            {
-                return new EightBitStream(stream);
-            }
-
-            throw new NotSupportedException();
-        }
-
         //use for encoding headers
         internal IEncodableStream GetEncoderForHeader(Encoding encoding, bool useBase64Encoding, int headerTextLength)
         {

--- a/src/System.Net.Mail/src/System/Net/Mime/EncodedStreamFactory.cs
+++ b/src/System.Net.Mail/src/System/Net/Mime/EncodedStreamFactory.cs
@@ -18,31 +18,31 @@ namespace System.Net.Mime
         //default buffer size for encoder
         private const int InitialBufferSize = 1024;
 
-		//get a raw encoder, not for use with header encoding
-		internal IEncodableStream GetEncoder(TransferEncoding encoding, Stream stream)
-		{
-			//raw encoder
-			if (encoding == TransferEncoding.Base64)
-			{
-				return new Base64Stream(stream, new Base64WriteStateInfo());
-			}
+        //get a raw encoder, not for use with header encoding
+        internal IEncodableStream GetEncoder(TransferEncoding encoding, Stream stream)
+        {
+            //raw encoder
+            if (encoding == TransferEncoding.Base64)
+            {
+                return new Base64Stream(stream, new Base64WriteStateInfo());
+            }
 
-			//return a QuotedPrintable stream because this is not being used for header encoding
-			if (encoding == TransferEncoding.QuotedPrintable)
-			{
-				return new QuotedPrintableStream(stream, true);
-			}
+            //return a QuotedPrintable stream because this is not being used for header encoding
+            if (encoding == TransferEncoding.QuotedPrintable)
+            {
+                return new QuotedPrintableStream(stream, true);
+            }
 
-			if (encoding == TransferEncoding.SevenBit || encoding == TransferEncoding.EightBit)
-			{
-				return new EightBitStream(stream);
-			}
+            if (encoding == TransferEncoding.SevenBit || encoding == TransferEncoding.EightBit)
+            {
+                return new EightBitStream(stream);
+            }
 
-			throw new NotSupportedException();
-		}
+            throw new NotSupportedException();
+        }
 
-		//use for encoding headers
-		internal IEncodableStream GetEncoderForHeader(Encoding encoding, bool useBase64Encoding, int headerTextLength)
+        //use for encoding headers
+        internal IEncodableStream GetEncoderForHeader(Encoding encoding, bool useBase64Encoding, int headerTextLength)
         {
             byte[] header = CreateHeader(encoding, useBase64Encoding);
             byte[] footer = CreateFooter();

--- a/src/System.Net.Mail/src/System/Net/Mime/EncodedStreamFactory.cs
+++ b/src/System.Net.Mail/src/System/Net/Mime/EncodedStreamFactory.cs
@@ -18,8 +18,31 @@ namespace System.Net.Mime
         //default buffer size for encoder
         private const int InitialBufferSize = 1024;
 
-        //use for encoding headers
-        internal IEncodableStream GetEncoderForHeader(Encoding encoding, bool useBase64Encoding, int headerTextLength)
+		//get a raw encoder, not for use with header encoding
+		internal IEncodableStream GetEncoder(TransferEncoding encoding, Stream stream)
+		{
+			//raw encoder
+			if (encoding == TransferEncoding.Base64)
+			{
+				return new Base64Stream(stream, new Base64WriteStateInfo());
+			}
+
+			//return a QuotedPrintable stream because this is not being used for header encoding
+			if (encoding == TransferEncoding.QuotedPrintable)
+			{
+				return new QuotedPrintableStream(stream, true);
+			}
+
+			if (encoding == TransferEncoding.SevenBit || encoding == TransferEncoding.EightBit)
+			{
+				return new EightBitStream(stream);
+			}
+
+			throw new NotSupportedException();
+		}
+
+		//use for encoding headers
+		internal IEncodableStream GetEncoderForHeader(Encoding encoding, bool useBase64Encoding, int headerTextLength)
         {
             byte[] header = CreateHeader(encoding, useBase64Encoding);
             byte[] footer = CreateFooter();

--- a/src/System.Net.Mail/src/System/Net/Mime/MimeBasePart.cs
+++ b/src/System.Net.Mail/src/System/Net/Mime/MimeBasePart.cs
@@ -135,28 +135,6 @@ namespace System.Net.Mime
             return true;
         }
 
-        internal static bool IsAnsi(string value, bool permitCROrLF)
-        {
-            if (value == null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
-
-            foreach (char c in value)
-            {
-                if (c > 0xff)
-                {
-                    return false;
-                }
-                if (!permitCROrLF && (c == '\r' || c == '\n'))
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
         internal string ContentID
         {
             get { return Headers[MailHeaderInfo.GetString(MailHeaderID.ContentID)]; }


### PR DESCRIPTION
Relative to issue #17905.
Code removed in Common was done after a grep to ensure it is not used anymore. Some resources were kept because they were used by other libraries.
Routing to @karelz as asked.