### PR TITLE
Handle the PNSE when opening LocalMachine\My store on Linux

### DIFF
--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/Utils.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/Utils.cs
@@ -680,7 +680,9 @@ namespace System.Security.Cryptography.Xml
                             }
                         }
                     }
+                    // Store doesn't exist, no read permissions, other system error
                     catch (CryptographicException) { }
+                    // Opening LocalMachine stores (other than Root or CertificateAuthority) on Linux
                     catch (PlatformNotSupportedException) { }
 
                     if (filters != null)

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/Utils.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/Utils.cs
@@ -681,6 +681,7 @@ namespace System.Security.Cryptography.Xml
                         }
                     }
                     catch (CryptographicException) { }
+                    catch (PlatformNotSupportedException) { }
 
                     if (filters != null)
                         collection.AddRange(filters);

--- a/src/System.Security.Cryptography.Xml/tests/EncryptedXmlTests.cs
+++ b/src/System.Security.Cryptography.Xml/tests/EncryptedXmlTests.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.Security.Cryptography.X509Certificates;
+using System.Xml;
+using Xunit;
+
+namespace System.Security.Cryptography.Xml.Tests
+{
+    public static class EncryptedXmlTests
+    {
+        [Fact]
+        public static void DecryptWithCertificate_NotInStore()
+        {
+            const string SecretMessage = "Grilled cheese is tasty";
+
+            XmlDocument document = new XmlDocument();
+            document.LoadXml($"<data><secret>{SecretMessage}</secret></data>");
+            XmlElement toEncrypt = (XmlElement)document.DocumentElement.FirstChild;
+
+            using (X509Certificate2 cert = TestHelpers.GetSampleX509Certificate())
+            {
+                EncryptedXml encryptor = new EncryptedXml(document);
+                EncryptedData encryptedElement = encryptor.Encrypt(toEncrypt, cert);
+                EncryptedXml.ReplaceElement(toEncrypt, encryptedElement, false);
+                
+                XmlDocument document2 = new XmlDocument();
+                document2.LoadXml(document.OuterXml);
+
+                EncryptedXml decryptor = new EncryptedXml(document2);
+
+                Assert.Throws<CryptographicException>(() => decryptor.DecryptDocument());
+                Assert.DoesNotContain(SecretMessage, document2.OuterXml);
+            }
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Xml/tests/System.Security.Cryptography.Xml.Tests.csproj
+++ b/src/System.Security.Cryptography.Xml/tests/System.Security.Cryptography.Xml.Tests.csproj
@@ -18,6 +18,7 @@
     <Compile Include="EncryptedXmlEqualityComparer.cs" />
     <Compile Include="EncryptionMethodTests.cs" />
     <Compile Include="EncryptedXmlTest.cs" />
+    <Compile Include="EncryptedXmlTests.cs" />
     <Compile Include="EncryptionPropertyCollectionTest.cs" />
     <Compile Include="EncryptionPropertyTest.cs" />
     <Compile Include="KeyInfoNameTest.cs" />


### PR DESCRIPTION
When an X509Data is being used as a source of hunting for a store certificate
with a (matching) private key it fails on Linux with a
PlatformNotSupportedException when trying to open the LocalMachine\My
store.

Since the code was already resilient to CryptographicException from the store
open, add PlatformNotSupportedException to things it expects as ignorable.

Fixes #19489.