### PR TITLE
Disable more recently added HttpListener tests

### DIFF
--- a/src/System.Net.HttpListener/tests/HttpListenerPrefixCollectionTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerPrefixCollectionTests.cs
@@ -362,6 +362,7 @@ namespace System.Net.Tests
             Assert.Throws<ArgumentNullException>("key", () => listener.Prefixes.Contains(null));
         }
 
+        [ActiveIssue(19526)]
         [Fact]
         public void Remove_PrefixExistsNotStarted_ReturnsTrue()
         {
@@ -373,6 +374,7 @@ namespace System.Net.Tests
             Assert.Equal(0, listener.Prefixes.Count);
         }
 
+        [ActiveIssue(19526)]
         [Fact]
         public async Task Remove_PrefixExistsStarted_ReturnsTrue()
         {


### PR DESCRIPTION
Also failing multiple CI legs. Related to #19526
cc: @danmosemsft, @hughbe 