### PR TITLE
adding SqlParameter constructor

### DIFF
--- a/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
+++ b/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
@@ -549,6 +549,21 @@ namespace System.Data.SqlClient
         public SqlParameter(string parameterName, System.Data.SqlDbType dbType, int size) { }
         public SqlParameter(string parameterName, System.Data.SqlDbType dbType, int size, string sourceColumn) { }
         public SqlParameter(string parameterName, object value) { }
+        public SqlParameter(
+            string parameterName,
+            SqlDbType dbType,
+            int size,
+            ParameterDirection direction,
+            byte precision,
+            byte scale,
+            string sourceColumn,
+            DataRowVersion sourceVersion,
+            bool sourceColumnNullMapping,
+            object value,
+            string xmlSchemaCollectionDatabase,
+            string xmlSchemaCollectionOwningSchema,
+            string xmlSchemaCollectionName
+        ) { }
         object ICloneable.Clone() { throw null; }
         public System.Data.SqlTypes.SqlCompareOptions CompareInfo { get { throw null; } set { } }
         public override System.Data.DbType DbType { get { throw null; } set { } }

--- a/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
+++ b/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
@@ -549,21 +549,7 @@ namespace System.Data.SqlClient
         public SqlParameter(string parameterName, System.Data.SqlDbType dbType, int size) { }
         public SqlParameter(string parameterName, System.Data.SqlDbType dbType, int size, string sourceColumn) { }
         public SqlParameter(string parameterName, object value) { }
-        public SqlParameter(
-            string parameterName,
-            SqlDbType dbType,
-            int size,
-            ParameterDirection direction,
-            byte precision,
-            byte scale,
-            string sourceColumn,
-            DataRowVersion sourceVersion,
-            bool sourceColumnNullMapping,
-            object value,
-            string xmlSchemaCollectionDatabase,
-            string xmlSchemaCollectionOwningSchema,
-            string xmlSchemaCollectionName
-        ) { }
+        public SqlParameter(string parameterName, System.Data.SqlDbType dbType, int size, System.Data.ParameterDirection direction, byte precision, byte scale, string sourceColumn, System.Data.DataRowVersion sourceVersion, bool sourceColumnNullMapping, object value, string xmlSchemaCollectionDatabase, string xmlSchemaCollectionOwningSchema, string xmlSchemaCollectionName) { }
         object ICloneable.Clone() { throw null; }
         public System.Data.SqlTypes.SqlCompareOptions CompareInfo { get { throw null; } set { } }
         public override System.Data.DbType DbType { get { throw null; } set { } }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameter.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameter.cs
@@ -114,6 +114,37 @@ namespace System.Data.SqlClient
             this.SourceColumn = sourceColumn;
         }
 
+        public SqlParameter(
+            string parameterName,
+            SqlDbType dbType, 
+            int size,
+            ParameterDirection direction,
+            byte precision,
+            byte scale,
+            string sourceColumn,
+            DataRowVersion sourceVersion,
+            bool sourceColumnNullMapping,
+            object value,
+            string xmlSchemaCollectionDatabase,
+            string xmlSchemaCollectionOwningSchema,
+            string xmlSchemaCollectionName
+        ) : this()
+        {
+            this.ParameterName = parameterName;
+            this.SqlDbType = dbType;
+            this.Size = size;
+            this.Direction = direction;
+            this.Precision = precision;
+            this.Scale = scale;
+            this.SourceColumn = sourceColumn;
+            this.SourceVersion = sourceVersion;
+            this.SourceColumnNullMapping = sourceColumnNullMapping;
+            this.Value = value;
+            this.XmlSchemaCollectionDatabase = xmlSchemaCollectionDatabase;
+            this.XmlSchemaCollectionOwningSchema = xmlSchemaCollectionOwningSchema;
+            this.XmlSchemaCollectionName = xmlSchemaCollectionName;
+        }
+
         private SqlParameter(SqlParameter source) : this()
         {
             ADP.CheckArgumentNull(source, nameof(source));


### PR DESCRIPTION
I added SqlParmeter constructor to resolve this issue:
***
Someone is trying to use good ol’ DataSets with a .NET Standard 2.0 class library.
* The designer doesn’t work in the new project system (it doesn’t like that the core assembly isn’t mscorlib)
*  Copying over the generated code from .NET Framework 4.6.1 doesn’t work 
   * The designer uses a bunch of types that .NET Standard 2.0 doesn’t have (e.g. TypedTableBase<T>, EnumerableRowCollection etc)
   * Worked this around by creating a .NET Framework 2.0 project and regenerated the code there
   * This fixes all compilation errors except for [one constructor on SqlParameter](https://msdn.microsoft.com/en-us/library/t547y10h(v=vs.110).aspx)

