### PR TITLE
Disabling xunit AppDomain in System.Configuration.ConfigurationManager in favor of consistent BaseDirectory path behavior

### DIFF
--- a/src/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
+++ b/src/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
@@ -4,6 +4,8 @@
   <PropertyGroup>
     <ProjectGuid>{7669C397-C21C-4C08-83F1-BE6691911E88}</ProjectGuid>
     <TestCategories>InnerLoop;OuterLoop</TestCategories>
+    <!-- XUnit AppDomain has different behavior when accessing AppDomain.BaseDirectory (trailing/no trailing slash) -->
+    <XUnitNoAppdomain>true</XUnitNoAppdomain>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Debug|AnyCPU'" />

--- a/src/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
+++ b/src/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <ProjectGuid>{7669C397-C21C-4C08-83F1-BE6691911E88}</ProjectGuid>
     <TestCategories>InnerLoop;OuterLoop</TestCategories>
-    <!-- XUnit AppDomain has different behavior when accessing AppDomain.BaseDirectory (trailing/no trailing slash) -->
+    <!-- XUnit AppDomains BaseDirectory path doesn't contain a trailing slash, which impacts our tests. -->
     <XUnitNoAppdomain>true</XUnitNoAppdomain>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->

--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/UrlPathTests.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/UrlPathTests.cs
@@ -25,7 +25,6 @@ namespace System.ConfigurationTests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18196")]
         public void GetDirectoryOrRootName_GettingDirectoryFromAFilePath()
         {
             string exePath = AppDomain.CurrentDomain.BaseDirectory;


### PR DESCRIPTION
Fixes https://github.com/dotnet/coreclr/issues/10920
Fixes: #18196

By disabling the xunit AppDomain for these tests we have a consistent behavior when accessing AppDomain.BaseDirectory. XUnits custom AppDomains have a different BaseDirectory path depending on TargetGroup netfx/netcoreapp. 

Thanks @safern for your great help!

https://github.com/xunit/xunit/blob/914e97d57e388b5c8c2bf5c4381b5c232ed64b5a/src/xunit.runner.utility/AppDomain/AppDomainManager_AppDomain.cs#L40