### PR TITLE
Fix rd.xml for Serialization Reflection Only Mode.

### DIFF
--- a/src/System.Private.DataContractSerialization/src/Resources/System.Private.DataContractSerialization.rd.xml
+++ b/src/System.Private.DataContractSerialization/src/Resources/System.Private.DataContractSerialization.rd.xml
@@ -10,6 +10,45 @@
           </Method>
         </Type>
         <Type Name="KeyValuePairAdapter`2" Dynamic="Required All" />
+        <!-- Reflection-based serialization requires the entries below. -->
+        <Type Name="CollectionDataContract">
+          <Type Name="CollectionDataContractCriticalHelper">
+            <Method Name="BuildCreateGenericDictionaryEnumerator{K, V}" Dynamic="Required">
+              <GenericParameter Name="K" Dynamic="Required All" />
+              <GenericParameter Name="V" Dynamic="Required All" />
+            </Method>
+            <Method Name="BuildIncrementCollectionCountDelegate{T}" Dynamic="Required">
+              <GenericParameter Name="T" Dynamic="Required All" />
+            </Method>
+          </Type>
+        </Type>
+        <Type Name="DataContractSerializer">
+          <Property Name="Option" Dynamic="Required" />
+        </Type>
+        <Type Name="FastInvokerBuilder" Dynamic="Required All" />
+        <Type Name="ReflectionReader">
+          <Method Name="GetCollectionSetItemDelegate{T}" Dynamic="Required">
+            <GenericParameter Name="T" Dynamic="Required All" />
+          </Method>
+          <Method Name="ObjectToKeyValuePairGetKey{K, V}" Dynamic="Required">
+            <GenericParameter Name="K" Dynamic="Required All" />
+            <GenericParameter Name="V" Dynamic="Required All" />
+          </Method>
+          <Method Name="ObjectToKeyValuePairGetValue{K, V}" Dynamic="Required">
+            <GenericParameter Name="K" Dynamic="Required All" />
+            <GenericParameter Name="V" Dynamic="Required All" />
+          </Method>
+        </Type>
+        <Type Name="XmlObjectSerializerReadContext">
+          <Method Name="TrimArraySize{T}" Dynamic="Required">
+            <GenericParameter Name="T" Dynamic="Required All" />
+          </Method>
+        </Type>
+        <Type Name="XmlObjectSerializerWriteContext">        
+          <Method Name="GetDefaultValue{T}" Dynamic="Required">
+            <GenericParameter Name="T" Dynamic="Required All" />
+          </Method>
+        </Type>
       </Namespace>
       <Namespace Name="System.Runtime.Serialization.Json">
         <Type Name="DataContractJsonSerializer">

--- a/src/System.Private.DataContractSerialization/src/Resources/System.Private.DataContractSerialization.rd.xml
+++ b/src/System.Private.DataContractSerialization/src/Resources/System.Private.DataContractSerialization.rd.xml
@@ -13,13 +13,8 @@
         <!-- Reflection-based serialization requires the entries below. -->
         <Type Name="CollectionDataContract">
           <Type Name="CollectionDataContractCriticalHelper">
-            <Method Name="BuildCreateGenericDictionaryEnumerator{K, V}" Dynamic="Required">
-              <GenericParameter Name="K" Dynamic="Required All" />
-              <GenericParameter Name="V" Dynamic="Required All" />
-            </Method>
-            <Method Name="BuildIncrementCollectionCountDelegate{T}" Dynamic="Required">
-              <GenericParameter Name="T" Dynamic="Required All" />
-            </Method>
+            <Method Name="BuildCreateGenericDictionaryEnumerator{K, V}" Dynamic="Required" />
+            <Method Name="BuildIncrementCollectionCountDelegate{T}" Dynamic="Required" />
           </Type>
         </Type>
         <Type Name="DataContractSerializer">
@@ -27,27 +22,15 @@
         </Type>
         <Type Name="FastInvokerBuilder" Dynamic="Required All" />
         <Type Name="ReflectionReader">
-          <Method Name="GetCollectionSetItemDelegate{T}" Dynamic="Required">
-            <GenericParameter Name="T" Dynamic="Required All" />
-          </Method>
-          <Method Name="ObjectToKeyValuePairGetKey{K, V}" Dynamic="Required">
-            <GenericParameter Name="K" Dynamic="Required All" />
-            <GenericParameter Name="V" Dynamic="Required All" />
-          </Method>
-          <Method Name="ObjectToKeyValuePairGetValue{K, V}" Dynamic="Required">
-            <GenericParameter Name="K" Dynamic="Required All" />
-            <GenericParameter Name="V" Dynamic="Required All" />
-          </Method>
+          <Method Name="GetCollectionSetItemDelegate{T}" Dynamic="Required" />
+          <Method Name="ObjectToKeyValuePairGetKey{K, V}" Dynamic="Required" />
+          <Method Name="ObjectToKeyValuePairGetValue{K, V}" Dynamic="Required" />
         </Type>
         <Type Name="XmlObjectSerializerReadContext">
-          <Method Name="TrimArraySize{T}" Dynamic="Required">
-            <GenericParameter Name="T" Dynamic="Required All" />
-          </Method>
+          <Method Name="TrimArraySize{T}" Dynamic="Required" />
         </Type>
         <Type Name="XmlObjectSerializerWriteContext">        
-          <Method Name="GetDefaultValue{T}" Dynamic="Required">
-            <GenericParameter Name="T" Dynamic="Required All" />
-          </Method>
+          <Method Name="GetDefaultValue{T}" Dynamic="Required" />
         </Type>
       </Namespace>
       <Namespace Name="System.Runtime.Serialization.Json">

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CollectionDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CollectionDataContract.cs
@@ -438,7 +438,12 @@ namespace System.Runtime.Serialization
                             {
                                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidDataContractException(SR.Format(SR.GetOnlyCollectionMustHaveAddMethod, GetClrTypeFullName(UnderlyingType))));
                             }
-                            Debug.Assert(AddMethod != null || Kind == CollectionKind.Array, "Add method cannot be null if the collection is being used as a get-only property");
+
+                            if (Kind != CollectionKind.Array && AddMethod == null)
+                            {
+                                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidDataContractException(SR.Format(SR.GetOnlyCollectionMustHaveAddMethod, GetClrTypeFullName(UnderlyingType))));
+                            }
+
                             XmlFormatGetOnlyCollectionReaderDelegate tempDelegate = new XmlFormatReaderGenerator().GenerateGetOnlyCollectionReader(this);
                             Interlocked.MemoryBarrier();
                             _helper.XmlFormatGetOnlyCollectionReaderDelegate = tempDelegate;

--- a/src/System.Runtime.Serialization.Json/tests/ReflectionOnly/Resources/System.Runtime.Serialization.Json.ReflectionOnly.Tests.rd.xml
+++ b/src/System.Runtime.Serialization.Json/tests/ReflectionOnly/Resources/System.Runtime.Serialization.Json.ReflectionOnly.Tests.rd.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
-  <Library Name="*System.Private.DataContractSerialization*">
-    <Assembly Name="System.Private.DataContractSerialization" Dynamic="Required All">
-    </Assembly>
-  </Library>
-</Directives>

--- a/src/System.Runtime.Serialization.Json/tests/ReflectionOnly/System.Runtime.Serialization.Json.ReflectionOnly.Tests.csproj
+++ b/src/System.Runtime.Serialization.Json/tests/ReflectionOnly/System.Runtime.Serialization.Json.ReflectionOnly.Tests.csproj
@@ -21,8 +21,5 @@
     <Compile Include="$(TestSourceFolder)..\DataContractJsonSerializer.CoreCLR.cs" />
     <Compile Include="$(TestSourceFolder)..\..\..\System.Runtime.Serialization.Xml\tests\SerializationTypes.CoreCLR.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'uap'">
-    <EmbeddedResource Include="$(MsBuildThisFileDirectory)Resources\$(AssemblyName).rd.xml" />
-  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime.Serialization.Xml/tests/ReflectionOnly/Resources/System.Runtime.Serialization.Xml.ReflectionOnly.Tests.rd.xml
+++ b/src/System.Runtime.Serialization.Xml/tests/ReflectionOnly/Resources/System.Runtime.Serialization.Xml.ReflectionOnly.Tests.rd.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
-  <Library Name="*System.Private.DataContractSerialization*">
-    <Assembly Name="System.Private.DataContractSerialization" Dynamic="Required All">
-    </Assembly>
-  </Library>
-</Directives>

--- a/src/System.Runtime.Serialization.Xml/tests/ReflectionOnly/System.Runtime.Serialization.Xml.ReflectionOnly.Tests.csproj
+++ b/src/System.Runtime.Serialization.Xml/tests/ReflectionOnly/System.Runtime.Serialization.Xml.ReflectionOnly.Tests.csproj
@@ -37,8 +37,5 @@
     <Compile Include="$(TestSourceFolder)..\SerializationTypes.CoreCLR.cs" />
     <Compile Include="$(TestSourceFolder)..\DataContractSerializer.CoreCLR.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'uap'">
-    <EmbeddedResource Include="$(MsBuildThisFileDirectory)Resources\$(AssemblyName).rd.xml" />
-  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
Reflection based serialization needs to reflect some types or methods defined in `System.Private.DataContractSerialization.dll`. #19006 added rd.xml to System.Runtime.Serialization.*.ReflectionOnly.Tests. Many tests passed after that fix. But that fix caused the test projects to not represent actual customer scenarios.

The PR changes `System.Private.DataContractSerialization.rd.xml` to keep necessary metadata and removes the rd.xml for the test projects.

Fix #19067 