### PR TITLE
Reference official targeting pack for 4.7 (version 1.0.1)

### DIFF
--- a/external/netfx/netfx.depproj
+++ b/external/netfx/netfx.depproj
@@ -21,8 +21,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="$(TargetingPackNugetPackageId)">
-      <Version Condition="'$(TargetGroup)' != 'net47'">1.0.1</Version>
-      <Version Condition="'$(TargetGroup)' == 'net47'">1.0.0-prerelease</Version>
+      <Version>1.0.1</Version>
     </PackageReference>
     <PackageReference Include="NETStandard.Library" Condition="'$(TargetGroup)' == 'netfx'">
       <Version>$(NETStandardPackageVersion)</Version>


### PR DESCRIPTION
Following up on PR https://github.com/dotnet/corefx/pull/18519 which used the pre-release targeting pack. Alex published the new targeting pack on myget (as version 1.0.1).

Fixes https://github.com/dotnet/corefx/issues/18518

@AlexGhiondea @ericstj @weshaggard for review. Thanks