### PR TITLE
System.Security.Cryptography.Xml.Tests now at 0 failures on ILC.

### DIFF
--- a/src/Common/tests/System/PlatformDetection.cs
+++ b/src/Common/tests/System/PlatformDetection.cs
@@ -385,5 +385,11 @@ namespace System
         }
 
         private static volatile Tuple<bool> s_lazyNonZeroLowerBoundArraySupported;
+
+        public static bool IsReflectionEmitSupported = !PlatformDetection.IsNetNative;
+
+        // System.Security.Cryptography.Xml.XmlDsigXsltTransform.GetOutput() relies on XslCompiledTransform which relies
+        // heavily on Reflection.Emit
+        public static bool IsXmlDsigXsltTransformSupported => PlatformDetection.IsReflectionEmitSupported;
     }
 }

--- a/src/System.Security.Cryptography.Xml/tests/EncryptedXmlTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/EncryptedXmlTest.cs
@@ -678,8 +678,11 @@ namespace System.Security.Cryptography.Xml.Tests
                 cipherDataByReference.InnerText = cipherValue;
                 doc.DocumentElement.AppendChild(cipherDataByReference);
 
-                string decryptedXmlString = Encoding.UTF8.GetString(exml.DecryptData(ed, aes));
-                Assert.Equal(xml, decryptedXmlString);
+                if (PlatformDetection.IsXmlDsigXsltTransformSupported)
+                {
+                    string decryptedXmlString = Encoding.UTF8.GetString(exml.DecryptData(ed, aes));
+                    Assert.Equal(xml, decryptedXmlString);
+                }
             }
         }
 

--- a/src/System.Security.Cryptography.Xml/tests/EncryptionMethodTests.cs
+++ b/src/System.Security.Cryptography.Xml/tests/EncryptionMethodTests.cs
@@ -48,7 +48,7 @@ namespace System.Security.Cryptography.Xml.Tests
             if (PlatformDetection.IsFullFramework)
                 Assert.Throws<ArgumentOutOfRangeException>("The key size should be a non negative integer.", () => method.KeySize = value);
             else
-                Assert.Throws<ArgumentOutOfRangeException>("value", () => method.KeySize = value);
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => method.KeySize = value);
         }
 
         [Theory]

--- a/src/System.Security.Cryptography.Xml/tests/KeyInfoX509DataTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/KeyInfoX509DataTest.cs
@@ -147,7 +147,7 @@ namespace System.Security.Cryptography.Xml.Tests
         public void AddIssuerSerial_Issuer_Null()
         {
             KeyInfoX509Data data = new KeyInfoX509Data();
-            Assert.Throws<ArgumentException>("issuerName", () => data.AddIssuerSerial(null, "serial"));
+            AssertExtensions.Throws<ArgumentException>("issuerName", () => data.AddIssuerSerial(null, "serial"));
         }
 
         [Fact]
@@ -155,7 +155,7 @@ namespace System.Security.Cryptography.Xml.Tests
         public void AddIssuerSerial_Null_Serial()
         {
             KeyInfoX509Data data = new KeyInfoX509Data();
-            Assert.Throws<ArgumentException>("serialNumber", () => data.AddIssuerSerial("issuer", null));
+            AssertExtensions.Throws<ArgumentException>("serialNumber", () => data.AddIssuerSerial("issuer", null));
         }
 
         [Fact]
@@ -163,7 +163,7 @@ namespace System.Security.Cryptography.Xml.Tests
         public void AddIssuerSerial_Invalid_Serial()
         {
             KeyInfoX509Data data = new KeyInfoX509Data();
-            Assert.Throws<ArgumentException>("serialNumber", () => data.AddIssuerSerial("issuer", "NotANumber"));
+            AssertExtensions.Throws<ArgumentException>("serialNumber", () => data.AddIssuerSerial("issuer", "NotANumber"));
         }
 
         [Fact]

--- a/src/System.Security.Cryptography.Xml/tests/Resources/System.Security.Cryptography.Xml.Tests.rd.xml
+++ b/src/System.Security.Cryptography.Xml/tests/Resources/System.Security.Cryptography.Xml.Tests.rd.xml
@@ -1,0 +1,13 @@
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Library>
+
+    <!-- These types are loaded through CryptoConfig -->
+    <Type Name="System.Security.Cryptography.RSAPKCS1SignatureFormatter" Dynamic="Required Public" />
+    <Type Name="System.Security.Cryptography.RSAPKCS1SignatureDeformatter" Dynamic="Required Public" />
+    <Type Name="System.Security.Cryptography.DSASignatureFormatter" Dynamic="Required Public" />
+    <Type Name="System.Security.Cryptography.DSASignatureDeformatter" Dynamic="Required Public" />
+
+  </Library>
+</Directives>
+
+

--- a/src/System.Security.Cryptography.Xml/tests/System.Security.Cryptography.Xml.Tests.csproj
+++ b/src/System.Security.Cryptography.Xml/tests/System.Security.Cryptography.Xml.Tests.csproj
@@ -67,6 +67,9 @@
     <EmbeddedResource Include="EncryptedXmlSample1.xml" />
     <EmbeddedResource Include="XmlLicenseSample.xml" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\$(AssemblyName).rd.xml" />
+  </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Security.Cryptography.Xml/tests/TestHelpers.cs
+++ b/src/System.Security.Cryptography.Xml/tests/TestHelpers.cs
@@ -195,12 +195,12 @@ namespace System.Security.Cryptography.Xml.Tests
 
         public static Stream LoadResourceStream(string resourceName)
         {
-            return Assembly.GetCallingAssembly().GetManifestResourceStream(resourceName);
+            return typeof(TestHelpers).Assembly.GetManifestResourceStream(resourceName);
         }
 
         public static byte[] LoadResource(string resourceName)
         {
-            using (Stream stream = Assembly.GetCallingAssembly().GetManifestResourceStream(resourceName))
+            using (Stream stream = typeof(TestHelpers).Assembly.GetManifestResourceStream(resourceName))
             {
                 long length = stream.Length;
                 byte[] buffer = new byte[length];

--- a/src/System.Security.Cryptography.Xml/tests/XmlDsigXsltTransformTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/XmlDsigXsltTransformTest.cs
@@ -127,7 +127,10 @@ namespace System.Security.Cryptography.Xml.Tests
             doc.LoadXml(test);
 
             transform.LoadInput(doc.ChildNodes);
-            Assert.Throws<ArgumentNullException>(() => transform.GetOutput());
+            if (PlatformDetection.IsXmlDsigXsltTransformSupported)
+            {
+                Assert.Throws<ArgumentNullException>(() => transform.GetOutput());
+            }
         }
 
         [Fact]
@@ -141,7 +144,10 @@ namespace System.Security.Cryptography.Xml.Tests
 
             transform.LoadInnerXml(doc.ChildNodes);
             transform.LoadInput(doc);
-            Stream s = (Stream)transform.GetOutput();
+            if (PlatformDetection.IsXmlDsigXsltTransformSupported)
+            {
+                Stream s = (Stream)transform.GetOutput();
+            }
         }
 
         [Fact]
@@ -182,7 +188,10 @@ namespace System.Security.Cryptography.Xml.Tests
             doc.LoadXml(test);
 
             transform.LoadInnerXml(doc.ChildNodes);
-            Assert.Throws<ArgumentNullException>(() => transform.GetOutput());
+            if (PlatformDetection.IsXmlDsigXsltTransformSupported)
+            {
+                Assert.Throws<ArgumentNullException>(() => transform.GetOutput());
+            }
         }
 
         private XmlDocument GetXslDoc()
@@ -205,8 +214,11 @@ namespace System.Security.Cryptography.Xml.Tests
             XmlDocument doc = GetXslDoc();
             transform.LoadInnerXml(doc.DocumentElement.ChildNodes);
             transform.LoadInput(doc);
-            Stream s = (Stream)transform.GetOutput();
-            string output = Stream2Array(s);
+            if (PlatformDetection.IsXmlDsigXsltTransformSupported)
+            {
+                Stream s = (Stream)transform.GetOutput();
+                string output = Stream2Array(s);
+            }
         }
 
         [Fact]
@@ -215,8 +227,11 @@ namespace System.Security.Cryptography.Xml.Tests
             XmlDocument doc = GetXslDoc();
             transform.LoadInnerXml(doc.DocumentElement.ChildNodes);
             transform.LoadInput(doc.ChildNodes);
-            Stream s = (Stream)transform.GetOutput();
-            string output = Stream2Array(s);
+            if (PlatformDetection.IsXmlDsigXsltTransformSupported)
+            {
+                Stream s = (Stream)transform.GetOutput();
+                string output = Stream2Array(s);
+            }
         }
 
         [Fact]
@@ -228,8 +243,11 @@ namespace System.Security.Cryptography.Xml.Tests
             doc.Save(ms);
             ms.Position = 0;
             transform.LoadInput(ms);
-            Stream s = (Stream)transform.GetOutput();
-            string output = Stream2Array(s);
+            if (PlatformDetection.IsXmlDsigXsltTransformSupported)
+            {
+                Stream s = (Stream)transform.GetOutput();
+                string output = Stream2Array(s);
+            }
         }
 
         protected void AreEqual(string msg, XmlNodeList expected, XmlNodeList actual)
@@ -265,8 +283,11 @@ namespace System.Security.Cryptography.Xml.Tests
             XmlDocument doc = GetXslDoc();
             transform.LoadInnerXml(doc.DocumentElement.ChildNodes);
             transform.LoadInput(doc);
-            Stream s = (Stream)transform.GetOutput();
-            string output = Stream2Array(s);
+            if (PlatformDetection.IsXmlDsigXsltTransformSupported)
+            {
+                Stream s = (Stream)transform.GetOutput();
+                string output = Stream2Array(s);
+            }
         }
 
         [Fact]


### PR DESCRIPTION
The usual suspects:

- Checking for Exception.ParamNames

- Types obtained through CryptoConfig being reduced away.

- Unnecessary use of GetCallingAssembly() in TestHelper

- XmlDsigXsltTransform relies on XslCompiledTransform which relies
  heavily on Reflection.Emit.

  Let me know if you want an issue opened on this, though
  it looks pretty fundamental...