### PR TITLE
[release/2.0.0] Exclude UAP from packages in rel/2.0.0

### DIFF
--- a/Packaging.props
+++ b/Packaging.props
@@ -63,4 +63,6 @@
         <SkipPackageFileCheck>true</SkipPackageFileCheck>
     </File>
   </ItemGroup>
+  
+  <Import Condition="'$(MSBuildProjectExtension)' == '.pkgproj'" Project="$(MSBuildThisFileDirectory)pkg/disableUap10.1.targets" />
 </Project>

--- a/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.pkgproj
+++ b/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.pkgproj
@@ -15,6 +15,9 @@
 
     <!-- Private packages need symbols -->
     <IncludeSymbolsInPackage Condition="'$(IncludeSymbolsInPackage)' == ''">true</IncludeSymbolsInPackage>
+
+    <!-- UAP10.1 is stripped out of other packages, but we don't want to do that for the framework package -->
+    <KeepUAPContent>true</KeepUAPContent>
   </PropertyGroup>
 
   <ItemGroup>

--- a/pkg/disableUap10.1.targets
+++ b/pkg/disableUap10.1.targets
@@ -1,0 +1,12 @@
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="RemoveUap101Content"
+          Condition="'$(KeepUAPContent)' != 'true'"
+          DependsOnTargets="GetPackageReport"
+          BeforeTargets="GenerateNuSpec">
+    <ItemGroup>
+      <PackageFile Remove="@(PackageFile)" Condition="'%(PackageFile.TargetFramework)' == 'uap10.1'" />
+      <PackageFile Remove="@(PackageFile)" Condition="$([System.String]::new('%(PackageFile.TargetPath)').Contains('/uap10.1'))" />
+      <Dependency Remove="@(Dependency)" Condition="'%(Dependency.TargetFramework)' == 'uap10.1'" />
+    </ItemGroup>
+  </Target>
+</Project>


### PR DESCRIPTION
**release/2.0.0 only** do not merge to master.

Fixes #19316 

This excludes all UAP files and dependencies from packages for 2.0.0 release.