### PR TITLE
Port the Html Encoder fix from VSO branch

### DIFF
--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/HtmlEncoder.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/HtmlEncoder.cs
@@ -94,7 +94,7 @@ namespace System.Text.Encodings.Web
 
         public override int MaxOutputCharactersPerInputCharacter
         {
-            get { return 9; } // "&#xFFFFF;" is the longest encoded form
+            get { return 10; } // "&#x10FFFF;" is the longest encoded form
         }
 
         static readonly char[] s_quote = "&quot;".ToCharArray();

--- a/src/System.Text.Encodings.Web/tests/HtmlEncoderTests.cs
+++ b/src/System.Text.Encodings.Web/tests/HtmlEncoderTests.cs
@@ -265,6 +265,19 @@ namespace Microsoft.Framework.WebEncoders
             Assert.Equal("lo&#x2B;wo", output.ToString());
         }
 
+        [Fact]
+        public void HtmlEncode_AstralWithTextWriter()
+        {
+            byte[] buffer = new byte[10];
+            MemoryStream ms = new MemoryStream(buffer);
+            using (StreamWriter sw = new StreamWriter(ms))
+            {
+                string input = "\U0010FFFF";
+                System.Text.Encodings.Web.HtmlEncoder.Default.Encode(sw, input);
+            }
+            Assert.Equal("&#x10FFFF;", System.Text.Encoding.UTF8.GetString(buffer));
+        }
+
         private static bool IsSurrogateCodePoint(int codePoint)
         {
             return (0xD800 <= codePoint && codePoint <= 0xDFFF);


### PR DESCRIPTION
This is the fix we have done in VSO branch and now we are porting it to corefx after we released the fix in the servicing packages