### PR TITLE
Remove unneeded Serializable attributes

### DIFF
--- a/src/Common/src/System/CodeDom/CodeTypeReference.cs
+++ b/src/Common/src/System/CodeDom/CodeTypeReference.cs
@@ -12,7 +12,6 @@ namespace System.CodeDom
 namespace System.Runtime.Serialization
 #endif
 {
-    [Serializable]
     [Flags]
 #if !FEATURE_SERIALIZATION
     public enum CodeTypeReferenceOptions

--- a/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryHive.cs
+++ b/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryHive.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Win32
     /**
      * Registry hive values.  Useful only for GetRemoteBaseKey
      */
-    [Serializable]
 #if REGISTRY_ASSEMBLY
     public
 #else

--- a/src/System.CodeDom/src/System/CodeDom/CodeBinaryOperatorType.cs
+++ b/src/System.CodeDom/src/System/CodeDom/CodeBinaryOperatorType.cs
@@ -4,7 +4,6 @@
 
 namespace System.CodeDom
 {
-    [Serializable]
     public enum CodeBinaryOperatorType
     {
         Add,

--- a/src/System.CodeDom/src/System/CodeDom/CodeRegionMode.cs
+++ b/src/System.CodeDom/src/System/CodeDom/CodeRegionMode.cs
@@ -4,7 +4,6 @@
 
 namespace System.CodeDom
 {
-    [Serializable]
     public enum CodeRegionMode
     {
         None = 0,

--- a/src/System.CodeDom/src/System/CodeDom/Compiler/GeneratorSupport.cs
+++ b/src/System.CodeDom/src/System/CodeDom/Compiler/GeneratorSupport.cs
@@ -4,7 +4,6 @@
 
 namespace System.CodeDom.Compiler
 {
-    [Serializable]
     [Flags]
     public enum GeneratorSupport
     {

--- a/src/System.CodeDom/src/System/CodeDom/Compiler/LanguageOptions.cs
+++ b/src/System.CodeDom/src/System/CodeDom/Compiler/LanguageOptions.cs
@@ -4,7 +4,6 @@
 
 namespace System.CodeDom.Compiler
 {
-    [Serializable]
     [Flags]
     public enum LanguageOptions
     {

--- a/src/System.CodeDom/src/System/CodeDom/FieldDirection.cs
+++ b/src/System.CodeDom/src/System/CodeDom/FieldDirection.cs
@@ -4,7 +4,6 @@
 
 namespace System.CodeDom
 {
-    [Serializable]
     public enum FieldDirection
     {
         In,

--- a/src/System.CodeDom/src/System/CodeDom/MemberAttributes.cs
+++ b/src/System.CodeDom/src/System/CodeDom/MemberAttributes.cs
@@ -4,7 +4,6 @@
 
 namespace System.CodeDom
 {
-    [Serializable]
     public enum MemberAttributes
     {
         Abstract = 0x0001,

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/PartitionerStatic.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/PartitionerStatic.cs
@@ -23,7 +23,6 @@ namespace System.Collections.Concurrent
     /// non-blocking.  These behaviors can be overridden via this enumeration.
     /// </summary>
     [Flags]
-    [Serializable]
     public enum EnumerablePartitionerOptions
     {
         /// <summary>

--- a/src/System.Console/src/System/ConsoleColor.cs
+++ b/src/System.Console/src/System/ConsoleColor.cs
@@ -7,7 +7,6 @@ namespace System
     // This enumeration represents the colors that can be used for 
     // console text foreground and background colors.
 
-    [Serializable]
     public enum ConsoleColor
     {
         Black = 0,

--- a/src/System.Console/src/System/ConsoleKey.cs
+++ b/src/System.Console/src/System/ConsoleKey.cs
@@ -4,7 +4,6 @@
 
 namespace System
 {
-    [Serializable]
     public enum ConsoleKey
     {
         Backspace = 0x8,

--- a/src/System.Console/src/System/ConsoleModifiers.cs
+++ b/src/System.Console/src/System/ConsoleModifiers.cs
@@ -5,7 +5,6 @@
 namespace System
 {
     [Flags]
-    [Serializable]
     public enum ConsoleModifiers
     {
         Alt = 1,

--- a/src/System.Console/src/System/ConsoleSpecialKey.cs
+++ b/src/System.Console/src/System/ConsoleSpecialKey.cs
@@ -4,7 +4,6 @@
 
 namespace System 
 {
-    [Serializable]
     public enum ConsoleSpecialKey
     {
         ControlC = 0,

--- a/src/System.Data.Common/src/System/Data/KeyRestrictionBehavior.cs
+++ b/src/System.Data.Common/src/System/Data/KeyRestrictionBehavior.cs
@@ -4,7 +4,6 @@
 
 namespace System.Data
 {
-    [Serializable]
     public enum KeyRestrictionBehavior
     {
         AllowOnly = 0,

--- a/src/System.Data.Common/src/System/Data/MappingType.cs
+++ b/src/System.Data.Common/src/System/Data/MappingType.cs
@@ -4,7 +4,6 @@
 
 namespace System.Data
 {
-    [Serializable]
     public enum MappingType
     {
         Element = 1,        // Element column

--- a/src/System.Data.Common/src/System/Data/SQLTypes/SQLBytes.cs
+++ b/src/System.Data.Common/src/System/Data/SQLTypes/SQLBytes.cs
@@ -13,7 +13,6 @@ using System.Runtime.CompilerServices;
 
 namespace System.Data.SqlTypes
 {
-    [Serializable]
     internal enum SqlBytesCharsState
     {
         Null = 0,

--- a/src/System.Data.Common/src/System/Data/SQLTypes/SQLString.cs
+++ b/src/System.Data.Common/src/System/Data/SQLTypes/SQLString.cs
@@ -14,7 +14,7 @@ using System.Xml.Serialization;
 namespace System.Data.SqlTypes
 {
     // Options that are used in comparison
-    [Flags, Serializable]
+    [Flags]
     public enum SqlCompareOptions
     {
         None = 0x00000000,

--- a/src/System.Data.Odbc/src/System/Data/Odbc/Odbc32.cs
+++ b/src/System.Data.Odbc/src/System/Data/Odbc/Odbc32.cs
@@ -136,7 +136,6 @@ namespace System.Data.Odbc
 
         // from .\public\sdk\inc\sqlext.h: and .\public\sdk\inc\sql.h
         // must be public because it is serialized by OdbcException
-        [Serializable]
         public enum RETCODE : int
         { // must be int instead of short for Everett OdbcException Serializablity.
             SUCCESS = 0,

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/ApplicationIntent.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/ApplicationIntent.cs
@@ -10,7 +10,6 @@ namespace System.Data.SqlClient
     /// <summary>
     /// represents the application workload type when connecting to a server
     /// </summary>
-    [Serializable]
     public enum ApplicationIntent
     {
         ReadWrite = 0,

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ThreadState.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ThreadState.cs
@@ -7,7 +7,6 @@ namespace System.Diagnostics
     /// <devdoc>
     ///     Specifies the execution state of a thread.
     /// </devdoc>
-    [Serializable]
     public enum ThreadState
     {
         /// <devdoc>

--- a/src/System.Diagnostics.StackTrace/src/System/Diagnostics/SymbolStore/SymAddressKind.cs
+++ b/src/System.Diagnostics.StackTrace/src/System/Diagnostics/SymbolStore/SymAddressKind.cs
@@ -4,7 +4,6 @@
 
 namespace System.Diagnostics.SymbolStore
 {
-    [Serializable]
     public enum SymAddressKind
     {
         // ILOffset: addr1 = IL local var or param index.

--- a/src/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceLevel.cs
+++ b/src/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceLevel.cs
@@ -11,7 +11,6 @@ namespace System.Diagnostics
     ///    <para>Specifies what messages to output for debugging
     ///       and tracing.</para>
     /// </devdoc>
-    [Serializable]
     public enum TraceLevel
     {
         /// <devdoc>

--- a/src/System.IO.FileSystem.DriveInfo/src/System/IO/DriveType.cs
+++ b/src/System.IO.FileSystem.DriveInfo/src/System/IO/DriveType.cs
@@ -7,7 +7,6 @@ using System;
 namespace System.IO
 {
     // Matches Win32's DRIVE_XXX #defines from winbase.h
-    [Serializable]
     public enum DriveType
     {
         Unknown = 0,

--- a/src/System.IO.FileSystem/src/System/IO/SearchOption.cs
+++ b/src/System.IO.FileSystem/src/System/IO/SearchOption.cs
@@ -11,7 +11,6 @@ namespace System.IO
     ///   retrieve files/directories from the current directory alone
     ///   or should include all the subdirectories also.
     /// </devdoc>
-    [Serializable]
     public enum SearchOption
     {
         /// <devdoc>

--- a/src/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageScope.cs
+++ b/src/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageScope.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -6,7 +6,6 @@ using System;
 
 namespace System.IO.IsolatedStorage
 {
-    [Serializable]
     [Flags]
     public enum IsolatedStorageScope
     {

--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFileAccess.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFileAccess.cs
@@ -4,7 +4,6 @@
 
 namespace System.IO.MemoryMappedFiles
 {
-    [Serializable]
     public enum MemoryMappedFileAccess
     {
         ReadWrite = 0,

--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFileOptions.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFileOptions.cs
@@ -4,7 +4,6 @@
 
 namespace System.IO.MemoryMappedFiles
 {
-    [Serializable]
     [Flags]
     public enum MemoryMappedFileOptions
     {

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeDirection.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeDirection.cs
@@ -4,7 +4,6 @@
 
 namespace System.IO.Pipes
 {
-    [Serializable]
     public enum PipeDirection
     {
         In = 1,

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeOptions.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeOptions.cs
@@ -4,7 +4,6 @@
 
 namespace System.IO.Pipes
 {
-    [Serializable]
     [Flags]
     public enum PipeOptions
     {

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeState.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeState.cs
@@ -1,10 +1,9 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace System.IO.Pipes
 {
-    [Serializable]
     internal enum PipeState
     {
         // Waiting to connect is the state before a live connection has been established. For named pipes, the 

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeTransmissionMode.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeTransmissionMode.cs
@@ -4,7 +4,6 @@
 
 namespace System.IO.Pipes
 {
-    [Serializable]
     public enum PipeTransmissionMode
     {
         Byte = 0,

--- a/src/System.Reflection.Primitives/src/System/Reflection/Emit/FlowControl.cs
+++ b/src/System.Reflection.Primitives/src/System/Reflection/Emit/FlowControl.cs
@@ -4,7 +4,6 @@
 
 namespace System.Reflection.Emit
 {
-    [Serializable]
     public enum FlowControl
     {
         Branch = 0,

--- a/src/System.Reflection.Primitives/src/System/Reflection/Emit/OpcodeType.cs
+++ b/src/System.Reflection.Primitives/src/System/Reflection/Emit/OpcodeType.cs
@@ -4,7 +4,6 @@
 
 namespace System.Reflection.Emit
 {
-    [Serializable]
     public enum OpCodeType
     {
         [Obsolete("This API has been deprecated. http://go.microsoft.com/fwlink/?linkid=14202")]

--- a/src/System.Reflection.Primitives/src/System/Reflection/Emit/OperandType.cs
+++ b/src/System.Reflection.Primitives/src/System/Reflection/Emit/OperandType.cs
@@ -4,7 +4,6 @@
 
 namespace System.Reflection.Emit
 {
-    [Serializable]
     public enum OperandType
     {
         InlineBrTarget = 0,

--- a/src/System.Reflection.Primitives/src/System/Reflection/Emit/PackingSize.cs
+++ b/src/System.Reflection.Primitives/src/System/Reflection/Emit/PackingSize.cs
@@ -4,7 +4,6 @@
 
 namespace System.Reflection.Emit
 {
-    [Serializable]
     public enum PackingSize
     {
         Unspecified = 0,

--- a/src/System.Reflection.Primitives/src/System/Reflection/Emit/StackBehaviour.cs
+++ b/src/System.Reflection.Primitives/src/System/Reflection/Emit/StackBehaviour.cs
@@ -4,7 +4,6 @@
 
 namespace System.Reflection.Emit
 {
-    [Serializable]
     public enum StackBehaviour
     {
         Pop0 = 0,

--- a/src/System.Resources.ResourceManager/ref/System.Resources.ResourceManager.cs
+++ b/src/System.Resources.ResourceManager/ref/System.Resources.ResourceManager.cs
@@ -105,7 +105,6 @@ namespace System.Resources
         public SatelliteContractVersionAttribute(string version) { }
         public string Version { get { throw null; } }
     }
-    [System.Serializable]
     public enum UltimateResourceFallbackLocation
     {
         MainAssembly,

--- a/src/System.Resources.Writer/src/System/Resources/ResourceWriter.cs
+++ b/src/System.Resources.Writer/src/System/Resources/ResourceWriter.cs
@@ -649,7 +649,6 @@ namespace System.Resources
         }
     }
 
-    [Serializable]
     internal enum ResourceTypeCode {
         // Primitives
         Null = 0,

--- a/src/System.Runtime.Extensions/src/System/PlatformID.cs
+++ b/src/System.Runtime.Extensions/src/System/PlatformID.cs
@@ -4,7 +4,6 @@
 
 namespace System
 {
-    [Serializable]
     public enum PlatformID
     {
         Win32S = 0,

--- a/src/System.Runtime.Extensions/src/System/Runtime/Versioning/ComponentGuaranteesOptions.cs
+++ b/src/System.Runtime.Extensions/src/System/Runtime/Versioning/ComponentGuaranteesOptions.cs
@@ -5,7 +5,6 @@
 namespace System.Runtime.Versioning
 {
     [Flags]
-    [Serializable]
     public enum ComponentGuaranteesOptions
     {
         None = 0,

--- a/src/System.Runtime.Extensions/src/System/Security/Permissions/SecurityAction.cs
+++ b/src/System.Runtime.Extensions/src/System/Security/Permissions/SecurityAction.cs
@@ -1,10 +1,9 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace System.Security.Permissions
 {
-    [Serializable]
     public enum SecurityAction
     {
         Assert = 3,

--- a/src/System.Runtime.Extensions/src/System/Security/Permissions/SecurityPermissionFlag.cs
+++ b/src/System.Runtime.Extensions/src/System/Security/Permissions/SecurityPermissionFlag.cs
@@ -1,10 +1,9 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace System.Security.Permissions
 {
-    [Serializable]
     [Flags]
     public enum SecurityPermissionFlag
     {

--- a/src/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -834,7 +834,6 @@ namespace System.Runtime.InteropServices
         public TypeLibImportClassAttribute(Type importClass) { }
         public String Value { get { throw null; } }
     }
-    [Serializable]
     [Flags()]
     public enum TypeLibTypeFlags
     {
@@ -853,7 +852,6 @@ namespace System.Runtime.InteropServices
         FDispatchable   = 0x1000,
         FReverseBind    = 0x2000,
     }
-    [Serializable]
     [Flags()]
     public enum TypeLibFuncFlags
     {
@@ -871,7 +869,6 @@ namespace System.Runtime.InteropServices
         FReplaceable        = 0x0800,
         FImmediateBind      = 0x1000,
     }
-    [Serializable]
     [Flags()]
     public enum TypeLibVarFlags
     {

--- a/src/System.Runtime.InteropServices/src/System/Runtime/InteropServices/Attributes.cs
+++ b/src/System.Runtime.InteropServices/src/System/Runtime/InteropServices/Attributes.cs
@@ -87,7 +87,6 @@ namespace System.Runtime.InteropServices
     }
 
     [Obsolete("The IDispatchImplAttribute is deprecated.", false)]
-    [Serializable]
     public enum IDispatchImplType
     {
         CompatibleImpl = 2,
@@ -150,7 +149,6 @@ namespace System.Runtime.InteropServices
         public string Value { get; }
     }
 
-    [Serializable]
     [Flags]
     public enum TypeLibTypeFlags
     {
@@ -170,7 +168,6 @@ namespace System.Runtime.InteropServices
         FReverseBind    = 0x2000,
     }
 
-    [Serializable]
     [Flags]
     public enum TypeLibFuncFlags
     {
@@ -189,7 +186,6 @@ namespace System.Runtime.InteropServices
         FImmediateBind      = 0x1000,
     }
 
-    [Serializable]
     [Flags]
     public enum TypeLibVarFlags
     {

--- a/src/System.Runtime.InteropServices/src/System/Runtime/InteropServices/ExporterEventKind.cs
+++ b/src/System.Runtime.InteropServices/src/System/Runtime/InteropServices/ExporterEventKind.cs
@@ -4,7 +4,6 @@
 
 namespace System.Runtime.InteropServices
 {
-    [Serializable]
     public enum ExporterEventKind
     {
         NOTIF_TYPECONVERTED = 0,

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/DeserializationEventHandler.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/DeserializationEventHandler.cs
@@ -4,9 +4,7 @@
 
 namespace System.Runtime.Serialization
 {
-    [Serializable]
     internal delegate void DeserializationEventHandler(object sender);
 
-    [Serializable]
     internal delegate void SerializationEventHandler(StreamingContext context);
 }

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryEnums.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryEnums.cs
@@ -5,7 +5,6 @@
 namespace System.Runtime.Serialization.Formatters.Binary
 {
     // BinaryHeaderEnum is the first byte on binary records (except for primitive types which do not have a header)
-    [Serializable]
     internal enum BinaryHeaderEnum
     {
         SerializedStreamHeader = 0,
@@ -34,7 +33,6 @@ namespace System.Runtime.Serialization.Formatters.Binary
     }
 
     // BinaryTypeEnum is used specify the type on the wire. Additional information is transmitted with Primitive and Object types
-    [Serializable]
     internal enum BinaryTypeEnum
     {
         Primitive = 0,
@@ -47,7 +45,6 @@ namespace System.Runtime.Serialization.Formatters.Binary
         PrimitiveArray = 7,
     }
 
-    [Serializable]
     internal enum BinaryArrayTypeEnum
     {
         Single = 0,
@@ -61,7 +58,6 @@ namespace System.Runtime.Serialization.Formatters.Binary
     // Enums are for internal use by the XML and Binary Serializers
 
     // Formatter Enums
-    [Serializable]
     internal enum InternalSerializerTypeE
     {
         Soap = 1,
@@ -69,7 +65,6 @@ namespace System.Runtime.Serialization.Formatters.Binary
     }
 
     // ParseRecord Enums
-    [Serializable]
     internal enum InternalParseTypeE
     {
         Empty = 0,
@@ -87,7 +82,6 @@ namespace System.Runtime.Serialization.Formatters.Binary
         BodyEnd = 12,
     }
 
-    [Serializable]
     internal enum InternalObjectTypeE
     {
         Empty = 0,
@@ -95,7 +89,6 @@ namespace System.Runtime.Serialization.Formatters.Binary
         Array = 2,
     }
 
-    [Serializable]
     internal enum InternalObjectPositionE
     {
         Empty = 0,
@@ -104,7 +97,6 @@ namespace System.Runtime.Serialization.Formatters.Binary
         Headers = 3,
     }
 
-    [Serializable]
     internal enum InternalArrayTypeE
     {
         Empty = 0,
@@ -114,7 +106,6 @@ namespace System.Runtime.Serialization.Formatters.Binary
         Base64 = 4,
     }
 
-    [Serializable]
     internal enum InternalMemberTypeE
     {
         Empty = 0,
@@ -123,7 +114,6 @@ namespace System.Runtime.Serialization.Formatters.Binary
         Item = 3,
     }
 
-    [Serializable]
     internal enum InternalMemberValueE
     {
         Empty = 0,
@@ -134,7 +124,6 @@ namespace System.Runtime.Serialization.Formatters.Binary
     }
 
     // Data Type Enums
-    [Serializable]
     internal enum InternalPrimitiveTypeE
     {
         Invalid = 0,
@@ -161,7 +150,6 @@ namespace System.Runtime.Serialization.Formatters.Binary
     }
 
     // ValueType Fixup Enum
-    [Serializable]
     internal enum ValueFixupEnum
     {
         Empty = 0,
@@ -171,7 +159,6 @@ namespace System.Runtime.Serialization.Formatters.Binary
     }
 
     // name space
-    [Serializable]
     internal enum InternalNameSpaceE
     {
         None = 0,

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/CommonEnums.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/CommonEnums.cs
@@ -4,7 +4,6 @@
 
 namespace System.Runtime.Serialization.Formatters
 {
-    [Serializable]
     public enum FormatterTypeStyle
     {
         TypesWhenNeeded = 0, // Types are outputted only for Arrays of Objects, Object Members of type Object, and ISerializable non-primitive value types
@@ -12,7 +11,6 @@ namespace System.Runtime.Serialization.Formatters
         XsdString = 0x2      // Strings are outputed as xsd rather then SOAP-ENC strings. No string ID's are transmitted
     }
 
-    [Serializable]
     public enum FormatterAssemblyStyle
     {
         Simple = 0,

--- a/src/System.Runtime/src/System/IO/FileAttributes.cs
+++ b/src/System.Runtime/src/System/IO/FileAttributes.cs
@@ -6,7 +6,6 @@ using System;
 
 namespace System.IO
 {
-    [Serializable]
     [Flags]
     public enum FileAttributes
     {

--- a/src/System.Runtime/src/System/IO/HandleInheritability.cs
+++ b/src/System.Runtime/src/System/IO/HandleInheritability.cs
@@ -4,7 +4,6 @@
 
 namespace System.IO
 {
-    [Serializable]
     public enum HandleInheritability
     {
         None = 0,

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CspProviderFlags.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CspProviderFlags.cs
@@ -6,7 +6,6 @@ namespace System.Security.Cryptography
 {
     // In case you are adding more values in the CspProviderFlags Flags below.
     // please change the Flags Set where int allFlags is initialized with 0x00FF;
-    [Serializable]
     [Flags]
     public enum CspProviderFlags
     {

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/KeyNumber.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/KeyNumber.cs
@@ -8,7 +8,6 @@ using System.Security.Cryptography;
 
 namespace System.Security.Cryptography
 {
-    [Serializable]
     public enum KeyNumber
     {
         //These are identifiers for the private keys from the key container

--- a/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/Base64Transforms.cs
+++ b/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/Base64Transforms.cs
@@ -9,7 +9,6 @@ using System.Text;
 
 namespace System.Security.Cryptography
 {
-    [Serializable]
     public enum FromBase64TransformMode
     {
         IgnoreWhiteSpaces = 0,

--- a/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/CipherMode.cs
+++ b/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/CipherMode.cs
@@ -11,7 +11,6 @@ namespace System.Security.Cryptography
     //  electronic code book (ECB),
     //  ciphertext-stealing (CTS).
     // Not all implementations will support all modes.
-    [Serializable]
     public enum CipherMode
     {
         CBC = 1,

--- a/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/CryptoStreamMode.cs
+++ b/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/CryptoStreamMode.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 
 namespace System.Security.Cryptography
 {
-    [Serializable]
     public enum CryptoStreamMode
     {
         Read = 0,

--- a/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/PaddingMode.cs
+++ b/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/PaddingMode.cs
@@ -15,7 +15,6 @@ namespace System.Security.Cryptography
     // "ISO 10126" is the same as PKCS5 except that it fills the bytes before the last one with 
     // random bytes. 
     // "ANSI X.923" fills the bytes with zeros and puts the number of padding  bytes in the last byte.
-    [Serializable]
     public enum PaddingMode
     {
         None = 1,

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509KeyStorageFlags.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509KeyStorageFlags.cs
@@ -6,7 +6,6 @@ namespace System.Security.Cryptography.X509Certificates
 {
     // DefaultKeySet, UserKeySet and MachineKeySet are mutually exclusive
     // PersistKeySet and EphemeralKeySet are mutually exclusive
-    [Serializable]
     [Flags]
     public enum X509KeyStorageFlags
     {

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CertUsageType.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CertUsageType.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -16,7 +16,6 @@ using System.Xml;
 
 namespace System.Security.Cryptography.Xml
 {
-    [Serializable]
     internal enum CertUsageType
     {
         Verification = 0,

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/ReferenceTargetType.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/ReferenceTargetType.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -6,7 +6,6 @@ using System;
 
 namespace System.Security.Cryptography.Xml
 {
-    [Serializable]
     internal enum ReferenceTargetType
     {
         Stream,

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/TransformInputType.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/TransformInputType.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -6,7 +6,6 @@ using System;
 
 namespace System.Security.Cryptography.Xml
 {
-    [Serializable]
     internal enum TransformInputType
     {
         XmlDocument = 1,

--- a/src/System.Security.Permissions/src/System/Drawing/Printing/PrintingPermissionLevel.cs
+++ b/src/System.Security.Permissions/src/System/Drawing/Printing/PrintingPermissionLevel.cs
@@ -1,10 +1,9 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace System.Drawing.Printing
 {
-    [Serializable]
     public enum PrintingPermissionLevel
     {
         AllPrinting = 3,

--- a/src/System.Security.Permissions/src/System/Security/HostSecurityManagerOptions.cs
+++ b/src/System.Security.Permissions/src/System/Security/HostSecurityManagerOptions.cs
@@ -1,10 +1,9 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace System.Security
 {
-    [Serializable]
     [Flags]
     public enum HostSecurityManagerOptions
     {

--- a/src/System.Security.Permissions/src/System/Security/Permissions/EnvironmentPermissionAccess.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/EnvironmentPermissionAccess.cs
@@ -1,10 +1,9 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace System.Security.Permissions
 {
-    [Serializable]
     [Flags]
     public enum EnvironmentPermissionAccess
     {

--- a/src/System.Security.Permissions/src/System/Security/Permissions/FileDialogPermissionAccess.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/FileDialogPermissionAccess.cs
@@ -1,10 +1,9 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace System.Security.Permissions
 {
-    [Serializable]
     [Flags]
     public enum FileDialogPermissionAccess
     {

--- a/src/System.Security.Permissions/src/System/Security/Permissions/FileIOPermissionAccess.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/FileIOPermissionAccess.cs
@@ -1,10 +1,9 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace System.Security.Permissions
 {
-    [Serializable]
     [Flags]
     public enum FileIOPermissionAccess
     {

--- a/src/System.Security.Permissions/src/System/Security/Permissions/HostProtectionResource.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/HostProtectionResource.cs
@@ -1,10 +1,9 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace System.Security.Permissions
 {
-    [Serializable]
     [Flags]
     public enum HostProtectionResource
     {

--- a/src/System.Security.Permissions/src/System/Security/Permissions/PermissionState.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/PermissionState.cs
@@ -1,10 +1,9 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace System.Security.Permissions
 {
-    [Serializable]
     public enum PermissionState
     {
         None = 0,

--- a/src/System.Security.Permissions/src/System/Security/Permissions/ReflectionPermissionFlag.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/ReflectionPermissionFlag.cs
@@ -1,10 +1,9 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace System.Security.Permissions
 {
-    [Serializable]
     [Flags]
     public enum ReflectionPermissionFlag
     {

--- a/src/System.Security.Permissions/src/System/Security/Permissions/RegistryPermissionAccess.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/RegistryPermissionAccess.cs
@@ -1,10 +1,9 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace System.Security.Permissions
 {
-    [Serializable]
     [Flags]
     public enum RegistryPermissionAccess
     {

--- a/src/System.Security.Permissions/src/System/Security/Permissions/TypeDescriptorPermissionFlags.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/TypeDescriptorPermissionFlags.cs
@@ -1,10 +1,9 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace System.Security.Permissions
 {
-    [Serializable]
     [Flags]
     public enum TypeDescriptorPermissionFlags
     {

--- a/src/System.Security.Permissions/src/System/Security/Permissions/UIPermissionClipboard.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/UIPermissionClipboard.cs
@@ -1,10 +1,9 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace System.Security.Permissions
 {
-    [Serializable]
     public enum UIPermissionClipboard
     {
         AllClipboard = 2,

--- a/src/System.Security.Permissions/src/System/Security/Permissions/UIPermissionWindow.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/UIPermissionWindow.cs
@@ -1,10 +1,9 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace System.Security.Permissions
 {
-    [Serializable]
     public enum UIPermissionWindow
     {
         AllWindows = 3,

--- a/src/System.Security.Permissions/src/System/Security/Policy/PolicyStatementAttribute.cs
+++ b/src/System.Security.Permissions/src/System/Security/Policy/PolicyStatementAttribute.cs
@@ -1,10 +1,9 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace System.Security.Policy
 {
-    [Serializable]
     [Flags]
     public enum PolicyStatementAttribute
     {

--- a/src/System.Security.Permissions/src/System/Security/PolicyLevelType.cs
+++ b/src/System.Security.Permissions/src/System/Security/PolicyLevelType.cs
@@ -1,10 +1,9 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace System.Security
 {
-    [Serializable]
     public enum PolicyLevelType
     {
         AppDomain = 3,

--- a/src/System.Security.Permissions/src/System/Security/SecurityZone.cs
+++ b/src/System.Security.Permissions/src/System/Security/SecurityZone.cs
@@ -1,10 +1,9 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace System.Security
 {
-    [Serializable]
     public enum SecurityZone
     {
         Internet = 3,

--- a/src/System.Security.Principal.Windows/src/System/Security/Principal/TokenAccessLevels.cs
+++ b/src/System.Security.Principal.Windows/src/System/Security/Principal/TokenAccessLevels.cs
@@ -4,7 +4,6 @@
 
 namespace System.Security.Principal
 {
-    [Serializable]
     [Flags]
     public enum TokenAccessLevels
     {

--- a/src/System.Security.Principal.Windows/src/System/Security/Principal/WindowsIdentity.cs
+++ b/src/System.Security.Principal.Windows/src/System/Security/Principal/WindowsIdentity.cs
@@ -1067,14 +1067,12 @@ namespace System.Security.Principal
         Both = 3 // OpenAsSelf = true, then OpenAsSelf = false
     }
 
-    [Serializable]
     internal enum TokenType : int
     {
         TokenPrimary = 1,
         TokenImpersonation
     }
 
-    [Serializable]
     internal enum TokenInformationClass : int
     {
         TokenUser = 1,

--- a/src/System.Security.Principal.Windows/src/System/Security/Principal/WindowsPrincipal.cs
+++ b/src/System.Security.Principal.Windows/src/System/Security/Principal/WindowsPrincipal.cs
@@ -11,7 +11,6 @@ using System.Security.Claims;
 
 namespace System.Security.Principal
 {
-    [Serializable]
     public enum WindowsBuiltInRole
     {
         Administrator = 0x220,

--- a/src/System.Security.Principal/src/System/Security/Principal/PrincipalPolicy.cs
+++ b/src/System.Security.Principal/src/System/Security/Principal/PrincipalPolicy.cs
@@ -9,7 +9,6 @@
 
 namespace System.Security.Principal
 {
-    [Serializable]
     public enum PrincipalPolicy 
     {
         // Note: it's important that the default policy has the value 0.

--- a/src/System.Security.Principal/src/System/Security/Principal/TokenImpersonationLevel.cs
+++ b/src/System.Security.Principal/src/System/Security/Principal/TokenImpersonationLevel.cs
@@ -6,7 +6,6 @@ using System;
 
 namespace System.Security.Principal
 {
-    [Serializable]
     public enum TokenImpersonationLevel
     {
         None = 0,


### PR DESCRIPTION
Removes unneeded Serializable attributes from enums and delegates. They
can be serialized without attributes and this will remove noise from
future serialization changes.

CC @joshfree @danmosemsft 