### PR TITLE
HttpWebRequest tests hardened & RequestStream tests disabled on Desktop

### DIFF
--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -121,6 +121,7 @@ namespace System.Net.Tests
             Assert.True(request.AllowReadStreamBuffering);
         }
 
+        [OuterLoop]
         [Theory, MemberData(nameof(EchoServers))]
         public async Task ContentLength_Get_ExpectSameAsGetResponseStream(Uri remoteServer)
         {
@@ -135,14 +136,19 @@ namespace System.Net.Tests
             }               
         }
 
-        [Theory, MemberData(nameof(EchoServers))]
-        public void ContentLength_SetAfterRequestSubmitted_ThrowsInvalidOperationException(Uri remoteServer)
+        [Fact]
+        public async Task ContentLength_SetAfterRequestSubmitted_ThrowsInvalidOperationException()
         {
-            HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
-            using (WebResponse response = request.GetResponse())
+            await LoopbackServer.CreateServerAsync(async (server, uri) =>
             {
-                Assert.Throws<InvalidOperationException>(() => request.ContentLength = 255);
-            }
+                HttpWebRequest request = WebRequest.CreateHttp(uri);
+                Task<WebResponse> getResponse = request.GetResponseAsync();
+                await LoopbackServer.ReadRequestAndSendResponseAsync(server);
+                using (WebResponse response = await getResponse)
+                {
+                    Assert.Throws<InvalidOperationException>(() => request.ContentLength = 255);
+                }
+            });
         }
 
         [Theory, MemberData(nameof(EchoServers))]
@@ -178,14 +184,19 @@ namespace System.Net.Tests
             Assert.Null(request.ContentType);
         }
 
-        [Theory, MemberData(nameof(EchoServers))]
-        public void MaximumResponseHeadersLength_SetAfterRequestSubmitted_ThrowsInvalidOperationException(Uri remoteServer)
+        [Fact]
+        public async Task MaximumResponseHeadersLength_SetAfterRequestSubmitted_ThrowsInvalidOperationException()
         {
-            HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
-            using (WebResponse response = request.GetResponse())
+            await LoopbackServer.CreateServerAsync(async (server, uri) =>
             {
-                Assert.Throws<InvalidOperationException>(() => request.MaximumResponseHeadersLength = 255);
-            }
+                HttpWebRequest request = WebRequest.CreateHttp(uri);
+                Task<WebResponse> getResponse = request.GetResponseAsync();
+                await LoopbackServer.ReadRequestAndSendResponseAsync(server);
+                using (WebResponse response = await getResponse)
+                {
+                    Assert.Throws<InvalidOperationException>(() => request.MaximumResponseHeadersLength = 255);
+                }
+            });
         }
 
         [Theory, MemberData(nameof(EchoServers))]
@@ -221,14 +232,19 @@ namespace System.Net.Tests
             Assert.Equal(MaximumAutomaticRedirections, request.MaximumAutomaticRedirections);
         }
 
-        [Theory, MemberData(nameof(EchoServers))]
-        public void ContinueTimeout_SetAfterRequestSubmitted_ThrowsInvalidOperationException(Uri remoteServer)
+        [Fact]
+        public async Task ContinueTimeout_SetAfterRequestSubmitted_ThrowsInvalidOperationException()
         {
-            HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
-            using (WebResponse response = request.GetResponse())
+            await LoopbackServer.CreateServerAsync(async (server, uri) =>
             {
-                Assert.Throws<InvalidOperationException>(() => request.ContinueTimeout = 255);
-            }
+                HttpWebRequest request = WebRequest.CreateHttp(uri);
+                Task<WebResponse> getResponse = request.GetResponseAsync();
+                await LoopbackServer.ReadRequestAndSendResponseAsync(server);
+                using (WebResponse response = await getResponse)
+                {
+                    Assert.Throws<InvalidOperationException>(() => request.ContinueTimeout = 255);
+                }
+            });
         }
 
         [Theory, MemberData(nameof(EchoServers))]
@@ -301,7 +317,8 @@ namespace System.Net.Tests
                 var sw = Stopwatch.StartNew();
                 WebException exception = Assert.Throws<WebException>(() =>
                 {
-                    var response = (HttpWebResponse)request.GetResponse();
+                    var response = request.GetResponse();
+                    response.Dispose();
                 });
                 
                 sw.Stop();
@@ -331,14 +348,19 @@ namespace System.Net.Tests
             Assert.Equal(UserAgent, request.UserAgent);
         }
 
-        [Theory, MemberData(nameof(EchoServers))]
-        public void Host_SetAfterRequestSubmitted_ThrowsInvalidOperationException(Uri remoteServer)
+        [Fact]
+        public async Task Host_SetAfterRequestSubmitted_ThrowsInvalidOperationException()
         {
-            HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
-            using (WebResponse response = request.GetResponse())
+            await LoopbackServer.CreateServerAsync(async (server, uri) =>
             {
-                Assert.Throws<InvalidOperationException>(() => request.Host = "localhost");
-            }
+                HttpWebRequest request = WebRequest.CreateHttp(uri);
+                Task<WebResponse> getResponse = request.GetResponseAsync();
+                await LoopbackServer.ReadRequestAndSendResponseAsync(server);
+                using (WebResponse response = await getResponse)
+                {
+                    Assert.Throws<InvalidOperationException>(() => request.Host = "localhost");
+                }
+            });
         }
 
         [Theory, MemberData(nameof(EchoServers))]
@@ -458,7 +480,7 @@ namespace System.Net.Tests
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #19225")]
         public void KeepAlive_CorrectConnectionHeaderSent(bool? keepAlive)
         {
-            HttpWebRequest request = WebRequest.CreateHttp(System.Net.Test.Common.Configuration.Http.RemoteEchoServer);
+            HttpWebRequest request = WebRequest.CreateHttp(Test.Common.Configuration.Http.RemoteEchoServer);
 
             if (keepAlive.HasValue)
             {
@@ -483,14 +505,19 @@ namespace System.Net.Tests
             }
         }
 
-        [Theory, MemberData(nameof(EchoServers))]
-        public void AutomaticDecompression_SetAfterRequestSubmitted_ThrowsInvalidOperationException(Uri remoteServer)
+        [Fact]
+        public async Task AutomaticDecompression_SetAfterRequestSubmitted_ThrowsInvalidOperationException()
         {
-            HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
-            using (WebResponse response = request.GetResponse())
+            await LoopbackServer.CreateServerAsync(async (server, uri) =>
             {
-                Assert.Throws<InvalidOperationException>(() => request.AutomaticDecompression = DecompressionMethods.Deflate);
-            }
+                HttpWebRequest request = WebRequest.CreateHttp(uri);
+                Task<WebResponse> getResponse = request.GetResponseAsync();
+                await LoopbackServer.ReadRequestAndSendResponseAsync(server);
+                using (WebResponse response = await getResponse)
+                {
+                    Assert.Throws<InvalidOperationException>(() => request.AutomaticDecompression = DecompressionMethods.Deflate);
+                }
+            });
         }
 
         [Theory, MemberData(nameof(EchoServers))]
@@ -692,14 +719,19 @@ namespace System.Net.Tests
             Assert.Equal(date, request.Date);
         }
 
-        [Theory, MemberData(nameof(EchoServers))]
-        public void SendChunked_SetAfterRequestSubmitted_ThrowsInvalidOperationException(Uri remoteServer)
+        [Fact]
+        public async Task SendChunked_SetAfterRequestSubmitted_ThrowsInvalidOperationException()
         {
-            HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
-            using (WebResponse response = request.GetResponse())
+            await LoopbackServer.CreateServerAsync(async (server, uri) =>
             {
-                Assert.Throws<InvalidOperationException>(() => request.SendChunked = true);
-            }
+                HttpWebRequest request = WebRequest.CreateHttp(uri);
+                Task<WebResponse> getResponse = request.GetResponseAsync();
+                await LoopbackServer.ReadRequestAndSendResponseAsync(server);
+                using (WebResponse response = await getResponse)
+                {
+                    Assert.Throws<InvalidOperationException>(() => request.SendChunked = true);
+                }
+            });
         }
 
         [Theory, MemberData(nameof(EchoServers))]
@@ -1039,7 +1071,8 @@ namespace System.Net.Tests
         {
             HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
             request.UseDefaultCredentials = true;
-            await request.GetResponseAsync();
+            var response = await request.GetResponseAsync();
+            response.Dispose();
         }
 
         [OuterLoop] // fails on networks with DNS servers that provide a dummy page for invalid addresses
@@ -1075,14 +1108,19 @@ namespace System.Net.Tests
             }
         }
 
-        [MemberData(nameof(EchoServers))]
-        public void Headers_SetAfterRequestSubmitted_ThrowsInvalidOperationException(Uri remoteServer)
+        [Fact]
+        public async Task Headers_SetAfterRequestSubmitted_ThrowsInvalidOperationException()
         {
-            HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
-            using (request.GetResponse())
+            await LoopbackServer.CreateServerAsync(async (server, uri) =>
             {
-                Assert.Throws<InvalidOperationException>(() => request.Headers = null);
-            }
+                HttpWebRequest request = WebRequest.CreateHttp(uri);
+                Task<WebResponse> getResponse = request.GetResponseAsync();
+                await LoopbackServer.ReadRequestAndSendResponseAsync(server);
+                using (WebResponse response = await getResponse)
+                {
+                    Assert.Throws<InvalidOperationException>(() => request.Headers = null);
+                }
+            });
         }
 
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotFedoraOrRedHatOrCentos))] // #16201
@@ -1123,15 +1161,19 @@ namespace System.Net.Tests
             Assert.Throws<ArgumentException>("value", () => request.Method = "Method(2");
         }
 
-        [OuterLoop]
-        [Theory, MemberData(nameof(EchoServers))]
-        public void Proxy_SetAfterRequestSubmitted_ThrowsInvalidOperationException(Uri remoteServer)
+        [Fact]
+        public async Task Proxy_SetAfterRequestSubmitted_ThrowsInvalidOperationException()
         {
-            HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
-            using (var response = (HttpWebResponse)request.GetResponse())
+            await LoopbackServer.CreateServerAsync(async (server, uri) =>
             {
-                Assert.Throws<InvalidOperationException>(() => request.Proxy = WebRequest.DefaultWebProxy);
-            }
+                HttpWebRequest request = WebRequest.CreateHttp(uri);
+                Task<WebResponse> getResponse = request.GetResponseAsync();
+                await LoopbackServer.ReadRequestAndSendResponseAsync(server);
+                using (WebResponse response = await getResponse)
+                {
+                    Assert.Throws<InvalidOperationException>(() => request.Proxy = WebRequest.DefaultWebProxy);
+                }
+            });
         }
 
         [Theory, MemberData(nameof(EchoServers))]

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -973,7 +973,6 @@ namespace System.Net.Tests
             Assert.Equal(WebExceptionStatus.RequestCanceled, ex.Status);
         }
 
-        [OuterLoop]
         [Theory, MemberData(nameof(EchoServers))]
         public async Task GetRequestStreamAsync_WriteAndDisposeRequestStreamThenOpenRequestStream_ThrowsArgumentException(Uri remoteServer)
         {
@@ -986,7 +985,6 @@ namespace System.Net.Tests
             }            
         }
 
-        [OuterLoop]
         [Theory, MemberData(nameof(EchoServers))]
         public async Task GetRequestStreamAsync_SetPOSTThenGet_ExpectNotNull(Uri remoteServer)
         {
@@ -998,7 +996,6 @@ namespace System.Net.Tests
             }
         }
 
-        [OuterLoop]
         [Theory, MemberData(nameof(EchoServers))]
         public async Task GetResponseAsync_GetResponseStream_ExpectNotNull(Uri remoteServer)
         {
@@ -1009,7 +1006,6 @@ namespace System.Net.Tests
             }
         }
 
-        [OuterLoop]
         [Theory, MemberData(nameof(EchoServers))]
         public async Task GetResponseAsync_GetResponseStream_ContainsHost(Uri remoteServer)
         {
@@ -1049,7 +1045,6 @@ namespace System.Net.Tests
             Assert.Equal(request.Headers["Range"], "bytes=1-5");
         }
 
-        [OuterLoop]
         [Theory, MemberData(nameof(EchoServers))]
         public async Task GetResponseAsync_PostRequestStream_ContainsData(Uri remoteServer)
         {
@@ -1070,7 +1065,6 @@ namespace System.Net.Tests
             }
         }
 
-        [OuterLoop]
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotFedoraOrRedHatOrCentos))] // #16201
         [MemberData(nameof(EchoServers))]
         public async Task GetResponseAsync_UseDefaultCredentials_ExpectSuccess(Uri remoteServer)
@@ -1096,7 +1090,6 @@ namespace System.Net.Tests
             new object[] { System.Net.Test.Common.Configuration.Http.StatusCodeUri(true, 404) },
         };
 
-        [OuterLoop]
         [Theory, MemberData(nameof(StatusCodeServers))]
         public async Task GetResponseAsync_ResourceNotFound_ThrowsWebException(Uri remoteServer)
         {
@@ -1105,7 +1098,6 @@ namespace System.Net.Tests
             Assert.Equal(WebExceptionStatus.ProtocolError, ex.Status);
         }
 
-        [OuterLoop]
         [Theory, MemberData(nameof(EchoServers))]
         public async Task HaveResponse_GetResponseAsync_ExpectTrue(Uri remoteServer)
         {
@@ -1116,7 +1108,6 @@ namespace System.Net.Tests
             }
         }
 
-        [OuterLoop]
         [Fact]
         public async Task Headers_SetAfterRequestSubmitted_ThrowsInvalidOperationException()
         {
@@ -1132,7 +1123,6 @@ namespace System.Net.Tests
             });
         }
 
-        [OuterLoop]
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotFedoraOrRedHatOrCentos))] // #16201
         [MemberData(nameof(EchoServers))]
         public async Task Headers_GetResponseHeaders_ContainsExpectedValue(Uri remoteServer)
@@ -1171,7 +1161,6 @@ namespace System.Net.Tests
             Assert.Throws<ArgumentException>("value", () => request.Method = "Method(2");
         }
 
-        [OuterLoop]
         [Fact]
         public async Task Proxy_SetAfterRequestSubmitted_ThrowsInvalidOperationException()
         {
@@ -1201,7 +1190,6 @@ namespace System.Net.Tests
             Assert.Equal(remoteServer, request.RequestUri);
         }
 
-        [OuterLoop]
         [Theory, MemberData(nameof(EchoServers))]
         public async Task ResponseUri_GetResponseAsync_ExpectSameUri(Uri remoteServer)
         {
@@ -1219,7 +1207,6 @@ namespace System.Net.Tests
             Assert.True(request.SupportsCookieContainer);
         }
 
-        [OuterLoop]
         [Theory, MemberData(nameof(EchoServers))]
         public async Task SimpleScenario_UseGETVerb_Success(Uri remoteServer)
         {
@@ -1233,7 +1220,6 @@ namespace System.Net.Tests
             }
         }
 
-        [OuterLoop]
         [Theory, MemberData(nameof(EchoServers))]
         public async Task SimpleScenario_UsePOSTVerb_Success(Uri remoteServer)
         {
@@ -1254,7 +1240,6 @@ namespace System.Net.Tests
             }
         }
 
-        [OuterLoop]
         [Theory, MemberData(nameof(EchoServers))]
         public async Task ContentType_AddHeaderWithNoContent_SendRequest_HeaderGetsSent(Uri remoteServer)
         {

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -973,6 +973,7 @@ namespace System.Net.Tests
             Assert.Equal(WebExceptionStatus.RequestCanceled, ex.Status);
         }
 
+        [OuterLoop]
         [Theory, MemberData(nameof(EchoServers))]
         public async Task GetRequestStreamAsync_WriteAndDisposeRequestStreamThenOpenRequestStream_ThrowsArgumentException(Uri remoteServer)
         {
@@ -985,6 +986,7 @@ namespace System.Net.Tests
             }            
         }
 
+        [OuterLoop]
         [Theory, MemberData(nameof(EchoServers))]
         public async Task GetRequestStreamAsync_SetPOSTThenGet_ExpectNotNull(Uri remoteServer)
         {
@@ -996,6 +998,7 @@ namespace System.Net.Tests
             }
         }
 
+        [OuterLoop]
         [Theory, MemberData(nameof(EchoServers))]
         public async Task GetResponseAsync_GetResponseStream_ExpectNotNull(Uri remoteServer)
         {
@@ -1006,6 +1009,7 @@ namespace System.Net.Tests
             }
         }
 
+        [OuterLoop]
         [Theory, MemberData(nameof(EchoServers))]
         public async Task GetResponseAsync_GetResponseStream_ContainsHost(Uri remoteServer)
         {
@@ -1045,6 +1049,7 @@ namespace System.Net.Tests
             Assert.Equal(request.Headers["Range"], "bytes=1-5");
         }
 
+        [OuterLoop]
         [Theory, MemberData(nameof(EchoServers))]
         public async Task GetResponseAsync_PostRequestStream_ContainsData(Uri remoteServer)
         {
@@ -1065,6 +1070,7 @@ namespace System.Net.Tests
             }
         }
 
+        [OuterLoop]
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotFedoraOrRedHatOrCentos))] // #16201
         [MemberData(nameof(EchoServers))]
         public async Task GetResponseAsync_UseDefaultCredentials_ExpectSuccess(Uri remoteServer)
@@ -1090,6 +1096,7 @@ namespace System.Net.Tests
             new object[] { System.Net.Test.Common.Configuration.Http.StatusCodeUri(true, 404) },
         };
 
+        [OuterLoop]
         [Theory, MemberData(nameof(StatusCodeServers))]
         public async Task GetResponseAsync_ResourceNotFound_ThrowsWebException(Uri remoteServer)
         {
@@ -1098,6 +1105,7 @@ namespace System.Net.Tests
             Assert.Equal(WebExceptionStatus.ProtocolError, ex.Status);
         }
 
+        [OuterLoop]
         [Theory, MemberData(nameof(EchoServers))]
         public async Task HaveResponse_GetResponseAsync_ExpectTrue(Uri remoteServer)
         {
@@ -1108,6 +1116,7 @@ namespace System.Net.Tests
             }
         }
 
+        [OuterLoop]
         [Fact]
         public async Task Headers_SetAfterRequestSubmitted_ThrowsInvalidOperationException()
         {
@@ -1123,6 +1132,7 @@ namespace System.Net.Tests
             });
         }
 
+        [OuterLoop]
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotFedoraOrRedHatOrCentos))] // #16201
         [MemberData(nameof(EchoServers))]
         public async Task Headers_GetResponseHeaders_ContainsExpectedValue(Uri remoteServer)
@@ -1161,6 +1171,7 @@ namespace System.Net.Tests
             Assert.Throws<ArgumentException>("value", () => request.Method = "Method(2");
         }
 
+        [OuterLoop]
         [Fact]
         public async Task Proxy_SetAfterRequestSubmitted_ThrowsInvalidOperationException()
         {
@@ -1190,6 +1201,7 @@ namespace System.Net.Tests
             Assert.Equal(remoteServer, request.RequestUri);
         }
 
+        [OuterLoop]
         [Theory, MemberData(nameof(EchoServers))]
         public async Task ResponseUri_GetResponseAsync_ExpectSameUri(Uri remoteServer)
         {
@@ -1207,6 +1219,7 @@ namespace System.Net.Tests
             Assert.True(request.SupportsCookieContainer);
         }
 
+        [OuterLoop]
         [Theory, MemberData(nameof(EchoServers))]
         public async Task SimpleScenario_UseGETVerb_Success(Uri remoteServer)
         {
@@ -1220,6 +1233,7 @@ namespace System.Net.Tests
             }
         }
 
+        [OuterLoop]
         [Theory, MemberData(nameof(EchoServers))]
         public async Task SimpleScenario_UsePOSTVerb_Success(Uri remoteServer)
         {
@@ -1240,6 +1254,7 @@ namespace System.Net.Tests
             }
         }
 
+        [OuterLoop]
         [Theory, MemberData(nameof(EchoServers))]
         public async Task ContentType_AddHeaderWithNoContent_SendRequest_HeaderGetsSent(Uri remoteServer)
         {

--- a/src/System.Net.Requests/tests/RequestStreamTest.cs
+++ b/src/System.Net.Requests/tests/RequestStreamTest.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace System.Net.Tests
 {
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Tests hang on .NET Framework")]
     public class RequestStreamTest
     {
         readonly byte[] buffer = new byte[1];
@@ -62,7 +63,7 @@ namespace System.Net.Tests
             }
         }
 
-        #endregion
+#endregion
 
         #region WriteAsync
 
@@ -223,7 +224,7 @@ namespace System.Net.Tests
         {
             HttpWebRequest request = HttpWebRequest.CreateHttp(System.Net.Test.Common.Configuration.Http.RemoteEchoServer);
             request.Method = "POST";
-            return request.GetRequestStreamAsync().GetAwaiter().GetResult();
+            return request.GetRequestStream();
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/19580

RequestStream tests aren't behaving correctly on Desktop and hang pretty often. Will follow up tomorrow and analyze the root cause.

Tested Innerloop in a loop 100 times
Tested Outerloop in a loop 100 times

thanks @safern for help!