### PR TITLE
Fix duplicated types in Unix build of System.Threading.Overlapped

### DIFF
--- a/pkg/test/frameworkSettings/netcoreapp2.0/settings.targets
+++ b/pkg/test/frameworkSettings/netcoreapp2.0/settings.targets
@@ -4,13 +4,6 @@
     <!-- XDocumentExtensions is duplicated -->
     <IgnoredTypes Include="System.Xml.XPath.XDocumentExtensions" />
 
-    <!-- Overlapped types are duplicated -->
-    <IgnoredTypes Include="System.Threading.IOCompletionCallback" />
-    <IgnoredTypes Include="System.Threading.NativeOverlapped" />
-    <IgnoredTypes Include="System.Threading.Overlapped" />
-    <IgnoredTypes Include="System.Threading.PreAllocatedOverlapped" />
-    <IgnoredTypes Include="System.Threading.ThreadPoolBoundHandle" />
-
     <IgnoredTypes Include="System.DBNull" />
   </ItemGroup>
 </Project>

--- a/src/System.Threading.Overlapped/src/Resources/Strings.resx
+++ b/src/System.Threading.Overlapped/src/Resources/Strings.resx
@@ -76,7 +76,4 @@
   <data name="InvalidOperation_NativeOverlappedReused" xml:space="preserve">
     <value>NativeOverlapped cannot be reused for multiple operations.</value>
   </data>
-  <data name="PlatformNotSupported_ThreadingOverlapped" xml:space="preserve">
-    <value>System.Threading.Overlapped APIs are specific to the way in which Windows handles asynchronous I/O, and are not supported on this platform.</value>
-  </data>
 </root>

--- a/src/System.Threading.Overlapped/src/System.Threading.Overlapped.csproj
+++ b/src/System.Threading.Overlapped/src/System.Threading.Overlapped.csproj
@@ -5,8 +5,7 @@
     <AssemblyName>System.Threading.Overlapped</AssemblyName>
     <ProjectGuid>{6A07CCB8-3E59-47e7-B3DD-DB1F6FC501D5}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <IsPartialFacadeAssembly Condition="'$(TargetsWindows)' == 'true'">true</IsPartialFacadeAssembly>
-    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsWindows)' != 'true'">SR.PlatformNotSupported_ThreadingOverlapped</GeneratePlatformNotSupportedAssemblyMessage>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <GenFacadesIgnoreMissingTypes Condition="'$(TargetGroup)'=='uapaot'">true</GenFacadesIgnoreMissingTypes>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
@@ -31,13 +30,8 @@
     <Reference Include="mscorlib" />
     <Reference Include="System" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' != 'netfx' and '$(TargetsWindows)' == 'true'">
+  <ItemGroup Condition="'$(TargetGroup)' != 'netfx'">
     <ReferenceFromRuntime Include="System.Private.CoreLib" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetsWindows)' != 'true'">
-    <Reference Include="System.Resources.ResourceManager" />
-    <Reference Include="System.Runtime" />
-    <Reference Include="System.Runtime.Handles" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/19553.  All of the types for Overlapped are in coreclr, so we shouldn't be building a PNSE assembly on Unix and instead just type forwarding everything. I wasn't sure if we should be consolidating the builds, as at this point there shouldn't be a diff between the Windows and Unix netcoreapp builds, but for now I left it as is. We should look at the implementations in coreclr to see if we want to add any explicit PNSEs there in its Unix build.

cc: @kouvel, @ericstj, @jkotas 