### PR TITLE
Fix 40 or so System.Net.Mail.Functional.Tests failures on ILC

### DIFF
--- a/src/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
+++ b/src/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
@@ -136,7 +136,16 @@ namespace System.Net.Mail
                 // machine connecting to public server).
 
                 // SMTP RFC's require ASCII only host names in the HELO/EHLO message.
-                string clientDomainRaw = IPGlobalProperties.GetIPGlobalProperties().HostName;
+                string clientDomainRaw;
+                try
+                {
+                    clientDomainRaw = IPGlobalProperties.GetIPGlobalProperties().HostName;
+                }
+                catch (NotSupportedException)
+                {
+                    clientDomainRaw = "LocalHost";
+                }
+
                 IdnMapping mapping = new IdnMapping();
                 try
                 {

--- a/src/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
+++ b/src/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
@@ -136,6 +136,12 @@ namespace System.Net.Mail
                 // machine connecting to public server).
 
                 // SMTP RFC's require ASCII only host names in the HELO/EHLO message.
+
+                // TODO: https://github.com/dotnet/corefx/issues/19605
+                //
+                //   Catching NotSupportedException here because HostName is currently PNSE
+                //   on UapAot. HostName is planned to be restored for .NetCore 2.1
+                //   so once that's done, the try-catch can be removed.
                 string clientDomainRaw;
                 try
                 {


### PR DESCRIPTION
SmtpClient class is trying to fill in the "client host name"
checkbox for the HELO message. By default, it tries to
use the local host name but this is PNS on .Net Native.
This one hiccup makes SmtpClient unusable.

Since the client host name is apparently discretionary anyway,
fall back to LocalHost if the actual local host is PNS (or NS - why
not) as we do in the garbled-Unicode case.