### PR TITLE
Fix slashes in test for Nano

### DIFF
--- a/src/System.Runtime.Extensions/tests/System/IO/PathTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/PathTests.cs
@@ -780,8 +780,8 @@ namespace System.IO.Tests
 
                     // Make sure the shortened name expands back to the original one
                     // Sometimes shortening or GetFullPath is changing the casing of "temp" on some test machines: normalize both sides
-                    tempFilePath = Regex.Replace(tempFilePath, @"\temp\\", @"\TEMP\\",  RegexOptions.IgnoreCase);
-                    shortName = Regex.Replace(Path.GetFullPath(shortName), @"\temp\\", @"\TEMP\\",  RegexOptions.IgnoreCase);
+                    tempFilePath = Regex.Replace(tempFilePath, @"\\temp\\", @"\TEMP\",  RegexOptions.IgnoreCase);
+                    shortName = Regex.Replace(Path.GetFullPath(shortName), @"\\temp\\", @"\TEMP\",  RegexOptions.IgnoreCase);
                     Assert.Equal(tempFilePath, shortName);
 
                     // Should work with device paths that aren't well-formed extended syntax


### PR DESCRIPTION
Fix https://github.com/dotnet/corefx/issues/7433

Apparently I lost a slash after testing the last change. Regex needs escaped slashes.