### PR TITLE
Fix SynchronizationContextTests.WaitTest on desktop

### DIFF
--- a/src/System.Threading/tests/SynchronizationContextTests.cs
+++ b/src/System.Threading/tests/SynchronizationContextTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading.Tasks;
 using Xunit;
 
 namespace System.Threading.Tests
@@ -9,7 +10,6 @@ namespace System.Threading.Tests
     public static class SynchronizationContextTests
     {
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #19570")]
         public static void WaitTest()
         {
             var tsc = new TestSynchronizationContext();
@@ -19,7 +19,7 @@ namespace System.Threading.Tests
             IntPtr eventHandle = e.SafeWaitHandle.DangerousGetHandle();
             var handles = new IntPtr[] { eventHandle, eventHandle };
             Assert.Equal(WaitHandle.WaitTimeout, tsc.Wait(handles, false, 0));
-            Assert.Throws<DuplicateWaitObjectException>(() => tsc.Wait(handles, true, 0));
+            Assert.Throws<DuplicateWaitObjectException>(() => Task.Run(() => tsc.Wait(handles, true, 0)).GetAwaiter().GetResult()); // ensure Wait runs on MTA thread
 
             var e2 = new ManualResetEvent(false);
             handles = new IntPtr[] { eventHandle, e2.SafeWaitHandle.DangerousGetHandle() };


### PR DESCRIPTION
SynchronizationContext.Wait behaves differently if run from an STA thread, so the test would fail on desktop if it happened to be.  This change ensures it's always on an MTA thread.

Fixes https://github.com/dotnet/corefx/issues/19570
cc: @kouvel, @safern 