### PR TITLE
System.Security.Permissions.Tests at 0 failures on ILC.

### DIFF
--- a/src/System.Security.Permissions/tests/ApplicationTrustTests.cs
+++ b/src/System.Security.Permissions/tests/ApplicationTrustTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.Serialization;
 using System.Security.Policy;
 using Xunit;
 
@@ -12,7 +13,7 @@ namespace System.Security.Permissions.Tests
         [Fact]
         public static void ApplicationTrustCollectionCallMethods()
         {
-            ApplicationTrustCollection atc = (ApplicationTrustCollection)Activator.CreateInstance(typeof(ApplicationTrustCollection), true);
+            ApplicationTrustCollection atc = (ApplicationTrustCollection)FormatterServices.GetUninitializedObject(typeof(ApplicationTrustCollection));
             ApplicationTrust at = new ApplicationTrust();
             int testint = atc.Add(at);
             ApplicationTrust[] atarray = new ApplicationTrust[1];
@@ -29,7 +30,7 @@ namespace System.Security.Permissions.Tests
         [Fact]
         public static void ApplicationTrustEnumeratorCallMethods()
         {
-            ApplicationTrustEnumerator ate = (ApplicationTrustEnumerator)Activator.CreateInstance(typeof(ApplicationTrustEnumerator), true);
+            ApplicationTrustEnumerator ate = (ApplicationTrustEnumerator)FormatterServices.GetUninitializedObject(typeof(ApplicationTrustEnumerator));
             bool testbool = ate.MoveNext();
             ate.Reset();
         }

--- a/src/System.Security.Permissions/tests/MembershipConditionTests.cs
+++ b/src/System.Security.Permissions/tests/MembershipConditionTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.Serialization;
 using System.Security.Policy;
 using Xunit;
 
@@ -19,7 +20,7 @@ namespace System.Security.Permissions.Tests
             int hash = amc.GetHashCode();
             string str = amc.ToString();
             SecurityElement se = new SecurityElement("");
-            PolicyLevel pl = (PolicyLevel)Activator.CreateInstance(typeof(PolicyLevel), true);
+            PolicyLevel pl = (PolicyLevel)FormatterServices.GetUninitializedObject(typeof(PolicyLevel));
             amc.FromXml(se);
             amc.FromXml(se, pl);
             se = amc.ToXml();
@@ -36,7 +37,7 @@ namespace System.Security.Permissions.Tests
             int hash = admc.GetHashCode();
             string str = admc.ToString();
             SecurityElement se = new SecurityElement("");
-            PolicyLevel pl = (PolicyLevel)Activator.CreateInstance(typeof(PolicyLevel), true);
+            PolicyLevel pl = (PolicyLevel)FormatterServices.GetUninitializedObject(typeof(PolicyLevel));
             admc.FromXml(se);
             admc.FromXml(se, pl);
             se = admc.ToXml();
@@ -53,7 +54,7 @@ namespace System.Security.Permissions.Tests
             int hash = gmc.GetHashCode();
             string str = gmc.ToString();
             SecurityElement se = new SecurityElement("");
-            PolicyLevel pl = (PolicyLevel)Activator.CreateInstance(typeof(PolicyLevel), true);
+            PolicyLevel pl = (PolicyLevel)FormatterServices.GetUninitializedObject(typeof(PolicyLevel));
             gmc.FromXml(se);
             gmc.FromXml(se, pl);
             se = gmc.ToXml();
@@ -70,7 +71,7 @@ namespace System.Security.Permissions.Tests
             int hash = hmc.GetHashCode();
             string str = hmc.ToString();
             SecurityElement se = new SecurityElement("");
-            PolicyLevel pl = (PolicyLevel)Activator.CreateInstance(typeof(PolicyLevel), true);
+            PolicyLevel pl = (PolicyLevel)FormatterServices.GetUninitializedObject(typeof(PolicyLevel));
             hmc.FromXml(se);
             hmc.FromXml(se, pl);
             se = hmc.ToXml();
@@ -87,7 +88,7 @@ namespace System.Security.Permissions.Tests
             int hash = pmc.GetHashCode();
             string str = pmc.ToString();
             SecurityElement se = new SecurityElement("");
-            PolicyLevel pl = (PolicyLevel)Activator.CreateInstance(typeof(PolicyLevel), true);
+            PolicyLevel pl = (PolicyLevel)FormatterServices.GetUninitializedObject(typeof(PolicyLevel));
             pmc.FromXml(se);
             pmc.FromXml(se, pl);
             se = pmc.ToXml();
@@ -104,7 +105,7 @@ namespace System.Security.Permissions.Tests
             int hash = smc.GetHashCode();
             string str = smc.ToString();
             SecurityElement se = new SecurityElement("");
-            PolicyLevel pl = (PolicyLevel)Activator.CreateInstance(typeof(PolicyLevel), true);
+            PolicyLevel pl = (PolicyLevel)FormatterServices.GetUninitializedObject(typeof(PolicyLevel));
             smc.FromXml(se);
             smc.FromXml(se, pl);
             se = smc.ToXml();
@@ -121,7 +122,7 @@ namespace System.Security.Permissions.Tests
             int hash = snmc.GetHashCode();
             string str = snmc.ToString();
             SecurityElement se = new SecurityElement("");
-            PolicyLevel pl = (PolicyLevel)Activator.CreateInstance(typeof(PolicyLevel), true);
+            PolicyLevel pl = (PolicyLevel)FormatterServices.GetUninitializedObject(typeof(PolicyLevel));
             snmc.FromXml(se);
             snmc.FromXml(se, pl);
             se = snmc.ToXml();

--- a/src/System.Security.Permissions/tests/PolicyTests.cs
+++ b/src/System.Security.Permissions/tests/PolicyTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.Serialization;
 using System.Security.Policy;
 using Xunit;
 
@@ -19,7 +20,7 @@ namespace System.Security.Permissions.Tests
         [Fact]
         public static void PolicyLevelCallMethods()
         {
-            PolicyLevel pl = (PolicyLevel)Activator.CreateInstance(typeof(PolicyLevel), true);
+            PolicyLevel pl = (PolicyLevel)FormatterServices.GetUninitializedObject(typeof(PolicyLevel));
             NamedPermissionSet nps = new NamedPermissionSet("test");
             pl.AddNamedPermissionSet(nps);
             nps = pl.ChangeNamedPermissionSet("test", new PermissionSet(new Permissions.PermissionState()));
@@ -45,7 +46,7 @@ namespace System.Security.Permissions.Tests
             bool equals = ps.Equals(ps2);
             int hash = ps.GetHashCode();
             SecurityElement se = new SecurityElement("");
-            PolicyLevel pl = (PolicyLevel)Activator.CreateInstance(typeof(PolicyLevel), true);
+            PolicyLevel pl = (PolicyLevel)FormatterServices.GetUninitializedObject(typeof(PolicyLevel));
             ps.FromXml(se);
             ps.FromXml(se, pl);
             se = ps.ToXml();

--- a/src/System.Security.Permissions/tests/Resources/System.Security.Permissions.Tests.rd.xml
+++ b/src/System.Security.Permissions/tests/Resources/System.Security.Permissions.Tests.rd.xml
@@ -1,0 +1,8 @@
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Library>
+    <!-- XUnit reflects for ToString() as part of enumerating theory data -->
+    <Type Name="System.Security.HostProtectionException" Dynamic="Required Public" />
+  </Library>
+</Directives>
+
+

--- a/src/System.Security.Permissions/tests/SecurityElementTests.cs
+++ b/src/System.Security.Permissions/tests/SecurityElementTests.cs
@@ -94,9 +94,12 @@ namespace System.Security.Permissions.Tests
             {
                 Assert.Equal(typeof(ArgumentException), ex.GetType());
                 Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.IndexOf(tagName) != -1);
-                Assert.Null(ex.ParamName);
+                if (!PlatformDetection.IsNetNative)  // .Net Native toolchain optimizes away exception messages and paramnames.
+                {
+                    Assert.NotNull(ex.Message);
+                    Assert.True(ex.Message.IndexOf(tagName) != -1);
+                    Assert.Null(ex.ParamName);
+                }
             }
         }
 
@@ -112,9 +115,13 @@ namespace System.Security.Permissions.Tests
             {
                 Assert.Equal(typeof(ArgumentNullException), ex.GetType());
                 Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.NotNull(ex.ParamName);
-                Assert.Equal("tag", ex.ParamName);
+                if (!PlatformDetection.IsNetNative)  // .Net Native toolchain optimizes away exception messages and paramnames.
+                {
+
+                    Assert.NotNull(ex.Message);
+                    Assert.NotNull(ex.ParamName);
+                    Assert.Equal("tag", ex.ParamName);
+                }
             }
         }
 
@@ -142,9 +149,12 @@ namespace System.Security.Permissions.Tests
             {
                 Assert.Equal(typeof(ArgumentException), ex.GetType());
                 Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.IndexOf(invalid) != -1);
-                Assert.Null(ex.ParamName);
+                if (!PlatformDetection.IsNetNative)  // .Net Native toolchain optimizes away exception messages and paramnames.
+                {
+                    Assert.NotNull(ex.Message);
+                    Assert.True(ex.Message.IndexOf(invalid) != -1);
+                    Assert.Null(ex.ParamName);
+                }
             }
         }
 
@@ -160,9 +170,12 @@ namespace System.Security.Permissions.Tests
             {
                 Assert.Equal(typeof(ArgumentNullException), ex.GetType());
                 Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.NotNull(ex.ParamName);
-                Assert.Equal("tag", ex.ParamName);
+                if (!PlatformDetection.IsNetNative)  // .Net Native toolchain optimizes away exception messages and paramnames.
+                {
+                    Assert.NotNull(ex.Message);
+                    Assert.NotNull(ex.ParamName);
+                    Assert.Equal("tag", ex.ParamName);
+                }
             }
         }
 
@@ -189,9 +202,12 @@ namespace System.Security.Permissions.Tests
             {
                 Assert.Equal(typeof(ArgumentNullException), ex.GetType());
                 Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.NotNull(ex.ParamName);
-                Assert.Equal("name", ex.ParamName);
+                if (!PlatformDetection.IsNetNative)  // .Net Native toolchain optimizes away exception messages and paramnames.
+                {
+                    Assert.NotNull(ex.Message);
+                    Assert.NotNull(ex.ParamName);
+                    Assert.Equal("name", ex.ParamName);
+                }
             }
         }
 
@@ -208,9 +224,12 @@ namespace System.Security.Permissions.Tests
             {
                 Assert.Equal(typeof(ArgumentNullException), ex.GetType());
                 Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.NotNull(ex.ParamName);
-                Assert.Equal("value", ex.ParamName);
+                if (!PlatformDetection.IsNetNative)  // .Net Native toolchain optimizes away exception messages and paramnames.
+                {
+                    Assert.NotNull(ex.Message);
+                    Assert.NotNull(ex.ParamName);
+                    Assert.Equal("value", ex.ParamName);
+                }
             }
         }
 
@@ -272,9 +291,12 @@ namespace System.Security.Permissions.Tests
             {
                 Assert.Equal(typeof(ArgumentNullException), ex.GetType());
                 Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.NotNull(ex.ParamName);
-                Assert.Equal("child", ex.ParamName);
+                if (!PlatformDetection.IsNetNative)  // .Net Native toolchain optimizes away exception messages and paramnames.
+                {
+                    Assert.NotNull(ex.Message);
+                    Assert.NotNull(ex.ParamName);
+                    Assert.Equal("child", ex.ParamName);
+                }
             }
         }
 
@@ -312,9 +334,12 @@ namespace System.Security.Permissions.Tests
             {
                 Assert.Equal(typeof(ArgumentException), ex.GetType());
                 Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.IndexOf("\"invalid\"") != -1);
-                Assert.Null(ex.ParamName);
+                if (!PlatformDetection.IsNetNative)  // .Net Native toolchain optimizes away exception messages and paramnames.
+                {
+                    Assert.NotNull(ex.Message);
+                    Assert.True(ex.Message.IndexOf("\"invalid\"") != -1);
+                    Assert.Null(ex.ParamName);
+                }
             }
         }
 
@@ -417,9 +442,12 @@ namespace System.Security.Permissions.Tests
             {
                 Assert.Equal(typeof(ArgumentNullException), ex.GetType());
                 Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.NotNull(ex.ParamName);
-                Assert.Equal("tag", ex.ParamName);
+                if (!PlatformDetection.IsNetNative)  // .Net Native toolchain optimizes away exception messages and paramnames.
+                {
+                    Assert.NotNull(ex.Message);
+                    Assert.NotNull(ex.ParamName);
+                    Assert.Equal("tag", ex.ParamName);
+                }
             }
         }
 
@@ -451,9 +479,12 @@ namespace System.Security.Permissions.Tests
             {
                 Assert.Equal(typeof(ArgumentNullException), ex.GetType());
                 Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.NotNull(ex.ParamName);
-                Assert.Equal("tag", ex.ParamName);
+                if (!PlatformDetection.IsNetNative)  // .Net Native toolchain optimizes away exception messages and paramnames.
+                {
+                    Assert.NotNull(ex.Message);
+                    Assert.NotNull(ex.ParamName);
+                    Assert.Equal("tag", ex.ParamName);
+                }
             }
         }
 
@@ -505,9 +536,12 @@ namespace System.Security.Permissions.Tests
             {
                 Assert.Equal(typeof(ArgumentException), ex.GetType());
                 Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.IndexOf(invalid) != -1);
-                Assert.Null(ex.ParamName);
+                if (!PlatformDetection.IsNetNative)  // .Net Native toolchain optimizes away exception messages and paramnames.
+                {
+                    Assert.NotNull(ex.Message);
+                    Assert.True(ex.Message.IndexOf(invalid) != -1);
+                    Assert.Null(ex.ParamName);
+                }
             }
         }
 
@@ -524,9 +558,12 @@ namespace System.Security.Permissions.Tests
             {
                 Assert.Equal(typeof(ArgumentNullException), ex.GetType());
                 Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.NotNull(ex.ParamName);
-                Assert.Equal("Tag", ex.ParamName);
+                if (!PlatformDetection.IsNetNative)  // .Net Native toolchain optimizes away exception messages and paramnames.
+                {
+                    Assert.NotNull(ex.Message);
+                    Assert.NotNull(ex.ParamName);
+                    Assert.Equal("Tag", ex.ParamName);
+                }
             }
         }
 
@@ -559,9 +596,12 @@ namespace System.Security.Permissions.Tests
             {
                 Assert.Equal(typeof(ArgumentException), ex.GetType());
                 Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.IndexOf(invalid) != -1);
-                Assert.Null(ex.ParamName);
+                if (!PlatformDetection.IsNetNative)  // .Net Native toolchain optimizes away exception messages and paramnames.
+                {
+                    Assert.NotNull(ex.Message);
+                    Assert.True(ex.Message.IndexOf(invalid) != -1);
+                    Assert.Null(ex.ParamName);
+                }
             }
         }
 
@@ -588,9 +628,12 @@ namespace System.Security.Permissions.Tests
             {
                 Assert.Equal(typeof(ArgumentNullException), ex.GetType());
                 Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.NotNull(ex.ParamName);
-                Assert.Equal("xml", ex.ParamName);
+                if (!PlatformDetection.IsNetNative)  // .Net Native toolchain optimizes away exception messages and paramnames.
+                {
+                    Assert.NotNull(ex.Message);
+                    Assert.NotNull(ex.ParamName);
+                    Assert.Equal("xml", ex.ParamName);
+                }
             }
         }
     }

--- a/src/System.Security.Permissions/tests/System.Security.Permissions.Tests.csproj
+++ b/src/System.Security.Permissions/tests/System.Security.Permissions.Tests.csproj
@@ -34,5 +34,8 @@
       <Link>Common\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
     </Compile>
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\$(AssemblyName).rd.xml" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
(An impressive amount of testing being done for
a component that is basically a reference assembly
masquerading as an implementation assembly...)

- The usual ParamName testing throttling.

- If you must create bogus parameter objects just to
  prove that Security.Permissions apis are nops,
  it can be done in a way that doesn't force internal
  framework Reflection.