### PR TITLE
Disable SendAsync_ReadFromSlowStreamingServer_PartialDataReturned test on netfx

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -950,7 +950,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ActiveIssue(18864)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "netfx's ConnectStream.ReadAsync tries to read beyond data already buffered, causing hangs #18864")]
         [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task SendAsync_ReadFromSlowStreamingServer_PartialDataReturned()


### PR DESCRIPTION
This test sends some of the data planned by Content-Length but keeps the connection open; the client is then supposed to read that data and verifies that it got only what was sent and didn't hang.  But it's hanging on netfx.  The problem is that ConnectStream.BeginRead on netfx first reads what it has buffered, and if it doesn't have buffered as much as was asked for, it then issues an asynchronous read rather than just returning the what it has.  This netfx behavior diverges from expectations around how Stream is meant to behave: Stream.Read/ReadAsync can block (asynchronously in the Async case) until there's any data available, but once there is data available they should return it rather than waiting arbitrarily long for more.

Closes https://github.com/dotnet/corefx/issues/18864
cc: @davidsh