### PR TITLE
Change EncryptPassword to ObfuscatePassword to reflect the functionality

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
@@ -5875,7 +5875,7 @@ namespace System.Data.SqlClient
 
             {
                 userName = rec.userName;
-                encryptedPassword = TdsParserStaticMethods.EncryptPassword(rec.password);
+                encryptedPassword = TdsParserStaticMethods.ObfuscatePassword(rec.password);
                 encryptedPasswordLengthInBytes = encryptedPassword.Length;  // password in clear text is already encrypted and its length is in byte
             }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStaticMethods.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStaticMethods.cs
@@ -13,12 +13,19 @@ namespace System.Data.SqlClient
 {
     internal sealed class TdsParserStaticMethods
     {
-        // Encrypt password to be sent to SQL Server
+        // Blurb from the TDS spec at https://msdn.microsoft.com/en-us/library/dd304523.aspx
+        // "Before submitting a password from the client to the server, for every byte in the password buffer 
+        // starting with the position pointed to by IbPassword, the client SHOULD first swap the four high bits 
+        // with the four low bits and then do a bit-XOR with 0xA5 (10100101). After reading a submitted password, 
+        // for every byte in the password buffer starting with the position pointed to by IbPassword, the server SHOULD 
+        // first do a bit-XOR with 0xA5 (10100101) and then swap the four high bits with the four low bits."
+        // The password exchange during Login phase happens over a secure channel i.e. SSL/TLS 
+        // Obfuscate password to be sent to SQL Server
         // Note: The same logic is used in SNIPacketSetData (SniManagedWrapper) to encrypt passwords stored in SecureString
         //       If this logic changed, SNIPacketSetData needs to be changed as well
-        internal static Byte[] EncryptPassword(string password)
+        internal static Byte[] ObfuscatePassword(string password)
         {
-            Byte[] bEnc = new Byte[password.Length << 1];
+            Byte[] bObfuscated = new Byte[password.Length << 1];
             int s;
             byte bLo;
             byte bHi;
@@ -28,10 +35,10 @@ namespace System.Data.SqlClient
                 s = (int)password[i];
                 bLo = (byte)(s & 0xff);
                 bHi = (byte)((s >> 8) & 0xff);
-                bEnc[i << 1] = (Byte)((((bLo & 0x0f) << 4) | (bLo >> 4)) ^ 0xa5);
-                bEnc[(i << 1) + 1] = (Byte)((((bHi & 0x0f) << 4) | (bHi >> 4)) ^ 0xa5);
+                bObfuscated[i << 1] = (Byte)((((bLo & 0x0f) << 4) | (bLo >> 4)) ^ 0xa5);
+                bObfuscated[(i << 1) + 1] = (Byte)((((bHi & 0x0f) << 4) | (bHi >> 4)) ^ 0xa5);
             }
-            return bEnc;
+            return bObfuscated;
         }
 
         private const int NoProcessId = -1;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStaticMethods.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStaticMethods.cs
@@ -13,6 +13,7 @@ namespace System.Data.SqlClient
 {
     internal sealed class TdsParserStaticMethods
     {
+        // Obfuscate password to be sent to SQL Server
         // Blurb from the TDS spec at https://msdn.microsoft.com/en-us/library/dd304523.aspx
         // "Before submitting a password from the client to the server, for every byte in the password buffer 
         // starting with the position pointed to by IbPassword, the client SHOULD first swap the four high bits 
@@ -20,7 +21,6 @@ namespace System.Data.SqlClient
         // for every byte in the password buffer starting with the position pointed to by IbPassword, the server SHOULD 
         // first do a bit-XOR with 0xA5 (10100101) and then swap the four high bits with the four low bits."
         // The password exchange during Login phase happens over a secure channel i.e. SSL/TLS 
-        // Obfuscate password to be sent to SQL Server
         // Note: The same logic is used in SNIPacketSetData (SniManagedWrapper) to encrypt passwords stored in SecureString
         //       If this logic changed, SNIPacketSetData needs to be changed as well
         internal static Byte[] ObfuscatePassword(string password)


### PR DESCRIPTION
Security scanning tools were flagging the EncryptPassword method. 
Changing the name of the utility method to reflect the method function to make sure that this method is not flagged by the tools. 

