### PR TITLE
Support KnownTypeAttribute.MethodName on UWP.

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
@@ -80,6 +80,12 @@ namespace System.Runtime.Serialization
                     }
                 }
             }
+
+            if (dataContract is InvalidDataContract && DataContractSerializer.Option == SerializationOption.ReflectionAsBackup)
+            {
+                return null;
+            }
+
             return dataContract;
 #else
             return null;


### PR DESCRIPTION
The PR is to support using `KnownTypeAttribute.MethodName` on UWP. The fix is to let the serialization to use reflection when the DataContract generated by SG is invalid.

Fix #19188