### PR TITLE
Make VerifyDecryptKeyExchange give more context on failure.

### DIFF
--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAKeyExchangeFormatter.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAKeyExchangeFormatter.cs
@@ -24,7 +24,6 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
-        [ActiveIssue(19436)]
         public static void VerifyDecryptKeyExchangePkcs1()
         {
             using (RSA rsa = RSAFactory.Create())
@@ -78,7 +77,20 @@ namespace System.Security.Cryptography.Rsa.Tests
             Assert.Equal(TestData.HelloBytes, decrypted);
 
             encrypted[encrypted.Length - 1] ^= 0xff;
-            Assert.ThrowsAny<CryptographicException>(() => deformatter.DecryptKeyExchange(encrypted));
+
+            try
+            {
+                deformatter.DecryptKeyExchange(encrypted);
+                string msg = $"Decrypt was unexpectedly successful: {encrypted.ByteArrayToHex()}";
+
+                // Just in case the exception text gets trimmed from test logs, Console.WriteLine it.
+                Console.WriteLine(msg);
+                throw new InvalidOperationException(msg);
+            }
+            catch (CryptographicException)
+            {
+                // Equivalent to Assert.ThrowsAny<CryptographicException>
+            }
         }
     }
 }


### PR DESCRIPTION
The Pkcs1 test failed twice within a week of each other, on different OSes.

If it happens again, log why... and we'll see if we simply "won" the lottery with
post-failure analysis.

Fixes #19436