### PR TITLE
Allow Deprecated and non-deprecated HTTP events simultaneously.

### DIFF
--- a/src/System.Net.Http/src/HttpDiagnosticsGuide.md
+++ b/src/System.Net.Http/src/HttpDiagnosticsGuide.md
@@ -91,5 +91,8 @@ Otherwise, `Activity.Current` represent some 'parent' activity (presumably incom
 7. `DiagnosticListener.Write("System.Net.Http.HttpRequestOut.Stop", new {Response, RequestTaskStatus})` - notifies that activity (outgoing request) is stopping
 
 # Non-Activity events (deprecated)
-If there is a subscriber to "HttpHandlerDiagnosticListener", but Activity events are disabled (`DiagnosticListener.IsEnabled("System.Net.Http.HttpRequestOut", request)` returns false), instrumentation attempts to send legacy "System.Net.Http.Request" and "System.Net.Http.Response" events if they are enabled.
-Consumers should consider migrating to Activity events instead of Request/Response events.
+There are two events System.Net.Http.Request and System.Net.Http.Response, currently are also emited for compatibility purposes.  
+They are redundant with the System.Net.Http.HttpRequestOut start and stop events (but do not set Activity.Current and follow activity conventions (start/stop)
+They are deprecated, and consumers are advised only to depend on them to suport.NET Core V1.1 apps (where the new events are not present).
+It is likely that these deprecated events will be remove at some point.  
+Consumers should  migrate to System.Net.Http.HttpRequestOut.Start and System.Net.Http.HttpRequestOut.Stop events instead.

--- a/src/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
@@ -128,7 +128,7 @@ namespace System.Net.Http
                         RequestTaskStatus = responseTask.Status
                     });
                 }
-                //if Activity events are disabled, try to write System.Net.Http.Response event (deprecated)
+                // Try to write System.Net.Http.Response event (deprecated)
                 if (s_diagnosticListener.IsEnabled(DiagnosticsHandlerLoggingStrings.ResponseWriteNameDeprecated))
                 {
                     long timestamp = Stopwatch.GetTimestamp();

--- a/src/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
@@ -55,8 +55,8 @@ namespace System.Net.Http
                     activity.Start();
                 }
             }
-            //if Activity events are disabled, try to write System.Net.Http.Request event (deprecated)
-            else if (s_diagnosticListener.IsEnabled(DiagnosticsHandlerLoggingStrings.RequestWriteNameDeprecated))
+            //try to write System.Net.Http.Request event (deprecated)
+            if (s_diagnosticListener.IsEnabled(DiagnosticsHandlerLoggingStrings.RequestWriteNameDeprecated))
             {
                 long timestamp = Stopwatch.GetTimestamp();
                 loggingRequestId = Guid.NewGuid();
@@ -129,7 +129,7 @@ namespace System.Net.Http
                     });
                 }
                 //if Activity events are disabled, try to write System.Net.Http.Response event (deprecated)
-                else if (s_diagnosticListener.IsEnabled(DiagnosticsHandlerLoggingStrings.ResponseWriteNameDeprecated))
+                if (s_diagnosticListener.IsEnabled(DiagnosticsHandlerLoggingStrings.ResponseWriteNameDeprecated))
                 {
                     long timestamp = Stopwatch.GetTimestamp();
                     s_diagnosticListener.Write(DiagnosticsHandlerLoggingStrings.ResponseWriteNameDeprecated,


### PR DESCRIPTION
Addresses https://github.com/dotnet/corefx/issues/18762 #18762
Basically we always check if a client needs deprecated events (previously we checked only if new events were not enabled).
This allows clients to support both new and old events simultaneously.

@davidsh @lmolkova @avanderhoorn 