### PR TITLE
Fix 79 System.Data.Common.Test failures on ILC

### DIFF
--- a/src/System.ComponentModel.TypeConverter/src/Resources/System.ComponentModel.TypeConverter.rd.xml
+++ b/src/System.ComponentModel.TypeConverter/src/Resources/System.ComponentModel.TypeConverter.rd.xml
@@ -16,5 +16,18 @@
         </Type>
       </Namespace>
     </Assembly>
+    <Assembly Name="System.ComponentModel.Primitives">
+      <Namespace Name="System.ComponentModel">
+        <Type Name="ReadOnlyAttribute">
+          <!-- ReadOnlyAttribute: need to be able to read the field named "Default" as System.ComponentModel.TypeConverter
+               relies on AttributeCollection returning ReadOnlyAttribute.Default if none was placed in the collection.
+               That lookup is done by Reflection.
+            -->
+          <Field Name="Default" Dynamic="Required Public">
+          </Field>
+        </Type>
+      </Namespace>
+    </Assembly>
   </Library> 
 </Directives>
+


### PR DESCRIPTION
These tests were null-referencing inside a IsReadOnly
property that looked up ReadOnlyAttributes in a collection
and invoked it without null-checking the lookup result.

The reason it's allowed to do that that is this
collection has some magic in it that lazily auto-populates
itself with the "default" value of the attribute
if the attribute itself isn't found on a lookup.
So as long a default exists, a lookup of this attribute
type never returns null.

Unfortunately, the "default" is discovered by reflecting
for a static field named "Default" on the attribute
type.