### PR TITLE
Workaround Issue Related to DateTimeOffsetAdapter.

### DIFF
--- a/src/System.Private.DataContractSerialization/src/Resources/Strings.resx
+++ b/src/System.Private.DataContractSerialization/src/Resources/Strings.resx
@@ -1114,16 +1114,16 @@
   <data name="XmlCanonicalizationStarted" xml:space="preserve">
     <value>Canonicalization already started.</value>
   </data>
-
   <data name="XmlCanonicalizationNotStarted" xml:space="preserve">
     <value>Canonicalization not started.</value>
   </data>
-
   <data name="CombinedPrefixNSLength" xml:space="preserve">
     <value>The combined length of the prefix and namespace must not be greater than {0}.</value>
   </data>
-
   <data name="InvalidInclusivePrefixListCollection" xml:space="preserve">
     <value>The inclusive namespace prefix collection cannot contain null as one of the items.</value>
+  </data>
+  <data name="FailedToCreateMethodDelegate" xml:space="preserve">
+    <value>Failed to create Delegate for method '{0}' of type '{1}'.</value>
   </data>
 </root>

--- a/src/System.Private.DataContractSerialization/src/Resources/System.Private.DataContractSerialization.rd.xml
+++ b/src/System.Private.DataContractSerialization/src/Resources/System.Private.DataContractSerialization.rd.xml
@@ -8,6 +8,7 @@
             <TypeParameter Name="type" DataContractSerializer="Public"/>
             <TypeEnumerableParameter Name="knownTypes" DataContractSerializer="Public"/>
           </Method>
+          <Property Name="Option" Dynamic="Required" />
         </Type>
         <Type Name="KeyValuePairAdapter`2" Dynamic="Required All" />
         <!-- Reflection-based serialization requires the entries below. -->
@@ -17,9 +18,7 @@
             <Method Name="BuildIncrementCollectionCountDelegate{T}" Dynamic="Required" />
           </Type>
         </Type>
-        <Type Name="DataContractSerializer">
-          <Property Name="Option" Dynamic="Required" />
-        </Type>
+        <Type Name="DateTimeOffsetAdapter" Dynamic="Required All" />
         <Type Name="FastInvokerBuilder" Dynamic="Required All" />
         <Type Name="ReflectionReader">
           <Method Name="GetCollectionSetItemDelegate{T}" Dynamic="Required" />

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/AccessorBuilder.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/AccessorBuilder.cs
@@ -179,7 +179,14 @@ namespace System.Runtime.Serialization
         // a generic extension for CreateDelegate
         public static T CreateDelegate<T>(this MethodInfo method) where T : class
         {
-            return method.CreateDelegate(typeof(T)) as T;
+            try
+            {
+                return method.CreateDelegate(typeof(T)) as T;
+            }
+            catch(Exception e)
+            {
+                throw new InvalidOperationException(SR.Format(SR.FailedToCreateMethodDelegate, method.Name, method.DeclaringType.FullName), e);
+            }
         }
     }
 }

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DateTimeOffsetAdapter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DateTimeOffsetAdapter.cs
@@ -11,8 +11,8 @@ using System.Globalization;
 namespace System.Runtime.Serialization
 {
     [DataContract(Name = "DateTimeOffset", Namespace = "http://schemas.datacontract.org/2004/07/System")]
-#if USE_REFEMIT
-    public struct DateTimeOffsetAdapter
+#if uapaot && DEBUG
+    internal class DateTimeOffsetAdapter
 #else
     internal struct DateTimeOffsetAdapter
 #endif

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DateTimeOffsetAdapter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DateTimeOffsetAdapter.cs
@@ -11,8 +11,8 @@ using System.Globalization;
 namespace System.Runtime.Serialization
 {
     [DataContract(Name = "DateTimeOffset", Namespace = "http://schemas.datacontract.org/2004/07/System")]
-#if uapaot && DEBUG
-    internal class DateTimeOffsetAdapter
+#if USE_REFEMIT
+    public struct DateTimeOffsetAdapter
 #else
     internal struct DateTimeOffsetAdapter
 #endif


### PR DESCRIPTION
Test `DataContractSerializerTests.DCS_BasicRoundTripResolveDTOTypes` is failing due to a bug in CoreRT. The PR works around the bug in `DEBUG` build.

Ref #19663