### PR TITLE
System.Data.Common.Tests down to 1 failure on ILC

### DIFF
--- a/src/System.Data.Common/tests/Resources/System.Data.Common.Tests.rd.xml
+++ b/src/System.Data.Common/tests/Resources/System.Data.Common.Tests.rd.xml
@@ -1,0 +1,7 @@
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Library>
+    <!-- Tests create an XmlSerializer on type System.Data.DataTable. -->
+    <Type Name="System.Data.DataTable" Dynamic="Required Public" />
+  </Library>
+</Directives>
+

--- a/src/System.Data.Common/tests/System.Data.Common.Tests.csproj
+++ b/src/System.Data.Common/tests/System.Data.Common.Tests.csproj
@@ -107,6 +107,15 @@
     <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs">
       <Link>Common\System\Diagnostics\Tracing\TestEventListener.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>System\PlatformDetection.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
+      <Link>System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\$(AssemblyName).rd.xml" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Data.Common/tests/System/Data/DataSetTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/DataSetTest2.cs
@@ -30,6 +30,7 @@ using System.IO;
 
 using System.Xml;
 using System.Runtime.Serialization.Formatters.Binary;
+using System.Runtime.Serialization.Formatters.Tests;
 using System.Globalization;
 
 namespace System.Data.Tests
@@ -3607,11 +3608,7 @@ namespace System.Data.Tests
 
             AssertDataTableValues(dt);
 
-            MemoryStream mstm = new MemoryStream();
-            BinaryFormatter bfmt = new BinaryFormatter();
-            bfmt.Serialize(mstm, dt);
-            MemoryStream mstm2 = new MemoryStream(mstm.ToArray());
-            DataTable vdt = (DataTable)bfmt.Deserialize(mstm2);
+            DataTable vdt = BinaryFormatterHelpers.Clone(dt);
             AssertDataTableValues(vdt);
         }
     }

--- a/src/System.Data.Common/tests/System/Data/DataSetTypedDataSetTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataSetTypedDataSetTest.cs
@@ -28,6 +28,7 @@ using System.ComponentModel;
 
 using System.Collections;
 using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Tests;
 using System.Xml;
 using System.Xml.Schema;
 using System.IO;
@@ -745,15 +746,7 @@ namespace System.Data.Tests
             ds1.DataTable1.AddDataTable1Row("test");
             ds1.DataTable1.AddDataTable1Row("test2");
 
-            global::System.Runtime.Serialization.Formatters.Binary.BinaryFormatter formatter =
-              new global::System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
-            MemoryStream stream = new MemoryStream();
-
-            formatter.Serialize(stream, ds1);
-
-            stream.Seek(0, SeekOrigin.Begin);
-
-            DataSet1 ds1load = (DataSet1)formatter.Deserialize(stream);
+            DataSet1 ds1load = BinaryFormatterHelpers.Clone(ds1);
 
             Assert.True(ds1load.Tables.Contains("DataTable1"));
             Assert.Equal("DataTable1DataTable", ds1load.Tables["DataTable1"].GetType().Name);
@@ -775,13 +768,7 @@ namespace System.Data.Tests
             //now test when the mode is exclude schema
             ds1.SchemaSerializationMode = global::System.Data.SchemaSerializationMode.ExcludeSchema;
 
-            stream = new MemoryStream();
-
-            formatter.Serialize(stream, ds1);
-
-            stream.Seek(0, SeekOrigin.Begin);
-
-            ds1load = (DataSet1)formatter.Deserialize(stream);
+            ds1load = BinaryFormatterHelpers.Clone(ds1);
 
             Assert.True(ds1load.Tables.Contains("DataTable1"));
             Assert.Equal("DataTable1DataTable", ds1load.Tables["DataTable1"].GetType().Name);

--- a/src/System.Data.Common/tests/System/Data/DataTableTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataTableTest.cs
@@ -32,6 +32,7 @@ using System.Data.SqlTypes;
 using System.Globalization;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
+using System.Runtime.Serialization.Formatters.Tests;
 using System.Xml;
 
 
@@ -1893,12 +1894,6 @@ Assert.False(true);
         [Fact]
         public void Serialize()
         {
-            MemoryStream fs = new MemoryStream();
-
-            // Construct a BinaryFormatter and use it 
-            // to serialize the data to the stream.
-            BinaryFormatter formatter = new BinaryFormatter();
-
             // Create an array with multiple elements refering to 
             // the one Singleton object.
             DataTable dt = new DataTable();
@@ -1919,13 +1914,7 @@ Assert.False(true);
             dt.Rows.Add(loRowToAdd);
 
             DataTable[] dtarr = new DataTable[] { dt };
-
-            // Serialize the array elements.
-            formatter.Serialize(fs, dtarr);
-
-            // Deserialize the array elements.
-            fs.Position = 0;
-            DataTable[] a2 = (DataTable[])formatter.Deserialize(fs);
+            DataTable[] a2 = BinaryFormatterHelpers.Clone(dtarr);
 
             var ds = new DataSet();
             ds.Tables.Add(a2[0]);


### PR DESCRIPTION
Divering more BinaryFormatter tests to our Aot-trapped
helper.

More rd.xml magic.