### PR TITLE
Fix a failure in System.Reflection.DispatchProxy.Tests on ILC

### DIFF
--- a/src/System.Reflection.DispatchProxy/tests/DispatchProxyTests.cs
+++ b/src/System.Reflection.DispatchProxy/tests/DispatchProxyTests.cs
@@ -70,7 +70,7 @@ namespace DispatchProxyTests
             Assert.NotNull(proxy1);
             Assert.NotNull(proxy2);
             Assert.False(object.ReferenceEquals(proxy1, proxy2),
-                        String.Format("First and second instance of proxy type {0} were the same instance", proxy1.GetType().Name));
+                        String.Format("First and second instance of proxy type {0} were the same instance", proxy1.GetType().ToString()));
         }
 
 


### PR DESCRIPTION
- unnecessary metadata dependency in Assert error string.