### PR TITLE
Fix System.Configuration.ConfigurationManager desktop ref

### DIFF
--- a/src/System.Configuration.ConfigurationManager/ref/System.Configuration.ConfigurationManager.csproj
+++ b/src/System.Configuration.ConfigurationManager/ref/System.Configuration.ConfigurationManager.csproj
@@ -18,6 +18,7 @@
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)'  == 'true'">
     <Reference Include="mscorlib" />
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
   </ItemGroup>


### PR DESCRIPTION
The desktop reference assembly for System.Configuration.ConfigurationManager
incorrectly had typedefs rather than type forwards.

This was because it was missing a reference to System.Configuration
so none of the types in that assembly were replaced with TypeForwards.

