### PR TITLE
SqlClientFactory: Override CreateDataAdapter

### DIFF
--- a/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
+++ b/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
@@ -273,6 +273,7 @@ namespace System.Data.SqlClient
         public override System.Data.Common.DbCommand CreateCommand() { throw null; }
         public override System.Data.Common.DbConnection CreateConnection() { throw null; }
         public override System.Data.Common.DbConnectionStringBuilder CreateConnectionStringBuilder() { throw null; }
+        public override System.Data.Common.DbDataAdapter CreateDataAdapter() { throw null; }
         public override System.Data.Common.DbParameter CreateParameter() { throw null; }
     }
     public sealed partial class SqlCommand : System.Data.Common.DbCommand, System.ICloneable

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlClientFactory.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlClientFactory.cs
@@ -2,12 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
-
-//------------------------------------------------------------------------------
-
 using System.Data.Common;
-
 
 namespace System.Data.SqlClient
 {
@@ -19,12 +14,10 @@ namespace System.Data.SqlClient
         {
         }
 
-
         public override DbCommand CreateCommand()
         {
             return new SqlCommand();
         }
-
 
         public override DbConnection CreateConnection()
         {
@@ -36,6 +29,10 @@ namespace System.Data.SqlClient
             return new SqlConnectionStringBuilder();
         }
 
+        public override DbDataAdapter CreateDataAdapter()
+        {
+            return new SqlDataAdapter();
+        }
 
         public override DbParameter CreateParameter()
         {
@@ -43,4 +40,3 @@ namespace System.Data.SqlClient
         }
     }
 }
-

--- a/src/System.Data.SqlClient/tests/FunctionalTests/SqlClientFactoryTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/SqlClientFactoryTest.cs
@@ -9,41 +9,35 @@ namespace System.Data.SqlClient.Tests
     public class SqlClientFactoryTest
     {
         [Fact]
-        public void Instance_NotNullSame()
+        public void InstanceTest()
         {
             SqlClientFactory instance = SqlClientFactory.Instance;
             Assert.NotNull(instance);
             Assert.Same(instance, SqlClientFactory.Instance);
         }
 
-        [Fact]
-        public void CreateCommand_NotNull()
+        public static readonly object[][] FactoryMethodTestData =
         {
-            Assert.NotNull(SqlClientFactory.Instance.CreateCommand());
-        }
+            new object[] { new Func<object>(SqlClientFactory.Instance.CreateCommand), typeof(SqlCommand) },
+            new object[] { new Func<object>(SqlClientFactory.Instance.CreateConnection), typeof(SqlConnection) },
+            new object[] { new Func<object>(SqlClientFactory.Instance.CreateConnectionStringBuilder), typeof(SqlConnectionStringBuilder) },
+            new object[] { new Func<object>(SqlClientFactory.Instance.CreateDataAdapter), typeof(SqlDataAdapter) },
+            new object[] { new Func<object>(SqlClientFactory.Instance.CreateParameter), typeof(SqlParameter) },
+        };
 
-        [Fact]
-        public void CreateConnection_NotNull()
+        [Theory]
+        [MemberData(nameof(FactoryMethodTestData))]
+        public void FactoryMethodTest(Func<object> factory, Type expectedType)
         {
-            Assert.NotNull(SqlClientFactory.Instance.CreateConnection());
-        }
+            object value1 = factory();
+            Assert.NotNull(value1);
+            Assert.IsType(expectedType, value1);
 
-        [Fact]
-        public void CreateConnectionStringBuilder_NotNull()
-        {
-            Assert.NotNull(SqlClientFactory.Instance.CreateConnectionStringBuilder());
-        }
+            object value2 = factory();
+            Assert.NotNull(value2);
+            Assert.IsType(expectedType, value2);
 
-        [Fact]
-        public void CreateDataAdapter_NotNull()
-        {
-            Assert.NotNull(SqlClientFactory.Instance.CreateDataAdapter());
-        }
-
-        [Fact]
-        public void CreateParameter_NotNull()
-        {
-            Assert.NotNull(SqlClientFactory.Instance.CreateParameter());
+            Assert.NotSame(value1, value2);
         }
     }
 }

--- a/src/System.Data.SqlClient/tests/FunctionalTests/SqlClientFactoryTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/SqlClientFactoryTest.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Data.SqlClient.Tests
+{
+    public class SqlClientFactoryTest
+    {
+        [Fact]
+        public void Instance_NotNullSame()
+        {
+            SqlClientFactory instance = SqlClientFactory.Instance;
+            Assert.NotNull(instance);
+            Assert.Same(instance, SqlClientFactory.Instance);
+        }
+
+        [Fact]
+        public void CreateCommand_NotNull()
+        {
+            Assert.NotNull(SqlClientFactory.Instance.CreateCommand());
+        }
+
+        [Fact]
+        public void CreateConnection_NotNull()
+        {
+            Assert.NotNull(SqlClientFactory.Instance.CreateConnection());
+        }
+
+        [Fact]
+        public void CreateConnectionStringBuilder_NotNull()
+        {
+            Assert.NotNull(SqlClientFactory.Instance.CreateConnectionStringBuilder());
+        }
+
+        [Fact]
+        public void CreateDataAdapter_NotNull()
+        {
+            Assert.NotNull(SqlClientFactory.Instance.CreateDataAdapter());
+        }
+
+        [Fact]
+        public void CreateParameter_NotNull()
+        {
+            Assert.NotNull(SqlClientFactory.Instance.CreateParameter());
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
@@ -18,6 +18,7 @@
     <Compile Include="ExceptionTest.cs" />
     <Compile Include="FakeDiagnosticListenerObserver.cs" />
     <Compile Include="SqlBulkCopyColumnMappingCollectionTest.cs" />
+    <Compile Include="SqlClientFactoryTest.cs" />
     <Compile Include="SqlConnectionTest.RetrieveStatistics.cs" />
     <Compile Include="SqlErrorCollectionTest.cs" />
     <Compile Include="TcpDefaultForAzureTest.cs" />


### PR DESCRIPTION
Override `CreateDataAdapter` and add tests.

Fixes #19651, #19673

cc: @saurabh500, @corivera
fyi: @RickStrahl, @FransBouma