### PR TITLE
Enable DCS to Serialize IEnumerable Types on UWP in ReflectionOnly Mode

### DIFF
--- a/src/System.Private.DataContractSerialization/src/Resources/System.Private.DataContractSerialization.rd.xml
+++ b/src/System.Private.DataContractSerialization/src/Resources/System.Private.DataContractSerialization.rd.xml
@@ -42,5 +42,9 @@
         </Type>
       </Namespace>
     </Assembly>
+    <Namespace Name="System.Collections">
+      <Type Name="IEnumerable" Dynamic="Required All" />
+      <Type Name="IEnumerator" Dynamic="Required All" />
+    </Namespace>
   </Library>
 </Directives>


### PR DESCRIPTION
DCS currently failed to serialize IEnumerable Types on UWP in ReflectionOnly mode. The root cause is that the reflection based serialization requires metadata for `IEnumerable` and `IEnumerator`. The fix is to keep the metadata for these two types. This fixed 6 failed tests.

The size of the output didn't change much (< 1 KB).

Fix #19677 