### PR TITLE
Re-enable tests on Fedora/Rhel/Centos.

### DIFF
--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -872,7 +872,7 @@ namespace System.Net.Tests
         }
 
         [OuterLoop]
-        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotFedoraOrRedHatOrCentos))] // #16201
+        [Theory]
         [MemberData(nameof(EchoServers))]
         public void UseDefaultCredentials_SetGetResponse_ExpectSuccess(Uri remoteServer)
         {
@@ -1064,8 +1064,8 @@ namespace System.Net.Tests
                 Assert.True(strContent.Contains(RequestBody));
             }
         }
-
-        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotFedoraOrRedHatOrCentos))] // #16201
+        
+        [Theory] 
         [MemberData(nameof(EchoServers))]
         public async Task GetResponseAsync_UseDefaultCredentials_ExpectSuccess(Uri remoteServer)
         {
@@ -1123,7 +1123,7 @@ namespace System.Net.Tests
             });
         }
 
-        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotFedoraOrRedHatOrCentos))] // #16201
+        [Theory]
         [MemberData(nameof(EchoServers))]
         public async Task Headers_GetResponseHeaders_ContainsExpectedValue(Uri remoteServer)
         {

--- a/src/System.Net.WebClient/tests/WebClientTest.cs
+++ b/src/System.Net.WebClient/tests/WebClientTest.cs
@@ -666,7 +666,7 @@ namespace System.Net.Tests
         }
 
         [OuterLoop("Networking test talking to remote server: issue #11345")]
-        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotFedoraOrRedHatOrCentos))] // #16201
+        [Theory]
         [MemberData(nameof(EchoServers))]
         public async Task UploadFile_Success(Uri echoServer)
         {


### PR DESCRIPTION
Updated the CI scripts to export env variable SSL_DIR to an empty dir without certs, in which case the nss initialization will not use the default location of /etc/pki/nssdb [here](https://github.com/curl/curl/blob/a40f58d/lib/nss.c#L908), which may contain out of date certs resulting in  CURLE_SSL_CACERT_BADFILE

test possible workaround for #16201 

cc @karelz @tmds @steveharter 