### PR TITLE
Changes to support ARM-requeue for UAPAOT testing

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-2.0.0-prerelease-01610-02
+2.0.0-prerelease-01611-05

--- a/src/upload-tests.proj
+++ b/src/upload-tests.proj
@@ -25,6 +25,9 @@
          - Command must produce testResults.xml on successful execution.
          - Command is expressed in terms of an .SH file if on *Nix -->
     <UseScriptRunner>true</UseScriptRunner>
+    <!-- For Windows ARM & ARM64 UAPAOT runs, we'll need a special runner that knows how to do this (TODO: Combine the runners) -->
+    <UseContinuationRunner Condition="'$(ArchGroup)'=='arm' AND '$(TargetGroup)'=='uapaot'">true</UseContinuationRunner>
+    <SecondaryPayloadDir   Condition="'$(ArchGroup)'=='arm' AND '$(TargetGroup)'=='uapaot'">%HELIX_WORKITEM_PAYLOAD%\native</SecondaryPayloadDir>
 
     <!-- Test builds consist of the tests that are platform specific in one root, plus others in AnyOS. -->
     <AnyOSPlatformConfig>AnyOS.AnyCPU.$(ConfigurationGroup)</AnyOSPlatformConfig>


### PR DESCRIPTION
I have intentionally avoided turning this on in official builds since the binaries we're producing for ARM right now don't quite execute on the Windows ARM64 clients.   Regardless, with just this small change you can get a full multi-queued Helix run by doing the same steps as the other UAP AOT runs, but changing out the arch to "arm".

@joperezr , FYI.