### PR TITLE
Disable HttpClientHandler test Default_ExpectedValue on Desktop, which fails on random occasions depending on xunit test execution order

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxConnectionsPerServer.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxConnectionsPerServer.cs
@@ -16,6 +16,7 @@ namespace System.Net.Http.Functional.Tests
     public class HttpClientHandler_MaxConnectionsPerServer_Test
     {
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "MaxConnectionsPerServer either returns two or int.MaxValue depending if ctor of HttpClientHandlerTest executed first. Disabling cause of random xunit execution order.")]
         public void Default_ExpectedValue()
         {
             using (var handler = new HttpClientHandler())


### PR DESCRIPTION
@safern Talked shortly with Stephen about it as he was available (not the other issue, only this one). He recommended disabling the test as removing the static assignment isn't worth for only fixing this test.