### PR TITLE
Fix Pipes tests to workaround desktop SafeHandle finalization bug

### DIFF
--- a/src/System.IO.Pipes.AccessControl/tests/System.IO.Pipes.AccessControl.Tests.csproj
+++ b/src/System.IO.Pipes.AccessControl/tests/System.IO.Pipes.AccessControl.Tests.csproj
@@ -17,6 +17,9 @@
     <Compile Include="$(CommonTestPath)\System\IO\FileCleanupTestBase.cs">
       <Link>Common\System\IO\FileCleanupTestBase.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>Common\System\PlatformDetection.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.IO.Pipes/tests/AnonymousPipeTests/AnonymousPipeTest.CreateClient.cs
+++ b/src/System.IO.Pipes/tests/AnonymousPipeTests/AnonymousPipeTest.CreateClient.cs
@@ -25,7 +25,9 @@ namespace System.IO.Pipes.Tests
         {
             using (var server = new AnonymousPipeServerStream(PipeDirection.Out))
             using (var client = new AnonymousPipeClientStream(server.GetClientHandleAsString()))
-            { }
+            {
+                SuppressClientHandleFinalizationIfNetFramework(server);
+            }
         }
 
         [Theory]

--- a/src/System.IO.Pipes/tests/AnonymousPipeTests/AnonymousPipeTest.Specific.cs
+++ b/src/System.IO.Pipes/tests/AnonymousPipeTests/AnonymousPipeTest.Specific.cs
@@ -39,7 +39,7 @@ namespace System.IO.Pipes.Tests
                 using (AnonymousPipeServerStream server = new AnonymousPipeServerStream(PipeDirection.Out, serverBase.SafePipeHandle, serverBase.ClientSafePipeHandle))
                 {
                     Assert.True(server.IsConnected);
-                    using (AnonymousPipeClientStream client = new AnonymousPipeClientStream(PipeDirection.In, server.GetClientHandleAsString()))
+                    using (AnonymousPipeClientStream client = new AnonymousPipeClientStream(PipeDirection.In, server.ClientSafePipeHandle))
                     {
                         Assert.True(server.IsConnected);
                         Assert.True(client.IsConnected);
@@ -61,7 +61,7 @@ namespace System.IO.Pipes.Tests
         {
             using (AnonymousPipeServerStream server = new AnonymousPipeServerStream(PipeDirection.Out))
             {
-                using (AnonymousPipeClientStream clientBase = new AnonymousPipeClientStream(PipeDirection.In, server.GetClientHandleAsString()))
+                using (AnonymousPipeClientStream clientBase = new AnonymousPipeClientStream(PipeDirection.In, server.ClientSafePipeHandle))
                 {
                     using (AnonymousPipeClientStream client = new AnonymousPipeClientStream(PipeDirection.In, clientBase.SafePipeHandle))
                     {
@@ -162,7 +162,7 @@ namespace System.IO.Pipes.Tests
         public void ReadModeToByte_Accepted(PipeDirection serverDirection, PipeDirection clientDirection)
         {
             using (AnonymousPipeServerStream server = new AnonymousPipeServerStream(serverDirection))
-            using (AnonymousPipeClientStream client = new AnonymousPipeClientStream(clientDirection, server.GetClientHandleAsString()))
+            using (AnonymousPipeClientStream client = new AnonymousPipeClientStream(clientDirection, server.ClientSafePipeHandle))
             {
                 server.ReadMode = PipeTransmissionMode.Byte;
                 client.ReadMode = PipeTransmissionMode.Byte;
@@ -175,7 +175,7 @@ namespace System.IO.Pipes.Tests
         public void MessageReadMode_Throws_NotSupportedException()
         {
             using (AnonymousPipeServerStream server = new AnonymousPipeServerStream(PipeDirection.Out))
-            using (AnonymousPipeClientStream client = new AnonymousPipeClientStream(PipeDirection.In, server.GetClientHandleAsString()))
+            using (AnonymousPipeClientStream client = new AnonymousPipeClientStream(PipeDirection.In, server.ClientSafePipeHandle))
             {
                 Assert.Throws<NotSupportedException>(() => server.ReadMode = PipeTransmissionMode.Message);
                 Assert.Throws<NotSupportedException>(() => client.ReadMode = PipeTransmissionMode.Message);
@@ -186,7 +186,7 @@ namespace System.IO.Pipes.Tests
         public void InvalidReadMode_Throws_ArgumentOutOfRangeException()
         {
             using (AnonymousPipeServerStream server = new AnonymousPipeServerStream(PipeDirection.Out))
-            using (AnonymousPipeClientStream client = new AnonymousPipeClientStream(PipeDirection.In, server.GetClientHandleAsString()))
+            using (AnonymousPipeClientStream client = new AnonymousPipeClientStream(PipeDirection.In, server.ClientSafePipeHandle))
             {
                 Assert.Throws<ArgumentOutOfRangeException>(() => server.ReadMode = (PipeTransmissionMode)999);
                 Assert.Throws<ArgumentOutOfRangeException>(() => client.ReadMode = (PipeTransmissionMode)999);

--- a/src/System.IO.Pipes/tests/Performance/System.IO.Pipes.Performance.Tests.csproj
+++ b/src/System.IO.Pipes/tests/Performance/System.IO.Pipes.Performance.Tests.csproj
@@ -18,6 +18,9 @@
     <Compile Include="$(CommonTestPath)\System\PerfUtils.cs">
       <Link>Common\System\PerfUtils.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>Common\System\PlatformDetection.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">

--- a/src/System.IO.Pipes/tests/PipeTestBase.cs
+++ b/src/System.IO.Pipes/tests/PipeTestBase.cs
@@ -28,6 +28,24 @@ namespace System.IO.Pipes.Tests
             }
         }
 
+        protected static void SuppressClientHandleFinalizationIfNetFramework(AnonymousPipeServerStream serverStream)
+        {
+            if (PlatformDetection.IsFullFramework)
+            {
+                // See https://github.com/dotnet/corefx/pull/1871.  When AnonymousPipeServerStream.GetClientHandleAsString()
+                // is called, the assumption is that this string is going to be passed to another process, rather than wrapped
+                // into a SafeHandle in the same process.  If it's wrapped into a SafeHandle in the same process, there are then
+                // two SafeHandles that believe they own the same underlying handle, which leads to use-after-free and recycling
+                // bugs.  AnonymousPipeServerStream incorrectly deals with this in desktop: it marks the SafeHandle as having
+                // been exposed, but that then only prevents the disposal of AnonymousPipeServerStream from calling Dispose
+                // on the SafeHandle... it doesn't prevent the SafeHandle itself from getting finalized, which leads to random
+                // "The handle is invalid" or "Pipe is broken" errors at some later point when the handle is recycled and used
+                // for another instance.  In core, this was addressed in 1871 by calling GC.SuppressFinalize(_clientHandle)
+                // in GetClientHandleAsString.  For desktop, we work around this by suppressing the handle in this explicit call.
+                GC.SuppressFinalize(serverStream.ClientSafePipeHandle);
+            }
+        }
+
         /// <summary>
         /// Represents a Server-Client pair where "readablePipe" refers to whichever
         /// of the two streams is defined with PipeDirection.In and "writeablePipe" is 


### PR DESCRIPTION
 When AnonymousPipeServerStream.GetClientHandleAsString() is called, the assumption is that this string is going to be passed to another process, rather than wrapped into a SafeHandle in the same process.  If it's wrapped into a SafeHandle in the same process, there are then two SafeHandles that believe they own the same underlying handle, which leads to use-after-free and recycling bugs. AnonymousPipeServerStream incorrectly deals with this in desktop: it marks the SafeHandle as having been exposed, but that then only prevents the disposal of AnonymousPipeServerStream from calling Dispose on the SafeHandle... it doesn't prevent the SafeHandle itself from getting finalized, which leads to random "The handle is invalid" or "Pipe is broken" errors at some later point when the handle is recycled and used for another instance.  In core, this was addressed in 1871 by calling GC.SuppressFinalize(_clientHandle) in GetClientHandleAsString.

This commit fixes the tests in two ways:
- Most uses of GetClientHandleAsString where it's used to create a client stream in the same process can just be replaced by ClientSafePipeHandle instead.  This avoids the issue because there's then only one SafeHandle instance.
- The remaining uses just need to have the SafeHandle suppressed for finalization (and then we need to make sure we dispose to avoid a leak in the tests).  There are very few of these.

Fixes https://github.com/dotnet/corefx/issues/19656
cc: @ianhays 