### PR TITLE
Fix using Directory to move files

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/Directory.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Directory.cs
@@ -563,8 +563,10 @@ namespace System.IO
             String destinationRoot = Path.GetPathRoot(destPath);
             if (!String.Equals(sourceRoot, destinationRoot, pathComparison))
                 throw new IOException(SR.IO_SourceDestMustHaveSameRoot);
-            
-            if (!FileSystem.Current.DirectoryExists(fullsourceDirName))
+
+            // Windows will throw if the source file/directory doesn't exist, we preemptively check
+            // to make sure our cross platform behavior matches NetFX behavior.
+            if (!FileSystem.Current.DirectoryExists(fullsourceDirName) && !FileSystem.Current.FileExists(fullsourceDirName))
                 throw new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, fullsourceDirName));
             
             if (FileSystem.Current.DirectoryExists(fulldestDirName))

--- a/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
+++ b/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
@@ -415,7 +415,7 @@ namespace System.IO
 
             // Windows will throw if the source file/directory doesn't exist, we preemptively check
             // to make sure our cross platform behavior matches NetFX behavior.
-            if (!Exists && !FileSystem.Current.FileExists(fullSourcePath))
+            if (!Exists && !FileSystem.Current.FileExists(FullPath))
                 throw new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, FullPath));
 
             if (FileSystem.Current.DirectoryExists(fullDestDirName))

--- a/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
+++ b/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
@@ -379,7 +379,7 @@ namespace System.IO
         }
 
         [System.Security.SecuritySafeCritical]
-        public void MoveTo(String destDirName)
+        public void MoveTo(string destDirName)
         {
             if (destDirName == null)
                 throw new ArgumentNullException(nameof(destDirName));
@@ -387,11 +387,12 @@ namespace System.IO
                 throw new ArgumentException(SR.Argument_EmptyFileName, nameof(destDirName));
             Contract.EndContractBlock();
 
-            String fullDestDirName = Path.GetFullPath(destDirName);
-            if (fullDestDirName[fullDestDirName.Length - 1] != Path.DirectorySeparatorChar)
-                fullDestDirName = fullDestDirName + PathHelpers.DirectorySeparatorCharAsString;
+            string destination = Path.GetFullPath(destDirName);
+            string destinationWithSeparator = destination;
+            if (destinationWithSeparator[destinationWithSeparator.Length - 1] != Path.DirectorySeparatorChar)
+                destinationWithSeparator = destinationWithSeparator + PathHelpers.DirectorySeparatorCharAsString;
 
-            String fullSourcePath;
+            string fullSourcePath;
             if (FullPath.Length > 0 && FullPath[FullPath.Length - 1] == Path.DirectorySeparatorChar)
                 fullSourcePath = FullPath;
             else
@@ -400,17 +401,17 @@ namespace System.IO
             if (PathInternal.IsDirectoryTooLong(fullSourcePath))
                 throw new PathTooLongException(SR.IO_PathTooLong);
 
-            if (PathInternal.IsDirectoryTooLong(fullDestDirName))
+            if (PathInternal.IsDirectoryTooLong(destinationWithSeparator))
                 throw new PathTooLongException(SR.IO_PathTooLong);
 
             StringComparison pathComparison = PathInternal.StringComparison;
-            if (String.Equals(fullSourcePath, fullDestDirName, pathComparison))
+            if (string.Equals(fullSourcePath, destinationWithSeparator, pathComparison))
                 throw new IOException(SR.IO_SourceDestMustBeDifferent);
 
-            String sourceRoot = Path.GetPathRoot(fullSourcePath);
-            String destinationRoot = Path.GetPathRoot(fullDestDirName);
+            string sourceRoot = Path.GetPathRoot(fullSourcePath);
+            string destinationRoot = Path.GetPathRoot(destinationWithSeparator);
 
-            if (!String.Equals(sourceRoot, destinationRoot, pathComparison))
+            if (!string.Equals(sourceRoot, destinationRoot, pathComparison))
                 throw new IOException(SR.IO_SourceDestMustHaveSameRoot);
 
             // Windows will throw if the source file/directory doesn't exist, we preemptively check
@@ -418,12 +419,12 @@ namespace System.IO
             if (!Exists && !FileSystem.Current.FileExists(FullPath))
                 throw new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, FullPath));
 
-            if (FileSystem.Current.DirectoryExists(fullDestDirName))
-                throw new IOException(SR.Format(SR.IO_AlreadyExists_Name, fullDestDirName));
+            if (FileSystem.Current.DirectoryExists(destinationWithSeparator))
+                throw new IOException(SR.Format(SR.IO_AlreadyExists_Name, destinationWithSeparator));
 
-            FileSystem.Current.MoveDirectory(FullPath, fullDestDirName);
+            FileSystem.Current.MoveDirectory(FullPath, destination);
 
-            FullPath = fullDestDirName;
+            FullPath = destinationWithSeparator;
             OriginalPath = destDirName;
             DisplayPath = GetDisplayName(OriginalPath);
 

--- a/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
+++ b/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
@@ -413,7 +413,9 @@ namespace System.IO
             if (!String.Equals(sourceRoot, destinationRoot, pathComparison))
                 throw new IOException(SR.IO_SourceDestMustHaveSameRoot);
 
-            if (!Exists)
+            // Windows will throw if the source file/directory doesn't exist, we preemptively check
+            // to make sure our cross platform behavior matches NetFX behavior.
+            if (!Exists && !FileSystem.Current.FileExists(fullSourcePath))
                 throw new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, FullPath));
 
             if (FileSystem.Current.DirectoryExists(fullDestDirName))

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
@@ -277,9 +277,20 @@ namespace System.IO
         public override void MoveDirectory(string sourceFullPath, string destFullPath)
         {
             // Windows doesn't care if you try and copy a file via "MoveDirectory"...
-            if (!PathHelpers.EndsInDirectorySeparator(sourceFullPath) && FileExists(sourceFullPath))
+            if (FileExists(sourceFullPath))
             {
-                // ... and it doesn't care if the destination has a trailing separator.
+                // ... but it doesn't like the source to have a trailing slash ...
+
+                // On Windows we end up with ERROR_INVALID_NAME, which is
+                // "The filename, directory name, or volume label syntax is incorrect."
+                //
+                // This surfaces as a IOException, if we let it go beyond here it would
+                // give DirectoryNotFound.
+
+                if (PathHelpers.EndsInDirectorySeparator(sourceFullPath))
+                    throw new IOException(SR.Format(SR.IO_PathNotFound_Path, sourceFullPath));
+
+                // ... but it doesn't care if the destination has a trailing separator.
                 destFullPath = PathHelpers.TrimEndingDirectorySeparator(destFullPath);
             }
 
@@ -290,23 +301,6 @@ namespace System.IO
                 {
                     case Interop.Error.EACCES: // match Win32 exception
                         throw new IOException(SR.Format(SR.UnauthorizedAccess_IODenied_Path, sourceFullPath), errorInfo.RawErrno);
-                    case Interop.Error.ENOENT:
-                        // If the source item was a file with a trailing separator on Windows we get ERROR_INVALIDNAME,
-                        // which is "The filename, directory name, or volume label syntax is incorrect."
-                        //
-                        // If there is a file that exists at sourceFullPath minus the directory separator we'll throw
-                        // as NetFX would, but use the text that DirectoryNotFound would.
-
-                        if (PathHelpers.EndsInDirectorySeparator(sourceFullPath)
-                            && FileExists(PathHelpers.TrimEndingDirectorySeparator(sourceFullPath)))
-                        {
-                            throw new IOException(SR.Format(SR.IO_PathNotFound_Path, sourceFullPath));
-                        }
-                        else
-                        {
-                            goto default;
-                        }
-
                     default:
                         throw Interop.GetExceptionForIoErrno(errorInfo, sourceFullPath, isDirectory: true);
                 }
@@ -413,7 +407,9 @@ namespace System.IO
         public override bool FileExists(string fullPath)
         {
             Interop.ErrorInfo ignored;
-            return FileExists(fullPath, Interop.Sys.FileTypes.S_IFREG, out ignored);
+
+            // Windows doesn't care about the trailing separator, str
+            return FileExists(PathHelpers.TrimEndingDirectorySeparator(fullPath), Interop.Sys.FileTypes.S_IFREG, out ignored);
         }
 
         private static bool FileExists(string fullPath, int fileType, out Interop.ErrorInfo errorInfo)

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
@@ -276,6 +276,24 @@ namespace System.IO
 
         public override void MoveDirectory(string sourceFullPath, string destFullPath)
         {
+            // Windows doesn't care if you try and copy a file via "MoveDirectory"...
+            if (FileExists(sourceFullPath))
+            {
+                // ... but it doesn't like the source to have a trailing slash ...
+
+                // On Windows we end up with ERROR_INVALID_NAME, which is
+                // "The filename, directory name, or volume label syntax is incorrect."
+                //
+                // This surfaces as a IOException, if we let it go beyond here it would
+                // give DirectoryNotFound.
+
+                if (PathHelpers.EndsInDirectorySeparator(sourceFullPath))
+                    throw new IOException(SR.Format(SR.IO_PathNotFound_Path, sourceFullPath));
+
+                // ... but it doesn't care if the destination has a trailing separator.
+                destFullPath = PathHelpers.TrimEndingDirectorySeparator(destFullPath);
+            }
+
             if (Interop.Sys.Rename(sourceFullPath, destFullPath) < 0)
             {
                 Interop.ErrorInfo errorInfo = Interop.Sys.GetLastErrorInfo();

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
@@ -408,7 +408,7 @@ namespace System.IO
         {
             Interop.ErrorInfo ignored;
 
-            // Windows doesn't care about the trailing separator, str
+            // Windows doesn't care about the trailing separator
             return FileExists(PathHelpers.TrimEndingDirectorySeparator(fullPath), Interop.Sys.FileTypes.S_IFREG, out ignored);
         }
 

--- a/src/System.IO.FileSystem/tests/Directory/Move.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Move.cs
@@ -81,12 +81,35 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void MoveFile_TrailingDestinationAltSlash_Windows()
+        {
+            // Regression https://github.com/dotnet/corefx/issues/19710
+            string source = GetTestFilePath();
+            string destination = GetTestFilePath();
+            File.Create(source).Dispose();
+            Move(source, destination + Path.AltDirectorySeparatorChar);
+            Assert.True(File.Exists(destination));
+            Assert.False(File.Exists(source));
+        }
+
+        [Fact]
         public void MoveFile_TrailingSourceSlash()
         {
             string source = GetTestFilePath();
             string destination = GetTestFilePath();
             File.Create(source).Dispose();
             Assert.Throws<IOException>(() => Move(source + Path.DirectorySeparatorChar, destination));
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void MoveFile_TrailingSourceAltSlash_Windows()
+        {
+            string source = GetTestFilePath();
+            string destination = GetTestFilePath();
+            File.Create(source).Dispose();
+            Assert.Throws<IOException>(() => Move(source + Path.AltDirectorySeparatorChar, destination));
         }
 
         [Fact]

--- a/src/System.IO.FileSystem/tests/Directory/Move.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Move.cs
@@ -69,6 +69,27 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        public void MoveFile_TrailingDestinationSlash()
+        {
+            // Regression https://github.com/dotnet/corefx/issues/19710
+            string source = GetTestFilePath();
+            string destination = GetTestFilePath();
+            File.Create(source).Dispose();
+            Move(source, destination + Path.DirectorySeparatorChar);
+            Assert.True(File.Exists(destination));
+            Assert.False(File.Exists(source));
+        }
+
+        [Fact]
+        public void MoveFile_TrailingSourceSlash()
+        {
+            string source = GetTestFilePath();
+            string destination = GetTestFilePath();
+            File.Create(source).Dispose();
+            Assert.Throws<IOException>(() => Move(source + Path.DirectorySeparatorChar, destination));
+        }
+
+        [Fact]
         public void MoveOntoFile()
         {
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());

--- a/src/System.IO.FileSystem/tests/Directory/Move.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Move.cs
@@ -57,6 +57,18 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        public void MoveFile()
+        {
+            // Regression https://github.com/dotnet/corefx/issues/19710
+            string source = GetTestFilePath();
+            string destination = GetTestFilePath();
+            File.Create(source).Dispose();
+            Move(source, destination);
+            Assert.True(File.Exists(destination));
+            Assert.False(File.Exists(source));
+        }
+
+        [Fact]
         public void MoveOntoFile()
         {
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());

--- a/src/System.IO.FileSystem/tests/File/Exists.cs
+++ b/src/System.IO.FileSystem/tests/File/Exists.cs
@@ -81,6 +81,31 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void PathEndsInAltTrailingSlash_Windows()
+        {
+            string path = GetTestFilePath() + Path.DirectorySeparatorChar;
+            Assert.False(Exists(path));
+        }
+
+        [Fact]
+        public void PathEndsInTrailingSlash_AndExists()
+        {
+            string path = GetTestFilePath();
+            File.Create(path).Dispose();
+            Assert.False(Exists(path + Path.DirectorySeparatorChar));
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void PathEndsInAltTrailingSlash_AndExists_Windows()
+        {
+            string path = GetTestFilePath();
+            File.Create(path).Dispose();
+            Assert.False(Exists(path + Path.DirectorySeparatorChar));
+        }
+
+        [Fact]
         public void PathAlreadyExistsAsDirectory()
         {
             string path = GetTestFilePath();


### PR DESCRIPTION
See #19710. NetFX behavior is that you can use Directory
to move files. This was broken trying to match other legacy
behavior in #17913. Tested on NetFX and CoreFX.