### PR TITLE
Make SqlParameter implement IDbDataParameter

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameter.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameter.cs
@@ -54,7 +54,7 @@ namespace System.Data.SqlClient
         }
     }
 
-    public sealed partial class SqlParameter : DbParameter, ICloneable
+    public sealed partial class SqlParameter : DbParameter, IDbDataParameter, ICloneable
     {
         private MetaType _metaType;
 

--- a/src/System.Data.SqlClient/tests/FunctionalTests/SqlParameterTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/SqlParameterTest.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Data.Common;
+using Xunit;
+
+namespace System.Data.SqlClient.Tests
+{
+    public class SqlParameterTests
+    {
+        [Fact]
+        public void ParameterPrecisionOnInterfaceType()
+        {
+            SqlParameter parameter = new SqlParameter();
+            IDbDataParameter interfaceParameter = parameter;
+            interfaceParameter.Precision = 10;
+            interfaceParameter.Scale = 5;
+
+            Assert.Equal(10, interfaceParameter.Precision);
+            Assert.Equal(5, interfaceParameter.Scale);
+
+            Assert.Equal(10, parameter.Precision);
+            Assert.Equal(5, parameter.Scale);
+        }
+
+        [Fact]
+        public void ParameterPrecisionOnBaseType()
+        {
+            SqlParameter parameter = new SqlParameter();
+            DbParameter baseParameter = parameter;
+            baseParameter.Precision = 10;
+            baseParameter.Scale = 5;
+
+            Assert.Equal(10, baseParameter.Precision);
+            Assert.Equal(5, baseParameter.Scale);
+
+            Assert.Equal(10, parameter.Precision);
+            Assert.Equal(5, parameter.Scale);
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
@@ -18,6 +18,7 @@
     <Compile Include="ExceptionTest.cs" />
     <Compile Include="FakeDiagnosticListenerObserver.cs" />
     <Compile Include="SqlBulkCopyColumnMappingCollectionTest.cs" />
+    <Compile Include="SqlParameterTest.cs" />
     <Compile Include="SqlClientFactoryTest.cs" />
     <Compile Include="SqlConnectionTest.RetrieveStatistics.cs" />
     <Compile Include="SqlErrorCollectionTest.cs" />


### PR DESCRIPTION
Since the SqlParameter didn't implement the IDbDataParameter, any Precision or scale values set on the base type wasn't propagating to the Object of the derived type. 

Fixes #19712 