### PR TITLE
Match desktop behavior GetRequestStream/BeginGetRequestStream throws on invalid verb

### DIFF
--- a/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -1023,11 +1023,6 @@ namespace System.Net
         {
             CheckAbort();
 
-            if (RequestSubmitted)
-            {
-                throw new InvalidOperationException(SR.net_reqsubmitted);
-            }
-
             // Match Desktop behavior: prevent someone from getting a request stream
             // if the protocol verb/method doesn't support it. Note that this is not
             // entirely compliant RFC2616 for the aforementioned compatibility reasons.
@@ -1036,6 +1031,11 @@ namespace System.Net
                 string.Equals("CONNECT", _originVerb, StringComparison.OrdinalIgnoreCase))
             {
                 throw new ProtocolViolationException(SR.net_nouploadonget);
+            }
+
+            if (RequestSubmitted)
+            {
+                throw new InvalidOperationException(SR.net_reqsubmitted);
             }
 
             _requestStream = new RequestStream();
@@ -1065,7 +1065,7 @@ namespace System.Net
             }
 
             _requestStreamCallback = callback;
-            _requestStreamOperation = GetRequestStreamTask().ToApm(callback, state);
+            _requestStreamOperation = InternalGetRequestStream().ToApm(callback, state);
 
             return _requestStreamOperation.Task;
         }
@@ -1095,30 +1095,6 @@ namespace System.Net
             }
 
             return stream;
-        }
-
-        private Task<Stream> GetRequestStreamTask()
-        {
-            CheckAbort();
-
-            if (RequestSubmitted)
-            {
-                throw new InvalidOperationException(SR.net_reqsubmitted);
-            }
-
-            // Match Desktop behavior: prevent someone from getting a request stream
-            // if the protocol verb/method doesn't support it. Note that this is not
-            // entirely compliant RFC2616 for the aforementioned compatibility reasons.
-            if (string.Equals(HttpMethod.Get.Method, _originVerb, StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(HttpMethod.Head.Method, _originVerb, StringComparison.OrdinalIgnoreCase) ||
-                string.Equals("CONNECT", _originVerb, StringComparison.OrdinalIgnoreCase))
-            {
-                throw new ProtocolViolationException(SR.net_nouploadonget);
-            }
-
-            _requestStream = new RequestStream();
-
-            return Task.FromResult((Stream)_requestStream);
         }
 
         private async Task<WebResponse> SendRequest()

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -861,13 +861,12 @@ namespace System.Net.Tests
         }
 
         [Theory, MemberData(nameof(EchoServers))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "request stream not allowed for GET on netfx")]
-        public void BeginGetRequestStream_CreateRequestThenBeginGetResponsePrior_ThrowsInvalidOperationException(Uri remoteServer)
+        public void BeginGetRequestStream_CreateRequestThenBeginGetResponsePrior_ThrowsProtocolViolationException(Uri remoteServer)
         {
             HttpWebRequest request = HttpWebRequest.CreateHttp(remoteServer);
 
             IAsyncResult asyncResult = request.BeginGetResponse(null, null);
-            Assert.Throws<InvalidOperationException>(() =>
+            Assert.Throws<ProtocolViolationException>(() =>
             {
                 request.BeginGetRequestStream(null, null);
             });


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/19732
