### PR TITLE
Add LongRunning option to managed SNI async reads

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIPacket.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIPacket.cs
@@ -267,7 +267,7 @@ namespace System.Data.SqlClient.SNI
                 callback(this, error ? TdsEnums.SNI_ERROR : TdsEnums.SNI_SUCCESS);
             },
             CancellationToken.None,
-            TaskContinuationOptions.DenyChildAttach,
+            TaskContinuationOptions.DenyChildAttach | TaskContinuationOptions.LongRunning,
             TaskScheduler.Default);
         }
 


### PR DESCRIPTION
When running Entity Framework tests in parallel, some MARS async reads hang for 30+ seconds until they timeout. This issue persists even when only running a single test with parallelization enabled. After adding the LongRunning task continuation option, these async reads complete immediately. So it's likely a thread availability/scheduling issue with the async reads that's resolved by oversubscription from the LongRunning option.

Fixes https://github.com/dotnet/corefx/issues/19810