### PR TITLE
Fixed CurrentCulture static property assignment causing side effects in other tests

### DIFF
--- a/src/Common/tests/System/Diagnostics/RemoteExecutorTestBase.cs
+++ b/src/Common/tests/System/Diagnostics/RemoteExecutorTestBase.cs
@@ -93,6 +93,37 @@ namespace System.Diagnostics
 
         /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
         /// <param name="method">The method to invoke.</param>
+        /// <param name="arg1">The first argument to pass to the method.</param>
+        /// <param name="arg2">The second argument to pass to the method.</param>
+        /// <param name="arg3">The third argument to pass to the method.</param>
+        /// <param name="arg4">The fourth argument to pass to the method.</param>
+        /// <param name="options">Options to use for the invocation.</param>
+        internal static RemoteInvokeHandle RemoteInvoke(
+            Func<string, string, string, string, int> method, 
+            string arg1, string arg2, string arg3, string arg4, 
+            RemoteInvokeOptions options = null)
+        {
+            return RemoteInvoke(method.GetMethodInfo(), new[] { arg1, arg2, arg3, arg4 }, options);
+        }
+
+        /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
+        /// <param name="method">The method to invoke.</param>
+        /// <param name="arg1">The first argument to pass to the method.</param>
+        /// <param name="arg2">The second argument to pass to the method.</param>
+        /// <param name="arg3">The third argument to pass to the method.</param>
+        /// <param name="arg4">The fourth argument to pass to the method.</param>
+        /// <param name="arg5">The fifth argument to pass to the method.</param>
+        /// <param name="options">Options to use for the invocation.</param>
+        internal static RemoteInvokeHandle RemoteInvoke(
+            Func<string, string, string, string, string, int> method, 
+            string arg1, string arg2, string arg3, string arg4, string arg5, 
+            RemoteInvokeOptions options = null)
+        {
+            return RemoteInvoke(method.GetMethodInfo(), new[] { arg1, arg2, arg3, arg4, arg5 }, options);
+        }
+
+        /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
+        /// <param name="method">The method to invoke.</param>
         /// <param name="args">The arguments to pass to the method.</param>
         /// <param name="options">Options to use for the invocation.</param>
         internal static RemoteInvokeHandle RemoteInvokeRaw(Delegate method, string unparsedArg,

--- a/src/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
@@ -3,12 +3,13 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using Xunit;
 
 namespace System.Text.RegularExpressions.Tests
 {
-    public class RegexGroupTests
+    public class RegexGroupTests : RemoteExecutorTestBase
     {
         private static readonly CultureInfo s_enUSCulture = new CultureInfo("en-US");
         private static readonly CultureInfo s_invariantCulture = new CultureInfo("");
@@ -622,43 +623,50 @@ namespace System.Text.RegularExpressions.Tests
         [MemberData(nameof(Groups_CustomCulture_TestData))]
         public void Groups(string pattern, string input, RegexOptions options, CultureInfo cultureInfo, string[] expectedGroups)
         {
-            CultureInfo originalCulture = CultureInfo.CurrentCulture;
-            try
+            string outerPattern = Convert.ToBase64String(Encoding.UTF8.GetBytes(pattern));
+            string outerInput = Convert.ToBase64String(Encoding.UTF8.GetBytes(input));
+            string outerOptions = ((int)options).ToString();
+            string outerCultureInfo = cultureInfo != null ? cultureInfo.ToString() : "-";
+            string outerExpectedGroups = expectedGroups != null && expectedGroups.Length > 0 ? "\"" + Convert.ToBase64String(Encoding.UTF8.GetBytes(string.Join(";", expectedGroups))) + "\"" : "-";
+
+            RemoteInvoke((innerPatternEnc, innerInputEnc, innerOptionsEnc, innerCultureInfoEnc, innerExpectedGroupsEnc) =>
             {
+                string innerPattern = Encoding.UTF8.GetString(Convert.FromBase64String(innerPatternEnc));
+                string innerInput = Encoding.UTF8.GetString(Convert.FromBase64String(innerInputEnc));
+                RegexOptions innerOptions = (RegexOptions)int.Parse(innerOptionsEnc);
+                CultureInfo innerCultureInfo = innerCultureInfoEnc != "-" ? new CultureInfo(innerCultureInfoEnc) : null;
+                string[] innerExpectedGroups = innerExpectedGroupsEnc != "-" ? Encoding.UTF8.GetString(Convert.FromBase64String(innerExpectedGroupsEnc)).Trim('"').Split(';') : new string[] { };
+
                 // In invariant culture, the unicode char matches differ from expected values provided.
-                if (originalCulture.Equals(CultureInfo.InvariantCulture))
+                if (CultureInfo.CurrentCulture.Equals(CultureInfo.InvariantCulture))
                 {
-                    CultureInfo.CurrentCulture = s_enUSCulture;
+                    CultureInfo.CurrentCulture = new CultureInfo("en-US");
                 }
-                if (cultureInfo != null)
+                if (innerCultureInfo != null)
                 {
-                    CultureInfo.CurrentCulture = cultureInfo;
+                    CultureInfo.CurrentCulture = innerCultureInfo;
                 }
-                Regex regex = new Regex(pattern, options);
-                Match match = regex.Match(input);
+
+                Regex regex = new Regex(innerPattern, innerOptions);
+                Match match = regex.Match(innerInput);
                 Assert.True(match.Success);
 
-                Assert.Equal(expectedGroups.Length, match.Groups.Count);
-                Assert.True(expectedGroups[0] == match.Value, string.Format("Culture used: {0}", CultureInfo.CurrentCulture));
+                Assert.Equal(innerExpectedGroups.Length, match.Groups.Count);
+                Assert.True(innerExpectedGroups[0] == match.Value, string.Format("Culture used: {0}", CultureInfo.CurrentCulture));
 
                 int[] groupNumbers = regex.GetGroupNumbers();
                 string[] groupNames = regex.GetGroupNames();
-                for (int i = 0; i < expectedGroups.Length; i++)
+                for (int i = 0; i < innerExpectedGroups.Length; i++)
                 {
-                    Assert.Equal(expectedGroups[i], match.Groups[groupNumbers[i]].Value);
+                    Assert.Equal(innerExpectedGroups[i], match.Groups[groupNumbers[i]].Value);
                     Assert.Equal(match.Groups[groupNumbers[i]], match.Groups[groupNames[i]]);
 
                     Assert.Equal(groupNumbers[i], regex.GroupNumberFromName(groupNames[i]));
                     Assert.Equal(groupNames[i], regex.GroupNameFromNumber(groupNumbers[i]));
                 }
-            }
-            finally
-            {
-                if (cultureInfo != null || originalCulture.Equals(CultureInfo.InvariantCulture))
-                {
-                    CultureInfo.CurrentCulture = originalCulture;
-                }
-            }
+
+                return SuccessExitCode;
+            }, outerPattern, outerInput, outerOptions, outerCultureInfo, outerExpectedGroups).Dispose();
         }
     }
 }

--- a/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -3,12 +3,13 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using Xunit;
 
 namespace System.Text.RegularExpressions.Tests
 {
-    public class RegexMatchTests
+    public class RegexMatchTests : RemoteExecutorTestBase
     {
         public static IEnumerable<object[]> Match_Basic_TestData()
         {
@@ -692,11 +693,9 @@ namespace System.Text.RegularExpressions.Tests
         [Fact]
         public void Match_SpecialUnicodeCharacters()
         {
-            CultureInfo currentCulture = CultureInfo.CurrentCulture;
-            CultureInfo enUSCulture = new CultureInfo("en-US");
-            try
+            RemoteInvoke(() =>
             {
-                CultureInfo.CurrentCulture = enUSCulture;
+                CultureInfo.CurrentCulture = new CultureInfo("en-US");
                 Match("\u0131", "\u0049", RegexOptions.IgnoreCase, 0, 1, false, string.Empty);
                 Match("\u0131", "\u0069", RegexOptions.IgnoreCase, 0, 1, false, string.Empty);
 
@@ -705,11 +704,9 @@ namespace System.Text.RegularExpressions.Tests
                 Match("\u0131", "\u0069", RegexOptions.IgnoreCase, 0, 1, false, string.Empty);
                 Match("\u0130", "\u0049", RegexOptions.IgnoreCase, 0, 1, false, string.Empty);
                 Match("\u0130", "\u0069", RegexOptions.IgnoreCase, 0, 1, false, string.Empty);
-            }
-            finally
-            {
-                CultureInfo.CurrentCulture = currentCulture;
-            }
+
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         [Fact]

--- a/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
@@ -15,6 +15,12 @@
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
       <Link>Common\tests\System\PlatformDetection.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorTestBase.cs">
+      <Link>Common\System\Diagnostics\RemoteExecutorTestBase.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\IO\FileCleanupTestBase.cs">
+      <Link>Common\System\IO\FileCleanupTestBase.cs</Link>
+    </Compile>
     <Compile Include="CaptureCollectionTests.cs" />
     <Compile Include="GroupCollectionTests.cs" />
     <Compile Include="MatchCollectionTests.cs" />
@@ -25,12 +31,20 @@
     <Compile Include="Regex.UnicodeChar.Tests.cs" />
     <Compile Include="Regex.Groups.Tests.cs" />
     <Compile Include="Regex.Replace.Tests.cs" />
+    <Compile Include="Regex.Serialization.cs" />
     <Compile Include="Regex.Split.Tests.cs" />
     <Compile Include="Regex.Match.Tests.cs" />
     <Compile Include="Regex.Tests.Common.cs" />
     <Compile Include="$(CommonTestPath)\System\AssertExtensions.cs">
       <Link>Common\System\AssertExtensions.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
+      <Link>System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
+    </Compile>
+    <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
+      <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
+      <Name>RemoteExecutorConsoleApp</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
     <Compile Include="PrecompiledRegexScenarioTest.cs" />
@@ -40,12 +54,6 @@
     <Compile Include="MatchCollectionTests.netcoreapp.cs" />
     <Compile Include="$(CommonTestPath)\System\Diagnostics\DebuggerAttributes.cs">
       <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Regex.Serialization.cs" />
-    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
-      <Link>System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
     </Compile>
   </ItemGroup>
   <!-- Automatically added by VS -->

--- a/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
@@ -42,7 +42,6 @@
       <Link>System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
     </Compile>
     <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
-      <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
       <Name>RemoteExecutorConsoleApp</Name>
     </ProjectReference>
   </ItemGroup>


### PR DESCRIPTION
Moved test method to RemoteExecutor to avoid side effects with static property change.

Fixes this occurrence but could have also happend on Core:

https://mc.dot.net/#/product/netcore/master/source/official~2Fcorefx~2Fmaster~2F/type/test~2Ffunctional~2Fuwp~2F/build/20170512.03/workItem/System.Text.RegularExpressions.Tests/analysis/xunit/System.Text.RegularExpressions.Tests.RegexMatchTests~2FMatch_SpecialUnicodeCharacters

I tried to fix the other test which manipulates CultureInfo.CurrentCulture too but I failed miserably... (Groups in Regex.Groups.Tests.cs). It's just not possible with all kind of different Unicode characters to pass it as a valid argument to the RemoteExecutor. Wrapping in quotes doesn't help either. So I reverted my changes and let this be the only occurrence in the assembly where a static property is changed.