### PR TITLE
Deactivating System.IO.FileSystem.AccessControl tests on uap/uapaot

### DIFF
--- a/src/System.IO.FileSystem.AccessControl/tests/Configurations.props
+++ b/src/System.IO.FileSystem.AccessControl/tests/Configurations.props
@@ -2,7 +2,8 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
-      netstandard-Windows_NT;
+      netfx-Windows_NT;
+      netcoreapp-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
+++ b/src/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
@@ -11,12 +11,14 @@ namespace System.IO
     public class FileSystemAclExtensionsTests
     {
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.UapAot)]
         public void GetAccessControl_DirectoryInfo_InvalidArguments()
         {
             Assert.Throws<NullReferenceException>(() => FileSystemAclExtensions.GetAccessControl((DirectoryInfo)null));
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.UapAot)]
         public void GetAccessControl_DirectoryInfo_ReturnsValidObject()
         {
             using (var directory = new TempDirectory())
@@ -31,12 +33,14 @@ namespace System.IO
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.UapAot)]
         public void GetAccessControl_DirectoryInfo_AccessControlSections_InvalidArguments()
         {
             Assert.Throws<NullReferenceException>(() => FileSystemAclExtensions.GetAccessControl((DirectoryInfo)null, new AccessControlSections()));
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.UapAot)]
         public void GetAccessControl_DirectoryInfo_AccessControlSections_ReturnsValidObject()
         {
             using (var directory = new TempDirectory())
@@ -52,12 +56,14 @@ namespace System.IO
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.UapAot)]
         public void GetAccessControl_FileInfo_InvalidArguments()
         {
             Assert.Throws<NullReferenceException>(() => FileSystemAclExtensions.GetAccessControl((FileInfo)null));
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.UapAot)]
         public void GetAccessControl_FileInfo_ReturnsValidObject()
         {
             using (var directory = new TempDirectory())
@@ -73,12 +79,14 @@ namespace System.IO
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.UapAot)]
         public void GetAccessControl_FileInfo_AccessControlSections_InvalidArguments()
         {
             Assert.Throws<NullReferenceException>(() => FileSystemAclExtensions.GetAccessControl((FileInfo)null, new AccessControlSections()));
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.UapAot)]
         public void GetAccessControl_FileInfo_AccessControlSections_ReturnsValidObject()
         {
             using (var directory = new TempDirectory())
@@ -95,12 +103,14 @@ namespace System.IO
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.UapAot)]
         public void GetAccessControl_Filestream_InvalidArguments()
         {
             Assert.Throws<NullReferenceException>(() => FileSystemAclExtensions.GetAccessControl((FileStream)null));
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.UapAot)]
         public void SetAccessControl_DirectoryInfo_DirectorySecurity_InvalidArguments()
         {
             using (var directory = new TempDirectory())
@@ -111,6 +121,7 @@ namespace System.IO
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.UapAot)]
         public void SetAccessControl_DirectoryInfo_DirectorySecurity_Success()
         {
             using (var directory = new TempDirectory())
@@ -123,6 +134,7 @@ namespace System.IO
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.UapAot)]
         public void SetAccessControl_FileInfo_FileSecurity_InvalidArguments()
         {
             using (var directory = new TempDirectory())
@@ -134,6 +146,7 @@ namespace System.IO
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.UapAot)]
         public void SetAccessControl_FileInfo_FileSecurity_Success()
         {
             using (var directory = new TempDirectory())
@@ -147,6 +160,7 @@ namespace System.IO
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.UapAot)]
         public void SetAccessControl_FileStream_FileSecurity_InvalidArguments()
         {
             Assert.Throws<NullReferenceException>(() => FileSystemAclExtensions.SetAccessControl((FileStream)null, (FileSecurity)null));

--- a/src/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
+++ b/src/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
@@ -2,23 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Security.AccessControl;
 using Xunit;
 
 namespace System.IO
 {
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.UapAot, "Access Control List (ACL) APIs are part of resource management on Windows and are not supported on this platform.")]
     public class FileSystemAclExtensionsTests
     {
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.UapAot)]
         public void GetAccessControl_DirectoryInfo_InvalidArguments()
         {
             Assert.Throws<NullReferenceException>(() => FileSystemAclExtensions.GetAccessControl((DirectoryInfo)null));
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.UapAot)]
         public void GetAccessControl_DirectoryInfo_ReturnsValidObject()
         {
             using (var directory = new TempDirectory())
@@ -33,14 +31,12 @@ namespace System.IO
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.UapAot)]
         public void GetAccessControl_DirectoryInfo_AccessControlSections_InvalidArguments()
         {
             Assert.Throws<NullReferenceException>(() => FileSystemAclExtensions.GetAccessControl((DirectoryInfo)null, new AccessControlSections()));
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.UapAot)]
         public void GetAccessControl_DirectoryInfo_AccessControlSections_ReturnsValidObject()
         {
             using (var directory = new TempDirectory())
@@ -56,14 +52,12 @@ namespace System.IO
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.UapAot)]
         public void GetAccessControl_FileInfo_InvalidArguments()
         {
             Assert.Throws<NullReferenceException>(() => FileSystemAclExtensions.GetAccessControl((FileInfo)null));
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.UapAot)]
         public void GetAccessControl_FileInfo_ReturnsValidObject()
         {
             using (var directory = new TempDirectory())
@@ -79,14 +73,12 @@ namespace System.IO
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.UapAot)]
         public void GetAccessControl_FileInfo_AccessControlSections_InvalidArguments()
         {
             Assert.Throws<NullReferenceException>(() => FileSystemAclExtensions.GetAccessControl((FileInfo)null, new AccessControlSections()));
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.UapAot)]
         public void GetAccessControl_FileInfo_AccessControlSections_ReturnsValidObject()
         {
             using (var directory = new TempDirectory())
@@ -103,14 +95,12 @@ namespace System.IO
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.UapAot)]
         public void GetAccessControl_Filestream_InvalidArguments()
         {
             Assert.Throws<NullReferenceException>(() => FileSystemAclExtensions.GetAccessControl((FileStream)null));
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.UapAot)]
         public void SetAccessControl_DirectoryInfo_DirectorySecurity_InvalidArguments()
         {
             using (var directory = new TempDirectory())
@@ -121,7 +111,6 @@ namespace System.IO
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.UapAot)]
         public void SetAccessControl_DirectoryInfo_DirectorySecurity_Success()
         {
             using (var directory = new TempDirectory())
@@ -134,7 +123,6 @@ namespace System.IO
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.UapAot)]
         public void SetAccessControl_FileInfo_FileSecurity_InvalidArguments()
         {
             using (var directory = new TempDirectory())
@@ -146,7 +134,6 @@ namespace System.IO
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.UapAot)]
         public void SetAccessControl_FileInfo_FileSecurity_Success()
         {
             using (var directory = new TempDirectory())
@@ -160,7 +147,6 @@ namespace System.IO
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.UapAot)]
         public void SetAccessControl_FileStream_FileSecurity_InvalidArguments()
         {
             Assert.Throws<NullReferenceException>(() => FileSystemAclExtensions.SetAccessControl((FileStream)null, (FileSecurity)null));

--- a/src/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
+++ b/src/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
@@ -7,7 +7,6 @@ using Xunit;
 
 namespace System.IO
 {
-    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.UapAot, "Access Control List (ACL) APIs are part of resource management on Windows and are not supported on this platform.")]
     public class FileSystemAclExtensionsTests
     {
         [Fact]

--- a/src/System.IO.FileSystem.AccessControl/tests/System.IO.FileSystem.AccessControl.Tests.csproj
+++ b/src/System.IO.FileSystem.AccessControl/tests/System.IO.FileSystem.AccessControl.Tests.csproj
@@ -4,8 +4,10 @@
   <PropertyGroup>
     <ProjectGuid>{5915DD11-5D57-45A9-BFB0-56FEB7741E1F}</ProjectGuid>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="FileSystemAclExtensionsTests.cs" />
     <Compile Include="$(CommonTestPath)\System\AssertExtensions.cs">


### PR DESCRIPTION
TargetGroup=uap/uapaot 

> Access Control List (ACL) APIs are part of resource management on Windows and are not supported on this platform.

Deactivating tests.

https://mc.dot.net/#/product/netcore/master/source/official~2Fcorefx~2Fmaster~2F/type/test~2Ffunctional~2Fuwp~2F/build/20170513.02/workItem/System.IO.FileSystem.AccessControl.Tests