### PR TITLE
Fixing uap/uapaot test issues in System.IO.Compression.ZipFile

### DIFF
--- a/src/System.IO.Compression.ZipFile/tests/ZipFileInvalidFileTests.cs
+++ b/src/System.IO.Compression.ZipFile/tests/ZipFileInvalidFileTests.cs
@@ -46,55 +46,85 @@ namespace System.IO.Compression.Tests
         [Fact]
         public void InvalidFiles()
         {
-            ConstructorThrows<InvalidDataException>(() => ZipFile.OpenRead(bad("EOCDmissing.zip")));
-            ConstructorThrows<InvalidDataException>(() => ZipFile.Open(bad("EOCDmissing.zip"), ZipArchiveMode.Update));
-            ConstructorThrows<InvalidDataException>(() => ZipFile.OpenRead(bad("CDoffsetOutOfBounds.zip")));
-            ConstructorThrows<InvalidDataException>(() => ZipFile.Open(bad("CDoffsetOutOfBounds.zip"), ZipArchiveMode.Update));
+            using (TempFile testArchive = CreateTempCopyFile(bad("EOCDmissing.zip"), GetTestFilePath()))
+            {
+                ConstructorThrows<InvalidDataException>(() => ZipFile.OpenRead(testArchive.Path));
+            }
+            using (TempFile testArchive = CreateTempCopyFile(bad("EOCDmissing.zip"), GetTestFilePath()))
+            {
+                ConstructorThrows<InvalidDataException>(() => ZipFile.Open(testArchive.Path, ZipArchiveMode.Update));
+            }
+            using (TempFile testArchive = CreateTempCopyFile(bad("CDoffsetOutOfBounds.zip"), GetTestFilePath()))
+            {
+                ConstructorThrows<InvalidDataException>(() => ZipFile.OpenRead(testArchive.Path));
+            }
+            using (TempFile testArchive = CreateTempCopyFile(bad("CDoffsetOutOfBounds.zip"), GetTestFilePath()))
+            {
+                ConstructorThrows<InvalidDataException>(() => ZipFile.Open(testArchive.Path, ZipArchiveMode.Update));
+            }
 
-            using (ZipArchive archive = ZipFile.OpenRead(bad("CDoffsetInBoundsWrong.zip")))
+            using (TempFile testArchive = CreateTempCopyFile(bad("CDoffsetInBoundsWrong.zip"), GetTestFilePath()))
+            using (ZipArchive archive = ZipFile.OpenRead(testArchive.Path))
             {
                 Assert.Throws<InvalidDataException>(() => { var x = archive.Entries; });
             }
-            ConstructorThrows<InvalidDataException>(() => ZipFile.Open(bad("CDoffsetInBoundsWrong.zip"), ZipArchiveMode.Update));
 
-            using (ZipArchive archive = ZipFile.OpenRead(bad("numberOfEntriesDifferent.zip")))
+            using (TempFile testArchive = CreateTempCopyFile(bad("CDoffsetInBoundsWrong.zip"), GetTestFilePath()))
+            {
+                ConstructorThrows<InvalidDataException>(() => ZipFile.Open(testArchive.Path, ZipArchiveMode.Update));
+            }
+
+            using (TempFile testArchive = CreateTempCopyFile(bad("numberOfEntriesDifferent.zip"), GetTestFilePath()))
+            using (ZipArchive archive = ZipFile.OpenRead(testArchive.Path))
             {
                 Assert.Throws<InvalidDataException>(() => { var x = archive.Entries; });
             }
-            ConstructorThrows<InvalidDataException>(() => ZipFile.Open(bad("numberOfEntriesDifferent.zip"), ZipArchiveMode.Update));
+            using (TempFile testArchive = CreateTempCopyFile(bad("numberOfEntriesDifferent.zip"), GetTestFilePath()))
+            {
+                ConstructorThrows<InvalidDataException>(() => ZipFile.Open(testArchive.Path, ZipArchiveMode.Update));
+            }
 
             //read mode on empty file
             ConstructorThrows<InvalidDataException>(() => new ZipArchive(new MemoryStream()));
 
             //offset out of bounds
-            using (ZipArchive archive = ZipFile.OpenRead(bad("localFileOffsetOutOfBounds.zip")))
+            using (TempFile testArchive = CreateTempCopyFile(bad("localFileOffsetOutOfBounds.zip"), GetTestFilePath()))
+            using (ZipArchive archive = ZipFile.OpenRead(testArchive.Path))
             {
                 ZipArchiveEntry e = archive.Entries[0];
                 Assert.Throws<InvalidDataException>(() => e.Open());
             }
 
-            ConstructorThrows<InvalidDataException>(() =>
-                ZipFile.Open(bad("localFileOffsetOutOfBounds.zip"), ZipArchiveMode.Update));
+            using (TempFile testArchive = CreateTempCopyFile(bad("localFileOffsetOutOfBounds.zip"), GetTestFilePath()))
+            {
+                ConstructorThrows<InvalidDataException>(() => ZipFile.Open(testArchive.Path, ZipArchiveMode.Update));
+            }
 
             //compressed data offset + compressed size out of bounds
-            using (ZipArchive archive = ZipFile.OpenRead(bad("compressedSizeOutOfBounds.zip")))
+            using (TempFile testArchive = CreateTempCopyFile(bad("compressedSizeOutOfBounds.zip"), GetTestFilePath()))
+            using (ZipArchive archive = ZipFile.OpenRead(testArchive.Path))
             {
                 ZipArchiveEntry e = archive.Entries[0];
                 Assert.Throws<InvalidDataException>(() => e.Open());
             }
 
-            ConstructorThrows<InvalidDataException>(() =>
-                ZipFile.Open(bad("compressedSizeOutOfBounds.zip"), ZipArchiveMode.Update));
+            using (TempFile testArchive = CreateTempCopyFile(bad("compressedSizeOutOfBounds.zip"), GetTestFilePath()))
+            {
+                ConstructorThrows<InvalidDataException>(() => ZipFile.Open(testArchive.Path, ZipArchiveMode.Update));
+            }
 
             //signature wrong
-            using (ZipArchive archive = ZipFile.OpenRead(bad("localFileHeaderSignatureWrong.zip")))
+            using (TempFile testArchive = CreateTempCopyFile(bad("localFileHeaderSignatureWrong.zip"), GetTestFilePath()))
+            using (ZipArchive archive = ZipFile.OpenRead(testArchive.Path))
             {
                 ZipArchiveEntry e = archive.Entries[0];
                 Assert.Throws<InvalidDataException>(() => e.Open());
             }
 
-            ConstructorThrows<InvalidDataException>(() =>
-                ZipFile.Open(bad("localFileHeaderSignatureWrong.zip"), ZipArchiveMode.Update));
+            using (TempFile testArchive = CreateTempCopyFile(bad("localFileHeaderSignatureWrong.zip"), GetTestFilePath()))
+            {
+                ConstructorThrows<InvalidDataException>(() => ZipFile.Open(testArchive.Path, ZipArchiveMode.Update));
+            }
         }
 
         [Theory]

--- a/src/System.IO.Compression.ZipFile/tests/ZipFileInvalidFileTests.cs
+++ b/src/System.IO.Compression.ZipFile/tests/ZipFileInvalidFileTests.cs
@@ -71,8 +71,10 @@ namespace System.IO.Compression.Tests
             //read mode on empty file
             Assert.Throws<InvalidDataException>(() =>
             {
-                using (ZipArchive archive = new ZipArchive(new MemoryStream()))
-                { }
+                using (var memoryStream = new MemoryStream())
+                {
+                    new ZipArchive(memoryStream);
+                }
             });
 
             //offset out of bounds

--- a/src/System.IO.Compression.ZipFile/tests/ZipFileInvalidFileTests.cs
+++ b/src/System.IO.Compression.ZipFile/tests/ZipFileInvalidFileTests.cs
@@ -69,13 +69,10 @@ namespace System.IO.Compression.Tests
             }
 
             //read mode on empty file
-            Assert.Throws<InvalidDataException>(() =>
+            using (var memoryStream = new MemoryStream())
             {
-                using (var memoryStream = new MemoryStream())
-                {
-                    new ZipArchive(memoryStream);
-                }
-            });
+                Assert.Throws<InvalidDataException>(() => new ZipArchive(memoryStream));
+            }
 
             //offset out of bounds
             using (ZipArchive archive = ZipFile.OpenRead(bad("localFileOffsetOutOfBounds.zip")))

--- a/src/System.IO.Compression.ZipFile/tests/ZipFileInvalidFileTests.cs
+++ b/src/System.IO.Compression.ZipFile/tests/ZipFileInvalidFileTests.cs
@@ -8,14 +8,6 @@ namespace System.IO.Compression.Tests
 {
     public partial class ZipFileTest_Invalid : ZipFileTestBase
     {
-        private static void ConstructorThrows<TException>(Func<ZipArchive> constructor, string Message = "") where TException : Exception
-        {
-            Assert.Throws<TException>(() =>
-            {
-                using (ZipArchive archive = constructor()) { }
-            });
-        }
-
         [Fact]
         public void InvalidInstanceMethods()
         {
@@ -39,57 +31,52 @@ namespace System.IO.Compression.Tests
         public void InvalidConstructors()
         {
             //out of range enum values
-            ConstructorThrows<ArgumentOutOfRangeException>(() =>
-              ZipFile.Open("bad file", (ZipArchiveMode)(10)));
+            Assert.Throws<ArgumentOutOfRangeException>(() => ZipFile.Open("bad file", (ZipArchiveMode)(10)));
         }
 
         [Fact]
         public void InvalidFiles()
         {
+            Assert.Throws<InvalidDataException>(() => ZipFile.OpenRead(bad("EOCDmissing.zip")));
             using (TempFile testArchive = CreateTempCopyFile(bad("EOCDmissing.zip"), GetTestFilePath()))
             {
-                ConstructorThrows<InvalidDataException>(() => ZipFile.OpenRead(testArchive.Path));
-            }
-            using (TempFile testArchive = CreateTempCopyFile(bad("EOCDmissing.zip"), GetTestFilePath()))
-            {
-                ConstructorThrows<InvalidDataException>(() => ZipFile.Open(testArchive.Path, ZipArchiveMode.Update));
-            }
-            using (TempFile testArchive = CreateTempCopyFile(bad("CDoffsetOutOfBounds.zip"), GetTestFilePath()))
-            {
-                ConstructorThrows<InvalidDataException>(() => ZipFile.OpenRead(testArchive.Path));
-            }
-            using (TempFile testArchive = CreateTempCopyFile(bad("CDoffsetOutOfBounds.zip"), GetTestFilePath()))
-            {
-                ConstructorThrows<InvalidDataException>(() => ZipFile.Open(testArchive.Path, ZipArchiveMode.Update));
+                Assert.Throws<InvalidDataException>(() => ZipFile.Open(testArchive.Path, ZipArchiveMode.Update));
             }
 
-            using (TempFile testArchive = CreateTempCopyFile(bad("CDoffsetInBoundsWrong.zip"), GetTestFilePath()))
-            using (ZipArchive archive = ZipFile.OpenRead(testArchive.Path))
+            Assert.Throws<InvalidDataException>(() => ZipFile.OpenRead(bad("CDoffsetOutOfBounds.zip")));
+            using (TempFile testArchive = CreateTempCopyFile(bad("CDoffsetOutOfBounds.zip"), GetTestFilePath()))
+            {
+                Assert.Throws<InvalidDataException>(() => ZipFile.Open(testArchive.Path, ZipArchiveMode.Update));
+            }
+
+            using (ZipArchive archive = ZipFile.OpenRead(bad("CDoffsetInBoundsWrong.zip")))
             {
                 Assert.Throws<InvalidDataException>(() => { var x = archive.Entries; });
             }
 
             using (TempFile testArchive = CreateTempCopyFile(bad("CDoffsetInBoundsWrong.zip"), GetTestFilePath()))
             {
-                ConstructorThrows<InvalidDataException>(() => ZipFile.Open(testArchive.Path, ZipArchiveMode.Update));
+                Assert.Throws<InvalidDataException>(() => ZipFile.Open(testArchive.Path, ZipArchiveMode.Update));
             }
 
-            using (TempFile testArchive = CreateTempCopyFile(bad("numberOfEntriesDifferent.zip"), GetTestFilePath()))
-            using (ZipArchive archive = ZipFile.OpenRead(testArchive.Path))
+            using (ZipArchive archive = ZipFile.OpenRead(bad("numberOfEntriesDifferent.zip")))
             {
                 Assert.Throws<InvalidDataException>(() => { var x = archive.Entries; });
             }
             using (TempFile testArchive = CreateTempCopyFile(bad("numberOfEntriesDifferent.zip"), GetTestFilePath()))
             {
-                ConstructorThrows<InvalidDataException>(() => ZipFile.Open(testArchive.Path, ZipArchiveMode.Update));
+                Assert.Throws<InvalidDataException>(() => ZipFile.Open(testArchive.Path, ZipArchiveMode.Update));
             }
 
             //read mode on empty file
-            ConstructorThrows<InvalidDataException>(() => new ZipArchive(new MemoryStream()));
+            Assert.Throws<InvalidDataException>(() =>
+            {
+                using (ZipArchive archive = new ZipArchive(new MemoryStream()))
+                { }
+            });
 
             //offset out of bounds
-            using (TempFile testArchive = CreateTempCopyFile(bad("localFileOffsetOutOfBounds.zip"), GetTestFilePath()))
-            using (ZipArchive archive = ZipFile.OpenRead(testArchive.Path))
+            using (ZipArchive archive = ZipFile.OpenRead(bad("localFileOffsetOutOfBounds.zip")))
             {
                 ZipArchiveEntry e = archive.Entries[0];
                 Assert.Throws<InvalidDataException>(() => e.Open());
@@ -97,12 +84,11 @@ namespace System.IO.Compression.Tests
 
             using (TempFile testArchive = CreateTempCopyFile(bad("localFileOffsetOutOfBounds.zip"), GetTestFilePath()))
             {
-                ConstructorThrows<InvalidDataException>(() => ZipFile.Open(testArchive.Path, ZipArchiveMode.Update));
+                Assert.Throws<InvalidDataException>(() => ZipFile.Open(testArchive.Path, ZipArchiveMode.Update));
             }
 
             //compressed data offset + compressed size out of bounds
-            using (TempFile testArchive = CreateTempCopyFile(bad("compressedSizeOutOfBounds.zip"), GetTestFilePath()))
-            using (ZipArchive archive = ZipFile.OpenRead(testArchive.Path))
+            using (ZipArchive archive = ZipFile.OpenRead(bad("compressedSizeOutOfBounds.zip")))
             {
                 ZipArchiveEntry e = archive.Entries[0];
                 Assert.Throws<InvalidDataException>(() => e.Open());
@@ -110,12 +96,11 @@ namespace System.IO.Compression.Tests
 
             using (TempFile testArchive = CreateTempCopyFile(bad("compressedSizeOutOfBounds.zip"), GetTestFilePath()))
             {
-                ConstructorThrows<InvalidDataException>(() => ZipFile.Open(testArchive.Path, ZipArchiveMode.Update));
+                Assert.Throws<InvalidDataException>(() => ZipFile.Open(testArchive.Path, ZipArchiveMode.Update));
             }
 
             //signature wrong
-            using (TempFile testArchive = CreateTempCopyFile(bad("localFileHeaderSignatureWrong.zip"), GetTestFilePath()))
-            using (ZipArchive archive = ZipFile.OpenRead(testArchive.Path))
+            using (ZipArchive archive = ZipFile.OpenRead(bad("localFileHeaderSignatureWrong.zip")))
             {
                 ZipArchiveEntry e = archive.Entries[0];
                 Assert.Throws<InvalidDataException>(() => e.Open());
@@ -123,7 +108,7 @@ namespace System.IO.Compression.Tests
 
             using (TempFile testArchive = CreateTempCopyFile(bad("localFileHeaderSignatureWrong.zip"), GetTestFilePath()))
             {
-                ConstructorThrows<InvalidDataException>(() => ZipFile.Open(testArchive.Path, ZipArchiveMode.Update));
+                Assert.Throws<InvalidDataException>(() => ZipFile.Open(testArchive.Path, ZipArchiveMode.Update));
             }
         }
 

--- a/src/System.IO.Compression.ZipFile/tests/ZipFileReadOpenUpdateTests.cs
+++ b/src/System.IO.Compression.ZipFile/tests/ZipFileReadOpenUpdateTests.cs
@@ -30,7 +30,8 @@ namespace System.IO.Compression.Tests
         [Fact]
         public void UpdateReadTwice()
         {
-            using (ZipArchive archive = ZipFile.Open(zfile("small.zip"), ZipArchiveMode.Update))
+            using (TempFile testArchive = CreateTempCopyFile(zfile("small.zip"), GetTestFilePath()))
+            using (ZipArchive archive = ZipFile.Open(testArchive.Path, ZipArchiveMode.Update))
             {
                 ZipArchiveEntry entry = archive.Entries[0];
                 string contents1, contents2;


### PR DESCRIPTION
Fixes two System.IO.Compression.ZipFile tempdir issues. Using temppath instead of directly reading from execution location.

https://mc.dot.net/#/product/netcore/master/source/official~2Fcorefx~2Fmaster~2F/type/test~2Ffunctional~2Fuwp~2F/build/20170513.02/workItem/System.IO.Compression.ZipFile.Tests