### PR TITLE
Use Windows implementation of HttpListenerRequest.KeepAlive in the managed implementation

### DIFF
--- a/src/Common/src/Interop/Windows/HttpApi/Interop.HttpApi.cs
+++ b/src/Common/src/Interop/Windows/HttpApi/Interop.HttpApi.cs
@@ -776,14 +776,6 @@ internal static partial class Interop
             return GetKnownHeader(request, 0, headerIndex);
         }
 
-        internal static unsafe string GetKnownHeader(byte[] memoryBlob, IntPtr originalAddress, int headerIndex)
-        {
-            fixed (byte* pMemoryBlob = memoryBlob)
-            {
-                return GetKnownHeader((HTTP_REQUEST*)pMemoryBlob, pMemoryBlob - (byte*)originalAddress, headerIndex);
-            }
-        }
-
         private static unsafe string GetVerb(HTTP_REQUEST* request, long fixup)
         {
             string verb = null;

--- a/src/System.Net.HttpListener/src/System/Net/Managed/HttpListenerRequest.Managed.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/HttpListenerRequest.Managed.cs
@@ -58,8 +58,6 @@ namespace System.Net
         private Stream _inputStream;
         private HttpListenerContext _context;
         private bool _isChunked;
-        private bool _kaSet;
-        private bool _keepAlive;
 
         private static byte[] s_100continue = Encoding.ASCII.GetBytes("HTTP/1.1 100 Continue\r\n\r\n");
 
@@ -346,36 +344,6 @@ namespace System.Net
         public bool IsAuthenticated => false;
 
         public bool IsSecureConnection => _context.Connection.IsSecure;
-
-        public bool KeepAlive
-        {
-            get
-            {
-                if (_kaSet)
-                    return _keepAlive;
-
-                _kaSet = true;
-                // 1. Connection header
-                // 2. Protocol (1.1 == keep-alive by default)
-                // 3. Keep-Alive header
-                string cnc = Headers[HttpKnownHeaderNames.Connection];
-                if (!String.IsNullOrEmpty(cnc))
-                {
-                    _keepAlive = string.Equals(cnc, "keep-alive", StringComparison.OrdinalIgnoreCase);
-                }
-                else if (_version == HttpVersion.Version11)
-                {
-                    _keepAlive = true;
-                }
-                else
-                {
-                    cnc = Headers[HttpKnownHeaderNames.KeepAlive];
-                    if (!String.IsNullOrEmpty(cnc))
-                        _keepAlive = !string.Equals(cnc, "closed", StringComparison.OrdinalIgnoreCase);
-                }
-                return _keepAlive;
-            }
-        }
 
         public IPEndPoint LocalEndPoint => _context.Connection.LocalEndPoint;
 

--- a/src/System.Net.HttpListener/src/System/Net/Windows/HttpListenerRequest.Windows.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/HttpListenerRequest.Windows.cs
@@ -165,7 +165,7 @@ namespace System.Net
             {
                 if (_boundaryType == BoundaryType.None)
                 {
-                    string transferEncodingHeader = GetKnownHeader(HttpRequestHeader.TransferEncoding);
+                    string transferEncodingHeader = Headers[HttpKnownHeaderNames.TransferEncoding];
                     if (transferEncodingHeader != null && transferEncodingHeader.Equals("chunked", StringComparison.OrdinalIgnoreCase))
                     {
                         _boundaryType = BoundaryType.Chunked;
@@ -175,7 +175,7 @@ namespace System.Net
                     {
                         _contentLength = 0;
                         _boundaryType = BoundaryType.ContentLength;
-                        string length = GetKnownHeader(HttpRequestHeader.ContentLength);
+                        string length = Headers[HttpKnownHeaderNames.ContentLength];
                         if (length != null)
                         {
                             bool success = long.TryParse(length, NumberStyles.None, CultureInfo.InvariantCulture.NumberFormat, out _contentLength);
@@ -611,11 +611,6 @@ namespace System.Net
                 if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"_requestUri:{_requestUri}");
                 return _requestUri;
             }
-        }
-
-        private string GetKnownHeader(HttpRequestHeader header)
-        {
-            return Interop.HttpApi.GetKnownHeader(RequestBuffer, OriginalBlobAddress, (int)header);
         }
 
         internal ChannelBinding GetChannelBinding()

--- a/src/System.Net.HttpListener/src/System/Net/Windows/HttpListenerRequest.Windows.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/HttpListenerRequest.Windows.cs
@@ -29,7 +29,6 @@ namespace System.Net
         private long _contentLength;
         private Stream _requestStream;
         private string _httpMethod;
-        private bool? _keepAlive;
         private WebHeaderCollection _webHeaders;
         private IPEndPoint _localEndPoint;
         private IPEndPoint _remoteEndPoint;
@@ -88,7 +87,6 @@ namespace System.Net
             }
             _version = new Version(memoryBlob.RequestBlob->Version.MajorVersion, memoryBlob.RequestBlob->Version.MinorVersion);
             _clientCertState = ListenerClientCertState.NotInitialized;
-            _keepAlive = null;
             if (NetEventSource.IsEnabled)
             {
                 NetEventSource.Info(this, $"RequestId:{RequestId} ConnectionId:{_connectionId} RawConnectionId:{memoryBlob.RequestBlob->RawConnectionId} UrlContext:{memoryBlob.RequestBlob->UrlContext} RawUrl:{_rawUrl} Version:{_version} Secure:{_sslStatus}");
@@ -348,43 +346,6 @@ namespace System.Net
                 // accessing the ContentLength property delay creates m_BoundaryType
                 return (ContentLength64 > 0 && _boundaryType == BoundaryType.ContentLength) ||
                     _boundaryType == BoundaryType.Chunked || _boundaryType == BoundaryType.Multipart;
-            }
-        }
-
-        public bool KeepAlive
-        {
-            get
-            {
-                if (!_keepAlive.HasValue)
-                {
-                    string header = Headers[HttpKnownHeaderNames.ProxyConnection];
-                    if (string.IsNullOrEmpty(header))
-                    {
-                        header = GetKnownHeader(HttpRequestHeader.Connection);
-                    }
-                    if (string.IsNullOrEmpty(header))
-                    {
-                        if (ProtocolVersion >= HttpVersion.Version11)
-                        {
-                            _keepAlive = true;
-                        }
-                        else
-                        {
-                            header = GetKnownHeader(HttpRequestHeader.KeepAlive);
-                            _keepAlive = !string.IsNullOrEmpty(header);
-                        }
-                    }
-                    else
-                    {
-                        header = header.ToLower(CultureInfo.InvariantCulture);
-                        _keepAlive =
-                            header.IndexOf("close", StringComparison.InvariantCultureIgnoreCase) < 0 ||
-                            header.IndexOf("keep-alive", StringComparison.InvariantCultureIgnoreCase) >= 0;
-                    }
-                }
-
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, "_keepAlive=" + _keepAlive);
-                return _keepAlive.Value;
             }
         }
 

--- a/src/System.Net.HttpListener/tests/HttpListenerFactory.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerFactory.cs
@@ -97,7 +97,7 @@ namespace System.Net.Tests
 
         public Socket GetConnectedSocket()
         {
-            // Some platforms or distributions require IPv6 sockets if the OS supports IPv6. Others (e.g. Ubunutu) don't.
+            // Some platforms or distributions require IPv6 sockets if the OS supports IPv6. Others (e.g. Ubuntu) don't.
             try
             {
                 AddressFamily addressFamily = Socket.OSSupportsIPv6 ? AddressFamily.InterNetworkV6 : AddressFamily.InterNetwork;
@@ -113,7 +113,7 @@ namespace System.Net.Tests
             }            
         }
 
-        public byte[] GetContent(string requestType, string query, string text, IEnumerable<string> headers, bool headerOnly)
+        public byte[] GetContent(string httpVersion, string requestType, string query, string text, IEnumerable<string> headers, bool headerOnly)
         {
             Uri listeningUri = new Uri(ListeningUrl);
             string rawUrl = listeningUri.PathAndQuery;
@@ -122,7 +122,7 @@ namespace System.Net.Tests
                 rawUrl += query;
             }
 
-            string content = $"{requestType} {rawUrl} HTTP/1.1\r\nHost: {listeningUri.Host}\r\n";
+            string content = $"{requestType} {rawUrl} HTTP/{httpVersion}\r\nHost: {listeningUri.Host}\r\n";
             if (text != null)
             {
                 content += $"Content-Length: {text.Length}\r\n";
@@ -143,7 +143,7 @@ namespace System.Net.Tests
 
         public byte[] GetContent(string requestType, string text, bool headerOnly)
         {
-            return GetContent(requestType, query: null, text: text, headers: null, headerOnly: headerOnly);
+            return GetContent("1.1", requestType, query: null, text: text, headers: null, headerOnly: headerOnly);
         }
     }
 

--- a/src/System.Net.HttpListener/tests/HttpListenerRequestTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerRequestTests.cs
@@ -24,6 +24,7 @@ namespace System.Net.Tests
         {
             await GetRequest("POST", "", new string[] { acceptString }, (_, request) =>
             {
+                Assert.Same(request.AcceptTypes, request.AcceptTypes);
                 Assert.Equal(expected, request.AcceptTypes);
             });
         }
@@ -219,6 +220,7 @@ namespace System.Net.Tests
         {
             await GetRequest("POST", "", new string[] { userLanguageString }, (_, request) =>
             {
+                Assert.Same(request.UserLanguages, request.UserLanguages);
                 Assert.Equal(expected, request.UserLanguages);
             });
         }
@@ -451,6 +453,47 @@ namespace System.Net.Tests
             });
         }
 
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
+        [InlineData("1.1", new string[] { "Proxy-Connection: random" }, true)]
+        [InlineData("1.1", new string[] { "Proxy-Connection: close" }, false)]
+        [InlineData("1.1", new string[] { "proxy-connection: CLOSE" }, false)]
+        [InlineData("1.1", new string[] { "Proxy-Connection: keep-alive" }, true)]
+        [InlineData("1.1", new string[] { "Proxy-Connection: " }, true)]
+        [InlineData("1.1", new string[] { "Connection: random" }, true)]
+        [InlineData("1.1", new string[] { "Connection: close" }, false)]
+        [InlineData("1.1", new string[] { "connection: CLOSE" }, false)]
+        [InlineData("1.1", new string[] { "Connection: keep-alive" }, true)]
+        [InlineData("1.1", new string[] { "Connection: " }, true)]
+        [InlineData("1.1", new string[] { "Keep-Alive: true" }, true)]
+        [InlineData("1.1", new string[] { "Proxy-Connection: ", "Connection: close" }, false)]
+        [InlineData("1.1", new string[] { "Proxy-Connection: ", "Connection: close", "Keep-Alive: true" }, false)]
+        [InlineData("1.1", new string[] { "Connection: close", "Keep-Alive: true" }, false)]
+        [InlineData("1.1", new string[] { "UnknownHeader: random" }, true)]
+        [InlineData("1.0", new string[] { "Keep-Alive: true" }, true)]
+        [InlineData("1.0", new string[] { "Keep-Alive: " }, false)]
+        [InlineData("1.0", new string[] { "UnknownHeader: random" }, false)]
+        public async Task KeepAlive_GetProperty_ReturnsExpected(string httpVersion, string[] headers, bool expected)
+        {
+            await GetRequest("POST", "", headers, (_, request) =>
+            {
+                Assert.Equal(request.KeepAlive, request.KeepAlive);
+                Assert.Equal(expected, request.KeepAlive);
+            }, httpVersion: httpVersion);
+        }
+
+        [Theory]
+        [InlineData("1.0")]
+        [InlineData("1.1")]
+        public async Task ProtocolVersion_GetProperty_ReturnsExpected(string httpVersion)
+        {
+            var version = new Version(httpVersion);
+
+            await GetRequest("POST", "", new string[0], (_, request) =>
+            {
+                Assert.Equal(version, request.ProtocolVersion);
+            }, httpVersion: httpVersion);
+        }
+
         public static IEnumerable<object[]> Cookies_TestData()
         {
             yield return new object[]
@@ -559,12 +602,12 @@ namespace System.Net.Tests
             });
         }
 
-        private async Task GetRequest(string requestType, string query, string[] headers, Action<Socket, HttpListenerRequest> requestAction, bool sendContent = true)
+        private async Task GetRequest(string requestType, string query, string[] headers, Action<Socket, HttpListenerRequest> requestAction, bool sendContent = true, string httpVersion = "1.1")
         {
             using (HttpListenerFactory factory = new HttpListenerFactory())
             using (Socket client = factory.GetConnectedSocket())
             {
-                client.Send(factory.GetContent(requestType, query, sendContent ? "Text" : "", headers, true));
+                client.Send(factory.GetContent(httpVersion, requestType, query, sendContent ? "Text" : "", headers, true));
 
                 HttpListener listener = factory.GetListener();
                 HttpListenerContext context = await listener.GetContextAsync();


### PR DESCRIPTION
Consolidates code - previously these tests would fail with the managed implementation, now they pass.

Contributes to #18128

@priya91 @stephentoub @ViktorHofer 