### PR TITLE
Fix 180 uap/uapaot tests in System.IO.MemoryMappedFiles.Tests

### DIFF
--- a/src/Common/tests/System/AssertExtensions.cs
+++ b/src/Common/tests/System/AssertExtensions.cs
@@ -104,5 +104,18 @@ namespace System
         {
            ThrowsAny(typeof(TFirstExceptionType), typeof(TSecondExceptionType), action);
         }
+
+        public static void ThrowsIf<T>(Action action, bool condition)
+            where T : Exception
+        {
+            if (condition)
+            {
+                Assert.Throws<T>(action);
+            }
+            else
+            {
+                action();
+            }
+        }
     }
 }

--- a/src/Common/tests/System/AssertExtensions.cs
+++ b/src/Common/tests/System/AssertExtensions.cs
@@ -105,7 +105,7 @@ namespace System
            ThrowsAny(typeof(TFirstExceptionType), typeof(TSecondExceptionType), action);
         }
 
-        public static void ThrowsIf<T>(Action action, bool condition)
+        public static void ThrowsIf<T>(bool condition, Action action)
             where T : Exception
         {
             if (condition)

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateNew.Tests.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateNew.Tests.cs
@@ -153,14 +153,13 @@ namespace System.IO.MemoryMappedFiles.Tests
                 ValidateMemoryMappedFile(mmf, 4096, MemoryMappedFileAccess.Read);
             }
 
-            // MemoryMappedFileAccess.ReadExecute or MemoryMappedFileAccess.ReadWriteExecute isn't permitted inside an AppContainer
-            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(() =>
+            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(PlatformDetection.IsWinRT, () =>
             {
                 using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(name, 4096, MemoryMappedFileAccess.ReadWriteExecute, MemoryMappedFileOptions.DelayAllocatePages, HandleInheritability.Inheritable))
                 {
                     ValidateMemoryMappedFile(mmf, 4096, MemoryMappedFileAccess.ReadWrite, HandleInheritability.Inheritable);
                 }
-            }, PlatformDetection.IsWinRT);
+            });
         }
 
         /// <summary>
@@ -201,22 +200,21 @@ namespace System.IO.MemoryMappedFiles.Tests
                 ValidateMemoryMappedFile(mmf, capacity);
             }
 
-            // MemoryMappedFileAccess.ReadExecute or MemoryMappedFileAccess.ReadWriteExecute isn't permitted inside an AppContainer
-            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(() =>
+            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(PlatformDetection.IsWinRT && (access == MemoryMappedFileAccess.ReadExecute || access == MemoryMappedFileAccess.ReadWriteExecute), () =>
             {
                 using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(mapName, capacity, access))
                 {
                     ValidateMemoryMappedFile(mmf, capacity, access);
                 }
-            }, PlatformDetection.IsWinRT && (access == MemoryMappedFileAccess.ReadExecute || access == MemoryMappedFileAccess.ReadWriteExecute));
+            });
 
-            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(() =>
+            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(PlatformDetection.IsWinRT && (access == MemoryMappedFileAccess.ReadExecute || access == MemoryMappedFileAccess.ReadWriteExecute), () =>
             {
                 using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(mapName, capacity, access, options, inheritability))
                 {
                     ValidateMemoryMappedFile(mmf, capacity, access, inheritability);
                 }
-            }, PlatformDetection.IsWinRT && (access == MemoryMappedFileAccess.ReadExecute|| access == MemoryMappedFileAccess.ReadWriteExecute));
+            });
         }
 
         /// <summary>

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateNew.Tests.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateNew.Tests.cs
@@ -152,10 +152,15 @@ namespace System.IO.MemoryMappedFiles.Tests
             {
                 ValidateMemoryMappedFile(mmf, 4096, MemoryMappedFileAccess.Read);
             }
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(name, 4096, MemoryMappedFileAccess.ReadWriteExecute, MemoryMappedFileOptions.DelayAllocatePages, HandleInheritability.Inheritable))
+
+            // MemoryMappedFileAccess.ReadExecute or MemoryMappedFileAccess.ReadWriteExecute isn't permitted inside an AppContainer
+            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(() =>
             {
-                ValidateMemoryMappedFile(mmf, 4096, MemoryMappedFileAccess.ReadWrite, HandleInheritability.Inheritable);
-            }
+                using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(name, 4096, MemoryMappedFileAccess.ReadWriteExecute, MemoryMappedFileOptions.DelayAllocatePages, HandleInheritability.Inheritable))
+                {
+                    ValidateMemoryMappedFile(mmf, 4096, MemoryMappedFileAccess.ReadWrite, HandleInheritability.Inheritable);
+                }
+            }, PlatformDetection.IsWinRT);
         }
 
         /// <summary>
@@ -195,14 +200,23 @@ namespace System.IO.MemoryMappedFiles.Tests
             {
                 ValidateMemoryMappedFile(mmf, capacity);
             }
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(mapName, capacity, access))
+
+            // MemoryMappedFileAccess.ReadExecute or MemoryMappedFileAccess.ReadWriteExecute isn't permitted inside an AppContainer
+            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(() =>
             {
-                ValidateMemoryMappedFile(mmf, capacity, access);
-            }
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(mapName, capacity, access, options, inheritability))
+                using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(mapName, capacity, access))
+                {
+                    ValidateMemoryMappedFile(mmf, capacity, access);
+                }
+            }, PlatformDetection.IsWinRT && (access == MemoryMappedFileAccess.ReadExecute || access == MemoryMappedFileAccess.ReadWriteExecute));
+
+            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(() =>
             {
-                ValidateMemoryMappedFile(mmf, capacity, access, inheritability);
-            }
+                using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(mapName, capacity, access, options, inheritability))
+                {
+                    ValidateMemoryMappedFile(mmf, capacity, access, inheritability);
+                }
+            }, PlatformDetection.IsWinRT && (access == MemoryMappedFileAccess.ReadExecute|| access == MemoryMappedFileAccess.ReadWriteExecute));
         }
 
         /// <summary>

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateOrOpen.Tests.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateOrOpen.Tests.cs
@@ -177,25 +177,24 @@ namespace System.IO.MemoryMappedFiles.Tests
         public void ValidArgumentCombinations_Execute(
             string mapName, long capacity, MemoryMappedFileAccess access, MemoryMappedFileOptions options, HandleInheritability inheritability)
         {
-            // MemoryMappedFileAccess.ReadExecute or MemoryMappedFileAccess.ReadWriteExecute isn't permitted inside an AppContainer
-            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(() =>
+            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(PlatformDetection.IsWinRT && (access == MemoryMappedFileAccess.ReadExecute || access == MemoryMappedFileAccess.ReadWriteExecute), () =>
             {
                 // Map doesn't exist
                 using (MemoryMappedFile mmf = MemoryMappedFile.CreateOrOpen(mapName, capacity, access))
                 {
                     ValidateMemoryMappedFile(mmf, capacity, access);
                 }
-            }, PlatformDetection.IsWinRT && (access == MemoryMappedFileAccess.ReadExecute || access == MemoryMappedFileAccess.ReadWriteExecute));
+            });
 
-            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(() =>
+            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(PlatformDetection.IsWinRT && (access == MemoryMappedFileAccess.ReadExecute || access == MemoryMappedFileAccess.ReadWriteExecute), () =>
             {
                 using (MemoryMappedFile mmf = MemoryMappedFile.CreateOrOpen(mapName, capacity, access, options, inheritability))
                 {
                     ValidateMemoryMappedFile(mmf, capacity, access, inheritability);
                 }
-            }, PlatformDetection.IsWinRT && (access == MemoryMappedFileAccess.ReadExecute || access == MemoryMappedFileAccess.ReadWriteExecute));
+            });
 
-            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(() =>
+            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(PlatformDetection.IsWinRT && (access == MemoryMappedFileAccess.ReadExecute || access == MemoryMappedFileAccess.ReadWriteExecute), () =>
             {
                 // Map does exist (CreateNew)
                 using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(mapName, capacity, access))
@@ -203,16 +202,16 @@ namespace System.IO.MemoryMappedFiles.Tests
                 {
                     ValidateMemoryMappedFile(mmf2, capacity, access);
                 }
-            }, PlatformDetection.IsWinRT && (access == MemoryMappedFileAccess.ReadExecute || access == MemoryMappedFileAccess.ReadWriteExecute));
+            });
 
-            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(() =>
+            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(PlatformDetection.IsWinRT && (access == MemoryMappedFileAccess.ReadExecute || access == MemoryMappedFileAccess.ReadWriteExecute), () =>
             {
                 using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(mapName, capacity, access, options, inheritability))
                 using (MemoryMappedFile mmf2 = MemoryMappedFile.CreateOrOpen(mapName, capacity, access, options, inheritability))
                 {
                     ValidateMemoryMappedFile(mmf2, capacity, access, inheritability);
                 }
-            }, PlatformDetection.IsWinRT && (access == MemoryMappedFileAccess.ReadExecute || access == MemoryMappedFileAccess.ReadWriteExecute));
+            });
 
             // (Avoid testing with CreateFromFile when using execute permissions.)
         }

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateOrOpen.Tests.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateOrOpen.Tests.cs
@@ -177,27 +177,42 @@ namespace System.IO.MemoryMappedFiles.Tests
         public void ValidArgumentCombinations_Execute(
             string mapName, long capacity, MemoryMappedFileAccess access, MemoryMappedFileOptions options, HandleInheritability inheritability)
         {
-            // Map doesn't exist
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateOrOpen(mapName, capacity, access))
+            // MemoryMappedFileAccess.ReadExecute or MemoryMappedFileAccess.ReadWriteExecute isn't permitted inside an AppContainer
+            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(() =>
             {
-                ValidateMemoryMappedFile(mmf, capacity, access);
-            }
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateOrOpen(mapName, capacity, access, options, inheritability))
-            {
-                ValidateMemoryMappedFile(mmf, capacity, access, inheritability);
-            }
+                // Map doesn't exist
+                using (MemoryMappedFile mmf = MemoryMappedFile.CreateOrOpen(mapName, capacity, access))
+                {
+                    ValidateMemoryMappedFile(mmf, capacity, access);
+                }
+            }, PlatformDetection.IsWinRT && (access == MemoryMappedFileAccess.ReadExecute || access == MemoryMappedFileAccess.ReadWriteExecute));
 
-            // Map does exist (CreateNew)
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(mapName, capacity, access))
-            using (MemoryMappedFile mmf2 = MemoryMappedFile.CreateOrOpen(mapName, capacity, access))
+            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(() =>
             {
-                ValidateMemoryMappedFile(mmf2, capacity, access);
-            }
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(mapName, capacity, access, options, inheritability))
-            using (MemoryMappedFile mmf2 = MemoryMappedFile.CreateOrOpen(mapName, capacity, access, options, inheritability))
+                using (MemoryMappedFile mmf = MemoryMappedFile.CreateOrOpen(mapName, capacity, access, options, inheritability))
+                {
+                    ValidateMemoryMappedFile(mmf, capacity, access, inheritability);
+                }
+            }, PlatformDetection.IsWinRT && (access == MemoryMappedFileAccess.ReadExecute || access == MemoryMappedFileAccess.ReadWriteExecute));
+
+            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(() =>
             {
-                ValidateMemoryMappedFile(mmf2, capacity, access, inheritability);
-            }
+                // Map does exist (CreateNew)
+                using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(mapName, capacity, access))
+                using (MemoryMappedFile mmf2 = MemoryMappedFile.CreateOrOpen(mapName, capacity, access))
+                {
+                    ValidateMemoryMappedFile(mmf2, capacity, access);
+                }
+            }, PlatformDetection.IsWinRT && (access == MemoryMappedFileAccess.ReadExecute || access == MemoryMappedFileAccess.ReadWriteExecute));
+
+            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(() =>
+            {
+                using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(mapName, capacity, access, options, inheritability))
+                using (MemoryMappedFile mmf2 = MemoryMappedFile.CreateOrOpen(mapName, capacity, access, options, inheritability))
+                {
+                    ValidateMemoryMappedFile(mmf2, capacity, access, inheritability);
+                }
+            }, PlatformDetection.IsWinRT && (access == MemoryMappedFileAccess.ReadExecute || access == MemoryMappedFileAccess.ReadWriteExecute));
 
             // (Avoid testing with CreateFromFile when using execute permissions.)
         }

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor.Tests.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor.Tests.cs
@@ -107,7 +107,9 @@ namespace System.IO.MemoryMappedFiles.Tests
         public void InvalidAccessLevelsCombinations(MemoryMappedFileAccess mapAccess, MemoryMappedFileAccess viewAccess)
         {
             const int Capacity = 4096;
-            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(PlatformDetection.IsWinRT && (mapAccess == MemoryMappedFileAccess.ReadExecute || mapAccess == MemoryMappedFileAccess.ReadWriteExecute), () =>
+            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(PlatformDetection.IsWinRT &&
+                (mapAccess == MemoryMappedFileAccess.ReadExecute ||
+                mapAccess == MemoryMappedFileAccess.ReadWriteExecute), () =>
             {
                 using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
                 {

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor.Tests.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor.Tests.cs
@@ -77,11 +77,17 @@ namespace System.IO.MemoryMappedFiles.Tests
         public void ValidAccessLevelCombinations(MemoryMappedFileAccess mapAccess, MemoryMappedFileAccess viewAccess)
         {
             const int Capacity = 4096;
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
-            using (MemoryMappedViewAccessor acc = mmf.CreateViewAccessor(0, Capacity, viewAccess))
+            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(() =>
             {
-                ValidateMemoryMappedViewAccessor(acc, Capacity, viewAccess);
-            }
+                using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
+                using (MemoryMappedViewAccessor acc = mmf.CreateViewAccessor(0, Capacity, viewAccess))
+                {
+                    ValidateMemoryMappedViewAccessor(acc, Capacity, viewAccess);
+                }
+            }, PlatformDetection.IsWinRT && (mapAccess == MemoryMappedFileAccess.ReadExecute || 
+            mapAccess == MemoryMappedFileAccess.ReadWriteExecute ||
+            viewAccess == MemoryMappedFileAccess.ReadExecute ||
+            viewAccess == MemoryMappedFileAccess.ReadWriteExecute));
         }
 
         [Theory]
@@ -101,10 +107,13 @@ namespace System.IO.MemoryMappedFiles.Tests
         public void InvalidAccessLevelsCombinations(MemoryMappedFileAccess mapAccess, MemoryMappedFileAccess viewAccess)
         {
             const int Capacity = 4096;
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
+            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(() =>
             {
-                Assert.Throws<UnauthorizedAccessException>(() => mmf.CreateViewAccessor(0, Capacity, viewAccess));
-            }
+                using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
+                {
+                    Assert.Throws<UnauthorizedAccessException>(() => mmf.CreateViewAccessor(0, Capacity, viewAccess));
+                }
+            }, PlatformDetection.IsWinRT && (mapAccess == MemoryMappedFileAccess.ReadExecute || mapAccess == MemoryMappedFileAccess.ReadWriteExecute));
         }
 
         /// <summary>

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor.Tests.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor.Tests.cs
@@ -77,17 +77,17 @@ namespace System.IO.MemoryMappedFiles.Tests
         public void ValidAccessLevelCombinations(MemoryMappedFileAccess mapAccess, MemoryMappedFileAccess viewAccess)
         {
             const int Capacity = 4096;
-            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(() =>
+            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(PlatformDetection.IsWinRT && (mapAccess == MemoryMappedFileAccess.ReadExecute ||
+                mapAccess == MemoryMappedFileAccess.ReadWriteExecute ||
+                viewAccess == MemoryMappedFileAccess.ReadExecute ||
+                viewAccess == MemoryMappedFileAccess.ReadWriteExecute), () =>
             {
                 using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
                 using (MemoryMappedViewAccessor acc = mmf.CreateViewAccessor(0, Capacity, viewAccess))
                 {
                     ValidateMemoryMappedViewAccessor(acc, Capacity, viewAccess);
                 }
-            }, PlatformDetection.IsWinRT && (mapAccess == MemoryMappedFileAccess.ReadExecute || 
-            mapAccess == MemoryMappedFileAccess.ReadWriteExecute ||
-            viewAccess == MemoryMappedFileAccess.ReadExecute ||
-            viewAccess == MemoryMappedFileAccess.ReadWriteExecute));
+            });
         }
 
         [Theory]
@@ -107,13 +107,13 @@ namespace System.IO.MemoryMappedFiles.Tests
         public void InvalidAccessLevelsCombinations(MemoryMappedFileAccess mapAccess, MemoryMappedFileAccess viewAccess)
         {
             const int Capacity = 4096;
-            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(() =>
+            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(PlatformDetection.IsWinRT && (mapAccess == MemoryMappedFileAccess.ReadExecute || mapAccess == MemoryMappedFileAccess.ReadWriteExecute), () =>
             {
                 using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
                 {
                     Assert.Throws<UnauthorizedAccessException>(() => mmf.CreateViewAccessor(0, Capacity, viewAccess));
                 }
-            }, PlatformDetection.IsWinRT && (mapAccess == MemoryMappedFileAccess.ReadExecute || mapAccess == MemoryMappedFileAccess.ReadWriteExecute));
+            });
         }
 
         /// <summary>

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream.Tests.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream.Tests.cs
@@ -77,11 +77,17 @@ namespace System.IO.MemoryMappedFiles.Tests
         public void ValidAccessLevelCombinations(MemoryMappedFileAccess mapAccess, MemoryMappedFileAccess viewAccess)
         {
             const int Capacity = 4096;
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
-            using (MemoryMappedViewStream s = mmf.CreateViewStream(0, Capacity, viewAccess))
+            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(() =>
             {
-                ValidateMemoryMappedViewStream(s, Capacity, viewAccess);
-            }
+                using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
+                using (MemoryMappedViewStream s = mmf.CreateViewStream(0, Capacity, viewAccess))
+                {
+                    ValidateMemoryMappedViewStream(s, Capacity, viewAccess);
+                }
+            }, PlatformDetection.IsWinRT && (mapAccess == MemoryMappedFileAccess.ReadExecute ||
+            mapAccess == MemoryMappedFileAccess.ReadWriteExecute ||
+            viewAccess == MemoryMappedFileAccess.ReadExecute ||
+            viewAccess == MemoryMappedFileAccess.ReadWriteExecute));
         }
 
         [Theory]
@@ -101,10 +107,13 @@ namespace System.IO.MemoryMappedFiles.Tests
         public void InvalidAccessLevelsCombinations(MemoryMappedFileAccess mapAccess, MemoryMappedFileAccess viewAccess)
         {
             const int Capacity = 4096;
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
+            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(() =>
             {
-                Assert.Throws<UnauthorizedAccessException>(() => mmf.CreateViewStream(0, Capacity, viewAccess));
-            }
+                using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
+                {
+                    Assert.Throws<UnauthorizedAccessException>(() => mmf.CreateViewStream(0, Capacity, viewAccess));
+                }
+            }, PlatformDetection.IsWinRT && (mapAccess == MemoryMappedFileAccess.ReadExecute || mapAccess == MemoryMappedFileAccess.ReadWriteExecute));
         }
 
         /// <summary>

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream.Tests.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream.Tests.cs
@@ -108,7 +108,9 @@ namespace System.IO.MemoryMappedFiles.Tests
         public void InvalidAccessLevelsCombinations(MemoryMappedFileAccess mapAccess, MemoryMappedFileAccess viewAccess)
         {
             const int Capacity = 4096;
-            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(PlatformDetection.IsWinRT && (mapAccess == MemoryMappedFileAccess.ReadExecute || mapAccess == MemoryMappedFileAccess.ReadWriteExecute), () =>
+            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(PlatformDetection.IsWinRT &&
+                (mapAccess == MemoryMappedFileAccess.ReadExecute ||
+                mapAccess == MemoryMappedFileAccess.ReadWriteExecute), () =>
             {
                 using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
                 {

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream.Tests.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream.Tests.cs
@@ -77,17 +77,18 @@ namespace System.IO.MemoryMappedFiles.Tests
         public void ValidAccessLevelCombinations(MemoryMappedFileAccess mapAccess, MemoryMappedFileAccess viewAccess)
         {
             const int Capacity = 4096;
-            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(() =>
+            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(PlatformDetection.IsWinRT && 
+                (mapAccess == MemoryMappedFileAccess.ReadExecute ||
+                mapAccess == MemoryMappedFileAccess.ReadWriteExecute ||
+                viewAccess == MemoryMappedFileAccess.ReadExecute ||
+                viewAccess == MemoryMappedFileAccess.ReadWriteExecute), () =>
             {
                 using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
                 using (MemoryMappedViewStream s = mmf.CreateViewStream(0, Capacity, viewAccess))
                 {
                     ValidateMemoryMappedViewStream(s, Capacity, viewAccess);
                 }
-            }, PlatformDetection.IsWinRT && (mapAccess == MemoryMappedFileAccess.ReadExecute ||
-            mapAccess == MemoryMappedFileAccess.ReadWriteExecute ||
-            viewAccess == MemoryMappedFileAccess.ReadExecute ||
-            viewAccess == MemoryMappedFileAccess.ReadWriteExecute));
+            });
         }
 
         [Theory]
@@ -107,13 +108,13 @@ namespace System.IO.MemoryMappedFiles.Tests
         public void InvalidAccessLevelsCombinations(MemoryMappedFileAccess mapAccess, MemoryMappedFileAccess viewAccess)
         {
             const int Capacity = 4096;
-            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(() =>
+            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(PlatformDetection.IsWinRT && (mapAccess == MemoryMappedFileAccess.ReadExecute || mapAccess == MemoryMappedFileAccess.ReadWriteExecute), () =>
             {
                 using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
                 {
                     Assert.Throws<UnauthorizedAccessException>(() => mmf.CreateViewStream(0, Capacity, viewAccess));
                 }
-            }, PlatformDetection.IsWinRT && (mapAccess == MemoryMappedFileAccess.ReadExecute || mapAccess == MemoryMappedFileAccess.ReadWriteExecute));
+            });
         }
 
         /// <summary>

--- a/src/System.IO.MemoryMappedFiles/tests/System.IO.MemoryMappedFiles.Tests.csproj
+++ b/src/System.IO.MemoryMappedFiles/tests/System.IO.MemoryMappedFiles.Tests.csproj
@@ -35,6 +35,9 @@
     <Compile Include="$(CommonTestPath)\System\AssertExtensions.cs">
       <Link>Common\System\AssertExtensions.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>Common\System\PlatformDetection.cs</Link>
+    </Compile>
     <Compile Include="XunitAssemblyAttributes.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
MemoryMappedFileAccess.ReadExecute or MemoryMappedFileAccess.ReadWriteExecute isn't permitted inside an AppContainer.

Fixes 180 tests here:
https://mc.dot.net/#/product/netcore/master/source/official~2Fcorefx~2Fmaster~2F/type/test~2Ffunctional~2Fuwp~2F/build/20170515.01/workItem/System.IO.MemoryMappedFiles.Tests