### PR TITLE
Add tests for HttpListenerContext.AcceptWebSocketAsync and fix the managed implementation

### DIFF
--- a/src/Common/src/System/Net/WebSockets/WebSocketValidate.cs
+++ b/src/Common/src/System/Net/WebSockets/WebSocketValidate.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Globalization;
 using System.Text;
 
@@ -123,9 +124,19 @@ namespace System.Net.WebSockets
 
         internal static void ValidateArraySegment(ArraySegment<byte> arraySegment, string parameterName)
         {
+            Debug.Assert(!string.IsNullOrEmpty(parameterName), "'parameterName' MUST NOT be NULL or string.Empty");
+
             if (arraySegment.Array == null)
             {
-                throw new ArgumentNullException(parameterName + ".Array");
+                throw new ArgumentNullException(parameterName + "." + nameof(arraySegment.Array));
+            }
+            if (arraySegment.Offset < 0 || arraySegment.Offset > arraySegment.Array.Length)
+            {
+                throw new ArgumentOutOfRangeException(parameterName + "." + nameof(arraySegment.Offset));
+            }
+            if (arraySegment.Count < 0 || arraySegment.Count > (arraySegment.Array.Length - arraySegment.Offset))
+            {
+                throw new ArgumentOutOfRangeException(parameterName + "." + nameof(arraySegment.Count));
             }
         }
 

--- a/src/System.Net.HttpListener/src/System/Net/HttpListenerContext.cs
+++ b/src/System.Net.HttpListener/src/System/Net/HttpListenerContext.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Net.WebSockets;
 using System.Security.Principal;
+using System.Threading.Tasks;
 
 namespace System.Net
 {
@@ -27,6 +29,16 @@ namespace System.Net
 
                 return _response;
             }
+        }
+
+        public Task<HttpListenerWebSocketContext> AcceptWebSocketAsync(string subProtocol)
+        {
+            return AcceptWebSocketAsync(subProtocol, HttpWebSocket.DefaultReceiveBufferSize, WebSocket.DefaultKeepAliveInterval);
+        }
+
+        public Task<HttpListenerWebSocketContext> AcceptWebSocketAsync(string subProtocol, TimeSpan keepAliveInterval)
+        {
+            return AcceptWebSocketAsync(subProtocol, HttpWebSocket.DefaultReceiveBufferSize, keepAliveInterval);
         }
     }
 }

--- a/src/System.Net.HttpListener/src/System/Net/Managed/HttpListenerContext.Managed.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/HttpListenerContext.Managed.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
 using System.Net.WebSockets;
 using System.Security.Principal;
 using System.Threading.Tasks;
@@ -87,21 +88,12 @@ namespace System.Net
             }
         }
 
-        public Task<HttpListenerWebSocketContext> AcceptWebSocketAsync(string subProtocol)
-        {
-            return AcceptWebSocketAsync(subProtocol, HttpWebSocket.DefaultReceiveBufferSize, WebSocket.DefaultKeepAliveInterval);
-        }
-
-        public Task<HttpListenerWebSocketContext> AcceptWebSocketAsync(string subProtocol, TimeSpan keepAliveInterval)
-        {
-            return AcceptWebSocketAsync(subProtocol, HttpWebSocket.DefaultReceiveBufferSize, keepAliveInterval);
-        }
-
         public Task<HttpListenerWebSocketContext> AcceptWebSocketAsync(string subProtocol, int receiveBufferSize, TimeSpan keepAliveInterval)
         {
             return HttpWebSocket.AcceptWebSocketAsyncCore(this, subProtocol, receiveBufferSize, keepAliveInterval);
         }
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public Task<HttpListenerWebSocketContext> AcceptWebSocketAsync(string subProtocol, int receiveBufferSize, TimeSpan keepAliveInterval, ArraySegment<byte> internalBuffer)
         {
             WebSocketValidate.ValidateArraySegment(internalBuffer, nameof(internalBuffer));

--- a/src/System.Net.HttpListener/src/System/Net/Managed/WebSockets/HttpWebSocket.Managed.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/WebSockets/HttpWebSocket.Managed.cs
@@ -16,6 +16,8 @@ namespace System.Net.WebSockets
             TimeSpan keepAliveInterval,
             ArraySegment<byte>? internalBuffer = null)
         {
+            ValidateOptions(subProtocol, receiveBufferSize, MinSendBufferSize, keepAliveInterval);
+
             // get property will create a new response if one doesn't exist.
             HttpListenerResponse response = context.Response;
             HttpListenerRequest request = context.Request;

--- a/src/System.Net.HttpListener/src/System/Net/Managed/WebSockets/HttpWebSocket.Managed.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/WebSockets/HttpWebSocket.Managed.cs
@@ -77,7 +77,7 @@ namespace System.Net.WebSockets
             return webSocketContext;
         }
 
-        private static void ValidateWebSocketHeadersCore(HttpListenerContext context) { }
+        private const bool WebSocketsSupported = true;
     }
 }
 

--- a/src/System.Net.HttpListener/src/System/Net/Managed/WebSockets/HttpWebSocket.Managed.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/WebSockets/HttpWebSocket.Managed.cs
@@ -75,45 +75,7 @@ namespace System.Net.WebSockets
             return webSocketContext;
         }
 
-        private static void ValidateWebSocketHeaders(HttpListenerContext context)
-        {
-            if (!context.Request.IsWebSocketRequest)
-            {
-                throw new WebSocketException(WebSocketError.NotAWebSocket,
-                    SR.Format(SR.net_WebSockets_AcceptNotAWebSocket,
-                    nameof(ValidateWebSocketHeaders),
-                    HttpKnownHeaderNames.Connection,
-                    HttpKnownHeaderNames.Upgrade,
-                    HttpWebSocket.WebSocketUpgradeToken,
-                    context.Request.Headers[HttpKnownHeaderNames.Upgrade]));
-            }
-
-            string secWebSocketVersion = context.Request.Headers[HttpKnownHeaderNames.SecWebSocketVersion];
-            if (string.IsNullOrEmpty(secWebSocketVersion))
-            {
-                throw new WebSocketException(WebSocketError.HeaderError,
-                    SR.Format(SR.net_WebSockets_AcceptHeaderNotFound,
-                    nameof(ValidateWebSocketHeaders),
-                    HttpKnownHeaderNames.SecWebSocketVersion));
-            }
-
-            if (!string.Equals(secWebSocketVersion, SupportedVersion))
-            {
-                throw new WebSocketException(WebSocketError.UnsupportedVersion,
-                    SR.Format(SR.net_WebSockets_AcceptUnsupportedWebSocketVersion,
-                    nameof(ValidateWebSocketHeaders),
-                    secWebSocketVersion,
-                    SupportedVersion));
-            }
-
-            if (string.IsNullOrWhiteSpace(context.Request.Headers[HttpKnownHeaderNames.SecWebSocketKey]))
-            {
-                throw new WebSocketException(WebSocketError.HeaderError,
-                    SR.Format(SR.net_WebSockets_AcceptHeaderNotFound,
-                    nameof(ValidateWebSocketHeaders),
-                    HttpKnownHeaderNames.SecWebSocketKey));
-            }
-        }
+        private static void ValidateWebSocketHeadersCore(HttpListenerContext context) { }
     }
 }
 

--- a/src/System.Net.HttpListener/src/System/Net/WebSockets/HttpWebSocket.cs
+++ b/src/System.Net.HttpListener/src/System/Net/WebSockets/HttpWebSocket.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading;
 
 namespace System.Net.WebSockets
 {
@@ -80,6 +81,96 @@ namespace System.Net.WebSockets
                 SR.Format(SR.net_WebSockets_AcceptUnsupportedProtocol,
                     clientSecWebSocketProtocol,
                     subProtocol));
+        }
+
+        internal static void ValidateOptions(string subProtocol, int receiveBufferSize, int sendBufferSize, TimeSpan keepAliveInterval)
+        {
+            if (subProtocol != null)
+            {
+                WebSocketValidate.ValidateSubprotocol(subProtocol);
+            }
+            
+            if (receiveBufferSize < MinReceiveBufferSize)
+            {
+                throw new ArgumentOutOfRangeException(nameof(receiveBufferSize), receiveBufferSize,
+                    SR.Format(SR.net_WebSockets_ArgumentOutOfRange_TooSmall, MinReceiveBufferSize));
+            }
+
+            if (sendBufferSize < MinSendBufferSize)
+            {
+                throw new ArgumentOutOfRangeException(nameof(sendBufferSize), sendBufferSize,
+                    SR.Format(SR.net_WebSockets_ArgumentOutOfRange_TooSmall, MinSendBufferSize));
+            }
+
+            if (receiveBufferSize > MaxBufferSize)
+            {
+                throw new ArgumentOutOfRangeException(nameof(receiveBufferSize), receiveBufferSize,
+                    SR.Format(SR.net_WebSockets_ArgumentOutOfRange_TooBig,
+                        nameof(receiveBufferSize),
+                        receiveBufferSize,
+                        MaxBufferSize));
+            }
+
+            if (sendBufferSize > MaxBufferSize)
+            {
+                throw new ArgumentOutOfRangeException(nameof(sendBufferSize), sendBufferSize,
+                    SR.Format(SR.net_WebSockets_ArgumentOutOfRange_TooBig,
+                        nameof(sendBufferSize),
+                        sendBufferSize,
+                        MaxBufferSize));
+            }
+
+            if (keepAliveInterval < Timeout.InfiniteTimeSpan) // -1 millisecond
+            {
+                throw new ArgumentOutOfRangeException(nameof(keepAliveInterval), keepAliveInterval,
+                    SR.Format(SR.net_WebSockets_ArgumentOutOfRange_TooSmall, Timeout.InfiniteTimeSpan.ToString()));
+            }
+        }
+
+        internal const int MinSendBufferSize = 16;
+        internal const int MinReceiveBufferSize = 256;
+        internal const int MaxBufferSize = 64 * 1024;
+
+        private static void ValidateWebSocketHeaders(HttpListenerContext context)
+        {
+            ValidateWebSocketHeadersCore(context);
+
+            if (!context.Request.IsWebSocketRequest)
+            {
+                throw new WebSocketException(WebSocketError.NotAWebSocket,
+                    SR.Format(SR.net_WebSockets_AcceptNotAWebSocket,
+                    nameof(ValidateWebSocketHeaders),
+                    HttpKnownHeaderNames.Connection,
+                    HttpKnownHeaderNames.Upgrade,
+                    HttpWebSocket.WebSocketUpgradeToken,
+                    context.Request.Headers[HttpKnownHeaderNames.Upgrade]));
+            }
+
+            string secWebSocketVersion = context.Request.Headers[HttpKnownHeaderNames.SecWebSocketVersion];
+            if (string.IsNullOrEmpty(secWebSocketVersion))
+            {
+                throw new WebSocketException(WebSocketError.HeaderError,
+                    SR.Format(SR.net_WebSockets_AcceptHeaderNotFound,
+                    nameof(ValidateWebSocketHeaders),
+                    HttpKnownHeaderNames.SecWebSocketVersion));
+            }
+
+            if (!string.Equals(secWebSocketVersion, SupportedVersion, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new WebSocketException(WebSocketError.UnsupportedVersion,
+                    SR.Format(SR.net_WebSockets_AcceptUnsupportedWebSocketVersion,
+                    nameof(ValidateWebSocketHeaders),
+                    secWebSocketVersion,
+                    SupportedVersion));
+            }
+
+            if (string.IsNullOrWhiteSpace(context.Request.Headers[HttpKnownHeaderNames.SecWebSocketKey]))
+            {
+                throw new WebSocketException(WebSocketError.HeaderError,
+                    SR.Format(SR.net_WebSockets_AcceptHeaderNotFound,
+                    nameof(ValidateWebSocketHeaders),
+                    HttpKnownHeaderNames.SecWebSocketKey));
+            }
         }
     }
 }

--- a/src/System.Net.HttpListener/src/System/Net/WebSockets/HttpWebSocket.cs
+++ b/src/System.Net.HttpListener/src/System/Net/WebSockets/HttpWebSocket.cs
@@ -133,7 +133,10 @@ namespace System.Net.WebSockets
 
         private static void ValidateWebSocketHeaders(HttpListenerContext context)
         {
-            ValidateWebSocketHeadersCore(context);
+            if (!WebSocketsSupported)
+            {
+                throw new PlatformNotSupportedException(SR.net_WebSockets_UnsupportedPlatform);
+            }
 
             if (!context.Request.IsWebSocketRequest)
             {

--- a/src/System.Net.HttpListener/src/System/Net/Windows/HttpListenerContext.Windows.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/HttpListenerContext.Windows.cs
@@ -54,9 +54,9 @@ namespace System.Net
             int receiveBufferSize,
             TimeSpan keepAliveInterval)
         {
-            HttpWebSocket.ValidateOptions(subProtocol, receiveBufferSize, WebSocketBuffer.MinSendBufferSize, keepAliveInterval);
+            HttpWebSocket.ValidateOptions(subProtocol, receiveBufferSize, HttpWebSocket.MinSendBufferSize, keepAliveInterval);
 
-            ArraySegment<byte> internalBuffer = WebSocketBuffer.CreateInternalBufferArraySegment(receiveBufferSize, WebSocketBuffer.MinSendBufferSize, true);
+            ArraySegment<byte> internalBuffer = WebSocketBuffer.CreateInternalBufferArraySegment(receiveBufferSize, HttpWebSocket.MinSendBufferSize, true);
             return this.AcceptWebSocketAsync(subProtocol,
                 receiveBufferSize,
                 keepAliveInterval,

--- a/src/System.Net.HttpListener/src/System/Net/Windows/HttpListenerContext.Windows.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/HttpListenerContext.Windows.cs
@@ -50,20 +50,6 @@ namespace System.Net
 
         internal ulong RequestId => Request.RequestId;
 
-        public Task<HttpListenerWebSocketContext> AcceptWebSocketAsync(string subProtocol)
-        {
-            return this.AcceptWebSocketAsync(subProtocol,
-                HttpWebSocket.DefaultReceiveBufferSize,
-                WebSocket.DefaultKeepAliveInterval);
-        }
-
-        public Task<HttpListenerWebSocketContext> AcceptWebSocketAsync(string subProtocol, TimeSpan keepAliveInterval)
-        {
-            return this.AcceptWebSocketAsync(subProtocol,
-                HttpWebSocket.DefaultReceiveBufferSize,
-                keepAliveInterval);
-        }
-
         public Task<HttpListenerWebSocketContext> AcceptWebSocketAsync(string subProtocol,
             int receiveBufferSize,
             TimeSpan keepAliveInterval)

--- a/src/System.Net.HttpListener/src/System/Net/Windows/WebSockets/HttpWebSocket.Windows.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/WebSockets/HttpWebSocket.Windows.cs
@@ -18,10 +18,7 @@ namespace System.Net.WebSockets
         private static readonly Random s_keyGenerator = new Random();
         private static readonly bool s_httpSysSupportsWebSockets = (Environment.OSVersion.Version >= new Version(6, 2));
 
-        internal static ArraySegment<byte> EmptyPayload
-        {
-            get { return s_EmptyPayload; }
-        }
+        internal static ArraySegment<byte> EmptyPayload => s_EmptyPayload;
 
         internal static Task<HttpListenerWebSocketContext> AcceptWebSocketAsync(HttpListenerContext context,
             string subProtocol,
@@ -29,9 +26,9 @@ namespace System.Net.WebSockets
             TimeSpan keepAliveInterval,
             ArraySegment<byte> internalBuffer)
         {
-            ValidateOptions(subProtocol, receiveBufferSize, WebSocketBuffer.MinSendBufferSize, keepAliveInterval);
-            ValidateArraySegment(internalBuffer, nameof(internalBuffer));
-            WebSocketBuffer.Validate(internalBuffer.Count, receiveBufferSize, WebSocketBuffer.MinSendBufferSize, true);
+            ValidateOptions(subProtocol, receiveBufferSize, MinSendBufferSize, keepAliveInterval);
+            WebSocketValidate.ValidateArraySegment(internalBuffer, nameof(internalBuffer));
+            WebSocketBuffer.Validate(internalBuffer.Count, receiveBufferSize, MinSendBufferSize, true);
 
             return AcceptWebSocketAsyncCore(context, subProtocol, receiveBufferSize, keepAliveInterval, internalBuffer);
         }
@@ -192,48 +189,6 @@ namespace System.Net.WebSockets
                 true);
         }
 
-        private static void ValidateWebSocketHeaders(HttpListenerContext context)
-        {
-            EnsureHttpSysSupportsWebSockets();
-
-            if (!context.Request.IsWebSocketRequest)
-            {
-                throw new WebSocketException(WebSocketError.NotAWebSocket,
-                    SR.Format(SR.net_WebSockets_AcceptNotAWebSocket,
-                    nameof(ValidateWebSocketHeaders),
-                    HttpKnownHeaderNames.Connection,
-                    HttpKnownHeaderNames.Upgrade,
-                    HttpWebSocket.WebSocketUpgradeToken,
-                    context.Request.Headers[HttpKnownHeaderNames.Upgrade]));
-            }
-
-            string secWebSocketVersion = context.Request.Headers[HttpKnownHeaderNames.SecWebSocketVersion];
-            if (string.IsNullOrEmpty(secWebSocketVersion))
-            {
-                throw new WebSocketException(WebSocketError.HeaderError,
-                    SR.Format(SR.net_WebSockets_AcceptHeaderNotFound,
-                    nameof(ValidateWebSocketHeaders),
-                    HttpKnownHeaderNames.SecWebSocketVersion));
-            }
-
-            if (string.Compare(secWebSocketVersion, WebSocketProtocolComponent.SupportedVersion, StringComparison.OrdinalIgnoreCase) != 0)
-            {
-                throw new WebSocketException(WebSocketError.UnsupportedVersion,
-                    SR.Format(SR.net_WebSockets_AcceptUnsupportedWebSocketVersion,
-                    nameof(ValidateWebSocketHeaders),
-                    secWebSocketVersion,
-                    WebSocketProtocolComponent.SupportedVersion));
-            }
-
-            if (string.IsNullOrWhiteSpace(context.Request.Headers[HttpKnownHeaderNames.SecWebSocketKey]))
-            {
-                throw new WebSocketException(WebSocketError.HeaderError,
-                    SR.Format(SR.net_WebSockets_AcceptHeaderNotFound,
-                    nameof(ValidateWebSocketHeaders),
-                    HttpKnownHeaderNames.SecWebSocketKey));
-            }
-        }
-
         internal static void ValidateInnerStream(Stream innerStream)
         {
             if (innerStream == null)
@@ -252,60 +207,6 @@ namespace System.Net.WebSockets
             }
         }
 
-
-        internal static void ValidateOptions(string subProtocol,
-            int receiveBufferSize,
-            int sendBufferSize,
-            TimeSpan keepAliveInterval)
-        {
-            // We allow the subProtocol to be null. Validate if it is not null.
-            if (subProtocol != null)
-            {
-                WebSocketValidate.ValidateSubprotocol(subProtocol);
-            }
-
-            ValidateBufferSizes(receiveBufferSize, sendBufferSize);
-
-            if (keepAliveInterval < Timeout.InfiniteTimeSpan) // -1
-            {
-                throw new ArgumentOutOfRangeException(nameof(keepAliveInterval), keepAliveInterval,
-                    SR.Format(SR.net_WebSockets_ArgumentOutOfRange_TooSmall, Timeout.InfiniteTimeSpan.ToString()));
-            }
-        }
-
-        internal static void ValidateBufferSizes(int receiveBufferSize, int sendBufferSize)
-        {
-            if (receiveBufferSize < WebSocketBuffer.MinReceiveBufferSize)
-            {
-                throw new ArgumentOutOfRangeException(nameof(receiveBufferSize), receiveBufferSize,
-                    SR.Format(SR.net_WebSockets_ArgumentOutOfRange_TooSmall, WebSocketBuffer.MinReceiveBufferSize));
-            }
-
-            if (sendBufferSize < WebSocketBuffer.MinSendBufferSize)
-            {
-                throw new ArgumentOutOfRangeException(nameof(sendBufferSize), sendBufferSize,
-                    SR.Format(SR.net_WebSockets_ArgumentOutOfRange_TooSmall, WebSocketBuffer.MinSendBufferSize));
-            }
-
-            if (receiveBufferSize > WebSocketBuffer.MaxBufferSize)
-            {
-                throw new ArgumentOutOfRangeException(nameof(receiveBufferSize), receiveBufferSize,
-                    SR.Format(SR.net_WebSockets_ArgumentOutOfRange_TooBig,
-                        nameof(receiveBufferSize),
-                        receiveBufferSize,
-                        WebSocketBuffer.MaxBufferSize));
-            }
-
-            if (sendBufferSize > WebSocketBuffer.MaxBufferSize)
-            {
-                throw new ArgumentOutOfRangeException(nameof(sendBufferSize), sendBufferSize,
-                    SR.Format(SR.net_WebSockets_ArgumentOutOfRange_TooBig,
-                        nameof(sendBufferSize),
-                        sendBufferSize,
-                        WebSocketBuffer.MaxBufferSize));
-            }
-        }
-
         internal static void ThrowIfConnectionAborted(Stream connection, bool read)
         {
             if ((!read && !connection.CanWrite) ||
@@ -320,35 +221,13 @@ namespace System.Net.WebSockets
             throw new PlatformNotSupportedException(SR.net_WebSockets_UnsupportedPlatform);
         }
 
-        private static void ThrowPlatformNotSupportedException_HTTPSYS()
-        {
-            throw new PlatformNotSupportedException(SR.net_WebSockets_UnsupportedPlatform);
-        }
+        private static string SupportedVersion => WebSocketProtocolComponent.SupportedVersion;
 
-        internal static void ValidateArraySegment<T>(ArraySegment<T> arraySegment, string parameterName)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(parameterName), "'parameterName' MUST NOT be NULL or string.Empty");
-
-            if (arraySegment.Array == null)
-            {
-                throw new ArgumentNullException(parameterName + "." + nameof(arraySegment.Array));
-            }
-
-            if (arraySegment.Offset < 0 || arraySegment.Offset > arraySegment.Array.Length)
-            {
-                throw new ArgumentOutOfRangeException(parameterName + "." + nameof(arraySegment.Offset));
-            }
-            if (arraySegment.Count < 0 || arraySegment.Count > (arraySegment.Array.Length - arraySegment.Offset))
-            {
-                throw new ArgumentOutOfRangeException(parameterName + "." + nameof(arraySegment.Count));
-            }
-        }
-
-        private static void EnsureHttpSysSupportsWebSockets()
+        private static void ValidateWebSocketHeadersCore(HttpListenerContext context)
         {
             if (!s_httpSysSupportsWebSockets)
             {
-                ThrowPlatformNotSupportedException_HTTPSYS();
+                throw new PlatformNotSupportedException(SR.net_WebSockets_UnsupportedPlatform);
             }
         }
     }

--- a/src/System.Net.HttpListener/src/System/Net/Windows/WebSockets/HttpWebSocket.Windows.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/WebSockets/HttpWebSocket.Windows.cs
@@ -14,11 +14,7 @@ namespace System.Net.WebSockets
 {
     internal static partial class HttpWebSocket
     {
-        private static readonly ArraySegment<byte> s_EmptyPayload = new ArraySegment<byte>(new byte[] { }, 0, 0);
         private static readonly Random s_keyGenerator = new Random();
-        private static readonly bool s_httpSysSupportsWebSockets = (Environment.OSVersion.Version >= new Version(6, 2));
-
-        internal static ArraySegment<byte> EmptyPayload => s_EmptyPayload;
 
         internal static Task<HttpListenerWebSocketContext> AcceptWebSocketAsync(HttpListenerContext context,
             string subProtocol,
@@ -154,7 +150,7 @@ namespace System.Net.WebSockets
 
             return webSocketContext;
         }
-        
+
         internal static string GetTraceMsgForParameters(int offset, int count, CancellationToken cancellationToken)
         {
             return string.Format(CultureInfo.InvariantCulture,
@@ -179,7 +175,7 @@ namespace System.Net.WebSockets
             // under the caller's synchronization context.
             return task.ConfigureAwait(false);
         }
-        
+
         private static unsafe ulong SendWebSocketHeaders(HttpListenerResponse response)
         {
             return response.SendHeaders(null, null,
@@ -223,12 +219,6 @@ namespace System.Net.WebSockets
 
         private static string SupportedVersion => WebSocketProtocolComponent.SupportedVersion;
 
-        private static void ValidateWebSocketHeadersCore(HttpListenerContext context)
-        {
-            if (!s_httpSysSupportsWebSockets)
-            {
-                throw new PlatformNotSupportedException(SR.net_WebSockets_UnsupportedPlatform);
-            }
-        }
+        private static bool WebSocketsSupported { get; } = Environment.OSVersion.Version >= new Version(6, 2);
     }
 }

--- a/src/System.Net.HttpListener/src/System/Net/Windows/WebSockets/ServerWebSocket.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/WebSockets/ServerWebSocket.cs
@@ -22,9 +22,9 @@ namespace System.Net.WebSockets
             }
 
             HttpWebSocket.ValidateInnerStream(innerStream);
-            HttpWebSocket.ValidateOptions(subProtocol, receiveBufferSize, WebSocketBuffer.MinSendBufferSize, keepAliveInterval);
+            HttpWebSocket.ValidateOptions(subProtocol, receiveBufferSize, HttpWebSocket.MinSendBufferSize, keepAliveInterval);
             WebSocketValidate.ValidateArraySegment(internalBuffer, nameof(internalBuffer));
-            WebSocketBuffer.Validate(internalBuffer.Count, receiveBufferSize, WebSocketBuffer.MinSendBufferSize, true);
+            WebSocketBuffer.Validate(internalBuffer.Count, receiveBufferSize, HttpWebSocket.MinSendBufferSize, true);
 
             return new ServerWebSocket(innerStream,
                 subProtocol,

--- a/src/System.Net.HttpListener/src/System/Net/Windows/WebSockets/WebSocketBase.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/WebSockets/WebSocketBase.cs
@@ -1961,10 +1961,8 @@ namespace System.Net.WebSockets
 
                         if (bufferType == WebSocketProtocolComponent.BufferType.Close)
                         {
-                            payload = HttpWebSocket.EmptyPayload;
-                            string reason;
-                            WebSocketCloseStatus closeStatus;
-                            _webSocket._internalBuffer.ConvertCloseBuffer(action, dataBuffers[0], out closeStatus, out reason);
+                            payload = ArraySegment<byte>.Empty;
+                            _webSocket._internalBuffer.ConvertCloseBuffer(action, dataBuffers[0], out WebSocketCloseStatus closeStatus, out string reason);
 
                             receiveResult = new WebSocketReceiveResult(bytesTransferred,
                                 messageType, true, closeStatus, reason);

--- a/src/System.Net.HttpListener/src/System/Net/Windows/WebSockets/WebSocketBase.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/WebSockets/WebSocketBase.cs
@@ -848,7 +848,7 @@ namespace System.Net.WebSockets
                     {
                         _closeAsyncStartedReceive = true;
                         ArraySegment<byte> closeMessageBuffer =
-                            new ArraySegment<byte>(new byte[WebSocketBuffer.MinReceiveBufferSize]);
+                            new ArraySegment<byte>(new byte[HttpWebSocket.MinReceiveBufferSize]);
                         EnsureReceiveOperation();
                         Task<WebSocketReceiveResult> receiveAsyncTask = _receiveOperation.Process(closeMessageBuffer,
                             linkedCancellationToken);

--- a/src/System.Net.HttpListener/src/System/Net/Windows/WebSockets/WebSocketBuffer.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/WebSockets/WebSocketBuffer.cs
@@ -25,9 +25,6 @@ namespace System.Net.WebSockets
     internal class WebSocketBuffer : IDisposable
     {
         private const int NativeOverheadBufferSize = 144;
-        internal const int MinSendBufferSize = 16;
-        internal const int MinReceiveBufferSize = 256;
-        internal const int MaxBufferSize = 64 * 1024;
         private static readonly int s_PropertyBufferSize = 3 * sizeof(uint) + IntPtr.Size;
 
         private readonly int _receiveBufferSize;
@@ -53,14 +50,14 @@ namespace System.Net.WebSockets
         private WebSocketBuffer(ArraySegment<byte> internalBuffer, int receiveBufferSize, int sendBufferSize)
         {
             Debug.Assert(internalBuffer.Array != null, "'internalBuffer.Array' MUST NOT be NULL.");
-            Debug.Assert(receiveBufferSize >= MinReceiveBufferSize,
-                "'receiveBufferSize' MUST be at least " + MinReceiveBufferSize.ToString(NumberFormatInfo.InvariantInfo) + ".");
-            Debug.Assert(sendBufferSize >= MinSendBufferSize,
-                "'sendBufferSize' MUST be at least " + MinSendBufferSize.ToString(NumberFormatInfo.InvariantInfo) + ".");
-            Debug.Assert(receiveBufferSize <= MaxBufferSize,
-                "'receiveBufferSize' MUST NOT exceed " + MaxBufferSize.ToString(NumberFormatInfo.InvariantInfo) + ".");
-            Debug.Assert(sendBufferSize <= MaxBufferSize,
-                "'sendBufferSize' MUST NOT exceed  " + MaxBufferSize.ToString(NumberFormatInfo.InvariantInfo) + ".");
+            Debug.Assert(receiveBufferSize >= HttpWebSocket.MinReceiveBufferSize,
+                "'receiveBufferSize' MUST be at least " + HttpWebSocket.MinReceiveBufferSize.ToString(NumberFormatInfo.InvariantInfo) + ".");
+            Debug.Assert(sendBufferSize >= HttpWebSocket.MinSendBufferSize,
+                "'sendBufferSize' MUST be at least " + HttpWebSocket.MinSendBufferSize.ToString(NumberFormatInfo.InvariantInfo) + ".");
+            Debug.Assert(receiveBufferSize <= HttpWebSocket.MaxBufferSize,
+                "'receiveBufferSize' MUST NOT exceed " + HttpWebSocket.MaxBufferSize.ToString(NumberFormatInfo.InvariantInfo) + ".");
+            Debug.Assert(sendBufferSize <= HttpWebSocket.MaxBufferSize,
+                "'sendBufferSize' MUST NOT exceed  " + HttpWebSocket.MaxBufferSize.ToString(NumberFormatInfo.InvariantInfo) + ".");
 
             _receiveBufferSize = receiveBufferSize;
             _sendBufferSize = sendBufferSize;
@@ -92,7 +89,7 @@ namespace System.Net.WebSockets
 
         internal static WebSocketBuffer CreateServerBuffer(ArraySegment<byte> internalBuffer, int receiveBufferSize)
         {
-            int sendBufferSize = GetNativeSendBufferSize(MinSendBufferSize, true);
+            int sendBufferSize = GetNativeSendBufferSize(HttpWebSocket.MinSendBufferSize, true);
             Debug.Assert(internalBuffer.Count >= GetInternalBufferSize(receiveBufferSize, sendBufferSize, true),
                 "Array 'internalBuffer' is TOO SMALL. Call Validate before instantiating WebSocketBuffer.");
 
@@ -506,7 +503,7 @@ namespace System.Net.WebSockets
 
         private static int GetNativeSendBufferSize(int sendBufferSize, bool isServerBuffer)
         {
-            return isServerBuffer ? MinSendBufferSize : sendBufferSize;
+            return isServerBuffer ? HttpWebSocket.MinSendBufferSize : sendBufferSize;
         }
 
         internal static void UnwrapWebSocketBuffer(Interop.WebSocket.Buffer buffer,
@@ -643,10 +640,10 @@ namespace System.Net.WebSockets
 
         internal static ArraySegment<byte> CreateInternalBufferArraySegment(int receiveBufferSize, int sendBufferSize, bool isServerBuffer)
         {
-            Debug.Assert(receiveBufferSize >= MinReceiveBufferSize,
-                "'receiveBufferSize' MUST be at least " + MinReceiveBufferSize.ToString(NumberFormatInfo.InvariantInfo) + ".");
-            Debug.Assert(sendBufferSize >= MinSendBufferSize,
-                "'sendBufferSize' MUST be at least " + MinSendBufferSize.ToString(NumberFormatInfo.InvariantInfo) + ".");
+            Debug.Assert(receiveBufferSize >= HttpWebSocket.MinReceiveBufferSize,
+                "'receiveBufferSize' MUST be at least " + HttpWebSocket.MinReceiveBufferSize.ToString(NumberFormatInfo.InvariantInfo) + ".");
+            Debug.Assert(sendBufferSize >= HttpWebSocket.MinSendBufferSize,
+                "'sendBufferSize' MUST be at least " + HttpWebSocket.MinSendBufferSize.ToString(NumberFormatInfo.InvariantInfo) + ".");
 
             int internalBufferSize = GetInternalBufferSize(receiveBufferSize, sendBufferSize, isServerBuffer);
             return new ArraySegment<byte>(new byte[internalBufferSize]);
@@ -654,10 +651,10 @@ namespace System.Net.WebSockets
 
         internal static void Validate(int count, int receiveBufferSize, int sendBufferSize, bool isServerBuffer)
         {
-            Debug.Assert(receiveBufferSize >= MinReceiveBufferSize,
-                "'receiveBufferSize' MUST be at least " + MinReceiveBufferSize.ToString(NumberFormatInfo.InvariantInfo) + ".");
-            Debug.Assert(sendBufferSize >= MinSendBufferSize,
-                "'sendBufferSize' MUST be at least " + MinSendBufferSize.ToString(NumberFormatInfo.InvariantInfo) + ".");
+            Debug.Assert(receiveBufferSize >= HttpWebSocket.MinReceiveBufferSize,
+                "'receiveBufferSize' MUST be at least " + HttpWebSocket.MinReceiveBufferSize.ToString(NumberFormatInfo.InvariantInfo) + ".");
+            Debug.Assert(sendBufferSize >= HttpWebSocket.MinSendBufferSize,
+                "'sendBufferSize' MUST be at least " + HttpWebSocket.MinSendBufferSize.ToString(NumberFormatInfo.InvariantInfo) + ".");
 
             int minBufferSize = GetInternalBufferSize(receiveBufferSize, sendBufferSize, isServerBuffer);
             if (count < minBufferSize)
@@ -669,15 +666,15 @@ namespace System.Net.WebSockets
 
         private static int GetInternalBufferSize(int receiveBufferSize, int sendBufferSize, bool isServerBuffer)
         {
-            Debug.Assert(receiveBufferSize >= MinReceiveBufferSize,
-                "'receiveBufferSize' MUST be at least " + MinReceiveBufferSize.ToString(NumberFormatInfo.InvariantInfo) + ".");
-            Debug.Assert(sendBufferSize >= MinSendBufferSize,
-                "'sendBufferSize' MUST be at least " + MinSendBufferSize.ToString(NumberFormatInfo.InvariantInfo) + ".");
+            Debug.Assert(receiveBufferSize >= HttpWebSocket.MinReceiveBufferSize,
+                "'receiveBufferSize' MUST be at least " + HttpWebSocket.MinReceiveBufferSize.ToString(NumberFormatInfo.InvariantInfo) + ".");
+            Debug.Assert(sendBufferSize >= HttpWebSocket.MinSendBufferSize,
+                "'sendBufferSize' MUST be at least " + HttpWebSocket.MinSendBufferSize.ToString(NumberFormatInfo.InvariantInfo) + ".");
 
-            Debug.Assert(receiveBufferSize <= MaxBufferSize,
-                "'receiveBufferSize' MUST be less than or equal to " + MaxBufferSize.ToString(NumberFormatInfo.InvariantInfo) + ".");
-            Debug.Assert(sendBufferSize <= MaxBufferSize,
-                "'sendBufferSize' MUST be at less than or equal to " + MaxBufferSize.ToString(NumberFormatInfo.InvariantInfo) + ".");
+            Debug.Assert(receiveBufferSize <= HttpWebSocket.MaxBufferSize,
+                "'receiveBufferSize' MUST be less than or equal to " + HttpWebSocket.MaxBufferSize.ToString(NumberFormatInfo.InvariantInfo) + ".");
+            Debug.Assert(sendBufferSize <= HttpWebSocket.MaxBufferSize,
+                "'sendBufferSize' MUST be at less than or equal to " + HttpWebSocket.MaxBufferSize.ToString(NumberFormatInfo.InvariantInfo) + ".");
 
             int nativeSendBufferSize = GetNativeSendBufferSize(sendBufferSize, isServerBuffer);
             return 2 * receiveBufferSize + nativeSendBufferSize + NativeOverheadBufferSize + s_PropertyBufferSize;

--- a/src/System.Net.HttpListener/src/System/Net/Windows/WebSockets/WebSocketBuffer.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/WebSockets/WebSocketBuffer.cs
@@ -291,7 +291,7 @@ namespace System.Net.WebSockets
                 _pinnedSendBufferHandle.Free();
             }
 
-            _pinnedSendBuffer = HttpWebSocket.EmptyPayload;
+            _pinnedSendBuffer = ArraySegment<byte>.Empty;
         }
 
         internal void BufferPayload(ArraySegment<byte> payload,
@@ -369,7 +369,7 @@ namespace System.Net.WebSockets
 
             if (bufferData == IntPtr.Zero)
             {
-                return HttpWebSocket.EmptyPayload;
+                return ArraySegment<byte>.Empty;
             }
 
             if (this.IsNativeBuffer(bufferData, bufferLength))

--- a/src/System.Net.HttpListener/tests/HttpListenerContextTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerContextTests.cs
@@ -1,0 +1,179 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Net.Sockets;
+using System.Net.WebSockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Net.Tests
+{
+    public class HttpListenerContextTests
+    {
+        public static bool IsNotWindows7 { get; } = !PlatformDetection.IsWindows7 && PlatformDetection.IsNotOneCoreUAP;
+
+        public static IEnumerable<object[]> SubProtocol_TestData()
+        {
+            yield return new object[] { new string[0], null };
+
+            yield return new object[] { new string[] { "MyProtocol1" }, null };
+            yield return new object[] { new string[] { "MyProtocol" }, "MyProtocol" };
+            yield return new object[] { new string[] { "MyProtocol" }, "myPROTOCOL" };
+
+            yield return new object[] { new string[] { "MyProtocol1", "MyProtocol2" }, null };
+            yield return new object[] { new string[] { "MyProtocol1", "MyProtocol2" }, "MyProtocol2" };
+        }
+
+        [ConditionalTheory(nameof(IsNotWindows7))]
+        [MemberData(nameof(SubProtocol_TestData))]
+        public async Task AcceptWebSocketAsync_ValidSubProtocol_Success(string[] clientProtocols, string serverProtocol)
+        {
+            await GetWebSocketContext((socket, context) =>
+            {
+                HttpListenerWebSocketContext socketContext = context.AcceptWebSocketAsync(serverProtocol).Result;
+                Assert.Equal(serverProtocol, socketContext.WebSocket.SubProtocol);
+            }, subProtocols: clientProtocols);
+        }
+
+        [ConditionalFact(nameof(IsNotWindows7))]
+        // The managed implementation doesn't validate that the socket is actually a web socket.
+        // This means that HttpListener can connect to a Socket masquerading as a web socket.
+        [ActiveIssue(18128, TestPlatforms.AnyUnix)]
+        public async Task AcceptWebSocketAsync_SocketSpoofingAsWebSocket_ThrowsWebSocketException()
+        {
+            await GetSocketContext(new string[] { "Connection: Upgrade", "Upgrade: websocket", "Sec-WebSocket-Version: 13", "Sec-WebSocket-Key: Key" }, context =>
+            {
+                Assert.ThrowsAsync<WebSocketException>(() => context.AcceptWebSocketAsync(null)).Wait();
+            });
+        }
+
+        [ConditionalFact(nameof(IsNotWindows7))]
+        public async Task AcceptWebSocketAsync_UnsupportedProtocol_ThrowsWebSocketException()
+        {
+            await GetWebSocketContext((socket, context) =>
+            {
+                Assert.ThrowsAsync<WebSocketException>(() => context.AcceptWebSocketAsync("MyOtherProtocol")).Wait();
+            }, subProtocols: new string[] { "MyProtocol" });
+        }
+
+        [ConditionalTheory(nameof(IsNotWindows7))]
+        [InlineData("Connection: ")]
+        [InlineData("Connection: Connection\r\nUpgrade: ")]
+        [InlineData("Connection: Test1\r\nUpgrade: Test2")]
+        [InlineData("Connection: Upgrade\r\nUpgrade: Test2")]
+        [InlineData("Connection: Upgrade\r\nUpgrade: websocket")]
+        [InlineData("Connection: Upgrade\r\nUpgrade: websocket\r\nSec-WebSocket-Version: ")]
+        [InlineData("Connection: Upgrade\r\nUpgrade: websocket\r\nSec-WebSocket-Version: 1")]
+        [InlineData("Connection: Upgrade\r\nUpgrade: websocket\r\nSec-WebSocket-Version: 13")]
+        [InlineData("Connection: Upgrade\r\nUpgrade: websocket\r\nSec-WebSocket-Version: 13\r\nSec-WebSocket-Key: ")]
+        [InlineData("UnknownHeader: random")]
+        public async Task AcceptWebSocketAsync_InvalidHeaders_ThrowsWebSocketException(string headers)
+        {
+            await GetSocketContext(new string[] { headers }, context =>
+            {
+                Assert.ThrowsAsync<WebSocketException>(() => context.AcceptWebSocketAsync(null)).Wait();
+            });
+        }
+
+        [ConditionalTheory(nameof(IsNotWindows7))]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("random(text")]
+        [InlineData("random)text")]
+        [InlineData("random<text")]
+        [InlineData("random>text")]
+        [InlineData("random@text")]
+        [InlineData("random,text")]
+        [InlineData("random;text")]
+        [InlineData("random:text")]
+        [InlineData("random\\text")]
+        [InlineData("random\"text")]
+        [InlineData("random/text")]
+        [InlineData("random[text")]
+        [InlineData("random]text")]
+        [InlineData("random?text")]
+        [InlineData("random=text")]
+        [InlineData("random{text")]
+        [InlineData("random}text")]
+        [InlineData("\x19")]
+        [InlineData("\x7f")]
+        public async Task AcceptWebSocketAsync_InvalidSubProtocol_ThrowsArgumentException(string subProtocol)
+        {
+            await GetWebSocketContext((socket, context) =>
+            {
+                Assert.ThrowsAsync<ArgumentException>("subProtocol", () => context.AcceptWebSocketAsync(subProtocol)).Wait();
+            });
+        }
+
+        [ConditionalTheory(nameof(IsNotWindows7))]
+        [InlineData("!")]
+        [InlineData("#")]
+        [InlineData("YouDontKnowMe")]
+        public async Task AcceptWebSocketAsync_NoSuchSubProtocol_ThrowsWebSocketException(string subProtocol)
+        {
+            await GetWebSocketContext((socket, context) =>
+            {
+                Assert.ThrowsAsync<WebSocketException>(() => context.AcceptWebSocketAsync(subProtocol)).Wait();
+            });
+        }
+
+        [ConditionalFact(nameof(IsNotWindows7))]
+        public async Task AcceptWebSocketAsync_InvalidKeepAlive_ThrowsWebSocketException()
+        {
+            await GetWebSocketContext((socket, context) =>
+            {
+                TimeSpan keepAlive = TimeSpan.FromMilliseconds(-2);
+                Assert.ThrowsAsync<ArgumentOutOfRangeException>("keepAliveInterval", () => context.AcceptWebSocketAsync(null, keepAlive)).Wait();
+            });
+        }
+
+        [ConditionalTheory(nameof(IsNotWindows7))]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(255)]
+        [InlineData(64 * 1024 + 1)]
+        public async Task AcceptWebSocketAsync_InvalidReceiveBufferSize_ThrowsWebSocketException(int receiveBufferSize)
+        {
+            await GetWebSocketContext((socket, context) =>
+            {
+                Assert.ThrowsAsync<ArgumentOutOfRangeException>("receiveBufferSize", () => context.AcceptWebSocketAsync(null, receiveBufferSize, TimeSpan.MaxValue)).Wait();
+            });
+        }
+
+        private static async Task GetSocketContext(string[] headers, Action<HttpListenerContext> contextAction)
+        {
+            using (HttpListenerFactory factory = new HttpListenerFactory())
+            using (Socket client = factory.GetConnectedSocket())
+            {
+                client.Send(factory.GetContent("1.1", "POST", null, "Text", headers, true));
+
+                HttpListener listener = factory.GetListener();
+                contextAction(await listener.GetContextAsync());
+            }
+        }
+
+        private static async Task GetWebSocketContext(Action<ClientWebSocket, HttpListenerContext> contextAction, string[] subProtocols = null)
+        {
+            using (HttpListenerFactory factory = new HttpListenerFactory())
+            using (ClientWebSocket clientWebSocket = new ClientWebSocket())
+            {
+                if (subProtocols != null)
+                {
+                    foreach (string subProtocol in subProtocols)
+                    {
+                        clientWebSocket.Options.AddSubProtocol(subProtocol);
+                    }
+                }
+
+                var uriBuilder = new UriBuilder(factory.ListeningUrl) { Scheme = "ws" };
+                Task<HttpListenerContext> serverContextTask = factory.GetListener().GetContextAsync();
+
+                Task clientConnectTask = clientWebSocket.ConnectAsync(uriBuilder.Uri, CancellationToken.None);
+                contextAction(clientWebSocket, await serverContextTask);
+            }
+        }
+    }
+}

--- a/src/System.Net.HttpListener/tests/HttpListenerContextTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerContextTests.cs
@@ -52,8 +52,8 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(IsNotWindows7OrUapCore))]
-        // The managed implementation doesn't validate that the socket is actually a web socket.
-        // This means that HttpListener can connect to a Socket masquerading as a web socket.
+        // Both the managed and Windows implementations send headers to the socket during connection.
+        // The Windows implementation fails with error code 1229: An operation was attempted on a nonexistent network connection.
         [ActiveIssue(18128, TestPlatforms.AnyUnix)]
         public async Task AcceptWebSocketAsync_SocketSpoofingAsWebSocket_ThrowsWebSocketException()
         {

--- a/src/System.Net.HttpListener/tests/System.Net.HttpListener.Tests.csproj
+++ b/src/System.Net.HttpListener/tests/System.Net.HttpListener.Tests.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <Compile Include="AuthenticationTests.cs" />
     <Compile Include="GetContextHelper.cs" />
+    <Compile Include="HttpListenerContextTests.cs" />
     <Compile Include="HttpListenerPrefixCollectionTests.cs" />
     <Compile Include="HttpListenerResponseTests.cs" />
     <Compile Include="HttpListenerRequestTests.cs" />


### PR DESCRIPTION
First commit fixes duplicate code and adds a missing EditorBrowsable attribute to a method

Second commit cleans up platform independent code for validating the arguments to AcceptWebSocketAsync in preparation for fixing the managed implementation

Third commit adds a bunch of tests for functionality related to this method (they passed before this PR). It then fixes the tests for the managed implementation. Previously almost all of these tests failed with either debug assertitions, incorrect exceptions thrown or no exception thrown.

Contributes to #18128

@stephentoub @priya91 @viktorhofer