### PR TITLE
Make HttpListenerResponse.ContentEncoding a Nop in the managed implementation to match Windows

### DIFF
--- a/src/System.Net.HttpListener/src/System/Net/HttpListenerResponse.cs
+++ b/src/System.Net.HttpListener/src/System/Net/HttpListenerResponse.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Text;
 
 namespace System.Net
 {
@@ -23,6 +24,8 @@ namespace System.Net
                 }
             }
         }
+
+        public Encoding ContentEncoding { get; set; }
 
         public CookieCollection Cookies
         {

--- a/src/System.Net.HttpListener/src/System/Net/HttpListenerResponse.cs
+++ b/src/System.Net.HttpListener/src/System/Net/HttpListenerResponse.cs
@@ -13,10 +13,7 @@ namespace System.Net
 
         public WebHeaderCollection Headers
         {
-            get
-            {
-                return _webHeaders;
-            }
+            get => _webHeaders;
             set
             {
                 _webHeaders = new WebHeaderCollection();
@@ -29,18 +26,8 @@ namespace System.Net
 
         public CookieCollection Cookies
         {
-            get
-            {
-                if (_cookies == null)
-                {
-                    _cookies = new CookieCollection();
-                }
-                return _cookies;
-            }
-            set
-            {
-                _cookies = value;
-            }
+            get => _cookies ?? (_cookies = new CookieCollection());
+            set =>_cookies = value;
         }
 
         public void AddHeader(string name, string value)
@@ -91,9 +78,6 @@ namespace System.Net
             }
         }
 
-        void IDisposable.Dispose()
-        {
-            Dispose();
-        }
+        void IDisposable.Dispose() => Dispose();
     }
 }

--- a/src/System.Net.HttpListener/src/System/Net/HttpListenerResponse.cs
+++ b/src/System.Net.HttpListener/src/System/Net/HttpListenerResponse.cs
@@ -30,7 +30,7 @@ namespace System.Net
         public CookieCollection Cookies
         {
             get => _cookies ?? (_cookies = new CookieCollection());
-            set =>_cookies = value;
+            set => _cookies = value;
         }
 
         public void AddHeader(string name, string value)

--- a/src/System.Net.HttpListener/src/System/Net/Managed/HttpConnection.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/HttpConnection.cs
@@ -450,7 +450,7 @@ namespace System.Net
                 else
                     str = string.Format("<h1>{0}</h1>", description);
 
-                byte[] error = _context.Response.ContentEncoding.GetBytes(str);
+                byte[] error = Encoding.Default.GetBytes(str);
                 response.Close(error, false);
             }
             catch

--- a/src/System.Net.HttpListener/src/System/Net/Managed/HttpListenerResponse.Managed.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/HttpListenerResponse.Managed.cs
@@ -59,10 +59,7 @@ namespace System.Net
             _context = context;
         }
 
-        internal bool ForceCloseChunked
-        {
-            get { return _forceCloseChunked; }
-        }
+        internal bool ForceCloseChunked => _forceCloseChunked;
 
         public Encoding ContentEncoding
         {
@@ -89,7 +86,7 @@ namespace System.Net
 
         public long ContentLength64
         {
-            get { return _contentLength; }
+            get => _contentLength;
             set
             {
                 if (_disposed)
@@ -108,7 +105,7 @@ namespace System.Net
 
         public string ContentType
         {
-            get { return _contentType; }
+            get => _contentType;
             set
             {
                 if (_disposed)
@@ -123,7 +120,7 @@ namespace System.Net
 
         public bool KeepAlive
         {
-            get { return _keepAlive; }
+            get => _keepAlive;
             set
             {
                 if (_disposed)
@@ -148,7 +145,7 @@ namespace System.Net
 
         public Version ProtocolVersion
         {
-            get { return _version; }
+            get => _version;
             set
             {
                 if (_disposed)
@@ -169,7 +166,7 @@ namespace System.Net
 
         public string RedirectLocation
         {
-            get { return _location; }
+            get => _location;
             set
             {
                 if (_disposed)
@@ -184,7 +181,7 @@ namespace System.Net
 
         public bool SendChunked
         {
-            get { return _chunked; }
+            get => _chunked;
             set
             {
                 if (_disposed)
@@ -199,7 +196,7 @@ namespace System.Net
 
         public int StatusCode
         {
-            get { return _statusCode; }
+            get => _statusCode;
             set
             {
                 if (_disposed)
@@ -217,17 +214,11 @@ namespace System.Net
 
         public string StatusDescription
         {
-            get { return _statusDescription; }
-            set
-            {
-                _statusDescription = value;
-            }
+            get => _statusDescription;
+            set => _statusDescription = value;
         }
 
-        private void Dispose()
-        {
-            Close(true);
-        }
+        private void Dispose() => Close(true);
 
         public void Close()
         {

--- a/src/System.Net.HttpListener/src/System/Net/Managed/HttpListenerResponse.Managed.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/HttpListenerResponse.Managed.cs
@@ -38,7 +38,6 @@ namespace System.Net
     public sealed partial class HttpListenerResponse : IDisposable
     {
         private bool _disposed;
-        private Encoding _contentEncoding;
         private long _contentLength;
         private bool _clSet;
         private string _contentType;
@@ -60,29 +59,6 @@ namespace System.Net
         }
 
         internal bool ForceCloseChunked => _forceCloseChunked;
-
-        public Encoding ContentEncoding
-        {
-            get
-            {
-                if (_contentEncoding == null)
-                {
-                    _contentEncoding = Encoding.Default;
-                }
-
-                return _contentEncoding;
-            }
-            set
-            {
-                if (_disposed)
-                    throw new ObjectDisposedException(GetType().ToString());
-
-                if (_headersSent)
-                    throw new InvalidOperationException(SR.net_cannot_change_after_headers);
-
-                _contentEncoding = value;
-            }
-        }
 
         public long ContentLength64
         {
@@ -292,23 +268,11 @@ namespace System.Net
 
         internal void SendHeaders(bool closing, MemoryStream ms, bool isWebSocketHandshake = false)
         {
-            Encoding encoding = _contentEncoding;
-            if (encoding == null)
-                encoding = Encoding.Default;
-
             if (!isWebSocketHandshake)
             {
                 if (_contentType != null)
                 {
-                    if (_contentEncoding != null && _contentType.IndexOf(HttpHeaderStrings.Charset, StringComparison.Ordinal) == -1)
-                    {
-                        string enc_name = _contentEncoding.WebName;
-                        _webHeaders.Set(HttpKnownHeaderNames.ContentType, _contentType + "; " + HttpHeaderStrings.Charset + enc_name);
-                    }
-                    else
-                    {
-                        _webHeaders.Set(HttpKnownHeaderNames.ContentType, _contentType);
-                    }
+                    _webHeaders.Set(HttpKnownHeaderNames.ContentType, _contentType);
                 }
 
                 if (_webHeaders[HttpKnownHeaderNames.Server] == null)
@@ -388,6 +352,7 @@ namespace System.Net
                 }
             }
 
+            Encoding encoding = Encoding.Default;
             StreamWriter writer = new StreamWriter(ms, encoding, 256);
             writer.Write("HTTP/{0} {1} {2}\r\n", _version, _statusCode, _statusDescription);
             string headers_str = FormatHeaders(_webHeaders);

--- a/src/System.Net.HttpListener/src/System/Net/Windows/HttpListenerResponse.Windows.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/HttpListenerResponse.Windows.cs
@@ -54,21 +54,9 @@ namespace System.Net
             _httpContext = httpContext;
         }
 
-        private HttpListenerContext HttpListenerContext
-        {
-            get
-            {
-                return _httpContext;
-            }
-        }
+        private HttpListenerContext HttpListenerContext => _httpContext;
 
-        private HttpListenerRequest HttpListenerRequest
-        {
-            get
-            {
-                return HttpListenerContext.Request;
-            }
-        }
+        private HttpListenerRequest HttpListenerRequest => HttpListenerContext.Request;
 
         public Encoding ContentEncoding
         {
@@ -84,10 +72,7 @@ namespace System.Net
 
         public string ContentType
         {
-            get
-            {
-                return Headers[HttpKnownHeaderNames.ContentType];
-            }
+            get => Headers[HttpKnownHeaderNames.ContentType];
             set
             {
                 CheckDisposed();
@@ -114,10 +99,7 @@ namespace System.Net
 
         public string RedirectLocation
         {
-            get
-            {
-                return Headers[HttpResponseHeader.Location];
-            }
+            get => Headers[HttpResponseHeader.Location];
             set
             {
                 // note that this doesn't set the status code to a redirect one
@@ -135,10 +117,7 @@ namespace System.Net
 
         public int StatusCode
         {
-            get
-            {
-                return (int)_nativeResponse.StatusCode;
-            }
+            get => _nativeResponse.StatusCode;
             set
             {
                 CheckDisposed();
@@ -206,20 +185,10 @@ namespace System.Net
 
         public bool SendChunked
         {
-            get
-            {
-                return (EntitySendFormat == EntitySendFormat.Chunked);
-            }
+            get => EntitySendFormat == EntitySendFormat.Chunked;
             set
             {
-                if (value)
-                {
-                    EntitySendFormat = EntitySendFormat.Chunked;
-                }
-                else
-                {
-                    EntitySendFormat = EntitySendFormat.ContentLength;
-                }
+                EntitySendFormat = value ? EntitySendFormat.Chunked : EntitySendFormat.ContentLength;
             }
         }
 
@@ -240,10 +209,7 @@ namespace System.Net
 
         internal EntitySendFormat EntitySendFormat
         {
-            get
-            {
-                return (EntitySendFormat)_boundaryType;
-            }
+            get => (EntitySendFormat)_boundaryType;
             set
             {
                 CheckDisposed();
@@ -265,10 +231,7 @@ namespace System.Net
 
         public bool KeepAlive
         {
-            get
-            {
-                return _keepAlive;
-            }
+            get => _keepAlive;
             set
             {
                 CheckDisposed();
@@ -286,10 +249,7 @@ namespace System.Net
 
         public long ContentLength64
         {
-            get
-            {
-                return _contentLength;
-            }
+            get => _contentLength;
             set
             {
                 CheckDisposed();
@@ -311,10 +271,7 @@ namespace System.Net
 
         public Version ProtocolVersion
         {
-            get
-            {
-                return new Version(_nativeResponse.Version.MajorVersion, _nativeResponse.Version.MinorVersion);
-            }
+            get => new Version(_nativeResponse.Version.MajorVersion, _nativeResponse.Version.MinorVersion);
             set
             {
                 CheckDisposed();
@@ -420,29 +377,11 @@ namespace System.Net
             HttpListenerContext.Close();
         }
 
-        internal BoundaryType BoundaryType
-        {
-            get
-            {
-                return _boundaryType;
-            }
-        }
+        internal BoundaryType BoundaryType => _boundaryType;
 
-        internal bool SentHeaders
-        {
-            get
-            {
-                return _responseState >= ResponseState.SentHeaders;
-            }
-        }
+        internal bool SentHeaders => _responseState >= ResponseState.SentHeaders;
 
-        internal bool ComputedHeaders
-        {
-            get
-            {
-                return _responseState >= ResponseState.ComputedHeaders;
-            }
-        }
+        internal bool ComputedHeaders => _responseState >= ResponseState.ComputedHeaders;
 
         private void EnsureResponseStream()
         {
@@ -921,16 +860,13 @@ $"flags: {flags} _boundaryType: {_boundaryType} _contentLength: {_contentLength}
         {
             if (_responseState >= ResponseState.Closed)
             {
-                throw new ObjectDisposedException(this.GetType().FullName);
+                throw new ObjectDisposedException(GetType().FullName);
             }
         }
 
         internal void CancelLastWrite(SafeHandle requestQueueHandle)
         {
-            if (_responseStream != null)
-            {
-                _responseStream.CancelLastWrite(requestQueueHandle);
-            }
+            _responseStream?.CancelLastWrite(requestQueueHandle);
         }
     }
 }

--- a/src/System.Net.HttpListener/src/System/Net/Windows/HttpListenerResponse.Windows.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/HttpListenerResponse.Windows.cs
@@ -23,8 +23,6 @@ namespace System.Net
             Closed,
         }
 
-        private Encoding _contentEncoding;
-
         private string _statusDescription;
         private bool _keepAlive;
         private ResponseState _responseState;
@@ -57,18 +55,6 @@ namespace System.Net
         private HttpListenerContext HttpListenerContext => _httpContext;
 
         private HttpListenerRequest HttpListenerRequest => HttpListenerContext.Request;
-
-        public Encoding ContentEncoding
-        {
-            get
-            {
-                return _contentEncoding;
-            }
-            set
-            {
-                _contentEncoding = value;
-            }
-        }
 
         public string ContentType
         {

--- a/src/System.Net.HttpListener/tests/HttpListenerResponseTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerResponseTests.cs
@@ -1,0 +1,66 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Net.Tests
+{
+    public class HttpListenerResponseTests : IDisposable
+    {
+        private HttpListenerFactory Factory { get; set; }
+        private HttpClient Client { get; set; }
+        private Task<HttpResponseMessage> Message { get; set; }
+
+        public HttpListenerResponseTests()
+        {
+            Factory = new HttpListenerFactory();
+            Client = new HttpClient();
+        }
+
+        public void Dispose()
+        {
+            Factory.Dispose();
+            Client.Dispose();
+        }
+
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
+        public async Task ContentEncoding_SetCustom_DoesNothing()
+        {
+            // Setting HttpListenerResponse.ContentEncoding does nothing - it is never used.
+            HttpListenerResponse response = await GetResponse();
+            Assert.Null(response.ContentEncoding);
+
+            response.ContentEncoding = Encoding.Unicode;
+            Assert.Equal(Encoding.Unicode, response.ContentEncoding);
+            response.Close();
+
+            HttpResponseMessage clientResponse = await Message;
+            Assert.Empty(clientResponse.Content.Headers.ContentEncoding);
+        }
+
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
+        public async Task ContentEncoding_SetDisposed_DoesNothing()
+        {
+            HttpListenerResponse response = await GetResponse();
+            response.Close();
+
+            response.ContentEncoding = Encoding.Unicode;
+            Assert.Equal(Encoding.Unicode, response.ContentEncoding);
+
+            HttpResponseMessage clientResponse = await Message;
+            Assert.Empty(clientResponse.Content.Headers.ContentEncoding);
+        }
+
+        private async Task<HttpListenerResponse> GetResponse()
+        {
+            Message = Client.GetAsync(Factory.ListeningUrl);
+            HttpListenerContext context = await Factory.GetListener().GetContextAsync();
+            return context.Response;
+        }
+    }
+}

--- a/src/System.Net.HttpListener/tests/HttpListenerResponseTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerResponseTests.cs
@@ -12,8 +12,8 @@ namespace System.Net.Tests
 {
     public class HttpListenerResponseTests : IDisposable
     {
-        private HttpListenerFactory Factory { get; set; }
-        private HttpClient Client { get; set; }
+        private HttpListenerFactory Factory { get; }
+        private HttpClient Client { get; }
         private Task<HttpResponseMessage> Message { get; set; }
 
         public HttpListenerResponseTests()

--- a/src/System.Net.HttpListener/tests/HttpListenerResponseTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerResponseTests.cs
@@ -24,6 +24,7 @@ namespace System.Net.Tests
 
         public void Dispose()
         {
+            Message?.Dispose();
             Factory.Dispose();
             Client.Dispose();
         }

--- a/src/System.Net.HttpListener/tests/System.Net.HttpListener.Tests.csproj
+++ b/src/System.Net.HttpListener/tests/System.Net.HttpListener.Tests.csproj
@@ -13,6 +13,7 @@
     <Compile Include="AuthenticationTests.cs" />
     <Compile Include="GetContextHelper.cs" />
     <Compile Include="HttpListenerPrefixCollectionTests.cs" />
+    <Compile Include="HttpListenerResponseTests.cs" />
     <Compile Include="HttpListenerRequestTests.cs" />
     <Compile Include="HttpListenerTests.cs" />
     <Compile Include="HttpRequestStreamTests.cs" />


### PR DESCRIPTION
So it looks like HttpListenerResponse.ContentEncoding does nothing and is never referenced in the Windows implementation of HttpListenerResponse.

In the managed implementation, it breaks the response (e.g. HttpClient can't read it) so both platforms don't really work. Since we prefer Windows, just align a bunch of these with the Windows behaviour.

Contributes to #18128 (as Windows and managed are now closer, and cases where managed would throw now don't throw to match Windows)

@stephentoub @ViktorHofer @Priya91 