### PR TITLE
Add Test Case for String.Index with Empty String

### DIFF
--- a/src/System.Globalization/tests/CompareInfo/CompareInfoTests.IndexOf.cs
+++ b/src/System.Globalization/tests/CompareInfo/CompareInfoTests.IndexOf.cs
@@ -18,6 +18,7 @@ namespace System.Globalization.Tests
         {
             // Empty string
             yield return new object[] { s_invariantCompare, "foo", "", 0, 3, CompareOptions.None, 0 };
+            yield return new object[] { s_invariantCompare, "foo", "", 2, 1, CompareOptions.None, 2 };
             yield return new object[] { s_invariantCompare, "", "", 0, 0, CompareOptions.None, 0 };
 
             // OrdinalIgnoreCase


### PR DESCRIPTION
We have some test cases with empty string but this case is covering the issue when start index to search is not zero.

Fixes https://github.com/dotnet/coreclr/issues/11578