### PR TITLE
Make sure source isn't included in NETStandard.Library.NETFramework

### DIFF
--- a/pkg/NETStandard.Library.NETFramework/NETStandard.Library.NETFramework.pkgproj
+++ b/pkg/NETStandard.Library.NETFramework/NETStandard.Library.NETFramework.pkgproj
@@ -132,6 +132,10 @@
   <!-- runs as initial target, overrides IncludeFiles in frameworkPackage.targets to define TFM-specific TargetPath 
        under the build folder  -->
   <Target Name="IncludeFiles" DependsOnTargets="IncludeNETStandardShims">
+    <PropertyGroup>
+      <_projectDirLength>$(ProjectDir.Length)</_projectDirLength>
+    </PropertyGroup>
+
     <ItemGroup>
       <!-- Include refs -->
       <File Include="@(RefFile)">
@@ -141,6 +145,14 @@
       <!-- Include lib -->
       <File Include="@(LibFile)">
         <TargetPath Condition="'%(LibFile.TargetPath)' == '' ">build/%(LibFile.TargetFramework)/lib%(LibFile.SubFolder)</TargetPath>
+      </File>
+    </ItemGroup>
+
+    <ItemGroup>
+      <!-- Set targetpath for sources to be under src so that it is excluded from the lib package -->
+      <File Condition="'%(File.IsSourceCodeFile)' == 'true'">
+        <TargetPath>src</TargetPath>
+        <TargetPath Condition="$([System.String]::Copy('%(FullPath)').StartsWith('$(ProjectDir)'))">src/$([System.String]::Copy('%(FullPath)').Substring($(_projectDirLength)).Replace('\', '/'))</TargetPath>
       </File>
     </ItemGroup>
   </Target>

--- a/pkg/frameworkPackage.targets
+++ b/pkg/frameworkPackage.targets
@@ -64,6 +64,10 @@
   </Target>
   
   <Target Name="IncludeFiles">
+    <PropertyGroup>
+      <_projectDirLength>$(ProjectDir.Length)</_projectDirLength>
+    </PropertyGroup>
+
     <ItemGroup>
       <!-- Include refs -->
       <File Include="@(RefFile)">
@@ -77,6 +81,14 @@
 
       <File Include="@(NativeFile)">
         <TargetPath>$(NativeFileTargetPath)</TargetPath>
+      </File>
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(IncludeSymbolsInPackage)' != 'true'">
+      <!-- Set targetpath for sources to be under src so that it is excluded from the lib package -->
+      <File Condition="'%(File.IsSourceCodeFile)' == 'true'">
+        <TargetPath>src</TargetPath>
+        <TargetPath Condition="$([System.String]::Copy('%(FullPath)').StartsWith('$(ProjectDir)'))">src/$([System.String]::Copy('%(FullPath)').Substring($(_projectDirLength)).Replace('\', '/'))</TargetPath>
       </File>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
Other framework packages (Microsoft.Private.*) are transport packages
and need to contain source and symbols in order to flow those up to the
actual framework packages that are built in core-setup.

We put the source files in the sources path in our other framework pacakges
because we need to workaround issues with myget assuming a symbols package
when it sees a src folder.

NETStandard.Library.NETFramework is not a transport package so we shouldn't
put its sources in the sources folder.  Instead they should be in the src
folder so that pack splits them out into the symbols package.

Fixes #19775