### PR TITLE
Revert "Remove some assemblies from some OS shared frameworks"

### DIFF
--- a/src/Microsoft.Win32.Registry/dir.props
+++ b/src/Microsoft.Win32.Registry/dir.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
-    <IsNETCoreApp Condition="'$(OSGroup)' == 'Windows_NT'">true</IsNETCoreApp>
+    <IsNETCoreApp>true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.FileSystem.AccessControl/dir.props
+++ b/src/System.IO.FileSystem.AccessControl/dir.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
-    <IsNETCoreApp Condition="'$(OSGroup)' == 'Windows_NT'">true</IsNETCoreApp>
+    <IsNETCoreApp>true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.AccessControl/dir.props
+++ b/src/System.Security.AccessControl/dir.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
-    <IsNETCoreApp Condition="'$(OSGroup)' == 'Windows_NT'">true</IsNETCoreApp>
+    <IsNETCoreApp>true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>
     <IsUAP>true</IsUAP>
     <ISUAPRef>false</ISUAPRef>

--- a/src/System.Security.Cryptography.Cng/dir.props
+++ b/src/System.Security.Cryptography.Cng/dir.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <AssemblyVersion>4.3.0.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
-    <IsNETCoreApp Condition="'$(OSGroup)' == 'Windows_NT'">true</IsNETCoreApp>
+    <IsNETCoreApp>true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>
     <IsUAP>true</IsUAP>
     <IsUAPRef>false</IsUAPRef>

--- a/src/System.Security.Cryptography.OpenSsl/dir.props
+++ b/src/System.Security.Cryptography.OpenSsl/dir.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
-    <IsNETCoreApp Condition="'$(OSGroup)' == 'Unix'">true</IsNETCoreApp>
+    <IsNETCoreApp>true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Principal.Windows/dir.props
+++ b/src/System.Security.Principal.Windows/dir.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
-    <IsNETCoreApp Condition="'$(OSGroup)' == 'Windows_NT'">true</IsNETCoreApp>
+    <IsNETCoreApp>true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>
     <IsUAP>true</IsUAP>
     <IsUAPRef>false</IsUAPRef>


### PR DESCRIPTION
Reverts dotnet/corefx#19327

As this change flowed up through core-setup and cli we have discovered various little issues (see https://github.com/dotnet/core-setup/issues/2377) so we are going to keep the shared framework in a place where it contains the same set of assemblies across all OS's RIDs. 

@ericstj @eerhardt @bartonjs 

