### PR TITLE
Fix SendAsync on Unix with multiple buffers

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -1385,6 +1385,7 @@ namespace System.Net.Sockets
                     Flags = flags,
                     SocketAddress = socketAddress,
                     SocketAddressLen = socketAddressLen,
+                    BytesTransferred = bytesSent
                 };
 
                 bool isStopped;


### PR DESCRIPTION
In the implementation of Send{To}Async for a list of array segments, we try to do the send operation synchronously, and if it doesn't send the full amount (e.g. because it does one send that's less than the full amount and then tries to complete it but gets an EAGAIN), we then fall back to creating a SendOperation that stores the data to try again later with the remainder.  But the number of bytes sent in that initial set of operations wasn't being copied into that SendOperation data structure, so although the data had been sent and although we were correctly updating the pointers to what to send next and when we were done sending, the actual total number of BytesTransferred at the end of the operation would be missing the sum from that initial successful set of synchronous sends prior to the EAGAIN.  The fix is simply to store the initial bytesSent into BytesTransferred, as is done for every other send operation on SocketAsyncContext.

I also added an explicit test for this, rather than relying on modifying our perf tests to catch it.

Fixes https://github.com/dotnet/corefx/issues/19307
cc: @steveharter, @Priya91, @davidsh, @cipop, @geoffkizer