### PR TITLE
Add Gentoo Linux and Buildroot RIDs

### DIFF
--- a/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -568,6 +568,13 @@
             "#import": [ "opensuse.42.1", "opensuse-x64" ]
         },
 
+        "gentoo": {
+            "#import": [ "linux" ]
+        },
+        "gentoo-x64": {
+            "#import": [ "gentoo", "linux-x64" ]
+        },
+
         "corert": {
             "#import": [ "any" ]
         },

--- a/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -575,6 +575,20 @@
             "#import": [ "gentoo", "linux-x64" ]
         },
 
+        "buildroot": {
+            "#import": [ "linux" ]
+        },
+        "buildroot-x64": {
+            "#import": [ "buildroot", "linux-x64" ]
+        },
+
+        "buildroot.2017.02.2": {
+            "#import": [ "buildroot" ]
+        },
+        "buildroot.2017.02.2-x64": {
+            "#import": [ "buildroot.2017.02.2", "buildroot-x64" ]
+        },
+
         "corert": {
             "#import": [ "any" ]
         },

--- a/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -575,20 +575,6 @@
             "#import": [ "gentoo", "linux-x64" ]
         },
 
-        "buildroot": {
-            "#import": [ "linux" ]
-        },
-        "buildroot-x64": {
-            "#import": [ "buildroot", "linux-x64" ]
-        },
-
-        "buildroot.2017.02.2": {
-            "#import": [ "buildroot" ]
-        },
-        "buildroot.2017.02.2-x64": {
-            "#import": [ "buildroot.2017.02.2", "buildroot-x64" ]
-        },
-
         "corert": {
             "#import": [ "any" ]
         },


### PR DESCRIPTION
Currently Gentoo Linux and Buildroot (a system to build embedded Linux images) is not in the list of RIDs.

These two commits adds them.

Gentoo is using a rolling release cycle, so there is no version number.
For more info on Gentoo, please see the discussion on this pull request on core-setup: https://github.com/dotnet/core-setup/pull/2381