### PR TITLE
Clone corefx copy that matches shared framework and run tests on it.

### DIFF
--- a/SharedFrameworkValidation.cmd
+++ b/SharedFrameworkValidation.cmd
@@ -5,5 +5,5 @@ call %~dp0sync.cmd
 if NOT [%ERRORLEVEL%]==[0] exit /b 1
 call %~dp0build-managed.cmd -Project:%~dp0src\SharedFrameworkValidation\SharedFrameworkValidation.proj -- /t:ReBuild
 if NOT [%ERRORLEVEL%]==[0] exit /b 1
-call %~dp0build-tests.cmd -- /p:RefPath=%~dp0bin\ref\SharedFrameworkValidation /p:RunningSharedFrameworkValidation=true /p:RuntimePath=%~dp0bin\runtime\SharedFrameworkValidation\
+call %~dp0bin\CloneAndRunTests.cmd
 exit /b %ERRORLEVEL%

--- a/src/SharedFrameworkValidation/RestoreSDKProject/NuGet.config
+++ b/src/SharedFrameworkValidation/RestoreSDKProject/NuGet.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <config>
+    <add key="globalPackagesFolder" value="..\..\..\packages" />
+  </config>
+</configuration>

--- a/src/SharedFrameworkValidation/RestoreSDKProject/RestoreSDKProject.csproj
+++ b/src/SharedFrameworkValidation/RestoreSDKProject/RestoreSDKProject.csproj
@@ -5,6 +5,7 @@
     <RuntimeFrameworkVersion>$(_RuntimeFrameworkVersion)</RuntimeFrameworkVersion>
     <CoreFxPackageVersion>4.4.0-$(CoreFxExpectedPrerelease)</CoreFxPackageVersion>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SharedFrameworkValidation/RestoreSDKProject/RestoreSDKProject.csproj
+++ b/src/SharedFrameworkValidation/RestoreSDKProject/RestoreSDKProject.csproj
@@ -61,14 +61,4 @@
     <Copy SourceFiles="%(ReferencePath.Identity)" DestinationFolder="$(_MetaPackageDestinationFolder)" />
   </Target>
 
-  <Target Name="CopyNETCoreAppVersionsFile" DependsOnTargets="ResolveLockFileCopyLocalProjectDeps" BeforeTargets="CoreCompile">
-    <PropertyGroup>
-        <NETCoreAppVersionsFilePath Condition="$([System.String]::new('%(FileDefinitions.Identity)').Contains('Microsoft.NETCore.App.versions.txt'))">%(FileDefinitions.ResolvedPath)</NETCoreAppVersionsFilePath>
-    </PropertyGroup>
-
-    <Warning Condition="!Exists('$(NETCoreAppVersionsFilePath)')" Text="Failed to get path to Microsoft.NETCore.app.versions.txt file" />
-
-    <Copy SourceFiles="$(NETCoreAppVersionsFilePath)" DestinationFolder="$(_MetaPackageDestinationFolder)" Condition="Exists('$(NETCoreAppVersionsFilePath)')" />
-  </Target>
-
 </Project>

--- a/src/SharedFrameworkValidation/RestoreSDKProject/RestoreSDKProject.csproj
+++ b/src/SharedFrameworkValidation/RestoreSDKProject/RestoreSDKProject.csproj
@@ -61,4 +61,14 @@
     <Copy SourceFiles="%(ReferencePath.Identity)" DestinationFolder="$(_MetaPackageDestinationFolder)" />
   </Target>
 
+  <Target Name="CopyNETCoreAppVersionsFile" DependsOnTargets="ResolveLockFileCopyLocalProjectDeps" BeforeTargets="CoreCompile">
+    <PropertyGroup>
+        <NETCoreAppVersionsFilePath Condition="$([System.String]::new('%(FileDefinitions.Identity)').Contains('Microsoft.NETCore.App.versions.txt'))">%(FileDefinitions.ResolvedPath)</NETCoreAppVersionsFilePath>
+    </PropertyGroup>
+
+    <Warning Condition="!Exists('$(NETCoreAppVersionsFilePath)')" Text="Failed to get path to Microsoft.NETCore.app.versions.txt file" />
+
+    <Copy SourceFiles="$(NETCoreAppVersionsFilePath)" DestinationFolder="$(_MetaPackageDestinationFolder)" Condition="Exists('$(NETCoreAppVersionsFilePath)')" />
+  </Target>
+
 </Project>

--- a/src/SharedFrameworkValidation/SharedFrameworkValidation.proj
+++ b/src/SharedFrameworkValidation/SharedFrameworkValidation.proj
@@ -56,6 +56,41 @@
              ContinueOnError="ErrorAndStop" />
   </Target>
 
+  <UsingTask TaskName="GetNetCoreAppVersionsFromFile" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
+
+  <Target Name="GetRepoVersionHashes">
+    <GetNetCoreAppVersionsFromFile 
+              PathToVersionsFile="$(PackagesDir)Microsoft.NETCore.App/$(MicrosoftNETCoreAppPackageVersion)/Microsoft.NETCore.App.versions.txt">
+      <Output TaskParameter="VersionHashes" ItemName="VersionHashes" /> 
+    </GetNetCoreAppVersionsFromFile>
+
+    <PropertyGroup>
+      <CoreFxHash Condition="'%(VersionHashes.Identity)' == 'corefx'">%(VersionHashes.VersionHash)</CoreFxHash>
+      <CoreFxCopyLocation>$(BinDir)corefxCopy</CoreFxCopyLocation>
+      <_RepoURL>https://github.com/dotnet/corefx.git</_RepoURL>
+    </PropertyGroup>
+
+    <!-- Windows script -->
+    <ItemGroup>
+      <_CloneRepoLines Include="REM @echo off" />
+      <_CloneRepoLines Include="pushd $(CoreFxCopyLocation.Replace('/', '\'))" />
+      <_CloneRepoLines Include="git clone $(_RepoURL)" />
+      <_CloneRepoLines Include="cd corefx" />
+      <_CloneRepoLines Include="git reset --hard $(CoreFxHash)" />
+      <_CloneRepoLines Include="call sync.cmd" />
+      <_CloneRepoLines Include="call build-tests.cmd -- /p:RefPath=$(BinDir)ref\SharedFrameworkValidation /p:RunningSharedFrameworkValidation=true /p:RuntimePath=$(BinDir)runtime\SharedFrameworkValidation\" />
+      <_CloneRepoLines Include="popd" />
+    </ItemGroup>
+
+    <MakeDir Directories="$(BinDir);$(CoreFxCopyLocation)" />
+
+    <WriteLinesToFile
+      File="$(BinDir)CloneAndRunTests.cmd"
+      Lines="@(_CloneRepoLines)"
+      Overwrite="true"
+      Encoding="Ascii" />
+  </Target>
+
   <PropertyGroup>
     <BuildDependsOn>
       RestorePackagesProject;
@@ -64,12 +99,13 @@
       CopyXunitAssemblies;
       ReplaceTestingSharedFrameworkWithRestoredPackages;
       GenerateTestSharedFrameworkDepsFile;
+      GetRepoVersionHashes;
     </BuildDependsOn>
   </PropertyGroup>
 
   <Target Name="Build" DependsOnTargets="$(BuildDependsOn)" />
   <Target Name="Clean">
-    <RemoveDir Directories="$(MSBuildThisFileDirectory)RestoreSDKProject\obj;$(MSBuildThisFileDirectory)RestoreSDKProject\bin;$(SharedFrameworkValidationRefPath);$(SharedFrameworkValidationRuntimePath)" />
+    <RemoveDir Directories="$(MSBuildThisFileDirectory)RestoreSDKProject\obj;$(MSBuildThisFileDirectory)RestoreSDKProject\bin;$(SharedFrameworkValidationRefPath);$(SharedFrameworkValidationRuntimePath);$(CoreFxCopyLocation)" />
   </Target>
   <Target Name="Rebuild" DependsOnTargets="Clean;Build" />
 

--- a/src/SharedFrameworkValidation/SharedFrameworkValidation.proj
+++ b/src/SharedFrameworkValidation/SharedFrameworkValidation.proj
@@ -72,13 +72,13 @@
 
     <!-- Windows script -->
     <ItemGroup>
-      <_CloneRepoLines Include="REM @echo off" />
+      <_CloneRepoLines Include="@echo off" />
       <_CloneRepoLines Include="pushd $(CoreFxCopyLocation.Replace('/', '\'))" />
       <_CloneRepoLines Include="git clone $(_RepoURL)" />
       <_CloneRepoLines Include="cd corefx" />
       <_CloneRepoLines Include="git reset --hard $(CoreFxHash)" />
       <_CloneRepoLines Include="call sync.cmd" />
-      <_CloneRepoLines Include="call build-tests.cmd -- /p:RefPath=$(BinDir)ref\SharedFrameworkValidation /p:RunningSharedFrameworkValidation=true /p:RuntimePath=$(BinDir)runtime\SharedFrameworkValidation\" />
+      <_CloneRepoLines Include="call build-tests.cmd -- /p:RefPath=$(BinDir)ref\SharedFrameworkValidation /p:RunningSharedFrameworkValidation=true /p:RuntimePath=$(BinDir)runtime\SharedFrameworkValidation\ /p:TestHostRootPath=$(TestHostRootPath)" />
       <_CloneRepoLines Include="popd" />
     </ItemGroup>
 


### PR DESCRIPTION
cc: @weshaggard @ericstj

UPDATE: I have pushed more things into this PR. Basically, with the changes here we are getting the hash of the shared framework we are testing against, and cloning it into the `bin\corefxCopy` directory. After that, we are building and running the tests using the shared framework.

Note that as of now, some of the test projects are failing to build because we are now building them against the shared framework instead of netstandard.dll, but I will create separate PRs that will address them and drive our tests into a 100% success in build and pass rate.