### PR TITLE
Change DefaultResolver in XmlReaderSettings to XmlUrlResolver

### DIFF
--- a/src/System.Private.Xml/src/System/Xml/Core/XmlReaderSettings.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlReaderSettings.cs
@@ -569,7 +569,7 @@ namespace System.Xml
 
         private static XmlResolver CreateDefaultResolver()
         {
-            return new XmlSystemPathResolver();
+            return new XmlUrlResolver();
         }
 
         internal XmlReader AddValidation(XmlReader reader)

--- a/src/System.Private.Xml/tests/XmlReader/TestFiles/ResolveDTD_1.xml
+++ b/src/System.Private.Xml/tests/XmlReader/TestFiles/ResolveDTD_1.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" standalone="no" ?>
+<!DOCTYPE doc [
+<!ENTITY otherFile SYSTEM "ResolveDTD_2.xml">
+]>
+<doc>
+  <foo>
+    <bar>&otherFile;</bar>
+  </foo>
+</doc>

--- a/src/System.Private.Xml/tests/XmlReader/TestFiles/ResolveDTD_2.xml
+++ b/src/System.Private.Xml/tests/XmlReader/TestFiles/ResolveDTD_2.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" standalone="no" ?>
+<doc>
+  <foo>
+    <bar><baz>this is my content</baz></bar>
+  </foo>
+</doc>

--- a/src/System.Private.Xml/tests/XmlReader/Tests/AsyncReaderLateInitTests.cs
+++ b/src/System.Private.Xml/tests/XmlReader/Tests/AsyncReaderLateInitTests.cs
@@ -68,23 +68,45 @@ namespace System.Xml.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap |  //[ActiveIssue(13121)]  // Path cannot be resolved in UWP
-        TargetFrameworkMonikers.NetFramework)]    // Full framework uses XmlUrlResolver instead of SystemPathResolver (which doesn't allow access to this path)
+        TargetFrameworkMonikers.NetFramework)]  //[ActiveIssue(19806)] // Full framework uses WebRequest instead of HttpRequest
         public static void ReadAsyncAfterInitializationWithUriThrows()
         {
             using (XmlReader reader = XmlReader.Create("http://test.test/test.html", new XmlReaderSettings() { Async = true }))
             {
-                Assert.Throws<XmlException>(() => reader.ReadAsync().GetAwaiter().GetResult());
+                Assert.Throws<System.Net.Http.HttpRequestException>(() => reader.ReadAsync().GetAwaiter().GetResult());
+            }
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)] // Full framework uses WebRequest instead of HttpRequest
+        public static void ReadAsyncAfterInitializationWithUriThrows_FullFramework()
+        {
+            using (XmlReader reader = XmlReader.Create("http://test.test/test.html", new XmlReaderSettings() { Async = true }))
+            {
+                Assert.Throws<System.Net.WebException>(() => reader.ReadAsync().GetAwaiter().GetResult());
             }
         }
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap |  //[ActiveIssue(13121)]  // Path cannot be resolved in UWP
-        TargetFrameworkMonikers.NetFramework)]    // Full framework uses XmlUrlResolver instead of SystemPathResolver (which doesn't allow access to this path)
+        TargetFrameworkMonikers.NetFramework)]  //[ActiveIssue(19806)] // Full framework uses WebRequest instead of HttpRequest
         public static void ReadAfterInitializationWithUriOnAsyncReaderTrows()
         {
             using (XmlReader reader = XmlReader.Create("http://test.test/test.html", new XmlReaderSettings() { Async = true }))
             {
-                Assert.Throws<XmlException>(() => reader.Read());
+                AggregateException ae = Assert.Throws<System.AggregateException>(() => reader.Read());
+                Assert.Equal(typeof(System.Net.Http.HttpRequestException), ae.InnerException.GetType());
+            }
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)] // Full framework uses WebRequest instead of HttpRequest
+        public static void ReadAfterInitializationWithUriOnAsyncReaderTrows_FullFramework()
+        {
+            using (XmlReader reader = XmlReader.Create("http://test.test/test.html", new XmlReaderSettings() { Async = true }))
+            {
+                AggregateException ae = Assert.Throws<System.AggregateException>(() => reader.Read());
+                Assert.Equal(typeof(System.Net.WebException), ae.InnerException.GetType());
             }
         }
     }

--- a/src/System.Private.Xml/tests/XmlReader/XmlResolver/System.Xml.RW.XmlSystemPathResolver.Tests.csproj
+++ b/src/System.Private.Xml/tests/XmlReader/XmlResolver/System.Xml.RW.XmlSystemPathResolver.Tests.csproj
@@ -11,6 +11,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="XmlSystemPathResolverTests.cs" />
+    <SupplementalTestData Include="..\TestFiles\**\*.*">
+      <Link>TestFiles\%(RecursiveDir)%(Filename)%(Extension)</Link>
+      <DestinationDir>TestFiles\%(RecursiveDir)</DestinationDir>
+    </SupplementalTestData>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Private.Xml/tests/XmlReader/XmlResolver/XmlSystemPathResolverTests.cs
+++ b/src/System.Private.Xml/tests/XmlReader/XmlResolver/XmlSystemPathResolverTests.cs
@@ -87,10 +87,34 @@ namespace System.Xml.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap |    //[ActiveIssue(13121)]  // Access to path is denied in UWP
-        TargetFrameworkMonikers.NetFramework)]    // Full framework uses XmlUrlResolver instead of SystemPathResolver (which doesn't allow access to this path)
+        TargetFrameworkMonikers.NetFramework)]    // Full framework uses WebRequest instead of HttpRequest
         public static void TestResolveInvalidPath()
         {
-            AssertInvalidPath("ftp://www.bing.com");
+            Assert.Throws<System.ArgumentException>(() => XmlReader.Create("ftp://www.bing.com")); // Only 'http' and 'https' schemes are allowed.
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)] // Full framework uses WebRequest instead of HttpRequest
+        public static void TestResolveInvalidPath_FullFramework()
+        {
+            Assert.Throws<System.Net.WebException>(() => XmlReader.Create("ftp://www.bing.com"));
+        }
+
+        [Fact]
+        public static void TestResolveDTD_Default()
+        {
+            XmlReaderSettings settings = new XmlReaderSettings();
+            XmlReader reader = XmlReader.Create("TestFiles/ResolveDTD_1.xml", settings);
+            Assert.Throws<XmlException>(() => reader.ReadToDescendant("baz")); // For security reasons DTD is prohibited in this XML document.
+        }
+
+        [Fact]
+        public static void TestResolveDTD_AllowDTDProcessing()
+        {
+            XmlReaderSettings settings = new XmlReaderSettings();
+            settings.DtdProcessing = DtdProcessing.Parse;
+            XmlReader reader = XmlReader.Create("TestFiles/ResolveDTD_1.xml", settings);
+            reader.ReadToDescendant("baz");
         }
     }
 }

--- a/src/System.Private.Xml/tests/XmlReader/XmlResolver/XmlSystemPathResolverTests.cs
+++ b/src/System.Private.Xml/tests/XmlReader/XmlResolver/XmlSystemPathResolverTests.cs
@@ -87,7 +87,7 @@ namespace System.Xml.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap |    //[ActiveIssue(13121)]  // Access to path is denied in UWP
-        TargetFrameworkMonikers.NetFramework)]    // Full framework uses WebRequest instead of HttpRequest
+        TargetFrameworkMonikers.NetFramework)]    //[ActiveIssue(19806)] // Full framework uses WebRequest instead of HttpRequest
         public static void TestResolveInvalidPath()
         {
             Assert.Throws<System.ArgumentException>(() => XmlReader.Create("ftp://www.bing.com")); // Only 'http' and 'https' schemes are allowed.


### PR DESCRIPTION
Addresses a behavior difference between Core and Desktop. On Desktop, default resolver for XmlReaderSettings is `XmlUrlResolver`, whereas in Core it is `SystemPathResolver`.
This difference makes Core not allow string uri to be resolved in `XmlReader.Create` method, while Desktop does.

cc: @danmosemsft @krwq @tarekgh 