### PR TITLE
Fix the Build of XmlSerializer Tests on UWP

### DIFF
--- a/src/System.Private.Xml/src/Resources/System.Private.Xml.rd.xml
+++ b/src/System.Private.Xml/src/Resources/System.Private.Xml.rd.xml
@@ -12,8 +12,13 @@
             <TypeParameter Name="type" XmlSerializer="Public"/>
             <TypeEnumerableParameter Name="extraTypes" XmlSerializer="Public"/>
           </Method>
+          <Property Name="Mode" Dynamic="Required" />
         </Type>
       </Namespace>
     </Assembly>
+    <Namespace Name="System.Collections">
+      <Type Name="IEnumerable" Dynamic="Required All" />
+      <Type Name="IEnumerator" Dynamic="Required All" />
+    </Namespace>
   </Library>
 </Directives>

--- a/src/System.Private.Xml/src/System.Private.Xml.csproj
+++ b/src/System.Private.Xml/src/System.Private.Xml.csproj
@@ -8,6 +8,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>$(NoWarn),649</NoWarn>
     <DefineConstants Condition="'$(TargetGroup)' == 'uapaot'">$(DefineConstants);uapaot</DefineConstants>
+    <!-- We do not want to block reflection for this assembly -->
+    <BlockReflectionAttribute Condition="'$(TargetGroup)'=='uapaot'">false</BlockReflectionAttribute>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />

--- a/src/System.Private.Xml/src/System.Private.Xml.csproj
+++ b/src/System.Private.Xml/src/System.Private.Xml.csproj
@@ -8,8 +8,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>$(NoWarn),649</NoWarn>
     <DefineConstants Condition="'$(TargetGroup)' == 'uapaot'">$(DefineConstants);uapaot</DefineConstants>
-    <!-- We do not want to block reflection for this assembly -->
-    <BlockReflectionAttribute Condition="'$(TargetGroup)'=='uapaot'">false</BlockReflectionAttribute>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
@@ -121,14 +121,22 @@ namespace System.Xml.Serialization
     /// </devdoc>
     public class XmlSerializer
     {
+#if uapaot
+        public enum SerializationMode
+#else
         internal enum SerializationMode
+#endif
         {
             CodeGenOnly,
             ReflectionOnly,
             ReflectionAsBackup
         }
 
+#if uapaot
+        public static SerializationMode Mode { get; set; } = SerializationMode.ReflectionAsBackup;
+#else
         internal static SerializationMode Mode { get; set; } = SerializationMode.ReflectionAsBackup;
+#endif
 
         private static bool ReflectionMethodEnabled
         {

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
@@ -446,19 +446,7 @@ namespace System.Xml.Serialization
 #if !uapaot
                 else if (ShouldUseReflectionBasedSerialization(_mapping))
                 {
-                    XmlMapping mapping;
-                    if (_mapping != null && _mapping.GenerateSerializer)
-                    {
-                        mapping = _mapping;
-                    }
-                    else
-                    {
-                        XmlReflectionImporter importer = new XmlReflectionImporter(DefaultNamespace);
-                        mapping = importer.ImportTypeMapping(_rootType, null, DefaultNamespace);
-                    }
-
-                    var writer = new ReflectionXmlSerializationWriter(mapping, xmlWriter, namespaces == null || namespaces.Count == 0 ? DefaultNamespaces : namespaces, encodingStyle, id);
-                    writer.WriteObject(o);
+                    SerializeUsingReflection(xmlWriter, o, namespaces, encodingStyle, id);
                 }
                 else if (_tempAssembly == null || _typedSerializer)
                 {
@@ -479,7 +467,11 @@ namespace System.Xml.Serialization
 #else
                 else
                 {
-                    if (this.innerSerializer != null)
+                    if (ShouldUseReflectionBasedSerialization(_mapping))
+                    {
+                        SerializeUsingReflection(xmlWriter, o, namespaces, encodingStyle, id);
+                    }
+                    else if (this.innerSerializer != null)
                     {
                         if (!string.IsNullOrEmpty(this.DefaultNamespace))
                         {
@@ -499,19 +491,7 @@ namespace System.Xml.Serialization
                     }
                     else if (ReflectionMethodEnabled)
                     {
-                        XmlMapping mapping;
-                        if (_mapping != null && _mapping.GenerateSerializer)
-                        {
-                            mapping = _mapping;
-                        }
-                        else
-                        {
-                            XmlReflectionImporter importer = new XmlReflectionImporter(DefaultNamespace);
-                            mapping = importer.ImportTypeMapping(_rootType, null, DefaultNamespace);
-                        }
-
-                        var writer = new ReflectionXmlSerializationWriter(mapping, xmlWriter, namespaces == null || namespaces.Count == 0 ? DefaultNamespaces : namespaces, encodingStyle, id);
-                        writer.WriteObject(o);
+                        SerializeUsingReflection(xmlWriter, o, namespaces, encodingStyle, id);
                     }
                     else
                     {
@@ -527,6 +507,23 @@ namespace System.Xml.Serialization
                 throw new InvalidOperationException(SR.XmlGenError, e);
             }
             xmlWriter.Flush();
+        }
+
+        private void SerializeUsingReflection(XmlWriter xmlWriter, object o, XmlSerializerNamespaces namespaces, string encodingStyle, string id)
+        {
+            XmlMapping mapping;
+            if (_mapping != null && _mapping.GenerateSerializer)
+            {
+                mapping = _mapping;
+            }
+            else
+            {
+                XmlReflectionImporter importer = new XmlReflectionImporter(DefaultNamespace);
+                mapping = importer.ImportTypeMapping(_rootType, null, DefaultNamespace);
+            }
+
+            var writer = new ReflectionXmlSerializationWriter(mapping, xmlWriter, namespaces == null || namespaces.Count == 0 ? DefaultNamespaces : namespaces, encodingStyle, id);
+            writer.WriteObject(o);
         }
 
         /// <include file='doc\XmlSerializer.uex' path='docs/doc[@for="XmlSerializer.Deserialize"]/*' />
@@ -593,19 +590,7 @@ namespace System.Xml.Serialization
 #if !uapaot
                 else if (ShouldUseReflectionBasedSerialization(_mapping))
                 {
-                    XmlMapping mapping;
-                    if (_mapping != null && _mapping.GenerateSerializer)
-                    {
-                        mapping = _mapping;
-                    }
-                    else
-                    {
-                        XmlReflectionImporter importer = new XmlReflectionImporter(DefaultNamespace);
-                        mapping = importer.ImportTypeMapping(_rootType, null, DefaultNamespace);
-                    }
-
-                    var reader = new ReflectionXmlSerializationReader(mapping, xmlReader, events, encodingStyle);
-                    return reader.ReadObject();
+                    return DeserializeUsingReflection(xmlReader, encodingStyle, events);
                 }
                 else if (_tempAssembly == null || _typedSerializer)
                 {
@@ -627,7 +612,11 @@ namespace System.Xml.Serialization
 #else
                 else
                 {
-                    if (this.innerSerializer != null)
+                    if (ShouldUseReflectionBasedSerialization(_mapping))
+                    {
+                        return DeserializeUsingReflection(xmlReader, encodingStyle, events);
+                    }
+                    else if (this.innerSerializer != null)
                     {
                         if (!string.IsNullOrEmpty(this.DefaultNamespace))
                         {
@@ -647,19 +636,7 @@ namespace System.Xml.Serialization
                     }
                     else if (ReflectionMethodEnabled)
                     {
-                        XmlMapping mapping;
-                        if (_mapping != null && _mapping.GenerateSerializer)
-                        {
-                            mapping = _mapping;
-                        }
-                        else
-                        {
-                            XmlReflectionImporter importer = new XmlReflectionImporter(DefaultNamespace);
-                            mapping = importer.ImportTypeMapping(_rootType, null, DefaultNamespace);
-                        }
-
-                        var reader = new ReflectionXmlSerializationReader(mapping, xmlReader, events, encodingStyle);
-                        return reader.ReadObject();
+                        return DeserializeUsingReflection(xmlReader, encodingStyle, events);
                     }
                     else
                     {
@@ -684,6 +661,23 @@ namespace System.Xml.Serialization
                     throw new InvalidOperationException(SR.XmlSerializeError, e);
                 }
             }
+        }
+
+        private object DeserializeUsingReflection(XmlReader xmlReader, string encodingStyle, XmlDeserializationEvents events)
+        {
+            XmlMapping mapping;
+            if (_mapping != null && _mapping.GenerateSerializer)
+            {
+                mapping = _mapping;
+            }
+            else
+            {
+                XmlReflectionImporter importer = new XmlReflectionImporter(DefaultNamespace);
+                mapping = importer.ImportTypeMapping(_rootType, null, DefaultNamespace);
+            }
+
+            var reader = new ReflectionXmlSerializationReader(mapping, xmlReader, events, encodingStyle);
+            return reader.ReadObject();
         }
 #endif
 

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
@@ -451,11 +451,11 @@ namespace System.Xml.Serialization
                     }
                     SerializePrimitive(xmlWriter, o, namespaces);
                 }
-#if !uapaot
                 else if (ShouldUseReflectionBasedSerialization(_mapping))
                 {
                     SerializeUsingReflection(xmlWriter, o, namespaces, encodingStyle, id);
                 }
+#if !uapaot
                 else if (_tempAssembly == null || _typedSerializer)
                 {
                     // The contion for the block is never true, thus the block is never hit.
@@ -475,11 +475,7 @@ namespace System.Xml.Serialization
 #else
                 else
                 {
-                    if (ShouldUseReflectionBasedSerialization(_mapping))
-                    {
-                        SerializeUsingReflection(xmlWriter, o, namespaces, encodingStyle, id);
-                    }
-                    else if (this.innerSerializer != null)
+                    if (this.innerSerializer != null)
                     {
                         if (!string.IsNullOrEmpty(this.DefaultNamespace))
                         {
@@ -595,11 +591,11 @@ namespace System.Xml.Serialization
                     }
                     return DeserializePrimitive(xmlReader, events);
                 }
-#if !uapaot
                 else if (ShouldUseReflectionBasedSerialization(_mapping))
                 {
                     return DeserializeUsingReflection(xmlReader, encodingStyle, events);
                 }
+#if !uapaot
                 else if (_tempAssembly == null || _typedSerializer)
                 {
                     XmlSerializationReader reader = CreateReader();
@@ -620,11 +616,7 @@ namespace System.Xml.Serialization
 #else
                 else
                 {
-                    if (ShouldUseReflectionBasedSerialization(_mapping))
-                    {
-                        return DeserializeUsingReflection(xmlReader, encodingStyle, events);
-                    }
-                    else if (this.innerSerializer != null)
+                    if (this.innerSerializer != null)
                     {
                         if (!string.IsNullOrEmpty(this.DefaultNamespace))
                         {

--- a/src/System.Private.Xml/tests/XmlSerializer/Configurations.props
+++ b/src/System.Private.Xml/tests/XmlSerializer/Configurations.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       netstandard;
+      uapaot;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Private.Xml/tests/XmlSerializer/ReflectionOnly/Configurations.props
+++ b/src/System.Private.Xml/tests/XmlSerializer/ReflectionOnly/Configurations.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       netstandard;
+      uapaot;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Private.Xml/tests/XmlSerializer/ReflectionOnly/System.Xml.XmlSerializer.ReflectionOnly.Tests.csproj
+++ b/src/System.Private.Xml/tests/XmlSerializer/ReflectionOnly/System.Xml.XmlSerializer.ReflectionOnly.Tests.csproj
@@ -4,9 +4,12 @@
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);ReflectionOnly</DefineConstants>
     <ProjectGuid>{4050F1D1-1DD2-4B48-A17B-E3F955518C4B}</ProjectGuid>
+    <DefineConstants Condition="'$(TargetGroup)' == 'uapaot'">$(DefineConstants);uapaot</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="$(TestSourceFolder)..\..\..\..\System.Runtime.Serialization.Xml\tests\Utils.cs" />
     <Compile Include="$(TestSourceFolder)..\..\..\..\System.Runtime.Serialization.Xml\tests\SerializationTypes.cs" />
@@ -16,9 +19,6 @@
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
       <Link>CommonTest\System\PlatformDetection.cs</Link>
     </Compile>
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' != 'uap'">
-    <Compile Include="$(TestSourceFolder)..\XmlSerializerTests.Internal.cs" Condition="'$(UseContractReferences)' == ''" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Private.Xml/tests/XmlSerializer/System.Xml.XmlSerializer.Tests.csproj
+++ b/src/System.Private.Xml/tests/XmlSerializer/System.Xml.XmlSerializer.Tests.csproj
@@ -4,9 +4,12 @@
   <PropertyGroup>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <ProjectGuid>{4050F1D1-1DD2-4B48-A17B-E3F90DD18C4B}</ProjectGuid>
+    <DefineConstants Condition="'$(TargetGroup)' == 'uapaot'">$(DefineConstants);uapaot</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="$(TestSourceFolder)..\..\..\System.Runtime.Serialization.Xml\tests\Utils.cs" />
     <Compile Include="$(TestSourceFolder)..\..\..\System.Runtime.Serialization.Xml\tests\SerializationTypes.cs" />
@@ -14,9 +17,6 @@
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
       <Link>CommonTest\System\PlatformDetection.cs</Link>
     </Compile>
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' != 'uap'">
-    <Compile Include="$(TestSourceFolder)XmlSerializerTests.Internal.cs" Condition="'$(UseContractReferences)' == ''" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -3285,6 +3285,7 @@ string.Format(@"<?xml version=""1.0"" encoding=""utf-8""?>
         Assert.Equal(value.value, ((DerivedClass)actual).value);
     }
 
+#if !uapaot
     [Fact]
     public static void Xml_DefaultValueAttributeSetToNaNTest()
     {
@@ -3300,6 +3301,7 @@ string.Format(@"<?xml version=""1.0"" encoding=""utf-8""?>
         Assert.NotNull(actual);
         Assert.Equal(value, actual);
     }
+#endif
 
     [Fact]
     public static void Xml_NullRefInXmlSerializerCtorTest()

--- a/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -25,7 +25,7 @@ public static partial class XmlSerializerTests
     {
         if (!PlatformDetection.IsFullFramework)
         {
-            MethodInfo method = typeof(XmlSerializer).GetMethod(SerializationModeSetterName, BindingFlags.NonPublic | BindingFlags.Static);
+            MethodInfo method = typeof(XmlSerializer).GetMethod(SerializationModeSetterName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
             Assert.True(method != null, $"No method named {SerializationModeSetterName}");
             method.Invoke(null, new object[] { 1 });
         }

--- a/src/System.Runtime.Serialization.Json/tests/Configurations.props
+++ b/src/System.Runtime.Serialization.Json/tests/Configurations.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       netstandard;
-      uap;
+      uapaot;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.Serialization.Json/tests/ReflectionOnly/Configurations.props
+++ b/src/System.Runtime.Serialization.Json/tests/ReflectionOnly/Configurations.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       netstandard;
-      uap;
+      uapaot;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.Serialization.Json/tests/ReflectionOnly/System.Runtime.Serialization.Json.ReflectionOnly.Tests.csproj
+++ b/src/System.Runtime.Serialization.Json/tests/ReflectionOnly/System.Runtime.Serialization.Json.ReflectionOnly.Tests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="$(TestSourceFolder)..\..\..\System.Runtime.Serialization.Xml\tests\Utils.cs" />
     <Compile Include="$(TestSourceFolder)..\..\..\System.Runtime.Serialization.Xml\tests\SerializationTypes.cs" />
@@ -17,7 +17,7 @@
       <Link>CommonTest\System\PlatformDetection.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' != 'uap'">
+  <ItemGroup Condition="'$(TargetGroup)' != 'uapaot'">
     <Compile Include="$(TestSourceFolder)..\DataContractJsonSerializer.CoreCLR.cs" />
     <Compile Include="$(TestSourceFolder)..\..\..\System.Runtime.Serialization.Xml\tests\SerializationTypes.CoreCLR.cs" />
   </ItemGroup>

--- a/src/System.Runtime.Serialization.Json/tests/System.Runtime.Serialization.Json.Tests.csproj
+++ b/src/System.Runtime.Serialization.Json/tests/System.Runtime.Serialization.Json.Tests.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)' != 'uap'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Release|AnyCPU'" />
+  <ItemGroup Condition="'$(TargetGroup)' != 'uapaot'">
     <Compile Include="$(TestSourceFolder)DataContractJsonSerializer.CoreCLR.cs" />
     <Compile Include="$(TestSourceFolder)..\..\System.Runtime.Serialization.Xml\tests\SerializationTypes.CoreCLR.cs" />
   </ItemGroup>

--- a/src/System.Runtime.Serialization.Xml/tests/Configurations.props
+++ b/src/System.Runtime.Serialization.Xml/tests/Configurations.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       netstandard;
-      uap;
+      uapaot;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -1685,7 +1685,7 @@ public static partial class DataContractSerializerTests
         Assert.StrictEqual<TypeWithCommonTypeProperties>(value, deserializedValue);
     }
 
-#if uapaot
+#if !uapaot
     [Fact]
     public static void DCS_TypeWithTypeProperty()
     {

--- a/src/System.Runtime.Serialization.Xml/tests/ReflectionOnly/Configurations.props
+++ b/src/System.Runtime.Serialization.Xml/tests/ReflectionOnly/Configurations.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       netstandard;
-      uap;
+      uapaot;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.Serialization.Xml/tests/ReflectionOnly/System.Runtime.Serialization.Xml.ReflectionOnly.Tests.csproj
+++ b/src/System.Runtime.Serialization.Xml/tests/ReflectionOnly/System.Runtime.Serialization.Xml.ReflectionOnly.Tests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="$(TestSourceFolder)..\DataContractSerializerStressTests.cs" />
     <Compile Include="$(TestSourceFolder)..\Utils.cs" />
@@ -33,7 +33,7 @@
       <Link>SerializationTestTypes\ObjRefSample.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' != 'uap'">
+  <ItemGroup Condition="'$(TargetGroup)' != 'uapaot'">
     <Compile Include="$(TestSourceFolder)..\SerializationTypes.CoreCLR.cs" />
     <Compile Include="$(TestSourceFolder)..\DataContractSerializer.CoreCLR.cs" />
   </ItemGroup>

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -1903,14 +1903,12 @@ namespace SerializationTypes
         public ICollection<int> Member1;
     }
 
-#if uapaot
     public class TypeWithTypeProperty
     {
         public int Id { get; set; }
         public Type Type { get; set; }
         public string Name { get; set; }
     }
-#endif
 
     [DataContract(Namespace = "SerializationTypes.GenericTypeWithPrivateSetter")]
     public class GenericTypeWithPrivateSetter<T>

--- a/src/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.csproj
+++ b/src/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="$(TestSourceFolder)DataContractSerializerStressTests.cs" />
     <Compile Include="$(TestSourceFolder)Utils.cs" />
@@ -30,7 +30,7 @@
     </Compile>
     <Compile Include="$(TestSourceFolder)SerializationTestTypes\ObjRefSample.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' != 'uap'">
+  <ItemGroup Condition="'$(TargetGroup)' != 'uapaot'">
     <Compile Include="$(TestSourceFolder)SerializationTypes.CoreCLR.cs" />
     <Compile Include="$(TestSourceFolder)DataContractSerializer.CoreCLR.cs" />
   </ItemGroup>


### PR DESCRIPTION
The PR addressed the following issues,
1. Fixed the build of XmlSerializer tests on UWP.
2. Fixed a bug that caused pre-generated XmlSerializers being used in reflection only mode.
3. Fixed the incorrect usage of uap/uapaot in Configrations.props across all serialization test projects.

Fix #19804.