### PR TITLE
Replace MANAGED_SNI flag in SQL tests with a reflection-based check of UseManagedSNI

### DIFF
--- a/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
@@ -25,6 +25,7 @@
     <Compile Include="TcpDefaultForAzureTest.cs" />
     <Compile Include="SqlConnectionTest.cs" />
     <Compile Include="TestTdsServer.cs" />
+    <Compile Include="..\ManualTests\DataCommon\DataTestUtility.cs" />
     <Compile Include="$(CommonTestPath)\System\AssertExtensions.cs">
       <Link>Common\System\AssertExtensions.cs</Link>
     </Compile>

--- a/src/System.Data.SqlClient/tests/FunctionalTests/TcpDefaultForAzureTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/TcpDefaultForAzureTest.cs
@@ -36,7 +36,14 @@ namespace System.Data.SqlClient.Tests
         public static void NonAzureNoProtocolConnectionTest()
         {
             builder.DataSource = InvalidHostname;
-            CheckConnectionFailure(builder.ConnectionString, null); // Managed and Native SNI have different default protocols for plain server names
+            if(ManualTesting.Tests.DataTestUtility.IsUsingManagedSNI())
+            {
+                CheckConnectionFailure(builder.ConnectionString, TCP);
+            }
+            else
+            {
+                CheckConnectionFailure(builder.ConnectionString, NP);
+            }
         }
 
         [Fact]

--- a/src/System.Data.SqlClient/tests/FunctionalTests/TcpDefaultForAzureTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/TcpDefaultForAzureTest.cs
@@ -36,14 +36,7 @@ namespace System.Data.SqlClient.Tests
         public static void NonAzureNoProtocolConnectionTest()
         {
             builder.DataSource = InvalidHostname;
-            if(ManualTesting.Tests.DataTestUtility.IsUsingManagedSNI())
-            {
-                CheckConnectionFailure(builder.ConnectionString, TCP);
-            }
-            else
-            {
-                CheckConnectionFailure(builder.ConnectionString, NP);
-            }
+            CheckConnectionFailure(builder.ConnectionString, ManualTesting.Tests.DataTestUtility.IsUsingManagedSNI() ? TCP : NP);
         }
 
         [Fact]

--- a/src/System.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -13,9 +13,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
     {
         public static readonly string NpConnStr = null;
         public static readonly string TcpConnStr = null;
-        private static Assembly s_systemDotData = typeof(System.Data.SqlClient.SqlConnection).GetTypeInfo().Assembly;
-        private static Type s_tdsParserStateObjectFactory = s_systemDotData.GetType("System.Data.SqlClient.TdsParserStateObjectFactory");
-        private static PropertyInfo s_useManagedSNI = s_tdsParserStateObjectFactory.GetProperty("UseManagedSNI", BindingFlags.Static | BindingFlags.Public);
+        private static readonly Assembly s_systemDotData = typeof(System.Data.SqlClient.SqlConnection).GetTypeInfo().Assembly;
+        private static readonly Type s_tdsParserStateObjectFactory = s_systemDotData.GetType("System.Data.SqlClient.TdsParserStateObjectFactory");
+        private static readonly PropertyInfo s_useManagedSNI = s_tdsParserStateObjectFactory.GetProperty("UseManagedSNI", BindingFlags.Static | BindingFlags.Public);
 
         static DataTestUtility()
         {

--- a/src/System.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Globalization;
+using System.Reflection;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -12,22 +13,22 @@ namespace System.Data.SqlClient.ManualTesting.Tests
     {
         public static readonly string NpConnStr = null;
         public static readonly string TcpConnStr = null;
+        private static Assembly s_systemDotData = typeof(System.Data.SqlClient.SqlConnection).GetTypeInfo().Assembly;
+        private static Type s_tdsParserStateObjectFactory = s_systemDotData.GetType("System.Data.SqlClient.TdsParserStateObjectFactory");
+        private static PropertyInfo s_useManagedSNI = s_tdsParserStateObjectFactory.GetProperty("UseManagedSNI", BindingFlags.Static | BindingFlags.Public);
 
         static DataTestUtility()
         {
             NpConnStr = Environment.GetEnvironmentVariable("TEST_NP_CONN_STR");
             TcpConnStr = Environment.GetEnvironmentVariable("TEST_TCP_CONN_STR");
-
-            if (!AreConnStringsSetup())
-            {
-                Console.WriteLine("INFO: Test connection strings not defined! Tests cannot be run. Refer README.md of Manual tests for more information. ");
-            }
         }
 
         public static bool AreConnStringsSetup()
         {
             return !string.IsNullOrEmpty(NpConnStr) && !string.IsNullOrEmpty(TcpConnStr);
         }
+
+        public static bool IsUsingManagedSNI() => (bool)s_useManagedSNI.GetValue(null);
 
         // the name length will be no more then (16 + prefix.Length + escapeLeft.Length + escapeRight.Length)
         // some providers does not support names (Oracle supports up to 30)

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/ConnectionPoolTest/ConnectionPoolTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/ConnectionPoolTest/ConnectionPoolTest.cs
@@ -30,10 +30,12 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         {
             BasicConnectionPoolingTest(tcpConnectionString);
             ClearAllPoolsTest(tcpConnectionString);
-#if MANAGED_SNI && DEBUG
-            KillConnectionTest(tcpConnectionString);
-#endif
             ReclaimEmancipatedOnOpenTest(tcpConnectionString);
+
+            if (DataTestUtility.IsUsingManagedSNI())
+            {
+                KillConnectionTest(tcpConnectionString);
+            }
         }
 
         /// <summary>
@@ -69,13 +71,13 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             connection4.Close();
         }
 
-#if MANAGED_SNI && DEBUG
         /// <summary>
         /// Tests if killing the connection using the InternalConnectionWrapper is working
         /// </summary>
         /// <param name="connectionString"></param>
         private static void KillConnectionTest(string connectionString)
         {
+#if DEBUG
             InternalConnectionWrapper wrapper = null;
 
             using (SqlConnection connection = new SqlConnection(connectionString))
@@ -100,8 +102,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                     DataTestUtility.AssertEqualsWithDescription(5, command.ExecuteScalar(), "Incorrect scalar result.");
                 }
             }
-        }
 #endif
+        }
 
         /// <summary>
         /// Tests if clearing all of the pools does actually remove the pools

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/LocalDBTest/LocalDBTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/LocalDBTest/LocalDBTest.cs
@@ -10,7 +10,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
     {
         private static bool IsLocalDBEnvironmentSet() => DataTestUtility.IsLocalDBInstalled();
 
-        [ConditionalFact(nameof(IsLocalDBEnvironmentSet))]
+        [ConditionalFact(nameof(IsLocalDBEnvironmentSet), Skip = "MSSQLLocalDB not setup")]
         public static void LocalDBConnectionTest()
         {
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(@"server=(localdb)\MSSQLLocalDB");
@@ -19,7 +19,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             OpenConnection(builder.ConnectionString);
         }
 
-        [ConditionalFact(nameof(IsLocalDBEnvironmentSet))]
+        [ConditionalFact(nameof(IsLocalDBEnvironmentSet), Skip = "MSSQLLocalDB not setup")]
         public static void LocalDBMarsTest()
         {
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(@"server=(localdb)\MSSQLLocalDB;");
@@ -29,7 +29,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             OpenConnection(builder.ConnectionString);
         }
 
-        [ConditionalFact(nameof(IsLocalDBEnvironmentSet))]
+        [ConditionalFact(nameof(IsLocalDBEnvironmentSet), Skip = "MSSQLLocalDB not setup")]
         public static void InvalidDBTest()
         {
             using (var connection = new SqlConnection(@"Data Source=(localdb)\MSSQLLOCALDB;Database=DOES_NOT_EXIST;Pooling=false;"))

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/LocalDBTest/LocalDBTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/LocalDBTest/LocalDBTest.cs
@@ -10,7 +10,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
     {
         private static bool IsLocalDBEnvironmentSet() => DataTestUtility.IsLocalDBInstalled();
 
-        [ConditionalFact(nameof(IsLocalDBEnvironmentSet), Skip = "MSSQLLocalDB not setup")]
+        [ConditionalFact(nameof(IsLocalDBEnvironmentSet))]
         public static void LocalDBConnectionTest()
         {
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(@"server=(localdb)\MSSQLLocalDB");
@@ -19,7 +19,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             OpenConnection(builder.ConnectionString);
         }
 
-        [ConditionalFact(nameof(IsLocalDBEnvironmentSet), Skip = "MSSQLLocalDB not setup")]
+        [ConditionalFact(nameof(IsLocalDBEnvironmentSet))]
         public static void LocalDBMarsTest()
         {
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(@"server=(localdb)\MSSQLLocalDB;");
@@ -29,7 +29,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             OpenConnection(builder.ConnectionString);
         }
 
-        [ConditionalFact(nameof(IsLocalDBEnvironmentSet), Skip = "MSSQLLocalDB not setup")]
+        [ConditionalFact(nameof(IsLocalDBEnvironmentSet))]
         public static void InvalidDBTest()
         {
             using (var connection = new SqlConnection(@"Data Source=(localdb)\MSSQLLOCALDB;Database=DOES_NOT_EXIST;Pooling=false;"))

--- a/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
@@ -6,9 +6,6 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
-  <PropertyGroup Condition=" '$(TargetsWindows)' != 'true' ">
-    <DefineConstants>$(DefineConstants);MANAGED_SNI</DefineConstants>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(CommonTestPath)\System\Collections\DictionaryExtensions.cs">
       <Link>Common\System\Collections\DictionaryExtensions.cs</Link>


### PR DESCRIPTION
Also added skip messages to LocalDBTest's ConditionalFacts

Edit: Skip message already gets printed for ConditionalFacts. Removed the LocalDBTest changes