### PR TITLE
Improve Socket scalability on Unix

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -46,7 +46,11 @@ namespace System.Net.Sockets
             }
         }
 
+#if DEBUG
         private const int EventBufferCount = 64;
+#else
+        private const int EventBufferCount = 1024;
+#endif
 
         private static readonly object s_lock = new object();
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -48,7 +48,7 @@ namespace System.Net.Sockets
 
         private const int EventBufferCount =
 #if DEBUG
-            64;
+            32;
 #else
             1024;
 #endif


### PR DESCRIPTION
- scale the number of socket engines with the number of processors

The number of socket engines is set to half of the number of available processors when there are at least 6 processors.
The lower bound is a heuristic to enable multiple socket engines only on systems that are servers.
Having too few socket engines leads to under-performing. Having too many leads to thread overhead. The performance penalty of the latter is much lower than that of the first.
A non-pipelined TechEmpower plaintext test of libuv on a 28 cpu thread machine (E5-2690 v4) shows best performance at 16 threads. 

- increase the number of events reported with a poll from 64 to 1024

1024 is the value used by libuv
nginx uses 512

CC @stephentoub @geoffkizer @davidfowl 