### PR TITLE
Adding the possibility to use resources for the property NullDisplayText in DisplayFormatAttribute

### DIFF
--- a/src/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.cs
+++ b/src/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.cs
@@ -122,6 +122,8 @@ namespace System.ComponentModel.DataAnnotations
         public string DataFormatString { get { throw null; } set { } }
         public bool HtmlEncode { get { throw null; } set { } }
         public string NullDisplayText { get { throw null; } set { } }
+        public System.Type NullDisplayTextResourceType { get { throw null; } set { } }
+        public string GetNullDisplayText() { throw null; }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(384), AllowMultiple = false, Inherited = true)]
     public sealed partial class EditableAttribute : System.Attribute

--- a/src/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.cs
+++ b/src/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.cs
@@ -122,7 +122,7 @@ namespace System.ComponentModel.DataAnnotations
         public string DataFormatString { get { throw null; } set { } }
         public bool HtmlEncode { get { throw null; } set { } }
         public string NullDisplayText { get { throw null; } set { } }
-        public System.Type NullDisplayTextResourceType { get { throw null; } set { } }
+        public Type NullDisplayTextResourceType { get { throw null; } set { } }
         public string GetNullDisplayText() { throw null; }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(384), AllowMultiple = false, Inherited = true)]

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/DisplayFormatAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/DisplayFormatAttribute.cs
@@ -14,7 +14,6 @@ namespace System.ComponentModel.DataAnnotations
     public class DisplayFormatAttribute : Attribute
     {
         private readonly LocalizableString _nullDisplayText = new LocalizableString("NullDisplayText");
-        private Type _nullDisplayTextResourceType;
 
         /// <summary>
         ///     Default constructor
@@ -53,13 +52,7 @@ namespace System.ComponentModel.DataAnnotations
         public string NullDisplayText
         {
             get { return _nullDisplayText.Value; }
-            set
-            {
-                if (_nullDisplayText.Value != value)
-                {
-                    _nullDisplayText.Value = value;
-                }
-            }
+            set { _nullDisplayText.Value = value; }
         }
 
         /// <summary>
@@ -84,15 +77,8 @@ namespace System.ComponentModel.DataAnnotations
 		/// </summary>
 		public Type NullDisplayTextResourceType
         {
-            get { return _nullDisplayTextResourceType; }
-            set
-            {
-                if (_nullDisplayTextResourceType != value)
-                {
-                    _nullDisplayTextResourceType = value;
-                    _nullDisplayText.ResourceType = value;
-                }
-            }
+            get { return _nullDisplayText.ResourceType; }
+            set { _nullDisplayText.ResourceType = value; }
         }
 
         /// <summary>

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/DisplayFormatAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/DisplayFormatAttribute.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Globalization;
-
 namespace System.ComponentModel.DataAnnotations
 {
     /// <summary>
@@ -71,7 +69,7 @@ namespace System.ComponentModel.DataAnnotations
         public bool HtmlEncode { get; set; }
 
 		/// <summary>
-		///     Gets or sets the <see cref="System.Type" /> that contains the resources for <see cref="NullDisplayText" />.
+		///     Gets or sets the <see cref="Type" /> that contains the resources for <see cref="NullDisplayText" />.
 		///     Using <see cref="NullDisplayTextResourceType" /> along with <see cref="NullDisplayText" />, allows the <see cref="GetNullDisplayText" />
 		///     method to return localized values.
 		/// </summary>
@@ -100,7 +98,7 @@ namespace System.ComponentModel.DataAnnotations
         ///         When <see cref="NullDisplayText" /> and <see cref="NullDisplayTextResourceType" /> have not been set, returns <c>null</c>.
         ///     </para>
         /// </returns>
-        /// <exception cref="System.InvalidOperationException">
+        /// <exception cref="InvalidOperationException">
         ///     After setting both the <see cref="NullDisplayTextResourceType" /> property and the <see cref="NullDisplayText" /> property,
         ///     but a public static property with a name matching the <see cref="NullDisplayText" /> value couldn't be found
         ///     on the <see cref="NullDisplayTextResourceType" />.

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/DisplayFormatAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/DisplayFormatAttribute.cs
@@ -13,8 +13,8 @@ namespace System.ComponentModel.DataAnnotations
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
     public class DisplayFormatAttribute : Attribute
     {
-        private readonly LocalizableString nullDisplayText = new LocalizableString("NulLDisplayText");
-        private Type resourceType;
+        private readonly LocalizableString _nullDisplayText = new LocalizableString("NullDisplayText");
+        private Type _nullDisplayTextResourceType;
 
         /// <summary>
         ///     Default constructor
@@ -31,11 +31,10 @@ namespace System.ComponentModel.DataAnnotations
         /// </summary>
         public string DataFormatString { get; set; }
 
-
         /// <summary>
         ///     Gets or sets the string to display when the value is null, which may be a resource key string.
         ///     <para>
-        ///         Consumers must use the <see cref="GetNullDisplayText" /> method to retrieve the UI display string.
+        ///         Consumers should use the <see cref="GetNullDisplayText" /> method to retrieve the UI display string.
         ///     </para>
         /// </summary>
         /// <remarks>
@@ -53,12 +52,12 @@ namespace System.ComponentModel.DataAnnotations
         /// </value>
         public string NullDisplayText
         {
-            get { return nullDisplayText.Value; }
+            get { return _nullDisplayText.Value; }
             set
             {
-                if (nullDisplayText.Value != value)
+                if (_nullDisplayText.Value != value)
                 {
-                    nullDisplayText.Value = value;
+                    _nullDisplayText.Value = value;
                 }
             }
         }
@@ -78,20 +77,20 @@ namespace System.ComponentModel.DataAnnotations
         /// </summary>
         public bool HtmlEncode { get; set; }
 
-        /// <summary>
-        ///     Gets or sets the <see cref="System.Type" /> that contains the resources for <see cref="NullDisplayText" />.
-        ///     Using <see cref="NullDisplayTextResourceType" /> along with this property, allows the <see cref="GetNullDisplayText" />
-        ///     method to return localized values.
-        /// </summary>
-        public Type NullDisplayTextResourceType
+		/// <summary>
+		///     Gets or sets the <see cref="System.Type" /> that contains the resources for <see cref="NullDisplayText" />.
+		///     Using <see cref="NullDisplayTextResourceType" /> along with <see cref="NullDisplayText" />, allows the <see cref="GetNullDisplayText" />
+		///     method to return localized values.
+		/// </summary>
+		public Type NullDisplayTextResourceType
         {
-            get { return resourceType; }
+            get { return _nullDisplayTextResourceType; }
             set
             {
-                if (resourceType != value)
+                if (_nullDisplayTextResourceType != value)
                 {
-                    resourceType = value;
-                    nullDisplayText.ResourceType = value;
+                    _nullDisplayTextResourceType = value;
+                    _nullDisplayText.ResourceType = value;
                 }
             }
         }
@@ -112,8 +111,7 @@ namespace System.ComponentModel.DataAnnotations
         ///         represents a resource key within that resource type, then the localized value will be returned.
         ///     </para>
         ///     <para>
-        ///         Can return <c>null</c> and will not fall back onto other values, as it's more likely for the
-        ///         consumer to want to fall back onto the property name.
+        ///         When <see cref="NullDisplayText" /> and <see cref="NullDisplayTextResourceType" /> have not been set, returns <c>null</c>.
         ///     </para>
         /// </returns>
         /// <exception cref="System.InvalidOperationException">
@@ -123,7 +121,7 @@ namespace System.ComponentModel.DataAnnotations
         /// </exception>
         public string GetNullDisplayText()
         {
-            return nullDisplayText.GetLocalizableValue();
+            return _nullDisplayText.GetLocalizableValue();
         }
     }
 }

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/DisplayFormatAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/DisplayFormatAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Globalization;
+
 namespace System.ComponentModel.DataAnnotations
 {
     /// <summary>
@@ -11,6 +13,9 @@ namespace System.ComponentModel.DataAnnotations
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
     public class DisplayFormatAttribute : Attribute
     {
+        private readonly LocalizableString nullDisplayText = new LocalizableString("NulLDisplayText");
+        private Type resourceType;
+
         /// <summary>
         ///     Default constructor
         /// </summary>
@@ -26,10 +31,37 @@ namespace System.ComponentModel.DataAnnotations
         /// </summary>
         public string DataFormatString { get; set; }
 
+
         /// <summary>
-        ///     Gets or sets the string to display when the value is null
+        ///     Gets or sets the string to display when the value is null, which may be a resource key string.
+        ///     <para>
+        ///         Consumers must use the <see cref="GetNullDisplayText" /> method to retrieve the UI display string.
+        ///     </para>
         /// </summary>
-        public string NullDisplayText { get; set; }
+        /// <remarks>
+        ///     The property contains either the literal, non-localized string or the resource key
+        ///     to be used in conjunction with <see cref="NullDisplayTextResourceType" /> to configure a localized
+        ///     name for display.
+        ///     <para>
+        ///         The <see cref="GetNullDisplayText" /> method will return either the literal, non-localized
+        ///         string or the localized string when <see cref="NullDisplayTextResourceType" /> has been specified.
+        ///     </para>
+        /// </remarks>
+        /// <value>
+        ///     The null dispay text is generally used as placeholder when the value is not specified.
+        ///     A <c>null</c> or empty string is legal, and consumers must allow for that.
+        /// </value>
+        public string NullDisplayText
+        {
+            get { return nullDisplayText.Value; }
+            set
+            {
+                if (nullDisplayText.Value != value)
+                {
+                    nullDisplayText.Value = value;
+                }
+            }
+        }
 
         /// <summary>
         ///     Gets or sets a value indicating whether empty strings should be set to null
@@ -45,5 +77,53 @@ namespace System.ComponentModel.DataAnnotations
         ///     Gets or sets a value indicating whether the field should be html encoded
         /// </summary>
         public bool HtmlEncode { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the <see cref="System.Type" /> that contains the resources for <see cref="NullDisplayText" />.
+        ///     Using <see cref="NullDisplayTextResourceType" /> along with this property, allows the <see cref="GetNullDisplayText" />
+        ///     method to return localized values.
+        /// </summary>
+        public Type NullDisplayTextResourceType
+        {
+            get { return resourceType; }
+            set
+            {
+                if (resourceType != value)
+                {
+                    resourceType = value;
+                    nullDisplayText.ResourceType = value;
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Gets the UI display string for NullDisplayText.
+        ///     <para>
+        ///         This can be either a literal, non-localized string provided to <see cref="NullDisplayText" /> or the
+        ///         localized string found when <see cref="NullDisplayTextResourceType" /> has been specified and <see cref="NullDisplayText" />
+        ///         represents a resource key within that resource type.
+        ///     </para>
+        /// </summary>
+        /// <returns>
+        ///     When <see cref="NullDisplayTextResourceType" /> has not been specified, the value of
+        ///     <see cref="NullDisplayText" /> will be returned.
+        ///     <para>
+        ///         When <see cref="NullDisplayTextResourceType" /> has been specified and <see cref="NullDisplayText" />
+        ///         represents a resource key within that resource type, then the localized value will be returned.
+        ///     </para>
+        ///     <para>
+        ///         Can return <c>null</c> and will not fall back onto other values, as it's more likely for the
+        ///         consumer to want to fall back onto the property name.
+        ///     </para>
+        /// </returns>
+        /// <exception cref="System.InvalidOperationException">
+        ///     After setting both the <see cref="NullDisplayTextResourceType" /> property and the <see cref="NullDisplayText" /> property,
+        ///     but a public static property with a name matching the <see cref="NullDisplayText" /> value couldn't be found
+        ///     on the <see cref="NullDisplayTextResourceType" />.
+        /// </exception>
+        public string GetNullDisplayText()
+        {
+            return nullDisplayText.GetLocalizableValue();
+        }
     }
 }

--- a/src/System.ComponentModel.Annotations/tests/DisplayFormatAttributeTest.cs
+++ b/src/System.ComponentModel.Annotations/tests/DisplayFormatAttributeTest.cs
@@ -122,6 +122,21 @@ namespace System.ComponentModel.DataAnnotations.Tests
             // Changing target resource
             attribute.NullDisplayText = "Resource2";
             Assert.Equal(FakeResourceType.Resource2, attribute.GetNullDisplayText());
+
+            // Not existing resource in the resource type
+            attribute.NullDisplayText = "Resource3";
+            Assert.Throws<InvalidOperationException>(() => attribute.GetNullDisplayText());
+        }
+
+        [Fact]
+        public void NullDisplayText_NotAResourceType()
+        {
+			DisplayFormatAttribute attribute = new DisplayFormatAttribute();
+            // Setting a type that is not a resource type
+            attribute.NullDisplayTextResourceType = typeof(string);
+
+            attribute.NullDisplayText = "foo";
+			Assert.Throws<InvalidOperationException>(() => attribute.GetNullDisplayText());
         }
 
         [Theory]

--- a/src/System.ComponentModel.Annotations/tests/DisplayFormatAttributeTest.cs
+++ b/src/System.ComponentModel.Annotations/tests/DisplayFormatAttributeTest.cs
@@ -131,12 +131,12 @@ namespace System.ComponentModel.DataAnnotations.Tests
         [Fact]
         public void NullDisplayText_NotAResourceType()
         {
-			DisplayFormatAttribute attribute = new DisplayFormatAttribute();
+            DisplayFormatAttribute attribute = new DisplayFormatAttribute();
             // Setting a type that is not a resource type
             attribute.NullDisplayTextResourceType = typeof(string);
 
             attribute.NullDisplayText = "foo";
-			Assert.Throws<InvalidOperationException>(() => attribute.GetNullDisplayText());
+            Assert.Throws<InvalidOperationException>(() => attribute.GetNullDisplayText());
         }
 
         [Theory]

--- a/src/System.ComponentModel.Annotations/tests/DisplayFormatAttributeTest.cs
+++ b/src/System.ComponentModel.Annotations/tests/DisplayFormatAttributeTest.cs
@@ -19,7 +19,9 @@ namespace System.ComponentModel.DataAnnotations.Tests
 
             Assert.Null(attribute.DataFormatString);
             Assert.Null(attribute.NullDisplayText);
+#if netcoreapp
             Assert.Null(attribute.NullDisplayTextResourceType);
+#endif
         }
 
         [Theory]
@@ -76,13 +78,16 @@ namespace System.ComponentModel.DataAnnotations.Tests
             attribute.NullDisplayText = input;
 
             Assert.Equal(input, attribute.NullDisplayText);
+#if netcoreapp
             Assert.NotNull(attribute.GetNullDisplayText());
+#endif
 
             // Set again, to cover the setter avoiding operations if the value is the same
             attribute.NullDisplayText = input;
             Assert.Equal(input, attribute.NullDisplayText);
         }
 
+#if netcoreapp
         public class FakeResourceType
         {
             public static string Resource1
@@ -129,5 +134,6 @@ namespace System.ComponentModel.DataAnnotations.Tests
 
             Assert.Null(attribute.GetNullDisplayText());
         }
+#endif
     }
 }

--- a/src/System.ComponentModel.Annotations/tests/DisplayFormatAttributeTest.cs
+++ b/src/System.ComponentModel.Annotations/tests/DisplayFormatAttributeTest.cs
@@ -1,0 +1,122 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.ComponentModel.DataAnnotations.Tests
+{
+    public class DisplayFormatAttributeTest
+    {
+        [Fact]
+        public void Ctor()
+        {
+            DisplayFormatAttribute attribute = new DisplayFormatAttribute();
+            Assert.True(attribute.ConvertEmptyStringToNull);
+            Assert.True(attribute.HtmlEncode);
+            Assert.False(attribute.ApplyFormatInEditMode);
+
+            Assert.Null(attribute.DataFormatString);
+            Assert.Null(attribute.NullDisplayText);
+            Assert.Null(attribute.NullDisplayTextResourceType);
+        }
+
+        [Theory]
+        [InlineData("{0:C}")]
+        [InlineData("{0:d}")]
+        public void DataFormatString_Get_Set(string input)
+        {
+            DisplayFormatAttribute attribute = new DisplayFormatAttribute();
+            attribute.DataFormatString = input;
+
+            Assert.Equal(input, attribute.DataFormatString);
+        }
+
+        [Fact]
+        public void ConvertEmptyStringToNull_Get_Set()
+        {
+            DisplayFormatAttribute attribute = new DisplayFormatAttribute();
+            attribute.ConvertEmptyStringToNull = false;
+
+            Assert.False(attribute.ConvertEmptyStringToNull);
+        }
+
+        [Fact]
+        public void ApplyFormatInEditMode_Get_Set()
+        {
+            DisplayFormatAttribute attribute = new DisplayFormatAttribute();
+            attribute.ApplyFormatInEditMode = true;
+
+            Assert.True(attribute.ApplyFormatInEditMode);
+        }
+
+        [Fact]
+        public void HtmlEncode_Get_Set()
+        {
+            DisplayFormatAttribute attribute = new DisplayFormatAttribute();
+            attribute.HtmlEncode = false;
+
+            Assert.False(attribute.HtmlEncode);
+        }
+
+        public static IEnumerable<object[]> Strings_TestData()
+        {
+            yield return new object[] { "" };
+            yield return new object[] { " \r \t \n " };
+            yield return new object[] { "abc" };
+        }
+
+        [Theory]
+        [MemberData(nameof(Strings_TestData))]
+        [InlineData("NullDisplayText")]
+        public void NullDisplayText_Get_Set(string input)
+        {
+            DisplayFormatAttribute attribute = new DisplayFormatAttribute();
+            attribute.NullDisplayText = input;
+
+            Assert.Equal(input, attribute.NullDisplayText);
+            Assert.Equal(input == null, attribute.GetNullDisplayText() == null);
+
+            // Set again, to cover the setter avoiding operations if the value is the same
+            attribute.NullDisplayText = input;
+            Assert.Equal(input, attribute.NullDisplayText);
+        }
+
+        public class FakeResourceType 
+        {
+            public static string Resource1
+            {
+                get { return "Resource1Text"; }
+            }    
+
+            public static string Resource2
+            {
+                get { return "Resource2Text"; }
+            }
+        }
+
+        [Fact]
+        public void NullDisplayTextResourceType_Get_Set()
+        {
+            DisplayFormatAttribute attribute = new DisplayFormatAttribute();
+            attribute.NullDisplayTextResourceType = typeof(FakeResourceType);
+
+            Assert.Equal(typeof(FakeResourceType), attribute.NullDisplayTextResourceType);
+        }
+
+        [Fact]
+        public void NullDisplayText_WithResource()
+        {
+			DisplayFormatAttribute attribute = new DisplayFormatAttribute();
+			attribute.NullDisplayTextResourceType = typeof(FakeResourceType);
+
+            attribute.NullDisplayText = "Resource1";
+            Assert.Equal(FakeResourceType.Resource1, attribute.GetNullDisplayText());
+
+            // Changing target resource
+            attribute.NullDisplayText = "Resource2";
+            Assert.Equal(FakeResourceType.Resource2, attribute.GetNullDisplayText());
+        }
+    }
+}

--- a/src/System.ComponentModel.Annotations/tests/DisplayFormatAttributeTest.cs
+++ b/src/System.ComponentModel.Annotations/tests/DisplayFormatAttributeTest.cs
@@ -65,30 +65,30 @@ namespace System.ComponentModel.DataAnnotations.Tests
             yield return new object[] { "" };
             yield return new object[] { " \r \t \n " };
             yield return new object[] { "abc" };
+            yield return new object[] { "NullDisplayText" };
         }
 
         [Theory]
         [MemberData(nameof(Strings_TestData))]
-        [InlineData("NullDisplayText")]
         public void NullDisplayText_Get_Set(string input)
         {
             DisplayFormatAttribute attribute = new DisplayFormatAttribute();
             attribute.NullDisplayText = input;
 
             Assert.Equal(input, attribute.NullDisplayText);
-            Assert.Equal(input == null, attribute.GetNullDisplayText() == null);
+            Assert.NotNull(attribute.GetNullDisplayText());
 
             // Set again, to cover the setter avoiding operations if the value is the same
             attribute.NullDisplayText = input;
             Assert.Equal(input, attribute.NullDisplayText);
         }
 
-        public class FakeResourceType 
+        public class FakeResourceType
         {
             public static string Resource1
             {
                 get { return "Resource1Text"; }
-            }    
+            }
 
             public static string Resource2
             {
@@ -108,8 +108,8 @@ namespace System.ComponentModel.DataAnnotations.Tests
         [Fact]
         public void NullDisplayText_WithResource()
         {
-			DisplayFormatAttribute attribute = new DisplayFormatAttribute();
-			attribute.NullDisplayTextResourceType = typeof(FakeResourceType);
+            DisplayFormatAttribute attribute = new DisplayFormatAttribute();
+            attribute.NullDisplayTextResourceType = typeof(FakeResourceType);
 
             attribute.NullDisplayText = "Resource1";
             Assert.Equal(FakeResourceType.Resource1, attribute.GetNullDisplayText());
@@ -117,6 +117,17 @@ namespace System.ComponentModel.DataAnnotations.Tests
             // Changing target resource
             attribute.NullDisplayText = "Resource2";
             Assert.Equal(FakeResourceType.Resource2, attribute.GetNullDisplayText());
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(typeof(FakeResourceType))]
+        public void GetNullDisplayText_WhenNullDisplayTextNotSet(Type input)
+        {
+            DisplayFormatAttribute attribute = new DisplayFormatAttribute();
+            attribute.NullDisplayTextResourceType = input;
+
+            Assert.Null(attribute.GetNullDisplayText());
         }
     }
 }

--- a/src/System.ComponentModel.Annotations/tests/System.ComponentModel.Annotations.Tests.csproj
+++ b/src/System.ComponentModel.Annotations/tests/System.ComponentModel.Annotations.Tests.csproj
@@ -46,6 +46,7 @@
     <Compile Include="$(CommonTestPath)\System\AssertExtensions.cs">
       <Link>Common\System\AssertExtensions.cs</Link>
     </Compile>
+    <Compile Include="DisplayFormatAttributeTest.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
Relative to issue #10526.
Tests were also added for existing code since the test class did not exist.
I copied the behaviour of `[Display]` for the `NullDisplayText` property. I also copied the same style of xml comments.