### PR TITLE
Remove IsoStorage lock from UAP and enable tests

### DIFF
--- a/src/System.IO.IsolatedStorage/System.IO.IsolatedStorage.sln
+++ b/src/System.IO.IsolatedStorage/System.IO.IsolatedStorage.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26430.4
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.IO.IsolatedStorage.Tests", "tests\System.IO.IsolatedStorage.Tests.csproj", "{BF4F9507-8FBD-45EA-81C9-3ED89C052C91}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -15,8 +15,14 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.IO.IsolatedStorage", "ref\System.IO.IsolatedStorage.csproj", "{750200D5-661A-42AA-9E1F-2A151F5AEE74}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{1A2F9F4A-A032-433E-B914-ADD5992BB178}"
+	ProjectSection(SolutionItems) = preProject
+		tests\Configurations.props = tests\Configurations.props
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E893-4E87-987E-04EF0DCEAEFD}"
+	ProjectSection(SolutionItems) = preProject
+		src\Configurations.props = src\Configurations.props
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject

--- a/src/System.IO.IsolatedStorage/src/System.IO.IsolatedStorage.csproj
+++ b/src/System.IO.IsolatedStorage/src/System.IO.IsolatedStorage.csproj
@@ -29,7 +29,7 @@
     <Compile Include="System\IO\IsolatedStorage\Helper.Win32Unix.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'uap' AND '$(TargetsWindows)' == 'true'">
-	<Compile Include="System\IO\IsolatedStorage\Helper.Win32.cs" />
+    <Compile Include="System\IO\IsolatedStorage\Helper.Win32.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'uap' AND '$(TargetsUnix)' == 'true'">
     <Compile Include="System\IO\IsolatedStorage\Helper.Unix.cs" />

--- a/src/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/Helper.WinRT.cs
+++ b/src/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/Helper.WinRT.cs
@@ -19,7 +19,14 @@ namespace System.IO.IsolatedStorage
 
             if (IsMachine(scope))
             {
-                dataDirectory = ApplicationData.Current.SharedLocalFolder.Path;
+                // Getting the shared local folder isn't possible if the policy for
+                // "Allow a Windows app to share application data between users".
+                dataDirectory = ApplicationData.Current.SharedLocalFolder?.Path;
+
+                if (dataDirectory == null)
+                {
+                    throw new IsolatedStorageException(SR.IsolatedStorage_Scope_Invalid);
+                }
             }
             if (!IsRoaming(scope))
             {
@@ -59,6 +66,13 @@ namespace System.IO.IsolatedStorage
             hash = IdentityHelper.GetNormalizedUriHash(codeBase);
             hash = "Url" + separator + hash;
             identity = codeBase;
+        }
+
+        internal static string GetRandomDirectory(string rootDirectory, IsolatedStorageScope scope)
+        {
+            // We didn't create random directories for UAP/UWP in the past. As the root locations are
+            // scoped beneath app isolated folders we don't need the extra layer of obfuscation.
+            return rootDirectory;
         }
     }
 }

--- a/src/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/Helper.cs
+++ b/src/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/Helper.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Security;
-using System.Threading;
-
 namespace System.IO.IsolatedStorage
 {
     internal static partial class Helper
@@ -17,7 +14,8 @@ namespace System.IO.IsolatedStorage
 
         /// <summary>
         /// The full root directory is the relevant special folder from Environment.GetFolderPath() plus "IsolatedStorage"
-        /// and a set of random directory names if not roaming.
+        /// and a set of random directory names if not roaming. (The random directories aren't created for WinRT as
+        /// the FolderPath locations for WinRT are app isolated already.)
         /// 
         /// Examples:
         /// 
@@ -51,71 +49,6 @@ namespace System.IO.IsolatedStorage
                 s_userRootDirectory = GetRandomDirectory(GetDataDirectory(scope), scope);
 
             return s_userRootDirectory;
-        }
-
-        internal static string GetRandomDirectory(string rootDirectory, IsolatedStorageScope scope)
-        {
-            string randomDirectory = GetExistingRandomDirectory(rootDirectory);
-            if (string.IsNullOrEmpty(randomDirectory))
-            {
-                using (Mutex m = CreateMutexNotOwned(rootDirectory))
-                {
-                    if (!m.WaitOne())
-                    {
-                        throw new IsolatedStorageException(SR.IsolatedStorage_Init);
-                    }
-
-                    try
-                    {
-                        randomDirectory = GetExistingRandomDirectory(rootDirectory);
-                        if (string.IsNullOrEmpty(randomDirectory))
-                        {
-                            // Someone else hasn't created the directory before we took the lock
-                            randomDirectory = Path.Combine(rootDirectory, Path.GetRandomFileName(), Path.GetRandomFileName());
-                            CreateDirectory(randomDirectory, scope);
-                        }
-                    }
-                    finally
-                    {
-                        m.ReleaseMutex();
-                    }
-                }
-            }
-
-            return randomDirectory;
-        }
-
-        internal static string GetExistingRandomDirectory(string rootDirectory)
-        {
-            // Look for an existing random directory at the given root
-            // (a set of nested directories that were created via Path.GetRandomFileName())
-
-            // Older versions of the desktop framework created longer (24 character) random paths and would
-            // migrate them if they could not find the new style directory.
-
-            if (!Directory.Exists(rootDirectory))
-                return null;
-
-            foreach (string directory in Directory.GetDirectories(rootDirectory))
-            {
-                if (Path.GetFileName(directory)?.Length == 12)
-                {
-                    foreach (string subdirectory in Directory.GetDirectories(directory))
-                    {
-                        if (Path.GetFileName(subdirectory)?.Length == 12)
-                        {
-                            return subdirectory;
-                        }
-                    }
-                }
-            }
-
-            return null;
-        }
-
-        private static Mutex CreateMutexNotOwned(string pathName)
-        {
-            return new Mutex(initiallyOwned: false, name: @"Global\" + IdentityHelper.GetStrongHashSuitableForObjectName(pathName));
         }
 
         internal static bool IsMachine(IsolatedStorageScope scope) => ((scope & IsolatedStorageScope.Machine) != 0);

--- a/src/System.IO.IsolatedStorage/tests/Configurations.props
+++ b/src/System.IO.IsolatedStorage/tests/Configurations.props
@@ -6,6 +6,7 @@
       netstandard-Windows_NT;
       netcoreapp-Unix;
       netcoreapp-Windows_NT;
+      uap-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.IsolatedStorage/tests/Resources/Strings.resx
+++ b/src/System.IO.IsolatedStorage/tests/Resources/Strings.resx
@@ -61,4 +61,7 @@
   <data name="IsolatedStorage_Init" xml:space="preserve">
     <value>Initialization failed.</value>
   </data>
+  <data name="IsolatedStorage_Scope_Invalid" xml:space="preserve">
+    <value>Invalid scope.</value>
+  </data>
 </root>

--- a/src/System.IO.IsolatedStorage/tests/System.IO.IsolatedStorage.Tests.csproj
+++ b/src/System.IO.IsolatedStorage/tests/System.IO.IsolatedStorage.Tests.csproj
@@ -15,16 +15,17 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Release|AnyCPU'" />
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
-      <Compile Include="System\IO\IsolatedStorage\IdentityTests.cs" />
-      <Compile Include="System\IO\IsolatedStorage\IsolatedStorageBaseClassTests.cs" />
+    <Compile Include="System\IO\IsolatedStorage\IdentityTests.cs" />
+    <Compile Include="System\IO\IsolatedStorage\IsolatedStorageBaseClassTests.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'uap'">
     <Compile Include="..\src\System\IO\IsolatedStorage\Helper.Win32Unix.cs">
       <Link>Internals\Helper.Win32Unix.cs</Link>
     </Compile>
+    <Compile Include="System\IO\IsolatedStorage\HelperTests.Win32Unix.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'uap' AND '$(TargetsWindows)' == 'true'">
-	  <Compile Include="..\src\System\IO\IsolatedStorage\Helper.Win32.cs">
+    <Compile Include="..\src\System\IO\IsolatedStorage\Helper.Win32.cs">
       <Link>Internals\Helper.Win32.cs</Link>
     </Compile>
   </ItemGroup>
@@ -54,6 +55,9 @@
     <Compile Include="$(CommonPath)\System\Security\IdentityHelper.cs">
       <Link>Common\System\Security\IdentityHelper.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>Common\System\PlatformDetection.cs</Link>
+    </Compile>
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="StoreTestsFixture.cs" />
     <Compile Include="System\IO\IsolatedStorage\ContainsUnknownFilesTests.cs" />
@@ -76,6 +80,10 @@
     <Compile Include="System\IO\IsolatedStorage\OpenFileTests.cs" />
     <Compile Include="System\IO\IsolatedStorage\TestHelper.cs" />
     <Compile Include="System\IO\IsolatedStorage\RemoveTests.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'uap'">
+    <Reference Include="mscorlib" />
+    <Reference Include="Windows" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/HelperTests.Win32Unix.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/HelperTests.Win32Unix.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.IO.IsolatedStorage
+{
+    public partial class HelperTests
+    {
+        [Fact]
+        public void GetExistingRandomDirectory()
+        {
+            using (var temp = new TempDirectory())
+            {
+                Assert.Null(Helper.GetExistingRandomDirectory(temp.Path));
+
+                string randomPath = Path.Combine(temp.Path, Path.GetRandomFileName(), Path.GetRandomFileName());
+                Directory.CreateDirectory(randomPath);
+                Assert.Equal(randomPath, Helper.GetExistingRandomDirectory(temp.Path));
+            }
+        }
+
+        [Theory,
+            InlineData(IsolatedStorageScope.User),
+            InlineData(IsolatedStorageScope.Machine),
+            ]
+        public void GetRandomDirectory(IsolatedStorageScope scope)
+        {
+            using (var temp = new TempDirectory())
+            {
+                string randomDir = Helper.GetRandomDirectory(temp.Path, scope);
+                Assert.True(Directory.Exists(randomDir));
+            }
+        }
+    }
+}

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/HelperTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/HelperTests.cs
@@ -7,11 +7,11 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage.Tests
 {
-    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
-    public class HelperTests
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework | TargetFrameworkMonikers.UapAot /* UapAot is #18940 */,
+        "These are unit tests for the CoreFX implementation and don't apply to NetFX.")]
+    public partial class HelperTests
     {
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18202")]
         public void GetDefaultIdentityAndHash()
         {
             object identity;
@@ -35,41 +35,20 @@ namespace System.IO.IsolatedStorage.Tests
             }
         }
 
-        [Theory
-            InlineData(IsolatedStorageScope.Assembly)
-            InlineData(IsolatedStorageScope.Assembly | IsolatedStorageScope.Roaming)
+        [Theory,
+            InlineData(IsolatedStorageScope.Assembly),
+            InlineData(IsolatedStorageScope.Assembly | IsolatedStorageScope.Roaming),
             InlineData(IsolatedStorageScope.Machine)
             ]
         public void GetDataDirectory(IsolatedStorageScope scope)
         {
+            // Machine scope is behind a policy that isn't enabled by default
+            // https://github.com/dotnet/corefx/issues/19839
+            if (scope == IsolatedStorageScope.Machine && PlatformDetection.IsWinRT)
+                return;
+
             string path = Helper.GetDataDirectory(scope);
             Assert.Equal("IsolatedStorage", Path.GetFileName(path));
-        }
-
-        [Fact]
-        public void GetExistingRandomDirectory()
-        {
-            using (var temp = new TempDirectory())
-            {
-                Assert.Null(Helper.GetExistingRandomDirectory(temp.Path));
-
-                string randomPath = Path.Combine(temp.Path, Path.GetRandomFileName(), Path.GetRandomFileName());
-                Directory.CreateDirectory(randomPath);
-                Assert.Equal(randomPath, Helper.GetExistingRandomDirectory(temp.Path));
-            }
-        }
-
-        [Theory
-            InlineData(IsolatedStorageScope.User)
-            InlineData(IsolatedStorageScope.Machine)
-            ]
-        public void GetRandomDirectory(IsolatedStorageScope scope)
-        {
-            using (var temp = new TempDirectory())
-            {
-                string randomDir = Helper.GetRandomDirectory(temp.Path, scope);
-                Assert.True(Directory.Exists(randomDir));
-            }
         }
     }
 }

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/IsoStorageTest.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/IsoStorageTest.cs
@@ -80,7 +80,8 @@ namespace System.IO.IsolatedStorage
                 };
 
                 // https://github.com/dotnet/corefx/issues/12628
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                    && !PlatformDetection.IsWinRT)
                 {
                     validScopes.Add(PresetScopes.MachineStoreForApplication);
                     validScopes.Add(PresetScopes.MachineStoreForAssembly);

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/TestHelper.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/TestHelper.cs
@@ -33,7 +33,9 @@ namespace System.IO.IsolatedStorage
             s_roots.Add(Path.Combine(userRoot, hash));
 
             // https://github.com/dotnet/corefx/issues/12628
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            // https://github.com/dotnet/corefx/issues/19839
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                && !PlatformDetection.IsWinRT)
             {
                 s_roots.Add(Helper.GetDataDirectory(IsolatedStorageScope.Machine));
             }
@@ -78,7 +80,6 @@ namespace System.IO.IsolatedStorage
                 stream.WriteAllText(content);
             }
         }
-
 
         public static void WriteAllText(this IsolatedStorageFileStream stream, string content)
         {


### PR DESCRIPTION
Removing the random directory logic when running on WinRT as
it wasn't used before and has no benefit. Additionally taking
a global lock isn't possible on WinRT.

This also enables tests for IsolatedStorage on UAP. Also update
skip for unit tests on desktop.

Issues #19227, #18202