### PR TITLE
Repro memberinfo bug

### DIFF
--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <ProjectGuid>{B1BF7CE0-CAB5-4FA2-A39C-450B05D5DB1C}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <AssemblyVersion>4.2.1.0</AssemblyVersion>
     <NoWarn>1718</NoWarn>
     <DefineConstants Condition="'$(TargetGroup)'=='netcoreapp'">$(DefineConstants);netcoreapp</DefineConstants>
     <DefineConstants Condition="'$(TargetGroup)'=='uapaot'">$(DefineConstants);uapaot</DefineConstants>


### PR DESCRIPTION
/cc @weshaggard @AtsushiKan 

For some reason, updating the assembly version of System.Runtime causes the list of members returned by type.GetMembers(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance); to be different on the first call.  Subsequent calls return a different (incorrect) order. 