### PR TITLE
Make private reflected methods in System.Composition.Hosting public.

### DIFF
--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/ExportFactory/ExportFactoryExportDescriptorProvider.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/ExportFactory/ExportFactoryExportDescriptorProvider.cs
@@ -11,7 +11,7 @@ using Microsoft.Internal;
 
 namespace System.Composition.Hosting.Providers.ExportFactory
 {
-    internal class ExportFactoryExportDescriptorProvider : ExportDescriptorProvider
+    public class ExportFactoryExportDescriptorProvider : ExportDescriptorProvider
     {
         private static readonly MethodInfo s_getExportFactoryDefinitionsMethod = typeof(ExportFactoryExportDescriptorProvider).GetTypeInfo().GetDeclaredMethod("GetExportFactoryDescriptors");
 
@@ -25,7 +25,7 @@ namespace System.Composition.Hosting.Providers.ExportFactory
             return (ExportDescriptorPromise[])gldm(exportKey, definitionAccessor);
         }
 
-        private static ExportDescriptorPromise[] GetExportFactoryDescriptors<TProduct>(CompositionContract exportFactoryContract, DependencyAccessor definitionAccessor)
+        public static ExportDescriptorPromise[] GetExportFactoryDescriptors<TProduct>(CompositionContract exportFactoryContract, DependencyAccessor definitionAccessor)
         {
             var productContract = exportFactoryContract.ChangeType(typeof(TProduct));
             var boundaries = EmptyArray<string>.Value;

--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/ExportFactory/ExportFactoryWithMetadataExportDescriptorProvider.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/ExportFactory/ExportFactoryWithMetadataExportDescriptorProvider.cs
@@ -12,7 +12,7 @@ using Microsoft.Internal;
 
 namespace System.Composition.Hosting.Providers.ExportFactory
 {
-    internal class ExportFactoryWithMetadataExportDescriptorProvider : ExportDescriptorProvider
+    public class ExportFactoryWithMetadataExportDescriptorProvider : ExportDescriptorProvider
     {
         private static readonly MethodInfo s_getLazyDefinitionsMethod =
             typeof(ExportFactoryWithMetadataExportDescriptorProvider).GetTypeInfo().GetDeclaredMethod("GetExportFactoryDescriptors");
@@ -29,7 +29,7 @@ namespace System.Composition.Hosting.Providers.ExportFactory
             return (ExportDescriptorPromise[])gldm(contract, definitionAccessor);
         }
 
-        private static ExportDescriptorPromise[] GetExportFactoryDescriptors<TProduct, TMetadata>(CompositionContract exportFactoryContract, DependencyAccessor definitionAccessor)
+        public static ExportDescriptorPromise[] GetExportFactoryDescriptors<TProduct, TMetadata>(CompositionContract exportFactoryContract, DependencyAccessor definitionAccessor)
         {
             var productContract = exportFactoryContract.ChangeType(typeof(TProduct));
             var boundaries = EmptyArray<string>.Value;

--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/ImportMany/ImportManyExportDescriptorProvider.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/ImportMany/ImportManyExportDescriptorProvider.cs
@@ -10,7 +10,7 @@ using System.Linq;
 
 namespace System.Composition.Hosting.Providers.ImportMany
 {
-    internal class ImportManyExportDescriptorProvider : ExportDescriptorProvider
+    public class ImportManyExportDescriptorProvider : ExportDescriptorProvider
     {
         private static readonly MethodInfo s_getImportManyDefinitionMethod = typeof(ImportManyExportDescriptorProvider).GetTypeInfo().GetDeclaredMethod("GetImportManyDescriptor");
         private static readonly Type[] s_supportedContractTypes = new[] { typeof(IList<>), typeof(ICollection<>), typeof(IEnumerable<>) };
@@ -37,7 +37,7 @@ namespace System.Composition.Hosting.Providers.ImportMany
             return new[] { (ExportDescriptorPromise)gimdm(contract, elementContract, definitionAccessor) };
         }
 
-        private static ExportDescriptorPromise GetImportManyDescriptor<TElement>(CompositionContract importManyContract, CompositionContract elementContract, DependencyAccessor definitionAccessor)
+        public static ExportDescriptorPromise GetImportManyDescriptor<TElement>(CompositionContract importManyContract, CompositionContract elementContract, DependencyAccessor definitionAccessor)
         {
             return new ExportDescriptorPromise(
                 importManyContract,

--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/Lazy/LazyExportDescriptorProvider.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/Lazy/LazyExportDescriptorProvider.cs
@@ -10,7 +10,8 @@ using System.Composition.Hosting.Util;
 
 namespace System.Composition.Hosting.Providers.Lazy
 {
-    internal class LazyExportDescriptorProvider : ExportDescriptorProvider
+
+    public class LazyExportDescriptorProvider : ExportDescriptorProvider
     {
         private static readonly MethodInfo s_getLazyDefinitionsMethod = typeof(LazyExportDescriptorProvider)
             .GetTypeInfo().GetDeclaredMethod("GetLazyDefinitions");
@@ -25,7 +26,7 @@ namespace System.Composition.Hosting.Providers.Lazy
             return (ExportDescriptorPromise[])gldm(exportKey, definitionAccessor);
         }
 
-        private static ExportDescriptorPromise[] GetLazyDefinitions<TValue>(CompositionContract lazyContract, DependencyAccessor definitionAccessor)
+        public static ExportDescriptorPromise[] GetLazyDefinitions<TValue>(CompositionContract lazyContract, DependencyAccessor definitionAccessor)
         {
             return definitionAccessor.ResolveDependencies("value", lazyContract.ChangeType(typeof(TValue)), false)
                 .Select(d => new ExportDescriptorPromise(

--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/Lazy/LazyWithMetadataExportDescriptorProvider.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/Lazy/LazyWithMetadataExportDescriptorProvider.cs
@@ -11,7 +11,8 @@ using System.Composition.Hosting.Providers.Metadata;
 
 namespace System.Composition.Hosting.Providers.Lazy
 {
-    internal class LazyWithMetadataExportDescriptorProvider : ExportDescriptorProvider
+
+    public class LazyWithMetadataExportDescriptorProvider : ExportDescriptorProvider
     {
         private static readonly MethodInfo s_getLazyDefinitionsMethod = typeof(LazyWithMetadataExportDescriptorProvider).GetTypeInfo().GetDeclaredMethod("GetLazyDefinitions");
 
@@ -26,7 +27,7 @@ namespace System.Composition.Hosting.Providers.Lazy
             return (ExportDescriptorPromise[])gldm(exportKey, definitionAccessor);
         }
 
-        private static ExportDescriptorPromise[] GetLazyDefinitions<TValue, TMetadata>(CompositionContract lazyContract, DependencyAccessor definitionAccessor)
+        public static ExportDescriptorPromise[] GetLazyDefinitions<TValue, TMetadata>(CompositionContract lazyContract, DependencyAccessor definitionAccessor)
         {
             var metadataProvider = MetadataViewProvider.GetMetadataViewProvider<TMetadata>();
 

--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/Metadata/MetadataViewProvider.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/Metadata/MetadataViewProvider.cs
@@ -11,7 +11,8 @@ using Microsoft.Internal;
 
 namespace System.Composition.Hosting.Providers.Metadata
 {
-    internal static class MetadataViewProvider
+
+    public static class MetadataViewProvider
     {
         private static readonly MethodInfo s_getMetadataValueMethod = typeof(MetadataViewProvider).GetTypeInfo().GetDeclaredMethod("GetMetadataValue");
 
@@ -74,7 +75,7 @@ namespace System.Composition.Hosting.Providers.Metadata
             throw new CompositionFailedException(string.Format(Properties.Resources.MetadataViewProvider_InvalidViewImplementation, typeof(TMetadata).Name));
         }
 
-        private static TValue GetMetadataValue<TValue>(IDictionary<string, object> metadata, string name, DefaultValueAttribute defaultValue)
+        public static TValue GetMetadataValue<TValue>(IDictionary<string, object> metadata, string name, DefaultValueAttribute defaultValue)
         {
             object result;
             if (metadata.TryGetValue(name, out result))


### PR DESCRIPTION
System.Composition.Hosting reflect over private generic method and
use MakeGenericMethod to create generic method instances.ILC toolchain
mark these types with [ReflectionBlocked] attribute since analysis
find the containing type internal and the method private.rdxml wont fix
this since toolchain decide to add the [ReflectionBlock] based on its
analysis.This fixes 50+ tests in System.Composition