### PR TITLE
Update to BuildTools 2.0.0-prerelease-01616-05

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-2.0.0-prerelease-01611-05
+2.0.0-prerelease-01616-05


### PR DESCRIPTION
This will pick up Eric M's recent fix to crossgen.sh to detect the
correct version of the shared framework instead of hard coding a
version.

Recent updates to the CLI we consume caused the static number to be
incorrect.