### PR TITLE
Fix Xml.Linq test failures on ILC

### DIFF
--- a/src/System.Private.Xml.Linq/tests/events/Resources/System.Xml.Linq.Events.Tests.rd.xml
+++ b/src/System.Private.Xml.Linq/tests/events/Resources/System.Xml.Linq.Events.Tests.rd.xml
@@ -1,0 +1,6 @@
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Library>
+    <!-- Needed because of XCData instance in [Theory] data which causes xunit to reflect on its ToString() -->
+    <Type Name="System.Xml.Linq.XCData" Dynamic="Required Public" />
+  </Library>
+</Directives>

--- a/src/System.Private.Xml.Linq/tests/events/System.Xml.Linq.Events.Tests.csproj
+++ b/src/System.Private.Xml.Linq/tests/events/System.Xml.Linq.Events.Tests.csproj
@@ -21,5 +21,9 @@
     </ProjectReference>
     <ProjectReference Include="..\XDocument.Test.ModuleCore\XDocument.Test.ModuleCore.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\$(AssemblyName).rd.xml" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Private.Xml.Linq/tests/xNodeBuilder/CommonTests.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeBuilder/CommonTests.cs
@@ -3413,12 +3413,14 @@ namespace CoreXml.Test.XLinq
                         w.WriteEndElement();
                     }
 
-                    string expectedMsg = "Cannot have ']]>' inside an XML CDATA block.";
-
                     using (XmlReader reader = doc.CreateReader())
                     {
                         Exception exception = Assert.Throws<ArgumentException>(() => MoveToFirstElement(reader).ReadOuterXml());
-                        Assert.Equal(expectedMsg, exception.Message);
+                        if (!PlatformDetection.IsNetNative) // .Net Native toolchain optimizes away Exception messages
+                        {
+                            string expectedMsg = "Cannot have ']]>' inside an XML CDATA block.";
+                            Assert.Equal(expectedMsg, exception.Message);
+                        }
                     }
                 }
 
@@ -3605,12 +3607,14 @@ namespace CoreXml.Test.XLinq
                         w.WriteEndElement();
                     }
 
-                    string expectedMsg = "An XML comment cannot contain '--', and '-' cannot be the last character.";
-
                     using (XmlReader reader = doc.CreateReader())
                     {
                         Exception exception = Assert.Throws<ArgumentException>(() => MoveToFirstElement(reader).ReadOuterXml());
-                        Assert.Equal(expectedMsg, exception.Message);
+                        if (!PlatformDetection.IsNetNative) // .Net Native toolchain optimizes away Exception messages
+                        {
+                            string expectedMsg = "An XML comment cannot contain '--', and '-' cannot be the last character.";
+                            Assert.Equal(expectedMsg, exception.Message);
+                        }
                     }
                 }
             }
@@ -4206,12 +4210,14 @@ namespace CoreXml.Test.XLinq
                         w.WriteEndElement();
                     }
 
-                    string expectedMsg = "Cannot have '?>' inside an XML processing instruction.";
-
                     using (XmlReader reader = doc.CreateReader())
                     {
                         Exception exception = Assert.Throws<ArgumentException>(() => MoveToFirstElement(reader).ReadOuterXml());
-                        Assert.Equal(expectedMsg, exception.Message);
+                        if (!PlatformDetection.IsNetNative) // .Net Native toolchain optimizes away Exception messages
+                        {
+                            string expectedMsg = "Cannot have '?>' inside an XML processing instruction.";
+                            Assert.Equal(expectedMsg, exception.Message);
+                        }
                     }
                 }
 

--- a/src/System.Private.Xml.Linq/tests/xNodeBuilder/System.Xml.Linq.xNodeBuilder.Tests.csproj
+++ b/src/System.Private.Xml.Linq/tests/xNodeBuilder/System.Xml.Linq.xNodeBuilder.Tests.csproj
@@ -13,6 +13,9 @@
     <Compile Include="$(CommonTestPath)\System\Collections\DictionaryExtensions.cs">
       <Link>Common\System\Collections\DictionaryExtensions.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>Common\System\PlatformDetection.cs</Link>
+    </Compile>
     <Compile Include="CommonTests.cs" />
     <Compile Include="EndOfLineHandlingTests.cs" />
     <Compile Include="ErrorConditions.cs" />


### PR DESCRIPTION
Fixes:
- Missing metadata for System.Xml.Linq.XCData
- Optimized exception messages
