### PR TITLE
Use RemoteEchoServer in DiagnosticSource HttpHandlerDiagnosticListenerTests

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/tests/System.Diagnostics.DiagnosticSource.Tests.csproj
+++ b/src/System.Diagnostics.DiagnosticSource/tests/System.Diagnostics.DiagnosticSource.Tests.csproj
@@ -25,7 +25,19 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetGroup)' == 'netfx'">
     <Compile Include="HttpHandlerDiagnosticListenerTests.cs" />
-    <Compile Include="ActivityDateTimeTests.cs" />    
+    <Compile Include="ActivityDateTimeTests.cs" />
+    <Compile Include="$(CommonTestPath)\System\Net\Configuration.cs">
+      <Link>Common\System\Net\Configuration.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Net\Configuration.Http.cs">
+      <Link>Common\System\Net\Configuration.Http.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\IO\FileCleanupTestBase.cs">
+      <Link>Common\System\IO\FileCleanupTestBase.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorTestBase.cs">
+      <Link>Common\System\Diagnostics\RemoteExecutorTestBase.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
Tests used bing.com and some other external URLs that may time out, etc... So the tests are not stable. 

It was changed to [RemoteEchoServer](https://github.com/dotnet/corefx/blob/ec2a6190efa743ab600317f44d757433e44e859b/src/Common/tests/System/Net/Configuration.Http.cs#L53), it is still remote, however is stable enough, and other Http tests [use](https://github.com/dotnet/corefx/blob/b21ad690d7cf03ca5559d9a86b1c29b0b4600ccf/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/WinHttpHandlerTest.cs) it too. 

It should address #19824.

cc @vancem @stephentoub