### PR TITLE
Adding GetSchemaTable() on SqlDataReader

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDataReader.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDataReader.cs
@@ -405,123 +405,123 @@ namespace System.Data.SqlClient
             schemaTable.Locale = CultureInfo.InvariantCulture;
             schemaTable.MinimumCapacity = md.Length;
 
-            DataColumn ColumnName = new DataColumn(SchemaTableColumn.ColumnName, typeof(System.String));
-            DataColumn Ordinal = new DataColumn(SchemaTableColumn.ColumnOrdinal, typeof(System.Int32));
-            DataColumn Size = new DataColumn(SchemaTableColumn.ColumnSize, typeof(System.Int32));
-            DataColumn Precision = new DataColumn(SchemaTableColumn.NumericPrecision, typeof(System.Int16));
-            DataColumn Scale = new DataColumn(SchemaTableColumn.NumericScale, typeof(System.Int16));
+            DataColumn columnName = new DataColumn(SchemaTableColumn.ColumnName, typeof(System.String));
+            DataColumn ordinal = new DataColumn(SchemaTableColumn.ColumnOrdinal, typeof(System.Int32));
+            DataColumn size = new DataColumn(SchemaTableColumn.ColumnSize, typeof(System.Int32));
+            DataColumn precision = new DataColumn(SchemaTableColumn.NumericPrecision, typeof(System.Int16));
+            DataColumn scale = new DataColumn(SchemaTableColumn.NumericScale, typeof(System.Int16));
 
-            DataColumn DataType = new DataColumn(SchemaTableColumn.DataType, typeof(System.Type));
-            DataColumn ProviderSpecificDataType = new DataColumn(SchemaTableOptionalColumn.ProviderSpecificDataType, typeof(System.Type));
-            DataColumn NonVersionedProviderType = new DataColumn(SchemaTableColumn.NonVersionedProviderType, typeof(System.Int32));
-            DataColumn ProviderType = new DataColumn(SchemaTableColumn.ProviderType, typeof(System.Int32));
+            DataColumn dataType = new DataColumn(SchemaTableColumn.DataType, typeof(System.Type));
+            DataColumn providerSpecificDataType = new DataColumn(SchemaTableOptionalColumn.ProviderSpecificDataType, typeof(System.Type));
+            DataColumn nonVersionedProviderType = new DataColumn(SchemaTableColumn.NonVersionedProviderType, typeof(System.Int32));
+            DataColumn providerType = new DataColumn(SchemaTableColumn.ProviderType, typeof(System.Int32));
 
-            DataColumn IsLong = new DataColumn(SchemaTableColumn.IsLong, typeof(System.Boolean));
-            DataColumn AllowDBNull = new DataColumn(SchemaTableColumn.AllowDBNull, typeof(System.Boolean));
-            DataColumn IsReadOnly = new DataColumn(SchemaTableOptionalColumn.IsReadOnly, typeof(System.Boolean));
-            DataColumn IsRowVersion = new DataColumn(SchemaTableOptionalColumn.IsRowVersion, typeof(System.Boolean));
+            DataColumn isLong = new DataColumn(SchemaTableColumn.IsLong, typeof(System.Boolean));
+            DataColumn allowDBNull = new DataColumn(SchemaTableColumn.AllowDBNull, typeof(System.Boolean));
+            DataColumn isReadOnly = new DataColumn(SchemaTableOptionalColumn.IsReadOnly, typeof(System.Boolean));
+            DataColumn isRowVersion = new DataColumn(SchemaTableOptionalColumn.IsRowVersion, typeof(System.Boolean));
 
-            DataColumn IsUnique = new DataColumn(SchemaTableColumn.IsUnique, typeof(System.Boolean));
-            DataColumn IsKey = new DataColumn(SchemaTableColumn.IsKey, typeof(System.Boolean));
-            DataColumn IsAutoIncrement = new DataColumn(SchemaTableOptionalColumn.IsAutoIncrement, typeof(System.Boolean));
-            DataColumn IsHidden = new DataColumn(SchemaTableOptionalColumn.IsHidden, typeof(System.Boolean));
+            DataColumn isUnique = new DataColumn(SchemaTableColumn.IsUnique, typeof(System.Boolean));
+            DataColumn isKey = new DataColumn(SchemaTableColumn.IsKey, typeof(System.Boolean));
+            DataColumn isAutoIncrement = new DataColumn(SchemaTableOptionalColumn.IsAutoIncrement, typeof(System.Boolean));
+            DataColumn isHidden = new DataColumn(SchemaTableOptionalColumn.IsHidden, typeof(System.Boolean));
 
-            DataColumn BaseCatalogName = new DataColumn(SchemaTableOptionalColumn.BaseCatalogName, typeof(System.String));
-            DataColumn BaseSchemaName = new DataColumn(SchemaTableColumn.BaseSchemaName, typeof(System.String));
-            DataColumn BaseTableName = new DataColumn(SchemaTableColumn.BaseTableName, typeof(System.String));
-            DataColumn BaseColumnName = new DataColumn(SchemaTableColumn.BaseColumnName, typeof(System.String));
+            DataColumn baseCatalogName = new DataColumn(SchemaTableOptionalColumn.BaseCatalogName, typeof(System.String));
+            DataColumn baseSchemaName = new DataColumn(SchemaTableColumn.BaseSchemaName, typeof(System.String));
+            DataColumn baseTableName = new DataColumn(SchemaTableColumn.BaseTableName, typeof(System.String));
+            DataColumn baseColumnName = new DataColumn(SchemaTableColumn.BaseColumnName, typeof(System.String));
 
             // unique to SqlClient
-            DataColumn BaseServerName = new DataColumn(SchemaTableOptionalColumn.BaseServerName, typeof(System.String));
-            DataColumn IsAliased = new DataColumn(SchemaTableColumn.IsAliased, typeof(System.Boolean));
-            DataColumn IsExpression = new DataColumn(SchemaTableColumn.IsExpression, typeof(System.Boolean));
-            DataColumn IsIdentity = new DataColumn("IsIdentity", typeof(System.Boolean));
-            DataColumn DataTypeName = new DataColumn("DataTypeName", typeof(System.String));
-            DataColumn UdtAssemblyQualifiedName = new DataColumn("UdtAssemblyQualifiedName", typeof(System.String));
+            DataColumn baseServerName = new DataColumn(SchemaTableOptionalColumn.BaseServerName, typeof(System.String));
+            DataColumn isAliased = new DataColumn(SchemaTableColumn.IsAliased, typeof(System.Boolean));
+            DataColumn isExpression = new DataColumn(SchemaTableColumn.IsExpression, typeof(System.Boolean));
+            DataColumn isIdentity = new DataColumn("IsIdentity", typeof(System.Boolean));
+            DataColumn dataTypeName = new DataColumn("DataTypeName", typeof(System.String));
+            DataColumn udtAssemblyQualifiedName = new DataColumn("UdtAssemblyQualifiedName", typeof(System.String));
             // Xml metadata specific
-            DataColumn XmlSchemaCollectionDatabase = new DataColumn("XmlSchemaCollectionDatabase", typeof(System.String));
-            DataColumn XmlSchemaCollectionOwningSchema = new DataColumn("XmlSchemaCollectionOwningSchema", typeof(System.String));
-            DataColumn XmlSchemaCollectionName = new DataColumn("XmlSchemaCollectionName", typeof(System.String));
+            DataColumn xmlSchemaCollectionDatabase = new DataColumn("XmlSchemaCollectionDatabase", typeof(System.String));
+            DataColumn xmlSchemaCollectionOwningSchema = new DataColumn("XmlSchemaCollectionOwningSchema", typeof(System.String));
+            DataColumn xmlSchemaCollectionName = new DataColumn("XmlSchemaCollectionName", typeof(System.String));
             // SparseColumnSet
-            DataColumn IsColumnSet = new DataColumn("IsColumnSet", typeof(System.Boolean));
+            DataColumn isColumnSet = new DataColumn("IsColumnSet", typeof(System.Boolean));
 
-            Ordinal.DefaultValue = 0;
-            IsLong.DefaultValue = false;
+            ordinal.DefaultValue = 0;
+            isLong.DefaultValue = false;
 
             DataColumnCollection columns = schemaTable.Columns;
 
             // must maintain order for backward compatibility
-            columns.Add(ColumnName);
-            columns.Add(Ordinal);
-            columns.Add(Size);
-            columns.Add(Precision);
-            columns.Add(Scale);
-            columns.Add(IsUnique);
-            columns.Add(IsKey);
-            columns.Add(BaseServerName);
-            columns.Add(BaseCatalogName);
-            columns.Add(BaseColumnName);
-            columns.Add(BaseSchemaName);
-            columns.Add(BaseTableName);
-            columns.Add(DataType);
-            columns.Add(AllowDBNull);
-            columns.Add(ProviderType);
-            columns.Add(IsAliased);
-            columns.Add(IsExpression);
-            columns.Add(IsIdentity);
-            columns.Add(IsAutoIncrement);
-            columns.Add(IsRowVersion);
-            columns.Add(IsHidden);
-            columns.Add(IsLong);
-            columns.Add(IsReadOnly);
-            columns.Add(ProviderSpecificDataType);
-            columns.Add(DataTypeName);
-            columns.Add(XmlSchemaCollectionDatabase);
-            columns.Add(XmlSchemaCollectionOwningSchema);
-            columns.Add(XmlSchemaCollectionName);
-            columns.Add(UdtAssemblyQualifiedName);
-            columns.Add(NonVersionedProviderType);
-            columns.Add(IsColumnSet);
+            columns.Add(columnName);
+            columns.Add(ordinal);
+            columns.Add(size);
+            columns.Add(precision);
+            columns.Add(scale);
+            columns.Add(isUnique);
+            columns.Add(isKey);
+            columns.Add(baseServerName);
+            columns.Add(baseCatalogName);
+            columns.Add(baseColumnName);
+            columns.Add(baseSchemaName);
+            columns.Add(baseTableName);
+            columns.Add(dataType);
+            columns.Add(allowDBNull);
+            columns.Add(providerType);
+            columns.Add(isAliased);
+            columns.Add(isExpression);
+            columns.Add(isIdentity);
+            columns.Add(isAutoIncrement);
+            columns.Add(isRowVersion);
+            columns.Add(isHidden);
+            columns.Add(isLong);
+            columns.Add(isReadOnly);
+            columns.Add(providerSpecificDataType);
+            columns.Add(dataTypeName);
+            columns.Add(xmlSchemaCollectionDatabase);
+            columns.Add(xmlSchemaCollectionOwningSchema);
+            columns.Add(xmlSchemaCollectionName);
+            columns.Add(udtAssemblyQualifiedName);
+            columns.Add(nonVersionedProviderType);
+            columns.Add(isColumnSet);
 
             for (int i = 0; i < md.Length; i++)
             {
                 _SqlMetaData col = md[i];
                 DataRow schemaRow = schemaTable.NewRow();
 
-                schemaRow[ColumnName] = col.column;
-                schemaRow[Ordinal] = col.ordinal;
+                schemaRow[columnName] = col.column;
+                schemaRow[ordinal] = col.ordinal;
                 //
                 // be sure to return character count for string types, byte count otherwise
                 // col.length is always byte count so for unicode types, half the length
                 //
                 // For MAX and XML datatypes, we get 0x7fffffff from the server. Do not divide this.
-                schemaRow[Size] = (col.metaType.IsSizeInCharacters && (col.length != 0x7fffffff)) ? (col.length / 2) : col.length;
+                schemaRow[size] = (col.metaType.IsSizeInCharacters && (col.length != 0x7fffffff)) ? (col.length / 2) : col.length;
                 
 
-                schemaRow[DataType] = GetFieldTypeInternal(col);
-                schemaRow[ProviderSpecificDataType] = GetProviderSpecificFieldTypeInternal(col);
-                schemaRow[NonVersionedProviderType] = (int)col.type; // SqlDbType enum value - does not change with TypeSystem.
-                schemaRow[DataTypeName] = GetDataTypeNameInternal(col);
+                schemaRow[dataType] = GetFieldTypeInternal(col);
+                schemaRow[providerSpecificDataType] = GetProviderSpecificFieldTypeInternal(col);
+                schemaRow[nonVersionedProviderType] = (int)col.type; // SqlDbType enum value - does not change with TypeSystem.
+                schemaRow[dataTypeName] = GetDataTypeNameInternal(col);
 
                 if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && col.IsNewKatmaiDateTimeType)
                 {
-                    schemaRow[ProviderType] = SqlDbType.NVarChar;
+                    schemaRow[providerType] = SqlDbType.NVarChar;
                     switch (col.type)
                     {
                         case SqlDbType.Date:
-                            schemaRow[Size] = TdsEnums.WHIDBEY_DATE_LENGTH;
+                            schemaRow[size] = TdsEnums.WHIDBEY_DATE_LENGTH;
                             break;
                         case SqlDbType.Time:
                             Debug.Assert(TdsEnums.UNKNOWN_PRECISION_SCALE == col.scale || (0 <= col.scale && col.scale <= 7), "Invalid scale for Time column: " + col.scale);
-                            schemaRow[Size] = TdsEnums.WHIDBEY_TIME_LENGTH[TdsEnums.UNKNOWN_PRECISION_SCALE != col.scale ? col.scale : col.metaType.Scale];
+                            schemaRow[size] = TdsEnums.WHIDBEY_TIME_LENGTH[TdsEnums.UNKNOWN_PRECISION_SCALE != col.scale ? col.scale : col.metaType.Scale];
                             break;
                         case SqlDbType.DateTime2:
                             Debug.Assert(TdsEnums.UNKNOWN_PRECISION_SCALE == col.scale || (0 <= col.scale && col.scale <= 7), "Invalid scale for DateTime2 column: " + col.scale);
-                            schemaRow[Size] = TdsEnums.WHIDBEY_DATETIME2_LENGTH[TdsEnums.UNKNOWN_PRECISION_SCALE != col.scale ? col.scale : col.metaType.Scale];
+                            schemaRow[size] = TdsEnums.WHIDBEY_DATETIME2_LENGTH[TdsEnums.UNKNOWN_PRECISION_SCALE != col.scale ? col.scale : col.metaType.Scale];
                             break;
                         case SqlDbType.DateTimeOffset:
                             Debug.Assert(TdsEnums.UNKNOWN_PRECISION_SCALE == col.scale || (0 <= col.scale && col.scale <= 7), "Invalid scale for DateTimeOffset column: " + col.scale);
-                            schemaRow[Size] = TdsEnums.WHIDBEY_DATETIMEOFFSET_LENGTH[TdsEnums.UNKNOWN_PRECISION_SCALE != col.scale ? col.scale : col.metaType.Scale];
+                            schemaRow[size] = TdsEnums.WHIDBEY_DATETIMEOFFSET_LENGTH[TdsEnums.UNKNOWN_PRECISION_SCALE != col.scale ? col.scale : col.metaType.Scale];
                             break;
                     }
                 }
@@ -529,12 +529,12 @@ namespace System.Data.SqlClient
                 {
                     if (_typeSystem == SqlConnectionString.TypeSystem.SQLServer2005)
                     {
-                        schemaRow[ProviderType] = SqlDbType.VarBinary;
+                        schemaRow[providerType] = SqlDbType.VarBinary;
                     }
                     else
                     {
                         // TypeSystem.SQLServer2000
-                        schemaRow[ProviderType] = SqlDbType.Image;
+                        schemaRow[providerType] = SqlDbType.Image;
                     }
                 }
                 else if (_typeSystem != SqlConnectionString.TypeSystem.SQLServer2000)
@@ -542,19 +542,19 @@ namespace System.Data.SqlClient
                     // TypeSystem.SQLServer2005 and above
 
                     // SqlDbType enum value - always the actual type for SQLServer2005.
-                    schemaRow[ProviderType] = (int)col.type;
+                    schemaRow[providerType] = (int)col.type;
 
                     if (col.type == SqlDbType.Udt)
                     { // Additional metadata for UDTs.
                         Debug.Assert(Connection.IsKatmaiOrNewer, "Invalid Column type received from the server");
-                        schemaRow[UdtAssemblyQualifiedName] = col.udtAssemblyQualifiedName;
+                        schemaRow[udtAssemblyQualifiedName] = col.udtAssemblyQualifiedName;
                     }
                     else if (col.type == SqlDbType.Xml)
                     { // Additional metadata for Xml.
                         Debug.Assert(Connection.IsKatmaiOrNewer, "Invalid DataType (Xml) for the column");
-                        schemaRow[XmlSchemaCollectionDatabase] = col.xmlSchemaCollectionDatabase;
-                        schemaRow[XmlSchemaCollectionOwningSchema] = col.xmlSchemaCollectionOwningSchema;
-                        schemaRow[XmlSchemaCollectionName] = col.xmlSchemaCollectionName;
+                        schemaRow[xmlSchemaCollectionDatabase] = col.xmlSchemaCollectionDatabase;
+                        schemaRow[xmlSchemaCollectionOwningSchema] = col.xmlSchemaCollectionOwningSchema;
+                        schemaRow[xmlSchemaCollectionName] = col.xmlSchemaCollectionName;
                     }
                 }
                 else
@@ -562,86 +562,86 @@ namespace System.Data.SqlClient
                     // TypeSystem.SQLServer2000
 
                     // SqlDbType enum value - variable for certain types when SQLServer2000.
-                    schemaRow[ProviderType] = GetVersionedMetaType(col.metaType).SqlDbType;
+                    schemaRow[providerType] = GetVersionedMetaType(col.metaType).SqlDbType;
                 }
 
                 if (TdsEnums.UNKNOWN_PRECISION_SCALE != col.precision)
                 {
-                    schemaRow[Precision] = col.precision;
+                    schemaRow[precision] = col.precision;
                 }
                 else
                 {
-                    schemaRow[Precision] = col.metaType.Precision;
+                    schemaRow[precision] = col.metaType.Precision;
                 }
 
                 if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && col.IsNewKatmaiDateTimeType)
                 {
-                    schemaRow[Scale] = MetaType.MetaNVarChar.Scale;
+                    schemaRow[scale] = MetaType.MetaNVarChar.Scale;
                 }
                 else if (TdsEnums.UNKNOWN_PRECISION_SCALE != col.scale)
                 {
-                    schemaRow[Scale] = col.scale;
+                    schemaRow[scale] = col.scale;
                 }
                 else
                 {
-                    schemaRow[Scale] = col.metaType.Scale;
+                    schemaRow[scale] = col.metaType.Scale;
                 }
 
-                schemaRow[AllowDBNull] = col.isNullable;
+                schemaRow[allowDBNull] = col.isNullable;
 
                 // If no ColInfo token received, do not set value, leave as null.
                 if (_browseModeInfoConsumed)
                 {
-                    schemaRow[IsAliased] = col.isDifferentName;
-                    schemaRow[IsKey] = col.isKey;
-                    schemaRow[IsHidden] = col.isHidden;
-                    schemaRow[IsExpression] = col.isExpression;
+                    schemaRow[isAliased] = col.isDifferentName;
+                    schemaRow[isKey] = col.isKey;
+                    schemaRow[isHidden] = col.isHidden;
+                    schemaRow[isExpression] = col.isExpression;
                 }
 
-                schemaRow[IsIdentity] = col.isIdentity;
-                schemaRow[IsAutoIncrement] = col.isIdentity;
+                schemaRow[isIdentity] = col.isIdentity;
+                schemaRow[isAutoIncrement] = col.isIdentity;
 
                 
-                schemaRow[IsLong] = col.metaType.IsLong;
+                schemaRow[isLong] = col.metaType.IsLong;
                 
                 // mark unique for timestamp columns
                 if (SqlDbType.Timestamp == col.type)
                 {
-                    schemaRow[IsUnique] = true;
-                    schemaRow[IsRowVersion] = true;
+                    schemaRow[isUnique] = true;
+                    schemaRow[isRowVersion] = true;
                 }
                 else
                 {
-                    schemaRow[IsUnique] = false;
-                    schemaRow[IsRowVersion] = false;
+                    schemaRow[isUnique] = false;
+                    schemaRow[isRowVersion] = false;
                 }
 
-                schemaRow[IsReadOnly] = (0 == col.updatability);
-                schemaRow[IsColumnSet] = col.isColumnSet;
+                schemaRow[isReadOnly] = (0 == col.updatability);
+                schemaRow[isColumnSet] = col.isColumnSet;
 
                 if (!string.IsNullOrEmpty(col.serverName))
                 {
-                    schemaRow[BaseServerName] = col.serverName;
+                    schemaRow[baseServerName] = col.serverName;
                 }
                 if (!string.IsNullOrEmpty(col.catalogName))
                 {
-                    schemaRow[BaseCatalogName] = col.catalogName;
+                    schemaRow[baseCatalogName] = col.catalogName;
                 }
                 if (!string.IsNullOrEmpty(col.schemaName))
                 {
-                    schemaRow[BaseSchemaName] = col.schemaName;
+                    schemaRow[baseSchemaName] = col.schemaName;
                 }
                 if (!string.IsNullOrEmpty(col.tableName))
                 {
-                    schemaRow[BaseTableName] = col.tableName;
+                    schemaRow[baseTableName] = col.tableName;
                 }
                 if (!string.IsNullOrEmpty(col.baseColumn))
                 {
-                    schemaRow[BaseColumnName] = col.baseColumn;
+                    schemaRow[baseColumnName] = col.baseColumn;
                 }
                 else if (!string.IsNullOrEmpty(col.column))
                 {
-                    schemaRow[BaseColumnName] = col.column;
+                    schemaRow[baseColumnName] = col.column;
                 }
 
                 schemaTable.Rows.Add(schemaRow);
@@ -1324,7 +1324,7 @@ namespace System.Data.SqlClient
             return GetSqlValues(values);
         }
 
-        override public DataTable GetSchemaTable()
+        public override DataTable GetSchemaTable()
         {
             SqlStatistics statistics = null;
             try
@@ -1334,16 +1334,11 @@ namespace System.Data.SqlClient
                 {
                     if (null != this.MetaData)
                     {
-
                         _metaData.schemaTable = BuildSchemaTable();
                         Debug.Assert(null != _metaData.schemaTable, "No schema information yet!");
                     }
                 }
-                if (null != _metaData)
-                {
-                    return _metaData.schemaTable;
-                }
-                return null;
+                return _metaData?.schemaTable;
             }
             finally
             {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDataReader.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDataReader.cs
@@ -1337,7 +1337,6 @@ namespace System.Data.SqlClient
 
                         _metaData.schemaTable = BuildSchemaTable();
                         Debug.Assert(null != _metaData.schemaTable, "No schema information yet!");
-                        // filter table?
                     }
                 }
                 if (null != _metaData)

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
@@ -3537,6 +3537,7 @@ namespace System.Data.SqlClient
                 return false;
             }
 
+            col.isColumnSet = (TdsEnums.IsColumnSet == (flags & TdsEnums.IsColumnSet));
 
             byte tdsType;
             if (!stateObj.TryReadByte(out tdsType))

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserHelperClasses.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserHelperClasses.cs
@@ -274,6 +274,7 @@ namespace System.Data.SqlClient
         internal bool isHidden;
         internal bool isExpression;
         internal bool isIdentity;
+        internal bool isColumnSet;
         internal string baseColumn;
         internal _SqlMetaData(int ordinal) : base()
         {
@@ -336,6 +337,7 @@ namespace System.Data.SqlClient
             result.isKey = isKey;
             result.isHidden = isHidden;
             result.isIdentity = isIdentity;
+            result.isColumnSet = isColumnSet;
             return result;
         }
     }
@@ -345,6 +347,7 @@ namespace System.Data.SqlClient
         internal ushort id;             // for altrow-columns only
         internal int[] indexMap;
         internal int visibleColumns;
+        internal DataTable schemaTable;
         private readonly _SqlMetaData[] _metaDataArray;
         internal ReadOnlyCollection<DbColumn> dbColumnSchema;
 

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderTest.cs
@@ -69,7 +69,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         public static void CheckSparseColumnBit()
         {
             const int sparseColumns = 4095;
-            string tempTableName = "MyTempTable";
+            string tempTableName = "SparseColumnTable";
 
             // TSQL for "CREATE TABLE" with sparse columns
             // table name will be provided as an argument

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderTest.cs
@@ -66,7 +66,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
 
         // Checks for the IsColumnSet bit in the GetSchemaTable for Sparse columns
         [CheckConnStrSetupFact]
-        public static void CheckSpareColumnBit()
+        public static void CheckSparseColumnBit()
         {
             const int sparseColumns = 4095;
             string tempTableName = "MyTempTable";

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderTest.cs
@@ -1,0 +1,151 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace System.Data.SqlClient.ManualTesting.Tests
+{
+    public static class DataReaderTest
+    {
+        [CheckConnStrSetupFact]
+        public static void LoadReaderIntoDataTableToTestGetSchemaTable()
+        {
+            using(SqlConnection connection = new SqlConnection(DataTestUtility.TcpConnStr)) {
+                connection.Open();
+                var dt = new DataTable();
+                using (SqlCommand command = connection.CreateCommand())
+                {
+                    command.CommandText = "select 3 as [three], 4 as [four]";
+                    // Datatables internally call IDataReader.GetSchemaTable()
+                    dt.Load(command.ExecuteReader());
+                    Assert.Equal(2, dt.Columns.Count);
+                    Assert.Equal("three", dt.Columns[0].ColumnName);
+                    Assert.Equal("four", dt.Columns[1].ColumnName);
+                    Assert.Equal(1, dt.Rows.Count);
+                    Assert.Equal(3, (int)dt.Rows[0][0]);
+                    Assert.Equal(4, (int)dt.Rows[0][1]);
+                }
+            }
+        }
+
+        [CheckConnStrSetupFact]
+        public static void MultiQuerySchema()
+        {
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr);
+            using (SqlConnection connection = new SqlConnection(DataTestUtility.TcpConnStr))
+            {
+                connection.Open();
+
+                using (SqlCommand command = connection.CreateCommand())
+                {
+                    // Use multiple queries
+                    command.CommandText = "SELECT 1 as ColInteger;  SELECT 'STRING' as ColString";
+                    using (SqlDataReader reader = command.ExecuteReader())
+                    {
+                        HashSet<string> columnNames = new HashSet<string>();
+                        do
+                        {
+                            DataTable schemaTable = reader.GetSchemaTable();
+                            foreach (DataRow myField in schemaTable.Rows)
+                            {
+                                columnNames.Add(myField["ColumnName"].ToString());
+                            }
+
+                        } while (reader.NextResult());
+
+                        Assert.True(columnNames.Contains("ColInteger"));
+                        Assert.True(columnNames.Contains("ColString"));
+                    }
+                }
+            }
+        }
+
+
+        // Checks for the IsColumnSet bit in the GetSchemaTable for Sparse columns
+        [CheckConnStrSetupFact]
+        public static void CheckSpareColumnBit()
+        {
+            const int sparseColumns = 4095;
+            string tempTableName = "MyTempTable";
+
+            // TSQL for "CREATE TABLE" with sparse columns
+            // table name will be provided as an argument
+            StringBuilder createBuilder = new StringBuilder("CREATE TABLE {0} ([ID] int PRIMARY KEY, [CSET] xml COLUMN_SET FOR ALL_SPARSE_COLUMNS NULL");
+
+            // TSQL to create the same table, but without the column set column and without sparse
+            // also, it has only 1024 columns, which is the server limit in this case
+            StringBuilder createNonSparseBuilder = new StringBuilder("CREATE TABLE {0} ([ID] int PRIMARY KEY");
+
+            // TSQL to select all columns from the sparse table, without columnset one
+            StringBuilder selectBuilder = new StringBuilder("SELECT [ID]");
+
+            // TSQL to select all columns from the sparse table, with a limit of 1024 (for bulk-copy test)
+            StringBuilder selectNonSparseBuilder = new StringBuilder("SELECT [ID]");
+
+            // add sparse columns
+            for (int c = 0; c < sparseColumns; c++)
+            {
+                createBuilder.AppendFormat(", [C{0}] int SPARSE NULL", c);
+                selectBuilder.AppendFormat(", [C{0}]", c);
+            }
+
+            createBuilder.Append(")");
+            // table name provided as an argument
+            selectBuilder.Append(" FROM {0}");
+
+            string selectStatementFormat = selectBuilder.ToString();
+            string createStatementFormat = createBuilder.ToString();
+            
+            // add a row with nulls only
+            using (SqlConnection con = new SqlConnection(DataTestUtility.TcpConnStr))
+            {
+                con.Open();
+
+                SqlCommand cmd = con.CreateCommand();
+                cmd.CommandType = CommandType.Text;
+
+                cmd.CommandText = string.Format(createStatementFormat, tempTableName);
+                cmd.ExecuteNonQuery();
+
+                cmd.CommandText = string.Format("INSERT INTO {0} ([ID]) VALUES (0)", tempTableName);// insert row with values set to their defaults (DBNULL)
+                cmd.ExecuteNonQuery();
+
+                // run the test cases
+                Assert.True(IsColumnBitSet(con, string.Format("SELECT [ID], [CSET], [C1] FROM {0}", tempTableName), indexOfColumnSet: 1));
+
+                // drop the temp table to release its resources
+                cmd.CommandText = "DROP TABLE " + tempTableName;
+                cmd.ExecuteNonQuery();
+            }
+        }
+
+        private static bool IsColumnBitSet(SqlConnection con, string selectQuery, int indexOfColumnSet)
+        {
+            bool columnSetPresent = false;
+            {
+                SqlCommand cmd = con.CreateCommand();
+                cmd.CommandText = selectQuery;
+
+                using (SqlDataReader reader = cmd.ExecuteReader())
+                {
+                    DataTable schemaTable = reader.GetSchemaTable();
+                    
+
+                    for (int i = 0; i < schemaTable.Rows.Count; i++)
+                    {
+                        bool isColumnSet = (bool)schemaTable.Rows[i]["IsColumnSet"];
+
+                        if (indexOfColumnSet == i)
+                        {
+                            columnSetPresent = true;
+                        }
+                    }
+                }
+            }
+            return columnSetPresent;
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderTest.cs
@@ -13,7 +13,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [CheckConnStrSetupFact]
         public static void LoadReaderIntoDataTableToTestGetSchemaTable()
         {
-            using(SqlConnection connection = new SqlConnection(DataTestUtility.TcpConnStr)) {
+            using (SqlConnection connection = new SqlConnection(DataTestUtility.TcpConnStr))
+            {
                 connection.Open();
                 var dt = new DataTable();
                 using (SqlCommand command = connection.CreateCommand())
@@ -98,7 +99,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
 
             string selectStatementFormat = selectBuilder.ToString();
             string createStatementFormat = createBuilder.ToString();
-            
+
             // add a row with nulls only
             using (SqlConnection con = new SqlConnection(DataTestUtility.TcpConnStr))
             {
@@ -132,7 +133,6 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                 using (SqlDataReader reader = cmd.ExecuteReader())
                 {
                     DataTable schemaTable = reader.GetSchemaTable();
-                    
 
                     for (int i = 0; i < schemaTable.Rows.Count; i++)
                     {

--- a/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
@@ -38,6 +38,7 @@
     <Compile Include="SQL\CommandCancelTest\CommandCancelTest.cs" />
     <Compile Include="SQL\ConnectionPoolTest\ConnectionPoolTest.cs" />
     <Compile Include="SQL\ConnectivityTests\ConnectivityTest.cs" />
+    <Compile Include="SQL\DataReaderTest\DataReaderTest.cs" />
     <Compile Include="SQL\ExceptionTest\ExceptionTest.cs" />
     <Compile Include="SQL\DataStreamTest\DataStreamTest.cs" />
     <Compile Include="SQL\DateTimeTest\DateTimeTest.cs" />


### PR DESCRIPTION
Porting over code to add GetSchemaTable in .Net Core SqlClient. 
The code is a port from NetFx code. The `CheckSparseColumnBit` test is a port from NetFx, 

Reduces failures in Dapper tests by 5 based on my internal runs. 

I ran the EF functional tests with my changes. No regressions observed with the changes. 

Fixes https://github.com/dotnet/corefx/issues/19748

cc @stephentoub @corivera @danmosemsft @karelz 