### PR TITLE
Fix deadlock in SslStream_SameCertUsedForClientAndServer_Ok test on single core

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamCredentialCacheTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamCredentialCacheTest.cs
@@ -18,12 +18,7 @@ namespace System.Net.Security.Tests
     {
         [ActiveIssue(19699, TestPlatforms.Windows)]
         [Fact]
-        public void SslStream_SameCertUsedForClientAndServer_Ok()
-        {
-            SslSessionsCacheTest().GetAwaiter().GetResult();
-        }   
-
-        private static async Task SslSessionsCacheTest()
+        public async Task SslStream_SameCertUsedForClientAndServer_Ok()
         {
             VirtualNetwork network = new VirtualNetwork();
 


### PR DESCRIPTION
Remove the synchronous blocking.

cc: @wfurt, @Priya91 