### PR TITLE
Revert: Disabling dynamic code execution in MemoryMappedFiles tests on UAP/UAPAOT - AppContainer now supports the capability

### DIFF
--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateNew.Tests.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateNew.Tests.cs
@@ -152,14 +152,10 @@ namespace System.IO.MemoryMappedFiles.Tests
             {
                 ValidateMemoryMappedFile(mmf, 4096, MemoryMappedFileAccess.Read);
             }
-
-            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(PlatformDetection.IsWinRT, () =>
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(name, 4096, MemoryMappedFileAccess.ReadWriteExecute, MemoryMappedFileOptions.DelayAllocatePages, HandleInheritability.Inheritable))
             {
-                using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(name, 4096, MemoryMappedFileAccess.ReadWriteExecute, MemoryMappedFileOptions.DelayAllocatePages, HandleInheritability.Inheritable))
-                {
-                    ValidateMemoryMappedFile(mmf, 4096, MemoryMappedFileAccess.ReadWrite, HandleInheritability.Inheritable);
-                }
-            });
+                ValidateMemoryMappedFile(mmf, 4096, MemoryMappedFileAccess.ReadWrite, HandleInheritability.Inheritable);
+            }
         }
 
         /// <summary>
@@ -200,21 +196,15 @@ namespace System.IO.MemoryMappedFiles.Tests
                 ValidateMemoryMappedFile(mmf, capacity);
             }
 
-            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(PlatformDetection.IsWinRT && (access == MemoryMappedFileAccess.ReadExecute || access == MemoryMappedFileAccess.ReadWriteExecute), () =>
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(mapName, capacity, access))
             {
-                using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(mapName, capacity, access))
-                {
-                    ValidateMemoryMappedFile(mmf, capacity, access);
-                }
-            });
+                ValidateMemoryMappedFile(mmf, capacity, access);
+            }
 
-            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(PlatformDetection.IsWinRT && (access == MemoryMappedFileAccess.ReadExecute || access == MemoryMappedFileAccess.ReadWriteExecute), () =>
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(mapName, capacity, access, options, inheritability))
             {
-                using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(mapName, capacity, access, options, inheritability))
-                {
-                    ValidateMemoryMappedFile(mmf, capacity, access, inheritability);
-                }
-            });
+                ValidateMemoryMappedFile(mmf, capacity, access, inheritability);
+            }
         }
 
         /// <summary>

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateOrOpen.Tests.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateOrOpen.Tests.cs
@@ -177,41 +177,29 @@ namespace System.IO.MemoryMappedFiles.Tests
         public void ValidArgumentCombinations_Execute(
             string mapName, long capacity, MemoryMappedFileAccess access, MemoryMappedFileOptions options, HandleInheritability inheritability)
         {
-            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(PlatformDetection.IsWinRT && (access == MemoryMappedFileAccess.ReadExecute || access == MemoryMappedFileAccess.ReadWriteExecute), () =>
+            // Map doesn't exist
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateOrOpen(mapName, capacity, access))
             {
-                // Map doesn't exist
-                using (MemoryMappedFile mmf = MemoryMappedFile.CreateOrOpen(mapName, capacity, access))
-                {
-                    ValidateMemoryMappedFile(mmf, capacity, access);
-                }
-            });
+                ValidateMemoryMappedFile(mmf, capacity, access);
+            }
 
-            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(PlatformDetection.IsWinRT && (access == MemoryMappedFileAccess.ReadExecute || access == MemoryMappedFileAccess.ReadWriteExecute), () =>
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateOrOpen(mapName, capacity, access, options, inheritability))
             {
-                using (MemoryMappedFile mmf = MemoryMappedFile.CreateOrOpen(mapName, capacity, access, options, inheritability))
-                {
-                    ValidateMemoryMappedFile(mmf, capacity, access, inheritability);
-                }
-            });
+                ValidateMemoryMappedFile(mmf, capacity, access, inheritability);
+            }
 
-            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(PlatformDetection.IsWinRT && (access == MemoryMappedFileAccess.ReadExecute || access == MemoryMappedFileAccess.ReadWriteExecute), () =>
+            // Map does exist (CreateNew)
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(mapName, capacity, access))
+            using (MemoryMappedFile mmf2 = MemoryMappedFile.CreateOrOpen(mapName, capacity, access))
             {
-                // Map does exist (CreateNew)
-                using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(mapName, capacity, access))
-                using (MemoryMappedFile mmf2 = MemoryMappedFile.CreateOrOpen(mapName, capacity, access))
-                {
-                    ValidateMemoryMappedFile(mmf2, capacity, access);
-                }
-            });
+                ValidateMemoryMappedFile(mmf2, capacity, access);
+            }
 
-            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(PlatformDetection.IsWinRT && (access == MemoryMappedFileAccess.ReadExecute || access == MemoryMappedFileAccess.ReadWriteExecute), () =>
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(mapName, capacity, access, options, inheritability))
+            using (MemoryMappedFile mmf2 = MemoryMappedFile.CreateOrOpen(mapName, capacity, access, options, inheritability))
             {
-                using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(mapName, capacity, access, options, inheritability))
-                using (MemoryMappedFile mmf2 = MemoryMappedFile.CreateOrOpen(mapName, capacity, access, options, inheritability))
-                {
-                    ValidateMemoryMappedFile(mmf2, capacity, access, inheritability);
-                }
-            });
+                ValidateMemoryMappedFile(mmf2, capacity, access, inheritability);
+            }
 
             // (Avoid testing with CreateFromFile when using execute permissions.)
         }

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor.Tests.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor.Tests.cs
@@ -77,17 +77,11 @@ namespace System.IO.MemoryMappedFiles.Tests
         public void ValidAccessLevelCombinations(MemoryMappedFileAccess mapAccess, MemoryMappedFileAccess viewAccess)
         {
             const int Capacity = 4096;
-            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(PlatformDetection.IsWinRT && (mapAccess == MemoryMappedFileAccess.ReadExecute ||
-                mapAccess == MemoryMappedFileAccess.ReadWriteExecute ||
-                viewAccess == MemoryMappedFileAccess.ReadExecute ||
-                viewAccess == MemoryMappedFileAccess.ReadWriteExecute), () =>
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
+            using (MemoryMappedViewAccessor acc = mmf.CreateViewAccessor(0, Capacity, viewAccess))
             {
-                using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
-                using (MemoryMappedViewAccessor acc = mmf.CreateViewAccessor(0, Capacity, viewAccess))
-                {
-                    ValidateMemoryMappedViewAccessor(acc, Capacity, viewAccess);
-                }
-            });
+                ValidateMemoryMappedViewAccessor(acc, Capacity, viewAccess);
+            }
         }
 
         [Theory]
@@ -107,15 +101,10 @@ namespace System.IO.MemoryMappedFiles.Tests
         public void InvalidAccessLevelsCombinations(MemoryMappedFileAccess mapAccess, MemoryMappedFileAccess viewAccess)
         {
             const int Capacity = 4096;
-            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(PlatformDetection.IsWinRT &&
-                (mapAccess == MemoryMappedFileAccess.ReadExecute ||
-                mapAccess == MemoryMappedFileAccess.ReadWriteExecute), () =>
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
             {
-                using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
-                {
-                    Assert.Throws<UnauthorizedAccessException>(() => mmf.CreateViewAccessor(0, Capacity, viewAccess));
-                }
-            });
+                Assert.Throws<UnauthorizedAccessException>(() => mmf.CreateViewAccessor(0, Capacity, viewAccess));
+            }
         }
 
         /// <summary>

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream.Tests.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream.Tests.cs
@@ -77,18 +77,11 @@ namespace System.IO.MemoryMappedFiles.Tests
         public void ValidAccessLevelCombinations(MemoryMappedFileAccess mapAccess, MemoryMappedFileAccess viewAccess)
         {
             const int Capacity = 4096;
-            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(PlatformDetection.IsWinRT && 
-                (mapAccess == MemoryMappedFileAccess.ReadExecute ||
-                mapAccess == MemoryMappedFileAccess.ReadWriteExecute ||
-                viewAccess == MemoryMappedFileAccess.ReadExecute ||
-                viewAccess == MemoryMappedFileAccess.ReadWriteExecute), () =>
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
+            using (MemoryMappedViewStream s = mmf.CreateViewStream(0, Capacity, viewAccess))
             {
-                using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
-                using (MemoryMappedViewStream s = mmf.CreateViewStream(0, Capacity, viewAccess))
-                {
-                    ValidateMemoryMappedViewStream(s, Capacity, viewAccess);
-                }
-            });
+                ValidateMemoryMappedViewStream(s, Capacity, viewAccess);
+            }
         }
 
         [Theory]
@@ -108,15 +101,10 @@ namespace System.IO.MemoryMappedFiles.Tests
         public void InvalidAccessLevelsCombinations(MemoryMappedFileAccess mapAccess, MemoryMappedFileAccess viewAccess)
         {
             const int Capacity = 4096;
-            AssertExtensions.ThrowsIf<UnauthorizedAccessException>(PlatformDetection.IsWinRT &&
-                (mapAccess == MemoryMappedFileAccess.ReadExecute ||
-                mapAccess == MemoryMappedFileAccess.ReadWriteExecute), () =>
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
             {
-                using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
-                {
-                    Assert.Throws<UnauthorizedAccessException>(() => mmf.CreateViewStream(0, Capacity, viewAccess));
-                }
-            });
+                Assert.Throws<UnauthorizedAccessException>(() => mmf.CreateViewStream(0, Capacity, viewAccess));
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Reverting my last change which disabled some tests for uap/uapaot because dynamic code execution wasn't allowed in appx. It still isn't, but I found the reason why. By adding a capability these calls become valid and the tests will pass.

This PR depends on a buildtools PR and a nuget package update: https://github.com/dotnet/buildtools/pull/1503. After PR gets accepted some more steps are required. This is planned to be done this week.