### PR TITLE
Revert and fix no exception thrown in the managed implementation registering an existing prefix

### DIFF
--- a/src/System.Net.HttpListener/src/System/Net/Managed/HttpEndPointListener.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/HttpEndPointListener.cs
@@ -343,10 +343,7 @@ namespace System.Net
                 prefs = _prefixes;
                 if (prefs.ContainsKey(prefix))
                 {
-                    HttpListener other = (HttpListener)prefs[prefix];
-                    if (other != listener)
-                        throw new HttpListenerException((int)HttpStatusCode.BadRequest, SR.Format(SR.net_listener_already, prefix));
-                    return;
+                    throw new HttpListenerException((int)HttpStatusCode.BadRequest, SR.Format(SR.net_listener_already, prefix));
                 }
                 p2 = new Dictionary<ListenerPrefix, HttpListener>(prefs);
                 p2[prefix] = listener;

--- a/src/System.Net.HttpListener/src/System/Net/Managed/HttpEndPointManager.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/HttpEndPointManager.cs
@@ -102,18 +102,12 @@ namespace System.Net
                 throw new HttpListenerException((int)HttpStatusCode.BadRequest, SR.net_invalid_path);
 
             // listens on all the interfaces if host name cannot be parsed by IPAddress.
-            HttpEndPointListener epl = GetEPListener(lp.Host, lp.Port, listener, lp.Secure, out bool alreadyExists);
-            if (alreadyExists)
-            {
-                throw new HttpListenerException(98, SR.Format(SR.net_listener_already, p));
-            }
+            HttpEndPointListener epl = GetEPListener(lp.Host, lp.Port, listener, lp.Secure);
             epl.AddPrefix(lp, listener);
         }
 
-        private static HttpEndPointListener GetEPListener(string host, int port, HttpListener listener, bool secure, out bool alreadyExists)
+        private static HttpEndPointListener GetEPListener(string host, int port, HttpListener listener, bool secure)
         {
-            alreadyExists = false;
-
             IPAddress addr;
             if (host == "*")
                 addr = IPAddress.Any;
@@ -146,7 +140,6 @@ namespace System.Net
             HttpEndPointListener epl = null;
             if (p.ContainsKey(port))
             {
-                alreadyExists = true;
                 epl = p[port];
             }
             else
@@ -208,7 +201,7 @@ namespace System.Net
             if (lp.Path.IndexOf("//", StringComparison.Ordinal) != -1)
                 return;
 
-            HttpEndPointListener epl = GetEPListener(lp.Host, lp.Port, listener, lp.Secure, out bool ignored);
+            HttpEndPointListener epl = GetEPListener(lp.Host, lp.Port, listener, lp.Secure);
             epl.RemovePrefix(lp, listener);
         }
     }

--- a/src/System.Net.HttpListener/tests/HttpListenerFactory.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerFactory.cs
@@ -52,20 +52,21 @@ namespace System.Net.Tests
                     // Remember the exception for later
                     _processPrefixException = e;
 
-                    // If this is not an HttpListenerException or SocketException, something very wrong has happened, and there's no point
-                    // in trying again.
-                    if (!(e is HttpListenerException) && !(e is SocketException))
-                        break;
-
-                    // If we can't access the host (e.g. if it is '+' or '*' and the current user is the administrator)
-                    // then throw.
                     if (e is HttpListenerException listenerException)
                     {
+                        // If we can't access the host (e.g. if it is '+' or '*' and the current user is the administrator)
+                        // then throw.
                         const int ERROR_ACCESS_DENIED = 5;
                         if (listenerException.ErrorCode == ERROR_ACCESS_DENIED && (hostname == "*" || hostname == "+"))
                         {
                             throw new InvalidOperationException($"Access denied for host {hostname}");
                         }
+                    }
+                    else if (!(e is SocketException))
+                    {
+                        // If this is not an HttpListenerException or SocketException, something very wrong has happened, and there's no point
+                        // in trying again.
+                        break;
                     }
                 }
             }

--- a/src/System.Net.HttpListener/tests/HttpListenerFactory.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerFactory.cs
@@ -15,22 +15,23 @@ namespace System.Net.Tests
         private readonly HttpListener _processPrefixListener;
         private readonly Exception _processPrefixException;
         private readonly string _processPrefix;
-        public const string Hostname = "localhost";
+        private readonly string _hostname;
         private readonly string _path;
         private readonly int _port;
 
-        internal HttpListenerFactory()
+        internal HttpListenerFactory(string hostname = "localhost")
         {
             // Find a URL prefix that is not in use on this machine *and* uses a port that's not in use.
             // Once we find this prefix, keep a listener on it for the duration of the process, so other processes
             // can't steal it.
 
             Guid processGuid = Guid.NewGuid();
+            _hostname = hostname;
             _path = processGuid.ToString("N");
 
-            for (int port = 1024; port <= IPEndPoint.MaxPort; port++)
+            for (int port = 1025; port <= IPEndPoint.MaxPort; port++)
             {
-                string prefix = $"http://{Hostname}:{port}/{_path}/";
+                string prefix = $"http://{hostname}:{port}/{_path}/";
 
                 var listener = new HttpListener();
                 try
@@ -55,6 +56,17 @@ namespace System.Net.Tests
                     // in trying again.
                     if (!(e is HttpListenerException) && !(e is SocketException))
                         break;
+
+                    // If we can't access the host (e.g. if it is '+' or '*' and the current user is the administrator)
+                    // then throw.
+                    if (e is HttpListenerException listenerException)
+                    {
+                        const int ERROR_ACCESS_DENIED = 5;
+                        if (listenerException.ErrorCode == ERROR_ACCESS_DENIED && (hostname == "*" || hostname == "+"))
+                        {
+                            throw new InvalidOperationException($"Access denied for host {hostname}");
+                        }
+                    }
                 }
             }
 
@@ -89,7 +101,30 @@ namespace System.Net.Tests
             }
         }
 
+        public string Hostname => _hostname;
         public string Path => _path;
+
+        private static bool? s_supportsWildcards;
+        public static bool SupportsWildcards
+        {
+            get
+            {
+                if (!s_supportsWildcards.HasValue)
+                {
+                    try
+                    {
+                        new HttpListenerFactory("*");
+                        s_supportsWildcards = true;
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        s_supportsWildcards = false;
+                    }
+                }
+
+                return s_supportsWildcards.Value;
+            }
+        }
 
         public HttpListener GetListener() => _processPrefixListener;
 

--- a/src/System.Net.HttpListener/tests/HttpListenerPrefixCollectionTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerPrefixCollectionTests.cs
@@ -210,10 +210,11 @@ namespace System.Net.Tests
             }
         }
 
-        [Fact]
-        public void Add_PrefixAlreadyRegisteredAndNotStarted_ThrowsHttpListenerException()
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
+        [MemberData(nameof(Hosts_TestData))]
+        public void Add_PrefixAlreadyRegisteredAndNotStarted_ThrowsHttpListenerException(string hostname)
         {
-            using (var factory = new HttpListenerFactory())
+            using (var factory = new HttpListenerFactory(hostname))
             {
                 string uriPrefix = Assert.Single(factory.GetListener().Prefixes);
 
@@ -224,16 +225,255 @@ namespace System.Net.Tests
             }
         }
 
-        [Fact]
-        public void Add_PrefixAlreadyRegisteredAndStarted_ThrowsHttpListenerException()
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
+        [MemberData(nameof(Hosts_TestData))]
+        public void Add_PrefixAlreadyRegisteredWithDifferentPathAndNotStarted_Works(string hostname)
         {
-            using (var factory = new HttpListenerFactory())
+            using (var factory = new HttpListenerFactory(hostname))
+            {
+                var listener = factory.GetListener();
+                string uriPrefix = Assert.Single(listener.Prefixes);
+
+                listener.Prefixes.Add(uriPrefix + "sub_path/");
+                Assert.Equal(2, listener.Prefixes.Count);
+
+                listener.Start();
+                Assert.True(listener.IsListening);
+            }
+        }
+
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
+        [MemberData(nameof(Hosts_TestData))]
+        public void Add_PrefixAlreadyRegisteredAndStarted_ThrowsHttpListenerException(string hostname)
+        {
+            using (var factory = new HttpListenerFactory(hostname))
             {
                 HttpListener listener = factory.GetListener();
                 string uriPrefix = Assert.Single(listener.Prefixes);
 
                 Assert.Throws<HttpListenerException>(() => listener.Prefixes.Add(uriPrefix));
                 Assert.Throws<HttpListenerException>(() => listener.Prefixes.Add(uriPrefix + "/sub_path/"));
+            }
+        }
+
+        public static IEnumerable<object[]> Hosts_TestData()
+        {
+            yield return new object[] { "localhost" };
+            yield return new object[] { "127.0.0.1" };
+
+            if (HttpListenerFactory.SupportsWildcards)
+            {
+                yield return new object[] { "*" };
+                yield return new object[] { "+" };
+            }
+        }
+        
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
+        [MemberData(nameof(Hosts_TestData))]
+        public void Add_SamePortDifferentPathDifferentListenerNotStarted_Works(string host)
+        {
+            var listener1 = new HttpListener();
+            var listener2 = new HttpListener();
+
+            int? freePort = null;
+
+            // Try to find a port that is not being used.
+            for (int port = 1025; port <= IPEndPoint.MaxPort; port++)
+            {
+                string uriPrefix = $"http://{host}:{port}/";
+                try
+                {
+                    listener1.Prefixes.Add(uriPrefix);
+                    Assert.Equal(1, listener1.Prefixes.Count);
+                    listener1.Start();
+
+                    freePort = port;
+                    break;
+                }
+                catch (HttpListenerException)
+                {
+                    // This port is already in use. Skip it and find a port that's not being used.
+                    listener1.Close();
+                    listener1 = new HttpListener();
+                }
+            }
+
+            try
+            {
+                if (!freePort.HasValue)
+                {
+                    throw new InvalidOperationException("Expected to have a port open on the machine.");
+                }
+
+                listener2.Prefixes.Add($"http://{host}:{freePort}/sub_path/");
+                Assert.Equal(1, listener2.Prefixes.Count);
+
+                listener2.Start();
+                Assert.True(listener2.IsListening);
+            }
+            finally
+            {
+                listener1?.Close();
+                listener2?.Close();
+            }
+        }
+
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
+        [MemberData(nameof(Hosts_TestData))]
+        public void Add_SamePortDifferentPathDifferentListenerStarted_Works(string host)
+        {
+            var listener1 = new HttpListener();
+            var listener2 = new HttpListener();
+
+            int? freePort1 = null;
+            int? freePort2 = null;
+
+            // Try to find a port that is not being used.
+            for (int port = 1025; port <= IPEndPoint.MaxPort; port++)
+            {
+                string uriPrefix = $"http://127.0.0.1:{port}/";
+                try
+                {
+                    if (!freePort1.HasValue)
+                    {
+                        listener1.Prefixes.Add(uriPrefix);
+                        Assert.Equal(1, listener1.Prefixes.Count);
+
+                        listener1.Start();
+                        freePort1 = port;
+                    }
+                    else if (!freePort2.HasValue)
+                    {
+                        listener2.Prefixes.Add(uriPrefix);
+                        Assert.Equal(1, listener2.Prefixes.Count);
+
+                        listener2.Start();
+                        freePort2 = port;
+
+                        break;
+                    }
+                }
+                catch (HttpListenerException)
+                {
+                    // This port is already in use. Skip it and find a port that's not being used.
+                    if (!freePort1.HasValue)
+                    {
+                        listener1.Close();
+                        listener1 = new HttpListener();
+                    }
+                    else if (!freePort2.HasValue)
+                    {
+                        listener2.Close();
+                        listener2 = new HttpListener();
+                    }
+                }
+            }
+
+            try
+            {
+                if (!freePort1.HasValue || !freePort2.HasValue)
+                {
+                    throw new InvalidOperationException("Expected to have a port open on the machine.");
+                }
+                
+                listener1.Prefixes.Add($"http://127.0.0.1:{freePort2}/hola/");
+                listener2.Prefixes.Add($"http://127.0.0.1:{freePort1}/hola/");
+
+                Assert.Equal(2, listener1.Prefixes.Count);
+                Assert.Equal(2, listener2.Prefixes.Count);
+
+                // Conflicts with existing registration: listener2 has registered to listen to http://127.0.0.1:{freePort1}/...
+                Assert.Throws<HttpListenerException>(() => listener1.Prefixes.Add($"http://127.0.0.1:{freePort1}/"));
+                Assert.Throws<HttpListenerException>(() => listener1.Prefixes.Add($"http://127.0.0.1:{freePort1}/hola/"));
+
+                // Conflicts with existing registration: listener1 has registered to listen to http://127.0.0.1:{freePort2}/...
+                Assert.Throws<HttpListenerException>(() => listener2.Prefixes.Add($"http://127.0.0.1:{freePort2}/"));
+                Assert.Throws<HttpListenerException>(() => listener2.Prefixes.Add($"http://127.0.0.1:{freePort2}/hola/"));
+            }
+            finally
+            {
+                listener1?.Close();
+                listener2?.Close();
+            }
+        }
+
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
+        [MemberData(nameof(Hosts_TestData))]
+        public void Add_SamePortDifferentPathMultipleStarted_Success(string host)
+        {
+            var listener1 = new HttpListener();
+            var listener2 = new HttpListener();
+
+            int? freePort1 = null;
+            int? freePort2 = null;
+
+            // Try to find a port that is not being used.
+            for (int port = 1025; port <= IPEndPoint.MaxPort; port++)
+            {
+                string uriPrefix = $"http://{host}:{port}/";
+                try
+                {
+                    if (!freePort1.HasValue)
+                    {
+                        listener1.Prefixes.Add(uriPrefix);
+                        Assert.Equal(1, listener1.Prefixes.Count);
+
+                        listener1.Start();
+                        freePort1 = port;
+                    }
+                    else if (!freePort2.HasValue)
+                    {
+                        listener2.Prefixes.Add(uriPrefix);
+                        Assert.Equal(1, listener2.Prefixes.Count);
+
+                        listener2.Start();
+                        freePort2 = port;
+
+                        break;
+                    }
+                }
+                catch (HttpListenerException)
+                {
+                    // This port is already in use. Skip it and find a port that's not being used.
+                    if (!freePort1.HasValue)
+                    {
+                        listener1.Close();
+                        listener1 = new HttpListener();
+                    }
+                    else if (!freePort2.HasValue)
+                    {
+                        listener2.Close();
+                        listener2 = new HttpListener();
+                    }
+                }
+            }
+
+            try
+            {
+                if (!freePort1.HasValue || !freePort2.HasValue)
+                {
+                    throw new InvalidOperationException("Expected to have a port open on the machine.");
+                }
+
+                listener1.Prefixes.Add($"http://{host}:{freePort1}/hola/");
+                Assert.Equal(2, listener1.Prefixes.Count);
+
+                listener2.Prefixes.Add($"http://{host}:{freePort2}/hola/");
+                Assert.Equal(2, listener2.Prefixes.Count);
+
+                // Conflict: listenerX is already listening to $"http://127.0.0.1:{freePortX}/hola/".
+                Assert.Throws<HttpListenerException>(() => listener1.Prefixes.Add($"http://{host}:{freePort1}/hola/"));
+                Assert.Throws<HttpListenerException>(() => listener2.Prefixes.Add($"http://{host}:{freePort2}/hola/"));
+
+                // Conflict: listenerX is already listening to $"http://127.0.0.1:{freePortY}/hola/".
+                Assert.Throws<HttpListenerException>(() => listener1.Prefixes.Add($"http://{host}:{freePort2}/hola/"));
+                Assert.Throws<HttpListenerException>(() => listener2.Prefixes.Add($"http://{host}:{freePort1}/hola/"));
+
+            }
+            finally
+            {
+                listener1?.Close();
+                listener2?.Close();
             }
         }
 


### PR DESCRIPTION
The first commit reverts the buggy commit that caused #19827. This revert causes test failures in 
Add_PrefixAlreadyRegisteredAndNotStarted_ThrowsHttpListenerException

The second commit adds a swathe of tests for various scenarios. Most of these tests failed before the revert.

It turns out the fix to the difference in behaviour between managed and Windows is actually as simple as removing an `if` in HttpEndPointListener.AddPrefix. 

Previously the managed implementation wouldn't throw if we tried to add the same prefix with the same listener - but it would with different listeners. Instead we should always throw, in order to match Windows behaviour.


Fixes #19827

@stephentoub @baulig @davidsh @priya91