### PR TITLE
CoreFx Tests: Add ActiveIssues for ILC

### DIFF
--- a/src/Common/tests/System/Collections/ICollectionTest.cs
+++ b/src/Common/tests/System/Collections/ICollectionTest.cs
@@ -254,7 +254,6 @@ namespace Tests.Collections
         [InlineData(16, 20, 0, 0)]
         [InlineData(16, 20, 0, 4)]
         [InlineData(16, 24, 0, 4)]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Multidim arrays of rank 1 still WIP on UapAot: https://github.com/dotnet/corert/issues/3331")]
         public void CopyTo(
             int size,
             int arraySize,

--- a/src/Microsoft.CSharp/tests/ArrayHandling.cs
+++ b/src/Microsoft.CSharp/tests/ArrayHandling.cs
@@ -11,8 +11,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
 {
     public class ArrayHandling
     {
-        [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "https://github.com/dotnet/corert/issues/3331")]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNonZeroLowerBoundArraySupported))]
         public void SingleRankNonSZArray()
         {
             dynamic d = Array.CreateInstance(typeof(int), new[] { 8 }, new[] { -2 });
@@ -25,58 +24,95 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         [Fact]
         public void ArrayTypeNames()
         {
-            dynamic d = Array.CreateInstance(typeof(int), new[] { 8 }, new[] { -2 });
-            RuntimeBinderException ex = Assert.Throws<RuntimeBinderException>(() => { string s = d; });
-            Assert.Contains("int[*]", ex.Message);
+            dynamic d;
+            RuntimeBinderException ex;
+
+            if (PlatformDetection.IsNonZeroLowerBoundArraySupported)
+            {
+                d = Array.CreateInstance(typeof(int), new[] { 8 }, new[] { -2 });
+                ex = Assert.Throws<RuntimeBinderException>(() => { string s = d; });
+                if (!PlatformDetection.IsNetNative) // .NET Native toolchain optimizes away Exception messages.
+                {
+                    Assert.Contains("int[*]", ex.Message);
+                }
+            }
 
             d = new int[3];
             ex = Assert.Throws<RuntimeBinderException>(() => { string s = d; });
-            Assert.Contains("int[]", ex.Message);
+            if (!PlatformDetection.IsNetNative) // .NET Native toolchain optimizes away Exception messages.
+            {
+                Assert.Contains("int[]", ex.Message);
+            }
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "https://github.com/dotnet/corert/issues/3331")]
         public void MultiDimArrayTypeNames()
         {
             dynamic d = new int[3, 2, 1];
             RuntimeBinderException ex = Assert.Throws<RuntimeBinderException>(() => { string s = d; });
-            Assert.Contains("int[,,]", ex.Message);
+            if (!PlatformDetection.IsNetNative) // .NET Native toolchain optimizes away Exception messages.
+            {
+                Assert.Contains("int[,,]", ex.Message);
+            }
 
-            d = Array.CreateInstance(typeof(int), new[] { 3, 2, 1 }, new[] { -2, 2, -0 });
-            ex = Assert.Throws<RuntimeBinderException>(() => { string s = d; });
-            Assert.Contains("int[,,]", ex.Message);
+            if (PlatformDetection.IsNonZeroLowerBoundArraySupported)
+            {
+                d = Array.CreateInstance(typeof(int), new[] { 3, 2, 1 }, new[] { -2, 2, -0 });
+                ex = Assert.Throws<RuntimeBinderException>(() => { string s = d; });
+                if (!PlatformDetection.IsNetNative) // .NET Native toolchain optimizes away Exception messages.
+                {
+                    Assert.Contains("int[,,]", ex.Message);
+                }
+            }
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "https://github.com/dotnet/corert/issues/3331")]
         public void IncorrectNumberOfIndices()
         {
             dynamic d = new int[2, 2, 2];
             RuntimeBinderException ex = Assert.Throws<RuntimeBinderException>(() => d[1] = 0);
-            Assert.Contains("[]", ex.Message);
-            Assert.Contains("'3'", ex.Message);
+            if (!PlatformDetection.IsNetNative) // .NET Native toolchain optimizes away Exception messages.
+            {
+                Assert.Contains("[]", ex.Message);
+                Assert.Contains("'3'", ex.Message);
+            }
 
 
             ex = Assert.Throws<RuntimeBinderException>(() => d[1, 2, 3, 4] = 0);
-            Assert.Contains("[]", ex.Message);
-            Assert.Contains("'3'", ex.Message);
+            if (!PlatformDetection.IsNetNative) // .NET Native toolchain optimizes away Exception messages.
+            {
+                Assert.Contains("[]", ex.Message);
+                Assert.Contains("'3'", ex.Message);
+            }
 
             ex = Assert.Throws<RuntimeBinderException>(() => d[1]);
-            Assert.Contains("[]", ex.Message);
-            Assert.Contains("'3'", ex.Message);
+            if (!PlatformDetection.IsNetNative) // .NET Native toolchain optimizes away Exception messages.
+            {
+                Assert.Contains("[]", ex.Message);
+                Assert.Contains("'3'", ex.Message);
+            }
 
             ex = Assert.Throws<RuntimeBinderException>(() => d[1, 2, 3, 4]);
-            Assert.Contains("[]", ex.Message);
-            Assert.Contains("'3'", ex.Message);
+            if (!PlatformDetection.IsNetNative) // .NET Native toolchain optimizes away Exception messages.
+            {
+                Assert.Contains("[]", ex.Message);
+                Assert.Contains("'3'", ex.Message);
+            }
 
             d = new int[2];
             ex = Assert.Throws<RuntimeBinderException>(() => d[1, 2, 3, 4] = 0);
-            Assert.Contains("[]", ex.Message);
-            Assert.Contains("'1'", ex.Message);
+            if (!PlatformDetection.IsNetNative) // .NET Native toolchain optimizes away Exception messages.
+            {
+                Assert.Contains("[]", ex.Message);
+                Assert.Contains("'1'", ex.Message);
+            }
 
             ex = Assert.Throws<RuntimeBinderException>(() => d[1, 2, 3, 4]);
-            Assert.Contains("[]", ex.Message);
-            Assert.Contains("'1'", ex.Message);
+            if (!PlatformDetection.IsNetNative) // .NET Native toolchain optimizes away Exception messages.
+            {
+                Assert.Contains("[]", ex.Message);
+                Assert.Contains("'1'", ex.Message);
+            }
         }
     }
 }

--- a/src/System.Collections.Concurrent/tests/ProducerConsumerCollectionTests.cs
+++ b/src/System.Collections.Concurrent/tests/ProducerConsumerCollectionTests.cs
@@ -415,7 +415,6 @@ namespace System.Collections.Concurrent.Tests
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(100)]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Multidim rank 1 arrays not supported: https://github.com/dotnet/corert/issues/3331")]
         public void CopyTo_ArrayZeroLowerBound_ZeroIndex_ExpectedElementsCopied(int size)
         {
             IEnumerable<int> initialItems = Enumerable.Range(1, size);

--- a/src/System.Collections.Immutable/tests/ImmutableHashSetTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableHashSetTest.cs
@@ -64,6 +64,7 @@ namespace System.Collections.Immutable.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19044 - HashBucket.Equals() always returning true", TargetFrameworkMonikers.UapAot)]
         public void EnumeratorWithHashCollisionsTest()
         {
             var emptySet = this.EmptyTyped<int>().WithComparer(new BadHasher<int>());
@@ -141,6 +142,7 @@ namespace System.Collections.Immutable.Tests
         /// that *is* in the set.
         /// </summary>
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19044 - HashBucket.Equals() always returning true", TargetFrameworkMonikers.UapAot)]
         public void RemoveValuesFromCollidedHashCode()
         {
             var set = ImmutableHashSet.Create<int>(new BadHasher<int>(), 5, 6);

--- a/src/System.Dynamic.Runtime/tests/Dynamic.OverloadResolution/Conformance.dynamic.overloadResolution.Methods.1class2methods.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.OverloadResolution/Conformance.dynamic.overloadResolution.Methods.1class2methods.cs
@@ -4170,6 +4170,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.overloadResolution.Meth
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19895 - Switch over to real HasSameMetadataDefinitionAs() - once CoreRt implements it.", TargetFrameworkMonikers.UapAot)]
         public static void DynamicCSharpRunTest()
         {
             Assert.Equal(0, MainMethod());

--- a/src/System.Linq.Expressions/tests/Array/ArrayArrayLengthTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayArrayLengthTests.cs
@@ -1929,7 +1929,6 @@ namespace System.Linq.Expressions.Tests
         #region Regression tests
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Multidim rank 1 arrays not supported: https://github.com/dotnet/corert/issues/3331")]
         public static void ArrayLength_MultiDimensionalOf1()
         {
             foreach (var e in new Expression[] { Expression.Parameter(typeof(int).MakeArrayType(1)), Expression.Constant(new int[2, 2]) })

--- a/src/System.Reflection.DispatchProxy/tests/DispatchProxyTests.cs
+++ b/src/System.Reflection.DispatchProxy/tests/DispatchProxyTests.cs
@@ -99,24 +99,28 @@ namespace DispatchProxyTests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corert/issues/3637 - wrong exception thrown from DispatchProxy.Create()", TargetFrameworkMonikers.UapAot)]
         public static void Create_Using_Concrete_Proxy_Type_Throws_ArgumentException()
         {
             AssertExtensions.Throws<ArgumentException>("T", () => DispatchProxy.Create<TestType_ConcreteClass, TestDispatchProxy>());
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corert/issues/3637 - wrong exception thrown from DispatchProxy.Create()", TargetFrameworkMonikers.UapAot)]
         public static void Create_Using_Sealed_BaseType_Throws_ArgumentException()
         {
             AssertExtensions.Throws<ArgumentException>("TProxy", () => DispatchProxy.Create<TestType_IHelloService, Sealed_TestDispatchProxy>());
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corert/issues/3637 - wrong exception thrown from DispatchProxy.Create()", TargetFrameworkMonikers.UapAot)]
         public static void Create_Using_Abstract_BaseType_Throws_ArgumentException()
         {
             AssertExtensions.Throws<ArgumentException>("TProxy", () => DispatchProxy.Create<TestType_IHelloService, Abstract_TestDispatchProxy>());
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corert/issues/3637 - wrong exception thrown from DispatchProxy.Create()", TargetFrameworkMonikers.UapAot)]
         public static void Create_Using_BaseType_Without_Default_Ctor_Throws_ArgumentException()
         {
             AssertExtensions.Throws<ArgumentException>("TProxy", () => DispatchProxy.Create<TestType_IHelloService, NoDefaultCtor_TestDispatchProxy>());
@@ -390,6 +394,7 @@ namespace DispatchProxyTests
 
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Reflection on generated dispatch proxy types not allowed.")]
         public static void Proxy_Declares_Interface_Properties()
         {
             TestType_IPropertyService proxy = DispatchProxy.Create<TestType_IPropertyService, TestDispatchProxy>();
@@ -448,6 +453,7 @@ namespace DispatchProxyTests
 #endif // netcoreapp
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Reflection on generated dispatch proxy types not allowed.")]
         public static void Proxy_Declares_Interface_Events()
         {
             TestType_IEventService proxy = DispatchProxy.Create<TestType_IEventService, TestDispatchProxy>();
@@ -489,6 +495,7 @@ namespace DispatchProxyTests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Reflection on generated dispatch proxy types not allowed.")]
         public static void Proxy_Declares_Interface_Indexers()
         {
             TestType_IIndexerService proxy = DispatchProxy.Create<TestType_IIndexerService, TestDispatchProxy>();

--- a/src/System.Reflection.TypeExtensions/tests/ConstructorInfo/ConstructorInfoInvokeArrayTests.cs
+++ b/src/System.Reflection.TypeExtensions/tests/ConstructorInfo/ConstructorInfoInvokeArrayTests.cs
@@ -33,7 +33,6 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Multidim arrays of rank 1 not supported on UapAot: https://github.com/dotnet/corert/issues/3331")]
         public void Invoke_1DArrayConstructor()
         {
             Type type = Type.GetType("System.Char[*]");
@@ -69,6 +68,10 @@ namespace System.Reflection.Tests
                     case 2:
                         {
                             int[] invalidLowerBounds = new int[] { -20, 0, 20 };
+                            if (!PlatformDetection.IsNonZeroLowerBoundArraySupported)
+                            {
+                                Array.Clear(invalidLowerBounds, 0, invalidLowerBounds.Length);
+                            }
                             int[] invalidLengths = new int[] { -100, -9, -1 };
                             for (int j = 0; j < invalidLengths.Length; j++)
                             {
@@ -76,6 +79,10 @@ namespace System.Reflection.Tests
                             }
 
                             int[] validLowerBounds = new int[] { 0, 1, -1, 2, -3, 5, -10, 99, 100 };
+                            if (!PlatformDetection.IsNonZeroLowerBoundArraySupported)
+                            {
+                                Array.Clear(validLowerBounds, 0, validLowerBounds.Length);
+                            }
                             int[] validLengths = new int[] { 0, 1, 3, 2, 3, 5, 10, 99, 0 };
                             for (int j = 0; j < validLengths.Length; j++)
                             {

--- a/src/System.Reflection.TypeExtensions/tests/CoreCLR/ModuleTests.CoreCLR.cs
+++ b/src/System.Reflection.TypeExtensions/tests/CoreCLR/ModuleTests.CoreCLR.cs
@@ -9,6 +9,7 @@ namespace System.Reflection.Tests
     public class ModuleTests
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corert/issues/3638 - HasMVID returns true but GetMVID violently disagrees.", TargetFrameworkMonikers.UapAot)]
         public void GetModuleVersionId_KnownAssembly_ReturnsExpected()
         {
             Module module = Assembly.Load(new AssemblyName("TinyAssembly")).ManifestModule;

--- a/src/System.Reflection/tests/TypeInfoTests.cs
+++ b/src/System.Reflection/tests/TypeInfoTests.cs
@@ -1029,7 +1029,6 @@ namespace System.Reflection.Tests
 
         [Theory]
         [InlineData(typeof(string))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Multidim arrays of rank 1 not supported on UapAot: https://github.com/dotnet/corert/issues/3331")]
         public void MakeArrayType_IntRank1(Type type)
         {
             Type arrayType = type.GetType().MakeArrayType(1);

--- a/src/System.Runtime/tests/System/AttributeTests.cs
+++ b/src/System.Runtime/tests/System/AttributeTests.cs
@@ -157,6 +157,7 @@ namespace System.Tests
 
         [Fact]
         [StringValue("\uDFFF")]
+        [ActiveIssue("TFS 437293 - Invalid Utf8 string in custom attribute argument falls back to wrong value.", TargetFrameworkMonikers.UapAot)]
         public static void StringArgument_InvalidCodeUnits_FallbackUsed()
         {
             MethodInfo thisMethod = typeof(AttributeTests).GetTypeInfo().GetDeclaredMethod("StringArgument_InvalidCodeUnits_FallbackUsed");

--- a/src/System.Runtime/tests/System/TypeTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/TypeTests.netcoreapp.cs
@@ -49,12 +49,9 @@ namespace System.Tests
         [Fact]
         public void IsSZArray_FalseForVariableBoundArrayTypes()
         {
-            if (!PlatformDetection.IsNetNative) // Multidim arrays of rank 1 not supported on UapAot: https://github.com/dotnet/corert/issues/3331
+            foreach (Type type in NonArrayBaseTypes.Select(nonArrayBaseType => nonArrayBaseType.MakeArrayType(1)))
             {
-                foreach (Type type in NonArrayBaseTypes.Select(nonArrayBaseType => nonArrayBaseType.MakeArrayType(1)))
-                {
-                    Assert.False(type.IsSZArray);
-                }
+                Assert.False(type.IsSZArray);
             }
 
             foreach (Type type in NonArrayBaseTypes.Select(nonArrayBaseType => nonArrayBaseType.MakeArrayType(2)))
@@ -103,12 +100,9 @@ namespace System.Tests
         [Fact]
         public void IsVariableBoundArray_TrueForVariableBoundArrayTypes()
         {
-            if (!PlatformDetection.IsNetNative) // Multidim arrays of rank 1 not supported on UapAot: https://github.com/dotnet/corert/issues/3331
+            foreach (Type type in NonArrayBaseTypes.Select(nonArrayBaseType => nonArrayBaseType.MakeArrayType(1)))
             {
-                foreach (Type type in NonArrayBaseTypes.Select(nonArrayBaseType => nonArrayBaseType.MakeArrayType(1)))
-                {
-                    Assert.True(type.IsVariableBoundArray);
-                }
+                Assert.True(type.IsVariableBoundArray);
             }
 
             foreach (Type type in NonArrayBaseTypes.Select(nonArrayBaseType => nonArrayBaseType.MakeArrayType(2)))


### PR DESCRIPTION
- Now that we have a per-framework ActiveIssueAttribute
  (and we have more than 1.5 people working on these tests on ILC),
  add ActiveIssues for those tests where we know the cause
  and don't anticipate a fix within a week.

- Now that ILC supports multidim arrays of rank 1,
  reenable all the tests that were disabled because of that.