### PR TITLE
Adding DataTable support in SqlParameter

### DIFF
--- a/src/System.Data.SqlClient/src/Microsoft/SqlServer/Server/MetadataUtilsSmi.cs
+++ b/src/System.Data.SqlClient/src/Microsoft/SqlServer/Server/MetadataUtilsSmi.cs
@@ -68,6 +68,7 @@ namespace Microsoft.SqlServer.Server
             SqlDbType.NVarChar,             // System.Data.SqlTypes.SqlChars
             SqlDbType.VarBinary,            // System.Data.SqlTypes.SqlBytes
             SqlDbType.Xml,                  // System.Data.SqlTypes.SqlXml
+            SqlDbType.Structured,           // System.Data.DataTable
             SqlDbType.Structured,           // System.Collections.IEnumerable, used for TVPs it must return IDataRecord
             SqlDbType.Structured,           // System.Collections.Generic.IEnumerable<Microsoft.SqlServer.Server.SqlDataRecord>
             SqlDbType.Time,                 // System.TimeSpan
@@ -121,12 +122,12 @@ namespace Microsoft.SqlServer.Server
                 { typeof(SqlChars), ExtendedClrTypeCode.SqlChars },
                 { typeof(SqlBytes), ExtendedClrTypeCode.SqlBytes },
                 { typeof(SqlXml), ExtendedClrTypeCode.SqlXml },
+                { typeof(DataTable), ExtendedClrTypeCode.DataTable },
                 { typeof(DbDataReader), ExtendedClrTypeCode.DbDataReader },
                 { typeof(IEnumerable<SqlDataRecord>), ExtendedClrTypeCode.IEnumerableOfSqlDataRecord },
                 { typeof(TimeSpan), ExtendedClrTypeCode.TimeSpan },
                 { typeof(DateTimeOffset), ExtendedClrTypeCode.DateTimeOffset },
             };
-            Debug.Assert(dictionary.Count == Count);
             return dictionary;
         }
 
@@ -336,7 +337,11 @@ namespace Microsoft.SqlServer.Server
                     case SqlDbType.Structured:
                         if (isMultiValued)
                         {
-                            if (value is IEnumerable<SqlDataRecord>)
+                            if (value is DataTable)
+                            {
+                                extendedCode = ExtendedClrTypeCode.DataTable;
+                            }
+                            else if (value is IEnumerable<SqlDataRecord>)
                             {
                                 extendedCode = ExtendedClrTypeCode.IEnumerableOfSqlDataRecord;
                             }
@@ -603,5 +608,189 @@ namespace Microsoft.SqlServer.Server
                                         null,
                                         null);
         }
+
+        // Extract metadata for a single DataColumn
+        static internal SmiExtendedMetaData SmiMetaDataFromDataColumn(DataColumn column, DataTable parent)
+        {
+            SqlDbType dbType = InferSqlDbTypeFromType_Katmai(column.DataType);
+            if (InvalidSqlDbType == dbType)
+            {
+                throw SQL.UnsupportedColumnTypeForSqlProvider(column.ColumnName, column.DataType.Name);
+            }
+
+            long maxLength = AdjustMaxLength(dbType, column.MaxLength);
+            if (InvalidMaxLength == maxLength)
+            {
+                throw SQL.InvalidColumnMaxLength(column.ColumnName, maxLength);
+            }
+
+            byte precision;
+            byte scale;
+            if (column.DataType == typeof(SqlDecimal))
+            {
+
+                // Must scan all values in column to determine best-fit precision & scale
+                Debug.Assert(null != parent);
+                scale = 0;
+                byte nonFractionalPrecision = 0; // finds largest non-Fractional portion of precision
+                foreach (DataRow row in parent.Rows)
+                {
+                    object obj = row[column];
+                    if (!(obj is DBNull))
+                    {
+                        SqlDecimal value = (SqlDecimal)obj;
+                        if (!value.IsNull)
+                        {
+                            byte tempNonFractPrec = checked((byte)(value.Precision - value.Scale));
+                            if (tempNonFractPrec > nonFractionalPrecision)
+                            {
+                                nonFractionalPrecision = tempNonFractPrec;
+                            }
+
+                            if (value.Scale > scale)
+                            {
+                                scale = value.Scale;
+                            }
+                        }
+                    }
+                }
+
+                precision = checked((byte)(nonFractionalPrecision + scale));
+
+                if (SqlDecimal.MaxPrecision < precision)
+                {
+                    throw SQL.InvalidTableDerivedPrecisionForTvp(column.ColumnName, precision);
+                }
+                else if (0 == precision)
+                {
+                    precision = 1;
+                }
+            }
+            else if (dbType == SqlDbType.DateTime2 || dbType == SqlDbType.DateTimeOffset || dbType == SqlDbType.Time)
+            {
+                // Time types care about scale, too.  But have to infer maximums for these.
+                precision = 0;
+                scale = SmiMetaData.DefaultTime.Scale;
+            }
+            else if (dbType == SqlDbType.Decimal)
+            {
+                // Must scan all values in column to determine best-fit precision & scale
+                Debug.Assert(null != parent);
+                scale = 0;
+                byte nonFractionalPrecision = 0; // finds largest non-Fractional portion of precision
+                foreach (DataRow row in parent.Rows)
+                {
+                    object obj = row[column];
+                    if (!(obj is DBNull))
+                    {
+                        SqlDecimal value = (SqlDecimal)(Decimal)obj;
+                        byte tempNonFractPrec = checked((byte)(value.Precision - value.Scale));
+                        if (tempNonFractPrec > nonFractionalPrecision)
+                        {
+                            nonFractionalPrecision = tempNonFractPrec;
+                        }
+
+                        if (value.Scale > scale)
+                        {
+                            scale = value.Scale;
+                        }
+                    }
+                }
+
+                precision = checked((byte)(nonFractionalPrecision + scale));
+
+                if (SqlDecimal.MaxPrecision < precision)
+                {
+                    throw SQL.InvalidTableDerivedPrecisionForTvp(column.ColumnName, precision);
+                }
+                else if (0 == precision)
+                {
+                    precision = 1;
+                }
+            }
+            else
+            {
+                precision = 0;
+                scale = 0;
+            }
+
+            // In Net Core, since DataColumn.Locale is not accessible because it is internal and in a separate assembly, 
+            // we try to get the Locale from the parent
+            CultureInfo columnLocale = ((null != parent) ? parent.Locale : CultureInfo.CurrentCulture);
+
+            return new SmiExtendedMetaData(
+                                        dbType,
+                                        maxLength,
+                                        precision,
+                                        scale,
+                                        columnLocale.LCID,
+                                        SmiMetaData.DefaultNVarChar.CompareOptions,
+                                        false,  // no support for multi-valued columns in a TVP yet
+                                        null,   // no support for structured columns yet
+                                        null,   // no support for structured columns yet
+                                        column.ColumnName,
+                                        null,
+                                        null,
+                                        null);
+        }
+
+        static internal long AdjustMaxLength(SqlDbType dbType, long maxLength)
+        {
+            if (SmiMetaData.UnlimitedMaxLengthIndicator != maxLength)
+            {
+                if (maxLength < 0)
+                {
+                    maxLength = InvalidMaxLength;
+                }
+
+                switch (dbType)
+                {
+                    case SqlDbType.Binary:
+                        if (maxLength > SmiMetaData.MaxBinaryLength)
+                        {
+                            maxLength = InvalidMaxLength;
+                        }
+                        break;
+                    case SqlDbType.Char:
+                        if (maxLength > SmiMetaData.MaxANSICharacters)
+                        {
+                            maxLength = InvalidMaxLength;
+                        }
+                        break;
+                    case SqlDbType.NChar:
+                        if (maxLength > SmiMetaData.MaxUnicodeCharacters)
+                        {
+                            maxLength = InvalidMaxLength;
+                        }
+                        break;
+                    case SqlDbType.NVarChar:
+                        // Promote to MAX type if it won't fit in a normal type
+                        if (SmiMetaData.MaxUnicodeCharacters < maxLength)
+                        {
+                            maxLength = SmiMetaData.UnlimitedMaxLengthIndicator;
+                        }
+                        break;
+                    case SqlDbType.VarBinary:
+                        // Promote to MAX type if it won't fit in a normal type
+                        if (SmiMetaData.MaxBinaryLength < maxLength)
+                        {
+                            maxLength = SmiMetaData.UnlimitedMaxLengthIndicator;
+                        }
+                        break;
+                    case SqlDbType.VarChar:
+                        // Promote to MAX type if it won't fit in a normal type
+                        if (SmiMetaData.MaxANSICharacters < maxLength)
+                        {
+                            maxLength = SmiMetaData.UnlimitedMaxLengthIndicator;
+                        }
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            return maxLength;
+        }
+
     }
 }

--- a/src/System.Data.SqlClient/src/Microsoft/SqlServer/Server/MetadataUtilsSmi.cs
+++ b/src/System.Data.SqlClient/src/Microsoft/SqlServer/Server/MetadataUtilsSmi.cs
@@ -610,7 +610,7 @@ namespace Microsoft.SqlServer.Server
         }
 
         // Extract metadata for a single DataColumn
-        static internal SmiExtendedMetaData SmiMetaDataFromDataColumn(DataColumn column, DataTable parent)
+        internal static SmiExtendedMetaData SmiMetaDataFromDataColumn(DataColumn column, DataTable parent)
         {
             SqlDbType dbType = InferSqlDbTypeFromType_Katmai(column.DataType);
             if (InvalidSqlDbType == dbType)
@@ -628,7 +628,6 @@ namespace Microsoft.SqlServer.Server
             byte scale;
             if (column.DataType == typeof(SqlDecimal))
             {
-
                 // Must scan all values in column to determine best-fit precision & scale
                 Debug.Assert(null != parent);
                 scale = 0;
@@ -734,7 +733,7 @@ namespace Microsoft.SqlServer.Server
                                         null);
         }
 
-        static internal long AdjustMaxLength(SqlDbType dbType, long maxLength)
+        internal static long AdjustMaxLength(SqlDbType dbType, long maxLength)
         {
             if (SmiMetaData.UnlimitedMaxLengthIndicator != maxLength)
             {

--- a/src/System.Data.SqlClient/src/Resources/Strings.resx
+++ b/src/System.Data.SqlClient/src/Resources/Strings.resx
@@ -1045,4 +1045,10 @@
   <data name="PlatformNotSupported_DataSqlClient" xml:space="preserve">
     <value>System.Data.SqlClient is not supported on this platform.</value>
   </data>
+  <data name="SqlParameter_InvalidTableDerivedPrecisionForTvp" xml:space="preserve">
+    <value>Precision '{0}' required to send all values in column '{1}' exceeds the maximum supported precision '{2}'. The values must all fit in a single precision.</value>
+  </data>
+  <data name="SqlProvider_InvalidDataColumnMaxLength" xml:space="preserve">
+    <value>The size of column '{0}' is not supported. The size is {1}.</value>
+  </data>
 </root>

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameter.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameter.cs
@@ -1079,9 +1079,8 @@ namespace System.Data.SqlClient
             peekAhead = null;
 
             object value = GetCoercedValue();
-            if (value is DataTable)
+            if (value is DataTable dt)
             {
-                DataTable dt = value as DataTable;
                 if (dt.Columns.Count <= 0)
                 {
                     throw SQL.NotEnoughColumnsInStructuredType();

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameter.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameter.cs
@@ -946,6 +946,7 @@ namespace System.Data.SqlClient
                         value = new DateTimeOffset((DateTime)value);
                     }
                     else if (TdsEnums.SQLTABLE == destinationType.TDSType && (
+                                value is DataTable ||
                                 value is DbDataReader ||
                                 value is System.Collections.Generic.IEnumerable<SqlDataRecord>))
                     {
@@ -1078,7 +1079,49 @@ namespace System.Data.SqlClient
             peekAhead = null;
 
             object value = GetCoercedValue();
-            if (value is SqlDataReader)
+            if (value is DataTable)
+            {
+                DataTable dt = value as DataTable;
+                if (dt.Columns.Count <= 0)
+                {
+                    throw SQL.NotEnoughColumnsInStructuredType();
+                }
+                fields = new List<MSS.SmiExtendedMetaData>(dt.Columns.Count);
+                bool[] keyCols = new bool[dt.Columns.Count];
+                bool hasKey = false;
+
+                // set up primary key as unique key list
+                //  do this prior to general metadata loop to favor the primary key
+                if (null != dt.PrimaryKey && 0 < dt.PrimaryKey.Length)
+                {
+                    foreach (DataColumn col in dt.PrimaryKey)
+                    {
+                        keyCols[col.Ordinal] = true;
+                        hasKey = true;
+                    }
+                }
+
+                for (int i = 0; i < dt.Columns.Count; i++)
+                {
+                    fields.Add(MSS.MetaDataUtilsSmi.SmiMetaDataFromDataColumn(dt.Columns[i], dt));
+
+                    // DataColumn uniqueness is only for a single column, so don't add
+                    //  more than one.  (keyCols.Count first for assumed minimal perf benefit)
+                    if (!hasKey && dt.Columns[i].Unique)
+                    {
+                        keyCols[i] = true;
+                        hasKey = true;
+                    }
+                }
+
+                // Add unique key property, if any found.
+                if (hasKey)
+                {
+                    props = new SmiMetaDataPropertyCollection();
+                    props[MSS.SmiPropertySelector.UniqueKey] = new MSS.SmiUniqueKeyProperty(new List<bool>(keyCols));
+                }
+            }
+            else if (value is SqlDataReader)
             {
                 fields = new List<MSS.SmiExtendedMetaData>(((SqlDataReader)value).GetInternalSmiMetaData());
                 if (fields.Count <= 0)

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlUtil.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlUtil.cs
@@ -533,7 +533,14 @@ namespace System.Data.SqlClient
         {
             return ADP.InvalidOperation(SR.GetString(SR.SQL_BulkLoadPendingOperation));
         }
-
+        static internal Exception InvalidTableDerivedPrecisionForTvp(string columnName, byte precision)
+        {
+            return ADP.InvalidOperation(SR.GetString(SR.SqlParameter_InvalidTableDerivedPrecisionForTvp, precision, columnName, System.Data.SqlTypes.SqlDecimal.MaxPrecision));
+        }
+        static internal Exception InvalidColumnMaxLength(string columnName, long maxLength)
+        {
+            return ADP.Argument(SR.GetString(SR.SqlProvider_InvalidDataColumnMaxLength, columnName, maxLength));
+        }
         //
         // transactions.
         //

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlUtil.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlUtil.cs
@@ -533,11 +533,11 @@ namespace System.Data.SqlClient
         {
             return ADP.InvalidOperation(SR.GetString(SR.SQL_BulkLoadPendingOperation));
         }
-        static internal Exception InvalidTableDerivedPrecisionForTvp(string columnName, byte precision)
+        internal static Exception InvalidTableDerivedPrecisionForTvp(string columnName, byte precision)
         {
             return ADP.InvalidOperation(SR.GetString(SR.SqlParameter_InvalidTableDerivedPrecisionForTvp, precision, columnName, System.Data.SqlTypes.SqlDecimal.MaxPrecision));
         }
-        static internal Exception InvalidColumnMaxLength(string columnName, long maxLength)
+        internal static Exception InvalidColumnMaxLength(string columnName, long maxLength)
         {
             return ADP.Argument(SR.GetString(SR.SqlProvider_InvalidDataColumnMaxLength, columnName, maxLength));
         }


### PR DESCRIPTION
Porting code from NetFx which enables DataTables to be passing as a parameter in SqlParameter.
Tested with Dapper, and EF tests. 

Dapper failures for netcoreapp2.0 reduce with this change.
No failures in EF tests.

Added new test to test DataTable as a parameter.
Fixes: https://github.com/dotnet/corefx/issues/19708

cc @NickCraver @danmosemsft @karelz 
