### PR TITLE
Add DangerousAcceptAnyServerCertificateValidator property to HttpClient

### DIFF
--- a/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.Initialization.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.Initialization.cs
@@ -26,7 +26,7 @@ internal static partial class Interop
 #if !SYSNETHTTP_NO_OPENSSL
             string opensslVersion = Interop.Http.GetSslVersionDescription();
             if (string.IsNullOrEmpty(opensslVersion) ||
-                opensslVersion.IndexOf("openssl/1.0", StringComparison.OrdinalIgnoreCase) != -1)
+                opensslVersion.IndexOf(Interop.Http.OpenSsl10Description, StringComparison.OrdinalIgnoreCase) != -1)
             {
                 // CURL uses OpenSSL which me must initialize first to guarantee thread-safety
                 // Only initialize for OpenSSL/1.0, any newer versions may have mismatched

--- a/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.VersionInfo.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.VersionInfo.cs
@@ -46,5 +46,8 @@ internal static partial class Interop
 
         [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_GetSslVersionDescription")]
         internal static extern string GetSslVersionDescription();
+
+        internal const string OpenSsl10Description = "openssl/1.0";
+        internal const string SecureTransportDescription = "SecureTransport";
     }
 }

--- a/src/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/System.Net.Http/ref/System.Net.Http.cs
@@ -85,6 +85,7 @@ namespace System.Net.Http
         public System.Security.Cryptography.X509Certificates.X509CertificateCollection ClientCertificates { get { throw null; } }
         public System.Net.CookieContainer CookieContainer { get { throw null; } set { } }
         public System.Net.ICredentials Credentials { get { throw null; } set { } }
+        public static System.Func<System.Net.Http.HttpRequestMessage, System.Security.Cryptography.X509Certificates.X509Certificate2, System.Security.Cryptography.X509Certificates.X509Chain, System.Net.Security.SslPolicyErrors, bool> DangerousAcceptAnyServerCertificateValidator { get { throw null; } }
         public System.Net.ICredentials DefaultProxyCredentials { get { throw null; } set { } }
         public int MaxAutomaticRedirections { get { throw null; } set { } }
         public int MaxConnectionsPerServer { get { throw null; } set { } }

--- a/src/System.Net.Http/src/Resources/Strings.resx
+++ b/src/System.Net.Http/src/Resources/Strings.resx
@@ -217,9 +217,6 @@
   <data name="net_cookie_attribute" xml:space="preserve">
     <value>The '{0}'='{1}' part of the cookie is invalid.</value>
   </data>
-  <data name="net_http_unix_invalid_certcallback_option" xml:space="preserve">
-    <value>The libcurl library in use ({0}) and its SSL backend ("{1}") do not support custom handling of certificates. A libcurl built with OpenSSL is required.</value>
-  </data>
   <data name="net_http_unix_invalid_credential" xml:space="preserve">
     <value>The libcurl library in use ({0}) does not support different credentials for different authentication schemes.</value>
   </data>

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Net46.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Net46.cs
@@ -331,6 +331,8 @@ namespace System.Net.Http
             }
         }
 
+        public static Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> DangerousAcceptAnyServerCertificateValidator { get; } = delegate { return true; };
+
         public Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> ServerCertificateCustomValidationCallback
         {
             get

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Unix.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Unix.cs
@@ -41,6 +41,8 @@ namespace System.Net.Http
 
         public X509CertificateCollection ClientCertificates => _curlHandler.ClientCertificates;
 
+        public static Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> DangerousAcceptAnyServerCertificateValidator { get; } = delegate { return true; };
+
         public Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> ServerCertificateCustomValidationCallback
         {
             get { return _curlHandler.ServerCertificateValidationCallback; }

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
@@ -164,6 +164,8 @@ namespace System.Net.Http
             get { return _winHttpHandler.ClientCertificates; }
         }
 
+        public static Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> DangerousAcceptAnyServerCertificateValidator { get; } = delegate { return true; };
+
         public Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> ServerCertificateCustomValidationCallback
         {
             get { return _winHttpHandler.ServerCertificateValidationCallback; }

--- a/src/System.Net.Http/src/System/Net/Http/OSX/CurlHandler.SslProvider.cs
+++ b/src/System.Net.Http/src/System/Net/Http/OSX/CurlHandler.SslProvider.cs
@@ -36,6 +36,19 @@ namespace System.Net.Http
                             CurlSslVersionDescription));
                 }
 
+                // Revocation checking is always on for darwinssl (SecureTransport).
+                // If any other backend is used and revocation is requested, we can't guarantee
+                // that assertion.
+                if (easy._handler.CheckCertificateRevocationList &&
+                    !CurlSslVersionDescription.Equals(Interop.Http.SecureTransportDescription))
+                {
+                    throw new PlatformNotSupportedException(
+                        SR.Format(
+                            SR.net_http_libcurl_revocation_notsupported,
+                            CurlVersionDescription,
+                            CurlSslVersionDescription));
+                }
+
                 if (easy._handler.ServerCertificateValidationCallback != null)
                 {
                     // libcurl (as of 7.49.1) does not have any callback which can be registered which fires
@@ -58,24 +71,23 @@ namespace System.Net.Http
                     // user's keychain and setting the SSL policy trust for it to "Always Trust".
                     // Similarly, the "block this" could be attained by setting the SSL policy for a cert in the
                     // keychain to "Never Trust".
-                    throw new PlatformNotSupportedException(
-                        SR.Format(
-                            SR.net_http_libcurl_callback_notsupported,
-                            CurlVersionDescription,
-                            CurlSslVersionDescription));
-                }
-
-                // Revocation checking is always on for darwinssl (SecureTransport).
-                // If any other backend is used and revocation is requested, we can't guarantee
-                // that assertion.
-                if (easy._handler.CheckCertificateRevocationList &&
-                    !CurlSslVersionDescription.Equals("SecureTransport"))
-                {
-                    throw new PlatformNotSupportedException(
-                    SR.Format(
-                        SR.net_http_libcurl_revocation_notsupported,
-                        CurlVersionDescription,
-                        CurlSslVersionDescription));
+                    //
+                    // However, one case we can support is when we know all certificates will pass validation.
+                    // We can detect a key case of that: whether DangerousAcceptAnyServerCertificateValidator was used.
+                    if (easy.ServerCertificateValidationCallbackAcceptsAll)
+                    {
+                        EventSourceTrace("Warning: Disabling peer verification per {0}", nameof(HttpClientHandler.DangerousAcceptAnyServerCertificateValidator), easy: easy);
+                        easy.SetCurlOption(Interop.Http.CURLoption.CURLOPT_SSL_VERIFYPEER, 0); // don't verify the peer
+                        // Don't set CURLOPT_SSL_VERIFHOST to 0; doing so disables SNI.
+                    }
+                    else
+                    {
+                        throw new PlatformNotSupportedException(
+                            SR.Format(
+                                SR.net_http_libcurl_callback_notsupported,
+                                CurlVersionDescription,
+                                CurlSslVersionDescription));
+                    }
                 }
 
                 SetSslVersion(easy);

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
@@ -742,6 +742,10 @@ namespace System.Net.Http
                 SslProvider.SetSslOptions(this, _handler.ClientCertificateOptions);
             }
 
+            internal bool ServerCertificateValidationCallbackAcceptsAll => ReferenceEquals(
+                _handler.ServerCertificateValidationCallback,
+                HttpClientHandler.DangerousAcceptAnyServerCertificateValidator);
+
             internal void SetCurlCallbacks(
                 IntPtr easyGCHandle,
                 ReadWriteCallback receiveHeadersCallback,

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.SslProvider.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.SslProvider.cs
@@ -47,84 +47,83 @@ namespace System.Net.Http
                         CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
                 }
 
-                // Register the callback with libcurl.  We need to register even if there's no user-provided
-                // server callback and even if there are no client certificates, because we support verifying
-                // server certificates against more than those known to OpenSSL.
-                if (CurlSslVersionDescription.IndexOf("openssl/1.0", StringComparison.OrdinalIgnoreCase) != -1)
+                // Configure the options.  Our best support is when targeting OpenSSL/1.0.  For other backends,
+                // we fall back to a minimal amount of support, and may throw a PNSE based on the options requested.
+                if (CurlSslVersionDescription.IndexOf(Interop.Http.OpenSsl10Description, StringComparison.OrdinalIgnoreCase) != -1)
                 {
-                    CURLcode answer = easy.SetSslCtxCallback(s_sslCtxCallback, userPointer);
-                    switch (answer)
-                    {
-                        case CURLcode.CURLE_OK:
-                            // We successfully registered.  If we'll be invoking a user-provided callback to verify the server
-                            // certificate as part of that, disable libcurl's verification of the host name.  The user's callback
-                            // needs to be given the opportunity to examine the cert, and our logic will determine whether
-                            // the host name matches and will inform the callback of that.
-                            if (easy._handler.ServerCertificateValidationCallback != null)
-                            {
-                                easy.SetCurlOption(Interop.Http.CURLoption.CURLOPT_SSL_VERIFYHOST, 0); // don't verify the peer cert's hostname
-                                // We don't change the SSL_VERIFYPEER setting, as setting it to 0 will cause
-                                // SSL and libcurl to ignore the result of the server callback.
-                            }
-
-                            // The allowed SSL protocols will be set in the configuration callback.
-                            break;
-
-                        case CURLcode.CURLE_UNKNOWN_OPTION: // Curl 7.38 and prior
-                        case CURLcode.CURLE_NOT_BUILT_IN:   // Curl 7.39 and later
-                            // It's ok if we failed to register the callback if all of the defaults are in play
-                            // with relation to handling of certificates.  But if that's not the case, failing to 
-                            // register the callback will result in those options not being factored in, which is
-                            // a significant enough error that we need to fail.
-                            EventSourceTrace("CURLOPT_SSL_CTX_FUNCTION not supported: {0}", answer, easy: easy);
-                            if (certProvider != null ||
-                                easy._handler.ServerCertificateValidationCallback != null ||
-                                easy._handler.CheckCertificateRevocationList)
-                            {
-                                throw new PlatformNotSupportedException(
-                                    SR.Format(SR.net_http_unix_invalid_certcallback_option, CurlVersionDescription, CurlSslVersionDescription));
-                            }
-
-                            // Since there won't be a callback to configure the allowed SSL protocols, configure them here.
-                            SetSslVersion(easy);
-
-                            break;
-
-                        default:
-                            ThrowIfCURLEError(answer);
-                            break;
-                    }
+                    // Register the callback with libcurl.  We need to register even if there's no user-provided
+                    // server callback and even if there are no client certificates, because we support verifying
+                    // server certificates against more than those known to OpenSSL.
+                    SetSslOptionsForSupportedBackend(easy, certProvider, userPointer);
                 }
                 else
                 {
-                    // For newer versions of openssl throw PNSE, if default not used.
-                    if (certProvider != null)
-                    {
-                        throw new PlatformNotSupportedException(
-                            SR.Format(
-                                SR.net_http_libcurl_clientcerts_notsupported,
-                                CurlVersionDescription, CurlSslVersionDescription));
-                    }
-
-                    if (easy._handler.ServerCertificateValidationCallback != null)
-                    {
-                        throw new PlatformNotSupportedException(
-                            SR.Format(
-                                SR.net_http_libcurl_callback_notsupported,
-                                CurlVersionDescription, CurlSslVersionDescription));
-                    }
-
-                    if (easy._handler.CheckCertificateRevocationList)
-                    {
-                        throw new PlatformNotSupportedException(
-                            SR.Format(
-                                SR.net_http_libcurl_revocation_notsupported,
-                                CurlVersionDescription, CurlSslVersionDescription));
-                    }
-
-                    // In case of defaults configure the allowed SSL protocols.
-                    SetSslVersion(easy);
+                    // Newer versions of OpenSSL, and other non-OpenSSL backends, do not currently support callbacks.
+                    // That means we'll throw a PNSE if a callback is required.
+                    SetSslOptionsForUnsupportedBackend(easy, certProvider);
                 }
+            }
+
+            private static void SetSslOptionsForSupportedBackend(EasyRequest easy, ClientCertificateProvider certProvider, IntPtr userPointer)
+            {
+                CURLcode answer = easy.SetSslCtxCallback(s_sslCtxCallback, userPointer);
+                switch (answer)
+                {
+                    case CURLcode.CURLE_OK:
+                        // We successfully registered.  If we'll be invoking a user-provided callback to verify the server
+                        // certificate as part of that, disable libcurl's verification of the host name; we need to get
+                        // the callback from libcurl even if the host name doesn't match, so we take on the responsibility
+                        // of doing the host name match in the callback prior to invoking the user's delegate.
+                        if (easy._handler.ServerCertificateValidationCallback != null)
+                        {
+                            easy.SetCurlOption(Interop.Http.CURLoption.CURLOPT_SSL_VERIFYHOST, 0);
+                            // But don't change the CURLOPT_SSL_VERIFYPEER setting, as setting it to 0 will
+                            // cause SSL and libcurl to ignore the result of the server callback.
+                        }
+
+                        // The allowed SSL protocols will be set in the configuration callback.
+                        break;
+
+                    case CURLcode.CURLE_UNKNOWN_OPTION: // Curl 7.38 and prior
+                    case CURLcode.CURLE_NOT_BUILT_IN:   // Curl 7.39 and later
+                        EventSourceTrace("CURLOPT_SSL_CTX_FUNCTION not supported: {0}", answer, easy: easy);
+                        SetSslOptionsForUnsupportedBackend(easy, certProvider);
+                        break;
+
+                    default:
+                        ThrowIfCURLEError(answer);
+                        break;
+                }
+            }
+
+            private static void SetSslOptionsForUnsupportedBackend(EasyRequest easy, ClientCertificateProvider certProvider)
+            {
+                if (certProvider != null)
+                {
+                    throw new PlatformNotSupportedException(SR.Format(SR.net_http_libcurl_clientcerts_notsupported, CurlVersionDescription, CurlSslVersionDescription));
+                }
+
+                if (easy._handler.CheckCertificateRevocationList)
+                {
+                    throw new PlatformNotSupportedException(SR.Format(SR.net_http_libcurl_revocation_notsupported, CurlVersionDescription, CurlSslVersionDescription));
+                }
+
+                if (easy._handler.ServerCertificateValidationCallback != null)
+                {
+                    if (easy.ServerCertificateValidationCallbackAcceptsAll)
+                    {
+                        EventSourceTrace("Warning: Disabling peer and host verification per {0}", nameof(HttpClientHandler.DangerousAcceptAnyServerCertificateValidator), easy: easy);
+                        easy.SetCurlOption(Interop.Http.CURLoption.CURLOPT_SSL_VERIFYPEER, 0);
+                        easy.SetCurlOption(Interop.Http.CURLoption.CURLOPT_SSL_VERIFYHOST, 0);
+                    }
+                    else
+                    {
+                        throw new PlatformNotSupportedException(SR.Format(SR.net_http_libcurl_callback_notsupported, CurlVersionDescription, CurlSslVersionDescription));
+                    }
+                }
+
+                // In case of defaults configure the allowed SSL protocols.
+                SetSslVersion(easy);
             }
 
             private static void SetSslVersion(EasyRequest easy, IntPtr sslCtx = default(IntPtr))

--- a/src/System.Net.Http/src/netcore50/System/Net/HttpClientHandler.cs
+++ b/src/System.Net.Http/src/netcore50/System/Net/HttpClientHandler.cs
@@ -364,6 +364,8 @@ namespace System.Net.Http
             }
         }
 
+        public static Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> DangerousAcceptAnyServerCertificateValidator { get; } = delegate { return true; };
+
         public Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> ServerCertificateCustomValidationCallback
         {
             // TODO: Not yet implemented. Issue #7623.

--- a/src/System.Net.Http/tests/FunctionalTests/Configurations.props
+++ b/src/System.Net.Http/tests/FunctionalTests/Configurations.props
@@ -2,6 +2,8 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
+      netcoreapp-Windows_NT;
+      netcoreapp-Unix;
       netstandard-Windows_NT;
       netstandard-Unix;
     </BuildConfigurations>

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.AcceptAllCerts.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.AcceptAllCerts.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Net.Security;
+using System.Net.Test.Common;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public class HttpClientHandler_DangerousAcceptAllCertificatesValidator_Test
+    {
+        [Fact]
+        public void SingletonReturnsTrue()
+        {
+            Assert.NotNull(HttpClientHandler.DangerousAcceptAnyServerCertificateValidator);
+            Assert.Same(HttpClientHandler.DangerousAcceptAnyServerCertificateValidator, HttpClientHandler.DangerousAcceptAnyServerCertificateValidator);
+            Assert.True(HttpClientHandler.DangerousAcceptAnyServerCertificateValidator(null, null, null, SslPolicyErrors.None));
+        }
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.AcceptAllCerts.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.AcceptAllCerts.cs
@@ -11,6 +11,8 @@ using Xunit;
 
 namespace System.Net.Http.Functional.Tests
 {
+    using Configuration = System.Net.Test.Common.Configuration;
+
     public class HttpClientHandler_DangerousAcceptAllCertificatesValidator_Test
     {
         [Fact]
@@ -19,6 +21,51 @@ namespace System.Net.Http.Functional.Tests
             Assert.NotNull(HttpClientHandler.DangerousAcceptAnyServerCertificateValidator);
             Assert.Same(HttpClientHandler.DangerousAcceptAnyServerCertificateValidator, HttpClientHandler.DangerousAcceptAnyServerCertificateValidator);
             Assert.True(HttpClientHandler.DangerousAcceptAnyServerCertificateValidator(null, null, null, SslPolicyErrors.None));
+        }
+
+        [Theory]
+        [InlineData(SslProtocols.Tls, false)] // try various protocols to ensure we correctly set versions even when accepting all certs
+        [InlineData(SslProtocols.Tls, true)]
+        [InlineData(SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls, false)]
+        [InlineData(SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls, true)]
+        [InlineData(SslProtocols.None, false)]
+        [InlineData(SslProtocols.None, true)]
+        public async Task SetDelegate_ConnectionSucceeds(SslProtocols acceptedProtocol, bool requestOnlyThisProtocol)
+        {
+            using (var handler = new HttpClientHandler() { ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator })
+            using (var client = new HttpClient(handler))
+            {
+                if (requestOnlyThisProtocol)
+                {
+                    handler.SslProtocols = acceptedProtocol;
+                }
+
+                var options = new LoopbackServer.Options { UseSsl = true, SslProtocols = acceptedProtocol };
+                await LoopbackServer.CreateServerAsync(async (server, url) =>
+                {
+                    await TestHelper.WhenAllCompletedOrAnyFailed(
+                        LoopbackServer.ReadRequestAndSendResponseAsync(server, options: options),
+                        client.GetAsync(url));
+                }, options);
+            }
+        }
+
+        public static readonly object[][] InvalidCertificateServers =
+        {
+            new object[] { Configuration.Http.ExpiredCertRemoteServer },
+            new object[] { Configuration.Http.SelfSignedCertRemoteServer },
+            new object[] { Configuration.Http.WrongHostNameCertRemoteServer },
+        };
+
+        [OuterLoop] // TODO: Issue #11345
+        [Theory]
+        [MemberData(nameof(InvalidCertificateServers))]
+        public async Task InvalidCertificateServers_CertificateValidationDisabled_Succeeds(string url)
+        {
+            using (var client = new HttpClient(new HttpClientHandler() { ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator }))
+            {
+                (await client.GetAsync(url)).Dispose();
+            }
         }
     }
 }

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -3,6 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{C85CF035-7804-41FF-9557-48B7C948B58D}</ProjectGuid>
+    <DefineConstants Condition="'$(TargetGroup)'=='netcoreapp'">$(DefineConstants);netcoreapp</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Unix-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Unix-Release|AnyCPU'" />
@@ -102,6 +103,9 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true' ">
     <Compile Include="DefaultCredentialsTest.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
+    <Compile Include="HttpClientHandlerTest.AcceptAllCerts.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">


### PR DESCRIPTION
It's a common pattern in certain situations (in particular in tests) to use HttpClient to connect to a server with a certificate that shouldn't be validated, e.g. a self-signed cert.  This is commonly achieved with HttpClientHandler by setting the ServerCertificateCustomValidationCallback property to a delegate that always returns true (returning true means that the cert passed validation):
```C#
handler.ServerCertificateCustomValidationCallback = delegate { return true; };
```
However, we can't support this callback on all implementations of HttpClientHandler.  For example, on macOS, the default libcurl built against SecureTransport doesn't provide the callback we'd need to properly implement the callback, and as such, today trying to set up such a callback results in a PlatformNotSupportedException.  This blocks some important scenarios; that includes testing (e.g. ASP.NET had to move away from HttpClient because of this, https://github.com/aspnet/MetaPackages/pull/100) but also higher level libraries and tools that provide similar functionality (e.g. PowerShell's `Invoke-WebRequest -SkipCertificateCheck` is blocked by this https://github.com/PowerShell/PowerShell/issues/3648).

This PR adds an approved API to address this case:
```C#
public static Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> DangerousAcceptAnyServerCertificateValidator { get; }
```
The actual implementation of this property is trivial, simply returning a cached always-return-true delegate:
```C#
public static Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> DangerousAcceptAnyServerCertificateValidator { get; } = delegate { return true; };
```
so developers can just substitute it for their custom delegate:
```C#
handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
```
The benefit of that is it gives HttpClientHandler implementations a known object reference identity that can be compared against to understand the developer's intention: if the object stored in ServerCertificateCustomValidationCallback is reference equals to DangerousAcceptAnyServerCertificateValidator, then we know that it will always return true, and on platforms where we'd otherwise throw a PlatformNotSupportedException because we can't hook up a callback, we can still entirely disable validation.  This enables such scenarios to work. (As a side benefit, such a property means developers can use this property and give tools an easier opportunity for flagging the danger of such disabling of validation, making it easier for developers to avoid shipping insecure applications.)

This PR:
- Adds the property and the singleton delegate implementation.
- Adds some tests to ensure it behaves correctly.
- On Unix, if we would throw a PNSE because a callback was supplied, we special-case DangerousAcceptAnyServerCertificateValidator to avoid throwing.  No changes were made to the implementation on Windows.

In the future, we could choose to go further and avoid hooking up the delegate at all on both Windows and Unix even if callbacks are supported, as doing so may save some overhead.  However, as this is not meant to be a common case in production, I've only modified code necessary to get these scenarios working.

Fixes https://github.com/dotnet/corefx/issues/19709
Related to https://github.com/dotnet/corefx/issues/19718

cc: @bartonjs, @davidsh, @cipop, @Priya91, @wfurt, @geoffkizer 