### PR TITLE
Turn System.Composition.Hosting to an application assembly

### DIFF
--- a/src/System.Composition.Hosting/src/System.Composition.Hosting.csproj
+++ b/src/System.Composition.Hosting/src/System.Composition.Hosting.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <ProjectGuid>{2B8FECC6-34A1-48FE-BA75-99572D2D6DB2}</ProjectGuid>
     <AssemblyName>System.Composition.Hosting</AssemblyName>
+    <BlockReflectionAttribute>false</BlockReflectionAttribute>
     <PackageTargetFramework Condition="'$(TargetGroup)' == 'netstandard1.0'">netstandard1.0;portable-net45+win8+wp8+wpa81</PackageTargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />


### PR DESCRIPTION
System.Composition.Hosting reflect over private generic method and
use MakeGenericMethod to create generic method instances.ILC toolchain
mark these types with [ReflectionBlocked] attribute since analysis
find the containing type internal and the method private.rdxml wont fix
this since toolchain decide to add the [ReflectionBlock] based on its
analysis.This fixes 50+ tests in System.Composition