### PR TITLE
Fix XmlSchemaTest on UWP

### DIFF
--- a/src/System.Private.Xml/src/Resources/System.Private.Xml.rd.xml
+++ b/src/System.Private.Xml/src/Resources/System.Private.Xml.rd.xml
@@ -14,6 +14,7 @@
           </Method>
         </Type>
       </Namespace>
+      <Namespace Name="System.Xml.Schema" Dynamic="Public" />
     </Assembly>
   </Library>
 </Directives>


### PR DESCRIPTION
The PR is to enable using `XmlSchema` on UWP in ReflectionOnly mode.  `XmlSchema.Write.Write` internally create the serializer for `typeof(XmlSchema)`, see [XmlSchema.cs](https://github.com/dotnet/corefx/blob/master/src/System.Private.Xml/src/System/Xml/Schema/XmlSchema.cs#L175). As XmlSchema has many known types (e.g. see [XmlSchema.Items](https://github.com/dotnet/corefx/blob/master/src/System.Private.Xml/src/System/Xml/Schema/XmlSchema.cs#L365)), we need to keep the metadata for all of those known types to make the serializer work in ReflectionOnly mode. The PR is to keep metadata for types under `System.Xml.Schema`. I tried to find a smaller closure for types to include, but I didn't find one.

Before the fix, the size of the output of XmlSerializer test was 18,553 KB; after the fix, the size became 18,579 KB.

Fix #19830