### PR TITLE
Decrease number of socket instances in SocketPerformance_MultipleSocketClientAsync_LocalHostServerAsync

### DIFF
--- a/src/System.Net.Sockets/tests/PerformanceTests/SocketPerformanceAsyncTests.cs
+++ b/src/System.Net.Sockets/tests/PerformanceTests/SocketPerformanceAsyncTests.cs
@@ -37,7 +37,7 @@ namespace System.Net.Sockets.Performance.Tests
             SocketImplementationType clientType = SocketImplementationType.Async;
             int iterations = 200 * _iterations;
             int bufferSize = 256;
-            int socket_instances = 200;
+            int socket_instances = 20;
 
             var test = new SocketPerformanceTests(_log);
 


### PR DESCRIPTION
Larger number causes listen queue to be exceeded, resulting in client failures due to connection being rejected by server.
Closes https://github.com/dotnet/corefx/issues/19702 (we need to revisit perf testing for this area all-up)
cc: @cipop, @steveharter 