### PR TITLE
Decrease number of socket instances in SocketPerformance_MultipleSocketClientAsync_LocalHostServerAsync

### DIFF
--- a/src/System.Net.Sockets/tests/PerformanceTests/SocketPerformanceAsyncTests.cs
+++ b/src/System.Net.Sockets/tests/PerformanceTests/SocketPerformanceAsyncTests.cs
@@ -37,7 +37,7 @@ namespace System.Net.Sockets.Performance.Tests
             SocketImplementationType clientType = SocketImplementationType.Async;
             int iterations = 200 * _iterations;
             int bufferSize = 256;
-            int socket_instances = 200;
+            int socket_instances = 20;
 
             var test = new SocketPerformanceTests(_log);
 


### PR DESCRIPTION
Port test-only one-character fix https://github.com/dotnet/corefx/pull/19920 fix to release/2.0