### PR TITLE
release/2.0: Fix Windows X509Certificate2.ToString(true) for ephemeral private keys

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.cs
@@ -405,13 +405,17 @@ namespace Internal.Cryptography.Pal
 
         public void AppendPrivateKeyInfo(StringBuilder sb)
         {
-            if (HasPrivateKey)
+            if (!HasPrivateKey)
             {
-                // Similar to the Unix implementation, in UWP merely acknowledge that there -is- a private key.
-                sb.AppendLine();
-                sb.AppendLine();
-                sb.AppendLine("[Private Key]");
+                return;
             }
+
+            // UWP, Windows CNG persisted, and Windows Ephemeral keys will all acknowledge that
+            // a private key exists, but detailed printing is limited to Windows CAPI persisted.
+            // (This is the same thing we do in Unix)
+            sb.AppendLine();
+            sb.AppendLine();
+            sb.AppendLine("[Private Key]");
 
 #if uap
             // Similar to the Unix implementation, in UWP merely acknowledge that there -is- a private key.
@@ -419,9 +423,10 @@ namespace Internal.Cryptography.Pal
             CspKeyContainerInfo cspKeyContainerInfo = null;
             try
             {
-                if (HasPrivateKey)
+                CspParameters parameters = GetPrivateKeyCsp();
+
+                if (parameters != null)
                 {
-                    CspParameters parameters = GetPrivateKeyCsp();
                     cspKeyContainerInfo = new CspKeyContainerInfo(parameters);
                 }
             }

--- a/src/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
 using Xunit;
@@ -11,6 +12,9 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 {
     public class CertTests
     {
+        private const string PrivateKeySectionHeader = "[Private Key]";
+        private const string PublicKeySectionHeader = "[Public Key]";
+
         private readonly ITestOutputHelper _log;
 
         public CertTests(ITestOutputHelper output)
@@ -187,6 +191,29 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
+        [Theory]
+        [MemberData(nameof(StorageFlags))]
+        public static void X509Certificate2ToStringVerbose_WithPrivateKey(X509KeyStorageFlags keyStorageFlags)
+        {
+            using (var cert = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword, keyStorageFlags))
+            {
+                string certToString = cert.ToString(verbose: true);
+                Assert.Contains(PrivateKeySectionHeader, certToString);
+                Assert.Contains(PublicKeySectionHeader, certToString);
+            }
+        }
+
+        [Fact]
+        public static void X509Certificate2ToStringVerbose_NoPrivateKey()
+        {
+            using (var cert = new X509Certificate2(TestData.MsCertificatePemBytes))
+            {
+                string certToString = cert.ToString(verbose: true);
+                Assert.DoesNotContain(PrivateKeySectionHeader, certToString);
+                Assert.Contains(PublicKeySectionHeader, certToString);
+            }
+        }
+
         [Fact]
         public static void X509Cert2CreateFromEmptyPfx()
         {
@@ -315,5 +342,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 }
             }
         }
+
+        public static IEnumerable<object> StorageFlags => CollectionImportTests.StorageFlags;
     }
 }


### PR DESCRIPTION
AppendPrivateKeyInfo handled not being able to resolve the container details
for a private key, but an ephemeral private key caused a NullReferenceException
instead of the caught CryptographicException.

The comments in the code suggest this worked properly at one time, but there
was no test guaranteeing functionality.  This change handles the null return from
GetPrivateKeyCsp, and adds some tests to ensure this doesn't break again.

Ports #19916. Fixes #19888.