### PR TITLE
release/2.0: Make all X509Store.Open exceptions be CryptographicException.

### DIFF
--- a/Documentation/project-docs/cross-platform-cryptography.md
+++ b/Documentation/project-docs/cross-platform-cryptography.md
@@ -213,26 +213,27 @@ On macOS the X509Store class is a projection of system trust decisions (read-onl
 | Open CurrentUser\My (ReadOnly) | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | Open CurrentUser\My (ReadWrite) | :white_check_mark: | :white_check_mark:  | :white_check_mark: |
 | Open CurrentUser\My (ExistingOnly) | :white_check_mark: | :question: | :white_check_mark: |
-| Open LocalMachine\My | :white_check_mark: | `PlatformNotSupportedException` | :white_check_mark: |
+| Open LocalMachine\My | :white_check_mark: | `CryptographicException` | :white_check_mark: |
 | Open CurrentUser\Root (ReadOnly) | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Open CurrentUser\Root (ReadWrite) | :white_check_mark: | :white_check_mark: | `PlatformNotSupportedException` |
+| Open CurrentUser\Root (ReadWrite) | :white_check_mark: | :white_check_mark: | `CryptographicException` |
 | Open CurrentUser\Root (ExistingOnly) | :white_check_mark: | :question: | :white_check_mark: (if ReadOnly) |
 | Open LocalMachine\Root (ReadOnly) | :white_check_mark:  | :white_check_mark:  | :white_check_mark: |
-| Open LocalMachine\Root (ReadWrite) | :white_check_mark: | `PlatformNotSupportedException` | `PlatformNotSupportedException` |
+| Open LocalMachine\Root (ReadWrite) | :white_check_mark: | `CryptographicException` | `CryptographicException` |
 | Open LocalMachine\Root (ExistingOnly) | :white_check_mark: | :question: | :white_check_mark:  (if ReadOnly) |
-| Open CurrentUser\Disallowed (ReadOnly) | :white_check_mark: | :question: | `PlatformNotSupportedException` |
-| Open CurrentUser\Disallowed (ReadWrite) | :white_check_mark: | :question: | `PlatformNotSupportedException` |
-| Open CurrentUser\Disallowed (ExistingOnly) | :white_check_mark: | :question: | `PlatformNotSupportedException` |
-| Open LocalMachine\Disallowed (ReadOnly) | :white_check_mark: | :question: | `PlatformNotSupportedException` |
-| Open LocalMachine\Disallowed (ReadWrite) | :white_check_mark: | :question: | `PlatformNotSupportedException` |
-| Open LocalMachine\Disallowed (ExistingOnly) | :white_check_mark: | :question: | `PlatformNotSupportedException`) |
+| Open CurrentUser\Disallowed (ReadOnly) | :white_check_mark: | :question: | :white_check_mark: |
+| Open CurrentUser\Disallowed (ReadWrite) | :white_check_mark: | :question: | `CryptographicException` |
+| Open CurrentUser\Disallowed (ExistingOnly) | :white_check_mark: | :question: | :white_check_mark: (if ReadOnly) |
+| Open LocalMachine\Disallowed (ReadOnly) | :white_check_mark: | `CryptographicException` | :white_check_mark: |
+| Open LocalMachine\Disallowed (ReadWrite) | :white_check_mark: | `CryptographicException` | `CryptographicException` |
+| Open LocalMachine\Disallowed (ExistingOnly) | :white_check_mark: | `CryptographicException` | :white_check_mark: (if ReadOnly) |
 | Open non-existant store (ExistingOnly) | `CryptographicException` | `CryptographicException` | `CryptographicException` |
-| Open CurrentUser non-existant store (ReadWrite)  | :white_check_mark: | :white_check_mark: | `PlatformNotSupportedException` |
-| Open LocalMachine non-existant store (ReadWrite)  | :white_check_mark: | `PlatformNotSupportedException` | `PlatformNotSupportedException` |
+| Open CurrentUser non-existant store (ReadWrite)  | :white_check_mark: | :white_check_mark: | `CryptographicException` |
+| Open LocalMachine non-existant store (ReadWrite)  | :white_check_mark: | `CryptographicException` | `CryptographicException` |
 
 On Linux stores are created on first-write, and no user stores exist by default, so opening CurrentUser\My with ExistingOnly may fail.
 
-On Linux the Disallowed store is not used in chain building, and attempting to open it will result in a `PlatformNotSupportedException` being thrown.
+On Linux the Disallowed store is not used in chain building, and attempting to add contents to it will result in a `CryptographicException` being thrown.
+A `CryptographicException` will be thrown when opening the Disallowed store on Linux if it has already acquired contents.
 
 The LocalMachnie\Root store on Linux is an interpretation of the CA bundle in the default path for OpenSSL.
 The LocalMachine\Intermediate store on Linux is an interpretation of the CA bundle in the default path for OpenSSL.

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/StorePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/StorePal.cs
@@ -123,11 +123,12 @@ namespace Internal.Cryptography.Pal
             if ((openFlags & OpenFlags.OpenExistingOnly) == OpenFlags.OpenExistingOnly)
                 throw new CryptographicException(SR.Cryptography_X509_StoreNotFound);
 
-            throw new PlatformNotSupportedException(
-                SR.Format(
-                    SR.Cryptography_X509_StoreCannotCreate,
-                    storeName,
-                    storeLocation));
+            string message = SR.Format(
+                SR.Cryptography_X509_StoreCannotCreate,
+                storeName,
+                storeLocation);
+
+            throw new CryptographicException(message, new PlatformNotSupportedException(message));
         }
 
         private static void ReadCollection(SafeCFArrayHandle matches, HashSet<X509Certificate2> collection)

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ChainPal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ChainPal.cs
@@ -49,6 +49,11 @@ namespace Internal.Cryptography.Pal
                 verificationTime = verificationTime.ToLocalTime();
             }
 
+            // Until we support the Disallowed store, ensure it's empty (which is done by the ctor)
+            using (new X509Store(StoreName.Disallowed, StoreLocation.CurrentUser, OpenFlags.ReadOnly))
+            {
+            }
+
             TimeSpan remainingDownloadTime = timeout;
 
             using (var leaf = new X509Certificate2(cert.Handle))

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/DirectoryBasedStoreProvider.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/DirectoryBasedStoreProvider.cs
@@ -48,19 +48,9 @@ namespace Internal.Cryptography.Pal
                 throw new CryptographicException(SR.Arg_EmptyOrNullString);
             }
 
-            string directoryName = GetDirectoryName(storeName);
+            Debug.Assert(!X509Store.DisallowedStoreName.Equals(storeName, StringComparison.OrdinalIgnoreCase));
 
-            if (s_userStoreRoot == null)
-            {
-                // Do this here instead of a static field initializer so that
-                // the static initializer isn't capable of throwing the "home directory not found"
-                // exception.
-                s_userStoreRoot = PersistedFiles.GetUserFeatureDirectory(
-                    X509Persistence.CryptographyFeatureName,
-                    X509Persistence.X509StoresSubFeatureName);
-            }
-
-            _storePath = Path.Combine(s_userStoreRoot, directoryName);
+            _storePath = GetStorePath(storeName);
 
             if (0 != (openFlags & OpenFlags.OpenExistingOnly))
             {
@@ -283,6 +273,23 @@ namespace Internal.Cryptography.Pal
             throw new CryptographicException(SR.Cryptography_X509_StoreNoFileAvailable);
         }
 
+        private static string GetStorePath(string storeName)
+        {
+            string directoryName = GetDirectoryName(storeName);
+
+            if (s_userStoreRoot == null)
+            {
+                // Do this here instead of a static field initializer so that
+                // the static initializer isn't capable of throwing the "home directory not found"
+                // exception.
+                s_userStoreRoot = PersistedFiles.GetUserFeatureDirectory(
+                    X509Persistence.CryptographyFeatureName,
+                    X509Persistence.X509StoresSubFeatureName);
+            }
+
+            return Path.Combine(s_userStoreRoot, directoryName);
+        }
+
         private static string GetDirectoryName(string storeName)
         {
             Debug.Assert(storeName != null);
@@ -394,6 +401,72 @@ namespace Internal.Cryptography.Pal
                     throw new CryptographicException(SR.Format(SR.Cryptography_InvalidFilePermissions, stream.Name));
                 }
             }
+        }
+
+        internal sealed class UnsupportedDisallowedStore : IStorePal
+        {
+            private readonly bool _readOnly;
+
+            internal UnsupportedDisallowedStore(OpenFlags openFlags)
+            {
+                // ReadOnly is 0x00, so it is implicit unless either ReadWrite or MaxAllowed
+                // was requested.
+                OpenFlags writeFlags = openFlags & (OpenFlags.ReadWrite | OpenFlags.MaxAllowed);
+
+                if (writeFlags == OpenFlags.ReadOnly)
+                {
+                    _readOnly = true;
+                }
+
+                string storePath = GetStorePath(X509Store.DisallowedStoreName);
+
+                try
+                {
+                    if (Directory.Exists(storePath))
+                    {
+                        // If it has no files, leave it alone.
+                        foreach (string filePath in Directory.EnumerateFiles(storePath))
+                        {
+                            string msg = SR.Format(SR.Cryptography_Unix_X509_DisallowedStoreNotEmpty, storePath);
+                            throw new CryptographicException(msg, new PlatformNotSupportedException(msg));
+                        }
+                    }
+                }
+                catch (IOException)
+                {
+                    // Suppress the exception, treat the store as empty.
+                }
+            }
+
+            public void Dispose()
+            {
+                // Nothing to do.
+            }
+
+            public void CloneTo(X509Certificate2Collection collection)
+            {
+                // Never show any data.
+            }
+
+            public void Add(ICertificatePal cert)
+            {
+                if (_readOnly)
+                {
+                    throw new CryptographicException(SR.Cryptography_X509_StoreReadOnly);
+                }
+
+                throw new CryptographicException(
+                    SR.Cryptography_Unix_X509_NoDisallowedStore,
+                    new PlatformNotSupportedException(SR.Cryptography_Unix_X509_NoDisallowedStore));
+            }
+
+            public void Remove(ICertificatePal cert)
+            {
+                // Remove never throws if it does no measurable work.
+                // Since CloneTo always says the store is empty, no measurable work is ever done.
+            }
+
+            SafeHandle IStorePal.SafeHandle { get; } = null;
         }
     }
 }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/StorePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/StorePal.cs
@@ -10,6 +10,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using Microsoft.Win32.SafeHandles;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 
 namespace Internal.Cryptography.Pal
 {
@@ -140,7 +141,7 @@ namespace Internal.Cryptography.Pal
             {
                 if (X509Store.DisallowedStoreName.Equals(storeName, StringComparison.OrdinalIgnoreCase))
                 {
-                    throw new PlatformNotSupportedException(SR.Cryptography_Unix_X509_NoDisallowedStore);
+                    return new DirectoryBasedStoreProvider.UnsupportedDisallowedStore(openFlags);
                 }
 
                 return new DirectoryBasedStoreProvider(storeName, openFlags);
@@ -150,7 +151,9 @@ namespace Internal.Cryptography.Pal
             
             if ((openFlags & OpenFlags.ReadWrite) == OpenFlags.ReadWrite)
             {
-                throw new PlatformNotSupportedException(SR.Cryptography_Unix_X509_MachineStoresReadOnly);
+                throw new CryptographicException(
+                    SR.Cryptography_Unix_X509_MachineStoresReadOnly,
+                    new PlatformNotSupportedException(SR.Cryptography_Unix_X509_MachineStoresReadOnly));
             }
 
             // The static store approach here is making an optimization based on not
@@ -177,7 +180,9 @@ namespace Internal.Cryptography.Pal
                 return s_machineIntermediateStore;
             }
 
-            throw new PlatformNotSupportedException(SR.Cryptography_Unix_X509_MachineStoresRootOnly);
+            throw new CryptographicException(
+                SR.Cryptography_Unix_X509_MachineStoresRootOnly,
+                new PlatformNotSupportedException(SR.Cryptography_Unix_X509_MachineStoresRootOnly));
         }
 
         private static ILoaderPal SingleCertToLoaderPal(ICertificatePal singleCert)

--- a/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
@@ -187,6 +187,9 @@
   <data name="Cryptography_PrivateKey_WrongAlgorithm" xml:space="preserve">
     <value>The provided key does not match the public key algorithm for this certificate.</value>
   </data>
+  <data name="Cryptography_Unix_X509_DisallowedStoreNotEmpty" xml:space="preserve">
+   <value>The Disallowed store is not supported on this platform, but already has data. All files under '{0}' must be removed.</value>
+  </data>
   <data name="Cryptography_Unix_X509_MachineStoresReadOnly" xml:space="preserve">
     <value>Unix LocalMachine X509Stores are read-only for all users.</value>
   </data>


### PR DESCRIPTION
The platform limitations are now
CryptographicException(PlatformNotSupportedException) instead of PNSE.

This should restore some user expectation around the exception model, given
that the call to Open can be delayed from the call to an X509Store .ctor.

This also softens the exceptions from the Disallowed store on Linux to let empty
reads succeed, only writes and pre-populated data will fail.

Updated the X509Store table in the xplat crypto doc.

Ports #19844.