### PR TITLE
Fix GetFolderPath test for nano

### DIFF
--- a/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
@@ -317,7 +317,12 @@ namespace System.Tests
         public unsafe void GetFolderPath_Windows(Environment.SpecialFolder folder)
         {
             string knownFolder = Environment.GetFolderPath(folder);
-            Assert.NotEmpty(knownFolder);
+
+            if (!PlatformDetection.IsWindowsNanoServer)
+            {
+                // See Nano comment below
+                Assert.NotEmpty(knownFolder);
+            }
 
             // Call the older folder API to compare our results.
             char* buffer = stackalloc char[260];


### PR DESCRIPTION
I missed a line when fixing this before -- since I haven't figured out yet how to run tests on Nano directly, I was pasting in a similar program.

Fixes https://github.com/dotnet/corefx/issues/19110 (which lists off all the API results and shows that Nano produces empty for many of them)