### PR TITLE
Fix some Http tests for UAP

### DIFF
--- a/src/Common/tests/System/PlatformDetection.cs
+++ b/src/Common/tests/System/PlatformDetection.cs
@@ -18,6 +18,7 @@ namespace System
         // do it in a way that failures don't cascade.
         //
 
+        public static bool IsUap => IsWinRT || IsNetNative;
         public static bool IsFullFramework => RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
         public static bool IsNetNative => RuntimeInformation.FrameworkDescription.StartsWith(".NET Native", StringComparison.OrdinalIgnoreCase);
 

--- a/src/System.Net.Http/tests/FunctionalTests/Configurations.props
+++ b/src/System.Net.Http/tests/FunctionalTests/Configurations.props
@@ -6,6 +6,7 @@
       netcoreapp-Unix;
       netstandard-Windows_NT;
       netstandard-Unix;
+      uap-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Net.Http/tests/FunctionalTests/HttpRequestMessageTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpRequestMessageTest.cs
@@ -14,7 +14,7 @@ namespace System.Net.Http.Functional.Tests
 {
     public class HttpRequestMessageTest
     {
-        Version _expectedRequestMessageVersion = new Version(1, 1);
+        Version _expectedRequestMessageVersion = PlatformDetection.IsUap ? new Version(2,0) : new Version(1, 1);
 
         [Fact]
         public void Ctor_Default_CorrectDefaults()


### PR DESCRIPTION
Fixed some of the HttpRequestMessage tests for UAP. HttpRequestMessage has a different
default value for the Version field on UAP platforms compared to netcore or netfx.

Added PlatformDetection.IsUap to support this. Implementation of this property was
based on investigations for #19907. This property is true on both 'uap' and 'uap-aot'
platforms.

Fixes #19907