### PR TITLE
Re-enable failing httplistener tests on osx.

### DIFF
--- a/src/System.Net.HttpListener/src/Resources/Strings.resx
+++ b/src/System.Net.HttpListener/src/Resources/Strings.resx
@@ -85,6 +85,9 @@
   <data name="net_listener_host" xml:space="preserve">
     <value>Only Uri prefixes with a valid hostname are supported.</value>
   </data>
+  <data name="net_listener_not_supported" xml:space="preserve">
+    <value>The request is not supported.</value>
+  </data>
   <data name="net_listener_mustcall" xml:space="preserve">
     <value>Please call the {0} method before calling this method.</value>
   </data>

--- a/src/System.Net.HttpListener/src/System/Net/Managed/HttpEndPointManager.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/HttpEndPointManager.cs
@@ -117,7 +117,15 @@ namespace System.Net
             IPAddress addr;
             if (host == "*")
                 addr = IPAddress.Any;
-            else if (IPAddress.TryParse(host, out addr) == false)
+            else if (IPAddress.TryParse(host, out addr))
+            {
+                if (IPAddress.Any.Equals(addr))
+                {
+                    // Throw same error code as windows, request is not supported.
+                    throw new HttpListenerException(50, SR.net_listener_not_supported);
+                }
+            }
+            else
             {
                 try
                 {

--- a/src/System.Net.HttpListener/tests/HttpListenerPrefixCollectionTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerPrefixCollectionTests.cs
@@ -240,6 +240,7 @@ namespace System.Net.Tests
         public static IEnumerable<object[]> InvalidPrefix_TestData()
         {
             yield return new object[] { "http://0.0.0.0/" };
+            yield return new object[] { "http://192./" };
             yield return new object[] { "http://[]/" };
             yield return new object[] { "http://[::1%2]/" };
             yield return new object[] { "http://[::]/" };
@@ -277,16 +278,6 @@ namespace System.Net.Tests
 
                 Assert.Throws<HttpListenerException>(() => listener.Prefixes.Add(uriPrefix));
             }
-        }
-
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)] // Issue #19619
-        [Theory]
-        [ActiveIssue(18128, TestPlatforms.AnyUnix)] // Fails by design on Windows but is allowed by the managed implementation
-        [InlineData("http://192./")]
-        public void Add_InvalidPrefix_ThrowsHttpListenerException_Windows(string uriPrefix)
-        {
-            Add_InvalidPrefixNotStarted_ThrowsHttpListenerExceptionOnStart(uriPrefix);
-            Add_InvalidPrefixAlreadyStarted_ThrowsHttpListenerExceptionOnAdd(uriPrefix);
         }
 
         [Theory]

--- a/src/System.Net.HttpListener/tests/HttpListenerPrefixCollectionTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerPrefixCollectionTests.cs
@@ -239,7 +239,7 @@ namespace System.Net.Tests
 
         public static IEnumerable<object[]> InvalidPrefix_TestData()
         {
-            yield return new object[] { $"http://{Guid.NewGuid().ToString("N")}/" };
+            yield return new object[] { "http://0.0.0.0/" };
             yield return new object[] { "http://[]/" };
             yield return new object[] { "http://[::1%2]/" };
             yield return new object[] { "http://[::]/" };

--- a/src/System.Net.HttpListener/tests/HttpListenerPrefixCollectionTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerPrefixCollectionTests.cs
@@ -239,11 +239,7 @@ namespace System.Net.Tests
 
         public static IEnumerable<object[]> InvalidPrefix_TestData()
         {
-            // [ActiveIssue(19593, TestPlatforms.OSX)]
-            if (!PlatformDetection.IsOSX)
-            {
-                yield return new object[] { $"http://{Guid.NewGuid().ToString("N")}/" };
-            }
+            yield return new object[] { $"http://{Guid.NewGuid().ToString("N")}/" };
             yield return new object[] { "http://[]/" };
             yield return new object[] { "http://[::1%2]/" };
             yield return new object[] { "http://[::]/" };
@@ -256,7 +252,7 @@ namespace System.Net.Tests
             yield return new object[] { "http://\\/" };
         }
 
-        [ActiveIssue(19619)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)] // Issue #19619
         [Theory]
         [MemberData(nameof(InvalidPrefix_TestData))]
         public void Add_InvalidPrefixNotStarted_ThrowsHttpListenerExceptionOnStart(string uriPrefix)
@@ -269,7 +265,7 @@ namespace System.Net.Tests
             Assert.Throws<HttpListenerException>(() => listener.Start());
         }
 
-        [ActiveIssue(19619)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)] // Issue #19619
         [Theory]
         [MemberData(nameof(InvalidPrefix_TestData))]
         public void Add_InvalidPrefixAlreadyStarted_ThrowsHttpListenerExceptionOnAdd(string uriPrefix)
@@ -283,7 +279,7 @@ namespace System.Net.Tests
             }
         }
 
-        [ActiveIssue(19619)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)] // Issue #19619
         [Theory]
         [ActiveIssue(18128, TestPlatforms.AnyUnix)] // Fails by design on Windows but is allowed by the managed implementation
         [InlineData("http://192./")]


### PR DESCRIPTION
cc @hughbe @stephentoub 

fixes #19593 #19986 