### PR TITLE
Enable more System.Runtime.Tests coverage for ILC

### DIFF
--- a/src/Common/tests/System/MockType.cs
+++ b/src/Common/tests/System/MockType.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 
 namespace System
 {
-    internal class MockType : NetCoreType
+    internal class MockType : Type
     {
         public override Assembly Assembly => throw Unexpected;
         public override string AssemblyQualifiedName => throw Unexpected;
@@ -90,10 +90,7 @@ namespace System
         public override bool IsSecurityTransparent => throw Unexpected;
         public override bool IsSerializable => throw Unexpected;
         public override bool IsSubclassOf(Type c) => throw Unexpected;
-        public override bool IsSZArray => throw Unexpected;
-        public override bool IsTypeDefinition => throw Unexpected;
         protected override bool IsValueTypeImpl() => throw Unexpected;
-        public override bool IsVariableBoundArray => throw Unexpected;
         public override Type MakeArrayType() => throw Unexpected;
         public override Type MakeArrayType(int rank) => throw Unexpected;
         public override Type MakeByRefType() => throw Unexpected;
@@ -107,16 +104,5 @@ namespace System
         public override RuntimeTypeHandle TypeHandle => throw Unexpected;
 
         protected virtual Exception Unexpected => new Exception("Did not expect to be called.");
-    }
-
-    internal abstract class NetCoreType : Type
-    {
-#if netcoreapp || uapaot
-#else
-        // Members that don't exist in netfx.
-        public virtual bool IsSZArray => throw new NotImplementedException();
-        public virtual bool IsVariableBoundArray => throw new NotImplementedException();
-        public virtual bool IsTypeDefinition => throw new NotImplementedException();
-#endif
     }
 }

--- a/src/Common/tests/System/MockType.cs
+++ b/src/Common/tests/System/MockType.cs
@@ -1,0 +1,122 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace System
+{
+    internal class MockType : NetCoreType
+    {
+        public override Assembly Assembly => throw Unexpected;
+        public override string AssemblyQualifiedName => throw Unexpected;
+        public override Type BaseType => throw Unexpected;
+        public override string FullName => throw Unexpected;
+        public override Guid GUID => throw Unexpected;
+        public override Module Module => throw Unexpected;
+        public override string Namespace => throw Unexpected;
+        public override Type UnderlyingSystemType => throw Unexpected;
+        public override string Name => throw Unexpected;
+        public override ConstructorInfo[] GetConstructors(BindingFlags bindingAttr) => throw Unexpected;
+        public override object[] GetCustomAttributes(bool inherit) => throw Unexpected;
+        public override object[] GetCustomAttributes(Type attributeType, bool inherit) => throw Unexpected;
+        public override Type GetElementType() => throw Unexpected;
+        public override EventInfo GetEvent(string name, BindingFlags bindingAttr) => throw Unexpected;
+        public override EventInfo[] GetEvents(BindingFlags bindingAttr) => throw Unexpected;
+        public override FieldInfo GetField(string name, BindingFlags bindingAttr) => throw Unexpected;
+        public override FieldInfo[] GetFields(BindingFlags bindingAttr) => throw Unexpected;
+        public override Type GetInterface(string name, bool ignoreCase) => throw Unexpected;
+        public override Type[] GetInterfaces() => throw Unexpected;
+        public override MemberInfo[] GetMembers(BindingFlags bindingAttr) => throw Unexpected;
+        public override MethodInfo[] GetMethods(BindingFlags bindingAttr) => throw Unexpected;
+        public override Type GetNestedType(string name, BindingFlags bindingAttr) => throw Unexpected;
+        public override Type[] GetNestedTypes(BindingFlags bindingAttr) => throw Unexpected;
+        public override PropertyInfo[] GetProperties(BindingFlags bindingAttr) => throw Unexpected;
+        public override object InvokeMember(string name, BindingFlags invokeAttr, Binder binder, object target, object[] args, ParameterModifier[] modifiers, CultureInfo culture, string[] namedParameters) => throw Unexpected;
+        public override bool IsDefined(Type attributeType, bool inherit) => throw Unexpected;
+        protected override TypeAttributes GetAttributeFlagsImpl() => throw Unexpected;
+        protected override ConstructorInfo GetConstructorImpl(BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers) => throw Unexpected;
+        protected override MethodInfo GetMethodImpl(string name, BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers) => throw Unexpected;
+        protected override PropertyInfo GetPropertyImpl(string name, BindingFlags bindingAttr, Binder binder, Type returnType, Type[] types, ParameterModifier[] modifiers) => throw Unexpected;
+        protected override bool HasElementTypeImpl() => throw Unexpected;
+        protected override bool IsArrayImpl() => throw Unexpected;
+        protected override bool IsByRefImpl() => throw Unexpected;
+        protected override bool IsCOMObjectImpl() => throw Unexpected;
+        protected override bool IsPointerImpl() => throw Unexpected;
+        protected override bool IsPrimitiveImpl() => throw Unexpected;
+        public override bool ContainsGenericParameters => throw Unexpected;
+        public override IEnumerable<CustomAttributeData> CustomAttributes => throw Unexpected;
+        public override MethodBase DeclaringMethod => throw Unexpected;
+        public override Type DeclaringType => throw Unexpected;
+        public override bool Equals(object o) => throw Unexpected;
+        public override bool Equals(Type o) => throw Unexpected;
+        public override Type[] FindInterfaces(TypeFilter filter, object filterCriteria) => throw Unexpected;
+        public override MemberInfo[] FindMembers(MemberTypes memberType, BindingFlags bindingAttr, MemberFilter filter, object filterCriteria) => throw Unexpected;
+        public override GenericParameterAttributes GenericParameterAttributes => throw Unexpected;
+        public override int GenericParameterPosition => throw Unexpected;
+        public override Type[] GenericTypeArguments => throw Unexpected;
+        public override int GetArrayRank() => throw Unexpected;
+        public override IList<CustomAttributeData> GetCustomAttributesData() => throw Unexpected;
+        public override MemberInfo[] GetDefaultMembers() => throw Unexpected;
+        public override string GetEnumName(object value) => throw Unexpected;
+        public override string[] GetEnumNames() => throw Unexpected;
+        public override Type GetEnumUnderlyingType() => throw Unexpected;
+        public override Array GetEnumValues() => throw Unexpected;
+        public override EventInfo[] GetEvents() => throw Unexpected;
+        public override Type[] GetGenericArguments() => throw Unexpected;
+        public override Type[] GetGenericParameterConstraints() => throw Unexpected;
+        public override Type GetGenericTypeDefinition() => throw Unexpected;
+        public override int GetHashCode() => throw Unexpected;
+        public override InterfaceMapping GetInterfaceMap(Type interfaceType) => throw Unexpected;
+        public override MemberInfo[] GetMember(string name, BindingFlags bindingAttr) => throw Unexpected;
+        public override MemberInfo[] GetMember(string name, MemberTypes type, BindingFlags bindingAttr) => throw Unexpected;
+        protected override TypeCode GetTypeCodeImpl() => throw Unexpected;
+        public override bool IsAssignableFrom(Type c) => throw Unexpected;
+        public override bool IsConstructedGenericType => throw Unexpected;
+        protected override bool IsContextfulImpl() => throw Unexpected;
+        public override bool IsEnum => throw Unexpected;
+        public override bool IsEnumDefined(object value) => throw Unexpected;
+        public override bool IsEquivalentTo(Type other) => throw Unexpected;
+        public override bool IsGenericParameter => throw Unexpected;
+        public override bool IsGenericType => throw Unexpected;
+        public override bool IsGenericTypeDefinition => throw Unexpected;
+        public override bool IsInstanceOfType(object o) => throw Unexpected;
+        protected override bool IsMarshalByRefImpl() => throw Unexpected;
+        public override bool IsSecurityCritical => throw Unexpected;
+        public override bool IsSecuritySafeCritical => throw Unexpected;
+        public override bool IsSecurityTransparent => throw Unexpected;
+        public override bool IsSerializable => throw Unexpected;
+        public override bool IsSubclassOf(Type c) => throw Unexpected;
+        public override bool IsSZArray => throw Unexpected;
+        public override bool IsTypeDefinition => throw Unexpected;
+        protected override bool IsValueTypeImpl() => throw Unexpected;
+        public override bool IsVariableBoundArray => throw Unexpected;
+        public override Type MakeArrayType() => throw Unexpected;
+        public override Type MakeArrayType(int rank) => throw Unexpected;
+        public override Type MakeByRefType() => throw Unexpected;
+        public override Type MakeGenericType(params Type[] typeArguments) => throw Unexpected;
+        public override Type MakePointerType() => throw Unexpected;
+        public override MemberTypes MemberType => throw Unexpected;
+        public override int MetadataToken => throw Unexpected;
+        public override Type ReflectedType => throw Unexpected;
+        public override StructLayoutAttribute StructLayoutAttribute => throw Unexpected;
+        public override string ToString() => throw Unexpected;
+        public override RuntimeTypeHandle TypeHandle => throw Unexpected;
+
+        protected virtual Exception Unexpected => new Exception("Did not expect to be called.");
+    }
+
+    internal abstract class NetCoreType : Type
+    {
+#if netcoreapp || uapaot
+#else
+        // Members that don't exist in netfx.
+        public virtual bool IsSZArray => throw new NotImplementedException();
+        public virtual bool IsVariableBoundArray => throw new NotImplementedException();
+        public virtual bool IsTypeDefinition => throw new NotImplementedException();
+#endif
+    }
+}

--- a/src/System.Runtime/tests/ArrayTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/ArrayTests.netcoreapp.cs
@@ -13,24 +13,36 @@ namespace System.Tests
     public static class ArrayNetcoreappTests
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corert/issues/3650 - Wrong exception thrown", TargetFrameworkMonikers.UapAot)]
         public static void CreateInstance_Type_Int_Invalid()
         {
-            // Type is not a valid RuntimeType
-            AssertExtensions.Throws<ArgumentException>("elementType", () => Array.CreateInstance(Helpers.NonRuntimeType(), 0));
+            foreach (Type nonRuntimeType in Helpers.NonRuntimeTypes)
+            {
+                // Type is not a valid RuntimeType
+                AssertExtensions.Throws<ArgumentException>("elementType", () => Array.CreateInstance(nonRuntimeType, 0));
+            }
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corert/issues/3650 - Wrong exception thrown", TargetFrameworkMonikers.UapAot)]
         public static void CreateInstance_Type_Int_Int_Invalid()
         {
-            // Type is not a valid RuntimeType
-            AssertExtensions.Throws<ArgumentException>("elementType", () => Array.CreateInstance(Helpers.NonRuntimeType(), 0, 1));
+            foreach (Type nonRuntimeType in Helpers.NonRuntimeTypes)
+            {
+                // Type is not a valid RuntimeType
+                AssertExtensions.Throws<ArgumentException>("elementType", () => Array.CreateInstance(nonRuntimeType, 0, 1));
+            }
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corert/issues/3650 - Wrong exception thrown", TargetFrameworkMonikers.UapAot)]
         public static void CreateInstance_Type_Int_Int_Int_Invalid()
         {
-            // Type is not a valid RuntimeType
-            AssertExtensions.Throws<ArgumentException>("elementType", () => Array.CreateInstance(Helpers.NonRuntimeType(), 0, 1, 2));
+            foreach (Type nonRuntimeType in Helpers.NonRuntimeTypes)
+            {
+                // Type is not a valid RuntimeType
+                AssertExtensions.Throws<ArgumentException>("elementType", () => Array.CreateInstance(nonRuntimeType, 0, 1, 2));
+            }
         }
     }
 }

--- a/src/System.Runtime/tests/Helpers.netcoreapp.cs
+++ b/src/System.Runtime/tests/Helpers.netcoreapp.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -10,11 +11,22 @@ namespace System.Tests
 {
     public static partial class Helpers
     {
-        private static Type s_nonRuntimeType;
+        private static Type s_refEmitType;
 
-        public static Type NonRuntimeType()
+        public static IEnumerable<Type> NonRuntimeTypes
         {
-            if (s_nonRuntimeType == null)
+            get
+            {
+                if (PlatformDetection.IsReflectionEmitSupported)
+                    yield return RefEmitType();
+
+                yield return new NonRuntimeType();
+            }
+        }
+
+        private static Type RefEmitType()
+        {
+            if (s_refEmitType == null)
             {
                 AssemblyName assemblyName = new AssemblyName("AssemblyName");
                 AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
@@ -23,10 +35,15 @@ namespace System.Tests
                 TypeBuilder typeBuilder = mboduleBuilder.DefineType("TestType", TypeAttributes.Public);
 
                 GenericTypeParameterBuilder[] typeParams = typeBuilder.DefineGenericParameters("T");
-                s_nonRuntimeType = typeParams[0].UnderlyingSystemType;
+                s_refEmitType = typeParams[0].UnderlyingSystemType;
             }
 
-            return s_nonRuntimeType;
+            return s_refEmitType;
+        }
+
+        private sealed class NonRuntimeType : MockType
+        {
+            public sealed override Type UnderlyingSystemType => this;
         }
     }
 }

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -24,6 +24,9 @@
     <Compile Include="$(CommonTestPath)\System\EnumTypes.cs">
       <Link>Common\System\EnumTypes.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\MockType.cs">
+      <Link>Common\System\MockType.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Collections\CollectionAsserts.cs">
       <Link>Common\System\Collections\CollectionAsserts.cs</Link>
     </Compile>
@@ -125,8 +128,6 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp' or '$(TargetGroup)' == 'uapaot'">
     <Compile Include="System\TypeTests.netcoreapp.cs" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
     <Compile Include="ArrayTests.netcoreapp.cs" />
     <Compile Include="Helpers.netcoreapp.cs" />
     <Compile Include="System\ActivatorTests.netcoreapp.cs" />

--- a/src/System.Runtime/tests/System/ActivatorTests.cs
+++ b/src/System.Runtime/tests/System/ActivatorTests.cs
@@ -92,10 +92,13 @@ namespace System.Tests
             Assert.ThrowsAny<MissingMemberException>(() => Activator.CreateInstance(typeof(AbstractTypeWithDefaultCtor))); // Type is abstract
             Assert.ThrowsAny<MissingMemberException>(() => Activator.CreateInstance(typeof(IInterfaceType))); // Type is an interface
 
-#if netcoreapp
-            // Type is not a valid RuntimeType
-            AssertExtensions.Throws<ArgumentException>("type", () => Activator.CreateInstance(Helpers.NonRuntimeType()));
-#endif // netcoreapp
+#if netcoreapp || uapaot
+            foreach (Type nonRuntimeType in Helpers.NonRuntimeTypes)
+            {
+                // Type is not a valid RuntimeType
+                AssertExtensions.Throws<ArgumentException>("type", () => Activator.CreateInstance(nonRuntimeType));
+            }
+#endif // netcoreapp || uapaot
         }
 
         [Fact]

--- a/src/System.Runtime/tests/System/ActivatorTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/ActivatorTests.netcoreapp.cs
@@ -12,8 +12,11 @@ namespace System.Tests
         [Fact]
         public static void CreateInstance_Invalid()
         {
-            // Type is not a valid RuntimeType
-            AssertExtensions.Throws<ArgumentException>("type", () => Activator.CreateInstance(Helpers.NonRuntimeType()));
+            foreach (Type nonRuntimeType in Helpers.NonRuntimeTypes)
+            {
+                // Type is not a valid RuntimeType
+                AssertExtensions.Throws<ArgumentException>("type", () => Activator.CreateInstance(nonRuntimeType));
+            }
         }
     }
 }

--- a/src/System.Runtime/tests/System/ArraySegmentTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/ArraySegmentTests.netcoreapp.cs
@@ -194,14 +194,14 @@ namespace System.Tests
             // ArraySegment.CopyTo calls Array.Copy internally, so the exception parameter names come from there.
 
             // Destination is null
-            Assert.Throws<ArgumentNullException>("destinationArray", () => arraySegment.CopyTo(null));
-            Assert.Throws<ArgumentNullException>("destinationArray", () => arraySegment.CopyTo(null, 0));
+            AssertExtensions.Throws<ArgumentNullException>("destinationArray", () => arraySegment.CopyTo(null));
+            AssertExtensions.Throws<ArgumentNullException>("destinationArray", () => arraySegment.CopyTo(null, 0));
 
             // Destination index not within range
-            Assert.Throws<ArgumentOutOfRangeException>("destinationIndex", () => arraySegment.CopyTo(new int[0], -1));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("destinationIndex", () => arraySegment.CopyTo(new int[0], -1));
 
             // Destination array too small arraySegment.Count + destinationIndex > destinationArray.Length
-            Assert.Throws<ArgumentException>("destinationArray", () => arraySegment.CopyTo(new int[arraySegment.Count * 2], arraySegment.Count + 1));
+            AssertExtensions.Throws<ArgumentException>("destinationArray", () => arraySegment.CopyTo(new int[arraySegment.Count * 2], arraySegment.Count + 1));
 
             if (arraySegment.Any())
             {
@@ -408,10 +408,10 @@ namespace System.Tests
         {
             if (index + count == arraySegment.Count)
             {
-                Assert.Throws<ArgumentOutOfRangeException>("index", () => arraySegment.Slice(index));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => arraySegment.Slice(index));
             }
 
-            Assert.Throws<ArgumentOutOfRangeException>("index", () => arraySegment.Slice(index, count));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => arraySegment.Slice(index, count));
         }
 
         public static IEnumerable<object[]> Slice_Invalid_TestData()

--- a/src/System.Runtime/tests/System/ArrayTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/ArrayTests.netcoreapp.cs
@@ -53,6 +53,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Fill_Generic_TestData))]
+        [ActiveIssue("TFS 437849 - Universal Shared Generics issue", TargetFrameworkMonikers.UapAot)]
         public static void Fill_Generic<T>(IEnumerable<T> source, T value, int startIndex, int count)
         {
             if (startIndex == 0 && count == source.Count())
@@ -141,11 +142,15 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corert/issues/3650 - Wrong exception thrown", TargetFrameworkMonikers.UapAot)]
         public static void CreateInstance_TypeNotRuntimeType_ThrowsArgumentException()
         {
-            AssertExtensions.Throws<ArgumentException>("elementType", () => Array.CreateInstance(Helpers.NonRuntimeType(), 0));
-            AssertExtensions.Throws<ArgumentException>("elementType", () => Array.CreateInstance(Helpers.NonRuntimeType(), new int[1]));
-            AssertExtensions.Throws<ArgumentException>("elementType", () => Array.CreateInstance(Helpers.NonRuntimeType(), new int[1], new int[1]));
+            foreach (Type nonRuntimeType in Helpers.NonRuntimeTypes)
+            {
+                AssertExtensions.Throws<ArgumentException>("elementType", () => Array.CreateInstance(nonRuntimeType, 0));
+                AssertExtensions.Throws<ArgumentException>("elementType", () => Array.CreateInstance(nonRuntimeType, new int[1]));
+                AssertExtensions.Throws<ArgumentException>("elementType", () => Array.CreateInstance(nonRuntimeType, new int[1], new int[1]));
+            }
         }
     }
 }

--- a/src/System.Runtime/tests/System/EnumTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/EnumTests.netcoreapp.cs
@@ -32,6 +32,7 @@ namespace System.Tests
         
         [Theory]
         [MemberData(nameof(Parse_Invalid_TestData))]
+        [ActiveIssue("https://github.com/dotnet/corert/issues/3651 Enum.Parse<T>() validation.", TargetFrameworkMonikers.UapAot)]
         public static void Parse_Invalid_NetCoreApp11(Type enumType, string value, bool ignoreCase, Type exceptionType)
         {
             Type typeArgument = enumType == null || !enumType.GetTypeInfo().IsEnum ? typeof(SimpleEnum) : enumType;
@@ -74,10 +75,14 @@ namespace System.Tests
 
         public static IEnumerable<object[]> UnsupportedEnumType_TestData()
         {
+#if netcoreapp
             yield return new object[] { s_floatEnumType, 1.0f };
             yield return new object[] { s_doubleEnumType, 1.0 };
             yield return new object[] { s_intPtrEnumType, (IntPtr)1 };
             yield return new object[] { s_uintPtrEnumType, (UIntPtr)1 };
+#else
+            return Array.Empty<object[]>();
+#endif //netcoreapp
         }
 
         [Theory]
@@ -97,6 +102,7 @@ namespace System.Tests
             Assert.True(exName == nameof(InvalidOperationException) || exName == "ContractException");
         }
 
+#if netcoreapp
         [Fact]
         public static void ToString_InvalidUnicodeChars()
         {
@@ -106,13 +112,18 @@ namespace System.Tests
             ToString_Format((Enum)Enum.ToObject(s_charEnumType, char.MaxValue), "F", char.MaxValue.ToString());
             ToString_Format((Enum)Enum.ToObject(s_charEnumType, char.MaxValue), "G", char.MaxValue.ToString());
         }
+#endif //netcoreapp
 
         public static IEnumerable<object[]> UnsupportedEnum_TestData()
         {
+#if netcoreapp
             yield return new object[] { Enum.ToObject(s_floatEnumType, 1) };
             yield return new object[] { Enum.ToObject(s_doubleEnumType, 2) };
             yield return new object[] { Enum.ToObject(s_intPtrEnumType, 1) };
             yield return new object[] { Enum.ToObject(s_uintPtrEnumType, 2) };
+#else
+            return Array.Empty<object[]>();
+#endif //netcoreapp
         }
 
         [Theory]
@@ -142,6 +153,8 @@ namespace System.Tests
             string formatFExceptionName = formatFException.GetType().Name;
             Assert.True(formatFExceptionName == nameof(InvalidOperationException) || formatFExceptionName == "ContractException");
         }
+
+#if netcoreapp // .NetNative does not support RefEmit nor any other way to create Enum types with unusual backing types.
         private static EnumBuilder GetNonRuntimeEnumTypeBuilder(Type underlyingType)
         {
             AssemblyBuilder assembly = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Name"), AssemblyBuilderAccess.Run);
@@ -229,6 +242,6 @@ namespace System.Tests
 
             return enumBuilder.CreateTypeInfo().AsType();
         }
-        
+#endif //netcoreapp        
     }
 }

--- a/src/System.Runtime/tests/System/GCTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/GCTests.netcoreapp.cs
@@ -12,6 +12,7 @@ namespace System.Tests
         [Theory]
         [InlineData(1000)]
         [InlineData(100000)]
+        [ActiveIssue("https://github.com/dotnet/corert/issues/3648 - GC.GetAllocatedBytesForCurrentThread not yet ported to CoreRT", TargetFrameworkMonikers.UapAot)]
         public static void GetAllocatedBytesForCurrentThread(int size)
         {
             long start = GC.GetAllocatedBytesForCurrentThread();

--- a/src/System.Runtime/tests/System/Reflection/TypeDelegatorTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/Reflection/TypeDelegatorTests.netcoreapp.cs
@@ -14,8 +14,11 @@ namespace System.Reflection.Tests
             yield return new object[] { typeof(int[]).MakeByRefType(), false };
             yield return new object[] { typeof(int[,]), false };
             yield return new object[] { typeof(TypeInfoTests), false };
-            yield return new object[] { Array.CreateInstance(typeof(int), new[] { 2 }, new[] { -1 }).GetType(), false };
-            yield return new object[] { Array.CreateInstance(typeof(int), new[] { 2 }, new[] { 1 }).GetType(), false };
+            if (PlatformDetection.IsNonZeroLowerBoundArraySupported)
+            {
+                yield return new object[] { Array.CreateInstance(typeof(int), new[] { 2 }, new[] { -1 }).GetType(), false };
+                yield return new object[] { Array.CreateInstance(typeof(int), new[] { 2 }, new[] { 1 }).GetType(), false };
+            }
             yield return new object[] { Array.CreateInstance(typeof(int), new[] { 2 }, new[] { 0 }).GetType(), true };
             yield return new object[] { typeof(int[][]), true };
             yield return new object[] { Type.GetType("System.Int32[]"), true };
@@ -28,7 +31,10 @@ namespace System.Reflection.Tests
             yield return new object[] { typeof(Outside<int>.Inside<string>), false };
             yield return new object[] { typeof(Outside<int>.Inside<string>[]), true };
             yield return new object[] { typeof(Outside<int>.Inside<string>[,]), false };
-            yield return new object[] { Array.CreateInstance(typeof(Outside<int>.Inside<string>), new[] { 2 }, new[] { -1 }).GetType(), false };
+            if (PlatformDetection.IsNonZeroLowerBoundArraySupported)
+            {
+                yield return new object[] { Array.CreateInstance(typeof(Outside<int>.Inside<string>), new[] { 2 }, new[] { -1 }).GetType(), false };
+            }
         }
 
         [Theory, MemberData(nameof(SZArrayOrNotTypes))]

--- a/src/System.Runtime/tests/System/Reflection/TypeInfoTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/Reflection/TypeInfoTests.netcoreapp.cs
@@ -14,8 +14,11 @@ namespace System.Reflection.Tests
             yield return new object[] { typeof(int[]).MakeByRefType(), false };
             yield return new object[] { typeof(int[,]), false };
             yield return new object[] { typeof(TypeInfoTests), false };
-            yield return new object[] { Array.CreateInstance(typeof(int), new[] { 2 }, new[] { -1 }).GetType(), false };
-            yield return new object[] { Array.CreateInstance(typeof(int), new[] { 2 }, new[] { 1 }).GetType(), false };
+            if (PlatformDetection.IsNonZeroLowerBoundArraySupported)
+            {
+                yield return new object[] { Array.CreateInstance(typeof(int), new[] { 2 }, new[] { -1 }).GetType(), false };
+                yield return new object[] { Array.CreateInstance(typeof(int), new[] { 2 }, new[] { 1 }).GetType(), false };
+            }
             yield return new object[] { Array.CreateInstance(typeof(int), new[] { 2 }, new[] { 0 }).GetType(), true };
             yield return new object[] { typeof(int[][]), true };
             yield return new object[] { Type.GetType("System.Int32[]"), true };
@@ -28,7 +31,10 @@ namespace System.Reflection.Tests
             yield return new object[] { typeof(Outside<int>.Inside<string>), false };
             yield return new object[] { typeof(Outside<int>.Inside<string>[]), true };
             yield return new object[] { typeof(Outside<int>.Inside<string>[,]), false };
-            yield return new object[] { Array.CreateInstance(typeof(Outside<int>.Inside<string>), new[] { 2 }, new[] { -1 }).GetType(), false };
+            if (PlatformDetection.IsNonZeroLowerBoundArraySupported)
+            {
+                yield return new object[] { Array.CreateInstance(typeof(Outside<int>.Inside<string>), new[] { 2 }, new[] { -1 }).GetType(), false };
+            }
         }
 
         [Theory, MemberData(nameof(SZArrayOrNotTypes))]

--- a/src/System.Runtime/tests/System/StringTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/StringTests.netcoreapp.cs
@@ -191,12 +191,14 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Replace_StringComparison_TestData))]
+        [ActiveIssue("https://github.com/dotnet/corert/issues/3646 - String.Replace(String, String, StringComparison) not yet ported", TargetFrameworkMonikers.UapAot)]
         public void Replace_StringComparison_ReturnsExpected(string original, string oldValue, string newValue, StringComparison comparisonType, string expected)
         {
             Assert.Equal(expected, original.Replace(oldValue, newValue, comparisonType));
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corert/issues/3646 - String.Replace(String, String, StringComparison) not yet ported", TargetFrameworkMonikers.UapAot)]
         public void Replace_StringComparison_TurkishI()
         {
             string source = "\u0069\u0130";
@@ -246,6 +248,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Replace_StringComparisonCulture_TestData))]
+        [ActiveIssue("https://github.com/dotnet/corert/issues/3647 - String.Replace(String, String, bool, StringComparison) not yet ported", TargetFrameworkMonikers.UapAot)]
         public void Replace_StringComparisonCulture_ReturnsExpected(string original, string oldValue, string newValue, bool ignoreCase, CultureInfo culture, string expected)
         {
             Assert.Equal(expected, original.Replace(oldValue, newValue, ignoreCase, culture));
@@ -256,25 +259,30 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corert/issues/3646 - String.Replace(String, String, StringComparison) not yet ported", TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue("https://github.com/dotnet/corert/issues/3647 - String.Replace(String, String, bool, StringComparison) not yet ported", TargetFrameworkMonikers.UapAot)]
         public void Replace_StringComparison_NullOldValue_ThrowsArgumentException()
         {
-            Assert.Throws<ArgumentNullException>("oldValue", () => "abc".Replace(null, "def", StringComparison.CurrentCulture));
-            Assert.Throws<ArgumentNullException>("oldValue", () => "abc".Replace(null, "def", true, CultureInfo.CurrentCulture));
+            AssertExtensions.Throws<ArgumentNullException>("oldValue", () => "abc".Replace(null, "def", StringComparison.CurrentCulture));
+            AssertExtensions.Throws<ArgumentNullException>("oldValue", () => "abc".Replace(null, "def", true, CultureInfo.CurrentCulture));
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corert/issues/3646 - String.Replace(String, String, StringComparison) not yet ported", TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue("https://github.com/dotnet/corert/issues/3647 - String.Replace(String, String, bool, StringComparison) not yet ported", TargetFrameworkMonikers.UapAot)]
         public void Replace_StringComparison_EmptyOldValue_ThrowsArgumentException()
         {
-            Assert.Throws<ArgumentException>("oldValue", () => "abc".Replace("", "def", StringComparison.CurrentCulture));
-            Assert.Throws<ArgumentException>("oldValue", () => "abc".Replace("", "def", true, CultureInfo.CurrentCulture));
+            AssertExtensions.Throws<ArgumentException>("oldValue", () => "abc".Replace("", "def", StringComparison.CurrentCulture));
+            AssertExtensions.Throws<ArgumentException>("oldValue", () => "abc".Replace("", "def", true, CultureInfo.CurrentCulture));
         }
 
         [Theory]
         [InlineData(StringComparison.CurrentCulture - 1)]
         [InlineData(StringComparison.OrdinalIgnoreCase + 1)]
+        [ActiveIssue("https://github.com/dotnet/corert/issues/3646 - String.Replace(String, String, StringComparison) not yet ported", TargetFrameworkMonikers.UapAot)]
         public void Replace_NoSuchStringComparison_ThrowsArgumentException(StringComparison comparisonType)
         {
-            Assert.Throws<ArgumentException>("comparisonType", () => "abc".Replace("abc", "def", comparisonType));
+            AssertExtensions.Throws<ArgumentException>("comparisonType", () => "abc".Replace("abc", "def", comparisonType));
         }
 
 
@@ -285,6 +293,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(GetHashCode_StringComparison_Data))]
+        [ActiveIssue("https://github.com/dotnet/corert/issues/3645 - String.GetHashCode(StringComparison) not yet ported", TargetFrameworkMonikers.UapAot)]
         public static void GetHashCode_StringComparison(StringComparison comparisonType)
         {
             Assert.Equal(StringComparer.FromComparison(comparisonType).GetHashCode("abc"), "abc".GetHashCode(comparisonType));
@@ -299,9 +308,10 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(GetHashCode_NoSuchStringComparison_ThrowsArgumentException_Data))]
+        [ActiveIssue("https://github.com/dotnet/corert/issues/3645 - String.GetHashCode(StringComparison) not yet ported", TargetFrameworkMonikers.UapAot)]
         public static void GetHashCode_NoSuchStringComparison_ThrowsArgumentException(StringComparison comparisonType)
         {
-            Assert.Throws<ArgumentException>("comparisonType", () => "abc".GetHashCode(comparisonType));
+            AssertExtensions.Throws<ArgumentException>("comparisonType", () => "abc".GetHashCode(comparisonType));
         }
     }
 }

--- a/src/System.Runtime/tests/System/Text/StringBuilderTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/Text/StringBuilderTests.netcoreapp.cs
@@ -13,12 +13,12 @@ namespace System.Text.Tests
         [Fact]
         public static void AppendJoin_NullValues_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>("values", () => new StringBuilder().AppendJoin('|', (object[])null));
-            Assert.Throws<ArgumentNullException>("values", () => new StringBuilder().AppendJoin('|', (IEnumerable<object>)null));
-            Assert.Throws<ArgumentNullException>("values", () => new StringBuilder().AppendJoin('|', (string[])null));
-            Assert.Throws<ArgumentNullException>("values", () => new StringBuilder().AppendJoin("|", (object[])null));
-            Assert.Throws<ArgumentNullException>("values", () => new StringBuilder().AppendJoin("|", (IEnumerable<object>)null));
-            Assert.Throws<ArgumentNullException>("values", () => new StringBuilder().AppendJoin("|", (string[])null));
+            AssertExtensions.Throws<ArgumentNullException>("values", () => new StringBuilder().AppendJoin('|', (object[])null));
+            AssertExtensions.Throws<ArgumentNullException>("values", () => new StringBuilder().AppendJoin('|', (IEnumerable<object>)null));
+            AssertExtensions.Throws<ArgumentNullException>("values", () => new StringBuilder().AppendJoin('|', (string[])null));
+            AssertExtensions.Throws<ArgumentNullException>("values", () => new StringBuilder().AppendJoin("|", (object[])null));
+            AssertExtensions.Throws<ArgumentNullException>("values", () => new StringBuilder().AppendJoin("|", (IEnumerable<object>)null));
+            AssertExtensions.Throws<ArgumentNullException>("values", () => new StringBuilder().AppendJoin("|", (string[])null));
         }
 
         [Theory]
@@ -118,13 +118,13 @@ namespace System.Text.Tests
 
             if (separator?.Length == 1)
             {
-                Assert.Throws<ArgumentOutOfRangeException>(s_noCapacityParamName, () => CreateBuilderWithNoSpareCapacity().AppendJoin(separator[0], values));
-                Assert.Throws<ArgumentOutOfRangeException>(s_noCapacityParamName, () => CreateBuilderWithNoSpareCapacity().AppendJoin(separator[0], enumerable));
-                Assert.Throws<ArgumentOutOfRangeException>(s_noCapacityParamName, () => CreateBuilderWithNoSpareCapacity().AppendJoin(separator[0], stringValues));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>(s_noCapacityParamName, () => CreateBuilderWithNoSpareCapacity().AppendJoin(separator[0], values));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>(s_noCapacityParamName, () => CreateBuilderWithNoSpareCapacity().AppendJoin(separator[0], enumerable));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>(s_noCapacityParamName, () => CreateBuilderWithNoSpareCapacity().AppendJoin(separator[0], stringValues));
             }
-            Assert.Throws<ArgumentOutOfRangeException>(s_noCapacityParamName, () => CreateBuilderWithNoSpareCapacity().AppendJoin(separator, values));
-            Assert.Throws<ArgumentOutOfRangeException>(s_noCapacityParamName, () => CreateBuilderWithNoSpareCapacity().AppendJoin(separator, enumerable));
-            Assert.Throws<ArgumentOutOfRangeException>(s_noCapacityParamName, () => CreateBuilderWithNoSpareCapacity().AppendJoin(separator, stringValues));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>(s_noCapacityParamName, () => CreateBuilderWithNoSpareCapacity().AppendJoin(separator, values));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>(s_noCapacityParamName, () => CreateBuilderWithNoSpareCapacity().AppendJoin(separator, enumerable));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>(s_noCapacityParamName, () => CreateBuilderWithNoSpareCapacity().AppendJoin(separator, stringValues));
         }
     }
 }

--- a/src/System.Runtime/tests/System/TypedReferenceTests.cs
+++ b/src/System.Runtime/tests/System/TypedReferenceTests.cs
@@ -72,6 +72,7 @@ namespace System.Tests
             Assert.Equal(structObj, TypedReference.ToObject(reference));
         }
 
+#if !uapaot  // ActiveIssue UapAot TFS 430781 - __makeref causes ILC fatal error.
         [Fact]
         public static void GetTargetTypeTests()
         {
@@ -107,7 +108,9 @@ namespace System.Tests
             reference = __makeref(boolValue);
             Assert.Equal(boolValue.GetType(), TypedReference.GetTargetType(reference));
         }
+#endif // !uapaot
 
+#if !uapaot  // ActiveIssue UapAot TFS 430781 - __makeref causes ILC fatal error.
         [Fact]
         public static unsafe void PointerTypeTests()
         {
@@ -120,5 +123,6 @@ namespace System.Tests
             Assert.Equal(typeof(UIntPtr), obj.GetType());
             Assert.Equal((UIntPtr)pointerValue, (UIntPtr)obj);
         }
+#endif // !uapaot
     }
 }


### PR DESCRIPTION
A lot the .netcore.cs files are testing stuff
that "should" work in .Net Native (and tend to
represent the newer stuff which *isn't* likely
to have been ported yet). They should be active
in the UapAot build.