### PR TITLE
System.Net.Primitives for UWP

### DIFF
--- a/src/System.Net.Primitives/src/System.Net.Primitives.csproj
+++ b/src/System.Net.Primitives/src/System.Net.Primitives.csproj
@@ -7,9 +7,6 @@
     <ProjectGuid>{8772BC91-7B55-49B9-94FA-4B1BE5BEAB55}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
-  <PropertyGroup>
-    <DefineConstants Condition="'$(TargetGroup)' == 'uap'">$(DefineConstants);uap</DefineConstants>
-  </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='uap-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='uap-Windows_NT-Release|AnyCPU'" />
@@ -135,9 +132,6 @@
     <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.NtStatus.cs">
       <Link>Common\Interop\Windows\NtDll\Interop.NtStatus.cs</Link>
     </Compile>
-  </ItemGroup>
-  <!-- Windows : Win32 only -->
-  <ItemGroup Condition="'$(TargetsWindows)' == 'true' AND '$(TargetGroup)' != 'uap'">
     <Compile Include="$(CommonPath)\System\Net\NetworkInformation\HostInformationPal.Windows.cs">
       <Link>Common\System\Net\NetworkInformation\HostInformationPal.Windows.cs</Link>
     </Compile>
@@ -155,12 +149,6 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.LocalFree.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.LocalFree.cs</Link>
-    </Compile>
-  </ItemGroup>
-  <!-- Windows : Win32 + WinRT -->
-  <ItemGroup Condition="'$(TargetsWindows)' == 'true' AND '$(TargetGroup)' == 'uap'">
-    <Compile Include="$(CommonPath)\System\Net\NetworkInformation\HostInformationPal.Uap.cs">
-      <Link>Common\System\Net\NetworkInformation\HostInformationPal.Uap.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true'">
@@ -198,10 +186,6 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.SocketAddress.cs">
       <Link>Interop\Unix\System.Native\Interop.SocketAddress.cs</Link>
     </Compile>
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'uap'">
-    <Reference Include="Windows" />
-    <Reference Include="mscorlib" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Win32.Primitives" />

--- a/src/System.Net.Primitives/src/System/Net/Cookie.cs
+++ b/src/System.Net.Primitives/src/System/Net/Cookie.cs
@@ -658,12 +658,11 @@ namespace System.Net
             set
             {
                 // Only set by HttpListenerRequest::Cookies_get()
-#if !uap
                 if (value != CookieVariant.Rfc2965)
                 {
                     NetEventSource.Fail(this, $"value != Rfc2965:{value}");
                 }
-#endif
+
                 _cookieVariant = value;
             }
         }
@@ -828,7 +827,6 @@ namespace System.Net
 #if DEBUG
         internal void Dump()
         {
-#if !uap
             if (NetEventSource.IsEnabled)
             {
                 if (NetEventSource.IsEnabled) NetEventSource.Info(this, 
@@ -850,7 +848,6 @@ namespace System.Net
                                 + "\tHttpOnly    = " + HttpOnly + "\n"
                                 );
             }
-#endif
         }
 #endif
     }

--- a/src/System.Net.Primitives/tests/FunctionalTests/LoggingTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/LoggingTest.cs
@@ -25,7 +25,10 @@ namespace System.Net.Primitives.Functional.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core")]
+        [SkipOnTargetFramework(
+            TargetFrameworkMonikers.NetFramework | TargetFrameworkMonikers.UapAot | TargetFrameworkMonikers.Uap, 
+            "NetFramework: NetEventSource is only part of .NET Core;" + 
+            "UapAot: RemoteExecutorConsoleApp.exe crashes trying to load netstandard.dll - StrongName issue")]
         public void EventSource_EventsRaisedAsExpected()
         {
             RemoteInvoke(() =>


### PR DESCRIPTION
1. Disabling failing UWP test (tracked by #19909)
2. Unifying Windows implementations
