### PR TITLE
Port of PR https://github.com/dotnet/corefx/pull/19905

### DIFF
--- a/src/System.Data.SqlClient/src/Resources/Strings.resx
+++ b/src/System.Data.SqlClient/src/Resources/Strings.resx
@@ -1045,4 +1045,10 @@
   <data name="PlatformNotSupported_DataSqlClient" xml:space="preserve">
     <value>System.Data.SqlClient is not supported on this platform.</value>
   </data>
+  <data name="SqlParameter_InvalidTableDerivedPrecisionForTvp" xml:space="preserve">
+    <value>Precision '{0}' required to send all values in column '{1}' exceeds the maximum supported precision '{2}'. The values must all fit in a single precision.</value>
+  </data>
+  <data name="SqlProvider_InvalidDataColumnMaxLength" xml:space="preserve">
+    <value>The size of column '{0}' is not supported. The size is {1}.</value>
+  </data>
 </root>

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameter.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameter.cs
@@ -946,6 +946,7 @@ namespace System.Data.SqlClient
                         value = new DateTimeOffset((DateTime)value);
                     }
                     else if (TdsEnums.SQLTABLE == destinationType.TDSType && (
+                                value is DataTable ||
                                 value is DbDataReader ||
                                 value is System.Collections.Generic.IEnumerable<SqlDataRecord>))
                     {
@@ -1078,7 +1079,48 @@ namespace System.Data.SqlClient
             peekAhead = null;
 
             object value = GetCoercedValue();
-            if (value is SqlDataReader)
+            if (value is DataTable dt)
+            {
+                if (dt.Columns.Count <= 0)
+                {
+                    throw SQL.NotEnoughColumnsInStructuredType();
+                }
+                fields = new List<MSS.SmiExtendedMetaData>(dt.Columns.Count);
+                bool[] keyCols = new bool[dt.Columns.Count];
+                bool hasKey = false;
+
+                // set up primary key as unique key list
+                //  do this prior to general metadata loop to favor the primary key
+                if (null != dt.PrimaryKey && 0 < dt.PrimaryKey.Length)
+                {
+                    foreach (DataColumn col in dt.PrimaryKey)
+                    {
+                        keyCols[col.Ordinal] = true;
+                        hasKey = true;
+                    }
+                }
+
+                for (int i = 0; i < dt.Columns.Count; i++)
+                {
+                    fields.Add(MSS.MetaDataUtilsSmi.SmiMetaDataFromDataColumn(dt.Columns[i], dt));
+
+                    // DataColumn uniqueness is only for a single column, so don't add
+                    //  more than one.  (keyCols.Count first for assumed minimal perf benefit)
+                    if (!hasKey && dt.Columns[i].Unique)
+                    {
+                        keyCols[i] = true;
+                        hasKey = true;
+                    }
+                }
+
+                // Add unique key property, if any found.
+                if (hasKey)
+                {
+                    props = new SmiMetaDataPropertyCollection();
+                    props[MSS.SmiPropertySelector.UniqueKey] = new MSS.SmiUniqueKeyProperty(new List<bool>(keyCols));
+                }
+            }
+            else if (value is SqlDataReader)
             {
                 fields = new List<MSS.SmiExtendedMetaData>(((SqlDataReader)value).GetInternalSmiMetaData());
                 if (fields.Count <= 0)

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlUtil.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlUtil.cs
@@ -533,7 +533,14 @@ namespace System.Data.SqlClient
         {
             return ADP.InvalidOperation(SR.GetString(SR.SQL_BulkLoadPendingOperation));
         }
-
+        internal static Exception InvalidTableDerivedPrecisionForTvp(string columnName, byte precision)
+        {
+            return ADP.InvalidOperation(SR.GetString(SR.SqlParameter_InvalidTableDerivedPrecisionForTvp, precision, columnName, System.Data.SqlTypes.SqlDecimal.MaxPrecision));
+        }
+        internal static Exception InvalidColumnMaxLength(string columnName, long maxLength)
+        {
+            return ADP.Argument(SR.GetString(SR.SqlProvider_InvalidDataColumnMaxLength, columnName, maxLength));
+        }
         //
         // transactions.
         //


### PR DESCRIPTION
Porting code from NetFx which enables DataTables to be passing as a parameter in SqlParameter.
Tested with Dapper, and EF tests.

Dapper failures for netcoreapp2.0 reduce with this change.
No failures in EF tests.

Added new test to test DataTable as a parameter.
PR in master https://github.com/dotnet/corefx/pull/19905 
Fixes: #19708

