### PR TITLE
Fix Process.Start() on Unix platforms to not leak file descriptors of redirection pipes to child processes

### DIFF
--- a/src/Native/Unix/System.Native/pal_process.cpp
+++ b/src/Native/Unix/System.Native/pal_process.cpp
@@ -4,6 +4,7 @@
 
 #include "pal_config.h"
 #include "pal_process.h"
+#include "pal_io.h"
 #include "pal_utilities.h"
 
 #include <assert.h>
@@ -136,9 +137,11 @@ extern "C" int32_t SystemNative_ForkAndExecProcess(const char* filename,
         goto done;
     }
 
-    // Open pipes for any requests to redirect stdin/stdout/stderr
-    if ((redirectStdin && pipe(stdinFds) != 0) || (redirectStdout && pipe(stdoutFds) != 0) ||
-        (redirectStderr && pipe(stderrFds) != 0))
+    // Open pipes for any requests to redirect stdin/stdout/stderr and set the
+    // close-on-exec flag to the pipe file descriptors.
+    if ((redirectStdin  && SystemNative_Pipe(stdinFds,  PAL_O_CLOEXEC) != 0) ||
+        (redirectStdout && SystemNative_Pipe(stdoutFds, PAL_O_CLOEXEC) != 0) ||
+        (redirectStderr && SystemNative_Pipe(stderrFds, PAL_O_CLOEXEC) != 0))
     {
         success = false;
         goto done;
@@ -163,22 +166,14 @@ extern "C" int32_t SystemNative_ForkAndExecProcess(const char* filename,
 
     if (processId == 0) // processId == 0 if this is child process
     {
-        // Close the child's copy of the parent end of any open pipes
-        CloseIfOpen(stdinFds[WRITE_END_OF_PIPE]);
-        CloseIfOpen(stdoutFds[READ_END_OF_PIPE]);
-        CloseIfOpen(stderrFds[READ_END_OF_PIPE]);
-
         // For any redirections that should happen, dup the pipe descriptors onto stdin/out/err.
-        // Then close out the old pipe descriptrs, which we no longer need.
+        // We don't need to explicitly close out the old pipe descriptors as they will be closed on the 'execve' call.
         if ((redirectStdin && Dup2WithInterruptedRetry(stdinFds[READ_END_OF_PIPE], STDIN_FILENO) == -1) ||
             (redirectStdout && Dup2WithInterruptedRetry(stdoutFds[WRITE_END_OF_PIPE], STDOUT_FILENO) == -1) ||
             (redirectStderr && Dup2WithInterruptedRetry(stderrFds[WRITE_END_OF_PIPE], STDERR_FILENO) == -1))
         {
             _exit(errno != 0 ? errno : EXIT_FAILURE);
         }
-        CloseIfOpen(stdinFds[READ_END_OF_PIPE]);
-        CloseIfOpen(stdoutFds[WRITE_END_OF_PIPE]);
-        CloseIfOpen(stderrFds[WRITE_END_OF_PIPE]);
 
         // Change to the designated working directory, if one was specified
         if (nullptr != cwd)
@@ -501,7 +496,7 @@ extern "C" int32_t SystemNative_SchedSetAffinity(int32_t pid, intptr_t* mask)
     cpu_set_t set;
     CPU_ZERO(&set);
 
-    intptr_t bits = *mask; 
+    intptr_t bits = *mask;
     for (int cpu = 0; cpu < maxCpu; cpu++)
     {
         if ((bits & static_cast<intptr_t>(1u << cpu)) != 0)
@@ -509,7 +504,7 @@ extern "C" int32_t SystemNative_SchedSetAffinity(int32_t pid, intptr_t* mask)
             CPU_SET(cpu, &set);
         }
     }
- 
+
     return sched_setaffinity(pid, sizeof(cpu_set_t), &set);
 }
 #endif

--- a/src/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
@@ -124,7 +124,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
-        public void TestClosingStandardInputShouldUnblockReadLineCallInChildProcess()
+        public void TestEOFReceivedWhenStdInClosed()
         {
             // This is the test for the fix of dotnet/corefx issue #13447.
             //
@@ -166,18 +166,16 @@ namespace System.Diagnostics.Tests
             p2.StartInfo.RedirectStandardInput = true;
             p2.Start();
 
-            // Close the standard input stream of the first child process.
-            // The first child process should be unblocked and write out 'NULL', and then exit.
-            p1.StandardInput.Close();
-
             try
             {
+                // Close the standard input stream of the first child process.
+                // The first child process should be unblocked and write out 'NULL', and then exit.
+                p1.StandardInput.Close();
                 Assert.True(p1.WaitForExit(WaitInMS));
             }
             finally
             {
-                // Clean up the child processes.
-                p1.Kill();
+                // Cleanup: kill the second child process
                 p2.Kill();
             }
         }

--- a/src/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
@@ -124,6 +124,65 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        public void TestClosingStandardInputShouldUnblockReadLineCallInChildProcess()
+        {
+            // This is the test for the fix of dotnet/corefx issue #13447.
+            //
+            // Summary of the issue:
+            // When an application starts more than one child processes with their standard inputs redirected on Unix,
+            // closing the standard input stream of the first child process won't unblock the 'Console.ReadLine()' call
+            // in the first child process (it's expected to receive EOF).
+            //
+            // Root cause of the issue:
+            // The file descriptor for the write end of the first child process standard input redirection pipe gets
+            // inherited by the second child process, which makes the reference count of the pipe write end become 2.
+            // When closing the standard input stream of the first child process, the file descriptor held by the parent
+            // process is released, but the one inherited by the second child process is still referencing the pipe
+            // write end, which cause the 'Console.ReadLine()' continue to be blocked in the first child process.
+            //
+            // Fix:
+            // Set the O_CLOEXEC flag when creating the redirection pipes. So that no child process would inherit the
+            // file descriptors referencing those pipes.
+            const string expected = "NULL";
+            Process p1 = CreateProcess(() =>
+            {
+                string line = Console.ReadLine();
+                Console.WriteLine(line == null ? "NULL" : "NOT_NULL");
+                return SuccessExitCode;
+            });
+            Process p2 = CreateProcess(() =>
+            {
+                Console.ReadLine();
+                return SuccessExitCode;
+            });
+
+            // Start the first child process
+            p1.StartInfo.RedirectStandardInput = true;
+            p1.StartInfo.RedirectStandardOutput = true;
+            p1.OutputDataReceived += (s, e) => { Assert.Equal(expected, e.Data); };
+            p1.Start();
+
+            // Start the second child process
+            p2.StartInfo.RedirectStandardInput = true;
+            p2.Start();
+
+            // Close the standard input stream of the first child process.
+            // The first child process should be unblocked and write out 'NULL', and then exit.
+            p1.StandardInput.Close();
+
+            try
+            {
+                Assert.True(p1.WaitForExit(WaitInMS));
+            }
+            finally
+            {
+                // Clean up the child processes.
+                p1.Kill();
+                p2.Kill();
+            }
+        }
+
+        [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "There is 2 bugs in Desktop in this codepath, see: dotnet/corefx #18437 and #18436")]
         public void TestAsyncHalfCharacterAtATime()
         {


### PR DESCRIPTION
Fix #13447.

Summary of the issue:
------------------------
When an application starts more than one child processes with their standard inputs redirected on Unix, closing the standard input stream of the first child process won't unblock the 'Console.ReadLine()' call in the first child process (it's expected to receive EOF).

Root cause of the issue:
--------------------------
The file descriptor for the write end of the first child process standard input redirection pipe gets inherited by the second child process, which makes the reference count of the pipe write end become 2. When closing the standard input stream of the first child process, the file descriptor held by the parent process is released, but the one inherited by the second child process is still referencing the pipe write end, which cause the 'Console.ReadLine()' continue to be blocked in the first child process.

Fix:
----
Set the O_CLOEXEC flag when creating the redirection pipes. So that no child process would inherit the file descriptors referencing those pipes after the 'execve' call.

/cc @stephentoub could you please review this PR?