### PR TITLE
Fix potential release of invalid GCHandle in PinnedObject.Release

### DIFF
--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/PinnedObject.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/PinnedObject.cs
@@ -4,6 +4,7 @@
 
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace System.Reflection.Internal
 {
@@ -11,6 +12,9 @@ namespace System.Reflection.Internal
     {
         // can't be read-only since GCHandle is a mutable struct
         private GCHandle _handle;
+
+        // non-zero indicates a valid handle
+        private int _isValid; 
 
         public PinnedObject(object obj)
         {
@@ -24,6 +28,7 @@ namespace System.Reflection.Internal
             finally
             {
                 _handle = GCHandle.Alloc(obj, GCHandleType.Pinned);
+                _isValid = 1;
             }
         }
 
@@ -38,7 +43,10 @@ namespace System.Reflection.Internal
             }
             finally
             {
-                _handle.Free();
+                if (Interlocked.Exchange(ref _isValid, 0) != 0)
+                {
+                    _handle.Free();
+                }
             }
         }
 

--- a/src/System.Reflection.Metadata/tests/Utilities/AbstractMemoryBlockTests.cs
+++ b/src/System.Reflection.Metadata/tests/Utilities/AbstractMemoryBlockTests.cs
@@ -214,6 +214,7 @@ namespace System.Reflection.Internal.Tests
         {
             var nativeBlocks = new NativeHeapMemoryBlock[20];
             var memoryMappedBlocks = new MemoryMappedFileBlock[20];
+            var pinnedObjects = new PinnedObject[20];
 
             for (int i = 0; i < nativeBlocks.Length; i++)
             {
@@ -223,6 +224,11 @@ namespace System.Reflection.Internal.Tests
             for (int i = 0; i < memoryMappedBlocks.Length; i++)
             {
                 memoryMappedBlocks[i] = new MemoryMappedFileBlock(new TestOnceDisposable(), new TestSafeBuffer(), offset: 0, size: 1);
+            }
+
+            for (int i = 0; i < memoryMappedBlocks.Length; i++)
+            {
+                pinnedObjects[i] = new PinnedObject(new byte[4]);
             }
 
             var worker = new ThreadStart(() =>
@@ -238,6 +244,12 @@ namespace System.Reflection.Internal.Tests
                     for (int i = 0; i < memoryMappedBlocks.Length; i++)
                     {
                         memoryMappedBlocks[i].Dispose();
+                        Thread.Yield();
+                    }
+
+                    for (int i = 0; i < pinnedObjects.Length; i++)
+                    {
+                        pinnedObjects[i].Dispose();
                         Thread.Yield();
                     }
                 }


### PR DESCRIPTION
If process shutdown happens to stop PinnedObject.Release processing within the GCHandle.Free call, then shutdown finalization of the same object will generate an InvalidOperationException. The same may occur if the constructor is preempted by shutdown.

Fixes https://github.com/dotnet/corefx/issues/19857

Port to Desktop FX tracked by VSO bug 437163.

Rebased to release/2.0.0 from https://github.com/dotnet/corefx/pull/19858.