### PR TITLE
Investigate WinHttpException: buffer too small

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -1343,10 +1343,12 @@ namespace System.Net.Http
                     state.Dispose();
                     WinHttpException.ThrowExceptionUsingLastError();
                 }
+#if DEBUG
                 int lastError = Marshal.GetLastWin32Error();
                 Debug.Assert(!(unchecked((int)lastError) == Interop.WinHttp.ERROR_INSUFFICIENT_BUFFER ||
                     unchecked((int)lastError) == unchecked((int)0x80090321)), // SEC_E_BUFFER_TOO_SMALL
                     $"Unexpected error: {unchecked((int)lastError)}");
+#endif
             }
 
             return state.LifecycleAwaitable;

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -1337,18 +1337,18 @@ namespace System.Net.Http
                     0,
                     state.ToIntPtr()))
                 {
+#if DEBUG
+                    int lastError = Marshal.GetLastWin32Error();
+                    Debug.Assert((unchecked((int)lastError) != Interop.WinHttp.ERROR_INSUFFICIENT_BUFFER &&
+                        unchecked((int)lastError) != unchecked((int)0x80090321)), // SEC_E_BUFFER_TOO_SMALL
+                        $"Unexpected async error in WinHttpRequestCallback: {unchecked((int)lastError)}");
+#endif
                     // Dispose (which will unpin) the state object. Since this failed, WinHTTP won't associate
                     // our context value (state object) to the request handle. And thus we won't get HANDLE_CLOSING
                     // notifications which would normally cause the state object to be unpinned and disposed.
                     state.Dispose();
                     WinHttpException.ThrowExceptionUsingLastError();
                 }
-#if DEBUG
-                int lastError = Marshal.GetLastWin32Error();
-                Debug.Assert(!(unchecked((int)lastError) == Interop.WinHttp.ERROR_INSUFFICIENT_BUFFER ||
-                    unchecked((int)lastError) == unchecked((int)0x80090321)), // SEC_E_BUFFER_TOO_SMALL
-                    $"Unexpected async error in WinHttpRequestCallback: {unchecked((int)lastError)}");
-#endif
             }
 
             return state.LifecycleAwaitable;

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -1343,6 +1343,10 @@ namespace System.Net.Http
                     state.Dispose();
                     WinHttpException.ThrowExceptionUsingLastError();
                 }
+                int lastError = Marshal.GetLastWin32Error();
+                Debug.Assert(!(unchecked((int)lastError) == Interop.WinHttp.ERROR_INSUFFICIENT_BUFFER ||
+                    unchecked((int)lastError) == unchecked((int)0x80090321)), // SEC_E_BUFFER_TOO_SMALL
+                    $"Unexpected error: {unchecked((int)lastError)}");
             }
 
             return state.LifecycleAwaitable;

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -1337,17 +1337,16 @@ namespace System.Net.Http
                     0,
                     state.ToIntPtr()))
                 {
-#if DEBUG
                     int lastError = Marshal.GetLastWin32Error();
                     Debug.Assert((unchecked((int)lastError) != Interop.WinHttp.ERROR_INSUFFICIENT_BUFFER &&
                         unchecked((int)lastError) != unchecked((int)0x80090321)), // SEC_E_BUFFER_TOO_SMALL
                         $"Unexpected async error in WinHttpRequestCallback: {unchecked((int)lastError)}");
-#endif
+
                     // Dispose (which will unpin) the state object. Since this failed, WinHTTP won't associate
                     // our context value (state object) to the request handle. And thus we won't get HANDLE_CLOSING
                     // notifications which would normally cause the state object to be unpinned and disposed.
                     state.Dispose();
-                    WinHttpException.ThrowExceptionUsingLastError();
+                    throw WinHttpException.CreateExceptionUsingError(lastError);
                 }
             }
 

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -1347,7 +1347,7 @@ namespace System.Net.Http
                 int lastError = Marshal.GetLastWin32Error();
                 Debug.Assert(!(unchecked((int)lastError) == Interop.WinHttp.ERROR_INSUFFICIENT_BUFFER ||
                     unchecked((int)lastError) == unchecked((int)0x80090321)), // SEC_E_BUFFER_TOO_SMALL
-                    $"Unexpected error: {unchecked((int)lastError)}");
+                    $"Unexpected async error in WinHttpRequestCallback: {unchecked((int)lastError)}");
 #endif
             }
 

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
@@ -309,6 +309,7 @@ namespace System.Net.Http
                 unchecked((int)asyncResult.dwError) == unchecked((int)0x80090321)), // SEC_E_BUFFER_TOO_SMALL
                 $"Unexpected async error in WinHttpRequestCallback: {unchecked((int)asyncResult.dwError)}, WinHttp API: {unchecked((uint)asyncResult.dwResult.ToInt32())}");
 
+#if DEBUG
             // Add instrumentation to catch unexpected errors and fail fast to produce a crash dump. Issue #7812.
             // If the failure is not caused by the above error codes, need to get more information from asyncResult.dwResult.
             // There are only two cases in the below switch statement which explicitly set WinHttpException.
@@ -320,6 +321,7 @@ namespace System.Net.Http
             {
                 Debug.Fail($"Unexpected error: {unchecked((int)asyncResult.dwError)}, WinHttp API: {unchecked((uint)asyncResult.dwResult.ToInt32())}");
             }
+#endif
 
             Exception innerException = WinHttpException.CreateExceptionUsingError(unchecked((int)asyncResult.dwError));
 

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
@@ -319,7 +319,7 @@ namespace System.Net.Http
                 (asyncResult.dwError != Interop.WinHttp.ERROR_WINHTTP_CLIENT_AUTH_CERT_NEEDED) &&
                 (asyncResult.dwError != Interop.WinHttp.ERROR_WINHTTP_OPERATION_CANCELLED)))
             {
-                Debug.Fail($"Unexpected error: {unchecked((int)asyncResult.dwError)}, WinHttp API: {unchecked((uint)asyncResult.dwResult.ToInt32())}");
+                Debug.Fail($"Unexpected async error in WinHttpRequestCallback: {unchecked((int)asyncResult.dwError)}, WinHttp API: {unchecked((uint)asyncResult.dwResult.ToInt32())}");
             }
 #endif
 

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
@@ -305,7 +305,7 @@ namespace System.Net.Http
             
             Debug.Assert(state != null, "OnRequestError: state is null");
 
-            // Add instrumentation for now to catch unexpected errors and fail fast and produce a crash dump.
+            // Add instrumentation to catch unexpected errors and fail fast to produce a crash dump.
             // Issue #7812
 #if DEBUG
             if (unchecked((int)asyncResult.dwError) == Interop.WinHttp.ERROR_INSUFFICIENT_BUFFER ||

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
@@ -305,23 +305,19 @@ namespace System.Net.Http
             
             Debug.Assert(state != null, "OnRequestError: state is null");
 
-            Debug.Assert(!(unchecked((int)asyncResult.dwError) == Interop.WinHttp.ERROR_INSUFFICIENT_BUFFER ||
-                unchecked((int)asyncResult.dwError) == unchecked((int)0x80090321)), // SEC_E_BUFFER_TOO_SMALL
+            Debug.Assert((unchecked((int)asyncResult.dwError) != Interop.WinHttp.ERROR_INSUFFICIENT_BUFFER &&
+                unchecked((int)asyncResult.dwError) != unchecked((int)0x80090321)), // SEC_E_BUFFER_TOO_SMALL
                 $"Unexpected async error in WinHttpRequestCallback: {unchecked((int)asyncResult.dwError)}, WinHttp API: {unchecked((uint)asyncResult.dwResult.ToInt32())}");
-
-#if DEBUG
-            // Add instrumentation to catch unexpected errors and fail fast to produce a crash dump. Issue #7812.
+            
             // If the failure is not caused by the above error codes, need to get more information from asyncResult.dwResult.
             // There are only two cases in the below switch statement which explicitly set WinHttpException.
-            if (unchecked((uint)asyncResult.dwResult.ToInt32()) == Interop.WinHttp.API_SEND_REQUEST ||
-                ((unchecked((uint)asyncResult.dwResult.ToInt32()) == Interop.WinHttp.API_RECEIVE_RESPONSE) &&
-                (asyncResult.dwError != Interop.WinHttp.ERROR_WINHTTP_RESEND_REQUEST) &&
-                (asyncResult.dwError != Interop.WinHttp.ERROR_WINHTTP_CLIENT_AUTH_CERT_NEEDED) &&
-                (asyncResult.dwError != Interop.WinHttp.ERROR_WINHTTP_OPERATION_CANCELLED)))
-            {
-                Debug.Fail($"Unexpected async error in WinHttpRequestCallback: {unchecked((int)asyncResult.dwError)}, WinHttp API: {unchecked((uint)asyncResult.dwResult.ToInt32())}");
-            }
-#endif
+            Debug.Assert((unchecked((uint)asyncResult.dwResult.ToInt32()) != Interop.WinHttp.API_SEND_REQUEST &&
+                ((unchecked((uint)asyncResult.dwResult.ToInt32()) != Interop.WinHttp.API_RECEIVE_RESPONSE) ||
+                (asyncResult.dwError == Interop.WinHttp.ERROR_WINHTTP_RESEND_REQUEST) ||
+                (asyncResult.dwError == Interop.WinHttp.ERROR_WINHTTP_CLIENT_AUTH_CERT_NEEDED) ||
+                (asyncResult.dwError == Interop.WinHttp.ERROR_WINHTTP_OPERATION_CANCELLED))),
+                $"Unexpected async error in WinHttpRequestCallback: {unchecked((int)asyncResult.dwError)}, WinHttp API: {unchecked((uint)asyncResult.dwResult.ToInt32())}"
+            );
 
             Exception innerException = WinHttpException.CreateExceptionUsingError(unchecked((int)asyncResult.dwError));
 

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
@@ -305,6 +305,16 @@ namespace System.Net.Http
             
             Debug.Assert(state != null, "OnRequestError: state is null");
 
+            // Add instrumentation for now to catch unexpected errors and fail fast and produce a crash dump.
+            // Issue #7812
+#if DEBUG
+            if (unchecked((int)asyncResult.dwError) == Interop.WinHttp.ERROR_INSUFFICIENT_BUFFER ||
+                unchecked((int)asyncResult.dwError) == unchecked((int)0x80090321)) // SEC_E_BUFFER_TOO_SMALL
+            {
+                Debug.Assert(false, $"Unexpected error: {unchecked((int)asyncResult.dwError)}, WinHttp API: {unchecked((uint)asyncResult.dwResult.ToInt32())}");
+            }
+#endif
+
             Exception innerException = WinHttpException.CreateExceptionUsingError(unchecked((int)asyncResult.dwError));
 
             switch (unchecked((uint)asyncResult.dwResult.ToInt32()))

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
@@ -305,15 +305,21 @@ namespace System.Net.Http
             
             Debug.Assert(state != null, "OnRequestError: state is null");
 
-            // Add instrumentation to catch unexpected errors and fail fast to produce a crash dump.
-            // Issue #7812
-#if DEBUG
-            if (unchecked((int)asyncResult.dwError) == Interop.WinHttp.ERROR_INSUFFICIENT_BUFFER ||
-                unchecked((int)asyncResult.dwError) == unchecked((int)0x80090321)) // SEC_E_BUFFER_TOO_SMALL
+            Debug.Assert(!(unchecked((int)asyncResult.dwError) == Interop.WinHttp.ERROR_INSUFFICIENT_BUFFER ||
+                unchecked((int)asyncResult.dwError) == unchecked((int)0x80090321)), // SEC_E_BUFFER_TOO_SMALL
+                $"Unexpected async error in WinHttpRequestCallback: {unchecked((int)asyncResult.dwError)}, WinHttp API: {unchecked((uint)asyncResult.dwResult.ToInt32())}");
+
+            // Add instrumentation to catch unexpected errors and fail fast to produce a crash dump. Issue #7812.
+            // If the failure is not caused by the above error codes, need to get more information from asyncResult.dwResult.
+            // There are only two cases in the below switch statement which explicitly set WinHttpException.
+            if (unchecked((uint)asyncResult.dwResult.ToInt32()) == Interop.WinHttp.API_SEND_REQUEST ||
+                ((unchecked((uint)asyncResult.dwResult.ToInt32()) == Interop.WinHttp.API_RECEIVE_RESPONSE) &&
+                (asyncResult.dwError != Interop.WinHttp.ERROR_WINHTTP_RESEND_REQUEST) &&
+                (asyncResult.dwError != Interop.WinHttp.ERROR_WINHTTP_CLIENT_AUTH_CERT_NEEDED) &&
+                (asyncResult.dwError != Interop.WinHttp.ERROR_WINHTTP_OPERATION_CANCELLED)))
             {
-                Debug.Assert(false, $"Unexpected error: {unchecked((int)asyncResult.dwError)}, WinHttp API: {unchecked((uint)asyncResult.dwResult.ToInt32())}");
+                Debug.Fail($"Unexpected error: {unchecked((int)asyncResult.dwError)}, WinHttp API: {unchecked((uint)asyncResult.dwResult.ToInt32())}");
             }
-#endif
 
             Exception innerException = WinHttpException.CreateExceptionUsingError(unchecked((int)asyncResult.dwError));
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
@@ -211,7 +211,6 @@ namespace System.Net.Http.Functional.Tests
             new object[] { Configuration.Http.WrongHostNameCertRemoteServer , SslPolicyErrors.RemoteCertificateNameMismatch},
         };
 
-        [ActiveIssue(7812, TestPlatforms.Windows)]
         [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(BackendSupportsCustomCertificateHandling))]
         [MemberData(nameof(CertificateValidationServersAndExpectedPolicies))]


### PR DESCRIPTION
Add instrumentation for now to catch unexpected errors and fail fast and produce a crash dump.

For #7812 