### PR TITLE
[release/2.0.0] Remove rid specific desktop builds

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/src/Configurations.props
+++ b/src/System.Diagnostics.DiagnosticSource/src/Configurations.props
@@ -4,14 +4,14 @@
     <PackageConfigurations>
       netstandard1.1;
       netstandard1.3;
-      net45-Windows_NT;
-      net46-Windows_NT;
+      net45;
+      net46;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);
       netcoreapp;
       netstandard;
-      netfx-Windows_NT;
+      netfx;
       uap-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
@@ -17,15 +17,14 @@
   <PropertyGroup Condition="'$(TargetGroup)' == 'net45' OR '$(TargetGroup)' == 'net46' OR '$(TargetGroup)' == 'netfx'">
     <DefineConstants>$(DefineConstants);ALLOW_PARTIALLY_TRUSTED_CALLERS;ENABLE_HTTP_HANDLER</DefineConstants>
   </PropertyGroup>
-  <!-- Default configurations to help VS understand the configurations -->
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net45-Windows_NT-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net45-Windows_NT-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46-Windows_NT-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net45-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net45-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Windows_NT-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.1-Debug|AnyCPU'" />
@@ -70,7 +69,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'net45' OR '$(TargetGroup)' == 'net46' OR '$(TargetGroup)' == 'netfx'">
     <Compile Include="AssemblyInfo.netfx.cs" />
-    <Compile Include="System\Diagnostics\Activity.DateTime.netfx.cs" />    
+    <Compile Include="System\Diagnostics\Activity.DateTime.netfx.cs" />
     <Reference Include="mscorlib" />
     <Reference Include="System" />
   </ItemGroup>

--- a/src/System.Diagnostics.Tracing/System.Diagnostics.Tracing.sln
+++ b/src/System.Diagnostics.Tracing/System.Diagnostics.Tracing.sln
@@ -26,10 +26,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{7E0E1B11-FF70-461E-99F7-C0AF252C0C60}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{7E0E1B11-FF70-461E-99F7-C0AF252C0C60}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{7E0E1B11-FF70-461E-99F7-C0AF252C0C60}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{7E0E1B11-FF70-461E-99F7-C0AF252C0C60}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{7E0E1B11-FF70-461E-99F7-C0AF252C0C60}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
+		{7E0E1B11-FF70-461E-99F7-C0AF252C0C60}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
+		{7E0E1B11-FF70-461E-99F7-C0AF252C0C60}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
+		{7E0E1B11-FF70-461E-99F7-C0AF252C0C60}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
 		{EB880FDC-326D-42B3-A3FD-0CD3BA29A7F4}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
 		{EB880FDC-326D-42B3-A3FD-0CD3BA29A7F4}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
 		{EB880FDC-326D-42B3-A3FD-0CD3BA29A7F4}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU

--- a/src/System.IO.FileSystem.AccessControl/System.IO.FileSystem.AccessControl.sln
+++ b/src/System.IO.FileSystem.AccessControl/System.IO.FileSystem.AccessControl.sln
@@ -26,10 +26,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{5915DD11-5D57-45A9-BFB0-56FEB7741E1F}.Debug|Any CPU.ActiveCfg = netstandard-Windows_NT-Debug|Any CPU
-		{5915DD11-5D57-45A9-BFB0-56FEB7741E1F}.Debug|Any CPU.Build.0 = netstandard-Windows_NT-Debug|Any CPU
-		{5915DD11-5D57-45A9-BFB0-56FEB7741E1F}.Release|Any CPU.ActiveCfg = netstandard-Windows_NT-Release|Any CPU
-		{5915DD11-5D57-45A9-BFB0-56FEB7741E1F}.Release|Any CPU.Build.0 = netstandard-Windows_NT-Release|Any CPU
+		{5915DD11-5D57-45A9-BFB0-56FEB7741E1F}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
+		{5915DD11-5D57-45A9-BFB0-56FEB7741E1F}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
+		{5915DD11-5D57-45A9-BFB0-56FEB7741E1F}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
+		{5915DD11-5D57-45A9-BFB0-56FEB7741E1F}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
 		{D77FBA6C-1AA6-45A4-93E2-97A370672C53}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
 		{D77FBA6C-1AA6-45A4-93E2-97A370672C53}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
 		{D77FBA6C-1AA6-45A4-93E2-97A370672C53}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU

--- a/src/System.IO.IsolatedStorage/System.IO.IsolatedStorage.sln
+++ b/src/System.IO.IsolatedStorage/System.IO.IsolatedStorage.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26430.4
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.IO.IsolatedStorage.Tests", "tests\System.IO.IsolatedStorage.Tests.csproj", "{BF4F9507-8FBD-45EA-81C9-3ED89C052C91}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -15,14 +15,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.IO.IsolatedStorage", "ref\System.IO.IsolatedStorage.csproj", "{750200D5-661A-42AA-9E1F-2A151F5AEE74}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{1A2F9F4A-A032-433E-B914-ADD5992BB178}"
-	ProjectSection(SolutionItems) = preProject
-		tests\Configurations.props = tests\Configurations.props
-	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E893-4E87-987E-04EF0DCEAEFD}"
-	ProjectSection(SolutionItems) = preProject
-		src\Configurations.props = src\Configurations.props
-	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject

--- a/src/System.IO.IsolatedStorage/tests/System.IO.IsolatedStorage.Tests.csproj
+++ b/src/System.IO.IsolatedStorage/tests/System.IO.IsolatedStorage.Tests.csproj
@@ -5,7 +5,6 @@
     <ProjectGuid>{BF4F9507-8FBD-45EA-81C9-3ED89C052C91}</ProjectGuid>
     <TestCategories>InnerLoop;OuterLoop</TestCategories>
   </PropertyGroup>
-  <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Debug|AnyCPU'" />
@@ -14,6 +13,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Unix-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
     <Compile Include="System\IO\IsolatedStorage\IdentityTests.cs" />
     <Compile Include="System\IO\IsolatedStorage\IsolatedStorageBaseClassTests.cs" />

--- a/src/System.Net.Http/System.Net.Http.sln
+++ b/src/System.Net.Http/System.Net.Http.sln
@@ -31,10 +31,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{C85CF035-7804-41FF-9557-48B7C948B58D}.Debug|Any CPU.ActiveCfg = netstandard-Windows_NT-Debug|Any CPU
-		{C85CF035-7804-41FF-9557-48B7C948B58D}.Debug|Any CPU.Build.0 = netstandard-Windows_NT-Debug|Any CPU
-		{C85CF035-7804-41FF-9557-48B7C948B58D}.Release|Any CPU.ActiveCfg = netstandard-Windows_NT-Release|Any CPU
-		{C85CF035-7804-41FF-9557-48B7C948B58D}.Release|Any CPU.Build.0 = netstandard-Windows_NT-Release|Any CPU
+		{C85CF035-7804-41FF-9557-48B7C948B58D}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
+		{C85CF035-7804-41FF-9557-48B7C948B58D}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
+		{C85CF035-7804-41FF-9557-48B7C948B58D}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
+		{C85CF035-7804-41FF-9557-48B7C948B58D}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
 		{5F9C3C9F-652E-461E-B2D6-85D264F5A733}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
 		{5F9C3C9F-652E-461E-B2D6-85D264F5A733}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
 		{5F9C3C9F-652E-461E-B2D6-85D264F5A733}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -5,10 +5,16 @@
     <ProjectGuid>{C85CF035-7804-41FF-9557-48B7C948B58D}</ProjectGuid>
     <DefineConstants Condition="'$(TargetGroup)'=='netcoreapp'">$(DefineConstants);netcoreapp</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Unix-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Unix-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="$(CommonTestPath)\System\AssertExtensions.cs">
       <Link>Common\System\AssertExtensions.cs</Link>
@@ -74,11 +80,11 @@
     <Compile Include="HttpClientHandlerTest.MaxConnectionsPerServer.cs" />
     <Compile Include="HttpClientHandlerTest.MaxResponseHeadersLength.cs" />
     <Compile Include="HttpClientHandlerTest.ServerCertificates.cs" />
-    <Compile Include="HttpClientHandlerTest.ServerCertificates.Unix.cs" Condition="'$(TargetsUnix)' == 'true'"/>
-    <Compile Include="HttpClientHandlerTest.ServerCertificates.Windows.cs" Condition="'$(TargetsWindows)' == 'true'"/>
+    <Compile Include="HttpClientHandlerTest.ServerCertificates.Unix.cs" Condition="'$(TargetsUnix)' == 'true'" />
+    <Compile Include="HttpClientHandlerTest.ServerCertificates.Windows.cs" Condition="'$(TargetsWindows)' == 'true'" />
     <Compile Include="HttpClientHandlerTest.SslProtocols.cs" />
-    <Compile Include="HttpClientHandlerTest.SslProtocols.Unix.cs" Condition="'$(TargetsUnix)' == 'true'"/>
-    <Compile Include="HttpClientHandlerTest.SslProtocols.Windows.cs" Condition="'$(TargetsWindows)' == 'true'"/>
+    <Compile Include="HttpClientHandlerTest.SslProtocols.Unix.cs" Condition="'$(TargetsUnix)' == 'true'" />
+    <Compile Include="HttpClientHandlerTest.SslProtocols.Windows.cs" Condition="'$(TargetsWindows)' == 'true'" />
     <Compile Include="DiagnosticsTests.cs" />
     <Compile Include="HttpClientTest.cs" />
     <Compile Include="HttpClientEKUTest.cs" />

--- a/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -12,6 +12,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
   <!-- Do not reference these assemblies from the TargetingPack since we are building part of the source code for tests. -->
   <ItemGroup>
     <TargetingPackExclusions Include="System.Net.Http" />

--- a/src/System.Reflection.DispatchProxy/src/Configurations.props
+++ b/src/System.Reflection.DispatchProxy/src/Configurations.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PackageConfigurations>
-      netfx-Windows_NT;
+      netfx;
       netstandard;
     </PackageConfigurations>
     <BuildConfigurations>

--- a/src/System.Reflection.DispatchProxy/src/System.Reflection.DispatchProxy.csproj
+++ b/src/System.Reflection.DispatchProxy/src/System.Reflection.DispatchProxy.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Windows_NT-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />

--- a/src/System.Reflection.TypeExtensions/src/Configurations.props
+++ b/src/System.Reflection.TypeExtensions/src/Configurations.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PackageConfigurations>
-      netfx-Windows_NT;
+      netfx;
       netstandard;
       netstandard1.3;
       netstandard1.5;

--- a/src/System.Reflection.TypeExtensions/src/System.Reflection.TypeExtensions.csproj
+++ b/src/System.Reflection.TypeExtensions/src/System.Reflection.TypeExtensions.csproj
@@ -11,13 +11,12 @@
     <AssemblyVersion Condition="'$(TargetGroup)' == 'netstandard1.3'">4.0.0.0</AssemblyVersion>
     <AssemblyVersion Condition="'$(TargetGroup)' == 'netstandard1.5'">4.1.0.0</AssemblyVersion>
   </PropertyGroup>
-  <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Windows_NT-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.3-Debug|AnyCPU'" />

--- a/src/System.Runtime.InteropServices.RuntimeInformation/src/System.Runtime.InteropServices.RuntimeInformation.csproj
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/src/System.Runtime.InteropServices.RuntimeInformation.csproj
@@ -20,9 +20,12 @@
     </PackageTargetRuntime>
     <ValidPInvokeMappings Condition="'$(TargetGroup)'=='wpa81' OR '$(TargetGroup)'=='win8'">$(MSBuildThisFileDirectory)PInvokeAnalyzer_win8-wpa81-APIs.txt</ValidPInvokeMappings>
   </PropertyGroup>
-  <!-- Help VS understand available configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net45-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net45-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net462-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net462-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net47-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net47-Windows_NT-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Debug|AnyCPU'" />
@@ -41,6 +44,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'win8-Windows_NT-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'wpa81-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'wpa81-Windows_NT-Release|AnyCPU'" />
+  <!-- Help VS understand available configurations -->
   <ItemGroup Condition="'$(TargetsUnix)'=='true'">
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetUnixName.cs">
       <Link>Common\Interop\Unix\System.Native\Interop.GetUnixName.cs</Link>

--- a/src/System.Runtime.Serialization.Xml/System.Runtime.Serialization.Xml.sln
+++ b/src/System.Runtime.Serialization.Xml/System.Runtime.Serialization.Xml.sln
@@ -2,12 +2,12 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Canonicalization.Tests", "tests\Canonicalization\Canonicalization.Tests.csproj", "{D3AD82FC-051D-4121-8E48-B13CE8024776}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.Serialization.Xml.Tests", "tests\System.Runtime.Serialization.Xml.Tests.csproj", "{30CAB353-089E-4294-B23B-F2DD1D945654}"
 	ProjectSection(ProjectDependencies) = postProject
 		{9D747A18-C8FD-4D7A-8913-4ED7911683B4} = {9D747A18-C8FD-4D7A-8913-4ED7911683B4}
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.Serialization.Xml.Tests", "tests\System.Runtime.Serialization.Xml.Tests.csproj", "{30CAB353-089E-4294-B23B-F2DD1D945654}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Canonicalization.Tests", "tests\Canonicalization\Canonicalization.Tests.csproj", "{D3AD82FC-051D-4121-8E48-B13CE8024776}"
 	ProjectSection(ProjectDependencies) = postProject
 		{9D747A18-C8FD-4D7A-8913-4ED7911683B4} = {9D747A18-C8FD-4D7A-8913-4ED7911683B4}
 	EndProjectSection
@@ -17,7 +17,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.Serializatio
 		{9D747A18-C8FD-4D7A-8913-4ED7911683B4} = {9D747A18-C8FD-4D7A-8913-4ED7911683B4}
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.Serialization.Xml.ReflectionOnly.Tests", "tests\ReflectionOnly\System.Runtime.Serialization.Xml.ReflectionOnly.Tests.csproj", "{38889701-0AF4-48B3-999C-E99D639C61B6}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.Serialization.Xml.ReflectionOnly.Tests", "tests\ReflectionOnly\System.Runtime.Serialization.Xml.ReflectionOnly.Tests.csproj", "{38889701-0af4-48b3-999c-e99d639c61b6}"
 	ProjectSection(ProjectDependencies) = postProject
 		{9D747A18-C8FD-4D7A-8913-4ED7911683B4} = {9D747A18-C8FD-4D7A-8913-4ED7911683B4}
 	EndProjectSection
@@ -41,22 +41,22 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{D3AD82FC-051D-4121-8E48-B13CE8024776}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
-		{D3AD82FC-051D-4121-8E48-B13CE8024776}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
-		{D3AD82FC-051D-4121-8E48-B13CE8024776}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
-		{D3AD82FC-051D-4121-8E48-B13CE8024776}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
 		{30CAB353-089E-4294-B23B-F2DD1D945654}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
 		{30CAB353-089E-4294-B23B-F2DD1D945654}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
 		{30CAB353-089E-4294-B23B-F2DD1D945654}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
 		{30CAB353-089E-4294-B23B-F2DD1D945654}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{D3AD82FC-051D-4121-8E48-B13CE8024776}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{D3AD82FC-051D-4121-8E48-B13CE8024776}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{D3AD82FC-051D-4121-8E48-B13CE8024776}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{D3AD82FC-051D-4121-8E48-B13CE8024776}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
 		{122A5432-C5B7-4293-AFDA-B24F4D54FDEF}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
 		{122A5432-C5B7-4293-AFDA-B24F4D54FDEF}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
 		{122A5432-C5B7-4293-AFDA-B24F4D54FDEF}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
 		{122A5432-C5B7-4293-AFDA-B24F4D54FDEF}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
-		{38889701-0AF4-48B3-999C-E99D639C61B6}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{38889701-0AF4-48B3-999C-E99D639C61B6}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{38889701-0AF4-48B3-999C-E99D639C61B6}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{38889701-0AF4-48B3-999C-E99D639C61B6}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{38889701-0af4-48b3-999c-e99d639c61b6}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{38889701-0af4-48b3-999c-e99d639c61b6}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{38889701-0af4-48b3-999c-e99d639c61b6}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{38889701-0af4-48b3-999c-e99d639c61b6}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
 		{9D747A18-C8FD-4D7A-8913-4ED7911683B4}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
 		{9D747A18-C8FD-4D7A-8913-4ED7911683B4}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
 		{9D747A18-C8FD-4D7A-8913-4ED7911683B4}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
@@ -70,10 +70,10 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
-		{D3AD82FC-051D-4121-8E48-B13CE8024776} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{30CAB353-089E-4294-B23B-F2DD1D945654} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{D3AD82FC-051D-4121-8E48-B13CE8024776} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{122A5432-C5B7-4293-AFDA-B24F4D54FDEF} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
-		{38889701-0AF4-48B3-999C-E99D639C61B6} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{38889701-0af4-48b3-999c-e99d639c61b6} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{9D747A18-C8FD-4D7A-8913-4ED7911683B4} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{025743B4-6E1E-4602-BE7F-1E479CC8EEBE} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 	EndGlobalSection

--- a/src/System.Runtime.Serialization.Xml/tests/Canonicalization/Canonicalization.Tests.csproj
+++ b/src/System.Runtime.Serialization.Xml/tests/Canonicalization/Canonicalization.Tests.csproj
@@ -5,14 +5,10 @@
     <ProjectGuid>{D3AD82FC-051D-4121-8E48-B13CE8024776}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="$(TestSourceFolder)CanonicalizationTestHelper.cs" />
     <Compile Include="$(TestSourceFolder)TestConfigHelper.cs" />

--- a/src/System.Security.Cryptography.Xml/ref/System.Security.Cryptography.Xml.csproj
+++ b/src/System.Security.Cryptography.Xml/ref/System.Security.Cryptography.Xml.csproj
@@ -5,6 +5,8 @@
     <ProjectGuid>{C7266957-DB20-4250-9C2E-E1FF83EDBD71}</ProjectGuid>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netfx'">true</IsPartialFacadeAssembly>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)'  == 'true'">

--- a/src/System.Security.Permissions/src/Configurations.props
+++ b/src/System.Security.Permissions/src/Configurations.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
-      netfx-Windows_NT;
+      netfx;
       netstandard;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Security.Permissions/src/System.Security.Permissions.csproj
+++ b/src/System.Security.Permissions/src/System.Security.Permissions.csproj
@@ -8,9 +8,8 @@
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <PackageAsRefAndLib Condition="'$(TargetGroup)' == 'netfx'">true</PackageAsRefAndLib>
   </PropertyGroup>
-  <!-- Default configurations to help VS understand the configurations -->
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Windows_NT-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">

--- a/src/System.Threading.Overlapped/System.Threading.Overlapped.sln
+++ b/src/System.Threading.Overlapped/System.Threading.Overlapped.sln
@@ -26,10 +26,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{861A3318-35AD-46ac-8257-8D5D2479BAD9}.Debug|Any CPU.ActiveCfg = netstandard-Windows_NT-Debug|Any CPU
-		{861A3318-35AD-46ac-8257-8D5D2479BAD9}.Debug|Any CPU.Build.0 = netstandard-Windows_NT-Debug|Any CPU
-		{861A3318-35AD-46ac-8257-8D5D2479BAD9}.Release|Any CPU.ActiveCfg = netstandard-Windows_NT-Release|Any CPU
-		{861A3318-35AD-46ac-8257-8D5D2479BAD9}.Release|Any CPU.Build.0 = netstandard-Windows_NT-Release|Any CPU
+		{861A3318-35AD-46ac-8257-8D5D2479BAD9}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{861A3318-35AD-46ac-8257-8D5D2479BAD9}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{861A3318-35AD-46ac-8257-8D5D2479BAD9}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{861A3318-35AD-46ac-8257-8D5D2479BAD9}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
 		{6A07CCB8-3E59-47e7-B3DD-DB1F6FC501D5}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
 		{6A07CCB8-3E59-47e7-B3DD-DB1F6FC501D5}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
 		{6A07CCB8-3E59-47e7-B3DD-DB1F6FC501D5}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU


### PR DESCRIPTION
Remove RID from desktop projects where it is not needed.

Fixes #19949

Port of https://github.com/dotnet/corefx/pull/19989

/cc @weshaggard 