### PR TITLE
Remove Build.Clean from definitions to skip VSTS cleanup.

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-OSX.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-OSX.json
@@ -270,9 +270,6 @@
     "PB_VsoCorefxGitUrl": {
       "value": "https://github.com/dotnet/corefx"
     },
-    "Build.Clean": {
-      "value": "all"
-    },
     "PB_BuildArguments": {
       "value": "-buildArch=x64 -Release",
       "allowOverride": true

--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows-NoTest.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows-NoTest.json
@@ -331,9 +331,6 @@
       "value": "HEAD",
       "allowOverride": true
     },
-    "Build.Clean": {
-      "value": "all"
-    },
     "PB_VsoAccountName": {
       "value": "dn-bot"
     },

--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
@@ -385,9 +385,6 @@
       "value": "HEAD",
       "allowOverride": true
     },
-    "Build.Clean": {
-      "value": "all"
-    },
     "PB_VsoAccountName": {
       "value": "dn-bot"
     },


### PR DESCRIPTION
We have a PowerShell script in the repo to do this cleanup and it is more robust.