### PR TITLE
Redistribute 4.0.1 clrcompression for netcore50

### DIFF
--- a/Packaging.props
+++ b/Packaging.props
@@ -16,7 +16,7 @@
     <XmlDocFileRoot>$(PackagesDir)Microsoft.Private.Intellisense/1.0.0-rc4-24206-00/xmldocs</XmlDocFileRoot>
     <!-- We're currently not building a "live" baseline, instead we're using .NETCore 1.0 RTM stable versions as the baseline -->
     <SkipBaseLineCheck>true</SkipBaseLineCheck>
-    <LineupPackageVersion Condition="'$(LineupPackageVersion)' == ''">1.1.0</LineupPackageVersion>
+    <LineupPackageVersion Condition="'$(LineupPackageVersion)' == ''">1.1.1</LineupPackageVersion>
     <PlatformPackageVersion Condition="'$(PlatformPackageVersion)' == ''">1.1.0</PlatformPackageVersion>
 
     <!-- by default all packages will use the same version which revs with respect to product version -->

--- a/pkg/Microsoft.NETCore.Targets/Microsoft.NETCore.Targets.pkgproj
+++ b/pkg/Microsoft.NETCore.Targets/Microsoft.NETCore.Targets.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <PackageVersion>1.1.0</PackageVersion>
+    <PackageVersion>1.1.1</PackageVersion>
     <IsLineupPackage>true</IsLineupPackage>
     <RuntimeFileSource>runtime.json</RuntimeFileSource>
     <SkipValidatePackage>true</SkipValidatePackage>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.pkgproj
@@ -3,7 +3,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
-    <SkipValidatePackage>true</SkipValidatePackage>
+    <SkipValidatePackage>true</SkipValidatePackage>    
+    <PackageVersion>4.3.1</PackageVersion>
+    <!-- the native compression packages require nuget >3.5 for nativeassets support -->
+    <MinClientVersion3>3.5</MinClientVersion3>    
   </PropertyGroup>
   <ItemGroup>
     <!-- When updating ExternalExpectedPrerelease with a version that 

--- a/src/Native/pkg/runtime.native.System.IO.Compression/win/redist/clrcompression.depproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/win/redist/clrcompression.depproj
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackagePlatform Condition="'$(PackagePlatform)' == ''">x64</PackagePlatform>
+    <NuGetTargetMoniker>.NETCore,Version=v5.0</NuGetTargetMoniker>
+    <NuGetRuntimeIdentifier>win10-$(PackagePlatform)-aot</NuGetRuntimeIdentifier>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageDestination Include="runtimes/$(PackageTargetRuntime)/nativeassets/netcore50" />
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/win/redist/project.json
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/win/redist/project.json
@@ -1,0 +1,13 @@
+{
+  "dependencies": {
+    "runtime.native.System.IO.Compression": "4.1.0"
+  },
+  "frameworks": {
+    "netcore50": {}
+  },
+  "runtimes": {
+    "win10-x86-aot": {},
+    "win10-x64-aot": {},
+    "win10-arm-aot": {}
+  }
+}

--- a/src/Native/pkg/runtime.native.System.IO.Compression/win/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/win/runtime.native.System.IO.Compression.pkgproj
@@ -17,6 +17,7 @@
     <!-- We redistribute the 4.0.1 binaries for netcore50 because they target the API sets 
          as kernel32 is unavailable on OneCore systems -->
     <ProjectReference Condition="'$(PackagePlatform)'!='arm64'" Include="redist\clrcompression.depproj">
+      <UndefineProperties>SkipCreatePackageOnMissingFiles</UndefineProperties>
       <AdditionalProperties>PackageTargetRuntime=$(PackageTargetRuntime)</AdditionalProperties>
     </ProjectReference>
   </ItemGroup>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/win/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/win/runtime.native.System.IO.Compression.pkgproj
@@ -6,11 +6,19 @@
     <WinVersion Condition="'$(PackagePlatform)'=='arm64'">win10</WinVersion>
     <WinVersion Condition="'$(PackagePlatform)'=='x86' OR '$(PackagePlatform)'=='x64'">win7</WinVersion>
     <PackageTargetRuntime>$(WinVersion)-$(PackagePlatform)</PackageTargetRuntime>
+    <PackageVersion>4.3.1</PackageVersion>
+    <!-- the native compression packages require nuget >3.5 for nativeassets support -->
+    <MinClientVersion3>3.5</MinClientVersion3>    
   </PropertyGroup>
   <ItemGroup>
     <NativeFile Include="$(WinNativePath)\clrcompression.dll">
       <TargetPath>runtimes/$(WinVersion)-$(PackagePlatform)/native</TargetPath>
     </NativeFile>
+    <!-- We redistribute the 4.0.1 binaries for netcore50 because they target the API sets 
+         as kernel32 is unavailable on OneCore systems -->
+    <ProjectReference Condition="'$(PackagePlatform)'!='arm64'" Include="redist\clrcompression.depproj">
+      <AdditionalProperties>PackageTargetRuntime=$(PackageTargetRuntime)</AdditionalProperties>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -26,10 +26,16 @@
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
     <!-- add specific builds / pkgproj's here to include in servicing builds -->
+    <Project Include="..\pkg\Microsoft.NETCore.Targets\Microsoft.NETCore.Targets.builds">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(BuildAllPackages)' == 'false' AND '$(SkipNativePackageBuild)' != 'true'" >
+  <ItemGroup Condition="'$(BuildAllPackages)' == 'false' AND '$(SkipNativePackageBuild)' != 'true'" >   
     <!-- add specific native builds / pkgproj's here to include in servicing builds -->
+    <Project Include=".\Native\pkg\runtime.native.System.IO.Compression\runtime.native.System.IO.Compression.builds">
+      <AdditionalProperties>$(AdditionalProperties);SkipCreatePackageOnMissingFiles=true</AdditionalProperties>
+    </Project>
   </ItemGroup>
 
   <UsingTask TaskName="GenerateNetStandardSupportTable" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll" />


### PR DESCRIPTION
We're running into issues in UWP apps where people are getting the 4.3.0 version of clrcompression that imports from kernel32.dll while in Debug. This is an issue on Onecore platforms where kernel32.dll is unavailable, so we should repackage the 4.0.1 AOT binaries that import from the api sets instead. This way, customers will be using the same dll for Debug as they are for Release when running under netcore50 for x86, x64, and arm.

Packages produced after this change will have this structure:

- runtime.win7-x64.*compression.4.3.0:
  - runtimes/win7-x64/native/clrcompression.dll - new build, non-appx, CFG enabled, kernel32
  - runtimes/win7-x64/nativeassets/netcore50/clrcompression.dll - 4.0.1, appx, no CFG flag, API sets
- runtime.win7-x86.*compression.4.3.0:
  - runtimes/win7-x86/native/clrcompression.dll - new build, non-appx, CFG enabled, kernel32
  - runtimes/win7-x86/nativeassets/netcore50/clrcompression.dll - 4.0.1, appx, no CFG flag, API sets
- runtime.win8-arm.*compression.4.3.0:
  - runtimes/win8-arm/native/clrcompression.dll - new build, non-appx, CFG enabled, kernel32
  - runtimes/win8-arm/nativeassets/netcore50/clrcompression.dll - 4.0.1, appx, no CFG flag, API sets

while the AOT packages are unchanged:
- runtime.win10-x64-aot.*compression:
  - runtimes\win10-x64-aot\lib\netcore50\clrcompression.dll - 4.0.1, appx, no CFG flag, API sets
- runtime.win10-x86-aot.*compression:
  - runtimes\win10-x86-aot\lib\netcore50\clrcompression.dll - 4.0.1, appx, no CFG flag, API sets
- runtime.win10-arm-aot.*compression:
  - runtimes\win10-arm-aot\lib\netcore50\clrcompression.dll - 4.0.1, appx, no CFG flag, API sets


cc: @MattWhilden @gkhanna79 @ericstj @weshaggard 