### PR TITLE
Reflection enable type clientconfigurationhost.

### DIFF
--- a/src/System.Configuration.ConfigurationManager/src/Resources/System.Configuration.ConfigurationManager.rd.xml
+++ b/src/System.Configuration.ConfigurationManager/src/Resources/System.Configuration.ConfigurationManager.rd.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Library Name="*System.Configuration.ConfigurationManager*">
+    <Assembly Name="System.Configuration.ConfigurationManager">
+       <Type Name="System.Configuration.ClientConfigurationHost" Dynamic="Required All" Activate="Required All" />
+    </Assembly>
+  </Library>
+</Directives>

--- a/src/System.Configuration.ConfigurationManager/src/System.Configuration.ConfigurationManager.csproj
+++ b/src/System.Configuration.ConfigurationManager/src/System.Configuration.ConfigurationManager.csproj
@@ -257,6 +257,9 @@
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
     <Reference Include="System.Security.Cryptography.ProtectedData" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\$(AssemblyName).rd.xml" />
+  </ItemGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' == 'true'">
     <Reference Include="mscorlib" />
     <Reference Include="System" />


### PR DESCRIPTION
ClientConfigurationHost is internal with
an internal default ctor and instantiated
from configsystem with Activator.CreateInstance.
Hense it need to be reflection enables in AOT.
Using new is not possible since IConfigSystem.Init
signature is public and cannot be changed.