### PR TITLE
Add System.Configuration shim

### DIFF
--- a/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.pkgproj
+++ b/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.pkgproj
@@ -22,11 +22,15 @@
     <!-- Exclude shims from the closure verification -->
     <ExcludeFromClosure Include="mscorlib" />
     <ExcludeFromClosure Include="System" />
+    <ExcludeFromClosure Include="System.Configuration" />
     <ExcludeFromClosure Include="System.Core" />
     <ExcludeFromClosure Include="System.Data" />
     <ExcludeFromClosure Include="System.Drawing" />
     <ExcludeFromClosure Include="System.Net" />
+    <ExcludeFromClosure Include="System.Security" />
+    <ExcludeFromClosure Include="System.ServiceProcess" />
     <ExcludeFromClosure Include="System.Transactions" />
+    <ExcludeFromClosure Include="WindowsBase" />
 
     <!-- Permit the following implementation-only assemblies -->
     <ValidatePackageSuppression Condition="'$(PackageTargetRuntime)' != ''" Include="PermitInbox">
@@ -45,6 +49,6 @@
       </Value>
     </ValidatePackageSuppression>
   </ItemGroup>
-  
+
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.pkgproj
+++ b/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.pkgproj
@@ -29,11 +29,15 @@
     <!-- Exclude shims from the closure verification -->
     <ExcludeFromClosure Include="mscorlib" />
     <ExcludeFromClosure Include="System" />
+    <ExcludeFromClosure Include="System.Configuration" />
     <ExcludeFromClosure Include="System.Core" />
     <ExcludeFromClosure Include="System.Data" />
     <ExcludeFromClosure Include="System.Drawing" />
     <ExcludeFromClosure Include="System.Net" />
+    <ExcludeFromClosure Include="System.Security" />
+    <ExcludeFromClosure Include="System.ServiceProcess" />
     <ExcludeFromClosure Include="System.Transactions" />
+    <ExcludeFromClosure Include="WindowsBase" />
 
     <ExcludeFromDuplicateTypes Include="System.Private.Reflection.Metadata.Ecma335" />
 

--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -969,7 +969,9 @@
     },
     "System.Configuration": {
       "InboxOn": {
-        "net45": "4.0.0.0"
+        "netcoreapp2.0": "4.0.0.0",
+        "net45": "4.0.0.0",
+        "uap10.1": "4.0.0.0"
       }
     },
     "System.Configuration.ConfigurationManager": {
@@ -3782,7 +3784,9 @@
     },
     "System.Security": {
       "InboxOn": {
-        "net45": "4.0.0.0"
+        "netcoreapp2.0": "4.0.0.0",
+        "net45": "4.0.0.0",
+        "uap10.1": "4.0.0.0"
       }
     },
     "System.Security.AccessControl": {
@@ -4263,7 +4267,9 @@
     },
     "System.ServiceProcess": {
       "InboxOn": {
-        "net45": "4.0.0.0"
+        "netcoreapp2.0": "4.0.0.0",
+        "net45": "4.0.0.0",
+        "uap10.1": "4.0.0.0"
       }
     },
     "System.ServiceProcess.ServiceController": {
@@ -5262,7 +5268,9 @@
     },
     "WindowsBase": {
       "InboxOn": {
-        "net45": "4.0.0.0"
+        "netcoreapp2.0": "4.0.0.0",
+        "net45": "4.0.0.0",
+        "uap10.1": "4.0.0.0"
       }
     },
     "WindowsFormsIntegration": {

--- a/src/shims/netfxreference.props
+++ b/src/shims/netfxreference.props
@@ -2,25 +2,29 @@
   <ItemGroup>
     <NetFxReference Include="mscorlib" />
     <NetFxReference Include="System" />
-    <NetFxReference Include="System.Core" />
     <NetFxReference Include="System.ComponentModel.Composition" />
     <NetFxReference Include="System.ComponentModel.DataAnnotations">
       <StrongNameSig>MSSharedLib</StrongNameSig>
     </NetFxReference>
+    <NetFxReference Include="System.Configuration" />
+    <NetFxReference Include="System.Core" />
     <NetFxReference Include="System.Data" />
     <NetFxReference Include="System.Drawing" />
     <NetFxReference Include="System.IO.Compression.FileSystem" />
     <NetFxReference Include="System.Net" />
     <NetFxReference Include="System.Numerics" />
     <NetFxReference Include="System.Runtime.Serialization" />
+    <NetFxReference Include="System.Security" />
+    <NetFxReference Include="System.ServiceProcess" />
     <NetFxReference Include="System.ServiceModel.Web">
       <StrongNameSig>MSSharedLib</StrongNameSig>
     </NetFxReference>
     <NetFxReference Include="System.Transactions" />
-    <NetFxReference Include="System.Windows" />
     <NetFxReference Include="System.Web" />
+    <NetFxReference Include="System.Windows" />
     <NetFxReference Include="System.Xml" />
     <NetFxReference Include="System.Xml.Serialization" />
     <NetFxReference Include="System.Xml.Linq" />
+    <NetFxReference Include="WindowsBase" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
@JeremyKuhne @danmosemsft @ericstj 

While helping a customer in consuming mysql desktop assembly I hit a missing dependency on System.Configuration which can be satisfied by our System.Configuration.ConfigurationManager OOB. This change adds that shim to the netcoreapp package which is a little odd because this shim only depends on S.C.ConfigurationManager which isn't part of the netcoreapp package, but we don't really have any other great way to ship that shim so I think it is still worth adding it here. 

Let me know what you guys think. Do you think it is worth having this shim?