### PR TITLE
Fix use-after-free handle problems in X509Certificates on macOS

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/CertificatePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/CertificatePal.cs
@@ -59,7 +59,9 @@ namespace Internal.Cryptography.Pal
         {
             Debug.Assert(cert.Pal != null);
 
-            return FromHandle(cert.Handle);
+            ICertificatePal pal = FromHandle(cert.Handle);
+            GC.KeepAlive(cert); // ensure cert's safe handle isn't finalized while raw handle is in use
+            return pal;
         }
 
         public static ICertificatePal FromBlob(

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/FindPal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/FindPal.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 
@@ -57,7 +58,9 @@ namespace Internal.Cryptography.Pal
 
             protected override X509Certificate2 CloneCertificate(X509Certificate2 cert)
             {
-                return new X509Certificate2(cert.Handle);
+                var clone = new X509Certificate2(cert.Handle);
+                GC.KeepAlive(cert); // ensure cert's safe handle isn't finalized while raw handle is in use
+                return clone;
             }
         }
     }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/StorePal.ExportPal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/StorePal.ExportPal.cs
@@ -90,7 +90,9 @@ namespace Internal.Cryptography.Pal
                     }
                 }
 
-                return Interop.AppleCrypto.X509ExportPfx(certHandles, password);
+                byte[] exported = Interop.AppleCrypto.X509ExportPfx(certHandles, password);
+                GC.KeepAlive(_certs); // ensure certs' safe handles aren't finalized while raw handles are in use
+                return exported;
             }
 
             private byte[] ExportPkcs7()

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ChainPal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ChainPal.cs
@@ -58,6 +58,8 @@ namespace Internal.Cryptography.Pal
 
             using (var leaf = new X509Certificate2(cert.Handle))
             {
+                GC.KeepAlive(cert); // ensure cert's safe handle isn't finalized while raw handle is in use
+
                 var downloaded = new HashSet<X509Certificate2>();
                 var systemTrusted = new HashSet<X509Certificate2>();
 

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ExportProvider.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ExportProvider.cs
@@ -92,6 +92,8 @@ namespace Internal.Cryptography.Pal
                     {
                         PushHandle(certPal.Handle, publicCerts);
                     }
+
+                    GC.KeepAlive(certPal); // ensure reader's safe handle isn't finalized while raw handle is in use
                 }
                 else
                 {
@@ -120,6 +122,8 @@ namespace Internal.Cryptography.Pal
                         {
                             PushHandle(cert.Handle, publicCerts);
                         }
+
+                        GC.KeepAlive(cert); // ensure cert's safe handle isn't finalized while raw handle is in use
                     }
                 }
 
@@ -175,6 +179,8 @@ namespace Internal.Cryptography.Pal
                     {
                         throw Interop.Crypto.CreateOpenSslCryptographicException();
                     }
+
+                    GC.KeepAlive(cert); // ensure cert's safe handle isn't finalized while raw handle is in use
                 }
 
                 return Interop.Crypto.OpenSslEncode(


### PR DESCRIPTION
The first commit fixes https://github.com/dotnet/corefx/issues/19996.  The raw IntPtr handle is read from the certificate object, after which the certificate object isn't referenced anymore by the implementation; if the caller also no longer referenced the certificate, it's possible that it can be collected and its SafeHandle finalized before the copy ctor finishes reading state from the handle, leading to handle recycling and use-after-free errors.

The second commit is then the result of me proactively searching the rest of the codebase for .Handle usage, and fixing any that (based just on examining the function itself and not on all possible call stacks) could potentially suffer a similar problem.

cc: @ianhays, @bartonjs, @steveharter 