### PR TITLE
Fix HttpListenerFactory Dispose after failure

### DIFF
--- a/src/System.Net.HttpListener/tests/HttpListenerFactory.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerFactory.cs
@@ -131,7 +131,7 @@ namespace System.Net.Tests
 
         public HttpListener GetListener() => _processPrefixListener;
 
-        public void Dispose() => _processPrefixListener.Close();
+        public void Dispose() => _processPrefixListener?.Close();
 
         public Socket GetConnectedSocket()
         {


### PR DESCRIPTION
If the ctor encounters a failure, _processPrefixListener may remain null; then when the factory is Dispose'd, it null refs.  This is taking out a bunch of runs, including almost all macOS runs.

cc: @hughbe, @Priya91 