### PR TITLE
Fix handling of root on Unix in directory error handling

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/PathHelpers.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/PathHelpers.Unix.cs
@@ -27,5 +27,10 @@ namespace System.IO
                 }
             }
         }
+
+        internal static string TrimEndingDirectorySeparator(string path) =>
+            path.Length > 1 && PathInternal.IsDirectorySeparator(path[path.Length - 1]) ? // exclude root "/"
+                path.Substring(0, path.Length - 1) :
+                path;
     }
 }

--- a/src/System.IO.FileSystem/src/System/IO/PathHelpers.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/PathHelpers.Windows.cs
@@ -118,5 +118,10 @@ namespace System.IO
 
             return tempStr;
         }
+
+        internal static string TrimEndingDirectorySeparator(string path) =>
+            EndsInDirectorySeparator(path) ?
+                path.Substring(0, path.Length - 1) :
+                path;
     }
 }

--- a/src/System.IO.FileSystem/src/System/IO/PathHelpers.cs
+++ b/src/System.IO.FileSystem/src/System/IO/PathHelpers.cs
@@ -38,12 +38,5 @@ namespace System.IO
         {
             return path.Length > 0 && PathInternal.IsDirectorySeparator(path[path.Length - 1]);
         }
-
-        internal static string TrimEndingDirectorySeparator(string path)
-        {
-            return EndsInDirectorySeparator(path) ?
-                path.Substring(0, path.Length - 1) :
-                path;
-        }
     }
 }


### PR DESCRIPTION
We shouldn't be trimming away the '/' at the end of a path when the entire path is "/".  The fix just moves the existing TrimEndingDirectorySeparator function to be Windows-specific, and adds a Unix-specific variant that only trims from paths greater than 1 char (if the path has a single char and it's '/', we don't want to trim it away, and if it's anything else, there's nothing to trim).

Fixes https://github.com/dotnet/corefx/issues/20034
cc: @danmosemsft, @JeremyKuhne 