### PR TITLE
Validate IAsyncResult passed to managed HttpListener.EndGetContext

### DIFF
--- a/src/System.Net.HttpListener/src/System/Net/Managed/HttpListener.Managed.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/HttpListener.Managed.cs
@@ -287,7 +287,7 @@ namespace System.Net
                 throw new InvalidOperationException(SR.Format(SR.net_listener_mustcall, "Start()"));
             }
 
-            ListenerAsyncResult ares = new ListenerAsyncResult(callback, state);
+            ListenerAsyncResult ares = new ListenerAsyncResult(this, callback, state);
 
             // lock wait_queue early to avoid race conditions
             lock ((_asyncWaitQueue as ICollection).SyncRoot)
@@ -317,7 +317,7 @@ namespace System.Net
             }
 
             ListenerAsyncResult ares = asyncResult as ListenerAsyncResult;
-            if (ares == null)
+            if (ares == null || !ReferenceEquals(this, ares._parent))
             {
                 throw new ArgumentException(SR.net_io_invalidasyncresult, nameof(asyncResult));
             }

--- a/src/System.Net.HttpListener/src/System/Net/Managed/ListenerAsyncResult.Managed.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/ListenerAsyncResult.Managed.cs
@@ -46,11 +46,13 @@ namespace System.Net
         private HttpListenerContext _context;
         private object _locker = new object();
         private ListenerAsyncResult _forward;
+        internal readonly HttpListener _parent;
         internal bool _endCalled;
         internal bool _inGet;
 
-        public ListenerAsyncResult(AsyncCallback cb, object state)
+        public ListenerAsyncResult(HttpListener parent, AsyncCallback cb, object state)
         {
+            _parent = parent;
             _cb = cb;
             _state = state;
         }

--- a/src/System.Net.HttpListener/tests/HttpListenerTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerTests.cs
@@ -123,7 +123,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
-        [ActiveIssue(18128, platforms: TestPlatforms.AnyUnix)] // No validation performed - hangs forever.
         public void EndGetContext_InvalidAsyncResult_ThrowsArgumentException()
         {
             using (var listener1 = new HttpListener())


### PR DESCRIPTION
Lack of doing so results in hangs if the IAsyncResult is from a different HttpListener.

Fixes https://github.com/dotnet/corefx/issues/19979
cc: @Priya91, @hughbe 