### PR TITLE
Validate Sec-WebSocket-Key header in managed HttpListener

### DIFF
--- a/src/System.Net.HttpListener/src/System/Net/WebSockets/HttpWebSocket.cs
+++ b/src/System.Net.HttpListener/src/System/Net/WebSockets/HttpWebSocket.cs
@@ -167,7 +167,21 @@ namespace System.Net.WebSockets
                     SupportedVersion));
             }
 
-            if (string.IsNullOrWhiteSpace(context.Request.Headers[HttpKnownHeaderNames.SecWebSocketKey]))
+            string secWebSocketKey = context.Request.Headers[HttpKnownHeaderNames.SecWebSocketKey];
+            bool isSecWebSocketKeyInvalid = string.IsNullOrWhiteSpace(secWebSocketKey);
+            if (!isSecWebSocketKeyInvalid)
+            {
+                try
+                {
+                    // key must be 16 bytes then base64-encoded
+                    isSecWebSocketKeyInvalid = Convert.FromBase64String(secWebSocketKey).Length != 16;
+                }
+                catch
+                {
+                    isSecWebSocketKeyInvalid = true;
+                }
+            }
+            if (isSecWebSocketKeyInvalid)
             {
                 throw new WebSocketException(WebSocketError.HeaderError,
                     SR.Format(SR.net_WebSockets_AcceptHeaderNotFound,
@@ -177,4 +191,3 @@ namespace System.Net.WebSockets
         }
     }
 }
-

--- a/src/System.Net.HttpListener/tests/HttpListenerContextTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerContextTests.cs
@@ -53,9 +53,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(IsNotWindows7OrUapCore))]
-        // Both the managed and Windows implementations send headers to the socket during connection.
-        // The Windows implementation fails with error code 1229: An operation was attempted on a nonexistent network connection.
-        [ActiveIssue(18128, TestPlatforms.AnyUnix)]
         public async Task AcceptWebSocketAsync_SocketSpoofingAsWebSocket_ThrowsWebSocketException()
         {
             await GetSocketContext(new string[] { "Connection: Upgrade", "Upgrade: websocket", "Sec-WebSocket-Version: 13", "Sec-WebSocket-Key: Key" }, async context =>


### PR DESCRIPTION
The managed implementation was not validating the Sec-WebSocket-Key header, such that invalid header values (which must be 16 bytes then base64 encoded) were getting through.

Fixes https://github.com/dotnet/corefx/issues/19982
cc: @Priya91, @hughbe 