### PR TITLE
Fix tests needing sudo

### DIFF
--- a/src/Common/tests/System/PlatformDetection.Unix.cs
+++ b/src/Common/tests/System/PlatformDetection.Unix.cs
@@ -30,5 +30,10 @@ namespace System
 
         [DllImport("libc", SetLastError = true)]
         private static extern int sysctlbyname(string ctlName, byte[] oldp, ref IntPtr oldpLen, byte[] newp, IntPtr newpLen);
+
+        [DllImport("libc", SetLastError = true)]
+        internal static extern unsafe uint geteuid();
+
+        public static bool IsSuperUser => geteuid() == 0;
     }
 }

--- a/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -17,7 +17,111 @@ namespace System.Diagnostics.Tests
     public partial class ProcessTests : ProcessTestBase
     {
         [Fact]
-        [PlatformSpecific(TestPlatforms.AnyUnix)]  // Uses P/Invokes to set permissions
+        private void TestWindowApisUnix()
+        {
+            // This tests the hardcoded implementations of these APIs on Unix.
+            using (Process p = Process.GetCurrentProcess())
+            {
+                Assert.True(p.Responding);
+                Assert.Equal(string.Empty, p.MainWindowTitle);
+                Assert.False(p.CloseMainWindow());
+                Assert.Throws<InvalidOperationException>(()=>p.WaitForInputIdle());
+            }
+        }
+
+        [Fact]
+        public void MainWindowHandle_GetUnix_ThrowsPlatformNotSupportedException()
+        {
+            CreateDefaultProcess();
+
+            Assert.Throws<PlatformNotSupportedException>(() => _process.MainWindowHandle);
+        }
+
+        [Fact]
+        public void TestProcessOnRemoteMachineUnix()
+        {
+            Process currentProcess = Process.GetCurrentProcess();
+
+            Assert.Throws<PlatformNotSupportedException>(() => Process.GetProcessesByName(currentProcess.ProcessName, "127.0.0.1"));
+            Assert.Throws<PlatformNotSupportedException>(() => Process.GetProcessById(currentProcess.Id, "127.0.0.1"));
+        }
+
+        [Theory]
+        [MemberData(nameof(MachineName_Remote_TestData))]
+        public void GetProcessesByName_RemoteMachineNameUnix_ThrowsPlatformNotSupportedException(string machineName)
+        {
+            Process currentProcess = Process.GetCurrentProcess();
+            Assert.Throws<PlatformNotSupportedException>(() => Process.GetProcessesByName(currentProcess.ProcessName, machineName));
+        }
+
+        [Fact]
+        public void TestRootGetProcessById()
+        {
+            Process p = Process.GetProcessById(1);
+            Assert.Equal(1, p.Id);
+        }
+
+        [Fact]
+        public void TestUseShellExecute_Unix_Succeeds()
+        {
+            using (var p = Process.Start(new ProcessStartInfo { UseShellExecute = true, FileName = "exit", Arguments = "42" }))
+            {
+                Assert.True(p.WaitForExit(WaitInMS));
+                Assert.Equal(42, p.ExitCode);
+            }
+        }
+
+        [Fact]
+        [Trait(XunitConstants.Category, XunitConstants.RequiresElevation)]
+        public void TestPriorityClassUnix()
+        {
+            CreateDefaultProcess();
+
+            ProcessPriorityClass priorityClass = _process.PriorityClass;
+
+            _process.PriorityClass = ProcessPriorityClass.Idle;
+            Assert.Equal(_process.PriorityClass, ProcessPriorityClass.Idle);
+
+            try
+            {
+                _process.PriorityClass = ProcessPriorityClass.High;
+                Assert.Equal(_process.PriorityClass, ProcessPriorityClass.High);
+
+                _process.PriorityClass = ProcessPriorityClass.Normal;
+                Assert.Equal(_process.PriorityClass, ProcessPriorityClass.Normal);
+
+                _process.PriorityClass = priorityClass;
+            }
+            catch (Win32Exception ex)
+            {
+                Assert.True(!PlatformDetection.IsSuperUser, $"Failed even though superuser {ex.ToString()}");
+            }
+        }
+
+        [Fact]
+        [Trait(XunitConstants.Category, XunitConstants.RequiresElevation)]
+        public void TestBasePriorityOnUnix()
+        {
+            CreateDefaultProcess();
+
+            ProcessPriorityClass originalPriority = _process.PriorityClass;
+            Assert.Equal(ProcessPriorityClass.Normal, originalPriority);
+
+            SetAndCheckBasePriority(ProcessPriorityClass.Idle, 19);
+
+            try
+            {
+                SetAndCheckBasePriority(ProcessPriorityClass.Normal, 0);
+                SetAndCheckBasePriority(ProcessPriorityClass.High, -11);
+                _process.PriorityClass = originalPriority;
+            }
+            catch (Win32Exception ex)
+            {
+                Assert.True(!PlatformDetection.IsSuperUser, $"Failed even though superuser {ex.ToString()}");
+            }
+        }
+
+        [Fact]
         public void TestStartOnUnixWithBadPermissions()
         {
             string path = GetTestFilePath();
@@ -29,7 +133,6 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.AnyUnix)]  // Uses P/Invokes to set permissions
         public void TestStartOnUnixWithBadFormat()
         {
             string path = GetTestFilePath();

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -85,29 +85,6 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [Fact] 
-        [PlatformSpecific(TestPlatforms.AnyUnix)]  // Expected behavior varies on Windows and Unix
-        [OuterLoop]
-        [Trait(XunitConstants.Category, XunitConstants.RequiresElevation)]
-        public void TestBasePriorityOnUnix()
-        {
-            CreateDefaultProcess();
-            
-            ProcessPriorityClass originalPriority = _process.PriorityClass;
-            Assert.Equal(ProcessPriorityClass.Normal, originalPriority);
-
-            try
-            {
-                SetAndCheckBasePriority(ProcessPriorityClass.High, -11);
-                SetAndCheckBasePriority(ProcessPriorityClass.Idle, 19);
-                SetAndCheckBasePriority(ProcessPriorityClass.Normal, 0);
-            }
-            finally
-            {
-                _process.PriorityClass = originalPriority;
-            }
-        }
-
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
@@ -154,17 +131,6 @@ namespace System.Diagnostics.Tests
                 Process p = CreateProcessLong();
                 StartSleepKillWait(p);
                 Assert.NotEqual(0, p.ExitCode);
-            }
-        }
-
-        [PlatformSpecific(TestPlatforms.AnyUnix)]  // Tests UseShellExecute with ProcessStartInfo
-        [Fact]
-        public void TestUseShellExecute_Unix_Succeeds()
-        {
-            using (var p = Process.Start(new ProcessStartInfo { UseShellExecute = true, FileName = "exit", Arguments = "42" }))
-            {
-                Assert.True(p.WaitForExit(WaitInMS));
-                Assert.Equal(42, p.ExitCode);
             }
         }
 
@@ -659,29 +625,6 @@ namespace System.Diagnostics.Tests
             Assert.Throws<InvalidOperationException>(() => process.PriorityBoostEnabled = true);
         }
 
-        [Fact] 
-        [PlatformSpecific(TestPlatforms.AnyUnix)]  // Expected behavior varies on Windows and Unix
-        [OuterLoop]
-        [Trait(XunitConstants.Category, XunitConstants.RequiresElevation)]
-        public void TestPriorityClassUnix()
-        {
-            CreateDefaultProcess();
-
-            ProcessPriorityClass priorityClass = _process.PriorityClass;
-            try
-            {
-                _process.PriorityClass = ProcessPriorityClass.High;
-                Assert.Equal(_process.PriorityClass, ProcessPriorityClass.High);
-
-                _process.PriorityClass = ProcessPriorityClass.Normal;
-                Assert.Equal(_process.PriorityClass, ProcessPriorityClass.Normal);
-            }
-            finally
-            {
-                _process.PriorityClass = priorityClass;
-            }
-        }
-
         [Fact, PlatformSpecific(TestPlatforms.Windows)]  // Expected behavior varies on Windows and Unix
         public void TestPriorityClassWindows()
         {
@@ -799,14 +742,6 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.AnyUnix)]  // Uses P/Invokes to get process Id
-        public void TestRootGetProcessById()
-        {
-            Process p = Process.GetProcessById(1);
-            Assert.Equal(1, p.Id);
-        }
-
-        [Fact]
         public void TestGetProcesses()
         {
             Process currentProcess = Process.GetCurrentProcess();
@@ -888,15 +823,6 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [Theory]
-        [MemberData(nameof(MachineName_Remote_TestData))]
-        [PlatformSpecific(TestPlatforms.AnyUnix)] // Accessing processes on remote machines is not supported on Unix.
-        public void GetProcessesByName_RemoteMachineNameUnix_ThrowsPlatformNotSupportedException(string machineName)
-        {
-            Process currentProcess = Process.GetCurrentProcess();
-            Assert.Throws<PlatformNotSupportedException>(() => Process.GetProcessesByName(currentProcess.ProcessName, machineName));
-        }
-
         [Fact]
         public void GetProcessesByName_NoSuchProcess_ReturnsEmpty()
         {
@@ -944,15 +870,6 @@ namespace System.Diagnostics.Tests
                 // As we can't detect reliably if performance counters are enabled 
                 // we let possible InvalidOperationExceptions pass silently.
             }
-        }
-
-        [Fact, PlatformSpecific(TestPlatforms.AnyUnix)]  // Behavior differs on Windows and Unix
-        public void TestProcessOnRemoteMachineUnix()
-        {
-            Process currentProcess = Process.GetCurrentProcess();
-
-            Assert.Throws<PlatformNotSupportedException>(() => Process.GetProcessesByName(currentProcess.ProcessName, "127.0.0.1"));
-            Assert.Throws<PlatformNotSupportedException>(() => Process.GetProcessById(currentProcess.Id, "127.0.0.1"));
         }
 
         [Fact]
@@ -1230,15 +1147,6 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.AnyUnix)] // MainWindowHandle is not supported on Unix.
-        public void MainWindowHandle_GetUnix_ThrowsPlatformNotSupportedException()
-        {
-            CreateDefaultProcess();
-
-            Assert.Throws<PlatformNotSupportedException>(() => _process.MainWindowHandle);
-        }
-
-        [Fact]
         public void MainWindowHandle_GetNotStarted_ThrowsInvalidOperationException()
         {
             var process = new Process();
@@ -1294,20 +1202,6 @@ namespace System.Diagnostics.Tests
         {
             var process = new Process();
             Assert.Throws<InvalidOperationException>(() => process.Responding);
-        }
-
-        [PlatformSpecific(TestPlatforms.AnyUnix)]  // Needs to get the process Id from OS
-        [Fact]
-        private void TestWindowApisUnix()
-        {
-            // This tests the hardcoded implementations of these APIs on Unix.
-            using (Process p = Process.GetCurrentProcess())
-            {
-                Assert.True(p.Responding);
-                Assert.Equal(string.Empty, p.MainWindowTitle);
-                Assert.False(p.CloseMainWindow());
-                Assert.Throws<InvalidOperationException>(()=>p.WaitForInputIdle());
-            }
         }
 
         [Fact]

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests.csproj
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests.csproj
@@ -18,6 +18,9 @@
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
       <Link>Common\tests\System\PlatformDetection.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.Unix.cs" Condition="'$(TargetsWindows)' != 'true'">
+      <Link>Common\System\PlatformDetection.Unix.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorTestBase.cs">
       <Link>Common\System\Diagnostics\RemoteExecutorTestBase.cs</Link>
     </Compile>

--- a/src/System.Globalization/tests/System.Globalization.Tests.csproj
+++ b/src/System.Globalization/tests/System.Globalization.Tests.csproj
@@ -2,6 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{484C92C6-6D2C-45BC-A5E2-4A12BA228E1E}</ProjectGuid>
     <DefineConstants Condition="'$(TargetGroup)' == 'uap'">$(DefineConstants);uap</DefineConstants>
   </PropertyGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/20070 by making the test pass if not sudo. 
Verified it passes with and without sudo. 
Note there are already some tests that behave differently with and without sudo.
Coverage of the few tests and implementation codepaths with sudo I will follow up on separately.

I moved the two tests to the unix-specific file in order to keep the libc pinvoke out of the windows build. In doing so, I moved all the other unix specific tests to keep things consistent.