### PR TITLE
Disable parallel execution of HttpListener tests

### DIFF
--- a/src/System.Net.HttpListener/tests/System.Net.HttpListener.Tests.csproj
+++ b/src/System.Net.HttpListener/tests/System.Net.HttpListener.Tests.csproj
@@ -22,6 +22,7 @@
     <Compile Include="SimpleHttpTests.cs" />
     <Compile Include="HttpListenerFactory.cs" />
     <Compile Include="WebSocketTests.cs" />
+    <Compile Include="XUnitAssemblyAttributes.cs" />
     <Compile Include="$(CommonTestPath)\System\AssertExtensions.cs">
       <Link>Common\System\AssertExtensions.cs</Link>
     </Compile>

--- a/src/System.Net.HttpListener/tests/XUnitAssemblyAttributes.cs
+++ b/src/System.Net.HttpListener/tests/XUnitAssemblyAttributes.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+// [ActiveIssue(20103)]: Disabling parallel execution of HttpListener tests
+// until all of the hangs can be addressed
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly, DisableTestParallelization = true, MaxParallelThreads = 1)]


### PR DESCRIPTION
https://github.com/dotnet/corefx/issues/20103
cc: @hughbe