### PR TITLE
Upgrade timeout on ServiceController tests

### DIFF
--- a/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/ServiceControllerTests.cs
+++ b/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/ServiceControllerTests.cs
@@ -23,7 +23,7 @@ namespace System.ServiceProcess.Tests
         public ServiceProvider()
         {
             TestMachineName = ".";
-            ControlTimeout = TimeSpan.FromSeconds(30);
+            ControlTimeout = TimeSpan.FromSeconds(120);
             TestServiceName = Guid.NewGuid().ToString();
             TestServiceDisplayName = "Test Service " + TestServiceName;
             DependentTestServiceNamePrefix = TestServiceName + ".Dependent";


### PR DESCRIPTION
Fix https://github.com/dotnet/corefx/issues/20089 by increasing timeout. Tests run in parallel, sometimes operations take a long time.