### PR TITLE
Remove old Nano testing

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -16,7 +16,6 @@ def projectFolder = Utilities.getFolderName(project) + '/' + Utilities.getFolder
 def osGroupMap = ['Windows 10':'Windows_NT',
                   'Windows 7':'Windows_NT',
                   'Windows_NT':'Windows_NT',
-                  'Windows Nano 2016' : 'Windows_NT',
                   'Ubuntu14.04':'Linux',
                   'Ubuntu16.04':'Linux',
                   'Ubuntu16.10':'Linux',
@@ -34,7 +33,6 @@ def osGroupMap = ['Windows 10':'Windows_NT',
 def osShortName = ['Windows 10': 'win10',
                    'Windows 7' : 'win7',
                    'Windows_NT' : 'windows_nt',
-                   'Windows Nano 2016' : 'winnano16',
                    'Ubuntu14.04' : 'ubuntu14.04',
                    'Ubuntu16.04' : 'ubuntu16.04',
                    'Ubuntu16.10' : 'ubuntu16.10',
@@ -124,93 +122,6 @@ def targetGroupOsMapInnerloop = ['netcoreapp': ['Windows_NT', 'Ubuntu14.04', 'Ub
     else {
         // Set a push trigger
         Utilities.addGithubPushTrigger(newJob)
-    }
-}
-
-// **************************
-// Define outerloop windows Nano testing.  Run locally on each machine.
-// **************************
-[true, false].each { isPR ->
-    ['Windows Nano 2016'].each { osName ->
-        ['Debug', 'Release'].each { configurationGroup ->
-
-            def newJobName = "outerloop_${osShortName[osName]}_${configurationGroup.toLowerCase()}"
-
-            def newBuildJobName = "outerloop_${osShortName[osName]}_${configurationGroup.toLowerCase()}_bld"
-
-            def newBuildJob = job(Utilities.getFullJobName(project, newBuildJobName, isPR)) {
-                steps {
-                    batchFile("call \"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat\" x86 && build.cmd -os=Windows_NT -${configurationGroup} -skipTests -outerloop -- /p:IsCIBuild=true")
-                    // Package up the results.
-                    batchFile("C:\\Packer\\Packer.exe .\\bin\\build.pack . bin packages")
-                }
-            }
-
-            // Set the affinity.  All of these run on Windows currently.
-            Utilities.setMachineAffinity(newBuildJob, 'Windows_NT', 'latest-or-auto')
-            // Set up standard options.
-            Utilities.standardJobSetup(newBuildJob, project, isPR, "*/${branch}")
-            // Archive the results
-            Utilities.addArchival(newBuildJob, "bin/build.pack,run-test.cmd,msbuild.log")
-
-            def fullCoreFXBuildJobName = projectFolder + '/' + newBuildJob.name
-            def newTestJobName =  "outerloop_${osShortName[osName]}_${configurationGroup.toLowerCase()}_tst"
-            def newTestJob = job(Utilities.getFullJobName(project, newTestJobName, isPR)) {
-                steps {
-                    // The tests/corefx components
-                    copyArtifacts(fullCoreFXBuildJobName) {
-                        includePatterns('bin/build.pack')
-                        includePatterns('run-test.cmd')
-                        buildSelector {
-                            buildNumber('\${COREFX_BUILD}')
-                        }
-                    }
-
-                    // Unpack the build data
-                    batchFile("PowerShell -command \"\"C:\\Packer\\unpacker.ps1 .\\bin\\build.pack . > .\\bin\\unpacker.log\"\"")
-                    // Run the tests
-                    batchFile("run-test.cmd .\\bin\\tests\\Windows_NT.AnyCPU.${configurationGroup} %WORKSPACE%\\packages")
-                    // Run the tests
-                    batchFile("run-test.cmd .\\bin\\tests\\AnyOS.AnyCPU.${configurationGroup} %WORKSPACE%\\packages")
-                }
-
-                parameters {
-                    stringParam('COREFX_BUILD', '', 'Build number to use for copying binaries for nano server bld.')
-                }
-            }
-
-            // Set the affinity.  All of these run on Windows Nano currently.
-            Utilities.setMachineAffinity(newTestJob, osName)
-            // Set up standard options.
-            Utilities.addStandardOptions(newTestJob, isPR)
-            // Add the unit test results
-            Utilities.addXUnitDotNETResults(newTestJob, 'bin/**/testResults.xml')
-
-            def fullCoreFXTestJobName = projectFolder + '/' + newTestJob.name
-            def newJob = buildFlowJob(Utilities.getFullJobName(project, newJobName, isPR)) {
-                buildFlow("""
-                    b = build(params, '${fullCoreFXBuildJobName}')
-                    build(params +
-                    [COREFX_BUILD: b.build.number], '${fullCoreFXTestJobName}')
-                    """)
-            }
-
-            // Set the machine affinity to windows_nt, since git fails on Nano.
-            Utilities.setMachineAffinity(newJob, 'Windows_NT', 'latest-or-auto')
-            // Set up standard options.
-            Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
-
-            // Set up appropriate triggers.  PR on demand, otherwise nightly
-            if (isPR) {
-                // Set PR trigger.
-                // TODO: More elaborate regex trigger?
-                Utilities.addGithubPRTriggerForBranch(newJob, branch, "OuterLoop ${osName} ${configurationGroup}", "(?i).*test\\W+outerloop\\W+${osName}\\W+${configurationGroup}.*")
-            }
-            else {
-                // Set a periodic trigger
-                Utilities.addPeriodicTrigger(newJob, '@daily')
-            }
-        }
     }
 }
 


### PR DESCRIPTION
Removes old nano testing, in favor of new pipelines
(@dotnet-bot test portable windows debug pipeline)
(@dotnet-bot test portable windows release pipeline)