### PR TITLE
Associate #19965 with existing test

### DIFF
--- a/src/System.IO.FileSystem/tests/File/Copy.cs
+++ b/src/System.IO.FileSystem/tests/File/Copy.cs
@@ -54,23 +54,16 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [ActiveIssue(19965, TestPlatforms.AnyUnix)]
         public void NonExistentPath()
         {
             FileInfo testFile = new FileInfo(GetTestFilePath());
             testFile.Create().Dispose();
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                Assert.Throws<FileNotFoundException>(() => Copy(GetTestFilePath(), testFile.FullName));
-                Assert.Throws<DirectoryNotFoundException>(() => Copy(testFile.FullName, Path.Combine(TestDirectory, GetTestFileName(), GetTestFileName())));
-                Assert.Throws<DirectoryNotFoundException>(() => Copy(Path.Combine(TestDirectory, GetTestFileName(), GetTestFileName()), testFile.FullName));
-            }
-            else
-            {
-                Assert.Throws<FileNotFoundException>(() => Copy(GetTestFilePath(), testFile.FullName));
-                Assert.Throws<DirectoryNotFoundException>(() => Copy(testFile.FullName, Path.Combine(TestDirectory, GetTestFileName(), GetTestFileName())));
-                Assert.Throws<FileNotFoundException>(() => Copy(Path.Combine(TestDirectory, GetTestFileName(), GetTestFileName()), testFile.FullName));
-            }
-}
+
+            Assert.Throws<FileNotFoundException>(() => Copy(GetTestFilePath(), testFile.FullName));
+            Assert.Throws<DirectoryNotFoundException>(() => Copy(testFile.FullName, Path.Combine(TestDirectory, GetTestFileName(), GetTestFileName())));
+            Assert.Throws<DirectoryNotFoundException>(() => Copy(Path.Combine(TestDirectory, GetTestFileName(), GetTestFileName()), testFile.FullName));
+        }
 
         [Fact]
         public void CopyValid()


### PR DESCRIPTION
There is a PR to fix the behavior in FileStream in CoreCLR. This
test will pass as per the Windows OS block once that change is taken.
Disabling and tracking to allow taking a new drop.

#19965, https://github.com/dotnet/coreclr/pull/11757

The primary issue is #19850.