### PR TITLE
add missing stub constructors

### DIFF
--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Add_Reader.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Add_Reader.cs
@@ -5,11 +5,19 @@
 using System.IO;
 using System.Xml.Schema;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace System.Xml.Tests
 {
     public class TC_SchemaSet_Add_Reader : TC_SchemaSetBase
     {
+        private ITestOutputHelper _output;
+
+        public TC_SchemaSet_Add_Reader(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
         [Fact]
         public void NullNamespaceAndNullReader()
         {

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Add_Schema.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Add_Schema.cs
@@ -13,6 +13,7 @@ namespace System.Xml.Tests
     public class TC_SchemaSet_Add_Schema : TC_SchemaSetBase
     {
         private ITestOutputHelper _output;
+
         public TC_SchemaSet_Add_Schema(ITestOutputHelper output)
         {
             _output = output;

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Add_URL.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Add_URL.cs
@@ -6,12 +6,20 @@ using Xunit;
 using System.IO;
 using System.Xml.Schema;
 using System.Xml.XPath;
+using Xunit.Abstractions;
 
 namespace System.Xml.Tests
 {
     //[TestCase(Name = "TC_SchemaSet_Add_URL", Desc = "")]
     public class TC_SchemaSet_Add_URL : TC_SchemaSetBase
     {
+        private ITestOutputHelper _output;
+
+        public TC_SchemaSet_Add_URL(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
         //-----------------------------------------------------------------------------------
         [Fact]
         //[Variation(Desc = "v1 - ns = null, URL = null", Priority = 0)]


### PR DESCRIPTION
Add private constructors to the System.Xml.XmlSchemaSet.Tests, where the constructors were missing. 
Adjusted TC classes in project so they all have the same constructor style.
