### PR TITLE
Port PR#19968 User message for non-support of Sys.Transactions in SqlClient

### DIFF
--- a/src/System.Data.SqlClient/src/Resources/Strings.resx
+++ b/src/System.Data.SqlClient/src/Resources/Strings.resx
@@ -1099,4 +1099,7 @@
   <data name="MDF_UnableToBuildCollection" xml:space="preserve">
     <value>Unable to build schema collection '{0}';</value>
   </data>
+  <data name="AmbientTransactionsNotSupported" xml:space="preserve">
+    <value>Enlisting in Ambient transactions is not supported.</value>
+  </data>
 </root>

--- a/src/System.Data.SqlClient/src/System/Data/Common/AdapterUtil.SqlClient.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Common/AdapterUtil.SqlClient.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Transactions;
 
 namespace System
 {
@@ -671,6 +672,11 @@ namespace System.Data.Common
             return Environment.MachineName;
         }
 
+        internal static Transaction GetCurrentTransaction()
+        {
+            return Transaction.Current;
+        }
+
         internal static bool IsDirection(DbParameter value, ParameterDirection condition)
         {
 #if DEBUG
@@ -733,6 +739,10 @@ namespace System.Data.Common
             }
         }
 
+        internal static Exception AmbientTransactionIsNotSupported()
+        {
+            return new NotSupportedException(SR.AmbientTransactionsNotSupported);
+        }
 
         private static Version s_systemDataVersion;
 

--- a/src/System.Data.SqlClient/src/System/Data/Common/DbConnectionStringCommon.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Common/DbConnectionStringCommon.cs
@@ -238,6 +238,7 @@ namespace System.Data.Common
         internal const string CurrentLanguage = "";
         internal const string DataSource = "";
         internal const bool Encrypt = false;
+        internal const bool Enlist = true;
         internal const string FailoverPartner = "";
         internal const string InitialCatalog = "";
         internal const bool IntegratedSecurity = false;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionFactory.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionFactory.cs
@@ -94,7 +94,7 @@ namespace System.Data.SqlClient
                         // NOTE: Cloning connection option opt to set 'UserInstance=True' and 'Enlist=False'
                         //       This first connection is established to SqlExpress to get the instance name 
                         //       of the UserInstance.
-                        SqlConnectionString sseopt = new SqlConnectionString(opt, opt.DataSource, true /* user instance=true */);
+                        SqlConnectionString sseopt = new SqlConnectionString(opt, opt.DataSource, userInstance: true, setEnlistValue: false);
                         sseConnection = new SqlInternalConnectionTds(identity, sseopt, null, false, applyTransientFaultHandling: applyTransientFaultHandling);
                         // NOTE: Retrieve <UserInstanceName> here. This user instance name will be used below to connect to the Sql Express User Instance.
                         instanceName = sseConnection.InstanceName;
@@ -129,7 +129,7 @@ namespace System.Data.SqlClient
                 // NOTE: Here connection option opt is cloned to set 'instanceName=<UserInstanceName>' that was
                 //       retrieved from the previous SSE connection. For this UserInstance connection 'Enlist=True'.
                 // options immutable - stored in global hash - don't modify
-                opt = new SqlConnectionString(opt, instanceName, false /* user instance=false */);
+                opt = new SqlConnectionString(opt, instanceName, userInstance: false, setEnlistValue: null);
                 poolGroupProviderInfo = null; // null so we do not pass to constructor below...
             }
             result = new SqlInternalConnectionTds(identity, opt, poolGroupProviderInfo, redirectedUserInstance, userOpt, recoverySessionData, applyTransientFaultHandling: applyTransientFaultHandling);

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionString.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionString.cs
@@ -29,6 +29,7 @@ namespace System.Data.SqlClient
             internal const string Current_Language = "";
             internal const string Data_Source = "";
             internal const bool Encrypt = false;
+            internal const bool Enlist = true;
             internal const string FailoverPartner = "";
             internal const string Initial_Catalog = "";
             internal const bool Integrated_Security = false;
@@ -159,6 +160,7 @@ namespace System.Data.SqlClient
 
         private readonly bool _encrypt;
         private readonly bool _trustServerCertificate;
+        private readonly bool _enlist;
         private readonly bool _mars;
         private readonly bool _persistSecurityInfo;
         private readonly bool _pooling;
@@ -193,7 +195,6 @@ namespace System.Data.SqlClient
             ThrowUnsupportedIfKeywordSet(KEY.AsynchronousProcessing);
             ThrowUnsupportedIfKeywordSet(KEY.Connection_Reset);
             ThrowUnsupportedIfKeywordSet(KEY.Context_Connection);
-            ThrowUnsupportedIfKeywordSet(KEY.Enlist);
             ThrowUnsupportedIfKeywordSet(KEY.TransactionBinding);
 
             // Network Library has its own special error message
@@ -204,6 +205,7 @@ namespace System.Data.SqlClient
 
             _integratedSecurity = ConvertValueToIntegratedSecurity();
             _encrypt = ConvertValueToBoolean(KEY.Encrypt, DEFAULT.Encrypt);
+            _enlist = ConvertValueToBoolean(KEY.Enlist, DEFAULT.Enlist);
             _mars = ConvertValueToBoolean(KEY.MARS, DEFAULT.MARS);
             _persistSecurityInfo = ConvertValueToBoolean(KEY.Persist_Security_Info, DEFAULT.Persist_Security_Info);
             _pooling = ConvertValueToBoolean(KEY.Pooling, DEFAULT.Pooling);
@@ -357,10 +359,19 @@ namespace System.Data.SqlClient
 
         // This c-tor is used to create SSE and user instance connection strings when user instance is set to true
         // BUG (VSTFDevDiv) 479687: Using TransactionScope with Linq2SQL against user instances fails with "connection has been broken" message
-        internal SqlConnectionString(SqlConnectionString connectionOptions, string dataSource, bool userInstance) : base(connectionOptions)
+        internal SqlConnectionString(SqlConnectionString connectionOptions, string dataSource, bool userInstance, bool? setEnlistValue) : base(connectionOptions)
         {
             _integratedSecurity = connectionOptions._integratedSecurity;
             _encrypt = connectionOptions._encrypt;
+
+            if (setEnlistValue.HasValue)
+            {
+                _enlist = setEnlistValue.Value;
+            }
+            else
+            {
+                _enlist = connectionOptions._enlist;
+            }
 
             _mars = connectionOptions._mars;
             _persistSecurityInfo = connectionOptions._persistSecurityInfo;
@@ -402,6 +413,7 @@ namespace System.Data.SqlClient
         //        internal bool EnableUdtDownload { get { return _enableUdtDownload;} }
         internal bool Encrypt { get { return _encrypt; } }
         internal bool TrustServerCertificate { get { return _trustServerCertificate; } }
+        internal bool Enlist { get { return _enlist; } }
         internal bool MARS { get { return _mars; } }
         internal bool MultiSubnetFailover { get { return _multiSubnetFailover; } }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionStringBuilder.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionStringBuilder.cs
@@ -31,6 +31,7 @@ namespace System.Data.SqlClient
             UserID,
             Password,
 
+            Enlist,
             Pooling,
             MinPoolSize,
             MaxPoolSize,
@@ -65,7 +66,7 @@ namespace System.Data.SqlClient
         }
 
         internal const int KeywordsCount = (int)Keywords.KeywordsCount;
-        internal const int DeprecatedKeywordsCount = 6;
+        internal const int DeprecatedKeywordsCount = 5;
 
         private static readonly string[] s_validKeywords = CreateValidKeywords();
         private static readonly Dictionary<string, Keywords> s_keywords = CreateKeywordsDictionary();
@@ -93,6 +94,7 @@ namespace System.Data.SqlClient
 
         private bool _encrypt = DbConnectionStringDefaults.Encrypt;
         private bool _trustServerCertificate = DbConnectionStringDefaults.TrustServerCertificate;
+        private bool _enlist = DbConnectionStringDefaults.Enlist;
         private bool _integratedSecurity = DbConnectionStringDefaults.IntegratedSecurity;
         private bool _multipleActiveResultSets = DbConnectionStringDefaults.MultipleActiveResultSets;
         private bool _multiSubnetFailover = DbConnectionStringDefaults.MultiSubnetFailover;
@@ -111,6 +113,7 @@ namespace System.Data.SqlClient
             validKeywords[(int)Keywords.CurrentLanguage] = DbConnectionStringKeywords.CurrentLanguage;
             validKeywords[(int)Keywords.DataSource] = DbConnectionStringKeywords.DataSource;
             validKeywords[(int)Keywords.Encrypt] = DbConnectionStringKeywords.Encrypt;
+            validKeywords[(int)Keywords.Enlist] = DbConnectionStringKeywords.Enlist;
             validKeywords[(int)Keywords.FailoverPartner] = DbConnectionStringKeywords.FailoverPartner;
             validKeywords[(int)Keywords.InitialCatalog] = DbConnectionStringKeywords.InitialCatalog;
             validKeywords[(int)Keywords.IntegratedSecurity] = DbConnectionStringKeywords.IntegratedSecurity;
@@ -145,6 +148,7 @@ namespace System.Data.SqlClient
             hash.Add(DbConnectionStringKeywords.CurrentLanguage, Keywords.CurrentLanguage);
             hash.Add(DbConnectionStringKeywords.DataSource, Keywords.DataSource);
             hash.Add(DbConnectionStringKeywords.Encrypt, Keywords.Encrypt);
+            hash.Add(DbConnectionStringKeywords.Enlist, Keywords.Enlist);
             hash.Add(DbConnectionStringKeywords.FailoverPartner, Keywords.FailoverPartner);
             hash.Add(DbConnectionStringKeywords.InitialCatalog, Keywords.InitialCatalog);
             hash.Add(DbConnectionStringKeywords.IntegratedSecurity, Keywords.IntegratedSecurity);
@@ -238,6 +242,7 @@ namespace System.Data.SqlClient
 
                         case Keywords.Encrypt: Encrypt = ConvertToBoolean(value); break;
                         case Keywords.TrustServerCertificate: TrustServerCertificate = ConvertToBoolean(value); break;
+                        case Keywords.Enlist: Enlist = ConvertToBoolean(value); break;
                         case Keywords.MultipleActiveResultSets: MultipleActiveResultSets = ConvertToBoolean(value); break;
                         case Keywords.MultiSubnetFailover: MultiSubnetFailover = ConvertToBoolean(value); break;
                         case Keywords.PersistSecurityInfo: PersistSecurityInfo = ConvertToBoolean(value); break;
@@ -345,6 +350,16 @@ namespace System.Data.SqlClient
             {
                 SetValue(DbConnectionStringKeywords.TrustServerCertificate, value);
                 _trustServerCertificate = value;
+            }
+        }
+
+        public bool Enlist
+        {
+            get { return _enlist; }
+            set
+            {
+                SetValue(DbConnectionStringKeywords.Enlist, value);
+                _enlist = value;
             }
         }
 
@@ -649,6 +664,7 @@ namespace System.Data.SqlClient
                 case Keywords.CurrentLanguage: return CurrentLanguage;
                 case Keywords.DataSource: return DataSource;
                 case Keywords.Encrypt: return Encrypt;
+                case Keywords.Enlist: return Enlist;
                 case Keywords.FailoverPartner: return FailoverPartner;
                 case Keywords.InitialCatalog: return InitialCatalog;
                 case Keywords.IntegratedSecurity: return IntegratedSecurity;
@@ -728,6 +744,9 @@ namespace System.Data.SqlClient
                     break;
                 case Keywords.Encrypt:
                     _encrypt = DbConnectionStringDefaults.Encrypt;
+                    break;
+                case Keywords.Enlist:
+                    _enlist = DbConnectionStringDefaults.Enlist;
                     break;
                 case Keywords.FailoverPartner:
                     _failoverPartner = DbConnectionStringDefaults.FailoverPartner;
@@ -840,7 +859,6 @@ namespace System.Data.SqlClient
             DbConnectionStringKeywords.AsynchronousProcessing,
             DbConnectionStringKeywords.ConnectionReset,
             DbConnectionStringKeywords.ContextConnection,
-            DbConnectionStringKeywords.Enlist,
             DbConnectionStringKeywords.TransactionBinding,
 
             DbConnectionStringSynonyms.Async

--- a/src/System.Data.SqlClient/tests/FunctionalTests/AmbientTransactionFailureTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/AmbientTransactionFailureTest.cs
@@ -1,0 +1,104 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using System.Transactions;
+using Xunit;
+
+namespace System.Data.SqlClient.Tests
+{
+    public class AmbientTransactionFailureTest
+    {
+
+        private static readonly string s_servername = Guid.NewGuid().ToString();
+        private static readonly string s_connectionStringWithEnlistAsDefault = $"Data Source={s_servername}; Integrated Security=true; Connect Timeout=1;";
+        private static readonly string s_connectionStringWithEnlistOff = $"Data Source={s_servername}; Integrated Security=true; Connect Timeout=1;Enlist=False";
+
+        private static Action<string> ConnectToServer = (connectionString) =>
+        {
+            using (SqlConnection connection = new SqlConnection(connectionString))
+            {
+                connection.Open();
+            }
+        };
+
+        private static Action<string> ConnectToServerTask = (connectionString) =>
+        {
+            using (SqlConnection connection = new SqlConnection(connectionString))
+            {
+                connection.OpenAsync();
+            }
+        };
+
+        private static Func<string, Task> ConnectToServerInTransactionScopeTask = (connectionString) =>
+        {
+            return Task.Run(() =>
+            {
+                using (TransactionScope scope = new TransactionScope())
+                {
+                    ConnectToServerTask(connectionString);
+                }
+            });
+        };
+
+        private static Action<string> ConnectToServerInTransactionScope = (connectionString) =>
+        {
+            using (TransactionScope scope = new TransactionScope())
+            {
+                ConnectToServer(connectionString);
+            }
+        };
+
+        private static Action<string> EnlistConnectionInTransaction = (connectionString) =>
+        {
+            using (TransactionScope scope = new TransactionScope())
+            {
+                SqlConnection connection = new SqlConnection(connectionString);
+                connection.EnlistTransaction(Transaction.Current);
+            }
+        };
+
+        public static readonly object[][] ExceptionTestDataForSqlException =
+        {
+            new object[] { ConnectToServerInTransactionScope, s_connectionStringWithEnlistOff },
+            new object[] { ConnectToServer, s_connectionStringWithEnlistAsDefault }
+        };
+
+        public static readonly object[][] ExceptionTestDataForNotSupportedException =
+        {
+            new object[] { ConnectToServerInTransactionScope, s_connectionStringWithEnlistAsDefault },
+            new object[] { EnlistConnectionInTransaction, s_connectionStringWithEnlistAsDefault },
+            new object[] { EnlistConnectionInTransaction, s_connectionStringWithEnlistOff }
+        };
+
+        [Theory]
+        [MemberData(nameof(ExceptionTestDataForSqlException))]
+        public void TestSqlException(Action<string> connectAction, string connectionString)
+        {
+            Assert.Throws<SqlException>(() =>
+            {
+                connectAction(connectionString);
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(ExceptionTestDataForNotSupportedException))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Framework doesn't throw the Not Supported Exception")]
+        public void TestNotSupportedException(Action<string> connectAction, string connectionString)
+        {
+            Assert.Throws<NotSupportedException>(() =>
+            {
+                connectAction(connectionString);
+            });
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Framework doesn't throw the Not Supported Exception")]
+        public void TestNotSupportedExceptionForTransactionScopeAsync()
+        {
+            Assert.ThrowsAsync<NotSupportedException>(() => ConnectToServerInTransactionScopeTask(s_connectionStringWithEnlistAsDefault));
+        }
+
+    }
+}

--- a/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
@@ -15,6 +15,7 @@
     <Compile Include="BaseProviderAsyncTest\MockConnection.cs" />
     <Compile Include="BaseProviderAsyncTest\MockDataReader.cs" />
     <Compile Include="DiagnosticTest.cs" />
+    <Compile Include="AmbientTransactionFailureTest.cs" />
     <Compile Include="ExceptionTest.cs" />
     <Compile Include="FakeDiagnosticListenerObserver.cs" />
     <Compile Include="SqlBulkCopyColumnMappingCollectionTest.cs" />


### PR DESCRIPTION
The PR does the following

Brings in Enlist keyword on connection string.
Throws exceptions when SqlConnection.Open or SqlConnection.OpenAsync() is called in Transaction Scope
Throws Exception when SqlConnection.EnlistTransaction is called.

Fixes #19894
