### PR TITLE
Several fixes for HttpListener on Unix

### DIFF
--- a/src/System.Net.HttpListener/src/System.Net.HttpListener.csproj
+++ b/src/System.Net.HttpListener/src/System.Net.HttpListener.csproj
@@ -94,6 +94,9 @@
     <Compile Include="$(CommonPath)\System\Net\UriScheme.cs">
       <Link>Common\System\Net\UriScheme.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Net\WebHeaderEncoding.cs">
+      <Link>Common\System\Net\WebHeaderEncoding.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Net\WebSockets\WebSocketValidate.cs">
       <Link>Common\System\Net\WebSockets\WebSocketValidate.cs</Link>
     </Compile>
@@ -124,9 +127,6 @@
     </Compile>
     <Compile Include="$(CommonPath)\System\Net\InternalException.cs">
       <Link>Common\System\Net\InternalException.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\System\Net\WebHeaderEncoding.cs">
-      <Link>Common\System\Net\WebHeaderEncoding.cs</Link>
     </Compile>
     <Compile Include="System\Net\Windows\HttpResponseStream.Windows.cs" />
     <Compile Include="System\Net\Windows\HttpResponseStreamAsyncResult.cs" />

--- a/src/System.Net.HttpListener/src/System/Net/HttpListenerResponse.cs
+++ b/src/System.Net.HttpListener/src/System/Net/HttpListenerResponse.cs
@@ -11,6 +11,7 @@ namespace System.Net
     {
         private CookieCollection _cookies;
         private bool _keepAlive = true;
+        private string _statusDescription;
         private WebHeaderCollection _webHeaders = new WebHeaderCollection();
 
         public WebHeaderCollection Headers
@@ -58,6 +59,45 @@ namespace System.Net
             {
                 CheckDisposed();
                 _keepAlive = value;
+            }
+        }
+
+        public string StatusDescription
+        {
+            get
+            {
+                if (_statusDescription == null)
+                {
+                    // if the user hasn't set this, generated on the fly, if possible.
+                    // We know this one is safe, no need to verify it as in the setter.
+                    _statusDescription = HttpStatusDescription.Get(StatusCode);
+                }
+                if (_statusDescription == null)
+                {
+                    _statusDescription = string.Empty;
+                }
+                return _statusDescription;
+            }
+            set
+            {
+                CheckDisposed();
+                if (value == null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+
+                // Need to verify the status description doesn't contain any control characters except HT.  We mask off the high
+                // byte since that's how it's encoded.
+                for (int i = 0; i < value.Length; i++)
+                {
+                    char c = (char)(0x000000ff & (uint)value[i]);
+                    if ((c <= 31 && c != (byte)'\t') || c == 127)
+                    {
+                        throw new ArgumentException(SR.net_WebHeaderInvalidControlChars, "name");
+                    }
+                }
+
+                _statusDescription = value;
             }
         }
 

--- a/src/System.Net.HttpListener/src/System/Net/HttpListenerResponse.cs
+++ b/src/System.Net.HttpListener/src/System/Net/HttpListenerResponse.cs
@@ -62,6 +62,24 @@ namespace System.Net
             }
         }
 
+        public string RedirectLocation
+        {
+            get => Headers[HttpResponseHeader.Location];
+            set
+            {
+                // note that this doesn't set the status code to a redirect one
+                CheckDisposed();
+                if (string.IsNullOrEmpty(value))
+                {
+                    Headers.Remove(HttpKnownHeaderNames.Location);
+                }
+                else
+                {
+                    Headers.Set(HttpKnownHeaderNames.Location, value);
+                }
+            }
+        }
+
         public string StatusDescription
         {
             get
@@ -121,6 +139,14 @@ namespace System.Net
             }
             if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"cookie: {cookie}");
             Cookies.Add(cookie);
+        }
+
+        public void Redirect(string url)
+        {
+            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"url={url}");
+            Headers[HttpResponseHeader.Location] = url;
+            StatusCode = (int)HttpStatusCode.Redirect;
+            StatusDescription = HttpStatusDescription.Get(StatusCode);
         }
 
         public void SetCookie(Cookie cookie)

--- a/src/System.Net.HttpListener/src/System/Net/HttpListenerResponse.cs
+++ b/src/System.Net.HttpListener/src/System/Net/HttpListenerResponse.cs
@@ -10,6 +10,7 @@ namespace System.Net
     public sealed unsafe partial class HttpListenerResponse : IDisposable
     {
         private CookieCollection _cookies;
+        private bool _keepAlive = true;
         private WebHeaderCollection _webHeaders = new WebHeaderCollection();
 
         public WebHeaderCollection Headers
@@ -48,6 +49,16 @@ namespace System.Net
         {
             get => _cookies ?? (_cookies = new CookieCollection());
             set => _cookies = value;
+        }
+
+        public bool KeepAlive
+        {
+            get => _keepAlive;
+            set
+            {
+                CheckDisposed();
+                _keepAlive = value;
+            }
         }
 
         public void AddHeader(string name, string value)

--- a/src/System.Net.HttpListener/src/System/Net/HttpListenerResponse.cs
+++ b/src/System.Net.HttpListener/src/System/Net/HttpListenerResponse.cs
@@ -27,6 +27,23 @@ namespace System.Net
 
         public Encoding ContentEncoding { get; set; }
 
+        public string ContentType
+        {
+            get => Headers[HttpKnownHeaderNames.ContentType];
+            set
+            {
+                CheckDisposed();
+                if (string.IsNullOrEmpty(value))
+                {
+                    Headers.Remove(HttpKnownHeaderNames.ContentType);
+                }
+                else
+                {
+                    Headers.Set(HttpKnownHeaderNames.ContentType, value);
+                }
+            }
+        }
+
         public CookieCollection Cookies
         {
             get => _cookies ?? (_cookies = new CookieCollection());

--- a/src/System.Net.HttpListener/src/System/Net/HttpListenerResponse.cs
+++ b/src/System.Net.HttpListener/src/System/Net/HttpListenerResponse.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.IO;
 using System.Text;
 
 namespace System.Net
@@ -11,6 +12,7 @@ namespace System.Net
     {
         private CookieCollection _cookies;
         private bool _keepAlive = true;
+        private HttpResponseStream _responseStream;
         private string _statusDescription;
         private WebHeaderCollection _webHeaders = new WebHeaderCollection();
 
@@ -59,6 +61,16 @@ namespace System.Net
             {
                 CheckDisposed();
                 _keepAlive = value;
+            }
+        }
+
+        public Stream OutputStream
+        {
+            get
+            {
+                CheckDisposed();
+                EnsureResponseStream();
+                return _responseStream;
             }
         }
 

--- a/src/System.Net.HttpListener/src/System/Net/Managed/HttpListenerResponse.Managed.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/HttpListenerResponse.Managed.cs
@@ -41,7 +41,6 @@ namespace System.Net
         private bool _clSet;
         private HttpResponseStream _outputStream;
         private Version _version = HttpVersion.Version11;
-        private string _location;
         private int _statusCode = 200;
         private bool _chunked;
         private HttpListenerContext _context;
@@ -96,18 +95,6 @@ namespace System.Net
                     throw new ArgumentException(SR.net_wrongversion, nameof(value));
 
                 _version = value;
-            }
-        }
-
-        public string RedirectLocation
-        {
-            get => _location;
-            set
-            {
-                CheckDisposed();
-                CheckSentHeaders();
-
-                _location = value;
             }
         }
 
@@ -183,12 +170,6 @@ namespace System.Net
             _statusDescription = templateResponse._statusDescription;
             _keepAlive = templateResponse._keepAlive;
             _version = templateResponse._version;
-        }
-
-        public void Redirect(string url)
-        {
-            StatusCode = 302; // Found
-            _location = url;
         }
 
         private bool FindCookie(Cookie cookie)
@@ -279,9 +260,6 @@ namespace System.Net
                     if (_context.Request.ProtocolVersion <= HttpVersion.Version10)
                         _webHeaders.Set(HttpKnownHeaderNames.Connection, HttpHeaderStrings.KeepAlive);
                 }
-
-                if (_location != null)
-                    _webHeaders.Set(HttpKnownHeaderNames.Location, _location);
 
                 if (_cookies != null)
                 {

--- a/src/System.Net.HttpListener/src/System/Net/Managed/HttpListenerResponse.Managed.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/HttpListenerResponse.Managed.cs
@@ -39,7 +39,6 @@ namespace System.Net
     {
         private long _contentLength;
         private bool _clSet;
-        private HttpResponseStream _outputStream;
         private Version _version = HttpVersion.Version11;
         private int _statusCode = 200;
         private bool _chunked;
@@ -70,13 +69,11 @@ namespace System.Net
             }
         }
 
-        public Stream OutputStream
+        private void EnsureResponseStream()
         {
-            get
+            if (_responseStream == null)
             {
-                if (_outputStream == null)
-                    _outputStream = _context.Connection.GetResponseStream();
-                return _outputStream;
+                _responseStream = _context.Connection.GetResponseStream();
             }
         }
 
@@ -275,8 +272,7 @@ namespace System.Net
             writer.Write(headers_str);
             writer.Flush();
             int preamble = encoding.GetPreamble().Length;
-            if (_outputStream == null)
-                _outputStream = _context.Connection.GetResponseStream();
+            EnsureResponseStream();
 
             /* Assumes that the ms was at position 0 */
             ms.Position = preamble;

--- a/src/System.Net.HttpListener/src/System/Net/Managed/HttpListenerResponse.Managed.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/HttpListenerResponse.Managed.cs
@@ -266,9 +266,13 @@ namespace System.Net
 
             Encoding encoding = Encoding.Default;
             StreamWriter writer = new StreamWriter(ms, encoding, 256);
-            writer.Write("HTTP/{0} {1} {2}\r\n", _version, _statusCode, StatusDescription);
-            string headers_str = FormatHeaders(_webHeaders);
-            writer.Write(headers_str);
+            writer.Write("HTTP/{0} {1} ", _version, _statusCode);
+            writer.Flush();
+            byte[] statusDescriptionBytes = WebHeaderEncoding.GetBytes(StatusDescription);
+            ms.Write(statusDescriptionBytes, 0, statusDescriptionBytes.Length);
+            writer.Write("\r\n");
+
+            writer.Write(FormatHeaders(_webHeaders));
             writer.Flush();
             int preamble = encoding.GetPreamble().Length;
             EnsureResponseStream();

--- a/src/System.Net.HttpListener/src/System/Net/Managed/HttpListenerResponse.Managed.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/HttpListenerResponse.Managed.cs
@@ -39,7 +39,6 @@ namespace System.Net
     {
         private long _contentLength;
         private bool _clSet;
-        private string _contentType;
         private bool _keepAlive = true;
         private HttpResponseStream _outputStream;
         private Version _version = HttpVersion.Version11;
@@ -71,18 +70,6 @@ namespace System.Net
 
                 _clSet = true;
                 _contentLength = value;
-            }
-        }
-
-        public string ContentType
-        {
-            get => _contentType;
-            set
-            {
-                CheckDisposed();
-                CheckSentHeaders();
-
-                _contentType = value;
             }
         }
 
@@ -247,11 +234,6 @@ namespace System.Net
         {
             if (!isWebSocketHandshake)
             {
-                if (_contentType != null)
-                {
-                    _webHeaders.Set(HttpKnownHeaderNames.ContentType, _contentType);
-                }
-
                 if (_webHeaders[HttpKnownHeaderNames.Server] == null)
                     _webHeaders.Set(HttpKnownHeaderNames.Server, HttpHeaderStrings.NetCoreServerName);
                 CultureInfo inv = CultureInfo.InvariantCulture;

--- a/src/System.Net.HttpListener/src/System/Net/Managed/HttpListenerResponse.Managed.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/HttpListenerResponse.Managed.cs
@@ -43,7 +43,6 @@ namespace System.Net
         private Version _version = HttpVersion.Version11;
         private string _location;
         private int _statusCode = 200;
-        private string _statusDescription = "OK";
         private bool _chunked;
         private HttpListenerContext _context;
         internal object _headersLock = new object();
@@ -130,19 +129,12 @@ namespace System.Net
             set
             {
                 CheckDisposed();
-                CheckSentHeaders();
 
                 if (value < 100 || value > 999)
                     throw new ProtocolViolationException(SR.net_invalidstatus);
 
                 _statusCode = value;
             }
-        }
-
-        public string StatusDescription
-        {
-            get => _statusDescription;
-            set => _statusDescription = value;
         }
 
         private void Dispose() => Close(true);
@@ -300,7 +292,7 @@ namespace System.Net
 
             Encoding encoding = Encoding.Default;
             StreamWriter writer = new StreamWriter(ms, encoding, 256);
-            writer.Write("HTTP/{0} {1} {2}\r\n", _version, _statusCode, _statusDescription);
+            writer.Write("HTTP/{0} {1} {2}\r\n", _version, _statusCode, StatusDescription);
             string headers_str = FormatHeaders(_webHeaders);
             writer.Write(headers_str);
             writer.Flush();

--- a/src/System.Net.HttpListener/src/System/Net/Managed/HttpListenerResponse.Managed.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/HttpListenerResponse.Managed.cs
@@ -39,7 +39,6 @@ namespace System.Net
     {
         private long _contentLength;
         private bool _clSet;
-        private bool _keepAlive = true;
         private HttpResponseStream _outputStream;
         private Version _version = HttpVersion.Version11;
         private string _location;
@@ -70,18 +69,6 @@ namespace System.Net
 
                 _clSet = true;
                 _contentLength = value;
-            }
-        }
-
-        public bool KeepAlive
-        {
-            get => _keepAlive;
-            set
-            {
-                CheckDisposed();
-                CheckSentHeaders();
-
-                _keepAlive = value;
             }
         }
 

--- a/src/System.Net.HttpListener/src/System/Net/Managed/HttpListenerResponse.Managed.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/HttpListenerResponse.Managed.cs
@@ -147,8 +147,7 @@ namespace System.Net
 
         public void Close(byte[] responseEntity, bool willBlock)
         {
-            if (Disposed)
-                return;
+            CheckDisposed();
 
             if (responseEntity == null)
                 throw new ArgumentNullException(nameof(responseEntity));

--- a/src/System.Net.HttpListener/src/System/Net/Windows/HttpListenerResponse.Windows.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/HttpListenerResponse.Windows.cs
@@ -24,7 +24,6 @@ namespace System.Net
         }
 
         private string _statusDescription;
-        private bool _keepAlive;
         private ResponseState _responseState;
 
         private HttpResponseStream _responseStream;
@@ -42,7 +41,6 @@ namespace System.Net
             _nativeResponse.StatusCode = (ushort)HttpStatusCode.OK;
             _nativeResponse.Version.MajorVersion = 1;
             _nativeResponse.Version.MinorVersion = 1;
-            _keepAlive = true;
             _responseState = ResponseState.Created;
         }
 
@@ -192,16 +190,6 @@ namespace System.Net
                 {
                     _contentLength = -1;
                 }
-            }
-        }
-
-        public bool KeepAlive
-        {
-            get => _keepAlive;
-            set
-            {
-                CheckDisposed();
-                _keepAlive = value;
             }
         }
 

--- a/src/System.Net.HttpListener/src/System/Net/Windows/HttpListenerResponse.Windows.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/HttpListenerResponse.Windows.cs
@@ -63,24 +63,6 @@ namespace System.Net
             }
         }
 
-        public string RedirectLocation
-        {
-            get => Headers[HttpResponseHeader.Location];
-            set
-            {
-                // note that this doesn't set the status code to a redirect one
-                CheckDisposed();
-                if (string.IsNullOrEmpty(value))
-                {
-                    Headers.Remove(HttpKnownHeaderNames.Location);
-                }
-                else
-                {
-                    Headers.Set(HttpKnownHeaderNames.Location, value);
-                }
-            }
-        }
-
         public int StatusCode
         {
             get => _nativeResponse.StatusCode;
@@ -151,14 +133,6 @@ namespace System.Net
                     _contentLength = -1;
                 }
             }
-        }
-
-        public void Redirect(string url)
-        {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"url={url}");
-            Headers[HttpResponseHeader.Location] = url;
-            StatusCode = (int)HttpStatusCode.Redirect;
-            StatusDescription = HttpStatusDescription.Get(StatusCode);
         }
 
         public long ContentLength64

--- a/src/System.Net.HttpListener/src/System/Net/Windows/HttpListenerResponse.Windows.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/HttpListenerResponse.Windows.cs
@@ -25,7 +25,6 @@ namespace System.Net
 
         private ResponseState _responseState;
 
-        private HttpResponseStream _responseStream;
         private long _contentLength;
         private BoundaryType _boundaryType;
         private Interop.HttpApi.HTTP_RESPONSE _nativeResponse;
@@ -52,16 +51,6 @@ namespace System.Net
         private HttpListenerContext HttpListenerContext => _httpContext;
 
         private HttpListenerRequest HttpListenerRequest => HttpListenerContext.Request;
-
-        public Stream OutputStream
-        {
-            get
-            {
-                CheckDisposed();
-                EnsureResponseStream();
-                return _responseStream;
-            }
-        }
 
         public int StatusCode
         {

--- a/src/System.Net.HttpListener/src/System/Net/Windows/HttpListenerResponse.Windows.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/HttpListenerResponse.Windows.cs
@@ -23,7 +23,6 @@ namespace System.Net
             Closed,
         }
 
-        private string _statusDescription;
         private ResponseState _responseState;
 
         private HttpResponseStream _responseStream;
@@ -93,45 +92,6 @@ namespace System.Net
                     throw new ProtocolViolationException(SR.net_invalidstatus);
                 }
                 _nativeResponse.StatusCode = (ushort)value;
-            }
-        }
-
-        public string StatusDescription
-        {
-            get
-            {
-                if (_statusDescription == null)
-                {
-                    // if the user hasn't set this, generated on the fly, if possible.
-                    // We know this one is safe, no need to verify it as in the setter.
-                    _statusDescription = HttpStatusDescription.Get(StatusCode);
-                }
-                if (_statusDescription == null)
-                {
-                    _statusDescription = string.Empty;
-                }
-                return _statusDescription;
-            }
-            set
-            {
-                CheckDisposed();
-                if (value == null)
-                {
-                    throw new ArgumentNullException(nameof(value));
-                }
-
-                // Need to verify the status description doesn't contain any control characters except HT.  We mask off the high
-                // byte since that's how it's encoded.
-                for (int i = 0; i < value.Length; i++)
-                {
-                    char c = (char)(0x000000ff & (uint)value[i]);
-                    if ((c <= 31 && c != (byte)'\t') || c == 127)
-                    {
-                        throw new ArgumentException(SR.net_WebHeaderInvalidControlChars, "name");
-                    }
-                }
-
-                _statusDescription = value;
             }
         }
 

--- a/src/System.Net.HttpListener/src/System/Net/Windows/HttpListenerResponse.Windows.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/HttpListenerResponse.Windows.cs
@@ -56,23 +56,6 @@ namespace System.Net
 
         private HttpListenerRequest HttpListenerRequest => HttpListenerContext.Request;
 
-        public string ContentType
-        {
-            get => Headers[HttpKnownHeaderNames.ContentType];
-            set
-            {
-                CheckDisposed();
-                if (string.IsNullOrEmpty(value))
-                {
-                    Headers.Remove(HttpKnownHeaderNames.ContentType);
-                }
-                else
-                {
-                    Headers.Set(HttpKnownHeaderNames.ContentType, value);
-                }
-            }
-        }
-
         public Stream OutputStream
         {
             get

--- a/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Headers.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Headers.cs
@@ -211,8 +211,7 @@ namespace System.Net.Tests
         [InlineData(404, "HTTP/1.1 404 Not Found", 127)]
         [InlineData(401, "HTTP/1.1 401 Unauthorized", 130)]
         [InlineData(999, "HTTP/1.1 999 ", 118)]
-        // The managed implementation should update StatusDescription when setting StatusCode.
-        [ConditionalTheory(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [ActiveIssue(19976, TestPlatforms.AnyUnix)]
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public async Task StatusCode_SetAndSend_Success(int statusCode, string startLine, int expectedNumberOfBytes)
         {
             using (HttpListenerResponse response = await GetResponse())
@@ -238,7 +237,7 @@ namespace System.Net.Tests
         }
 
         // The managed implementation should not throw setting StatusCode after headers were sent.
-        [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [ActiveIssue(19971, TestPlatforms.AnyUnix)]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public async Task StatusCode_SetAfterHeadersSent_DoesNothing()
         {
             using (HttpListenerResponse response = await GetResponse())
@@ -314,8 +313,7 @@ namespace System.Net.Tests
         [InlineData(505, "Http Version Not Supported")]
         [InlineData(507, "Insufficient Storage")]
         [InlineData(999, "")]
-        // The managed implementation should set StatusDescription when setting the StatusCode.
-        [ConditionalTheory(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [ActiveIssue(19976, TestPlatforms.AnyUnix)]
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public async Task StatusDescription_GetWithCustomStatusCode_ReturnsExpected(int statusCode, string expectedDescription)
         {
             using (HttpListenerResponse response = await GetResponse())
@@ -350,8 +348,7 @@ namespace System.Net.Tests
             Assert.StartsWith($"HTTP/1.1 200 {expectedStatusDescription}\r\n", clientResponse);
         }
         
-        // The managed implementation should throw an ArgumentNullException setting StatusDescription to null.
-        [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [ActiveIssue(19976, TestPlatforms.AnyUnix)]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public async Task StatusDescription_SetNull_ThrowsArgumentNullException()
         {
             using (HttpListenerResponse response = await GetResponse())
@@ -365,8 +362,7 @@ namespace System.Net.Tests
         [InlineData("\u007F")]
         [InlineData("\r")]
         [InlineData("\n")]
-        // The managed implementation should validate the value to make sure it contains no control characters.
-        [ConditionalTheory(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [ActiveIssue(19976, TestPlatforms.AnyUnix)]
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public async Task StatusDescription_SetInvalid_ThrowsArgumentException(string statusDescription)
         {
             using (HttpListenerResponse response = await GetResponse())
@@ -377,7 +373,7 @@ namespace System.Net.Tests
         }
         
         // The managed implementation should throw setting StatusDescription when disposed.
-        [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [ActiveIssue(19971, TestPlatforms.AnyUnix)]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public async Task StatusDescription_SetDisposed_ThrowsObjectDisposedException()
         {
             HttpListenerResponse response = await GetResponse();

--- a/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Headers.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Headers.cs
@@ -110,8 +110,7 @@ namespace System.Net.Tests
             Assert.Null(response.ContentType);
         }
 
-        // The managed implementation should not throw setting ContentType after the headers are sent.
-        [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [ActiveIssue(19971, TestPlatforms.AnyUnix)]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public async Task ContentType_SetAfterHeadersSent_DoesNothing()
         {
             using (HttpListenerResponse response = await GetResponse())

--- a/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Headers.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Headers.cs
@@ -546,7 +546,7 @@ namespace System.Net.Tests
         }
         
         // The managed implementation should not throw setting KeepAlive after sending the headers.
-        [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [ActiveIssue(19971, TestPlatforms.AnyUnix)]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public async Task KeepAlive_SetAfterHeadersSent_DoesNothing()
         {
             using (HttpListenerResponse response = await GetResponse())

--- a/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Headers.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Headers.cs
@@ -333,8 +333,7 @@ namespace System.Net.Tests
         [InlineData("A !#\t1\u1234", "A !#\t14", 125)] // 
         [InlineData("StatusDescription", "StatusDescription", 135)]
         [InlineData("  StatusDescription  ", "  StatusDescription  ", 139)]
-        // The managed implementation should use WebHeaderEncoding to encode unicode headers.
-        [ConditionalTheory(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [ActiveIssue(19976, TestPlatforms.AnyUnix)]
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public async Task StatusDescription_SetCustom_Success(string statusDescription, string expectedStatusDescription, int expectedNumberOfBytes)
         {
             using (HttpListenerResponse response = await GetResponse())

--- a/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Headers.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Headers.cs
@@ -63,9 +63,7 @@ namespace System.Net.Tests
         [InlineData("application/json", 152)]
         [InlineData("  applICATion/jSOn   ", 152)]
         [InlineData("garbage", 143)]
-        // The managed implementation should set ContentType directly in the headers instead of tracking it with its own field.
-        // The managed implementation should trim the value.
-        [ConditionalTheory(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [ActiveIssue(19972, TestPlatforms.AnyUnix)]
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public async Task ContentType_SetAndSend_Success(string contentType, int expectedNumberOfBytes)
         {
             using (HttpListenerResponse response = await GetResponse())
@@ -82,8 +80,7 @@ namespace System.Net.Tests
         [InlineData(null, null)]
         [InlineData("", null)]
         [InlineData("\r \t \n", "")]
-        // The managed implementation should store ContentType in Headers, not as a separate variable.
-        [ConditionalTheory(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [ActiveIssue(19972, TestPlatforms.AnyUnix)]
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public async Task ContentType_SetNullEmptyOrWhitespace_ResetsContentType(string contentType, string expectedContentType)
         {
             using (HttpListenerResponse response = await GetResponse())
@@ -139,9 +136,7 @@ namespace System.Net.Tests
         [InlineData("  http://MICROSOFT.com   ", 152)]
         [InlineData("garbage", 139)]
         [InlineData("http://domain:-1", 148)]
-        // The managed implementation should set Location directly in Headers rather than track it with its own variable.
-        // The managed implementation should trim the value.
-        [ConditionalTheory(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [ActiveIssue(19972, TestPlatforms.AnyUnix)]
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public async Task RedirectLocation_SetAndSend_Success(string redirectLocation, int expectedNumberOfBytes)
         {
             using (HttpListenerResponse response = await GetResponse())

--- a/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Headers.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Headers.cs
@@ -126,8 +126,7 @@ namespace System.Net.Tests
             Assert.DoesNotContain("Content-Type", clientResponse);
         }
 
-        // The managed implementation should throw an ObjectDisposedException getting OutputStream when disposed.
-        [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [ActiveIssue(19971, TestPlatforms.AnyUnix)]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public async Task OutputStream_GetDisposed_ThrowsObjectDisposedException()
         {
             HttpListenerResponse response = await GetResponse();

--- a/src/System.Net.HttpListener/tests/HttpListenerResponseTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerResponseTests.cs
@@ -380,8 +380,7 @@ namespace System.Net.Tests
             }
         }
 
-        // The managed implementation should throw an ObjectDisposedException calling CloseResponseEntity when already disposed.
-        [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [ActiveIssue(19971, TestPlatforms.AnyUnix)]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public async Task CloseResponseEntity_AlreadyDisposed_ThrowsObjectDisposedException()
         {
             HttpListenerResponse response = await GetResponse();

--- a/src/System.Net.HttpListener/tests/HttpListenerResponseTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerResponseTests.cs
@@ -137,8 +137,7 @@ namespace System.Net.Tests
             }
         }
 
-        // The managed implementation should set Location directly in the Headers rather than tracking it with its own field.
-        [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [ActiveIssue(19971, TestPlatforms.AnyUnix)]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public async Task Redirect_Disposed_ThrowsObjectDisposedException()
         {
             HttpListenerResponse response = await GetResponse();


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/19971
Fixes https://github.com/dotnet/corefx/issues/19976
Also most of https://github.com/dotnet/corefx/issues/19972

Primarily involved moving shareable implementations from the Windows code to the shared code and then fixing up the managed implementation to use it.  Nothing functional changed on the Windows side.

cc: @janvorli, @hughbe, @Priya91, @geoffkizer 
