### PR TITLE
add explicit check for OSX version to avoid mysterious breakages

### DIFF
--- a/Documentation/building/unix-instructions.md
+++ b/Documentation/building/unix-instructions.md
@@ -57,7 +57,7 @@ most systems when you install the development packages).
 
 ### macOS
 
-macOS 10.12 or higher is needed to build corefx 2.0.
+macOS 10.12 or higher is needed to build corefx 2.x.
 
 On macOS a few components are needed which are not provided by a default developer setup:
 * CMake

--- a/Documentation/building/unix-instructions.md
+++ b/Documentation/building/unix-instructions.md
@@ -57,7 +57,7 @@ most systems when you install the development packages).
 
 ### macOS
 
-OSX 10.12 or higer is needed to build corefx 2.0.
+macOS 10.12 or higher is needed to build corefx 2.0.
 
 On macOS a few components are needed which are not provided by a default developer setup:
 * CMake

--- a/Documentation/building/unix-instructions.md
+++ b/Documentation/building/unix-instructions.md
@@ -57,6 +57,8 @@ most systems when you install the development packages).
 
 ### macOS
 
+OSX 10.12 or higer is needed to build corefx 2.0.
+
 On macOS a few components are needed which are not provided by a default developer setup:
 * CMake
 * pkgconfig

--- a/init-tools.sh
+++ b/init-tools.sh
@@ -28,7 +28,7 @@ OSName=$(uname -s)
             # Format x.y.z as single integer with three digits for each part
             VERSION=`sw_vers -productVersion| sed -e 's/\./ /g' | xargs printf "%03d%03d%03d"`
             if [ "$VERSION" -lt 010012000 ]; then
-                echo error: OSX version `sw_vers -productVersion` is too old. 10.12 is needed as minimum.
+                echo error: macOS version `sw_vers -productVersion` is too old. 10.12 is needed as minimum.
                 exit 1
             fi
             ;;

--- a/init-tools.sh
+++ b/init-tools.sh
@@ -25,11 +25,11 @@ OSName=$(uname -s)
             OS=OSX
             __DOTNET_PKG=dotnet-dev-osx-x64
             ulimit -n 2048
-	    # Format x.y.z as single integer with three digits for each part
-	    VERSION=`sw_vers -productVersion| sed -e 's/\./ /g' | xargs printf "%03d%03d%03d"`
-	    if [ "$VERSION" -lt 010012000 ]; then
-	        echo error: OSX version `sw_vers -productVersion` is too old!
-	        exit 1
+            # Format x.y.z as single integer with three digits for each part
+            VERSION=`sw_vers -productVersion| sed -e 's/\./ /g' | xargs printf "%03d%03d%03d"`
+            if [ "$VERSION" -lt 010012000 ]; then
+                echo error: OSX version `sw_vers -productVersion` is too old. 10.12 is needed as minimum.
+                exit 1
             fi
             ;;
 

--- a/init-tools.sh
+++ b/init-tools.sh
@@ -25,6 +25,12 @@ OSName=$(uname -s)
             OS=OSX
             __DOTNET_PKG=dotnet-dev-osx-x64
             ulimit -n 2048
+	    # Format x.y.z as single integer with three digits for each part
+	    VERSION=`sw_vers -productVersion| sed -e 's/\./ /g' | xargs printf "%03d%03d%03d"`
+	    if [ "$VERSION" -lt 010012000 ]; then
+	        echo error: OSX version `sw_vers -productVersion` is too old!
+	        exit 1
+            fi
             ;;
 
         Linux)


### PR DESCRIPTION
This change adds explicit check for OSX version.

On my 10.11 it fails with following message:
./init-tools.sh
error: OSX version 10.11.6 is too old!

bash -x init.sh

I verified that version expands to VERSION=010011006 as expected. 
I run same script on Sierra and init.sh runs expected. 
(version expands to VERSION=010012005)





