### PR TITLE
Fixing test name.

### DIFF
--- a/src/System.Net.WebHeaderCollection/tests/LoggingTest.cs
+++ b/src/System.Net.WebHeaderCollection/tests/LoggingTest.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace System.Net.Tests
 {
-    public class LoggingTest
+    public class WebHeaderCollectionLoggingTest
     {
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core")]

--- a/src/System.Net.WebHeaderCollection/tests/WebHeaderCollectionTest.cs
+++ b/src/System.Net.WebHeaderCollection/tests/WebHeaderCollectionTest.cs
@@ -9,7 +9,7 @@ using System.Runtime.Serialization.Formatters.Tests;
 
 using Xunit;
 
-namespace System.Net.WebHeaderCollectionTests
+namespace System.Net.Tests
 {
     public partial class WebHeaderCollectionTest
     {


### PR DESCRIPTION
Small test name changes to easily identify failing tests in CI.
No actual changes required for UWP (no test is failing).

Fixes #20138 
