### PR TITLE
Disable System.Net.* tests for issue #19967

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -1664,6 +1664,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Specifying Version(2,0) throws exception on netfx")]
         [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(IsWindows10Version1607OrGreater)), MemberData(nameof(Http2NoPushServers))]
         public async Task SendAsync_RequestVersion20_ResponseVersion20(Uri server)

--- a/src/System.Net.HttpListener/tests/HttpListenerRequestTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerRequestTests.cs
@@ -14,6 +14,7 @@ namespace System.Net.Tests
 {
     public class HttpListenerRequestTests
     {
+        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         [InlineData("Accept: Test", new string[] { "Test" })]
         [InlineData("Accept: Test, Test2,Test3 ,  Test4", new string[] { "Test", "Test2", "Test3 ", " Test4" })]
@@ -208,6 +209,7 @@ namespace System.Net.Tests
             });
         }
 
+        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         [InlineData("Accept-Language: Lang1,Lang2,Lang3", new string[] { "Lang1", "Lang2", "Lang3" })]
         [InlineData("Accept-Language: Lang1, Lang2, Lang3", new string[] { "Lang1", "Lang2", "Lang3" })]
@@ -418,6 +420,7 @@ namespace System.Net.Tests
             };
         }
 
+        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         [MemberData(nameof(QueryString_TestData))]
         public async Task QueryString_GetProperty_ReturnsExpected(string query, NameValueCollection expected)

--- a/src/System.Net.HttpListener/tests/HttpListenerTimeoutManagerTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerTimeoutManagerTests.cs
@@ -114,6 +114,7 @@ namespace System.Net.Tests
 
         public void Dispose() => _listener.Close();
 
+        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public void TimeoutManager_AccessNoStart_Success()
         {
@@ -125,6 +126,7 @@ namespace System.Net.Tests
             Assert.Equal(rate, timeoutManager.MinSendBytesPerSecond);
         }
 
+        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public void TimeoutManager_AccessAfterStart_Success()
         {
@@ -157,6 +159,7 @@ namespace System.Net.Tests
             Assert.Throws<ObjectDisposedException>(() => timeoutManager.MinSendBytesPerSecond = 10);
         }
 
+        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public void TimeoutManager_AccessAfterStop_Success()
         {
@@ -171,6 +174,7 @@ namespace System.Net.Tests
             Assert.Equal(rate, timeoutManager.MinSendBytesPerSecond);
         }
 
+        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public void DrainEntityBody_SetTimeoutNoStart_GetReturnsNewValue()
         {
@@ -181,6 +185,7 @@ namespace System.Net.Tests
             Assert.Equal(seconds, _listener.TimeoutManager.DrainEntityBody.TotalSeconds);
         }
 
+        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public void DrainEntityBody_SetTimeoutAfterStart_GetReturnsNewValue()
         {
@@ -192,6 +197,7 @@ namespace System.Net.Tests
             Assert.Equal(seconds, _listener.TimeoutManager.DrainEntityBody.TotalSeconds);
         }
 
+        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public void EntityBody_SetTimeoutNoStart_GetReturnsNewValue()
         {
@@ -202,6 +208,7 @@ namespace System.Net.Tests
             Assert.Equal(seconds, _listener.TimeoutManager.EntityBody.TotalSeconds);
         }
 
+        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public void EntityBody_SetTimeoutAfterStart_GetReturnsNewValue()
         {
@@ -213,6 +220,7 @@ namespace System.Net.Tests
             Assert.Equal(seconds, _listener.TimeoutManager.EntityBody.TotalSeconds);
         }
 
+        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public void HeaderWait_SetTimeoutNoStart_GetReturnsNewValue()
         {
@@ -223,6 +231,7 @@ namespace System.Net.Tests
             Assert.Equal(seconds, _listener.TimeoutManager.HeaderWait.TotalSeconds);
         }
 
+        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public void HeaderWait_SetTimeoutAfterStart_GetReturnsNewValue()
         {
@@ -234,6 +243,7 @@ namespace System.Net.Tests
             Assert.Equal(seconds, _listener.TimeoutManager.HeaderWait.TotalSeconds);
         }
 
+        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public void RequestQueue_SetTimeoutNoStart_GetReturnsNewValue()
         {
@@ -244,6 +254,7 @@ namespace System.Net.Tests
             Assert.Equal(seconds, _listener.TimeoutManager.RequestQueue.TotalSeconds);
         }
 
+        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public void RequestQueue_SetTimeoutAfterStart_GetReturnsNewValue()
         {
@@ -255,6 +266,7 @@ namespace System.Net.Tests
             Assert.Equal(seconds, _listener.TimeoutManager.RequestQueue.TotalSeconds);
         }
 
+        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public void IdleConnection_SetTimeoutNoStart_GetReturnsNewValue()
         {
@@ -265,6 +277,7 @@ namespace System.Net.Tests
             Assert.Equal(seconds, _listener.TimeoutManager.IdleConnection.TotalSeconds);
         }
 
+        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public void IdleConnection_SetTimeoutAfterStart_GetReturnsNewValue()
         {
@@ -276,6 +289,7 @@ namespace System.Net.Tests
             Assert.Equal(seconds, _listener.TimeoutManager.IdleConnection.TotalSeconds);
         }
 
+        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public void MinSendBytesPerSecond_SetNoStart_GetReturnsNewValue()
         {
@@ -287,6 +301,7 @@ namespace System.Net.Tests
             Assert.Equal(rate, _listener.TimeoutManager.MinSendBytesPerSecond);
         }
 
+        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public void MinSendBytesPerSecond_SetAfterStart_GetReturnsNewValue()
         {
@@ -308,6 +323,7 @@ namespace System.Net.Tests
             Assert.Throws<ObjectDisposedException>(() => _listener.TimeoutManager.MinSendBytesPerSecond = 10 * 1024 * 1024);
         }
 
+        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public void MinSendBytesPerSecond_SetAfterStop_GetReturnsNewValue()
         {

--- a/src/System.Net.WebSockets.Client/tests/CancelTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/CancelTest.cs
@@ -150,6 +150,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
         
+        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task ReceiveAsync_AfterCancellationDoReceiveAsync_ThrowsWebSocketException(Uri server)

--- a/src/System.Net.WebSockets.Client/tests/ClientWebSocketOptionsTests.cs
+++ b/src/System.Net.WebSockets.Client/tests/ClientWebSocketOptionsTests.cs
@@ -27,6 +27,7 @@ namespace System.Net.WebSockets.Client.Tests
             Assert.False(cws.Options.UseDefaultCredentials);
         }
 
+        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(WebSocketsSupported))]
         public static void SetBuffer_InvalidArgs_Throws()
         {

--- a/src/System.Net.WebSockets.Client/tests/CloseTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/CloseTest.cs
@@ -256,6 +256,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
+        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task CloseOutputAsync_DuringConcurrentReceiveAsync_ExpectedStates(Uri server)

--- a/src/System.Net.WebSockets.Client/tests/ConnectTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/ConnectTest.cs
@@ -16,6 +16,7 @@ namespace System.Net.WebSockets.Client.Tests
     {
         public ConnectTest(ITestOutputHelper output) : base(output) { }
 
+        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(UnavailableWebSocketServers))]
         public async Task ConnectAsync_NotWebSocketServer_ThrowsWebSocketExceptionWithMessage(Uri server)
@@ -84,6 +85,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
+        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [OuterLoop]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoHeadersServers))]
         public async Task ConnectAsync_AddHostHeader_Success(Uri server)


### PR DESCRIPTION
Contributes to: #18483 

In order to consume the new buildtools version that fixes [ConditionalFact/Theory] netfx discovery I have to disable failing tests so that CI is green. 

This tests are tracked by: https://github.com/dotnet/corefx/issues/19967

cc: @davidsh @CIPop @stephentoub 