### PR TITLE
uapaot fixes for System.Config.ConfigurationManager

### DIFF
--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/ExportFactory/ExportFactoryExportDescriptorProvider.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/ExportFactory/ExportFactoryExportDescriptorProvider.cs
@@ -11,7 +11,7 @@ using Microsoft.Internal;
 
 namespace System.Composition.Hosting.Providers.ExportFactory
 {
-    internal class ExportFactoryExportDescriptorProvider : ExportDescriptorProvider
+    public class ExportFactoryExportDescriptorProvider : ExportDescriptorProvider
     {
         private static readonly MethodInfo s_getExportFactoryDefinitionsMethod = typeof(ExportFactoryExportDescriptorProvider).GetTypeInfo().GetDeclaredMethod("GetExportFactoryDescriptors");
 
@@ -25,7 +25,7 @@ namespace System.Composition.Hosting.Providers.ExportFactory
             return (ExportDescriptorPromise[])gldm(exportKey, definitionAccessor);
         }
 
-        private static ExportDescriptorPromise[] GetExportFactoryDescriptors<TProduct>(CompositionContract exportFactoryContract, DependencyAccessor definitionAccessor)
+        public static ExportDescriptorPromise[] GetExportFactoryDescriptors<TProduct>(CompositionContract exportFactoryContract, DependencyAccessor definitionAccessor)
         {
             var productContract = exportFactoryContract.ChangeType(typeof(TProduct));
             var boundaries = EmptyArray<string>.Value;

--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/ExportFactory/ExportFactoryWithMetadataExportDescriptorProvider.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/ExportFactory/ExportFactoryWithMetadataExportDescriptorProvider.cs
@@ -12,7 +12,7 @@ using Microsoft.Internal;
 
 namespace System.Composition.Hosting.Providers.ExportFactory
 {
-    internal class ExportFactoryWithMetadataExportDescriptorProvider : ExportDescriptorProvider
+    public class ExportFactoryWithMetadataExportDescriptorProvider : ExportDescriptorProvider
     {
         private static readonly MethodInfo s_getLazyDefinitionsMethod =
             typeof(ExportFactoryWithMetadataExportDescriptorProvider).GetTypeInfo().GetDeclaredMethod("GetExportFactoryDescriptors");
@@ -29,7 +29,7 @@ namespace System.Composition.Hosting.Providers.ExportFactory
             return (ExportDescriptorPromise[])gldm(contract, definitionAccessor);
         }
 
-        private static ExportDescriptorPromise[] GetExportFactoryDescriptors<TProduct, TMetadata>(CompositionContract exportFactoryContract, DependencyAccessor definitionAccessor)
+        public static ExportDescriptorPromise[] GetExportFactoryDescriptors<TProduct, TMetadata>(CompositionContract exportFactoryContract, DependencyAccessor definitionAccessor)
         {
             var productContract = exportFactoryContract.ChangeType(typeof(TProduct));
             var boundaries = EmptyArray<string>.Value;

--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/ImportMany/ImportManyExportDescriptorProvider.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/ImportMany/ImportManyExportDescriptorProvider.cs
@@ -10,7 +10,7 @@ using System.Linq;
 
 namespace System.Composition.Hosting.Providers.ImportMany
 {
-    internal class ImportManyExportDescriptorProvider : ExportDescriptorProvider
+    public class ImportManyExportDescriptorProvider : ExportDescriptorProvider
     {
         private static readonly MethodInfo s_getImportManyDefinitionMethod = typeof(ImportManyExportDescriptorProvider).GetTypeInfo().GetDeclaredMethod("GetImportManyDescriptor");
         private static readonly Type[] s_supportedContractTypes = new[] { typeof(IList<>), typeof(ICollection<>), typeof(IEnumerable<>) };
@@ -37,7 +37,7 @@ namespace System.Composition.Hosting.Providers.ImportMany
             return new[] { (ExportDescriptorPromise)gimdm(contract, elementContract, definitionAccessor) };
         }
 
-        private static ExportDescriptorPromise GetImportManyDescriptor<TElement>(CompositionContract importManyContract, CompositionContract elementContract, DependencyAccessor definitionAccessor)
+        public static ExportDescriptorPromise GetImportManyDescriptor<TElement>(CompositionContract importManyContract, CompositionContract elementContract, DependencyAccessor definitionAccessor)
         {
             return new ExportDescriptorPromise(
                 importManyContract,

--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/Lazy/LazyExportDescriptorProvider.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/Lazy/LazyExportDescriptorProvider.cs
@@ -10,7 +10,8 @@ using System.Composition.Hosting.Util;
 
 namespace System.Composition.Hosting.Providers.Lazy
 {
-    internal class LazyExportDescriptorProvider : ExportDescriptorProvider
+
+    public class LazyExportDescriptorProvider : ExportDescriptorProvider
     {
         private static readonly MethodInfo s_getLazyDefinitionsMethod = typeof(LazyExportDescriptorProvider)
             .GetTypeInfo().GetDeclaredMethod("GetLazyDefinitions");
@@ -25,7 +26,7 @@ namespace System.Composition.Hosting.Providers.Lazy
             return (ExportDescriptorPromise[])gldm(exportKey, definitionAccessor);
         }
 
-        private static ExportDescriptorPromise[] GetLazyDefinitions<TValue>(CompositionContract lazyContract, DependencyAccessor definitionAccessor)
+        public static ExportDescriptorPromise[] GetLazyDefinitions<TValue>(CompositionContract lazyContract, DependencyAccessor definitionAccessor)
         {
             return definitionAccessor.ResolveDependencies("value", lazyContract.ChangeType(typeof(TValue)), false)
                 .Select(d => new ExportDescriptorPromise(

--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/Lazy/LazyWithMetadataExportDescriptorProvider.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/Lazy/LazyWithMetadataExportDescriptorProvider.cs
@@ -11,7 +11,8 @@ using System.Composition.Hosting.Providers.Metadata;
 
 namespace System.Composition.Hosting.Providers.Lazy
 {
-    internal class LazyWithMetadataExportDescriptorProvider : ExportDescriptorProvider
+
+    public class LazyWithMetadataExportDescriptorProvider : ExportDescriptorProvider
     {
         private static readonly MethodInfo s_getLazyDefinitionsMethod = typeof(LazyWithMetadataExportDescriptorProvider).GetTypeInfo().GetDeclaredMethod("GetLazyDefinitions");
 
@@ -26,7 +27,7 @@ namespace System.Composition.Hosting.Providers.Lazy
             return (ExportDescriptorPromise[])gldm(exportKey, definitionAccessor);
         }
 
-        private static ExportDescriptorPromise[] GetLazyDefinitions<TValue, TMetadata>(CompositionContract lazyContract, DependencyAccessor definitionAccessor)
+        public static ExportDescriptorPromise[] GetLazyDefinitions<TValue, TMetadata>(CompositionContract lazyContract, DependencyAccessor definitionAccessor)
         {
             var metadataProvider = MetadataViewProvider.GetMetadataViewProvider<TMetadata>();
 

--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/Metadata/MetadataViewProvider.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/Metadata/MetadataViewProvider.cs
@@ -11,7 +11,8 @@ using Microsoft.Internal;
 
 namespace System.Composition.Hosting.Providers.Metadata
 {
-    internal static class MetadataViewProvider
+
+    public static class MetadataViewProvider
     {
         private static readonly MethodInfo s_getMetadataValueMethod = typeof(MetadataViewProvider).GetTypeInfo().GetDeclaredMethod("GetMetadataValue");
 
@@ -74,7 +75,7 @@ namespace System.Composition.Hosting.Providers.Metadata
             throw new CompositionFailedException(string.Format(Properties.Resources.MetadataViewProvider_InvalidViewImplementation, typeof(TMetadata).Name));
         }
 
-        private static TValue GetMetadataValue<TValue>(IDictionary<string, object> metadata, string name, DefaultValueAttribute defaultValue)
+        public static TValue GetMetadataValue<TValue>(IDictionary<string, object> metadata, string name, DefaultValueAttribute defaultValue)
         {
             object result;
             if (metadata.TryGetValue(name, out result))

--- a/src/System.Configuration.ConfigurationManager/src/Resources/System.Configuration.ConfigurationManager.rd.xml
+++ b/src/System.Configuration.ConfigurationManager/src/Resources/System.Configuration.ConfigurationManager.rd.xml
@@ -2,7 +2,10 @@
 <Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
   <Library Name="*System.Configuration.ConfigurationManager*">
     <Assembly Name="System.Configuration.ConfigurationManager">
-       <Type Name="System.Configuration.ClientConfigurationHost" Dynamic="Required All" Activate="Required All" />
+      <!--Required since ClientConfigurationHost instantiated using CreateInstance from TypeUtil.CreateInstance -->
+      <Type Name="System.Configuration.ClientConfigurationHost" Dynamic="Required All" />
+      <!--Required since ProtectedConfigurationSection instantiated using CreateInstance from TypeUtil.CreateInstance -->
+      <Type Name="System.Configuration.ProtectedConfigurationSection" Dynamic="Required All" />
     </Assembly>
   </Library>
 </Directives>

--- a/src/System.Configuration.ConfigurationManager/src/System.Configuration.ConfigurationManager.csproj
+++ b/src/System.Configuration.ConfigurationManager/src/System.Configuration.ConfigurationManager.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <ProjectGuid>{B7697463-7C98-4462-BA09-67B7BF3842B6}</ProjectGuid>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netfx'">true</IsPartialFacadeAssembly>
+    <BlockReflectionAttribute>false</BlockReflectionAttribute>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Release|AnyCPU'" />

--- a/src/System.Configuration.ConfigurationManager/src/System/Configuration/ProtectedConfigurationSection.cs
+++ b/src/System.Configuration.ConfigurationManager/src/System/Configuration/ProtectedConfigurationSection.cs
@@ -34,6 +34,8 @@ namespace System.Configuration
             s_properties = new ConfigurationPropertyCollection { s_propProviders, s_propDefaultProvider };
         }
 
+        public ProtectedConfigurationSection() { }
+
         protected internal override ConfigurationPropertyCollection Properties => s_properties;
 
         private ProtectedProviderSettings ProtectedProviders => (ProtectedProviderSettings)base[s_propProviders];

--- a/src/System.Runtime.InteropServices/src/System/Runtime/InteropServices/RuntimeEnvironment.cs
+++ b/src/System.Runtime.InteropServices/src/System/Runtime/InteropServices/RuntimeEnvironment.cs
@@ -23,7 +23,10 @@ namespace System.Runtime.InteropServices
         }
         public static string GetRuntimeDirectory()
         {
-            return Path.GetDirectoryName(typeof(object).Assembly.Location) + Path.DirectorySeparatorChar;
+            string asmLocation = typeof(object).Assembly.Location;
+            if (!string.IsNullOrEmpty(asmLocation))
+                return Path.GetDirectoryName(asmLocation) + Path.DirectorySeparatorChar;
+            return asmLocation;
         }
         public static System.IntPtr GetRuntimeInterfaceAsIntPtr(Guid clsid, Guid riid)
         {


### PR DESCRIPTION
-Explicit default public ctor for ProtectedConfigurationSection.
-Reflection enable ProtectedConfigurationSection.
-Add skip reflection block attribute
-GetRuntimeDirectory from S.Runtime.InteropService use Assembly.Location
 and in uwpaot it's always empty since we dont have a good way to implement
 it.Path.GetDirectoryName throws on empty or null , adding a check to skip
 calling GetDirectoryName if location is null ot empty.