### PR TITLE
Fix some HttpListener tests for netfx

### DIFF
--- a/src/System.Net.HttpListener/src/System/Net/HttpListenerRequest.cs
+++ b/src/System.Net.HttpListener/src/System/Net/HttpListenerRequest.cs
@@ -16,39 +16,15 @@ namespace System.Net
 {
     public sealed unsafe partial class HttpListenerRequest
     {
-        private string[] _acceptTypes;
-        private string[] _userLanguages;
         private CookieCollection _cookies;
         private bool? _keepAlive;
         private string _rawUrl;
         private Uri _requestUri;
         private Version _version;
 
-        public string[] AcceptTypes
-        {
-            get
-            {
-                if (_acceptTypes == null)
-                {
-                    _acceptTypes = Helpers.ParseMultivalueHeader(Headers[HttpKnownHeaderNames.Accept]);
-                }
+        public string[] AcceptTypes => Helpers.ParseMultivalueHeader(Headers[HttpKnownHeaderNames.Accept]);
 
-                return _acceptTypes;
-            }
-        }
-
-        public string[] UserLanguages
-        {
-            get
-            {
-                if (_userLanguages == null)
-                {
-                    _userLanguages = Helpers.ParseMultivalueHeader(Headers[HttpKnownHeaderNames.AcceptLanguage]);
-                }
-
-                return _userLanguages;
-            }
-        }
+        public string[] UserLanguages => Helpers.ParseMultivalueHeader(Headers[HttpKnownHeaderNames.AcceptLanguage]);
 
         private static Func<CookieCollection, Cookie, bool, int> s_internalAddMethod = null;
         private static Func<CookieCollection, Cookie, bool, int> InternalAddMethod

--- a/src/System.Net.HttpListener/tests/HttpListenerRequestTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerRequestTests.cs
@@ -14,7 +14,6 @@ namespace System.Net.Tests
 {
     public class HttpListenerRequestTests
     {
-        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         [InlineData("Accept: Test", new string[] { "Test" })]
         [InlineData("Accept: Test, Test2,Test3 ,  Test4", new string[] { "Test", "Test2", "Test3 ", " Test4" })]
@@ -25,7 +24,11 @@ namespace System.Net.Tests
         {
             await GetRequest("POST", "", new string[] { acceptString }, (_, request) =>
             {
-                Assert.Same(request.AcceptTypes, request.AcceptTypes);
+                Assert.Equal(request.AcceptTypes, request.AcceptTypes);
+                if (expected != null)
+                {
+                    Assert.NotSame(request.AcceptTypes, request.AcceptTypes);
+                }
                 Assert.Equal(expected, request.AcceptTypes);
             });
         }
@@ -209,7 +212,6 @@ namespace System.Net.Tests
             });
         }
 
-        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         [InlineData("Accept-Language: Lang1,Lang2,Lang3", new string[] { "Lang1", "Lang2", "Lang3" })]
         [InlineData("Accept-Language: Lang1, Lang2, Lang3", new string[] { "Lang1", "Lang2", "Lang3" })]
@@ -222,7 +224,11 @@ namespace System.Net.Tests
         {
             await GetRequest("POST", "", new string[] { userLanguageString }, (_, request) =>
             {
-                Assert.Same(request.UserLanguages, request.UserLanguages);
+                Assert.Equal(request.UserLanguages, request.UserLanguages);
+                if (expected != null)
+                {
+                    Assert.NotSame(request.UserLanguages, request.UserLanguages);
+                }
                 Assert.Equal(expected, request.UserLanguages);
             });
         }
@@ -378,16 +384,21 @@ namespace System.Net.Tests
             };
 
             // Unicode queries are destroyed by HttpListener.
-            yield return new object[]
+            // [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
+            // 
+            if (!PlatformDetection.IsFullFramework)
             {
-                "?name1=+&name2=\u1234&\u0100=value&name3=\u00FF", new NameValueCollection
+                yield return new object[]
                 {
-                    { "name1", " " },
-                    { "name2", "á\u0088´" },
-                    { "Ä\u0080", "value" },
-                    { "name3", "Ã¿" }
-                }
-            };
+                    "?name1=+&name2=\u1234&\u0100=value&name3=\u00FF", new NameValueCollection
+                    {
+                        { "name1", " " },
+                        { "name2", "á\u0088´" },
+                        { "Ä\u0080", "value" },
+                        { "name3", "Ã¿" }
+                    }
+                };
+            }
 
             yield return new object[] { "", new NameValueCollection() };
             yield return new object[] { "?", new NameValueCollection() };
@@ -420,7 +431,6 @@ namespace System.Net.Tests
             };
         }
 
-        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         [MemberData(nameof(QueryString_TestData))]
         public async Task QueryString_GetProperty_ReturnsExpected(string query, NameValueCollection expected)

--- a/src/System.Net.HttpListener/tests/HttpListenerTimeoutManagerTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerTimeoutManagerTests.cs
@@ -114,7 +114,6 @@ namespace System.Net.Tests
 
         public void Dispose() => _listener.Close();
 
-        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public void TimeoutManager_AccessNoStart_Success()
         {
@@ -126,7 +125,6 @@ namespace System.Net.Tests
             Assert.Equal(rate, timeoutManager.MinSendBytesPerSecond);
         }
 
-        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public void TimeoutManager_AccessAfterStart_Success()
         {
@@ -159,7 +157,6 @@ namespace System.Net.Tests
             Assert.Throws<ObjectDisposedException>(() => timeoutManager.MinSendBytesPerSecond = 10);
         }
 
-        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public void TimeoutManager_AccessAfterStop_Success()
         {
@@ -174,7 +171,6 @@ namespace System.Net.Tests
             Assert.Equal(rate, timeoutManager.MinSendBytesPerSecond);
         }
 
-        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public void DrainEntityBody_SetTimeoutNoStart_GetReturnsNewValue()
         {
@@ -185,7 +181,6 @@ namespace System.Net.Tests
             Assert.Equal(seconds, _listener.TimeoutManager.DrainEntityBody.TotalSeconds);
         }
 
-        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public void DrainEntityBody_SetTimeoutAfterStart_GetReturnsNewValue()
         {
@@ -197,7 +192,6 @@ namespace System.Net.Tests
             Assert.Equal(seconds, _listener.TimeoutManager.DrainEntityBody.TotalSeconds);
         }
 
-        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public void EntityBody_SetTimeoutNoStart_GetReturnsNewValue()
         {
@@ -208,7 +202,6 @@ namespace System.Net.Tests
             Assert.Equal(seconds, _listener.TimeoutManager.EntityBody.TotalSeconds);
         }
 
-        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public void EntityBody_SetTimeoutAfterStart_GetReturnsNewValue()
         {
@@ -220,7 +213,6 @@ namespace System.Net.Tests
             Assert.Equal(seconds, _listener.TimeoutManager.EntityBody.TotalSeconds);
         }
 
-        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public void HeaderWait_SetTimeoutNoStart_GetReturnsNewValue()
         {
@@ -231,7 +223,6 @@ namespace System.Net.Tests
             Assert.Equal(seconds, _listener.TimeoutManager.HeaderWait.TotalSeconds);
         }
 
-        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public void HeaderWait_SetTimeoutAfterStart_GetReturnsNewValue()
         {
@@ -243,7 +234,6 @@ namespace System.Net.Tests
             Assert.Equal(seconds, _listener.TimeoutManager.HeaderWait.TotalSeconds);
         }
 
-        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public void RequestQueue_SetTimeoutNoStart_GetReturnsNewValue()
         {
@@ -254,7 +244,6 @@ namespace System.Net.Tests
             Assert.Equal(seconds, _listener.TimeoutManager.RequestQueue.TotalSeconds);
         }
 
-        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public void RequestQueue_SetTimeoutAfterStart_GetReturnsNewValue()
         {
@@ -266,7 +255,6 @@ namespace System.Net.Tests
             Assert.Equal(seconds, _listener.TimeoutManager.RequestQueue.TotalSeconds);
         }
 
-        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public void IdleConnection_SetTimeoutNoStart_GetReturnsNewValue()
         {
@@ -277,7 +265,6 @@ namespace System.Net.Tests
             Assert.Equal(seconds, _listener.TimeoutManager.IdleConnection.TotalSeconds);
         }
 
-        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public void IdleConnection_SetTimeoutAfterStart_GetReturnsNewValue()
         {
@@ -289,7 +276,6 @@ namespace System.Net.Tests
             Assert.Equal(seconds, _listener.TimeoutManager.IdleConnection.TotalSeconds);
         }
 
-        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public void MinSendBytesPerSecond_SetNoStart_GetReturnsNewValue()
         {
@@ -301,7 +287,6 @@ namespace System.Net.Tests
             Assert.Equal(rate, _listener.TimeoutManager.MinSendBytesPerSecond);
         }
 
-        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public void MinSendBytesPerSecond_SetAfterStart_GetReturnsNewValue()
         {
@@ -323,7 +308,6 @@ namespace System.Net.Tests
             Assert.Throws<ObjectDisposedException>(() => _listener.TimeoutManager.MinSendBytesPerSecond = 10 * 1024 * 1024);
         }
 
-        [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public void MinSendBytesPerSecond_SetAfterStop_GetReturnsNewValue()
         {
@@ -343,7 +327,8 @@ namespace System.Net.Tests
             uint[] timeouts = new uint[6];
 
             // We need url group id which is private so we get it using reflection.
-            FieldInfo info = typeof(HttpListener).GetField("_urlGroupId", BindingFlags.Instance | BindingFlags.NonPublic);
+            string urlGroupIdName = PlatformDetection.IsFullFramework ? "m_UrlGroupId" : "_urlGroupId";
+            FieldInfo info = typeof(HttpListener).GetField(urlGroupIdName, BindingFlags.Instance | BindingFlags.NonPublic);
             ulong urlGroupId = (ulong)info.GetValue(_listener);
 
             HTTP_TIMEOUT_LIMIT_INFO timeoutinfo = new HTTP_TIMEOUT_LIMIT_INFO();


### PR DESCRIPTION
Contributes to #19967

The remaining HttpListener test failure is in the encoding of QueryString.

It looks like the query string `?name1=+&name2=\u1234&\u0100=value&name3=\u00FF` is encoded differently in netfx and netcoreapp.

I couldn't quite figure this out so I left it out of this PR. It looks like the listener is actually receiving different content from the connected socket as the value of `_cookedUrlQuery/m_CookedUrlQuery` in HttpListenerRequest is different between netfx and netcoreapp.
