### PR TITLE
Add win-arm and win-arm64 to RID graph.

### DIFF
--- a/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -36,6 +36,12 @@
         "win-x64": {
             "#import": [ "win" ]
         },
+        "win-arm": {
+            "#import": [ "win" ]
+        },
+        "win-arm64": {
+            "#import": [ "win" ]
+        },
 
         "win7": {
             "#import": [ "win" ]
@@ -57,7 +63,7 @@
             "#import": [ "win8", "win7-x64" ]
         },
         "win8-arm": {
-            "#import": [ "win8" ]
+            "#import": [ "win8", "win-arm" ]
         },
 
         "win81": {
@@ -86,7 +92,7 @@
             "#import": [ "win10", "win81-arm" ]
         },
         "win10-arm64": {
-            "#import": [ "win10" ]
+            "#import": [ "win10", "win-arm64" ]
         },
 
         "aot": {


### PR DESCRIPTION
Porting https://github.com/dotnet/corefx/pull/20187 to `release/2.0.0`.

We don't have win-arm and win-arm64 "portable" RIDs in our graph. Thus, when trying to use RIDs like win10-arm in a self-contained app, no assets are getting selected.

Fix dotnet/sdk#1239.

@gkhanna79 @ericstj