### PR TITLE
Disable some System.Net.* tests for ILC

### DIFF
--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_Windows.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_Windows.cs
@@ -21,6 +21,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20014", TargetFrameworkMonikers.Uap)]
         public void IPInfoTest_AccessAllProperties_NoErrors()
         {
             foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
@@ -111,6 +112,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20014", TargetFrameworkMonikers.Uap)]
         public void IPInfoTest_AccessAllIPv4Properties_NoErrors()
         {
             foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
@@ -141,6 +143,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20014", TargetFrameworkMonikers.Uap)]
         public void IPInfoTest_AccessAllIPv6Properties_NoErrors()
         {
             foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
@@ -174,6 +177,7 @@ namespace System.Net.NetworkInformation.Tests
 
         [Fact]
         [Trait("IPv6", "true")]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20014", TargetFrameworkMonikers.Uap)]
         public void IPv6ScopeId_GetLinkLevel_MatchesIndex()
         {
             Assert.True(Capability.IPv6Support());
@@ -195,6 +199,7 @@ namespace System.Net.NetworkInformation.Tests
 
         [Fact]
         [Trait("IPv6", "true")]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20014", TargetFrameworkMonikers.Uap)]
         public void IPv6ScopeId_AccessAllValues_Success()
         {
             Assert.True(Capability.IPv6Support());

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/LoggingTest.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/LoggingTest.cs
@@ -11,6 +11,7 @@ namespace System.Net.NetworkInformation.Tests
     {
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core")]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20130", TargetFrameworkMonikers.Uap)]
         public void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(NetworkChange).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
@@ -21,6 +21,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/308
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20014", TargetFrameworkMonikers.Uap)]
         public void BasicTest_GetNetworkInterfaces_AtLeastOne()
         {
             Assert.NotEqual<int>(0, NetworkInterface.GetAllNetworkInterfaces().Length);
@@ -28,6 +29,7 @@ namespace System.Net.NetworkInformation.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]  // Not all APIs are supported on Linux and OSX
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20014", TargetFrameworkMonikers.Uap)]
         public void BasicTest_AccessInstanceProperties_NoExceptions()
         {
             foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
@@ -111,6 +113,7 @@ namespace System.Net.NetworkInformation.Tests
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/308
         [Trait("IPv4", "true")]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20014", TargetFrameworkMonikers.Uap)]
         public void BasicTest_StaticLoopbackIndex_MatchesLoopbackNetworkInterface()
         {
             Assert.True(Capability.IPv4Support());
@@ -133,6 +136,7 @@ namespace System.Net.NetworkInformation.Tests
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/308
         [Trait("IPv4", "true")]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20014", TargetFrameworkMonikers.Uap)]
         public void BasicTest_StaticLoopbackIndex_ExceptionIfV4NotSupported()
         {
             Assert.True(Capability.IPv4Support());
@@ -142,6 +146,7 @@ namespace System.Net.NetworkInformation.Tests
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/308
         [Trait("IPv6", "true")]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20014", TargetFrameworkMonikers.Uap)]
         public void BasicTest_StaticIPv6LoopbackIndex_MatchesLoopbackNetworkInterface()
         {
             Assert.True(Capability.IPv6Support());
@@ -166,6 +171,7 @@ namespace System.Net.NetworkInformation.Tests
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/Microsoft/BashOnWindows/issues/308
         [Trait("IPv6", "true")]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20014", TargetFrameworkMonikers.Uap)]
         public void BasicTest_StaticIPv6LoopbackIndex_ExceptionIfV6NotSupported()
         {
             Assert.True(Capability.IPv6Support());
@@ -174,6 +180,7 @@ namespace System.Net.NetworkInformation.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]  // Not all APIs are supported on Linux and OSX
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20014", TargetFrameworkMonikers.Uap)]
         public void BasicTest_GetIPInterfaceStatistics_Success()
         {
             foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceIPv4Statistics.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceIPv4Statistics.cs
@@ -22,6 +22,7 @@ namespace System.Net.NetworkInformation.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]  // Not all APIs are supported on Linux and OSX
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20014", TargetFrameworkMonikers.Uap)]
         public void BasicTest_GetIPv4InterfaceStatistics_Success()
         {
             // This API is not actually IPv4 specific.

--- a/src/System.Net.Ping/tests/FunctionalTests/LoggingTest.cs
+++ b/src/System.Net.Ping/tests/FunctionalTests/LoggingTest.cs
@@ -11,6 +11,7 @@ namespace System.Net.NetworkInformation.Tests
     {
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core")]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20130", TargetFrameworkMonikers.Uap)]
         public void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(Ping).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);


### PR DESCRIPTION
Disables tests for:

1. API Not Implemented for Uap by design
2. Tests that do white box testing and reflect on internal type

cc: @tijoytom 