### PR TITLE
Set DefaultNameSpace be empty string

### DIFF
--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlReflectionImporter.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlReflectionImporter.cs
@@ -2236,6 +2236,7 @@ namespace System.Xml.Serialization
         // will create a shallow type mapping for a top-level type
         internal static XmlTypeMapping GetTopLevelMapping(Type type, string defaultNamespace)
         {
+            defaultNamespace = defaultNamespace ?? string.Empty;
             XmlAttributes a = new XmlAttributes(type);
             TypeDesc typeDesc = new TypeScope().GetTypeDesc(type);
             ElementAccessor element = new ElementAccessor();


### PR DESCRIPTION
When the serializer was loaded from pregenerated assembly, the DefaultNameSpace of the mapping is null. It should be the empty string.

Fix #19729 
@shmao @zhenlan @mconnew 