### PR TITLE
building System.IO.MemoryMappedFiles.Performance.Tests and System.Runtime.Loader.Tests on uapaot

### DIFF
--- a/src/System.IO.MemoryMappedFiles/tests/Performance/System.IO.MemoryMappedFiles.Performance.Tests.csproj
+++ b/src/System.IO.MemoryMappedFiles/tests/Performance/System.IO.MemoryMappedFiles.Performance.Tests.csproj
@@ -1,8 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <Configuration Condition="'$(Configuration)'==''">Windows_Debug</Configuration>
-  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/System.Runtime.Loader/tests/Configurations.props
+++ b/src/System.Runtime.Loader/tests/Configurations.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       netcoreapp;
+      uap;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.Loader/tests/DefaultContext/Configurations.props
+++ b/src/System.Runtime.Loader/tests/DefaultContext/Configurations.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       netcoreapp;
+      uap;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.Loader/tests/RefEmitLoadContext/Configurations.props
+++ b/src/System.Runtime.Loader/tests/RefEmitLoadContext/Configurations.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       netcoreapp;
+      uap;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.Loader/tests/System.Runtime.Loader.Noop.Assembly/Configurations.props
+++ b/src/System.Runtime.Loader/tests/System.Runtime.Loader.Noop.Assembly/Configurations.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       netcoreapp;
+      uap;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
this PR is not meant to make them pass, just so that we are able to see run results

List of csprojes not building on uapaot was produced by running all csproj files inside test directories and running them with: `msbuild /t:Rebuild /p:TargetGroup=uapaot`.

Remaining projects are: System.Security.Cryptography.OpenSsl.Tests - this one is not meant to build on Windows
WebServer - exists in the common directory and thus I ignored it - likely used by other project
