### PR TITLE
uapaot fixes for System.Config.ConfigurationManager.

### DIFF
--- a/src/System.Configuration.ConfigurationManager/src/Resources/System.Configuration.ConfigurationManager.rd.xml
+++ b/src/System.Configuration.ConfigurationManager/src/Resources/System.Configuration.ConfigurationManager.rd.xml
@@ -2,7 +2,9 @@
 <Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
   <Library Name="*System.Configuration.ConfigurationManager*">
     <Assembly Name="System.Configuration.ConfigurationManager">
-       <Type Name="System.Configuration.ClientConfigurationHost" Dynamic="Required All" Activate="Required All" />
+       <!--Both types are instantiated using CreateInstance from TypeUtil.CreateInstance -->
+       <Type Name="System.Configuration.ClientConfigurationHost" Dynamic="Required All" />
+       <Type Name="System.Configuration.ProtectedConfigurationSection" Dynamic="Required All" />
     </Assembly>
   </Library>
 </Directives>

--- a/src/System.Configuration.ConfigurationManager/src/System.Configuration.ConfigurationManager.csproj
+++ b/src/System.Configuration.ConfigurationManager/src/System.Configuration.ConfigurationManager.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <ProjectGuid>{B7697463-7C98-4462-BA09-67B7BF3842B6}</ProjectGuid>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netfx'">true</IsPartialFacadeAssembly>
+    <BlockReflectionAttribute>false</BlockReflectionAttribute>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Release|AnyCPU'" />

--- a/src/System.Configuration.ConfigurationManager/src/System/Configuration/ProtectedConfigurationSection.cs
+++ b/src/System.Configuration.ConfigurationManager/src/System/Configuration/ProtectedConfigurationSection.cs
@@ -34,6 +34,8 @@ namespace System.Configuration
             s_properties = new ConfigurationPropertyCollection { s_propProviders, s_propDefaultProvider };
         }
 
+        public ProtectedConfigurationSection(){}       
+
         protected internal override ConfigurationPropertyCollection Properties => s_properties;
 
         private ProtectedProviderSettings ProtectedProviders => (ProtectedProviderSettings)base[s_propProviders];


### PR DESCRIPTION
Explicit default public ctor for ProtectedConfigurationSection.
Reflection enable ProtectedConfigurationSection.
Add skip reflection block attribute.
This is https://github.com/dotnet/corefx/pull/20146 , but the Assembly.CodeBase change  removed since we will implement it in N