### PR TITLE
Adding UAP target to System.Net.Primtives tests

### DIFF
--- a/src/System.Net.Primitives/tests/FunctionalTests/LoggingTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/LoggingTest.cs
@@ -25,10 +25,8 @@ namespace System.Net.Primitives.Functional.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(
-            ~TargetFrameworkMonikers.Netcoreapp, 
-            "NetFramework: NetEventSource is only part of .NET Core;" + 
-            "UapAot: RemoteExecutorConsoleApp.exe crashes trying to load netstandard.dll - StrongName issue")]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.Uap)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetFramework: NetEventSource is only part of .NET Core;")]
         public void EventSource_EventsRaisedAsExpected()
         {
             RemoteInvoke(() =>

--- a/src/System.Net.Primitives/tests/FunctionalTests/LoggingTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/LoggingTest.cs
@@ -25,7 +25,7 @@ namespace System.Net.Primitives.Functional.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.Uap)]
+        [ActiveIssue(19909, TargetFrameworkMonikers.Uap)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetFramework: NetEventSource is only part of .NET Core;")]
         public void EventSource_EventsRaisedAsExpected()
         {

--- a/src/System.Net.Primitives/tests/FunctionalTests/System.Net.Primitives.Functional.Tests.csproj
+++ b/src/System.Net.Primitives/tests/FunctionalTests/System.Net.Primitives.Functional.Tests.csproj
@@ -5,6 +5,8 @@
     <ProjectGuid>{E671BC9F-A64C-4504-8B00-7A3215B99AF9}</ProjectGuid>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Unix-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Unix-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Debug|AnyCPU'" />

--- a/src/System.Net.Primitives/tests/PalTests/System.Net.Primitives.Pal.Tests.csproj
+++ b/src/System.Net.Primitives/tests/PalTests/System.Net.Primitives.Pal.Tests.csproj
@@ -15,6 +15,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Unix-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
   <PropertyGroup>
     <!-- SYSTEM_NET_PRIMITIVES_DLL is required to allow source-level code sharing for types defined within the 
          System.Net.Internals namespace. -->

--- a/src/System.Net.Primitives/tests/PerformanceTests/System.Net.Primitives.Performance.Tests.csproj
+++ b/src/System.Net.Primitives/tests/PerformanceTests/System.Net.Primitives.Performance.Tests.csproj
@@ -10,6 +10,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Unix-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="CredentialCacheTests.cs" />
   </ItemGroup>

--- a/src/System.Net.Primitives/tests/UnitTests/System.Net.Primitives.UnitTests.Tests.csproj
+++ b/src/System.Net.Primitives/tests/UnitTests/System.Net.Primitives.UnitTests.Tests.csproj
@@ -16,6 +16,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Unix-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
   <PropertyGroup>
     <!-- SYSTEM_NET_PRIMITIVES_DLL is required to allow source-level code sharing for types defined within the 
          System.Net.Internals namespace. -->


### PR DESCRIPTION
Using the new ActiveIssue UAP option to disable the test.
Re: #20007 