### PR TITLE
Fix ConditionalFact/Theory attributes in desktop

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -39,7 +39,7 @@
     <AppXRunnerVersion>1.0.3-prerelease-00921-01</AppXRunnerVersion>
     <XunitPerfAnalysisPackageVersion>1.0.0-beta-build0003</XunitPerfAnalysisPackageVersion>
     <TraceEventPackageVersion>1.0.3-alpha-experimental</TraceEventPackageVersion>
-    <XunitNetcoreExtensionsVersion>1.0.1-prerelease-01620-02</XunitNetcoreExtensionsVersion>
+    <XunitNetcoreExtensionsVersion>1.0.1-prerelease-01622-05</XunitNetcoreExtensionsVersion>
   </PropertyGroup>
 
   <!-- Package dependency verification/auto-upgrade configuration. -->

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
@@ -42,6 +42,7 @@ namespace System.Security.Cryptography.Rsa.Tests
             Assert.Equal(privateParams.Exponent, publicParams.Exponent);
         }
 
+        [ActiveIssue(20214, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(EphemeralKeysAreExportable))]
         public static void PaddedExport()
         {
@@ -69,6 +70,7 @@ namespace System.Security.Cryptography.Rsa.Tests
             AssertKeyEquals(ref diminishedDPParameters, ref exported);
         }
 
+        [ActiveIssue(20214, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(EphemeralKeysAreExportable))]
         public static void LargeKeyImportExport()
         {
@@ -98,6 +100,7 @@ namespace System.Security.Cryptography.Rsa.Tests
             }
         }
 
+        [ActiveIssue(20214, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(EphemeralKeysAreExportable))]
         public static void UnusualExponentImportExport()
         {
@@ -122,6 +125,7 @@ namespace System.Security.Cryptography.Rsa.Tests
             AssertKeyEquals(ref unusualExponentParameters, ref exported);
         }
 
+        [ActiveIssue(20214, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(EphemeralKeysAreExportable))]
         public static void ImportExport1032()
         {
@@ -143,6 +147,7 @@ namespace System.Security.Cryptography.Rsa.Tests
             Assert.Null(exportedPublic.D);
         }
 
+        [ActiveIssue(20214, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(EphemeralKeysAreExportable))]
         public static void ImportReset()
         {
@@ -191,6 +196,7 @@ namespace System.Security.Cryptography.Rsa.Tests
             }
         }
 
+        [ActiveIssue(20214, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(nameof(EphemeralKeysAreExportable))]
         public static void MultiExport()
         {
@@ -274,7 +280,7 @@ namespace System.Security.Cryptography.Rsa.Tests
 
         [Fact]
 #if TESTING_CNG_IMPLEMENTATION
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "https://github.com/dotnet/corefx/issues/18882")]
+        [ActiveIssue(18882, TargetFrameworkMonikers.NetFramework)]
 #endif
         public static void ImportNoDP()
         {


### PR DESCRIPTION
This updates the xunit.netcore.extensions that has the fix for ConditionalFact/Theory attributes and disable some Crypto tests that are failing.

Fixes: https://github.com/dotnet/corefx/issues/18483

cc: @danmosemsft @weshaggard 