### PR TITLE
Add ShellEx support for Windows & fix issues

### DIFF
--- a/src/Common/src/Interop/Windows/Interop.Errors.cs
+++ b/src/Common/src/Interop/Windows/Interop.Errors.cs
@@ -53,6 +53,9 @@ internal partial class Interop
         internal const int ERROR_NO_TOKEN = 0x3f0;
         internal const int ERROR_DLL_INIT_FAILED = 0x45A;
         internal const int ERROR_COUNTER_TIMEOUT = 0x461;
+        internal const int ERROR_NO_ASSOCIATION = 0x483;
+        internal const int ERROR_DDE_FAIL = 0x484;
+        internal const int ERROR_DLL_NOT_FOUND = 0x485;
         internal const int ERROR_NOT_FOUND = 0x490;
         internal const int ERROR_NON_ACCOUNT_SID = 0x4E9;
         internal const int ERROR_NOT_ALL_ASSIGNED = 0x514;

--- a/src/Common/src/Interop/Windows/shell32/Interop.ShellExecuteExW.cs
+++ b/src/Common/src/Interop/Windows/shell32/Interop.ShellExecuteExW.cs
@@ -25,7 +25,8 @@ internal partial class Interop
             public IntPtr lpClass;
             public IntPtr hkeyClass;
             public uint dwHotKey;
-            public IntPtr hIcon;
+            // This is a union of hIcon and hMonitor
+            public IntPtr hIconMonitor;
             public IntPtr hProcess;
         }
 

--- a/src/Common/src/Interop/Windows/shell32/Interop.ShellExecuteExW.cs
+++ b/src/Common/src/Interop/Windows/shell32/Interop.ShellExecuteExW.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Shell32
+    {
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        internal unsafe struct SHELLEXECUTEINFO
+        {
+            public uint cbSize;
+            public uint fMask;
+            public IntPtr hwnd;
+            public char* lpVerb;
+            public char* lpFile;
+            public char* lpParameters;
+            public char* lpDirectory;
+            public int nShow;
+            public IntPtr hInstApp;
+            public IntPtr lpIDList;
+            public IntPtr lpClass;
+            public IntPtr hkeyClass;
+            public uint dwHotKey;
+            public IntPtr hIcon;
+            public IntPtr hProcess;
+        }
+
+        internal const int SW_HIDE = 0;
+        internal const int SW_SHOWNORMAL = 1;
+        internal const int SW_SHOWMINIMIZED = 2;
+        internal const int SW_SHOWMAXIMIZED = 3;
+
+        internal const int SE_ERR_FNF = 2;
+        internal const int SE_ERR_PNF = 3;
+        internal const int SE_ERR_ACCESSDENIED = 5;
+        internal const int SE_ERR_OOM = 8;
+        internal const int SE_ERR_DLLNOTFOUND = 32;
+        internal const int SE_ERR_SHARE = 26;
+        internal const int SE_ERR_ASSOCINCOMPLETE = 27;
+        internal const int SE_ERR_DDETIMEOUT = 28;
+        internal const int SE_ERR_DDEFAIL = 29;
+        internal const int SE_ERR_DDEBUSY = 30;
+        internal const int SE_ERR_NOASSOC = 31;
+
+        internal const uint SEE_MASK_FLAG_DDEWAIT = 0x00000100;
+        internal const uint SEE_MASK_NOCLOSEPROCESS = 0x00000040;
+        internal const uint SEE_MASK_FLAG_NO_UI = 0x00000400;
+
+        [DllImport(Libraries.Shell32, ExactSpelling = true, CharSet = CharSet.Unicode, SetLastError = true)]
+        internal unsafe static extern bool ShellExecuteExW(
+            SHELLEXECUTEINFO* pExecInfo);
+    }
+}

--- a/src/Common/src/Interop/Windows/user32/Interop.GetWindowTextLengthW.cs
+++ b/src/Common/src/Interop/Windows/user32/Interop.GetWindowTextLengthW.cs
@@ -4,13 +4,12 @@
 
 using System;
 using System.Runtime.InteropServices;
-using System.Text;
 
 internal partial class Interop
 {
     internal partial class User32
     {
-        [DllImport(Libraries.User32, EntryPoint = "GetWindowTextW")]
-        public static extern int GetWindowText(IntPtr hWnd, [Out]StringBuilder lpString, int nMaxCount);
+        [DllImport(Libraries.User32, SetLastError = true, ExactSpelling = true)]
+        public static extern int GetWindowTextLengthW(IntPtr hWnd);
     }
 }

--- a/src/Common/src/Interop/Windows/user32/Interop.GetWindowTextW.cs
+++ b/src/Common/src/Interop/Windows/user32/Interop.GetWindowTextW.cs
@@ -4,12 +4,13 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Text;
 
 internal partial class Interop
 {
     internal partial class User32
     {
-        [DllImport(Libraries.User32, EntryPoint = "GetWindowTextLengthW")]
-        public static extern int GetWindowTextLength(IntPtr hWnd);
+        [DllImport(Libraries.User32, ExactSpelling = true, SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern int GetWindowTextW(IntPtr hWnd, [Out]StringBuilder lpString, int nMaxCount);
     }
 }

--- a/src/System.Diagnostics.Process/System.Diagnostics.Process.sln
+++ b/src/System.Diagnostics.Process/System.Diagnostics.Process.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26430.4
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Diagnostics.Process.Tests", "tests\System.Diagnostics.Process.Tests.csproj", "{E1114510-844C-4BB2-BBAD-8595BD16E24B}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -20,8 +20,14 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Diagnostics.Process", "ref\System.Diagnostics.Process.csproj", "{98B33275-39D8-4997-867D-04C69C69885E}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{1A2F9F4A-A032-433E-B914-ADD5992BB178}"
+	ProjectSection(SolutionItems) = preProject
+		tests\Configurations.props = tests\Configurations.props
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E893-4E87-987E-04EF0DCEAEFD}"
+	ProjectSection(SolutionItems) = preProject
+		src\PinvokeAnalyzerExceptionList.analyzerdata = src\PinvokeAnalyzerExceptionList.analyzerdata
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject

--- a/src/System.Diagnostics.Process/src/PinvokeAnalyzerExceptionList.analyzerdata
+++ b/src/System.Diagnostics.Process/src/PinvokeAnalyzerExceptionList.analyzerdata
@@ -32,3 +32,4 @@ user32.dll!IsWindowVisible
 user32.dll!PostMessageW
 user32.dll!SendMessageTimeoutW
 user32.dll!WaitForInputIdle
+shell32.dll!ShellExecuteExW

--- a/src/System.Diagnostics.Process/src/Resources/Strings.resx
+++ b/src/System.Diagnostics.Process/src/Resources/Strings.resx
@@ -154,9 +154,6 @@
   <data name="PendingAsyncOperation" xml:space="preserve">
     <value>An async read operation has already been started on the stream.</value>
   </data>
-  <data name="UseShellExecute" xml:space="preserve">
-    <value>UseShellExecute must always be set to false.</value>
-  </data>
   <data name="InvalidParameter" xml:space="preserve">
     <value>Invalid value '{1}' for parameter '{0}'.</value>
   </data>

--- a/src/System.Diagnostics.Process/src/Resources/Strings.resx
+++ b/src/System.Diagnostics.Process/src/Resources/Strings.resx
@@ -238,4 +238,10 @@
   <data name="ArgumentOutOfRange_NeedNonNegNum" xml:space="preserve">
     <value>Non-negative number required.</value>
   </data>
+  <data name="CantStartAsUser" xml:space="preserve">
+    <value>The Process object must have the UseShellExecute property set to false in order to start a process as a user.</value>
+  </data>
+  <data name="CantUseEnvVars" xml:space="preserve">
+    <value>The Process object must have the UseShellExecute property set to false in order to use environment variables.</value>
+  </data>
 </root>

--- a/src/System.Diagnostics.Process/src/Resources/Strings.resx
+++ b/src/System.Diagnostics.Process/src/Resources/Strings.resx
@@ -244,4 +244,7 @@
   <data name="CantUseEnvVars" xml:space="preserve">
     <value>The Process object must have the UseShellExecute property set to false in order to use environment variables.</value>
   </data>
+  <data name="UseShellExecuteNotSupported" xml:space="preserve">
+    <value>UseShellExecute is not supported on this platform.</value>
+  </data>
 </root>

--- a/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
+++ b/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
@@ -30,14 +30,20 @@
     <Compile Include="System\Collections\Specialized\DictionaryWrapper.cs" />
     <Compile Include="System\Diagnostics\AsyncStreamReader.cs" />
     <Compile Include="System\Diagnostics\DataReceivedEventArgs.cs" />
-    <Compile Include="System\Diagnostics\Process.cs" />
+    <Compile Include="System\Diagnostics\Process.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="System\Diagnostics\ProcessInfo.cs" />
     <Compile Include="System\Diagnostics\ProcessManager.cs" />
-    <Compile Include="System\Diagnostics\ProcessModule.cs" />
+    <Compile Include="System\Diagnostics\ProcessModule.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="System\Diagnostics\ProcessModuleCollection.cs" />
     <Compile Include="System\Diagnostics\ProcessPriorityClass.cs" />
     <Compile Include="System\Diagnostics\ProcessStartInfo.cs" />
-    <Compile Include="System\Diagnostics\ProcessThread.cs" />
+    <Compile Include="System\Diagnostics\ProcessThread.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="System\Diagnostics\ProcessThreadCollection.cs" />
     <Compile Include="System\Diagnostics\ProcessWindowStyle.cs" />
     <Compile Include="System\Diagnostics\ThreadInfo.cs" />
@@ -52,160 +58,160 @@
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\user32\Interop.EnumWindows.cs">
-      <Link>Common\Interop\Windows\Interop.EnumWindows.cs</Link>
+      <Link>Common\Interop\Windows\user32\Interop.EnumWindows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\user32\Interop.GetWindowTextLength.cs">
-      <Link>Common\Interop\Windows\Interop.GetWindowTextLength.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Windows\user32\Interop.GetWindowTextLengthW.cs">
+      <Link>Common\Interop\Windows\user32\Interop.GetWindowTextLengthW.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\user32\Interop.SendMessageTimeout.cs">
-      <Link>Common\Interop\Windows\Interop.SendMessageTimeout.cs</Link>
+      <Link>Common\Interop\Windows\user32\Interop.SendMessageTimeout.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\user32\Interop.GetWindowText.cs">
-      <Link>Common\Interop\Windows\Interop.GetWindowText.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Windows\user32\Interop.GetWindowTextW.cs">
+      <Link>Common\Interop\Windows\user32\Interop.GetWindowTextW.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\user32\Interop.GetWindow.cs">
-      <Link>Common\Interop\Windows\Interop.GetWindow.cs</Link>
+      <Link>Common\Interop\Windows\user32\Interop.GetWindow.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\user32\Interop.PostMessage.cs">
-      <Link>Common\Interop\Windows\Interop.PostMessage.cs</Link>
+      <Link>Common\Interop\Windows\user32\Interop.PostMessage.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\user32\Interop.GetWindowLong.cs">
-      <Link>Common\Interop\Windows\Interop.GetWindowLong.cs</Link>
+      <Link>Common\Interop\Windows\user32\Interop.GetWindowLong.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\user32\Interop.WaitForInputIdle.cs">
-      <Link>Common\Interop\Windows\Interop.WaitForInputIdle.cs</Link>
+      <Link>Common\Interop\Windows\user32\Interop.WaitForInputIdle.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\user32\Interop.IsWindowVisible.cs">
-      <Link>Common\Interop\Windows\Interop.IsWindowVisible.cs</Link>
+      <Link>Common\Interop\Windows\user32\Interop.IsWindowVisible.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\user32\Interop.GetWindowThreadProcessId.cs">
-      <Link>Common\Interop\Windows\Interop.GetWindowThreadProcessId.cs</Link>
+      <Link>Common\Interop\Windows\user32\Interop.GetWindowThreadProcessId.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.CloseHandle.cs">
       <Link>Common\Interop\Windows\Interop.CloseHandle.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.PERF_INFO.cs">
-      <Link>Common\Interop\Windows\Interop.PERF_INFO.cs</Link>
+      <Link>Common\Interop\Windows\advapi32\Interop.PERF_INFO.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.IsWow64Process_SafeProcessHandle.cs">
-      <Link>Common\Interop\Windows\Interop.IsWow64Process_SafeProcessHandle.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.IsWow64Process_SafeProcessHandle.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetExitCodeProcess.cs">
-      <Link>Common\Interop\Windows\Interop.GetExitCodeProcess.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.GetExitCodeProcess.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetProcessTimes.cs">
-      <Link>Common\Interop\Windows\Interop.GetProcessTimes.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.GetProcessTimes.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetThreadTimes.cs">
-      <Link>Common\Interop\Windows\Interop.GetThreadTimes.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.GetThreadTimes.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetStdHandle.cs">
-      <Link>Common\Interop\Windows\Interop.GetStdHandle.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.GetStdHandle.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.CreateProcess.cs">
-      <Link>Common\Interop\Windows\Interop.CreateProcess.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.CreateProcess.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.TerminateProcess.cs">
-      <Link>Common\Interop\Windows\Interop.TerminateProcess.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.TerminateProcess.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetCurrentProcess_SafeProcessHandle.cs">
-      <Link>Common\Interop\Windows\Interop.GetCurrentProcess.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.GetCurrentProcess.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.OpenProcess.cs">
-      <Link>Common\Interop\Windows\Interop.OpenProcess.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.OpenProcess.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.EnumProcessModules.cs">
-      <Link>Common\Interop\Windows\Interop.EnumProcessModules.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.EnumProcessModules.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.EnumProcesses.cs">
-      <Link>Common\Interop\Windows\Interop.EnumProcesses.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.EnumProcesses.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetModuleInformation.cs">
-      <Link>Common\Interop\Windows\Interop.GetModuleInformation.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.GetModuleInformation.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetModuleBaseName.cs">
-      <Link>Common\Interop\Windows\Interop.GetModuleBaseName.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.GetModuleBaseName.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetModuleFileNameEx.cs">
-      <Link>Common\Interop\Windows\Interop.GetModuleFileNameEx.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.GetModuleFileNameEx.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.SetProcessWorkingSetSizeEx.cs">
-      <Link>Common\Interop\Windows\Interop.SetProcessWorkingSetSizeEx.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.SetProcessWorkingSetSizeEx.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetProcessWorkingSetSizeEx.cs">
-      <Link>Common\Interop\Windows\Interop.GetProcessWorkingSetSizeEx.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.GetProcessWorkingSetSizeEx.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.SetProcessAffinityMask.cs">
-      <Link>Common\Interop\Windows\Interop.SetProcessAffinityMask.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.SetProcessAffinityMask.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetProcessAffinityMask.cs">
-      <Link>Common\Interop\Windows\Interop.GetProcessAffinityMask.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.GetProcessAffinityMask.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetThreadPriorityBoost.cs">
-      <Link>Common\Interop\Windows\Interop.GetThreadPriorityBoost.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.GetThreadPriorityBoost.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.SetThreadPriorityBoost.cs">
-      <Link>Common\Interop\Windows\Interop.SetThreadPriorityBoost.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.SetThreadPriorityBoost.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetProcessPriorityBoost.cs">
-      <Link>Common\Interop\Windows\Interop.GetProcessPriorityBoost.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.GetProcessPriorityBoost.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.SetProcessPriorityBoost.cs">
-      <Link>Common\Interop\Windows\Interop.SetProcessPriorityBoost.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.SetProcessPriorityBoost.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.OpenThread.cs">
-      <Link>Common\Interop\Windows\Interop.OpenThread.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.OpenThread.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.SetThreadPriority.cs">
-      <Link>Common\Interop\Windows\Interop.SetThreadPriority.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.SetThreadPriority.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetThreadPriority.cs">
-      <Link>Common\Interop\Windows\Interop.GetThreadPriority.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.GetThreadPriority.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.SetThreadAffinityMask.cs">
-      <Link>Common\Interop\Windows\Interop.SetThreadAffinityMask.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.SetThreadAffinityMask.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.SetThreadIdealProcessor.cs">
-      <Link>Common\Interop\Windows\Interop.SetThreadIdealProcessor.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.SetThreadIdealProcessor.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetPriorityClass.cs">
-      <Link>Common\Interop\Windows\Interop.GetPriorityClass.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.GetPriorityClass.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.SetPriorityClass.cs">
-      <Link>Common\Interop\Windows\Interop.SetPriorityClass.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.SetPriorityClass.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.NtQueryInformationProcess.cs">
-      <Link>Common\Interop\Windows\Interop.NtQueryInformationProcess.cs</Link>
+      <Link>Common\Interop\Windows\NtDll\Interop.NtQueryInformationProcess.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.NtQuerySystemInformation.cs">
-      <Link>Common\Interop\Windows\Interop.NtQuerySystemInformation.cs</Link>
+      <Link>Common\Interop\Windows\NtDll\Interop.NtQuerySystemInformation.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.DuplicateHandle_SafeProcessHandle.cs">
-      <Link>Common\Interop\Windows\Interop.DuplicateHandle.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.DuplicateHandle.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.OpenProcessToken.cs">
-      <Link>Common\Interop\Windows\Interop.OpenProcessToken.cs</Link>
+      <Link>Common\Interop\Windows\advapi32\Interop.OpenProcessToken.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.LookupPrivilegeValue.cs">
-      <Link>Common\Interop\Windows\Interop.LookupPrivilegeValue.cs</Link>
+      <Link>Common\Interop\Windows\advapi32\Interop.LookupPrivilegeValue.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.AdjustTokenPrivileges.cs">
-      <Link>Common\Interop\Windows\Interop.AdjustTokenPrivileges.cs</Link>
+      <Link>Common\Interop\Windows\advapi32\Interop.AdjustTokenPrivileges.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetComputerName.cs">
-      <Link>Common\Interop\Windows\Interop.GetComputerName.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.GetComputerName.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetCurrentProcessId.cs">
-      <Link>Common\Interop\Windows\Interop.GetCurrentProcessId.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.GetCurrentProcessId.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.Encoding.Constants.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.Encoding.Constants.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetConsoleCP.cs">
-      <Link>Common\Interop\Windows\Interop.GetConsoleCP.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.GetConsoleCP.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetConsoleOutputCP.cs">
-      <Link>Common\Interop\Windows\Interop.GetConsoleOutputCP.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.GetConsoleOutputCP.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.CreateProcessWithLogon.cs">
       <Link>Common\Interop\Windows\Interop.CreateProcessWithLogon.cs</Link>
@@ -214,34 +220,37 @@
       <Link>Common\Interop\Windows\Interop.BOOL.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.SECURITY_ATTRIBUTES.cs">
-      <Link>Common\Interop\Windows\Interop.SECURITY_ATTRIBUTES.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.SECURITY_ATTRIBUTES.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.LUID.cs">
-      <Link>Common\Interop\Windows\Interop.LUID.cs</Link>
+      <Link>Common\Interop\Windows\advapi32\Interop.LUID.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.CreatePipe_SafeFileHandle.cs">
-      <Link>Common\Interop\Windows\Interop.CreatePipe.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.CreatePipe.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Errors.cs">
       <Link>Common\Interop\Windows\Interop.Errors.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.ThreadOptions.cs">
-      <Link>Common\Interop\Windows\Interop.ThreadOptions.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.ThreadOptions.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.HandleTypes.cs">
-      <Link>Common\Interop\Windows\Interop.HandleTypes.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.HandleTypes.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.ProcessOptions.cs">
-      <Link>Common\Interop\Windows\Interop.ProcessOptions.cs</Link>
+      <Link>Common\Interop\Windows\advapi32\Interop.ProcessOptions.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.HandleOptions.cs">
-      <Link>Common\Interop\Windows\Interop.ProcessOptions.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.ProcessOptions.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.MultiByteToWideChar.cs">
-      <Link>Common\Interop\Windows\Interop.MultiByteToWideChar.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.MultiByteToWideChar.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.WideCharToMultiByte.cs">
-      <Link>Common\Interop\Windows\Interop.WideCharToMultiByte.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.WideCharToMultiByte.cs</Link>
+    </Compile>
+    <Compile Condition="'$(TargetGroup)' != 'uap'" Include="$(CommonPath)\Interop\Windows\shell32\Interop.ShellExecuteExW.cs">
+      <Link>Common\Interop\Windows\shell32\Interop.ShellExecuteExW.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\Text\ConsoleEncoding.cs">
       <Link>Common\System\Text\ConsoleEncoding.cs</Link>
@@ -265,10 +274,22 @@
     <Compile Include="Microsoft\Win32\SafeHandles\SafeThreadHandle.cs" />
     <Compile Include="Microsoft\Win32\SafeHandles\SafeTokenHandle.cs" />
     <Compile Include="System\Diagnostics\PerformanceCounterLib.cs" />
-    <Compile Include="System\Diagnostics\Process.Windows.cs" />
+    <Compile Include="System\Diagnostics\Process.Windows.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Condition="'$(TargetGroup)' != 'uap'" Include="System\Diagnostics\Process.Win32.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Condition="'$(TargetGroup)' == 'uap'" Include="System\Diagnostics\Process.WinRT.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="System\Diagnostics\ProcessManager.Windows.cs" />
     <Compile Include="System\Diagnostics\ProcessStartInfo.Windows.cs" />
-    <Compile Include="System\Diagnostics\ProcessThread.Windows.cs" />
+    <Compile Condition="'$(TargetGroup)' != 'uap'" Include="System\Diagnostics\ProcessStartInfo.Win32.cs" />
+    <Compile Condition="'$(TargetGroup)' == 'uap'" Include="System\Diagnostics\ProcessStartInfo.WinRT.cs" />
+    <Compile Include="System\Diagnostics\ProcessThread.Windows.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="System\Diagnostics\ProcessThreadTimes.cs" />
     <Compile Include="System\Diagnostics\ProcessWaitHandle.Windows.cs" />
   </ItemGroup>

--- a/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
+++ b/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
@@ -88,7 +88,7 @@
       <Link>Common\Interop\Windows\user32\Interop.GetWindowThreadProcessId.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.CloseHandle.cs">
-      <Link>Common\Interop\Windows\Interop.CloseHandle.cs</Link>
+      <Link>Common\Interop\Windows\kernel32\Interop.CloseHandle.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.PERF_INFO.cs">
       <Link>Common\Interop\Windows\advapi32\Interop.PERF_INFO.cs</Link>
@@ -214,7 +214,7 @@
       <Link>Common\Interop\Windows\kernel32\Interop.GetConsoleOutputCP.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.CreateProcessWithLogon.cs">
-      <Link>Common\Interop\Windows\Interop.CreateProcessWithLogon.cs</Link>
+      <Link>Common\Interop\Windows\advapi32\Interop.CreateProcessWithLogon.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.BOOL.cs">
       <Link>Common\Interop\Windows\Interop.BOOL.cs</Link>

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Win32.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Win32.cs
@@ -1,0 +1,168 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Microsoft.Win32.SafeHandles;
+
+namespace System.Diagnostics
+{
+    public partial class Process : IDisposable
+    {
+        private bool StartCore(ProcessStartInfo startInfo)
+        {
+            return startInfo.UseShellExecute
+                ? StartWithShellExecuteEx(startInfo)
+                : StartWithCreateProcess(startInfo);
+        }
+
+        private unsafe bool StartWithShellExecuteEx(ProcessStartInfo startInfo)
+        {
+            if (!string.IsNullOrEmpty(startInfo.UserName) || startInfo.Password != null)
+                throw new InvalidOperationException(SR.CantStartAsUser);
+
+            if (startInfo.RedirectStandardInput || startInfo.RedirectStandardOutput || startInfo.RedirectStandardError)
+                throw new InvalidOperationException(SR.CantRedirectStreams);
+
+            if (startInfo.StandardErrorEncoding != null)
+                throw new InvalidOperationException(SR.StandardErrorEncodingNotAllowed);
+
+            if (startInfo.StandardOutputEncoding != null)
+                throw new InvalidOperationException(SR.StandardOutputEncodingNotAllowed);
+
+            if (startInfo._environmentVariables != null)
+                throw new InvalidOperationException(SR.CantUseEnvVars);
+
+            fixed (char* fileName = startInfo.FileName.Length > 0 ? startInfo.FileName : null)
+            fixed (char* verb = startInfo.Verb.Length > 0 ? startInfo.Verb : null)
+            fixed (char* parameters = startInfo.Arguments.Length > 0 ? startInfo.Arguments : null)
+            fixed (char* directory = startInfo.WorkingDirectory.Length > 0 ? startInfo.WorkingDirectory : null)
+            {
+                Interop.Shell32.SHELLEXECUTEINFO shellExecuteInfo = new Interop.Shell32.SHELLEXECUTEINFO()
+                {
+                    cbSize = (uint)sizeof(Interop.Shell32.SHELLEXECUTEINFO),
+                    lpFile = fileName,
+                    lpVerb = verb,
+                    lpParameters = parameters,
+                    lpDirectory = directory,
+                    fMask = Interop.Shell32.SEE_MASK_NOCLOSEPROCESS | Interop.Shell32.SEE_MASK_FLAG_DDEWAIT
+                };
+
+                if (startInfo.ErrorDialog)
+                    shellExecuteInfo.hwnd = startInfo.ErrorDialogParentHandle;
+                else
+                    shellExecuteInfo.fMask |= Interop.Shell32.SEE_MASK_FLAG_NO_UI;
+
+                switch (startInfo.WindowStyle)
+                {
+                    case ProcessWindowStyle.Hidden:
+                        shellExecuteInfo.nShow = Interop.Shell32.SW_HIDE;
+                        break;
+                    case ProcessWindowStyle.Minimized:
+                        shellExecuteInfo.nShow = Interop.Shell32.SW_SHOWMINIMIZED;
+                        break;
+                    case ProcessWindowStyle.Maximized:
+                        shellExecuteInfo.nShow = Interop.Shell32.SW_SHOWMAXIMIZED;
+                        break;
+                    default:
+                        shellExecuteInfo.nShow = Interop.Shell32.SW_SHOWNORMAL;
+                        break;
+                }
+
+                ShellExecuteHelper executeHelper = new ShellExecuteHelper(&shellExecuteInfo);
+                if (!executeHelper.ShellExecuteOnSTAThread())
+                {
+                    int error = executeHelper.ErrorCode;
+                    if (error == 0)
+                    {
+                        error = GetShellError(shellExecuteInfo.hInstApp);
+                    }
+
+                    switch (error)
+                    {
+                        case Interop.Errors.ERROR_BAD_EXE_FORMAT:
+                        case Interop.Errors.ERROR_EXE_MACHINE_TYPE_MISMATCH:
+                            throw new Win32Exception(error, SR.InvalidApplication);
+                        default:
+                            throw new Win32Exception(error);
+                    }
+                }
+
+                if (shellExecuteInfo.hProcess != IntPtr.Zero)
+                {
+                    SetProcessHandle(new SafeProcessHandle(shellExecuteInfo.hProcess));
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private int GetShellError(IntPtr error)
+        {
+            switch ((long)error)
+            {
+                case Interop.Shell32.SE_ERR_FNF:
+                    return Interop.Errors.ERROR_FILE_NOT_FOUND;
+                case Interop.Shell32.SE_ERR_PNF:
+                    return Interop.Errors.ERROR_PATH_NOT_FOUND;
+                case Interop.Shell32.SE_ERR_ACCESSDENIED:
+                    return Interop.Errors.ERROR_ACCESS_DENIED;
+                case Interop.Shell32.SE_ERR_OOM:
+                    return Interop.Errors.ERROR_NOT_ENOUGH_MEMORY;
+                case Interop.Shell32.SE_ERR_DDEFAIL:
+                case Interop.Shell32.SE_ERR_DDEBUSY:
+                case Interop.Shell32.SE_ERR_DDETIMEOUT:
+                    return Interop.Errors.ERROR_DDE_FAIL;
+                case Interop.Shell32.SE_ERR_SHARE:
+                    return Interop.Errors.ERROR_SHARING_VIOLATION;
+                case Interop.Shell32.SE_ERR_NOASSOC:
+                    return Interop.Errors.ERROR_NO_ASSOCIATION;
+                case Interop.Shell32.SE_ERR_DLLNOTFOUND:
+                    return Interop.Errors.ERROR_DLL_NOT_FOUND;
+                default:
+                    return (int)(long)error;
+            }
+        }
+
+        internal unsafe class ShellExecuteHelper
+        {
+            private Interop.Shell32.SHELLEXECUTEINFO* _executeInfo;
+            private bool _succeeded;
+
+            public ShellExecuteHelper(Interop.Shell32.SHELLEXECUTEINFO* executeInfo)
+            {
+                _executeInfo = executeInfo;
+            }
+
+            public void ShellExecuteFunction()
+            {
+                if (!(_succeeded = Interop.Shell32.ShellExecuteExW(_executeInfo)))
+                    ErrorCode = Marshal.GetLastWin32Error();
+            }
+
+            public bool ShellExecuteOnSTAThread()
+            {
+                // ShellExecute() requires STA in order to work correctly.
+
+                if (Thread.CurrentThread.GetApartmentState() != ApartmentState.STA)
+                {
+                    ThreadStart threadStart = new ThreadStart(ShellExecuteFunction);
+                    Thread executionThread = new Thread(threadStart);
+                    executionThread.SetApartmentState(ApartmentState.STA);
+                    executionThread.Start();
+                    executionThread.Join();
+                }
+                else
+                {
+                    ShellExecuteFunction();
+                }
+                return _succeeded;
+            }
+
+            public int ErrorCode { get; private set; }
+        }
+    }
+}

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.WinRT.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.WinRT.cs
@@ -9,7 +9,7 @@ namespace System.Diagnostics
         private bool StartCore(ProcessStartInfo startInfo)
         {
             return startInfo.UseShellExecute
-                ? throw new PlatformNotSupportedException(SR.UseShellExecute)
+                ? throw new PlatformNotSupportedException(SR.UseShellExecuteNotSupported)
                 : StartWithCreateProcess(startInfo);
         }
     }

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.WinRT.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.WinRT.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Diagnostics
+{
+    public partial class Process : IDisposable
+    {
+        private bool StartCore(ProcessStartInfo startInfo)
+        {
+            return startInfo.UseShellExecute
+                ? throw new PlatformNotSupportedException(SR.UseShellExecute)
+                : StartWithCreateProcess(startInfo);
+        }
+    }
+}

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -784,28 +784,6 @@ namespace System.Diagnostics
         }
 
         /// <devdoc>
-        ///     Release the temporary handle we used to get process information.
-        ///     If we used the process handle stored in the process object (we have all access to the handle,) don't release it.
-        /// </devdoc>
-        /// <internalonly/>
-        private void ReleaseProcessHandle(SafeProcessHandle handle)
-        {
-            if (handle == null)
-            {
-                return;
-            }
-
-            if (_haveProcessHandle && handle == _processHandle)
-            {
-                return;
-            }
-#if FEATURE_TRACESWITCH
-            Debug.WriteLineIf(_processTracing.TraceVerbose, "Process - CloseHandle(process)");
-#endif
-            handle.Dispose();
-        }
-
-        /// <devdoc>
         ///     This is called from the threadpool when a process exits.
         /// </devdoc>
         /// <internalonly/>

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.Win32.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.Win32.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32;
+using System.Collections.Generic;
+using System.IO;
+
+namespace System.Diagnostics
+{
+    public sealed partial class ProcessStartInfo
+    {
+        public string[] Verbs
+        {
+            get
+            {
+                string extension = Path.GetExtension(FileName);
+                if (string.IsNullOrEmpty(extension))
+                    return Array.Empty<string>();
+
+                using (RegistryKey key = Registry.ClassesRoot.OpenSubKey(extension))
+                {
+                    if (key == null)
+                        return Array.Empty<string>();
+
+                    string value = key.GetValue(string.Empty) as string;
+                    if (string.IsNullOrEmpty(value))
+                        return Array.Empty<string>();
+
+                    using (RegistryKey subKey = Registry.ClassesRoot.OpenSubKey(value + "\\shell"))
+                    {
+                        if (subKey == null)
+                            return Array.Empty<string>();
+
+                        string[] names = subKey.GetSubKeyNames();
+                        List<string> verbs = new List<string>();
+                        foreach (string name in names)
+                        {
+                            if (!string.Equals(name, "new", StringComparison.OrdinalIgnoreCase))
+                            {
+                                verbs.Add(name);
+                            }
+                        }
+                        return verbs.ToArray();
+                    }
+                }
+            }
+        }
+
+        public bool UseShellExecute { get; set; }
+    }
+}

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.WinRT.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.WinRT.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Diagnostics
+{
+    public sealed partial class ProcessStartInfo
+    {
+        public string[] Verbs => Array.Empty<string>();
+
+        // Not available on WinRT as ShellExecuteEx isn't whitelisted. Note that using ShellExecuteEx
+        // also depends on being able to change the apartment state for a thread to STA (CLR is MTA).
+        public bool UseShellExecute
+        {
+            get { return false; }
+            set { if (value == true) throw new PlatformNotSupportedException(SR.UseShellExecute); }
+        }
+    }
+}

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.WinRT.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.WinRT.cs
@@ -13,7 +13,7 @@ namespace System.Diagnostics
         public bool UseShellExecute
         {
             get { return false; }
-            set { if (value == true) throw new PlatformNotSupportedException(SR.UseShellExecuteNotSupported); }
+            set { if (value) throw new PlatformNotSupportedException(SR.UseShellExecuteNotSupported); }
         }
     }
 }

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.WinRT.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.WinRT.cs
@@ -13,7 +13,7 @@ namespace System.Diagnostics
         public bool UseShellExecute
         {
             get { return false; }
-            set { if (value == true) throw new PlatformNotSupportedException(SR.UseShellExecute); }
+            set { if (value == true) throw new PlatformNotSupportedException(SR.UseShellExecuteNotSupported); }
         }
     }
 }

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.Windows.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.Windows.cs
@@ -2,11 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if FEATURE_REGISTRY
-using Microsoft.Win32;
-#endif
-using System.Collections.Generic;
-using System.IO;
 using System.Security;
 
 namespace System.Diagnostics
@@ -34,62 +29,7 @@ namespace System.Diagnostics
 
         public bool LoadUserProfile { get; set; }
 
-        public string[] Verbs 
-        {
-            get 
-            {
-#if FEATURE_REGISTRY
-                string extension = Path.GetExtension(FileName);
-                if (string.IsNullOrEmpty(extension))
-                    return Array.Empty<string>();
-
-                using (RegistryKey key = Registry.ClassesRoot.OpenSubKey(extension))
-                {
-                    if (key == null)
-                        return Array.Empty<string>();
-
-                    string value = key.GetValue(string.Empty) as string;
-                    if (string.IsNullOrEmpty(value))
-                        return Array.Empty<string>();
-
-                    using (RegistryKey subKey = Registry.ClassesRoot.OpenSubKey(value + "\\shell"))
-                    {
-                        if (subKey == null)
-                            return Array.Empty<string>();
-
-                        string[] names = subKey.GetSubKeyNames();
-                        List<string> verbs = new List<string>();
-                        foreach (string name in names)
-                        {
-                            if (!string.Equals(name, "new", StringComparison.OrdinalIgnoreCase))
-                            {
-                                verbs.Add(name);
-                            }
-                        }
-                        return verbs.ToArray();
-                    }
-                }
-#else
-                return Array.Empty<string>();
-#endif
-            }
-        }
-
         [CLSCompliant(false)]
         public SecureString Password { get; set; }
-
-        // CoreCLR can't correctly support UseShellExecute=true for the following reasons
-        // 1. ShellExecuteEx is not supported on onecore.
-        // 2. ShellExecuteEx needs to run as STA but managed code runs as MTA by default and Thread.SetApartmentState() is not supported on all platforms.
-        //
-        // Irrespective of the limited functionality of the property we still expose it in the contract as it can be implemented
-        // on other platforms.  Further, the default value of UseShellExecute is true on desktop and scenarios like redirection mandates 
-        // the value to be false. So in order to provide maximum code portability we expose UseShellExecute in the contract 
-        // and throw PlatformNotSupportedException in portable library in case it is set to true.
-        public bool UseShellExecute
-        {
-            get { return false; }
-            set { if (value == true) throw new PlatformNotSupportedException(SR.UseShellExecute); }
-        }
     }
 }

--- a/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -15,6 +15,7 @@ using Xunit;
 using System.Text;
 using System.ComponentModel;
 using System.Security;
+using System.Threading;
 
 namespace System.Diagnostics.Tests
 {
@@ -242,10 +243,10 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [PlatformSpecific(TestPlatforms.Windows)] // UseShellExecute currently not supported on Windows on .NET Core
+        [PlatformSpecific(TestPlatforms.Windows)]
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Desktop UseShellExecute is set to true by default but UseShellExecute=true is not supported on Core")]
-        public void UseShellExecute_GetSetWindows_Success_Netcore()
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.Uap, "Only UAP blocks setting ShellExecute to true")]
+        public void UseShellExecute_GetSetWindows_Success_Uap()
         {
             ProcessStartInfo psi = new ProcessStartInfo();
             Assert.False(psi.UseShellExecute);
@@ -260,7 +261,7 @@ namespace System.Diagnostics.Tests
 
         [PlatformSpecific(TestPlatforms.Windows)]
         [Fact]
-        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "Desktop UseShellExecute is set to true by default but UseShellExecute=true is not supported on Core")]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "Desktop UseShellExecute is set to true by default")]
         public void UseShellExecute_GetSetWindows_Success_Netfx()
         {
             ProcessStartInfo psi = new ProcessStartInfo();
@@ -273,9 +274,9 @@ namespace System.Diagnostics.Tests
             Assert.True(psi.UseShellExecute);
         }
 
-        [PlatformSpecific(TestPlatforms.AnyUnix)] // UseShellExecute currently not supported on Windows
         [Fact]
-        public void TestUseShellExecuteProperty_SetAndGet_Unix()
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.NetFramework)]
+        public void TestUseShellExecuteProperty_SetAndGet_NotUapOrNetFX()
         {
             ProcessStartInfo psi = new ProcessStartInfo();
             Assert.False(psi.UseShellExecute);
@@ -287,11 +288,11 @@ namespace System.Diagnostics.Tests
             Assert.False(psi.UseShellExecute);
         }
 
-        [PlatformSpecific(TestPlatforms.AnyUnix)] // UseShellExecute currently not supported on Windows
         [Theory]
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(2)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)]
         public void TestUseShellExecuteProperty_Redirects_NotSupported(int std)
         {
             Process p = CreateProcessLong();
@@ -496,7 +497,7 @@ namespace System.Diagnostics.Tests
             Assert.Equal("NewValue", kvpaOrdered[2].Value);
 
             psi.EnvironmentVariables.Remove("NewKey3");
-            Assert.False(psi.Environment.Contains(new KeyValuePair<string,string>("NewKey3", "NewValue3")));            
+            Assert.False(psi.Environment.Contains(new KeyValuePair<string,string>("NewKey3", "NewValue3")));
         }
 
         [PlatformSpecific(TestPlatforms.Windows)]  // Test case is specific to Windows
@@ -930,6 +931,108 @@ namespace System.Diagnostics.Tests
         {
             var info = new ProcessStartInfo { WorkingDirectory = workingDirectory };
             Assert.Equal(workingDirectory ?? string.Empty, info.WorkingDirectory);
+        }
+
+        [Fact(Skip = "Manual test")]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)]
+        public void StartInfo_WebPage()
+        {
+            ProcessStartInfo info = new ProcessStartInfo
+            {
+                UseShellExecute = true,
+                FileName = @"http://www.microsoft.com"
+            };
+
+            Process.Start(info);
+        }
+
+        [Theory, MemberData(nameof(UseShellExecute))]
+        [OuterLoop("Launches notepad")]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)]
+        public void StartInfo_NotepadWithContent(bool useShellExecute)
+        {
+            string tempFile = GetTestFilePath() + ".txt";
+            File.WriteAllText(tempFile, $"StartInfo_NotepadWithContent({useShellExecute})");
+
+            ProcessStartInfo info = new ProcessStartInfo
+            {
+                UseShellExecute = useShellExecute,
+                FileName = @"notepad.exe",
+                Arguments = tempFile,
+                WindowStyle = ProcessWindowStyle.Minimized
+            };
+
+            var process = Process.Start(info);
+            process.WaitForInputIdle(); // Give the file a chance to load
+            Assert.Equal("notepad", process.ProcessName);
+            Assert.StartsWith(Path.GetFileName(tempFile), process.MainWindowTitle);
+            process.Kill();
+        }
+
+        [Fact]
+        [OuterLoop("Launches notepad")]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)]
+        public void StartInfo_TextFile_ShellExecute()
+        {
+            string tempFile = GetTestFilePath() + ".txt";
+            File.WriteAllText(tempFile, $"StartInfo_TextFile_ShellExecute");
+
+            ProcessStartInfo info = new ProcessStartInfo
+            {
+                UseShellExecute = true,
+                FileName = tempFile,
+                WindowStyle = ProcessWindowStyle.Minimized
+            };
+
+            var process = Process.Start(info);
+            process.WaitForInputIdle(); // Give the file a chance to load
+            Assert.Equal("notepad", process.ProcessName);
+            Assert.StartsWith(Path.GetFileName(tempFile), process.MainWindowTitle);
+            process.Kill();
+        }
+
+        public static TheoryData<bool> UseShellExecute
+        {
+            get
+            {
+                TheoryData<bool> data = new TheoryData<bool> { false };
+                if (!PlatformDetection.IsUap)
+                    data.Add(true);
+                return data;
+            }
+        }
+
+        [Theory, MemberData(nameof(UseShellExecute))]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void StartInfo_BadVerb(bool useShellExecute)
+        {
+            ProcessStartInfo info = new ProcessStartInfo
+            {
+                UseShellExecute = useShellExecute,
+                FileName = @"foo.txt",
+                Verb = "Zlorp"
+            };
+
+            Assert.Equal(2, Assert.Throws<Win32Exception>(() => Process.Start(info)).NativeErrorCode);
+        }
+
+        [Theory, MemberData(nameof(UseShellExecute))]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void StartInfo_BadExe(bool useShellExecute)
+        {
+            string tempFile = GetTestFilePath() + ".exe";
+            File.Create(tempFile).Dispose();
+
+            ProcessStartInfo info = new ProcessStartInfo
+            {
+                UseShellExecute = useShellExecute,
+                FileName = tempFile
+            };
+
+            Assert.Equal(193, Assert.Throws<Win32Exception>(() => Process.Start(info)).NativeErrorCode);
         }
     }
 }

--- a/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -964,11 +964,13 @@ namespace System.Diagnostics.Tests
                 WindowStyle = ProcessWindowStyle.Minimized
             };
 
-            var process = Process.Start(info);
-            process.WaitForInputIdle(); // Give the file a chance to load
-            Assert.Equal("notepad", process.ProcessName);
-            Assert.StartsWith(Path.GetFileName(tempFile), process.MainWindowTitle);
-            process.Kill();
+            using (var process = Process.Start(info))
+            {
+                process.WaitForInputIdle(); // Give the file a chance to load
+                Assert.Equal("notepad", process.ProcessName);
+                Assert.StartsWith(Path.GetFileName(tempFile), process.MainWindowTitle);
+                process.Kill();
+            }
         }
 
         [Fact]
@@ -987,11 +989,13 @@ namespace System.Diagnostics.Tests
                 WindowStyle = ProcessWindowStyle.Minimized
             };
 
-            var process = Process.Start(info);
-            process.WaitForInputIdle(); // Give the file a chance to load
-            Assert.Equal("notepad", process.ProcessName);
-            Assert.StartsWith(Path.GetFileName(tempFile), process.MainWindowTitle);
-            process.Kill();
+            using (var process = Process.Start(info))
+            {
+                process.WaitForInputIdle(); // Give the file a chance to load
+                Assert.Equal("notepad", process.ProcessName);
+                Assert.StartsWith(Path.GetFileName(tempFile), process.MainWindowTitle);
+                process.Kill();
+            }
         }
 
         public static TheoryData<bool> UseShellExecute


### PR DESCRIPTION
Adds ShellExecute support for Windows (outside of UAP). Unlike desktop
UseShellExecute is not the default.

In the process of doing this I ran across two issues (covered by the new tests):

1- The owned process handle would be disposed after hitting members on
Process. Getting the ProcessName, for example, would cause a closed
handle exception on the next call that used the handle.

2- The MainWindowTitle import wasn't set to the right charset. In addition
the allocated buffer size wasn't correct. Fixed and added debug checks
for failed api calls.

See issue #18949