### PR TITLE
Provide consistent support for null elements in immutable sets

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet_1.cs
@@ -189,7 +189,6 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableHashSet<T> Add(T item)
         {
-            Requires.NotNullAllowStructs(item, nameof(item));
             Contract.Ensures(Contract.Result<ImmutableHashSet<T>>() != null);
 
             var result = Add(item, this.Origin);
@@ -201,7 +200,6 @@ namespace System.Collections.Immutable
         /// </summary>
         public ImmutableHashSet<T> Remove(T item)
         {
-            Requires.NotNullAllowStructs(item, nameof(item));
             Contract.Ensures(Contract.Result<ImmutableHashSet<T>>() != null);
 
             var result = Remove(item, this.Origin);
@@ -223,8 +221,6 @@ namespace System.Collections.Immutable
         [Pure]
         public bool TryGetValue(T equalValue, out T actualValue)
         {
-            Requires.NotNullAllowStructs(equalValue, nameof(equalValue));
-
             int hashCode = _equalityComparer.GetHashCode(equalValue);
             HashBucket bucket;
             if (_root.TryGetValue(hashCode, out bucket))
@@ -435,7 +431,6 @@ namespace System.Collections.Immutable
         /// </summary>
         public bool Contains(T item)
         {
-            Requires.NotNullAllowStructs(item, nameof(item));
             return Contains(item, this.Origin);
         }
 
@@ -644,8 +639,6 @@ namespace System.Collections.Immutable
         /// </summary>
         private static MutationResult Add(T item, MutationInput origin)
         {
-            Requires.NotNullAllowStructs(item, nameof(item));
-
             OperationResult result;
             int hashCode = origin.EqualityComparer.GetHashCode(item);
             HashBucket bucket = origin.Root.GetValueOrDefault(hashCode);
@@ -665,8 +658,6 @@ namespace System.Collections.Immutable
         /// </summary>
         private static MutationResult Remove(T item, MutationInput origin)
         {
-            Requires.NotNullAllowStructs(item, nameof(item));
-
             var result = OperationResult.NoChangeRequired;
             int hashCode = origin.EqualityComparer.GetHashCode(item);
             HashBucket bucket;

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.Node.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.Node.cs
@@ -82,7 +82,6 @@ namespace System.Collections.Immutable
             /// <param name="frozen">Whether this node is prefrozen.</param>
             private Node(T key, Node left, Node right, bool frozen = false)
             {
-                Requires.NotNullAllowStructs(key, nameof(key));
                 Requires.NotNull(left, nameof(left));
                 Requires.NotNull(right, nameof(right));
                 Debug.Assert(!frozen || (left._frozen && right._frozen));
@@ -343,7 +342,6 @@ namespace System.Collections.Immutable
             /// <returns>The new tree.</returns>
             internal Node Add(T key, IComparer<T> comparer, out bool mutated)
             {
-                Requires.NotNullAllowStructs(key, nameof(key));
                 Requires.NotNull(comparer, nameof(comparer));
 
                 if (this.IsEmpty)
@@ -390,7 +388,6 @@ namespace System.Collections.Immutable
             /// <returns>The new tree.</returns>
             internal Node Remove(T key, IComparer<T> comparer, out bool mutated)
             {
-                Requires.NotNullAllowStructs(key, nameof(key));
                 Requires.NotNull(comparer, nameof(comparer));
 
                 if (this.IsEmpty)
@@ -469,7 +466,6 @@ namespace System.Collections.Immutable
             [Pure]
             internal bool Contains(T key, IComparer<T> comparer)
             {
-                Requires.NotNullAllowStructs(key, nameof(key));
                 Requires.NotNull(comparer, nameof(comparer));
                 return !this.Search(key, comparer).IsEmpty;
             }
@@ -497,7 +493,6 @@ namespace System.Collections.Immutable
             [Pure]
             internal Node Search(T key, IComparer<T> comparer)
             {
-                Requires.NotNullAllowStructs(key, nameof(key));
                 Requires.NotNull(comparer, nameof(comparer));
 
                 if (this.IsEmpty)
@@ -531,7 +526,6 @@ namespace System.Collections.Immutable
             [Pure]
             internal int IndexOf(T key, IComparer<T> comparer)
             {
-                Requires.NotNullAllowStructs(key, nameof(key));
                 Requires.NotNull(comparer, nameof(comparer));
 
                 if (this.IsEmpty)

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.cs
@@ -182,7 +182,6 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableSortedSet<T> Add(T value)
         {
-            Requires.NotNullAllowStructs(value, nameof(value));
             Contract.Ensures(Contract.Result<ImmutableSortedSet<T>>() != null);
             bool mutated;
             return this.Wrap(_root.Add(value, _comparer, out mutated));
@@ -194,7 +193,6 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableSortedSet<T> Remove(T value)
         {
-            Requires.NotNullAllowStructs(value, nameof(value));
             Contract.Ensures(Contract.Result<ImmutableSortedSet<T>>() != null);
             bool mutated;
             return this.Wrap(_root.Remove(value, _comparer, out mutated));
@@ -215,8 +213,6 @@ namespace System.Collections.Immutable
         [Pure]
         public bool TryGetValue(T equalValue, out T actualValue)
         {
-            Requires.NotNullAllowStructs(equalValue, nameof(equalValue));
-
             Node searchResult = _root.Search(equalValue, _comparer);
             if (searchResult.IsEmpty)
             {
@@ -593,7 +589,6 @@ namespace System.Collections.Immutable
         /// </returns>
         public int IndexOf(T item)
         {
-            Requires.NotNullAllowStructs(item, nameof(item));
             return _root.IndexOf(item, _comparer);
         }
 
@@ -606,7 +601,6 @@ namespace System.Collections.Immutable
         /// </summary>
         public bool Contains(T value)
         {
-            Requires.NotNullAllowStructs(value, nameof(value));
             return _root.Contains(value, _comparer);
         }
 

--- a/src/System.Collections.Immutable/tests/ImmutableHashSetBuilderTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableHashSetBuilderTest.cs
@@ -249,7 +249,6 @@ namespace System.Collections.Immutable.Tests
         public void Remove()
         {
             var builder = ImmutableHashSet.Create("a").ToBuilder();
-            AssertExtensions.Throws<ArgumentNullException>("item", () => builder.Remove(null));
             Assert.False(builder.Remove("b"));
             Assert.True(builder.Remove("a"));
         }
@@ -279,6 +278,28 @@ namespace System.Collections.Immutable.Tests
             Assert.False(builder.IsReadOnly);
 
             CollectionAssertAreEquivalent(new[] { "a", "b" }, builder.ToArray()); // tests enumerator
+        }
+
+        [Fact]
+        public void NullHandling()
+        {
+            var builder = ImmutableHashSet<string>.Empty.ToBuilder();
+            Assert.True(builder.Add(null));
+            Assert.False(builder.Add(null));
+            Assert.True(builder.Contains(null));
+            Assert.True(builder.Remove(null));
+
+            builder.UnionWith(new[] { null, "a" });
+            Assert.True(builder.IsSupersetOf(new[] { null, "a" }));
+            Assert.True(builder.IsSubsetOf(new[] { null, "a" }));
+            Assert.True(builder.IsProperSupersetOf(new[] { default(string) }));
+            Assert.True(builder.IsProperSubsetOf(new[] { null, "a", "b" }));
+
+            builder.IntersectWith(new[] { default(string) });
+            Assert.Equal(1, builder.Count);
+
+            builder.ExceptWith(new[] { default(string) });
+            Assert.False(builder.Remove(null));
         }
 
         [Fact]

--- a/src/System.Collections.Immutable/tests/ImmutableHashSetTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableHashSetTest.cs
@@ -134,6 +134,12 @@ namespace System.Collections.Immutable.Tests
             set = ImmutableHashSet.CreateRange(comparer, (IEnumerable<string>)new[] { "a", "b" });
             Assert.Equal(2, set.Count);
             Assert.Same(comparer, set.KeyComparer);
+
+            set = ImmutableHashSet.Create(default(string));
+            Assert.Equal(1, set.Count);
+
+            set = ImmutableHashSet.CreateRange(new[] { null, "a", null, "b" });
+            Assert.Equal(3, set.Count);
         }
 
         /// <summary>

--- a/src/System.Collections.Immutable/tests/ImmutableSetTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableSetTest.cs
@@ -221,6 +221,31 @@ namespace System.Collections.Immutable.Tests
             Assert.Same(builder.SyncRoot, builder.SyncRoot);
         }
 
+        [Fact]
+        public void NullHandling()
+        {
+            var empty = this.Empty<string>();
+            var set = empty.Add(null);
+            Assert.True(set.Contains(null));
+            Assert.True(set.TryGetValue(null, out var @null));
+            Assert.Null(@null);
+            Assert.Equal(empty, set.Remove(null));
+
+            set = empty.Union(new[] { null, "a" });
+            Assert.True(set.IsSupersetOf(new[] { null, "a" }));
+            Assert.True(set.IsSubsetOf(new[] { null, "a" }));
+            Assert.True(set.IsProperSupersetOf(new[] { default(string) }));
+            Assert.True(set.IsProperSubsetOf(new[] { null, "a", "b" }));
+            Assert.True(set.Overlaps(new[] { null, "b" }));
+            Assert.True(set.SetEquals(new[] { null, null, "a", "a" }));
+
+            set = set.Intersect(new[] { default(string) });
+            Assert.Equal(1, set.Count);
+
+            set = set.Except(new[] { default(string) });
+            Assert.False(set.Contains(null));
+        }
+
         protected abstract bool IncludesGetHashCodeDerivative { get; }
 
         internal static List<T> ToListNonGeneric<T>(System.Collections.IEnumerable sequence)

--- a/src/System.Collections.Immutable/tests/ImmutableSortedSetBuilderTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableSortedSetBuilderTest.cs
@@ -265,7 +265,6 @@ namespace System.Collections.Immutable.Tests
         public void Remove()
         {
             var builder = ImmutableSortedSet.Create("a").ToBuilder();
-            AssertExtensions.Throws<ArgumentNullException>("key", () => builder.Remove(null));
             Assert.False(builder.Remove("b"));
             Assert.True(builder.Remove("a"));
         }
@@ -327,6 +326,28 @@ namespace System.Collections.Immutable.Tests
 
             AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => builder[-1]);
             AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => builder[3]);
+        }
+
+        [Fact]
+        public void NullHandling()
+        {
+            var builder = ImmutableSortedSet<string>.Empty.ToBuilder();
+            Assert.True(builder.Add(null));
+            Assert.False(builder.Add(null));
+            Assert.True(builder.Contains(null));
+            Assert.True(builder.Remove(null));
+
+            builder.UnionWith(new[] { null, "a" });
+            Assert.True(builder.IsSupersetOf(new[] { null, "a" }));
+            Assert.True(builder.IsSubsetOf(new[] { null, "a" }));
+            Assert.True(builder.IsProperSupersetOf(new[] { default(string) }));
+            Assert.True(builder.IsProperSubsetOf(new[] { null, "a", "b" }));
+
+            builder.IntersectWith(new[] { default(string) });
+            Assert.Equal(1, builder.Count);
+
+            builder.ExceptWith(new[] { default(string) });
+            Assert.False(builder.Remove(null));
         }
 
         [Fact]

--- a/src/System.Collections.Immutable/tests/ImmutableSortedSetTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableSortedSetTest.cs
@@ -185,6 +185,11 @@ namespace System.Collections.Immutable.Tests
             Assert.Equal(~5, set.IndexOf(55));
             Assert.Equal(~9, set.IndexOf(95));
             Assert.Equal(~10, set.IndexOf(105));
+
+            var nullableSet = ImmutableSortedSet<int?>.Empty;
+            Assert.Equal(~0, nullableSet.IndexOf(null));
+            nullableSet = nullableSet.Add(null).Add(0);
+            Assert.Equal(0, nullableSet.IndexOf(null));
         }
 
         [Fact]
@@ -305,6 +310,12 @@ namespace System.Collections.Immutable.Tests
             set = ImmutableSortedSet.CreateRange(comparer, (IEnumerable<string>)new[] { "a", "b" });
             Assert.Equal(2, set.Count);
             Assert.Same(comparer, set.KeyComparer);
+
+            set = ImmutableSortedSet.Create(default(string));
+            Assert.Equal(1, set.Count);
+
+            set = ImmutableSortedSet.CreateRange(new[] { null, "a", null, "b" });
+            Assert.Equal(3, set.Count);
         }
 
         [Fact]


### PR DESCRIPTION
Provide consistent support for null elements in ImmutableHashSet<T> and ImmutableSortedSet<T>.

Fix #15403

Previously, ImmutableHashSet rejected nulls via some entry points (e. g. Add()) but allowed them via others (e. g. Union()), while ImmutableSortedSet rejected all nulls. The mutable counterparts HashSet<T> and SortedSet<T> both permit null elements.