### PR TITLE
release/2.0: Fix off-by-one error in NetEventSource.WriteEvent

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/NetEventSource.Http.cs
+++ b/src/System.Net.Http/src/System/Net/Http/NetEventSource.Http.cs
@@ -75,7 +75,7 @@ namespace System.Net
                 fixed (char* string4Bytes = arg4)
                 fixed (char* string5Bytes = arg5)
                 {
-                    const int NumEventDatas = 4;
+                    const int NumEventDatas = 5;
                     var descrs = stackalloc EventData[NumEventDatas];
 
                     descrs[0].DataPointer = (IntPtr)(&arg1);


### PR DESCRIPTION
Port #20235 to release/2.0.0 branch.
cc: @janvorli, @steveharter 

Fixes #20199