### PR TITLE
Move reference expansion to a target and handle simple name conflicts

### DIFF
--- a/pkg/NETStandard.Library.NETFramework/NETStandard.Library.NETFramework.pkgproj
+++ b/pkg/NETStandard.Library.NETFramework/NETStandard.Library.NETFramework.pkgproj
@@ -26,6 +26,9 @@
     <File Include="targets\**\*.*" Exclude="@(StampFile)">
       <TargetPath>build/%(RecursiveDir)</TargetPath>
     </File>
+    <File Include="$(PlaceHolderFile)">
+      <TargetPath>build/net471</TargetPath>
+    </File>
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/NETStandard.Library.NETFramework/targets/NETStandard.Library.NETFramework.common.targets
+++ b/pkg/NETStandard.Library.NETFramework/targets/NETStandard.Library.NETFramework.common.targets
@@ -1,0 +1,59 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Choose>
+    <!-- Allow completely disabling the conflict resolution targets-->
+    <When Condition="'$(ImplicitlyExpandNETStandardFacades)' != 'true'" />
+    <!-- Condition here is a hack until https://github.com/dotnet/sdk/issues/534 is fixed -->
+    <When Condition="'$(TargetFramework)' != '' or '$(TargetFrameworks)' != ''">
+      <!-- NuGet 4, run after references are resolved -->
+      <PropertyGroup>
+        <ImplicitlyExpandNETStandardFacadesAfter>ResolveLockFileReferences</ImplicitlyExpandNETStandardFacadesAfter>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(ResolveNuGetPackages)' == 'true' and Exists('$(ProjectLockFile)')">
+      <!-- NuGet 3, run after nuget assets are resolved -->
+      <PropertyGroup>
+        <ImplicitlyExpandNETStandardFacadesAfter>ResolveNuGetPackageAssets</ImplicitlyExpandNETStandardFacadesAfter>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <!-- NuGet 2, run before targets that consume references -->
+      <PropertyGroup>
+        <ResolveAssemblyReferencesDependsOn>ImplicitlyExpandNETStandardFacades;$(ResolveAssemblyReferencesDependsOn)</ResolveAssemblyReferencesDependsOn>
+        <PrepareResourcesDependsOn>ImplicitlyExpandNETStandardFacades;$(PrepareResourcesDependsOn)</PrepareResourcesDependsOn>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+
+  <PropertyGroup>
+    <!-- Ensure this runs before conflict resolution since the added files may cause conflicts -->
+    <HandlePackageFileConflictsDependsOn>ImplicitlyExpandNETStandardFacades;$(HandlePackageFileConflictsDependsOn)</HandlePackageFileConflictsDependsOn>
+  </PropertyGroup>
+
+  <Target Name="ImplicitlyExpandNETStandardFacades"
+          AfterTargets="$(ImplicitlyExpandNETStandardFacadesAfter)">
+    <ItemGroup>
+      <!-- Remove simple name references if we're directly providing a reference assembly to the compiler. For example,
+           consider a project with an Reference Include="System", and some NuGet package is providing System.dll.
+           Simple references can also come from NuGet framework assemblies, hence this statement should occur after
+           including all computed references. -->
+      <Reference Remove="%(_NETStandardLibraryNETFrameworkReference.FileName)" />
+
+      <Reference Include="@(_NETStandardLibraryNETFrameworkReference)">
+        <!-- Private = false to make these reference only -->
+        <Private>false</Private>
+        <NuGetPackageId>NETStandard.Library.NETFramework</NuGetPackageId>
+        <NuGetPackageVersion>$(NETStandardLibraryNETFrameworkPackageVersion)</NuGetPackageVersion>
+        <NuGetIsFrameworkReference>false</NuGetIsFrameworkReference>
+        <NuGetSourceType>Package</NuGetSourceType>
+      </Reference>
+
+      <ReferenceCopyLocalPaths Include="@(_NETStandardLibraryNETFrameworkLib)">
+        <Private>false</Private>
+        <NuGetPackageId>NETStandard.Library.NETFramework</NuGetPackageId>
+        <NuGetPackageVersion>$(NETStandardLibraryPackageVersion)</NuGetPackageVersion>
+        <NuGetIsFrameworkReference>false</NuGetIsFrameworkReference>
+        <NuGetSourceType>Package</NuGetSourceType>
+      </ReferenceCopyLocalPaths>
+    </ItemGroup>
+  </Target>
+</Project>

--- a/pkg/NETStandard.Library.NETFramework/targets/NETStandard.Library.NETFramework.common.targets
+++ b/pkg/NETStandard.Library.NETFramework/targets/NETStandard.Library.NETFramework.common.targets
@@ -24,7 +24,7 @@
     </Otherwise>
   </Choose>
 
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(ImplicitlyExpandNETStandardFacades)' == 'true'">
     <!-- Ensure this runs before conflict resolution since the added files may cause conflicts -->
     <HandlePackageFileConflictsDependsOn>ImplicitlyExpandNETStandardFacades;$(HandlePackageFileConflictsDependsOn)</HandlePackageFileConflictsDependsOn>
   </PropertyGroup>

--- a/pkg/NETStandard.Library.NETFramework/targets/net461/NETStandard.Library.NETFramework.targets
+++ b/pkg/NETStandard.Library.NETFramework/targets/net461/NETStandard.Library.NETFramework.targets
@@ -2,23 +2,10 @@
   <ItemGroup Condition="'$(ImplicitlyExpandNETStandardFacades)' == 'true'">
     <_NETStandardLibraryNETFrameworkReference Include="$(MSBuildThisFileDirectory)\ref\*.dll" 
                                               Exclude="@(_NETStandardLibraryNETFrameworkReference->'$(MSBuildThisFileDirectory)\ref\%(FileName).dll'" />
-    <Reference Include="@(_NETStandardLibraryNETFrameworkReference)">
-      <!-- Private = false to make these reference only -->
-      <Private>false</Private>
-      <NuGetPackageId>NETStandard.Library.NETFramework</NuGetPackageId>
-      <NuGetPackageVersion>$(NETStandardLibraryNETFrameworkPackageVersion)</NuGetPackageVersion>
-      <NuGetIsFrameworkReference>false</NuGetIsFrameworkReference>
-      <NuGetSourceType>Package</NuGetSourceType>
-    </Reference>
 
     <_NETStandardLibraryNETFrameworkLib Include="$(MSBuildThisFileDirectory)\lib\*.dll" 
                                         Exclude="@(_NETStandardLibraryNETFrameworkLib->'$(MSBuildThisFileDirectory)\ref\%(FileName).dll'" />
-    <ReferenceCopyLocalPaths Include="@(_NETStandardLibraryNETFrameworkLib)">
-      <Private>false</Private>
-      <NuGetPackageId>NETStandard.Library.NETFramework</NuGetPackageId>
-      <NuGetPackageVersion>$(NETStandardLibraryPackageVersion)</NuGetPackageVersion>
-      <NuGetIsFrameworkReference>false</NuGetIsFrameworkReference>
-      <NuGetSourceType>Package</NuGetSourceType>
-    </ReferenceCopyLocalPaths>
   </ItemGroup>
+
+  <Import Project="..\$(MSBuildThisFileName).common.targets" />
 </Project>

--- a/pkg/NETStandard.Library.NETFramework/targets/net462/NETStandard.Library.NETFramework.targets
+++ b/pkg/NETStandard.Library.NETFramework/targets/net462/NETStandard.Library.NETFramework.targets
@@ -8,4 +8,5 @@
   </ItemGroup>
 
   <Import Project="..\net461\$(MSBuildThisFile)" />
+  <Import Project="..\$(MSBuildThisFileName).common.targets" />
 </Project>

--- a/pkg/NETStandard.Library.NETFramework/targets/net47/NETStandard.Library.NETFramework.targets
+++ b/pkg/NETStandard.Library.NETFramework/targets/net47/NETStandard.Library.NETFramework.targets
@@ -8,4 +8,5 @@
   </ItemGroup>
 
   <Import Project="..\net462\$(MSBuildThisFile)" />
+  <Import Project="..\$(MSBuildThisFileName).common.targets" />
 </Project>


### PR DESCRIPTION
We cannot let simple name references that overlap with our assemblies reach
RAR because RAR will choose the files in the targeting pack over the ones we
add to the reference item, due to the default AssemblySearchPaths.

We could change AssemblySearchPaths to consider all the NuGetPackage paths
before `{TargetFrameworkDirectory}` but that has broader implications for
compatibility and performance of RAR.

I chose to follow a similar pattern to what the SDK does already and took the
opportunity to move the reference item setting into the target as well, to more
closely match what the SDK is doing.

Port of https://github.com/dotnet/corefx/pull/20021 to release/2.0.0.

Fixes #20015

/cc @weshaggard 