### PR TITLE
Enable portable pipelines by default in CI

### DIFF
--- a/buildpipeline/pipelinejobs.groovy
+++ b/buildpipeline/pipelinejobs.groovy
@@ -22,7 +22,7 @@ def linuxPipeline = Pipeline.createPipelineForGithub(this, project, branch, 'bui
             // CentOS 7.3, RedHat 7.3, Debian 8.7, Ubuntu 14.04, Ubuntu 16.04, Ubuntu 16.10, openSuSE 42.2 and Fedora 25
 
             // One for just innerloop.
-            linuxPipeline.triggerPipelineOnGithubPRComment("Portable ${osName} ${configurationGroup} Build", "(?i).*test\\W+portable\\W+linux\\W+${configurationGroup}\\W+pipeline.*",
+            linuxPipeline.triggerPipelineOnEveryGithubPR("Portable ${osName} ${configurationGroup} Build", "(?i).*test\\W+portable\\W+linux\\W+${configurationGroup}\\W+pipeline.*",
                 ['Config':configurationGroup, 'OuterLoop':false])
             // Add one for outerloop
             linuxPipeline.triggerPipelineOnGithubPRComment("Portable Outerloop ${osName} ${configurationGroup} Build", "(?i).*test\\W+outerloop\\W+portable\\W+linux\\W+${configurationGroup}\\W+pipeline.*",
@@ -40,7 +40,7 @@ def windowsPipeline = Pipeline.createPipelineForGithub(this, project, branch, 'b
             // Windows 10, Windows 7, Windows 8.1 and Windows Nano
 
             // One for just innerloop
-            windowsPipeline.triggerPipelineOnGithubPRComment("Portable ${osName} ${configurationGroup} Build", "(?i).*test\\W+portable\\W+windows\\W+${configurationGroup}\\W+pipeline.*",
+            windowsPipeline.triggerPipelineOnEveryGithubPR("Portable ${osName} ${configurationGroup} Build", "(?i).*test\\W+portable\\W+windows\\W+${configurationGroup}\\W+pipeline.*",
                 ['Config':configurationGroup, 'OuterLoop':false])
             // Add one for outerloop
             windowsPipeline.triggerPipelineOnGithubPRComment("Portable Outerloop ${osName} ${configurationGroup} Build", "(?i).*test\\W+outerloop\\W+portable\\W+windows\\W+${configurationGroup}\\W+pipeline.*",

--- a/buildpipeline/portable-windows.groovy
+++ b/buildpipeline/portable-windows.groovy
@@ -1,9 +1,9 @@
 @Library('dotnet-ci') _
 
-// Incoming parameters
+// Incoming parameters.  Access with "params.<param name>".
 // Config - Build configuration. Note that we don't using 'Configuration' since it's used
 //          in the build scripts and this can cause problems.
-// Outerloop - If true, runs outerloop, if false runs just innerloop
+// OuterLoop - If true, runs outerloop, if false runs just innerloop
 
 def submittedHelixJson = null
 
@@ -24,14 +24,14 @@ simpleNode('Windows_NT','latest') {
         bat '.\\build-managed.cmd -GenerateVersion'
     }
     stage ('Build Product') {
-        bat ".\\build.cmd -buildArch=x64 -${Config} -portable -- /p:SignType=real /p:RuntimeOS=win10"
+        bat ".\\build.cmd -buildArch=x64 -${params.Config} -portable -- /p:SignType=real /p:RuntimeOS=win10"
     }
     stage ('Build Tests') {
         def additionalArgs = ''
-        if (OuterLoop == true) {
+        if (params.OuterLoop) {
             additionalArgs = '-Outerloop'
         }
-        bat ".\\build-tests.cmd -buildArch=x64 -${Config} -SkipTests -portable ${additionalArgs} -- /p:RuntimeOS=win10 /p:ArchiveTests=true"
+        bat ".\\build-tests.cmd -buildArch=x64 -${params.Config} -SkipTests -portable ${additionalArgs} -- /p:RuntimeOS=win10 /p:ArchiveTests=true"
     }
     stage ('Submit To Helix For Testing') {
         // Bind the credentials
@@ -50,7 +50,7 @@ simpleNode('Windows_NT','latest') {
                                      'Windows.7.Amd64.Open',
                                      'Windows.81.Amd64.Open']
 
-            bat "\"%VS140COMNTOOLS%\\VsDevCmd.bat\" && msbuild src\\upload-tests.proj /p:ArchGroup=x64 /p:ConfigurationGroup=${Config} /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:HelixJobType=test/functional/portable/cli/ /p:HelixSource=${helixSource} /p:BuildMoniker=${helixBuild} /p:HelixCreator=${helixCreator} /p:CloudDropAccountName=dotnetbuilddrops /p:CloudResultsAccountName=dotnetjobresults /p:CloudDropAccessToken=%CloudDropAccessToken% /p:CloudResultsAccessToken=%OutputCloudResultsAccessToken% /p:HelixApiEndpoint=https://helix.dot.net/api/2017-04-14/jobs /p:TargetQueues=\"${targetHelixQueues.join(',')}\" /p:HelixLogFolder= /p:HelixLogFolder=${WORKSPACE}\\${logFolder}\\ /p:HelixCorrelationInfoFileName=SubmittedHelixRuns.txt"
+            bat "\"%VS140COMNTOOLS%\\VsDevCmd.bat\" && msbuild src\\upload-tests.proj /p:ArchGroup=x64 /p:ConfigurationGroup=${params.Config} /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:HelixJobType=test/functional/portable/cli/ /p:HelixSource=${helixSource} /p:BuildMoniker=${helixBuild} /p:HelixCreator=${helixCreator} /p:CloudDropAccountName=dotnetbuilddrops /p:CloudResultsAccountName=dotnetjobresults /p:CloudDropAccessToken=%CloudDropAccessToken% /p:CloudResultsAccessToken=%OutputCloudResultsAccessToken% /p:HelixApiEndpoint=https://helix.dot.net/api/2017-04-14/jobs /p:TargetQueues=\"${targetHelixQueues.join(',')}\" /p:HelixLogFolder= /p:HelixLogFolder=${WORKSPACE}\\${logFolder}\\ /p:HelixCorrelationInfoFileName=SubmittedHelixRuns.txt"
 
             submittedHelixJson = readJSON file: "${logFolder}\\SubmittedHelixRuns.txt"
         }
@@ -59,11 +59,11 @@ simpleNode('Windows_NT','latest') {
 
 stage ('Execute Tests') {
     def contextBase
-    if (OuterLoop == true) {
-        contextBase = "Win x64 tests w/outer - ${Config}"
+    if (params.OuterLoop) {
+        contextBase = "Win x64 tests w/outer - ${params.Config}"
     }
     else {
-        contextBase = "Win x64 tests - ${Config}"
+        contextBase = "Win x64 tests - ${params.Config}"
     }
     waitForHelixRuns(submittedHelixJson, contextBase)
 }

--- a/src/System.Net.HttpListener/tests/GetContextHelper.cs
+++ b/src/System.Net.HttpListener/tests/GetContextHelper.cs
@@ -59,7 +59,7 @@ namespace System.Net.Tests
     public static class Helpers
     {
         public static bool IsWindowsImplementation { get; } = PlatformDetection.IsWindows && PlatformDetection.IsNotOneCoreUAP;
-        public static bool IsNotWindowsImplementation => !IsWindowsImplementation;
+        public static bool IsNotWindowsImplementation => !IsWindowsImplementation && PlatformDetection.IsNotOneCoreUAP;
 
         public static void WaitForSocketShutdown(Socket socket)
         {


### PR DESCRIPTION
* Enable the portable innerloop pipelines by default
* Modify the pipelines so that they access incoming parameters with "param.".  This typically has no effect, but without "param.", you're implictly accessing the environment.  If the incoming parameter is boolean, then it would be converted to a string, meaning that boolean checks like if (foo) would return true.