### PR TITLE
Fix XmlSchemaSet test failures with absolute Uri on Unix

### DIFF
--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -86,7 +86,6 @@ namespace System.Xml.Tests
         }
 
         [Fact]
-        [ActiveIssue(20148, ~TestPlatforms.Windows)]
         //[Variation(Desc = "TFS_470021 Unexpected local particle qualified name when chameleon schema is added to set")]
         public void TFS_470021()
         {
@@ -138,7 +137,7 @@ namespace System.Xml.Tests
                 ss.Add(null, XmlReader.Create(new StringReader(cham)));
                 // TempDirectory path must end with a DirectorySeratorChar, otherwise it will throw in the Xml validation.
                 var settings = new XmlReaderSettings() { XmlResolver = new XmlUrlResolver() };
-                ss.Add(null, XmlReader.Create(new StringReader(main), settings, tempDirectoryPath));
+                ss.Add(null, XmlReader.Create(new StringReader(main), settings, ToAbsoluteUri(tempDirectoryPath)));
                 ss.Compile();
 
                 Assert.Equal(2, ss.Count);
@@ -156,6 +155,13 @@ namespace System.Xml.Tests
                 Assert.Equal(0, warningCount);
                 Assert.Equal(0, errorCount);
             }
+        }
+
+        // This is a workaround for https://github.com/dotnet/corefx/issues/20046
+        private static string ToAbsoluteUri(string path)
+        {
+            Uri uri = new Uri(path, UriKind.Absolute);
+            return uri.ToString();
         }
     }
 }

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateMisc.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateMisc.cs
@@ -894,7 +894,6 @@ namespace System.Xml.Tests
 
         //TFS_538324
         [Fact]
-        [ActiveIssue(20148, ~TestPlatforms.Windows)]
         public void XSDValidationGeneratesInvalidError_1()
         {
             using (var tempDirectory = new TempDirectory())
@@ -905,7 +904,7 @@ namespace System.Xml.Tests
                 settings.XmlResolver = new XmlUrlResolver();
                 settings.Schemas.XmlResolver = new XmlUrlResolver();
                 // TempDirectory path must end with a DirectorySeratorChar, otherwise it will throw in the Xml validation.
-                settings.Schemas.Add("mainschema", XmlReader.Create(new StringReader(xsd), null, EnsureTrailingSlash(tempDirectory.Path)));
+                settings.Schemas.Add("mainschema", XmlReader.Create(new StringReader(xsd), null, EnsureTrailingSlash(ToAbsoluteUri(tempDirectory.Path))));
                 settings.ValidationType = ValidationType.Schema;
                 XmlReader reader = XmlReader.Create(new StringReader(xml), settings);
                 XmlDocument doc = new XmlDocument();
@@ -921,7 +920,6 @@ namespace System.Xml.Tests
 
         //TFS_538324
         [Fact]
-        [ActiveIssue(20148, ~TestPlatforms.Windows)]
         public void XSDValidationGeneratesInvalidError_2()
         {
             using (var tempDirectory = new TempDirectory())
@@ -932,7 +930,7 @@ namespace System.Xml.Tests
                 settings.XmlResolver = new XmlUrlResolver();
                 settings.Schemas.XmlResolver = new XmlUrlResolver();
                 // TempDirectory path must end with a DirectorySeratorChar, otherwise it will throw in the Xml validation.
-                settings.Schemas.Add("mainschema", XmlReader.Create(new StringReader(xsd), null, EnsureTrailingSlash(tempDirectory.Path)));
+                settings.Schemas.Add("mainschema", XmlReader.Create(new StringReader(xsd), null, EnsureTrailingSlash(ToAbsoluteUri(tempDirectory.Path))));
                 settings.ValidationType = ValidationType.Schema;
                 XmlReader reader = XmlReader.Create(new StringReader(xml), settings);
                 XmlDocument doc = new XmlDocument();
@@ -954,6 +952,13 @@ namespace System.Xml.Tests
             return path[path.Length - 1] == Path.DirectorySeparatorChar ? 
                 path : 
                 path + Path.DirectorySeparatorChar;
+        }
+
+        // This is a workaround for https://github.com/dotnet/corefx/issues/20046
+        private static string ToAbsoluteUri(string path)
+        {
+            Uri uri = new Uri(path, UriKind.Absolute);
+            return uri.ToString();
         }
 
         private static string xsd445844 = @"<?xml version='1.0' encoding='utf-8' ?>


### PR DESCRIPTION
Re-enables and fixes failing tests of XmlSchemaSet that depend on System.Uri.IsAbsoluteUri 's behavior when the passed string to Uri starts with "/" on Unix. The method returns `False` for these types of paths, although the path in Unix is considered as absolute.

Resolves https://github.com/dotnet/corefx/issues/20148

cc: @danmosemsft @krwq @stephentoub 