### PR TITLE
Fix Parallel.For* to consistently throw exception upon cancellation

### DIFF
--- a/src/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/Parallel.cs
+++ b/src/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/Parallel.cs
@@ -1062,10 +1062,10 @@ namespace System.Threading.Tasks
                             ? default(CancellationTokenRegistration)
                             : parallelOptions.CancellationToken.Register((o) =>
                             {
+                                // Record our cancellation before stopping processing
+                                oce = new OperationCanceledException(parallelOptions.CancellationToken);
                                 // Cause processing to stop
                                 sharedPStateFlags.Cancel();
-                                // Record our cancellation
-                                oce = new OperationCanceledException(parallelOptions.CancellationToken);
                             }, state: null, useSynchronizationContext: false);
 
             // ETW event for Parallel For begin
@@ -1080,137 +1080,146 @@ namespace System.Threading.Tasks
 
             try
             {
-                TaskReplicator.Run(
-                    (ref RangeWorker currentWorker, int timeout, out bool replicationDelegateYieldedBeforeCompletion) =>
-                    {
-                        // First thing we do upon entering the task is to register as a new "RangeWorker" with the
-                        // shared RangeManager instance.
-
-                        if (!currentWorker.IsInitialized)
-                            currentWorker = rangeManager.RegisterNewWorker();
-
-                        // We will need to reset this to true if we exit due to a timeout:
-                        replicationDelegateYieldedBeforeCompletion = false;
-
-                        // We need to call FindNewWork32() on it to see whether there's a chunk available.
-                        // These are the local index values to be used in the sequential loop.
-                        // Their values filled in by FindNewWork32
-                        int nFromInclusiveLocal;
-                        int nToExclusiveLocal;
-
-                        if (currentWorker.FindNewWork32(out nFromInclusiveLocal, out nToExclusiveLocal) == false ||
-                            sharedPStateFlags.ShouldExitLoop(nFromInclusiveLocal) == true)
+                try
+                {
+                    TaskReplicator.Run(
+                        (ref RangeWorker currentWorker, int timeout, out bool replicationDelegateYieldedBeforeCompletion) =>
                         {
-                            return; // no need to run
-                        }
+                            // First thing we do upon entering the task is to register as a new "RangeWorker" with the
+                            // shared RangeManager instance.
 
-                        // ETW event for ParallelFor Worker Fork
-                        if (ParallelEtwProvider.Log.IsEnabled())
-                        {
-                            ParallelEtwProvider.Log.ParallelFork(TaskScheduler.Current.Id, Task.CurrentId ?? 0, forkJoinContextID);
-                        }
+                            if (!currentWorker.IsInitialized)
+                                currentWorker = rangeManager.RegisterNewWorker();
 
-                        TLocal localValue = default(TLocal);
-                        bool bLocalValueInitialized = false; // Tracks whether localInit ran without exceptions, so that we can skip localFinally if it wasn't
+                            // We will need to reset this to true if we exit due to a timeout:
+                            replicationDelegateYieldedBeforeCompletion = false;
 
-                        try
-                        {
-                            // Create a new state object that references the shared "stopped" and "exceptional" flags
-                            // If needed, it will contain a new instance of thread-local state by invoking the selector.
-                            ParallelLoopState32 state = null;
+                            // We need to call FindNewWork32() on it to see whether there's a chunk available.
+                            // These are the local index values to be used in the sequential loop.
+                            // Their values filled in by FindNewWork32
+                            int nFromInclusiveLocal;
+                            int nToExclusiveLocal;
 
-                            if (bodyWithState != null)
+                            if (currentWorker.FindNewWork32(out nFromInclusiveLocal, out nToExclusiveLocal) == false ||
+                                sharedPStateFlags.ShouldExitLoop(nFromInclusiveLocal) == true)
                             {
-                                Debug.Assert(sharedPStateFlags != null);
-                                state = new ParallelLoopState32(sharedPStateFlags);
-                            }
-                            else if (bodyWithLocal != null)
-                            {
-                                Debug.Assert(sharedPStateFlags != null);
-                                state = new ParallelLoopState32(sharedPStateFlags);
-                                if (localInit != null)
-                                {
-                                    localValue = localInit();
-                                    bLocalValueInitialized = true;
-                                }
+                                return; // no need to run
                             }
 
-                            // initialize a loop timer which will help us decide whether we should exit early
-                            Int32 loopTimeout = ComputeTimeoutPoint(timeout);
-
-                            // Now perform the loop itself.
-                            do
-                            {
-                                if (body != null)
-                                {
-                                    for (int j = nFromInclusiveLocal;
-                                         j < nToExclusiveLocal && (sharedPStateFlags.LoopStateFlags == ParallelLoopStateFlags.ParallelLoopStateNone  // fast path check as SEL() doesn't inline
-                                                                   || !sharedPStateFlags.ShouldExitLoop()); // the no-arg version is used since we have no state
-                                         j += 1)
-                                    {
-                                        body(j);
-                                    }
-                                }
-                                else if (bodyWithState != null)
-                                {
-                                    for (int j = nFromInclusiveLocal;
-                                        j < nToExclusiveLocal && (sharedPStateFlags.LoopStateFlags == ParallelLoopStateFlags.ParallelLoopStateNone  // fast path check as SEL() doesn't inline
-                                                                   || !sharedPStateFlags.ShouldExitLoop(j));
-                                        j += 1)
-                                    {
-                                        state.CurrentIteration = j;
-                                        bodyWithState(j, state);
-                                    }
-                                }
-                                else
-                                {
-                                    for (int j = nFromInclusiveLocal;
-                                        j < nToExclusiveLocal && (sharedPStateFlags.LoopStateFlags == ParallelLoopStateFlags.ParallelLoopStateNone  // fast path check as SEL() doesn't inline
-                                                                   || !sharedPStateFlags.ShouldExitLoop(j));
-                                        j += 1)
-                                    {
-                                        state.CurrentIteration = j;
-                                        localValue = bodyWithLocal(j, state, localValue);
-                                    }
-                                }
-
-                                // Cooperative multitasking:
-                                // Check if allowed loop time is exceeded, if so save current state and return.
-                                // The task replicator will queue up a replacement task. Note that we don't do this on the root task.
-                                if (CheckTimeoutReached(loopTimeout))
-                                {
-                                    replicationDelegateYieldedBeforeCompletion = true;
-                                    break;
-                                }
-                                // Exit DO-loop if we can't find new work, or if the loop was stopped:
-                            } while (currentWorker.FindNewWork32(out nFromInclusiveLocal, out nToExclusiveLocal) &&
-                                      ((sharedPStateFlags.LoopStateFlags == ParallelLoopStateFlags.ParallelLoopStateNone) ||
-                                        !sharedPStateFlags.ShouldExitLoop(nFromInclusiveLocal)));
-                        }
-                        catch (Exception ex)
-                        {
-                            // if we catch an exception in a worker, we signal the other workers to exit the loop, and we rethrow
-                            sharedPStateFlags.SetExceptional();
-                            ExceptionDispatchInfo.Throw(ex);
-                        }
-                        finally
-                        {
-                            // If a cleanup function was specified, call it. Otherwise, if the type is
-                            // IDisposable, we will invoke Dispose on behalf of the user.
-                            if (localFinally != null && bLocalValueInitialized)
-                            {
-                                localFinally(localValue);
-                            }
-
-                            // ETW event for ParallelFor Worker Join
+                            // ETW event for ParallelFor Worker Fork
                             if (ParallelEtwProvider.Log.IsEnabled())
                             {
-                                ParallelEtwProvider.Log.ParallelJoin(TaskScheduler.Current.Id, Task.CurrentId ?? 0, forkJoinContextID);
+                                ParallelEtwProvider.Log.ParallelFork(TaskScheduler.Current.Id, Task.CurrentId ?? 0, forkJoinContextID);
                             }
-                        }
-                    },
-                    parallelOptions,
-                    stopOnFirstFailure: true);
+
+                            TLocal localValue = default(TLocal);
+                            bool bLocalValueInitialized = false; // Tracks whether localInit ran without exceptions, so that we can skip localFinally if it wasn't
+
+                            try
+                            {
+                                // Create a new state object that references the shared "stopped" and "exceptional" flags
+                                // If needed, it will contain a new instance of thread-local state by invoking the selector.
+                                ParallelLoopState32 state = null;
+
+                                if (bodyWithState != null)
+                                {
+                                    Debug.Assert(sharedPStateFlags != null);
+                                    state = new ParallelLoopState32(sharedPStateFlags);
+                                }
+                                else if (bodyWithLocal != null)
+                                {
+                                    Debug.Assert(sharedPStateFlags != null);
+                                    state = new ParallelLoopState32(sharedPStateFlags);
+                                    if (localInit != null)
+                                    {
+                                        localValue = localInit();
+                                        bLocalValueInitialized = true;
+                                    }
+                                }
+
+                                // initialize a loop timer which will help us decide whether we should exit early
+                                Int32 loopTimeout = ComputeTimeoutPoint(timeout);
+
+                                // Now perform the loop itself.
+                                do
+                                {
+                                    if (body != null)
+                                    {
+                                        for (int j = nFromInclusiveLocal;
+                                             j < nToExclusiveLocal && (sharedPStateFlags.LoopStateFlags == ParallelLoopStateFlags.ParallelLoopStateNone  // fast path check as SEL() doesn't inline
+                                                                       || !sharedPStateFlags.ShouldExitLoop()); // the no-arg version is used since we have no state
+                                             j += 1)
+                                        {
+                                            body(j);
+                                        }
+                                    }
+                                    else if (bodyWithState != null)
+                                    {
+                                        for (int j = nFromInclusiveLocal;
+                                            j < nToExclusiveLocal && (sharedPStateFlags.LoopStateFlags == ParallelLoopStateFlags.ParallelLoopStateNone  // fast path check as SEL() doesn't inline
+                                                                       || !sharedPStateFlags.ShouldExitLoop(j));
+                                            j += 1)
+                                        {
+                                            state.CurrentIteration = j;
+                                            bodyWithState(j, state);
+                                        }
+                                    }
+                                    else
+                                    {
+                                        for (int j = nFromInclusiveLocal;
+                                            j < nToExclusiveLocal && (sharedPStateFlags.LoopStateFlags == ParallelLoopStateFlags.ParallelLoopStateNone  // fast path check as SEL() doesn't inline
+                                                                       || !sharedPStateFlags.ShouldExitLoop(j));
+                                            j += 1)
+                                        {
+                                            state.CurrentIteration = j;
+                                            localValue = bodyWithLocal(j, state, localValue);
+                                        }
+                                    }
+
+                                    // Cooperative multitasking:
+                                    // Check if allowed loop time is exceeded, if so save current state and return.
+                                    // The task replicator will queue up a replacement task. Note that we don't do this on the root task.
+                                    if (CheckTimeoutReached(loopTimeout))
+                                    {
+                                        replicationDelegateYieldedBeforeCompletion = true;
+                                        break;
+                                    }
+                                    // Exit DO-loop if we can't find new work, or if the loop was stopped:
+                                } while (currentWorker.FindNewWork32(out nFromInclusiveLocal, out nToExclusiveLocal) &&
+                                          ((sharedPStateFlags.LoopStateFlags == ParallelLoopStateFlags.ParallelLoopStateNone) ||
+                                            !sharedPStateFlags.ShouldExitLoop(nFromInclusiveLocal)));
+                            }
+                            catch (Exception ex)
+                            {
+                                // if we catch an exception in a worker, we signal the other workers to exit the loop, and we rethrow
+                                sharedPStateFlags.SetExceptional();
+                                ExceptionDispatchInfo.Throw(ex);
+                            }
+                            finally
+                            {
+                                // If a cleanup function was specified, call it. Otherwise, if the type is
+                                // IDisposable, we will invoke Dispose on behalf of the user.
+                                if (localFinally != null && bLocalValueInitialized)
+                                {
+                                    localFinally(localValue);
+                                }
+
+                                // ETW event for ParallelFor Worker Join
+                                if (ParallelEtwProvider.Log.IsEnabled())
+                                {
+                                    ParallelEtwProvider.Log.ParallelJoin(TaskScheduler.Current.Id, Task.CurrentId ?? 0, forkJoinContextID);
+                                }
+                            }
+                        },
+                        parallelOptions,
+                        stopOnFirstFailure: true);
+                }
+                finally
+                {
+                    // Dispose the cancellation token registration before checking for a cancellation exception
+                    if (parallelOptions.CancellationToken.CanBeCanceled)
+                        ctr.Dispose();
+                }
 
                 // If we got through that with no exceptions, and we were canceled, then
                 // throw our cancellation exception  
@@ -1223,9 +1232,6 @@ namespace System.Threading.Tasks
             }
             finally
             {
-                if (parallelOptions.CancellationToken.CanBeCanceled)
-                    ctr.Dispose();
-
                 int sb_status = sharedPStateFlags.LoopStateFlags;
                 result._completed = (sb_status == ParallelLoopStateFlags.ParallelLoopStateNone);
                 if ((sb_status & ParallelLoopStateFlags.ParallelLoopStateBroken) != 0)
@@ -1318,10 +1324,10 @@ namespace System.Threading.Tasks
                             ? default(CancellationTokenRegistration)
                             : parallelOptions.CancellationToken.Register((o) =>
                             {
+                                // Record our cancellation before stopping processing
+                                oce = new OperationCanceledException(parallelOptions.CancellationToken);
                                 // Cause processing to stop
                                 sharedPStateFlags.Cancel();
-                                // Record our cancellation
-                                oce = new OperationCanceledException(parallelOptions.CancellationToken);
                             }, state: null, useSynchronizationContext: false);
 
             // ETW event for Parallel For begin
@@ -1336,140 +1342,149 @@ namespace System.Threading.Tasks
 
             try
             {
-                TaskReplicator.Run(
-                    (ref RangeWorker currentWorker, int timeout, out bool replicationDelegateYieldedBeforeCompletion) =>
-                    {
-                        // First thing we do upon entering the task is to register as a new "RangeWorker" with the
-                        // shared RangeManager instance.
-
-                        if (!currentWorker.IsInitialized)
-                            currentWorker = rangeManager.RegisterNewWorker();
-
-                        // We will need to reset this to true if we exit due to a timeout:
-                        replicationDelegateYieldedBeforeCompletion = false;
-
-
-                        // These are the local index values to be used in the sequential loop.
-                        // Their values filled in by FindNewWork
-                        long nFromInclusiveLocal;
-                        long nToExclusiveLocal;
-
-                        if (currentWorker.FindNewWork(out nFromInclusiveLocal, out nToExclusiveLocal) == false ||
-                            sharedPStateFlags.ShouldExitLoop(nFromInclusiveLocal) == true)
+                try
+                {
+                    TaskReplicator.Run(
+                        (ref RangeWorker currentWorker, int timeout, out bool replicationDelegateYieldedBeforeCompletion) =>
                         {
-                            return; // no need to run
-                        }
+                            // First thing we do upon entering the task is to register as a new "RangeWorker" with the
+                            // shared RangeManager instance.
+
+                            if (!currentWorker.IsInitialized)
+                                currentWorker = rangeManager.RegisterNewWorker();
+
+                            // We will need to reset this to true if we exit due to a timeout:
+                            replicationDelegateYieldedBeforeCompletion = false;
 
 
-                        // ETW event for ParallelFor Worker Fork                    
-                        if (ParallelEtwProvider.Log.IsEnabled())
-                        {
-                            ParallelEtwProvider.Log.ParallelFork(TaskScheduler.Current.Id, Task.CurrentId ?? 0, forkJoinContextID);
-                        }
+                            // These are the local index values to be used in the sequential loop.
+                            // Their values filled in by FindNewWork
+                            long nFromInclusiveLocal;
+                            long nToExclusiveLocal;
 
-                        TLocal localValue = default(TLocal);
-                        bool bLocalValueInitialized = false; // Tracks whether localInit ran without exceptions, so that we can skip localFinally if it wasn't
-
-                        try
-                        {
-                            // Create a new state object that references the shared "stopped" and "exceptional" flags
-                            // If needed, it will contain a new instance of thread-local state by invoking the selector.
-                            ParallelLoopState64 state = null;
-
-                            if (bodyWithState != null)
+                            if (currentWorker.FindNewWork(out nFromInclusiveLocal, out nToExclusiveLocal) == false ||
+                                sharedPStateFlags.ShouldExitLoop(nFromInclusiveLocal) == true)
                             {
-                                Debug.Assert(sharedPStateFlags != null);
-                                state = new ParallelLoopState64(sharedPStateFlags);
-                            }
-                            else if (bodyWithLocal != null)
-                            {
-                                Debug.Assert(sharedPStateFlags != null);
-                                state = new ParallelLoopState64(sharedPStateFlags);
-
-                                // If a thread-local selector was supplied, invoke it. Otherwise, use the default.
-                                if (localInit != null)
-                                {
-                                    localValue = localInit();
-                                    bLocalValueInitialized = true;
-                                }
+                                return; // no need to run
                             }
 
-                            // initialize a loop timer which will help us decide whether we should exit early
-                            Int32 loopTimeout = ComputeTimeoutPoint(timeout);
 
-                            // Now perform the loop itself.
-                            do
-                            {
-                                if (body != null)
-                                {
-                                    for (long j = nFromInclusiveLocal;
-                                         j < nToExclusiveLocal && (sharedPStateFlags.LoopStateFlags == ParallelLoopStateFlags.ParallelLoopStateNone  // fast path check as SEL() doesn't inline
-                                                                   || !sharedPStateFlags.ShouldExitLoop()); // the no-arg version is used since we have no state
-                                         j += 1)
-                                    {
-                                        body(j);
-                                    }
-                                }
-                                else if (bodyWithState != null)
-                                {
-                                    for (long j = nFromInclusiveLocal;
-                                         j < nToExclusiveLocal && (sharedPStateFlags.LoopStateFlags == ParallelLoopStateFlags.ParallelLoopStateNone  // fast path check as SEL() doesn't inline
-                                                                   || !sharedPStateFlags.ShouldExitLoop(j));
-                                         j += 1)
-                                    {
-                                        state.CurrentIteration = j;
-                                        bodyWithState(j, state);
-                                    }
-                                }
-                                else
-                                {
-                                    for (long j = nFromInclusiveLocal;
-                                         j < nToExclusiveLocal && (sharedPStateFlags.LoopStateFlags == ParallelLoopStateFlags.ParallelLoopStateNone  // fast path check as SEL() doesn't inline
-                                                                   || !sharedPStateFlags.ShouldExitLoop(j));
-                                         j += 1)
-                                    {
-                                        state.CurrentIteration = j;
-                                        localValue = bodyWithLocal(j, state, localValue);
-                                    }
-                                }
-
-                                // Cooperative multitasking:
-                                // Check if allowed loop time is exceeded, if so save current state and return.
-                                // The task replicator will queue up a replacement task. Note that we don't do this on the root task.
-                                if (CheckTimeoutReached(loopTimeout))
-                                {
-                                    replicationDelegateYieldedBeforeCompletion = true;
-                                    break;
-                                }
-                                // Exit DO-loop if we can't find new work, or if the loop was stopped:
-                            } while (currentWorker.FindNewWork(out nFromInclusiveLocal, out nToExclusiveLocal) &&
-                                      ((sharedPStateFlags.LoopStateFlags == ParallelLoopStateFlags.ParallelLoopStateNone) ||
-                                        !sharedPStateFlags.ShouldExitLoop(nFromInclusiveLocal)));
-                        }
-                        catch (Exception ex)
-                        {
-                            // if we catch an exception in a worker, we signal the other workers to exit the loop, and we rethrow
-                            sharedPStateFlags.SetExceptional();
-                            ExceptionDispatchInfo.Throw(ex);
-                        }
-                        finally
-                        {
-                            // If a cleanup function was specified, call it. Otherwise, if the type is
-                            // IDisposable, we will invoke Dispose on behalf of the user.
-                            if (localFinally != null && bLocalValueInitialized)
-                            {
-                                localFinally(localValue);
-                            }
-
-                            // ETW event for ParallelFor Worker Join
+                            // ETW event for ParallelFor Worker Fork                    
                             if (ParallelEtwProvider.Log.IsEnabled())
                             {
-                                ParallelEtwProvider.Log.ParallelJoin(TaskScheduler.Current.Id, Task.CurrentId ?? 0, forkJoinContextID);
+                                ParallelEtwProvider.Log.ParallelFork(TaskScheduler.Current.Id, Task.CurrentId ?? 0, forkJoinContextID);
                             }
-                        }
-                    },
-                    parallelOptions,
-                    stopOnFirstFailure: true);
+
+                            TLocal localValue = default(TLocal);
+                            bool bLocalValueInitialized = false; // Tracks whether localInit ran without exceptions, so that we can skip localFinally if it wasn't
+
+                            try
+                            {
+                                // Create a new state object that references the shared "stopped" and "exceptional" flags
+                                // If needed, it will contain a new instance of thread-local state by invoking the selector.
+                                ParallelLoopState64 state = null;
+
+                                if (bodyWithState != null)
+                                {
+                                    Debug.Assert(sharedPStateFlags != null);
+                                    state = new ParallelLoopState64(sharedPStateFlags);
+                                }
+                                else if (bodyWithLocal != null)
+                                {
+                                    Debug.Assert(sharedPStateFlags != null);
+                                    state = new ParallelLoopState64(sharedPStateFlags);
+
+                                    // If a thread-local selector was supplied, invoke it. Otherwise, use the default.
+                                    if (localInit != null)
+                                    {
+                                        localValue = localInit();
+                                        bLocalValueInitialized = true;
+                                    }
+                                }
+
+                                // initialize a loop timer which will help us decide whether we should exit early
+                                Int32 loopTimeout = ComputeTimeoutPoint(timeout);
+
+                                // Now perform the loop itself.
+                                do
+                                {
+                                    if (body != null)
+                                    {
+                                        for (long j = nFromInclusiveLocal;
+                                             j < nToExclusiveLocal && (sharedPStateFlags.LoopStateFlags == ParallelLoopStateFlags.ParallelLoopStateNone  // fast path check as SEL() doesn't inline
+                                                                       || !sharedPStateFlags.ShouldExitLoop()); // the no-arg version is used since we have no state
+                                             j += 1)
+                                        {
+                                            body(j);
+                                        }
+                                    }
+                                    else if (bodyWithState != null)
+                                    {
+                                        for (long j = nFromInclusiveLocal;
+                                             j < nToExclusiveLocal && (sharedPStateFlags.LoopStateFlags == ParallelLoopStateFlags.ParallelLoopStateNone  // fast path check as SEL() doesn't inline
+                                                                       || !sharedPStateFlags.ShouldExitLoop(j));
+                                             j += 1)
+                                        {
+                                            state.CurrentIteration = j;
+                                            bodyWithState(j, state);
+                                        }
+                                    }
+                                    else
+                                    {
+                                        for (long j = nFromInclusiveLocal;
+                                             j < nToExclusiveLocal && (sharedPStateFlags.LoopStateFlags == ParallelLoopStateFlags.ParallelLoopStateNone  // fast path check as SEL() doesn't inline
+                                                                       || !sharedPStateFlags.ShouldExitLoop(j));
+                                             j += 1)
+                                        {
+                                            state.CurrentIteration = j;
+                                            localValue = bodyWithLocal(j, state, localValue);
+                                        }
+                                    }
+
+                                    // Cooperative multitasking:
+                                    // Check if allowed loop time is exceeded, if so save current state and return.
+                                    // The task replicator will queue up a replacement task. Note that we don't do this on the root task.
+                                    if (CheckTimeoutReached(loopTimeout))
+                                    {
+                                        replicationDelegateYieldedBeforeCompletion = true;
+                                        break;
+                                    }
+                                    // Exit DO-loop if we can't find new work, or if the loop was stopped:
+                                } while (currentWorker.FindNewWork(out nFromInclusiveLocal, out nToExclusiveLocal) &&
+                                          ((sharedPStateFlags.LoopStateFlags == ParallelLoopStateFlags.ParallelLoopStateNone) ||
+                                            !sharedPStateFlags.ShouldExitLoop(nFromInclusiveLocal)));
+                            }
+                            catch (Exception ex)
+                            {
+                                // if we catch an exception in a worker, we signal the other workers to exit the loop, and we rethrow
+                                sharedPStateFlags.SetExceptional();
+                                ExceptionDispatchInfo.Throw(ex);
+                            }
+                            finally
+                            {
+                                // If a cleanup function was specified, call it. Otherwise, if the type is
+                                // IDisposable, we will invoke Dispose on behalf of the user.
+                                if (localFinally != null && bLocalValueInitialized)
+                                {
+                                    localFinally(localValue);
+                                }
+
+                                // ETW event for ParallelFor Worker Join
+                                if (ParallelEtwProvider.Log.IsEnabled())
+                                {
+                                    ParallelEtwProvider.Log.ParallelJoin(TaskScheduler.Current.Id, Task.CurrentId ?? 0, forkJoinContextID);
+                                }
+                            }
+                        },
+                        parallelOptions,
+                        stopOnFirstFailure: true);
+                }
+                finally
+                {
+                    // Dispose the cancellation token registration before checking for a cancellation exception
+                    if (parallelOptions.CancellationToken.CanBeCanceled)
+                        ctr.Dispose();
+                }
 
                 // If we got through that with no exceptions, and we were canceled, then
                 // throw our cancellation exception
@@ -1482,9 +1497,6 @@ namespace System.Threading.Tasks
             }
             finally
             {
-                if (parallelOptions.CancellationToken.CanBeCanceled)
-                    ctr.Dispose();
-
                 int sb_status = sharedPStateFlags.LoopStateFlags;
                 result._completed = (sb_status == ParallelLoopStateFlags.ParallelLoopStateNone);
                 if ((sb_status & ParallelLoopStateFlags.ParallelLoopStateBroken) != 0)
@@ -2101,10 +2113,7 @@ namespace System.Threading.Tasks
                 "thread local functions should only be supplied for loops w/ thread local bodies");
 
             // Before getting started, do a quick peek to see if we have been canceled already
-            if (parallelOptions.CancellationToken.IsCancellationRequested)
-            {
-                throw new OperationCanceledException(parallelOptions.CancellationToken);
-            }
+            parallelOptions.CancellationToken.ThrowIfCancellationRequested();
 
             // If it's an array, we can use a fast-path that uses ldelems in the IL.
             TSource[] sourceAsArray = source as TSource[];
@@ -3114,10 +3123,10 @@ namespace System.Threading.Tasks
                             ? default(CancellationTokenRegistration)
                             : parallelOptions.CancellationToken.Register((o) =>
                             {
+                                // Record our cancellation before stopping processing
+                                oce = new OperationCanceledException(parallelOptions.CancellationToken);
                                 // Cause processing to stop
                                 sharedPStateFlags.Cancel();
-                                // Record our cancellation
-                                oce = new OperationCanceledException(parallelOptions.CancellationToken);
                             }, state: null, useSynchronizationContext: false);
 
             // Get our dynamic partitioner -- depends on whether source is castable to OrderablePartitioner
@@ -3143,168 +3152,177 @@ namespace System.Threading.Tasks
 
             try
             {
-                TaskReplicator.Run(
-                    (ref IEnumerator partitionState, int timeout, out bool replicationDelegateYieldedBeforeCompletion) =>
-                    {
-                        // We will need to reset this to true if we exit due to a timeout:
-                        replicationDelegateYieldedBeforeCompletion = false;
-
-                        // ETW event for ParallelForEach Worker Fork
-                        if (ParallelEtwProvider.Log.IsEnabled())
+                try
+                {
+                    TaskReplicator.Run(
+                        (ref IEnumerator partitionState, int timeout, out bool replicationDelegateYieldedBeforeCompletion) =>
                         {
-                            ParallelEtwProvider.Log.ParallelFork(TaskScheduler.Current.Id, Task.CurrentId ?? 0, forkJoinContextID);
-                        }
+                            // We will need to reset this to true if we exit due to a timeout:
+                            replicationDelegateYieldedBeforeCompletion = false;
 
-                        TLocal localValue = default(TLocal);
-                        bool bLocalValueInitialized = false; // Tracks whether localInit ran without exceptions, so that we can skip localFinally if it wasn't
-
-                        try
-                        {
-                            // Create a new state object that references the shared "stopped" and "exceptional" flags.
-                            // If needed, it will contain a new instance of thread-local state by invoking the selector.
-                            ParallelLoopState64 state = null;
-
-                            if (bodyWithState != null || bodyWithStateAndIndex != null)
-                            {
-                                state = new ParallelLoopState64(sharedPStateFlags);
-                            }
-                            else if (bodyWithStateAndLocal != null || bodyWithEverything != null)
-                            {
-                                state = new ParallelLoopState64(sharedPStateFlags);
-                                // If a thread-local selector was supplied, invoke it. Otherwise, stick with the default.
-                                if (localInit != null)
-                                {
-                                    localValue = localInit();
-                                    bLocalValueInitialized = true;
-                                }
-                            }
-
-                            // initialize a loop timer which will help us decide whether we should exit early
-                            Int32 loopTimeout = ComputeTimeoutPoint(timeout);
-
-                            if (orderedSource != null)  // Use this path for OrderablePartitioner:
-                            {
-                                // first check if there's saved state from a previous replica that we might be replacing.
-                                // the only state to be passed down in such a transition is the enumerator                     
-                                IEnumerator<KeyValuePair<long, TSource>> myPartition = partitionState as IEnumerator<KeyValuePair<long, TSource>>;
-                                if (myPartition == null)
-                                {
-                                    myPartition = orderablePartitionerSource.GetEnumerator();
-                                    partitionState = myPartition;
-                                }
-
-                                if (myPartition == null)
-                                    throw new InvalidOperationException(SR.Parallel_ForEach_NullEnumerator);
-
-                                while (myPartition.MoveNext())
-                                {
-                                    KeyValuePair<long, TSource> kvp = myPartition.Current;
-                                    long index = kvp.Key;
-                                    TSource value = kvp.Value;
-
-                                    // Update our iteration index
-                                    if (state != null) state.CurrentIteration = index;
-
-                                    if (simpleBody != null)
-                                        simpleBody(value);
-                                    else if (bodyWithState != null)
-                                        bodyWithState(value, state);
-                                    else if (bodyWithStateAndIndex != null)
-                                        bodyWithStateAndIndex(value, state, index);
-                                    else if (bodyWithStateAndLocal != null)
-                                        localValue = bodyWithStateAndLocal(value, state, localValue);
-                                    else
-                                        localValue = bodyWithEverything(value, state, index, localValue);
-
-                                    if (sharedPStateFlags.ShouldExitLoop(index)) break;
-
-                                    // Cooperative multitasking:
-                                    // Check if allowed loop time is exceeded, if so save current state and return.
-                                    // The task replicator will queue up a replacement task. Note that we don't do this on the root task.
-                                    if (CheckTimeoutReached(loopTimeout))
-                                    {
-                                        replicationDelegateYieldedBeforeCompletion = true;
-                                        break;
-                                    }
-                                }
-                            }
-                            else  // Use this path for Partitioner that is not OrderablePartitioner:
-                            {
-                                // first check if there's saved state from a previous replica that we might be replacing.
-                                // the only state to be passed down in such a transition is the enumerator
-                                IEnumerator<TSource> myPartition = partitionState as IEnumerator<TSource>;
-                                if (myPartition == null)
-                                {
-                                    myPartition = partitionerSource.GetEnumerator();
-                                    partitionState = myPartition;
-                                }
-
-                                if (myPartition == null)
-                                    throw new InvalidOperationException(SR.Parallel_ForEach_NullEnumerator);
-
-                                // I'm not going to try to maintain this
-                                if (state != null)
-                                    state.CurrentIteration = 0;
-
-                                while (myPartition.MoveNext())
-                                {
-                                    TSource t = myPartition.Current;
-
-                                    if (simpleBody != null)
-                                        simpleBody(t);
-                                    else if (bodyWithState != null)
-                                        bodyWithState(t, state);
-                                    else if (bodyWithStateAndLocal != null)
-                                        localValue = bodyWithStateAndLocal(t, state, localValue);
-                                    else
-                                        Debug.Fail("PartitionerForEach: illegal body type in Partitioner handler");
-
-                                    // Any break, stop or exception causes us to halt
-                                    // We don't have the global indexing information to discriminate whether or not
-                                    // we are before or after a break point.
-                                    if (sharedPStateFlags.LoopStateFlags != ParallelLoopStateFlags.ParallelLoopStateNone)
-                                        break;
-
-                                    // Cooperative multitasking:
-                                    // Check if allowed loop time is exceeded, if so save current state and return.
-                                    // The task replicator will queue up a replacement task. Note that we don't do this on the root task.
-                                    if (CheckTimeoutReached(loopTimeout))
-                                    {
-                                        replicationDelegateYieldedBeforeCompletion = true;
-                                        break;
-                                    }
-                                }
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            // Inform other tasks of the exception, then rethrow
-                            sharedPStateFlags.SetExceptional();
-                            ExceptionDispatchInfo.Throw(ex);
-                        }
-                        finally
-                        {
-                            if (localFinally != null && bLocalValueInitialized)
-                            {
-                                localFinally(localValue);
-                            }
-
-                            if (!replicationDelegateYieldedBeforeCompletion)
-                            {
-                                IDisposable partitionToDispose = partitionState as IDisposable;
-                                if (partitionToDispose != null)
-                                    partitionToDispose.Dispose();
-                            }
-
-                            // ETW event for ParallelFor Worker Join
+                            // ETW event for ParallelForEach Worker Fork
                             if (ParallelEtwProvider.Log.IsEnabled())
                             {
-                                ParallelEtwProvider.Log.ParallelJoin(TaskScheduler.Current.Id, Task.CurrentId ?? 0, forkJoinContextID);
+                                ParallelEtwProvider.Log.ParallelFork(TaskScheduler.Current.Id, Task.CurrentId ?? 0, forkJoinContextID);
                             }
-                        }
-                    },
-                    parallelOptions,
-                    stopOnFirstFailure: true);
+
+                            TLocal localValue = default(TLocal);
+                            bool bLocalValueInitialized = false; // Tracks whether localInit ran without exceptions, so that we can skip localFinally if it wasn't
+
+                            try
+                            {
+                                // Create a new state object that references the shared "stopped" and "exceptional" flags.
+                                // If needed, it will contain a new instance of thread-local state by invoking the selector.
+                                ParallelLoopState64 state = null;
+
+                                if (bodyWithState != null || bodyWithStateAndIndex != null)
+                                {
+                                    state = new ParallelLoopState64(sharedPStateFlags);
+                                }
+                                else if (bodyWithStateAndLocal != null || bodyWithEverything != null)
+                                {
+                                    state = new ParallelLoopState64(sharedPStateFlags);
+                                    // If a thread-local selector was supplied, invoke it. Otherwise, stick with the default.
+                                    if (localInit != null)
+                                    {
+                                        localValue = localInit();
+                                        bLocalValueInitialized = true;
+                                    }
+                                }
+
+                                // initialize a loop timer which will help us decide whether we should exit early
+                                Int32 loopTimeout = ComputeTimeoutPoint(timeout);
+
+                                if (orderedSource != null)  // Use this path for OrderablePartitioner:
+                                {
+                                    // first check if there's saved state from a previous replica that we might be replacing.
+                                    // the only state to be passed down in such a transition is the enumerator                     
+                                    IEnumerator<KeyValuePair<long, TSource>> myPartition = partitionState as IEnumerator<KeyValuePair<long, TSource>>;
+                                    if (myPartition == null)
+                                    {
+                                        myPartition = orderablePartitionerSource.GetEnumerator();
+                                        partitionState = myPartition;
+                                    }
+
+                                    if (myPartition == null)
+                                        throw new InvalidOperationException(SR.Parallel_ForEach_NullEnumerator);
+
+                                    while (myPartition.MoveNext())
+                                    {
+                                        KeyValuePair<long, TSource> kvp = myPartition.Current;
+                                        long index = kvp.Key;
+                                        TSource value = kvp.Value;
+
+                                        // Update our iteration index
+                                        if (state != null) state.CurrentIteration = index;
+
+                                        if (simpleBody != null)
+                                            simpleBody(value);
+                                        else if (bodyWithState != null)
+                                            bodyWithState(value, state);
+                                        else if (bodyWithStateAndIndex != null)
+                                            bodyWithStateAndIndex(value, state, index);
+                                        else if (bodyWithStateAndLocal != null)
+                                            localValue = bodyWithStateAndLocal(value, state, localValue);
+                                        else
+                                            localValue = bodyWithEverything(value, state, index, localValue);
+
+                                        if (sharedPStateFlags.ShouldExitLoop(index)) break;
+
+                                        // Cooperative multitasking:
+                                        // Check if allowed loop time is exceeded, if so save current state and return.
+                                        // The task replicator will queue up a replacement task. Note that we don't do this on the root task.
+                                        if (CheckTimeoutReached(loopTimeout))
+                                        {
+                                            replicationDelegateYieldedBeforeCompletion = true;
+                                            break;
+                                        }
+                                    }
+                                }
+                                else  // Use this path for Partitioner that is not OrderablePartitioner:
+                                {
+                                    // first check if there's saved state from a previous replica that we might be replacing.
+                                    // the only state to be passed down in such a transition is the enumerator
+                                    IEnumerator<TSource> myPartition = partitionState as IEnumerator<TSource>;
+                                    if (myPartition == null)
+                                    {
+                                        myPartition = partitionerSource.GetEnumerator();
+                                        partitionState = myPartition;
+                                    }
+
+                                    if (myPartition == null)
+                                        throw new InvalidOperationException(SR.Parallel_ForEach_NullEnumerator);
+
+                                    // I'm not going to try to maintain this
+                                    if (state != null)
+                                        state.CurrentIteration = 0;
+
+                                    while (myPartition.MoveNext())
+                                    {
+                                        TSource t = myPartition.Current;
+
+                                        if (simpleBody != null)
+                                            simpleBody(t);
+                                        else if (bodyWithState != null)
+                                            bodyWithState(t, state);
+                                        else if (bodyWithStateAndLocal != null)
+                                            localValue = bodyWithStateAndLocal(t, state, localValue);
+                                        else
+                                            Debug.Fail("PartitionerForEach: illegal body type in Partitioner handler");
+
+                                        // Any break, stop or exception causes us to halt
+                                        // We don't have the global indexing information to discriminate whether or not
+                                        // we are before or after a break point.
+                                        if (sharedPStateFlags.LoopStateFlags != ParallelLoopStateFlags.ParallelLoopStateNone)
+                                            break;
+
+                                        // Cooperative multitasking:
+                                        // Check if allowed loop time is exceeded, if so save current state and return.
+                                        // The task replicator will queue up a replacement task. Note that we don't do this on the root task.
+                                        if (CheckTimeoutReached(loopTimeout))
+                                        {
+                                            replicationDelegateYieldedBeforeCompletion = true;
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                            catch (Exception ex)
+                            {
+                                // Inform other tasks of the exception, then rethrow
+                                sharedPStateFlags.SetExceptional();
+                                ExceptionDispatchInfo.Throw(ex);
+                            }
+                            finally
+                            {
+                                if (localFinally != null && bLocalValueInitialized)
+                                {
+                                    localFinally(localValue);
+                                }
+
+                                if (!replicationDelegateYieldedBeforeCompletion)
+                                {
+                                    IDisposable partitionToDispose = partitionState as IDisposable;
+                                    if (partitionToDispose != null)
+                                        partitionToDispose.Dispose();
+                                }
+
+                                // ETW event for ParallelFor Worker Join
+                                if (ParallelEtwProvider.Log.IsEnabled())
+                                {
+                                    ParallelEtwProvider.Log.ParallelJoin(TaskScheduler.Current.Id, Task.CurrentId ?? 0, forkJoinContextID);
+                                }
+                            }
+                        },
+                        parallelOptions,
+                        stopOnFirstFailure: true);
+                }
+                finally
+                {
+                    // Dispose the cancellation token registration before checking for a cancellation exception
+                    if (parallelOptions.CancellationToken.CanBeCanceled)
+                        ctr.Dispose();
+                }
 
                 // If we got through that with no exceptions, and we were canceled, then
                 // throw our cancellation exception
@@ -3317,9 +3335,6 @@ namespace System.Threading.Tasks
             }
             finally
             {
-                if (parallelOptions.CancellationToken.CanBeCanceled)
-                    ctr.Dispose();
-
                 int sb_status = sharedPStateFlags.LoopStateFlags;
                 result._completed = (sb_status == ParallelLoopStateFlags.ParallelLoopStateNone);
                 if ((sb_status & ParallelLoopStateFlags.ParallelLoopStateBroken) != 0)

--- a/src/System.Threading.Tasks.Parallel/tests/ParallelForTests.cs
+++ b/src/System.Threading.Tasks.Parallel/tests/ParallelForTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Security;
 
 using Xunit;
@@ -1225,6 +1226,138 @@ namespace System.Threading.Tasks.Tests
 
             // Verification
             Assert.False(withinTaskId == null || withinTaskId < 0, "Task.CurrentId called from within a Task must be non-negative");
+        }
+
+        private const int CancelForTestLoopIterations = 500;
+
+        private static void VerifyCancelTestState(
+            bool gotCancellationException,
+            bool reportedAsCompleted,
+            int actuallyCompletedCount)
+        {
+            Assert.Equal(reportedAsCompleted, !gotCancellationException);
+            if (reportedAsCompleted)
+            {
+                Assert.Equal(CancelForTestLoopIterations, actuallyCompletedCount);
+            }
+        }
+
+        [Fact]
+        public static void CancelForIntTest()
+        {
+            for (int i = 0; i < 100; ++i)
+            {
+                var cancellationTokenSource = new CancellationTokenSource();
+                bool gotCancellationException = false;
+                bool reportedAsCompleted = false;
+                var parallelOptions = new ParallelOptions { CancellationToken = cancellationTokenSource.Token };
+                int completedCount = 0;
+                try
+                {
+                    reportedAsCompleted =
+                        Parallel.For(
+                            0,
+                            CancelForTestLoopIterations,
+                            parallelOptions,
+                            value =>
+                            {
+                                Interlocked.Increment(ref completedCount);
+
+                                if (!cancellationTokenSource.IsCancellationRequested)
+                                {
+                                    Task.Run(() => cancellationTokenSource.Cancel());
+                                }
+                            }).IsCompleted;
+                }
+                catch (OperationCanceledException)
+                {
+                    gotCancellationException = true;
+                }
+                int actuallyCompletedCount = Interlocked.CompareExchange(ref completedCount, 0, 0);
+
+                VerifyCancelTestState(gotCancellationException, reportedAsCompleted, actuallyCompletedCount);
+            }
+        }
+
+        [Fact]
+        public static void CancelForLongTest()
+        {
+            for (int i = 0; i < 100; ++i)
+            {
+                var cancellationTokenSource = new CancellationTokenSource();
+                bool gotCancellationException = false;
+                bool reportedAsCompleted = false;
+                var parallelOptions = new ParallelOptions { CancellationToken = cancellationTokenSource.Token };
+                int completedCount = 0;
+                try
+                {
+                    reportedAsCompleted =
+                        Parallel.For(
+                            (long)0,
+                            (long)CancelForTestLoopIterations,
+                            parallelOptions,
+                            value =>
+                            {
+                                Interlocked.Increment(ref completedCount);
+
+                                if (!cancellationTokenSource.IsCancellationRequested)
+                                {
+                                    Task.Run(() => cancellationTokenSource.Cancel());
+                                }
+                            }).IsCompleted;
+                }
+                catch (OperationCanceledException)
+                {
+                    gotCancellationException = true;
+                }
+                int actuallyCompletedCount = Interlocked.CompareExchange(ref completedCount, 0, 0);
+
+                VerifyCancelTestState(gotCancellationException, reportedAsCompleted, actuallyCompletedCount);
+            }
+        }
+
+        private static IEnumerable<object[]> CancelForEachTest_MemberData()
+        {
+            var array = new int[CancelForTestLoopIterations];
+            yield return new object[] { array };
+            yield return new object[] { array.Select(i => i) };
+        }
+
+        [Theory]
+        [MemberData(nameof(CancelForEachTest_MemberData))]
+        public static void CancelForEachTest(IEnumerable<int> enumerable)
+        {
+            for (int i = 0; i < 100; ++i)
+            {
+                var cancellationTokenSource = new CancellationTokenSource();
+                bool gotCancellationException = false;
+                bool reportedAsCompleted = false;
+                var parallelOptions = new ParallelOptions { CancellationToken = cancellationTokenSource.Token };
+                int completedCount = 0;
+                try
+                {
+                    reportedAsCompleted =
+                        Parallel.ForEach(
+                            enumerable,
+                            parallelOptions,
+                            value =>
+                            {
+                                Interlocked.Increment(ref completedCount);
+
+                                if (!cancellationTokenSource.IsCancellationRequested)
+                                {
+                                    Task.Run(() => cancellationTokenSource.Cancel());
+                                }
+                            }).IsCompleted;
+                }
+                catch (OperationCanceledException)
+                {
+                    gotCancellationException = true;
+                }
+                int actuallyCompletedCount = Interlocked.CompareExchange(ref completedCount, 0, 0);
+
+                VerifyCancelTestState(gotCancellationException, reportedAsCompleted, actuallyCompletedCount);
+            }
         }
 
         #region Helper Classes and Methods


### PR DESCRIPTION
Port of PR #20259, commit 62bfba654acf00e4b0fc0811be057c637b135bba to release/2.0.0

Fixes #20093:
- Write the exception to be thrown upon cancellation before setting the canceled state so that the exception will be visible upon cancellation
- Dispose the cancellation token registration before checking the exception so that a late cancellation would never yield an incomplete return status with no exception