### PR TITLE
Disable IStorageFile test for uapaot.

### DIFF
--- a/src/System.Runtime.WindowsRuntime/tests/System/IO/CreateSafeFileHandleTests.cs
+++ b/src/System.Runtime.WindowsRuntime/tests/System/IO/CreateSafeFileHandleTests.cs
@@ -7,7 +7,8 @@ using Windows.Storage;
 using Xunit;
 
 namespace System.IO
-{
+{   
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "https://github.com/dotnet/corefx/issues/18940")]
     public class CreateSafeFileHandleTests
     {
         [Fact]


### PR DESCRIPTION
These test need to run in app-container
since the native API validate it.#18940