### PR TITLE
Implementation of ProcessStartInfo.CreateNewProcessGroup property

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.ForkAndExecProcess.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.ForkAndExecProcess.cs
@@ -14,7 +14,7 @@ internal static partial class Interop
     {
         internal static unsafe void ForkAndExecProcess(
             string filename, string[] argv, string[] envp, string cwd,
-            bool redirectStdin, bool redirectStdout, bool redirectStderr,
+            bool redirectStdin, bool redirectStdout, bool redirectStderr, bool createNewProcessGroup,
             out int lpChildPid, out int stdinFd, out int stdoutFd, out int stderrFd)
         {
             byte** argvPtr = null, envpPtr = null;
@@ -24,7 +24,7 @@ internal static partial class Interop
                 AllocNullTerminatedArray(envp, ref envpPtr);
                 int result = ForkAndExecProcess(
                     filename, argvPtr, envpPtr, cwd,
-                    redirectStdin ? 1 : 0, redirectStdout ? 1 : 0, redirectStderr ? 1 :0,
+                    redirectStdin ? 1 : 0, redirectStdout ? 1 : 0, redirectStderr ? 1 : 0, createNewProcessGroup ? 1 : 0,
                     out lpChildPid, out stdinFd, out stdoutFd, out stderrFd);
                 if (result != 0)
                 {

--- a/src/Common/src/Interop/Unix/System.Native/Interop.ForkAndExecProcess.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.ForkAndExecProcess.cs
@@ -51,7 +51,7 @@ internal static partial class Interop
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ForkAndExecProcess", SetLastError = true)]
         private static extern unsafe int ForkAndExecProcess(
             string filename, byte** argv, byte** envp, string cwd,
-            int redirectStdin, int redirectStdout, int redirectStderr,
+            int redirectStdin, int redirectStdout, int redirectStderr, int createNewProcessGroup,
             out int lpChildPid, out int stdinFd, out int stdoutFd, out int stderrFd);
 
         private static unsafe void AllocNullTerminatedArray(string[] arr, ref byte** arrPtr)

--- a/src/Common/src/Interop/Windows/advapi32/Interop.ProcessOptions.cs
+++ b/src/Common/src/Interop/Windows/advapi32/Interop.ProcessOptions.cs
@@ -46,6 +46,7 @@ internal partial class Interop
         internal partial class StartupInfoOptions
         {
             internal const int STARTF_USESTDHANDLES = 0x00000100;
+            internal const int CREATE_NEW_PROCESS_GROUP = 0x00000200;
             internal const int CREATE_UNICODE_ENVIRONMENT = 0x00000400;
             internal const int CREATE_NO_WINDOW = 0x08000000;
             internal const uint STATUS_INFO_LENGTH_MISMATCH = 0xC0000004;

--- a/src/Native/Unix/System.Native/pal_process.cpp
+++ b/src/Native/Unix/System.Native/pal_process.cpp
@@ -197,7 +197,7 @@ extern "C" int32_t SystemNative_ForkAndExecProcess(const char* filename,
         if (createNewProcessGroup)
         {
             int result;
-            while (CheckInterrupted(result = setpgid(0)));
+            while (CheckInterrupted(result = setpgid(0, 0)));
             if (result == -1)
             {
                 _exit(errno != 0 ? errno : EXIT_FAILURE);

--- a/src/Native/Unix/System.Native/pal_process.cpp
+++ b/src/Native/Unix/System.Native/pal_process.cpp
@@ -98,6 +98,7 @@ extern "C" int32_t SystemNative_ForkAndExecProcess(const char* filename,
                                       int32_t redirectStdin,
                                       int32_t redirectStdout,
                                       int32_t redirectStderr,
+                                      int32_t createNewProcessGroup,
                                       int32_t* childPid,
                                       int32_t* stdinFd,
                                       int32_t* stdoutFd,
@@ -117,9 +118,9 @@ extern "C" int32_t SystemNative_ForkAndExecProcess(const char* filename,
         goto done;
     }
 
-    if ((redirectStdin & ~1) != 0 || (redirectStdout & ~1) != 0 || (redirectStderr & ~1) != 0)
+    if ((redirectStdin & ~1) != 0 || (redirectStdout & ~1) != 0 || (redirectStderr & ~1) != 0 || (createNewProcessGroup & ~1) != 0)
     {
-        assert(false && "Boolean redirect* inputs must be 0 or 1.");
+        assert(false && "Boolean redirect* and createNewProcessGroup inputs must be 0 or 1.");
         errno = EINVAL;
         success = false;
         goto done;
@@ -185,6 +186,18 @@ extern "C" int32_t SystemNative_ForkAndExecProcess(const char* filename,
         {
             int result;
             while (CheckInterrupted(result = chdir(cwd)));
+            if (result == -1)
+            {
+                _exit(errno != 0 ? errno : EXIT_FAILURE);
+            }
+        }
+
+        // If CreateNewProcessGroup was chosen then set the child process group Id to its
+        // own process Id so that it is in its own process group.
+        if (createNewProcessGroup)
+        {
+            int result;
+            while (CheckInterrupted(result = setpgid(0)));
             if (result == -1)
             {
                 _exit(errno != 0 ? errno : EXIT_FAILURE);

--- a/src/Native/Unix/System.Native/pal_process.h
+++ b/src/Native/Unix/System.Native/pal_process.h
@@ -20,16 +20,17 @@
  */
 extern "C" int32_t
 SystemNative_ForkAndExecProcess(const char* filename,   // filename argument to execve
-                   char* const argv[],     // argv argument to execve
-                   char* const envp[],     // envp argument to execve
-                   const char* cwd,        // path passed to chdir in child process
-                   int32_t redirectStdin,  // whether to redirect standard input from the parent
-                   int32_t redirectStdout, // whether to redirect standard output to the parent
-                   int32_t redirectStderr, // whether to redirect standard error to the parent
-                   int32_t* childPid,      // [out] the child process' id
-                   int32_t* stdinFd,       // [out] if redirectStdin, the parent's fd for the child's stdin
-                   int32_t* stdoutFd,      // [out] if redirectStdout, the parent's fd for the child's stdout
-                   int32_t* stderrFd);     // [out] if redirectStderr, the parent's fd for the child's stderr
+                   char* const argv[],            // argv argument to execve
+                   char* const envp[],            // envp argument to execve
+                   const char* cwd,               // path passed to chdir in child process
+                   int32_t redirectStdin,         // whether to redirect standard input from the parent
+                   int32_t redirectStdout,        // whether to redirect standard output to the parent
+                   int32_t redirectStderr,        // whether to redirect standard error to the parent
+                   int32_t createNewProcessGroup, // whether to create child process in its own group
+                   int32_t* childPid,             // [out] the child process' id
+                   int32_t* stdinFd,              // [out] if redirectStdin, the parent's fd for the child's stdin
+                   int32_t* stdoutFd,             // [out] if redirectStdout, the parent's fd for the child's stdout
+                   int32_t* stderrFd);            // [out] if redirectStderr, the parent's fd for the child's stderr
 
 /**
  * Shim for the popen function.

--- a/src/System.Diagnostics.Process/ref/System.Diagnostics.Process.cs
+++ b/src/System.Diagnostics.Process/ref/System.Diagnostics.Process.cs
@@ -159,6 +159,7 @@ namespace System.Diagnostics
         public ProcessStartInfo(string fileName, string arguments) { }
         public string Arguments { get { throw null; } set { } }
         public bool CreateNoWindow { get { throw null; } set { } }
+        public bool CreateNewProcessGroup { get { throw null; } set { } }
         public string Domain { get { throw null; } set { } }
         [System.ComponentModel.DefaultValueAttribute(null)]
         public System.Collections.Generic.IDictionary<string, string> Environment { get { throw null; } }

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
@@ -255,7 +255,7 @@ namespace System.Diagnostics
             int childPid, stdinFd, stdoutFd, stderrFd;
             Interop.Sys.ForkAndExecProcess(
                 filename, argv, envp, cwd,
-                startInfo.RedirectStandardInput, startInfo.RedirectStandardOutput, startInfo.RedirectStandardError,
+                startInfo.RedirectStandardInput, startInfo.RedirectStandardOutput, startInfo.RedirectStandardError, startInfo.CreateNewProcessGroup,
                 out childPid,
                 out stdinFd, out stdoutFd, out stderrFd);
 

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
@@ -642,6 +642,7 @@ namespace System.Diagnostics
                     // set up the creation flags parameter
                     int creationFlags = 0;
                     if (startInfo.CreateNoWindow) creationFlags |= Interop.Advapi32.StartupInfoOptions.CREATE_NO_WINDOW;
+                    if (startInfo.CreateNewProcessGroup) creationFlags |= Interop.Advapi32.StartupInfoOptions.CREATE_NEW_PROCESS_GROUP;
 
                     // set up the environment block parameter
                     IntPtr environmentPtr = (IntPtr)0;

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.cs
@@ -144,5 +144,11 @@ namespace System.Diagnostics
                 _windowStyle = value;
             }
         }
+
+        /// <summary>
+        /// When set to true this will create the process in a new process group rather
+        /// than in the same group as the parent process.
+        /// </summary>
+        public bool CreateNewProcessGroup { get; set; }
     }
 }

--- a/src/System.Diagnostics.Process/tests/Interop.Unix.cs
+++ b/src/System.Diagnostics.Process/tests/Interop.Unix.cs
@@ -17,7 +17,7 @@ namespace System.Diagnostics.Tests
         [DllImport("libc")]
         internal static extern int getsid(int pid);
 
-        [DllImport("libc)")]
+        [DllImport("libc")]
         internal static extern int getpgid(int pid);
     }
 }

--- a/src/System.Diagnostics.Process/tests/Interop.Unix.cs
+++ b/src/System.Diagnostics.Process/tests/Interop.Unix.cs
@@ -16,5 +16,8 @@ namespace System.Diagnostics.Tests
 
         [DllImport("libc")]
         internal static extern int getsid(int pid);
+
+        [DllImport("libc)")]
+        internal static extern int getpgid(int pid);
     }
 }

--- a/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -341,6 +341,67 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        public void TestCreateNewProcessGroupProperty()
+        {
+            // Verify that StartInfo.CreateNewProcessGroup property is available and settable
+            Process p = CreateProcess();
+            p.StartInfo.CreateNewProcessGroup = true;
+            Assert.Equal(true, p.StartInfo.CreateNewProcessGroup);
+        }
+
+        [PlatformSpecific(TestPlatforms.AnyUnix)] // Group Ids are only available on Unix platforms
+        [Theory]
+        public void TestCreateNewProcessGroup()
+        {
+            // Verify that StartInfo.CreateNewProcessGroup creates a process having its own process group
+            Process p = CreateProcess();
+            p.StartInfo.CreateNewProcessGroup = true;
+
+            try
+            {
+                p.Start();
+#if !TargetsWindows
+                // Group Id should be the same as the process Id instead of a parent process Id
+                int pgid = Interop.getpgid(p.Id);
+                Assert.Equal(pgid, p.Id);
+#endif
+            }
+            finally
+            {
+                if (!p.HasExited)
+                    p.Kill();
+
+                Assert.True(p.WaitForExit(WaitInMS));
+            }
+        }
+
+        [PlatformSpecific(TestPlatforms.AnyUnix)] // Group Ids are only available on Unix platforms
+        [Theory]
+        public void TestCreateNoNewProcessGroup()
+        {
+            // Verify that StartInfo.CreateNewProcessGroup == false does not create a process having its own process group
+            Process p = CreateProcess();
+            p.StartInfo.CreateNewProcessGroup = false;
+
+            try
+            {
+                p.Start();
+#if !TargetsWindows
+                // Group Id should not be the same as the process Id
+                int pgid = Interop.getpgid(p.Id);
+                Assert.NotEqual(pgid, p.Id);
+#endif
+            }
+            finally
+            {
+                if (!p.HasExited)
+                    p.Kill();
+
+                Assert.True(p.WaitForExit(WaitInMS));
+            }
+        }
+
+        [Fact]
         public void TestWorkingDirectoryProperty()
         {
             CreateDefaultProcess();

--- a/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -350,7 +350,7 @@ namespace System.Diagnostics.Tests
         }
 
         [PlatformSpecific(TestPlatforms.AnyUnix)] // Group Ids are only available on Unix platforms
-        [Theory]
+        [Fact]
         public void TestCreateNewProcessGroup()
         {
             // Verify that StartInfo.CreateNewProcessGroup creates a process having its own process group
@@ -376,7 +376,7 @@ namespace System.Diagnostics.Tests
         }
 
         [PlatformSpecific(TestPlatforms.AnyUnix)] // Group Ids are only available on Unix platforms
-        [Theory]
+        [Fact]
         public void TestCreateNoNewProcessGroup()
         {
             // Verify that StartInfo.CreateNewProcessGroup == false does not create a process having its own process group


### PR DESCRIPTION
This is an implementation for the API request issue #17412.

Normally a new child process is created in the same process group as the parent process.  This change allows a child process to be created in its own process group.

For Windows this change simply sets the CREATE_NEW_PROCESS_GROUP flag when creating the process.

For Unix this change uses the setpgid system call to set the process group id to be the same as the process id.  

I wasn't able to find any Windows managed or native API to determine a process group id.  So functional tests work only in Unix where they use system calls to verify a process group id.