### PR TITLE
Fix XmlSerializer(Type type, Types[] extraTypes) on UWP

### DIFF
--- a/src/System.Private.Xml/src/Resources/System.Private.Xml.rd.xml
+++ b/src/System.Private.Xml/src/Resources/System.Private.Xml.rd.xml
@@ -10,7 +10,7 @@
         <Type Name="XmlSerializer">
           <Method Name=".ctor">
             <TypeParameter Name="type" XmlSerializer="Public"/>
-            <TypeEnumerableParameter Name="extraTypes" XmlSerializer="Public"/>
+            <TypeEnumerableParameter Name="extraTypes" Dynamic="Public"/>
           </Method>
           <Property Name="Mode" Dynamic="Required" />
         </Type>

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
@@ -160,7 +160,6 @@ namespace System.Xml.Serialization
         internal string DefaultNamespace = null;
 #endif
         private Type _rootType;
-        private Type[] _extraTypes;
 
         private static TempAssemblyCache s_cache = new TempAssemblyCache();
         private static volatile XmlSerializerNamespaces s_defaultNamespaces;
@@ -211,13 +210,8 @@ namespace System.Xml.Serialization
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
-#if !uapaot
         public XmlSerializer(Type type, Type[] extraTypes) : this(type, null, extraTypes, null, null, null)
-#else
-        public XmlSerializer(Type type, Type[] extraTypes) : this(type)
-#endif
         {
-            _extraTypes = extraTypes;
         }
 
         /// <include file='doc\XmlSerializer.uex' path='docs/doc[@for="XmlSerializer.XmlSerializer4"]/*' />
@@ -521,7 +515,7 @@ namespace System.Xml.Serialization
         {
             if (_mapping == null || !_mapping.GenerateSerializer)
             {
-                _mapping = GenerateXmlTypeMapping(_rootType, null, _extraTypes, null, DefaultNamespace);
+                _mapping = GenerateXmlTypeMapping(_rootType, null, null, null, DefaultNamespace);
             }
 
             return _mapping;


### PR DESCRIPTION
On UWP, if one used `XmlSerializer(Type type, Types[] extraTypes)` to create serializer for `type`, UWP toolchain would pre-generate the serializer for the type and make the `extraTypes` as the type's known types. To achieve the latter, UWP toolchain uses one `XmlReflectionImporter` to import *all types* (all types require serialization in the app) so that the `extraTypes` would be treated as known types. But there're some problems with this.

1. The type would have more known types than those included by `extraTypes`.
2. There might be type conflicts as the importer imports all types and the type scope grows.
And etc.

The fix is to make the constructor to always use reflection based serialization.

Fix #19811