### PR TITLE
disable two Process tests for nano

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -1009,8 +1009,9 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [Theory, MemberData(nameof(UseShellExecute))]
+        [MemberData(nameof(UseShellExecute))]
         [PlatformSpecific(TestPlatforms.Windows)]
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]  //https://github.com/dotnet/corefx/issues/20288
         public void StartInfo_BadVerb(bool useShellExecute)
         {
             ProcessStartInfo info = new ProcessStartInfo
@@ -1023,8 +1024,9 @@ namespace System.Diagnostics.Tests
             Assert.Equal(2, Assert.Throws<Win32Exception>(() => Process.Start(info)).NativeErrorCode);
         }
 
-        [Theory, MemberData(nameof(UseShellExecute))]
+        [MemberData(nameof(UseShellExecute))]
         [PlatformSpecific(TestPlatforms.Windows)]
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]  //https://github.com/dotnet/corefx/issues/20288
         public void StartInfo_BadExe(bool useShellExecute)
         {
             string tempFile = GetTestFilePath() + ".exe";


### PR DESCRIPTION
relates to https://github.com/dotnet/corefx/issues/20288