### PR TITLE
Add debian 9 to CI

### DIFF
--- a/buildpipeline/portable-linux.groovy
+++ b/buildpipeline/portable-linux.groovy
@@ -58,6 +58,7 @@ simpleDockerNode('microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2') {
             def targetHelixQueues = ['Centos.73.Amd64.Open',
                                      'RedHat.73.Amd64.Open',
                                      'Debian.87.Amd64.Open',
+                                     'Debian.90.Amd64.Open',
                                      'Ubuntu.1404.Amd64.Open',
                                      'Ubuntu.1604.Amd64.Open',
                                      'Ubuntu.1610.Amd64.Open',


### PR DESCRIPTION
I want to add Debian 9 and Nano as optional legs to CI jobs.

@mmitche you said to edit this file - is that it? Where does it indicate that it's an optional leg?

To add Nano, do I edit netci.groovy, or somthing else?

How do I test - do I do @dotnet-bot test ci please?