### PR TITLE
Download Shared Framework Zips and adding their ApiCompat runs

### DIFF
--- a/SharedFrameworkValidation.cmd
+++ b/SharedFrameworkValidation.cmd
@@ -3,7 +3,10 @@ setlocal
 
 call %~dp0sync.cmd
 if NOT [%ERRORLEVEL%]==[0] exit /b 1
-call %~dp0build-managed.cmd -Project:%~dp0src\SharedFrameworkValidation\SharedFrameworkValidation.proj -- /t:ReBuild
+call %~dp0build-managed.cmd -Project:%~dp0src\SharedFrameworkValidation\SharedFrameworkValidation.proj -- /t:CreateScriptToDownloadSharedFrameworkZip
+if NOT [%ERRORLEVEL%]==[0] exit /b 1
+powershell -NoProfile -ExecutionPolicy unrestricted -Command "%~dp0bin\DownloadSharedFramework.ps1"
+call %~dp0build-managed.cmd -Project:%~dp0src\SharedFrameworkValidation\SharedFrameworkValidation.proj
 if NOT [%ERRORLEVEL%]==[0] exit /b 1
 call %~dp0bin\CloneAndRunTests.cmd
 exit /b %ERRORLEVEL%

--- a/SharedFrameworkValidation.cmd
+++ b/SharedFrameworkValidation.cmd
@@ -1,12 +1,14 @@
 @if not defined _echo @echo off
 setlocal
+set BUILDARCH=%1
+if /I [%BUILDARCH%] == [] set BUILDARCH=x64
 
-call %~dp0sync.cmd
+call %~dp0sync.cmd -- /p:ArchGroup=%BUILDARCH%
 if NOT [%ERRORLEVEL%]==[0] exit /b 1
 call %~dp0build-managed.cmd -Project:%~dp0src\SharedFrameworkValidation\SharedFrameworkValidation.proj -- /t:CreateScriptToDownloadSharedFrameworkZip
 if NOT [%ERRORLEVEL%]==[0] exit /b 1
 powershell -NoProfile -ExecutionPolicy unrestricted -Command "%~dp0bin\DownloadSharedFramework.ps1"
-call %~dp0build-managed.cmd -Project:%~dp0src\SharedFrameworkValidation\SharedFrameworkValidation.proj
+call %~dp0build-managed.cmd -Project:%~dp0src\SharedFrameworkValidation\SharedFrameworkValidation.proj -buildArch=%BUILDARCH%
 if NOT [%ERRORLEVEL%]==[0] exit /b 1
 call %~dp0bin\CloneAndRunTests.cmd
 exit /b %ERRORLEVEL%

--- a/SharedFrameworkValidation.sh
+++ b/SharedFrameworkValidation.sh
@@ -6,7 +6,14 @@ if [ "$?" != "0" ]; then
     echo "ERROR: An error occured when trying to initialize the tools. Please check '$__scriptpath/init-tools.log' for more details."
     exit 1
 fi
-$__scriptpath/build-managed.sh -Project:$__scriptpath/src/SharedFrameworkValidation/SharedFrameworkValidation.proj -- /t:ReBuild
+$__scriptpath/build-managed.sh -Project:$__scriptpath/src/SharedFrameworkValidation/SharedFrameworkValidation.proj  -- /t:CreateScriptToDownloadSharedFrameworkZip
+if [ "$?" != "0" ]; then
+    echo "ERROR: An error occured when trying to write the script to download the shared framework. Please check '$__scriptpath/msbuild.log' for more details."
+    exit 1
+fi
+chmod a+x $__scriptpath/bin/DownloadSharedFramework.sh
+$__scriptpath/bin/DownloadSharedFramework.sh
+$__scriptpath/build-managed.sh -Project:$__scriptpath/src/SharedFrameworkValidation/SharedFrameworkValidation.proj
 if [ "$?" != "0" ]; then
     echo "ERROR: An error occured when trying to restore the shared framework. Please check '$__scriptpath/msbuild.log' for more details."
     exit 1

--- a/src/SharedFrameworkValidation/ApiCompatBaseline.LKGSharedFramework.CurrentSharedFramework.txt
+++ b/src/SharedFrameworkValidation/ApiCompatBaseline.LKGSharedFramework.CurrentSharedFramework.txt
@@ -1,19 +1,145 @@
-ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/runtime/SharedFrameworkValidation.LKG/clrcompression.dll
-ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/runtime/SharedFrameworkValidation.LKG/clretwrc.dll
-ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/runtime/SharedFrameworkValidation.LKG/clrjit.dll
-ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/runtime/SharedFrameworkValidation.LKG/coreclr.dll
-ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/runtime/SharedFrameworkValidation.LKG/dbgshim.dll
-ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/runtime/SharedFrameworkValidation.LKG/hostfxr.dll
-ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/runtime/SharedFrameworkValidation.LKG/hostpolicy.dll
-ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/runtime/SharedFrameworkValidation.LKG/libuv.dll
-ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/runtime/SharedFrameworkValidation.LKG/Microsoft.DiaSymReader.Native.amd64.dll
-ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/runtime/SharedFrameworkValidation.LKG/mscordaccore.dll
-ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/runtime/SharedFrameworkValidation.LKG/mscordbi.dll
-ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/runtime/SharedFrameworkValidation.LKG/mscorrc.debug.dll
-ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/runtime/SharedFrameworkValidation.LKG/mscorrc.dll
-ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/runtime/SharedFrameworkValidation.LKG/sos.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/API-MS-Win-Base-Util-L1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-com-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-com-private-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-comm-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-console-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-console-l2-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-datetime-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-datetime-l1-1-1.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-debug-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-debug-l1-1-1.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-delayload-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-errorhandling-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-errorhandling-l1-1-1.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-fibers-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-fibers-l1-1-1.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-file-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-file-l1-2-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-file-l1-2-1.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-file-l2-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-file-l2-1-1.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-handle-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-heap-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-heap-obsolete-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-interlocked-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-io-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-io-l1-1-1.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-kernel32-legacy-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-kernel32-legacy-l1-1-1.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-kernel32-legacy-l1-1-2.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/API-MS-Win-Core-Kernel32-Private-L1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/API-MS-Win-Core-Kernel32-Private-L1-1-1.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-libraryloader-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-libraryloader-l1-1-1.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-localization-l1-2-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-localization-l1-2-1.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-localization-l2-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-localization-obsolete-l1-2-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-memory-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-memory-l1-1-1.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-memory-l1-1-2.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-memory-l1-1-3.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-namedpipe-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-namedpipe-l1-2-1.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-normalization-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/API-MS-Win-Core-PrivateProfile-L1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-privateprofile-l1-1-1.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-processenvironment-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-processenvironment-l1-2-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-processsecurity-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-processthreads-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-processthreads-l1-1-1.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-processthreads-l1-1-2.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/API-MS-Win-Core-ProcessTopology-Obsolete-L1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-profile-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-psapi-ansi-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-psapi-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-psapi-obsolete-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-realtime-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-registry-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-registry-l2-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-rtlsupport-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-shlwapi-legacy-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-shlwapi-obsolete-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-shutdown-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-shutdown-l1-1-1.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-string-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/API-MS-Win-Core-String-L2-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-string-obsolete-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-string-obsolete-l1-1-1.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/API-MS-Win-Core-StringAnsi-L1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-stringloader-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-stringloader-l1-1-1.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-synch-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-synch-l1-2-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-sysinfo-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-sysinfo-l1-2-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-sysinfo-l1-2-1.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-sysinfo-l1-2-2.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-sysinfo-l1-2-3.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-threadpool-l1-2-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-threadpool-legacy-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-threadpool-private-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-timezone-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-url-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-util-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-version-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-winrt-error-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-winrt-error-l1-1-1.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-winrt-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-winrt-registration-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-winrt-robuffer-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-winrt-roparameterizediid-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-winrt-string-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-wow64-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-xstate-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-core-xstate-l2-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/API-MS-Win-devices-config-L1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/API-MS-Win-devices-config-L1-1-1.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/API-MS-Win-Eventing-ClassicProvider-L1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/API-MS-Win-Eventing-Consumer-L1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/API-MS-Win-Eventing-Controller-L1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/API-MS-Win-Eventing-Legacy-L1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/API-MS-Win-Eventing-Provider-L1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/API-MS-Win-EventLog-Legacy-L1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-ro-typeresolution-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-security-base-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-security-cpwl-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-security-cryptoapi-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-security-lsalookup-l2-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-security-lsalookup-l2-1-1.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/API-MS-Win-Security-LsaPolicy-L1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-security-provider-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-security-sddl-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-service-core-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-service-core-l1-1-1.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-service-management-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-service-management-l2-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-service-private-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-service-private-l1-1-1.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/api-ms-win-service-winsvc-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/clrcompression.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/clretwrc.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/clrjit.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/coreclr.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/dbgshim.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/ext-ms-win-advapi32-encryptedfile-l1-1-0.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/ext-ms-win-ntuser-keyboard-l1-2-1.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/hostfxr.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/hostpolicy.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/libuv.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/Microsoft.DiaSymReader.Native.amd64.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/mscordaccore.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/mscordbi.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/mscorrc.debug.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/mscorrc.dll
+ApiCompat Error: 0 : Failed to load assembly F:\git\corefx\bin/ref/sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/1.1.2/sos.dll
 ApiCompat Warning: 0 : Found 'mscorlib' with PublicKeyToken 'b77a5c561934e089' instead of '7cec85d7bea7798e'.
 ApiCompat Warning: 0 : Found 'mscorlib' with PublicKeyToken 'b77a5c561934e089' instead of '7cec85d7bea7798e'.
+ApiCompat Error: 0 : Failed to find or load matching assembly 'System.Text.Encoding.CodePages'.
+ApiCompat Error: 0 : Unable to resolve assembly 'Assembly(Name=System.Security.Permissions, Version=0.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)' referenced by the implementation assembly 'Assembly(Name=mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)'.
+ApiCompat Error: 0 : Unable to resolve assembly 'Assembly(Name=System.Threading.AccessControl, Version=0.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)' referenced by the implementation assembly 'Assembly(Name=mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)'.
 Compat issues with assembly Microsoft.CSharp:
 TypesMustExist : Type 'Microsoft.CSharp.RuntimeBinder.Errors.ErrorCode' does not exist in the implementation but it does exist in the contract.
 Compat issues with assembly mscorlib:
@@ -54,6 +180,7 @@ TypesMustExist : Type 'System.Runtime.CompilerServices.ICastable' does not exist
 TypesMustExist : Type 'System.Runtime.InteropServices.NativeCallableAttribute' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Runtime.Loader.AssemblyLoadContext' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Runtime.Remoting.ObjectHandle' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.Security.SecurityState' does not exist in the implementation but it does exist in the contract.
 CannotAddAbstractMembers : Member 'System.Security.Permissions.SecurityAttribute.CreatePermission()' is abstract in the implementation but is missing in the contract.
 TypesMustExist : Type 'System.Threading.Semaphore' does not exist in the implementation but it does exist in the contract.
 Compat issues with assembly System.Diagnostics.Debug:
@@ -176,6 +303,8 @@ MembersMustExist : Member 'System.Activator.CreateInstanceFrom(System.String, Sy
 MembersMustExist : Member 'System.Activator.CreateInstanceFrom(System.String, System.String, System.Object[])' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.String.Split(System.Char)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.String.Split(System.String)' does not exist in the implementation but it does exist in the contract.
+Compat issues with assembly System.Text.Encoding.CodePages:
+TypesMustExist : Type 'System.Text.CodePagesEncodingProvider' does not exist in the implementation but it does exist in the contract.
 Compat issues with assembly System.Xml.XDocument:
 MembersMustExist : Member 'System.Xml.Linq.XElement..ctor()' does not exist in the implementation but it does exist in the contract.
-Total Issues: 153
+Total Issues: 155

--- a/src/SharedFrameworkValidation/SharedFrameworkValidation.proj
+++ b/src/SharedFrameworkValidation/SharedFrameworkValidation.proj
@@ -5,13 +5,55 @@
   <PropertyGroup>
     <SharedFrameworkValidationRefPath>$(RefRootPath)SharedFrameworkValidation</SharedFrameworkValidationRefPath>
     <SharedFrameworkValidationRuntimePath>$(BinDir)runtime/SharedFrameworkValidation</SharedFrameworkValidationRuntimePath>
+    <_LKGSharedFrameworkVersion>1.1.2</_LKGSharedFrameworkVersion>
+    <SharedFrameworkExtractPath>$(RefRootPath)sharedFrameworkZip/shared/Microsoft.NETCore.App/$(MicrosoftNETCoreAppPackageVersion)</SharedFrameworkExtractPath>
+    <LKGSharedFrameworkExtractPath>$(RefRootPath)sharedFrameworkZip.LKG/shared/Microsoft.NETCore.App/$(_LKGSharedFrameworkVersion)</LKGSharedFrameworkExtractPath>
     <_RunTestsScriptName Condition="'$(RunningOnUnix)' != 'true'">CloneAndRunTests.cmd</_RunTestsScriptName>
     <_RunTestsScriptName Condition="'$(RunningOnUnix)' == 'true'">CloneAndRunTests.sh</_RunTestsScriptName>
-    <_PublishRID Condition="'$(OSGroup)'=='Windows_NT'">win-$(ArchGroup)</_PublishRID>
-    <_PublishRID Condition="'$(OSGroup)'=='OSX'">osx-$(ArchGroup)</_PublishRID>
-    <_PublishRID Condition="'$(OSGroup)'=='Linux'">linux-$(ArchGroup)</_PublishRID>
-    <_PublishRID Condition="'$(_PublishRID)'==''">unix-$(ArchGroup)</_PublishRID>
+    <_PublishRID>$(RuntimeOS)-$(ArchGroup)</_PublishRID>
   </PropertyGroup>
+
+  <Target Name="CreateScriptToDownloadSharedFrameworkZip">
+
+    <ItemGroup Condition="'$(RunningOnUnix)' != 'true'">
+      <_DownloadSharedFrameworkScriptLines Include="Invoke-WebRequest %22https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.ps1%22 -OutFile $(ToolsDir.Replace('/', '\'))bootstrap.ps1" />
+      <_DownloadSharedFrameworkScriptLines Include="%26 %22$(ToolsDir.Replace('/', '\'))bootstrap.ps1%22 -Channel %22master%22 -SharedRuntime -Version %22$(MicrosoftNETCoreAppPackageVersion)%22 -InstallDir %22$(RefRootPath.Replace('/', '\'))sharedFrameworkZip%22 | Out-File %22$(BinDir.Replace('/', '\'))bootstrap.log%22" />
+      <_DownloadSharedFrameworkScriptLines Include="%26 %22$(ToolsDir.Replace('/', '\'))bootstrap.ps1%22 -Channel %22rel-1.1.0%22 -InstallDir %22$(RefRootPath.Replace('/', '\'))sharedFrameworkZip.LKG%22 | Out-File %22$(BinDir.Replace('/', '\'))bootstrap.LKG.log%22" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_ScriptName Condition="'$(RunningOnUnix)' != 'true'">$(BinDir)DownloadSharedFramework.ps1</_ScriptName>
+      <_ScriptName Condition="'$(RunningOnUnix)' == 'true'">$(BinDir)DownloadSharedFramework.sh</_ScriptName>
+    </PropertyGroup>
+
+    <ItemGroup Condition="'$(RunningOnUnix)' == 'true'">
+      <_DownloadSharedFrameworkScriptLines Include="download() {" />
+      <_DownloadSharedFrameworkScriptLines Include="    eval %24invocation" />
+      <_DownloadSharedFrameworkScriptLines Include="    local remote_path=%241" />
+      <_DownloadSharedFrameworkScriptLines Include="    local out_path=%24{2:-}" />
+      <_DownloadSharedFrameworkScriptLines Include="    local failed=false" />
+      <_DownloadSharedFrameworkScriptLines Include="    if [ -z %22%24out_path%22 ]; then" />
+      <_DownloadSharedFrameworkScriptLines Include="        curl --retry 10 -sSL --create-dirs %24remote_path || failed=true" />
+      <_DownloadSharedFrameworkScriptLines Include="    else" />
+      <_DownloadSharedFrameworkScriptLines Include="        curl --retry 10 -sSL --create-dirs -o %24out_path %24remote_path || failed=true" />
+      <_DownloadSharedFrameworkScriptLines Include="    fi" />
+      <_DownloadSharedFrameworkScriptLines Include="    if [ %22%24failed%22 = true ]; then" />
+      <_DownloadSharedFrameworkScriptLines Include="        say_err %22Download failed%22" />
+      <_DownloadSharedFrameworkScriptLines Include="        return 1" />
+      <_DownloadSharedFrameworkScriptLines Include="    fi" />
+      <_DownloadSharedFrameworkScriptLines Include="}" />
+      <_DownloadSharedFrameworkScriptLines Include="download %22https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.sh%22 %22$(ToolsDir.Replace('/', '\'))bootstrap.sh%22" />
+      <_DownloadSharedFrameworkScriptLines Include="chmod a+x %22$(ToolsDir.Replace('/', '\'))bootstrap.sh%22" />
+      <_DownloadSharedFrameworkScriptLines Include="%22$(ToolsDir.Replace('/', '\'))bootstrap.sh%22 --channel %22master%22 --shared-runtime --version %22$(MicrosoftNETCoreAppPackageVersion)%22 --install-dir %22$(RefRootPath.Replace('/', '\'))sharedFrameworkZip%22" />
+      <_DownloadSharedFrameworkScriptLines Include="%22$(ToolsDir.Replace('/', '\'))bootstrap.sh%22 --channel %22rel-1.1.0%22 --install-dir %22$(RefRootPath.Replace('/', '\'))sharedFrameworkZip.LKG%22" />
+    </ItemGroup>
+
+    <WriteLinesToFile
+      File="$(_ScriptName)"
+      Lines="@(_DownloadSharedFrameworkScriptLines)"
+      Overwrite="true"
+      Encoding="Ascii" />
+  </Target>
 
   <Target Name="BuildPackagesProject">
     <PropertyGroup>
@@ -32,6 +74,18 @@
     <PropertyGroup>
       <ApiCompatCmd>$(ToolHostCmd) "$(ToolsDir)ApiCompat.exe"</ApiCompatCmd>
     </PropertyGroup>
+
+    <!-- Exclude Roslyn assemblies as they don't live in our packages any longer -->
+    <ItemGroup>
+      <_SharedFrameworkLKGAssemblies Include="$(BinDir)runtime/SharedFrameworkValidation.LKG/*.dll" />
+      <_SharedFrameworkAssembliesToRemove Include="@(_SharedFrameworkLKGAssemblies)" Condition="$([System.String]::new('%(_SharedFrameworkLKGAssemblies.Identity)').Contains('Microsoft.CodeAnalysis'))" />
+      <_SharedFrameworkLKGAssemblies Remove="@(_SharedFrameworkAssembliesToRemove)" />
+
+      <_LKGSharedFrameworkAssemblies Include="$(LKGSharedFrameworkExtractPath)/*.dll" />
+      <_LKGSharedFrameworkAssembliesToRemove Include="@(_LKGSharedFrameworkAssemblies)" Condition="$([System.String]::new('%(_LKGSharedFrameworkAssemblies.Identity)').Contains('Microsoft.CodeAnalysis'))" />
+      <_LKGSharedFrameworkAssemblies Remove="@(_LKGSharedFrameworkAssembliesToRemove)" />
+
+    </ItemGroup>
 
     <MakeDir Directories="$(IntermediateOutputPath)" />
 
@@ -54,7 +108,19 @@
           StandardOutputImportance="Low" />
 
     <!-- Last shipped runtime packages vs current runtime packages -->
-    <Exec Command="$(ApiCompatCmd) &quot;$(BinDir)runtime/SharedFrameworkValidation.LKG&quot; $(ApiCompatArgs) -implDirs:&quot;$(SharedFrameworkValidationRuntimePath)&quot; -baseline:&quot;$(MSBuildThisFileDirectory)ApiCompatBaseline.LKGRuntime.CurrentRuntime.txt&quot;"
+    <Exec Command="$(ApiCompatCmd) &quot;@(_SharedFrameworkLKGAssemblies)&quot; $(ApiCompatArgs) -implDirs:&quot;$(SharedFrameworkValidationRuntimePath)&quot; -baseline:&quot;$(MSBuildThisFileDirectory)ApiCompatBaseline.LKGRuntime.CurrentRuntime.txt&quot;"
+          CustomErrorRegularExpression="Total Issues: [^0]"
+          IgnoreStandardErrorWarningFormat="true"
+          StandardOutputImportance="Low" />
+
+    <!-- Microsoft.NETCore.App Ref vs. shared framework -->
+    <Exec Command="$(ApiCompatCmd) &quot;$(PackagesDir)microsoft.netcore.app/$(MicrosoftNETCoreAppPackageVersion)/ref/netcoreapp2.0&quot; $(ApiCompatArgs) -implDirs:&quot;$(SharedFrameworkExtractPath)&quot;"
+          CustomErrorRegularExpression="Total Issues: [^0]"
+          IgnoreStandardErrorWarningFormat="true"
+          StandardOutputImportance="Low" />
+
+    <!-- Last shipped shared framework vs. current shared framework -->
+    <Exec Command="$(ApiCompatCmd) &quot;@(_LKGSharedFrameworkAssemblies)&quot; $(ApiCompatArgs) -implDirs:&quot;$(SharedFrameworkExtractPath)&quot; -baseline:&quot;$(MSBuildThisFileDirectory)ApiCompatBaseline.LKGSharedFramework.CurrentSharedFramework.txt&quot;"
           CustomErrorRegularExpression="Total Issues: [^0]"
           IgnoreStandardErrorWarningFormat="true"
           StandardOutputImportance="Low" />


### PR DESCRIPTION
cc: @weshaggard @ericstj @danmosemsft 

fixes #18083

Last piece of the puzzle. This will add those two last apicompat runs that we cared about by restoring the last shipped shared framework and the current one in order to do testing against it. Once this is merged, all work will be ready, and the next step would be enabling all of this through an official build (or maybe a whole new pipeline build)