### PR TITLE
[release/2.0.0] Mark NETStandard.Library.NETFramework as trimmable

### DIFF
--- a/pkg/NETStandard.Library.NETFramework/targets/NETStandard.Library.NETFramework.common.targets
+++ b/pkg/NETStandard.Library.NETFramework/targets/NETStandard.Library.NETFramework.common.targets
@@ -28,6 +28,11 @@
     <!-- Ensure this runs before conflict resolution since the added files may cause conflicts -->
     <HandlePackageFileConflictsDependsOn>ImplicitlyExpandNETStandardFacades;$(HandlePackageFileConflictsDependsOn)</HandlePackageFileConflictsDependsOn>
   </PropertyGroup>
+  
+  <ItemGroup Condition="$(DontTrimNETStandardLibraryNETFramework)' != 'true'">
+    <!-- mark this package as trimmable so that files in the same package aren't automatically rooted -->
+    <TrimmablePackages Include="NETStandard.Library.NETFramework" />
+  </ItemGroup>
 
   <Target Name="ImplicitlyExpandNETStandardFacades"
           AfterTargets="$(ImplicitlyExpandNETStandardFacadesAfter)">

--- a/pkg/NETStandard.Library.NETFramework/targets/NETStandard.Library.NETFramework.common.targets
+++ b/pkg/NETStandard.Library.NETFramework/targets/NETStandard.Library.NETFramework.common.targets
@@ -29,7 +29,7 @@
     <HandlePackageFileConflictsDependsOn>ImplicitlyExpandNETStandardFacades;$(HandlePackageFileConflictsDependsOn)</HandlePackageFileConflictsDependsOn>
   </PropertyGroup>
   
-  <ItemGroup Condition="$(DontTrimNETStandardLibraryNETFramework)' != 'true'">
+  <ItemGroup Condition="'$(DontTrimNETStandardLibraryNETFramework)' != 'true'">
     <!-- mark this package as trimmable so that files in the same package aren't automatically rooted -->
     <TrimmablePackages Include="NETStandard.Library.NETFramework" />
   </ItemGroup>


### PR DESCRIPTION
This lets folks use the assembly level trimming from Microsoft.Packaging.Tools.Trimming to reduce the set of assemblies deployed with their application.

Port of https://github.com/dotnet/corefx/pull/20271

Fixes https://github.com/dotnet/standard/issues/339

@weshaggard @Petermarcu 