### PR TITLE
Disable a bunch of HttpListener tests potentially causing hangs/failures in CI

### DIFF
--- a/src/System.Net.HttpListener/tests/HttpListenerContextTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerContextTests.cs
@@ -43,6 +43,7 @@ namespace System.Net.Tests
             yield return new object[] { new string[] { "MyProtocol1", "MyProtocol2" }, "MyProtocol2" };
         }
 
+        [ActiveIssue(20246)] // CI hanging frequently
         [ConditionalTheory(nameof(IsNotWindows7OrUapCore))]
         [MemberData(nameof(SubProtocol_TestData))]
         public async Task AcceptWebSocketAsync_ValidSubProtocol_Success(string[] clientProtocols, string serverProtocol)
@@ -87,6 +88,7 @@ namespace System.Net.Tests
             });
         }
 
+        [ActiveIssue(20246)] // CI hanging frequently
         [ConditionalTheory(nameof(IsNotWindows7OrUapCore))]
         [InlineData("")]
         [InlineData(" ")]
@@ -115,6 +117,7 @@ namespace System.Net.Tests
             await Assert.ThrowsAsync<ArgumentException>("subProtocol", () => context.AcceptWebSocketAsync(subProtocol));
         }
 
+        [ActiveIssue(20246)] // CI hanging frequently
         [ConditionalTheory(nameof(IsNotWindows7OrUapCore))]
         [InlineData("!")]
         [InlineData("#")]
@@ -134,6 +137,7 @@ namespace System.Net.Tests
             await Assert.ThrowsAsync<ArgumentOutOfRangeException>("keepAliveInterval", () => context.AcceptWebSocketAsync(null, keepAlive));
         }
 
+        [ActiveIssue(20246)] // CI hanging frequently
         [ConditionalTheory(nameof(IsNotWindows7OrUapCore))]
         [InlineData(-1)]
         [InlineData(0)]
@@ -154,6 +158,7 @@ namespace System.Net.Tests
             await Assert.ThrowsAsync<ArgumentNullException>("internalBuffer.Array", () => context.AcceptWebSocketAsync(null, 1024, TimeSpan.MaxValue, internalBuffer));
         }
 
+        [ActiveIssue(20246)] // CI hanging frequently
         [ConditionalTheory(nameof(IsNotWindows7OrUapCore))]
         [InlineData(-1)]
         [InlineData(11)]
@@ -165,6 +170,7 @@ namespace System.Net.Tests
             await Assert.ThrowsAsync<ArgumentOutOfRangeException>("internalBuffer.Offset", () => context.AcceptWebSocketAsync(null, 1024, TimeSpan.MaxValue, internalBuffer));
         }
 
+        [ActiveIssue(20246)] // CI hanging frequently
         [ConditionalTheory(nameof(IsNotWindows7OrUapCore))]
         [InlineData(0, -1)]
         [InlineData(0, 11)]

--- a/src/System.Net.HttpListener/tests/HttpListenerResponseTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerResponseTests.cs
@@ -436,6 +436,7 @@ namespace System.Net.Tests
             }
         }
         
+        [ActiveIssue(20246)] // CI hanging frequently
         [InlineData(true)]
         [InlineData(false)]
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]

--- a/src/System.Net.HttpListener/tests/HttpRequestStreamTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpRequestStreamTests.cs
@@ -33,9 +33,9 @@ namespace System.Net.Tests
         }
 
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
-        [InlineData(true, "")]
+        //[InlineData(true, "")] // [ActiveIssue(20246)] // CI hanging frequently
         [InlineData(false, "")]
-        [InlineData(true, "Non-Empty")]
+        //[InlineData(true, "Non-Empty")]  // [ActiveIssue(20246)] // CI hanging frequently
         [InlineData(false, "Non-Empty")]
         public async Task Read_FullLengthAsynchronous_Success(bool transferEncodingChunked, string text)
         {
@@ -77,9 +77,9 @@ namespace System.Net.Tests
         }
 
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
-        [InlineData(true, "")]
+        // [InlineData(true, "")] // [ActiveIssue(20246)] // CI hanging frequently
         [InlineData(false, "")]
-        [InlineData(true, "Non-Empty")]
+        // [InlineData(true, "Non-Empty")] // [ActiveIssue(20246)] // CI hanging frequently
         [InlineData(false, "Non-Empty")]
         public async Task Read_FullLengthSynchronous_Success(bool transferEncodingChunked, string text)
         {
@@ -121,7 +121,7 @@ namespace System.Net.Tests
         }
 
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
-        [InlineData(true)]
+        // [InlineData(true)] // [ActiveIssue(20246)] // CI hanging frequently
         [InlineData(false)]
         public async Task Read_LargeLengthAsynchronous_Success(bool transferEncodingChunked)
         {
@@ -160,7 +160,7 @@ namespace System.Net.Tests
         }
 
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
-        [InlineData(true)]
+        // [InlineData(true)] // [ActiveIssue(20246)] // CI hanging frequently
         [InlineData(false)]
         public async Task Read_LargeLengthSynchronous_Success(bool transferEncodingChunked)
         {
@@ -197,9 +197,9 @@ namespace System.Net.Tests
                 context.Response.Close();
             }
         }
-
+        
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
-        [InlineData(true)]
+        // [InlineData(true)] // [ActiveIssue(20246)] // CI hanging frequently
         [InlineData(false)]
         public async Task Read_TooMuchAsynchronous_Success(bool transferEncodingChunked)
         {
@@ -224,7 +224,7 @@ namespace System.Net.Tests
         }
 
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
-        [InlineData(true)]
+        // [InlineData(true)] // [ActiveIssue(20246)] // CI hanging frequently
         [InlineData(false)]
         public async Task Read_TooMuchSynchronous_Success(bool transferEncodingChunked)
         {
@@ -249,7 +249,7 @@ namespace System.Net.Tests
         }
 
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
-        [InlineData(true)]
+        // [InlineData(true)] // [ActiveIssue(20246)] // CI hanging frequently
         [InlineData(false)]
         public async Task Read_NotEnoughThenCloseAsynchronous_Success(bool transferEncodingChunked)
         {
@@ -436,6 +436,7 @@ namespace System.Net.Tests
             }
         }
 
+        [ActiveIssue(20246)] // CI hanging frequently
         [Fact]
         [ActiveIssue(19983, platforms: TestPlatforms.AnyUnix)] // No exception thrown
         public async Task Read_FromClosedConnectionAsynchronously_ThrowsHttpListenerException()
@@ -466,6 +467,7 @@ namespace System.Net.Tests
             }
         }
 
+        [ActiveIssue(20246)] // CI hanging frequently
         [Fact]
         [ActiveIssue(19983, platforms: TestPlatforms.AnyUnix)] // No exception thrown
         public async Task Read_FromClosedConnectionSynchronously_ThrowsHttpListenerException()

--- a/src/System.Net.HttpListener/tests/HttpResponseStreamTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpResponseStreamTests.cs
@@ -376,6 +376,7 @@ namespace System.Net.Tests
             }
         }
 
+        [ActiveIssue(20246)] // CI hanging frequently
         [ActiveIssue(19534, TestPlatforms.OSX)]
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         [InlineData(true)]
@@ -414,6 +415,7 @@ namespace System.Net.Tests
             }
         }
 
+        [ActiveIssue(20246)] // CI hanging frequently
         [ActiveIssue(19534, TestPlatforms.OSX)]
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         [InlineData(true)]


### PR DESCRIPTION
I've been unable to reliably repro hangs on Unix locally.  As a stand-in, I'm running the managed HttpListener implementation on Windows.  There must be enough differences in timing or client behavior or Socket behavior or whatever to trigger a multitude of hangs/asserts, even though this should work reliably.  Since it's likely that some subset of these tests are the same ones failing in CI, I've temporarily disabled them all, in hopes of getting CI green reliably.  We should aggressively investigate and get these running again; the underlying cause(s) is likely something in the product that would impact real scenarios.  A large chunk of them have to do with chunked encoding, so there's very likely a product issue there; also with establishing web socket connections.

https://github.com/dotnet/corefx/issues/20246
cc: @geoffkizer, @danmosemsft, @hughbe, @karelz 