### PR TITLE
Support Two-Key Triple DES (#20275)

### DIFF
--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/TripleDES/TripleDESCipherTests.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/TripleDES/TripleDESCipherTests.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Security.Cryptography;
 using Test.Cryptography;
 using Xunit;
 
@@ -23,19 +20,45 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
         }
 
         [Fact]
-        public static void TripleDESRoundTrip192BitsNoneECB()
+        public static void TripleDESGenerate128Key()
         {
-            byte[] key = "c5629363d957054eba793093b83739bb78711db221a82379".HexToByteArray();
+            using (TripleDES des = TripleDESFactory.Create())
+            {
+                des.KeySize = 128;
+                byte[] key = des.Key;
+                Assert.Equal(128, key.Length * 8);
+            }
+        }
+
+        [Fact]
+        public static void TripleDESInvalidKeySizes()
+        {
+            using (TripleDES des = TripleDESFactory.Create())
+            {
+                Assert.Throws<CryptographicException>(() => des.KeySize = 128 - des.BlockSize);
+                Assert.Throws<CryptographicException>(() => des.KeySize = 192 + des.BlockSize);
+            }
+        }
+
+        [Theory]
+        [InlineData(192, "e56f72478c7479d169d54c0548b744af5b53efb1cdd26037", "c5629363d957054eba793093b83739bb78711db221a82379")]
+        [InlineData(128, "1387b981dbb40f34b915c4ed89fd681a740d3b4869c0b575", "c5629363d957054eba793093b83739bb")]
+        [InlineData(192, "1387b981dbb40f34b915c4ed89fd681a740d3b4869c0b575", "c5629363d957054eba793093b83739bbc5629363d957054e")]
+        public static void TripleDESRoundTripNoneECB(int keySize, string expectedCipherHex, string keyHex)
+        {
+            byte[] key = keyHex.HexToByteArray();
 
             using (TripleDES alg = TripleDESFactory.Create())
             {
                 alg.Key = key;
+                Assert.Equal(keySize, alg.KeySize);
+
                 alg.Padding = PaddingMode.None;
                 alg.Mode = CipherMode.ECB;
 
                 byte[] plainText = "de7d2dddea96b691e979e647dc9d3ca27d7f1ad673ca9570".HexToByteArray();
                 byte[] cipher = alg.Encrypt(plainText);
-                byte[] expectedCipher = "e56f72478c7479d169d54c0548b744af5b53efb1cdd26037".HexToByteArray();
+                byte[] expectedCipher = expectedCipherHex.HexToByteArray();
                 Assert.Equal<byte>(expectedCipher, cipher);
 
                 byte[] decrypted = alg.Decrypt(cipher);
@@ -44,22 +67,27 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
             }
         }
 
-        [Fact]
-        public static void TripleDESRoundTrip192BitsNoneCBC()
+        [Theory]
+        [InlineData(192, "dea36279600f19c602b6ed9bf3ffdac5ebf25c1c470eb61c", "b43eaf0260813fb47c87ae073a146006d359ad04061eb0e6")]
+        [InlineData(128, "a25e55381f0cc45541741b9ce6e96b7799aa1e0db70780f7", "b43eaf0260813fb47c87ae073a146006")]
+        [InlineData(192, "a25e55381f0cc45541741b9ce6e96b7799aa1e0db70780f7", "b43eaf0260813fb47c87ae073a146006b43eaf0260813fb4")]
+        public static void TripleDESRoundTripNoneCBC(int keySize, string expectedCipherHex, string keyHex)
         {
-            byte[] key = "b43eaf0260813fb47c87ae073a146006d359ad04061eb0e6".HexToByteArray();
+            byte[] key = keyHex.HexToByteArray();
             byte[] iv = "5fbc5bc21b8597d8".HexToByteArray();
 
             using (TripleDES alg = TripleDESFactory.Create())
             {
                 alg.Key = key;
+                Assert.Equal(keySize, alg.KeySize);
+
                 alg.IV = iv;
                 alg.Padding = PaddingMode.None;
                 alg.Mode = CipherMode.CBC;
 
                 byte[] plainText = "79a86903608e133e020e1dc68c9835250c2f17b0ebeed91b".HexToByteArray();
                 byte[] cipher = alg.Encrypt(plainText);
-                byte[] expectedCipher = "dea36279600f19c602b6ed9bf3ffdac5ebf25c1c470eb61c".HexToByteArray();
+                byte[] expectedCipher = expectedCipherHex.HexToByteArray();
                 Assert.Equal<byte>(expectedCipher, cipher);
 
                 byte[] decrypted = alg.Decrypt(cipher);
@@ -68,20 +96,25 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
             }
         }
 
-        [Fact]
-        public static void TripleDESRoundTrip192BitsZerosECB()
+        [Theory]
+        [InlineData(192, "149ec32f558b27c7e4151e340d8184f18b4e25d2518f69d9", "9da5b265179d65f634dfc95513f25094411e51bb3be877ef")]
+        [InlineData(128, "02ac5db31cfada874f6042c4e92b09175fd08e93a20f936b", "9da5b265179d65f634dfc95513f25094")]
+        [InlineData(192, "02ac5db31cfada874f6042c4e92b09175fd08e93a20f936b", "9da5b265179d65f634dfc95513f250949da5b265179d65f6")]
+        public static void TripleDESRoundTripZerosECB(int keySize, string expectedCipherHex, string keyHex)
         {
-            byte[] key = "9da5b265179d65f634dfc95513f25094411e51bb3be877ef".HexToByteArray();
+            byte[] key = keyHex.HexToByteArray();
 
             using (TripleDES alg = TripleDESFactory.Create())
             {
                 alg.Key = key;
+                Assert.Equal(keySize, alg.KeySize);
+
                 alg.Padding = PaddingMode.Zeros;
                 alg.Mode = CipherMode.ECB;
 
                 byte[] plainText = "77a8b2efb45addb38d7ef3aa9e6ab5d71957445ab8".HexToByteArray();
                 byte[] cipher = alg.Encrypt(plainText);
-                byte[] expectedCipher = "149ec32f558b27c7e4151e340d8184f18b4e25d2518f69d9".HexToByteArray();
+                byte[] expectedCipher = expectedCipherHex.HexToByteArray();
                 Assert.Equal<byte>(expectedCipher, cipher);
 
                 byte[] decrypted = alg.Decrypt(cipher);
@@ -90,14 +123,19 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
             }
         }
 
-        [Fact]
-        public static void TripleDESRoundTrip192BitsISO10126ECB()
+        [Theory]
+        [InlineData(192, "9da5b265179d65f634dfc95513f25094411e51bb3be877ef")]
+        [InlineData(128, "9da5b265179d65f634dfc95513f25094")]
+        [InlineData(192, "9da5b265179d65f634dfc95513f250949da5b265179d65f6")]
+        public static void TripleDESRoundTripISO10126ECB(int keySize, string keyHex)
         {
-            byte[] key = "9da5b265179d65f634dfc95513f25094411e51bb3be877ef".HexToByteArray();
+            byte[] key = keyHex.HexToByteArray();
 
             using (TripleDES alg = TripleDESFactory.Create())
             {
                 alg.Key = key;
+                Assert.Equal(keySize, alg.KeySize);
+
                 alg.Padding = PaddingMode.ISO10126;
                 alg.Mode = CipherMode.ECB;
 
@@ -112,21 +150,26 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
             }
         }
 
-        [Fact]
-        public static void TripleDESRoundTrip192BitsANSIX923ECB()
+        [Theory]
+        [InlineData(192, "149ec32f558b27c7e4151e340d8184f1c90f0a499e20fda9", "9da5b265179d65f634dfc95513f25094411e51bb3be877ef")]
+        [InlineData(128, "02ac5db31cfada874f6042c4e92b091783620e54a1e75957", "9da5b265179d65f634dfc95513f25094")]
+        [InlineData(192, "02ac5db31cfada874f6042c4e92b091783620e54a1e75957", "9da5b265179d65f634dfc95513f250949da5b265179d65f6")]
+        public static void TripleDESRoundTripANSIX923ECB(int keySize, string expectedCipherHex, string keyHex)
         {
-            byte[] key = "9da5b265179d65f634dfc95513f25094411e51bb3be877ef".HexToByteArray();
+            byte[] key = keyHex.HexToByteArray();
 
             using (TripleDES alg = TripleDESFactory.Create())
             {
                 alg.Key = key;
+                Assert.Equal(keySize, alg.KeySize);
+
                 alg.Padding = PaddingMode.ANSIX923;
                 alg.Mode = CipherMode.ECB;
 
                 byte[] plainText = "77a8b2efb45addb38d7ef3aa9e6ab5d71957445ab8".HexToByteArray();
                 byte[] cipher = alg.Encrypt(plainText);
-                
-                byte[] expectedCipher = "149ec32f558b27c7e4151e340d8184f1c90f0a499e20fda9".HexToByteArray();
+
+                byte[] expectedCipher = expectedCipherHex.HexToByteArray();
                 Assert.Equal<byte>(expectedCipher, cipher);
 
                 byte[] decrypted = alg.Decrypt(cipher);
@@ -161,22 +204,27 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
             }
         }
 
-        [Fact]
-        public static void TripleDESRoundTrip192BitsZerosCBC()
+        [Theory]
+        [InlineData(192, "65f3dc211876a9daad238aa7d0c7ed7a3662296faf77dff9", "5e970c0d2323d53b28fa3de507d6d20f9f0cd97123398b4d")]
+        [InlineData(128, "2f55ff6bd8270f1d68dcb342bb674f914d9e1c0e61017a77", "5e970c0d2323d53b28fa3de507d6d20f")]
+        [InlineData(192, "2f55ff6bd8270f1d68dcb342bb674f914d9e1c0e61017a77", "5e970c0d2323d53b28fa3de507d6d20f5e970c0d2323d53b")]
+        public static void TripleDESRoundTripZerosCBC(int keySize, string expectedCipherHex, string keyHex)
         {
-            byte[] key = "5e970c0d2323d53b28fa3de507d6d20f9f0cd97123398b4d".HexToByteArray();
+            byte[] key = keyHex.HexToByteArray();
             byte[] iv = "95498b5bf570f4c8".HexToByteArray();
 
             using (TripleDES alg = TripleDESFactory.Create())
             {
                 alg.Key = key;
+                Assert.Equal(keySize, alg.KeySize);
+
                 alg.IV = iv;
                 alg.Padding = PaddingMode.Zeros;
                 alg.Mode = CipherMode.CBC;
 
                 byte[] plainText = "f9e9a1385bf3bd056d6a06eac662736891bd3e6837".HexToByteArray();
                 byte[] cipher = alg.Encrypt(plainText);
-                byte[] expectedCipher = "65f3dc211876a9daad238aa7d0c7ed7a3662296faf77dff9".HexToByteArray();
+                byte[] expectedCipher = expectedCipherHex.HexToByteArray();
                 Assert.Equal<byte>(expectedCipher, cipher);
 
                 byte[] decrypted = alg.Decrypt(cipher);
@@ -185,20 +233,25 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
             }
         }
 
-        [Fact]
-        public static void TripleDESRoundTrip192BitsPKCS7ECB()
+        [Theory]
+        [InlineData(192, "7b8d982ee0c14821daf1b8cf4e407c2eb328627b696ac36e", "155425f12109cd89378795a4ca337b3264689dca497ba2fa")]
+        [InlineData(128, "ce7daa4723c4f880fb44c2809821fc2183b46f0c32084620", "155425f12109cd89378795a4ca337b32")]
+        [InlineData(192, "ce7daa4723c4f880fb44c2809821fc2183b46f0c32084620", "155425f12109cd89378795a4ca337b32155425f12109cd89")]
+        public static void TripleDESRoundTripPKCS7ECB(int keySize, string expectedCipherHex, string keyHex)
         {
-            byte[] key = "155425f12109cd89378795a4ca337b3264689dca497ba2fa".HexToByteArray();
+            byte[] key = keyHex.HexToByteArray();
 
             using (TripleDES alg = TripleDESFactory.Create())
             {
                 alg.Key = key;
+                Assert.Equal(keySize, alg.KeySize);
+
                 alg.Padding = PaddingMode.PKCS7;
                 alg.Mode = CipherMode.ECB;
 
                 byte[] plainText = "5bd3c4e16a723a17ac60dd0efdb158e269cddfd0fa".HexToByteArray();
                 byte[] cipher = alg.Encrypt(plainText);
-                byte[] expectedCipher = "7b8d982ee0c14821daf1b8cf4e407c2eb328627b696ac36e".HexToByteArray();
+                byte[] expectedCipher = expectedCipherHex.HexToByteArray();
                 Assert.Equal<byte>(expectedCipher, cipher);
 
                 byte[] decrypted = alg.Decrypt(cipher);
@@ -207,22 +260,27 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
             }
         }
 
-        [Fact]
-        public static void TripleDESRoundTrip192BitsPKCS7CBC()
+        [Theory]
+        [InlineData(192, "446f57875e107702afde16b57eaf250b87b8110bef29af89", "6b42da08f93e819fbd26fce0785b0eec3d0cb6bfa053c505")]
+        [InlineData(128, "ebf995606ceceddf5c90a7302521bc1f6d31f330969cb768", "6b42da08f93e819fbd26fce0785b0eec")]
+        [InlineData(192, "ebf995606ceceddf5c90a7302521bc1f6d31f330969cb768", "6b42da08f93e819fbd26fce0785b0eec6b42da08f93e819f")]
+        public static void TripleDESRoundTripPKCS7CBC(int keySize, string expectedCipherHex, string keyHex)
         {
-            byte[] key = "6b42da08f93e819fbd26fce0785b0eec3d0cb6bfa053c505".HexToByteArray();
+            byte[] key = keyHex.HexToByteArray();
             byte[] iv = "8fc67ce5e7f28cde".HexToByteArray();
 
             using (TripleDES alg = TripleDESFactory.Create())
             {
                 alg.Key = key;
+                Assert.Equal(keySize, alg.KeySize);
+
                 alg.IV = iv;
                 alg.Padding = PaddingMode.PKCS7;
                 alg.Mode = CipherMode.CBC;
 
                 byte[] plainText = "e867f915e275eab27d6951165d26dec6dd0acafcfc".HexToByteArray();
                 byte[] cipher = alg.Encrypt(plainText);
-                byte[] expectedCipher = "446f57875e107702afde16b57eaf250b87b8110bef29af89".HexToByteArray();
+                byte[] expectedCipher = expectedCipherHex.HexToByteArray();
                 Assert.Equal<byte>(expectedCipher, cipher);
 
                 byte[] decrypted = alg.Decrypt(cipher);

--- a/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
+++ b/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
@@ -601,8 +601,6 @@ namespace System.Security.Cryptography
     {
         protected TripleDES() { }
         public override byte[] Key { get { throw null; } set { } }
-        public override System.Security.Cryptography.KeySizes[] LegalBlockSizes { get { throw null; } }
-        public override System.Security.Cryptography.KeySizes[] LegalKeySizes { get { throw null; } }
         public static new System.Security.Cryptography.TripleDES Create() { throw null; }
         public static new System.Security.Cryptography.TripleDES Create(string str) { throw null; }
         public static bool IsWeakKey(byte[] rgbKey) { throw null; }

--- a/src/System.Security.Cryptography.Cng/ref/System.Security.Cryptography.Cng.cs
+++ b/src/System.Security.Cryptography.Cng/ref/System.Security.Cryptography.Cng.cs
@@ -339,7 +339,6 @@ namespace System.Security.Cryptography
         public TripleDESCng(string keyName, System.Security.Cryptography.CngProvider provider, System.Security.Cryptography.CngKeyOpenOptions openOptions) { }
         public override byte[] Key { get { throw null; } set { } }
         public override int KeySize { get { throw null; } set { } }
-        public override System.Security.Cryptography.KeySizes[] LegalKeySizes { get { throw null; } }
         public override System.Security.Cryptography.ICryptoTransform CreateDecryptor() { throw null; }
         public override System.Security.Cryptography.ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV) { throw null; }
         public override System.Security.Cryptography.ICryptoTransform CreateEncryptor() { throw null; }

--- a/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/CngSymmetricAlgorithmCore.cs
+++ b/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/CngSymmetricAlgorithmCore.cs
@@ -151,6 +151,8 @@ namespace Internal.Cryptography
             // is correct, and detached from the input parameter.
             byte[] iv = _outer.Mode.GetCipherIv(rgbIV).CloneByteArray();
 
+            key = _outer.PreprocessKey(key);
+
             return CreateEphemeralCryptoTransformCore(key, iv, encrypting);
         }
 

--- a/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/ICngSymmetricAlgorithm.cs
+++ b/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/ICngSymmetricAlgorithm.cs
@@ -30,6 +30,7 @@ namespace Internal.Cryptography
         bool IsWeakKey(byte[] key);
         SafeAlgorithmHandle GetEphemeralModeHandle();
         string GetNCryptAlgorithmIdentifier();
+        byte[] PreprocessKey(byte[] key);
     }
 }
 

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/AesCng.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/AesCng.cs
@@ -116,6 +116,11 @@ namespace System.Security.Cryptography
             return Interop.NCrypt.NCRYPT_AES_ALGORITHM;
         }
 
+        byte[] ICngSymmetricAlgorithm.PreprocessKey(byte[] key)
+        {
+            return key;
+        }
+
         private CngSymmetricAlgorithmCore _core;
     }
 }

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/TripleDESCng.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/TripleDESCng.cs
@@ -94,15 +94,6 @@ namespace System.Security.Cryptography
             _core.GenerateIV();
         }
 
-        public override KeySizes[] LegalKeySizes
-        {
-            get
-            {
-                // CNG does not support 128-bit keys.
-                return new KeySizes[] { new KeySizes(minSize: 3 * 64, maxSize: 3 * 64, skipSize: 0) };
-            }
-        }
-
         protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);
@@ -124,6 +115,21 @@ namespace System.Security.Cryptography
         string ICngSymmetricAlgorithm.GetNCryptAlgorithmIdentifier()
         {
             return Interop.NCrypt.NCRYPT_3DES_ALGORITHM;
+        }
+
+        byte[] ICngSymmetricAlgorithm.PreprocessKey(byte[] key)
+        {
+            if (key.Length == 16)
+            {
+                // Cng does not support Two-Key Triple DES, so manually support it here for consistency with System.Security.Cryptography.Algorithms.
+                // Two-Key Triple DES contains two 8-byte keys {K1}{K2} with {K1} appended to make {K1}{K2}{K1}.
+                byte[] newkey = new byte[24];
+                Array.Copy(key, 0, newkey, 0, 16);
+                Array.Copy(key, 0, newkey, 16, 8);
+                return newkey;
+            }
+
+            return key;
         }
 
         private CngSymmetricAlgorithmCore _core;


### PR DESCRIPTION
Direct port of https://github.com/dotnet/corefx/commit/1ce37dfb5a03e5decdb25ee67ef765f89424ceb1

Issue https://github.com/dotnet/corefx/issues/9966 (support 16-byte TripleDES keys for compat with desktop clr)
