### PR TITLE
Fix some of System.Net.HttpListener test failures on ILC

### DIFF
--- a/src/Common/tests/System/AssertExtensions.cs
+++ b/src/Common/tests/System/AssertExtensions.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Sdk;
 
@@ -53,6 +54,17 @@ namespace System
             where T : ArgumentException
         {
             T exception = Assert.Throws<T>(testCode);
+
+            if (!RuntimeInformation.FrameworkDescription.StartsWith(".NET Native"))
+                Assert.Equal(paramName, exception.ParamName);
+
+            return exception;
+        }
+
+        public static async Task<T> ThrowsAsync<T>(string paramName, Func<Task> testCode)
+            where T : ArgumentException
+        {
+            T exception = await Assert.ThrowsAsync<T>(testCode);
 
             if (!RuntimeInformation.FrameworkDescription.StartsWith(".NET Native"))
                 Assert.Equal(paramName, exception.ParamName);

--- a/src/System.Net.HttpListener/tests/AuthenticationTests.cs
+++ b/src/System.Net.HttpListener/tests/AuthenticationTests.cs
@@ -289,7 +289,7 @@ namespace System.Net.Tests
         {
             using (var listener = new HttpListener())
             {
-                Assert.Throws<ArgumentNullException>("value", () => listener.ExtendedProtectionPolicy = null);
+                AssertExtensions.Throws<ArgumentNullException>("value", () => listener.ExtendedProtectionPolicy = null);
             }
         }
 

--- a/src/System.Net.HttpListener/tests/HttpListenerContextTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerContextTests.cs
@@ -112,7 +112,7 @@ namespace System.Net.Tests
         public async Task AcceptWebSocketAsync_InvalidSubProtocol_ThrowsArgumentException(string subProtocol)
         {
             HttpListenerContext context = await GetWebSocketContext();
-            await Assert.ThrowsAsync<ArgumentException>("subProtocol", () => context.AcceptWebSocketAsync(subProtocol));
+            await AssertExtensions.ThrowsAsync<ArgumentException>("subProtocol", () => context.AcceptWebSocketAsync(subProtocol));
         }
 
         [ConditionalTheory(nameof(IsNotWindows7OrUapCore))]
@@ -151,7 +151,7 @@ namespace System.Net.Tests
             HttpListenerContext context = await GetWebSocketContext();
 
             ArraySegment<byte> internalBuffer = new FakeArraySegment() { Array = null }.ToActual();
-            await Assert.ThrowsAsync<ArgumentNullException>("internalBuffer.Array", () => context.AcceptWebSocketAsync(null, 1024, TimeSpan.MaxValue, internalBuffer));
+            await AssertExtensions.ThrowsAsync<ArgumentNullException>("internalBuffer.Array", () => context.AcceptWebSocketAsync(null, 1024, TimeSpan.MaxValue, internalBuffer));
         }
 
         [ConditionalTheory(nameof(IsNotWindows7OrUapCore))]
@@ -162,7 +162,7 @@ namespace System.Net.Tests
             HttpListenerContext context = await GetWebSocketContext();
 
             ArraySegment<byte> internalBuffer = new FakeArraySegment() { Array = new byte[10], Offset = offset }.ToActual();
-            await Assert.ThrowsAsync<ArgumentOutOfRangeException>("internalBuffer.Offset", () => context.AcceptWebSocketAsync(null, 1024, TimeSpan.MaxValue, internalBuffer));
+            await AssertExtensions.ThrowsAsync<ArgumentOutOfRangeException>("internalBuffer.Offset", () => context.AcceptWebSocketAsync(null, 1024, TimeSpan.MaxValue, internalBuffer));
         }
 
         [ConditionalTheory(nameof(IsNotWindows7OrUapCore))]
@@ -175,7 +175,7 @@ namespace System.Net.Tests
             HttpListenerContext context = await GetWebSocketContext();
 
             ArraySegment<byte> internalBuffer = new FakeArraySegment() { Array = new byte[10], Offset = offset, Count = count }.ToActual();
-            await Assert.ThrowsAsync<ArgumentOutOfRangeException>("internalBuffer.Count", () => context.AcceptWebSocketAsync(null, 1024, TimeSpan.MaxValue, internalBuffer));
+            await AssertExtensions.ThrowsAsync<ArgumentOutOfRangeException>("internalBuffer.Count", () => context.AcceptWebSocketAsync(null, 1024, TimeSpan.MaxValue, internalBuffer));
         }
 
         private async Task GetSocketContext(string[] headers, Func<HttpListenerContext, Task> contextAction)

--- a/src/System.Net.HttpListener/tests/HttpListenerPrefixCollectionTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerPrefixCollectionTests.cs
@@ -138,8 +138,8 @@ namespace System.Net.Tests
         {
             var listener = new HttpListener();
             listener.Prefixes.Add("http://localhost:9200/");
-            Assert.Throws<ArgumentOutOfRangeException>("array", () => listener.Prefixes.CopyTo((Array)new string[0], 0));
-            Assert.Throws<ArgumentOutOfRangeException>("array", () => listener.Prefixes.CopyTo(new string[0], 0));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("array", () => listener.Prefixes.CopyTo((Array)new string[0], 0));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("array", () => listener.Prefixes.CopyTo(new string[0], 0));
         }
 
         [Theory]
@@ -149,8 +149,8 @@ namespace System.Net.Tests
         {
             var listener = new HttpListener();
             listener.Prefixes.Add("http://localhost:9200/");
-            Assert.Throws<ArgumentOutOfRangeException>("offset", () => listener.Prefixes.CopyTo((Array)new string[1], offset));
-            Assert.Throws<ArgumentOutOfRangeException>("offset", () => listener.Prefixes.CopyTo(new string[1], offset));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => listener.Prefixes.CopyTo((Array)new string[1], offset));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => listener.Prefixes.CopyTo(new string[1], offset));
         }
 
         [Fact]
@@ -408,7 +408,7 @@ namespace System.Net.Tests
         public void Add_InvalidPrefix_ThrowsArgumentException(string uriPrefix)
         {
             var listener = new HttpListener();
-            Assert.Throws<ArgumentException>("uriPrefix", () => listener.Prefixes.Add(uriPrefix));
+            AssertExtensions.Throws<ArgumentException>("uriPrefix", () => listener.Prefixes.Add(uriPrefix));
 
             // If the prefix was invalid, it shouldn't be added to the list.
             Assert.Empty(listener.Prefixes);
@@ -419,7 +419,7 @@ namespace System.Net.Tests
         public void Add_NullPrefix_ThrowsArgumentNullException()
         {
             var listener = new HttpListener();
-            Assert.Throws<ArgumentNullException>("uriPrefix", () => listener.Prefixes.Add(null));
+            AssertExtensions.Throws<ArgumentNullException>("uriPrefix", () => listener.Prefixes.Add(null));
         }
 
         [Fact]
@@ -465,7 +465,7 @@ namespace System.Net.Tests
         public void Contains_NullPrefix_ThrowsArgumentNullException()
         {
             var listener = new HttpListener();
-            Assert.Throws<ArgumentNullException>("key", () => listener.Prefixes.Contains(null));
+            AssertExtensions.Throws<ArgumentNullException>("key", () => listener.Prefixes.Contains(null));
         }
 
         [Fact]
@@ -523,7 +523,7 @@ namespace System.Net.Tests
         public void Remove_NullPrefix_ThrowsArgumentNullException()
         {
             var listener = new HttpListener();
-            Assert.Throws<ArgumentNullException>("uriPrefix", () => listener.Prefixes.Remove(null));
+            AssertExtensions.Throws<ArgumentNullException>("uriPrefix", () => listener.Prefixes.Remove(null));
         }
 
         [Fact]

--- a/src/System.Net.HttpListener/tests/HttpListenerRequestTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerRequestTests.cs
@@ -265,7 +265,7 @@ namespace System.Net.Tests
         {
             await GetRequest("POST", null, null, (_, request) =>
             {
-                Assert.Throws<ArgumentNullException>("asyncResult", () => request.EndGetClientCertificate(null));
+                AssertExtensions.Throws<ArgumentNullException>("asyncResult", () => request.EndGetClientCertificate(null));
             });
         }
 
@@ -278,8 +278,8 @@ namespace System.Net.Tests
                 {
                     IAsyncResult beginGetClientCertificateResult1 = request1.BeginGetClientCertificate(null, null);
 
-                    Assert.Throws<ArgumentException>("asyncResult", () => request2.EndGetClientCertificate(new CustomAsyncResult()));
-                    Assert.Throws<ArgumentException>("asyncResult", () => request2.EndGetClientCertificate(beginGetClientCertificateResult1));
+                    AssertExtensions.Throws<ArgumentException>("asyncResult", () => request2.EndGetClientCertificate(new CustomAsyncResult()));
+                    AssertExtensions.Throws<ArgumentException>("asyncResult", () => request2.EndGetClientCertificate(beginGetClientCertificateResult1));
                 }).Wait();
             });
         }

--- a/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Cookies.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Cookies.cs
@@ -196,7 +196,7 @@ namespace System.Net.Tests
         public async Task AppendCookie_NullCookie_ThrowsArgumentNullException()
         {
             HttpListenerResponse response = await GetResponse();
-            Assert.Throws<ArgumentNullException>("cookie", () => response.AppendCookie(null));
+            AssertExtensions.Throws<ArgumentNullException>("cookie", () => response.AppendCookie(null));
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
@@ -228,7 +228,7 @@ namespace System.Net.Tests
         public async Task SetCookie_NullCookie_ThrowsArgumentNullException()
         {
             HttpListenerResponse response = await GetResponse();
-            Assert.Throws<ArgumentNullException>("cookie", () => response.SetCookie(null));
+            AssertExtensions.Throws<ArgumentNullException>("cookie", () => response.SetCookie(null));
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
@@ -238,10 +238,10 @@ namespace System.Net.Tests
             var cookie1 = new Cookie("name", "value");
 
             response.SetCookie(cookie1);
-            Assert.Throws<ArgumentException>("cookie", () => response.SetCookie(cookie1));
+            AssertExtensions.Throws<ArgumentException>("cookie", () => response.SetCookie(cookie1));
 
             var cookie2 = new Cookie("name", "value2");
-            Assert.Throws<ArgumentException>("cookie", () => response.SetCookie(cookie2));
+            AssertExtensions.Throws<ArgumentException>("cookie", () => response.SetCookie(cookie2));
             Assert.Equal(new Cookie[] { cookie2 }, response.Cookies.Cast<Cookie>());
         }
     }

--- a/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Headers.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Headers.cs
@@ -29,17 +29,17 @@ namespace System.Net.Tests
         public async Task AddHeader_NullOrEmptyName_ThrowsArgumentNullException()
         {
             HttpListenerResponse response = await GetResponse();
-            Assert.Throws<ArgumentNullException>("name", () => response.AddHeader(null, ""));
-            Assert.Throws<ArgumentNullException>("name", () => response.AddHeader("", ""));
+            AssertExtensions.Throws<ArgumentNullException>("name", () => response.AddHeader(null, ""));
+            AssertExtensions.Throws<ArgumentNullException>("name", () => response.AddHeader("", ""));
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public async Task AddHeader_InvalidNameOrValue_ThrowsArgumentException()
         {
             HttpListenerResponse response = await GetResponse();
-            Assert.Throws<ArgumentException>("name", () => response.AddHeader("\r \t \n", ""));
-            Assert.Throws<ArgumentException>("name", () => response.AddHeader("(", ""));
-            Assert.Throws<ArgumentException>("value", () => response.AddHeader("name", "value1\rvalue2\r"));
+            AssertExtensions.Throws<ArgumentException>("name", () => response.AddHeader("\r \t \n", ""));
+            AssertExtensions.Throws<ArgumentException>("name", () => response.AddHeader("(", ""));
+            AssertExtensions.Throws<ArgumentException>("value", () => response.AddHeader("name", "value1\rvalue2\r"));
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
@@ -60,16 +60,16 @@ namespace System.Net.Tests
         public async Task AppendHeader_NullOrEmptyName_ThrowsArgumentNullException(string name)
         {
             HttpListenerResponse response = await GetResponse();
-            Assert.Throws<ArgumentNullException>("name", () => response.AppendHeader(null, ""));
+            AssertExtensions.Throws<ArgumentNullException>("name", () => response.AppendHeader(null, ""));
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public async Task AppendHeader_InvalidNameOrValue_ThrowsArgumentException()
         {
             HttpListenerResponse response = await GetResponse();
-            Assert.Throws<ArgumentException>("name", () => response.AppendHeader("\r \t \n", ""));
-            Assert.Throws<ArgumentException>("name", () => response.AppendHeader("(", ""));
-            Assert.Throws<ArgumentException>("value", () => response.AppendHeader("name", "value1\rvalue2\r"));
+            AssertExtensions.Throws<ArgumentException>("name", () => response.AppendHeader("\r \t \n", ""));
+            AssertExtensions.Throws<ArgumentException>("name", () => response.AppendHeader("(", ""));
+            AssertExtensions.Throws<ArgumentException>("value", () => response.AppendHeader("name", "value1\rvalue2\r"));
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
@@ -401,7 +401,7 @@ namespace System.Net.Tests
         {
             using (HttpListenerResponse response = await GetResponse())
             {
-                Assert.Throws<ArgumentNullException>("value", () => response.StatusDescription = null);
+                AssertExtensions.Throws<ArgumentNullException>("value", () => response.StatusDescription = null);
                 Assert.Equal("OK", response.StatusDescription);
             }
         }
@@ -415,7 +415,7 @@ namespace System.Net.Tests
         {
             using (HttpListenerResponse response = await GetResponse())
             {
-                Assert.Throws<ArgumentException>("name", () => response.StatusDescription = statusDescription);
+                AssertExtensions.Throws<ArgumentException>("name", () => response.StatusDescription = statusDescription);
                 Assert.Equal("OK", response.StatusDescription);
             }
         }
@@ -764,7 +764,7 @@ namespace System.Net.Tests
         {
             using (HttpListenerResponse response = await GetResponse())
             {
-                Assert.Throws<ArgumentNullException>("value", () => response.ProtocolVersion = null);
+                AssertExtensions.Throws<ArgumentNullException>("value", () => response.ProtocolVersion = null);
                 Assert.Equal(new Version(1, 1), response.ProtocolVersion);
             }
         }
@@ -777,7 +777,7 @@ namespace System.Net.Tests
         {
             using (HttpListenerResponse response = await GetResponse())
             {
-                Assert.Throws<ArgumentException>("value", () => response.ProtocolVersion = new Version(major, minor));
+                AssertExtensions.Throws<ArgumentException>("value", () => response.ProtocolVersion = new Version(major, minor));
                 Assert.Equal(new Version(1, 1), response.ProtocolVersion);
             }
         }

--- a/src/System.Net.HttpListener/tests/HttpListenerResponseTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerResponseTests.cs
@@ -387,7 +387,7 @@ namespace System.Net.Tests
         {
             using (HttpListenerResponse response = await GetResponse())
             {
-                Assert.Throws<ArgumentNullException>("responseEntity", () => response.Close(null, true));
+                AssertExtensions.Throws<ArgumentNullException>("responseEntity", () => response.Close(null, true));
             }
         }
 


### PR DESCRIPTION
Fixes failures due to ParamName being null on Uap

cc: @davidsh @tijoytom 