### PR TITLE
Fixing System.Data.SqlClient.ManualTesting tests and System.Data.SqlClient.Stress tests for uapaot

### DIFF
--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -87,6 +87,16 @@
     <PackageToInclude Include="$(XUnitRunnerPackageId)" />
   </ItemGroup>
 
+  <!-- System.Data.SqlClient tests require sni.dll in the test folder -->
+  <ItemGroup Condition="'$(TargetGroup)' == 'uapaot'">
+    <PackageReference Include="runtime.native.System.Data.SqlClient.sni">
+      <Version>$(PackageVersion)-$(CoreFxExpectedPrerelease)</Version>
+    </PackageReference>
+    <PackageToInclude Include="runtime.win-arm64.runtime.native.System.Data.SqlClient.sni"/>
+    <PackageToInclude Include="runtime.win-x64.runtime.native.System.Data.SqlClient.sni"/>
+    <PackageToInclude Include="runtime.win-x86.runtime.native.System.Data.SqlClient.sni"/>
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetGroup)' != 'uapaot'">
     <PackageToInclude Include="xunit.performance.core"/>
     <PackageToInclude Include="xunit.performance.api"/>

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/Common/InternalConnectionWrapper.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/Common/InternalConnectionWrapper.cs
@@ -12,12 +12,6 @@ namespace System.Data.SqlClient.ManualTesting.Tests
 {
     public class InternalConnectionWrapper
     {
-        private static class SNIInternals
-        {
-            [DllImport("sniinternals.dll", CallingConvention = CallingConvention.Cdecl)]
-            internal static extern uint SNIKillConnection(SafeHandle connection);
-        }
-
         private static Dictionary<string, string> s_killByTSqlConnectionStrings = new Dictionary<string, string>();
         private static ReaderWriterLockSlim s_killByTSqlConnectionStringsLock = new ReaderWriterLockSlim();
 

--- a/src/System.Data.SqlClient/tests/Tools/TDS/TDS.EndPoint/SSPI/SecurityWrapper.cs
+++ b/src/System.Data.SqlClient/tests/Tools/TDS/TDS.EndPoint/SSPI/SecurityWrapper.cs
@@ -24,7 +24,7 @@ namespace Microsoft.SqlServer.TDS.EndPoint.SSPI
         /// <param name="pvGetKeyArgument">This parameter is not used and should be set to NULL</param>
         /// <param name="phCredential">A pointer to a CredHandle structure to receive the credential handle</param>
         /// <param name="ptsExpiry">A pointer to a TimeStamp structure that receives the time at which the returned credentials expire</param>
-        [DllImport(Interop.Libraries.SspiCli, CharSet = CharSet.Auto, EntryPoint="AcquireCredentialsHandleW")]
+        [DllImport(Interop.Libraries.SspiCli, CharSet = CharSet.Unicode, EntryPoint="AcquireCredentialsHandleW")]
         internal static extern int AcquireCredentialsHandle(
             string pszPrincipal,
             string pszPackage,
@@ -51,7 +51,7 @@ namespace Microsoft.SqlServer.TDS.EndPoint.SSPI
         /// <param name="pOutput">A pointer to a SecBufferDesc structure that contains the output buffer descriptor</param>
         /// <param name="pfContextAttr">A pointer to a variable that receives a set of bit flags that indicate the attributes of the established context</param>
         /// <param name="ptsTimeStamp">A pointer to a TimeStamp structure that receives the expiration time of the context</param>
-        [DllImport(Interop.Libraries.SspiCli, CharSet = CharSet.Auto, SetLastError = false, EntryPoint="InitializeSecurityContextW")]
+        [DllImport(Interop.Libraries.SspiCli, CharSet = CharSet.Unicode, SetLastError = false, EntryPoint="InitializeSecurityContextW")]
         internal static extern int InitializeSecurityContext(ref SecurityHandle phCredential,
             IntPtr phContext,
             string pszTargetName,
@@ -80,7 +80,7 @@ namespace Microsoft.SqlServer.TDS.EndPoint.SSPI
         /// <param name="pOutput">A pointer to a SecBufferDesc structure that contains the output buffer descriptor</param>
         /// <param name="pfContextAttr">A pointer to a variable that receives a set of bit flags that indicate the attributes of the established context</param>
         /// <param name="ptsTimeStamp">A pointer to a TimeStamp structure that receives the expiration time of the context</param>
-        [DllImport(Interop.Libraries.SspiCli, CharSet = CharSet.Auto, SetLastError = false, EntryPoint="InitializeSecurityContextW")]
+        [DllImport(Interop.Libraries.SspiCli, CharSet = CharSet.Unicode, SetLastError = false, EntryPoint="InitializeSecurityContextW")]
         internal static extern int InitializeSecurityContext(ref SecurityHandle phCredential,
             ref SecurityHandle phContext,
             string pszTargetName,
@@ -168,7 +168,7 @@ namespace Microsoft.SqlServer.TDS.EndPoint.SSPI
         /// </summary>
         /// <param name="packageName">Pointer to a null-terminated string that specifies the name of the security package</param>
         /// <param name="ppPackageInfo">Pointer to a variable that receives a pointer to a SecPkgInfo structure containing information about the specified security package</param>
-        [DllImport(Interop.Libraries.SspiCli, CharSet = CharSet.Auto, EntryPoint="QuerySecurityPackageInfoW")]
+        [DllImport(Interop.Libraries.SspiCli, CharSet = CharSet.Unicode, EntryPoint="QuerySecurityPackageInfoW")]
         internal static extern int QuerySecurityPackageInfo([MarshalAs(UnmanagedType.LPTStr)] string packageName, ref IntPtr ppPackageInfo);
 
         /// <summary>

--- a/src/System.Data.SqlClient/tests/Tools/TDS/TDS.EndPoint/SSPI/SecurityWrapper.cs
+++ b/src/System.Data.SqlClient/tests/Tools/TDS/TDS.EndPoint/SSPI/SecurityWrapper.cs
@@ -24,7 +24,7 @@ namespace Microsoft.SqlServer.TDS.EndPoint.SSPI
         /// <param name="pvGetKeyArgument">This parameter is not used and should be set to NULL</param>
         /// <param name="phCredential">A pointer to a CredHandle structure to receive the credential handle</param>
         /// <param name="ptsExpiry">A pointer to a TimeStamp structure that receives the time at which the returned credentials expire</param>
-        [DllImport(Interop.Libraries.SspiCli, CharSet = CharSet.Auto)]
+        [DllImport(Interop.Libraries.SspiCli, CharSet = CharSet.Auto, EntryPoint="AcquireCredentialsHandleW")]
         internal static extern int AcquireCredentialsHandle(
             string pszPrincipal,
             string pszPackage,
@@ -51,7 +51,7 @@ namespace Microsoft.SqlServer.TDS.EndPoint.SSPI
         /// <param name="pOutput">A pointer to a SecBufferDesc structure that contains the output buffer descriptor</param>
         /// <param name="pfContextAttr">A pointer to a variable that receives a set of bit flags that indicate the attributes of the established context</param>
         /// <param name="ptsTimeStamp">A pointer to a TimeStamp structure that receives the expiration time of the context</param>
-        [DllImport(Interop.Libraries.SspiCli, CharSet = CharSet.Auto, SetLastError = false)]
+        [DllImport(Interop.Libraries.SspiCli, CharSet = CharSet.Auto, SetLastError = false, EntryPoint="InitializeSecurityContextW")]
         internal static extern int InitializeSecurityContext(ref SecurityHandle phCredential,
             IntPtr phContext,
             string pszTargetName,
@@ -80,7 +80,7 @@ namespace Microsoft.SqlServer.TDS.EndPoint.SSPI
         /// <param name="pOutput">A pointer to a SecBufferDesc structure that contains the output buffer descriptor</param>
         /// <param name="pfContextAttr">A pointer to a variable that receives a set of bit flags that indicate the attributes of the established context</param>
         /// <param name="ptsTimeStamp">A pointer to a TimeStamp structure that receives the expiration time of the context</param>
-        [DllImport(Interop.Libraries.SspiCli, CharSet = CharSet.Auto, SetLastError = false)]
+        [DllImport(Interop.Libraries.SspiCli, CharSet = CharSet.Auto, SetLastError = false, EntryPoint="InitializeSecurityContextW")]
         internal static extern int InitializeSecurityContext(ref SecurityHandle phCredential,
             ref SecurityHandle phContext,
             string pszTargetName,
@@ -168,7 +168,7 @@ namespace Microsoft.SqlServer.TDS.EndPoint.SSPI
         /// </summary>
         /// <param name="packageName">Pointer to a null-terminated string that specifies the name of the security package</param>
         /// <param name="ppPackageInfo">Pointer to a variable that receives a pointer to a SecPkgInfo structure containing information about the specified security package</param>
-        [DllImport(Interop.Libraries.SspiCli, CharSet = CharSet.Auto)]
+        [DllImport(Interop.Libraries.SspiCli, CharSet = CharSet.Auto, EntryPoint="QuerySecurityPackageInfoW")]
         internal static extern int QuerySecurityPackageInfo([MarshalAs(UnmanagedType.LPTStr)] string packageName, ref IntPtr ppPackageInfo);
 
         /// <summary>


### PR DESCRIPTION
cc: @weshaggard @danmosemsft @tijoytom 

Fixing all 3 System.Data.SqlClient.* tests projects that where failing to produce testresults.xml due to missing sni.dll in the test folder.