### PR TITLE
Update buildtools and extensions and do tests cleanup for new attributes behavior

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-2.0.0-prerelease-01623-02
+2.0.0-prerelease-01624-02

--- a/dependencies.props
+++ b/dependencies.props
@@ -40,7 +40,7 @@
     <AppXRunnerVersion>1.0.3-prerelease-00921-01</AppXRunnerVersion>
     <XunitPerfAnalysisPackageVersion>1.0.0-beta-build0003</XunitPerfAnalysisPackageVersion>
     <TraceEventPackageVersion>1.0.3-alpha-experimental</TraceEventPackageVersion>
-    <XunitNetcoreExtensionsVersion>1.0.1-prerelease-01622-05</XunitNetcoreExtensionsVersion>
+    <XunitNetcoreExtensionsVersion>1.0.1-prerelease-01625-01</XunitNetcoreExtensionsVersion>
   </PropertyGroup>
 
   <!-- Package dependency verification/auto-upgrade configuration. -->

--- a/src/System.Collections/tests/Generic/Comparers/Comparer.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/Comparers/Comparer.Generic.Tests.cs
@@ -35,7 +35,7 @@ namespace System.Collections.Generic.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "See dotnet/corert#1736")]
+        [ActiveIssue("dotnet/corert#1736", TargetFrameworkMonikers.Uap)]
         public void Comparer_EqualsShouldBeOverriddenAndWorkForDifferentInstances_cloned()
         {
             var comparer = Comparer<T>.Default;
@@ -62,7 +62,7 @@ namespace System.Collections.Generic.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "See dotnet/corert#1736")]
+        [ActiveIssue("dotnet/corert#1736", TargetFrameworkMonikers.Uap)]
         public void Comparer_GetHashCodeShouldBeOverriddenAndBeTheSameAsLongAsTheTypeIsTheSame_cloned()
         {
             var comparer = Comparer<T>.Default;

--- a/src/System.Collections/tests/Generic/Comparers/EqualityComparer.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/Comparers/EqualityComparer.Generic.Tests.cs
@@ -31,7 +31,7 @@ namespace System.Collections.Generic.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "See dotnet/corert#1736")]
+        [ActiveIssue("dotnet/corert#1736", TargetFrameworkMonikers.Uap)]
         public void EqualityComparer_EqualsShouldBeOverriddenAndWorkForDifferentInstances_cloned()
         {
             var comparer = EqualityComparer<T>.Default;
@@ -58,7 +58,7 @@ namespace System.Collections.Generic.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "See dotnet/corert#1736")]
+        [ActiveIssue("dotnet/corert#1736", TargetFrameworkMonikers.Uap)]
         public void EqualityComparer_GetHashCodeShouldBeOverriddenAndBeTheSameAsLongAsTheTypeIsTheSame_cloned()
         {
             var comparer = EqualityComparer<T>.Default;

--- a/src/System.Collections/tests/Generic/SortedList/SortedList.Tests.cs
+++ b/src/System.Collections/tests/Generic/SortedList/SortedList.Tests.cs
@@ -117,7 +117,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx#7019")]
+        [ActiveIssue("dotnet/corefx#7019", TargetFrameworkMonikers.NetFramework)]
         public void CantAcceptDuplicateKeysFromSourceDictionary()
         {
             Dictionary<string, int> source = new Dictionary<string, int> { { "a", 1 }, { "A", 1 } };

--- a/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.Tests.cs
@@ -57,7 +57,7 @@ namespace System.Collections.Tests
 
         [Theory]
         [MemberData(nameof(EnumerableTestData))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #16790")] 
+        [ActiveIssue("dotnet/corefx #16790", TargetFrameworkMonikers.NetFramework)]
         public void SortedSet_Generic_Constructor_IEnumerable_IComparer_Netcoreapp(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
             IEnumerable<T> enumerable = CreateEnumerable(enumerableType, null, enumerableLength, 0, 0);
@@ -67,7 +67,7 @@ namespace System.Collections.Tests
 
         [Theory]
         [MemberData(nameof(EnumerableTestData))]
-        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "dotnet/corefx #16790")]
+        [ActiveIssue("dotnet/corefx #16790", ~TargetFrameworkMonikers.NetFramework)]
         public void SortedSet_Generic_Constructor_IEnumerable_IComparer_Netfx(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
             IEnumerable<T> enumerable = CreateEnumerable(enumerableType, null, enumerableLength, 0, 0);
@@ -77,7 +77,7 @@ namespace System.Collections.Tests
 
         [Theory]
         [MemberData(nameof(EnumerableTestData))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #16790")]
+        [ActiveIssue("dotnet/corefx #16790", TargetFrameworkMonikers.NetFramework)]
         public void SortedSet_Generic_Constructor_IEnumerable_IComparer_NullComparer_Netcoreapp(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
             IEnumerable<T> enumerable = CreateEnumerable(enumerableType, null, enumerableLength, 0, 0);

--- a/src/System.ComponentModel.TypeConverter/tests/MemberDescriptorTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/MemberDescriptorTests.cs
@@ -10,7 +10,7 @@ namespace System.ComponentModel.Tests
     public class MemberDescriptorTests
     {
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18201")]
+        [ActiveIssue("dotnet/corefx #18201", TargetFrameworkMonikers.NetFramework)]
         public void CopiedMemberDescriptorEqualsItsSource()
         {
             string description = "MockCategory";

--- a/src/System.Configuration.ConfigurationManager/tests/Mono/ConfigurationLockCollectionTest.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/Mono/ConfigurationLockCollectionTest.cs
@@ -140,7 +140,7 @@ namespace MonoTests.System.Configuration
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18195")]
+        [ActiveIssue("dotnet/corefx #18195", TargetFrameworkMonikers.NetFramework)]
         public void DuplicateAdd()
         {
             SysConfig cfg = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);

--- a/src/System.Configuration.ConfigurationManager/tests/Mono/ConfigurationManagerTest.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/Mono/ConfigurationManagerTest.cs
@@ -43,7 +43,7 @@ namespace MonoTests.System.Configuration
     public class ConfigurationManagerTest
     {
         [Fact] // OpenExeConfiguration (ConfigurationUserLevel)
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #19384")]
+        [ActiveIssue("dotnet/corefx #19384", TargetFrameworkMonikers.NetFramework)]
         public void OpenExeConfiguration1_UserLevel_None()
         {
             SysConfig config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
@@ -132,7 +132,7 @@ namespace MonoTests.System.Configuration
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18831")]
+        [ActiveIssue("dotnet/corefx #18831", TargetFrameworkMonikers.NetFramework)]
         public void exePath_UserLevelNone()
         {
             string name = TestUtil.ThisApplicationPath;
@@ -263,7 +263,7 @@ namespace MonoTests.System.Configuration
         [Fact]
         // Doesn't pass on Mono
         // [Category("NotWorking")]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #19384")]
+        [ActiveIssue("dotnet/corefx #19384", TargetFrameworkMonikers.NetFramework)]
         public void mapped_ExeConfiguration_null()
         {
             SysConfig config = ConfigurationManager.OpenMappedExeConfiguration(null, ConfigurationUserLevel.None);

--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/AppSettingsTests.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/AppSettingsTests.cs
@@ -61,7 +61,7 @@ namespace System.ConfigurationTests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #19336")]
+        [ActiveIssue("dotnet/corefx #19336", TargetFrameworkMonikers.NetFramework)]
         public void AddToAppSettings_Save()
         {
             using (var temp = new TempConfig(TestData.EmptyConfig))

--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/ApplicationSettingsBaseTests.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/ApplicationSettingsBaseTests.cs
@@ -46,7 +46,7 @@ namespace System.ConfigurationTests
             InlineData(true)
             InlineData(false)
             ]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18832")]
+        [ActiveIssue("dotnet/corefx #18832", TargetFrameworkMonikers.NetFramework)]
         public void Context_SimpleSettings_InNotNull(bool isSynchronized)
         {
             SimpleSettings settings = isSynchronized
@@ -60,7 +60,7 @@ namespace System.ConfigurationTests
             InlineData(true)
             InlineData(false)
             ]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18832")]
+        [ActiveIssue("dotnet/corefx #18832", TargetFrameworkMonikers.NetFramework)]
         public void Providers_SimpleSettings_Empty(bool isSynchronized)
         {
             SimpleSettings settings = isSynchronized
@@ -75,7 +75,7 @@ namespace System.ConfigurationTests
             InlineData(true)
             InlineData(false)
             ]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18832")]
+        [ActiveIssue("dotnet/corefx #18832", TargetFrameworkMonikers.NetFramework)]
         public void GetSetStringProperty_SimpleSettings_Ok(bool isSynchronized)
         {
             SimpleSettings settings = isSynchronized 
@@ -91,7 +91,7 @@ namespace System.ConfigurationTests
             InlineData(true)
             InlineData(false)
             ]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18832")]
+        [ActiveIssue("dotnet/corefx #18832", TargetFrameworkMonikers.NetFramework)]
         public void GetSetIntProperty_SimpleSettings_Ok(bool isSynchronized)
         {
             SimpleSettings settings = isSynchronized
@@ -104,7 +104,7 @@ namespace System.ConfigurationTests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18832")]
+        [ActiveIssue("dotnet/corefx #18832", TargetFrameworkMonikers.NetFramework)]
         public void Reload_SimpleSettings_Ok()
         {
             var settings = new SimpleSettings();
@@ -141,7 +141,7 @@ namespace System.ConfigurationTests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18832")]
+        [ActiveIssue("dotnet/corefx #18832", TargetFrameworkMonikers.NetFramework)]
         public void SettingsProperty_SettingsWithAttributes_Ok()
         {
             SettingsWithAttributes settings = new SettingsWithAttributes();

--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/ConfigurationElementCollectionTests.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/ConfigurationElementCollectionTests.cs
@@ -204,7 +204,7 @@ namespace System.ConfigurationTests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #19338")]
+        [ActiveIssue("dotnet/corefx #19338", TargetFrameworkMonikers.NetFramework)]
         public void EqualsNullIsFalse()
         {
             // Note: this null refs on desktop

--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/SectionGroupsTests.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/SectionGroupsTests.cs
@@ -53,7 +53,7 @@ namespace System.ConfigurationTests
 </configuration>";
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #19383")]
+        [ActiveIssue("dotnet/corefx #19383", TargetFrameworkMonikers.NetFramework)]
         public void SimpleSectionGroup()
         {
             using (var temp = new TempConfig(SimpleSectionGroupConfiguration))

--- a/src/System.Data.SqlClient/tests/FunctionalTests/DiagnosticTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/DiagnosticTest.cs
@@ -26,7 +26,7 @@ namespace System.Data.SqlClient.Tests
         public static bool IsConnectionStringConfigured() => s_tcpConnStr != "\"\"";
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17925")]
+        [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
         public void ExecuteScalarTest()
         {
             RemoteInvoke(() =>
@@ -48,7 +48,7 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17925")]
+        [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
         public void ExecuteScalarErrorTest()
         {
             RemoteInvoke(() =>
@@ -72,7 +72,7 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17925")]
+        [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
         public void ExecuteNonQueryTest()
         {
             RemoteInvoke(() =>
@@ -94,7 +94,7 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17925")]
+        [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
         public void ExecuteNonQueryErrorTest()
         {
             RemoteInvoke(() =>
@@ -132,7 +132,7 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17925")]
+        [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
         public void ExecuteReaderTest()
         {
             RemoteInvoke(() =>
@@ -155,7 +155,7 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17925")]
+        [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
         public void ExecuteReaderErrorTest()
         {
             RemoteInvoke(() =>
@@ -181,7 +181,7 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17925")]
+        [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
         public void ExecuteReaderWithCommandBehaviorTest()
         {
             RemoteInvoke(() =>
@@ -226,7 +226,7 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17925")]
+        [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
         public void ExecuteXmlReaderErrorTest()
         {
             RemoteInvoke(() =>
@@ -252,7 +252,7 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17925")]
+        [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
         public void ExecuteScalarAsyncTest()
         {
             RemoteInvoke(() =>
@@ -274,7 +274,7 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17925")]
+        [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
         public void ExecuteScalarAsyncErrorTest()
         {
             RemoteInvoke(() =>
@@ -298,7 +298,7 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17925")]
+        [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
         public void ExecuteNonQueryAsyncTest()
         {
             RemoteInvoke(() =>
@@ -320,7 +320,7 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17925")]
+        [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
         public void ExecuteNonQueryAsyncErrorTest()
         {
             RemoteInvoke(() =>
@@ -343,7 +343,7 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17925")]
+        [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
         public void ExecuteReaderAsyncTest()
         {
             RemoteInvoke(() =>
@@ -366,7 +366,7 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17925")]
+        [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
         public void ExecuteReaderAsyncErrorTest()
         {
             RemoteInvoke(() =>
@@ -439,7 +439,7 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17925")]
+        [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
         public void ConnectionOpenTest()
         {
             RemoteInvoke(() =>
@@ -460,7 +460,7 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17925")]
+        [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
         public void ConnectionOpenErrorTest()
         {
             RemoteInvoke(() =>
@@ -477,7 +477,7 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17925")]
+        [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
         public void ConnectionOpenAsyncTest()
         {
             RemoteInvoke(() =>
@@ -494,7 +494,7 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #17925")]
+        [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]
         public void ConnectionOpenAsyncErrorTest()
         {
             RemoteInvoke(() =>

--- a/src/System.Diagnostics.DiagnosticSource/tests/ActivityDateTimeTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/ActivityDateTimeTests.cs
@@ -6,7 +6,7 @@ namespace System.Diagnostics.Tests
     public class ActivityDateTimeTests
     {
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #19545")]
+        [ActiveIssue("dotnet/corefx #19545", TargetFrameworkMonikers.NetFramework)]
         public void StartStopReturnsPreciseDuration()
         {
             var activity = new Activity("test");

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsManifestGeneration.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsManifestGeneration.cs
@@ -25,7 +25,7 @@ namespace BasicEventSourceTests
         /// EventSource would fail when an EventSource was named "EventSource".
         /// </summary>
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18808")]
+        [ActiveIssue("dotnet/corefx #18808", TargetFrameworkMonikers.NetFramework)]
         public void Test_EventSource_NamedEventSource()
         {
             using (var es = new SdtEventSources.DontPollute.EventSource())

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsManifestNegative.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsManifestNegative.cs
@@ -48,7 +48,7 @@ namespace BasicEventSourceTests
         /// These tests use the NuGet EventSource to validate *both* NuGet and BCL user-defined EventSources
         /// For NuGet EventSources we validate both "runtime" and "validation" behavior
         /// </summary>
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #19091")]
+        [ActiveIssue("dotnet/corefx #19091", TargetFrameworkMonikers.NetFramework)]
         [Fact]
         public void Test_GenerateManifest_InvalidEventSources()
         {

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWrite.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWrite.cs
@@ -39,7 +39,7 @@ namespace BasicEventSourceTests
         /// Tests the EventListener code path
         /// </summary>
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #19455")]
+        [ActiveIssue("dotnet/corefx #19455", TargetFrameworkMonikers.NetFramework)]
         public void Test_Write_T_EventListener()
         {
             using (var listener = new EventListenerListener())
@@ -53,7 +53,7 @@ namespace BasicEventSourceTests
         /// Tests the EventListener code path using events instead of virtual callbacks.
         /// </summary>
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #19455")]
+        [ActiveIssue("dotnet/corefx #19455", TargetFrameworkMonikers.NetFramework)]
         public void Test_Write_T_EventListener_UseEvents()
         {
             Test_Write_T(new EventListenerListener(true));
@@ -409,7 +409,7 @@ namespace BasicEventSourceTests
         /// events MUST use SelfDescribing serialization.  
         /// </summary>
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18806")]
+        [ActiveIssue("dotnet/corefx #18806", TargetFrameworkMonikers.NetFramework)]
         public void Test_Write_T_In_Manifest_Serialization()
         {
             using (var eventListener = new EventListenerListener())

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWriteEvent.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWriteEvent.cs
@@ -39,7 +39,7 @@ namespace BasicEventSourceTests
         /// Tests bTraceListener path. 
         /// </summary>
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18806")]
+        [ActiveIssue("dotnet/corefx #18806", TargetFrameworkMonikers.NetFramework)]
         public void Test_WriteEvent_Manifest_EventListener()
         {
             using (var listener = new EventListenerListener())
@@ -53,7 +53,7 @@ namespace BasicEventSourceTests
         /// Tests bTraceListener path using events instead of virtual callbacks. 
         /// </summary>
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18806")]
+        [ActiveIssue("dotnet/corefx #18806", TargetFrameworkMonikers.NetFramework)]
         public void Test_WriteEvent_Manifest_EventListener_UseEvents()
         {
             Test_WriteEvent(new EventListenerListener(true), false);
@@ -77,7 +77,7 @@ namespace BasicEventSourceTests
         /// Tests both the ETW and TraceListener paths. 
         /// </summary>
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18806")]
+        [ActiveIssue("dotnet/corefx #18806", TargetFrameworkMonikers.NetFramework)]
         public void Test_WriteEvent_SelfDescribing_EventListener()
         {
             using (var listener = new EventListenerListener())
@@ -92,7 +92,7 @@ namespace BasicEventSourceTests
         /// instead of virtual callbacks. 
         /// </summary>
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18806")]
+        [ActiveIssue("dotnet/corefx #18806", TargetFrameworkMonikers.NetFramework)]
         public void Test_WriteEvent_SelfDescribing_EventListener_UseEvents()
         {
             Test_WriteEvent(new EventListenerListener(true), true);

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWriteEventToListener.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWriteEventToListener.cs
@@ -16,7 +16,7 @@ namespace BasicEventSourceTests
     public class TestsWriteEventToListener
     {
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #19462")]
+        [ActiveIssue("dotnet/corefx #19462", TargetFrameworkMonikers.NetFramework)]
         public void Test_WriteEvent_ArgsBasicTypes()
         {
             TestUtilities.CheckNoEventSourcesRunning("Start");
@@ -161,7 +161,7 @@ namespace BasicEventSourceTests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #19462")]
+        [ActiveIssue("dotnet/corefx #19462", TargetFrameworkMonikers.NetFramework)]
         public void Test_WriteEvent_ArgsCornerCases()
         {
             TestUtilities.CheckNoEventSourcesRunning("Start");
@@ -313,7 +313,7 @@ namespace BasicEventSourceTests
 #endif // USE_ETW
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #19462")]
+        [ActiveIssue("dotnet/corefx #19462", TargetFrameworkMonikers.NetFramework)]
         public void Test_WriteEvent_ZeroKwds()
         {
             TestUtilities.CheckNoEventSourcesRunning("Start");

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.WaitForChanged.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.WaitForChanged.cs
@@ -128,7 +128,7 @@ namespace System.IO.Tests
         [OuterLoop("This test has a longer than average timeout and may fail intermittently")]
         [InlineData(WatcherChangeTypes.Created)]
         [InlineData(WatcherChangeTypes.Deleted)]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18308")]
+        [ActiveIssue("dotnet/corefx #18308", TargetFrameworkMonikers.NetFramework)]
         public void CreatedDeleted_Success(WatcherChangeTypes changeType)
         {
             using (var testDirectory = new TempDirectory(GetTestFilePath()))

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/ContainsUnknownFilesTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/ContainsUnknownFilesTests.cs
@@ -7,14 +7,14 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage
 {
-    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
+    [ActiveIssue(18940, TargetFrameworkMonikers.UapAot)]
     public class ContainsUnknownFilesTests : IsoStorageTest
     {
         private static MethodInfo s_containsUnknownFilesMethod
             = typeof(IsolatedStorageFile).GetMethod("ContainsUnknownFiles", BindingFlags.NonPublic | BindingFlags.Instance);
 
         [Theory MemberData(nameof(ValidStores))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18265")]
+        [ActiveIssue("dotnet/corefx #18265", TargetFrameworkMonikers.NetFramework)]
         public void ContainsUnknownFiles_CleanStore(PresetScopes scope)
         {
             TestHelper.WipeStores();
@@ -26,7 +26,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Theory MemberData(nameof(ValidStores))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18265")]
+        [ActiveIssue("dotnet/corefx #18265", TargetFrameworkMonikers.NetFramework)]
         public void ContainsUnknownFiles_OkFiles(PresetScopes scope)
         {
             TestHelper.WipeStores();
@@ -46,7 +46,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Theory MemberData(nameof(ValidStores))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18265")]
+        [ActiveIssue("dotnet/corefx #18265", TargetFrameworkMonikers.NetFramework)]
         public void ContainsUnknownFiles_NotOkFiles(PresetScopes scope)
         {
             TestHelper.WipeStores();
@@ -69,7 +69,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Theory MemberData(nameof(ValidStores))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18265")]
+        [ActiveIssue("dotnet/corefx #18265", TargetFrameworkMonikers.NetFramework)]
         public void ContainsUnknownFiles_NotOkDirectory(PresetScopes scope)
         {
             TestHelper.WipeStores();

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/CopyFileTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/CopyFileTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage
 {
-    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
+    [ActiveIssue(18940, TargetFrameworkMonikers.UapAot)]
     public class CopyFileTests : IsoStorageTest
     {
         [Fact]
@@ -84,7 +84,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Theory MemberData(nameof(ValidStores))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18265")]
+        [ActiveIssue("dotnet/corefx #18265", TargetFrameworkMonikers.NetFramework)]
         public void CopyFile_CopyOver(PresetScopes scope)
         {
             TestHelper.WipeStores();
@@ -101,7 +101,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Theory MemberData(nameof(ValidStores))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18265")]
+        [ActiveIssue("dotnet/corefx #18265", TargetFrameworkMonikers.NetFramework)]
         public void CopyFile_CopiesFile(PresetScopes scope)
         {
             TestHelper.WipeStores();

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/CreateDirectoryTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/CreateDirectoryTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage
 {
-    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
+    [ActiveIssue(18940, TargetFrameworkMonikers.UapAot)]
     public class CreateDirectoryTests : IsoStorageTest
     {
         [Fact]
@@ -59,7 +59,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Theory MemberData(nameof(ValidStores))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18268")]
+        [ActiveIssue("dotnet/corefx #18268", TargetFrameworkMonikers.NetFramework)]
         public void CreateDirectory_Existance(PresetScopes scope)
         {
             using (var isf = GetPresetScope(scope))

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/CreateFileTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/CreateFileTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage
 {
-    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
+    [ActiveIssue(18940, TargetFrameworkMonikers.UapAot)]
     public class CreateFileTests : IsoStorageTest
     {
         [Fact]
@@ -59,7 +59,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Theory MemberData(nameof(ValidStores))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18268")]
+        [ActiveIssue("dotnet/corefx #18268", TargetFrameworkMonikers.NetFramework)]
         public void CreateFile_Existence(PresetScopes scope)
         {
             using (var isf = GetPresetScope(scope))

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/DeleteDirectoryTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/DeleteDirectoryTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage
 {
-    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
+    [ActiveIssue(18940, TargetFrameworkMonikers.UapAot)]
     public class DeleteDirectoryTests : IsoStorageTest
     {
         [Fact]
@@ -78,7 +78,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Theory MemberData(nameof(ValidStores))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18265")]
+        [ActiveIssue("dotnet/corefx #18265", TargetFrameworkMonikers.NetFramework)]
         public void DeleteDirectory_DeletesDirectory(PresetScopes scope)
         {
             TestHelper.WipeStores();
@@ -106,7 +106,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Theory MemberData(nameof(ValidStores))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18265")]
+        [ActiveIssue("dotnet/corefx #18265", TargetFrameworkMonikers.NetFramework)]
         public void DeleteDirectory_CannotDeleteWithContent(PresetScopes scope)
         {
             TestHelper.WipeStores();

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/DeleteFileTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/DeleteFileTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage
 {
-    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
+    [ActiveIssue(18940, TargetFrameworkMonikers.UapAot)]
     public class DeleteFileTests : IsoStorageTest
     {
         [Fact]
@@ -59,7 +59,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Theory MemberData(nameof(ValidStores))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18265")]
+        [ActiveIssue("dotnet/corefx #18265", TargetFrameworkMonikers.NetFramework)]
         public void DeleteFile_DeletesFile(PresetScopes scope)
         {
             TestHelper.WipeStores();

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/DirectoryExistsTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/DirectoryExistsTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage
 {
-    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
+    [ActiveIssue(18940, TargetFrameworkMonikers.UapAot)]
     public class DirectoryExistsTests : IsoStorageTest
     {
         [Fact]
@@ -72,7 +72,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Theory MemberData(nameof(ValidStores))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18268")]
+        [ActiveIssue("dotnet/corefx #18268", TargetFrameworkMonikers.NetFramework)]
         public void DirectoryExists_Existance(PresetScopes scope)
         {
             using (var isf = GetPresetScope(scope))

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/FileExistsTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/FileExistsTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage
 {
-    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
+    [ActiveIssue(18940, TargetFrameworkMonikers.UapAot)]
     public class FileExistsTests : IsoStorageTest
     {
         [Fact]
@@ -59,7 +59,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Theory MemberData(nameof(ValidStores))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18268")]
+        [ActiveIssue("dotnet/corefx #18268", TargetFrameworkMonikers.NetFramework)]
         public void FileExists_Existance(PresetScopes scope)
         {
             using (var isf = GetPresetScope(scope))

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetCreationTimeTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetCreationTimeTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage
 {
-    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
+    [ActiveIssue(18940, TargetFrameworkMonikers.UapAot)]
     public class GetCreationTimeTests : IsoStorageTest
     {
         [Fact]
@@ -80,7 +80,7 @@ namespace System.IO.IsolatedStorage
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX)]  // Filesystem timestamps vary in granularity
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18265")]
+        [ActiveIssue("dotnet/corefx #18265", TargetFrameworkMonikers.NetFramework)]
         public void GetCreationTime_GetsTime_Windows_OSX()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetFileNamesTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetFileNamesTests.cs
@@ -8,11 +8,11 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage
 {
-    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
+    [ActiveIssue(18940, TargetFrameworkMonikers.UapAot)]
     public class GetFileNamesTests : IsoStorageTest
     {
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18268")]
+        [ActiveIssue("dotnet/corefx #18268", TargetFrameworkMonikers.NetFramework)]
         public void GetFileNames_ThrowsArgumentNull()
         {
             using (var isf = IsolatedStorageFile.GetUserStoreForApplication())
@@ -62,7 +62,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Theory MemberData(nameof(ValidStores))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18265")]
+        [ActiveIssue("dotnet/corefx #18265", TargetFrameworkMonikers.NetFramework)]
         public void GetFileNames_GetsFileNames(PresetScopes scope)
         {
             TestHelper.WipeStores();

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetLastAccessTimeTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetLastAccessTimeTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage
 {
-    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
+    [ActiveIssue(18940, TargetFrameworkMonikers.UapAot)]
     public class GetLastAccessTimeTests : IsoStorageTest
     {
         [Fact]
@@ -59,7 +59,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18265")]
+        [ActiveIssue("dotnet/corefx #18265", TargetFrameworkMonikers.NetFramework)]
         public void GetLastAccessTime_GetsTime()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetLastWriteTimeTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetLastWriteTimeTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage
 {
-    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
+    [ActiveIssue(18940, TargetFrameworkMonikers.UapAot)]
     public class GetLastWriteTimeTests : IsoStorageTest
     {
         [Fact]
@@ -59,7 +59,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18265")]
+        [ActiveIssue("dotnet/corefx #18265", TargetFrameworkMonikers.NetFramework)]
         public void GetLastWriteTime_GetsTime()
         {
             using (IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly())

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetStoreTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/GetStoreTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage
 {
-    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
+    [ActiveIssue(18940, TargetFrameworkMonikers.UapAot)]
     public class GetStoreTests : IsoStorageTest
     {
         private static MethodInfo s_verifyScopeMethod;
@@ -50,7 +50,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18268")]
+        [ActiveIssue("dotnet/corefx #18268", TargetFrameworkMonikers.NetFramework)]
         public void GetUserStoreForApplication()
         {
             var isf = IsolatedStorageFile.GetUserStoreForApplication();
@@ -65,7 +65,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18265")]
+        [ActiveIssue("dotnet/corefx #18265", TargetFrameworkMonikers.NetFramework)]
         public void GetUserStoreForAssembly()
         {
             var isf = IsolatedStorageFile.GetUserStoreForAssembly();
@@ -75,7 +75,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18265")]
+        [ActiveIssue("dotnet/corefx #18265", TargetFrameworkMonikers.NetFramework)]
         public void GetUserStoreForDomain()
         {
             var isf = IsolatedStorageFile.GetUserStoreForDomain();
@@ -95,7 +95,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18268")]
+        [ActiveIssue("dotnet/corefx #18268", TargetFrameworkMonikers.NetFramework)]
         public void GetStore_NullParamsAllowed()
         {
             VerifyApplicationStore(IsolatedStorageFile.GetStore(IsolatedStorageScope.User | IsolatedStorageScope.Application, (Type)null));
@@ -105,7 +105,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18269")]
+        [ActiveIssue("dotnet/corefx #18269", TargetFrameworkMonikers.NetFramework)]
         public void GetEnumerator_NoOp()
         {
             IEnumerator e = IsolatedStorageFile.GetEnumerator(IsolatedStorageScope.Assembly);
@@ -116,7 +116,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18269")]
+        [ActiveIssue("dotnet/corefx #18269", TargetFrameworkMonikers.NetFramework)]
         public void GetEnumerator_ThrowsForCurrent()
         {
             IEnumerator e = IsolatedStorageFile.GetEnumerator(IsolatedStorageScope.Assembly);

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/IdentityTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/IdentityTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage
 {
-    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
+    [ActiveIssue(18940, TargetFrameworkMonikers.UapAot)]
     public class IdentityTests : IsoStorageTest
     {
         private class TestStorage : IsolatedStorage

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/IsoStorageTest.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/IsoStorageTest.cs
@@ -11,7 +11,7 @@ namespace System.IO.IsolatedStorage
     // We put the tests in the "Store collection" to get them to pick up the StoreTestsFixture. This will run the fixture
     // at the start and end of the collection, cleaning the test environment.
     [Collection("Store collection")]
-    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
+    [ActiveIssue(18940, TargetFrameworkMonikers.UapAot)]
     public class IsoStorageTest
     {
         public static IEnumerable<object[]> ValidScopes

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/IsolatedStorageBaseClassTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/IsolatedStorageBaseClassTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 namespace System.IO.IsolatedStorage
 {
     // Test default IsolatedStorage base class behaviors
-    [SkipOnTargetFramework(18940, TargetFrameworkMonikers.UapAot)]
+    [ActiveIssue(18940, TargetFrameworkMonikers.UapAot)]
     public class IsolatedStorageBaseClassTests : IsoStorageTest
     {
         private class TestStorage : IsolatedStorage

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/IsolatedStorageBaseClassTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/IsolatedStorageBaseClassTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 namespace System.IO.IsolatedStorage
 {
     // Test default IsolatedStorage base class behaviors
-    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
+    [SkipOnTargetFramework(18940, TargetFrameworkMonikers.UapAot)]
     public class IsolatedStorageBaseClassTests : IsoStorageTest
     {
         private class TestStorage : IsolatedStorage

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/MoveDirectoryTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/MoveDirectoryTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage
 {
-    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
+    [ActiveIssue(18940, TargetFrameworkMonikers.UapAot)]
     public class MoveDirectoryTests : IsoStorageTest
     {
         [Fact]
@@ -80,7 +80,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Theory MemberData(nameof(ValidStores))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18265")]
+        [ActiveIssue("dotnet/corefx #18265", TargetFrameworkMonikers.NetFramework)]
         public void MoveDirectory_MoveOver(PresetScopes scope)
         {
             TestHelper.WipeStores();
@@ -94,7 +94,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Theory MemberData(nameof(ValidStores))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18265")]
+        [ActiveIssue("dotnet/corefx #18265", TargetFrameworkMonikers.NetFramework)]
         public void MoveDirectory_MovesDirectory(PresetScopes scope)
         {
             TestHelper.WipeStores();

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/MoveFileTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/MoveFileTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage
 {
-    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
+    [ActiveIssue(18940, TargetFrameworkMonikers.UapAot)]
     public class MoveFileTests : IsoStorageTest
     {
         [Fact]
@@ -81,7 +81,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Theory MemberData(nameof(ValidStores))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18265")]
+        [ActiveIssue("dotnet/corefx #18265", TargetFrameworkMonikers.NetFramework)]
         public void MoveFile_MoveOver(PresetScopes scope)
         {
             TestHelper.WipeStores();
@@ -95,7 +95,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Theory MemberData(nameof(ValidStores))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18265")]
+        [ActiveIssue("dotnet/corefx #18265", TargetFrameworkMonikers.NetFramework)]
         public void MoveFile_MovesFile(PresetScopes scope)
         {
             TestHelper.WipeStores();

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/OpenFileTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/OpenFileTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage
 {
-    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
+    [ActiveIssue(18940, TargetFrameworkMonikers.UapAot)]
     public class OpenFileTests : IsoStorageTest
     {
         [Fact]
@@ -69,7 +69,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18265")]
+        [ActiveIssue("dotnet/corefx #18265", TargetFrameworkMonikers.NetFramework)]
         public void OpenFile_PassesFileShare()
         {
             TestHelper.WipeStores();
@@ -92,7 +92,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18265")]
+        [ActiveIssue("dotnet/corefx #18265", TargetFrameworkMonikers.NetFramework)]
         public void OpenFile_PassesFileAccess()
         {
             TestHelper.WipeStores();
@@ -115,7 +115,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18265")]
+        [ActiveIssue("dotnet/corefx #18265", TargetFrameworkMonikers.NetFramework)]
         public void OpenFile_PassesFileMode()
         {
             TestHelper.WipeStores();
@@ -132,7 +132,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Theory MemberData(nameof(ValidStores))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18265")]
+        [ActiveIssue("dotnet/corefx #18265", TargetFrameworkMonikers.NetFramework)]
         public void OpenFile_Existence(PresetScopes scope)
         {
             TestHelper.WipeStores();

--- a/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/RemoveTests.cs
+++ b/src/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/RemoveTests.cs
@@ -6,11 +6,11 @@ using Xunit;
 
 namespace System.IO.IsolatedStorage
 {
-    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "#18940")]
+    [ActiveIssue(18940, TargetFrameworkMonikers.UapAot)]
     public class RemoveTests : IsoStorageTest
     {
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18265")]
+        [ActiveIssue("dotnet/corefx #18265", TargetFrameworkMonikers.NetFramework)]
         public void RemoveUserStoreForApplication()
         {
             TestHelper.WipeStores();
@@ -26,7 +26,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18265")]
+        [ActiveIssue("dotnet/corefx #18265", TargetFrameworkMonikers.NetFramework)]
         public void RemoveUserStoreForAssembly()
         {
             TestHelper.WipeStores();
@@ -42,7 +42,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18265")]
+        [ActiveIssue("dotnet/corefx #18265", TargetFrameworkMonikers.NetFramework)]
         public void RemoveUserStoreForDomain()
         {
             TestHelper.WipeStores();
@@ -60,7 +60,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [Theory MemberData(nameof(ValidStores))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18265")]
+        [ActiveIssue("dotnet/corefx #18265", TargetFrameworkMonikers.NetFramework)]
         public void RemoveStoreWithContent(PresetScopes scope)
         {
             TestHelper.WipeStores();

--- a/src/System.IO.Pipes/tests/AnonymousPipeTests/AnonymousPipeTest.Specific.cs
+++ b/src/System.IO.Pipes/tests/AnonymousPipeTests/AnonymousPipeTest.Specific.cs
@@ -158,7 +158,7 @@ namespace System.IO.Pipes.Tests
         [Theory]
         [InlineData(PipeDirection.Out, PipeDirection.In)]
         [InlineData(PipeDirection.In, PipeDirection.Out)]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18546")]
+        [ActiveIssue("dotnet/corefx #18546", TargetFrameworkMonikers.NetFramework)]
         public void ReadModeToByte_Accepted(PipeDirection serverDirection, PipeDirection clientDirection)
         {
             using (AnonymousPipeServerStream server = new AnonymousPipeServerStream(serverDirection))

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Simple.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Simple.cs
@@ -523,7 +523,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #16934")] //Hangs forever in desktop as it doesn't have cancellation support
+        [ActiveIssue("dotnet/corefx #16934", TargetFrameworkMonikers.NetFramework)] //Hangs forever in desktop as it doesn't have cancellation support
         public async Task Server_ReadWriteCancelledToken_Throws_OperationCanceledException()
         {
             using (NamedPipePair pair = CreateNamedPipePair())
@@ -622,7 +622,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #16934")] //Hangs forever in desktop as it doesn't have cancellation support
+        [ActiveIssue("dotnet/corefx #16934", TargetFrameworkMonikers.NetFramework)] //Hangs forever in desktop as it doesn't have cancellation support
         public async Task Client_ReadWriteCancelledToken_Throws_OperationCanceledException()
         {
             using (NamedPipePair pair = CreateNamedPipePair())

--- a/src/System.IO.Pipes/tests/PipeTest.Write.cs
+++ b/src/System.IO.Pipes/tests/PipeTest.Write.cs
@@ -212,7 +212,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #19287")]
+        [ActiveIssue("dotnet/corefx #19287", TargetFrameworkMonikers.NetFramework)]
         public async Task ValidFlush_DoesntThrow()
         {
             using (ServerClientPair pair = CreateServerClientPair())

--- a/src/System.Linq.Queryable/tests/EnumerableQueryTests.cs
+++ b/src/System.Linq.Queryable/tests/EnumerableQueryTests.cs
@@ -20,7 +20,7 @@ namespace System.Linq.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #16916")] //This test hangs forever in query.GetEnumerator()
+        [ActiveIssue("dotnet/corefx #16916", TargetFrameworkMonikers.NetFramework)] //This test hangs forever in query.GetEnumerator()
         public void NullEnumerableConstantNullExpression()
         {
             IQueryable<int> query = new EnumerableQuery<int>((IEnumerable<int>)null);

--- a/src/System.Runtime.WindowsRuntime/tests/System/IO/CreateSafeFileHandleTests.cs
+++ b/src/System.Runtime.WindowsRuntime/tests/System/IO/CreateSafeFileHandleTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace System.IO
 {   
-    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "https://github.com/dotnet/corefx/issues/18940")]
+    [ActiveIssue("https://github.com/dotnet/corefx/issues/18940", TargetFrameworkMonikers.UapAot)]
     public class CreateSafeFileHandleTests
     {
         [Fact]


### PR DESCRIPTION
This updates Xunit.NetCore.Extensions to have the new behavior of SkipOnTargetAttribute and ActiveIssueAttribute.

Updates buildtools to consume the version that fix an issue where -notrait category=nonosgrouptests was added duplicated to RunTests.cmd in tests.targets

Also this is an initial cleanup to use the new behaviors of the Attributes.

Will open more PRs to do this cleanup but I wanted to split it in different PRs to make it easier to review.

cc: @danmosemsft @tijoytom @weshaggard 

FYI: @hughbe @davidsh @CIPop you can now use ActiveIssue for test classes. I'm preparing a new doc for the test attributes. Will push it later when I'm done and I'll point it to you. 