### PR TITLE
Added cleanup for cached async state in SqlCommand's EndExecute metho…

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
@@ -1002,6 +1002,10 @@ namespace System.Data.SqlClient
             if (asyncException != null)
             {
                 // Leftover exception from the Begin...InternalReadStage
+                if (cachedAsyncState != null)
+                {
+                    cachedAsyncState.ResetAsyncState();
+                }
                 ReliablePutStateObject();
                 throw asyncException.InnerException;
             }
@@ -1266,6 +1270,10 @@ namespace System.Data.SqlClient
             if (asyncException != null)
             {
                 // Leftover exception from the Begin...InternalReadStage
+                if (cachedAsyncState != null)
+                {
+                    cachedAsyncState.ResetAsyncState();
+                }
                 ReliablePutStateObject();
                 throw asyncException.InnerException;
             }
@@ -1396,6 +1404,10 @@ namespace System.Data.SqlClient
             if (asyncException != null)
             {
                 // Leftover exception from the Begin...InternalReadStage
+                if (cachedAsyncState != null)
+                {
+                    cachedAsyncState.ResetAsyncState();
+                }
                 ReliablePutStateObject();
                 throw asyncException.InnerException;
             }


### PR DESCRIPTION
…ds before they throw exceptions. Without this cleanup, a subsequent command execution will fail since it will appear as though other async commands are still pending.

When running SqlClient's TVP tests with Managed SNI enabled, exceptions were getting thrown earlier during async execution than with Native SNI, which surfaced this bug. The SqlCommand would throw an exception without resetting the async state, causing subsequent commands to fail due to pending async operations. This async state cleanup matches the other exception cleanup behavior elsewhere in SqlCommand.

Fixes in master #20340