### PR TITLE
Fixing null-ref in HttpListener's IOCP implementation.

### DIFF
--- a/src/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
@@ -1915,7 +1915,7 @@ namespace System.Net
                 _httpListener = httpListener;
                 _connectionId = connectionId;
                 // we can call the Unsafe API here, we won't ever call user code
-                _nativeOverlapped = httpListener._requestQueueBoundHandle.AllocateNativeOverlapped(s_IOCallback, state: this, pinData: null);
+                _nativeOverlapped = httpListener.RequestQueueBoundHandle.AllocateNativeOverlapped(s_IOCallback, state: this, pinData: null);
             }
 
             internal bool StartOwningDisconnectHandling()

--- a/src/System.Net.HttpListener/tests/GetContextHelper.cs
+++ b/src/System.Net.HttpListener/tests/GetContextHelper.cs
@@ -59,11 +59,13 @@ namespace System.Net.Tests
     public static class Helpers
     {
         public static bool IsWindowsImplementation { get; } =
-            typeof(HttpListener).Assembly.GetType("Interop+HttpApi", throwOnError: false, ignoreCase: false) != null &&
-            PlatformDetection.IsNotOneCoreUAP; // never run for UAP
+            (typeof(HttpListener).Assembly.GetType("Interop+HttpApi", throwOnError: false, ignoreCase: false) != null ||                  // CoreFX + HttpApi
+            typeof(HttpListener).Assembly.GetType("System.Net.UnsafeNclNativeMethods", throwOnError: false, ignoreCase: false) != null)   // NetFX
+            && PlatformDetection.IsNotOneCoreUAP; // never run for UAP
         public static bool IsNotWindowsImplementation =>
-            typeof(HttpListener).Assembly.GetType("Interop+HttpApi", throwOnError: false, ignoreCase: false) == null &&
-            PlatformDetection.IsNotOneCoreUAP; // never run for UAP
+            !(typeof(HttpListener).Assembly.GetType("Interop+HttpApi", throwOnError: false, ignoreCase: false) != null ||                  // CoreFX + HttpApi
+             typeof(HttpListener).Assembly.GetType("System.Net.UnsafeNclNativeMethods", throwOnError: false, ignoreCase: false) != null)   // NetFX
+            && PlatformDetection.IsNotOneCoreUAP; // never run for UAP
 
         public static void WaitForSocketShutdown(Socket socket)
         {

--- a/src/System.Net.HttpListener/tests/System.Net.HttpListener.Tests.csproj
+++ b/src/System.Net.HttpListener/tests/System.Net.HttpListener.Tests.csproj
@@ -10,8 +10,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Release|AnyCPU'" />
   <ItemGroup>
-    <Compile Include="AuthenticationTests.cs" />
     <Compile Include="GetContextHelper.cs" />
+    <Compile Include="HttpListenerAuthenticationTest.cs" />
     <Compile Include="HttpListenerContextTests.cs" />
     <Compile Include="HttpListenerPrefixCollectionTests.cs" />
     <Compile Include="HttpListenerResponseTests.Cookies.cs" />


### PR DESCRIPTION
Fixing test platform detection, stabilizing NetFX tests and
renaming tests to fit the naming convention.

Contributes to #20096