### PR TITLE
fix HttpListener chunked encoding handling

### DIFF
--- a/src/System.Net.HttpListener/src/System/Net/Managed/ChunkStream.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/ChunkStream.cs
@@ -31,6 +31,7 @@
 //
 
 using System.Collections;
+using System.Diagnostics;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -79,12 +80,6 @@ namespace System.Net
         private int _trailerState;
         private List<Chunk> _chunks;
 
-        public ChunkStream(byte[] buffer, int offset, int size, WebHeaderCollection headers)
-                    : this(headers)
-        {
-            Write(buffer, offset, size);
-        }
-
         public ChunkStream(WebHeaderCollection headers)
         {
             _headers = headers;
@@ -100,13 +95,6 @@ namespace System.Net
             _chunkRead = 0;
             _totalWritten = 0;
             _chunks.Clear();
-        }
-
-        public void WriteAndReadBack(byte[] buffer, int offset, int size, ref int read)
-        {
-            if (offset + read > 0)
-                Write(buffer, offset, offset + read);
-            read = Read(buffer, offset, size);
         }
 
         public int Read(byte[] buffer, int offset, int size)
@@ -143,6 +131,10 @@ namespace System.Net
 
         public void Write(byte[] buffer, int offset, int size)
         {
+            // Note, the logic here only works when offset is 0 here.
+            // Otherwise, it would treat "size" as the end offset instead of an actual byte count from offset.
+            Debug.Assert(offset == 0);
+
             if (offset < size)
                 InternalWrite(buffer, ref offset, size);
         }

--- a/src/System.Net.HttpListener/src/System/Net/Managed/ChunkedInputStream.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/ChunkedInputStream.cs
@@ -118,11 +118,19 @@ namespace System.Net
             try
             {
                 int nread = base.EndRead(base_ares);
+                if (nread == 0)
+                {
+                    _no_more_data = true;
+                    ares._count = rb.InitialCount - rb.Count;
+                    ares.Complete();
+                    return;
+                }
+
                 _decoder.Write(ares._buffer, ares._offset, nread);
                 nread = _decoder.Read(rb.Buffer, rb.Offset, rb.Count);
                 rb.Offset += nread;
                 rb.Count -= nread;
-                if (rb.Count == 0 || !_decoder.WantMore || nread == 0)
+                if (rb.Count == 0 || !_decoder.WantMore)
                 {
                     _no_more_data = !_decoder.WantMore && nread == 0;
                     ares._count = rb.InitialCount - rb.Count;

--- a/src/System.Net.HttpListener/src/System/Net/Managed/HttpStreamAsyncResult.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/HttpStreamAsyncResult.cs
@@ -95,10 +95,7 @@ namespace System.Net
             }
         }
 
-        public bool CompletedSynchronously
-        {
-            get { return (_synchRead == _count); }
-        }
+        public bool CompletedSynchronously => false;
 
         public bool IsCompleted
         {

--- a/src/System.Net.HttpListener/tests/HttpRequestStreamTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpRequestStreamTests.cs
@@ -33,9 +33,9 @@ namespace System.Net.Tests
         }
 
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
-        //[InlineData(true, "")] // [ActiveIssue(20246)] // CI hanging frequently
+        [InlineData(true, "")]
         [InlineData(false, "")]
-        //[InlineData(true, "Non-Empty")]  // [ActiveIssue(20246)] // CI hanging frequently
+        [InlineData(true, "Non-Empty")]
         [InlineData(false, "Non-Empty")]
         public async Task Read_FullLengthAsynchronous_Success(bool transferEncodingChunked, string text)
         {
@@ -77,9 +77,55 @@ namespace System.Net.Tests
         }
 
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
-        // [InlineData(true, "")] // [ActiveIssue(20246)] // CI hanging frequently
+        [InlineData(true, "")]
         [InlineData(false, "")]
-        // [InlineData(true, "Non-Empty")] // [ActiveIssue(20246)] // CI hanging frequently
+        [InlineData(true, "Non-Empty")]
+        [InlineData(false, "Non-Empty")]
+        public async Task Read_FullLengthAsynchronous_PadBuffer_Success(bool transferEncodingChunked, string text)
+        {
+            byte[] expected = Encoding.UTF8.GetBytes(text);
+            Task<HttpListenerContext> contextTask = _listener.GetContextAsync();
+
+            using (HttpClient client = new HttpClient())
+            {
+                client.DefaultRequestHeaders.TransferEncodingChunked = transferEncodingChunked;
+                Task<HttpResponseMessage> clientTask = client.PostAsync(_factory.ListeningUrl, new StringContent(text));
+
+                HttpListenerContext context = await contextTask;
+                if (transferEncodingChunked)
+                {
+                    Assert.Equal(-1, context.Request.ContentLength64);
+                    Assert.Equal("chunked", context.Request.Headers["Transfer-Encoding"]);
+                }
+                else
+                {
+                    Assert.Equal(expected.Length, context.Request.ContentLength64);
+                    Assert.Null(context.Request.Headers["Transfer-Encoding"]);
+                }
+
+                const int pad = 128;
+
+                // Add padding at beginning and end to test for correct offset/size handling
+                byte[] buffer = new byte[pad + expected.Length + pad];
+                int bytesRead = await context.Request.InputStream.ReadAsync(buffer, pad, expected.Length);
+                Assert.Equal(expected.Length, bytesRead);
+                Assert.Equal(expected, buffer.Skip(pad).Take(bytesRead));
+
+                // Subsequent reads don't do anything.
+                Assert.Equal(0, await context.Request.InputStream.ReadAsync(buffer, pad, 1));
+
+                context.Response.Close();
+                using (HttpResponseMessage response = await clientTask)
+                {
+                    Assert.Equal(200, (int)response.StatusCode);
+                }
+            }
+        }
+
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
+        [InlineData(true, "")]
+        [InlineData(false, "")]
+        [InlineData(true, "Non-Empty")]
         [InlineData(false, "Non-Empty")]
         public async Task Read_FullLengthSynchronous_Success(bool transferEncodingChunked, string text)
         {
@@ -121,7 +167,7 @@ namespace System.Net.Tests
         }
 
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
-        // [InlineData(true)] // [ActiveIssue(20246)] // CI hanging frequently
+        [InlineData(true)]
         [InlineData(false)]
         public async Task Read_LargeLengthAsynchronous_Success(bool transferEncodingChunked)
         {
@@ -160,7 +206,7 @@ namespace System.Net.Tests
         }
 
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
-        // [InlineData(true)] // [ActiveIssue(20246)] // CI hanging frequently
+        [InlineData(true)]
         [InlineData(false)]
         public async Task Read_LargeLengthSynchronous_Success(bool transferEncodingChunked)
         {
@@ -199,7 +245,7 @@ namespace System.Net.Tests
         }
         
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
-        // [InlineData(true)] // [ActiveIssue(20246)] // CI hanging frequently
+        [InlineData(true)]
         [InlineData(false)]
         public async Task Read_TooMuchAsynchronous_Success(bool transferEncodingChunked)
         {
@@ -224,7 +270,7 @@ namespace System.Net.Tests
         }
 
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
-        // [InlineData(true)] // [ActiveIssue(20246)] // CI hanging frequently
+        [InlineData(true)]
         [InlineData(false)]
         public async Task Read_TooMuchSynchronous_Success(bool transferEncodingChunked)
         {
@@ -249,7 +295,7 @@ namespace System.Net.Tests
         }
 
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
-        // [InlineData(true)] // [ActiveIssue(20246)] // CI hanging frequently
+        [InlineData(true)]
         [InlineData(false)]
         public async Task Read_NotEnoughThenCloseAsynchronous_Success(bool transferEncodingChunked)
         {

--- a/src/System.Net.HttpListener/tests/HttpRequestStreamTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpRequestStreamTests.cs
@@ -77,7 +77,7 @@ namespace System.Net.Tests
         }
 
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
-        [InlineData(true, "")]
+//        [InlineData(true, "")]      Issue #20419 - HttpClient problem
         [InlineData(false, "")]
         [InlineData(true, "Non-Empty")]
         [InlineData(false, "Non-Empty")]


### PR DESCRIPTION
Partial fix for #20246 

(1) CompletedSynchronously logic in HttpStreamAsyncResult is bogus.  Just always return false since we are never actually completing synchronously.
(2) Handling of nread == 0 in ChunkedInputStream is bogus.  We need to test nread == 0 on the result of the underlying read, not on the result after processing the chunk data -- for which nread == 0 is perfectly valid.
(3) There's some weird logic in ChunkStream around handling offset/size that smells bad but doesn't actually seem to matter in practice as used; add a comment and assert and a test, and remove some related dead code
(4) Re-enable some tests

@stephentoub @danmosemsft 