### PR TITLE
Remove NuGet metadata

### DIFF
--- a/pkg/NETStandard.Library.NETFramework/targets/NETStandard.Library.NETFramework.common.targets
+++ b/pkg/NETStandard.Library.NETFramework/targets/NETStandard.Library.NETFramework.common.targets
@@ -48,16 +48,12 @@
         <Private>false</Private>
         <NuGetPackageId>NETStandard.Library.NETFramework</NuGetPackageId>
         <NuGetPackageVersion>$(NETStandardLibraryNETFrameworkPackageVersion)</NuGetPackageVersion>
-        <NuGetIsFrameworkReference>false</NuGetIsFrameworkReference>
-        <NuGetSourceType>Package</NuGetSourceType>
       </Reference>
 
       <ReferenceCopyLocalPaths Include="@(_NETStandardLibraryNETFrameworkLib)">
         <Private>false</Private>
         <NuGetPackageId>NETStandard.Library.NETFramework</NuGetPackageId>
         <NuGetPackageVersion>$(NETStandardLibraryPackageVersion)</NuGetPackageVersion>
-        <NuGetIsFrameworkReference>false</NuGetIsFrameworkReference>
-        <NuGetSourceType>Package</NuGetSourceType>
       </ReferenceCopyLocalPaths>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
This metadata is read by SDK targets and can trip them up
since these packages don't appear in the deps file.

/cc @eerhardt @weshaggard 