### PR TITLE
Disable two S.T.Overlapped tests on uapaot

### DIFF
--- a/src/System.Threading.Overlapped/tests/OverlappedTests.cs
+++ b/src/System.Threading.Overlapped/tests/OverlappedTests.cs
@@ -146,6 +146,7 @@ public static partial class OverlappedTests
 
     [Fact]
     [PlatformSpecific(TestPlatforms.Windows)] // ThreadPool.UnsafeQueueNativeOverlapped is not supported on Unix
+    [ActiveIssue("https://github.com/dotnet/corefx/issues/20365", TargetFrameworkMonikers.UapAot)]
     public static unsafe void PackPosTest()
     {
 #pragma warning disable 618
@@ -171,6 +172,7 @@ public static partial class OverlappedTests
 
     [Fact]
     [PlatformSpecific(TestPlatforms.Windows)] // ThreadPool.UnsafeQueueNativeOverlapped is not supported on Unix
+    [ActiveIssue("https://github.com/dotnet/corefx/issues/20365", TargetFrameworkMonikers.UapAot)]
     public static unsafe void PackPosTest1()
     {
         Overlapped ov = new Overlapped();


### PR DESCRIPTION
cc: @danmosemsft @weshaggard @AtsushiKan 

Disabling two tests on S.T.Overlapped that were crashing test execution on uapaot. Once this is merged, a valid testResults.xml will be produced when running them.

Issue #20365 will track the work to enable them back once the method we are calling with them gets implemented on uapaot.