### PR TITLE
Fixing System.Net.Http.Functional tests on uapaot

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientEKUTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientEKUTest.cs
@@ -19,8 +19,11 @@ namespace System.Net.Http.Functional.Tests
     {
         // Curl + OSX SecureTransport doesn't support the custom certificate callback.
         private static bool BackendSupportsCustomCertificateHandling =>
-            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
-            (CurlSslVersionDescription()?.StartsWith("OpenSSL") ?? false);
+#if TargetsWindows
+            true;
+#else
+            CurlSslVersionDescription()?.StartsWith("OpenSSL") ?? false;
+#endif
 
         private static bool CanTestCertificates =>
             Capability.IsTrustedRootCertificateInstalled() && 
@@ -29,8 +32,10 @@ namespace System.Net.Http.Functional.Tests
         private static bool CanTestClientCertificates =>
             CanTestCertificates && BackendSupportsCustomCertificateHandling;
 
+#if !TargetsWindows
         [DllImport("System.Net.Http.Native", EntryPoint = "HttpNative_GetSslVersionDescription")]
         private static extern string CurlSslVersionDescription();
+#endif
         
         public const int TestTimeoutMilliseconds = 15 * 1000;
 

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <ProjectGuid>{C85CF035-7804-41FF-9557-48B7C948B58D}</ProjectGuid>
     <DefineConstants Condition="'$(TargetGroup)'=='netcoreapp'">$(DefineConstants);netcoreapp</DefineConstants>
+    <DefineConstants Condition="'$(TargetsWindows)'=='true'">$(DefineConstants);TargetsWindows</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Release|AnyCPU'" />


### PR DESCRIPTION
cc: @davidsh @danmosemsft 

A recent change added the dependency to SYstem.Net.Http.Native library on non-Windows for the S.N.H.Functional tests. Given that in uapaot you can't lazy-load a native assembly, we are crashing because we can't find it in execution. With these changes, that won't happen any longer and the tests can continue executing as expected on uapaot.