### PR TITLE
[release/2.0.0] Remove NuGet metadata

### DIFF
--- a/pkg/NETStandard.Library.NETFramework/targets/NETStandard.Library.NETFramework.common.targets
+++ b/pkg/NETStandard.Library.NETFramework/targets/NETStandard.Library.NETFramework.common.targets
@@ -48,16 +48,12 @@
         <Private>false</Private>
         <NuGetPackageId>NETStandard.Library.NETFramework</NuGetPackageId>
         <NuGetPackageVersion>$(NETStandardLibraryNETFrameworkPackageVersion)</NuGetPackageVersion>
-        <NuGetIsFrameworkReference>false</NuGetIsFrameworkReference>
-        <NuGetSourceType>Package</NuGetSourceType>
       </Reference>
 
       <ReferenceCopyLocalPaths Include="@(_NETStandardLibraryNETFrameworkLib)">
         <Private>false</Private>
         <NuGetPackageId>NETStandard.Library.NETFramework</NuGetPackageId>
         <NuGetPackageVersion>$(NETStandardLibraryPackageVersion)</NuGetPackageVersion>
-        <NuGetIsFrameworkReference>false</NuGetIsFrameworkReference>
-        <NuGetSourceType>Package</NuGetSourceType>
       </ReferenceCopyLocalPaths>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
This metadata is read by SDK targets and can trip them up
since these packages don't appear in the deps file.

We still require the SDK to fix https://github.com/dotnet/sdk/issues/1259 to make the scenario work end-to-end.

Fixes #20364

/cc @eerhardt @weshaggard 