### PR TITLE
Update ProjectNTfs, ProjectNTfsTestILC to beta-25325-00, beta-25325-00 respectivly (master)

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -13,8 +13,8 @@
     <CoreClrCurrentRef>fcd99ed86a703a16698fcd0027707739c8ef3501</CoreClrCurrentRef>
     <CoreSetupCurrentRef>5a0606fccb09fce4b47545ae9896139acca547f5</CoreSetupCurrentRef>
     <ExternalCurrentRef>5a0606fccb09fce4b47545ae9896139acca547f5</ExternalCurrentRef>
-    <ProjectNTfsCurrentRef>5a0606fccb09fce4b47545ae9896139acca547f5</ProjectNTfsCurrentRef>
-    <ProjectNTfsTestILCCurrentRef>5a0606fccb09fce4b47545ae9896139acca547f5</ProjectNTfsTestILCCurrentRef>
+    <ProjectNTfsCurrentRef>c5bb08107fd63be2cb4ffba50220d124ab1fab48</ProjectNTfsCurrentRef>
+    <ProjectNTfsTestILCCurrentRef>c5bb08107fd63be2cb4ffba50220d124ab1fab48</ProjectNTfsTestILCCurrentRef>
     <SniCurrentRef>97059fa979a3c8fb8b9fba127c526f15e48c9dde</SniCurrentRef>
     <StandardCurrentRef>5a0606fccb09fce4b47545ae9896139acca547f5</StandardCurrentRef>
   </PropertyGroup>
@@ -25,9 +25,9 @@
     <CoreFxExpectedPrerelease>preview1-25322-02</CoreFxExpectedPrerelease>
     <CoreClrPackageVersion>2.0.0-preview2-25316-03</CoreClrPackageVersion>
     <ExternalExpectedPrerelease>beta-25322-00</ExternalExpectedPrerelease>
-    <ProjectNTfsExpectedPrerelease>beta-25322-00</ProjectNTfsExpectedPrerelease>
-    <ProjectNTfsTestILCExpectedPrerelease>beta-25322-00</ProjectNTfsTestILCExpectedPrerelease>
-    <ProjectNTfsTestILCPackageVersion>1.0.0-beta-25322-00</ProjectNTfsTestILCPackageVersion>
+    <ProjectNTfsExpectedPrerelease>beta-25325-00</ProjectNTfsExpectedPrerelease>
+    <ProjectNTfsTestILCExpectedPrerelease>beta-25325-00</ProjectNTfsTestILCExpectedPrerelease>
+    <ProjectNTfsTestILCPackageVersion>1.0.0-beta-25325-00</ProjectNTfsTestILCPackageVersion>
     <NETStandardPackageVersion>2.1.0-preview1-25322-01</NETStandardPackageVersion>
     <NETStandardPackageId>NETStandard.Library</NETStandardPackageId>
     <MicrosoftNETCoreAppPackageVersion>2.1.0-preview1-25321-02</MicrosoftNETCoreAppPackageVersion>

--- a/external/test-runtime/optional.json
+++ b/external/test-runtime/optional.json
@@ -4,9 +4,9 @@
       "dependencies": {
         "Microsoft.DotNet.IBCMerge": "4.6.0-alpha-00001",
         "Microsoft.DotNet.UAP.TestTools": "1.0.2",
-        "TestILC.amd64ret": "1.0.0-beta-25322-00",
-        "TestILC.armret": "1.0.0-beta-25322-00",
-        "TestILC.x86ret": "1.0.0-beta-25322-00"
+        "TestILC.amd64ret": "1.0.0-beta-25325-00",
+        "TestILC.armret": "1.0.0-beta-25325-00",
+        "TestILC.x86ret": "1.0.0-beta-25325-00"
       }
     }
   }


### PR DESCRIPTION
cc: @stephentoub @dagood @tijoytom 

Manually updating PN dependencies since we need to run tests with more recent packages and auto-update seems to be blocked by coreclr update. (see #20290)