### PR TITLE
Added cleanup for cached async state in SqlCommand's EndExecute methods before they throw exceptions. 

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
@@ -1002,6 +1002,10 @@ namespace System.Data.SqlClient
             if (asyncException != null)
             {
                 // Leftover exception from the Begin...InternalReadStage
+                if (cachedAsyncState != null)
+                {
+                    cachedAsyncState.ResetAsyncState();
+                }
                 ReliablePutStateObject();
                 throw asyncException.InnerException;
             }
@@ -1266,6 +1270,10 @@ namespace System.Data.SqlClient
             if (asyncException != null)
             {
                 // Leftover exception from the Begin...InternalReadStage
+                if (cachedAsyncState != null)
+                {
+                    cachedAsyncState.ResetAsyncState();
+                }
                 ReliablePutStateObject();
                 throw asyncException.InnerException;
             }
@@ -1396,6 +1404,10 @@ namespace System.Data.SqlClient
             if (asyncException != null)
             {
                 // Leftover exception from the Begin...InternalReadStage
+                if (cachedAsyncState != null)
+                {
+                    cachedAsyncState.ResetAsyncState();
+                }
                 ReliablePutStateObject();
                 throw asyncException.InnerException;
             }


### PR DESCRIPTION
Without this cleanup, a subsequent command execution will fail since it will appear as though other async commands are still pending. (#20339)

Porting this change to 2.0.0