### PR TITLE
Fixing initialization issue for IOCP handle.

### DIFF
--- a/src/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
@@ -1915,7 +1915,7 @@ namespace System.Net
                 _httpListener = httpListener;
                 _connectionId = connectionId;
                 // we can call the Unsafe API here, we won't ever call user code
-                _nativeOverlapped = httpListener._requestQueueBoundHandle.AllocateNativeOverlapped(s_IOCallback, state: this, pinData: null);
+                _nativeOverlapped = httpListener.RequestQueueBoundHandle.AllocateNativeOverlapped(s_IOCallback, state: this, pinData: null);
             }
 
             internal bool StartOwningDisconnectHandling()


### PR DESCRIPTION
Contributes to #20096.

Testing was manually performed. 
The change was minimized to simplify a 2.0 port.
