### PR TITLE
More serialization test fixes

### DIFF
--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -1437,48 +1437,6 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
-    public static void DCS_ExceptionObject()
-    {
-        var value = new ArgumentException("Test Exception");
-        var actual = SerializeAndDeserialize<ArgumentException>(value, @"<ArgumentException xmlns=""http://schemas.datacontract.org/2004/07/System"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:x=""http://www.w3.org/2001/XMLSchema""><ClassName i:type=""x:string"" xmlns="""">System.ArgumentException</ClassName><Message i:type=""x:string"" xmlns="""">Test Exception</Message><Data i:nil=""true"" xmlns=""""/><InnerException i:nil=""true"" xmlns=""""/><HelpURL i:nil=""true"" xmlns=""""/><StackTraceString i:nil=""true"" xmlns=""""/><RemoteStackTraceString i:nil=""true"" xmlns=""""/><RemoteStackIndex i:type=""x:int"" xmlns="""">0</RemoteStackIndex><ExceptionMethod i:nil=""true"" xmlns=""""/><HResult i:type=""x:int"" xmlns="""">-2147024809</HResult><Source i:nil=""true"" xmlns=""""/><WatsonBuckets i:nil=""true"" xmlns=""""/><ParamName i:nil=""true"" xmlns=""""/></ArgumentException>");
-
-        Assert.StrictEqual(value.Message, actual.Message);
-        Assert.StrictEqual(value.ParamName, actual.ParamName);
-        Assert.StrictEqual(value.Source, actual.Source);
-        Assert.StrictEqual(value.StackTrace, actual.StackTrace);
-        Assert.StrictEqual(value.HResult, actual.HResult);
-        Assert.StrictEqual(value.HelpLink, actual.HelpLink);
-    }
-
-    [Fact]
-    public static void DCS_ArgumentExceptionObject()
-    {
-        var value = new ArgumentException("Test Exception", "paramName");
-        var actual = SerializeAndDeserialize<ArgumentException>(value, @"<ArgumentException xmlns=""http://schemas.datacontract.org/2004/07/System"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:x=""http://www.w3.org/2001/XMLSchema""><ClassName i:type=""x:string"" xmlns="""">System.ArgumentException</ClassName><Message i:type=""x:string"" xmlns="""">Test Exception</Message><Data i:nil=""true"" xmlns=""""/><InnerException i:nil=""true"" xmlns=""""/><HelpURL i:nil=""true"" xmlns=""""/><StackTraceString i:nil=""true"" xmlns=""""/><RemoteStackTraceString i:nil=""true"" xmlns=""""/><RemoteStackIndex i:type=""x:int"" xmlns="""">0</RemoteStackIndex><ExceptionMethod i:nil=""true"" xmlns=""""/><HResult i:type=""x:int"" xmlns="""">-2147024809</HResult><Source i:nil=""true"" xmlns=""""/><WatsonBuckets i:nil=""true"" xmlns=""""/><ParamName i:type=""x:string"" xmlns="""">paramName</ParamName></ArgumentException>");
-
-        Assert.StrictEqual(value.Message, actual.Message);
-        Assert.StrictEqual(value.ParamName, actual.ParamName);
-        Assert.StrictEqual(value.Source, actual.Source);
-        Assert.StrictEqual(value.StackTrace, actual.StackTrace);
-        Assert.StrictEqual(value.HResult, actual.HResult);
-        Assert.StrictEqual(value.HelpLink, actual.HelpLink);
-    }
-
-    [Fact]
-    public static void DCS_ExceptionMessageWithSpecialChars()
-    {
-        var value = new ArgumentException("Test Exception<>&'\"");
-        var actual = SerializeAndDeserialize<ArgumentException>(value, @"<ArgumentException xmlns=""http://schemas.datacontract.org/2004/07/System"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:x=""http://www.w3.org/2001/XMLSchema""><ClassName i:type=""x:string"" xmlns="""">System.ArgumentException</ClassName><Message i:type=""x:string"" xmlns="""">Test Exception&lt;&gt;&amp;'""</Message><Data i:nil=""true"" xmlns=""""/><InnerException i:nil=""true"" xmlns=""""/><HelpURL i:nil=""true"" xmlns=""""/><StackTraceString i:nil=""true"" xmlns=""""/><RemoteStackTraceString i:nil=""true"" xmlns=""""/><RemoteStackIndex i:type=""x:int"" xmlns="""">0</RemoteStackIndex><ExceptionMethod i:nil=""true"" xmlns=""""/><HResult i:type=""x:int"" xmlns="""">-2147024809</HResult><Source i:nil=""true"" xmlns=""""/><WatsonBuckets i:nil=""true"" xmlns=""""/><ParamName i:nil=""true"" xmlns=""""/></ArgumentException>");
-
-        Assert.StrictEqual(value.Message, actual.Message);
-        Assert.StrictEqual(value.ParamName, actual.ParamName);
-        Assert.StrictEqual(value.Source, actual.Source);
-        Assert.StrictEqual(value.StackTrace, actual.StackTrace);
-        Assert.StrictEqual(value.HResult, actual.HResult);
-        Assert.StrictEqual(value.HelpLink, actual.HelpLink);
-    }
-
-    [Fact]
     public static void DCS_InnerExceptionMessageWithSpecialChars()
     {
         var value = new Exception("", new Exception("Test Exception<>&'\""));

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -1436,6 +1436,51 @@ public static partial class DataContractSerializerTests
         Assert.StrictEqual(((SimpleKnownTypeValue)actual.SimpleTypeValue).StrProperty, "PropertyValue");
     }
 
+    [ActiveIssue(20361)]
+    [Fact]
+    public static void DCS_ExceptionObject()
+    {
+        var value = new ArgumentException("Test Exception");
+        var actual = SerializeAndDeserialize<ArgumentException>(value, @"<ArgumentException xmlns=""http://schemas.datacontract.org/2004/07/System"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:x=""http://www.w3.org/2001/XMLSchema""><ClassName i:type=""x:string"" xmlns="""">System.ArgumentException</ClassName><Message i:type=""x:string"" xmlns="""">Test Exception</Message><Data i:nil=""true"" xmlns=""""/><InnerException i:nil=""true"" xmlns=""""/><HelpURL i:nil=""true"" xmlns=""""/><StackTraceString i:nil=""true"" xmlns=""""/><RemoteStackTraceString i:nil=""true"" xmlns=""""/><RemoteStackIndex i:type=""x:int"" xmlns="""">0</RemoteStackIndex><ExceptionMethod i:nil=""true"" xmlns=""""/><HResult i:type=""x:int"" xmlns="""">-2147024809</HResult><Source i:nil=""true"" xmlns=""""/><WatsonBuckets i:nil=""true"" xmlns=""""/><ParamName i:nil=""true"" xmlns=""""/></ArgumentException>");
+
+        Assert.StrictEqual(value.Message, actual.Message);
+        Assert.StrictEqual(value.ParamName, actual.ParamName);
+        Assert.StrictEqual(value.Source, actual.Source);
+        Assert.StrictEqual(value.StackTrace, actual.StackTrace);
+        Assert.StrictEqual(value.HResult, actual.HResult);
+        Assert.StrictEqual(value.HelpLink, actual.HelpLink);
+    }
+
+    [ActiveIssue(20361)]
+    [Fact]
+    public static void DCS_ArgumentExceptionObject()
+    {
+        var value = new ArgumentException("Test Exception", "paramName");
+        var actual = SerializeAndDeserialize<ArgumentException>(value, @"<ArgumentException xmlns=""http://schemas.datacontract.org/2004/07/System"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:x=""http://www.w3.org/2001/XMLSchema""><ClassName i:type=""x:string"" xmlns="""">System.ArgumentException</ClassName><Message i:type=""x:string"" xmlns="""">Test Exception</Message><Data i:nil=""true"" xmlns=""""/><InnerException i:nil=""true"" xmlns=""""/><HelpURL i:nil=""true"" xmlns=""""/><StackTraceString i:nil=""true"" xmlns=""""/><RemoteStackTraceString i:nil=""true"" xmlns=""""/><RemoteStackIndex i:type=""x:int"" xmlns="""">0</RemoteStackIndex><ExceptionMethod i:nil=""true"" xmlns=""""/><HResult i:type=""x:int"" xmlns="""">-2147024809</HResult><Source i:nil=""true"" xmlns=""""/><WatsonBuckets i:nil=""true"" xmlns=""""/><ParamName i:type=""x:string"" xmlns="""">paramName</ParamName></ArgumentException>");
+
+        Assert.StrictEqual(value.Message, actual.Message);
+        Assert.StrictEqual(value.ParamName, actual.ParamName);
+        Assert.StrictEqual(value.Source, actual.Source);
+        Assert.StrictEqual(value.StackTrace, actual.StackTrace);
+        Assert.StrictEqual(value.HResult, actual.HResult);
+        Assert.StrictEqual(value.HelpLink, actual.HelpLink);
+    }
+
+    [ActiveIssue(20361)]
+    [Fact]
+    public static void DCS_ExceptionMessageWithSpecialChars()
+    {
+        var value = new ArgumentException("Test Exception<>&'\"");
+        var actual = SerializeAndDeserialize<ArgumentException>(value, @"<ArgumentException xmlns=""http://schemas.datacontract.org/2004/07/System"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:x=""http://www.w3.org/2001/XMLSchema""><ClassName i:type=""x:string"" xmlns="""">System.ArgumentException</ClassName><Message i:type=""x:string"" xmlns="""">Test Exception&lt;&gt;&amp;'""</Message><Data i:nil=""true"" xmlns=""""/><InnerException i:nil=""true"" xmlns=""""/><HelpURL i:nil=""true"" xmlns=""""/><StackTraceString i:nil=""true"" xmlns=""""/><RemoteStackTraceString i:nil=""true"" xmlns=""""/><RemoteStackIndex i:type=""x:int"" xmlns="""">0</RemoteStackIndex><ExceptionMethod i:nil=""true"" xmlns=""""/><HResult i:type=""x:int"" xmlns="""">-2147024809</HResult><Source i:nil=""true"" xmlns=""""/><WatsonBuckets i:nil=""true"" xmlns=""""/><ParamName i:nil=""true"" xmlns=""""/></ArgumentException>");
+
+        Assert.StrictEqual(value.Message, actual.Message);
+        Assert.StrictEqual(value.ParamName, actual.ParamName);
+        Assert.StrictEqual(value.Source, actual.Source);
+        Assert.StrictEqual(value.StackTrace, actual.StackTrace);
+        Assert.StrictEqual(value.HResult, actual.HResult);
+        Assert.StrictEqual(value.HelpLink, actual.HelpLink);
+    }
+
     [Fact]
     public static void DCS_InnerExceptionMessageWithSpecialChars()
     {

--- a/src/System.Runtime.Serialization.Xml/tests/Utils.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/Utils.cs
@@ -283,6 +283,11 @@ internal static class Utils
         XElement[] deskChildElems = baselineXElement.Descendants().OrderBy(m => m.Name.NamespaceName).ToArray();
         XElement[] coreCLRChildElems = actualXElement.Descendants().OrderBy(m => m.Name.NamespaceName).ToArray();
 
+        if(deskChildElems.Length != coreCLRChildElems.Length)
+        {
+            return false;
+        }
+
         for (int i = 0; i < deskChildElems.Length; i++)
         {
             if (!CompareXElements(deskChildElems[i], coreCLRChildElems[i])) return false;

--- a/src/System.Runtime/tests/System/Reflection/StrongNameKeyPairTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/StrongNameKeyPairTests.cs
@@ -17,16 +17,6 @@ namespace System.Reflection.Tests
         public SNKeyPairDerived(byte[] arr) : base(arr) {}
         public SNKeyPairDerived(FileStream keyPairFileStream) : base(keyPairFileStream) {}
         protected SNKeyPairDerived(SerializationInfo info, StreamingContext context) : base(info, context) {}
-
-        public SNKeyPairDerived SNKeyPairDerivedClone(ISerializable inter)
-        {
-            SerializationInfo info = new SerializationInfo(typeof(StrongNameKeyPair), new FormatterConverter());
-            StreamingContext context = new StreamingContext();
-
-            inter.GetObjectData(info, context);
-
-            return new SNKeyPairDerived(info, context);
-        }
     }
 
     public class StrongNameKeyPairTests
@@ -37,10 +27,8 @@ namespace System.Reflection.Tests
         public void SNKeyPairDerivedTestPosTest()
         {
             var sKeyPairDerived = new SNKeyPairDerived(s_data);
-            var sKeyPair = sKeyPairDerived.SNKeyPairDerivedClone(sKeyPairDerived);
 
             RunActionWithDataFileStream(fileStream => sKeyPairDerived = new SNKeyPairDerived(fileStream));
-            sKeyPair = sKeyPairDerived.SNKeyPairDerivedClone(sKeyPairDerived);
         }
 
         [Fact]


### PR DESCRIPTION
Removes a couple more tests that depend on ISerializable implementations and fixes a diagnosability issue in DataContractSerializer tests.

Progress toward #19119