### PR TITLE
2.0 Port: AppCompat: converting two HWR properties to no-op.

### DIFF
--- a/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -22,6 +22,7 @@ namespace System.Net
     public class HttpWebRequest : WebRequest, ISerializable
     {
         private const int DefaultContinueTimeout = 350; // Current default value from .NET Desktop.
+        private const int DefaultReadWriteTimeout = 5 * 60 * 1000; // 5 minutes
 
         private WebHeaderCollection _webHeaderCollection = new WebHeaderCollection();
 
@@ -50,6 +51,8 @@ namespace System.Net
         private int _maximumResponseHeadersLen = _defaultMaxResponseHeadersLength;
         private ServicePoint _servicePoint;
         private int _timeout = WebRequest.DefaultTimeoutMilliseconds;
+        private int _readWriteTimeout = DefaultReadWriteTimeout;
+
         private HttpContinueDelegate _continueDelegate;
 
         // stores the user provided Host header as Uri. If the user specified a default port explicitly we'll lose
@@ -500,17 +503,7 @@ namespace System.Net
             }
         }
 
-        public override string ConnectionGroupName
-        {
-            get
-            {
-                throw NotImplemented.ByDesignWithMessage(SR.net_PropertyNotImplementedException);
-            }
-            set
-            {
-                throw NotImplemented.ByDesignWithMessage(SR.net_PropertyNotImplementedException);
-            }
-        }
+        public override string ConnectionGroupName { get; set; }
 
         public override bool PreAuthenticate
         {
@@ -795,16 +788,25 @@ namespace System.Net
             }
         }
 
-
         public int ReadWriteTimeout
         {
             get
             {
-                throw NotImplemented.ByDesignWithMessage(SR.net_PropertyNotImplementedException);
+                return _readWriteTimeout;
             }
             set
             {
-                throw NotImplemented.ByDesignWithMessage(SR.net_PropertyNotImplementedException);
+                if (RequestSubmitted)
+                {
+                    throw new InvalidOperationException(SR.net_reqsubmitted);
+                }
+
+                if (value <= 0 && value != System.Threading.Timeout.Infinite)
+                {
+                    throw new ArgumentOutOfRangeException("value", SR.net_io_timeout_use_gt_zero);
+                }
+
+                _readWriteTimeout = value;
             }
         }
 

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -9,6 +9,7 @@ using System.Net.Http;
 using System.Net.Test.Common;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Xunit;
@@ -485,22 +486,15 @@ namespace System.Net.Tests
             Assert.False(request.AllowAutoRedirect);
         }
 
-        [Theory, MemberData(nameof(EchoServers))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp, "ConnectionGroupName isn't implemented in Core")]
-        public void ConnectionGroupName_SetAndGetGroup_ValuesMatch(Uri remoteServer)
+        [Fact]
+        public void ConnectionGroupName_SetAndGetGroup_ValuesMatch()
         {
-            HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
-
-            if (!PlatformDetection.IsFullFramework)
-            {
-                Assert.Throws<NotImplementedException>(() => request.ConnectionGroupName);
-            }
-            else
-            {
-                Assert.Null(request.ConnectionGroupName);
-                request.ConnectionGroupName = "Group";
-                Assert.Equal("Group", request.ConnectionGroupName);
-            }
+            // Note: In CoreFX changing this value will not have any effect on HTTP stack's behavior.
+            //       For app-compat reasons we allow applications to alter and read the property.
+            HttpWebRequest request = WebRequest.CreateHttp("http://test");
+            Assert.Null(request.ConnectionGroupName);
+            request.ConnectionGroupName = "Group";
+            Assert.Equal("Group", request.ConnectionGroupName);
         }
 
         [Theory, MemberData(nameof(EchoServers))]
@@ -740,13 +734,29 @@ namespace System.Net.Tests
             Assert.Equal(HttpVersion.Version11, request.ProtocolVersion);
         }
 
-        [Theory, MemberData(nameof(EchoServers))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Implemented in .NET Framework")]
-        public void ReadWriteTimeout_SetThenGet_ThrowsNotImplementedException(Uri remoteServer)
+        [Fact]
+        public void ReadWriteTimeout_SetThenGet_ValuesMatch()
         {
-            HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
-            Assert.Throws<NotImplementedException>(() => request.ReadWriteTimeout = 5);
-            Assert.Throws<NotImplementedException>(() => request.ReadWriteTimeout);
+            // Note: In CoreFX changing this value will not have any effect on HTTP stack's behavior.
+            //       For app-compat reasons we allow applications to alter and read the property.
+            HttpWebRequest request = WebRequest.CreateHttp("http://test");
+            request.ReadWriteTimeout = 5;
+            Assert.Equal(5, request.ReadWriteTimeout);
+        }
+
+        [Fact]
+        public void ReadWriteTimeout_InfiniteValue_Ok()
+        {
+            HttpWebRequest request = WebRequest.CreateHttp("http://test");
+            request.ReadWriteTimeout = Timeout.Infinite;
+        }
+
+        [Fact]
+        public void ReadWriteTimeout_NegativeOrZeroValue_Fail()
+        {
+            HttpWebRequest request = WebRequest.CreateHttp("http://test");
+            Assert.Throws<ArgumentOutOfRangeException>(() => { request.ReadWriteTimeout = 0; });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { request.ReadWriteTimeout = -10; });
         }
 
         [Theory, MemberData(nameof(EchoServers))]


### PR DESCRIPTION
Port of #20332
Tracking bug: #20043
