### PR TITLE
fix handling of client Close before writing entire Content-Length

### DIFF
--- a/src/System.Net.HttpListener/tests/GetContextHelper.cs
+++ b/src/System.Net.HttpListener/tests/GetContextHelper.cs
@@ -69,15 +69,7 @@ namespace System.Net.Tests
 
         public static void WaitForSocketShutdown(Socket socket)
         {
-            if (PlatformDetection.IsWindows || PlatformDetection.IsOSX)
-            {
-                socket.Shutdown(SocketShutdown.Both);
-                while (SocketConnected(socket));
-            }
-            else
-            {
-                socket.Close();
-            }
+            socket.Close();
         }
 
         public static bool SocketConnected(Socket socket)

--- a/src/System.Net.HttpListener/tests/HttpListenerResponseTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerResponseTests.cs
@@ -436,7 +436,6 @@ namespace System.Net.Tests
             }
         }
         
-        [ActiveIssue(20246)] // CI hanging frequently
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         [InlineData(true)]
         [InlineData(false)]

--- a/src/System.Net.HttpListener/tests/HttpRequestStreamTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpRequestStreamTests.cs
@@ -482,7 +482,7 @@ namespace System.Net.Tests
             }
         }
 
-        [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementationAndNotUap))] // [ActiveIssue(20246, TestPlatforms.AnyUnix)] // CI hanging frequently, [ActiveIssue(19983, platforms: TestPlatforms.AnyUnix)] // No exception thrown
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public async Task Read_FromClosedConnectionAsynchronously_ThrowsHttpListenerException()
         {
             const string Text = "Some-String";
@@ -505,13 +505,10 @@ namespace System.Net.Tests
                 byte[] buffer = new byte[expected.Length];
                 await Assert.ThrowsAsync<HttpListenerException>(() => context.Request.InputStream.ReadAsync(buffer, 0, buffer.Length));
                 await Assert.ThrowsAsync<HttpListenerException>(() => context.Request.InputStream.ReadAsync(buffer, 0, buffer.Length));
-
-                // Closing a response from a closed client if no writing has failed should fail.
-                Assert.Throws<HttpListenerException>(() => context.Response.Close());
             }
         }
 
-        [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementationAndNotUap))] // [ActiveIssue(20246, TestPlatforms.AnyUnix)] // CI hanging frequently, [ActiveIssue(19983, platforms: TestPlatforms.AnyUnix)] // No exception thrown
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
         public async Task Read_FromClosedConnectionSynchronously_ThrowsHttpListenerException()
         {
             const string Text = "Some-String";
@@ -534,9 +531,6 @@ namespace System.Net.Tests
                 byte[] buffer = new byte[expected.Length];
                 Assert.Throws<HttpListenerException>(() => context.Request.InputStream.Read(buffer, 0, buffer.Length));
                 Assert.Throws<HttpListenerException>(() => context.Request.InputStream.Read(buffer, 0, buffer.Length));
-
-                // Closing a response from a closed client if no writing has occured should fail.
-                Assert.Throws<HttpListenerException>(() => context.Response.Close());
             }
         }
     }


### PR DESCRIPTION
If the client closes the connection before writing the full body, as specified by the Content-Length header, we should throw an exception on InputStream.Read/ReadAsync.

Partial fix for #20246.

@stephentoub @hughbe 