### PR TITLE
Workaround pooling issue with managed HttpListener and Windows ClientWebSocket

### DIFF
--- a/src/System.Net.HttpListener/tests/GetContextHelper.cs
+++ b/src/System.Net.HttpListener/tests/GetContextHelper.cs
@@ -61,8 +61,10 @@ namespace System.Net.Tests
         public static bool IsWindowsImplementationAndNotUap { get; } =
             (TypeExists("Interop+HttpApi") || TypeExists("System.Net.UnsafeNclNativeMethods")) && // types only in Windows netcoreapp/netfx builds, respectively
             PlatformDetection.IsNotOneCoreUAP; // never run for UAP
+
+        public static bool IsManagedImplementation => TypeExists("System.Net.WebSockets.ManagedWebSocket"); // type only in managed build
         public static bool IsManagedImplementationAndNotUap =>
-            TypeExists("System.Net.WebSockets.ManagedWebSocket") && // type only in managed build
+            IsManagedImplementation &&
             PlatformDetection.IsNotOneCoreUAP; // never run for UAP
 
         private static bool TypeExists(string name) => typeof(HttpListener).Assembly.GetType(name, throwOnError: false, ignoreCase: false) != null;

--- a/src/System.Net.HttpListener/tests/HttpListenerContextTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerContextTests.cs
@@ -32,7 +32,6 @@ namespace System.Net.Tests
         }
 
         public static bool IsNotWindows7OrUapCore { get; } = !PlatformDetection.IsWindows7 && PlatformDetection.IsNotOneCoreUAP;
-        public static bool IsNotWindows7OrUapCoreAndIsWindowsImplementation { get; } = IsNotWindows7OrUapCore && Helpers.IsWindowsImplementationAndNotUap;
 
         public static IEnumerable<object[]> SubProtocol_TestData()
         {
@@ -46,7 +45,7 @@ namespace System.Net.Tests
             yield return new object[] { new string[] { "MyProtocol1", "MyProtocol2" }, "MyProtocol2" };
         }
 
-        [ConditionalTheory(nameof(IsNotWindows7OrUapCoreAndIsWindowsImplementation))] // [ActiveIssue(20246, TestPlatforms.AnyUnix)] // CI hanging frequently
+        [ConditionalTheory(nameof(IsNotWindows7OrUapCore))]
         [MemberData(nameof(SubProtocol_TestData))]
         public async Task AcceptWebSocketAsync_ValidSubProtocol_Success(string[] clientProtocols, string serverProtocol)
         {
@@ -55,7 +54,7 @@ namespace System.Net.Tests
             Assert.Equal(serverProtocol, socketContext.WebSocket.SubProtocol);
         }
 
-        [ConditionalFact(nameof(IsNotWindows7OrUapCoreAndIsWindowsImplementation))] // [ActiveIssue(20246, TestPlatforms.AnyUnix)] // CI hanging frequently
+        [ConditionalTheory(nameof(IsNotWindows7OrUapCore))]
         public async Task AcceptWebSocketAsync_ValidWebSocket_SetsUpHeadersInResponse()
         {
             HttpListenerContext context = await GetWebSocketContext(new string[] { "SubProtocol", "SubProtocol2" });
@@ -116,7 +115,7 @@ namespace System.Net.Tests
             Assert.Equal("Basic", webSocketContext.User.Identity.AuthenticationType);
         }
 
-        [ConditionalFact(nameof(IsNotWindows7OrUapCoreAndIsWindowsImplementation))] // [ActiveIssue(20246, TestPlatforms.AnyUnix)] // CI hanging frequently
+        [ConditionalFact(nameof(IsNotWindows7OrUapCore))]
         public async Task AcceptWebSocketAsync_UnsupportedProtocol_ThrowsWebSocketException()
         {
             HttpListenerContext context = await GetWebSocketContext(new string[] { "MyProtocol" });
@@ -150,7 +149,6 @@ namespace System.Net.Tests
             });
         }
 
-        [ActiveIssue(20246)] // CI hanging frequently
         [ConditionalTheory(nameof(IsNotWindows7OrUapCore))]
         [InlineData("")]
         [InlineData(" ")]
@@ -179,7 +177,6 @@ namespace System.Net.Tests
             await AssertExtensions.ThrowsAsync<ArgumentException>("subProtocol", () => context.AcceptWebSocketAsync(subProtocol));
         }
 
-        [ActiveIssue(20246)] // CI hanging frequently
         [ConditionalTheory(nameof(IsNotWindows7OrUapCore))]
         [InlineData("!")]
         [InlineData("#")]
@@ -190,7 +187,6 @@ namespace System.Net.Tests
             await Assert.ThrowsAsync<WebSocketException>(() => context.AcceptWebSocketAsync(subProtocol));
         }
 
-        [ActiveIssue(20246)] // CI hanging frequently
         [ConditionalFact(nameof(IsNotWindows7OrUapCore))]
         public async Task AcceptWebSocketAsync_InvalidKeepAlive_ThrowsWebSocketException()
         {
@@ -200,7 +196,6 @@ namespace System.Net.Tests
             await Assert.ThrowsAsync<ArgumentOutOfRangeException>("keepAliveInterval", () => context.AcceptWebSocketAsync(null, keepAlive));
         }
 
-        [ActiveIssue(20246)] // CI hanging frequently
         [ConditionalTheory(nameof(IsNotWindows7OrUapCore))]
         [InlineData(-1)]
         [InlineData(0)]
@@ -221,7 +216,6 @@ namespace System.Net.Tests
             await AssertExtensions.ThrowsAsync<ArgumentNullException>("internalBuffer.Array", () => context.AcceptWebSocketAsync(null, 1024, TimeSpan.MaxValue, internalBuffer));
         }
 
-        [ActiveIssue(20246)] // CI hanging frequently
         [ConditionalTheory(nameof(IsNotWindows7OrUapCore))]
         [InlineData(-1)]
         [InlineData(11)]
@@ -233,7 +227,6 @@ namespace System.Net.Tests
             await AssertExtensions.ThrowsAsync<ArgumentOutOfRangeException>("internalBuffer.Offset", () => context.AcceptWebSocketAsync(null, 1024, TimeSpan.MaxValue, internalBuffer));
         }
 
-        [ActiveIssue(20246)] // CI hanging frequently
         [ConditionalTheory(nameof(IsNotWindows7OrUapCore))]
         [InlineData(0, -1)]
         [InlineData(0, 11)]

--- a/src/System.Net.HttpListener/tests/HttpListenerFactory.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerFactory.cs
@@ -5,14 +5,18 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Sockets;
+using System.Runtime.InteropServices;
 using System.Text;
-using Xunit;
 
 namespace System.Net.Tests
 {
     // Utilities for generating URL prefixes for HttpListener
     public class HttpListenerFactory : IDisposable
     {
+        const int MinPort = 1025;
+        private static readonly object s_createListenerLock = new object();
+        private static int s_nextPort = MinPort;
+
         private readonly HttpListener _processPrefixListener;
         private readonly Exception _processPrefixException;
         private readonly string _processPrefix;
@@ -29,44 +33,54 @@ namespace System.Net.Tests
             _path = path ?? Guid.NewGuid().ToString("N");
             string pathComponent = string.IsNullOrEmpty(_path) ? _path : $"{_path}/";
 
-            for (int port = 1025; port <= IPEndPoint.MaxPort; port++)
+            lock (s_createListenerLock)
             {
-                string prefix = $"http://{hostname}:{port}/{pathComponent}";
-
-                var listener = new HttpListener();
-                try
+                foreach (int port in Enumerable.Range(s_nextPort, IPEndPoint.MaxPort - s_nextPort + 1).Concat(Enumerable.Range(MinPort, s_nextPort - MinPort)))
                 {
-                    listener.Prefixes.Add(prefix);
-                    listener.Start();
+                    string prefix = $"http://{hostname}:{port}/{pathComponent}";
 
-                    _processPrefixListener = listener;
-                    _processPrefix = prefix;
-                    _port = port;
-                    break;
-                }
-                catch (Exception e)
-                {
-                    // can't use this prefix
-                    listener.Close();
-
-                    // Remember the exception for later
-                    _processPrefixException = e;
-
-                    if (e is HttpListenerException listenerException)
+                    var listener = new HttpListener();
+                    try
                     {
-                        // If we can't access the host (e.g. if it is '+' or '*' and the current user is the administrator)
-                        // then throw.
-                        const int ERROR_ACCESS_DENIED = 5;
-                        if (listenerException.ErrorCode == ERROR_ACCESS_DENIED && (hostname == "*" || hostname == "+"))
+                        listener.Prefixes.Add(prefix);
+                        listener.Start();
+
+                        _processPrefixListener = listener;
+                        _processPrefix = prefix;
+                        _port = port;
+                        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && Helpers.IsManagedImplementation)
                         {
-                            throw new InvalidOperationException($"Access denied for host {hostname}");
+                            // Try to avoid reusing the same port from test to test if we're using
+                            // the WinHttp ClientWebSocket against the managed HttpListener.
+                            // https://github.com/dotnet/corefx/issues/20439
+                            s_nextPort = port + 1;
                         }
-                    }
-                    else if (!(e is SocketException))
-                    {
-                        // If this is not an HttpListenerException or SocketException, something very wrong has happened, and there's no point
-                        // in trying again.
                         break;
+                    }
+                    catch (Exception e)
+                    {
+                        // can't use this prefix
+                        listener.Close();
+
+                        // Remember the exception for later
+                        _processPrefixException = e;
+
+                        if (e is HttpListenerException listenerException)
+                        {
+                            // If we can't access the host (e.g. if it is '+' or '*' and the current user is the administrator)
+                            // then throw.
+                            const int ERROR_ACCESS_DENIED = 5;
+                            if (listenerException.ErrorCode == ERROR_ACCESS_DENIED && (hostname == "*" || hostname == "+"))
+                            {
+                                throw new InvalidOperationException($"Access denied for host {hostname}");
+                            }
+                        }
+                        else if (!(e is SocketException))
+                        {
+                            // If this is not an HttpListenerException or SocketException, something very wrong has happened, and there's no point
+                            // in trying again.
+                            break;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
When using the managed HttpListener on Windows, try to create each HttpListener on a different port than the one used for the last test's HttpListener.

Workaround for https://github.com/dotnet/corefx/issues/20439
Contributes to https://github.com/dotnet/corefx/issues/20246

(Easiest to review when ignoring whitespace diffs: https://github.com/dotnet/corefx/pull/20440/files?w=1)

cc: @geoffkizer 