### PR TITLE
Disable UseShellExecute test

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -977,7 +977,8 @@ namespace System.Diagnostics.Tests
                 }
                 finally
                 {
-                    process.Kill();
+                    if (process != null && !process.HasExited)
+                        process.Kill();
                 }
             }
         }
@@ -1011,7 +1012,8 @@ namespace System.Diagnostics.Tests
                 }
                 finally
                 {
-                    process.Kill();
+                    if (process != null && !process.HasExited)
+                        process.Kill();
                 }
             }
         }

--- a/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -944,7 +944,7 @@ namespace System.Diagnostics.Tests
                 FileName = @"http://www.microsoft.com"
             };
 
-            Process.Start(info);
+            Process.Start(info); // Returns null after navigating browser
         }
 
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))] // No Notepad on Nano
@@ -967,6 +967,8 @@ namespace System.Diagnostics.Tests
 
             using (var process = Process.Start(info))
             {
+                Assert.True(process != null, $"Could not start {info.FileName} {info.Arguments} UseShellExecute={info.UseShellExecute}");
+
                 try
                 {
                     process.WaitForInputIdle(); // Give the file a chance to load
@@ -1002,6 +1004,8 @@ namespace System.Diagnostics.Tests
 
             using (var process = Process.Start(info))
             {
+                Assert.True(process != null, $"Could not start {info.FileName} UseShellExecute={info.UseShellExecute}");
+
                 try
                 {
                     process.WaitForInputIdle(); // Give the file a chance to load

--- a/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -986,6 +986,7 @@ namespace System.Diagnostics.Tests
         [OuterLoop("Launches notepad")]
         [PlatformSpecific(TestPlatforms.Windows)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "https://github.com/dotnet/corefx/issues/20204")]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20388")]
         public void StartInfo_TextFile_ShellExecute()
         {
             string tempFile = GetTestFilePath() + ".txt";


### PR DESCRIPTION
Relates to https://github.com/dotnet/corefx/issues/20388

Sometimes Process.Start is returning null when trying to start notepad using shell execute. I can't repro this locally. Disable test while we figure this out.