### PR TITLE
Update WOA builds to build and send test jobs to .NET Helix

### DIFF
--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -85,7 +85,8 @@
         "PB_ConfigurationGroup": "Release",
         "PB_PipelineBuildMSBuildArguments": "/p:EnableProfileGuidedOptimization=true"
       },
-      "Definitions": [{
+      "Definitions": [
+        {
           "Name": "DotNet-CoreFx-Trusted-Windows",
           "Parameters": {
             "PB_Platform": "arm",
@@ -203,11 +204,13 @@
           }
         },
         {
-          "Name": "DotNet-CoreFx-Trusted-Windows-NoTest",
+          "Name": "DotNet-CoreFx-Trusted-Windows",
           "Parameters": {
             "PB_Platform": "arm",
             "PB_BuildArguments": "-framework=uapaot -buildArch=arm -Release -- /p:SignType=real /p:RuntimeOS=win10",
-            "PB_SyncArguments": "-p -- /p:ArchGroup=arm /p:RuntimeOS=win10"
+            "PB_BuildTestsArguments": "-framework=uapaot -buildArch=arm -Release -SkipTests -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=arm /p:RuntimeOS=win10 /p:TargetGroup=uapaot",
+            "PB_CreateHelixArguments": "/p:ArchGroup=arm /p:TargetGroup=uapaot /p:ConfigurationGroup=Release /p:TargetQueues=Windows.10.Amd64 /p:SecondaryQueue=Windows.10.Arm64 /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/ilc/\""
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",
@@ -375,12 +378,15 @@
       "BuildParameters": {
         "PB_ConfigurationGroup": "Debug"
       },
-      "Definitions": [{
-          "Name": "DotNet-CoreFx-Trusted-Windows-NoTest",
+      "Definitions": [
+        {
+          "Name": "DotNet-CoreFx-Trusted-Windows",
           "Parameters": {
             "PB_Platform": "arm",
-            "PB_BuildArguments": "-framework:uap -buildArch=arm -Debug -- /p:SignType=real /p:RuntimeOS=win10",
-            "PB_SyncArguments": "-p -- /p:ArchGroup=arm /p:RuntimeOS=win10"
+            "PB_BuildArguments": "-framework=uap -buildArch=arm -Debug -- /p:SignType=real /p:RuntimeOS=win10",
+            "PB_BuildTestsArguments": "-framework=uap -buildArch=arm -Debug -SkipTests -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=arm /p:RuntimeOS=win10 /p:TargetGroup=uap",
+            "PB_CreateHelixArguments": "/p:ArchGroup=arm /p:TargetGroup=uap /p:ConfigurationGroup=Debug /p:TargetQueues=Windows.10.Amd64 /p:SecondaryQueue=Windows.10.Arm64 /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/uwp/\""
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",


### PR DESCRIPTION
We're ready to go for WOA Helix runs, this change enables them.
Correlation Id of test run: aa6d4f4b-da7e-4931-a70b-927be875aa53

@chcosta @joshfree @joperezr FYI