### PR TITLE
Get rid of assorted CoreFx test on ILC noise.

### DIFF
--- a/src/System.Collections.Immutable/tests/Resources/System.Collections.Immutable.Tests.rd.xml
+++ b/src/System.Collections.Immutable/tests/Resources/System.Collections.Immutable.Tests.rd.xml
@@ -1,0 +1,7 @@
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Library>
+    <!-- Needed because of objects in [Theory] data which causes xunit to reflect on its ToString() -->
+    <Type Name="System.Collections.Generic.ComparisonComparer&lt;T&gt;" Dynamic="Required Public" />
+  </Library>
+</Directives>
+

--- a/src/System.Collections.Immutable/tests/System.Collections.Immutable.Tests.csproj
+++ b/src/System.Collections.Immutable/tests/System.Collections.Immutable.Tests.csproj
@@ -121,5 +121,8 @@
     <TargetingPackExclusions Include="System.Collections.Immutable" />
     <ReferenceFromRuntime Include="System.Collections.Immutable" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\$(AssemblyName).rd.xml" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Diagnostics.Contracts/tests/System.Diagnostics.Contracts.Tests.csproj
+++ b/src/System.Diagnostics.Contracts/tests/System.Diagnostics.Contracts.Tests.csproj
@@ -14,6 +14,9 @@
     <Compile Include="ForAllTests.cs" />
     <Compile Include="Utilities.cs" />
     <Compile Include="ValueTests.cs" />
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>Common\System\PlatformDetection.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\ShouldNotBeInvokedException.cs">
       <Link>Common\System\ShouldNotBeInvokedException.cs</Link>
     </Compile>

--- a/src/System.Diagnostics.Contracts/tests/Utilities.cs
+++ b/src/System.Diagnostics.Contracts/tests/Utilities.cs
@@ -14,7 +14,10 @@ namespace System.Diagnostics.Contracts.Tests
         internal static void AssertThrowsContractException(Action action)
         {
             Exception exc = Assert.ThrowsAny<Exception>(action);
-            Assert.Equal("ContractException", exc.GetType().Name);
+            if (!PlatformDetection.IsNetNative) // Cannot do internal framework Reflection on .Net Native
+            {
+                Assert.Equal("ContractException", exc.GetType().Name);
+            }
         }
 
         internal static IDisposable WithContractFailed(EventHandler<ContractFailedEventArgs> handler)

--- a/src/System.Linq/tests/Resources/System.Linq.Tests.rd.xml
+++ b/src/System.Linq/tests/Resources/System.Linq.Tests.rd.xml
@@ -1,7 +1,7 @@
 <Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
   <Library>
     <!-- Needed because of StringComparer instance in [Theory] data which causes xunit to reflect on its ToString() -->
-    <Type Name="System.StringComparer" Dynamic="Required Public" />
+    <Type Name="System.OrdinalComparer" Dynamic="Required Public" />
 
     <!-- ConsistencyTests.MatchSequencePattern() test explicitly probes these types -->
     <Type Name="System.Linq.Enumerable" Dynamic="Required Public" />

--- a/src/System.Runtime.Loader/tests/AssemblyLoadContextTest.cs
+++ b/src/System.Runtime.Loader/tests/AssemblyLoadContextTest.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 
 namespace System.Runtime.Loader.Tests
 {
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "AssemblyLoadContext not supported on .Net Native")]
     public class AssemblyLoadContextTest
     {
         private const string TestAssembly = "System.Runtime.Loader.Test.Assembly";

--- a/src/System.Runtime.Loader/tests/DefaultContext/DefaultLoadContextTest.cs
+++ b/src/System.Runtime.Loader/tests/DefaultContext/DefaultLoadContextTest.cs
@@ -56,6 +56,7 @@ namespace System.Runtime.Loader.Tests
         }
     }
 
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "AssemblyLoadContext not supported on .Net Native")]
     public class DefaultLoadContextTests
     {
         private static string s_loadFromPath = null;

--- a/src/System.Runtime.Loader/tests/RefEmitLoadContext/RefEmitLoadContextTest.cs
+++ b/src/System.Runtime.Loader/tests/RefEmitLoadContext/RefEmitLoadContextTest.cs
@@ -30,6 +30,7 @@ namespace System.Runtime.Loader.Tests
         }
     }
 
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "AssemblyLoadContext not supported on .Net Native")]
     public class RefEmitLoadContextTests
     {
         public static string s_loadFromPath = null;


### PR DESCRIPTION
The recent change to unblock all serializable types
for Reflection (even if the types themselves are
internal) woke up the XUnit ToString() problem
again.

Now, reflecting on ToString() on these types
are throwing MME's rather than bleeding through
the prevaricator Type that pretends to have no
members to the public base type.

This is most irritating but there's not much for
it except to rd.xml these internal types
directly.