### PR TITLE
Remove portable parameter from CI builds

### DIFF
--- a/buildpipeline/portable-linux.groovy
+++ b/buildpipeline/portable-linux.groovy
@@ -32,10 +32,10 @@ simpleDockerNode('microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2') {
         sh "./build-managed.sh -- /t:GenerateVersionSourceFile /p:GenerateVersionSourceFile=true"
     }
     stage ('Sync') {
-        sh "./sync.sh -p -portable -- /p:ArchGroup=x64"
+        sh "./sync.sh -p -- /p:ArchGroup=x64"
     }
     stage ('Build Product') {
-        sh "./build.sh -buildArch=x64 -${params.Config} -portable"
+        sh "./build.sh -buildArch=x64 -${params.Config}"
     }
     stage ('Build Tests') {
         def additionalArgs = ''
@@ -64,9 +64,9 @@ simpleDockerNode('microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2') {
                                      // 'Ubuntu.1704.Amd64.Open',
                                      'suse.422.amd64.Open',
                                      'fedora.25.amd64.Open']
-            
 
-            sh "./Tools/msbuild.sh src/upload-tests.proj /p:ArchGroup=x64 /p:ConfigurationGroup=${params.Config} /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Linux /p:HelixJobType=test/functional/portable/cli/ /p:HelixSource=${helixSource} /p:BuildMoniker=${helixBuild} /p:HelixCreator=${helixCreator} /p:CloudDropAccountName=dotnetbuilddrops /p:CloudResultsAccountName=dotnetjobresults /p:CloudDropAccessToken=\$CloudDropAccessToken /p:CloudResultsAccessToken=\$OutputCloudResultsAccessToken /p:HelixApiEndpoint=https://helix.dot.net/api/2017-04-14/jobs /p:TargetQueues=${targetHelixQueues.join('+')} /p:HelixLogFolder=${WORKSPACE}/${logFolder}/ /p:HelixCorrelationInfoFileName=SubmittedHelixRuns.txt"
+
+            sh "./Tools/msbuild.sh src/upload-tests.proj /p:ArchGroup=x64 /p:ConfigurationGroup=${params.Config} /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Linux /p:HelixJobType=test/functional/cli/ /p:HelixSource=${helixSource} /p:BuildMoniker=${helixBuild} /p:HelixCreator=${helixCreator} /p:CloudDropAccountName=dotnetbuilddrops /p:CloudResultsAccountName=dotnetjobresults /p:CloudDropAccessToken=\$CloudDropAccessToken /p:CloudResultsAccessToken=\$OutputCloudResultsAccessToken /p:HelixApiEndpoint=https://helix.dot.net/api/2017-04-14/jobs /p:TargetQueues=${targetHelixQueues.join('+')} /p:HelixLogFolder=${WORKSPACE}/${logFolder}/ /p:HelixCorrelationInfoFileName=SubmittedHelixRuns.txt"
 
             submittedHelixJson = readJSON file: "${logFolder}/SubmittedHelixRuns.txt"
         }

--- a/buildpipeline/portable-windows.groovy
+++ b/buildpipeline/portable-windows.groovy
@@ -18,20 +18,20 @@ simpleNode('Windows_NT','latest') {
         bat '.\\clean.cmd -all'
     }
     stage ('Sync') {
-        bat '.\\sync.cmd -p -portable -- /p:ArchGroup=x64 /p:RuntimeOS=win10'
+        bat '.\\sync.cmd -p -- /p:ArchGroup=x64 /p:RuntimeOS=win10'
     }
     stage ('Generate Version Assets') {
         bat '.\\build-managed.cmd -GenerateVersion'
     }
     stage ('Build Product') {
-        bat ".\\build.cmd -buildArch=x64 -${params.Config} -portable -- /p:SignType=real /p:RuntimeOS=win10"
+        bat ".\\build.cmd -buildArch=x64 -${params.Config} -- /p:SignType=real /p:RuntimeOS=win10"
     }
     stage ('Build Tests') {
         def additionalArgs = ''
         if (params.OuterLoop) {
             additionalArgs = '-Outerloop'
         }
-        bat ".\\build-tests.cmd -buildArch=x64 -${params.Config} -SkipTests -portable ${additionalArgs} -- /p:RuntimeOS=win10 /p:ArchiveTests=true"
+        bat ".\\build-tests.cmd -buildArch=x64 -${params.Config} -SkipTests ${additionalArgs} -- /p:RuntimeOS=win10 /p:ArchiveTests=true"
     }
     stage ('Submit To Helix For Testing') {
         // Bind the credentials
@@ -43,14 +43,14 @@ simpleNode('Windows_NT','latest') {
             def helixBuild = getCommit()
             // Get the user that should be associated with the submission
             def helixCreator = getUser()
-            
+
             // Target queues
             def targetHelixQueues = ['Windows.10.Amd64.Open',
                                      'Windows.10.Nano.Amd64.Open',
                                      'Windows.7.Amd64.Open',
                                      'Windows.81.Amd64.Open']
 
-            bat "\"%VS140COMNTOOLS%\\VsDevCmd.bat\" && msbuild src\\upload-tests.proj /p:ArchGroup=x64 /p:ConfigurationGroup=${params.Config} /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:HelixJobType=test/functional/portable/cli/ /p:HelixSource=${helixSource} /p:BuildMoniker=${helixBuild} /p:HelixCreator=${helixCreator} /p:CloudDropAccountName=dotnetbuilddrops /p:CloudResultsAccountName=dotnetjobresults /p:CloudDropAccessToken=%CloudDropAccessToken% /p:CloudResultsAccessToken=%OutputCloudResultsAccessToken% /p:HelixApiEndpoint=https://helix.dot.net/api/2017-04-14/jobs /p:TargetQueues=\"${targetHelixQueues.join(',')}\" /p:HelixLogFolder= /p:HelixLogFolder=${WORKSPACE}\\${logFolder}\\ /p:HelixCorrelationInfoFileName=SubmittedHelixRuns.txt"
+            bat "\"%VS140COMNTOOLS%\\VsDevCmd.bat\" && msbuild src\\upload-tests.proj /p:ArchGroup=x64 /p:ConfigurationGroup=${params.Config} /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:HelixJobType=test/functional/cli/ /p:HelixSource=${helixSource} /p:BuildMoniker=${helixBuild} /p:HelixCreator=${helixCreator} /p:CloudDropAccountName=dotnetbuilddrops /p:CloudResultsAccountName=dotnetjobresults /p:CloudDropAccessToken=%CloudDropAccessToken% /p:CloudResultsAccessToken=%OutputCloudResultsAccessToken% /p:HelixApiEndpoint=https://helix.dot.net/api/2017-04-14/jobs /p:TargetQueues=\"${targetHelixQueues.join(',')}\" /p:HelixLogFolder= /p:HelixLogFolder=${WORKSPACE}\\${logFolder}\\ /p:HelixCorrelationInfoFileName=SubmittedHelixRuns.txt"
 
             submittedHelixJson = readJSON file: "${logFolder}\\SubmittedHelixRuns.txt"
         }


### PR DESCRIPTION
@gkhanna79 @mmitche PTAL 

Once this goes in I will also rename the files and usage inside buildpipeline/pipelinejobs.groovy to no longer mention portable. 