### PR TITLE
Skipping test on uapaot since it was crashing the S.C.Concurrent run

### DIFF
--- a/src/System.Collections.Concurrent/tests/ProducerConsumerCollectionTests.cs
+++ b/src/System.Collections.Concurrent/tests/ProducerConsumerCollectionTests.cs
@@ -879,6 +879,7 @@ namespace System.Collections.Concurrent.Tests
 
         [Theory]
         [InlineData(ConcurrencyTestSeconds)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20474", TargetFrameworkMonikers.UapAot)]
         public void ManyConcurrentAddsTakes_ForceContentionWithToArray(double seconds)
         {
             IProducerConsumerCollection<int> c = CreateProducerConsumerCollection();


### PR DESCRIPTION
cc: @stephentoub @danmosemsft 

With this change System.Collections.Concurrent tests run clean now on uapaot for all of our different 
legs.