### PR TITLE
ActiveIssue the GetCommandLineArgs tests on ILC.

### DIFF
--- a/src/System.Runtime.Extensions/tests/System/Environment.GetCommandLineArgs.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.GetCommandLineArgs.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace System.Tests
 {
+    [ActiveIssue("https://github.com/dotnet/corert/issues/3743 - Environment.GetCommandLineArgs() returning null on .Net Native", TargetFrameworkMonikers.UapAot)]
     public class GetCommandLineArgs : RemoteExecutorTestBase
     {
         [Fact]


### PR DESCRIPTION
The implementation is not complete on .NET Native.