### PR TITLE
Mark DiagnosticSource 4.4.0 as stable

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -1235,7 +1235,8 @@
     "System.Diagnostics.DiagnosticSource": {
       "StableVersions": [
         "4.0.0",
-        "4.3.0"
+        "4.3.0",
+        "4.4.0"
       ],
       "BaselineVersion": "4.4.0",
       "InboxOn": {

--- a/src/System.Diagnostics.DiagnosticSource/pkg/System.Diagnostics.DiagnosticSource.pkgproj
+++ b/src/System.Diagnostics.DiagnosticSource/pkg/System.Diagnostics.DiagnosticSource.pkgproj
@@ -4,6 +4,8 @@
   <PropertyGroup>
     <!-- we need to be supported on pre-nuget-3 platforms (Dev12, Dev11, etc) -->
     <MinClientVersion>2.8.6</MinClientVersion>
+    <!-- workaround for https://github.com/dotnet/buildtools/issues/1529 -->
+    <HarvestVersion>4.3.0</HarvestVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\System.Diagnostics.DiagnosticSource.csproj">


### PR DESCRIPTION
New DiagnosticSource API (Activity) is consumed by partner teams (ApplicationInsigthts, ASP.NET). 
In order to align schedules, we want ship 4.4.0 version of DiagnosticSource now, it does not depend on any non-stable packages.

@ericstj, please review

