### PR TITLE
ConfigurationManager fix for UAPAOT

### DIFF
--- a/src/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigPaths.cs
+++ b/src/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigPaths.cs
@@ -60,7 +60,7 @@ namespace System.Configuration
                 // used for local paths and "file://" for UNCs. Simply removing the prefix will make
                 // local paths relative on Unix (e.g. "file:///home" will become "home" instead of
                 // "/home").
-                string configBasePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, exeAssembly.GetName().Name);
+                string configBasePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, exeAssembly.ManifestModule.Name);
                 Uri uri = new Uri(configBasePath);
 
                 if (uri.IsFile)
@@ -203,7 +203,7 @@ namespace System.Configuration
             if (assembly != null)
             {
                 AssemblyName assemblyName = assembly.GetName();
-                Uri codeBase = new Uri(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, assemblyName.Name));
+                Uri codeBase = new Uri(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, assembly.ManifestModule.Name));
 
                 hash = IdentityHelper.GetNormalizedStrongNameHash(assemblyName);
                 if (hash != null)

--- a/src/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigPaths.cs
+++ b/src/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigPaths.cs
@@ -60,7 +60,9 @@ namespace System.Configuration
                 // used for local paths and "file://" for UNCs. Simply removing the prefix will make
                 // local paths relative on Unix (e.g. "file:///home" will become "home" instead of
                 // "/home").
-                Uri uri = new Uri(exeAssembly.CodeBase);
+                string configBasePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, exeAssembly.GetName().Name);
+                Uri uri = new Uri(configBasePath);
+
                 if (uri.IsFile)
                 {
                     ApplicationUri = uri.LocalPath;
@@ -68,7 +70,7 @@ namespace System.Configuration
                 }
                 else
                 {
-                    ApplicationUri = exeAssembly.EscapedCodeBase;
+                    ApplicationUri =  Uri.EscapeDataString(configBasePath);
                 }
             }
 
@@ -201,7 +203,7 @@ namespace System.Configuration
             if (assembly != null)
             {
                 AssemblyName assemblyName = assembly.GetName();
-                Uri codeBase = new Uri(assembly.CodeBase);
+                Uri codeBase = new Uri(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, assemblyName.Name));
 
                 hash = IdentityHelper.GetNormalizedStrongNameHash(assemblyName);
                 if (hash != null)

--- a/src/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigurationHost.cs
+++ b/src/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigurationHost.cs
@@ -46,7 +46,7 @@ namespace System.Configuration
             {
                 if (s_machineConfigFilePath == null)
                 {
-                    string directory = RuntimeEnvironment.GetRuntimeDirectory();
+                    string directory = AppDomain.CurrentDomain.BaseDirectory;
                     s_machineConfigFilePath = Path.Combine(Path.Combine(directory, MachineConfigSubdirectory),
                         MachineConfigFilename);
                 }


### PR DESCRIPTION
Use Assembly.CodeBase is not available on
uapaot,replacing with 
Path.Combine(AppDomain.CurrentDomain.BaseDirectory,
assembly.ManifestModule.Name)