### PR TITLE
Fix HttpClient on Unix handling of 0-len content with chunked upload

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
@@ -72,6 +72,14 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(EchoServers))]
+        public async Task PostEmptyContentUsingConflictingSemantics_Success(Uri serverUri)
+        {
+            await PostHelper(serverUri, string.Empty, new StringContent(string.Empty),
+                useContentLengthUpload: true, useChunkedEncodingUpload: true);
+        }
+
+        [OuterLoop] // TODO: Issue #11345
+        [Theory, MemberData(nameof(EchoServers))]
         public async Task PostUsingContentLengthSemantics_Success(Uri serverUri)
         {
             await PostHelper(serverUri, ExpectedContent, new StringContent(ExpectedContent),

--- a/src/System.Net.HttpListener/tests/HttpRequestStreamTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpRequestStreamTests.cs
@@ -77,7 +77,7 @@ namespace System.Net.Tests
         }
 
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotOneCoreUAP))]
-//        [InlineData(true, "")]      Issue #20419 - HttpClient problem
+        [InlineData(true, "")]
         [InlineData(false, "")]
         [InlineData(true, "Non-Empty")]
         [InlineData(false, "Non-Empty")]


### PR DESCRIPTION
When there's a disagreement between Content-Length and Transfer-Encoding being specified in the HttpRequestMessage, WinHttpHandler sanitizes the request to ensure it makes sense.  CurlHandler does the same thing, except it's currently doing it a bit too late in the send process: it should be doing it before the curl easy handle is configured based on the contents of the request, but it's currently doing it in the middle, after some configuration has already been done based on the content length.  The fix is simply to move the sanitization up earlier.  For the most part this didn't matter, but it was manifesting as incorrect handling of 0-length content with chunked uploads, where neither the content length nor chunks were being sent.

cc: @geoffkizer, @davidsh 
Fixes https://github.com/dotnet/corefx/issues/20419