### PR TITLE
Trigger phrases should match contexts

### DIFF
--- a/buildpipeline/pipelinejobs.groovy
+++ b/buildpipeline/pipelinejobs.groovy
@@ -22,11 +22,9 @@ def linuxPipeline = Pipeline.createPipelineForGithub(this, project, branch, 'bui
             // CentOS 7.3, RedHat 7.3, Debian 8.7, Ubuntu 14.04, Ubuntu 16.04, Ubuntu 16.10, openSuSE 42.2 and Fedora 25
 
             // One for just innerloop.
-            linuxPipeline.triggerPipelineOnEveryGithubPR("Portable ${osName} ${configurationGroup} Build", "(?i).*test\\W+portable\\W+linux\\W+${configurationGroup}\\W+pipeline.*",
-                ['Config':configurationGroup, 'OuterLoop':false])
+            linuxPipeline.triggerPipelineOnEveryGithubPR("Portable ${osName} ${configurationGroup} Build", ['Config':configurationGroup, 'OuterLoop':false])
             // Add one for outerloop
-            linuxPipeline.triggerPipelineOnGithubPRComment("Portable Outerloop ${osName} ${configurationGroup} Build", "(?i).*test\\W+outerloop\\W+portable\\W+linux\\W+${configurationGroup}\\W+pipeline.*",
-                ['Config':configurationGroup, 'OuterLoop':true])
+            linuxPipeline.triggerPipelineOnGithubPRComment("Portable Outerloop ${osName} ${configurationGroup} Build", ['Config':configurationGroup, 'OuterLoop':true])
 		}
 	}
 }
@@ -40,11 +38,9 @@ def windowsPipeline = Pipeline.createPipelineForGithub(this, project, branch, 'b
             // Windows 10, Windows 7, Windows 8.1 and Windows Nano
 
             // One for just innerloop
-            windowsPipeline.triggerPipelineOnEveryGithubPR("Portable ${osName} ${configurationGroup} Build", "(?i).*test\\W+portable\\W+windows\\W+${configurationGroup}\\W+pipeline.*",
-                ['Config':configurationGroup, 'OuterLoop':false])
+            windowsPipeline.triggerPipelineOnEveryGithubPR("Portable ${osName} ${configurationGroup} Build", ['Config':configurationGroup, 'OuterLoop':false])
             // Add one for outerloop
-            windowsPipeline.triggerPipelineOnGithubPRComment("Portable Outerloop ${osName} ${configurationGroup} Build", "(?i).*test\\W+outerloop\\W+portable\\W+windows\\W+${configurationGroup}\\W+pipeline.*",
-                ['Config':configurationGroup, 'OuterLoop':true])
+            windowsPipeline.triggerPipelineOnGithubPRComment("Portable Outerloop ${osName} ${configurationGroup} Build", ['Config':configurationGroup, 'OuterLoop':true])
 		}
 	}
 }


### PR DESCRIPTION
Trigger phrases for pipelines will now match the GitHub status context:
@dotnet-bot test Portable Linux x64 Debug Build
@dotnet-bot test Portable Linux x64 Release Build
@dotnet-bot test Portable Outerloop Linux x64 Debug Build
@dotnet-bot test Portable Outerloop Linux x64 Release Build
@dotnet-bot test Portable Windows x64 Debug Build
@dotnet-bot test Portable Windows x64 Release Build
@dotnet-bot test Portable Outerloop Windows x64 Debug Build
@dotnet-bot test Portable Outerloop Windows x64 Release Build