### PR TITLE
Fixing issue where xunit.console.netcore.exe is not copied down on arm builds

### DIFF
--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <!-- Given that xunit packages bring with them part of the framework, we need to specify a runtime in order to get the assets
          The only asset that we copy which is RID-specific is sni.dll which is only used in windows, which is why we default to Windows as the RID -->
-    <NugetRuntimeIdentifier>win7-$(ArchGroup)</NugetRuntimeIdentifier>
+    <NugetRuntimeIdentifier>win10-$(ArchGroup)</NugetRuntimeIdentifier>
     <RidSpecificAssets>true</RidSpecificAssets>
     <OutputPath>$(RuntimePath)</OutputPath>
     <XUnitRunnerPackageId Condition="'$(TargetGroup)' != 'netfx'">xunit.console.netcore</XUnitRunnerPackageId>


### PR DESCRIPTION
cc: @MattGal @weshaggard @ericstj 

Fixing ARM builds since xunit.console.netcore.exe was not being copied anymore because win7-arm is not a valid RID, which was causing that the asset located at `runtimes/any/native/xunit.console.netcore.exe` was not getting copied. I have verified that this fix works for `x86` `x64` and `arm`