### PR TITLE
Poring SqlSchemaInfoTest into .NET Core

### DIFF
--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlSchemaInfoTest/SqlSchemaInfoTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlSchemaInfoTest/SqlSchemaInfoTest.cs
@@ -3,46 +3,46 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Data.Common;
+using Xunit;
 
 namespace System.Data.SqlClient.ManualTesting.Tests
 {
     public static class SqlSchemaInfoTest
     {
         [CheckConnStrSetupFact]
-        public static void TestSqlSchemaInfo()
+        public static void TestGetSchema()
         {
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr);
-
             using (SqlConnection connection = new SqlConnection(builder.ConnectionString))
             {
                 connection.Open();
 
-                TestGetSchema(connection);
-                TestCommandBuilder(connection);
-                TestInitialCatalogStandardValues(connection);
+                DataTable dataTable = connection.GetSchema("DATABASES");
+
+                if (dataTable.Rows.Count > 0)
+                {
+                    DataTable metaDataCollections = connection.GetSchema(DbMetaDataCollectionNames.MetaDataCollections);
+                    Assert.True(metaDataCollections != null && metaDataCollections.Rows.Count > 0);
+                    
+                    DataTable metaDataSourceInfo = connection.GetSchema(DbMetaDataCollectionNames.DataSourceInformation);
+                    Assert.True(metaDataSourceInfo != null && metaDataSourceInfo.Rows.Count > 0);
+
+                    DataTable metaDataTypes = connection.GetSchema(DbMetaDataCollectionNames.DataTypes);
+                    Assert.True(metaDataTypes != null && metaDataTypes.Rows.Count > 0);
+                }
 
                 connection.Close();
             }
         }
 
-        public static void TestGetSchema(SqlConnection connection)
-        {
-            DataTable dataTable = connection.GetSchema("DATABASES");
-
-            if (dataTable.Rows.Count > 0)
-            {
-                DataTable metaDataCollections = connection.GetSchema(DbMetaDataCollectionNames.MetaDataCollections);
-                DataTable metaDataSourceInfo = connection.GetSchema(DbMetaDataCollectionNames.DataSourceInformation);
-                DataTable metaDataTypes = connection.GetSchema(DbMetaDataCollectionNames.DataTypes);
-            }
-        }
-
-        public static void TestCommandBuilder(SqlConnection connection)
+        [CheckConnStrSetupFact]
+        public static void TestCommandBuilder()
         {
             // CommandBuilder is not supported yet in .NET Core.
         }
 
-        public static void TestInitialCatalogStandardValues(SqlConnection connection)
+        [CheckConnStrSetupFact]
+        public static void TestInitialCatalogStandardValues()
         {
             // PropertyDescriptor is not supported yet in .NET Core.
         }

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlSchemaInfoTest/SqlSchemaInfoTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlSchemaInfoTest/SqlSchemaInfoTest.cs
@@ -1,0 +1,50 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Data.Common;
+
+namespace System.Data.SqlClient.ManualTesting.Tests
+{
+    public static class SqlSchemaInfoTest
+    {
+        [CheckConnStrSetupFact]
+        public static void TestSqlSchemaInfo()
+        {
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr);
+
+            using (SqlConnection connection = new SqlConnection(builder.ConnectionString))
+            {
+                connection.Open();
+
+                TestGetSchema(connection);
+                TestCommandBuilder(connection);
+                TestInitialCatalogStandardValues(connection);
+
+                connection.Close();
+            }
+        }
+
+        public static void TestGetSchema(SqlConnection connection)
+        {
+            DataTable dataTable = connection.GetSchema("DATABASES");
+
+            if (dataTable.Rows.Count > 0)
+            {
+                DataTable metaDataCollections = connection.GetSchema(DbMetaDataCollectionNames.MetaDataCollections);
+                DataTable metaDataSourceInfo = connection.GetSchema(DbMetaDataCollectionNames.DataSourceInformation);
+                DataTable metaDataTypes = connection.GetSchema(DbMetaDataCollectionNames.DataTypes);
+            }
+        }
+
+        public static void TestCommandBuilder(SqlConnection connection)
+        {
+            // CommandBuilder is not supported yet in .NET Core.
+        }
+
+        public static void TestInitialCatalogStandardValues(SqlConnection connection)
+        {
+            // PropertyDescriptor is not supported yet in .NET Core.
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
@@ -56,6 +56,7 @@
     <Compile Include="SQL\MARSSessionPoolingTest\MARSSessionPoolingTest.cs" />
     <Compile Include="SQL\MARSTest\MARSTest.cs" />
     <Compile Include="SQL\ParallelTransactionsTest\ParallelTransactionsTest.cs" />
+    <Compile Include="SQL\SqlSchemaInfoTest\SqlSchemaInfoTest.cs" />
     <Compile Include="SQL\SqlBulkCopyTest\ErrorOnRowsMarkedAsDeleted.cs" />
     <Compile Include="SQL\SqlBulkCopyTest\Bug84548.cs" />
     <Compile Include="SQL\SqlBulkCopyTest\Bug85007.cs" />


### PR DESCRIPTION
*`SqlSchemaInfoTest`* was ported from .NET Framework into .NET Core manual test.