### PR TITLE
Add InteropEventProvider to  built in provider  list for  UAPAOT

### DIFF
--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestUtilities.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestUtilities.cs
@@ -26,7 +26,9 @@ namespace BasicEventSourceTests
                 if (eventSource.Name != "System.Threading.Tasks.TplEventSource" &&
                     eventSource.Name != "System.Diagnostics.Eventing.FrameworkEventSource" &&
                     eventSource.Name != "System.Buffers.ArrayPoolEventSource" &&
-                    eventSource.Name != "System.Threading.SynchronizationEventSource")
+                    eventSource.Name != "System.Threading.SynchronizationEventSource" &&
+                    eventSource.Name != "System.Runtime.InteropServices.InteropEventProvider"
+                    )
                 {
                     eventSourceNames += eventSource.Name + " ";
                 }


### PR DESCRIPTION
CheckNoEventSourcesRunning fails in uapaot since
InteropEventProvider was include in the
built in provide list.

@brianrob 