### PR TITLE
Disable some WebProxy tests for UAP/ILC test runs

### DIFF
--- a/src/System.Net.WebProxy/tests/WebProxyTest.cs
+++ b/src/System.Net.WebProxy/tests/WebProxyTest.cs
@@ -175,6 +175,7 @@ namespace System.Net.Tests
             yield return new object[] { new Uri($"http://{IPAddress.None}"), false };
         }
 
+        [ActiveIssue(20137, TargetFrameworkMonikers.Uap)]
         [Theory]
         [MemberData(nameof(BypassOnLocal_MemberData))]
         public static void BypassOnLocal_MatchesExpected(Uri destination, bool isLocal)


### PR DESCRIPTION
Disable some WebProxy tests on 'uap' and 'uap-aot' test runs
Contributes to #20137.