### PR TITLE
Skipping two System.Text.Encoding tests on uapaot since they were crashing the ilc test run

### DIFF
--- a/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingDecode.cs
+++ b/src/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingDecode.cs
@@ -103,6 +103,7 @@ namespace System.Text.Tests
 
         [Theory]
         [MemberData(nameof(Decode_TestData))]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20525", TargetFrameworkMonikers.UapAot)]
         public void Decode(byte[] bytes, int index, int count, string expected)
         {
             EncodingHelpers.Decode(new UTF8Encoding(true, false), bytes, index, count, expected);

--- a/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingDecode.cs
+++ b/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingDecode.cs
@@ -73,6 +73,7 @@ namespace System.Text.Tests
 
         [Theory]
         [MemberData(nameof(Decode_TestData))]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20525", TargetFrameworkMonikers.UapAot)]
         public void Decode(byte[] littleEndianBytes, int index, int count, string expected)
         {
             byte[] bigEndianBytes = GetBigEndianBytes(littleEndianBytes, index, count);


### PR DESCRIPTION
cc: @danmosemsft @stephentoub 

Two theories where causing a crash in uapaot test runs for System.Text.Encoding only on Debug runs. I believe the reason is we were hitting a Debug.Assert() when trying to parse some of the member data that gets passed in. I have added more details + callstack on bug #20525 