### PR TITLE
Fix inheritance of console dup'd file descriptors

### DIFF
--- a/src/Native/Unix/System.Native/pal_io.cpp
+++ b/src/Native/Unix/System.Native/pal_io.cpp
@@ -264,7 +264,7 @@ extern "C" int32_t SystemNative_Close(intptr_t fd)
 extern "C" intptr_t SystemNative_Dup(intptr_t oldfd)
 {
     int result;
-    while (CheckInterrupted(result = dup(ToFileDescriptor(oldfd))));
+    while (CheckInterrupted(result = fcntl(ToFileDescriptor(oldfd), F_DUPFD_CLOEXEC, 0)));
     return result;
 }
 


### PR DESCRIPTION
Console file descriptors are being dup'd but without CLOEXEC.  As a result, the dup'd descriptors end up being inherited into any child processes unnecessarily.

cc: @tmds, @janvorli 