### PR TITLE
Fix temp keychain timeout

### DIFF
--- a/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Keychain.cs
+++ b/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Keychain.cs
@@ -40,6 +40,9 @@ internal static partial class Interop
             out SafeKeychainHandle keychain);
 
         [DllImport(Libraries.AppleCryptoNative)]
+        private static extern int AppleCryptoNative_SetKeychainNeverLock(SafeKeychainHandle keychain);
+
+        [DllImport(Libraries.AppleCryptoNative)]
         private static extern int AppleCryptoNative_SecKeychainEnumerateCerts(
             SafeKeychainHandle keychain,
             out SafeCFArrayHandle matches,
@@ -178,6 +181,11 @@ internal static partial class Interop
                 out keychain);
 
             SafeTemporaryKeychainHandle.TrackKeychain(keychain);
+
+            if (osStatus == 0)
+            {
+                osStatus = AppleCryptoNative_SetKeychainNeverLock(keychain);
+            }
 
             if (osStatus != 0)
             {

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_keychain.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_keychain.cpp
@@ -67,6 +67,15 @@ extern "C" int32_t AppleCryptoNative_SecKeychainOpen(const char* pszKeychainPath
     return SecKeychainOpen(pszKeychainPath, pKeychainOut);
 }
 
+extern "C" int32_t AppleCryptoNative_SetKeychainNeverLock(SecKeychainRef keychain)
+{
+    SecKeychainSettings settings = {
+        .version = SEC_KEYCHAIN_SETTINGS_VERS1, .useLockInterval = 0, .lockOnSleep = 0, .lockInterval = INT_MAX,
+    };
+
+    return SecKeychainSetSettings(keychain, &settings);
+}
+
 static int32_t
 EnumerateKeychain(SecKeychainRef keychain, CFStringRef matchType, CFArrayRef* pCertsOut, int32_t* pOSStatus)
 {

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_keychain.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_keychain.h
@@ -61,6 +61,13 @@ pKeychainOut: Receives the SecKeychainRef for the named keychain.
 extern "C" int32_t AppleCryptoNative_SecKeychainOpen(const char* pszKeychainPath, SecKeychainRef* pKeychainOut);
 
 /*
+Set a keychain to never (automatically) lock.
+
+Returns the result of SecKeychainSetSettings to a never-auto-lock policy.
+*/
+extern "C" int32_t AppleCryptoNative_SetKeychainNeverLock(SecKeychainRef keychain);
+
+/*
 Enumerate the certificate objects within the given keychain.
 
 Returns 1 on success (including "no certs found"), 0 on failure, any other value for invalid state.


### PR DESCRIPTION
The default lock policy on a new keychain is to lock on sleep and after 5 minutes
of being idle.  This means that if more than 5 minutes pass from usages of a
certificate private key (where the cert was opened from a PFX) the user gets
prompted for a password for the temporary keychain.  Since that keychain has
a randomly generated password it's not really possible for the user to accomplish
this successfully.

No tests cover this scenario, since they require more than 5 minutes of idle time.

Master version of #20509.