### PR TITLE
Fix BinaryFormatter to properly deserialize objects with different ve…

### DIFF
--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryObjectReader.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryObjectReader.cs
@@ -942,37 +942,33 @@ namespace System.Runtime.Serialization.Formatters.Binary
 
             if (entry == null || entry.AssemblyName != assemblyName)
             {
-                Assembly assm = null;
-
                 // Check early to avoid throwing unnecessary exceptions
                 if (assemblyName == null)
                 {
                     return null;
                 }
 
+                Assembly assm = null;
+                AssemblyName assmName = null;
+
+                try
+                {
+                    assmName = new AssemblyName(assemblyName);
+                }
+                catch
+                {
+                    return null;
+                }
+
                 if (_isSimpleAssembly)
                 {
-                    try
-                    {
-                        assm = Assembly.Load(assemblyName);
-                    }
-                    catch { }
-
-                    if (assm == null)
-                    {
-                        try
-                        {
-                            AssemblyName asmName = new AssemblyName(assemblyName);
-                            assm = Assembly.Load(asmName.Name);
-                        }
-                        catch { }
-                    }
+                    assm = ResolveSimpleAssemblyName(assmName);
                 }
                 else
                 {
                     try
                     {
-                        assm = Assembly.Load(new AssemblyName(assemblyName));
+                        assm = Assembly.Load(assmName);
                     }
                     catch { }
                 }
@@ -1040,7 +1036,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
             catch (FileLoadException) { }
             catch (BadImageFormatException) { }
 
-            if(type == null)
+            if (type == null)
             {
                 type = Type.GetType(typeName, ResolveSimpleAssemblyName, new TopLevelAssemblyTypeResolver(assm).ResolveType, throwOnError: false);
             }

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryObjectReader.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryObjectReader.cs
@@ -943,6 +943,13 @@ namespace System.Runtime.Serialization.Formatters.Binary
             if (entry == null || entry.AssemblyName != assemblyName)
             {
                 Assembly assm = null;
+
+                // Check early to avoid throwing unnecessary exceptions
+                if (assemblyName == null)
+                {
+                    return null;
+                }
+
                 if (_isSimpleAssembly)
                 {
                     try
@@ -1033,7 +1040,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
             catch (FileLoadException) { }
             catch (BadImageFormatException) { }
 
-            if((object)type == null)
+            if(type == null)
             {
                 type = Type.GetType(typeName, ResolveSimpleAssemblyName, new TopLevelAssemblyTypeResolver(assm).ResolveType, throwOnError: false);
             }
@@ -1089,19 +1096,21 @@ namespace System.Runtime.Serialization.Formatters.Binary
 
         internal sealed class TopLevelAssemblyTypeResolver
         {
-            private Assembly m_topLevelAssembly;
+            private readonly Assembly _topLevelAssembly;
 
             public TopLevelAssemblyTypeResolver(Assembly topLevelAssembly)
             {
-                m_topLevelAssembly = topLevelAssembly;
+                _topLevelAssembly = topLevelAssembly;
             }
 
             public Type ResolveType(Assembly assembly, string simpleTypeName, bool ignoreCase)
             {
                 if (assembly == null)
-                    assembly = m_topLevelAssembly;
+                {
+                    assembly = _topLevelAssembly;
+                }
 
-                return assembly.GetType(simpleTypeName, false, ignoreCase);
+                return assembly.GetType(simpleTypeName, throwOnError: false, ignoreCase: ignoreCase);
             }
         }
     }

--- a/src/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
@@ -140,6 +140,30 @@ namespace System.Runtime.Serialization.Formatters.Tests
             }
         }
 
+        [Fact]
+        public void ValidateDeserializationOfObjectWithDifferentAssemblyVersion()
+        {
+            // To generate this properly, change AssemblyVersion to a value which is unlikely to happen in production and generate base64(serialized-data)
+            // For this test 9.98.7.987 is being used
+            var obj = new SomeType() { SomeField = 7 };
+            string serializedObj = @"AAEAAAD/////AQAAAAAAAAAMAgAAAHNTeXN0ZW0uUnVudGltZS5TZXJpYWxpemF0aW9uLkZvcm1hdHRlcnMuVGVzdHMsIFZlcnNpb249OS45OC43Ljk4NywgQ3VsdHVyZT1uZXV0cmFsLCBQdWJsaWNLZXlUb2tlbj05ZDc3Y2M3YWQzOWI2OGViBQEAAAA2U3lzdGVtLlJ1bnRpbWUuU2VyaWFsaXphdGlvbi5Gb3JtYXR0ZXJzLlRlc3RzLlNvbWVUeXBlAQAAAAlTb21lRmllbGQACAIAAAAHAAAACw==";
+
+            var deserialized = (SomeType)DeserializeObjectHash(serializedObj);
+            Assert.Equal(obj, deserialized);
+        }
+
+        [Fact]
+        public void ValidateDeserializationOfObjectWithGenericTypeWhichGenericArgumentHasDifferentAssemblyVersion()
+        {
+            // To generate this properly, change AssemblyVersion to a value which is unlikely to happen in production and generate base64(serialized-data)
+            // For this test 9.98.7.987 is being used
+            var obj = new GenericTypeWithArg<SomeType>() { Test = new SomeType() { SomeField = 9 } };
+            string serializedObj = @"AAEAAAD/////AQAAAAAAAAAMAgAAAHNTeXN0ZW0uUnVudGltZS5TZXJpYWxpemF0aW9uLkZvcm1hdHRlcnMuVGVzdHMsIFZlcnNpb249OS45OC43Ljk4NywgQ3VsdHVyZT1uZXV0cmFsLCBQdWJsaWNLZXlUb2tlbj05ZDc3Y2M3YWQzOWI2OGViBQEAAADxAVN5c3RlbS5SdW50aW1lLlNlcmlhbGl6YXRpb24uRm9ybWF0dGVycy5UZXN0cy5HZW5lcmljVHlwZVdpdGhBcmdgMVtbU3lzdGVtLlJ1bnRpbWUuU2VyaWFsaXphdGlvbi5Gb3JtYXR0ZXJzLlRlc3RzLlNvbWVUeXBlLCBTeXN0ZW0uUnVudGltZS5TZXJpYWxpemF0aW9uLkZvcm1hdHRlcnMuVGVzdHMsIFZlcnNpb249OS45OC43Ljk4NywgQ3VsdHVyZT1uZXV0cmFsLCBQdWJsaWNLZXlUb2tlbj05ZDc3Y2M3YWQzOWI2OGViXV0BAAAABFRlc3QENlN5c3RlbS5SdW50aW1lLlNlcmlhbGl6YXRpb24uRm9ybWF0dGVycy5UZXN0cy5Tb21lVHlwZQIAAAACAAAACQMAAAAFAwAAADZTeXN0ZW0uUnVudGltZS5TZXJpYWxpemF0aW9uLkZvcm1hdHRlcnMuVGVzdHMuU29tZVR5cGUBAAAACVNvbWVGaWVsZAAIAgAAAAkAAAAL";
+
+            var deserialized = (GenericTypeWithArg<SomeType>)DeserializeObjectHash(serializedObj);
+            Assert.Equal(obj, deserialized);
+        }
+
         [Theory]
         [MemberData(nameof(EqualityComparers))]
         public void ValidateDeserializationOfEqualityComparers(object original, string[] base64SerializedObj)

--- a/src/System.Runtime.Serialization.Formatters/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/SerializationTypes.cs
@@ -466,6 +466,46 @@ namespace System.Runtime.Serialization.Formatters.Tests
         }
     }
 
+    [Serializable]
+    internal class GenericTypeWithArg<T>
+    {
+        public T Test;
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null || GetType() != obj.GetType())
+                return false;
+
+            var p = (GenericTypeWithArg<T>)obj;
+            return Test.Equals(p.Test);
+        }
+
+        public override int GetHashCode()
+        {
+            return Test == null ? 0 : Test.GetHashCode();
+        }
+    }
+
+    [Serializable]
+    internal class SomeType
+    {
+        public int SomeField;
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null || GetType() != obj.GetType())
+                return false;
+
+            var p = (SomeType)obj;
+            return SomeField.Equals(p.SomeField);
+        }
+
+        public override int GetHashCode()
+        {
+            return SomeField;
+        }
+    }
+
     internal static class EqualityHelpers
     {
         public static bool ArraysAreEqual<T>(T[] array1, T[] array2)


### PR DESCRIPTION
Fix BinaryFormatter to properly deserialize objects with different version when AssemblyFormat is set to Simple

- [x] needs clean up to match desktop more closely
- [ ] once PR is merged replace last commit in https://github.com/dotnet/corefx/pull/20530