### PR TITLE
XmlResolver: remove workaround for lack of Unix path support in Uri

### DIFF
--- a/src/System.Private.Xml/src/System/Xml/XmlResolver.cs
+++ b/src/System.Private.Xml/src/System/Xml/XmlResolver.cs
@@ -40,7 +40,7 @@ namespace System.Xml
                 Uri uri = new Uri(relativeUri, UriKind.RelativeOrAbsolute);
                 if (!uri.IsAbsoluteUri && uri.OriginalString.Length > 0)
                 {
-                    uri = new Uri(Uri.UriSchemeFile + Uri.SchemeDelimiter + Path.GetFullPath(relativeUri));
+                    uri = new Uri(Path.GetFullPath(relativeUri));
                 }
                 return uri;
             }

--- a/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XslTransformMultith.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XslTransformMultith.cs
@@ -29,7 +29,7 @@ namespace System.Xml.Tests
         public new void Init(object objParam)
         {
             xsltSameInstance = new XslCompiledTransform();
-            _strPath = Path.Combine(@"TestFiles\", FilePathUtil.GetTestDataPath(), @"XsltApiV2\");
+            _strPath = Path.Combine("TestFiles", FilePathUtil.GetTestDataPath(), "XsltApiV2");
             return;
         }
     }
@@ -48,7 +48,7 @@ namespace System.Xml.Tests
 
         public void Load(string _strXslFile, string _strXmlFile)
         {
-            _xrData = XmlReader.Create(_strPath + _strXmlFile);
+            _xrData = XmlReader.Create(Path.Combine(_strPath, _strXmlFile));
             _xd = new XPathDocument(_xrData, XmlSpace.Preserve);
             _xrData.Dispose();
 
@@ -56,7 +56,7 @@ namespace System.Xml.Tests
 #pragma warning disable 0618
             xrs.ProhibitDtd = false;
 #pragma warning restore 0618
-            XmlReader xrTemp = XmlReader.Create(_strPath + _strXslFile, xrs);
+            XmlReader xrTemp = XmlReader.Create(Path.Combine(_strPath, _strXslFile), xrs);
             xsltSameInstance.Load(xrTemp);
         }
 
@@ -362,7 +362,7 @@ namespace System.Xml.Tests
 
         public void Load(string _strXslFile, string _strXmlFile)
         {
-            _xrData = XmlReader.Create(_strPath + _strXmlFile);
+            _xrData = XmlReader.Create(Path.Combine(_strPath, _strXmlFile));
             _xd = new XPathDocument(_xrData, XmlSpace.Preserve);
             _xrData.Dispose();
 
@@ -370,7 +370,7 @@ namespace System.Xml.Tests
 #pragma warning disable 0618
             xrs.ProhibitDtd = false;
 #pragma warning restore 0618
-            XmlReader xrTemp = XmlReader.Create(_strPath + _strXslFile, xrs);
+            XmlReader xrTemp = XmlReader.Create(Path.Combine(_strPath, _strXslFile), xrs);
             xsltSameInstance.Load(xrTemp);
         }
 

--- a/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XsltArgumentListMultith.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XsltArgumentListMultith.cs
@@ -29,7 +29,7 @@ namespace System.Xml.Tests
         public new void Init(object objParam)
         {
             // Get parameter info
-            _strPath = Path.Combine(@"TestFiles\", FilePathUtil.GetTestDataPath(), @"XsltApiV2\");
+            _strPath = Path.Combine("TestFiles", FilePathUtil.GetTestDataPath(), "XsltApiV2");
             xsltArg1 = new XsltArgumentList();
 
             MyObject obj1 = new MyObject(1, _output);
@@ -246,9 +246,9 @@ namespace System.Xml.Tests
             string _strXmlFile = ((object[])args)[2].ToString();
 
             if (_strXslFile.Substring(0, 5) != "http:")
-                _strXslFile = _strPath + _strXslFile;
+                _strXslFile = Path.Combine(_strPath, _strXslFile);
             if (_strXmlFile.Substring(0, 5) != "http:")
-                _strXmlFile = _strPath + _strXmlFile;
+                _strXmlFile = Path.Combine(_strPath, _strXmlFile);
 
             XmlReader xrData = XmlReader.Create(_strXmlFile);
             XPathDocument xd = new XPathDocument(xrData, XmlSpace.Preserve);

--- a/src/System.Private.Xml/tests/Xslt/XslTransformApi/CXsltArgumentListMultith.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslTransformApi/CXsltArgumentListMultith.cs
@@ -31,7 +31,7 @@ namespace System.Xml.Tests
         public new void Init(object objParam)
         {
             // Get parameter info
-            _strPath = Path.Combine(@"TestFiles\", FilePathUtil.GetTestDataPath(), @"XsltApi\");
+            _strPath = Path.Combine("TestFiles", FilePathUtil.GetTestDataPath(), "XsltApi");
 
             xsltArg1 = new XsltArgumentList();
 


### PR DESCRIPTION
cc @stephentoub 

Some tests were relying on the Uri class to convert backslashes to forward slashes.