### PR TITLE
Enable temporary auto-retry for scm checkout

### DIFF
--- a/buildpipeline/portable-windows.groovy
+++ b/buildpipeline/portable-windows.groovy
@@ -9,7 +9,9 @@ def submittedHelixJson = null
 
 simpleNode('Windows_NT','latest') {
     stage ('Checkout source') {
-        checkout scm
+        retry (10) {
+            checkout scm
+        }
     }
 
     def logFolder = getLogFolder()


### PR DESCRIPTION
Wrap the scm checkout in a retry.  This is not ideal as it doesn't cover the scm checkout of the pipeline script itself.  It should fix some of the git issues we've seen.  The real bug is https://issues.jenkins-ci.org/browse/JENKINS-39194.  This means that "checkout scm" would honor the global scm checkout retry count for both the step as well as the pipeline checkout