### PR TITLE
Set EnableDefaultItems=false in the environment in init-tools scripts

### DIFF
--- a/init-tools.cmd
+++ b/init-tools.cmd
@@ -1,4 +1,7 @@
 @if not defined _echo @echo off
+:: want this environment variable to persist for the other build steps so moving above setlocal.
+set DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+
 setlocal
 
 set INIT_TOOLS_LOG=%~dp0init-tools.log

--- a/init-tools.cmd
+++ b/init-tools.cmd
@@ -56,6 +56,9 @@ if NOT exist "%BUILD_TOOLS_PATH%init-tools.cmd" (
 
 :afterbuildtoolsrestore
 
+:: We restore a few msbuild base projects that don't need any default items discovered so to disable those default
+:: item traversals setting the env variable to false. This should probably be done in BuildTools once we confirm it works.
+set EnableDefaultItems=false
 echo Initializing BuildTools...
 echo Running: "%BUILD_TOOLS_PATH%init-tools.cmd" "%~dp0" "%DOTNET_CMD%" "%TOOLRUNTIME_DIR%" >> "%INIT_TOOLS_LOG%"
 call "%BUILD_TOOLS_PATH%init-tools.cmd" "%~dp0" "%DOTNET_CMD%" "%TOOLRUNTIME_DIR%" >> "%INIT_TOOLS_LOG%"

--- a/init-tools.cmd
+++ b/init-tools.cmd
@@ -56,10 +56,6 @@ if NOT exist "%BUILD_TOOLS_PATH%init-tools.cmd" (
 
 :afterbuildtoolsrestore
 
-:: We restore a few msbuild base projects that don't need any default items discovered so to disable those default
-:: item traversals setting the env variable to false. This should probably be done in BuildTools once we confirm it works.
-set EnableDefaultItems=false
-echo Initializing BuildTools...
 echo Running: "%BUILD_TOOLS_PATH%init-tools.cmd" "%~dp0" "%DOTNET_CMD%" "%TOOLRUNTIME_DIR%" >> "%INIT_TOOLS_LOG%"
 call "%BUILD_TOOLS_PATH%init-tools.cmd" "%~dp0" "%DOTNET_CMD%" "%TOOLRUNTIME_DIR%" >> "%INIT_TOOLS_LOG%"
 set INIT_TOOLS_ERRORLEVEL=%ERRORLEVEL%
@@ -71,4 +67,6 @@ if not [%INIT_TOOLS_ERRORLEVEL%]==[0] (
 :: Create sempahore file
 echo Done initializing tools.
 echo Init-Tools.cmd completed for BuildTools Version: %BUILDTOOLS_VERSION% > "%BUILD_TOOLS_SEMAPHORE%"
+
+type %INIT_TOOLS_LOG%
 exit /b 0


### PR DESCRIPTION
This should block the restore command from trying to discover all
the default items on the disk when they aren't needed for anything.

@danmosemsft @mmitche this is an attempt to see if we can reduce the time it takes during init-tools. 