### PR TITLE
Change RuntimeEnvironment.GetRuntimeDirectory to use AppDomain.CurrentDomain.BaseDirectory

### DIFF
--- a/src/System.Runtime.InteropServices/src/System.Runtime.InteropServices.csproj
+++ b/src/System.Runtime.InteropServices/src/System.Runtime.InteropServices.csproj
@@ -44,15 +44,13 @@
   </ItemGroup>
   <ItemGroup>
     <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="..\..\System.Runtime.Extensions\src\System.Runtime.Extensions.csproj"/>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'uapaot'">
     <ReferenceFromRuntime Include="System.Private.Interop" />
     <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj">
       <TargetGroup>uapaot</TargetGroup>
-    </ProjectReference>
-    <ProjectReference Include="..\..\System.Runtime.Extensions\src\System.Runtime.Extensions.csproj">
-      <TargetGroup>uapaot</TargetGroup>
-    </ProjectReference>
+    </ProjectReference>  
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime.InteropServices/src/System/Runtime/InteropServices/RuntimeEnvironment.cs
+++ b/src/System.Runtime.InteropServices/src/System/Runtime/InteropServices/RuntimeEnvironment.cs
@@ -23,7 +23,12 @@ namespace System.Runtime.InteropServices
         }
         public static string GetRuntimeDirectory()
         {
-            return Path.GetDirectoryName(typeof(object).Assembly.Location) + Path.DirectorySeparatorChar;
+            string runtimeDirectory = typeof(object).Assembly.Location;
+            if(string.IsNullOrEmpty(runtimeDirectory) || !Path.IsPathRooted(runtimeDirectory))
+            { 
+                return Path.GetDirectoryName(AppDomain.CurrentDomain.BaseDirectory) + Path.DirectorySeparatorChar;
+            }
+            return Path.GetDirectoryName(runtimeDirectory) + Path.DirectorySeparatorChar;
         }
         public static System.IntPtr GetRuntimeInterfaceAsIntPtr(Guid clsid, Guid riid)
         {

--- a/src/System.Runtime.InteropServices/src/System/Runtime/InteropServices/RuntimeEnvironment.cs
+++ b/src/System.Runtime.InteropServices/src/System/Runtime/InteropServices/RuntimeEnvironment.cs
@@ -24,9 +24,9 @@ namespace System.Runtime.InteropServices
         public static string GetRuntimeDirectory()
         {
             string runtimeDirectory = typeof(object).Assembly.Location;
-            if(string.IsNullOrEmpty(runtimeDirectory) || !Path.IsPathRooted(runtimeDirectory))
-            { 
-                return Path.GetDirectoryName(AppDomain.CurrentDomain.BaseDirectory) + Path.DirectorySeparatorChar;
+            if (!Path.IsPathRooted(runtimeDirectory))
+            {
+                runtimeDirectory = AppDomain.CurrentDomain.BaseDirectory;
             }
             return Path.GetDirectoryName(runtimeDirectory) + Path.DirectorySeparatorChar;
         }

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/HandleCollectorTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/HandleCollectorTests.cs
@@ -60,6 +60,7 @@ namespace System.Runtime.InteropServices
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot,"Reflects on private member handleCount")]
         public static void CountOverflow()
         {
             HandleCollector collector = new HandleCollector("CountOverflow", int.MaxValue);

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/MarshalTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/MarshalTests.cs
@@ -417,11 +417,11 @@ namespace System.Runtime.InteropServices
             Marshal.FreeCoTaskMem(ptr);                          
         }
         
-        [Fact]
+        [Fact]        
         public static void BindToMoniker()
         {
             String monikerName = null;
-            if(PlatformDetection.IsWindows)
+            if(PlatformDetection.IsWindows && !PlatformDetection.IsNetNative)
             {
                 if (PlatformDetection.IsNotWindowsNanoServer)
                 {
@@ -434,10 +434,10 @@ namespace System.Runtime.InteropServices
             }        
         }
 
-        [Fact]
+        [Fact]        
         public static void ChangeWrapperHandleStrength() 
         {
-            if(PlatformDetection.IsWindows)
+            if(PlatformDetection.IsWindows && !PlatformDetection.IsNetNative)
             {
                 Assert.Throws<ArgumentNullException>(() => Marshal.ChangeWrapperHandleStrength(null, true));
             }  

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/RuntimeEnvironmentTest.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/RuntimeEnvironmentTest.cs
@@ -13,9 +13,15 @@ namespace System.Runtime.InteropServices
     public static class RuntimeEnvironmentTest
     {
         [Fact]
-        public static void RuntimeEnvironmentPosTest()
+        public static void RuntimeEnvironmentRuntimeDirectory()
         {
             Assert.True(Directory.Exists(RuntimeEnvironment.GetRuntimeDirectory()));
+        }
+
+        [Fact]
+        [ActiveIssue(20600, TargetFrameworkMonikers.UapAot)]
+        public static void RuntimeEnvironmentSysVersion()
+        {            
             Assert.True(!String.IsNullOrEmpty(RuntimeEnvironment.GetSystemVersion()));
         }
 


### PR DESCRIPTION
AppDomain.CurrentDomain.BaseDirectory

Change RuntimeEnvironment.GetRuntimeDirectory
Disable couple of InteropServices tests which
won't work on UWP.
@yizhang82 @botaberg @AtsushiKan 