### PR TITLE
Port fix for debian9 test

### DIFF
--- a/src/Common/tests/System/PlatformDetection.cs
+++ b/src/Common/tests/System/PlatformDetection.cs
@@ -173,6 +173,7 @@ namespace System
             return false;
         }
 
+        public static bool IsDebian => IsDistroAndVersion("debian");
         public static bool IsDebian8 => IsDistroAndVersion("debian", "8");
         public static bool IsUbuntu1404 => IsDistroAndVersion("ubuntu", "14.04");
         public static bool IsCentos7 => IsDistroAndVersion("centos", "7");

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoData.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoData.cs
@@ -14,7 +14,9 @@ namespace System.Globalization.Tests
                 ||
                 (PlatformDetection.IsOSX && PlatformDetection.OSXKernelVersion >= new Version(15, 0))
 #endif
-                || (PlatformDetection.IsUbuntu && !PlatformDetection.IsUbuntu1404) || PlatformDetection.IsFedora
+                || (PlatformDetection.IsUbuntu && !PlatformDetection.IsUbuntu1404)
+                || PlatformDetection.IsFedora
+                || (PlatformDetection.IsDebian && !PlatformDetection.IsDebian8)
                )
             {
                 return new int[] { 3 };


### PR DESCRIPTION
We recently enabled Debian9 in 2.0. Port fix to test from https://github.com/dotnet/corefx/pull/20218