### PR TITLE
Fix System.Diagnostics.Process.Tests and skip some others

### DIFF
--- a/src/Common/tests/System/Diagnostics/RemoteExecutorTestBase.cs
+++ b/src/Common/tests/System/Diagnostics/RemoteExecutorTestBase.cs
@@ -16,7 +16,7 @@ namespace System.Diagnostics
         /// <summary>The name of the test console app.</summary>
         protected static readonly string TestConsoleApp = "RemoteExecutorConsoleApp.exe";
         /// <summary>The name, without an extension, of the host used to host the test console app.</summary>
-        private static readonly string HostRunnerExecutableName = IsFullFramework ? "xunit.console" : "dotnet";
+        private static readonly string HostRunnerExecutableName = IsFullFramework ? "xunit.console" : IsNetNative ? "xunit.console.netcore" : "dotnet";
         /// <summary>The name, with an extension, of the host host used to host the test console app.</summary>
         protected static readonly string HostRunnerName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? HostRunnerExecutableName + ".exe" : HostRunnerExecutableName;
         /// <summary>The absolute path to the host runner executable.</summary>

--- a/src/System.Diagnostics.Process/tests/ProcessCollectionTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessCollectionTests.cs
@@ -59,6 +59,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestThreadCollectionBehavior()
         {
             CreateDefaultProcess();

--- a/src/System.Diagnostics.Process/tests/ProcessStandardConsoleTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStandardConsoleTests.cs
@@ -14,6 +14,7 @@ namespace System.Diagnostics.Tests
         private const int s_ConsoleEncoding = 437;
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestChangesInConsoleEncoding()
         {
             Action<int> run = expectedCodePage =>

--- a/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -196,6 +196,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestEnvironmentOfChildProcess()
         {
             const string ItemSeparator = "CAFF9451396B4EEF8A5155A15BDC2080"; // random string that shouldn't be in any env vars; used instead of newline to separate env var strings
@@ -322,6 +323,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Theory, InlineData(true), InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestCreateNoWindowProperty(bool value)
         {
             Process testProcess = CreateProcessLong();
@@ -342,6 +344,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestWorkingDirectoryProperty()
         {
             CreateDefaultProcess();
@@ -505,6 +508,13 @@ namespace System.Diagnostics.Tests
         public void Verbs_GetWithExeExtension_ReturnsExpected()
         {
             var psi = new ProcessStartInfo { FileName = $"{Process.GetCurrentProcess().ProcessName}.exe" };
+
+            if (PlatformDetection.IsNetNative)
+            {
+                // UapAot doesn't have RegistryKey apis available so ProcessStartInfo.Verbs returns Array<string>.Empty().
+                Assert.Equal(0, psi.Verbs.Length);
+                return;
+            }
 
             Assert.Contains("open", psi.Verbs, StringComparer.OrdinalIgnoreCase);
             if (PlatformDetection.IsNotWindowsNanoServer)

--- a/src/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace System.Diagnostics.Tests
 {
+    [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
     public class ProcessStreamReadTests : ProcessTestBase
     {
         [Fact]

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -60,6 +60,7 @@ namespace System.Diagnostics.Tests
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [PlatformSpecific(TestPlatforms.Windows)]  // Expected behavior varies on Windows and Unix
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestBasePriorityOnWindows()
         {
             CreateDefaultProcess();
@@ -89,6 +90,7 @@ namespace System.Diagnostics.Tests
         [InlineData(true)]
         [InlineData(false)]
         [InlineData(null)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestEnableRaiseEvents(bool? enable)
         {
             bool exitedInvoked = false;
@@ -118,6 +120,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestExitCode()
         {
             {
@@ -135,6 +138,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestExitTime()
         {
             // ExitTime resolution on some platforms is less accurate than our DateTime.UtcNow resolution, so
@@ -162,6 +166,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestId()
         {
             CreateDefaultProcess();
@@ -178,6 +183,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestHasExited()
         {
             {
@@ -219,6 +225,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestMachineName()
         {
             CreateDefaultProcess();
@@ -245,6 +252,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestMaxWorkingSet()
         {
             CreateDefaultProcess();
@@ -299,6 +307,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestMinWorkingSet()
         {
             CreateDefaultProcess();
@@ -370,6 +379,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestNonpagedSystemMemorySize64()
         {
             CreateDefaultProcess();
@@ -385,6 +395,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestPagedMemorySize64()
         {
             CreateDefaultProcess();
@@ -400,6 +411,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestPagedSystemMemorySize64()
         {
             CreateDefaultProcess();
@@ -415,6 +427,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestPeakPagedMemorySize64()
         {
             CreateDefaultProcess();
@@ -430,6 +443,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestPeakVirtualMemorySize64()
         {
             CreateDefaultProcess();
@@ -445,6 +459,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestPeakWorkingSet64()
         {
             CreateDefaultProcess();
@@ -460,6 +475,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestPrivateMemorySize64()
         {
             CreateDefaultProcess();
@@ -475,6 +491,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestVirtualMemorySize64()
         {
             CreateDefaultProcess();
@@ -490,6 +507,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestWorkingSet64()
         {
             CreateDefaultProcess();
@@ -512,6 +530,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestProcessorTime()
         {
             CreateDefaultProcess();
@@ -555,6 +574,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestProcessStartTime()
         {
             TimeSpan allowedWindow = TimeSpan.FromSeconds(3);
@@ -579,6 +599,7 @@ namespace System.Diagnostics.Tests
 
         [Fact]
         [PlatformSpecific(~TestPlatforms.OSX)] // getting/setting affinity not supported on OSX
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestProcessorAffinity()
         {
             CreateDefaultProcess();
@@ -597,6 +618,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestPriorityBoostEnabled()
         {
             CreateDefaultProcess();
@@ -626,6 +648,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact, PlatformSpecific(TestPlatforms.Windows)]  // Expected behavior varies on Windows and Unix
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestPriorityClassWindows()
         {
             CreateDefaultProcess();
@@ -662,12 +685,13 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestProcessName()
         {
             CreateDefaultProcess();
 
             // Processes are not hosted by dotnet in the full .NET Framework.
-            string expected = PlatformDetection.IsFullFramework ? TestConsoleApp : HostRunner;
+            string expected = PlatformDetection.IsFullFramework || PlatformDetection.IsNetNative ? TestConsoleApp : HostRunner;
             Assert.Equal(Path.GetFileNameWithoutExtension(_process.ProcessName), Path.GetFileNameWithoutExtension(expected), StringComparer.OrdinalIgnoreCase);
         }
 
@@ -679,6 +703,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestSafeHandle()
         {
             CreateDefaultProcess();
@@ -694,6 +719,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestSessionId()
         {
             CreateDefaultProcess();
@@ -732,6 +758,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestGetProcessById()
         {
             CreateDefaultProcess();
@@ -773,6 +800,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void GetProcessesByName_ProcessName_ReturnsExpected()
         {
             // Get the current process using its name
@@ -874,13 +902,14 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void StartInfo_GetFileName_ReturnsExpected()
         {
             Process process = CreateProcessLong();
             process.Start();
 
             // Processes are not hosted by dotnet in the full .NET Framework.
-            string expectedFileName = PlatformDetection.IsFullFramework ? TestConsoleApp : HostRunner;
+            string expectedFileName = PlatformDetection.IsFullFramework || PlatformDetection.IsNetNative ? TestConsoleApp : HostRunner;
             Assert.Equal(expectedFileName, process.StartInfo.FileName);
 
             process.Kill();
@@ -888,6 +917,7 @@ namespace System.Diagnostics.Tests
         }
         
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void StartInfo_SetOnRunningProcess_ThrowsInvalidOperationException()
         {
             Process process = CreateProcessLong();
@@ -922,7 +952,7 @@ namespace System.Diagnostics.Tests
         public void StartInfo_SetNull_ThrowsArgumentNullException()
         {
             var process = new Process();
-            Assert.Throws<ArgumentNullException>("value", () => process.StartInfo = null);
+            Assert.Throws<ArgumentNullException>(() => process.StartInfo = null);
         }
 
         [Fact]
@@ -954,6 +984,7 @@ namespace System.Diagnostics.Tests
         [InlineData(@"a""b c""d e""f g""h i""j k""l", @"ab cd,ef gh,ij kl")]
         [InlineData(@"a b c""def", @"a,b,cdef")]
         [InlineData(@"""\a\"" \\""\\\ b c", @"\a"" \\\\,b,c")]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)] // Process.Start returns null in UapAot due to this issue, so it throws NRE.
         public void TestArgumentParsing(string inputArguments, string expectedArgv)
         {
             using (var handle = RemoteInvokeRaw((Func<string, string, string, int>)ConcatThreeArguments,
@@ -1126,6 +1157,7 @@ namespace System.Diagnostics.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // MainWindowHandle is not supported on Unix.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void MainWindowHandle_NoWindow_ReturnsEmptyHandle()
         {
             CreateDefaultProcess();
@@ -1142,6 +1174,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void MainWindowTitle_NoWindow_ReturnsEmpty()
         {
             CreateDefaultProcess();
@@ -1159,6 +1192,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void CloseMainWindow_NoWindow_ReturnsFalse()
         {
             CreateDefaultProcess();
@@ -1193,6 +1227,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestNonpagedSystemMemorySize()
         {
             CreateDefaultProcess();
@@ -1212,6 +1247,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestPagedMemorySize()
         {
             CreateDefaultProcess();
@@ -1231,6 +1267,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestPagedSystemMemorySize()
         {
             CreateDefaultProcess();
@@ -1250,6 +1287,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestPeakPagedMemorySize()
         {
             CreateDefaultProcess();
@@ -1269,6 +1307,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestPeakVirtualMemorySize()
         {
             CreateDefaultProcess();
@@ -1288,6 +1327,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestPeakWorkingSet()
         {
             CreateDefaultProcess();
@@ -1307,6 +1347,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestPrivateMemorySize()
         {
             CreateDefaultProcess();
@@ -1326,6 +1367,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestVirtualMemorySize()
         {
             CreateDefaultProcess();
@@ -1345,6 +1387,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestWorkingSet()
         {
             CreateDefaultProcess();
@@ -1392,6 +1435,7 @@ namespace System.Diagnostics.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]  // Starting process with authentication not supported on Unix
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void Process_StartTest()
         {
             string currentProcessName = GetCurrentProcessName();
@@ -1412,6 +1456,7 @@ namespace System.Diagnostics.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]  // Starting process with authentication not supported on Unix
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void Process_StartWithArgumentsTest()
         {
             string currentProcessName = GetCurrentProcessName();

--- a/src/System.Diagnostics.Process/tests/ProcessThreadTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessThreadTests.cs
@@ -14,6 +14,7 @@ namespace System.Diagnostics.Tests
     public class ProcessThreadTests : ProcessTestBase
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestCommonPriorityAndTimeProperties()
         {
             CreateDefaultProcess();
@@ -153,6 +154,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestPriorityLevelProperty()
         {
             CreateDefaultProcess();
@@ -186,6 +188,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void TestThreadStateProperty()
         {
             CreateDefaultProcess();
@@ -198,6 +201,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void Threads_GetMultipleTimes_ReturnsSameInstance()
         {
             CreateDefaultProcess();

--- a/src/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
@@ -11,6 +11,7 @@ namespace System.Diagnostics.Tests
     public class ProcessWaitingTests : ProcessTestBase
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void MultipleProcesses_StartAllKillAllWaitAll()
         {
             const int Iters = 10;
@@ -22,6 +23,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void MultipleProcesses_SerialStartKillWait()
         {
             const int Iters = 10;
@@ -35,6 +37,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void MultipleProcesses_ParallelStartKillWait()
         {
             const int Tasks = 4, ItersPerTask = 10;
@@ -60,6 +63,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void SingleProcess_TryWaitMultipleTimesBeforeCompleting()
         {
             Process p = CreateProcessLong();
@@ -82,6 +86,7 @@ namespace System.Diagnostics.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public async Task SingleProcess_WaitAfterExited(bool addHandlerBeforeStart)
         {
             Process p = CreateProcessLong();
@@ -123,6 +128,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void SingleProcess_CopiesShareExitInformation()
         {
             Process p = CreateProcessLong();
@@ -141,6 +147,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void WaitForPeerProcess()
         {
             Process child1 = CreateProcessLong();
@@ -168,6 +175,7 @@ namespace System.Diagnostics.Tests
 
         [Fact]
         [ActiveIssue(15844, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void WaitChain()
         {
             Process root = CreateProcess(() =>
@@ -195,6 +203,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19909", TargetFrameworkMonikers.UapAot)]
         public void WaitForSelfTerminatingChild()
         {
             Process child = CreateProcess(() =>


### PR DESCRIPTION
This PR disables System.Diagnostics.ProcessTests that are hitting: https://github.com/dotnet/corefx/issues/19909

I also fixed some tests where the executable name is different for UapAot and some differences in behavior. 

cc: @danmosemsft @tijoytom @Priya91 @AtsushiKan 