### PR TITLE
Update serialization fuzzing test to add 2 new exceptions

### DIFF
--- a/src/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
@@ -569,6 +569,8 @@ namespace System.Runtime.Serialization.Formatters.Tests
             catch (NullReferenceException) { }
             catch (SerializationException) { }
             catch (TargetInvocationException) { }
+            catch (ArgumentException) { }
+            catch (FileLoadException) { }
         }
 
         [Fact]


### PR DESCRIPTION
This test verifies that only "expected" exception types are thrown when deserializing fuzzed blobs. After we updated the blobs in our serialization work, it caused two new exception types to be thrown.

Both these are also thrown when running on Desktop, so this is not a break we introduced and we just have to update the list of exceptions.

Although the test is deterministically random, I can only repro the ArgumentException locally when running on Desktop. However I repro the FileLoadException in Helix. Perhaps the behavior of `Random(42)` is different on a different framework version. It might be interesting to change to a non deterministic (but logged) seed.

Fixes https://github.com/dotnet/corefx/issues/20611
Fixes https://github.com/dotnet/corefx/issues/20578