### PR TITLE
update process/thread structs to match updated Windows header

### DIFF
--- a/src/Common/src/Interop/Windows/Interop.UNICODE_STRING.cs
+++ b/src/Common/src/Interop/Windows/Interop.UNICODE_STRING.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct UNICODE_STRING
+    {
+        internal ushort Length;
+        internal ushort MaximumLength;
+        internal IntPtr Buffer;
+    }
+}

--- a/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
+++ b/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
@@ -245,6 +245,9 @@
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.MultiByteToWideChar.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.MultiByteToWideChar.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\Interop.UNICODE_STRING.cs">
+      <Link>Common\Interop\Interop.UNICODE_STRING.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.WideCharToMultiByte.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.WideCharToMultiByte.cs</Link>
     </Compile>

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
@@ -942,8 +942,8 @@ namespace System.Diagnostics
 
         private static unsafe ProcessInfo[] GetProcessInfos(IntPtr dataPtr)
         {
-            // 60 is a reasonable number for processes on a normal machine.
-            Dictionary<int, ProcessInfo> processInfos = new Dictionary<int, ProcessInfo>(60);
+            // 250 is a reasonable number for processes on a normal machine.
+            var processInfos = new List<ProcessInfo>(250);
 
             long totalOffset = 0;
 
@@ -993,7 +993,7 @@ namespace System.Diagnostics
                 }
 
                 // get the threads for current process
-                processInfos[processInfo.ProcessId] = processInfo;
+                processInfos.Add(processInfo);
 
                 currentPtr = (IntPtr)((long)currentPtr + Marshal.SizeOf(pi));
                 int i = 0;
@@ -1022,9 +1022,7 @@ namespace System.Diagnostics
                 totalOffset += pi.NextEntryOffset;
             }
 
-            ProcessInfo[] temp = new ProcessInfo[processInfos.Values.Count];
-            processInfos.Values.CopyTo(temp, 0);
-            return temp;
+            return processInfos.ToArray();
         }
 
         // This function generates the short form of process name. 

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
@@ -950,7 +950,7 @@ namespace System.Diagnostics
             while (true)
             {
                 IntPtr currentPtr = (IntPtr)((long)dataPtr + totalOffset);
-                SystemProcessInformation pi = Marshal.PtrToStructure<SystemProcessInformation>(currentPtr);
+                ref SystemProcessInformation pi = ref *(SystemProcessInformation *)(currentPtr);
 
                 // get information for a process
                 ProcessInfo processInfo = new ProcessInfo();

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
@@ -942,8 +942,8 @@ namespace System.Diagnostics
 
         private static unsafe ProcessInfo[] GetProcessInfos(IntPtr dataPtr)
         {
-            // 250 is a reasonable number for processes on a normal machine.
-            var processInfos = new List<ProcessInfo>(250);
+            // 60 is a reasonable number for processes on a normal machine.
+            Dictionary<int, ProcessInfo> processInfos = new Dictionary<int, ProcessInfo>(60);
 
             long totalOffset = 0;
 
@@ -993,7 +993,7 @@ namespace System.Diagnostics
                 }
 
                 // get the threads for current process
-                processInfos.Add(processInfo);
+                processInfos[processInfo.ProcessId] = processInfo;
 
                 currentPtr = (IntPtr)((long)currentPtr + Marshal.SizeOf(pi));
                 int i = 0;
@@ -1022,7 +1022,9 @@ namespace System.Diagnostics
                 totalOffset += pi.NextEntryOffset;
             }
 
-            return processInfos.ToArray();
+            ProcessInfo[] temp = new ProcessInfo[processInfos.Values.Count];
+            processInfos.Values.CopyTo(temp, 0);
+            return temp;
         }
 
         // This function generates the short form of process name. 

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
@@ -940,7 +940,7 @@ namespace System.Diagnostics
         // Cache a single buffer for use in GetProcessInfos().
         private static long[] CachedBuffer;
 
-        static ProcessInfo[] GetProcessInfos(IntPtr dataPtr)
+        private static ProcessInfo[] GetProcessInfos(IntPtr dataPtr)
         {
             // 60 is a reasonable number for processes on a normal machine.
             Dictionary<int, ProcessInfo> processInfos = new Dictionary<int, ProcessInfo>(60);
@@ -950,9 +950,7 @@ namespace System.Diagnostics
             while (true)
             {
                 IntPtr currentPtr = (IntPtr)((long)dataPtr + totalOffset);
-                SystemProcessInformation pi = new SystemProcessInformation();
-
-                Marshal.PtrToStructure(currentPtr, pi);
+                SystemProcessInformation pi = Marshal.PtrToStructure<SystemProcessInformation>(currentPtr);
 
                 // get information for a process
                 ProcessInfo processInfo = new ProcessInfo();
@@ -1001,8 +999,7 @@ namespace System.Diagnostics
                 int i = 0;
                 while (i < pi.NumberOfThreads)
                 {
-                    SystemThreadInformation ti = new SystemThreadInformation();
-                    Marshal.PtrToStructure(currentPtr, ti);
+                    SystemThreadInformation ti = Marshal.PtrToStructure<SystemThreadInformation>(currentPtr);
                     ThreadInfo threadInfo = new ThreadInfo();
 
                     threadInfo._processId = (int)ti.UniqueProcess;
@@ -1082,16 +1079,11 @@ namespace System.Diagnostics
 
         // native struct defined in ntexapi.h
         [StructLayout(LayoutKind.Sequential)]
-        internal class SystemProcessInformation
+        internal unsafe struct SystemProcessInformation
         {
             internal uint NextEntryOffset;
             internal uint NumberOfThreads;
-            private long _SpareLi1;
-            private long _SpareLi2;
-            private long _SpareLi3;
-            private long _CreateTime;
-            private long _UserTime;
-            private long _KernelTime;
+            private fixed byte Reserved1[48];
 
             internal ushort NameLength;   // UNICODE_STRING   
             internal ushort MaximumNameLength;
@@ -1099,46 +1091,39 @@ namespace System.Diagnostics
 
             internal int BasePriority;
             internal IntPtr UniqueProcessId;
-            internal IntPtr InheritedFromUniqueProcessId;
+            internal IntPtr Reserved2;
             internal uint HandleCount;
             internal uint SessionId;
-            internal UIntPtr PageDirectoryBase;
+            internal UIntPtr Reserved3;
             internal UIntPtr PeakVirtualSize;  // SIZE_T
             internal UIntPtr VirtualSize;
-            internal uint PageFaultCount;
+            internal uint Reserved4;
 
-            internal UIntPtr PeakWorkingSetSize;
-            internal UIntPtr WorkingSetSize;
-            internal UIntPtr QuotaPeakPagedPoolUsage;
-            internal UIntPtr QuotaPagedPoolUsage;
-            internal UIntPtr QuotaPeakNonPagedPoolUsage;
-            internal UIntPtr QuotaNonPagedPoolUsage;
-            internal UIntPtr PagefileUsage;
-            internal UIntPtr PeakPagefileUsage;
-            internal UIntPtr PrivatePageCount;
+            internal UIntPtr PeakWorkingSetSize;  // SIZE_T
+            internal UIntPtr WorkingSetSize;  // SIZE_T
+            internal UIntPtr Reserved5;
+            internal UIntPtr QuotaPagedPoolUsage;  // SIZE_T
+            internal UIntPtr Reserved6;
+            internal UIntPtr QuotaNonPagedPoolUsage;  // SIZE_T
+            internal UIntPtr PagefileUsage;  // SIZE_T
+            internal UIntPtr PeakPagefileUsage;  // SIZE_T
+            internal UIntPtr PrivatePageCount;  // SIZE_T
 
-            private long _ReadOperationCount;
-            private long _WriteOperationCount;
-            private long _OtherOperationCount;
-            private long _ReadTransferCount;
-            private long _WriteTransferCount;
-            private long _OtherTransferCount;
+            private fixed byte Reserved7[48];
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        internal class SystemThreadInformation
+        internal unsafe struct SystemThreadInformation
         {
-            private long _KernelTime;
-            private long _UserTime;
-            private long _CreateTime;
+            private fixed byte Reserved1[24];
 
-            private uint _WaitTime;
+            private uint Reserved2;
             internal IntPtr StartAddress;
             internal IntPtr UniqueProcess;
             internal IntPtr UniqueThread;
             internal int Priority;
             internal int BasePriority;
-            internal uint ContextSwitches;
+            internal uint Reserved3;
             internal uint ThreadState;
             internal uint WaitReason;
         }

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
@@ -942,6 +942,7 @@ namespace System.Diagnostics
 
         private static unsafe ProcessInfo[] GetProcessInfos(IntPtr dataPtr)
         {
+            // Use a dictionary to avoid duplicate entries if any
             // 60 is a reasonable number for processes on a normal machine.
             Dictionary<int, ProcessInfo> processInfos = new Dictionary<int, ProcessInfo>(60);
 

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
@@ -971,7 +971,7 @@ namespace System.Diagnostics
                 processInfo.HandleCount = (int)pi.HandleCount;
 
 
-                if (pi.Name.Buffer == IntPtr.Zero)
+                if (pi.ImageName.Buffer == IntPtr.Zero)
                 {
                     if (processInfo.ProcessId == NtProcessManager.SystemProcessID)
                     {
@@ -989,7 +989,7 @@ namespace System.Diagnostics
                 }
                 else
                 {
-                    string processName = GetProcessShortName(Marshal.PtrToStringUni(pi.Name.Buffer, pi.Name.Length / sizeof(char)));
+                    string processName = GetProcessShortName(Marshal.PtrToStringUni(pi.ImageName.Buffer, pi.ImageName.Length / sizeof(char)));
                     processInfo.ProcessName = processName;
                 }
 
@@ -1085,10 +1085,10 @@ namespace System.Diagnostics
             internal uint NextEntryOffset;
             internal uint NumberOfThreads;
             private fixed byte Reserved1[48];
-            internal Interop.UNICODE_STRING Name;
+            internal Interop.UNICODE_STRING ImageName;
             internal int BasePriority;
             internal IntPtr UniqueProcessId;
-            private IntPtr Reserved2;
+            private UIntPtr Reserved2;
             internal uint HandleCount;
             internal uint SessionId;
             private UIntPtr Reserved3;


### PR DESCRIPTION
Another shot at https://github.com/dotnet/corefx/pull/20142 now I have the official header, which I can share offline.