### PR TITLE
Enable DirectoryServices packages

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -1486,16 +1486,25 @@
     "System.DirectoryServices": {
       "InboxOn": {
         "net45": "4.0.0.0"
+      },
+      "AssemblyVersionInPackageVersion": {
+        "4.0.0.0": "4.5.0"
       }
     },
     "System.DirectoryServices.AccountManagement": {
       "InboxOn": {
         "net45": "4.0.0.0"
+      },
+      "AssemblyVersionInPackageVersion": {
+        "4.0.0.0": "4.5.0"
       }
     },
     "System.DirectoryServices.Protocols": {
       "InboxOn": {
         "net45": "4.0.0.0"
+      },
+      "AssemblyVersionInPackageVersion": {
+        "4.0.0.0": "4.5.0"
       }
     },
     "System.Drawing": {

--- a/pkg/descriptions.json
+++ b/pkg/descriptions.json
@@ -569,6 +569,32 @@
     ]
   },
   {
+    "Name": "System.DirectoryServices",
+    "Description": "Provides easy access to Active Directory Domain Services.",
+    "CommonTypes": [
+      "System.DirectoryServices.DirectoryEntry",
+      "System.DirectoryServices.DirectorySearcher",
+      "System.DirectoryServices.ActiveDirectory.ActiveDirectorySite",
+      "System.DirectoryServices.ActiveDirectory.ApplicationPartition",
+      "System.DirectoryServices.ActiveDirectory.DirectoryContext",
+      "System.DirectoryServices.ActiveDirectory.DirectoryServer",
+      "System.DirectoryServices.ActiveDirectory.Domain",
+      "System.DirectoryServices.ActiveDirectory.DomainController"
+    ]
+  },
+  {
+    "Name": "System.DirectoryServices.AccountManagement",
+    "Description": "Provides uniform access and manipulation of user, computer, and group security principals across the multiple principal stores: Active Directory Domain Services (AD DS), Active Directory Lightweight Directory Services (AD LDS), and Machine SAM (MSAM).",
+    "CommonTypes": [
+    ]
+  },
+  {
+    "Name": "System.DirectoryServices.Protocols",
+    "Description": "Provides the methods defined in the Lightweight Directory Access Protocol (LDAP) version 3 (V3) and Directory Services Markup Language (DSML) version 2.0 (V2) standards.",
+    "CommonTypes": [
+    ]
+  },
+  {
     "Name": "System.Drawing.Primitives",
     "Description": "Provides basic drawing primitive structures, that exposes the corresponding System.Drawing.dll types in .NET Core.",
     "CommonTypes": [

--- a/src/System.DirectoryServices.AccountManagement/dir.props
+++ b/src/System.DirectoryServices.AccountManagement/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
   </PropertyGroup>
 </Project>

--- a/src/System.DirectoryServices.AccountManagement/dir.props
+++ b/src/System.DirectoryServices.AccountManagement/dir.props
@@ -3,6 +3,8 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
-    <AssemblyKey>Open</AssemblyKey>
+    <AssemblyKey>MSFT</AssemblyKey>
+    <!-- disable package until https://github.com/dotnet/corefx/issues/18090 is addressed -->
+    <ShouldCreatePackage>false</ShouldCreatePackage>
   </PropertyGroup>
 </Project>

--- a/src/System.DirectoryServices.AccountManagement/pkg/Configurations.props
+++ b/src/System.DirectoryServices.AccountManagement/pkg/Configurations.props
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <BuildConfigurations>
-    	<!-- Empty build configurations as this project is not currently building for any vertical -->
-    	;
-    </BuildConfigurations>
-  </PropertyGroup>
-</Project>

--- a/src/System.DirectoryServices.AccountManagement/pkg/System.DirectoryServices.AccountManagement.pkgproj
+++ b/src/System.DirectoryServices.AccountManagement/pkg/System.DirectoryServices.AccountManagement.pkgproj
@@ -3,15 +3,15 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <ProjectReference Include="..\ref\System.DirectoryServices.AccountManagement.csproj">
-      <SupportedFramework>netcoreapp2.0;$(AllXamarinFrameworks)</SupportedFramework>
+      <SupportedFramework>netcoreapp2.0;net45;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.DirectoryServices.AccountManagement.csproj" />
-    <InboxOnTargetFramework Include="MonoAndroid10" />
-    <InboxOnTargetFramework Include="MonoTouch10" />
-    <InboxOnTargetFramework Include="xamarinios10" />
-    <InboxOnTargetFramework Include="xamarinmac20" />
-    <InboxOnTargetFramework Include="xamarintvos10" />
-    <InboxOnTargetFramework Include="xamarinwatchos10" />
+    <InboxOnTargetFramework Include="net45">
+      <AsFrameworkReference>true</AsFrameworkReference>
+    </InboxOnTargetFramework>
+    <File Include="$(PlaceHolderFile)">
+      <TargetPath>runtimes/win/lib/net45</TargetPath>
+    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.DirectoryServices.AccountManagement/src/Configurations.props
+++ b/src/System.DirectoryServices.AccountManagement/src/Configurations.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       netstandard-Windows_NT;
+      netstandard;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.DirectoryServices.AccountManagement/src/System.DirectoryServices.AccountManagement.csproj
+++ b/src/System.DirectoryServices.AccountManagement/src/System.DirectoryServices.AccountManagement.csproj
@@ -10,11 +10,14 @@
     <!-- Although we have a netstandard configuration, we know we are not currently UAP compatible-->
     <UWPCompatible>false</UWPCompatible>
     <IncludeDllSafeSearchPathAttribute>true</IncludeDllSafeSearchPathAttribute>
+    <GeneratePlatformNotSupportedAssembly Condition="'$(TargetsWindows)' != 'true'">true</GeneratePlatformNotSupportedAssembly>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Release|AnyCPU'" />
-  <ItemGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
     <Compile Include="System\DirectoryServices\AccountManagement\externdll.cs" />
     <Compile Include="System\DirectoryServices\AccountManagement\interopt.cs" />
     <Compile Include="System\DirectoryServices\AccountManagement\PrincipalSearcher.cs" />

--- a/src/System.DirectoryServices.Protocols/dir.props
+++ b/src/System.DirectoryServices.Protocols/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
   </PropertyGroup>
 </Project>

--- a/src/System.DirectoryServices.Protocols/dir.props
+++ b/src/System.DirectoryServices.Protocols/dir.props
@@ -3,6 +3,8 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
-    <AssemblyKey>Open</AssemblyKey>
+    <AssemblyKey>MSFT</AssemblyKey>
+    <!-- disable package until https://github.com/dotnet/corefx/issues/18090 is addressed -->
+    <ShouldCreatePackage>false</ShouldCreatePackage>
   </PropertyGroup>
 </Project>

--- a/src/System.DirectoryServices.Protocols/pkg/Configurations.props
+++ b/src/System.DirectoryServices.Protocols/pkg/Configurations.props
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <BuildConfigurations>
-    	<!-- Empty build configurations as this project is not currently building for any vertical -->
-    	;
-    </BuildConfigurations>
-  </PropertyGroup>
-</Project>

--- a/src/System.DirectoryServices.Protocols/pkg/System.DirectoryServices.Protocols.pkgproj
+++ b/src/System.DirectoryServices.Protocols/pkg/System.DirectoryServices.Protocols.pkgproj
@@ -3,15 +3,16 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <ProjectReference Include="..\ref\System.DirectoryServices.Protocols.csproj">
-      <SupportedFramework>netcoreapp2.0;$(AllXamarinFrameworks)</SupportedFramework>
+      <SupportedFramework>netcoreapp2.0;net45;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.DirectoryServices.Protocols.csproj" />
-    <InboxOnTargetFramework Include="MonoAndroid10" />
-    <InboxOnTargetFramework Include="MonoTouch10" />
-    <InboxOnTargetFramework Include="xamarinios10" />
-    <InboxOnTargetFramework Include="xamarinmac20" />
-    <InboxOnTargetFramework Include="xamarintvos10" />
-    <InboxOnTargetFramework Include="xamarinwatchos10" />
+
+    <InboxOnTargetFramework Include="net45">
+      <AsFrameworkReference>true</AsFrameworkReference>
+    </InboxOnTargetFramework>
+    <File Include="$(PlaceHolderFile)">
+      <TargetPath>runtimes/win/lib/net45</TargetPath>
+    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.DirectoryServices.Protocols/src/Configurations.props
+++ b/src/System.DirectoryServices.Protocols/src/Configurations.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <BuildConfigurations>
         netstandard-Windows_NT;
+        netstandard;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.DirectoryServices.Protocols/src/FxCopBaseline.AnyOS.cs
+++ b/src/System.DirectoryServices.Protocols/src/FxCopBaseline.AnyOS.cs
@@ -1,0 +1,1 @@
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA1821", Justification = "Finalizer has implementation in Windows version.")]

--- a/src/System.DirectoryServices.Protocols/src/System.DirectoryServices.Protocols.csproj
+++ b/src/System.DirectoryServices.Protocols/src/System.DirectoryServices.Protocols.csproj
@@ -9,11 +9,17 @@
     <!-- Although we have a netstandard configuration, we know we are not currently UAP compatible-->
     <UWPCompatible>false</UWPCompatible>
     <IncludeDllSafeSearchPathAttribute>true</IncludeDllSafeSearchPathAttribute>
+    <GeneratePlatformNotSupportedAssembly Condition="'$(TargetsWindows)' != 'true'">true</GeneratePlatformNotSupportedAssembly>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Release|AnyCPU'" />
-  <ItemGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
+  <ItemGroup Condition="'$(TargetsWindows)' != 'true'">
+    <Compile Include="FxCopBaseline.AnyOS.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
     <Compile Include="System\DirectoryServices\Protocols\externdll.cs" />
     <Compile Include="System\DirectoryServices\Protocols\common\AuthTypes.cs" />
     <Compile Include="System\DirectoryServices\Protocols\common\BerConverter.cs" />

--- a/src/System.DirectoryServices/dir.props
+++ b/src/System.DirectoryServices/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
   </PropertyGroup>
 </Project>

--- a/src/System.DirectoryServices/dir.props
+++ b/src/System.DirectoryServices/dir.props
@@ -3,6 +3,8 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
-    <AssemblyKey>Open</AssemblyKey>
+    <AssemblyKey>MSFT</AssemblyKey>
+    <!-- disable package until https://github.com/dotnet/corefx/issues/18090 is addressed -->
+    <ShouldCreatePackage>false</ShouldCreatePackage>
   </PropertyGroup>
 </Project>

--- a/src/System.DirectoryServices/pkg/Configurations.props
+++ b/src/System.DirectoryServices/pkg/Configurations.props
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <BuildConfigurations>
-    	<!-- Empty build configurations as this project is not currently building for any vertical -->
-    	;
-    </BuildConfigurations>
-  </PropertyGroup>
-</Project>

--- a/src/System.DirectoryServices/pkg/System.DirectoryServices.pkgproj
+++ b/src/System.DirectoryServices/pkg/System.DirectoryServices.pkgproj
@@ -3,15 +3,16 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <ProjectReference Include="..\ref\System.DirectoryServices.csproj">
-      <SupportedFramework>netcoreapp2.0;$(AllXamarinFrameworks)</SupportedFramework>
+      <SupportedFramework>netcoreapp2.0;net45;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.DirectoryServices.csproj" />
-    <InboxOnTargetFramework Include="MonoAndroid10" />
-    <InboxOnTargetFramework Include="MonoTouch10" />
-    <InboxOnTargetFramework Include="xamarinios10" />
-    <InboxOnTargetFramework Include="xamarinmac20" />
-    <InboxOnTargetFramework Include="xamarintvos10" />
-    <InboxOnTargetFramework Include="xamarinwatchos10" />
+    
+    <InboxOnTargetFramework Include="net45">
+      <AsFrameworkReference>true</AsFrameworkReference>
+    </InboxOnTargetFramework>
+    <File Include="$(PlaceHolderFile)">
+      <TargetPath>runtimes/win/lib/net45</TargetPath>
+    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.DirectoryServices/src/Configurations.props
+++ b/src/System.DirectoryServices/src/Configurations.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       netstandard-Windows_NT;
+      netstandard;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.DirectoryServices/src/FxCopBaseline.AnyOS.cs
+++ b/src/System.DirectoryServices/src/FxCopBaseline.AnyOS.cs
@@ -1,0 +1,1 @@
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA1821", Justification = "Finalizer has implementation in Windows version.")]

--- a/src/System.DirectoryServices/src/System.DirectoryServices.csproj
+++ b/src/System.DirectoryServices/src/System.DirectoryServices.csproj
@@ -8,10 +8,16 @@
     <NoWarn>$(NoWarn);0649</NoWarn>
     <!-- Although we have a netstandard configuration, we know we are not currently UAP compatible-->
     <UWPCompatible>false</UWPCompatible>
+    <GeneratePlatformNotSupportedAssembly Condition="'$(TargetsWindows)' != 'true'">true</GeneratePlatformNotSupportedAssembly>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Release|AnyCPU'" />
-  <ItemGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
+  <ItemGroup Condition="'$(TargetsWindows)' != 'true'">
+    <Compile Include="FxCopBaseline.AnyOS.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
     <Compile Include="System\DirectoryServices\externdll.cs" />
     <Compile Include="System\DirectoryServices\PrivilegedConfigurationManager.cs" />
     <Compile Include="System\DirectoryServices\ActiveDirectorySecurity.cs" />


### PR DESCRIPTION
/cc @weshaggard @jay98014 

A couple problems I dealt with:
1. These have the same assembly name as desktop, a higher version than desktop, and fewer types.  I dialed the version back to match desktop, though they still have fewer types.  You won't be able to add anything to these until you can support everything that desktop supported.  Alternatively give them different names than the desktop assemblies.
2. They are signing with the open key rather than the one used by desktop.
3. They don't support all runtimes.  I added a platform-not-supported assembly for non-windows runtimes.
