### PR TITLE
Reenable the Fill_Generics test for ILC.

### DIFF
--- a/src/System.Runtime/tests/System/ArrayTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/ArrayTests.netcoreapp.cs
@@ -53,7 +53,6 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Fill_Generic_TestData))]
-        [ActiveIssue("TFS 437849 - Universal Shared Generics issue", TargetFrameworkMonikers.UapAot)]
         public static void Fill_Generic<T>(IEnumerable<T> source, T value, int startIndex, int count)
         {
             if (startIndex == 0 && count == source.Count())


### PR DESCRIPTION
The underlying bug has been fixed.