### PR TITLE
Enable Remote Execution for UAP

### DIFF
--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -114,7 +114,7 @@
           Condition="'$(TargetGroup)'=='uap'" >
 
     <PropertyGroup>
-      <UAPToolsPackageVersion>1.0.2</UAPToolsPackageVersion>
+      <UAPToolsPackageVersion>1.0.4</UAPToolsPackageVersion>
       <UAPToolsPackageName>microsoft.dotnet.uap.testtools</UAPToolsPackageName>
 
       <UAPToolsFolder Condition="'$(UAPToolsFolder)'==''">$(PackagesDir)$(UAPToolsPackageName)\$(UAPToolsPackageVersion)\Tools</UAPToolsFolder>

--- a/external/test-runtime/optional.json
+++ b/external/test-runtime/optional.json
@@ -3,7 +3,7 @@
     "net45": {
       "dependencies": {
         "Microsoft.DotNet.IBCMerge": "4.6.0-alpha-00001",
-        "Microsoft.DotNet.UAP.TestTools": "1.0.2",
+        "Microsoft.DotNet.UAP.TestTools": "1.0.4",
         "TestILC.amd64ret": "1.0.0-beta-25402-00",
         "TestILC.armret": "1.0.0-beta-25402-00",
         "TestILC.x86ret": "1.0.0-beta-25402-00"

--- a/src/Common/tests/System/Diagnostics/RemoteExecutorTestBase.cs
+++ b/src/Common/tests/System/Diagnostics/RemoteExecutorTestBase.cs
@@ -159,26 +159,26 @@ namespace System.Diagnostics
             Assembly a = t.GetTypeInfo().Assembly;
             Assert.Equal(typeof(RemoteExecutorTestBase).GetTypeInfo().Assembly, a);
 
-            using (var remoteExecutionService = new AppServiceConnection())
+            using (AppServiceConnection remoteExecutionService = new AppServiceConnection())
             {
                 // Here, we use the app service name defined in the app service provider's Package.appxmanifest file in the <Extension> section.
                 remoteExecutionService.AppServiceName = "com.microsoft.corefxuaptests";
                 remoteExecutionService.PackageFamilyName = Package.Current.Id.FamilyName;
 
-                var status = remoteExecutionService.OpenAsync().GetAwaiter().GetResult();
+                AppServiceConnectionStatus status = remoteExecutionService.OpenAsync().GetAwaiter().GetResult();
                 if (status != AppServiceConnectionStatus.Success)
                 {
                     throw new IOException($"RemoteInvoke cannot open the remote service. Open Service Status: {status}");
                 }
 
-                var message = new ValueSet();
+                ValueSet message = new ValueSet();
 
                 message.Add("AssemblyName", a.FullName);
                 message.Add("TypeName", t.FullName);
                 message.Add("MethodName", method.Name);
 
                 int i = 0;
-                foreach (var arg in args)
+                foreach (string arg in args)
                 {
                     message.Add("Arg" + i, arg);
                     i++;

--- a/src/Common/tests/System/Diagnostics/RemoteExecutorTestBase.cs
+++ b/src/Common/tests/System/Diagnostics/RemoteExecutorTestBase.cs
@@ -8,6 +8,12 @@ using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Xunit;
 
+#if uap
+using Windows.ApplicationModel;
+using Windows.ApplicationModel.AppService;
+using Windows.Foundation.Collections;
+#endif // uap
+
 namespace System.Diagnostics
 {
     /// <summary>Base class used for all tests that need to spawn a remote process.</summary>
@@ -132,6 +138,64 @@ namespace System.Diagnostics
             return RemoteInvoke(method.GetMethodInfo(), new[] { unparsedArg }, options);
         }
 
+#if uap
+        /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
+        /// <param name="method">The method to invoke.</param>
+        /// <param name="args">The arguments to pass to the method.</param>
+        /// <param name="start">true if this function should Start the Process; false if that responsibility is left up to the caller.</param>
+        /// <param name="psi">The ProcessStartInfo to use, or null for a default.</param>
+        private static RemoteInvokeHandle RemoteInvoke(MethodInfo method, string[] args, RemoteInvokeOptions options)
+        {
+            options = options ?? new RemoteInvokeOptions();
+
+            // Verify the specified method is and that it returns an int (the exit code),
+            // and that if it accepts any arguments, they're all strings.
+            Assert.True(method.ReturnType == typeof(int) || method.ReturnType == typeof(Task<int>));
+            Assert.All(method.GetParameters(), pi => Assert.Equal(typeof(string), pi.ParameterType));
+
+            // And make sure it's in this assembly.  This isn't critical, but it helps with deployment to know
+            // that the method to invoke is available because we're already running in this assembly.
+            Type t = method.DeclaringType;
+            Assembly a = t.GetTypeInfo().Assembly;
+            Assert.Equal(typeof(RemoteExecutorTestBase).GetTypeInfo().Assembly, a);
+
+            using (var remoteExecutionService = new AppServiceConnection())
+            {
+                // Here, we use the app service name defined in the app service provider's Package.appxmanifest file in the <Extension> section.
+                remoteExecutionService.AppServiceName = "com.microsoft.corefxuaptests";
+                remoteExecutionService.PackageFamilyName = Package.Current.Id.FamilyName;
+
+                var status = remoteExecutionService.OpenAsync().GetAwaiter().GetResult();
+                if (status != AppServiceConnectionStatus.Success)
+                {
+                    throw new IOException($"RemoteInvoke cannot open the remote service. Open Service Status: {status}");
+                }
+
+                var message = new ValueSet();
+
+                message.Add("AssemblyName", a.FullName);
+                message.Add("TypeName", t.FullName);
+                message.Add("MethodName", method.Name);
+
+                int i = 0;
+                foreach (var arg in args)
+                {
+                    message.Add("Arg" + i, arg);
+                    i++;
+                }
+
+                AppServiceResponse response = remoteExecutionService.SendMessageAsync(message).GetAwaiter().GetResult();
+
+                Assert.True(response.Status == AppServiceResponseStatus.Success, $"response.Status = {response.Status}");
+                int res = (int) response.Message["Results"];
+                Assert.True(res == SuccessExitCode, (string) response.Message["Log"] + Environment.NewLine + $"Returned Error code: {res}");
+            }
+
+            // RemoteInvokeHandle is not really needed in the UAP scenario but we use it just to have consistent interface as non UAP
+            return new RemoteInvokeHandle(null, options);
+        }
+#else
+
         /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
         /// <param name="method">The method to invoke.</param>
         /// <param name="args">The arguments to pass to the method.</param>
@@ -190,6 +254,7 @@ namespace System.Diagnostics
                 Process.Start(psi) :
                 new Process() { StartInfo = psi }, options);
         }
+#endif
 
         /// <summary>A cleanup handle to the Process created for the remote invocation.</summary>
         internal sealed class RemoteInvokeHandle : IDisposable

--- a/src/System.Globalization/tests/CultureInfo/CultureInfoCurrentCulture.cs
+++ b/src/System.Globalization/tests/CultureInfo/CultureInfoCurrentCulture.cs
@@ -57,6 +57,7 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Thread cultures is not honored in UWP.")]
         public void DefaultThreadCurrentCulture()
         {
             RemoteInvoke(() =>
@@ -76,6 +77,7 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Thread cultures is not honored in UWP.")]
         public void DefaultThreadCurrentUICulture()
         {
             RemoteInvoke(() =>

--- a/src/System.Globalization/tests/System.Globalization.Tests.csproj
+++ b/src/System.Globalization/tests/System.Globalization.Tests.csproj
@@ -149,11 +149,16 @@
     <Compile Include="$(CommonTestPath)\System\IO\FileCleanupTestBase.cs">
       <Link>Common\System\IO\FileCleanupTestBase.cs</Link>
     </Compile>
-    <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
+    <ProjectReference Condition="'$(TargetGroup)' != 'uap'" Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
       <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
       <Name>RemoteExecutorConsoleApp</Name>
     </ProjectReference>
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetGroup)' == 'uap'">
+    <Reference Include="Windows" />
+  </ItemGroup>
+  
   <ItemGroup>
     <EmbeddedResource Include="$(CommonTestPath)\Data\UnicodeData.8.0.txt">
       <Link>CharUnicodeInfo\UnicodeData8.0.txt</Link>

--- a/src/System.Runtime.WindowsRuntime/src/System/Resources/WindowsRuntimeResourceManager.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Resources/WindowsRuntimeResourceManager.cs
@@ -436,6 +436,13 @@ namespace System.Resources
 
             if (s_globalResourceContextBestFitCultureInfo != null && s_globalResourceContextBestFitCultureInfo.Name.Equals(ci.Name, StringComparison.OrdinalIgnoreCase))
             {
+                if (!ReferenceEquals(s_globalResourceContextBestFitCultureInfo, ci))
+                {
+                    // We have same culture name but different reference, we'll need to update s_globalResourceContextBestFitCultureInfo only as ci can 
+                    // be a customized subclassed culture which setting different values for NFI, DTFI...etc.
+                    s_globalResourceContextBestFitCultureInfo = ci;
+                }
+
                 // the default culture is already set. nothing more need to be done
                 return true;
             }


### PR DESCRIPTION
This change is to enable the infrastructure to run code remotely in isolated container app for corefx test projects. Note that this change is just enabling the infrastructure so the next step would be to visit all test projects using remote execution and update them to work as expected with UAP runs.
I have modified System.Globalization test project to be an example what need to be done in the test projects to enable remote execution for UAP.
The changes here also fix issue when setting the current culture in UAP app and using customized sub-classed CultureInfo object. This scenario was not possible before exposing CultureInfo.CurrentCulture setter because there was no way to set the current culture in UWP apps except through WinRT APIs. Now after exposing CurrentCulture setter, this scenario is enabled and callers can set customized culture instance. We used not to bother before but now we should honor such culture instance to give the expected behavior when setting the culture.