### PR TITLE
Use monotonic clock for measuring time in sleep test

### DIFF
--- a/src/System.Threading.Thread/tests/ThreadTests.cs
+++ b/src/System.Threading.Thread/tests/ThreadTests.cs
@@ -769,8 +769,7 @@ namespace System.Threading.Threads.Tests
 
             Thread.Sleep(0);
 
-            var stopwatch = new Stopwatch();
-            stopwatch.Start();
+            var stopwatch = Stopwatch.StartNew();
             Thread.Sleep(500);
             stopwatch.Stop();
             Assert.InRange((int)stopwatch.ElapsedMilliseconds, 100, int.MaxValue);

--- a/src/System.Threading.Thread/tests/ThreadTests.cs
+++ b/src/System.Threading.Thread/tests/ThreadTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -767,9 +768,12 @@ namespace System.Threading.Threads.Tests
             Assert.Throws<ArgumentOutOfRangeException>(() => Thread.Sleep(TimeSpan.FromMilliseconds((double)int.MaxValue + 1)));
 
             Thread.Sleep(0);
-            var startTime = DateTime.UtcNow;
+
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
             Thread.Sleep(500);
-            Assert.InRange((DateTime.UtcNow - startTime).TotalMilliseconds, 100, int.MaxValue);
+            stopwatch.Stop();
+            Assert.InRange((int)stopwatch.ElapsedMilliseconds, 100, int.MaxValue);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #20173