### PR TITLE
Remove unnecessary reference in test project

### DIFF
--- a/src/System.Collections.Immutable/tests/System.Collections.Immutable.Tests.csproj
+++ b/src/System.Collections.Immutable/tests/System.Collections.Immutable.Tests.csproj
@@ -125,8 +125,5 @@
   <ItemGroup>
     <EmbeddedResource Include="Resources\$(AssemblyName).rd.xml" />
   </ItemGroup>
-  <ItemGroup>
-    <Reference Include="System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL" />
-  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
This reference was added in https://github.com/dotnet/corefx/pull/20629/files#diff-901fb3723ba45165116ce0805ad0d637

Test projects shouldn't add references as they are added automatically.

cc: @ianhays 