### PR TITLE
ObservableCollection: Avoid SimpleMonitor allocation

### DIFF
--- a/src/System.ObjectModel/src/System/Collections/ObjectModel/ObservableCollection.cs
+++ b/src/System.ObjectModel/src/System/Collections/ObjectModel/ObservableCollection.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Runtime.Serialization;
 
 namespace System.Collections.ObjectModel
 {
@@ -238,9 +239,15 @@ namespace System.Collections.ObjectModel
             NotifyCollectionChangedEventHandler handler = CollectionChanged;
             if (handler != null)
             {
-                using (BlockReentrancy())
+                // Not calling BlockReentrancy() here to avoid the SimpleMonitor allocation.
+                _blockReentrancyCount++;
+                try
                 {
                     handler(this, e);
+                }
+                finally
+                {
+                    _blockReentrancyCount--;
                 }
             }
         }
@@ -260,8 +267,8 @@ namespace System.Collections.ObjectModel
         /// </remarks>
         protected IDisposable BlockReentrancy()
         {
-            _monitor.Enter();
-            return _monitor;
+            _blockReentrancyCount++;
+            return EnsureMonitorInitialized();
         }
 
         /// <summary> Check and assert for reentrant attempts to change this collection. </summary>
@@ -269,7 +276,7 @@ namespace System.Collections.ObjectModel
         /// while another collection change is still being notified to other listeners </exception>
         protected void CheckReentrancy()
         {
-            if (_monitor.Busy)
+            if (_blockReentrancyCount > 0)
             {
                 // we can allow changes if there's only one listener - the problem
                 // only arises if reentrant changes make the original event args
@@ -337,6 +344,25 @@ namespace System.Collections.ObjectModel
         {
             OnCollectionChanged(EventArgsCache.ResetCollectionChanged);
         }
+
+        private SimpleMonitor EnsureMonitorInitialized()
+        {
+            return _monitor ?? (_monitor = new SimpleMonitor(this));
+        }
+
+        [OnSerializing]
+        private void OnSerializing(StreamingContext context)
+        {
+            EnsureMonitorInitialized();
+            _monitor._busyCount = _blockReentrancyCount;
+        }
+
+        [OnDeserialized]
+        private void OnDeserialized(StreamingContext context)
+        {
+            _blockReentrancyCount = _monitor._busyCount;
+            _monitor._collection = this;
+        }
         #endregion Private Methods
 
         //------------------------------------------------------
@@ -349,21 +375,23 @@ namespace System.Collections.ObjectModel
 
         // this class helps prevent reentrant calls
         [Serializable]
-        private class SimpleMonitor : IDisposable
+        private sealed class SimpleMonitor : IDisposable
         {
-            public void Enter()
+            internal int _busyCount; // Only used during (de)serialization to maintain compatibility with desktop.
+
+            [NonSerialized]
+            internal ObservableCollection<T> _collection;
+
+            public SimpleMonitor(ObservableCollection<T> collection)
             {
-                ++_busyCount;
+                Debug.Assert(collection != null);
+                _collection = collection;
             }
 
             public void Dispose()
             {
-                --_busyCount;
+                _collection._blockReentrancyCount--;
             }
-
-            public bool Busy { get { return _busyCount > 0; } }
-
-            int _busyCount;
         }
 
         #endregion Private Types
@@ -376,7 +404,10 @@ namespace System.Collections.ObjectModel
 
         #region Private Fields
 
-        private readonly SimpleMonitor _monitor = new SimpleMonitor();
+        private SimpleMonitor _monitor; // Lazily allocated only when a subclass calls BlockReentrancy() or during serialization.
+
+        [NonSerialized]
+        private int _blockReentrancyCount;
         #endregion Private Fields
     }
 

--- a/src/System.ObjectModel/src/System/Collections/ObjectModel/ObservableCollection.cs
+++ b/src/System.ObjectModel/src/System/Collections/ObjectModel/ObservableCollection.cs
@@ -18,6 +18,7 @@ namespace System.Collections.ObjectModel
     [Serializable]
     [DebuggerTypeProxy(typeof(CollectionDebugView<>))]
     [DebuggerDisplay("Count = {Count}")]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("WindowsBase, Version=3.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35")]
     public class ObservableCollection<T> : Collection<T>, INotifyCollectionChanged, INotifyPropertyChanged
     {
         //------------------------------------------------------
@@ -375,6 +376,7 @@ namespace System.Collections.ObjectModel
 
         // this class helps prevent reentrant calls
         [Serializable]
+        [System.Runtime.CompilerServices.TypeForwardedFrom("WindowsBase, Version=3.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35")]
         private sealed class SimpleMonitor : IDisposable
         {
             internal int _busyCount; // Only used during (de)serialization to maintain compatibility with desktop.


### PR DESCRIPTION
I was a little sad to see the optimization from #12705 reverted in 6393248c7a986476f1e2d9dc4b1e5aff96459690 for serialization compat.

This PR adds back the optimization, but in terms of `SimpleMonitor`, maintaining serialization compat with desktop.

~~I didn't included the `[TypeForwardedFrom]` attributes in this PR as they're being added in #20599~~ (Edit: added a commit that includes them). However, if I do temporarily add the attribute to a private copy of `ObservableCollection<T>` (and its private `SimpleMonitor`) in a one-off console project, the collection serializes to the exact same bytes as desktop.

cc: @stephentoub, @ViktorHofer