### PR TITLE
Disable test for issue #19897

### DIFF
--- a/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -1817,6 +1817,7 @@ string.Format(@"<?xml version=""1.0"" encoding=""utf-8""?>
     }
 
     [Fact]
+    [ActiveIssue("dotnet/corefx #19897", TargetFrameworkMonikers.UapAot)]
     public static void Xml_TypeWithTwoDimensionalArrayProperty1()
     {
         SimpleType[][] simpleType2D = GetObjectwith2DArrayOfSimpleType();


### PR DESCRIPTION
Previously I made a fix in UWP toolchain for test `Xml_TypeWithTwoDimensionalArrayProperty1`. But that fix caused a regression, see #19897 for details. I revert the fix to unblock integration. The PR is to mark the test with ActiveIssue on uapaot.