### PR TITLE
Fix tests to catch exceptions from CanCreateSymbolicLinks

### DIFF
--- a/src/System.IO.FileSystem/tests/FileSystemTest.cs
+++ b/src/System.IO.FileSystem/tests/FileSystemTest.cs
@@ -29,27 +29,34 @@ namespace System.IO.Tests
         /// the symbolic link may fail to create. Only run this test if it creates
         /// links successfully.
         /// </summary>
-        protected static bool CanCreateSymbolicLinks { get; } = ComputeCanCreateSymbolicLinks();
+        protected static bool CanCreateSymbolicLinks => s_canCreateSymbolicLinks.Value;
 
-        private static bool ComputeCanCreateSymbolicLinks()
+        private static readonly Lazy<bool> s_canCreateSymbolicLinks = new Lazy<bool>(() =>
         {
-            bool success = true;
+            try
+            {
+                // Verify file symlink creation
+                string path = Path.GetTempFileName();
+                string linkPath = path + ".link";
+                bool success = MountHelper.CreateSymbolicLink(linkPath, path, isDirectory: false);
+                try { File.Delete(path); } catch { }
+                try { File.Delete(linkPath); } catch { }
 
-            // Verify file symlink creation
-            string path = Path.GetTempFileName();
-            string linkPath = path + ".link";
-            success = MountHelper.CreateSymbolicLink(linkPath, path, isDirectory: false);
-            try { File.Delete(path); } catch { }
-            try { File.Delete(linkPath); } catch { }
+                // Verify directory symlink creation
+                path = Path.GetTempFileName();
+                linkPath = path + ".link";
+                success = success && MountHelper.CreateSymbolicLink(linkPath, path, isDirectory: true);
+                try { Directory.Delete(path); } catch { }
+                try { Directory.Delete(linkPath); } catch { }
 
-            // Verify directory symlink creation
-            path = Path.GetTempFileName();
-            linkPath = path + ".link";
-            success = success && MountHelper.CreateSymbolicLink(linkPath, path, isDirectory: true);
-            try { Directory.Delete(path); } catch { }
-            try { Directory.Delete(linkPath); } catch { }
-
-            return success;
-        }
+                return success;
+            }
+            catch
+            {
+                // Problems with Process.Start (used by CreateSymbolicLinks) on some platforms
+                // https://github.com/dotnet/corefx/issues/19909
+                return false;
+            }
+        });
     }
 }


### PR DESCRIPTION
It's failing on some platforms.
cc: @tijoytom, @danmosemsft 