### PR TITLE
Improve Activity.Id overflow handling if Parent Id has only root node

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md
+++ b/src/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md
@@ -202,7 +202,7 @@ Activity.Id serves as hierarchical Request-Id in terms of [HTTP standard proposa
 
 e.g. 
 
-`|a000b421-5d183ab6-Server1.1.8e2d4c28_1.`
+`|a000b421-5d183ab6.1.8e2d4c28_1.`
 
 It starts with '|' followed by [root-id](#root-id) followed by '.' and small identifiers of local Activities, separated by '.' or '_'. 
 
@@ -217,7 +217,7 @@ Where base64 and '-' are used in nodes and other characters delimit nodes. Id al
 ### Root Id
 When you start the first Activity for the operation, you may optionaly provide root-id through `Activity.SetParentId(string)` API. 
 
-If you don't provide it, Activity will generate root-id: e.g. `a000b421-5d183ab6-Server1`
+If you don't provide it, Activity will generate root-id: e.g. `a000b421-5d183ab6`
 
 If don't have ParentId from external process and want to generate one, keep in mind that Root-Id
 * MUST be sufficiently large to identify single operation in entire system: use 64(or 128) bit random number or Guid

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -45,11 +45,11 @@ namespace System.Diagnostics
         /// See <see href="https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md#id-format"/> for more details
         /// </summary>
         /// <example>
-        /// Id looks like '|a000b421-5d183ab6-Server1.1.8e2d4c28_1.':<para />
-        ///  - '|a000b421-5d183ab6-Server1.' - Id of the first, top-most, Activity created<para />
-        ///  - '|a000b421-5d183ab6-Server1.1.' - Id of a child activity. It was started in the same process as the first activity and ends with '.'<para />
-        ///  - '|a000b421-5d183ab6-Server1.1.8e2d4c28_' - Id of the grand child activity. It was started in another process and ends with '_'<para />
-        /// 'a000b421-5d183ab6-Server1' is a <see cref="RootId"/> for the first Activity and all its children
+        /// Id looks like '|a000b421-5d183ab6.1.8e2d4c28_1.':<para />
+        ///  - '|a000b421-5d183ab6.' - Id of the first, top-most, Activity created<para />
+        ///  - '|a000b421-5d183ab6.1.' - Id of a child activity. It was started in the same process as the first activity and ends with '.'<para />
+        ///  - '|a000b421-5d183ab6.1.8e2d4c28_' - Id of the grand child activity. It was started in another process and ends with '_'<para />
+        /// 'a000b421-5d183ab6' is a <see cref="RootId"/> for the first Activity and all its children
         /// </example>
         public string Id { get; private set; }
 
@@ -421,7 +421,7 @@ namespace System.Diagnostics
             }
 
             //ParentId is not valid Request-Id, let's generate proper one.
-            if (trimPosition == 0)
+            if (trimPosition == 1)
                 return GenerateRootId();
 
             //generate overflow suffix
@@ -433,8 +433,7 @@ namespace System.Diagnostics
         {
             // It is important that the part that changes frequently be first, because
             // many hash functions don't 'randomize' the tail of a string.   This makes
-            // sampling based on the hash produce poor samples.   Thus the 'machine part'
-            // of the ID is last.  
+            // sampling based on the hash produce poor samples.
             return  '|' + Interlocked.Increment(ref s_currentRootId).ToString("x") + s_uniqSuffix;
         }
 #if ALLOW_PARTIALLY_TRUSTED_CALLERS


### PR DESCRIPTION
Activity.Id is generated by adding suffix and delimiter to the 'parent id' that comes from the parent Activity or from the external process. So the Activity.Id may have multiple 'nodes' separated by delimiters.

Maximum Id length is 1024 and when the limit is reached, last node(s) are trimmed to make space for random overflow suffix.

In case there is single node 1024 bytes or longer, overflow if not handled correctly: instead of completely new Id, Activity generated overflow suffix only. 

This in general is invalid corner case but may happen because of the bug or some compatibility issue.
Currently the only problem that overflow suffix is not long enough and does not guarantee global uniqueness of Activity.Id.

This change has a fix for this issue and also updates comments/docs unrelated to this change.