### PR TITLE
Hardcode Environment.UserName and Environment.UserDomainName on UAP

### DIFF
--- a/src/System.Runtime.Extensions/System.Runtime.Extensions.sln
+++ b/src/System.Runtime.Extensions/System.Runtime.Extensions.sln
@@ -1,13 +1,13 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26228.9
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.Extensions.Tests", "tests\System.Runtime.Extensions.Tests.csproj", "{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}"
 	ProjectSection(ProjectDependencies) = postProject
 		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A} = {845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssemblyResolveTests", "tests\AssemblyResolveTests\AssemblyResolveTests.csproj", "ad83807c-8be5-4f27-85df-9793613233e1"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssemblyResolveTests", "tests\AssemblyResolveTests\AssemblyResolveTests.csproj", "{E60AFAE8-2EA7-471C-9E24-52A99453B26B}"
 	ProjectSection(ProjectDependencies) = postProject
 		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A} = {845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}
 	EndProjectSection
@@ -55,10 +55,10 @@ Global
 		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
 		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
 		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
-		ad83807c-8be5-4f27-85df-9793613233e1.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		ad83807c-8be5-4f27-85df-9793613233e1.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		ad83807c-8be5-4f27-85df-9793613233e1.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		ad83807c-8be5-4f27-85df-9793613233e1.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{E60AFAE8-2EA7-471C-9E24-52A99453B26B}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{E60AFAE8-2EA7-471C-9E24-52A99453B26B}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{E60AFAE8-2EA7-471C-9E24-52A99453B26B}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{E60AFAE8-2EA7-471C-9E24-52A99453B26B}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
 		{978FA427-F87B-46E2-B276-F5B727C50A01}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{978FA427-F87B-46E2-B276-F5B727C50A01}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{978FA427-F87B-46E2-B276-F5B727C50A01}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -89,7 +89,6 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
-		ad83807c-8be5-4f27-85df-9793613233e1 = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{978FA427-F87B-46E2-B276-F5B727C50A01} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{24BCEC6B-B9D2-47BC-9D66-725BD6B526FA} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{C44B33E3-F89F-40B9-B353-D380C1524988} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}

--- a/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
+++ b/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
@@ -8,7 +8,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <IncludeDllSafeSearchPathAttribute>true</IncludeDllSafeSearchPathAttribute>
-    <DefineConstants Condition="'$(TargetGroup)' == 'uapaot' or '$(TargetGroup)' == 'uap'">$(DefineConstants);uap</DefineConstants>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />
@@ -92,7 +91,7 @@
   <!-- WINDOWS: Shared CoreCLR and .NET Native -->
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
     <Compile Include="System\Environment.Windows.cs" />
-    <Compile Include="System\Environment.Win32.cs" />
+    <Compile Include="System\Environment.Win32.cs"  Condition="'$(TargetGroup)' != 'uapaot' and '$(TargetGroup)' != 'uap'" />
     <Compile Include="System\Runtime\Versioning\VersioningHelper.Windows.cs" />
     <Compile Include="System\Diagnostics\Stopwatch.Windows.cs" />
     <Compile Include="$(CommonPath)\System\IO\Win32Marshal.cs">

--- a/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
+++ b/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
@@ -8,6 +8,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <IncludeDllSafeSearchPathAttribute>true</IncludeDllSafeSearchPathAttribute>
+    <DefineConstants Condition="'$(TargetGroup)' == 'uapaot' or '$(TargetGroup)' == 'uap'">$(DefineConstants);uap</DefineConstants>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />

--- a/src/System.Runtime.Extensions/src/System/Environment.Win32.cs
+++ b/src/System.Runtime.Extensions/src/System/Environment.Win32.cs
@@ -12,374 +12,50 @@ namespace System
 {
     public static partial class Environment
     {
-        public static int ExitCode { get { return EnvironmentAugments.ExitCode; } set { EnvironmentAugments.ExitCode = value; } }
-
-        private static string ExpandEnvironmentVariablesCore(string name)
+        static partial void GetUserName(ref string username)
         {
-            int currentSize = 100;
-            StringBuilder result = StringBuilderCache.Acquire(currentSize); // A somewhat reasonable default size
-
-            result.Length = 0;
-            int size = Interop.Kernel32.ExpandEnvironmentStringsW(name, result, currentSize);
-            if (size == 0)
+            // Use GetUserNameExW, as GetUserNameW isn't available on all platforms, e.g. Win7
+            var domainName = new StringBuilder(1024);
+            uint domainNameLen = (uint)domainName.Capacity;
+            if (Interop.Secur32.GetUserNameExW(Interop.Secur32.NameSamCompatible, domainName, ref domainNameLen) == 1)
             {
-                StringBuilderCache.Release(result);
-                Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
-            }
-
-            while (size > currentSize)
-            {
-                currentSize = size;
-                result.Length = 0;
-                result.Capacity = currentSize;
-
-                size = Interop.Kernel32.ExpandEnvironmentStringsW(name, result, currentSize);
-                if (size == 0)
+                string samName = domainName.ToString();
+                int index = samName.IndexOf('\\');
+                if (index != -1)
                 {
-                    StringBuilderCache.Release(result);
-                    Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+                    username = samName.Substring(index + 1);
+                    return;
                 }
             }
 
-            return StringBuilderCache.GetStringAndRelease(result);
+            username = string.Empty;
         }
 
-        private static string GetFolderPathCore(SpecialFolder folder, SpecialFolderOption option)
+        static partial void GetDomainName(ref string userDomainName)
         {
-            // We're using SHGetKnownFolderPath instead of SHGetFolderPath as SHGetFolderPath is
-            // capped at MAX_PATH.
-            //
-            // Because we validate both of the input enums we shouldn't have to care about CSIDL and flag
-            // definitions we haven't mapped. If we remove or loosen the checks we'd have to account
-            // for mapping here (this includes tweaking as SHGetFolderPath would do).
-            //
-            // The only SpecialFolderOption defines we have are equivalent to KnownFolderFlags.
-
-            string folderGuid;
-
-            switch (folder)
+            var domainName = new StringBuilder(1024);
+            uint domainNameLen = (uint)domainName.Capacity;
+            if (Interop.Secur32.GetUserNameExW(Interop.Secur32.NameSamCompatible, domainName, ref domainNameLen) == 1)
             {
-                case SpecialFolder.ApplicationData:
-                    folderGuid = Interop.Shell32.KnownFolders.RoamingAppData;
-                    break;
-                case SpecialFolder.CommonApplicationData:
-                    folderGuid = Interop.Shell32.KnownFolders.ProgramData;
-                    break;
-                case SpecialFolder.LocalApplicationData:
-                    folderGuid = Interop.Shell32.KnownFolders.LocalAppData;
-                    break;
-                case SpecialFolder.Cookies:
-                    folderGuid = Interop.Shell32.KnownFolders.Cookies;
-                    break;
-                case SpecialFolder.Desktop:
-                    folderGuid = Interop.Shell32.KnownFolders.Desktop;
-                    break;
-                case SpecialFolder.Favorites:
-                    folderGuid = Interop.Shell32.KnownFolders.Favorites;
-                    break;
-                case SpecialFolder.History:
-                    folderGuid = Interop.Shell32.KnownFolders.History;
-                    break;
-                case SpecialFolder.InternetCache:
-                    folderGuid = Interop.Shell32.KnownFolders.InternetCache;
-                    break;
-                case SpecialFolder.Programs:
-                    folderGuid = Interop.Shell32.KnownFolders.Programs;
-                    break;
-                case SpecialFolder.MyComputer:
-                    folderGuid = Interop.Shell32.KnownFolders.ComputerFolder;
-                    break;
-                case SpecialFolder.MyMusic:
-                    folderGuid = Interop.Shell32.KnownFolders.Music;
-                    break;
-                case SpecialFolder.MyPictures:
-                    folderGuid = Interop.Shell32.KnownFolders.Pictures;
-                    break;
-                case SpecialFolder.MyVideos:
-                    folderGuid = Interop.Shell32.KnownFolders.Videos;
-                    break;
-                case SpecialFolder.Recent:
-                    folderGuid = Interop.Shell32.KnownFolders.Recent;
-                    break;
-                case SpecialFolder.SendTo:
-                    folderGuid = Interop.Shell32.KnownFolders.SendTo;
-                    break;
-                case SpecialFolder.StartMenu:
-                    folderGuid = Interop.Shell32.KnownFolders.StartMenu;
-                    break;
-                case SpecialFolder.Startup:
-                    folderGuid = Interop.Shell32.KnownFolders.Startup;
-                    break;
-                case SpecialFolder.System:
-                    folderGuid = Interop.Shell32.KnownFolders.System;
-                    break;
-                case SpecialFolder.Templates:
-                    folderGuid = Interop.Shell32.KnownFolders.Templates;
-                    break;
-                case SpecialFolder.DesktopDirectory:
-                    folderGuid = Interop.Shell32.KnownFolders.Desktop;
-                    break;
-                case SpecialFolder.Personal:
-                    // Same as Personal
-                    // case SpecialFolder.MyDocuments:
-                    folderGuid = Interop.Shell32.KnownFolders.Documents;
-                    break;
-                case SpecialFolder.ProgramFiles:
-                    folderGuid = Interop.Shell32.KnownFolders.ProgramFiles;
-                    break;
-                case SpecialFolder.CommonProgramFiles:
-                    folderGuid = Interop.Shell32.KnownFolders.ProgramFilesCommon;
-                    break;
-                case SpecialFolder.AdminTools:
-                    folderGuid = Interop.Shell32.KnownFolders.AdminTools;
-                    break;
-                case SpecialFolder.CDBurning:
-                    folderGuid = Interop.Shell32.KnownFolders.CDBurning;
-                    break;
-                case SpecialFolder.CommonAdminTools:
-                    folderGuid = Interop.Shell32.KnownFolders.CommonAdminTools;
-                    break;
-                case SpecialFolder.CommonDocuments:
-                    folderGuid = Interop.Shell32.KnownFolders.PublicDocuments;
-                    break;
-                case SpecialFolder.CommonMusic:
-                    folderGuid = Interop.Shell32.KnownFolders.PublicMusic;
-                    break;
-                case SpecialFolder.CommonOemLinks:
-                    folderGuid = Interop.Shell32.KnownFolders.CommonOEMLinks;
-                    break;
-                case SpecialFolder.CommonPictures:
-                    folderGuid = Interop.Shell32.KnownFolders.PublicPictures;
-                    break;
-                case SpecialFolder.CommonStartMenu:
-                    folderGuid = Interop.Shell32.KnownFolders.CommonStartMenu;
-                    break;
-                case SpecialFolder.CommonPrograms:
-                    folderGuid = Interop.Shell32.KnownFolders.CommonPrograms;
-                    break;
-                case SpecialFolder.CommonStartup:
-                    folderGuid = Interop.Shell32.KnownFolders.CommonStartup;
-                    break;
-                case SpecialFolder.CommonDesktopDirectory:
-                    folderGuid = Interop.Shell32.KnownFolders.PublicDesktop;
-                    break;
-                case SpecialFolder.CommonTemplates:
-                    folderGuid = Interop.Shell32.KnownFolders.CommonTemplates;
-                    break;
-                case SpecialFolder.CommonVideos:
-                    folderGuid = Interop.Shell32.KnownFolders.PublicVideos;
-                    break;
-                case SpecialFolder.Fonts:
-                    folderGuid = Interop.Shell32.KnownFolders.Fonts;
-                    break;
-                case SpecialFolder.NetworkShortcuts:
-                    folderGuid = Interop.Shell32.KnownFolders.NetHood;
-                    break;
-                case SpecialFolder.PrinterShortcuts:
-                    folderGuid = Interop.Shell32.KnownFolders.PrintersFolder;
-                    break;
-                case SpecialFolder.UserProfile:
-                    folderGuid = Interop.Shell32.KnownFolders.Profile;
-                    break;
-                case SpecialFolder.CommonProgramFilesX86:
-                    folderGuid = Interop.Shell32.KnownFolders.ProgramFilesCommonX86;
-                    break;
-                case SpecialFolder.ProgramFilesX86:
-                    folderGuid = Interop.Shell32.KnownFolders.ProgramFilesX86;
-                    break;
-                case SpecialFolder.Resources:
-                    folderGuid = Interop.Shell32.KnownFolders.ResourceDir;
-                    break;
-                case SpecialFolder.LocalizedResources:
-                    folderGuid = Interop.Shell32.KnownFolders.LocalizedResourcesDir;
-                    break;
-                case SpecialFolder.SystemX86:
-                    folderGuid = Interop.Shell32.KnownFolders.SystemX86;
-                    break;
-                case SpecialFolder.Windows:
-                    folderGuid = Interop.Shell32.KnownFolders.Windows;
-                    break;
-                default:
-                    return string.Empty;
-            }
-
-            return GetKnownFolderPath(folderGuid, option);
-        }
-
-        private static string GetKnownFolderPath(string folderGuid, SpecialFolderOption option)
-        {
-            Guid folderId = new Guid(folderGuid);
-
-            string path;
-            int hr = Interop.Shell32.SHGetKnownFolderPath(folderId, (uint)option, IntPtr.Zero, out path);
-            if (hr != 0) // Not S_OK
-            {
-                return string.Empty;
-            }
-
-            return path;
-        }
-
-        private static bool Is64BitOperatingSystemWhen32BitProcess
-        {
-            get
-            {
-                bool isWow64;
-                return Interop.Kernel32.IsWow64Process(Interop.Kernel32.GetCurrentProcess(), out isWow64) && isWow64;
-            }
-        }
-
-        public static string MachineName
-        {
-            get
-            {
-                string name = Interop.Kernel32.GetComputerName();
-                if (name == null)
+                string samName = domainName.ToString();
+                int index = samName.IndexOf('\\');
+                if (index != -1)
                 {
-                    throw new InvalidOperationException(SR.InvalidOperation_ComputerName);
-                }
-                return name;
-            }
-        }
-
-        private static unsafe Lazy<OperatingSystem> s_osVersion = new Lazy<OperatingSystem>(() =>
-        {
-            var version = new Interop.Kernel32.OSVERSIONINFOEX { dwOSVersionInfoSize = sizeof(Interop.Kernel32.OSVERSIONINFOEX) };
-            if (!Interop.Kernel32.GetVersionExW(ref version))
-            {
-                throw new InvalidOperationException(SR.InvalidOperation_GetVersion);
-            }
-
-            return new OperatingSystem(
-                PlatformID.Win32NT,
-                new Version(version.dwMajorVersion, version.dwMinorVersion, version.dwBuildNumber, (version.wServicePackMajor << 16) | version.wServicePackMinor),
-                Marshal.PtrToStringUni((IntPtr)version.szCSDVersion));
-        });
-
-        public static int ProcessorCount
-        {
-            get
-            {
-                // First try GetLogicalProcessorInformationEx, caching the result as desktop/coreclr does.
-                // If that fails for some reason, fall back to a non-cached result from GetSystemInfo.
-                // (See SystemNative::GetProcessorCount in coreclr for a comparison.)
-                int pc = s_processorCountFromGetLogicalProcessorInformationEx.Value;
-                return pc != 0 ? pc : ProcessorCountFromSystemInfo;
-            }
-        }
-
-        private static readonly unsafe Lazy<int> s_processorCountFromGetLogicalProcessorInformationEx = new Lazy<int>(() =>
-        {
-            // Determine how much size we need for a call to GetLogicalProcessorInformationEx
-            uint len = 0;
-            if (!Interop.Kernel32.GetLogicalProcessorInformationEx(Interop.Kernel32.LOGICAL_PROCESSOR_RELATIONSHIP.RelationGroup, IntPtr.Zero, ref len) &&
-                Marshal.GetLastWin32Error() == Interop.Errors.ERROR_INSUFFICIENT_BUFFER)
-            {
-                // Allocate that much space
-                Debug.Assert(len > 0);
-                var buffer = new byte[len];
-                fixed (byte* bufferPtr = buffer)
-                {
-                    // Call GetLogicalProcessorInformationEx with the allocated buffer
-                    if (Interop.Kernel32.GetLogicalProcessorInformationEx(Interop.Kernel32.LOGICAL_PROCESSOR_RELATIONSHIP.RelationGroup, (IntPtr)bufferPtr, ref len))
-                    {
-                        // Walk each SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX in the buffer, where the Size of each dictates how
-                        // much space it's consuming.  For each group relation, count the number of active processors in each of its group infos.
-                        int processorCount = 0;
-                        byte* ptr = bufferPtr, endPtr = bufferPtr + len;
-                        while (ptr < endPtr)
-                        {
-                            var current = (Interop.Kernel32.SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX*)ptr;
-                            if (current->Relationship == Interop.Kernel32.LOGICAL_PROCESSOR_RELATIONSHIP.RelationGroup)
-                            {
-                                Interop.Kernel32.PROCESSOR_GROUP_INFO* groupInfo = &current->Group.GroupInfo;
-                                int groupCount = current->Group.ActiveGroupCount;
-                                for (int i = 0; i < groupCount; i++)
-                                {
-                                    processorCount += (groupInfo + i)->ActiveProcessorCount;
-                                }
-                            }
-                            ptr += current->Size;
-                        }
-                        return processorCount;
-                    }
+                    userDomainName = samName.Substring(0, index);
+                    return;
                 }
             }
+            domainNameLen = (uint)domainName.Capacity;
 
-            return 0;
-        });
-
-        public static string SystemDirectory
-        {
-            get
+            byte[] sid = new byte[1024];
+            int sidLen = sid.Length;
+            int peUse;
+            if (!Interop.Advapi32.LookupAccountNameW(null, UserName, sid, ref sidLen, domainName, ref domainNameLen, out peUse))
             {
-                StringBuilder sb = StringBuilderCache.Acquire(PathInternal.MaxShortPath);
-                if (Interop.Kernel32.GetSystemDirectoryW(sb, PathInternal.MaxShortPath) == 0)
-                {
-                    StringBuilderCache.Release(sb);
-                    throw Win32Marshal.GetExceptionForLastWin32Error();
-                }
-                return StringBuilderCache.GetStringAndRelease(sb);
+                throw new InvalidOperationException(Win32Marshal.GetExceptionForLastWin32Error().Message);
             }
+
+            userDomainName = domainName.ToString();
         }
-
-        public static string UserName
-        {
-            get
-            {
-#if !uap
-                // Use GetUserNameExW, as GetUserNameW isn't available on all platforms, e.g. Win7
-                var domainName = new StringBuilder(1024);
-                uint domainNameLen = (uint)domainName.Capacity;
-                if (Interop.Secur32.GetUserNameExW(Interop.Secur32.NameSamCompatible, domainName, ref domainNameLen) == 1)
-                {
-                    string samName = domainName.ToString();
-                    int index = samName.IndexOf('\\');
-                    if (index != -1)
-                    {
-                        return samName.Substring(index + 1);
-                    }
-                }
-
-                return string.Empty;
-#else
-                return "Windows User";
-#endif
-            }
-        }
-
-        public static string UserDomainName
-        {
-            get
-            {
-#if !uap
-                var domainName = new StringBuilder(1024);
-                uint domainNameLen = (uint)domainName.Capacity;
-                if (Interop.Secur32.GetUserNameExW(Interop.Secur32.NameSamCompatible, domainName, ref domainNameLen) == 1)
-                {
-                    string samName = domainName.ToString();
-                    int index = samName.IndexOf('\\');
-                    if (index != -1)
-                    {
-                        return samName.Substring(0, index);
-                    }
-                }
-                domainNameLen = (uint)domainName.Capacity;
-
-                byte[] sid = new byte[1024];
-                int sidLen = sid.Length;
-                int peUse;
-                if (!Interop.Advapi32.LookupAccountNameW(null, UserName, sid, ref sidLen, domainName, ref domainNameLen, out peUse))
-                {
-                    throw new InvalidOperationException(Win32Marshal.GetExceptionForLastWin32Error().Message);
-                }
-
-                return domainName.ToString();
-#else
-                return "Windows Domain";
-#endif
-            }
-        }
-
     }
 }

--- a/src/System.Runtime.Extensions/src/System/Environment.Win32.cs
+++ b/src/System.Runtime.Extensions/src/System/Environment.Win32.cs
@@ -327,6 +327,7 @@ namespace System
         {
             get
             {
+#if !uap
                 // Use GetUserNameExW, as GetUserNameW isn't available on all platforms, e.g. Win7
                 var domainName = new StringBuilder(1024);
                 uint domainNameLen = (uint)domainName.Capacity;
@@ -341,6 +342,9 @@ namespace System
                 }
 
                 return string.Empty;
+#else
+                return "Windows User";
+#endif
             }
         }
 
@@ -348,6 +352,7 @@ namespace System
         {
             get
             {
+#if !uap
                 var domainName = new StringBuilder(1024);
                 uint domainNameLen = (uint)domainName.Capacity;
                 if (Interop.Secur32.GetUserNameExW(Interop.Secur32.NameSamCompatible, domainName, ref domainNameLen) == 1)
@@ -370,6 +375,9 @@ namespace System
                 }
 
                 return domainName.ToString();
+#else
+                return "Windows Domain";
+#endif
             }
         }
 

--- a/src/System.Runtime.Extensions/src/System/Environment.Windows.cs
+++ b/src/System.Runtime.Extensions/src/System/Environment.Windows.cs
@@ -2,9 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
+using Internal.Runtime.Augments;
 
 namespace System
 {
@@ -85,5 +87,340 @@ namespace System
                 return info.dwPageSize;
             }
         }
+
+        public static int ExitCode { get { return EnvironmentAugments.ExitCode; } set { EnvironmentAugments.ExitCode = value; } }
+
+        private static string ExpandEnvironmentVariablesCore(string name)
+        {
+            int currentSize = 100;
+            StringBuilder result = StringBuilderCache.Acquire(currentSize); // A somewhat reasonable default size
+
+            result.Length = 0;
+            int size = Interop.Kernel32.ExpandEnvironmentStringsW(name, result, currentSize);
+            if (size == 0)
+            {
+                StringBuilderCache.Release(result);
+                Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+            }
+
+            while (size > currentSize)
+            {
+                currentSize = size;
+                result.Length = 0;
+                result.Capacity = currentSize;
+
+                size = Interop.Kernel32.ExpandEnvironmentStringsW(name, result, currentSize);
+                if (size == 0)
+                {
+                    StringBuilderCache.Release(result);
+                    Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+                }
+            }
+
+            return StringBuilderCache.GetStringAndRelease(result);
+        }
+
+        private static string GetFolderPathCore(SpecialFolder folder, SpecialFolderOption option)
+        {
+            // We're using SHGetKnownFolderPath instead of SHGetFolderPath as SHGetFolderPath is
+            // capped at MAX_PATH.
+            //
+            // Because we validate both of the input enums we shouldn't have to care about CSIDL and flag
+            // definitions we haven't mapped. If we remove or loosen the checks we'd have to account
+            // for mapping here (this includes tweaking as SHGetFolderPath would do).
+            //
+            // The only SpecialFolderOption defines we have are equivalent to KnownFolderFlags.
+
+            string folderGuid;
+
+            switch (folder)
+            {
+                case SpecialFolder.ApplicationData:
+                    folderGuid = Interop.Shell32.KnownFolders.RoamingAppData;
+                    break;
+                case SpecialFolder.CommonApplicationData:
+                    folderGuid = Interop.Shell32.KnownFolders.ProgramData;
+                    break;
+                case SpecialFolder.LocalApplicationData:
+                    folderGuid = Interop.Shell32.KnownFolders.LocalAppData;
+                    break;
+                case SpecialFolder.Cookies:
+                    folderGuid = Interop.Shell32.KnownFolders.Cookies;
+                    break;
+                case SpecialFolder.Desktop:
+                    folderGuid = Interop.Shell32.KnownFolders.Desktop;
+                    break;
+                case SpecialFolder.Favorites:
+                    folderGuid = Interop.Shell32.KnownFolders.Favorites;
+                    break;
+                case SpecialFolder.History:
+                    folderGuid = Interop.Shell32.KnownFolders.History;
+                    break;
+                case SpecialFolder.InternetCache:
+                    folderGuid = Interop.Shell32.KnownFolders.InternetCache;
+                    break;
+                case SpecialFolder.Programs:
+                    folderGuid = Interop.Shell32.KnownFolders.Programs;
+                    break;
+                case SpecialFolder.MyComputer:
+                    folderGuid = Interop.Shell32.KnownFolders.ComputerFolder;
+                    break;
+                case SpecialFolder.MyMusic:
+                    folderGuid = Interop.Shell32.KnownFolders.Music;
+                    break;
+                case SpecialFolder.MyPictures:
+                    folderGuid = Interop.Shell32.KnownFolders.Pictures;
+                    break;
+                case SpecialFolder.MyVideos:
+                    folderGuid = Interop.Shell32.KnownFolders.Videos;
+                    break;
+                case SpecialFolder.Recent:
+                    folderGuid = Interop.Shell32.KnownFolders.Recent;
+                    break;
+                case SpecialFolder.SendTo:
+                    folderGuid = Interop.Shell32.KnownFolders.SendTo;
+                    break;
+                case SpecialFolder.StartMenu:
+                    folderGuid = Interop.Shell32.KnownFolders.StartMenu;
+                    break;
+                case SpecialFolder.Startup:
+                    folderGuid = Interop.Shell32.KnownFolders.Startup;
+                    break;
+                case SpecialFolder.System:
+                    folderGuid = Interop.Shell32.KnownFolders.System;
+                    break;
+                case SpecialFolder.Templates:
+                    folderGuid = Interop.Shell32.KnownFolders.Templates;
+                    break;
+                case SpecialFolder.DesktopDirectory:
+                    folderGuid = Interop.Shell32.KnownFolders.Desktop;
+                    break;
+                case SpecialFolder.Personal:
+                    // Same as Personal
+                    // case SpecialFolder.MyDocuments:
+                    folderGuid = Interop.Shell32.KnownFolders.Documents;
+                    break;
+                case SpecialFolder.ProgramFiles:
+                    folderGuid = Interop.Shell32.KnownFolders.ProgramFiles;
+                    break;
+                case SpecialFolder.CommonProgramFiles:
+                    folderGuid = Interop.Shell32.KnownFolders.ProgramFilesCommon;
+                    break;
+                case SpecialFolder.AdminTools:
+                    folderGuid = Interop.Shell32.KnownFolders.AdminTools;
+                    break;
+                case SpecialFolder.CDBurning:
+                    folderGuid = Interop.Shell32.KnownFolders.CDBurning;
+                    break;
+                case SpecialFolder.CommonAdminTools:
+                    folderGuid = Interop.Shell32.KnownFolders.CommonAdminTools;
+                    break;
+                case SpecialFolder.CommonDocuments:
+                    folderGuid = Interop.Shell32.KnownFolders.PublicDocuments;
+                    break;
+                case SpecialFolder.CommonMusic:
+                    folderGuid = Interop.Shell32.KnownFolders.PublicMusic;
+                    break;
+                case SpecialFolder.CommonOemLinks:
+                    folderGuid = Interop.Shell32.KnownFolders.CommonOEMLinks;
+                    break;
+                case SpecialFolder.CommonPictures:
+                    folderGuid = Interop.Shell32.KnownFolders.PublicPictures;
+                    break;
+                case SpecialFolder.CommonStartMenu:
+                    folderGuid = Interop.Shell32.KnownFolders.CommonStartMenu;
+                    break;
+                case SpecialFolder.CommonPrograms:
+                    folderGuid = Interop.Shell32.KnownFolders.CommonPrograms;
+                    break;
+                case SpecialFolder.CommonStartup:
+                    folderGuid = Interop.Shell32.KnownFolders.CommonStartup;
+                    break;
+                case SpecialFolder.CommonDesktopDirectory:
+                    folderGuid = Interop.Shell32.KnownFolders.PublicDesktop;
+                    break;
+                case SpecialFolder.CommonTemplates:
+                    folderGuid = Interop.Shell32.KnownFolders.CommonTemplates;
+                    break;
+                case SpecialFolder.CommonVideos:
+                    folderGuid = Interop.Shell32.KnownFolders.PublicVideos;
+                    break;
+                case SpecialFolder.Fonts:
+                    folderGuid = Interop.Shell32.KnownFolders.Fonts;
+                    break;
+                case SpecialFolder.NetworkShortcuts:
+                    folderGuid = Interop.Shell32.KnownFolders.NetHood;
+                    break;
+                case SpecialFolder.PrinterShortcuts:
+                    folderGuid = Interop.Shell32.KnownFolders.PrintersFolder;
+                    break;
+                case SpecialFolder.UserProfile:
+                    folderGuid = Interop.Shell32.KnownFolders.Profile;
+                    break;
+                case SpecialFolder.CommonProgramFilesX86:
+                    folderGuid = Interop.Shell32.KnownFolders.ProgramFilesCommonX86;
+                    break;
+                case SpecialFolder.ProgramFilesX86:
+                    folderGuid = Interop.Shell32.KnownFolders.ProgramFilesX86;
+                    break;
+                case SpecialFolder.Resources:
+                    folderGuid = Interop.Shell32.KnownFolders.ResourceDir;
+                    break;
+                case SpecialFolder.LocalizedResources:
+                    folderGuid = Interop.Shell32.KnownFolders.LocalizedResourcesDir;
+                    break;
+                case SpecialFolder.SystemX86:
+                    folderGuid = Interop.Shell32.KnownFolders.SystemX86;
+                    break;
+                case SpecialFolder.Windows:
+                    folderGuid = Interop.Shell32.KnownFolders.Windows;
+                    break;
+                default:
+                    return string.Empty;
+            }
+
+            return GetKnownFolderPath(folderGuid, option);
+        }
+
+        private static string GetKnownFolderPath(string folderGuid, SpecialFolderOption option)
+        {
+            Guid folderId = new Guid(folderGuid);
+
+            string path;
+            int hr = Interop.Shell32.SHGetKnownFolderPath(folderId, (uint)option, IntPtr.Zero, out path);
+            if (hr != 0) // Not S_OK
+            {
+                return string.Empty;
+            }
+
+            return path;
+        }
+
+        private static bool Is64BitOperatingSystemWhen32BitProcess
+        {
+            get
+            {
+                bool isWow64;
+                return Interop.Kernel32.IsWow64Process(Interop.Kernel32.GetCurrentProcess(), out isWow64) && isWow64;
+            }
+        }
+
+        public static string MachineName
+        {
+            get
+            {
+                string name = Interop.Kernel32.GetComputerName();
+                if (name == null)
+                {
+                    throw new InvalidOperationException(SR.InvalidOperation_ComputerName);
+                }
+                return name;
+            }
+        }
+
+        private static unsafe Lazy<OperatingSystem> s_osVersion = new Lazy<OperatingSystem>(() =>
+        {
+            var version = new Interop.Kernel32.OSVERSIONINFOEX { dwOSVersionInfoSize = sizeof(Interop.Kernel32.OSVERSIONINFOEX) };
+            if (!Interop.Kernel32.GetVersionExW(ref version))
+            {
+                throw new InvalidOperationException(SR.InvalidOperation_GetVersion);
+            }
+
+            return new OperatingSystem(
+                PlatformID.Win32NT,
+                new Version(version.dwMajorVersion, version.dwMinorVersion, version.dwBuildNumber, (version.wServicePackMajor << 16) | version.wServicePackMinor),
+                Marshal.PtrToStringUni((IntPtr)version.szCSDVersion));
+        });
+
+        public static int ProcessorCount
+        {
+            get
+            {
+                // First try GetLogicalProcessorInformationEx, caching the result as desktop/coreclr does.
+                // If that fails for some reason, fall back to a non-cached result from GetSystemInfo.
+                // (See SystemNative::GetProcessorCount in coreclr for a comparison.)
+                int pc = s_processorCountFromGetLogicalProcessorInformationEx.Value;
+                return pc != 0 ? pc : ProcessorCountFromSystemInfo;
+            }
+        }
+
+        private static readonly unsafe Lazy<int> s_processorCountFromGetLogicalProcessorInformationEx = new Lazy<int>(() =>
+        {
+            // Determine how much size we need for a call to GetLogicalProcessorInformationEx
+            uint len = 0;
+            if (!Interop.Kernel32.GetLogicalProcessorInformationEx(Interop.Kernel32.LOGICAL_PROCESSOR_RELATIONSHIP.RelationGroup, IntPtr.Zero, ref len) &&
+                Marshal.GetLastWin32Error() == Interop.Errors.ERROR_INSUFFICIENT_BUFFER)
+            {
+                // Allocate that much space
+                Debug.Assert(len > 0);
+                var buffer = new byte[len];
+                fixed (byte* bufferPtr = buffer)
+                {
+                    // Call GetLogicalProcessorInformationEx with the allocated buffer
+                    if (Interop.Kernel32.GetLogicalProcessorInformationEx(Interop.Kernel32.LOGICAL_PROCESSOR_RELATIONSHIP.RelationGroup, (IntPtr)bufferPtr, ref len))
+                    {
+                        // Walk each SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX in the buffer, where the Size of each dictates how
+                        // much space it's consuming.  For each group relation, count the number of active processors in each of its group infos.
+                        int processorCount = 0;
+                        byte* ptr = bufferPtr, endPtr = bufferPtr + len;
+                        while (ptr < endPtr)
+                        {
+                            var current = (Interop.Kernel32.SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX*)ptr;
+                            if (current->Relationship == Interop.Kernel32.LOGICAL_PROCESSOR_RELATIONSHIP.RelationGroup)
+                            {
+                                Interop.Kernel32.PROCESSOR_GROUP_INFO* groupInfo = &current->Group.GroupInfo;
+                                int groupCount = current->Group.ActiveGroupCount;
+                                for (int i = 0; i < groupCount; i++)
+                                {
+                                    processorCount += (groupInfo + i)->ActiveProcessorCount;
+                                }
+                            }
+                            ptr += current->Size;
+                        }
+                        return processorCount;
+                    }
+                }
+            }
+
+            return 0;
+        });
+
+        public static string SystemDirectory
+        {
+            get
+            {
+                StringBuilder sb = StringBuilderCache.Acquire(PathInternal.MaxShortPath);
+                if (Interop.Kernel32.GetSystemDirectoryW(sb, PathInternal.MaxShortPath) == 0)
+                {
+                    StringBuilderCache.Release(sb);
+                    throw Win32Marshal.GetExceptionForLastWin32Error();
+                }
+                return StringBuilderCache.GetStringAndRelease(sb);
+            }
+        }
+
+        public static string UserName
+        {
+            get
+            {
+                string username = "Windows User";
+                GetUserName(ref username);
+                return username;
+            }
+        }
+
+        static partial void GetUserName(ref string username);
+
+        public static string UserDomainName
+        {
+            get
+            {
+                string userDomainName = "Windows Domain";
+                GetDomainName(ref userDomainName);
+                return userDomainName;
+            }
+        }
+
+        static partial void GetDomainName(ref string userDomainName);
     }
 }

--- a/src/System.Runtime.Extensions/tests/AssemblyResolveTests/AssemblyResolveTests.csproj
+++ b/src/System.Runtime.Extensions/tests/AssemblyResolveTests/AssemblyResolveTests.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <ProjectGuid>ad83807c-8be5-4f27-85df-9793613233e1</ProjectGuid>
+    <ProjectGuid>{E60AFAE8-2EA7-471C-9E24-52A99453B26B}</ProjectGuid>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <ProjectGuid>{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DefineConstants Condition="'$(TargetsUnix)' == 'true'" >$(DefineConstants);Unix</DefineConstants>
+    <DefineConstants Condition="'$(TargetsUnix)' == 'true'">$(DefineConstants);Unix</DefineConstants>
     <DefineConstants Condition="'$(TargetGroup)'=='netcoreapp'">$(DefineConstants);netcoreapp</DefineConstants>
     <DefineConstants Condition="'$(TargetGroup)'=='uapaot'">$(DefineConstants);uapaot</DefineConstants>
   </PropertyGroup>
@@ -39,6 +39,8 @@
     <Compile Include="System\UnloadingAndProcessExitTests.netcoreapp.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="System\Environment.UserDomainName.cs" />
+    <Compile Include="System\Environment.UserName.cs" />
     <Compile Include="System\Diagnostics\Stopwatch.cs" />
     <Compile Include="System\Environment.MachineName.cs" />
     <Compile Include="System\IO\Path.Combine.cs" />

--- a/src/System.Runtime.Extensions/tests/System/Environment.UserDomainName.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.UserDomainName.cs
@@ -8,7 +8,7 @@ namespace System.Tests
         [SkipOnTargetFramework(~TargetFrameworkMonikers.Uap)]
         public void UserDomainNameIsHardCodedOnUap()
         {
-            Assert.Equal("Windows Domain", Environment.UserName);
+            Assert.Equal("Windows Domain", Environment.UserDomainName);
         }
 
         [Fact]
@@ -16,7 +16,7 @@ namespace System.Tests
         public void UserDomainNameIsCorrectOnNonUap()
         {
             // Highly unlikely anyone is using domain with this name
-            Assert.NotEqual("Windows Domain", Environment.UserName);
+            Assert.NotEqual("Windows Domain", Environment.UserDomainName);
         }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/Environment.UserDomainName.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.UserDomainName.cs
@@ -1,0 +1,22 @@
+﻿using Xunit;
+
+namespace System.Tests
+{
+    public class EnvironmentUserDomainName
+    {
+        [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.Uap)]
+        public void UserDomainNameIsHardCodedOnUap()
+        {
+            Assert.Equal("Windows Domain", Environment.UserName);
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)]
+        public void UserDomainNameIsCorrectOnNonUap()
+        {
+            // Highly unlikely anyone is using domain with this name
+            Assert.NotEqual("Windows Domain", Environment.UserName);
+        }
+    }
+}

--- a/src/System.Runtime.Extensions/tests/System/Environment.UserName.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.UserName.cs
@@ -1,0 +1,22 @@
+﻿using Xunit;
+
+namespace System.Tests
+{
+    public class EnvironmentUserName
+    {
+        [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.Uap)]
+        public void UserNameIsHardCodedOnUap()
+        {
+            Assert.Equal("Windows User", Environment.UserName);
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)]
+        public void UserNameIsCorrectOnNonUap()
+        {
+            // Highly unlikely anyone is using user with this name
+            Assert.NotEqual("Windows User", Environment.UserName);
+        }
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/20618

Please review also hard coded string.

Notes:
- Content of Environment.Win32 moved to Environment.Windows (largest part of the diff)
- non UAP implementation is now in Environment.Win32
