### PR TITLE
SerialPort: Use correct charset when unpacking port names

### DIFF
--- a/src/System.IO.Ports/tests/Support/PortHelper.cs
+++ b/src/System.IO.Ports/tests/Support/PortHelper.cs
@@ -35,7 +35,7 @@ namespace Legacy.Support
                         returnSize = QueryDosDevice(null, mem, maxSize);
                         if (returnSize != 0)
                         {
-                            string allDevices = Marshal.PtrToStringAnsi(mem, returnSize);
+                            string allDevices = Marshal.PtrToStringUni(mem, returnSize);
                             retval = allDevices.Split('\0');
                             break;    // not really needed, but makes it more clear...
                         }


### PR DESCRIPTION
This fixes a regression caused by changing the p/invoke character set of a `QueryDosDevice` call in #18928.

The symptom prior to applying this is that the test suite does not detect any serial ports so doesn't run any tests.