### PR TITLE
Fix WinHttpResponseStream when reading 0 bytes

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
@@ -207,6 +207,11 @@ namespace System.Net.Http
 
         private async Task<int> ReadAsyncCore(byte[] buffer, int offset, int count, CancellationToken token)
         {
+            if (count == 0)
+            {
+                return 0;
+            }
+
             _state.PinReceiveBuffer(buffer);
             var ctr = token.Register(s => ((WinHttpResponseStream)s).CancelPendingResponseStreamReadOperation(), this);
             _state.AsyncReadInProgress = true;

--- a/src/System.Net.Http/tests/FunctionalTests/ResponseStreamTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ResponseStreamTest.cs
@@ -94,6 +94,18 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop] // TODO: Issue #11345
         [Fact]
+        public async Task GetStreamAsync_ReadZeroBytes_Success()
+        {
+            using (var client = new HttpClient())
+            using (Stream stream = await client.GetStreamAsync(Configuration.Http.RemoteEchoServer))
+            {
+                int bytesRead = await stream.ReadAsync(new byte[1], 0, 0);
+                Assert.Equal(0, bytesRead);
+            }
+        }
+
+        [OuterLoop] // TODO: Issue #11345
+        [Fact]
         public async Task ReadAsStreamAsync_Cancel_TaskIsCanceled()
         {
             var cts = new CancellationTokenSource();


### PR DESCRIPTION
Fixes #20676