### PR TITLE
Disable more HttpListener tests on UAP/UAPAOT test runs

### DIFF
--- a/src/System.Net.HttpListener/tests/HttpListenerPrefixCollectionTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerPrefixCollectionTests.cs
@@ -107,6 +107,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue(17462, TargetFrameworkMonikers.UapAot)]
         public void CopyTo_NonZeroLowerBoundArray_ThrowsIndexOutOfRangeException()
         {
             var listener = new HttpListener();

--- a/src/System.Net.HttpListener/tests/HttpListenerRequestTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerRequestTests.cs
@@ -244,6 +244,7 @@ namespace System.Net.Tests
             Assert.NotEqual(Guid.Empty, request.RequestTraceIdentifier);
         }
 
+        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [Theory]
         [InlineData("Connection: ", false)]
         [InlineData("Connection: Connection\r\nUpgrade: ", false)]
@@ -504,6 +505,7 @@ namespace System.Net.Tests
             Assert.Equal(expected, request.KeepAlive);
         }
 
+        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [Theory]
         [InlineData("1.0")]
         [InlineData("1.1")]

--- a/src/System.Net.HttpListener/tests/HttpRequestStreamTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpRequestStreamTests.cs
@@ -327,6 +327,7 @@ namespace System.Net.Tests
         }
 
         [Theory]
+        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task Read_Disposed_ReturnsZero(bool transferEncodingChunked)
@@ -355,6 +356,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task CanSeek_Get_ReturnsFalse()
         {
             HttpListenerRequest response = await _helper.GetRequest(chunked: true);
@@ -373,6 +375,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task CanRead_Get_ReturnsTrue()
         {
             HttpListenerRequest request = await _helper.GetRequest(chunked: true);
@@ -383,6 +386,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task CanWrite_Get_ReturnsFalse()
         {
             HttpListenerRequest request = await _helper.GetRequest(chunked: true);
@@ -401,6 +405,7 @@ namespace System.Net.Tests
         }
 
         [Theory]
+        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task Read_NullBuffer_ThrowsArgumentNullException(bool chunked)
@@ -414,6 +419,7 @@ namespace System.Net.Tests
         }
 
         [Theory]
+        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(-1, true)]
         [InlineData(3, true)]
         [InlineData(-1, false)]
@@ -429,6 +435,7 @@ namespace System.Net.Tests
         }
 
         [Theory]
+        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(0, 3, true)]
         [InlineData(1, 2, true)]
         [InlineData(2, 1, true)]
@@ -446,6 +453,7 @@ namespace System.Net.Tests
         }
 
         [Theory]
+        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task EndRead_NullAsyncResult_ThrowsArgumentNullException(bool chunked)
@@ -458,6 +466,7 @@ namespace System.Net.Tests
         }
 
         [Theory]
+        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task EndRead_InvalidAsyncResult_ThrowsArgumentException(bool chunked)
@@ -476,6 +485,7 @@ namespace System.Net.Tests
         }
 
         [Theory]
+        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task EndRead_CalledTwice_ThrowsInvalidOperationException(bool chunked)

--- a/src/System.Net.HttpListener/tests/HttpResponseStreamTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpResponseStreamTests.cs
@@ -219,6 +219,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task CanSeek_Get_ReturnsFalse()
         {
             using (HttpListenerResponse response = await _helper.GetResponse())
@@ -237,6 +238,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task CanRead_Get_ReturnsFalse()
         {
             using (HttpListenerResponse response = await _helper.GetResponse())
@@ -251,6 +253,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task CanWrite_Get_ReturnsTrue()
         {
             using (HttpListenerResponse response = await _helper.GetResponse())
@@ -265,6 +268,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task Write_NullBuffer_ThrowsArgumentNullException()
         {
             using (HttpListenerResponse response = await _helper.GetResponse())
@@ -275,6 +279,7 @@ namespace System.Net.Tests
             }
         }
 
+        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [Theory]
         [InlineData(-1)]
         [InlineData(3)]
@@ -288,6 +293,7 @@ namespace System.Net.Tests
             }
         }
 
+        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [Theory]
         [InlineData(0, 3)]
         [InlineData(1, 2)]
@@ -548,6 +554,7 @@ namespace System.Net.Tests
             }
         }
 
+        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
@@ -561,6 +568,7 @@ namespace System.Net.Tests
             }
         }
 
+        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [Fact]
         public async Task EndWrite_InvalidAsyncResult_ThrowsArgumentException()
         {
@@ -576,6 +584,7 @@ namespace System.Net.Tests
             }
         }
 
+        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [Fact]
         public async Task EndWrite_CalledTwice_ThrowsInvalidOperationException()
         {


### PR DESCRIPTION
HttpListener is not ready for UAP/UAPAOT.  It is currently trying to use
the .NET Core implementation which uses http.sys.  Instead, the plan is
to use the maanaged implementation (currently only used on *Nix).

Contributes to #17462