### PR TITLE
SerialPort: Adjust CI-suppression rules for difficult serial tests

### DIFF
--- a/src/System.IO.Ports/tests/Configurations.props
+++ b/src/System.IO.Ports/tests/Configurations.props
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <BuildConfigurations>
       netstandard-Windows_NT;
-      netstandard;
       netfx;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.IO.Ports/tests/Configurations.props
+++ b/src/System.IO.Ports/tests/Configurations.props
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <BuildConfigurations>
       netstandard-Windows_NT;
+      netstandard;
+      netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.Ports/tests/SerialPort/Event_Close_Stress.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Event_Close_Stress.cs
@@ -82,7 +82,6 @@ namespace System.IO.Ports.Tests
             }
         }
 
-        [OuterLoop("Slow Test")]
         [ConditionalFact(nameof(HasNullModem))]
         public void ErrorReceived_Close_Stress()
         {

--- a/src/System.IO.Ports/tests/SerialPort/Event_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Event_Generic.cs
@@ -21,7 +21,6 @@ namespace System.IO.Ports.Tests
 
         #region Test Cases
 
-        [OuterLoop("Slow Test")]
         [ConditionalFact(nameof(HasNullModem))]
         public void EventHandlers_CalledSerially()
         {
@@ -219,7 +218,6 @@ namespace System.IO.Ports.Tests
             }
         }
 
-        [OuterLoop("Slow Test")]
         [ConditionalFact(nameof(HasNullModem))]
         public void Thread_In_PinChangedEvent()
         {
@@ -256,7 +254,6 @@ namespace System.IO.Ports.Tests
             }
         }
 
-        [OuterLoop("Slow Test")]
         [ConditionalFact(nameof(HasNullModem))]
         public void Thread_In_ReceivedEvent()
         {
@@ -296,7 +293,6 @@ namespace System.IO.Ports.Tests
             }
         }
 
-        [OuterLoop("Slow Test")]
         [ConditionalFact(nameof(HasNullModem))]
         public void Thread_In_ErrorEvent()
         {

--- a/src/System.IO.Ports/tests/SerialPort/ReadByte_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReadByte_Generic.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading;
 using Legacy.Support;
 using Xunit;
+using Xunit.NetCore.Extensions;
 
 namespace System.IO.Ports.Tests
 {
@@ -68,7 +69,7 @@ namespace System.IO.Ports.Tests
             }
         }
 
-        [OuterLoop("Slow test")]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]  // Timing-sensitive
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void Timeout()
         {
@@ -85,7 +86,7 @@ namespace System.IO.Ports.Tests
             }
         }
 
-        [OuterLoop("Slow test")]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]  // Timing-sensitive
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void SuccessiveReadTimeoutNoData()
         {

--- a/src/System.IO.Ports/tests/SerialPort/ReadChar_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReadChar_Generic.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Threading;
 using Legacy.Support;
 using Xunit;
+using Xunit.NetCore.Extensions;
 
 namespace System.IO.Ports.Tests
 {
@@ -70,7 +71,7 @@ namespace System.IO.Ports.Tests
             }
         }
 
-        [OuterLoop("Slow test")]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]  // Timing-sensitive
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void Timeout()
         {
@@ -86,7 +87,7 @@ namespace System.IO.Ports.Tests
             }
         }
 
-        [OuterLoop("Slow test")]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]  // Timing-sensitive
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void SuccessiveReadTimeoutNoData()
         {

--- a/src/System.IO.Ports/tests/SerialPort/ReadLine_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReadLine_Generic.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading;
 using Legacy.Support;
 using Xunit;
+using Xunit.NetCore.Extensions;
 
 namespace System.IO.Ports.Tests
 {
@@ -79,7 +80,7 @@ namespace System.IO.Ports.Tests
             }
         }
 
-        [OuterLoop("Slow test")]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]  // Timing-sensitive
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void Timeout()
         {
@@ -95,7 +96,7 @@ namespace System.IO.Ports.Tests
             }
         }
 
-        [OuterLoop("Slow test")]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]  // Timing-sensitive
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void SuccessiveReadTimeoutNoData()
         {

--- a/src/System.IO.Ports/tests/SerialPort/ReadTo_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReadTo_Generic.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading;
 using Legacy.Support;
 using Xunit;
+using Xunit.NetCore.Extensions;
 
 namespace System.IO.Ports.Tests
 {
@@ -77,7 +78,7 @@ namespace System.IO.Ports.Tests
             }
         }
 
-        [OuterLoop("Slow test")]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]  // Timing-sensitive
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void Timeout()
         {
@@ -94,7 +95,7 @@ namespace System.IO.Ports.Tests
             }
         }
 
-        [OuterLoop("Slow test")]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]  // Timing-sensitive
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void SuccessiveReadTimeoutNoData()
         {

--- a/src/System.IO.Ports/tests/SerialPort/Read_byte_int_int_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Read_byte_int_int_Generic.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Threading;
 using Legacy.Support;
 using Xunit;
+using Xunit.NetCore.Extensions;
 
 namespace System.IO.Ports.Tests
 {
@@ -80,7 +81,7 @@ namespace System.IO.Ports.Tests
             }
         }
 
-        [OuterLoop("Slow test")]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]  // Timing-sensitive
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void Timeout()
         {
@@ -96,7 +97,7 @@ namespace System.IO.Ports.Tests
             }
         }
 
-        [OuterLoop("Slow test")]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]  // Timing-sensitive
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void SuccessiveReadTimeoutNoData()
         {

--- a/src/System.IO.Ports/tests/SerialPort/Read_char_int_int_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Read_char_int_int_Generic.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading;
 using Legacy.Support;
 using Xunit;
+using Xunit.NetCore.Extensions;
 
 namespace System.IO.Ports.Tests
 {
@@ -82,7 +83,7 @@ namespace System.IO.Ports.Tests
             }
         }
 
-        [OuterLoop("Slow test")]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]  // Timing-sensitive
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void Timeout()
         {
@@ -98,7 +99,7 @@ namespace System.IO.Ports.Tests
             }
         }
 
-        [OuterLoop("Slow test")]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]  // Timing-sensitive
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void SuccessiveReadTimeoutNoData()
         {

--- a/src/System.IO.Ports/tests/SerialPort/WriteLine_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/WriteLine_Generic.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Legacy.Support;
 using Xunit;
+using Xunit.NetCore.Extensions;
 using ThreadState = System.Threading.ThreadState;
 
 namespace System.IO.Ports.Tests
@@ -105,7 +106,7 @@ namespace System.IO.Ports.Tests
             }
         }
 
-        [OuterLoop("Slow test")]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]  // Timing-sensitive
         [ConditionalFact(nameof(HasOneSerialPort), nameof(HasHardwareFlowControl))]
         public void SuccessiveReadTimeout()
         {

--- a/src/System.IO.Ports/tests/SerialPort/Write_byte_int_int_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Write_byte_int_int_Generic.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading;
 using Legacy.Support;
 using Xunit;
+using Xunit.NetCore.Extensions;
 using ThreadState = System.Threading.ThreadState;
 
 namespace System.IO.Ports.Tests
@@ -79,7 +80,6 @@ namespace System.IO.Ports.Tests
             }
         }
 
-        [OuterLoop("Slow test")]
         [ConditionalFact(nameof(HasNullModem))]
         public void Timeout()
         {
@@ -107,7 +107,7 @@ namespace System.IO.Ports.Tests
             }
         }
 
-        [OuterLoop("Slow test")]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]  // Timing-sensitive
         [ConditionalFact(nameof(HasOneSerialPort), nameof(HasHardwareFlowControl))]
         public void SuccessiveReadTimeout()
         {

--- a/src/System.IO.Ports/tests/SerialPort/Write_char_int_int_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Write_char_int_int_Generic.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading;
 using Legacy.Support;
 using Xunit;
+using Xunit.NetCore.Extensions;
 using ThreadState = System.Threading.ThreadState;
 
 namespace System.IO.Ports.Tests
@@ -80,7 +81,6 @@ namespace System.IO.Ports.Tests
             }
         }
 
-        [OuterLoop("Slow test")]
         [ConditionalFact(nameof(HasNullModem))]
         public void Timeout()
         {
@@ -109,7 +109,7 @@ namespace System.IO.Ports.Tests
             }
         }
 
-        [OuterLoop("Slow test")]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]  // Timing-sensitive
         [ConditionalFact(nameof(HasOneSerialPort), nameof(HasHardwareFlowControl))]
         public void SuccessiveReadTimeout()
         {

--- a/src/System.IO.Ports/tests/SerialPort/Write_str_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Write_str_Generic.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading;
 using Legacy.Support;
 using Xunit;
+using Xunit.NetCore.Extensions;
 using ThreadState = System.Threading.ThreadState;
 
 namespace System.IO.Ports.Tests
@@ -106,7 +107,7 @@ namespace System.IO.Ports.Tests
             }
         }
 
-        [OuterLoop("Slow test")]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]  // Timing-sensitive
         [ConditionalFact(nameof(HasOneSerialPort), nameof(HasHardwareFlowControl))]
         public void SuccessiveReadTimeout()
         {

--- a/src/System.IO.Ports/tests/SerialStream/ReadByte_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialStream/ReadByte_Generic.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading;
 using Legacy.Support;
 using Xunit;
+using Xunit.NetCore.Extensions;
 
 namespace System.IO.Ports.Tests
 {
@@ -61,7 +62,7 @@ namespace System.IO.Ports.Tests
             }
         }
 
-        [OuterLoop("Slow test")]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]  // Timing-sensitive
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void Timeout()
         {
@@ -78,7 +79,7 @@ namespace System.IO.Ports.Tests
             }
         }
 
-        [OuterLoop("Slow test")]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]  // Timing-sensitive
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void SuccessiveReadTimeoutNoData()
         {

--- a/src/System.IO.Ports/tests/SerialStream/ReadTimeout.cs
+++ b/src/System.IO.Ports/tests/SerialStream/ReadTimeout.cs
@@ -7,6 +7,7 @@ using System.IO.PortsTests;
 using System.Threading;
 using Legacy.Support;
 using Xunit;
+using Xunit.NetCore.Extensions;
 
 namespace System.IO.Ports.Tests
 {
@@ -114,7 +115,7 @@ namespace System.IO.Ports.Tests
             VerifyLongTimeout(ReadByte, int.MaxValue - 1);
         }
 
-        [OuterLoop("Slow Test")]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]  // Timing-sensitive
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void ReadTimeout_750_Read_byte_int_int()
         {
@@ -122,7 +123,7 @@ namespace System.IO.Ports.Tests
             VerifyTimeout(Read_byte_int_int, 750);
         }
 
-        [OuterLoop("Slow Test")]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]  // Timing-sensitive
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void ReadTimeout_750_ReadByte()
         {
@@ -130,7 +131,7 @@ namespace System.IO.Ports.Tests
             VerifyTimeout(ReadByte, 750);
         }
 
-        [OuterLoop("Slow test")]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]  // Timing-sensitive
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void SuccessiveReadTimeoutNoData_Read_byte_int_int()
         {
@@ -157,6 +158,7 @@ namespace System.IO.Ports.Tests
             }
         }
 
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]  // Timing-sensitive
         [ConditionalFact(nameof(HasNullModem))]
         public void SuccessiveReadTimeoutSomeData_Read_byte_int_int()
         {
@@ -195,7 +197,7 @@ namespace System.IO.Ports.Tests
             }
         }
 
-        [OuterLoop("Slow Test")]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]  // Timing-sensitive
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void SuccessiveReadTimeoutNoData_ReadByte()
         {
@@ -252,6 +254,7 @@ namespace System.IO.Ports.Tests
         }
 
 
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]  // Timing-sensitive
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void ReadTimeout_0_Read_byte_int_int()
         {
@@ -260,6 +263,7 @@ namespace System.IO.Ports.Tests
             Verify0Timeout(Read_byte_int_int);
         }
 
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]  // Timing-sensitive
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void ReadTimeout_0_ReadByte()
         {

--- a/src/System.IO.Ports/tests/SerialStream/Read_byte_int_int_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialStream/Read_byte_int_int_Generic.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading;
 using Legacy.Support;
 using Xunit;
+using Xunit.NetCore.Extensions;
 
 namespace System.IO.Ports.Tests
 {
@@ -73,7 +74,7 @@ namespace System.IO.Ports.Tests
             }
         }
 
-        [OuterLoop("Slow test")]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]  // Timing-sensitive
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void Timeout()
         {
@@ -89,7 +90,7 @@ namespace System.IO.Ports.Tests
             }
         }
 
-        [OuterLoop("Slow Test")]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]  // Timing-sensitive
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void SuccessiveReadTimeoutNoData()
         {

--- a/src/System.IO.Ports/tests/SerialStream/WriteByte_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialStream/WriteByte_Generic.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Legacy.Support;
 using Xunit;
+using Xunit.NetCore.Extensions;
 using ThreadState = System.Threading.ThreadState;
 
 namespace System.IO.Ports.Tests
@@ -86,7 +87,7 @@ namespace System.IO.Ports.Tests
             }
         }
 
-        [OuterLoop("Slow test")]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]  // Timing-sensitive
         [ConditionalFact(nameof(HasOneSerialPort), nameof(HasHardwareFlowControl))]
         public void SuccessiveReadTimeout()
         {
@@ -187,7 +188,7 @@ namespace System.IO.Ports.Tests
             }
         }
 
-        [OuterLoop("Slow Test")]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]  // Timing-sensitive
         [ConditionalFact(nameof(HasOneSerialPort), nameof(HasHardwareFlowControl))]
         public void BytesToWriteSuccessive()
         {

--- a/src/System.IO.Ports/tests/SerialStream/WriteTimeout.cs
+++ b/src/System.IO.Ports/tests/SerialStream/WriteTimeout.cs
@@ -7,6 +7,7 @@ using System.IO.PortsTests;
 using System.Threading;
 using Legacy.Support;
 using Xunit;
+using Xunit.NetCore.Extensions;
 using ThreadState = System.Threading.ThreadState;
 
 namespace System.IO.Ports.Tests
@@ -149,7 +150,7 @@ namespace System.IO.Ports.Tests
             VerifyLongTimeout(WriteByte, int.MaxValue - 1);
         }
 
-        [OuterLoop("Slow test")]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]  // Timing-sensitive
         [ConditionalFact(nameof(HasOneSerialPort), nameof(HasHardwareFlowControl))]
         public void WriteTimeout_750_Write_byte_int_int()
         {
@@ -158,7 +159,7 @@ namespace System.IO.Ports.Tests
             VerifyTimeout(Write_byte_int_int, 750);
         }
 
-        [OuterLoop("Slow test")]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]  // Timing-sensitive
         [ConditionalFact(nameof(HasOneSerialPort), nameof(HasSingleByteTransmitBlocking))]
         public void WriteTimeout_750_WriteByte()
         {
@@ -167,7 +168,7 @@ namespace System.IO.Ports.Tests
             VerifyTimeout(WriteByte, 750);
         }
 
-        [OuterLoop("Slow test")]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]  // Timing-sensitive
         [ConditionalFact(nameof(HasOneSerialPort), nameof(HasHardwareFlowControl))]
         public void SuccessiveWriteTimeoutNoData_Write_byte_int_int()
         {
@@ -238,7 +239,7 @@ namespace System.IO.Ports.Tests
             }
         }
 
-        [OuterLoop("Slow test")]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]  // Timing-sensitive
         [ConditionalFact(nameof(HasOneSerialPort), nameof(HasSingleByteTransmitBlocking))]
         public void SuccessiveWriteTimeoutNoData_WriteByte()
         {

--- a/src/System.IO.Ports/tests/SerialStream/Write_byte_int_int_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialStream/Write_byte_int_int_Generic.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Threading;
 using Legacy.Support;
 using Xunit;
+using Xunit.NetCore.Extensions;
 using ThreadState = System.Threading.ThreadState;
 
 namespace System.IO.Ports.Tests
@@ -100,7 +101,7 @@ namespace System.IO.Ports.Tests
             }
         }
 
-        [OuterLoop("Slow Test")]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]  // Timing-sensitive
         [ConditionalFact(nameof(HasOneSerialPort), nameof(HasHardwareFlowControl))]
         public void SuccessiveWriteTimeout()
         {
@@ -208,7 +209,7 @@ namespace System.IO.Ports.Tests
             }
         }
 
-        [OuterLoop("Slow Test")]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]  // Timing-sensitive
         [ConditionalFact(nameof(HasOneSerialPort), nameof(HasHardwareFlowControl))]
         public void BytesToWriteSuccessive()
         {

--- a/src/System.IO.Ports/tests/Support/TCSupport.cs
+++ b/src/System.IO.Ports/tests/Support/TCSupport.cs
@@ -100,14 +100,6 @@ namespace Legacy.Support
                 portName2 = openablePortNames.FirstOrDefault(name => name != portName1);
             }
 
-            // See Github issue #15961 and #16033 - hardware tests are currently insufficiently stable on master CI
-            if (loopbackPortName == null && !nullModemPresent)
-            {
-                // We don't have any supporting hardware - disable all the tests which would use just an open port
-                PrintInfo("No support hardware - not using serial ports");
-                portName1 = portName2 = null;
-            }
-
             PrintInfo("First available port name  : " + portName1);
             PrintInfo("Second available port name : " + portName2);
             PrintInfo("Loopback port name         : " + loopbackPortName);

--- a/src/System.IO.Ports/tests/Support/TCSupport.cs
+++ b/src/System.IO.Ports/tests/Support/TCSupport.cs
@@ -22,7 +22,7 @@ namespace Legacy.Support
         private static SerialPortRequirements s_localMachineSerialPortRequirements;
 
         // Set this true to display port info to the console rather than Debug.WriteLine
-        private static bool s_displayPortInfoOnConsole = false;
+        private static bool s_displayPortInfoOnConsole = true;
 
         static TCSupport()
         {


### PR DESCRIPTION
At present we have almost all `SerialPort` tests suppressed on the CI because they can't be trusted to run reliably on a VM.  Lots of past issues refer to this and discuss the issues, but the canonical one is #15961

This PR re-enables (they were disabled in #16102) a large number of tests that should be able to run against the CI's emulated serial port, but completely suppresses those that are known to be difficult.

There are a small number of tests where `OuterLoop` attributes have been removed but not replaced with other suppression - these are tests which would not run on the CI *anyway* because of their specific hardware requirements, and I think it's confusing to have OuterLoop suppression on something which isn't going to run on any loop.
