### PR TITLE
Update buildtools, hook in new Dumpling target

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-2.0.0-prerelease-01702-02
+2.0.0-prerelease-01706-01

--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-2.0.0-prerelease-01706-01
+2.0.0-prerelease-01706-03

--- a/dir.traversal.targets
+++ b/dir.traversal.targets
@@ -78,7 +78,7 @@
   </Target>
 
   <!-- Dumpling.targets needs to install dumpling.py before running tests. -->
-  <Import Project="$(ToolsDir)Dumpling.targets" Condition="'$(EnableDumpling)' == 'true' OR '$(EnableCloudTest)' == 'true'" />
+  <Import Project="$(ToolsDir)Dumpling.targets" Condition="Exists('$(ToolsDir)Dumpling.targets') AND ('$(EnableDumpling)' == 'true' OR '$(EnableCloudTest)' == 'true')" />
 
   <Target Name="GetFilesToPackage"
           DependsOnTargets="FilterProjects"

--- a/dir.traversal.targets
+++ b/dir.traversal.targets
@@ -77,6 +77,9 @@
     <Error Condition="'$(MSBuildLastTaskResult)'=='false'" />
   </Target>
 
+  <!-- Dumpling.targets needs to install dumpling.py before running tests. -->
+  <Import Project="$(ToolsDir)Dumpling.targets" Condition="'$(EnableDumpling)' == 'true' OR '$(EnableCloudTest)' == 'true'" />
+
   <Target Name="GetFilesToPackage"
           DependsOnTargets="FilterProjects"
           Returns="@(FilesToPackage)">


### PR DESCRIPTION
* Update buildtools. This has a bunch of new Dumpling features and fixes.
* Hook in a new Dumpling target in dir.traversal.targets which causes dumpling.py to be pre-installed before we do our parallel test runs.