### PR TITLE
Disable some Ping tests for UAP test runs

### DIFF
--- a/src/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -81,7 +81,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/20528", TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue(20130, TargetFrameworkMonikers.Uap)]
         public async Task SendPingAsyncWithIPAddress()
         {
             IPAddress localIpAddress = await TestSettings.GetLocalIPAddress();
@@ -96,7 +96,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/20528", TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue(20130, TargetFrameworkMonikers.Uap)]
         public async Task SendPingAsyncWithIPAddress_AddressAsString()
         {
             IPAddress localIpAddress = await TestSettings.GetLocalIPAddress();
@@ -111,7 +111,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/20528", TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue(20130, TargetFrameworkMonikers.Uap)]
         public async Task SendPingAsyncWithIPAddressAndTimeout()
         {
             IPAddress localIpAddress = await TestSettings.GetLocalIPAddress();
@@ -126,7 +126,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [PlatformSpecific(TestPlatforms.Windows)]  // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/20528", TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue(20130, TargetFrameworkMonikers.Uap)]
         [Fact]
         public async Task SendPingAsyncWithIPAddressAndTimeoutAndBuffer()
         {
@@ -171,7 +171,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [PlatformSpecific(TestPlatforms.Windows)]  // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/20528", TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue(20130, TargetFrameworkMonikers.Uap)]
         [Fact]
         public async Task SendPingAsyncWithIPAddressAndTimeoutAndBufferAndPingOptions()
         {
@@ -217,7 +217,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/20528", TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue(20130, TargetFrameworkMonikers.Uap)]
         public async Task SendPingAsyncWithHost()
         {
             IPAddress localIpAddress = await TestSettings.GetLocalIPAddress();
@@ -232,7 +232,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/20528", TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue(20130, TargetFrameworkMonikers.Uap)]
         public async Task SendPingAsyncWithHostAndTimeout()
         {
             IPAddress localIpAddress = await TestSettings.GetLocalIPAddress();
@@ -247,7 +247,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [PlatformSpecific(TestPlatforms.Windows)]  // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/20528", TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue(20130, TargetFrameworkMonikers.Uap)]
         [Fact]
         public async Task SendPingAsyncWithHostAndTimeoutAndBuffer()
         {
@@ -292,7 +292,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [PlatformSpecific(TestPlatforms.Windows)]  // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/20528", TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue(20130, TargetFrameworkMonikers.Uap)]
         [Fact]
         public async Task SendPingAsyncWithHostAndTimeoutAndBufferAndPingOptions()
         {
@@ -337,7 +337,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/20528", TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue(20130, TargetFrameworkMonikers.Uap)]
         public static async Task SendPings_ReuseInstance_Hostname()
         {
             IPAddress localIpAddress = await TestSettings.GetLocalIPAddress();
@@ -354,7 +354,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/20528", TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue(20130, TargetFrameworkMonikers.Uap)]
         public static async Task Sends_ReuseInstance_Hostname()
         {
             IPAddress localIpAddress = await TestSettings.GetLocalIPAddress();
@@ -371,7 +371,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/20528", TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue(20130, TargetFrameworkMonikers.Uap)]
         public static async Task SendAsyncs_ReuseInstance_Hostname()
         {
             IPAddress localIpAddress = await TestSettings.GetLocalIPAddress();
@@ -423,7 +423,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/20528", TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue(20130, TargetFrameworkMonikers.Uap)]
         public static async Task Ping_DisposeAfterSend_Success()
         {
             Ping p = new Ping();
@@ -432,7 +432,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/20528", TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue(20130, TargetFrameworkMonikers.Uap)]
         public static void Ping_DisposeMultipletimes_Success()
         {
             Ping p = new Ping();
@@ -441,7 +441,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/20528", TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue(20130, TargetFrameworkMonikers.Uap)]
         public static void Ping_SendAfterDispose_ThrowsSynchronously()
         {
             Ping p = new Ping();


### PR DESCRIPTION
System.Net.Ping now runs clean for UAP test runs.

I'm not sure if #20528 has been fixed or not. I deleted all ActiveIssue labels and found that all tests passed on uapaot mode. https://github.com/dotnet/corefx/issues/20528#issuecomment-306068673

Contributes to: #19583