### PR TITLE
Temporary Rollback UAP Test Tools version

### DIFF
--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -114,7 +114,7 @@
           Condition="'$(TargetGroup)'=='uap'" >
 
     <PropertyGroup>
-      <UAPToolsPackageVersion>1.0.4</UAPToolsPackageVersion>
+      <UAPToolsPackageVersion>1.0.2</UAPToolsPackageVersion>
       <UAPToolsPackageName>microsoft.dotnet.uap.testtools</UAPToolsPackageName>
 
       <UAPToolsFolder Condition="'$(UAPToolsFolder)'==''">$(PackagesDir)$(UAPToolsPackageName)\$(UAPToolsPackageVersion)\Tools</UAPToolsFolder>

--- a/external/test-runtime/optional.json
+++ b/external/test-runtime/optional.json
@@ -3,7 +3,7 @@
     "net45": {
       "dependencies": {
         "Microsoft.DotNet.IBCMerge": "4.6.0-alpha-00001",
-        "Microsoft.DotNet.UAP.TestTools": "1.0.4",
+        "Microsoft.DotNet.UAP.TestTools": "1.0.2",
         "TestILC.amd64ret": "1.0.0-beta-25405-00",
         "TestILC.armret": "1.0.0-beta-25405-00",
         "TestILC.x86ret": "1.0.0-beta-25405-00"


### PR DESCRIPTION
The latest changes in the UAP test tools was depending on Windows 10 RS2. Our current helix test runs using Windows 2016 server which is RS1 which failed to run the new updated test runner. we are currently working to upgrade our runs to use RS2 and later. Meanwhile, I am reverting to older tools version to unblock UAP test runs till we do the upgrade to RS2 OS images.