### PR TITLE
Correct versions for System.Drawing.Primitives and .Common.

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -1532,7 +1532,7 @@
         "netstandard2.0": "4.0.0.0",
         "monoandroid10": "Any",
         "monotouch10": "Any",
-        "uap10.1": "4.1.1.0",
+        "uap10.1": "4.2.0.0",
         "xamarinios10": "Any",
         "xamarinmac20": "Any",
         "xamarintvos10": "Any",

--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -1527,7 +1527,7 @@
       ],
       "BaselineVersion": "4.3.0",
       "InboxOn": {
-        "netcoreapp2.0": "4.1.1.0",
+        "netcoreapp2.0": "4.2.0.0",
         "net461": "4.0.0.0",
         "netstandard2.0": "4.0.0.0",
         "monoandroid10": "Any",
@@ -1540,7 +1540,8 @@
       },
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
-        "4.0.1.0": "4.3.0"
+        "4.0.1.0": "4.3.0",
+        "4.2.0.0": "4.5.0"
       }
     },
     "System.Dynamic": {

--- a/src/System.Drawing.Common/dir.props
+++ b/src/System.Drawing.Common/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
-    <AssemblyKey>MSFT</AssemblyKey>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyKey>Open</AssemblyKey>
   </PropertyGroup>
 </Project>

--- a/src/System.Drawing.Primitives/dir.props
+++ b/src/System.Drawing.Primitives/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <AssemblyKey>MSFT</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>


### PR DESCRIPTION
Also, use Open key for System.Drawing.Common.

@weshaggard 

I've moved System.Drawing.Common's version down to 4.0.0 since it's brand new. Should I just go ahead and make it 1.0.0, or are we still making things start at 4.0.0?