### PR TITLE
Specify explicit SetLastError semantics for Sockets related delegates

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/DynamicWinsockMethods.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/DynamicWinsockMethods.cs
@@ -261,6 +261,7 @@ namespace System.Net.Sockets
         }
     }
 
+    [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError=true)]
     internal unsafe delegate bool AcceptExDelegate(
                 SafeCloseSocket listenSocketHandle,
                 SafeCloseSocket acceptSocketHandle,
@@ -271,6 +272,7 @@ namespace System.Net.Sockets
                 out int bytesReceived,
                 NativeOverlapped* overlapped);
 
+    [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError=true)]
     internal delegate void GetAcceptExSockaddrsDelegate(
                 IntPtr buffer,
                 int receiveDataLength,
@@ -282,6 +284,7 @@ namespace System.Net.Sockets
                 out int remoteSocketAddressLength);
 
 
+    [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError=true)]
     internal unsafe delegate bool ConnectExDelegate(
                 SafeCloseSocket socketHandle,
                 IntPtr socketAddress,
@@ -291,18 +294,21 @@ namespace System.Net.Sockets
                 out int bytesSent,
                 NativeOverlapped* overlapped);
 
+    [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError=true)]
     internal unsafe delegate bool DisconnectExDelegate(
                 SafeCloseSocket socketHandle, 
                 NativeOverlapped* overlapped, 
                 int flags, 
                 int reserved);
 
+    [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError=true)]
     internal delegate bool DisconnectExDelegateBlocking(
                 SafeCloseSocket socketHandle, 
                 IntPtr overlapped, 
                 int flags, 
                 int reserved);
 
+    [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError=true)]
     internal unsafe delegate SocketError WSARecvMsgDelegate(
                 SafeCloseSocket socketHandle,
                 IntPtr msg,
@@ -310,6 +316,7 @@ namespace System.Net.Sockets
                 NativeOverlapped* overlapped,
                 IntPtr completionRoutine);
 
+    [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError=true)]
     internal delegate SocketError WSARecvMsgDelegateBlocking(
                 IntPtr socketHandle,
                 IntPtr msg,
@@ -317,6 +324,7 @@ namespace System.Net.Sockets
                 IntPtr overlapped,
                 IntPtr completionRoutine);
 
+    [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError=true)]
     internal unsafe delegate bool TransmitPacketsDelegate(
                 SafeCloseSocket socketHandle,
                 IntPtr packetArray,


### PR DESCRIPTION
The MSDN default for the 'UnmanagedFunctionPointer' attribute regarding
SetLastError is false. However, due to historical issues, the .NET Framework
and .NET Core used a default of true. This is why these attributes have never decorated
these Sockets APIs in the source code.

See:
https://github.com/dotnet/coreclr/blob/fd3668c7c9b9f5d64b5e6d1edf8c55a307cd3c2d/src/vm/dllimport.cpp#L3642

While .NET Core continues to have a 'true' default, .NET Native started failing
with these Sockets APIs. The default is currently undefined in .NET Native and
there is pending feature work to implemented the 'UnmanagedFunctionPointer' attribute.

This PR alone will not fix the .NET Native failures for these Sockets APIs. But
pending feature work in .NET Native will make the attributes functional.