### PR TITLE
Fixing System.Diagnostics.Tracing tests on uap-aot

### DIFF
--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/FuzzyTests.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/FuzzyTests.cs
@@ -22,6 +22,7 @@ namespace BasicEventSourceTests
         /// 
         /// </summary>
         [Fact]
+        [ActiveIssue(20744,TargetFrameworkMonikers.UapAot)]
         public void Test_Write_Fuzzy()
         {
             using (var logger = new EventSource("EventSourceName"))

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestUtilities.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestUtilities.cs
@@ -27,7 +27,8 @@ namespace BasicEventSourceTests
                     eventSource.Name != "System.Diagnostics.Eventing.FrameworkEventSource" &&
                     eventSource.Name != "System.Buffers.ArrayPoolEventSource" &&
                     eventSource.Name != "System.Threading.SynchronizationEventSource" &&
-                    eventSource.Name != "System.Runtime.InteropServices.InteropEventProvider"
+                    eventSource.Name != "System.Runtime.InteropServices.InteropEventProvider" &&
+                    eventSource.Name != "System.Reflection.Runtime.Tracing"
                     )
                 {
                     eventSourceNames += eventSource.Name + " ";

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsEventSourceLifetime.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsEventSourceLifetime.cs
@@ -21,7 +21,6 @@ namespace BasicEventSourceTests
         /// </summary>
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // non-Windows EventSources don't have lifetime
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "ExerciseEventSource use private member reflection")]
         public void Test_EventSource_Lifetime()
         {
             TestUtilities.CheckNoEventSourcesRunning("Start");

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsEventSourceLifetime.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsEventSourceLifetime.cs
@@ -21,6 +21,7 @@ namespace BasicEventSourceTests
         /// </summary>
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // non-Windows EventSources don't have lifetime
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "ExerciseEventSource use private member reflection")]
         public void Test_EventSource_Lifetime()
         {
             TestUtilities.CheckNoEventSourcesRunning("Start");

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWrite.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWrite.cs
@@ -40,6 +40,7 @@ namespace BasicEventSourceTests
         /// </summary>
         [Fact]
         [ActiveIssue("dotnet/corefx #19455", TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue(20744, TargetFrameworkMonikers.UapAot)]
         public void Test_Write_T_EventListener()
         {
             using (var listener = new EventListenerListener())
@@ -54,6 +55,7 @@ namespace BasicEventSourceTests
         /// </summary>
         [Fact]
         [ActiveIssue("dotnet/corefx #19455", TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue(20744, TargetFrameworkMonikers.UapAot)]
         public void Test_Write_T_EventListener_UseEvents()
         {
             Test_Write_T(new EventListenerListener(true));
@@ -410,6 +412,7 @@ namespace BasicEventSourceTests
         /// </summary>
         [Fact]
         [ActiveIssue("dotnet/corefx #18806", TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue(20744, TargetFrameworkMonikers.UapAot)]
         public void Test_Write_T_In_Manifest_Serialization()
         {
             using (var eventListener = new EventListenerListener())


### PR DESCRIPTION
All tests expect 4 are fixed , the four fails because
of reflectionblock.These need to be looked at by
tracing folks.
@brianrob @vancem @danmosemsft @joshfree 