### PR TITLE
Fix System.IO.MemoryMappedFile.Tests failures

### DIFF
--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CrossProcess.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CrossProcess.cs
@@ -10,6 +10,7 @@ namespace System.IO.MemoryMappedFiles.Tests
     public class CrossProcessTests : RemoteExecutorTestBase
     {
         [Fact]
+        [ActiveIssue(19909, TargetFrameworkMonikers.Uap)] // Remote executor in Uap and Process.Start() in UapAot
         public void DataShared()
         {
             // Create a new file and load it into an MMF

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor.Tests.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor.Tests.cs
@@ -76,6 +76,9 @@ namespace System.IO.MemoryMappedFiles.Tests
         [InlineData(MemoryMappedFileAccess.Read, MemoryMappedFileAccess.CopyOnWrite)]
         public void ValidAccessLevelCombinations(MemoryMappedFileAccess mapAccess, MemoryMappedFileAccess viewAccess)
         {
+            if (PlatformDetection.IsNetNative && viewAccess == MemoryMappedFileAccess.ReadWriteExecute) // ActiveIssue https://github.com/dotnet/corefx/issues/20751 throws IOException.
+                return;
+
             const int Capacity = 4096;
             using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
             using (MemoryMappedViewAccessor acc = mmf.CreateViewAccessor(0, Capacity, viewAccess))
@@ -100,6 +103,9 @@ namespace System.IO.MemoryMappedFiles.Tests
         [InlineData(MemoryMappedFileAccess.Read, MemoryMappedFileAccess.ReadWriteExecute)]
         public void InvalidAccessLevelsCombinations(MemoryMappedFileAccess mapAccess, MemoryMappedFileAccess viewAccess)
         {
+            if (PlatformDetection.IsNetNative && viewAccess == MemoryMappedFileAccess.ReadWriteExecute) // ActiveIssue https://github.com/dotnet/corefx/issues/20751 throws IOException.
+                return;
+
             const int Capacity = 4096;
             using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
             {

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor.Tests.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor.Tests.cs
@@ -76,40 +76,64 @@ namespace System.IO.MemoryMappedFiles.Tests
         [InlineData(MemoryMappedFileAccess.Read, MemoryMappedFileAccess.CopyOnWrite)]
         public void ValidAccessLevelCombinations(MemoryMappedFileAccess mapAccess, MemoryMappedFileAccess viewAccess)
         {
-            if (PlatformDetection.IsNetNative && viewAccess == MemoryMappedFileAccess.ReadWriteExecute) // ActiveIssue https://github.com/dotnet/corefx/issues/20751 throws IOException.
-                return;
-
             const int Capacity = 4096;
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
-            using (MemoryMappedViewAccessor acc = mmf.CreateViewAccessor(0, Capacity, viewAccess))
+            AssertExtensions.ThrowsIf<IOException>(PlatformDetection.IsUap && mapAccess == MemoryMappedFileAccess.ReadWriteExecute && viewAccess == MemoryMappedFileAccess.ReadWriteExecute,
+            () =>
             {
-                ValidateMemoryMappedViewAccessor(acc, Capacity, viewAccess);
-            }
+                using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
+                using (MemoryMappedViewAccessor acc = mmf.CreateViewAccessor(0, Capacity, viewAccess))
+                {
+                    ValidateMemoryMappedViewAccessor(acc, Capacity, viewAccess);
+                }
+            });
         }
 
         [Theory]
         [InlineData(MemoryMappedFileAccess.ReadExecute, MemoryMappedFileAccess.Write)]
         [InlineData(MemoryMappedFileAccess.ReadExecute, MemoryMappedFileAccess.ReadWrite)]
-        [InlineData(MemoryMappedFileAccess.ReadExecute, MemoryMappedFileAccess.ReadWriteExecute)]
         [InlineData(MemoryMappedFileAccess.CopyOnWrite, MemoryMappedFileAccess.Write)]
         [InlineData(MemoryMappedFileAccess.CopyOnWrite, MemoryMappedFileAccess.ReadWrite)]
         [InlineData(MemoryMappedFileAccess.CopyOnWrite, MemoryMappedFileAccess.ReadExecute)]
-        [InlineData(MemoryMappedFileAccess.CopyOnWrite, MemoryMappedFileAccess.ReadWriteExecute)]
         [InlineData(MemoryMappedFileAccess.ReadWrite, MemoryMappedFileAccess.ReadExecute)]
-        [InlineData(MemoryMappedFileAccess.ReadWrite, MemoryMappedFileAccess.ReadWriteExecute)]
         [InlineData(MemoryMappedFileAccess.Read, MemoryMappedFileAccess.Write)]
         [InlineData(MemoryMappedFileAccess.Read, MemoryMappedFileAccess.ReadWrite)]
         [InlineData(MemoryMappedFileAccess.Read, MemoryMappedFileAccess.ReadExecute)]
-        [InlineData(MemoryMappedFileAccess.Read, MemoryMappedFileAccess.ReadWriteExecute)]
         public void InvalidAccessLevelsCombinations(MemoryMappedFileAccess mapAccess, MemoryMappedFileAccess viewAccess)
         {
-            if (PlatformDetection.IsNetNative && viewAccess == MemoryMappedFileAccess.ReadWriteExecute) // ActiveIssue https://github.com/dotnet/corefx/issues/20751 throws IOException.
-                return;
-
             const int Capacity = 4096;
             using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
             {
                 Assert.Throws<UnauthorizedAccessException>(() => mmf.CreateViewAccessor(0, Capacity, viewAccess));
+            }
+        }
+
+        [Theory]
+        [InlineData(MemoryMappedFileAccess.ReadExecute, MemoryMappedFileAccess.ReadWriteExecute)]
+        [InlineData(MemoryMappedFileAccess.CopyOnWrite, MemoryMappedFileAccess.ReadWriteExecute)]
+        [InlineData(MemoryMappedFileAccess.ReadWrite, MemoryMappedFileAccess.ReadWriteExecute)]
+        [InlineData(MemoryMappedFileAccess.Read, MemoryMappedFileAccess.ReadWriteExecute)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Windows API returns IO exception error code when viewAccess is ReadWriteExecute")]
+        public void InvalidAccessLevels_ReadWrite_NonUwp(MemoryMappedFileAccess mapAccess, MemoryMappedFileAccess viewAccess)
+        {
+            const int Capacity = 4096;
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
+            {
+                Assert.Throws<UnauthorizedAccessException>(() => mmf.CreateViewAccessor(0, Capacity, viewAccess));
+            }
+        }
+
+        [Theory]
+        [InlineData(MemoryMappedFileAccess.ReadExecute, MemoryMappedFileAccess.ReadWriteExecute)]
+        [InlineData(MemoryMappedFileAccess.CopyOnWrite, MemoryMappedFileAccess.ReadWriteExecute)]
+        [InlineData(MemoryMappedFileAccess.ReadWrite, MemoryMappedFileAccess.ReadWriteExecute)]
+        [InlineData(MemoryMappedFileAccess.Read, MemoryMappedFileAccess.ReadWriteExecute)]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.Uap, "Windows API returns IO exception error code when viewAccess is ReadWriteExecute")]
+        public void InvalidAccessLevels_ReadWrite_Uwp(MemoryMappedFileAccess mapAccess, MemoryMappedFileAccess viewAccess)
+        {
+            const int Capacity = 4096;
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
+            {
+                Assert.Throws<IOException>(() => mmf.CreateViewAccessor(0, Capacity, viewAccess));
             }
         }
 

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream.Tests.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream.Tests.cs
@@ -76,40 +76,64 @@ namespace System.IO.MemoryMappedFiles.Tests
         [InlineData(MemoryMappedFileAccess.Read, MemoryMappedFileAccess.CopyOnWrite)]
         public void ValidAccessLevelCombinations(MemoryMappedFileAccess mapAccess, MemoryMappedFileAccess viewAccess)
         {
-            if (PlatformDetection.IsNetNative && viewAccess == MemoryMappedFileAccess.ReadWriteExecute) // ActiveIssue https://github.com/dotnet/corefx/issues/20751 throws IOException.
-                return;
-
             const int Capacity = 4096;
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
-            using (MemoryMappedViewStream s = mmf.CreateViewStream(0, Capacity, viewAccess))
+            AssertExtensions.ThrowsIf<IOException>(PlatformDetection.IsUap && mapAccess == MemoryMappedFileAccess.ReadWriteExecute && viewAccess == MemoryMappedFileAccess.ReadWriteExecute,
+            () =>
             {
-                ValidateMemoryMappedViewStream(s, Capacity, viewAccess);
-            }
+                using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
+                using (MemoryMappedViewStream s = mmf.CreateViewStream(0, Capacity, viewAccess))
+                {
+                    ValidateMemoryMappedViewStream(s, Capacity, viewAccess);
+                }
+            });
         }
 
         [Theory]
         [InlineData(MemoryMappedFileAccess.ReadExecute, MemoryMappedFileAccess.Write)]
         [InlineData(MemoryMappedFileAccess.ReadExecute, MemoryMappedFileAccess.ReadWrite)]
-        [InlineData(MemoryMappedFileAccess.ReadExecute, MemoryMappedFileAccess.ReadWriteExecute)]
         [InlineData(MemoryMappedFileAccess.CopyOnWrite, MemoryMappedFileAccess.Write)]
         [InlineData(MemoryMappedFileAccess.CopyOnWrite, MemoryMappedFileAccess.ReadWrite)]
         [InlineData(MemoryMappedFileAccess.CopyOnWrite, MemoryMappedFileAccess.ReadExecute)]
-        [InlineData(MemoryMappedFileAccess.CopyOnWrite, MemoryMappedFileAccess.ReadWriteExecute)]
         [InlineData(MemoryMappedFileAccess.ReadWrite, MemoryMappedFileAccess.ReadExecute)]
-        [InlineData(MemoryMappedFileAccess.ReadWrite, MemoryMappedFileAccess.ReadWriteExecute)]
         [InlineData(MemoryMappedFileAccess.Read, MemoryMappedFileAccess.Write)]
         [InlineData(MemoryMappedFileAccess.Read, MemoryMappedFileAccess.ReadWrite)]
         [InlineData(MemoryMappedFileAccess.Read, MemoryMappedFileAccess.ReadExecute)]
-        [InlineData(MemoryMappedFileAccess.Read, MemoryMappedFileAccess.ReadWriteExecute)]
         public void InvalidAccessLevelsCombinations(MemoryMappedFileAccess mapAccess, MemoryMappedFileAccess viewAccess)
         {
-            if (PlatformDetection.IsNetNative && viewAccess == MemoryMappedFileAccess.ReadWriteExecute) // ActiveIssue https://github.com/dotnet/corefx/issues/20751 throws IOException in UapAot
-                return;
-
             const int Capacity = 4096;
             using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
             {
                 Assert.Throws<UnauthorizedAccessException>(() => mmf.CreateViewStream(0, Capacity, viewAccess));
+            }
+        }
+
+        [Theory]
+        [InlineData(MemoryMappedFileAccess.Read, MemoryMappedFileAccess.ReadWriteExecute)]
+        [InlineData(MemoryMappedFileAccess.ReadWrite, MemoryMappedFileAccess.ReadWriteExecute)]
+        [InlineData(MemoryMappedFileAccess.CopyOnWrite, MemoryMappedFileAccess.ReadWriteExecute)]
+        [InlineData(MemoryMappedFileAccess.ReadExecute, MemoryMappedFileAccess.ReadWriteExecute)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Windows API returns IO exception error code when viewAccess is ReadWriteExecute")]
+        public void InvalidAccessLevels_ReadWriteExecute_NonUwp(MemoryMappedFileAccess mapAccess, MemoryMappedFileAccess viewAccess)
+        {
+            const int Capacity = 4096;
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
+            {
+                Assert.Throws<UnauthorizedAccessException>(() => mmf.CreateViewStream(0, Capacity, viewAccess));
+            }
+        }
+
+        [Theory]
+        [InlineData(MemoryMappedFileAccess.Read, MemoryMappedFileAccess.ReadWriteExecute)]
+        [InlineData(MemoryMappedFileAccess.ReadWrite, MemoryMappedFileAccess.ReadWriteExecute)]
+        [InlineData(MemoryMappedFileAccess.CopyOnWrite, MemoryMappedFileAccess.ReadWriteExecute)]
+        [InlineData(MemoryMappedFileAccess.ReadExecute, MemoryMappedFileAccess.ReadWriteExecute)]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.Uap, "Windows API returns IO exception error code when viewAccess is ReadWriteExecute")]
+        public void InvalidAccessLevels_ReadWriteExecute_Uwp(MemoryMappedFileAccess mapAccess, MemoryMappedFileAccess viewAccess)
+        {
+            const int Capacity = 4096;
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
+            {
+                Assert.Throws<IOException>(() => mmf.CreateViewStream(0, Capacity, viewAccess));
             }
         }
 

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream.Tests.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream.Tests.cs
@@ -76,6 +76,9 @@ namespace System.IO.MemoryMappedFiles.Tests
         [InlineData(MemoryMappedFileAccess.Read, MemoryMappedFileAccess.CopyOnWrite)]
         public void ValidAccessLevelCombinations(MemoryMappedFileAccess mapAccess, MemoryMappedFileAccess viewAccess)
         {
+            if (PlatformDetection.IsNetNative && viewAccess == MemoryMappedFileAccess.ReadWriteExecute) // ActiveIssue https://github.com/dotnet/corefx/issues/20751 throws IOException.
+                return;
+
             const int Capacity = 4096;
             using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
             using (MemoryMappedViewStream s = mmf.CreateViewStream(0, Capacity, viewAccess))
@@ -100,6 +103,9 @@ namespace System.IO.MemoryMappedFiles.Tests
         [InlineData(MemoryMappedFileAccess.Read, MemoryMappedFileAccess.ReadWriteExecute)]
         public void InvalidAccessLevelsCombinations(MemoryMappedFileAccess mapAccess, MemoryMappedFileAccess viewAccess)
         {
+            if (PlatformDetection.IsNetNative && viewAccess == MemoryMappedFileAccess.ReadWriteExecute) // ActiveIssue https://github.com/dotnet/corefx/issues/20751 throws IOException in UapAot
+                return;
+
             const int Capacity = 4096;
             using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
             {


### PR DESCRIPTION
This PR disables one test related to the Process.Start issue.

I also temporary worked around some tests to skip cases when `MemoryMappedFileAccess` is `ReadWriteExecute` as they are hitting: #20751 

This gets System.IO.MemoryMappedFileAccess.Tests to 0 failures.

cc: @ianhays @danmosemsft @JeremyKuhne 