### PR TITLE
Disable SerialPort tests where no additional hardware is present

### DIFF
--- a/src/System.IO.Ports/tests/Support/TCSupport.cs
+++ b/src/System.IO.Ports/tests/Support/TCSupport.cs
@@ -100,6 +100,14 @@ namespace Legacy.Support
                 portName2 = openablePortNames.FirstOrDefault(name => name != portName1);
             }
 
+            // See Github issues #15961, #16033, #20764 - hardware tests are currently insufficiently stable on master CI
+            if (loopbackPortName == null && !nullModemPresent)
+            {
+                // We don't have any supporting hardware - disable all the tests which would use just an open port
+                PrintInfo("No support hardware - not using serial ports");
+                portName1 = portName2 = null;
+            }
+
             PrintInfo("First available port name  : " + portName1);
             PrintInfo("Second available port name : " + portName2);
             PrintInfo("Loopback port name         : " + loopbackPortName);


### PR DESCRIPTION
This disables all port-requiring SerialPort tests on the CI - essentially it's a reversion of PR #20707 

Fixes #20764 
Fixes #20768

I will not reintroduce these again using an 'opt-out' strategy - when I can work out how to opt them in selectively on the CI we can try that.