### PR TITLE
Handle escaping in Unix file enumeration

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
@@ -14,6 +14,7 @@ namespace System.IO
     internal sealed partial class UnixFileSystem : FileSystem
     {
         internal const int DefaultBufferSize = 4096;
+        private static char[] s_EscapeCharacters = new char[] { '\\', '[' };
 
         public override int MaxPath { get { return Interop.Sys.MaxPath; } }
 
@@ -505,11 +506,15 @@ namespace System.IO
                         searchPattern = searchPattern.Substring(lastSlash + 1);
                     }
 
-                    // We need to escape any escape characters in the search pattern
-                    searchPattern = searchPattern.Replace(@"\", @"\\");
+                    // Typically we shouldn't see either of these cases
+                    if (searchPattern.IndexOfAny(s_EscapeCharacters) != -1)
+                    {
+                        // We need to escape any escape characters in the search pattern
+                        searchPattern = searchPattern.Replace(@"\", @"\\");
 
-                    // And then escape '[' to prevent it being picked up as a wildcard
-                    searchPattern = searchPattern.Replace(@"[", @"\[");
+                        // And then escape '[' to prevent it being picked up as a wildcard
+                        searchPattern = searchPattern.Replace(@"[", @"\[");
+                    }
 
                     string fullPath = Path.GetFullPath(userPath);
 

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
@@ -506,7 +506,7 @@ namespace System.IO
                     }
 
                     // Typically we shouldn't see either of these cases, an upfront check is much faster
-                    for (int i = 0; i < name.Length; i++)
+                    for (int i = 0; i < searchPattern.Length; i++)
                         if (searchPattern[i] == '\\' || searchPattern[i] == '[')
                         {
                             // We need to escape any escape characters in the search pattern

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
@@ -506,8 +506,9 @@ namespace System.IO
                     }
 
                     // Typically we shouldn't see either of these cases, an upfront check is much faster
-                    for (int i = 0; i < searchPattern.Length; i++)
-                        if (searchPattern[i] == '\\' || searchPattern[i] == '[')
+                    foreach (char c in searchPattern)
+                    {
+                        if (c == '\\' || c == '[')
                         {
                             // We need to escape any escape characters in the search pattern
                             searchPattern = searchPattern.Replace(@"\", @"\\");
@@ -516,6 +517,7 @@ namespace System.IO
                             searchPattern = searchPattern.Replace(@"[", @"\[");
                             break;
                         }
+                    }
 
                     string fullPath = Path.GetFullPath(userPath);
 

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
@@ -14,7 +14,6 @@ namespace System.IO
     internal sealed partial class UnixFileSystem : FileSystem
     {
         internal const int DefaultBufferSize = 4096;
-        private static char[] s_EscapeCharacters = new char[] { '\\', '[' };
 
         public override int MaxPath { get { return Interop.Sys.MaxPath; } }
 
@@ -506,15 +505,17 @@ namespace System.IO
                         searchPattern = searchPattern.Substring(lastSlash + 1);
                     }
 
-                    // Typically we shouldn't see either of these cases
-                    if (searchPattern.IndexOfAny(s_EscapeCharacters) != -1)
-                    {
-                        // We need to escape any escape characters in the search pattern
-                        searchPattern = searchPattern.Replace(@"\", @"\\");
+                    // Typically we shouldn't see either of these cases, an upfront check is much faster
+                    for (int i = 0; i < name.Length; i++)
+                        if (searchPattern[i] == '\\' || searchPattern[i] == '[')
+                        {
+                            // We need to escape any escape characters in the search pattern
+                            searchPattern = searchPattern.Replace(@"\", @"\\");
 
-                        // And then escape '[' to prevent it being picked up as a wildcard
-                        searchPattern = searchPattern.Replace(@"[", @"\[");
-                    }
+                            // And then escape '[' to prevent it being picked up as a wildcard
+                            searchPattern = searchPattern.Replace(@"[", @"\[");
+                            break;
+                        }
 
                     string fullPath = Path.GetFullPath(userPath);
 

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
@@ -504,6 +504,13 @@ namespace System.IO
                         }
                         searchPattern = searchPattern.Substring(lastSlash + 1);
                     }
+
+                    // We need to escape any escape characters in the search pattern
+                    searchPattern = searchPattern.Replace(@"\", @"\\");
+
+                    // And then escape '[' to prevent it being picked up as a wildcard
+                    searchPattern = searchPattern.Replace(@"[", @"\[");
+
                     string fullPath = Path.GetFullPath(userPath);
 
                     // Store everything for the enumerator
@@ -638,6 +645,7 @@ namespace System.IO
                 {
                     searchPattern += "*";
                 }
+
                 return searchPattern;
             }
 

--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str.cs
@@ -20,6 +20,17 @@ namespace System.IO.Tests
             return Directory.GetFileSystemEntries(dirName);
         }
 
+        /// <summary>
+        /// Create a file at the given path or directory if GetEntries doesn't return files
+        /// </summary>
+        protected void CreateItem(string path)
+        {
+            if (TestFiles)
+                File.WriteAllText(path, path);
+            else
+                Directory.CreateDirectory(path);
+        }
+
         #endregion
 
         #region UniversalTests

--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
@@ -393,7 +393,11 @@ namespace System.IO.Tests
             InlineData(
                 "foodies*.",
                 new string[] { @"foodies. ", @"foodies.  ", @"foodies.   ", @"foodies.    ", @"foodies.     " },
-                new string[] { })
+                new string[] { }),
+            InlineData(
+                "foo*.",
+                new string[] { @"foo..", @"foo...", @"foo....", @"foo.....", @"foo......" },
+                new string[] { @"foo..", @"foo...", @"foo....", @"foo.....", @"foo......" }),
             ]
         public void PatternTests_DosStarSpace(string pattern, string[] sourceFiles, string[] expected)
         {
@@ -409,127 +413,152 @@ namespace System.IO.Tests
         [OuterLoop("These are pretty corner, don't need to run all the time.")]
         // Can't do these without extended path support on Windows, UsingNewNormalization filters appropriately
         [ConditionalTheory(nameof(UsingNewNormalization)),
-            // "foo*." actually becomes "foo<" when passed to NT.
+            // "foo*." actually becomes "foo<" when passed to NT. It matches all characters up to, and including, the final period.
             //
-            // This one is really awkward- it matches all characters up to, and including, the final period.
             // There is a "bug" somewhere in the Windows stack where *some* files with trailing spaces after the final period will be returned when
             // using "*." at the end of a string (which becomes "<"). According to the rules (and the actual pattern matcher used FsRtlIsNameInExpression)
             // *nothing* should match after the final period.
+            //
+            // The results as passed to RtlIsNameInExpression (after changing *. to <) are in comments.
             InlineData(
                 "foo*.",
                 new string[] { @"foo", @"foo.", @"foo.t", @"foo.tx", @"foo.txt", @"bar.txt", @"foo..", @"foo...", @"foo. ", @"foo.  ", @"foo .", @"foo. . .", @"foo. t" },
+                // Really should be: new string[] { @"foo", @"foo.", @"foo..", @"foo...", @"foo .", @"foo. . ." }), but is
                 new string[] { @"foo", @"foo .", @"foo.", @"foo..", @"foo...", @"foo. ", @"foo. . ." }),
             InlineData(
                 "*.",
                 new string[] { @"foo. ", @"foo.  ", @"foo..", @"foo. t" },
+                // Really should be: new string[] { @"foo.." }), but is
                 new string[] { @"foo. ", @"foo.  ", @"foo.." }),
             InlineData(
                 "f*.",
                 new string[] { @"foo. ", @"foo.  ", @"foo..", @"foo. t" },
+                // Really should be: new string[] { @"foo.." }), but is
                 new string[] { @"foo. ", @"foo.  ", @"foo.." }),
             InlineData(
                 "fo*.",
                 new string[] { @"foo. ", @"foo.  ", @"foo..", @"foo. t" },
+                // Really should be: new string[] { @"foo.." }), but is
                 new string[] { @"foo. ", @"foo.  ", @"foo.." }),
             InlineData(
                 "foo*.",
                 new string[] { @"foo. ", @"foo.  ", @"foo.   ", @"foo.    " },
+                // Really should be: new string[] { }), but is
                 new string[] { @"foo. ", @"foo.  ", @"foo.   ", @"foo.    " }),
             InlineData(
                 "foo*.",
                 new string[] { @"foo. ", @"foo.  ", @"foo.   ", @"foo.    ", @"foo." },
+                // Really should be: new string[] { @"foo." }), but is
                 new string[] { @"foo. ", @"foo.  ", @"foo.   ", @"foo.    ", @"foo." }),
             InlineData(
                 "foo*.",
                 new string[] { @"foo.", @"foo. ", @"foo.  ", @"foo.   ", @"foo.    " },
+                // Really should be: new string[] { @"foo." }), but is
                 new string[] { @"foo. ", @"foo.  ", @"foo.   ", @"foo." }),
             InlineData(
                 "foo*.",
                 new string[] { @"foo.", @"foo", @"foo. ", @"foo.  ", @"foo.   ", @"foo.    " },
+                // Really should be: new string[] { @"foo.", @"foo" }), but is
                 new string[] { @"foo.", @"foo", @"foo.  ", @"foo.   ", @"foo. " }),
             InlineData(
                 "foo*.",
                 new string[] { @"foo.", @"foo. ", @"foo.  ", @"foo.   ", @"foo.    ", @"foo" },
+                // Really should be: new string[] { @"foo.", @"foo" }), but is
                 new string[] { @"foo.", @"foo", @"foo.  ", @"foo.   ", @"foo. " }),
             InlineData(
                 "foo*.",
                 new string[] { @"foo.    ", @"foo", @"foo.", @"foo. ", @"foo.  ", @"foo.   " },
+                // Really should be: new string[] { @"foo.", @"foo" }), but is
                 new string[] { @"foo.", @"foo", @"foo.  ", @"foo.    ", @"foo. " }),
             InlineData(
                 "foo*.",
                 new string[] { @"foo.    ", @"foo", @"food", @"foo.", @"foo. ", @"foo.  ", @"foo.   " },
+                // Really should be: new string[] { @"foo.", @"foo", @"food" }), but is
                 new string[] { @"foo.", @"foo", @"foo.  ", @"foo.    ", @"foo. ", @"food" }),
             InlineData(
                 "fo*.",
                 new string[] { @"foo.", @"foo. ", @"foo.  ", @"foo.   ", @"foo.    " },
+                // Really should be: new string[] { @"foo." }), but is
                 new string[] { @"foo. ", @"foo.  ", @"foo.   ", @"foo.", @"foo.    " }),
             InlineData(
                 "foo*.",
                 new string[] { @"foo. ", @"foo.  ", @"foo.   ", @"foo.    ", @"foo.     " },
+                // Really should be: new string[] { }), but is
                 new string[] { @"foo. ", @"foo.  ", @"foo.   ", @"foo.    " }),
             InlineData(
                 "foo*.",
                 new string[] { @"foo. ", @"foo. .", @"foo. . ", @"foo. . .", @"foo. . . " },
+                // Really should be: new string[] { @"foo. .", @"foo. . ." }), but is
                 new string[] { @"foo. ", @"foo. .", @"foo. . ", @"foo. . ." }),
             InlineData(
                 "foo*.",
                 new string[] { @"foo. ", @"foo. .", @"foo.. .", @"foo.... .", @"foo..... ." },
+                // Really should be: new string[] { @"foo. .", @"foo.. .", @"foo.... .", @"foo..... ." }), but is
                 new string[] { @"foo. ", @"foo. .", @"foo.. .", @"foo.... .", @"foo..... ." }),
-            InlineData(
-                "foo*.",
-                new string[] { @"foo..", @"foo...", @"foo....", @"foo.....", @"foo......" },
-                new string[] { @"foo..", @"foo...", @"foo....", @"foo.....", @"foo......" }),
             InlineData(
                 "fo*.",
                 new string[] { @"foo. ", @"foo. .", @"foo. . ", @"foo. . .", @"foo. . . " },
+                // Really should be: new string[] { @"foo. .", @"foo. . ."}), but is
                 new string[] { @"foo. ", @"foo. .", @"foo. . ", @"foo. . .", @"foo. . . " }),
             InlineData(
                 "foo*.",
                 new string[] { @"foo.", @"foo. ", @"foo.  ", @"foo.   ", @"foo.    ", @"foo.     " },
+                // Really should be: new string[] { @"foo." }), but is
                 new string[] { @"foo.", @"foo. ", @"foo.  ", @"foo.   " }),
             InlineData(
                 "food*.",
                 new string[] { @"food.", @"food. ", @"food.  ", @"food.   ", @"food.    ", @"food.     " },
+                // Really should be: new string[] { @"food." }), but is
                 new string[] { @"food.", @"food. ", @"food.  ", @"food.   " }),
             InlineData(
                 "food*.",
                 new string[] { @"food.", @"food. ", @"food.  ", @"food.   ", @"food.    ", @"food.     ", @"foodi." },
+                // Really should be: new string[] { @"food.", @"foodi." }), but is
                 new string[] { @"food.", @"food. ", @"food.  ", @"food.   ", @"foodi." }),
             InlineData(
                 "foodi*.",
                 new string[] { @"foodi.", @"foodi. ", @"foodi.  ", @"foodi.   ", @"foodi.    ", @"foodi.     " },
+                // Really should be: new string[] { @"foodi." }), but is
                 new string[] { @"foodi.", @"foodi. ", @"foodi.  ", @"foodi.   " }),
             InlineData(
                 "foodie*.",
                 new string[] { @"foodie.", @"foodie. ", @"foodie.  ", @"foodie.   ", @"foodie.    ", @"foodie.     " },
+                // Really should be: new string[] { @"foodie." }), but is
                 new string[] { @"foodie.", @"foodie. ", @"foodie.  ", @"foodie.   " }),
             InlineData(
                 "fooooo*.",
                 new string[] { @"foooooo.", @"foooooo. ", @"foooooo.  " },
+                // Really should be: new string[] { @"foooooo." }), but is
                 new string[] { @"foooooo.", @"foooooo. ", @"foooooo.  " }),
             InlineData(
                 "fooooo*.",
                 new string[] { @"foooooo. ", @"foooooo.  ", @"foooooo.   " },
+                // Really should be: new string[] { }), but is
                 new string[] { @"foooooo. ", @"foooooo.  ", @"foooooo.   " }),
             InlineData(
                 "fo*.",
                 new string[] { @"foo. ", @"foo.  ", @"foo.   ", @"foo.    ", @"foo.     " },
+                // Really should be: new string[] { }), but is
                 new string[] { @"foo. ", @"foo.  ", @"foo.   ", @"foo.    ", @"foo.     " }),
             InlineData(
                 "fo*.",
                 new string[] { @"foo. ", @"foo.  ", @"foo.   ", @"foo.    ", @"foo.     ", @"foo.      ", @"foo.       " },
+                // Really should be: new string[] { }), but is
                 new string[] { @"foo. ", @"foo.  ", @"foo.   ", @"foo.    ", @"foo.     ", @"foo.      ", @"foo.       " }),
             InlineData(
                 "fo*.",
                 new string[] { @"fo. ", @"fo.  ", @"fo.   ", @"fo.    ", @"foo.  ", @"foo.   ", @"foo.    ", @"foo.     ", @"foo.      ", @"foo.       " },
+                // Really should be: new string[] { }), but is
                 new string[] { @"fo. ", @"fo.  ", @"fo.   ", @"fo.    ", @"foo.  ", @"foo.   ", @"foo.    ", @"foo.     ", @"foo.      ", @"foo.       " }),
             InlineData(
                 "fo*.",
                 new string[] { @"fo. ", @"fo.  ", @"fo.   ", @"fo.    ", @"fo.     ", @"fo.      ", @"foo.  ", @"foo.   ", @"foo.    ", @"foo.     ", @"foo.      ", @"foo.       " },
+                // Really should be: new string[] { }), but is
                 new string[] { @"fo. ", @"fo.  ", @"fo.   ", @"fo.    ", @"fo.     ", @"fo.      ", @"foo.  ", @"foo.   ", @"foo.    ", @"foo.     ", @"foo.      ", @"foo.       " }),
             InlineData(
                 "foo*.",
                 new string[] { @"foo. ", @"foo.  ", @"foo..", @"foo. t", @"foo.   ", @"foo.    " },
+                // Really should be: new string[] { @"foo.." }), but is
                 new string[] { @"foo. ", @"foo.  ", @"foo.   ", @"foo.." }),
             ]
         public void PatternTests_DosStarOddSpace(string pattern, string[] sourceFiles, string[] expected)


### PR DESCRIPTION
We try and align with Windows, so we'll escape out [ and /.

Adds a bunch of tests and issues for other cases that we don't
match Windows behavior.

Addresses #20688