### PR TITLE
Improve test table cleanup in SqlClient ManualTests

### DIFF
--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/DateTimeVariantTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/DateTimeVariantTest.cs
@@ -776,6 +776,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                 {
                     conn.Open();
                     DropTable(conn, bulkCopyTableName);
+                    DropTable(conn, bulkCopySrcTableName);
                 }
             }
 


### PR DESCRIPTION
Noticed some test tables were building up in my test server, so added some extra table cleanup in the Manual Tests.