### PR TITLE
Fix issue #20609 - RemoveAll on ImmutableList<T>.Builder removes wrong elements.

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.cs
@@ -2205,19 +2205,22 @@ namespace System.Collections.Immutable
                 Contract.Ensures(Contract.Result<Node>() != null);
 
                 var result = this;
-                int index = 0;
-                foreach (var item in this)
+                var index = 0;
+                var count = this.Count;
+                var removed = 0;
+                for(;;)
                 {
+                    if (index + removed >= count)
+                        break;
+                    var item = result[index];
                     if (match(item))
                     {
                         result = result.RemoveAt(index);
+                        removed++;
                     }
                     else
-                    {
                         index++;
-                    }
                 }
-
                 return result;
             }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.cs
@@ -2209,7 +2209,7 @@ namespace System.Collections.Immutable
                 try
                 {
                     var startIndex = 0;
-                    while(enumerator.MoveNext())
+                    while (enumerator.MoveNext())
                     {
                         if (match(enumerator.Current))
                         {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.cs
@@ -2205,22 +2205,29 @@ namespace System.Collections.Immutable
                 Contract.Ensures(Contract.Result<Node>() != null);
 
                 var result = this;
-                var index = 0;
-                var count = this.Count;
-                var removed = 0;
-                while(index + removed < count)
+                var enumerator = new Enumerator(result);
+                try
                 {
-                    var item = result[index];
-                    if (match(item))
+                    var startIndex = 0;
+                    while(enumerator.MoveNext())
                     {
-                        result = result.RemoveAt(index);
-                        removed++;
-                    }
-                    else
-                    {
-                        index++;
+                        if (match(enumerator.Current))
+                        {
+                            result = result.RemoveAt(startIndex);
+                            enumerator.Dispose();
+                            enumerator = new Enumerator(result, startIndex: startIndex);
+                        }
+                        else
+                        {
+                            startIndex++;
+                        }
                     }
                 }
+                finally
+                {
+                    enumerator.Dispose();
+                }
+
                 return result;
             }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.cs
@@ -2208,10 +2208,8 @@ namespace System.Collections.Immutable
                 var index = 0;
                 var count = this.Count;
                 var removed = 0;
-                for(;;)
+                while(index + removed < count)
                 {
-                    if (index + removed >= count)
-                        break;
                     var item = result[index];
                     if (match(item))
                     {
@@ -2219,7 +2217,9 @@ namespace System.Collections.Immutable
                         removed++;
                     }
                     else
+                    {
                         index++;
+                    }
                 }
                 return result;
             }

--- a/src/System.Collections.Immutable/tests/ImmutableListBuilderTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableListBuilderTest.cs
@@ -178,6 +178,17 @@ namespace System.Collections.Immutable.Tests
         }
 
         [Fact]
+        public void RemoveAllBugTest()
+        {
+            var builder = ImmutableList.CreateBuilder<int>();
+            var elemsToRemove = new[]{0, 1, 2, 3, 4, 5}.ToImmutableHashSet();
+            foreach(var elem in new[]{0, 1, 2, 3, 4, 5, 6})
+                builder.Add(elem);
+            builder.RemoveAll(elemsToRemove.Contains);
+            Assert.Equal(new int[]{ 6 }, builder);
+        }
+
+        [Fact]
         public void RemoveAt()
         {
             var mutable = ImmutableList<int>.Empty.ToBuilder();

--- a/src/System.Collections.Immutable/tests/ImmutableListBuilderTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableListBuilderTest.cs
@@ -185,7 +185,7 @@ namespace System.Collections.Immutable.Tests
             foreach(var elem in new[]{0, 1, 2, 3, 4, 5, 6})
                 builder.Add(elem);
             builder.RemoveAll(elemsToRemove.Contains);
-            Assert.Equal(new int[]{ 6 }, builder);
+            Assert.Equal(new[]{ 6 }, builder);
         }
 
         [Fact]

--- a/src/System.Collections.Immutable/tests/ImmutableListBuilderTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableListBuilderTest.cs
@@ -182,6 +182,7 @@ namespace System.Collections.Immutable.Tests
         {
             var builder = ImmutableList.CreateBuilder<int>();
             var elemsToRemove = new[]{0, 1, 2, 3, 4, 5}.ToImmutableHashSet();
+            // NOTE: this uses Add instead of AddRange because AddRange doesn't exhibit the same issue due to a different order of tree building.  Don't change it without testing with the bug repro from issue #20609
             foreach(var elem in new[]{0, 1, 2, 3, 4, 5, 6})
                 builder.Add(elem);
             builder.RemoveAll(elemsToRemove.Contains);


### PR DESCRIPTION
This pull request resolves #20609.