### PR TITLE
More AOT serialization fixes

### DIFF
--- a/src/System.Net.Primitives/src/System/Net/Cookie.cs
+++ b/src/System.Net.Primitives/src/System/Net/Cookie.cs
@@ -10,7 +10,7 @@ using System.Text;
 
 namespace System.Net
 {
-    internal enum CookieVariant
+    public enum CookieVariant
     {
         Unknown,
         Plain,

--- a/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
+++ b/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
@@ -982,18 +982,19 @@ namespace System.Net
         }
     }
 
+    [Serializable]
     internal struct PathList
     {
         // Usage of PathList depends on it being shallowly immutable;
         // adding any mutable fields to it would result in breaks.
-        private readonly SortedList<string, CookieCollection> _list;
+        private readonly SortedList<string, CookieCollection> m_list; // Do not rename (binary serialization)
 
         public static PathList Create() => new PathList(new SortedList<string, CookieCollection>(PathListComparer.StaticInstance));
 
         private PathList(SortedList<string, CookieCollection> list)
         {
             Debug.Assert(list != null, $"{nameof(list)} must not be null.");
-            _list = list;
+            m_list = list;
         }
 
         public int Count
@@ -1002,7 +1003,7 @@ namespace System.Net
             {
                 lock (SyncRoot)
                 {
-                    return _list.Count;
+                    return m_list.Count;
                 }
             }
         }
@@ -1012,7 +1013,7 @@ namespace System.Net
             int count = 0;
             lock (SyncRoot)
             {
-                foreach (KeyValuePair<string, CookieCollection> pair in _list)
+                foreach (KeyValuePair<string, CookieCollection> pair in m_list)
                 {
                     CookieCollection cc = pair.Value;
                     count += cc.Count;
@@ -1028,7 +1029,7 @@ namespace System.Net
                 lock (SyncRoot)
                 {
                     CookieCollection value;
-                    _list.TryGetValue(s, out value);
+                    m_list.TryGetValue(s, out value);
                     return value;
                 }
             }
@@ -1037,7 +1038,7 @@ namespace System.Net
                 lock (SyncRoot)
                 {
                     Debug.Assert(value != null);
-                    _list[s] = value;
+                    m_list[s] = value;
                 }
             }
         }
@@ -1046,7 +1047,7 @@ namespace System.Net
         {
             lock (SyncRoot)
             {
-                return _list.GetEnumerator();
+                return m_list.GetEnumerator();
             }
         }
 
@@ -1054,11 +1055,12 @@ namespace System.Net
         {
             get
             {
-                Debug.Assert(_list != null, $"{nameof(PathList)} should never be default initialized and only ever created with {nameof(Create)}.");
-                return _list;
+                Debug.Assert(m_list != null, $"{nameof(PathList)} should never be default initialized and only ever created with {nameof(Create)}.");
+                return m_list;
             }
         }
 
+        [Serializable]
         private sealed class PathListComparer : IComparer<string>
         {
             internal static readonly PathListComparer StaticInstance = new PathListComparer();

--- a/src/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.rd.xml
+++ b/src/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.rd.xml
@@ -8,5 +8,8 @@
     <Assembly Name="System.Collections.NonGeneric" BinaryFormatter="All" Dynamic="Required Public" />
     <Assembly Name="System.Collections.Specialized" BinaryFormatter="All" Dynamic="Required Public" />
     <Assembly Name="System.ComponentModel.TypeConverter" BinaryFormatter="All" Dynamic="Required Public" />
+    <Assembly Name="System.Net.Primitives" BinaryFormatter="All" Dynamic="Required Public" />
+    <Assembly Name="System.ObjectModel" BinaryFormatter="All" Dynamic="Required Public" />
+    <Assembly Name="System.Runtime.Extensions" BinaryFormatter="All" Dynamic="Required Public" />
   </Library>
 </Directives>

--- a/src/System.Runtime.Serialization.Formatters/tests/EqualityExtensions.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/EqualityExtensions.cs
@@ -100,12 +100,22 @@ namespace System.Runtime.Serialization.Formatters.Tests
 
         public static bool IsEqual(this Comparer @this, Comparer other)
         {
-            CompareInfo GetCompareInfoName(Comparer comparer) => 
-                comparer.GetType().GetField("_compareInfo", Reflection.BindingFlags.Instance | Reflection.BindingFlags.NonPublic).GetValue(comparer) as CompareInfo;
+            if(@this == null || other == null)
+            {
+                return false;
+            }
 
-            return @this != null &&
-                other != null &&
-                Object.Equals(GetCompareInfoName(@this), GetCompareInfoName(other));
+            // The compareInfos are internal and get reflection blocked on .NET Native, so use
+            // GetObjectData to get them
+            SerializationInfo thisInfo = new SerializationInfo(typeof(Comparer), new FormatterConverter());
+            @this.GetObjectData(thisInfo, new StreamingContext());
+            CompareInfo thisCompareInfo = (CompareInfo)thisInfo.GetValue("CompareInfo", typeof(CompareInfo));
+
+            SerializationInfo otherInfo = new SerializationInfo(typeof(Comparer), new FormatterConverter());
+            other.GetObjectData(otherInfo, new StreamingContext());
+            CompareInfo otherCompareInfo = (CompareInfo)otherInfo.GetValue("CompareInfo", typeof(CompareInfo));
+            
+            return Object.Equals(thisCompareInfo, otherCompareInfo);
         }
 
 

--- a/src/System.Runtime.Serialization.Formatters/tests/FormatterServicesTests.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/FormatterServicesTests.cs
@@ -103,14 +103,19 @@ namespace System.Runtime.Serialization.Formatters.Tests
 
         public static IEnumerable<object[]> GetUninitializedObject_ByRefLikeType_TestData()
         {
-            yield return new object[] { typeof(RuntimeArgumentHandle) };
             yield return new object[] { typeof(TypedReference) };
 
-            // .NET Standard 2.0 doesn't have ArgIterator, but .NET Core 2.0 does
-            Type argIterator = typeof(object).Assembly.GetType("System.ArgIterator");
-            if (argIterator != null)
+            // These types are stubs on .NET Native and thus not byref-like
+            if (!PlatformDetection.IsNetNative)
             {
-                yield return new object[] { argIterator };
+                yield return new object[] { typeof(RuntimeArgumentHandle) };
+
+                // .NET Standard 2.0 doesn't have ArgIterator, but .NET Core 2.0 does
+                Type argIterator = typeof(object).Assembly.GetType("System.ArgIterator");
+                if (argIterator != null)
+                {
+                    yield return new object[] { argIterator };
+                }
             }
         }
 


### PR DESCRIPTION
More fixes for UAP AOT BinaryFormatter tests: 
* Making Cookie and CookieContainer serialize correctly (I'm not sure why this wasn't needed for CoreCLR)
* More rd.xml
* Avoid private reflection in the test Comparer comparison
* Minor tweaks to the byreflike test