### PR TITLE
Fixes System.Runtime.Numerics tests compilation

### DIFF
--- a/src/System.Runtime.Numerics/tests/BigInteger/MyBigInt.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/MyBigInt.cs
@@ -100,6 +100,7 @@ namespace System.Numerics.Tests
             List<byte> bytes1 = new List<byte>(num1.ToByteArray());
             List<byte> bytes2 = new List<byte>(num2.ToByteArray());
 
+            num3 = 0;
             switch (op)
             {
                 case "bMin":

--- a/src/System.Runtime.Numerics/tests/BigInteger/stackcalculator.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/stackcalculator.cs
@@ -183,6 +183,7 @@ namespace System.Numerics.Tests
 
         private BigInteger DoBinaryOperatorSN(BigInteger num1, BigInteger num2, string op, out BigInteger num3)
         {
+            num3 = 0;
             switch (op)
             {
                 case "bMin":


### PR DESCRIPTION
Fixes C# compiler error `The out parameter 'num3' must be assigned to before control leaves the current method`.

It appears that corefx is using pre-RTM buggy version of C# compiler