### PR TITLE
Fill out FileSystemInfo state when enumerating (#20716)

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
@@ -448,14 +448,27 @@ namespace System.IO
             {
                 case SearchTarget.Files:
                     return new FileSystemEnumerable<FileInfo>(fullPath, searchPattern, searchOption, searchTarget, (path, isDir) =>
-                        new FileInfo(path, null));
+                        {
+                            var info = new FileInfo(path, null);
+                            info.Refresh();
+                            return info;
+                        });
                 case SearchTarget.Directories:
                     return new FileSystemEnumerable<DirectoryInfo>(fullPath, searchPattern, searchOption, searchTarget, (path, isDir) =>
-                        new DirectoryInfo(path, null));
+                        {
+                            var info = new DirectoryInfo(path, null);
+                            info.Refresh();
+                            return info;
+                        });
                 default:
-                    return new FileSystemEnumerable<FileSystemInfo>(fullPath, searchPattern, searchOption, searchTarget, (path, isDir) => isDir ?
-                        (FileSystemInfo)new DirectoryInfo(path, null) :
-                        (FileSystemInfo)new FileInfo(path, null));
+                    return new FileSystemEnumerable<FileSystemInfo>(fullPath, searchPattern, searchOption, searchTarget, (path, isDir) =>
+                        {
+                            var info = isDir ?
+                                (FileSystemInfo)new DirectoryInfo(path, null) :
+                                (FileSystemInfo)new FileInfo(path, null);
+                            info.Refresh();
+                            return info;
+                        });
             }
         }
 

--- a/src/System.IO.FileSystem/tests/Base/AllGetSetAttributes.cs
+++ b/src/System.IO.FileSystem/tests/Base/AllGetSetAttributes.cs
@@ -1,0 +1,71 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.IO.Tests
+{
+    // Tests that are valid for File, FileInfo, and DirectoryInfo
+    public abstract class AllGetSetAttributes : BaseGetSetAttributes
+    {
+        [Fact]
+        public void NullParameters()
+        {
+            Assert.Throws<ArgumentNullException>(() => GetAttributes(null));
+            Assert.Throws<ArgumentNullException>(() => SetAttributes(null, FileAttributes.Normal));
+        }
+
+        [Fact]
+        public void InvalidParameters()
+        {
+            Assert.Throws<ArgumentException>(() => GetAttributes(string.Empty));
+            Assert.Throws<ArgumentException>(() => SetAttributes(string.Empty, FileAttributes.Normal));
+        }
+
+        [Theory, MemberData(nameof(TrailingCharacters))]
+        public void SetAttributes_MissingFile(char trailingChar)
+        {
+            Assert.Throws<FileNotFoundException>(() => SetAttributes(GetTestFilePath() + trailingChar, FileAttributes.ReadOnly));
+        }
+
+        [Theory, MemberData(nameof(TrailingCharacters))]
+        public void SetAttributes_MissingDirectory(char trailingChar)
+        {
+            Assert.Throws<DirectoryNotFoundException>(() => SetAttributes(Path.Combine(GetTestFilePath(), "file" + trailingChar), FileAttributes.ReadOnly));
+        }
+
+
+        [ConditionalFact(nameof(CanCreateSymbolicLinks))]
+        public void SymLinksAreReparsePoints()
+        {
+            string path = CreateItem();
+            string linkPath = GetTestFilePath();
+
+            Assert.True(MountHelper.CreateSymbolicLink(linkPath, path, isDirectory: IsDirectory));
+
+            Assert.NotEqual(FileAttributes.ReparsePoint, FileAttributes.ReparsePoint & GetAttributes(path));
+            Assert.Equal(FileAttributes.ReparsePoint, FileAttributes.ReparsePoint & GetAttributes(linkPath));
+        }
+
+        [ConditionalFact(nameof(CanCreateSymbolicLinks))]
+        public void SymLinksReflectSymLinkAttributes()
+        {
+            string path = CreateItem();
+            string linkPath = GetTestFilePath();
+
+            Assert.True(MountHelper.CreateSymbolicLink(linkPath, path, isDirectory: IsDirectory));
+
+            SetAttributes(path, FileAttributes.ReadOnly);
+            try
+            {
+                Assert.Equal(FileAttributes.ReadOnly, FileAttributes.ReadOnly & GetAttributes(path));
+                Assert.NotEqual(FileAttributes.ReadOnly, FileAttributes.ReadOnly & GetAttributes(linkPath));
+            }
+            finally
+            {
+                SetAttributes(path, GetAttributes(path) & ~FileAttributes.ReadOnly);
+            }
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/Base/BaseGetSetAttributes.cs
+++ b/src/System.IO.FileSystem/tests/Base/BaseGetSetAttributes.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+namespace System.IO.Tests
+{
+    public abstract class BaseGetSetAttributes : FileSystemTest
+    {
+        protected abstract FileAttributes GetAttributes(string path);
+        protected abstract void SetAttributes(string path, FileAttributes attributes);
+
+        /// <summary>
+        /// Create an appropriate filesystem object at the given path.
+        /// </summary>
+        protected virtual string CreateItem(string path = null, [CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)
+        {
+            path =  path ?? GetTestFilePath(null, memberName, lineNumber);
+            File.Create(path).Dispose();
+            return path;
+        }
+
+        protected virtual void DeleteItem(string path) => File.Delete(path);
+
+        protected virtual bool IsDirectory => false;
+    }
+}

--- a/src/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
@@ -1,0 +1,98 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public abstract class BaseGetSetTimes<T> : FileSystemTest
+    {
+        public delegate void SetTime(T item, DateTime time);
+        public delegate DateTime GetTime(T item);
+
+        public abstract T GetExistingItem();
+        public abstract T GetMissingItem();
+
+        public abstract IEnumerable<TimeFunction> TimeFunctions(bool requiresRoundtripping = false);
+
+        public class TimeFunction : Tuple<SetTime, GetTime, DateTimeKind>
+        {
+            public TimeFunction(SetTime setter, GetTime getter, DateTimeKind kind)
+                : base(item1: setter, item2: getter, item3: kind)
+            {
+            }
+
+            public static TimeFunction Create(SetTime setter, GetTime getter, DateTimeKind kind)
+                => new TimeFunction(setter, getter, kind);
+
+            public SetTime Setter => Item1;
+            public GetTime Getter => Item2;
+            public DateTimeKind Kind => Item3;
+        }
+
+        [Fact]
+        public void SettingUpdatesProperties()
+        {
+            T item = GetExistingItem();
+
+            Assert.All(TimeFunctions(requiresRoundtripping: true), (function) =>
+            {
+                DateTime dt = new DateTime(2014, 12, 1, 12, 0, 0, function.Kind);
+                function.Setter(item, dt);
+                DateTime result = function.Getter(item);
+                Assert.Equal(dt, result);
+                Assert.Equal(dt.ToLocalTime(), result.ToLocalTime());
+
+                // File and Directory UTC APIs treat a DateTimeKind.Unspecified as UTC whereas
+                // ToUniversalTime treats it as local.
+                if (function.Kind == DateTimeKind.Unspecified)
+                {
+                    Assert.Equal(dt, result.ToUniversalTime());
+                }
+                else
+                {
+                    Assert.Equal(dt.ToUniversalTime(), result.ToUniversalTime());
+                }
+            });
+        }
+
+        [Fact]
+        public void CanGetAllTimesAfterCreation()
+        {
+            DateTime beforeTime = DateTime.UtcNow.AddSeconds(-3);
+            T item = GetExistingItem();
+            DateTime afterTime = DateTime.UtcNow.AddSeconds(3);
+            ValidateSetTimes(item, beforeTime, afterTime);
+        }
+
+        protected void ValidateSetTimes(T item, DateTime beforeTime, DateTime afterTime)
+        {
+            Assert.All(TimeFunctions(), (function) =>
+            {
+                // We want to test all possible DateTimeKind conversions to ensure they function as expected
+                if (function.Kind == DateTimeKind.Local)
+                    Assert.InRange(function.Getter(item).Ticks, beforeTime.ToLocalTime().Ticks, afterTime.ToLocalTime().Ticks);
+                else
+                    Assert.InRange(function.Getter(item).Ticks, beforeTime.Ticks, afterTime.Ticks);
+                Assert.InRange(function.Getter(item).ToLocalTime().Ticks, beforeTime.ToLocalTime().Ticks, afterTime.ToLocalTime().Ticks);
+                Assert.InRange(function.Getter(item).ToUniversalTime().Ticks, beforeTime.Ticks, afterTime.Ticks);
+            });
+        }
+
+        public void DoesntExist_ReturnsDefaultValues()
+        {
+            T item = GetMissingItem();
+
+            Assert.All(TimeFunctions(), (function) =>
+            {
+                Assert.Equal(
+                    function.Kind == DateTimeKind.Local
+                        ? DateTime.FromFileTime(0).Ticks
+                        : DateTime.FromFileTimeUtc(0).Ticks,
+                    function.Getter(item).Ticks);
+            });
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/Base/FileGetSetAttributes.cs
+++ b/src/System.IO.FileSystem/tests/Base/FileGetSetAttributes.cs
@@ -1,0 +1,69 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.IO.Tests
+{
+    // Tests that are valid for File and FileInfo
+    public abstract class FileGetSetAttributes : BaseGetSetAttributes
+    {
+        [Theory]
+        [InlineData(FileAttributes.ReadOnly)]
+        [InlineData(FileAttributes.Normal)]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]  // Unix valid file attributes
+        public void UnixAttributeSetting(FileAttributes attr)
+        {
+            string path = CreateItem();
+            SetAttributes(path, attr);
+            Assert.Equal(attr, GetAttributes(path));
+            SetAttributes(path, 0);
+        }
+
+        [Theory]
+        [InlineData(FileAttributes.ReadOnly)]
+        [InlineData(FileAttributes.Hidden)]
+        [InlineData(FileAttributes.System)]
+        [InlineData(FileAttributes.Archive)]
+        [InlineData(FileAttributes.Normal)]
+        [InlineData(FileAttributes.Temporary)]
+        [InlineData(FileAttributes.ReadOnly | FileAttributes.Hidden)]
+        [PlatformSpecific(TestPlatforms.Windows)]  // Valid Windows file attribute
+        public void WindowsAttributeSetting(FileAttributes attr)
+        {
+            string path = CreateItem();
+            SetAttributes(path, attr);
+            Assert.Equal(attr, GetAttributes(path));
+            SetAttributes(path, 0);
+        }
+
+        [Theory]
+        [InlineData(FileAttributes.Temporary)]
+        [InlineData(FileAttributes.Encrypted)]
+        [InlineData(FileAttributes.SparseFile)]
+        [InlineData(FileAttributes.ReparsePoint)]
+        [InlineData(FileAttributes.Compressed)]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]  // Unix invalid file attributes
+        public void UnixInvalidAttributes(FileAttributes attr)
+        {
+            string path = CreateItem();
+            SetAttributes(path, attr);
+            Assert.Equal(FileAttributes.Normal, GetAttributes(path));
+        }
+
+        [Theory]
+        [InlineData(FileAttributes.Normal)]
+        [InlineData(FileAttributes.Encrypted)]
+        [InlineData(FileAttributes.SparseFile)]
+        [InlineData(FileAttributes.ReparsePoint)]
+        [InlineData(FileAttributes.Compressed)]
+        [PlatformSpecific(TestPlatforms.Windows)]  // Invalid Windows file attributes 
+        public void WindowsInvalidAttributes(FileAttributes attr)
+        {
+            string path = CreateItem();
+            SetAttributes(path, attr);
+            Assert.Equal(FileAttributes.Normal, GetAttributes(path));
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/Base/InfoGetSetAttributes.cs
+++ b/src/System.IO.FileSystem/tests/Base/InfoGetSetAttributes.cs
@@ -1,0 +1,65 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using System.Linq;
+
+namespace System.IO.Tests
+{
+    // Tests that are valid for FileInfo and DirectoryInfo
+    public abstract class InfoGetSetAttributes<T> : AllGetSetAttributes where T : FileSystemInfo
+    {
+        protected abstract T CreateInfo(string path);
+
+        // In NetFX we ignore "not found" errors, which leaves the attributes
+        // state as invalid (0xFFFFFFFF), which makes all flags true.
+
+        [Theory, MemberData(nameof(TrailingCharacters))]
+        public void GetAttributes_MissingFile(char trailingChar)
+        {
+            Assert.Equal((FileAttributes)(-1), GetAttributes(GetTestFilePath() + trailingChar));
+        }
+
+        [Theory, MemberData(nameof(TrailingCharacters))]
+        public void GetAttributes_MissingDirectory(char trailingChar)
+        {
+            Assert.Equal((FileAttributes)(-1), GetAttributes(Path.Combine(GetTestFilePath(), "file" + trailingChar)));
+        }
+
+        [Theory, MemberData(nameof(TrailingCharacters))]
+        public void GetAttributes_CreateAfter(char trailingChar)
+        {
+            string path = GetTestFilePath();
+            T info = CreateInfo(trailingChar == 'a' ? path : path + trailingChar);
+            CreateItem(path);
+
+            // The actual value will vary depending on the OS and what is running.
+            // Archive, NotContentIndexed, etc. might be set.
+            Assert.NotEqual((FileAttributes)(-1), info.Attributes);
+        }
+
+        [Theory, MemberData(nameof(TrailingCharacters))]
+        public void GetAttributes_DeleteAfter(char trailingChar)
+        {
+            string path = CreateItem();
+            T info = CreateInfo(trailingChar == 'a' ? path : path + trailingChar);
+            DeleteItem(path);
+            Assert.Equal((FileAttributes)(-1), info.Attributes);
+        }
+
+        public void GetAttributes_DeleteAfterEnumerate()
+        {
+            // When enumerating we populate the state as we already have it.
+            string path = CreateItem();
+            FileSystemInfo info = new DirectoryInfo(TestDirectory).EnumerateFileSystemInfos().First();
+            DeleteItem(path);
+
+            // The actual value will vary depending on the OS and what is running.
+            // Archive, NotContentIndexed, etc. might be set.
+            Assert.NotEqual((FileAttributes)(-1), info.Attributes);
+            info.Refresh();
+            Assert.Equal((FileAttributes)(-1), info.Attributes);
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/Base/InfoGetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/Base/InfoGetSetTimes.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace System.IO.Tests
@@ -46,16 +48,24 @@ namespace System.IO.Tests
         [Fact]
         public void TimesStillSetAfterDelete()
         {
-            DateTime beforeTime = DateTime.UtcNow.AddSeconds(-1);
             T item = GetExistingItem();
 
             // Refresh to fill state
             item.Refresh();
-            DateTime afterTime = DateTime.UtcNow.AddSeconds(1);
 
-            // Deleting doesn't change any info state
+            // Get our initial times
+            var times = new Dictionary<TimeFunction, DateTime>();
+            foreach (var timeFunction in TimeFunctions())
+            {
+                times.Add(timeFunction, timeFunction.Getter(item));
+            }
+
+            // Deleting shouldn't change any info state
             item.Delete();
-            ValidateSetTimes(item, beforeTime, afterTime);
+            Assert.All(times, time =>
+            {
+                Assert.Equal(time.Value, time.Key.Getter(item));
+            });
         }
     }
 }

--- a/src/System.IO.FileSystem/tests/Base/InfoGetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/Base/InfoGetSetTimes.cs
@@ -1,0 +1,61 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public abstract class InfoGetSetTimes<T> : BaseGetSetTimes<T> where T : FileSystemInfo
+    {
+        public abstract void InvokeCreate(T item);
+
+        public void DoesntExistThenCreate_ReturnsDefaultValues()
+        {
+            T item = GetMissingItem();
+            InvokeCreate(item);
+
+            Assert.All(TimeFunctions(), (function) =>
+            {
+                Assert.Equal(
+                    function.Kind == DateTimeKind.Local
+                        ? DateTime.FromFileTime(0).Ticks
+                        : DateTime.FromFileTimeUtc(0).Ticks,
+                    function.Getter(item).Ticks);
+            });
+        }
+
+        public void ExistsThenDelete_ReturnsDefaultValues()
+        {
+            // Because we haven't hit the property the item should be in
+            // an uninitialized state, hence still 0.
+
+            T item = GetExistingItem();
+            item.Delete();
+
+            Assert.All(TimeFunctions(), (function) =>
+            {
+                Assert.Equal(
+                    function.Kind == DateTimeKind.Local
+                        ? DateTime.FromFileTime(0).Ticks
+                        : DateTime.FromFileTimeUtc(0).Ticks,
+                    function.Getter(item).Ticks);
+            });
+        }
+
+        [Fact]
+        public void TimesStillSetAfterDelete()
+        {
+            DateTime beforeTime = DateTime.UtcNow.AddSeconds(-1);
+            T item = GetExistingItem();
+
+            // Refresh to fill state
+            item.Refresh();
+            DateTime afterTime = DateTime.UtcNow.AddSeconds(1);
+
+            // Deleting doesn't change any info state
+            item.Delete();
+            ValidateSetTimes(item, beforeTime, afterTime);
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/Base/StaticGetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/Base/StaticGetSetTimes.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public abstract class StaticGetSetTimes : BaseGetSetTimes<string>
+    {
+        public override string GetMissingItem() => GetTestFilePath();
+
+        [Fact]
+        public void NullPath_ThrowsArgumentNullException()
+        {
+            Assert.All(TimeFunctions(), (item) =>
+            {
+                Assert.Throws<ArgumentNullException>(() => item.Setter(null, DateTime.Today));
+                Assert.Throws<ArgumentNullException>(() => item.Getter(null));
+            });
+        }
+
+        [Fact]
+        public void EmptyPath_ThrowsArgumentException()
+        {
+            Assert.All(TimeFunctions(), (item) =>
+            {
+                Assert.Throws<ArgumentException>(() => item.Setter(string.Empty, DateTime.Today));
+                Assert.Throws<ArgumentException>(() => item.Getter(string.Empty));
+            });
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/Directory/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetSetTimes.cs
@@ -3,148 +3,54 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Threading.Tasks;
-using Xunit;
 
 namespace System.IO.Tests
 {
-    public class Directory_GetSetTimes : FileSystemTest
+    public class Directory_GetSetTimes : StaticGetSetTimes
     {
-        public delegate void SetTime(string path, DateTime time);
-        public delegate DateTime GetTime(string path);
+        public override string GetExistingItem() => Directory.CreateDirectory(GetTestFilePath()).FullName;
 
-        public IEnumerable<Tuple<SetTime, GetTime, DateTimeKind>> TimeFunctions(bool requiresRoundtripping = false)
+        public override IEnumerable<TimeFunction> TimeFunctions(bool requiresRoundtripping = false)
         {
             if (IOInputs.SupportsGettingCreationTime && (!requiresRoundtripping || IOInputs.SupportsSettingCreationTime))
             {
-                yield return Tuple.Create<SetTime, GetTime, DateTimeKind>(
+                yield return TimeFunction.Create(
                     ((path, time) => Directory.SetCreationTime(path, time)),
                     ((path) => Directory.GetCreationTime(path)),
                     DateTimeKind.Local);
-                yield return Tuple.Create<SetTime, GetTime, DateTimeKind>(
+                yield return TimeFunction.Create(
                     ((path, time) => Directory.SetCreationTimeUtc(path, time)),
                     ((path) => Directory.GetCreationTimeUtc(path)),
                     DateTimeKind.Unspecified);
-                yield return Tuple.Create<SetTime, GetTime, DateTimeKind>(
+                yield return TimeFunction.Create(
                     ((path, time) => Directory.SetCreationTimeUtc(path, time)),
                     ((path) => Directory.GetCreationTimeUtc(path)),
                     DateTimeKind.Utc);
             }
-            yield return Tuple.Create<SetTime, GetTime, DateTimeKind>(
+            yield return TimeFunction.Create(
                 ((path, time) => Directory.SetLastAccessTime(path, time)),
                 ((path) => Directory.GetLastAccessTime(path)),
                 DateTimeKind.Local);
-            yield return Tuple.Create<SetTime, GetTime, DateTimeKind>(
+            yield return TimeFunction.Create(
                 ((path, time) => Directory.SetLastAccessTimeUtc(path, time)),
                 ((path) => Directory.GetLastAccessTimeUtc(path)),
                 DateTimeKind.Unspecified);
-            yield return Tuple.Create<SetTime, GetTime, DateTimeKind>(
+            yield return TimeFunction.Create(
                 ((path, time) => Directory.SetLastAccessTimeUtc(path, time)),
                 ((path) => Directory.GetLastAccessTimeUtc(path)),
                 DateTimeKind.Utc);
-            yield return Tuple.Create<SetTime, GetTime, DateTimeKind>(
+            yield return TimeFunction.Create(
                 ((path, time) => Directory.SetLastWriteTime(path, time)),
                 ((path) => Directory.GetLastWriteTime(path)),
                 DateTimeKind.Local);
-            yield return Tuple.Create<SetTime, GetTime, DateTimeKind>(
+            yield return TimeFunction.Create(
                 ((path, time) => Directory.SetLastWriteTimeUtc(path, time)),
                 ((path) => Directory.GetLastWriteTimeUtc(path)),
                 DateTimeKind.Unspecified);
-            yield return Tuple.Create<SetTime, GetTime, DateTimeKind>(
+            yield return TimeFunction.Create(
                 ((path, time) => Directory.SetLastWriteTimeUtc(path, time)),
                 ((path) => Directory.GetLastWriteTimeUtc(path)),
                 DateTimeKind.Utc);
-        }
-
-        [Fact]
-        public void NullPath_ThrowsArgumentNullException()
-        {
-            Assert.All(TimeFunctions(), (tuple) =>
-            {
-                Assert.Throws<ArgumentNullException>(() => tuple.Item1(null, DateTime.Today));
-                Assert.Throws<ArgumentNullException>(() => tuple.Item2(null));
-            });
-        }
-
-        [Fact]
-        public void EmptyPath_ThrowsArgumentException()
-        {
-            Assert.All(TimeFunctions(), (tuple) =>
-            {
-                Assert.Throws<ArgumentException>(() => tuple.Item1(string.Empty, DateTime.Today));
-                Assert.Throws<ArgumentException>(() => tuple.Item2(string.Empty));
-            });
-        }
-
-        [Fact]
-        public void SettingUpdatesProperties()
-        {
-            DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
-
-            Assert.All(TimeFunctions(requiresRoundtripping: true), (tuple) =>
-            {
-                DateTime dt = new DateTime(2014, 12, 1, 12, 0, 0, tuple.Item3);
-                tuple.Item1(testDir.FullName, dt);
-                var result = tuple.Item2(testDir.FullName);
-                Assert.Equal(dt, result);
-                Assert.Equal(dt.ToLocalTime(), result.ToLocalTime());
-
-                // File and Directory UTC APIs treat a DateTimeKind.Unspecified as UTC whereas
-                // ToUniversalTime treats it as local.
-                if (tuple.Item3 == DateTimeKind.Unspecified)
-                {
-                    Assert.Equal(dt, result.ToUniversalTime());
-                }
-                else
-                {
-                    Assert.Equal(dt.ToUniversalTime(), result.ToUniversalTime());
-                }
-            });
-        }
-
-        [Fact]
-        public void CreationSetsAllTimes()
-        {
-            string path = GetTestFilePath();
-            long beforeTime = DateTime.UtcNow.AddSeconds(-3).Ticks;
-
-            DirectoryInfo testDirectory = new DirectoryInfo(GetTestFilePath());
-            testDirectory.Create();
-
-            long afterTime = DateTime.UtcNow.AddSeconds(3).Ticks;
-
-            Assert.All(TimeFunctions(), (tuple) =>
-            {
-                Assert.InRange(tuple.Item2(testDirectory.FullName).ToUniversalTime().Ticks, beforeTime, afterTime);
-            });
-        }
-
-        [Fact]
-        public void Windows_DirectoryDoesntExist_ReturnDefaultValues()
-        {
-            string path = GetTestFilePath();
-
-            //non-utc
-            Assert.Equal(DateTime.FromFileTime(0).Ticks, Directory.GetLastAccessTime(path).Ticks);
-            Assert.Equal(DateTime.FromFileTime(0).Ticks, new DirectoryInfo(path).LastAccessTime.Ticks);
-            Assert.Equal(DateTime.FromFileTime(0).Ticks, Directory.GetLastWriteTime(path).Ticks);
-            Assert.Equal(DateTime.FromFileTime(0).Ticks, new DirectoryInfo(path).LastWriteTime.Ticks);
-            if (IOInputs.SupportsGettingCreationTime)
-            {
-                Assert.Equal(DateTime.FromFileTime(0).Ticks, Directory.GetCreationTime(path).Ticks);
-                Assert.Equal(DateTime.FromFileTime(0).Ticks, new DirectoryInfo(path).CreationTime.Ticks);
-            }
-
-            //utc
-            Assert.Equal(DateTime.FromFileTimeUtc(0).Ticks, Directory.GetLastAccessTimeUtc(path).Ticks);
-            Assert.Equal(DateTime.FromFileTimeUtc(0).Ticks, new DirectoryInfo(path).LastAccessTimeUtc.Ticks);
-            Assert.Equal(DateTime.FromFileTimeUtc(0).Ticks, Directory.GetLastWriteTimeUtc(path).Ticks);
-            Assert.Equal(DateTime.FromFileTimeUtc(0).Ticks, new DirectoryInfo(path).LastWriteTimeUtc.Ticks);
-            if (IOInputs.SupportsGettingCreationTime)
-            {
-                Assert.Equal(DateTime.FromFileTimeUtc(0).Ticks, Directory.GetCreationTimeUtc(path).Ticks);
-                Assert.Equal(DateTime.FromFileTimeUtc(0).Ticks, new DirectoryInfo(path).CreationTimeUtc.Ticks);
-            }
         }
     }
 }

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/GetSetAttributes.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/GetSetAttributes.cs
@@ -2,79 +2,30 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.CompilerServices;
 using Xunit;
 
 namespace System.IO.Tests
 {
-    public class DirectoryInfo_GetSetAttributes : FileSystemTest
+    public class DirectoryInfo_GetSetAttributes : InfoGetSetAttributes<DirectoryInfo>
     {
-        #region Utilities
-
-        protected virtual FileAttributes Get(string path)
-        {
-            var info = new DirectoryInfo(path);
-            return info.Attributes;
-        }
-
-        protected virtual void Set(string path, FileAttributes attributes)
-        {
-            var info = new DirectoryInfo(path);
-            info.Attributes = attributes;
-        }
-
-        #endregion
-
-        [Fact]
-        public void NullParameters()
-        {
-            Assert.Throws<ArgumentNullException>(() => Get(null));
-            Assert.Throws<ArgumentNullException>(() => Set(null, FileAttributes.Normal));
-        }
-
-        [Fact]
-        public void InvalidParameters()
-        {
-            Assert.Throws<ArgumentException>(() => Get(string.Empty));
-            Assert.Throws<ArgumentException>(() => Set(string.Empty, FileAttributes.Normal));
-        }
-
-        // In NetFX we ignore "not found" errors, which leaves the attributes
-        // state as invalid (0xFFFFFFFF), which makes all flags true.
-
-        [Theory, MemberData(nameof(TrailingCharacters))]
-        public void GetAttributes_MissingFile(char trailingChar)
-        {
-            Assert.Equal((FileAttributes)(-1), Get(GetTestFilePath() + trailingChar));
-        }
-
-        [Theory, MemberData(nameof(TrailingCharacters))]
-        public void GetAttributes_MissingDirectory(char trailingChar)
-        {
-            Assert.Equal((FileAttributes)(-1), Get(Path.Combine(GetTestFilePath(), "file" + trailingChar)));
-        }
-
-        [Theory, MemberData(nameof(TrailingCharacters))]
-        public void SetAttributes_MissingFile(char trailingChar)
-        {
-            Assert.Throws<FileNotFoundException>(() => Set(GetTestFilePath() + trailingChar, FileAttributes.ReadOnly));
-        }
-
-        [Theory, MemberData(nameof(TrailingCharacters))]
-        public void SetAttributes_MissingDirectory(char trailingChar)
-        {
-            Assert.Throws<DirectoryNotFoundException>(() => Set(Path.Combine(GetTestFilePath(), "file" + trailingChar), FileAttributes.ReadOnly));
-        }
+        protected override FileAttributes GetAttributes(string path) => new DirectoryInfo(path).Attributes;
+        protected override void SetAttributes(string path, FileAttributes attributes) => new DirectoryInfo(path).Attributes = attributes;
+        protected override string CreateItem(string path = null, [CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)
+            => Directory.CreateDirectory(path ?? GetTestFilePath()).FullName;
+        protected override DirectoryInfo CreateInfo(string path) => new DirectoryInfo(path);
+        protected override void DeleteItem(string path) => Directory.Delete(path);
+        protected override bool IsDirectory => true;
 
         [Theory]
         [InlineData(FileAttributes.ReadOnly)]
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // Tests Unix file attributes
         public void UnixAttributeSetting(FileAttributes attr)
         {
-            var test = new DirectoryInfo(GetTestFilePath());
-            test.Create();
-            Set(test.FullName, attr);
-            Assert.Equal(attr | FileAttributes.Directory, Get(test.FullName));
-            Set(test.FullName, 0);
+            string path = CreateItem();
+            SetAttributes(path, attr);
+            Assert.Equal(attr | FileAttributes.Directory, GetAttributes(path));
+            SetAttributes(path, 0);
         }
 
         [Theory]
@@ -97,11 +48,10 @@ namespace System.IO.Tests
         [PlatformSpecific(TestPlatforms.Windows)]  // Tests Windows file attributes
         public void WindowsAttributeSetting(FileAttributes attr)
         {
-            var test = new DirectoryInfo(GetTestFilePath());
-            test.Create();
-            Set(test.FullName, attr);
-            Assert.Equal(attr | FileAttributes.Directory, Get(test.FullName));
-            Set(test.FullName, 0);
+            string path = CreateItem();
+            SetAttributes(path, attr);
+            Assert.Equal(attr | FileAttributes.Directory, GetAttributes(path));
+            SetAttributes(path, 0);
         }
 
         [Theory]
@@ -114,10 +64,9 @@ namespace System.IO.Tests
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // Unix-invalid file attributes that don't get set
         public void UnixInvalidAttributes(FileAttributes attr)
         {
-            var path = GetTestFilePath();
-            File.Create(path).Dispose();
-            Set(path, attr);
-            Assert.Equal(FileAttributes.Normal, Get(path));
+            string path = CreateItem();
+            SetAttributes(path, attr);
+            Assert.Equal(FileAttributes.Directory, GetAttributes(path));
         }
 
         [Theory]
@@ -129,10 +78,9 @@ namespace System.IO.Tests
         [PlatformSpecific(TestPlatforms.Windows)]  // Windows-invalid file attributes that don't get set
         public void WindowsInvalidAttributes(FileAttributes attr)
         {
-            var path = GetTestFilePath();
-            File.Create(path).Dispose();
-            Set(path, attr);
-            Assert.Equal(FileAttributes.Normal, Get(path));
+            string path = CreateItem();
+            SetAttributes(path, attr);
+            Assert.Equal(FileAttributes.Directory, GetAttributes(path));
         }
 
         [Theory]
@@ -141,9 +89,8 @@ namespace System.IO.Tests
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // Unix-invalid file attributes that throw
         public void UnixInvalidAttributes_ThrowArgumentException(FileAttributes attr)
         {
-            var test = new DirectoryInfo(GetTestFilePath());
-            test.Create();
-            Assert.Throws<ArgumentException>(() => Set(test.FullName, attr));
+            string path = CreateItem();
+            Assert.Throws<ArgumentException>(() => SetAttributes(path, attr));
         }
 
         [Theory]
@@ -153,43 +100,8 @@ namespace System.IO.Tests
         [PlatformSpecific(TestPlatforms.Windows)]  // Windows-invalid file attributes that throw
         public void WindowsInvalidAttributes_ThrowArgumentException(FileAttributes attr)
         {
-            var test = new DirectoryInfo(GetTestFilePath());
-            test.Create();
-            Assert.Throws<ArgumentException>(() => Set(test.FullName, attr));
-        }
-
-        [ConditionalFact(nameof(CanCreateSymbolicLinks))]
-        public void SymLinksAreReparsePoints()
-        {
-            var path = GetTestFilePath();
-            var linkPath = GetTestFilePath();
-
-            Directory.CreateDirectory(path);
-            Assert.True(MountHelper.CreateSymbolicLink(linkPath, path, isDirectory: true));
-
-            Assert.NotEqual(FileAttributes.ReparsePoint, FileAttributes.ReparsePoint & Get(path));
-            Assert.Equal(FileAttributes.ReparsePoint, FileAttributes.ReparsePoint & Get(linkPath));
-        }
-
-        [ConditionalFact(nameof(CanCreateSymbolicLinks))]
-        public void SymLinksReflectSymLinkAttributes()
-        {
-            var path = GetTestFilePath();
-            var linkPath = GetTestFilePath();
-
-            Directory.CreateDirectory(path);
-            Assert.True(MountHelper.CreateSymbolicLink(linkPath, path, isDirectory: true));
-
-            Set(path, FileAttributes.ReadOnly);
-            try
-            {
-                Assert.Equal(FileAttributes.ReadOnly, FileAttributes.ReadOnly & Get(path));
-                Assert.NotEqual(FileAttributes.ReadOnly, FileAttributes.ReadOnly & Get(linkPath));
-            }
-            finally
-            {
-                Set(path, Get(path) & ~FileAttributes.ReadOnly);
-            }
+            string path = CreateItem();
+            Assert.Throws<ArgumentException>(() => SetAttributes(path, attr));
         }
     }
 }

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/GetSetTimes.cs
@@ -3,100 +3,58 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Threading.Tasks;
-using Xunit;
 
 namespace System.IO.Tests
 {
-    public class DirectoryInfo_GetSetTimes : FileSystemTest
+    public class DirectoryInfo_GetSetTimes : InfoGetSetTimes<DirectoryInfo>
     {
-        public delegate void SetTime(DirectoryInfo testDir, DateTime time);
-        public delegate DateTime GetTime(DirectoryInfo testDir);
+        public override DirectoryInfo GetExistingItem() => Directory.CreateDirectory(GetTestFilePath());
 
-        public IEnumerable<Tuple<SetTime, GetTime, DateTimeKind>> TimeFunctions(bool requiresRoundtripping = false)
+        public override DirectoryInfo GetMissingItem() => new DirectoryInfo(GetTestFilePath());
+
+        public override void InvokeCreate(DirectoryInfo item) => item.Create();
+
+        public override IEnumerable<TimeFunction> TimeFunctions(bool requiresRoundtripping = false)
         {
             if (IOInputs.SupportsGettingCreationTime && (!requiresRoundtripping || IOInputs.SupportsSettingCreationTime))
             {
-                yield return Tuple.Create<SetTime, GetTime, DateTimeKind>(
+                yield return TimeFunction.Create(
                     ((testDir, time) => {testDir.CreationTime = time; }), 
                     ((testDir) => testDir.CreationTime), 
                     DateTimeKind.Local);
-                yield return Tuple.Create<SetTime, GetTime, DateTimeKind>(
+                yield return TimeFunction.Create(
                     ((testDir, time) => {testDir.CreationTimeUtc = time; }),
                     ((testDir) => testDir.CreationTimeUtc),
                     DateTimeKind.Unspecified); 
-                yield return Tuple.Create<SetTime, GetTime, DateTimeKind>(
+                yield return TimeFunction.Create(
                      ((testDir, time) => { testDir.CreationTimeUtc = time; }),
                      ((testDir) => testDir.CreationTimeUtc),
                      DateTimeKind.Utc);
             }
-            yield return Tuple.Create<SetTime, GetTime, DateTimeKind>(
+            yield return TimeFunction.Create(
                 ((testDir, time) => {testDir.LastAccessTime = time; }),
                 ((testDir) => testDir.LastAccessTime),
                 DateTimeKind.Local);
-            yield return Tuple.Create<SetTime, GetTime, DateTimeKind>(
+            yield return TimeFunction.Create(
                 ((testDir, time) => {testDir.LastAccessTimeUtc = time; }),
                 ((testDir) => testDir.LastAccessTimeUtc),
                 DateTimeKind.Unspecified);
-            yield return Tuple.Create<SetTime, GetTime, DateTimeKind>(
+            yield return TimeFunction.Create(
                 ((testDir, time) => { testDir.LastAccessTimeUtc = time; }),
                 ((testDir) => testDir.LastAccessTimeUtc),
                 DateTimeKind.Utc);
-            yield return Tuple.Create<SetTime, GetTime, DateTimeKind>(
+            yield return TimeFunction.Create(
                 ((testDir, time) => {testDir.LastWriteTime = time; }),
                 ((testDir) => testDir.LastWriteTime),
                 DateTimeKind.Local);
-            yield return Tuple.Create<SetTime, GetTime, DateTimeKind>(
+            yield return TimeFunction.Create(
                 ((testDir, time) => {testDir.LastWriteTimeUtc = time; }),
                 ((testDir) => testDir.LastWriteTimeUtc),
                 DateTimeKind.Unspecified);
-            yield return Tuple.Create<SetTime, GetTime, DateTimeKind>(
+            yield return TimeFunction.Create(
                 ((testDir, time) => { testDir.LastWriteTimeUtc = time; }),
                 ((testDir) => testDir.LastWriteTimeUtc),
                 DateTimeKind.Utc);
-        }
-
-        [Fact]
-        public void SettingUpdatesProperties()
-        {
-            DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
-
-            Assert.All(TimeFunctions(requiresRoundtripping: true), (tuple) =>
-            {
-                DateTime dt = new DateTime(2014, 12, 1, 12, 0, 0, tuple.Item3);
-                tuple.Item1(testDir, dt);
-                var result = tuple.Item2(testDir);
-                Assert.Equal(dt, result);
-                Assert.Equal(dt.ToLocalTime(), result.ToLocalTime());
-
-                // File and Directory UTC APIs treat a DateTimeKind.Unspecified as UTC whereas
-                // ToUniversalTime treats it as local.
-                if (tuple.Item3 == DateTimeKind.Unspecified)
-                {
-                    Assert.Equal(dt, result.ToUniversalTime());
-                }
-                else
-                {
-                    Assert.Equal(dt.ToUniversalTime(), result.ToUniversalTime());
-                }
-            });
-        }
-
-        [Fact]
-        public void CreationSetsAllTimes()
-        {
-            string path = GetTestFilePath();
-            long beforeTime = DateTime.UtcNow.AddSeconds(-3).Ticks;
-
-            DirectoryInfo testDirectory = new DirectoryInfo(GetTestFilePath());
-            testDirectory.Create();
-
-            long afterTime = DateTime.UtcNow.AddSeconds(3).Ticks;
-
-            Assert.All(TimeFunctions(), (tuple) =>
-            {
-                Assert.InRange(tuple.Item2(testDirectory).ToUniversalTime().Ticks, beforeTime, afterTime);
-            });
         }
     }
 }

--- a/src/System.IO.FileSystem/tests/File/GetSetAttributes.cs
+++ b/src/System.IO.FileSystem/tests/File/GetSetAttributes.cs
@@ -2,164 +2,26 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.IO.Tests
 {
-    public class File_GetSetAttributes : FileSystemTest
+    public class File_GetSetAttributes : BaseGetSetAttributes
     {
-        #region Utilities
+        protected override FileAttributes GetAttributes(string path) => File.GetAttributes(path);
+        protected override void SetAttributes(string path, FileAttributes attributes) => File.SetAttributes(path, attributes);
 
-        protected virtual FileAttributes Get(string path)
-        {
-            return File.GetAttributes(path);
-        }
-
-        protected virtual void Set(string path, FileAttributes attributes)
-        {
-            File.SetAttributes(path, attributes);
-        }
-
-        #endregion
-
-        [Fact]
-        public void NullParameters()
-        {
-            Assert.Throws<ArgumentNullException>(() => Get(null));
-            Assert.Throws<ArgumentNullException>(() => Set(null, FileAttributes.Normal));
-        }
-
-        [Fact]
-        public void InvalidParameters()
-        {
-            Assert.Throws<ArgumentException>(() => Get(string.Empty));
-            Assert.Throws<ArgumentException>(() => Set(string.Empty, FileAttributes.Normal));
-        }
-
-        [Fact]
-        public void NonExistentFile()
-        {
-            Assert.Throws<FileNotFoundException>(() => Set(GetTestFilePath(), FileAttributes.Normal));
-        }
-
-        [Theory]
-        [InlineData(FileAttributes.ReadOnly)]
-        [InlineData(FileAttributes.Normal)]
-        [PlatformSpecific(TestPlatforms.AnyUnix)]  // Valid Unix file attribute
-        public void UnixAttributeSetting(FileAttributes attr)
-        {
-            var path = GetTestFilePath();
-            File.Create(path).Dispose();
-            Set(path, attr);
-            Assert.Equal(attr, Get(path));
-            Set(path, 0);
-        }
-
-        [Theory]
-        [InlineData(FileAttributes.ReadOnly)]
-        [InlineData(FileAttributes.Hidden)]
-        [InlineData(FileAttributes.System)]
-        [InlineData(FileAttributes.Archive)]
-        [InlineData(FileAttributes.Normal)]
-        [InlineData(FileAttributes.Temporary)]
-        [InlineData(FileAttributes.ReadOnly | FileAttributes.Hidden)]
-        [PlatformSpecific(TestPlatforms.Windows)]  // Valid Windows file attribute
-        public void WindowsAttributeSetting(FileAttributes attr)
-        {
-            var path = GetTestFilePath();
-            File.Create(path).Dispose();
-            Set(path, attr);
-            Assert.Equal(attr, Get(path));
-            Set(path, 0);
-        }
-
-        [Theory]
-        [InlineData(FileAttributes.SparseFile)]
-        [InlineData(FileAttributes.Temporary)]
-        [InlineData(FileAttributes.ReparsePoint)]
-        [InlineData(FileAttributes.Compressed)]
-        [InlineData(FileAttributes.Encrypted)]
-        [PlatformSpecific(TestPlatforms.AnyUnix)]  // Invalid Unix file attributes
-        public void UnixInvalidAttributes(FileAttributes attr)
-        {
-            var path = GetTestFilePath();
-            File.Create(path).Dispose();
-            Set(path, attr);
-            Assert.Equal(FileAttributes.Normal, Get(path));
-        }
-
-        [Theory]
-        [InlineData(FileAttributes.Normal)]
-        [InlineData(FileAttributes.Encrypted)]
-        [InlineData(FileAttributes.SparseFile)]
-        [InlineData(FileAttributes.ReparsePoint)]
-        [InlineData(FileAttributes.Compressed)]
-        [PlatformSpecific(TestPlatforms.Windows)]  // Invalid Windows file attributes 
-        public void WindowsInvalidAttributes(FileAttributes attr)
-        {
-            var path = GetTestFilePath();
-            File.Create(path).Dispose();
-            Set(path, attr);
-            Assert.Equal(FileAttributes.Normal, Get(path));
-        }
-
-        [ConditionalFact(nameof(CanCreateSymbolicLinks))]
-        public void SymLinksAreReparsePoints()
-        {
-            var path = GetTestFilePath();
-            var linkPath = GetTestFilePath();
-
-            File.Create(path).Dispose();
-            Assert.True(MountHelper.CreateSymbolicLink(linkPath, path, isDirectory: false));
-
-            Assert.NotEqual(FileAttributes.ReparsePoint, FileAttributes.ReparsePoint & Get(path));
-            Assert.Equal(FileAttributes.ReparsePoint, FileAttributes.ReparsePoint & Get(linkPath));
-        }
-
-        [ConditionalFact(nameof(CanCreateSymbolicLinks))]
-        public void SymLinksReflectSymLinkAttributes()
-        {
-            var path = GetTestFilePath();
-            var linkPath = GetTestFilePath();
-
-            File.Create(path).Dispose();
-            Assert.True(MountHelper.CreateSymbolicLink(linkPath, path, isDirectory: false));
-
-            Set(path, FileAttributes.ReadOnly);
-            try
-            {
-                Assert.Equal(FileAttributes.ReadOnly, FileAttributes.ReadOnly & Get(path));
-                Assert.NotEqual(FileAttributes.ReadOnly, FileAttributes.ReadOnly & Get(linkPath));
-            }
-            finally
-            {
-                Set(path, Get(path) & ~FileAttributes.ReadOnly);
-            }
-        }
-
+        // Getting only throws for File, not FileInfo
         [Theory, MemberData(nameof(TrailingCharacters))]
         public void GetAttributes_MissingFile(char trailingChar)
         {
-            Assert.Throws<FileNotFoundException>(() => Get(GetTestFilePath() + trailingChar));
+            Assert.Throws<FileNotFoundException>(() => GetAttributes(GetTestFilePath() + trailingChar));
         }
 
         [Theory, MemberData(nameof(TrailingCharacters))]
         public void GetAttributes_MissingDirectory(char trailingChar)
         {
-            Assert.Throws<DirectoryNotFoundException>(() => Get(Path.Combine(GetTestFilePath(), "dir" + trailingChar)));
-        }
-
-        [Theory, MemberData(nameof(TrailingCharacters))]
-        public void SetAttributes_MissingFile(char trailingChar)
-        {
-            Assert.Throws<FileNotFoundException>(() => Set(GetTestFilePath() + trailingChar, FileAttributes.ReadOnly));
-        }
-
-        [Theory, MemberData(nameof(TrailingCharacters))]
-        public void SetAttributes_MissingDirectory(char trailingChar)
-        {
-            Assert.Throws<DirectoryNotFoundException>(() => Set(Path.Combine(GetTestFilePath(), "dir" + trailingChar), FileAttributes.ReadOnly));
+            Assert.Throws<DirectoryNotFoundException>(() => GetAttributes(Path.Combine(GetTestFilePath(), "dir" + trailingChar)));
         }
     }
 }

--- a/src/System.IO.FileSystem/tests/File/GetSetAttributesCommon.cs
+++ b/src/System.IO.FileSystem/tests/File/GetSetAttributesCommon.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.IO.Tests
+{
+    // Concrete class to run common file attributes tests on the File class
+    public class File_GetSetAttributesCommon : FileGetSetAttributes
+    {
+        protected override FileAttributes GetAttributes(string path) => File.GetAttributes(path);
+        protected override void SetAttributes(string path, FileAttributes attributes) => File.SetAttributes(path, attributes);
+    }
+}

--- a/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
@@ -3,149 +3,59 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Threading.Tasks;
-using Xunit;
 
 namespace System.IO.Tests
 {
-    public class File_GetSetTimes : FileSystemTest
+    public class File_GetSetTimes : StaticGetSetTimes
     {
-        public delegate void SetTime(string path, DateTime time);
-        public delegate DateTime GetTime(string path);
+        public override string GetExistingItem()
+        {
+            string path = GetTestFilePath();
+            File.Create(path).Dispose();
+            return path;
+        }
 
-        public IEnumerable<Tuple<SetTime, GetTime, DateTimeKind>> TimeFunctions(bool requiresRoundtripping = false)
+        public override IEnumerable<TimeFunction> TimeFunctions(bool requiresRoundtripping = false)
         {
             if (IOInputs.SupportsGettingCreationTime && (!requiresRoundtripping || IOInputs.SupportsSettingCreationTime))
             {
-                yield return Tuple.Create<SetTime, GetTime, DateTimeKind>(
+                yield return TimeFunction.Create(
                     ((path, time) => File.SetCreationTime(path, time)),
                     ((path) => File.GetCreationTime(path)),
                     DateTimeKind.Local);
-                yield return Tuple.Create<SetTime, GetTime, DateTimeKind>(
+                yield return TimeFunction.Create(
                     ((path, time) => File.SetCreationTimeUtc(path, time)),
                     ((path) => File.GetCreationTimeUtc(path)),
                     DateTimeKind.Unspecified);
-                yield return Tuple.Create<SetTime, GetTime, DateTimeKind>(
+                yield return TimeFunction.Create(
                     ((path, time) => File.SetCreationTimeUtc(path, time)),
                     ((path) => File.GetCreationTimeUtc(path)),
                     DateTimeKind.Utc);
             }
-            yield return Tuple.Create<SetTime, GetTime, DateTimeKind>(
+            yield return TimeFunction.Create(
                 ((path, time) => File.SetLastAccessTime(path, time)),
                 ((path) => File.GetLastAccessTime(path)),
                 DateTimeKind.Local);
-            yield return Tuple.Create<SetTime, GetTime, DateTimeKind>(
+            yield return TimeFunction.Create(
                 ((path, time) => File.SetLastAccessTimeUtc(path, time)),
                 ((path) => File.GetLastAccessTimeUtc(path)),
                 DateTimeKind.Unspecified);
-            yield return Tuple.Create<SetTime, GetTime, DateTimeKind>(
+            yield return TimeFunction.Create(
                 ((path, time) => File.SetLastAccessTimeUtc(path, time)),
                 ((path) => File.GetLastAccessTimeUtc(path)),
                 DateTimeKind.Utc);
-            yield return Tuple.Create<SetTime, GetTime, DateTimeKind>(
+            yield return TimeFunction.Create(
                 ((path, time) => File.SetLastWriteTime(path, time)),
                 ((path) => File.GetLastWriteTime(path)),
                 DateTimeKind.Local);
-            yield return Tuple.Create<SetTime, GetTime, DateTimeKind>(
+            yield return TimeFunction.Create(
                 ((path, time) => File.SetLastWriteTimeUtc(path, time)),
                 ((path) => File.GetLastWriteTimeUtc(path)),
                 DateTimeKind.Unspecified);
-            yield return Tuple.Create<SetTime, GetTime, DateTimeKind>(
+            yield return TimeFunction.Create(
                 ((path, time) => File.SetLastWriteTimeUtc(path, time)),
                 ((path) => File.GetLastWriteTimeUtc(path)),
                 DateTimeKind.Utc);
-        }
-
-        [Fact]
-        public void NullPath_ThrowsArgumentNullException()
-        {
-            Assert.All(TimeFunctions(), (tuple) =>
-            {
-                Assert.Throws<ArgumentNullException>(() => tuple.Item1(null, DateTime.Today));
-                Assert.Throws<ArgumentNullException>(() => tuple.Item2(null));
-            });
-        }
-
-        [Fact]
-        public void EmptyPath_ThrowsArgumentException()
-        {
-            Assert.All(TimeFunctions(), (tuple) =>
-            {
-                Assert.Throws<ArgumentException>(() => tuple.Item1(string.Empty, DateTime.Today));
-                Assert.Throws<ArgumentException>(() => tuple.Item2(string.Empty));
-            });
-        }
-
-        [Fact]
-        public void SettingUpdatesProperties()
-        {
-            FileInfo testFile = new FileInfo(GetTestFilePath());
-            testFile.Create().Dispose();
-
-            Assert.All(TimeFunctions(requiresRoundtripping: true), (tuple) =>
-            {
-                DateTime dt = new DateTime(2014, 12, 1, 12, 0, 0, tuple.Item3);
-                tuple.Item1(testFile.FullName, dt);
-                var result = tuple.Item2(testFile.FullName);
-                Assert.Equal(dt, result);
-                Assert.Equal(dt.ToLocalTime(), result.ToLocalTime());
-
-                // File and Directory UTC APIs treat a DateTimeKind.Unspecified as UTC whereas
-                // ToUniversalTime treats it as local.
-                if (tuple.Item3 == DateTimeKind.Unspecified)
-                {
-                    Assert.Equal(dt, result.ToUniversalTime());
-                }
-                else
-                {
-                    Assert.Equal(dt.ToUniversalTime(), result.ToUniversalTime());
-                }
-            });
-        }
-
-        [Fact]
-        public void CreationSetsAllTimes()
-        {
-            string path = GetTestFilePath();
-            long beforeTime = DateTime.UtcNow.AddSeconds(-3).Ticks;
-
-            FileInfo testFile = new FileInfo(GetTestFilePath());
-            testFile.Create().Dispose();
-
-            long afterTime = DateTime.UtcNow.AddSeconds(3).Ticks;
-
-            Assert.All(TimeFunctions(), (tuple) =>
-            {
-                Assert.InRange(tuple.Item2(testFile.FullName).ToUniversalTime().Ticks, beforeTime, afterTime);
-            });
-        }
-
-        [Fact]
-        public void Windows_FileDoesntExist_ReturnDefaultValues()
-        {
-            string path = GetTestFilePath();
-
-            //non-utc
-            Assert.Equal(DateTime.FromFileTime(0).Ticks, File.GetLastAccessTime(path).Ticks);
-            Assert.Equal(DateTime.FromFileTime(0).Ticks, new FileInfo(path).LastAccessTime.Ticks);
-            Assert.Equal(DateTime.FromFileTime(0).Ticks, File.GetLastWriteTime(path).Ticks);
-            Assert.Equal(DateTime.FromFileTime(0).Ticks, new FileInfo(path).LastWriteTime.Ticks);
-            if (IOInputs.SupportsGettingCreationTime)
-            {
-                Assert.Equal(DateTime.FromFileTime(0).Ticks, File.GetCreationTime(path).Ticks);
-                Assert.Equal(DateTime.FromFileTime(0).Ticks, new FileInfo(path).CreationTime.Ticks);
-            }
-
-            //utc
-            Assert.Equal(DateTime.FromFileTimeUtc(0).Ticks, File.GetLastAccessTimeUtc(path).Ticks);
-            Assert.Equal(DateTime.FromFileTimeUtc(0).Ticks, new FileInfo(path).LastAccessTimeUtc.Ticks);
-            Assert.Equal(DateTime.FromFileTimeUtc(0).Ticks, File.GetLastWriteTimeUtc(path).Ticks);
-            Assert.Equal(DateTime.FromFileTimeUtc(0).Ticks, new FileInfo(path).LastWriteTimeUtc.Ticks);
-            if (IOInputs.SupportsGettingCreationTime)
-            {
-                Assert.Equal(DateTime.FromFileTimeUtc(0).Ticks, File.GetCreationTimeUtc(path).Ticks);
-                Assert.Equal(DateTime.FromFileTimeUtc(0).Ticks, new FileInfo(path).CreationTimeUtc.Ticks);
-            }
         }
     }
 }

--- a/src/System.IO.FileSystem/tests/FileInfo/GetSetAttributes.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/GetSetAttributes.cs
@@ -6,49 +6,18 @@ using Xunit;
 
 namespace System.IO.Tests
 {
-    public class FileInfo_GetSetAttributes : FileSystemTest
+    public class FileInfo_GetSetAttributes : InfoGetSetAttributes<FileInfo>
     {
-        #region Utilities
-
-        protected virtual FileAttributes Get(string path)
-        {
-            var info = new FileInfo(path);
-            return info.Attributes;
-        }
-
-        protected virtual void Set(string path, FileAttributes attributes)
-        {
-            var info = new FileInfo(path);
-            info.Attributes = attributes;
-        }
-
-        #endregion
+        protected override FileAttributes GetAttributes(string path) => new FileInfo(path).Attributes;
+        protected override void SetAttributes(string path, FileAttributes attributes) => new FileInfo(path).Attributes = attributes;
+        protected override FileInfo CreateInfo(string path) => new FileInfo(path);
 
         [Fact]
-        public void NullParameters()
+        public void IsReadOnly_SetAndGet()
         {
-            Assert.Throws<ArgumentNullException>(() => Get(null));
-            Assert.Throws<ArgumentNullException>(() => Set(null, FileAttributes.Normal));
-        }
-
-        [Fact]
-        public void InvalidParameters()
-        {
-            Assert.Throws<ArgumentException>(() => Get(string.Empty));
-            Assert.Throws<ArgumentException>(() => Set(string.Empty, FileAttributes.Normal));
-        }
-
-        [Fact]
-        public void NonExistentFile()
-        {
-            Assert.Throws<FileNotFoundException>(() => Set(GetTestFilePath(), FileAttributes.Normal));
-        }
-
-        [Fact]
-        public void IsReadOnly_Set_And_Get()
-        {
-            var test = new FileInfo(GetTestFilePath());
+            FileInfo test = new FileInfo(GetTestFilePath());
             test.Create().Dispose();
+
             // Set to True
             test.IsReadOnly = true;
             test.Refresh();
@@ -58,96 +27,6 @@ namespace System.IO.Tests
             test.IsReadOnly = false;
             test.Refresh();
             Assert.Equal(false, test.IsReadOnly);
-        }
-
-        [Theory]
-        [InlineData(FileAttributes.ReadOnly)]
-        [InlineData(FileAttributes.Normal)]
-        [PlatformSpecific(TestPlatforms.AnyUnix)]  // Unix valid file attributes
-        public void UnixAttributeSetting(FileAttributes attr)
-        {
-            var test = new FileInfo(GetTestFilePath());
-            test.Create().Dispose();
-            Set(test.FullName, attr);
-            test.Refresh();
-            Assert.Equal(attr, Get(test.FullName));
-            Set(test.FullName, 0);
-        }
-
-        [Theory]
-        [InlineData(FileAttributes.ReadOnly)]
-        [InlineData(FileAttributes.Hidden)]
-        [InlineData(FileAttributes.System)]
-        [InlineData(FileAttributes.Archive)]
-        [InlineData(FileAttributes.Normal)]
-        [InlineData(FileAttributes.Temporary)]
-        [InlineData(FileAttributes.ReadOnly | FileAttributes.Hidden)]
-        [PlatformSpecific(TestPlatforms.Windows)]  // Windows valid file attributes
-        public void WindowsAttributeSetting(FileAttributes attr)
-        {
-            var test = new FileInfo(GetTestFilePath());
-            test.Create().Dispose();
-            Set(test.FullName, attr);
-            test.Refresh();
-            Assert.Equal(attr, Get(test.FullName));
-            Set(test.FullName, 0);
-        }
-
-        [Theory]
-        [InlineData(FileAttributes.Temporary)]
-        [InlineData(FileAttributes.Encrypted)]
-        [InlineData(FileAttributes.SparseFile)]
-        [InlineData(FileAttributes.ReparsePoint)]
-        [InlineData(FileAttributes.Compressed)]
-        [PlatformSpecific(TestPlatforms.AnyUnix)]  // Unix invalid file attributes
-        public void UnixInvalidAttributes(FileAttributes attr)
-        {
-            var path = GetTestFilePath();
-            File.Create(path).Dispose();
-            Set(path, attr);
-            Assert.Equal(FileAttributes.Normal, Get(path));
-        }
-
-        [Theory]
-        [InlineData(FileAttributes.Normal)]
-        [InlineData(FileAttributes.Encrypted)]
-        [InlineData(FileAttributes.SparseFile)]
-        [InlineData(FileAttributes.ReparsePoint)]
-        [InlineData(FileAttributes.Compressed)]
-        [PlatformSpecific(TestPlatforms.Windows)] // Windows invalid file attributes
-        public void WindowsInvalidAttributes(FileAttributes attr)
-        {
-            var path = GetTestFilePath();
-            File.Create(path).Dispose();
-            Set(path, attr);
-            Assert.Equal(FileAttributes.Normal, Get(path));
-        }
-
-        // In NetFX we ignore "not found" errors, which leaves the attributes
-        // state as invalid (0xFFFFFFFF), which makes all flags true.
-
-        [Theory, MemberData(nameof(TrailingCharacters))]
-        public void GetAttributes_MissingFile(char trailingChar)
-        {
-            Assert.Equal((FileAttributes)(-1), Get(GetTestFilePath() + trailingChar));
-        }
-
-        [Theory, MemberData(nameof(TrailingCharacters))]
-        public void GetAttributes_MissingDirectory(char trailingChar)
-        {
-            Assert.Equal((FileAttributes)(-1), Get(Path.Combine(GetTestFilePath(), "file" + trailingChar)));
-        }
-
-        [Theory, MemberData(nameof(TrailingCharacters))]
-        public void SetAttributes_MissingFile(char trailingChar)
-        {
-            Assert.Throws<FileNotFoundException>(() => Set(GetTestFilePath() + trailingChar, FileAttributes.ReadOnly));
-        }
-
-        [Theory, MemberData(nameof(TrailingCharacters))]
-        public void SetAttributes_MissingDirectory(char trailingChar)
-        {
-            Assert.Throws<DirectoryNotFoundException>(() => Set(Path.Combine(GetTestFilePath(), "file" + trailingChar), FileAttributes.ReadOnly));
         }
     }
 }

--- a/src/System.IO.FileSystem/tests/FileInfo/GetSetAttributesCommon.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/GetSetAttributesCommon.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.IO.Tests
+{
+    // Concrete class to run common file attributes tests on the FileInfo class
+    public class FileInfo_GetSetAttributesCommon : FileGetSetAttributes
+    {
+        protected override FileAttributes GetAttributes(string path) => new FileInfo(path).Attributes;
+        protected override void SetAttributes(string path, FileAttributes attributes) => new FileInfo(path).Attributes = attributes;
+    }
+}

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -14,6 +14,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
+    <Compile Include="Base\BaseGetSetAttributes.cs" />
+    <Compile Include="Base\BaseGetSetTimes.cs" />
+    <Compile Include="Base\FileGetSetAttributes.cs" />
+    <Compile Include="Base\InfoGetSetAttributes.cs" />
+    <Compile Include="Base\InfoGetSetTimes.cs" />
+    <Compile Include="Base\AllGetSetAttributes.cs" />
+    <Compile Include="Base\StaticGetSetTimes.cs" />
+    <Compile Include="FileInfo\GetSetAttributesCommon.cs" />
     <Compile Include="FileInfo\IsReadOnly.cs" />
     <Compile Include="FileInfo\Replace.cs" />
     <Compile Include="FileStream\Handle.cs" />
@@ -23,6 +31,7 @@
     <Compile Include="FileStream\LockUnlock.cs" />
     <Compile Include="FileSystemTest.cs" />
     <Compile Include="File\EncryptDecrypt.cs" />
+    <Compile Include="File\GetSetAttributesCommon.cs" />
     <Compile Include="File\Replace.cs" />
     <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
       <Link>Common\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>


### PR DESCRIPTION
Ports #20716, which addresses #20456.

On Windows FileSystemInfos are filled in with state as we have
all of the state from FindFirstFileEx.

Refactor Time tests and add cases for refresh state.
