### PR TITLE
Make XPath resilient to resources problems

### DIFF
--- a/src/System.Private.Xml/src/System/Xml/XPath/XPathException.cs
+++ b/src/System.Private.Xml/src/System/Xml/XPath/XPathException.cs
@@ -77,6 +77,12 @@ namespace System.Xml.XPath
         {
             try
             {
+                if (res == null)
+                {
+                    string argsStr = args != null ? $"[{string.Join(", ", args)}]" : "<null>";
+                    return $"Resource message not available. Arguments passed: {argsStr}";
+                }
+
                 string message = args == null ? res : string.Format(res, args);
                 if (message == null)
                     message = "UNKNOWN(" + res + ")";


### PR DESCRIPTION
UAP's resources started giving null strings - this is making XPath resilient to that.

I'm investigating if there is more places than this which need this