### PR TITLE
Add socket connectivity test in the Test TDS server

### DIFF
--- a/src/System.Data.SqlClient/tests/FunctionalTests/DiagnosticTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/DiagnosticTest.cs
@@ -697,7 +697,7 @@ namespace System.Data.SqlClient.Tests
             {
 
                 Console.WriteLine(string.Format("Test: {0} Enabled Listeners", methodName));
-                using (var server = TestTdsServer.StartServerWithQueryEngine(new DiagnosticsQueryEngine(), enableLog:enableServerLogging))
+                using (var server = TestTdsServer.StartServerWithQueryEngine(new DiagnosticsQueryEngine(), enableLog:enableServerLogging, methodName: methodName))
                 {
                     Console.WriteLine(string.Format("Test: {0} Started Server", methodName));
                     sqlOperation(server.ConnectionString);
@@ -886,7 +886,7 @@ namespace System.Data.SqlClient.Tests
             using (DiagnosticListener.AllListeners.Subscribe(diagnosticListenerObserver))
             {
                 Console.WriteLine(string.Format("Test: {0} Enabled Listeners", methodName));
-                using (var server = TestTdsServer.StartServerWithQueryEngine(new DiagnosticsQueryEngine()))
+                using (var server = TestTdsServer.StartServerWithQueryEngine(new DiagnosticsQueryEngine(), methodName: methodName))
                 {
                     Console.WriteLine(string.Format("Test: {0} Started Server", methodName));
 

--- a/src/System.Data.SqlClient/tests/FunctionalTests/TestTdsServer.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/TestTdsServer.cs
@@ -6,6 +6,7 @@
 using Microsoft.SqlServer.TDS.EndPoint;
 using Microsoft.SqlServer.TDS.Servers;
 using System.Net;
+using System.Runtime.CompilerServices;
 
 namespace System.Data.SqlClient.Tests
 {
@@ -22,7 +23,7 @@ namespace System.Data.SqlClient.Tests
             this.Engine = engine;
         }
 
-        public static TestTdsServer StartServerWithQueryEngine(QueryEngine engine, bool enableFedAuth = false, bool enableLog = false)
+        public static TestTdsServer StartServerWithQueryEngine(QueryEngine engine, bool enableFedAuth = false, bool enableLog = false, [CallerMemberName] string methodName = "")
         {
             TDSServerArguments args = new TDSServerArguments()
             {
@@ -36,10 +37,10 @@ namespace System.Data.SqlClient.Tests
 
             TestTdsServer server = engine == null ? new TestTdsServer(args) : new TestTdsServer(engine, args);
             server._endpoint = new TDSServerEndPoint(server) { ServerEndPoint = new IPEndPoint(IPAddress.Any, 0) };
-            server._endpoint.Start();
-
+            server._endpoint.EndpointName = methodName;
             // The server EventLog should be enabled as it logs the exceptions.
             server._endpoint.EventLog = Console.Out;
+            server._endpoint.Start();
 
             int port = server._endpoint.ServerEndPoint.Port;
             server.connectionStringBuilder = new SqlConnectionStringBuilder() { DataSource = "localhost," + port, ConnectTimeout = 5, Encrypt = false };
@@ -47,9 +48,9 @@ namespace System.Data.SqlClient.Tests
             return server;
         }
 
-        public static TestTdsServer StartTestServer(bool enableFedAuth = false, bool enableLog = false)
+        public static TestTdsServer StartTestServer(bool enableFedAuth = false, bool enableLog = false, [CallerMemberName] string methodName = "")
         {
-            return StartServerWithQueryEngine(null, false, false);
+            return StartServerWithQueryEngine(null, false, false, methodName);
         }
 
         public void Dispose() => _endpoint?.Stop();

--- a/src/System.Data.SqlClient/tests/Tools/TDS/TDS.EndPoint/TDSServerEndPoint.cs
+++ b/src/System.Data.SqlClient/tests/Tools/TDS/TDS.EndPoint/TDSServerEndPoint.cs
@@ -67,6 +67,12 @@ namespace Microsoft.SqlServer.TDS.EndPoint
         /// </summary>
         internal bool StopRequested { get; set; }
 
+
+        /// <summary>
+        /// Identifier to recognize the client of the Endpoint.
+        /// </summary>
+        public string EndpointName { get; set; }
+
         /// <summary>
         /// Initialization constructor
         /// </summary>
@@ -98,6 +104,8 @@ namespace Microsoft.SqlServer.TDS.EndPoint
             ListenerThread = new Thread(new ThreadStart(_RequestListener)) { IsBackground = true };
             ListenerThread.Name = "TDS Server EndPoint Listener";
             ListenerThread.Start();
+
+            Log($"{GetType().Name} {EndpointName} Listener Thread Started ");
         }
 
         /// <summary>
@@ -214,6 +222,7 @@ namespace Microsoft.SqlServer.TDS.EndPoint
             {
                 // Remove the existing connection from the list
                 Connections.Remove(sender as T);
+                Log($"{GetType().Name} {EndpointName} Connection Closed");
             }
         }
 

--- a/src/System.Data.SqlClient/tests/Tools/TDS/TDS.EndPoint/TDSServerEndPoint.cs
+++ b/src/System.Data.SqlClient/tests/Tools/TDS/TDS.EndPoint/TDSServerEndPoint.cs
@@ -100,6 +100,22 @@ namespace Microsoft.SqlServer.TDS.EndPoint
             // Update ServerEndpoint with the actual address/port, e.g. if port=0 was given
             ServerEndPoint = (IPEndPoint)ListenerSocket.LocalEndpoint;
 
+            Log($"{GetType().Name} {EndpointName} Is Server Socket Bound: {ListenerSocket.Server.IsBound} Testing connectivity to the endpoint created for the server.");
+
+            using (TcpClient client = new TcpClient())
+            {
+                try
+                {
+                    client.Connect("localhost", ServerEndPoint.Port);
+                }
+                catch (Exception e)
+                {
+                    Log($"{GetType().Name} {EndpointName} Error occured while testing server endpoint {e.Message}");
+                    throw e;
+                }
+            }
+            Log($"{GetType().Name} {EndpointName} Endpoint test successful.");
+
             // Initialize the listener
             ListenerThread = new Thread(new ThreadStart(_RequestListener)) { IsBackground = true };
             ListenerThread.Name = "TDS Server EndPoint Listener";


### PR DESCRIPTION
This PR adds a test to connect to the socket when the server initializes the TcpListener to listen to incoming connections. 