### PR TITLE
Add socket connectivity test in the Test TDS server

### DIFF
--- a/src/System.Data.SqlClient/tests/Tools/TDS/TDS.EndPoint/TDSServerEndPoint.cs
+++ b/src/System.Data.SqlClient/tests/Tools/TDS/TDS.EndPoint/TDSServerEndPoint.cs
@@ -100,6 +100,21 @@ namespace Microsoft.SqlServer.TDS.EndPoint
             // Update ServerEndpoint with the actual address/port, e.g. if port=0 was given
             ServerEndPoint = (IPEndPoint)ListenerSocket.LocalEndpoint;
 
+            Log($"{GetType().Name} {EndpointName} Is Server Socket Bound: {ListenerSocket.Server.IsBound} Testing connectivity to the endpoint created for the server.");
+            using (TcpClient client = new TcpClient())
+            {
+                try
+                {
+                    client.Connect("localhost", ServerEndPoint.Port);
+                }
+                catch (Exception e)
+                {
+                    Log($"{GetType().Name} {EndpointName} Error occured while testing server endpoint {e.Message}");
+                    throw e;
+                }
+            }
+            Log($"{GetType().Name} {EndpointName} Endpoint test successful.");
+
             // Initialize the listener
             ListenerThread = new Thread(new ThreadStart(_RequestListener)) { IsBackground = true };
             ListenerThread.Name = "TDS Server EndPoint Listener";

--- a/src/System.Data.SqlClient/tests/Tools/TDS/TDS.EndPoint/TDSServerEndPoint.cs
+++ b/src/System.Data.SqlClient/tests/Tools/TDS/TDS.EndPoint/TDSServerEndPoint.cs
@@ -110,7 +110,7 @@ namespace Microsoft.SqlServer.TDS.EndPoint
                 catch (Exception e)
                 {
                     Log($"{GetType().Name} {EndpointName} Error occured while testing server endpoint {e.Message}");
-                    throw e;
+                    throw;
                 }
             }
             Log($"{GetType().Name} {EndpointName} Endpoint test successful.");


### PR DESCRIPTION
This PR adds a test to connect to the socket when the server initializes the TcpListener to listen to incoming connections before the test can try to connect to the socket. 
For Diagnosing #20441