### PR TITLE
Workaround for recent CMake bug w.r.t. CF guard

### DIFF
--- a/src/Native/Windows/CMakeLists.txt
+++ b/src/Native/Windows/CMakeLists.txt
@@ -65,7 +65,7 @@ endif ()
 
 # enable control-flow-guard support for native components
 add_compile_options(/guard:cf) 
-set(__LinkArgs "${__LinkArgs} /guard:cf")
+set(__LinkArgs "${__LinkArgs} /GUARD:CF")
 
 # Statically linked CRT (libcmt[d].lib, libvcruntime[d].lib and libucrt[d].lib) by default. This is done to avoid
 # linking in VCRUNTIME140.DLL for a simplified xcopy experience by reducing the dependency on VC REDIST.


### PR DESCRIPTION
Recent versions of CMake generates the <LinkControlFlowGuard> node
under the <Link> node when it finds /guard:cf linker option in the
linker options. But that is not correct. It should generate it under
the <PropertyGroup> node so that the Microsoft.CppCommon.targets would
then generate <ControlFlowGuard> node under the <Link>.

To workaround the problem, change the casing of /guard:cf to uppercase.
CMake then doesn't detect the option as something known to it and passes
the option to the linker as additional option, which fixes the problem.