### PR TITLE
DCJS_VerifyDictionaryFormat Failed in ReflectionOnly Mode.

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/ReflectionJsonFormatWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/ReflectionJsonFormatWriter.cs
@@ -65,6 +65,8 @@ namespace System.Runtime.Serialization.Json
                 if (canWriteSimpleDictionary && useSimpleDictionaryFormat)
                 {
                     ReflectionWriteObjectAttribute(jsonWriter);
+                    Type[] itemTypeGenericArguments = collectionContract.ItemType.GetGenericArguments();
+                    Type dictionaryValueType = itemTypeGenericArguments.Length == 2 ? itemTypeGenericArguments[1] : null;
 
                     while (enumerator.MoveNext())
                     {
@@ -72,7 +74,7 @@ namespace System.Runtime.Serialization.Json
                         object key = ((IKeyValue)current).Key;
                         object value = ((IKeyValue)current).Value;
                         _reflectionClassWriter.ReflectionWriteStartElement(jsonWriter, key.ToString());
-                        _reflectionClassWriter.ReflectionWriteValue(jsonWriter, context, value.GetType(), value, false, primitiveContractForParamType: null);
+                        _reflectionClassWriter.ReflectionWriteValue(jsonWriter, context, dictionaryValueType ?? value.GetType(), value, false, primitiveContractForParamType: null);
                         _reflectionClassWriter.ReflectionWriteEndElement(jsonWriter);
                     }
                 }

--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -2702,11 +2702,7 @@ public static partial class DataContractJsonSerializerTests
         Assert.Equal(4, actual2["a4"]);
     }
 
-#if ReflectionOnly
-    [ActiveIssue(18373)]
-#else
     [ActiveIssue("dotnet/corefx #20481", TargetFrameworkMonikers.UapAot)]
-#endif
     [Fact]
     public static void DCJS_VerifyDictionaryFormat()
     {


### PR DESCRIPTION
When writing a Dictionary type's values, DCJS needs to know the declared value type instead of the actual type of an object.

Fix #20636 