### PR TITLE
Fix Intermittent Failure on DiagnosticSourceTest

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
@@ -439,8 +439,7 @@ namespace System.Diagnostics.Tests
 
                     var activity = new Activity("activity");
 
-                    var stopWatch = new Stopwatch();
-                    stopWatch.Start();
+                    var stopWatch = Stopwatch.StartNew();
                     // Test Activity.Start
                     source.StartActivity(activity, arguments);
 
@@ -466,7 +465,7 @@ namespace System.Diagnostics.Tests
                     Assert.InRange(observer.Activity.Duration, TimeSpan.FromTicks(1), TimeSpan.MaxValue);
 
                     // let's only check that Duration is set in StopActivity, we do not intend to check precision here
-                    Assert.InRange(observer.Activity.Duration, TimeSpan.MinValue, stopWatch.Elapsed.Add(TimeSpan.FromMilliseconds(2 * MaxClockErrorMSec)));
+                    Assert.InRange(observer.Activity.Duration, TimeSpan.FromTicks(1), stopWatch.Elapsed.Add(TimeSpan.FromMilliseconds(2 * MaxClockErrorMSec)));
                 } 
             }
         }


### PR DESCRIPTION
The intermittent failure appears to be due to discontinuous jumps in the clock source used by the test on Linux (CLOCK_REALTIME).  This is fixed by using CLOCK_MONOTONIC.

Fixes #20418.