### PR TITLE
Changing binplace configurations so the default only contains TargetGroup and OSGroup

### DIFF
--- a/dir.targets
+++ b/dir.targets
@@ -26,7 +26,7 @@
 
   <ItemGroup Condition="'@(BinPlaceConfiguration)' == ''">
     <!-- binplace to directories for the target vertical -->
-    <BinPlaceConfiguration Include="$(BuildConfiguration)">
+    <BinPlaceConfiguration Include="$(_bc_TargetGroup)-$(_bc_OSGroup)">
       <RefPath>$(BuildConfigurationRefPath)</RefPath>
       <RuntimePath>$(RuntimePath)</RuntimePath>
     </BinPlaceConfiguration>


### PR DESCRIPTION
Fixing BuildAllConfigurations Release leg of official builds. The problem seemed to be that in buildallconfigurations, the child builds were not passing ConfigurationGroup through, which caused that the BinPlaceConfiguration didn't match when ConfigurationGroup was different than default (e.g. Release). With this change, we have validated that everything gets binplaced in release leg as well so the shim should be able to build fine now.

cc: @weshaggard @ericstj 
FYI: @MattGal 

fixes #20832