### PR TITLE
Console encoding not supported

### DIFF
--- a/src/System.Diagnostics.Process/src/Resources/Strings.resx
+++ b/src/System.Diagnostics.Process/src/Resources/Strings.resx
@@ -303,4 +303,10 @@
   <data name="UseShellExecuteNotSupported" xml:space="preserve">
     <value>UseShellExecute is not supported on this platform.</value>
   </data>
+  <data name="ConsoleEncodingNotDetected" xml:space="preserve">
+    <value>Console encoding could not be detected.</value>
+  </data>
+  <data name="ConsoleEncodingNotSupported" xml:space="preserve">
+    <value>Console encoding detection is not supported on this platform.</value>
+  </data>
 </root>

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
@@ -631,31 +631,23 @@ namespace System.Diagnostics
 
         private static Encoding GetConsoleEncodingOrThrow(ConsoleStreamDirection encodingType)
         {
-            int codePage;
-            try
-            {
-                codePage = (encodingType == ConsoleStreamDirection.Input) ?
+            int codePage = (encodingType == ConsoleStreamDirection.Input) ?
                     (int)Interop.Kernel32.GetConsoleCP() :
                     (int)Interop.Kernel32.GetConsoleOutputCP();
 
-                int error = Marshal.GetLastWin32Error();
-                if (error == Interop.Errors.ERROR_INVALID_HANDLE)
-                {
-                    throw new PlatformNotSupportedException(SR.ConsoleEncodingNotSupported);
-                }
-                else if (error != 0)
-                {
-                    string api = encodingType == ConsoleStreamDirection.Input ? 
-                        "Kernel32!GetConsoleCP" : 
-                        "Kernel32!GetConsoleOutputCP";
-                    Debug.Fail(
-                        "Console encoding could not be detected.",
-                        $"{api} has set last error to {error} ({new Win32Exception(error).Message}).");
-                }
-            }
-            catch (EntryPointNotFoundException)
+            int error = Marshal.GetLastWin32Error();
+            if (error == Interop.Errors.ERROR_INVALID_HANDLE)
             {
                 throw new PlatformNotSupportedException(SR.ConsoleEncodingNotSupported);
+            }
+            else if (error != 0)
+            {
+                string api = encodingType == ConsoleStreamDirection.Input ?
+                    "Kernel32!GetConsoleCP" :
+                    "Kernel32!GetConsoleOutputCP";
+                Debug.Fail(
+                    "Console encoding could not be detected.",
+                    $"{api} has set last error to {error} ({new Win32Exception(error).Message}).");
             }
 
             Encoding enc = EncodingHelper.GetSupportedConsoleEncoding(codePage);

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
@@ -631,7 +631,6 @@ namespace System.Diagnostics
 
         private static Encoding GetConsoleEncodingOrThrow(ConsoleStreamDirection encodingType)
         {
-            const int INVALID_HANDLE = 6;
             int codePage;
             try
             {
@@ -640,13 +639,18 @@ namespace System.Diagnostics
                     (int)Interop.Kernel32.GetConsoleOutputCP();
 
                 int error = Marshal.GetLastWin32Error();
-                if (error == INVALID_HANDLE)
+                if (error == Interop.Errors.ERROR_INVALID_HANDLE)
                 {
                     throw new PlatformNotSupportedException(SR.ConsoleEncodingNotSupported);
                 }
                 else if (error != 0)
                 {
-                    throw new InvalidOperationException(SR.ConsoleEncodingNotDetected);
+                    string api = encodingType == ConsoleStreamDirection.Input ? 
+                        "Kernel32!GetConsoleCP" : 
+                        "Kernel32!GetConsoleOutputCP";
+                    Debug.Fail(
+                        "Console encoding could not be detected.",
+                        $"{api} has set last error to {error} ({new Win32Exception(error).Message}).");
                 }
             }
             catch (EntryPointNotFoundException)

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
@@ -602,18 +602,18 @@ namespace System.Diagnostics
 
             if (startInfo.RedirectStandardInput)
             {
-                Encoding enc = GetEncoding((int)Interop.Kernel32.GetConsoleCP());
+                Encoding enc = GetConsoleEncodingOrThrow(ConsoleStreamDirection.Input);
                 _standardInput = new StreamWriter(new FileStream(standardInputWritePipeHandle, FileAccess.Write, 4096, false), enc, 4096);
                 _standardInput.AutoFlush = true;
             }
             if (startInfo.RedirectStandardOutput)
             {
-                Encoding enc = startInfo.StandardOutputEncoding ?? GetEncoding((int)Interop.Kernel32.GetConsoleOutputCP());
+                Encoding enc = startInfo.StandardOutputEncoding ?? GetConsoleEncodingOrThrow(ConsoleStreamDirection.Output);
                 _standardOutput = new StreamReader(new FileStream(standardOutputReadPipeHandle, FileAccess.Read, 4096, false), enc, true, 4096);
             }
             if (startInfo.RedirectStandardError)
             {
-                Encoding enc = startInfo.StandardErrorEncoding ?? GetEncoding((int)Interop.Kernel32.GetConsoleOutputCP());
+                Encoding enc = startInfo.StandardErrorEncoding ?? GetConsoleEncodingOrThrow(ConsoleStreamDirection.Output);
                 _standardError = new StreamReader(new FileStream(standardErrorReadPipeHandle, FileAccess.Read, 4096, false), enc, true, 4096);
             }
 
@@ -629,8 +629,31 @@ namespace System.Diagnostics
             return ret;
         }
 
-        private static Encoding GetEncoding(int codePage)
+        private static Encoding GetConsoleEncodingOrThrow(ConsoleStreamDirection encodingType)
         {
+            const int INVALID_HANDLE = 6;
+            int codePage;
+            try
+            {
+                codePage = (encodingType == ConsoleStreamDirection.Input) ?
+                    (int)Interop.Kernel32.GetConsoleCP() :
+                    (int)Interop.Kernel32.GetConsoleOutputCP();
+
+                int error = Marshal.GetLastWin32Error();
+                if (error == INVALID_HANDLE)
+                {
+                    throw new PlatformNotSupportedException(SR.ConsoleEncodingNotSupported);
+                }
+                else if (error != 0)
+                {
+                    throw new InvalidOperationException(SR.ConsoleEncodingNotDetected);
+                }
+            }
+            catch (EntryPointNotFoundException)
+            {
+                throw new PlatformNotSupportedException(SR.ConsoleEncodingNotSupported);
+            }
+
             Encoding enc = EncodingHelper.GetSupportedConsoleEncoding(codePage);
             return new ConsoleEncoding(enc); // ensure encoding doesn't output a preamble
         }
@@ -898,6 +921,12 @@ namespace System.Diagnostics
             stringBuff.Append('\0');
             envBlock = Encoding.Unicode.GetBytes(stringBuff.ToString());
             return envBlock;
+        }
+
+        private enum ConsoleStreamDirection
+        {
+            Input,
+            Output
         }
     }
 }

--- a/src/System.Diagnostics.Process/tests/ProcessStandardConsoleTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStandardConsoleTests.cs
@@ -14,6 +14,7 @@ namespace System.Diagnostics.Tests
         private const int s_ConsoleEncoding = 437;
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Console encoding not supported")]
         public void TestChangesInConsoleEncoding()
         {
             Action<int> run = expectedCodePage =>
@@ -57,6 +58,21 @@ namespace System.Diagnostics.Tests
                 Interop.SetConsoleCP(inputEncoding);
                 Interop.SetConsoleOutputCP(outputEncoding);
             }
+        }
+
+        [Theory]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.Uap)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        public void ConsoleEncodingOnUap(int whichStream)
+        {
+            Process p = CreateProcessLong();
+            p.StartInfo.RedirectStandardInput = whichStream == 1;
+            p.StartInfo.RedirectStandardOutput = whichStream == 2;
+            p.StartInfo.RedirectStandardError = whichStream == 3;
+
+            Assert.Throws<PlatformNotSupportedException>(() => p.Start());
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/17927

Talked offline with @JeremyKuhne and seem like this should start working at some time in the future

@AtsushiKan has recently reenabled this test but it seems to still be failing on Ctrl+F5 (possibly works on UapAot)