### PR TITLE
Fix DCJS_VerifyIndentation.

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
@@ -2181,7 +2181,7 @@ namespace System.Runtime.Serialization
             else if (nameToDataContractTable.TryGetValue(dataContract.StableName, out alreadyExistingContract))
             {
                 // Don't throw duplicate if its a KeyValuePair<K,T> as it could have been added by Dictionary<K,T>
-                if (alreadyExistingContract.UnderlyingType != DataContractCriticalHelper.GetDataContractAdapterType(type) &&
+                if (DataContractCriticalHelper.GetDataContractAdapterType(alreadyExistingContract.UnderlyingType) != DataContractCriticalHelper.GetDataContractAdapterType(type) &&
                     !(alreadyExistingContract is ClassDataContract && ((ClassDataContract)alreadyExistingContract).IsKeyValuePairAdapter))
                     throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.DupContractInKnownTypes, type, alreadyExistingContract.UnderlyingType, dataContract.StableName.Namespace, dataContract.StableName.Name)));
                 return;

--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -2764,7 +2764,6 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    [ActiveIssue("dotnet/corefx #20483", TargetFrameworkMonikers.UapAot)]
     public static void DCJS_VerifyIndentation()
     {
         var testClass = new TestClass()


### PR DESCRIPTION
DataContractCriticalHelper.GetDataContractAdapterType returned different value on NetCore and in SG.exe. This caused the following line not valid,

```alreadyExistingContract.UnderlyingType != DataContractCriticalHelper.GetDataContractAdapterType(type)```

The fix is to call GetDataContractAdapterType on the UnderlyingType and then do the comparison.

Fix #20483