### PR TITLE
Workaround System.Collections.Tests to fix 150 failures in uap due to codegen bug

### DIFF
--- a/src/System.Collections/tests/ILCConfigurations.rd.xml
+++ b/src/System.Collections/tests/ILCConfigurations.rd.xml
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Library Name="System.Collections.Tests">
+    <Assembly Name="*Application*" DoNotInline="true" DoNotOptimize="true" />
+    <Assembly Name="System.Collections" DoNotInline="true" DoNotOptimize="true" />
+  </Library>
+</Directives>

--- a/src/System.Collections/tests/System.Collections.Tests.csproj
+++ b/src/System.Collections/tests/System.Collections.Tests.csproj
@@ -81,7 +81,7 @@
       <Link>System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
     </Compile>
     <!-- Generic tests -->
-    <Compile Include="Generic\Dictionary\Dictionary.Generic.Tests.netcoreapp.cs"  Condition="'$(TargetGroup)' == 'netcoreapp'"/>
+    <Compile Include="Generic\Dictionary\Dictionary.Generic.Tests.netcoreapp.cs" Condition="'$(TargetGroup)' == 'netcoreapp'" />
     <Compile Include="Generic\SortedSet\SortedSet.TreeSubSet.Tests.cs" />
     <Compile Include="StructuralComparisonsTests.cs" />
     <Compile Include="BitArray\BitArray_CtorTests.cs" />
@@ -165,6 +165,9 @@
     <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.Generic.Serialization.Tests.cs">
       <Link>Common\System\Collections\IEnumerable.Generic.Serialization.Tests.cs</Link>
     </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="ILCConfigurations.rd.xml" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
There is a bug in .NET Native's codegen that when running the Collections tests in retail mode (optimized and inlined) there is 150 failures due to codegen. If we run the tests in check mode they wouldn't fail. So this is to workaround that by disabling optimizations and inlining through an embedded .rd.xml file, so that we get those tests passing while this is fixed.

cc: @danmosemsft @morganbr 