### PR TITLE
Use unqualified reference to SR in System/Windows/Rect.cs

### DIFF
--- a/src/System.Runtime.WindowsRuntime/src/System/Windows/Rect.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Windows/Rect.cs
@@ -313,7 +313,7 @@ namespace Windows.Foundation
         {
             if (IsEmpty)
             {
-                return global::System.SR.DirectUI_Empty;
+                return SR.DirectUI_Empty;
             }
 
             // Helper to get the numeric list separator for a given culture.


### PR DESCRIPTION
I'm porting `System.Runtime.WindowsRuntime` to Mono. Using `global::System.SR` makes it hard to compile `Rect.cs` against the Mono BCL since `SR` is usually placed in the root namespace in Mono rather than in `System`.

Changing the qualified reference `global::System.SR.DirectUI_Empty` to simply `SR.DirectUI_Empty` doesn't seem to break the build, at least when I build locally.