### PR TITLE
Update buildtools to 2.0.0-prerelease-01708-02

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-2.0.0-prerelease-01708-01
+2.0.0-prerelease-01708-02


### PR DESCRIPTION
There were two buildtools merges around the same time yesterday, and I accidentally picked the nuget version which didn't have my Dumpling fix in it. This version does.