### PR TITLE
Using mscorlib shim as default resolving assembly for BinaryFormatter serialization instead of System.Private.Corelib

### DIFF
--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/FormatterServices.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/FormatterServices.cs
@@ -207,7 +207,14 @@ namespace System.Runtime.Serialization
                 throw new ArgumentNullException(nameof(type));
             }
 
-            foreach (Attribute first in type.GetCustomAttributes(typeof(TypeForwardedFromAttribute), false))
+            // Special case types likes primitive type arrays
+            Type attributedType = type;
+            if (type.HasElementType)
+            {
+                attributedType = type.GetElementType();
+            }
+
+            foreach (Attribute first in attributedType.GetCustomAttributes(typeof(TypeForwardedFromAttribute), false))
             {
                 hasTypeForwardedFrom = true;
                 return ((TypeForwardedFromAttribute)first).AssemblyFullName;

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/FormatterServices.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/FormatterServices.cs
@@ -207,11 +207,11 @@ namespace System.Runtime.Serialization
                 throw new ArgumentNullException(nameof(type));
             }
 
-            // Special case types likes primitive type arrays
+            // Special case types like arrays            
             Type attributedType = type;
-            if (type.HasElementType)
+            while (attributedType.HasElementType)
             {
-                attributedType = type.GetElementType();
+                attributedType = attributedType.GetElementType();
             }
 
             foreach (Attribute first in attributedType.GetCustomAttributes(typeof(TypeForwardedFromAttribute), false))

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryObjectWriter.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryObjectWriter.cs
@@ -984,7 +984,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
             {
                 assemId = 0;
             }
-            else if (assemblyString.Equals(Converter.s_urtAssemblyString))
+            else if (assemblyString.Equals(Converter.s_urtAssemblyString) || assemblyString.Equals(Converter.s_urtAlternativeAssemblyString))
             {
                 // Urt type is an assemId of 0. No assemblyString needs
                 // to be sent 

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryObjectWriter.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryObjectWriter.cs
@@ -984,7 +984,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
             {
                 assemId = 0;
             }
-            else if (assemblyString.Equals(Converter.s_urtAssemblyString))
+            else if (Converter.s_urtAssembly.GetType(objectInfo.GetTypeFullName(), throwOnError: false) == objectInfo._objectType)
             {
                 // Urt type is an assemId of 0. No assemblyString needs
                 // to be sent 

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryObjectWriter.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryObjectWriter.cs
@@ -984,7 +984,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
             {
                 assemId = 0;
             }
-            else if (Converter.s_urtAssembly.GetType(objectInfo.GetTypeFullName(), throwOnError: false) == objectInfo._objectType)
+            else if (assemblyString.Equals(Converter.s_urtAssemblyString))
             {
                 // Urt type is an assemId of 0. No assemblyString needs
                 // to be sent 

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryTypeConverter.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryTypeConverter.cs
@@ -57,7 +57,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
                             typeInformation = objectInfo.GetTypeFullName();
                         }
 
-                        if (assembly.Equals(Converter.s_urtAssemblyString))
+                        if (assembly.Equals(Converter.s_urtAssemblyString) || assembly.Equals(Converter.s_urtAlternativeAssemblyString))
                         {
                             binaryTypeEnum = BinaryTypeEnum.ObjectUrt;
                             assemId = 0;

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryTypeConverter.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryTypeConverter.cs
@@ -57,7 +57,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
                             typeInformation = objectInfo.GetTypeFullName();
                         }
 
-                        if (assembly.Equals(Converter.s_urtAssemblyString))
+                        if (Converter.s_urtAssembly.GetType(objectInfo.GetTypeFullName(), throwOnError: false) == objectInfo._objectType)
                         {
                             binaryTypeEnum = BinaryTypeEnum.ObjectUrt;
                             assemId = 0;

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryTypeConverter.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryTypeConverter.cs
@@ -57,7 +57,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
                             typeInformation = objectInfo.GetTypeFullName();
                         }
 
-                        if (Converter.s_urtAssembly.GetType(objectInfo.GetTypeFullName(), throwOnError: false) == objectInfo._objectType)
+                        if (assembly.Equals(Converter.s_urtAssemblyString))
                         {
                             binaryTypeEnum = BinaryTypeEnum.ObjectUrt;
                             assemId = 0;

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/Converter.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/Converter.cs
@@ -30,7 +30,12 @@ namespace System.Runtime.Serialization.Formatters.Binary
         internal static readonly Type s_typeofUInt64 = typeof(ulong);
         internal static readonly Type s_typeofObject = typeof(object);
         internal static readonly Type s_typeofSystemVoid = typeof(void);
-        internal static readonly Assembly s_urtAssembly = s_typeofString.Assembly;
+
+        // In netfx the default assembly is mscorlib.dll --> typeof(string).Assembly.
+        // In Core type string lives in System.Private.Corelib.dll which doesn't 
+        // contain all the types which are living in mscorlib in netfx. Therefore we
+        // use our mscorlib facade which also contains manual type forwards for deserialization.
+        internal static readonly Assembly s_urtAssembly = Assembly.Load("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
         internal static readonly string s_urtAssemblyString = s_urtAssembly.FullName;
 
         // Arrays

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/Converter.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/Converter.cs
@@ -38,6 +38,9 @@ namespace System.Runtime.Serialization.Formatters.Binary
         internal static readonly Assembly s_urtAssembly = Assembly.Load("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
         internal static readonly string s_urtAssemblyString = s_urtAssembly.FullName;
 
+        internal static readonly Assembly s_urtAlternativeAssembly = s_typeofString.Assembly;
+        internal static readonly string s_urtAlternativeAssemblyString = s_urtAlternativeAssembly.FullName;
+
         // Arrays
         internal static readonly Type s_typeofTypeArray = typeof(Type[]);
         internal static readonly Type s_typeofObjectArray = typeof(object[]);


### PR DESCRIPTION
If a type gets serialized in netfx which lives in mscorlib the serialized blob won't contain the Assembly Information (because mscorlib is special cased to remove unnecessary blob info):



System.Collections.Comparer
CompareInfo System.Globalization.CompareInfo	 System.Globalization.CompareInfom_name	win32LCID culture
m_SortVersion System.Globalization.SortVersionen-US	 
`

BinaryFormatter checks if that is the case here: https://github.com/dotnet/corefx/blob/0ebc867d6bad9d777dd61afb78d0445c86143b34/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryParser.cs#L430-L435 and will use the default assembly for resolving the type.

In netfx the default assembly is mscorlib.dll because it gets checked by `typeof(string).Assembly`. In Core this is System.Private.Corelib.dll which doesn't contain all the types which are living in mscorlib in netfx. Therefore we should change the default assembly to the mscorlib shim which contains manual and auto-generated TypeForwards.

The `Assembly.Load(string)` call should also work in uap/uapaot as the mscorlib shim is already loaded.

This fixes e.g. that the correct System.Collections.Comparer is picked when trying to deserialize in core. Before this change this one was resolved (internal)  https://github.com/dotnet/coreclr/blob/master/src/mscorlib/src/System/Collections/Comparer.cs instead of this one (public) https://github.com/dotnet/corefx/blob/master/src/System.Runtime.Extensions/src/System/Collections/Comparer.cs

Thanks @ericstj

## Optimization
This PR also improves the serialization payload dramatically and brings it pack on pair with netfx.
Testing with byte.MinValue.

### Before
**Base64:**
AAEAAAD/////AQAAAAAAAAAMAgAAAEttc2NvcmxpYiwgVmVyc2lvbj00LjAuMC4wLCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkEAQAAAAtTeXN0ZW0uQnl0ZQEAAAAHbV92YWx1ZQACAAs=
**UTF8:**
�����������
���Kmscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089���
System.Byte���m_value��

### After
**Base 64:**
AAEAAAD/////AQAAAAAAAAAEAQAAAAtTeXN0ZW0uQnl0ZQEAAAAHbV92YWx1ZQACAAs=
**UTF-8:**
��������������
System.Byte���m_value��

cc @weshaggard @danmosemsft @morganbr @stephentoub 