### PR TITLE
SerialPort: Verify GetPortNames is consistent

### DIFF
--- a/src/System.IO.Ports/tests/SerialPort/GetPortNames.cs
+++ b/src/System.IO.Ports/tests/SerialPort/GetPortNames.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics;
 using System.IO.PortsTests;
 using System.Linq;
+using System.Text;
 using Legacy.Support;
 using Xunit;
 
@@ -14,6 +15,9 @@ namespace System.IO.Ports.Tests
     {
         #region Test Cases
 
+        /// <summary>
+        /// Check that all ports either open correctly or fail with UnauthorizedAccessException (which implies they're already open)
+        /// </summary>
         [Fact]
         [ActiveIssue("https://github.com/dotnet/corefx/issues/20588 - GetPortNames() has registry dependency.", TargetFrameworkMonikers.UapAot)]
         private void OpenEveryPortName()
@@ -32,6 +36,10 @@ namespace System.IO.Ports.Tests
             }
         }
 
+        /// <summary>
+        /// Test that SerialPort.GetPortNames finds every port that the test helpers have found. 
+        /// (On Windows, the latter uses a different technique to SerialPort to find ports).
+        /// </summary>
         [Fact]
         [ActiveIssue("https://github.com/dotnet/corefx/issues/20588 - GetPortNames() has registry dependency.", TargetFrameworkMonikers.UapAot)]
         private void AllHelperPortsAreInGetPortNames()
@@ -40,10 +48,14 @@ namespace System.IO.Ports.Tests
             foreach (string helperPortName in PortHelper.GetPorts())
             {
                 Assert.True(serialPortNames.Contains(helperPortName),
-                    $"{helperPortName} is not present in SerialPort.GetPortNames result");
+                    $"{helperPortName} is not present in SerialPort.GetPortNames result\r\n{PortInformationString}");
             }
         }
 
+        /// <summary>
+        /// Test that the test helpers have found every port that SerialPort.GetPortNames has found
+        /// This catches regressions in the test helpers, eg GH #18928 / #20668
+        /// </summary>
         [Fact]
         [ActiveIssue("https://github.com/dotnet/corefx/issues/20588 - GetPortNames() has registry dependency.", TargetFrameworkMonikers.UapAot)]
         private void AllGetPortNamesAreInHelperPorts()
@@ -52,12 +64,22 @@ namespace System.IO.Ports.Tests
             foreach (string serialPortName in SerialPort.GetPortNames())
             {
                 Assert.True(helperPortNames.Contains(serialPortName),
-                    $"{serialPortName} is not present in PortHelper.GetPorts result");
+                    $"{serialPortName} is not present in PortHelper.GetPorts result\r\n{PortInformationString}");
             }
         }
 
         #endregion
 
+        static string PortInformationString
+        {
+            get
+            {
+                var sb = new StringBuilder();
+                sb.AppendLine("PortHelper Ports: " + string.Join(",", PortHelper.GetPorts()));
+                sb.AppendLine("SerialPort Ports: " + string.Join(",", SerialPort.GetPortNames()));
+                return sb.ToString();
+            }
+        }
     }
 }
 

--- a/src/System.IO.Ports/tests/SerialPort/GetPortNames.cs
+++ b/src/System.IO.Ports/tests/SerialPort/GetPortNames.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Linq;
 using Legacy.Support;
 using Xunit;
 
@@ -17,26 +18,10 @@ namespace System.IO.Ports.Tests
         [ActiveIssue("https://github.com/dotnet/corefx/issues/20588 - GetPortNames() has registry dependency.", TargetFrameworkMonikers.UapAot)]
         private void OpenEveryPortName()
         {
-            string[] portNames = SerialPort.GetPortNames();
-
-            for (int i = 0; i < portNames.Length; ++i)
+            foreach (string portName in SerialPort.GetPortNames())
             {
-                Debug.WriteLine("Opening port " + portNames[i]);
-                bool portExists = false;
-                foreach (string str in PortHelper.GetPorts())
-                {
-                    if (str == portNames[i])
-                    {
-                        portExists = true;
-                        break;
-                    }
-                }
-                if (!portExists)
-                {
-                    Debug.WriteLine("Real Port does not exist. Ignore the output from SerialPort.GetPortNames()");
-                    continue;
-                }
-                using (SerialPort serialPort = new SerialPort(portNames[i]))
+                Debug.WriteLine("Opening port " + portName);
+                using (SerialPort serialPort = new SerialPort(portName))
                 {
                     try
                     {
@@ -46,7 +31,33 @@ namespace System.IO.Ports.Tests
                 }
             }
         }
+
+        [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20588 - GetPortNames() has registry dependency.", TargetFrameworkMonikers.UapAot)]
+        private void AllHelperPortsAreInGetPortNames()
+        {
+            string[] serialPortNames = SerialPort.GetPortNames();
+            foreach (string helperPortName in PortHelper.GetPorts())
+            {
+                Assert.True(serialPortNames.Contains(helperPortName),
+                    $"{helperPortName} is not present in SerialPort.GetPortNames result");
+            }
+        }
+
+        [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20588 - GetPortNames() has registry dependency.", TargetFrameworkMonikers.UapAot)]
+        private void AllGetPortNamesAreInHelperPorts()
+        {
+            string[] helperPortNames = PortHelper.GetPorts();
+            foreach (string serialPortName in SerialPort.GetPortNames())
+            {
+                Assert.True(helperPortNames.Contains(serialPortName),
+                    $"{serialPortName} is not present in PortHelper.GetPorts result");
+            }
+        }
+
         #endregion
+
     }
 }
 


### PR DESCRIPTION
This improves and extends an existing test which is supposed to verify that all the ports which are returned by `SerialPort.GetPortNames` are also returned by `PortHelpers.GetPorts`. 

The new tests would have found the regression that was fixed in #20668 and #20842
