### PR TITLE
Add SqlCommandBuilder to SqlClient

### DIFF
--- a/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
+++ b/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
@@ -282,6 +282,7 @@ namespace System.Data.SqlClient
         internal SqlClientFactory() { }
         public static readonly System.Data.SqlClient.SqlClientFactory Instance;
         public override System.Data.Common.DbCommand CreateCommand() { throw null; }
+        public override System.Data.Common.DbCommandBuilder CreateCommandBuilder() { throw null; }
         public override System.Data.Common.DbConnection CreateConnection() { throw null; }
         public override System.Data.Common.DbConnectionStringBuilder CreateConnectionStringBuilder() { throw null; }
         public override System.Data.Common.DbDataAdapter CreateDataAdapter() { throw null; }
@@ -343,6 +344,33 @@ namespace System.Data.SqlClient
         public System.Threading.Tasks.Task<System.Xml.XmlReader> ExecuteXmlReaderAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
         public override void Prepare() { }
         public System.Data.Sql.SqlNotificationRequest Notification { get { throw null; } set { } }
+    }
+    public sealed class SqlCommandBuilder : System.Data.Common.DbCommandBuilder
+    {
+        public SqlCommandBuilder() { }
+        public SqlCommandBuilder(SqlDataAdapter adapter) { }
+        public override System.Data.Common.CatalogLocation CatalogLocation { get { throw null; } set { } }
+        public override string CatalogSeparator { get { throw null; } set { } }
+        new public SqlDataAdapter DataAdapter { get { throw null; } set { } }
+        public override string QuotePrefix { get { throw null; } set { } }
+        public override string QuoteSuffix { get { throw null; } set { } }
+        public override string SchemaSeparator { get { throw null; } set { } }
+        new public SqlCommand GetInsertCommand() { throw null; }
+        new public SqlCommand GetInsertCommand(bool useColumnsForParameterNames) { throw null; }
+        new public SqlCommand GetUpdateCommand() { throw null; }
+        new public SqlCommand GetUpdateCommand(bool useColumnsForParameterNames) { throw null; }
+        new public SqlCommand GetDeleteCommand() { throw null; }
+        new public SqlCommand GetDeleteCommand(bool useColumnsForParameterNames) { throw null; }
+        protected override void ApplyParameterInfo(System.Data.Common.DbParameter parameter, System.Data.DataRow datarow, System.Data.StatementType statementType, bool whereClause) { }
+        protected override string GetParameterName(int parameterOrdinal) { throw null; }
+        protected override string GetParameterName(string parameterName) { throw null; }
+        protected override string GetParameterPlaceholder(int parameterOrdinal) { throw null; }
+        public static void DeriveParameters(SqlCommand command) { }
+        protected override DataTable GetSchemaTable(System.Data.Common.DbCommand srcCommand) { throw null; }
+        protected override System.Data.Common.DbCommand InitializeCommand(System.Data.Common.DbCommand command) { throw null; }
+        public override string QuoteIdentifier(string unquotedIdentifier) { throw null; }
+        protected override void SetRowUpdatingHandler(System.Data.Common.DbDataAdapter adapter) { }
+        public override string UnquoteIdentifier(string quotedIdentifier) { throw null; }
     }
     public sealed partial class SqlConnection : System.Data.Common.DbConnection, System.ICloneable
     {

--- a/src/System.Data.SqlClient/src/Microsoft/SqlServer/Server/MetadataUtilsSmi.cs
+++ b/src/System.Data.SqlClient/src/Microsoft/SqlServer/Server/MetadataUtilsSmi.cs
@@ -901,20 +901,19 @@ namespace Microsoft.SqlServer.Server
             }
 
             return new SmiExtendedMetaData(
-                                        colDbType,
-                                        maxLength,
-                                        precision,
-                                        scale,
-                                        System.Globalization.CultureInfo.CurrentCulture.LCID,
-                                        SmiMetaData.GetDefaultForType(colDbType).CompareOptions,
-                                        null,   // no support for UDTs from SchemaTable
-                                        false,  // no support for multi-valued columns in a TVP yet
-                                        null,   // no support for structured columns yet
-                                        null,   // no support for structured columns yet
-                                        colName,
-                                        null,
-                                        null,
-                                        null);
+                            colDbType,
+                            maxLength,
+                            precision,
+                            scale,
+                            System.Globalization.CultureInfo.CurrentCulture.LCID,
+                            SmiMetaData.GetDefaultForType(colDbType).CompareOptions,
+                            false,  // no support for multi-valued columns in a TVP yet
+                            null,   // no support for structured columns yet
+                            null,   // no support for structured columns yet
+                            colName,
+                            null,
+                            null,
+                            null);
         }
     }
 }

--- a/src/System.Data.SqlClient/src/Microsoft/SqlServer/Server/SmiMetaData.cs
+++ b/src/System.Data.SqlClient/src/Microsoft/SqlServer/Server/SmiMetaData.cs
@@ -2,10 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
-
-//------------------------------------------------------------------------------
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -60,8 +56,6 @@ namespace Microsoft.SqlServer.Server
         // DevNote: For now, since the list of extended property types is small, we can handle them in a simple list.
         //  In the future, we may need to create a more performant storage & lookup mechanism, such as a hash table
         //  of lists indexed by type of property or an array of lists with a well-known index for each type.
-
-
 
         // Limits for attributes (SmiMetaData will assert that these limits as applicable in constructor)
         internal const long UnlimitedMaxLengthIndicator = -1;  // unlimited (except by implementation) max-length.
@@ -123,7 +117,6 @@ namespace Microsoft.SqlServer.Server
         internal static readonly SmiMetaData DefaultDateTimeOffset = new SmiMetaData(SqlDbType.DateTimeOffset, 10, 0, 7, SqlCompareOptions.None);     // SqlDbType.DateTimeOffset
         // No default for generic UDT
 
-
         internal static SmiMetaData DefaultNVarChar
         {
             get
@@ -134,21 +127,17 @@ namespace Microsoft.SqlServer.Server
                         DefaultNVarChar_NoCollation.Precision,
                         DefaultNVarChar_NoCollation.Scale,
                         CultureInfo.CurrentCulture.LCID,
-                        SqlCompareOptions.IgnoreCase | SqlCompareOptions.IgnoreKanaType | SqlCompareOptions.IgnoreWidth
-                        );
+                        SqlCompareOptions.IgnoreCase | SqlCompareOptions.IgnoreKanaType | SqlCompareOptions.IgnoreWidth);
             }
         }
 
-
-        // SMI V100 (aka V3) constructor.  Superseded in V200.
         internal SmiMetaData(
                                 SqlDbType dbType,
                                 long maxLength,
                                 byte precision,
                                 byte scale,
                                 long localeId,
-                                SqlCompareOptions compareOptions
-            ) :
+                                SqlCompareOptions compareOptions) :
                         this(dbType,
                                 maxLength,
                                 precision,
@@ -161,31 +150,6 @@ namespace Microsoft.SqlServer.Server
         {
         }
 
-        // SMI V200 ctor.
-        internal SmiMetaData(
-                                SqlDbType dbType,
-                                long maxLength,
-                                byte precision,
-                                byte scale,
-                                long localeId,
-                                SqlCompareOptions compareOptions,
-                                bool isMultiValued,
-                                IList<SmiExtendedMetaData> fieldTypes,
-                                SmiMetaDataPropertyCollection extendedProperties)
-            :
-                        this(dbType,
-                                maxLength,
-                                precision,
-                                scale,
-                                localeId,
-                                compareOptions,
-                                null,
-                                isMultiValued,
-                                fieldTypes,
-                                extendedProperties)
-        {
-        }
-
         // SMI V220 ctor.
         internal SmiMetaData(
                                 SqlDbType dbType,
@@ -194,7 +158,6 @@ namespace Microsoft.SqlServer.Server
                                 byte scale,
                                 long localeId,
                                 SqlCompareOptions compareOptions,
-                                string udtAssemblyQualifiedName,
                                 bool isMultiValued,
                                 IList<SmiExtendedMetaData> fieldTypes,
                                 SmiMetaDataPropertyCollection extendedProperties)
@@ -293,11 +256,10 @@ namespace Microsoft.SqlServer.Server
             Debug.Assert(null != _fieldMetaData && _fieldMetaData.IsReadOnly, "SmiMetaData.ctor: _fieldMetaData is " + (null != _fieldMetaData ? "writable" : "null"));
 #if DEBUG
             ((SmiDefaultFieldsProperty)_extendedProperties[SmiPropertySelector.DefaultFields]).CheckCount(_fieldMetaData.Count);
+            ((SmiOrderProperty)_extendedProperties[SmiPropertySelector.SortOrder]).CheckCount(_fieldMetaData.Count);
             ((SmiUniqueKeyProperty)_extendedProperties[SmiPropertySelector.UniqueKey]).CheckCount(_fieldMetaData.Count);
 #endif
         }
-
-
 
         // Sql-style compare options for character types.
         internal SqlCompareOptions CompareOptions
@@ -352,7 +314,6 @@ namespace Microsoft.SqlServer.Server
             }
         }
 
-
         internal bool IsMultiValued
         {
             get
@@ -398,11 +359,11 @@ namespace Microsoft.SqlServer.Server
         // Private constructor used only to initialize default instance array elements.
         // DO NOT EXPOSE OUTSIDE THIS CLASS!
         private SmiMetaData(
-                                SqlDbType sqlDbType,
-                                long maxLength,
-                                byte precision,
-                                byte scale,
-                                SqlCompareOptions compareOptions)
+            SqlDbType sqlDbType,
+            long maxLength,
+            byte precision,
+            byte scale,
+            SqlCompareOptions compareOptions)
         {
             _databaseType = sqlDbType;
             _maxLength = maxLength;
@@ -451,7 +412,7 @@ namespace Microsoft.SqlServer.Server
                 DefaultNVarChar_NoCollation,   // Placeholder for value 26
                 DefaultNVarChar_NoCollation,   // Placeholder for value 27
                 DefaultNVarChar_NoCollation,   // Placeholder for value 28
-                null,
+                null,                          // Generic Udt (not supported)
                 DefaultStructured,             // Generic structured type
                 DefaultDate,                   // SqlDbType.Date
                 DefaultTime,                   // SqlDbType.Time
@@ -475,13 +436,13 @@ namespace Microsoft.SqlServer.Server
         }
     }
 
-
     // SmiExtendedMetaData
     //
     //  Adds server-specific type extension information to base metadata, but still portable across a specific server.
     //
     internal class SmiExtendedMetaData : SmiMetaData
     {
+
         private string _name;           // context-dependent identifier, i.e. parameter name for parameters, column name for columns, etc.
 
         // three-part name for typed xml schema and for udt names
@@ -489,93 +450,58 @@ namespace Microsoft.SqlServer.Server
         private string _typeSpecificNamePart2;
         private string _typeSpecificNamePart3;
 
-
         internal SmiExtendedMetaData(
-                                        SqlDbType dbType,
-                                        long maxLength,
-                                        byte precision,
-                                        byte scale,
-                                        long localeId,
-                                        SqlCompareOptions compareOptions,
-                                        string name,
-                                        string typeSpecificNamePart1,
-                                        string typeSpecificNamePart2,
-                                        string typeSpecificNamePart3) :
-                                    this(
-                                        dbType,
-                                        maxLength,
-                                        precision,
-                                        scale,
-                                        localeId,
-                                        compareOptions,
-                                        false,
-                                        null,
-                                        null,
-                                        name,
-                                        typeSpecificNamePart1,
-                                        typeSpecificNamePart2,
-                                        typeSpecificNamePart3)
-        {
-        }
-
-        // SMI V200 ctor.
-        internal SmiExtendedMetaData(
-                                        SqlDbType dbType,
-                                        long maxLength,
-                                        byte precision,
-                                        byte scale,
-                                        long localeId,
-                                        SqlCompareOptions compareOptions,
-                                        bool isMultiValued,
-                                        IList<SmiExtendedMetaData> fieldMetaData,
-                                        SmiMetaDataPropertyCollection extendedProperties,
-                                        string name,
-                                        string typeSpecificNamePart1,
-                                        string typeSpecificNamePart2,
-                                        string typeSpecificNamePart3) :
-                                this(dbType,
-                                        maxLength,
-                                        precision,
-                                        scale,
-                                        localeId,
-                                        compareOptions,
-                                        null,
-                                        isMultiValued,
-                                        fieldMetaData,
-                                        extendedProperties,
-                                        name,
-                                        typeSpecificNamePart1,
-                                        typeSpecificNamePart2,
-                                        typeSpecificNamePart3)
+            SqlDbType dbType,
+            long maxLength,
+            byte precision,
+            byte scale,
+            long localeId,
+            SqlCompareOptions compareOptions,
+            string name,
+            string typeSpecificNamePart1,
+            string typeSpecificNamePart2,
+            string typeSpecificNamePart3) :
+            this(
+                dbType,
+                maxLength,
+                precision,
+                scale,
+                localeId,
+                compareOptions,
+                false,
+                null,
+                null,
+                name,
+                typeSpecificNamePart1,
+                typeSpecificNamePart2,
+                typeSpecificNamePart3)
         {
         }
 
         // SMI V220 ctor.
         internal SmiExtendedMetaData(
-                                        SqlDbType dbType,
-                                        long maxLength,
-                                        byte precision,
-                                        byte scale,
-                                        long localeId,
-                                        SqlCompareOptions compareOptions,
-                                        string udtAssemblyQualifiedName,
-                                        bool isMultiValued,
-                                        IList<SmiExtendedMetaData> fieldMetaData,
-                                        SmiMetaDataPropertyCollection extendedProperties,
-                                        string name,
-                                        string typeSpecificNamePart1,
-                                        string typeSpecificNamePart2,
-                                        string typeSpecificNamePart3) :
-                                    base(dbType,
-                                        maxLength,
-                                        precision,
-                                        scale,
-                                        localeId,
-                                        compareOptions,
-                                        udtAssemblyQualifiedName,
-                                        isMultiValued,
-                                        fieldMetaData,
-                                        extendedProperties)
+            SqlDbType dbType,
+            long maxLength,
+            byte precision,
+            byte scale,
+            long localeId,
+            SqlCompareOptions compareOptions,
+            bool isMultiValued,
+            IList<SmiExtendedMetaData> fieldMetaData,
+            SmiMetaDataPropertyCollection extendedProperties,
+            string name,
+            string typeSpecificNamePart1,
+            string typeSpecificNamePart2,
+            string typeSpecificNamePart3) :
+            base(dbType,
+                maxLength,
+                precision,
+                scale,
+                localeId,
+                compareOptions,
+                isMultiValued,
+                fieldMetaData,
+                extendedProperties)
         {
             Debug.Assert(null == name || MaxNameLength >= name.Length, "Name is too long");
 
@@ -618,7 +544,6 @@ namespace Microsoft.SqlServer.Server
         }
     }
 
-
     // SmiParameterMetaData
     //
     //  MetaData class to send parameter definitions to server.
@@ -627,72 +552,35 @@ namespace Microsoft.SqlServer.Server
     {
         private ParameterDirection _direction;
 
-
-        // SMI V200 ctor.
-        internal SmiParameterMetaData(
-                                        SqlDbType dbType,
-                                        long maxLength,
-                                        byte precision,
-                                        byte scale,
-                                        long localeId,
-                                        SqlCompareOptions compareOptions,
-                                        bool isMultiValued,
-                                        IList<SmiExtendedMetaData> fieldMetaData,
-                                        SmiMetaDataPropertyCollection extendedProperties,
-                                        string name,
-                                        string typeSpecificNamePart1,
-                                        string typeSpecificNamePart2,
-                                        string typeSpecificNamePart3,
-                                        ParameterDirection direction) :
-                                    this(dbType,
-                                        maxLength,
-                                        precision,
-                                        scale,
-                                        localeId,
-                                        compareOptions,
-                                        null,
-                                        isMultiValued,
-                                        fieldMetaData,
-                                        extendedProperties,
-                                        name,
-                                        typeSpecificNamePart1,
-                                        typeSpecificNamePart2,
-                                        typeSpecificNamePart3,
-                                        direction)
-        {
-        }
-
         // SMI V220 ctor.
         internal SmiParameterMetaData(
-                                        SqlDbType dbType,
-                                        long maxLength,
-                                        byte precision,
-                                        byte scale,
-                                        long localeId,
-                                        SqlCompareOptions compareOptions,
-                                        string udtAssemblyQualifiedName,
-                                        bool isMultiValued,
-                                        IList<SmiExtendedMetaData> fieldMetaData,
-                                        SmiMetaDataPropertyCollection extendedProperties,
-                                        string name,
-                                        string typeSpecificNamePart1,
-                                        string typeSpecificNamePart2,
-                                        string typeSpecificNamePart3,
-                                        ParameterDirection direction) :
-                                    base(dbType,
-                                        maxLength,
-                                        precision,
-                                        scale,
-                                        localeId,
-                                        compareOptions,
-                                        udtAssemblyQualifiedName,
-                                        isMultiValued,
-                                        fieldMetaData,
-                                        extendedProperties,
-                                        name,
-                                        typeSpecificNamePart1,
-                                        typeSpecificNamePart2,
-                                        typeSpecificNamePart3)
+            SqlDbType dbType,
+            long maxLength,
+            byte precision,
+            byte scale,
+            long localeId,
+            SqlCompareOptions compareOptions,
+            bool isMultiValued,
+            IList<SmiExtendedMetaData> fieldMetaData,
+            SmiMetaDataPropertyCollection extendedProperties,
+            string name,
+            string typeSpecificNamePart1,
+            string typeSpecificNamePart2,
+            string typeSpecificNamePart3,
+            ParameterDirection direction) :
+            base(dbType,
+                maxLength,
+                precision,
+                scale,
+                localeId,
+                compareOptions,
+                isMultiValued,
+                fieldMetaData,
+                extendedProperties,
+                name,
+                typeSpecificNamePart1,
+                typeSpecificNamePart2,
+                typeSpecificNamePart3)
         {
             Debug.Assert(ParameterDirection.Input == direction
                        || ParameterDirection.Output == direction
@@ -710,7 +598,6 @@ namespace Microsoft.SqlServer.Server
         }
     }
 
-
     // SmiStorageMetaData
     //
     //  This class represents the addition of storage-level attributes to the hierarchy (i.e. attributes from 
@@ -722,42 +609,65 @@ namespace Microsoft.SqlServer.Server
     //  Maps approximately to TDS' COLMETADATA token with TABNAME and part of COLINFO thrown in.
     internal class SmiStorageMetaData : SmiExtendedMetaData
     {
-        private SqlBoolean _isKey;             // Is this one of a set of key columns that uniquely identify an underlying table?
+        // AllowsDBNull is the only value required to be specified.
+        private bool _allowsDBNull;  // could the column return nulls? equivalent to TDS's IsNullable bit
+        private string _serverName;  // underlying column's server
+        private string _catalogName; // underlying column's database
+        private string _schemaName;  // underlying column's schema
+        private string _tableName;   // underlying column's table
+        private string _columnName;  // underlying column's name
+        private SqlBoolean _isKey;   // Is this one of a set of key columns that uniquely identify an underlying table?
+        private bool _isIdentity;    // Is this from an identity column
+        private bool _isColumnSet;   // Is this column the XML representation of a columnset?
 
         // SMI V220 ctor.
         internal SmiStorageMetaData(
-                                        SqlDbType dbType,
-                                        long maxLength,
-                                        byte precision,
-                                        byte scale,
-                                        long localeId,
-                                        SqlCompareOptions compareOptions,
-                                        bool isMultiValued,
-                                        IList<SmiExtendedMetaData> fieldMetaData,
-                                        SmiMetaDataPropertyCollection extendedProperties,
-                                        string name,
-                                        string typeSpecificNamePart1,
-                                        string typeSpecificNamePart2,
-                                        string typeSpecificNamePart3,
-                                        SqlBoolean isKey
-            ) :
-                                    base(dbType,
-                                        maxLength,
-                                        precision,
-                                        scale,
-                                        localeId,
-                                        compareOptions,
-                                        isMultiValued,
-                                        fieldMetaData,
-                                        extendedProperties,
-                                        name,
-                                        typeSpecificNamePart1,
-                                        typeSpecificNamePart2,
-                                        typeSpecificNamePart3)
+            SqlDbType dbType,
+            long maxLength,
+            byte precision,
+            byte scale,
+            long localeId,
+            SqlCompareOptions compareOptions,
+            bool isMultiValued,
+            IList<SmiExtendedMetaData> fieldMetaData,
+            SmiMetaDataPropertyCollection extendedProperties,
+            string name,
+            string typeSpecificNamePart1,
+            string typeSpecificNamePart2,
+            string typeSpecificNamePart3,
+            bool allowsDBNull,
+            string serverName,
+            string catalogName,
+            string schemaName,
+            string tableName,
+            string columnName,
+            SqlBoolean isKey,
+            bool isIdentity,
+            bool isColumnSet) :
+            base(dbType,
+                maxLength,
+                precision,
+                scale,
+                localeId,
+                compareOptions,
+                isMultiValued,
+                fieldMetaData,
+                extendedProperties,
+                name,
+                typeSpecificNamePart1,
+                typeSpecificNamePart2,
+                typeSpecificNamePart3)
         {
+            _allowsDBNull = allowsDBNull;
+            _serverName = serverName;
+            _catalogName = catalogName;
+            _schemaName = schemaName;
+            _tableName = tableName;
+            _columnName = columnName;
             _isKey = isKey;
+            _isIdentity = isIdentity;
+            _isColumnSet = isColumnSet;
         }
-
 
         internal SqlBoolean IsKey
         {
@@ -775,39 +685,122 @@ namespace Microsoft.SqlServer.Server
     //  Maps to full COLMETADATA + COLINFO + TABNAME tokens on TDS.
     internal class SmiQueryMetaData : SmiStorageMetaData
     {
-        // SMI V220 ctor.
-        internal SmiQueryMetaData(SqlDbType dbType,
-                                        long maxLength,
-                                        byte precision,
-                                        byte scale,
-                                        long localeId,
-                                        SqlCompareOptions compareOptions,
-                                        bool isMultiValued,
-                                        IList<SmiExtendedMetaData> fieldMetaData,
-                                        SmiMetaDataPropertyCollection extendedProperties,
-                                        string name,
-                                        string typeSpecificNamePart1,
-                                        string typeSpecificNamePart2,
-                                        string typeSpecificNamePart3,
-                                        SqlBoolean isKey
-            ) :
-                                    base(dbType,
-                                        maxLength,
-                                        precision,
-                                        scale,
-                                        localeId,
-                                        compareOptions,
-                                        isMultiValued,
-                                        fieldMetaData,
-                                        extendedProperties,
-                                        name,
-                                        typeSpecificNamePart1,
-                                        typeSpecificNamePart2,
-                                        typeSpecificNamePart3,
-                                        isKey
-                                        )
+        private bool _isReadOnly;
+        private SqlBoolean _isExpression;
+        private SqlBoolean _isAliased;
+        private SqlBoolean _isHidden;
+
+        // SMI V200 ctor.
+        internal SmiQueryMetaData(
+            SqlDbType dbType,
+            long maxLength,
+            byte precision,
+            byte scale,
+            long localeId,
+            SqlCompareOptions compareOptions,
+            bool isMultiValued,
+            IList<SmiExtendedMetaData> fieldMetaData,
+            SmiMetaDataPropertyCollection extendedProperties,
+            string name,
+            string typeSpecificNamePart1,
+            string typeSpecificNamePart2,
+            string typeSpecificNamePart3,
+            bool allowsDBNull,
+            string serverName,
+            string catalogName,
+            string schemaName,
+            string tableName,
+            string columnName,
+            SqlBoolean isKey,
+            bool isIdentity,
+            bool isReadOnly,
+            SqlBoolean isExpression,
+            SqlBoolean isAliased,
+            SqlBoolean isHidden) :
+            this(dbType,
+                maxLength,
+                precision,
+                scale,
+                localeId,
+                compareOptions,
+                isMultiValued,
+                fieldMetaData,
+                extendedProperties,
+                name,
+                typeSpecificNamePart1,
+                typeSpecificNamePart2,
+                typeSpecificNamePart3,
+                allowsDBNull,
+                serverName,
+                catalogName,
+                schemaName,
+                tableName,
+                columnName,
+                isKey,
+                isIdentity,
+                false,
+                isReadOnly,
+                isExpression,
+                isAliased,
+                isHidden)
         {
+        }
+
+        // SMI V220 ctor.
+        internal SmiQueryMetaData(
+            SqlDbType dbType,
+            long maxLength,
+            byte precision,
+            byte scale,
+            long localeId,
+            SqlCompareOptions compareOptions,
+            bool isMultiValued,
+            IList<SmiExtendedMetaData> fieldMetaData,
+            SmiMetaDataPropertyCollection extendedProperties,
+            string name,
+            string typeSpecificNamePart1,
+            string typeSpecificNamePart2,
+            string typeSpecificNamePart3,
+            bool allowsDBNull,
+            string serverName,
+            string catalogName,
+            string schemaName,
+            string tableName,
+            string columnName,
+            SqlBoolean isKey,
+            bool isIdentity,
+            bool isColumnSet,
+            bool isReadOnly,
+            SqlBoolean isExpression,
+            SqlBoolean isAliased,
+            SqlBoolean isHidden) :
+            base(dbType,
+                maxLength,
+                precision,
+                scale,
+                localeId,
+                compareOptions,
+                isMultiValued,
+                fieldMetaData,
+                extendedProperties,
+                name,
+                typeSpecificNamePart1,
+                typeSpecificNamePart2,
+                typeSpecificNamePart3,
+                allowsDBNull,
+                serverName,
+                catalogName,
+                schemaName,
+                tableName,
+                columnName,
+                isKey,
+                isIdentity,
+                isColumnSet)
+        {
+            _isReadOnly = isReadOnly;
+            _isExpression = isExpression;
+            _isAliased = isAliased;
+            _isHidden = isHidden;
         }
     }
 }
-

--- a/src/System.Data.SqlClient/src/Resources/Strings.resx
+++ b/src/System.Data.SqlClient/src/Resources/Strings.resx
@@ -130,6 +130,15 @@
   <data name="ADP_NonPooledOpenTimeout" xml:space="preserve">
     <value>Timeout attempting to open the connection.  The time period elapsed prior to attempting to open the connection has been exceeded.  This may have occurred because of too many simultaneous non-pooled connection attempts.</value>
   </data>
+  <data name="ADP_SingleValuedProperty" xml:space="preserve">
+    <value>The only acceptable value for the property '{0}' is '{1}'.</value>
+  </data>
+  <data name="ADP_DoubleValuedProperty" xml:space="preserve">
+    <value>The acceptable values for the property '{0}' are '{1}' or '{2}'.</value>
+  </data>
+  <data name="ADP_InvalidPrefixSuffix" xml:space="preserve">
+    <value>Specified QuotePrefix and QuoteSuffix values do not match.</value>
+  </data>
   <data name="Arg_ArrayPlusOffTooSmall" xml:space="preserve">
     <value>Destination array is not long enough to copy all the items in the collection. Check array index and length.</value>
   </data>
@@ -150,6 +159,12 @@
   </data>
   <data name="SQL_WrongType" xml:space="preserve">
     <value>Expecting argument of type {1}, but received type {0}.</value>
+  </data>
+  <data name="ADP_DeriveParametersNotSupported" xml:space="preserve">
+    <value>{0} DeriveParameters only supports CommandType.StoredProcedure, not CommandType.{1}.</value>
+  </data>
+  <data name="ADP_NoStoredProcedureExists" xml:space="preserve">
+    <value>The stored procedure '{0}' doesn't exist.</value>
   </data>
   <data name="ADP_InvalidConnectionOptionValue" xml:space="preserve">
     <value>Invalid value for key '{0}'.</value>
@@ -174,6 +189,12 @@
   </data>
   <data name="ADP_InvalidMultipartNameToManyParts" xml:space="preserve">
     <value>{0} '{1}', the current limit of '{2}' is insufficient.</value>
+  </data>
+  <data name="SQL_SqlCommandCommandText" xml:space="preserve">
+    <value>SqlCommand.DeriveParameters failed because the SqlCommand.CommandText property value is an invalid multipart name</value>
+  </data>
+  <data name="SQL_BatchedUpdatesNotAvailableOnContextConnection" xml:space="preserve">
+    <value>Batching updates is not supported on the context connection.</value>
   </data>
   <data name="SQL_BulkCopyDestinationTableName" xml:space="preserve">
     <value>SqlBulkCopy.WriteToServer failed because the SqlBulkCopy.DestinationTableName is an invalid multipart name</value>

--- a/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
+++ b/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
@@ -105,6 +105,8 @@
     <Compile Include="System\Data\SqlClient\SqlClientFactory.cs" />
     <Compile Include="System\Data\SqlClient\SqlClientMetaDataCollectionNames.cs" />
     <Compile Include="System\Data\SqlClient\SqlCommand.cs" />
+    <Compile Include="System\Data\SqlClient\SqlCommandBuilder.cs" />
+    <Compile Include="System\Data\SqlClient\SqlCommandSet.cs" />
     <Compile Include="System\Data\SqlClient\SqlConnection.cs" />
     <Compile Include="System\Data\SqlClient\SqlConnectionFactory.cs" />
     <Compile Include="System\Data\SqlClient\SqlConnectionHelper.cs" />
@@ -395,6 +397,7 @@
     <Reference Include="Microsoft.Win32.Primitives" />
     <Reference Include="System.Collections" />
     <Reference Include="System.Collections.Concurrent" />
+    <Reference Include="System.ComponentModel" />
     <Reference Include="System.ComponentModel.Primitives" />
     <Reference Include="System.ComponentModel.TypeConverter" />
     <Reference Include="System.Diagnostics.Debug" />

--- a/src/System.Data.SqlClient/src/System/Data/Common/AdapterUtil.SqlClient.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Common/AdapterUtil.SqlClient.cs
@@ -816,5 +816,123 @@ namespace System.Data.Common
 #endif
             return InvalidEnumerationValue(typeof(DataRowVersion), (int)value);
         }
+
+        internal static ArgumentException SingleValuedProperty(string propertyName, string value)
+        {
+            ArgumentException e = new ArgumentException(SR.GetString(SR.ADP_SingleValuedProperty, propertyName, value));
+            TraceExceptionAsReturnValue(e);
+            return e;
+        }
+
+        internal static ArgumentException DoubleValuedProperty(string propertyName, string value1, string value2)
+        {
+            ArgumentException e = new ArgumentException(SR.GetString(SR.ADP_DoubleValuedProperty, propertyName, value1, value2));
+            TraceExceptionAsReturnValue(e);
+            return e;
+        }
+
+        internal static ArgumentException InvalidPrefixSuffix()
+        {
+            ArgumentException e = new ArgumentException(SR.GetString(SR.ADP_InvalidPrefixSuffix));
+            TraceExceptionAsReturnValue(e);
+            return e;
+        }
+
+        // the return value is true if the string was quoted and false if it was not
+        // this allows the caller to determine if it is an error or not for the quotedString to not be quoted
+        internal static bool RemoveStringQuotes(string quotePrefix, string quoteSuffix, string quotedString, out string unquotedString)
+        {
+            int prefixLength = quotePrefix != null ? quotePrefix.Length : 0;
+            int suffixLength = quoteSuffix != null ? quoteSuffix.Length : 0;
+
+            if ((suffixLength + prefixLength) == 0)
+            {
+                unquotedString = quotedString;
+                return true;
+            }
+
+            if (quotedString == null)
+            {
+                unquotedString = quotedString;
+                return false;
+            }
+
+            int quotedStringLength = quotedString.Length;
+
+            // is the source string too short to be quoted
+            if (quotedStringLength < prefixLength + suffixLength)
+            {
+                unquotedString = quotedString;
+                return false;
+            }
+
+            // is the prefix present?
+            if (prefixLength > 0)
+            {
+                if (!quotedString.StartsWith(quotePrefix, StringComparison.Ordinal))
+                {
+                    unquotedString = quotedString;
+                    return false;
+                }
+            }
+
+            // is the suffix present?
+            if (suffixLength > 0)
+            {
+                if (!quotedString.EndsWith(quoteSuffix, StringComparison.Ordinal))
+                {
+                    unquotedString = quotedString;
+                    return false;
+                }
+                unquotedString = quotedString.Substring(prefixLength, quotedStringLength - (prefixLength + suffixLength)).Replace(quoteSuffix + quoteSuffix, quoteSuffix);
+            }
+            else
+            {
+                unquotedString = quotedString.Substring(prefixLength, quotedStringLength - prefixLength);
+            }
+            return true;
+        }
+
+        internal static ArgumentOutOfRangeException InvalidCommandBehavior(CommandBehavior value)
+        {
+            Debug.Assert((0 > (int)value) || ((int)value > 0x3F), "valid CommandType " + value.ToString());
+
+            return InvalidEnumerationValue(typeof(CommandBehavior), (int)value);
+        }
+
+        internal static void ValidateCommandBehavior(CommandBehavior value)
+        {
+            if (((int)value < 0) || (0x3F < (int)value))
+            {
+                throw InvalidCommandBehavior(value);
+            }
+        }
+
+        internal static ArgumentOutOfRangeException NotSupportedEnumerationValue(Type type, string value, string method)
+        {
+            return ArgumentOutOfRange(SR.GetString(SR.ADP_NotSupportedEnumerationValue, type.Name, value, method), type.Name);
+        }
+
+        internal static ArgumentOutOfRangeException NotSupportedCommandBehavior(CommandBehavior value, string method)
+        {
+            return NotSupportedEnumerationValue(typeof(CommandBehavior), value.ToString(), method);
+        }
+
+        internal static ArgumentException BadParameterName(string parameterName)
+        {
+            ArgumentException e = new ArgumentException(SR.GetString(SR.ADP_BadParameterName, parameterName));
+            TraceExceptionAsReturnValue(e);
+            return e;
+        }
+
+        internal static Exception DeriveParametersNotSupported(IDbCommand value)
+        {
+            return DataAdapter(SR.GetString(SR.ADP_DeriveParametersNotSupported, value.GetType().Name, value.CommandType.ToString()));
+        }
+
+        internal static Exception NoStoredProcedureExists(string sproc)
+        {
+            return InvalidOperation(SR.GetString(SR.ADP_NoStoredProcedureExists, sproc));
+        }
     }
 }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlClientFactory.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlClientFactory.cs
@@ -19,6 +19,11 @@ namespace System.Data.SqlClient
             return new SqlCommand();
         }
 
+        public override DbCommandBuilder CreateCommandBuilder()
+        {
+            return new SqlCommandBuilder();
+        }
+
         public override DbConnection CreateConnection()
         {
             return new SqlConnection();

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Data.Common;
 using System.Data.Sql;
 using System.Data.SqlTypes;
@@ -201,7 +202,11 @@ namespace System.Data.SqlClient
         // by the stateObject.
         private volatile bool _pendingCancel;
 
-
+        private bool _batchRPCMode;
+        private List<_SqlRPC> _RPCList;
+        private _SqlRPC[] _SqlRPCBatchArray;
+        private List<SqlParameterCollection> _parameterCollectionList;
+        private int _currentlyExecutingBatch;
 
 
         public SqlCommand() : base()
@@ -1847,6 +1852,72 @@ namespace System.Data.SqlClient
             return returnedTask;
         }
 
+        // If the user part is quoted, remove first and last brackets and then unquote any right square
+        // brackets in the procedure.  This is a very simple parser that performs no validation.  As
+        // with the function below, ideally we should have support from the server for this.
+        private static string UnquoteProcedurePart(string part)
+        {
+            if ((null != part) && (2 <= part.Length))
+            {
+                if ('[' == part[0] && ']' == part[part.Length - 1])
+                {
+                    part = part.Substring(1, part.Length - 2); // strip outer '[' & ']'
+                    part = part.Replace("]]", "]"); // undo quoted "]" from "]]" to "]"
+                }
+            }
+            return part;
+        }
+
+        // User value in this format: [server].[database].[schema].[sp_foo];1
+        // This function should only be passed "[sp_foo];1".
+        // This function uses a pretty simple parser that doesn't do any validation.
+        // Ideally, we would have support from the server rather than us having to do this.
+        private static string UnquoteProcedureName(string name, out object groupNumber)
+        {
+            groupNumber = null; // Out param - initialize value to no value.
+            string sproc = name;
+
+            if (null != sproc)
+            {
+                if (char.IsDigit(sproc[sproc.Length - 1]))
+                { // If last char is a digit, parse.
+                    int semicolon = sproc.LastIndexOf(';');
+                    if (semicolon != -1)
+                    { // If we found a semicolon, obtain the integer.
+                        string part = sproc.Substring(semicolon + 1);
+                        int number = 0;
+                        if (int.TryParse(part, out number))
+                        { // No checking, just fail if this doesn't work.
+                            groupNumber = number;
+                            sproc = sproc.Substring(0, semicolon);
+                        }
+                    }
+                }
+                sproc = UnquoteProcedurePart(sproc);
+            }
+            return sproc;
+        }
+
+        // Index into indirection arrays for columns of interest to DeriveParameters
+        private enum ProcParamsColIndex
+        {
+            ParameterName = 0,
+            ParameterType,
+            DataType, // obsolete in katmai, use ManagedDataType instead
+            ManagedDataType, // new in katmai
+            CharacterMaximumLength,
+            NumericPrecision,
+            NumericScale,
+            TypeCatalogName,
+            TypeSchemaName,
+            TypeName,
+            XmlSchemaCollectionCatalogName,
+            XmlSchemaCollectionSchemaName,
+            XmlSchemaCollectionName,
+            UdtTypeName, // obsolete in Katmai.  Holds the actual typename if UDT, since TypeName didn't back then.
+            DateTimeScale // new in Katmai
+        };
+
         // Yukon- column ordinals (this array indexed by ProcParamsColIndex
         internal static readonly string[] PreKatmaiProcParamsNames = new string[] {
             "PARAMETER_NAME",           // ParameterName,
@@ -1885,7 +1956,268 @@ namespace System.Data.SqlClient
             "SS_DATETIME_PRECISION",    // Scale for datetime types with scale
         };
 
+        internal void DeriveParameters()
+        {
+            switch (CommandType)
+            {
+                case CommandType.Text:
+                    throw ADP.DeriveParametersNotSupported(this);
+                case CommandType.StoredProcedure:
+                    break;
+                case CommandType.TableDirect:
+                    // CommandType.TableDirect - do nothing, parameters are not supported
+                    throw ADP.DeriveParametersNotSupported(this);
+                default:
+                    throw ADP.InvalidCommandType(CommandType);
+            }
 
+            // validate that we have a valid connection
+            ValidateCommand(false /*not async*/, nameof(DeriveParameters));
+
+            // Use common parser for SqlClient and OleDb - parse into 4 parts - Server, Catalog, Schema, ProcedureName
+            string[] parsedSProc = MultipartIdentifier.ParseMultipartIdentifier(CommandText, "[\"", "]\"", SR.SQL_SqlCommandCommandText, false);
+            if (null == parsedSProc[3] || string.IsNullOrEmpty(parsedSProc[3]))
+            {
+                throw ADP.NoStoredProcedureExists(CommandText);
+            }
+
+            Debug.Assert(parsedSProc.Length == 4, "Invalid array length result from SqlCommandBuilder.ParseProcedureName");
+
+            SqlCommand paramsCmd = null;
+            StringBuilder cmdText = new StringBuilder();
+
+            // Build call for sp_procedure_params_rowset built of unquoted values from user:
+            // [user server, if provided].[user catalog, else current database].[sys if Yukon, else blank].[sp_procedure_params_rowset]
+
+            // Server - pass only if user provided.
+            if (!string.IsNullOrEmpty(parsedSProc[0]))
+            {
+                SqlCommandSet.BuildStoredProcedureName(cmdText, parsedSProc[0]);
+                cmdText.Append(".");
+            }
+
+            // Catalog - pass user provided, otherwise use current database.
+            if (string.IsNullOrEmpty(parsedSProc[1]))
+            {
+                parsedSProc[1] = Connection.Database;
+            }
+            SqlCommandSet.BuildStoredProcedureName(cmdText, parsedSProc[1]);
+            cmdText.Append(".");
+
+            // Schema - only if Yukon, and then only pass sys.  Also - pass managed version of sproc
+            // for Yukon, else older sproc.
+            string[] colNames;
+            bool useManagedDataType;
+            if (Connection.IsKatmaiOrNewer)
+            {
+                // Procedure - [sp_procedure_params_managed]
+                cmdText.Append("[sys].[").Append(TdsEnums.SP_PARAMS_MGD10).Append("]");
+
+                colNames = KatmaiProcParamsNames;
+                useManagedDataType = true;
+            }
+            else
+            {
+                // Procedure - [sp_procedure_params_managed]
+                cmdText.Append("[sys].[").Append(TdsEnums.SP_PARAMS_MANAGED).Append("]");
+
+                colNames = PreKatmaiProcParamsNames;
+                useManagedDataType = false;
+            }
+
+            paramsCmd = new SqlCommand(cmdText.ToString(), Connection, Transaction)
+            {
+                CommandType = CommandType.StoredProcedure
+            };
+
+            object groupNumber;
+
+            // Prepare parameters for sp_procedure_params_rowset:
+            // 1) procedure name - unquote user value
+            // 2) group number - parsed at the time we unquoted procedure name
+            // 3) procedure schema - unquote user value
+
+            paramsCmd.Parameters.Add(new SqlParameter("@procedure_name", SqlDbType.NVarChar, 255));
+            paramsCmd.Parameters[0].Value = UnquoteProcedureName(parsedSProc[3], out groupNumber); // ProcedureName is 4rd element in parsed array
+
+            if (null != groupNumber)
+            {
+                SqlParameter param = paramsCmd.Parameters.Add(new SqlParameter("@group_number", SqlDbType.Int));
+                param.Value = groupNumber;
+            }
+
+            if (!string.IsNullOrEmpty(parsedSProc[2]))
+            { // SchemaName is 3rd element in parsed array
+                SqlParameter param = paramsCmd.Parameters.Add(new SqlParameter("@procedure_schema", SqlDbType.NVarChar, 255));
+                param.Value = UnquoteProcedurePart(parsedSProc[2]);
+            }
+
+            SqlDataReader r = null;
+
+            List<SqlParameter> parameters = new List<SqlParameter>();
+            bool processFinallyBlock = true;
+
+            try
+            {
+                r = paramsCmd.ExecuteReader();
+
+                SqlParameter p = null;
+
+                while (r.Read())
+                {
+                    // each row corresponds to a parameter of the stored proc.  Fill in all the info
+                    p = new SqlParameter()
+                    {
+                        ParameterName = (string)r[colNames[(int)ProcParamsColIndex.ParameterName]]
+                    };
+
+                    // type
+                    if (useManagedDataType)
+                    {
+                        p.SqlDbType = (SqlDbType)(short)r[colNames[(int)ProcParamsColIndex.ManagedDataType]];
+
+                        // Yukon didn't have as accurate of information as we're getting for Katmai, so re-map a couple of
+                        //  types for backward compatability.
+                        switch (p.SqlDbType)
+                        {
+                            case SqlDbType.Image:
+                            case SqlDbType.Timestamp:
+                                p.SqlDbType = SqlDbType.VarBinary;
+                                break;
+
+                            case SqlDbType.NText:
+                                p.SqlDbType = SqlDbType.NVarChar;
+                                break;
+
+                            case SqlDbType.Text:
+                                p.SqlDbType = SqlDbType.VarChar;
+                                break;
+
+                            default:
+                                break;
+                        }
+                    }
+                    else
+                    {
+                        p.SqlDbType = MetaType.GetSqlDbTypeFromOleDbType((short)r[colNames[(int)ProcParamsColIndex.DataType]],
+                            ADP.IsNull(r[colNames[(int)ProcParamsColIndex.TypeName]]) ?
+                                ADP.StrEmpty :
+                                (string)r[colNames[(int)ProcParamsColIndex.TypeName]]);
+                    }
+
+                    // size
+                    object a = r[colNames[(int)ProcParamsColIndex.CharacterMaximumLength]];
+                    if (a is int)
+                    {
+                        int size = (int)a;
+
+                        // Map MAX sizes correctly.  The Katmai server-side proc sends 0 for these instead of -1.
+                        //  Should be fixed on the Katmai side, but would likely hold up the RI, and is safer to fix here.
+                        //  If we can get the server-side fixed before shipping Katmai, we can remove this mapping.
+                        if (0 == size &&
+                                (p.SqlDbType == SqlDbType.NVarChar ||
+                                 p.SqlDbType == SqlDbType.VarBinary ||
+                                 p.SqlDbType == SqlDbType.VarChar))
+                        {
+                            size = -1;
+                        }
+                        p.Size = size;
+                    }
+
+                    // direction
+                    p.Direction = ParameterDirectionFromOleDbDirection((short)r[colNames[(int)ProcParamsColIndex.ParameterType]]);
+
+                    if (p.SqlDbType == SqlDbType.Decimal)
+                    {
+                        p.ScaleInternal = (byte)((short)r[colNames[(int)ProcParamsColIndex.NumericScale]] & 0xff);
+                        p.PrecisionInternal = (byte)((short)r[colNames[(int)ProcParamsColIndex.NumericPrecision]] & 0xff);
+                    }
+
+                    // type name for Structured types (same as for Udt's except assign p.TypeName instead of p.UdtTypeName
+                    if (SqlDbType.Structured == p.SqlDbType)
+                    {
+
+                        Debug.Assert(_activeConnection.IsKatmaiOrNewer, "Invalid datatype token received from pre-katmai server");
+
+                        //read the type name
+                        p.TypeName = r[colNames[(int)ProcParamsColIndex.TypeCatalogName]] + "." +
+                            r[colNames[(int)ProcParamsColIndex.TypeSchemaName]] + "." +
+                            r[colNames[(int)ProcParamsColIndex.TypeName]];
+                    }
+
+                    // XmlSchema name for Xml types
+                    if (SqlDbType.Xml == p.SqlDbType)
+                    {
+                        object value;
+
+                        value = r[colNames[(int)ProcParamsColIndex.XmlSchemaCollectionCatalogName]];
+                        p.XmlSchemaCollectionDatabase = ADP.IsNull(value) ? String.Empty : (string)value;
+
+                        value = r[colNames[(int)ProcParamsColIndex.XmlSchemaCollectionSchemaName]];
+                        p.XmlSchemaCollectionOwningSchema = ADP.IsNull(value) ? String.Empty : (string)value;
+
+                        value = r[colNames[(int)ProcParamsColIndex.XmlSchemaCollectionName]];
+                        p.XmlSchemaCollectionName = ADP.IsNull(value) ? String.Empty : (string)value;
+                    }
+
+                    if (MetaType._IsVarTime(p.SqlDbType))
+                    {
+                        object value = r[colNames[(int)ProcParamsColIndex.DateTimeScale]];
+                        if (value is int)
+                        {
+                            p.ScaleInternal = (byte)(((int)value) & 0xff);
+                        }
+                    }
+
+                    parameters.Add(p);
+                }
+            }
+            catch (Exception e)
+            {
+                processFinallyBlock = ADP.IsCatchableExceptionType(e);
+                throw;
+            }
+            finally
+            {
+                if (processFinallyBlock)
+                {
+                    r?.Close();
+
+                    // always unhook the user's connection
+                    paramsCmd.Connection = null;
+                }
+            }
+
+            if (parameters.Count == 0)
+            {
+                throw ADP.NoStoredProcedureExists(this.CommandText);
+            }
+
+            Parameters.Clear();
+
+            foreach (SqlParameter temp in parameters)
+            {
+                _parameters.Add(temp);
+            }
+        }
+
+        private ParameterDirection ParameterDirectionFromOleDbDirection(short oledbDirection)
+        {
+            Debug.Assert(oledbDirection >= 1 && oledbDirection <= 4, "invalid parameter direction from params_rowset!");
+
+            switch (oledbDirection)
+            {
+                case 2:
+                    return ParameterDirection.InputOutput;
+                case 3:
+                    return ParameterDirection.Output;
+                case 4:
+                    return ParameterDirection.ReturnValue;
+                default:
+                    return ParameterDirection.Input;
+            }
+
+        }
 
         // get cached metadata
         internal _SqlMetaDataSet MetaData
@@ -2568,17 +2900,59 @@ namespace System.Data.SqlClient
                 stateObj.CloseSession();
             }
         }
-
         internal void OnDoneProc()
         { // called per rpc batch complete
-        }
+            if (BatchRPCMode)
+            {
+                // track the records affected for the just completed rpc batch
+                // _rowsAffected is cumulative for ExecuteNonQuery across all rpc batches
+                _SqlRPCBatchArray[_currentlyExecutingBatch].cumulativeRecordsAffected = _rowsAffected;
 
+                _SqlRPCBatchArray[_currentlyExecutingBatch].recordsAffected =
+                    (((0 < _currentlyExecutingBatch) && (0 <= _rowsAffected))
+                        ? (_rowsAffected - Math.Max(_SqlRPCBatchArray[_currentlyExecutingBatch - 1].cumulativeRecordsAffected, 0))
+                        : _rowsAffected);
+
+                // track the error collection (not available from TdsParser after ExecuteNonQuery)
+                // and the which errors are associated with the just completed rpc batch
+                _SqlRPCBatchArray[_currentlyExecutingBatch].errorsIndexStart =
+                    ((0 < _currentlyExecutingBatch)
+                        ? _SqlRPCBatchArray[_currentlyExecutingBatch - 1].errorsIndexEnd
+                        : 0);
+                _SqlRPCBatchArray[_currentlyExecutingBatch].errorsIndexEnd = _stateObj.ErrorCount;
+                _SqlRPCBatchArray[_currentlyExecutingBatch].errors = _stateObj._errors;
+
+                // track the warning collection (not available from TdsParser after ExecuteNonQuery)
+                // and the which warnings are associated with the just completed rpc batch
+                _SqlRPCBatchArray[_currentlyExecutingBatch].warningsIndexStart =
+                    ((0 < _currentlyExecutingBatch)
+                        ? _SqlRPCBatchArray[_currentlyExecutingBatch - 1].warningsIndexEnd
+                        : 0);
+                _SqlRPCBatchArray[_currentlyExecutingBatch].warningsIndexEnd = _stateObj.WarningCount;
+                _SqlRPCBatchArray[_currentlyExecutingBatch].warnings = _stateObj._warnings;
+
+                _currentlyExecutingBatch++;
+                Debug.Assert(_parameterCollectionList.Count >= _currentlyExecutingBatch, "OnDoneProc: Too many DONEPROC events");
+            }
+        }
         internal void OnReturnStatus(int status)
         {
             if (_inPrepare)
                 return;
 
             SqlParameterCollection parameters = _parameters;
+            if (BatchRPCMode)
+            {
+                if (_parameterCollectionList.Count > _currentlyExecutingBatch)
+                {
+                    parameters = _parameterCollectionList[_currentlyExecutingBatch];
+                }
+                else
+                {
+                    Debug.Assert(false, "OnReturnStatus: SqlCommand got too many DONEPROC events");
+                    parameters = null;
+                }
+            }
             // see if a return value is bound
             int count = GetParameterCount(parameters);
             for (int i = 0; i < count; i++)
@@ -2596,7 +2970,9 @@ namespace System.Data.SqlClient
                     else
                     {
                         parameter.Value = status;
+
                     }
+
                     break;
                 }
             }
@@ -2610,6 +2986,7 @@ namespace System.Data.SqlClient
         //
         internal void OnReturnValue(SqlReturnValue rec)
         {
+
             if (_inPrepare)
             {
                 if (!rec.value.IsNull)
@@ -2620,7 +2997,7 @@ namespace System.Data.SqlClient
                 return;
             }
 
-            SqlParameterCollection parameters = _parameters;
+            SqlParameterCollection parameters = GetCurrentParameterCollection();
             int count = GetParameterCount(parameters);
 
 
@@ -2634,15 +3011,7 @@ namespace System.Data.SqlClient
                 // to the com type
                 object val = thisParam.Value;
 
-                //set the UDT value as typed object rather than bytes
-                if (SqlDbType.Udt == thisParam.SqlDbType)
-                {
-                    throw ADP.DbTypeNotSupported(SqlDbType.Udt.ToString());
-                }
-                else
-                {
-                    thisParam.SetSqlBuffer(rec.value);
-                }
+                thisParam.SetSqlBuffer(rec.value);
 
                 MetaType mt = MetaType.GetMetaTypeFromSqlDbType(rec.type, false);
 
@@ -2674,6 +3043,25 @@ namespace System.Data.SqlClient
             return;
         }
 
+        private SqlParameterCollection GetCurrentParameterCollection()
+        {
+            if (BatchRPCMode)
+            {
+                if (_parameterCollectionList.Count > _currentlyExecutingBatch)
+                {
+                    return _parameterCollectionList[_currentlyExecutingBatch];
+                }
+                else
+                {
+                    Debug.Assert(false, "OnReturnValue: SqlCommand got too many DONEPROC events");
+                    return null;
+                }
+            }
+            else
+            {
+                return _parameters;
+            }
+        }
 
         private SqlParameter GetParameterForOutputValueExtraction(SqlParameterCollection parameters,
                         string paramName, int paramCount)
@@ -2939,8 +3327,9 @@ namespace System.Data.SqlClient
         // sp_executesql(@batch_text nvarchar(4000),@batch_params nvarchar(4000), param1,.. paramN)
         private void BuildExecuteSql(CommandBehavior behavior, string commandText, SqlParameterCollection parameters, ref _SqlRPC rpc)
         {
+
             Debug.Assert(_prepareHandle == -1, "This command has an existing handle, use sp_execute!");
-            Debug.Assert(System.Data.CommandType.Text == this.CommandType, "invalid use of sp_executesql for stored proc invocation!");
+            Debug.Assert(CommandType.Text == this.CommandType, "invalid use of sp_executesql for stored proc invocation!");
             int j;
             SqlParameter sqlParam;
 
@@ -2969,7 +3358,7 @@ namespace System.Data.SqlClient
 
             if (cParams > 0)
             {
-                string paramList = BuildParamList(_stateObj.Parser, _parameters);
+                string paramList = BuildParamList(_stateObj.Parser, BatchRPCMode ? parameters : _parameters);
                 sqlParam = new SqlParameter(null, ((paramList.Length << 1) <= TdsEnums.TYPE_SIZE_LIMIT) ? SqlDbType.NVarChar : SqlDbType.NText, paramList.Length);
                 sqlParam.Value = paramList;
                 rpc.parameters[1] = sqlParam;
@@ -3282,6 +3671,117 @@ namespace System.Data.SqlClient
                     _rowsAffected += value;
                 }
             }
+        }
+
+        internal void ClearBatchCommand()
+        {
+            List<_SqlRPC> rpcList = _RPCList;
+            if (null != rpcList)
+            {
+                rpcList.Clear();
+            }
+            if (null != _parameterCollectionList)
+            {
+                _parameterCollectionList.Clear();
+            }
+
+            _SqlRPCBatchArray = null;
+            _currentlyExecutingBatch = 0;
+        }
+
+        internal bool BatchRPCMode
+        {
+            get
+            {
+                return _batchRPCMode;
+            }
+            set
+            {
+                _batchRPCMode = value;
+
+                if (_batchRPCMode == false)
+                {
+                    ClearBatchCommand();
+                }
+                else
+                {
+                    if (_RPCList == null)
+                    {
+                        _RPCList = new List<_SqlRPC>();
+                    }
+                    if (_parameterCollectionList == null)
+                    {
+                        _parameterCollectionList = new List<SqlParameterCollection>();
+                    }
+                }
+            }
+        }
+
+        internal void AddBatchCommand(string commandText, SqlParameterCollection parameters, CommandType cmdType)
+        {
+            Debug.Assert(BatchRPCMode, "Command is not in batch RPC Mode");
+            Debug.Assert(_RPCList != null);
+            Debug.Assert(_parameterCollectionList != null);
+
+            _SqlRPC rpc = new _SqlRPC();
+
+            CommandText = commandText;
+            CommandType = cmdType;
+
+            GetStateObject();
+            if (cmdType == CommandType.StoredProcedure)
+            {
+                BuildRPC(false, parameters, ref rpc);
+            }
+            else
+            {
+                // All batch sql statements must be executed inside sp_executesql, including those without parameters
+                BuildExecuteSql(CommandBehavior.Default, commandText, parameters, ref rpc);
+            }
+
+            _RPCList.Add(rpc);
+            // Always add a parameters collection per RPC, even if there are no parameters.
+            _parameterCollectionList.Add(parameters);
+
+            ReliablePutStateObject();
+        }
+
+        internal int ExecuteBatchRPCCommand()
+        {
+
+            Debug.Assert(BatchRPCMode, "Command is not in batch RPC Mode");
+            Debug.Assert(_RPCList != null, "No batch commands specified");
+
+            _SqlRPCBatchArray = _RPCList.ToArray();
+            _currentlyExecutingBatch = 0;
+            return ExecuteNonQuery();       // Check permissions, execute, return output params
+        }
+
+        internal int? GetRecordsAffected(int commandIndex)
+        {
+            Debug.Assert(BatchRPCMode, "Command is not in batch RPC Mode");
+            Debug.Assert(_SqlRPCBatchArray != null, "batch command have been cleared");
+            return _SqlRPCBatchArray[commandIndex].recordsAffected;
+        }
+
+        internal SqlException GetErrors(int commandIndex)
+        {
+            SqlException result = null;
+            int length = (_SqlRPCBatchArray[commandIndex].errorsIndexEnd - _SqlRPCBatchArray[commandIndex].errorsIndexStart);
+            if (0 < length)
+            {
+                SqlErrorCollection errors = new SqlErrorCollection();
+                for (int i = _SqlRPCBatchArray[commandIndex].errorsIndexStart; i < _SqlRPCBatchArray[commandIndex].errorsIndexEnd; ++i)
+                {
+                    errors.Add(_SqlRPCBatchArray[commandIndex].errors[i]);
+                }
+                for (int i = _SqlRPCBatchArray[commandIndex].warningsIndexStart; i < _SqlRPCBatchArray[commandIndex].warningsIndexEnd; ++i)
+                {
+                    errors.Add(_SqlRPCBatchArray[commandIndex].warnings[i]);
+                }
+                result = SqlException.CreateException(errors, Connection.ServerVersion, Connection.ClientConnectionId);
+            }
+            return result;
         }
 
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommandBuilder.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommandBuilder.cs
@@ -1,0 +1,272 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.Data.Common;
+using System.Data.Sql;
+using System.Diagnostics;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace System.Data.SqlClient
+{
+    public sealed class SqlCommandBuilder : DbCommandBuilder
+    {
+        public SqlCommandBuilder() : base()
+        {
+            GC.SuppressFinalize(this);
+            base.QuotePrefix = "["; // initialize base with defaults
+            base.QuoteSuffix = "]";
+        }
+
+        public SqlCommandBuilder(SqlDataAdapter adapter) : this()
+        {
+            DataAdapter = adapter;
+        }
+
+        /// <devnote>SqlServer only supports CatalogLocation.Start</devnote>
+        public override CatalogLocation CatalogLocation
+        {
+            get
+            {
+                return CatalogLocation.Start;
+            }
+            set
+            {
+                if (CatalogLocation.Start != value)
+                {
+                    throw ADP.SingleValuedProperty(nameof(CatalogLocation), nameof(CatalogLocation.Start));
+                }
+            }
+        }
+
+        /// <devnote>SqlServer only supports '.'</devnote>
+        public override string CatalogSeparator
+        {
+            get
+            {
+                return ".";
+            }
+            set
+            {
+                if ("." != value)
+                {
+                    throw ADP.SingleValuedProperty(nameof(CatalogSeparator), ".");
+                }
+            }
+        }
+
+        new public SqlDataAdapter DataAdapter
+        {
+            get
+            {
+                return (SqlDataAdapter)base.DataAdapter;
+            }
+            set
+            {
+                base.DataAdapter = value;
+            }
+        }
+
+        /// <devnote>SqlServer only supports '.'</devnote>
+        public override string QuotePrefix
+        {
+            get
+            {
+                return base.QuotePrefix;
+            }
+            set
+            {
+                if (("[" != value) && ("\"" != value))
+                {
+                    throw ADP.DoubleValuedProperty(nameof(QuotePrefix), "[", "\"");
+                }
+                base.QuotePrefix = value;
+            }
+        }
+
+        public override string QuoteSuffix
+        {
+            get
+            {
+                return base.QuoteSuffix;
+            }
+            set
+            {
+                if (("]" != value) && ("\"" != value))
+                {
+                    throw ADP.DoubleValuedProperty(nameof(QuoteSuffix), "]", "\"");
+                }
+                base.QuoteSuffix = value;
+            }
+        }
+
+        public override string SchemaSeparator
+        {
+            get
+            {
+                return ".";
+            }
+            set
+            {
+                if ("." != value)
+                {
+                    throw ADP.SingleValuedProperty(nameof(SchemaSeparator), ".");
+                }
+            }
+        }
+
+        private void SqlRowUpdatingHandler(object sender, SqlRowUpdatingEventArgs ruevent)
+        {
+            base.RowUpdatingHandler(ruevent);
+        }
+
+        new public SqlCommand GetInsertCommand()
+            => (SqlCommand)base.GetInsertCommand();
+
+        new public SqlCommand GetInsertCommand(bool useColumnsForParameterNames)
+            => (SqlCommand)base.GetInsertCommand(useColumnsForParameterNames);
+
+        new public SqlCommand GetUpdateCommand()
+            => (SqlCommand)base.GetUpdateCommand();
+
+        new public SqlCommand GetUpdateCommand(bool useColumnsForParameterNames)
+            => (SqlCommand)base.GetUpdateCommand(useColumnsForParameterNames);
+
+        new public SqlCommand GetDeleteCommand()
+            => (SqlCommand)base.GetDeleteCommand();
+
+        new public SqlCommand GetDeleteCommand(bool useColumnsForParameterNames)
+            => (SqlCommand)base.GetDeleteCommand(useColumnsForParameterNames);
+
+        protected override void ApplyParameterInfo(DbParameter parameter, DataRow datarow, StatementType statementType, bool whereClause)
+        {
+            SqlParameter p = (SqlParameter)parameter;
+            object valueType = datarow[SchemaTableColumn.ProviderType];
+            p.SqlDbType = (SqlDbType)valueType;
+            p.Offset = 0;
+
+            object bvalue = datarow[SchemaTableColumn.NumericPrecision];
+            if (DBNull.Value != bvalue)
+            {
+                byte bval = (byte)(short)bvalue;
+                p.PrecisionInternal = ((0xff != bval) ? bval : (byte)0);
+            }
+
+            bvalue = datarow[SchemaTableColumn.NumericScale];
+            if (DBNull.Value != bvalue)
+            {
+                byte bval = (byte)(short)bvalue;
+                p.ScaleInternal = ((0xff != bval) ? bval : (byte)0);
+            }
+        }
+
+        protected override string GetParameterName(int parameterOrdinal)
+            => ("@p" + parameterOrdinal.ToString(CultureInfo.InvariantCulture));
+
+        protected override string GetParameterName(string parameterName)
+            => ("@" + parameterName);
+
+        protected override string GetParameterPlaceholder(int parameterOrdinal)
+            => ("@p" + parameterOrdinal.ToString(CultureInfo.InvariantCulture));
+
+        private void ConsistentQuoteDelimiters(string quotePrefix, string quoteSuffix)
+        {
+            Debug.Assert(quotePrefix == "\"" || quotePrefix == "[");
+            if ((("\"" == quotePrefix) && ("\"" != quoteSuffix)) ||
+                (("[" == quotePrefix) && ("]" != quoteSuffix)))
+            {
+                throw ADP.InvalidPrefixSuffix();
+            }
+        }
+
+        public static void DeriveParameters(SqlCommand command)
+        {
+            if (null == command)
+            {
+                throw ADP.ArgumentNull(nameof(command));
+            }
+
+            RuntimeHelpers.PrepareConstrainedRegions();
+            try
+            {
+                command.DeriveParameters();
+            }
+            catch (OutOfMemoryException e)
+            {
+                command?.Connection?.Abort(e);
+                throw;
+            }
+            catch (StackOverflowException e)
+            {
+                command?.Connection?.Abort(e);
+                throw;
+            }
+            catch (ThreadAbortException e)
+            {
+                command?.Connection?.Abort(e);
+                throw;
+            }
+        }
+
+        protected override DataTable GetSchemaTable(DbCommand srcCommand)
+        {
+            SqlCommand sqlCommand = srcCommand as SqlCommand;
+            SqlNotificationRequest notificationRequest = sqlCommand.Notification;
+
+            sqlCommand.Notification = null;
+
+            try
+            {
+                using (SqlDataReader dataReader = sqlCommand.ExecuteReader(CommandBehavior.SchemaOnly | CommandBehavior.KeyInfo))
+                {
+                    return dataReader.GetSchemaTable();
+                }
+            }
+            finally
+            {
+                sqlCommand.Notification = notificationRequest;
+            }
+
+        }
+
+        protected override DbCommand InitializeCommand(DbCommand command)
+            => (SqlCommand)base.InitializeCommand(command);
+
+        public override string QuoteIdentifier(string unquotedIdentifier)
+        {
+            ADP.CheckArgumentNull(unquotedIdentifier, nameof(unquotedIdentifier));
+            string quoteSuffixLocal = QuoteSuffix;
+            string quotePrefixLocal = QuotePrefix;
+            ConsistentQuoteDelimiters(quotePrefixLocal, quoteSuffixLocal);
+            return ADP.BuildQuotedString(quotePrefixLocal, quoteSuffixLocal, unquotedIdentifier);
+        }
+
+        protected override void SetRowUpdatingHandler(DbDataAdapter adapter)
+        {
+            Debug.Assert(adapter is SqlDataAdapter, "Adapter is not a SqlDataAdapter.");
+            if (adapter == base.DataAdapter)
+            { // removal case
+                ((SqlDataAdapter)adapter).RowUpdating -= SqlRowUpdatingHandler;
+            }
+            else
+            { // adding case
+                ((SqlDataAdapter)adapter).RowUpdating += SqlRowUpdatingHandler;
+            }
+        }
+
+        public override string UnquoteIdentifier(string quotedIdentifier)
+        {
+            ADP.CheckArgumentNull(quotedIdentifier, nameof(quotedIdentifier));
+            string unquotedIdentifier;
+            string quoteSuffixLocal = QuoteSuffix;
+            string quotePrefixLocal = QuotePrefix;
+            ConsistentQuoteDelimiters(quotePrefixLocal, quoteSuffixLocal);
+            // ignoring the return value becasue an unquoted source string is OK here
+            ADP.RemoveStringQuotes(quotePrefixLocal, quoteSuffixLocal, quotedIdentifier, out unquotedIdentifier);
+            return unquotedIdentifier;
+        }
+    }
+}

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommandSet.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommandSet.cs
@@ -1,0 +1,300 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace System.Data.SqlClient
+{
+    internal sealed class SqlCommandSet
+    {
+        private const string SqlIdentifierPattern = "^@[\\p{Lo}\\p{Lu}\\p{Ll}\\p{Lm}_@#][\\p{Lo}\\p{Lu}\\p{Ll}\\p{Lm}\\p{Nd}\uff3f_@#\\$]*$";
+        private static readonly Regex s_sqlIdentifierParser = new Regex(SqlIdentifierPattern, RegexOptions.ExplicitCapture | RegexOptions.Singleline);
+
+        private List<LocalCommand> _commandList = new List<LocalCommand>();
+
+        private SqlCommand _batchCommand;
+
+        private sealed class LocalCommand
+        {
+            internal readonly string CommandText;
+            internal readonly SqlParameterCollection Parameters;
+            internal readonly int ReturnParameterIndex;
+            internal readonly CommandType CmdType;
+
+            internal LocalCommand(string commandText, SqlParameterCollection parameters, int returnParameterIndex, CommandType cmdType)
+            {
+                Debug.Assert(0 <= commandText.Length, "no text");
+                CommandText = commandText;
+                Parameters = parameters;
+                ReturnParameterIndex = returnParameterIndex;
+                CmdType = cmdType;
+            }
+        }
+
+        internal SqlCommandSet() : base()
+        {
+            _batchCommand = new SqlCommand();
+        }
+
+        private SqlCommand BatchCommand
+        {
+            get
+            {
+                SqlCommand command = _batchCommand;
+                if (null == command)
+                {
+                    throw ADP.ObjectDisposed(this);
+                }
+                return command;
+            }
+        }
+
+        internal int CommandCount => CommandList.Count;
+
+        private List<LocalCommand> CommandList
+        {
+            get
+            {
+                List<LocalCommand> commandList = _commandList;
+                if (null == commandList)
+                {
+                    throw ADP.ObjectDisposed(this);
+                }
+                return commandList;
+            }
+        }
+
+        internal int CommandTimeout
+        {
+            set
+            {
+                BatchCommand.CommandTimeout = value;
+            }
+        }
+
+        internal SqlConnection Connection
+        {
+            get
+            {
+                return BatchCommand.Connection;
+            }
+            set
+            {
+                BatchCommand.Connection = value;
+            }
+        }
+
+        internal SqlTransaction Transaction
+        {
+            set
+            {
+                BatchCommand.Transaction = value;
+            }
+        }
+
+        internal void Append(SqlCommand command)
+        {
+            ADP.CheckArgumentNull(command, nameof(command));
+
+            string cmdText = command.CommandText;
+            if (string.IsNullOrEmpty(cmdText))
+            {
+                throw ADP.CommandTextRequired(nameof(Append));
+            }
+
+            CommandType commandType = command.CommandType;
+            switch (commandType)
+            {
+                case CommandType.Text:
+                case CommandType.StoredProcedure:
+                    break;
+                case CommandType.TableDirect:
+                    throw SQL.NotSupportedCommandType(commandType);
+                default:
+                    throw ADP.InvalidCommandType(commandType);
+            }
+
+            SqlParameterCollection parameters = null;
+
+            SqlParameterCollection collection = command.Parameters;
+            if (0 < collection.Count)
+            {
+                parameters = new SqlParameterCollection();
+
+                // clone parameters so they aren't destroyed
+                for (int i = 0; i < collection.Count; ++i)
+                {
+                    SqlParameter p = new SqlParameter();
+                    collection[i].CopyTo(p);
+                    parameters.Add(p);
+
+                    // SQL Injection awareness
+                    if (!s_sqlIdentifierParser.IsMatch(p.ParameterName))
+                    {
+                        throw ADP.BadParameterName(p.ParameterName);
+                    }
+                }
+
+                foreach (SqlParameter p in parameters)
+                {
+                    // deep clone the parameter value if byte[] or char[]
+                    object obj = p.Value;
+                    byte[] byteValues = (obj as byte[]);
+                    if (null != byteValues)
+                    {
+                        int offset = p.Offset;
+                        int size = p.Size;
+                        int countOfBytes = byteValues.Length - offset;
+                        if ((0 != size) && (size < countOfBytes))
+                        {
+                            countOfBytes = size;
+                        }
+                        byte[] copy = new byte[Math.Max(countOfBytes, 0)];
+                        Buffer.BlockCopy(byteValues, offset, copy, 0, copy.Length);
+                        p.Offset = 0;
+                        p.Value = copy;
+                    }
+                    else
+                    {
+                        char[] charValues = (obj as char[]);
+                        if (null != charValues)
+                        {
+                            int offset = p.Offset;
+                            int size = p.Size;
+                            int countOfChars = charValues.Length - offset;
+                            if ((0 != size) && (size < countOfChars))
+                            {
+                                countOfChars = size;
+                            }
+                            char[] copy = new char[Math.Max(countOfChars, 0)];
+                            Buffer.BlockCopy(charValues, offset, copy, 0, copy.Length * 2);
+                            p.Offset = 0;
+                            p.Value = copy;
+                        }
+                        else
+                        {
+                            ICloneable cloneable = (obj as ICloneable);
+                            if (null != cloneable)
+                            {
+                                p.Value = cloneable.Clone();
+                            }
+                        }
+                    }
+                }
+            }
+
+            int returnParameterIndex = -1;
+            if (null != parameters)
+            {
+                for (int i = 0; i < parameters.Count; ++i)
+                {
+                    if (ParameterDirection.ReturnValue == parameters[i].Direction)
+                    {
+                        returnParameterIndex = i;
+                        break;
+                    }
+                }
+            }
+            LocalCommand cmd = new LocalCommand(cmdText, parameters, returnParameterIndex, command.CommandType);
+            CommandList.Add(cmd);
+        }
+
+        internal static void BuildStoredProcedureName(StringBuilder builder, string part)
+        {
+            if ((null != part) && (0 < part.Length))
+            {
+                if ('[' == part[0])
+                {
+                    int count = 0;
+                    foreach (char c in part)
+                    {
+                        if (']' == c)
+                        {
+                            count++;
+                        }
+                    }
+                    if (1 == (count % 2))
+                    {
+                        builder.Append(part);
+                        return;
+                    }
+                }
+
+                // the part is not escaped, escape it now
+                SqlServerEscapeHelper.EscapeIdentifier(builder, part);
+            }
+        }
+
+        internal void Clear()
+        {
+            DbCommand batchCommand = BatchCommand;
+            if (null != batchCommand)
+            {
+                batchCommand.Parameters.Clear();
+                batchCommand.CommandText = null;
+            }
+            List<LocalCommand> commandList = _commandList;
+            if (null != commandList)
+            {
+                commandList.Clear();
+            }
+        }
+
+        internal void Dispose()
+        {
+            SqlCommand command = _batchCommand;
+            _commandList = null;
+            _batchCommand = null;
+
+            if (null != command)
+            {
+                command.Dispose();
+            }
+        }
+
+        internal int ExecuteNonQuery()
+        {
+            ValidateCommandBehavior(nameof(ExecuteNonQuery), CommandBehavior.Default);
+
+            BatchCommand.BatchRPCMode = true;
+            BatchCommand.ClearBatchCommand();
+            BatchCommand.Parameters.Clear();
+            for (int ii = 0; ii < _commandList.Count; ii++)
+            {
+                LocalCommand cmd = _commandList[ii];
+                BatchCommand.AddBatchCommand(cmd.CommandText, cmd.Parameters, cmd.CmdType);
+            }
+
+            return BatchCommand.ExecuteBatchRPCCommand();
+        }
+
+        internal SqlParameter GetParameter(int commandIndex, int parameterIndex)
+            => CommandList[commandIndex].Parameters[parameterIndex];
+
+        internal bool GetBatchedAffected(int commandIdentifier, out int recordsAffected, out Exception error)
+        {
+            error = BatchCommand.GetErrors(commandIdentifier);
+            int? affected = BatchCommand.GetRecordsAffected(commandIdentifier);
+            recordsAffected = affected.GetValueOrDefault();
+            return affected.HasValue;
+        }
+
+        internal int GetParameterCount(int commandIndex)
+            => CommandList[commandIndex].Parameters.Count;
+
+        private void ValidateCommandBehavior(string method, CommandBehavior behavior)
+        {
+            if (0 != (behavior & ~(CommandBehavior.SequentialAccess | CommandBehavior.CloseConnection)))
+            {
+                ADP.ValidateCommandBehavior(behavior);
+                throw ADP.NotSupportedCommandBehavior(behavior & ~(CommandBehavior.SequentialAccess | CommandBehavior.CloseConnection), method);
+            }
+        }
+    }
+}
+

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlEnums.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlEnums.cs
@@ -653,6 +653,11 @@ namespace System.Data.SqlClient
             return sqlVal;
         }
 
+        internal static SqlDbType GetSqlDbTypeFromOleDbType(short dbType, string typeName)
+        {
+            // OleDbTypes not supported
+            return SqlDbType.Variant;
+        }
 
         internal static MetaType GetSqlDataType(int tdsType, UInt32 userType, int length)
         {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameterHelper.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameterHelper.cs
@@ -217,6 +217,21 @@ namespace System.Data.SqlClient
             }
             return 0;
         }
+
+        internal void CopyTo(SqlParameter destination)
+        {
+            ADP.CheckArgumentNull(destination, nameof(destination));
+
+            // NOTE: _parent is not cloned
+            destination._value = _value;
+            destination._direction = _direction;
+            destination._size = _size;
+            destination._offset = _offset;
+            destination._sourceColumn = _sourceColumn;
+            destination._sourceVersion = _sourceVersion;
+            destination._sourceColumnNullMapping = _sourceColumnNullMapping;
+            destination._isNullable = _isNullable;
+        }
     }
 }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlUtil.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlUtil.cs
@@ -839,6 +839,11 @@ namespace System.Data.SqlClient
             return exc;
         }
 
+        internal static Exception BatchedUpdatesNotAvailableOnContextConnection()
+        {
+            return ADP.InvalidOperation(SR.GetString(SR.SQL_BatchedUpdatesNotAvailableOnContextConnection));
+        }
+
         /// <summary>
         /// gets a message for SNI error (sniError must be valid, non-zero error code)
         /// </summary>

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserHelperClasses.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserHelperClasses.cs
@@ -266,16 +266,20 @@ namespace System.Data.SqlClient
     sealed internal class _SqlMetaData : SqlMetaDataPriv
     {
         internal string column;
+        internal string baseColumn;
         internal MultiPartTableName multiPartTableName;
         internal readonly int ordinal;
         internal byte updatability;     // two bit field (0 is read only, 1 is updatable, 2 is updatability unknown)
+        internal byte tableNum;
         internal bool isDifferentName;
         internal bool isKey;
         internal bool isHidden;
         internal bool isExpression;
         internal bool isIdentity;
         internal bool isColumnSet;
-        internal string baseColumn;
+        internal byte op;        // for altrow-columns only
+        internal ushort operand; // for altrow-columns only
+
         internal _SqlMetaData(int ordinal) : base()
         {
             this.ordinal = ordinal;
@@ -302,7 +306,6 @@ namespace System.Data.SqlClient
                 return multiPartTableName.SchemaName;
             }
         }
-
         internal string tableName
         {
             get
@@ -332,12 +335,18 @@ namespace System.Data.SqlClient
             _SqlMetaData result = new _SqlMetaData(ordinal);
             result.CopyFrom(this);
             result.column = column;
+            result.baseColumn = baseColumn;
             result.multiPartTableName = multiPartTableName;
             result.updatability = updatability;
+            result.tableNum = tableNum;
+            result.isDifferentName = isDifferentName;
             result.isKey = isKey;
             result.isHidden = isHidden;
+            result.isExpression = isExpression;
             result.isIdentity = isIdentity;
             result.isColumnSet = isColumnSet;
+            result.op = op;
+            result.operand = operand;
             return result;
         }
     }
@@ -513,7 +522,6 @@ namespace System.Data.SqlClient
             this.metaType = original.metaType;
         }
     }
-
     sealed internal class _SqlRPC
     {
         internal string rpcName;
@@ -521,6 +529,30 @@ namespace System.Data.SqlClient
         internal ushort options;
         internal SqlParameter[] parameters;
         internal byte[] paramoptions;
+
+        internal int? recordsAffected;
+        internal int cumulativeRecordsAffected;
+
+        internal int errorsIndexStart;
+        internal int errorsIndexEnd;
+        internal SqlErrorCollection errors;
+
+        internal int warningsIndexStart;
+        internal int warningsIndexEnd;
+        internal SqlErrorCollection warnings;
+
+        internal string GetCommandTextOrRpcName()
+        {
+            if (TdsEnums.RPC_PROCID_EXECUTESQL == ProcID)
+            {
+                // Param 0 is the actual sql executing
+                return (string)parameters[0].Value;
+            }
+            else
+            {
+                return rpcName;
+            }
+        }
     }
 
     sealed internal class SqlReturnValue : SqlMetaDataPriv

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlSchemaInfoTest/SqlSchemaInfoTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlSchemaInfoTest/SqlSchemaInfoTest.cs
@@ -3,48 +3,199 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Data.Common;
+using System.ComponentModel;
+using System.Collections.Generic;
 using Xunit;
 
 namespace System.Data.SqlClient.ManualTesting.Tests
 {
     public static class SqlSchemaInfoTest
     {
+        #region TestMethods
         [CheckConnStrSetupFact]
         public static void TestGetSchema()
         {
-            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr);
-            using (SqlConnection connection = new SqlConnection(builder.ConnectionString))
+            using (SqlConnection conn = new SqlConnection(DataTestUtility.TcpConnStr))
             {
-                connection.Open();
+                conn.Open();
+                DataTable dataBases = conn.GetSchema("DATABASES");
 
-                DataTable dataTable = connection.GetSchema("DATABASES");
+                Assert.True(dataBases.Rows.Count > 0, "At least one database is expected");
 
-                if (dataTable.Rows.Count > 0)
-                {
-                    DataTable metaDataCollections = connection.GetSchema(DbMetaDataCollectionNames.MetaDataCollections);
-                    Assert.True(metaDataCollections != null && metaDataCollections.Rows.Count > 0);
-                    
-                    DataTable metaDataSourceInfo = connection.GetSchema(DbMetaDataCollectionNames.DataSourceInformation);
-                    Assert.True(metaDataSourceInfo != null && metaDataSourceInfo.Rows.Count > 0);
+                DataTable metaDataCollections = conn.GetSchema(DbMetaDataCollectionNames.MetaDataCollections);
+                Assert.True(metaDataCollections != null && metaDataCollections.Rows.Count > 0);
 
-                    DataTable metaDataTypes = connection.GetSchema(DbMetaDataCollectionNames.DataTypes);
-                    Assert.True(metaDataTypes != null && metaDataTypes.Rows.Count > 0);
-                }
+                DataTable metaDataSourceInfo = conn.GetSchema(DbMetaDataCollectionNames.DataSourceInformation);
+                Assert.True(metaDataSourceInfo != null && metaDataSourceInfo.Rows.Count > 0);
 
-                connection.Close();
+                DataTable metaDataTypes = conn.GetSchema(DbMetaDataCollectionNames.DataTypes);
+                Assert.True(metaDataTypes != null && metaDataTypes.Rows.Count > 0);
             }
         }
 
         [CheckConnStrSetupFact]
         public static void TestCommandBuilder()
         {
-            // CommandBuilder is not supported yet in .NET Core.
+            using (SqlConnection connection = new SqlConnection(DataTestUtility.TcpConnStr))
+            using (SqlCommandBuilder commandBuilder = new SqlCommandBuilder())
+            using (SqlCommand command = connection.CreateCommand())
+            {
+                string identifier = "TestIdentifier";
+                string quotedIdentifier = commandBuilder.QuoteIdentifier(identifier);
+                DataTestUtility.AssertEqualsWithDescription(
+                    "[TestIdentifier]", quotedIdentifier,
+                    "Unexpected QuotedIdentifier string.");
+
+                string unquotedIdentifier = commandBuilder.UnquoteIdentifier(quotedIdentifier);
+                DataTestUtility.AssertEqualsWithDescription(
+                    "TestIdentifier", unquotedIdentifier,
+                    "Unexpected UnquotedIdentifier string.");
+
+                identifier = "identifier]withclosesquarebracket";
+                quotedIdentifier = commandBuilder.QuoteIdentifier(identifier);
+                DataTestUtility.AssertEqualsWithDescription(
+                    "[identifier]]withclosesquarebracket]", quotedIdentifier,
+                    "Unexpected QuotedIdentifier string.");
+
+                unquotedIdentifier = null;
+                unquotedIdentifier = commandBuilder.UnquoteIdentifier(quotedIdentifier);
+                DataTestUtility.AssertEqualsWithDescription(
+                    "identifier]withclosesquarebracket", unquotedIdentifier,
+                    "Unexpected UnquotedIdentifier string.");
+            }
         }
 
+        // This test validates behavior of SqlInitialCatalogConverter used to present database names in PropertyGrid
+        // with the SqlConnectionStringBuilder object presented in the control underneath.
         [CheckConnStrSetupFact]
         public static void TestInitialCatalogStandardValues()
         {
-            // PropertyDescriptor is not supported yet in .NET Core.
+            using (SqlConnection connection = new SqlConnection(DataTestUtility.TcpConnStr))
+            {
+                string currentDb = connection.Database;
+                SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(connection.ConnectionString);
+                PropertyDescriptorCollection properties = TypeDescriptor.GetProperties(builder);
+                PropertyDescriptor descriptor = properties["InitialCatalog"];
+
+                DataTestUtility.AssertEqualsWithDescription(
+                    "SqlInitialCatalogConverter", descriptor.Converter.GetType().Name,
+                    "Unexpected TypeConverter type.");
+
+                // GetStandardValues of this converter calls GetSchema("DATABASES")
+                var dbNames = descriptor.Converter.GetStandardValues(new DescriptorContext(descriptor, builder));
+                HashSet<string> searchSet = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
+                foreach (string name in dbNames)
+                {
+                    searchSet.Add(name);
+                }
+
+                // ensure master and current database exist there
+                Assert.True(searchSet.Contains("master"), "Cannot find database: master.");
+                Assert.True(searchSet.Contains(currentDb), $"Cannot find database: {currentDb}.");
+            }
         }
+        #endregion
+
+        #region UtilityMethodsClasses
+        // primitive implementation of ITypeDescriptorContext to be used with component model APIs
+        private class DescriptorContext : ITypeDescriptorContext
+        {
+            SqlConnectionStringBuilder _instance;
+            PropertyDescriptor _descriptor;
+
+            public DescriptorContext(PropertyDescriptor descriptor, SqlConnectionStringBuilder instance)
+            {
+                _instance = instance;
+                _descriptor = descriptor;
+            }
+
+            public object Instance
+            {
+                get { return _instance; }
+            }
+
+            public IContainer Container
+            {
+                get { return null; }
+            }
+
+            public PropertyDescriptor PropertyDescriptor
+            {
+                get { return _descriptor; }
+            }
+
+            public void OnComponentChanged()
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool OnComponentChanging()
+            {
+                throw new NotImplementedException();
+            }
+
+            public object GetService(Type serviceType)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private static void DumpDataTable(DataTable dataTable, int rowPrintCount)
+        {
+            Console.WriteLine("DumpDataTable");
+            Console.WriteLine("");
+
+            if (dataTable == null)
+            {
+                Console.WriteLine("DataTable object is null.");
+                return;
+            }
+            int columnCount = dataTable.Columns.Count;
+            int currentColumn;
+
+            int rowCount = dataTable.Rows.Count;
+            int currentRow;
+
+            Console.WriteLine("Table \"{0}\" has {1} columns", dataTable.TableName.ToString(), columnCount.ToString());
+            Console.WriteLine("Table \"{0}\" has {1} rows. At most the first {2} are dumped.", dataTable.TableName.ToString(), rowCount.ToString(), rowPrintCount.ToString());
+
+            if ((rowPrintCount != 0) && (rowPrintCount < rowCount))
+            {
+                rowCount = rowPrintCount;
+            }
+
+            for (currentColumn = 0; currentColumn < columnCount; currentColumn++)
+            {
+                DumpDataColumn(dataTable.Columns[currentColumn]);
+            }
+
+            for (currentRow = 0; currentRow < rowCount; currentRow++)
+            {
+                DumpDataRow(dataTable.Rows[currentRow], dataTable);
+            }
+
+            return;
+
+        }
+
+        private static void DumpDataRow(DataRow dataRow, DataTable dataTable)
+        {
+            Console.WriteLine(" ");
+            Console.WriteLine("<DumpDataRow>");
+
+            foreach (DataColumn dataColumn in dataTable.Columns)
+            {
+                Console.WriteLine("{0}.{1} = {2}", dataTable.TableName, dataColumn.ColumnName, dataRow[dataColumn, DataRowVersion.Current].ToString());
+            }
+            return;
+        }
+
+        private static void DumpDataColumn(DataColumn dataColumn)
+        {
+
+            Console.WriteLine("Column Name = {0}, Column Type =  {1}", dataColumn.ColumnName, dataColumn.DataType.ToString());
+            return;
+        }
+        #endregion
     }
 }


### PR DESCRIPTION
Also modifies some TdsParser query metadata parsing code. Some fields, like the query TableName, weren't being set correctly, so dynamic SQL query generation would fail in the AdapterTests.

Mostly ported code from Framework.