### PR TITLE
Fix UnauthorizedAccessException for Sockets tests running in app-container

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/SendPacketsAsync.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendPacketsAsync.cs
@@ -16,8 +16,9 @@ namespace System.Net.Sockets.Tests
         private readonly ITestOutputHelper _log;
 
         private IPAddress _serverAddress = IPAddress.IPv6Loopback;
-        // In the current directory
-        private const string TestFileName = "NCLTest.Socket.SendPacketsAsync.testpayload";
+        // Accessible directories for UWP app:
+        // C:\Users\<UserName>\AppData\Local\Packages\<ApplicationPackageName>\
+        private string TestFileName = Environment.GetEnvironmentVariable("LocalAppData") + @"\NCLTest.Socket.SendPacketsAsync.testpayload";
         private static int s_testFileSize = 1024;
 
         #region Additional test attributes


### PR DESCRIPTION
In UAP mode, all tests are running inside an UWP app. The app doesn't have direct access to most of the file system, which causes System.UnauthorizedAccessException.

Now all innerloop Functional tests for System.Net.Sockets should run clean on UAP mode.

Fix: #20302 