### PR TITLE
Disable UapAot System.Collections tests related to serialization issue

### DIFF
--- a/src/Common/tests/System/Collections/IEnumerable.Generic.Serialization.Tests.cs
+++ b/src/Common/tests/System/Collections/IEnumerable.Generic.Serialization.Tests.cs
@@ -12,6 +12,7 @@ namespace System.Collections.Tests
     {
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
+        [ActiveIssue(20888, TargetFrameworkMonikers.UapAot)]
         public void IGenericSharedAPI_SerializeDeserialize(int count)
         {
             IEnumerable<T> expected = GenericIEnumerableFactory(count);

--- a/src/System.Collections/tests/Generic/Comparers/EqualityComparer.Generic.Serialization.Tests.cs
+++ b/src/System.Collections/tests/Generic/Comparers/EqualityComparer.Generic.Serialization.Tests.cs
@@ -13,6 +13,7 @@ namespace System.Collections.Generic.Tests
     public abstract partial class ComparersGenericTests<T>
     {
         [Fact]
+        [ActiveIssue(20888, TargetFrameworkMonikers.UapAot)]
         public void EqualityComparer_SerializationRoundtrip()
         {
             var bf = new BinaryFormatter();

--- a/src/System.Collections/tests/Generic/Dictionary/Dictionary.Tests.cs
+++ b/src/System.Collections/tests/Generic/Dictionary/Dictionary.Tests.cs
@@ -198,6 +198,7 @@ namespace System.Collections.Tests
 
         [Theory]
         [MemberData(nameof(CopyConstructorInt32ComparerData))]
+        [ActiveIssue(20888, TargetFrameworkMonikers.UapAot)]
         public void CopyConstructorInt32Comparer(int size, Func<int, int> keyValueSelector, Func<IDictionary<int, int>, IDictionary<int, int>> dictionarySelector, IEqualityComparer<int> comparer)
         {
             TestCopyConstructor(size, keyValueSelector, dictionarySelector, comparer);
@@ -219,6 +220,7 @@ namespace System.Collections.Tests
 
         [Theory]
         [MemberData(nameof(CopyConstructorStringComparerData))]
+        [ActiveIssue(20888, TargetFrameworkMonikers.UapAot)]
         public void CopyConstructorStringComparer(int size, Func<int, string> keyValueSelector, Func<IDictionary<string, string>, IDictionary<string, string>> dictionarySelector, IEqualityComparer<string> comparer)
         {
             TestCopyConstructor(size, keyValueSelector, dictionarySelector, comparer);


### PR DESCRIPTION
This should bring System.Collections.Tests failures to 7, which are caused by the same issue in only two different tests.

cc: @danmosemsft 

FYI: @morganbr 