### PR TITLE
Add tests for enum attributes in System.ComponentModel.Primitives

### DIFF
--- a/src/System.ComponentModel.Primitives/src/System/ComponentModel/DesignerSerializationVisibilityAttribute.cs
+++ b/src/System.ComponentModel.Primitives/src/System/ComponentModel/DesignerSerializationVisibilityAttribute.cs
@@ -49,17 +49,12 @@ namespace System.ComponentModel
         /// </summary>
         public static readonly DesignerSerializationVisibilityAttribute Default = Visible;
 
-        private readonly DesignerSerializationVisibility _visibility;
-
         /// <summary>
         ///    <para>
         ///       Initializes a new instance of the System.ComponentModel.PersistContentsAttribute class.
         ///    </para>
         /// </summary>
-        public DesignerSerializationVisibilityAttribute(DesignerSerializationVisibility visibility)
-        {
-            _visibility = visibility;
-        }
+        public DesignerSerializationVisibilityAttribute(DesignerSerializationVisibility visibility) => Visibility = visibility;
 
         /// <summary>
         ///    <para>
@@ -67,17 +62,8 @@ namespace System.ComponentModel
         ///       visual designer must generate special code to persist the value of a property.
         ///    </para>
         /// </summary>
-        public DesignerSerializationVisibility Visibility
-        {
-            get
-            {
-                return _visibility;
-            }
-        }
+        public DesignerSerializationVisibility Visibility { get; }
 
-        /// <internalonly/>
-        /// <summary>
-        /// </summary>
         public override bool Equals(object obj)
         {
             if (obj == this)
@@ -86,22 +72,11 @@ namespace System.ComponentModel
             }
 
             DesignerSerializationVisibilityAttribute other = obj as DesignerSerializationVisibilityAttribute;
-            return other != null && other.Visibility == _visibility;
+            return other?.Visibility == Visibility;
         }
 
-        /// <summary>
-        ///    <para>
-        ///       Returns the hashcode for this object.
-        ///    </para>
-        /// </summary>
-        public override int GetHashCode()
-        {
-            return base.GetHashCode();
-        }
+        public override int GetHashCode() => base.GetHashCode();
 
-        public override bool IsDefaultAttribute()
-        {
-            return Equals(DesignerSerializationVisibilityAttribute.Default);
-        }        
+        public override bool IsDefaultAttribute() => Equals(Default);
     }
 }

--- a/src/System.ComponentModel.Primitives/src/System/ComponentModel/EventHandlerList.cs
+++ b/src/System.ComponentModel.Primitives/src/System/ComponentModel/EventHandlerList.cs
@@ -16,10 +16,7 @@ namespace System.ComponentModel
         ///     Creates a new event handler list.  The parent component is used to check the component's
         ///     CanRaiseEvents property.
         /// </summary>
-        internal EventHandlerList(Component parent)
-        {
-            _parent = parent;
-        }
+        internal EventHandlerList(Component parent) => _parent = parent;
 
         /// <summary>
         ///    Creates a new event handler list.
@@ -41,21 +38,14 @@ namespace System.ComponentModel
                     e = Find(key);
                 }
 
-                if (e != null)
-                {
-                    return e.Handler;
-                }
-                else
-                {
-                    return null;
-                }
+                return e?._handler;
             }
             set
             {
                 ListEntry e = Find(key);
                 if (e != null)
                 {
-                    e.Handler = value;
+                    e._handler = value;
                 }
                 else
                 {
@@ -72,7 +62,7 @@ namespace System.ComponentModel
             ListEntry e = Find(key);
             if (e != null)
             {
-                e.Handler = Delegate.Combine(e.Handler, value);
+                e._handler = Delegate.Combine(e._handler, value);
             }
             else
             {
@@ -86,42 +76,33 @@ namespace System.ComponentModel
             ListEntry currentListEntry = listToAddFrom._head;
             while (currentListEntry != null)
             {
-                AddHandler(currentListEntry.Key, currentListEntry.Handler);
-                currentListEntry = currentListEntry.Next;
+                AddHandler(currentListEntry._key, currentListEntry._handler);
+                currentListEntry = currentListEntry._next;
             }
         }
 
-        /// <summary>
-        ///    <para>[To be supplied.]</para>
-        /// </summary>
-        public void Dispose()
-        {
-            _head = null;
-        }
+        public void Dispose() => _head = null;
 
         private ListEntry Find(object key)
         {
             ListEntry found = _head;
             while (found != null)
             {
-                if (found.Key == key)
+                if (found._key == key)
                 {
                     break;
                 }
-                found = found.Next;
+                found = found._next;
             }
             return found;
         }
 
-        /// <summary>
-        ///    <para>[To be supplied.]</para>
-        /// </summary>
         public void RemoveHandler(object key, Delegate value)
         {
             ListEntry e = Find(key);
             if (e != null)
             {
-                e.Handler = Delegate.Remove(e.Handler, value);
+                e._handler = Delegate.Remove(e._handler, value);
             }
             // else... no error for removal of non-existent delegate
             //
@@ -129,15 +110,15 @@ namespace System.ComponentModel
 
         private sealed class ListEntry
         {
-            internal ListEntry Next;
-            internal object Key;
-            internal Delegate Handler;
+            internal ListEntry _next;
+            internal object _key;
+            internal Delegate _handler;
 
             public ListEntry(object key, Delegate handler, ListEntry next)
             {
-                Next = next;
-                Key = key;
-                Handler = handler;
+                _next = next;
+                _key = key;
+                _handler = handler;
             }
         }
     }

--- a/src/System.ComponentModel.Primitives/src/System/ComponentModel/RefreshPropertiesAttribute.cs
+++ b/src/System.ComponentModel.Primitives/src/System/ComponentModel/RefreshPropertiesAttribute.cs
@@ -12,8 +12,7 @@ namespace System.ComponentModel
     {
         /// <summary>
         ///    <para>
-        ///       Indicates all properties should
-        ///       be refreshed if the property value is changed. This field is
+        ///       Indicates all properties should be refreshed if the property value is changed. This field is
         ///       read-only.
         ///    </para>
         /// </summary>
@@ -21,8 +20,7 @@ namespace System.ComponentModel
 
         /// <summary>
         ///    <para>
-        ///       Indicates all properties should
-        ///       be invalidated and repainted if the
+        ///       Indicates all properties should be invalidated and repainted if the
         ///       property value is changed. This field is read-only.
         ///    </para>
         /// </summary>
@@ -30,35 +28,21 @@ namespace System.ComponentModel
 
         /// <summary>
         ///    <para>
-        ///       Indicates that by default
-        ///       no
-        ///       properties should be refreshed if the property value
+        ///       Indicates that by default no properties should be refreshed if the property value
         ///       is changed. This field is read-only.
         ///    </para>
         /// </summary>
         public static readonly RefreshPropertiesAttribute Default = new RefreshPropertiesAttribute(RefreshProperties.None);
 
-        /// <summary>
-        /// </summary>
-        /// <internalonly/>
-        public RefreshPropertiesAttribute(RefreshProperties refresh)
-        {
-            RefreshProperties = refresh;
-        }
+        public RefreshPropertiesAttribute(RefreshProperties refresh) => RefreshProperties = refresh;
 
         /// <summary>
         ///    <para>
-        ///       Gets or sets
-        ///       the refresh properties for the member.
+        ///       Gets the refresh properties for the member.
         ///    </para>
         /// </summary>
         public RefreshProperties RefreshProperties { get; }
 
-        /// <summary>
-        ///    <para>
-        ///       Overrides object's Equals method.
-        ///    </para>
-        /// </summary>
         public override bool Equals(object obj)
         {
             if (obj == this)
@@ -67,22 +51,11 @@ namespace System.ComponentModel
             }
 
             RefreshPropertiesAttribute other = obj as RefreshPropertiesAttribute;
-            return (other != null) && other.RefreshProperties == RefreshProperties;
+            return other?.RefreshProperties == RefreshProperties;
         }
 
-        /// <summary>
-        ///    <para>
-        ///       Returns the hashcode for this object.
-        ///    </para>
-        /// </summary>
-        public override int GetHashCode()
-        {
-            return base.GetHashCode();
-        }
+        public override int GetHashCode() => base.GetHashCode();
 
-        public override bool IsDefaultAttribute()
-        {
-            return Equals(RefreshPropertiesAttribute.Default);
-        }
+        public override bool IsDefaultAttribute() => Equals(Default);
     }
 }

--- a/src/System.ComponentModel.Primitives/tests/DesignerSerializationVisibilityAttributeTests.cs
+++ b/src/System.ComponentModel.Primitives/tests/DesignerSerializationVisibilityAttributeTests.cs
@@ -2,33 +2,60 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Xunit;
 
 namespace System.ComponentModel.Tests
 {
     public class DesignerSerializationVisibilityAttributeTests
     {
-        [Fact]
-        public void Equals_DifferentVisibilities()
+        [Theory]
+        [InlineData(DesignerSerializationVisibility.Hidden - 1, false)]
+        [InlineData(DesignerSerializationVisibility.Content, false)]
+        [InlineData(DesignerSerializationVisibility.Hidden, false)]
+        [InlineData(DesignerSerializationVisibility.Visible, true)]
+        public static void Ctor_Visibility(DesignerSerializationVisibility visibility, bool expectedIsDefaultAttribute)
         {
-            Assert.False(DesignerSerializationVisibilityAttribute.Hidden.Equals(DesignerSerializationVisibilityAttribute.Visible));
+            var attribute = new DesignerSerializationVisibilityAttribute(visibility);
+            Assert.Equal(visibility, attribute.Visibility);
+            Assert.Equal(expectedIsDefaultAttribute, attribute.IsDefaultAttribute());
         }
 
-        [Fact]
-        public void Equals_SameVisibility()
+        public static IEnumerable<object[]> Equals_TestData()
         {
-            Assert.True(DesignerSerializationVisibilityAttribute.Visible.Equals(DesignerSerializationVisibilityAttribute.Visible));
+            yield return new object[] { DesignerSerializationVisibilityAttribute.Visible, DesignerSerializationVisibilityAttribute.Visible, true };
+            yield return new object[] { DesignerSerializationVisibilityAttribute.Visible, new DesignerSerializationVisibilityAttribute(DesignerSerializationVisibility.Visible), true };
+            yield return new object[] { DesignerSerializationVisibilityAttribute.Visible, DesignerSerializationVisibilityAttribute.Hidden, false };
+
+            yield return new object[] { DesignerSerializationVisibilityAttribute.Visible, new object(), false };
+            yield return new object[] { DesignerSerializationVisibilityAttribute.Visible, null, false };
         }
 
         [Theory]
-        [InlineData(DesignerSerializationVisibility.Content)]
-        [InlineData(DesignerSerializationVisibility.Hidden)]
-        [InlineData(DesignerSerializationVisibility.Visible)]
-        public static void Visibility(DesignerSerializationVisibility visibility)
+        [MemberData(nameof(Equals_TestData))]
+        public void Equals_Object_ReturnsExpected(DesignerSerializationVisibilityAttribute attribute, object other, bool expected)
         {
-            var attribute = new DesignerSerializationVisibilityAttribute(visibility);
+            Assert.Equal(expected, attribute.Equals(other));
+            if (other is DesignerSerializationVisibilityAttribute)
+            {
+                Assert.Equal(expected, attribute.GetHashCode().Equals(other.GetHashCode()));
+            }
+        }
 
-            Assert.Equal(visibility, attribute.Visibility);
+        public static IEnumerable<object[]> DefaultProperties_TestData()
+        {
+            yield return new object[] { DesignerSerializationVisibilityAttribute.Content, DesignerSerializationVisibility.Content, false };
+            yield return new object[] { DesignerSerializationVisibilityAttribute.Default, DesignerSerializationVisibility.Visible, true };
+            yield return new object[] { DesignerSerializationVisibilityAttribute.Hidden, DesignerSerializationVisibility.Hidden, false };
+            yield return new object[] { DesignerSerializationVisibilityAttribute.Visible, DesignerSerializationVisibility.Visible, true };
+        }
+
+        [Theory]
+        [MemberData(nameof(DefaultProperties_TestData))]
+        public void DefaultProperties_GetVisibility_ReturnsExpected(DesignerSerializationVisibilityAttribute attribute, DesignerSerializationVisibility expectedVisibility, bool expectedIsDefaultAttribute)
+        {
+            Assert.Equal(expectedVisibility, attribute.Visibility);
+            Assert.Equal(expectedIsDefaultAttribute, attribute.IsDefaultAttribute());
         }
     }
 }

--- a/src/System.ComponentModel.Primitives/tests/EventHandlerListTests.cs
+++ b/src/System.ComponentModel.Primitives/tests/EventHandlerListTests.cs
@@ -9,7 +9,7 @@ namespace System.ComponentModel.Tests
     public class EventHandlerListTests
     {
         [Fact]
-        public void AddHandle_RemoveHandle_Roundtrips()
+        public void AddHandler_RemoveHandler_Roundtrips()
         {
             var list = new EventHandlerList();
 
@@ -38,7 +38,7 @@ namespace System.ComponentModel.Tests
         }
 
         [Fact]
-        public void AddHandle_SameKey_CombinesDelegates()
+        public void AddHandler_SameKey_CombinesDelegates()
         {
             var list = new EventHandlerList();
 

--- a/src/System.ComponentModel.Primitives/tests/EventHandlerListTests.cs
+++ b/src/System.ComponentModel.Primitives/tests/EventHandlerListTests.cs
@@ -4,78 +4,72 @@
 
 using Xunit;
 
-namespace System.ComponentModel.Primitives.Tests
+namespace System.ComponentModel.Tests
 {
     public class EventHandlerListTests
     {
         [Fact]
-        public void AddHandler_Getter_RemoveHandler_Getter_Roundtrips()
+        public void AddHandle_RemoveHandle_Roundtrips()
         {
             var list = new EventHandlerList();
 
-            // Create two different delegate instances
-            Action a1 = () => Assert.True(false);
-            Action a2 = () => Assert.False(true);
-            Assert.NotSame(a1, a2);
+            Action action1 = () => Assert.True(false);
+            Action action2 = () => Assert.False(true);
 
-            // Neither entry in the list has a delegate
-            Assert.Null(list["key1"]);
+            // Add the first delegate to the first entry.
+            list.AddHandler("key1", action1);
+            Assert.Same(action1, list["key1"]);
             Assert.Null(list["key2"]);
 
-            // Add the first delegate to the first entry
-            list.AddHandler("key1", a1);
-            Assert.Same(a1, list["key1"]);
-            Assert.Null(list["key2"]);
+            // Add the second delegate to the second entry.
+            list.AddHandler("key2", action2);
+            Assert.Same(action1, list["key1"]);
+            Assert.Same(action2, list["key2"]);
 
-            // Add the second delegate to the second entry
-            list.AddHandler("key2", a2);
-            Assert.Same(a1, list["key1"]);
-            Assert.Same(a2, list["key2"]);
-
-            // Then remove the first delegate
-            list.RemoveHandler("key1", a1);
+            // Then remove the first delegate.
+            list.RemoveHandler("key1", action1);
             Assert.Null(list["key1"]);
-            Assert.Same(a2, list["key2"]);
+            Assert.Same(action2, list["key2"]);
 
-            // And remove the second delegate
-            list.RemoveHandler("key2", a2);
+            // And remove the second delegate.
+            list.RemoveHandler("key2", action2);
             Assert.Null(list["key1"]);
             Assert.Null(list["key2"]);
         }
 
         [Fact]
-        public void AddHandler_MultipleInSameKey_Getter_CombinedDelegates()
+        public void AddHandle_SameKey_CombinesDelegates()
         {
             var list = new EventHandlerList();
 
-            // Create two delegates that will increase total by different amounts
+            // Create two delegates that will increase total by different amounts.
             int total = 0;
             Action a1 = () => total += 1;
             Action a2 = () => total += 2;
 
-            // Add both delegates for the same key and make sure we get them both out of the indexer
+            // Add both delegates for the same key and make sure we get them both out of the indexer.
             list.AddHandler("key1", a1);
             list.AddHandler("key1", a2);
             list["key1"].DynamicInvoke();
             Assert.Equal(3, total);
 
-            // Remove the first delegate and make sure the second delegate can still be retrieved
+            // Remove the first delegate and make sure the second delegate can still be retrieved.
             list.RemoveHandler("key1", a1);
             list["key1"].DynamicInvoke();
             Assert.Equal(5, total);
 
-            // Remove a delegate that was never in the list; nop
+            // Remove a delegate that was never in the list; nop.
             list.RemoveHandler("key1", new Action(() => { }));
             list["key1"].DynamicInvoke();
             Assert.Equal(7, total);
 
-            // Then remove the second delegate
+            // Then remove the second delegate.
             list.RemoveHandler("key1", a2);
             Assert.Null(list["key1"]);
         }
 
         [Fact]
-        public void AddHandlers_Gettable()
+        public void AddHandlers_ValidList_AddsDelegates()
         {
             var list1 = new EventHandlerList();
             var list2 = new EventHandlerList();
@@ -97,33 +91,34 @@ namespace System.ComponentModel.Primitives.Tests
         }
 
         [Fact]
+        public void AddHandlers_NullList_ThrowsNullReferenceException()
+        {
+            var list = new EventHandlerList();
+            Assert.Throws<NullReferenceException>(() => list.AddHandlers(null));
+        }
+
+        [Fact]
         public void Dispose_ClearsList()
         {
             var list = new EventHandlerList();
 
-            // Create two different delegate instances
-            Action a1 = () => Assert.True(false);
-            Action a2 = () => Assert.False(true);
-            Assert.NotSame(a1, a2);
+            // Create two different delegate instances.
+            Action action1 = () => Assert.True(false);
+            Action action2 = () => Assert.False(true);
 
-            // Neither entry in the list has a delegate
-            Assert.Null(list["key1"]);
-            Assert.Null(list["key2"]);
-
+            // The list is still usable after disposal.
             for (int i = 0; i < 2; i++)
             {
                 // Add the delegates
-                list.AddHandler("key1", a1);
-                list.AddHandler("key2", a2);
-                Assert.Same(a1, list["key1"]);
-                Assert.Same(a2, list["key2"]);
+                list.AddHandler("key1", action1);
+                list.AddHandler("key2", action2);
+                Assert.Same(action1, list["key1"]);
+                Assert.Same(action2, list["key2"]);
 
-                // Dispose to clear the list
+                // Dispose to clear the list.
                 list.Dispose();
                 Assert.Null(list["key1"]);
                 Assert.Null(list["key2"]);
-
-                // List is still usable, though, so loop around to do it again
             }
         }
 
@@ -150,28 +145,36 @@ namespace System.ComponentModel.Primitives.Tests
         public void RemoveHandler_EmptyList_Nop()
         {
             var list = new EventHandlerList();
-            list.RemoveHandler("key1", new Action(() => { })); // no error
+            list.RemoveHandler("key1", new Action(() => { }));
+            list.RemoveHandler("key1", null);
+            list.RemoveHandler(null, null);
         }
 
         [Fact]
-        public void NullKey_Valid()
+        public void Indexer_SetNullKey_Nop()
         {
             var list = new EventHandlerList();
 
-            int total = 0;
-            Action a1 = () => total += 1;
-
-            list[null] = a1;
-            Assert.Same(a1, list[null]);
+            Action action = () => { };
+            list[null] = action;
+            Assert.Same(action, list[null]);
         }
 
         [Fact]
-        public void NullValue_Nop()
+        public void Indexer_SetNullValue_Nop()
         {
             var list = new EventHandlerList();
 
             list["key1"] = null;
             Assert.Null(list["key1"]);
+        }
+
+        [Fact]
+        public void Indexer_GetNoSuchKey_ReturnsNull()
+        {
+            var list = new EventHandlerList();
+            Assert.Null(list["key"]);
+            Assert.Null(list[null]);
         }
     }
 }

--- a/src/System.ComponentModel.Primitives/tests/RefreshPropertiesAttributeTests.cs
+++ b/src/System.ComponentModel.Primitives/tests/RefreshPropertiesAttributeTests.cs
@@ -9,47 +9,52 @@ namespace System.ComponentModel.Primitives.Tests
 {
     public class RefreshPropertiesAttributeTests
     {
-        [Fact]
-        public void Equals_DifferentValues()
+        [Theory]
+        [InlineData(RefreshProperties.None - 1, false)]
+        [InlineData(RefreshProperties.All, false)]
+        [InlineData(RefreshProperties.None, true)]
+        [InlineData(RefreshProperties.Repaint, false)]
+        public static void Ctor_Refresh(RefreshProperties refresh, bool expectedIsDefaultAttribute)
         {
-            Assert.False(RefreshPropertiesAttribute.All.Equals(RefreshPropertiesAttribute.Repaint));
+            var attribute = new RefreshPropertiesAttribute(refresh);
+            Assert.Equal(refresh, attribute.RefreshProperties);
+            Assert.Equal(expectedIsDefaultAttribute, attribute.IsDefaultAttribute());
         }
 
-        [Fact]
-        public void Equals_Null()
+        public static IEnumerable<object[]> Equals_TestData()
         {
-            Assert.False(RefreshPropertiesAttribute.All.Equals(null));
-        }
+            yield return new object[] { RefreshPropertiesAttribute.All, RefreshPropertiesAttribute.All, true };
+            yield return new object[] { RefreshPropertiesAttribute.All, new RefreshPropertiesAttribute(RefreshProperties.All), true };
+            yield return new object[] { RefreshPropertiesAttribute.All, RefreshPropertiesAttribute.Repaint, false };
 
-        [Fact]
-        public void Equals_SameValue()
-        {
-            Assert.True(RefreshPropertiesAttribute.Default.Equals(RefreshPropertiesAttribute.Default));
+            yield return new object[] { RefreshPropertiesAttribute.All, new object(), false };
+            yield return new object[] { RefreshPropertiesAttribute.All, null, false };
         }
 
         [Theory]
-        [InlineData(RefreshProperties.All)]
-        [InlineData(RefreshProperties.None)]
-        [InlineData(RefreshProperties.Repaint)]
-        public void GetRefreshProperties(RefreshProperties value)
+        [MemberData(nameof(Equals_TestData))]
+        public void Equals_Object_ReturnsExpected(RefreshPropertiesAttribute attribute, object other, bool expected)
         {
-            var attribute = new RefreshPropertiesAttribute(value);
+            Assert.Equal(expected, attribute.Equals(other));
+            if (other is RefreshPropertiesAttribute)
+            {
+                Assert.Equal(expected, attribute.GetHashCode().Equals(other.GetHashCode()));
+            }
+        }
 
-            Assert.Equal(value, attribute.RefreshProperties);
+        public static IEnumerable<object[]> DefaultProperties_TestData()
+        {
+            yield return new object[] { RefreshPropertiesAttribute.Default, RefreshProperties.None, true };
+            yield return new object[] { RefreshPropertiesAttribute.All, RefreshProperties.All, false };
+            yield return new object[] { RefreshPropertiesAttribute.Repaint, RefreshProperties.Repaint, false };
         }
 
         [Theory]
-        [MemberData(nameof(RefreshPropertiesAttributeData))]
-        public void NameTests(RefreshPropertiesAttribute attribute, RefreshProperties refreshProperties)
+        [MemberData(nameof(DefaultProperties_TestData))]
+        public void DefaultProperties_GetRefreshProperties_ReturnsExpected(RefreshPropertiesAttribute attribute, RefreshProperties expectedRefreshProperties, bool expectedIsDefaultAttribute)
         {
-            Assert.Equal(refreshProperties, attribute.RefreshProperties);
-        }
-
-        private static IEnumerable<object[]> RefreshPropertiesAttributeData()
-        {
-            yield return new object[] { RefreshPropertiesAttribute.Default, RefreshProperties.None };
-            yield return new object[] { RefreshPropertiesAttribute.All, RefreshProperties.All };
-            yield return new object[] { RefreshPropertiesAttribute.Repaint, RefreshProperties.Repaint };
+            Assert.Equal(expectedRefreshProperties, attribute.RefreshProperties);
+            Assert.Equal(expectedIsDefaultAttribute, attribute.IsDefaultAttribute());
         }
     }
 }


### PR DESCRIPTION
~I moved some code to ComponentModel.Primitives and saw that theres ~70% coverage. So here are some tests to bring it up to 100%.~

I've now split up this PR as it was v large. Together, they increase CC to 100%