### PR TITLE
Add RemoteInvoke checks for closed-over state

### DIFF
--- a/src/System.Console/tests/WindowAndCursorProps.cs
+++ b/src/System.Console/tests/WindowAndCursorProps.cs
@@ -138,7 +138,7 @@ public class WindowAndCursorProps : RemoteExecutorTestBase
         Assert.NotNull(Console.Title);
     }
 
-    [Theory]
+    [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))] // Nano currently ignores set title
     [InlineData(10)]
     [InlineData(256)]
     [InlineData(1024)]

--- a/src/System.Console/tests/WindowAndCursorProps.cs
+++ b/src/System.Console/tests/WindowAndCursorProps.cs
@@ -146,13 +146,13 @@ public class WindowAndCursorProps : RemoteExecutorTestBase
     public static void Title_Set_Windows(int lengthOfTitle)
     {
         // Try to set the title to some other value.
-        RemoteInvoke(() =>
+        RemoteInvoke(lengthOfTitleString =>
         {
-            string newTitle = new string('a', lengthOfTitle);
+            string newTitle = new string('a', int.Parse(lengthOfTitleString));
             Console.Title = newTitle;
             Assert.Equal(newTitle, Console.Title);
             return SuccessExitCode;
-        }).Dispose();
+        }, lengthOfTitle.ToString()).Dispose();
     }
 
     [Fact]


### PR DESCRIPTION
Try to proactively catch some specific misuses of RemoteInvoke, e.g. closing over state in a lambda passed to it.  Right now such data isn't serialized/marshaled to the remote process.  Several folks have bumped up against this when writing new tests, and diagnosing the problem isn't always obvious.

The check also ended up catching an existing case where a test wasn't actually doing what was intended because of such an error, so I fixed that, too.

cc: @danmosemsft, @Priya91 