### PR TITLE
Adding Span<char> IndexOf performance test

### DIFF
--- a/src/System.Memory/tests/Performance/Perf.Span.IndexOf.cs
+++ b/src/System.Memory/tests/Performance/Perf.Span.IndexOf.cs
@@ -1,0 +1,94 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Xunit.Performance;
+using Xunit;
+
+namespace System.Memory.Tests
+{
+    public class Perf_Span_IndexOf
+    {
+        private const int InnerCount = 100000;
+
+        [Benchmark(InnerIterationCount = InnerCount)]
+        [InlineData(1)]
+        [InlineData(10)]
+        [InlineData(100)]
+        [InlineData(1000)]
+        [InlineData(10000)]
+        public void SpanIndexOfChar(int size)
+        {
+            Span<char> charSpan = new char[size];
+            charSpan[size/2] = '5';
+
+            int index = 0;
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        index |= charSpan.IndexOf('5');
+                    }
+                }
+            }
+            Assert.Equal(size/2, index);
+        }
+        
+        [Benchmark(InnerIterationCount = InnerCount)]
+        [InlineData(1)]
+        [InlineData(10)]
+        [InlineData(100)]
+        [InlineData(1000)]
+        [InlineData(10000)]
+        public void SpanIndexOfCharAsBytes(int size)
+        {
+            Span<char> charSpan = new char[size];
+            charSpan[size/2] = '5';
+            Span<byte> byteSpan = charSpan.AsBytes();
+
+            int index = 0;
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        index |= byteSpan.IndexOf(53);        // '5' = 53
+                    }
+                }
+            }
+
+            Assert.Equal(size > 1 ? size : 0, index);
+        }
+        
+        [Benchmark(InnerIterationCount = InnerCount)]
+        [InlineData(1)]
+        [InlineData(10)]
+        [InlineData(100)]
+        [InlineData(1000)]
+        [InlineData(10000)]
+        public void StringIndexOfChar(int size)
+        {
+            string str = new string('0', size/2) + "5";
+            if (size > 1)
+            {
+                str += new string('0', size/2 - 1);
+            }
+
+            int index = 0;
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        index |= str.IndexOf('5');
+                    }
+                }
+            }
+            Assert.Equal(size/2, index);
+        }
+    }
+}

--- a/src/System.Memory/tests/Performance/Perf.Span.IndexOf.cs
+++ b/src/System.Memory/tests/Performance/Perf.Span.IndexOf.cs
@@ -16,14 +16,13 @@ namespace System.Memory.Tests
         [InlineData(10)]
         [InlineData(100)]
         [InlineData(1000)]
-        [InlineData(10000)]
         public void SpanIndexOfChar(int size)
         {
             Span<char> charSpan = new char[size];
             charSpan[size/2] = '5';
 
             int index = 0;
-            foreach (var iteration in Benchmark.Iterations)
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
@@ -41,7 +40,6 @@ namespace System.Memory.Tests
         [InlineData(10)]
         [InlineData(100)]
         [InlineData(1000)]
-        [InlineData(10000)]
         public void SpanIndexOfCharAsBytes(int size)
         {
             Span<char> charSpan = new char[size];
@@ -49,7 +47,7 @@ namespace System.Memory.Tests
             Span<byte> byteSpan = charSpan.AsBytes();
 
             int index = 0;
-            foreach (var iteration in Benchmark.Iterations)
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
@@ -67,7 +65,6 @@ namespace System.Memory.Tests
         [InlineData(10)]
         [InlineData(100)]
         [InlineData(1000)]
-        [InlineData(10000)]
         public void StringIndexOfChar(int size)
         {
             string str = new string('0', size/2) + "5";
@@ -77,7 +74,7 @@ namespace System.Memory.Tests
             }
 
             int index = 0;
-            foreach (var iteration in Benchmark.Iterations)
+            foreach (BenchmarkIteration iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {

--- a/src/System.Memory/tests/Performance/Perf.Span.IndexOf.cs
+++ b/src/System.Memory/tests/Performance/Perf.Span.IndexOf.cs
@@ -59,7 +59,6 @@ namespace System.Memory.Tests
                     }
                 }
             }
-
             Assert.Equal(size > 1 ? size : 0, index);
         }
         


### PR DESCRIPTION
cc @shiftylogic, @KrzysztofCwalina, @benaadams 

Please note the (expected?) performance degradation when hardware acceleration is disabled for SpanIndexOfCharAsBytes.
Can we improve the performance for \<byte\> IndexOf when IsHardwareAcceleration == false? Shouldn't it still match the performance of SpanIndexOfChar? Why is it ~2x worst? **Is this expected since we have twice as many bytes to search through compared to the number of chars?**

![image](https://user-images.githubusercontent.com/6527137/27054036-64316c6a-4f74-11e7-8768-5464a8c33477.png)

![image](https://user-images.githubusercontent.com/6527137/27054037-66171b88-4f74-11e7-9d70-3d503483d89a.png)

![image](https://user-images.githubusercontent.com/6527137/27054034-5f1b743c-4f74-11e7-907c-77264f55be8a.png)
