### PR TITLE
Fix regressions in corefx tests on ILC.

### DIFF
--- a/src/System.Collections.Immutable/tests/Resources/System.Collections.Immutable.Tests.rd.xml
+++ b/src/System.Collections.Immutable/tests/Resources/System.Collections.Immutable.Tests.rd.xml
@@ -1,7 +1,10 @@
 <Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
   <Library>
     <!-- Needed because of objects in [Theory] data which causes xunit to reflect on its ToString() -->
-    <Type Name="System.Collections.Generic.ComparisonComparer&lt;T&gt;" Dynamic="Required Public" />
+    <Type Name="System.Collections.Generic.ComparisonComparer`1" Dynamic="Required Public" />
+    <Type Name="System.Collections.Generic.GenericComparer`1" Dynamic="Required Public" />
+    <Type Name="System.Collections.Generic.GenericEqualityComparer`1" Dynamic="Required Public" />
+    <Type Name="System.Collections.Generic.ObjectComparer`1" Dynamic="Required Public" />
   </Library>
 </Directives>
 

--- a/src/System.Linq/tests/Resources/System.Linq.Tests.rd.xml
+++ b/src/System.Linq/tests/Resources/System.Linq.Tests.rd.xml
@@ -2,6 +2,7 @@
   <Library>
     <!-- Needed because of StringComparer instance in [Theory] data which causes xunit to reflect on its ToString() -->
     <Type Name="System.OrdinalComparer" Dynamic="Required Public" />
+    <Type Name="System.Collections.Generic.GenericEqualityComparer`1" Dynamic="Required Public" />
 
     <!-- ConsistencyTests.MatchSequencePattern() test explicitly probes these types -->
     <Type Name="System.Linq.Enumerable" Dynamic="Required Public" />


### PR DESCRIPTION
This was caused by the changes to reflection policy
for serialized types. A few internal comparer objects
that used to be reflection-blocked now became unblocked
and prone to throwing MME's.