### PR TITLE
Make Cookie.InternalSetName public for uapaot

### DIFF
--- a/src/System.Net.Primitives/src/System.Net.Primitives.csproj
+++ b/src/System.Net.Primitives/src/System.Net.Primitives.csproj
@@ -17,6 +17,7 @@
     <!-- SYSTEM_NET_PRIMITIVES_DLL is required to allow source-level code sharing for types defined within the
          System.Net.Internals namespace. -->
     <DefineConstants>$(DefineConstants);SYSTEM_NET_PRIMITIVES_DLL</DefineConstants>
+    <DefineConstants Condition="'$(TargetGroup)' == 'uap'">$(DefineConstants);uap</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Net\AuthenticationSchemes.cs" />

--- a/src/System.Net.Primitives/src/System/Net/Cookie.cs
+++ b/src/System.Net.Primitives/src/System/Net/Cookie.cs
@@ -214,8 +214,7 @@ namespace System.Net
         }
 
 /* 
-
-git push 
+   VSO 449560
    Reflecting on internal method wont work on AOT without rd.xml and DisableReflection
    block in toolchain.Networking team will be working on exposing methods from S.Net.Primitive
    public,this is a temporary workaround till that happens. 

--- a/src/System.Net.Primitives/src/System/Net/Cookie.cs
+++ b/src/System.Net.Primitives/src/System/Net/Cookie.cs
@@ -213,7 +213,19 @@ namespace System.Net
             }
         }
 
-        internal bool InternalSetName(string value)
+/* 
+
+git push 
+   Reflecting on internal method wont work on AOT without rd.xml and DisableReflection
+   block in toolchain.Networking team will be working on exposing methods from S.Net.Primitive
+   public,this is a temporary workaround till that happens. 
+*/
+#if uap 
+        public
+#else 
+        internal
+#endif
+        bool InternalSetName(string value)
         {
             if (String.IsNullOrEmpty(value) || value[0] == '$' || value.IndexOfAny(ReservedToName) != -1)
             {


### PR DESCRIPTION
This is a workaround till the required methods from
System.Net.Primitives are made public

Internal Bug: 449560