### PR TITLE
Fix failure in GCNotificationTests

### DIFF
--- a/src/System.Runtime/tests/System/GCTests.cs
+++ b/src/System.Runtime/tests/System/GCTests.cs
@@ -488,11 +488,11 @@ namespace System.Tests
         {
             RemoteInvokeOptions options = new RemoteInvokeOptions();
             options.TimeOut = TimeoutMilliseconds;
-            RemoteInvoke(() =>
+            RemoteInvoke((approachString, timeoutString) =>
                 {
-                    TestWait(approach, timeout);
+                    TestWait(bool.Parse(approachString), int.Parse(timeoutString));
                     return SuccessExitCode;
-                }, options).Dispose();
+                }, approach.ToString(), timeout.ToString(), options).Dispose();
         }
 
         [Fact]


### PR DESCRIPTION
Assert added in 8058ec1b0c3eecf9b9835951c46aeefd601831ec exposed that this test was always using the same values of timeout and approach.