### PR TITLE
Dump runtime info

### DIFF
--- a/src/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
@@ -10,6 +10,21 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
     public class DescriptionNameTests
     {
         [Fact]
+        public void DumpRuntimeInformationToConsole()
+        {
+            // Not really a test, but useful to dump to the log to
+            // sanity check that the test run or CI job
+            // was actually run on the OS that it claims to be on
+            string osd = RuntimeInformation.OSDescription.Trim();
+            string osv = Environment.OSVersion.ToString();
+            string osa = RuntimeInformation.OSArchitecture.ToString();
+            string pra = RuntimeInformation.ProcessArchitecture.ToString();
+            string frd = RuntimeInformation.FrameworkDescription.Trim();
+
+            Console.WriteLine($@"OSDescription={osd} OSVersion={osv} OSArchitecture={osa} ProcessArchitecture={pra} FrameworkDescription={frd}");
+        }
+
+        [Fact]
         [SkipOnTargetFramework(~TargetFrameworkMonikers.Netcoreapp)]
         public void VerifyRuntimeDebugNameOnNetCoreApp()
         {

--- a/src/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
@@ -15,13 +15,14 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
             // Not really a test, but useful to dump to the log to
             // sanity check that the test run or CI job
             // was actually run on the OS that it claims to be on
+            string dvs = PlatformDetection.GetDistroVersionString();
             string osd = RuntimeInformation.OSDescription.Trim();
             string osv = Environment.OSVersion.ToString();
             string osa = RuntimeInformation.OSArchitecture.ToString();
             string pra = RuntimeInformation.ProcessArchitecture.ToString();
             string frd = RuntimeInformation.FrameworkDescription.Trim();
 
-            Console.WriteLine($@"OSDescription={osd} OSVersion={osv} OSArchitecture={osa} ProcessArchitecture={pra} FrameworkDescription={frd}");
+            Console.WriteLine($@"{dvs} OS={osd} OSVer={osv} OSArch={osa} Arch={pra} Framework={frd}");
         }
 
         [Fact]

--- a/src/System.Runtime.InteropServices.RuntimeInformation/tests/System.Runtime.InteropServices.RuntimeInformation.Tests.csproj
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/tests/System.Runtime.InteropServices.RuntimeInformation.Tests.csproj
@@ -14,6 +14,9 @@
     <Compile Include="CheckArchitectureTests.cs" />
     <Compile Include="CheckPlatformTests.cs" />
     <Compile Include="DescriptionNameTests.cs" />
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>Common\System\PlatformDetection.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
For many distros, the only testing we do is in our full test runs. We are trusting that the correct images are used in those runs: if a mistake creeps in, we could end up not testing on the platform we expect. As a simple sanity check, this adds a "test" that dumps relevant information to the console so we can inspect the logs and verify the platform.