### PR TITLE
Store Activity wrapped into ObjectHandle in Logical CallContext 

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.Current.net45.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.Current.net45.cs
@@ -2,13 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.Remoting;
 using System.Runtime.Remoting.Messaging;
 using System.Security;
 
 namespace System.Diagnostics
 {
-    // this code is specific to .NET 4.5 and uses CallContext to store Activity.Current which requires Activity to be Serializable.
-    [Serializable] // DO NOT remove
     public partial class Activity
     {
         /// <summary>
@@ -22,7 +21,14 @@ namespace System.Diagnostics
 #endif
             get
             {
-                return (Activity)CallContext.LogicalGetData(FieldKey);
+                ObjectHandle activityHandle = (ObjectHandle)CallContext.LogicalGetData(FieldKey);
+                
+                // Unwrap the Activity if it was set in the same AppDomain (as FieldKey is AppDomain-specific). 
+                if (activityHandle != null)
+                {
+                    return (Activity)activityHandle.Unwrap();
+                }
+                return null;
             }
             
 #if ALLOW_PARTIALLY_TRUSTED_CALLERS
@@ -30,18 +36,23 @@ namespace System.Diagnostics
 #endif
             private set
             {
-                CallContext.LogicalSetData(FieldKey, value);
+                // Applications may implicitly or explicitly call other AppDomains
+                // that do not have DiagnosticSource DLL, therefore may not be able to resolve Activity type stored in the logical call context. 
+                // To avoid it, we wrap Activity with ObjectHandle.
+                CallContext.LogicalSetData(FieldKey, new ObjectHandle(value));
             }
         }
 
 #region private
 
-        [Serializable] // DO NOT remove
         private partial class KeyValueListNode
         {
         }
 
-        private static readonly string FieldKey = $"{typeof(Activity).FullName}";
+        // Slot name depends on the AppDomain Id in order to prevent AppDomains to use the same Activity
+        // Cross AppDomain calls are considered as 'external' i.e. only Activity Id and Baggage should be propagated and 
+        // new Activity should be started for the RPC calls (incoming and outgoing) 
+        private static readonly string FieldKey = $"{typeof(Activity).FullName}_{AppDomain.CurrentDomain.Id}";
 #endregion
     }
 }


### PR DESCRIPTION
This change addresses issue when an application has Activity stored in the logical call context and makes a call to another AppDomain that do not have DiagnosticSource.dll loaded.
In this case, an application may crash failing to find DiagnosticSource.dll. This issue potentially affects Azure CloudService users on NET .45 that use some features (role environments change events) of WindowsAzure.ServiceRuntime and ApplicationInsights

So this change stores Activity wrapped into `ObjectHandle` in the logical call context.
First of all, it allows using AppDomains that do not load DiagnosticSource. It also allows to remove Serializable attribute (see below why it's a good thing) as `ObjectHandle` implements `MarshalByRefObject`.

Supporting [Serializable] Activity across AppDomains creates several issues:
1. Copy of the Activity is created when Activity is serialized and it may lead to collisions in Activity.Id generation.
2. If users will start to serialize Activity while they are on 4.5 and later upgrade to 4.6+, their code will stop working, as @stephentoub [noticed](https://github.com/dotnet/corefx/issues/20640#issuecomment-305894583), since it's not serializable on .net46 
3.  On other .NET versions, Activity uses AsyncLocal to flow Current, that does not flow across AppDomains. Only Activity.Id and Baggage are supposed to propagate. Flowing it between AppDomains is not a requirement, on the contrary, it is inconsistent behavior.

So, this change does not allow different AppDomains reuse Activity.
This is also important to allow wrapping Activity into `ObjectHandle`: Activity does not inherit from  `MarshalByRefObject` and could not be used remotely by reference anyway.
Changing Activity to inherit from the `MarshalByRefObject` creates some complications and does not bring any value (see p3 above).

Activity was never released as stable and chances that someone already uses it in cross AppDomain calls on .NET 4.5 are inconceivable.

These changes were tested manually on .NET 4.5. Automation is in progress in partner team infrastructure (ApplicationInsights).

@vancem @SergeyKanzhelev @stephentoub please review


Fixes #21027
