### PR TITLE
Add a helper to BinaryFormatterHelpers to check that exceptions throw a PNSE on deserialization

### DIFF
--- a/src/Common/tests/System/PlatformDetection.cs
+++ b/src/Common/tests/System/PlatformDetection.cs
@@ -21,6 +21,7 @@ namespace System
         public static bool IsUap => IsWinRT || IsNetNative;
         public static bool IsFullFramework => RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
         public static bool IsNetNative => RuntimeInformation.FrameworkDescription.StartsWith(".NET Native", StringComparison.OrdinalIgnoreCase);
+        public static bool IsNetCore => RuntimeInformation.FrameworkDescription.StartsWith(".NET Core", StringComparison.OrdinalIgnoreCase);
 
         public static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
         public static bool IsWindows7 => IsWindows && GetWindowsVersion() == 6 && GetWindowsMinorVersion() == 1;

--- a/src/Common/tests/System/Runtime/Serialization/Formatters/BinaryFormatterHelpers.cs
+++ b/src/Common/tests/System/Runtime/Serialization/Formatters/BinaryFormatterHelpers.cs
@@ -81,6 +81,7 @@ namespace System.Runtime.Serialization.Formatters.Tests
                 return;
             }
 
+            // Construct a valid serialization payload.
             var info = new SerializationInfo(typeof(T), new FormatterConverter());
             info.AddValue("ClassName", "ClassName");
             info.AddValue("Message", "Message");
@@ -93,7 +94,16 @@ namespace System.Runtime.Serialization.Formatters.Tests
             info.AddValue("Source", null);
             info.AddValue("ExceptionMethod", null);
 
-            ConstructorInfo constructor = typeof(T).GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, null, new Type[] { typeof(SerializationInfo), typeof(StreamingContext) }, null);
+            ConstructorInfo constructor = null;
+            foreach (ConstructorInfo c in typeof(T).GetTypeInfo().DeclaredConstructors)
+            {
+                ParameterInfo[] parameters = c.GetParameters();
+                if (parameters.Length == 2 && parameters[0].ParameterType == typeof(SerializationInfo) && parameters[1].ParameterType == typeof(StreamingContext))
+                {
+                    constructor = c;
+                    break;
+                }
+            };
             Assert.NotNull(constructor);
 
             Exception ex = Assert.Throws<TargetInvocationException>(() => constructor.Invoke(new object[] { info, new StreamingContext() }));

--- a/src/Common/tests/System/Runtime/Serialization/Formatters/BinaryFormatterHelpers.cs
+++ b/src/Common/tests/System/Runtime/Serialization/Formatters/BinaryFormatterHelpers.cs
@@ -108,7 +108,12 @@ namespace System.Runtime.Serialization.Formatters.Tests
                     break;
                 }
             };
-            Assert.NotNull(constructor);
+
+            // .NET Native prevents reflection on private constructors on non-serializable types.
+            if (constructor == null)
+            {
+                return;
+            }
 
             Exception ex = Assert.Throws<TargetInvocationException>(() => constructor.Invoke(new object[] { info, new StreamingContext() }));
             Assert.IsType<PlatformNotSupportedException>(ex.InnerException);

--- a/src/Microsoft.Win32.Primitives/src/System/ComponentModel/Win32Exception.cs
+++ b/src/Microsoft.Win32.Primitives/src/System/ComponentModel/Win32Exception.cs
@@ -7,80 +7,57 @@ using System.Runtime.Serialization;
 
 namespace System.ComponentModel
 {
-    /// <devdoc>
-    ///    <para>The exception that is thrown for a Win32 error code.</para>
-    /// </devdoc>
+    /// <summary>
+    /// The exception that is thrown for a Win32 error code.
+    /// </summary>
     public partial class Win32Exception : ExternalException, ISerializable
     {
-        /// <devdoc>
-        ///    <para>Represents the Win32 error code associated with this exception. This 
-        ///       field is read-only.</para>
-        /// </devdoc>
-        private readonly int nativeErrorCode;
-
         private const int E_FAIL = unchecked((int)0x80004005);
 
-        /// <devdoc>
-        /// <para>Initializes a new instance of the <see cref='System.ComponentModel.Win32Exception'/> class with the last Win32 error 
-        ///    that occurred.</para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='System.ComponentModel.Win32Exception'/> class with the last Win32 error 
+        /// that occurred.
+        /// </summary>
         public Win32Exception() : this(Marshal.GetLastWin32Error())
         {
         }
-        /// <devdoc>
-        /// <para>Initializes a new instance of the <see cref='System.ComponentModel.Win32Exception'/> class with the specified error.</para>
-        /// </devdoc>
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref='System.ComponentModel.Win32Exception'/> class with the specified error.
+        /// </summary>
         public Win32Exception(int error) : this(error, GetErrorMessage(error))
         {
         }
-        /// <devdoc>
-        /// <para>Initializes a new instance of the <see cref='System.ComponentModel.Win32Exception'/> class with the specified error and the 
-        ///    specified detailed description.</para>
-        /// </devdoc>
-        public Win32Exception(int error, string message)
-        : base(message)
+        /// <summary>
+        /// Initializes a new instance of the <see cref='System.ComponentModel.Win32Exception'/> class with the specified error and the 
+        /// specified detailed description.
+        /// </summary>
+        public Win32Exception(int error, string message) : base(message)
         {
-            nativeErrorCode = error;
+            NativeErrorCode = error;
         }
 
-        /// <devdoc>
-        ///     Initializes a new instance of the Exception class with a specified error message.
-        ///     FxCop CA1032: Multiple constructors are required to correctly implement a custom exception.
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the Exception class with a specified error message.
+        /// </summary>
         public Win32Exception(string message) : this(Marshal.GetLastWin32Error(), message)
         {
         }
 
-        /// <devdoc>
-        ///     Initializes a new instance of the Exception class with a specified error message and a 
-        ///     reference to the inner exception that is the cause of this exception.
-        ///     FxCop CA1032: Multiple constructors are required to correctly implement a custom exception.
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the Exception class with a specified error message and a 
+        /// reference to the inner exception that is the cause of this exception.
+        /// </summary>
         public Win32Exception(string message, Exception innerException) : base(message, innerException)
         {
-            nativeErrorCode = Marshal.GetLastWin32Error();
+            NativeErrorCode = Marshal.GetLastWin32Error();
         }
 
-        protected Win32Exception(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
-            throw new PlatformNotSupportedException();
-        }
+        protected Win32Exception(SerializationInfo info, StreamingContext context) : base(info, context) { }
 
-        public override void GetObjectData(SerializationInfo info, StreamingContext context)
-        {
-            base.GetObjectData(info, context);
-        }
-
-        /// <devdoc>
-        ///    <para>Represents the Win32 error code associated with this exception. This 
-        ///       field is read-only.</para>
-        /// </devdoc>
-        public int NativeErrorCode
-        {
-            get
-            {
-                return nativeErrorCode;
-            }
-        }
+        /// <summary>
+        /// Represents the Win32 error code associated with this exception. This field is read-only.
+        /// </summary>
+        public int NativeErrorCode { get; }
     }
 }

--- a/src/Microsoft.Win32.Primitives/tests/Microsoft.Win32.Primitives.Tests.csproj
+++ b/src/Microsoft.Win32.Primitives/tests/Microsoft.Win32.Primitives.Tests.csproj
@@ -7,9 +7,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <ItemGroup>
-    <Compile Include="Win32Exception.cs" />
+    <Compile Include="Win32ExceptionTests.cs" />
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
-      <Link>CommonTest\System\PlatformDetection.cs</Link>
+      <Link>Common\System\PlatformDetection.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
       <Link>Common\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>

--- a/src/Microsoft.Win32.Primitives/tests/Win32ExceptionTests.cs
+++ b/src/Microsoft.Win32.Primitives/tests/Win32ExceptionTests.cs
@@ -2,10 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Tests;
 using System.Text;
 using Xunit;
@@ -100,6 +97,12 @@ namespace System.ComponentModel.Tests
                 ex = new Win32Exception(0x23);
                 Assert.Equal(expected: "Unknown error (0x23)", actual: ex.Message);
             }
+        }
+
+        [Fact]
+        public static void Deserialize_NetCore_ThrowsPlatformNotSupportedException()
+        {
+            BinaryFormatterHelpers.AssertExceptionDeserializationFails<Win32Exception>();
         }
     }
 }


### PR DESCRIPTION
This could be considered an experiment as I'm not sure what the reaction of y'all will be to it.

I've limited it to Win32Exception right now, but the idea is to use this helper in other places