### PR TITLE
Step 1 of fix for disabled System.Dynamic.Runtime test on ILC

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinderExtensions.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinderExtensions.cs
@@ -278,11 +278,36 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         public static bool HasSameMetadataDefinitionAs(this MemberInfo mi1, MemberInfo mi2)
         {
+            if (s_lazyHasSameMetadataDefinitionAsApi == null)
+            {
+                MethodInfo apiMethod = typeof(MemberInfo).GetMethod(
+                    "HasSameMetadataDefinitionAs",
+                    BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly | BindingFlags.ExactBinding,
+                    binder: null,
+                    types: new Type[] { typeof(MemberInfo) },
+                    modifiers: null);
+                if (apiMethod != null)
+                {
+                    s_lazyHasSameMetadataDefinitionAsApi = (Func<MemberInfo, MemberInfo, bool>)Delegate.CreateDelegate(typeof(Func<MemberInfo, MemberInfo, bool>), apiMethod);
+                }
+                else
+                {
+                    s_lazyHasSameMetadataDefinitionAsApi = HasSameMetadataDefinitionAsEmulator;
+                }
+            }
+
+            return s_lazyHasSameMetadataDefinitionAsApi(mi1, mi2);
+        }
+
+        private static bool HasSameMetadataDefinitionAsEmulator(this MemberInfo mi1, MemberInfo mi2)
+        {
 #if UNSUPPORTEDAPI
             return (mi1.MetadataToken == mi2.MetadataToken) && (mi1.Module == mi2.Module));
 #else
             return mi1.Module.Equals(mi2.Module) && s_MemberEquivalence(mi1, mi2);
 #endif
         }
+
+        private static volatile Func<MemberInfo, MemberInfo, bool> s_lazyHasSameMetadataDefinitionAsApi;
     }
 }

--- a/src/Microsoft.CSharp/src/Resources/Microsoft.CSharp.rd.xml
+++ b/src/Microsoft.CSharp/src/Resources/Microsoft.CSharp.rd.xml
@@ -82,6 +82,11 @@
         </Type>
         <Type Name="Object" Dynamic="Required Public" />
       </Namespace>
+      <Namespace Name="System.Reflection">
+        <Type Name="MemberInfo">
+          <Method Name="HasSameMetadataDefinitionAs" Dynamic="Required"/>
+        </Type>
+      </Namespace>
     </Assembly>
 
     <Assembly Name="System.Linq.Expressions">


### PR DESCRIPTION
(https://github.com/dotnet/corefx/issues/19895)

Make Microsoft.CSharp use the the real HasMetadataDefinitionAs()
api if it exists on the running framework. Since this library
is built on netstandard, it still needs to fall back on its
emulation on older frameworks.

Actual removal of the ActiveIssue will have to wait until
the new System.Runtime reference assembly propagates to
the Project N tree and the new api becomes reflectable.