### PR TITLE
Disable tests in System.Net.Requests for UAP

### DIFF
--- a/src/System.Net.Requests/tests/AuthenticationManagerTest.cs
+++ b/src/System.Net.Requests/tests/AuthenticationManagerTest.cs
@@ -26,6 +26,7 @@ namespace System.Net.Tests
             Assert.Throws<ArgumentNullException>(() => AuthenticationManager.Register(null));
         }
 
+        [ActiveIssue(20136, TargetFrameworkMonikers.Uap)]
         [Fact]
         public void Register_Unregister_ModuleCountUnchanged()
         {
@@ -41,6 +42,7 @@ namespace System.Net.Tests
             }).Dispose();           
         }
 
+        [ActiveIssue(20136, TargetFrameworkMonikers.Uap)]
         public void Register_UnregisterByScheme_ModuleCountUnchanged()
         {
             RemoteInvoke(() =>
@@ -64,6 +66,7 @@ namespace System.Net.Tests
             Assert.Equal(PlatformDetection.IsFullFramework ? 5 : 0, count);
         }
 
+        [ActiveIssue(20136, TargetFrameworkMonikers.Uap)]
         [Fact]
         public void CredentialPolicy_Roundtrip()
         {
@@ -82,6 +85,7 @@ namespace System.Net.Tests
             }).Dispose();
         }
 
+        [ActiveIssue(20136, TargetFrameworkMonikers.Uap)]
         [Fact]
         public void CustomTargetNameDictionary_ValidCollection()
         {

--- a/src/System.Net.Requests/tests/GlobalProxySelectionTest.cs
+++ b/src/System.Net.Requests/tests/GlobalProxySelectionTest.cs
@@ -38,6 +38,7 @@ namespace System.Net.Tests
             }
         }
 
+        [ActiveIssue(20136, TargetFrameworkMonikers.Uap)]
         [Fact]
         public void Select_Success()
         {

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -556,6 +556,7 @@ namespace System.Net.Tests
             Assert.Throws<ArgumentException>("value", () => request.Expect = "100-continue");
         }
 
+        [ActiveIssue(20136, TargetFrameworkMonikers.Uap)]
         [Fact]
         public void DefaultMaximumResponseHeadersLength_SetAndGetLength_ValuesMatch()
         {
@@ -578,6 +579,7 @@ namespace System.Net.Tests
             }).Dispose();
         }
 
+        [ActiveIssue(20136, TargetFrameworkMonikers.Uap)]
         [Fact]
         public void DefaultMaximumErrorResponseLength_SetAndGetLength_ValuesMatch()
         {
@@ -600,6 +602,7 @@ namespace System.Net.Tests
             }).Dispose();
         }
 
+        [ActiveIssue(20136, TargetFrameworkMonikers.Uap)]
         [Fact]
         public void DefaultCachePolicy_SetAndGetPolicyReload_ValuesMatch()
         {


### PR DESCRIPTION
Disable tests related to RemoteExecutor which still doesn't work in UAP.

This PR results in a clean UAP test run for System.Net.Requests.

Contributes to #20136