### PR TITLE
Fixing System.Security.AccessControl tests for uapaot

### DIFF
--- a/src/System.Security.AccessControl/tests/AccessRule.Tests.cs
+++ b/src/System.Security.AccessControl/tests/AccessRule.Tests.cs
@@ -39,6 +39,7 @@ namespace System.Security.AccessControl.Tests
 
         [Theory]
         [MemberData(nameof(AccessRule_TestData))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "FileSystemAccessRule is not supported on UAP")]
         public void AccessRule_Constructor(string sid, int accessMask, bool isInherited, int inheritanceFlags, int propagationFlags, int accessControlType)
         {
             IdentityReference identityReference = new SecurityIdentifier(sid);
@@ -59,6 +60,7 @@ namespace System.Security.AccessControl.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "FileSystemAccessRule is not supported on UAP")]
         public override void AccessRule_Constructor_Invalid()
         {
             AssertExtensions.Throws<ArgumentNullException>("identity", () => Constructor(null, 1, true, (InheritanceFlags)1, (PropagationFlags)1, (AccessControlType)0));

--- a/src/System.Security.AccessControl/tests/AuditRule.Tests.cs
+++ b/src/System.Security.AccessControl/tests/AuditRule.Tests.cs
@@ -40,6 +40,7 @@ namespace System.Security.AccessControl.Tests
 
         [Theory]
         [MemberData(nameof(AuditRule_TestData))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "FileSystemAuditRule is not supported on UAP")]
         public void AuditRule_Constructor(string sid, int accessMask, bool isInherited, int inheritanceFlags, int propagationFlags, int AuditFlags)
         {
             IdentityReference identityReference = new SecurityIdentifier(sid);
@@ -60,6 +61,7 @@ namespace System.Security.AccessControl.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "FileSystemAuditRule is not supported on UAP")]
         public override void AuditRule_Constructor_Invalid()
         {
             AssertExtensions.Throws<ArgumentNullException>("identity", () => Constructor(null, 1, true, (InheritanceFlags)1, (PropagationFlags)1, (AuditFlags)0));

--- a/src/System.Security.AccessControl/tests/Resources/System.Security.AccessControl.Tests.rd.xml
+++ b/src/System.Security.AccessControl/tests/Resources/System.Security.AccessControl.Tests.rd.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Library Name="System.Security.AccessControl.Tests">
+    <Assembly Name="System.Security.AccessControl">
+      <!-- Needed for 2 CustomAce tests that require constructor metadata -->
+      <Namespace Name="System.Security.AccessControl" Dynamic="Required All" />
+    </Assembly>
+  </Library>
+</Directives>

--- a/src/System.Security.AccessControl/tests/System.Security.AccessControl.Tests.csproj
+++ b/src/System.Security.AccessControl/tests/System.Security.AccessControl.Tests.csproj
@@ -76,5 +76,8 @@
       <Link>Common\System\AssertExtensions.cs</Link>
     </Compile>
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\$(AssemblyName).rd.xml" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
FYI: @bartonjs @steveharter @JeremyKuhne 

Disabling tests that require System.IO.Filesystem.AccessControl since its not supported on uap, and adding rd.xml to fix two additional tests that were failing due to missing metadata.

cc: @danmosemsft @safern 