### PR TITLE
Disable tests in System.Net.Mail for UAP

### DIFF
--- a/src/System.Net.Mail/tests/Functional/LoggingTest.cs
+++ b/src/System.Net.Mail/tests/Functional/LoggingTest.cs
@@ -24,6 +24,7 @@ namespace System.Net.Mail.Tests
             Assert.NotEmpty(EventSource.GenerateManifest(esType, esType.Assembly.Location));
         }
 
+        [ActiveIssue(20131, TargetFrameworkMonikers.Uap)]
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core")]
         public void EventSource_EventsRaisedAsExpected()


### PR DESCRIPTION
Disable tests related to RemoteExecutor which still doesn't work in UAP.

This PR results in a clean UAP test run for System.Net.Mail.

Contributes to #20131