### PR TITLE
Adjust WebSocketException serialization test

### DIFF
--- a/src/System.Net.WebSockets/tests/System.Net.WebSockets.Tests.csproj
+++ b/src/System.Net.WebSockets/tests/System.Net.WebSockets.Tests.csproj
@@ -16,6 +16,9 @@
     <Compile Include="$(CommonTestPath)\System\AssertExtensions.cs">
       <Link>Common\System\AssertExtensions.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>Common\System\PlatformDetection.cs</Link>
+    </Compile>    
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Net.WebSockets/tests/WebSocketExceptionTests.cs
+++ b/src/System.Net.WebSockets/tests/WebSocketExceptionTests.cs
@@ -180,7 +180,7 @@ namespace System.Net.WebSockets.Tests
             Assert.Same(inner, wse.InnerException);
         }
 
-        [Fact]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsFullFramework))]
         public void GetObjectData_Success()
         {
             var wse = new WebSocketException();


### PR DESCRIPTION
Disable test related to serialization. The test works in netcoreapp and
uap test runs. Not sure why it fails in uapaot.

Is serialization supported for this type in the first place?

This PR results in a clean UAPAOT test run for System.Net.WebSockets.

Contributes to #20132