### PR TITLE
Fix the remaining System.ConfigManager tests.

### DIFF
--- a/src/System.Configuration.ConfigurationManager/tests/Mono/ConfigurationSectionGroupTest.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/Mono/ConfigurationSectionGroupTest.cs
@@ -46,6 +46,7 @@ namespace MonoTests.System.Configuration
         }
 
         [Fact]
+        [ActiveIssue(21000, TargetFrameworkMonikers.UapAot)]
         public void EditAfterAdd()
         {
             Config cfg = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);

--- a/src/System.Configuration.ConfigurationManager/tests/Mono/TestUtil.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/Mono/TestUtil.cs
@@ -58,8 +58,8 @@ namespace MonoTests.System.Configuration.Util
         {
             get
             {
-                var asm = Assembly.GetEntryAssembly();
-                return asm.Location;
+                return Path.Combine(AppDomain.CurrentDomain.BaseDirectory,
+                    Assembly.GetEntryAssembly().ManifestModule.Name);
             }
         }
 
@@ -67,7 +67,7 @@ namespace MonoTests.System.Configuration.Util
         {
             get
             {
-                return Assembly.GetEntryAssembly().GetName().Name + ".config";
+                return Assembly.GetEntryAssembly().ManifestModule.Name + ".config";
             }
         }
     }

--- a/src/System.Configuration.ConfigurationManager/tests/Mono/TestUtil.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/Mono/TestUtil.cs
@@ -67,8 +67,7 @@ namespace MonoTests.System.Configuration.Util
         {
             get
             {
-                var exe = Path.GetFileName(ThisApplicationPath);
-                return exe + ".config";
+                return Assembly.GetEntryAssembly().GetName().Name + ".config";
             }
         }
     }

--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/ConfigurationElementCollectionTests.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/ConfigurationElementCollectionTests.cs
@@ -47,6 +47,7 @@ namespace System.ConfigurationTests
         }
 
         [Fact]
+        [ActiveIssue(21004, TargetFrameworkMonikers.UapAot)]
         public void NullComparerThrows()
         {
             Assert.Equal("comparer", Assert.Throws<ArgumentNullException>(() => new SimpleCollection(null)).ParamName);

--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/SectionGroupsTests.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/SectionGroupsTests.cs
@@ -54,6 +54,7 @@ namespace System.ConfigurationTests
 
         [Fact]
         [ActiveIssue("dotnet/corefx #19383", TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue(21000, TargetFrameworkMonikers.UapAot)]
         public void SimpleSectionGroup()
         {
             using (var temp = new TempConfig(SimpleSectionGroupConfiguration))

--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/TimeSpanValidatorAttributeTests.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/TimeSpanValidatorAttributeTests.cs
@@ -111,6 +111,7 @@ namespace System.ConfigurationTests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot,"Exception messages are different")]
         public void MinValueString_TooSmall()
         {
             TimeSpanValidatorAttribute attribute = new TimeSpanValidatorAttribute();
@@ -122,6 +123,7 @@ namespace System.ConfigurationTests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Exception messages are different")]
         public void MaxValueString_TooBig()
         {
             TimeSpanValidatorAttribute attribute = new TimeSpanValidatorAttribute();

--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/UriSectionTests.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/UriSectionTests.cs
@@ -39,6 +39,7 @@ namespace System.ConfigurationTests
 </configuration>";
 
         [Fact]
+        [ActiveIssue(21000, TargetFrameworkMonikers.UapAot)]
         public void UriSectionIdnIriParsing()
         {
             using (var temp = new TempConfig(PlatformDetection.IsFullFramework ? UriSectionConfiguration_NetFX : UriSectionConfiguration_Core))
@@ -51,6 +52,7 @@ namespace System.ConfigurationTests
         }
 
         [Fact]
+        [ActiveIssue(21000, TargetFrameworkMonikers.UapAot)]
         public void UriSectionSchemeSettings()
         {
             using (var temp = new TempConfig(PlatformDetection.IsFullFramework ? UriSectionConfiguration_NetFX : UriSectionConfiguration_Core))


### PR DESCRIPTION
Fix the TestUtil.ThisConfigFileName so it works on uap-aot and disable the rest of the tests.
@JeremyKuhne 