### PR TITLE
Force invariant culture for some ColorTranslator tests

### DIFF
--- a/src/Common/tests/System/ThreadCultureChange.cs
+++ b/src/Common/tests/System/ThreadCultureChange.cs
@@ -17,9 +17,25 @@ namespace System.Common.Tests
             _originalUICultureInfo = CultureInfo.CurrentUICulture;
         }
 
+        public ThreadCultureChange(string culture) : this()
+        {
+            ChangeCultureInfo(culture);
+        }
+
+        public ThreadCultureChange(CultureInfo newCulture) : this()
+        {
+            ChangeCultureInfo(newCulture);
+        }
+
         public void ChangeCultureInfo(string culture)
         {
             var newCulture = new CultureInfo(culture);
+            CultureInfo.CurrentCulture = newCulture;
+            CultureInfo.CurrentUICulture = newCulture;
+        }
+
+        public void ChangeCultureInfo(CultureInfo newCulture)
+        {
             CultureInfo.CurrentCulture = newCulture;
             CultureInfo.CurrentUICulture = newCulture;
         }

--- a/src/Common/tests/System/ThreadCultureChange.cs
+++ b/src/Common/tests/System/ThreadCultureChange.cs
@@ -8,14 +8,10 @@ namespace System.Common.Tests
 {
     public sealed class ThreadCultureChange : IDisposable
     {
-        private readonly CultureInfo _originalCultureInfo;
-        private readonly CultureInfo _originalUICultureInfo;
+        private readonly CultureInfo _originalCultureInfo = CultureInfo.CurrentCulture;
+        private readonly CultureInfo _originalUICultureInfo = CultureInfo.CurrentUICulture;
 
-        public ThreadCultureChange()
-        {
-            _originalCultureInfo = CultureInfo.CurrentCulture;
-            _originalUICultureInfo = CultureInfo.CurrentUICulture;
-        }
+        public ThreadCultureChange() { }
 
         public ThreadCultureChange(string culture) : this()
         {
@@ -27,12 +23,7 @@ namespace System.Common.Tests
             ChangeCultureInfo(newCulture);
         }
 
-        public void ChangeCultureInfo(string culture)
-        {
-            var newCulture = new CultureInfo(culture);
-            CultureInfo.CurrentCulture = newCulture;
-            CultureInfo.CurrentUICulture = newCulture;
-        }
+        public void ChangeCultureInfo(string culture) => ChangeCultureInfo(new CultureInfo(culture));
 
         public void ChangeCultureInfo(CultureInfo newCulture)
         {

--- a/src/System.Drawing.Common/tests/ColorTranslatorTests.cs
+++ b/src/System.Drawing.Common/tests/ColorTranslatorTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Common.Tests;
 using System.Globalization;
 using System.Reflection;
 using System.Threading;
@@ -190,15 +191,9 @@ namespace System.Drawing.Tests
         [MemberData(nameof(FromHtml_TestData))]
         public void FromHtml_String_ReturnsExpected(string htmlColor, Color expected)
         {
-            CultureInfo originalCulture = Thread.CurrentThread.CurrentCulture;
-            try
+            using (new ThreadCultureChange(CultureInfo.InvariantCulture))
             {
-                Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
                 Assert.Equal(expected, ColorTranslator.FromHtml(htmlColor));
-            }
-            finally
-            {
-                Thread.CurrentThread.CurrentCulture = originalCulture;
             }
         }
 
@@ -227,15 +222,9 @@ namespace System.Drawing.Tests
         [InlineData("1,2,256", typeof(ArgumentException))]
         public void FromHtml_Invalid_Throws(string htmlColor, Type exception)
         {
-            CultureInfo originalCulture = Thread.CurrentThread.CurrentCulture;
-            try
+            using (new ThreadCultureChange(CultureInfo.InvariantCulture))
             {
-                Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
                 Assert.Throws(exception, () => ColorTranslator.FromHtml(htmlColor));
-            }
-            finally
-            {
-                Thread.CurrentThread.CurrentCulture = originalCulture;
             }
         }
 

--- a/src/System.Drawing.Common/tests/ColorTranslatorTests.cs
+++ b/src/System.Drawing.Common/tests/ColorTranslatorTests.cs
@@ -3,7 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Globalization;
 using System.Reflection;
+using System.Threading;
 using Xunit;
 
 namespace System.Drawing.Tests
@@ -188,7 +190,16 @@ namespace System.Drawing.Tests
         [MemberData(nameof(FromHtml_TestData))]
         public void FromHtml_String_ReturnsExpected(string htmlColor, Color expected)
         {
-            Assert.Equal(expected, ColorTranslator.FromHtml(htmlColor));
+            CultureInfo originalCulture = Thread.CurrentThread.CurrentCulture;
+            try
+            {
+                Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+                Assert.Equal(expected, ColorTranslator.FromHtml(htmlColor));
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = originalCulture;
+            }
         }
 
         [Theory]
@@ -216,7 +227,16 @@ namespace System.Drawing.Tests
         [InlineData("1,2,256", typeof(ArgumentException))]
         public void FromHtml_Invalid_Throws(string htmlColor, Type exception)
         {
-            Assert.Throws(exception, () => ColorTranslator.FromHtml(htmlColor));
+            CultureInfo originalCulture = Thread.CurrentThread.CurrentCulture;
+            try
+            {
+                Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+                Assert.Throws(exception, () => ColorTranslator.FromHtml(htmlColor));
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = originalCulture;
+            }
         }
 
         public static IEnumerable<object[]> ToHtml_TestData()

--- a/src/System.Drawing.Common/tests/System.Drawing.Common.Tests.csproj
+++ b/src/System.Drawing.Common/tests/System.Drawing.Common.Tests.csproj
@@ -17,6 +17,9 @@
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
       <Link>Common\System\PlatformDetection.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\ThreadCultureChange.cs">
+      <Link>Common\System\ThreadCultureChange.cs</Link>
+    </Compile>
     <Compile Include="ColorTranslatorTests.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
These tests fail on some cultures, including Polish. This change forces us to use InvariantCulture for these tests.

@hughbe @norek