### PR TITLE
Disable test in System.Net.Sockets for UAP

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/LoggingTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/LoggingTest.cs
@@ -13,7 +13,8 @@ namespace System.Net.Sockets.Tests
     public class LoggingTest : RemoteExecutorTestBase
     {
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework | TargetFrameworkMonikers.Uap, "NetEventSource is only part of .NET Core and requires internal Reflection.")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core")]
+        [ActiveIssue(20135, TargetFrameworkMonikers.Uap)]
         public static void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(Socket).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);
@@ -27,7 +28,8 @@ namespace System.Net.Sockets.Tests
 
         [OuterLoop]
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework | TargetFrameworkMonikers.Uap, "NetEventSource is only part of .NET Core and requires internal Reflection.")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core")]
+        [ActiveIssue(20135, TargetFrameworkMonikers.Uap)]
         public void EventSource_EventsRaisedAsExpected()
         {
             RemoteInvoke(() =>

--- a/src/System.Net.Sockets/tests/FunctionalTests/LoggingTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/LoggingTest.cs
@@ -13,7 +13,7 @@ namespace System.Net.Sockets.Tests
     public class LoggingTest : RemoteExecutorTestBase
     {
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework | TargetFrameworkMonikers.Uap, "NetEventSource is only part of .NET Core and requires internal Reflection.")]
         public static void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(Socket).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);
@@ -27,7 +27,7 @@ namespace System.Net.Sockets.Tests
 
         [OuterLoop]
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework | TargetFrameworkMonikers.Uap, "NetEventSource is only part of .NET Core and requires internal Reflection.")]
         public void EventSource_EventsRaisedAsExpected()
         {
             RemoteInvoke(() =>

--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -55,7 +55,7 @@ namespace System.Net.Sockets.Tests
         // TODO: Issue #4887
         // The socket option 'ReuseUnicastPost' only works on Windows 10 systems. In addition, setting the option
         // is a no-op unless specialized network settings using PowerShell configuration are first applied to the
-        // machine. This is currently difficult to test in the CI environment. So, this ests will be disabled for now
+        // machine. This is currently difficult to test in the CI environment. So, this test will be disabled for now
         [OuterLoop] // TODO: Issue #11345
         [ActiveIssue(4887)]
         public void ReuseUnicastPort_CreateSocketSetOptionToOneAndGetOption_SocketsReuseUnicastPortSupport_OptionIsOne()
@@ -83,6 +83,8 @@ namespace System.Net.Sockets.Tests
         }
 
         [OuterLoop] // TODO: Issue #11345
+        [Fact]
+        [ActiveIssue(21018, TargetFrameworkMonikers.Uap)]
         public async Task MulticastInterface_Set_AnyInterface_Succeeds()
         {
             // On all platforms, index 0 means "any interface"
@@ -92,6 +94,7 @@ namespace System.Net.Sockets.Tests
         [OuterLoop] // TODO: Issue #11345
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // see comment below
+        [ActiveIssue(21018, TargetFrameworkMonikers.Uap)]
         public async Task MulticastInterface_Set_Loopback_Succeeds()
         {
             // On Windows, we can apparently assume interface 1 is "loopback."  On other platforms, this is not a


### PR DESCRIPTION
Now System.Net.Sockets.Functional tests will run clean in both innerloop and outerloop for UAP.

I added the [Fact] label back for MulticastInterface_Set_AnyInterface_Succeeds(). The test will never run with only [Outerloop] label. See details here: https://github.com/dotnet/corefx/commit/6257f450653381af91ca5ff097dab837426e91ef#commitcomment-22500352

Contributes to: #20135 