### PR TITLE
Add other compare extensions and tests.

### DIFF
--- a/src/Common/Common.Tests.sln
+++ b/src/Common/Common.Tests.sln
@@ -1,6 +1,7 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26430.13
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Common.Tests", "tests\Common.Tests.csproj", "{C72FD34C-539A-4447-9796-62A229571199}"
 EndProject
@@ -10,10 +11,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{C72FD34C-539A-4447-9796-62A229571199}.Debug|Any CPU.ActiveCfg = netstandard1.3-Unix-Debug|Any CPU
-		{C72FD34C-539A-4447-9796-62A229571199}.Debug|Any CPU.Build.0 = netstandard1.3-Unix-Debug|Any CPU
-		{C72FD34C-539A-4447-9796-62A229571199}.Release|Any CPU.ActiveCfg = netstandard1.3-Unix-Release|Any CPU
-		{C72FD34C-539A-4447-9796-62A229571199}.Release|Any CPU.Build.0 = netstandard1.3-Unix-Release|Any CPU
+		{C72FD34C-539A-4447-9796-62A229571199}.Debug|Any CPU.ActiveCfg = netstandard-Windows_NT-Debug|Any CPU
+		{C72FD34C-539A-4447-9796-62A229571199}.Debug|Any CPU.Build.0 = netstandard-Windows_NT-Debug|Any CPU
+		{C72FD34C-539A-4447-9796-62A229571199}.Release|Any CPU.ActiveCfg = netstandard-Windows_NT-Release|Any CPU
+		{C72FD34C-539A-4447-9796-62A229571199}.Release|Any CPU.Build.0 = netstandard-Windows_NT-Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Common/tests/Common.Tests.csproj
+++ b/src/Common/tests/Common.Tests.csproj
@@ -64,6 +64,7 @@
       <Link>Common\System\Security\IdentityHelper.cs</Link>
     </Compile>
     <Compile Include="Tests\Interop\procfsTests.cs" />
+    <Compile Include="Tests\System\AssertExtensionTests.cs" />
     <Compile Include="Tests\System\CharArrayHelpersTests.cs" />
     <Compile Include="Tests\System\IO\StringParserTests.cs" />
     <Compile Include="Tests\System\Security\IdentityHelperTests.cs" />

--- a/src/Common/tests/System/AssertExtensions.cs
+++ b/src/Common/tests/System/AssertExtensions.cs
@@ -156,6 +156,30 @@ namespace System
         }
 
         /// <summary>
+        /// Validate that a given value is less than another value.
+        /// </summary>
+        /// <param name="actual">The value that should be less than <paramref name="lessThan"/>.</param>
+        /// <param name="lessThan">The value that <paramref name="actual"/> should be less than.</param>
+        public static void LessThan<T>(T actual, T lessThan, string userMessage = null) where T : IComparable
+        {
+            if (actual == null)
+            {
+                if (lessThan == null)
+                {
+                    throw new XunitException(AddOptionalUserMessage($"Expected: <null> to be less than <null>.", userMessage));
+                }
+                else
+                {
+                    // Null is always less than non-null
+                    return;
+                }
+            }
+
+            if (actual.CompareTo(lessThan) >= 0)
+                throw new XunitException(AddOptionalUserMessage($"Expected: {actual} to be less than {lessThan}", userMessage));
+        }
+
+        /// <summary>
         /// Validate that a given value is less than or equal to another value.
         /// </summary>
         /// <param name="actual">The value that should be less than or equal to <paramref name="lessThanOrEqualTo"/></param>
@@ -168,6 +192,32 @@ namespace System
 
             if (actual.CompareTo(lessThanOrEqualTo) > 0)
                 throw new XunitException(AddOptionalUserMessage($"Expected: {actual} to be less than or equal to {lessThanOrEqualTo}", userMessage));
+        }
+
+        /// <summary>
+        /// Validate that a given value is greater than or equal to another value.
+        /// </summary>
+        /// <param name="actual">The value that should be greater than or equal to <paramref name="greaterThanOrEqualTo"/></param>
+        /// <param name="greaterThanOrEqualTo">The value that <paramref name="actual"/> should be greater than or equal to.</param>
+        public static void GreaterThanOrEqualTo<T>(T actual, T greaterThanOrEqualTo, string userMessage = null) where T : IComparable
+        {
+            // null, by definition is always less than or equal to
+            if (actual == null)
+            {
+                if (greaterThanOrEqualTo == null)
+                {
+                    // We're equal
+                    return;
+                }
+                else
+                {
+                    // Null is always less than non-null
+                    throw new XunitException(AddOptionalUserMessage($"Expected: <null> to be greater than or equal to <null>.", userMessage));
+                }
+            }
+
+            if (actual.CompareTo(greaterThanOrEqualTo) < 0)
+                throw new XunitException(AddOptionalUserMessage($"Expected: {actual} to be greater than or equal to {greaterThanOrEqualTo}", userMessage));
         }
     }
 }

--- a/src/Common/tests/Tests/System/AssertExtensionTests.cs
+++ b/src/Common/tests/Tests/System/AssertExtensionTests.cs
@@ -1,0 +1,211 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Tests.System
+{
+    public class AssertExtensionTests
+    {
+        private const string Null = "<null>";
+
+        [Theory,
+            InlineData(0, 0, false),
+            InlineData(1, 1, false),
+            InlineData(0, 1, false),
+            InlineData(0, -1, true),
+            InlineData(-1, 0, false),
+            InlineData(1, 0, true),
+            InlineData(1, -1, true),
+            InlineData(-1, 1, false)
+            ]
+        public void GreaterThan_ValueType(int actual, int greaterThan, bool expected)
+        {
+            try
+            {
+                AssertExtensions.GreaterThan(actual, greaterThan);
+                Assert.True(expected, $"{actual} > {greaterThan} should have failed the assertion.");
+            }
+            catch (XunitException)
+            {
+                Assert.False(expected, $"{actual} > {greaterThan} should *not* have failed the assertion.");
+            }
+        }
+
+        [Theory,
+            // Null is always less than anything other than null
+            InlineData("", null, true),
+            InlineData(null, null, false),
+            InlineData(null, "", false),
+            InlineData("b", "b", false),
+            InlineData("b", "c", false),
+            InlineData("b", "a", true),
+            InlineData("a", "b", false),
+            InlineData("c", "b", true),
+            InlineData("c", "a", true),
+            InlineData("a", "c", false)
+            ]
+        public void GreaterThan_ReferenceType(string actual, string greaterThan, bool expected)
+        {
+            try
+            {
+                AssertExtensions.GreaterThan(actual, greaterThan);
+                Assert.True(expected, $"{actual ?? Null} > {greaterThan ?? Null} should have failed the assertion.");
+            }
+            catch (XunitException)
+            {
+                Assert.False(expected, $"{actual ?? Null} > {greaterThan ?? Null} should *not* have failed the assertion.");
+            }
+        }
+
+        [Theory,
+            InlineData(0, 0, false),
+            InlineData(1, 1, false),
+            InlineData(0, 1, true),
+            InlineData(0, -1, false),
+            InlineData(-1, 0, true),
+            InlineData(1, 0, false),
+            InlineData(1, -1, false),
+            InlineData(-1, 1, true)
+            ]
+        public void LessThan_ValueType(int actual, int lessThan, bool expected)
+        {
+            try
+            {
+                AssertExtensions.LessThan(actual, lessThan);
+                Assert.True(expected, $"{actual} < {lessThan} should have failed the assertion.");
+            }
+            catch (XunitException)
+            {
+                Assert.False(expected, $"{actual} < {lessThan} should *not* have failed the assertion.");
+            }
+        }
+
+        [Theory,
+            // Null is always less than anything other than null
+            InlineData("", null, false),
+            InlineData(null, null, false),
+            InlineData(null, "", true),
+            InlineData("b", "b", false),
+            InlineData("b", "c", true),
+            InlineData("b", "a", false),
+            InlineData("a", "b", true),
+            InlineData("c", "b", false),
+            InlineData("c", "a", false),
+            InlineData("a", "c", true)
+            ]
+        public void LessThan_ReferenceType(string actual, string lessThan, bool expected)
+        {
+            try
+            {
+                AssertExtensions.LessThan(actual, lessThan);
+                Assert.True(expected, $"'{actual ?? Null}' < '{lessThan ?? Null}' should have failed the assertion.");
+            }
+            catch (XunitException)
+            {
+                Assert.False(expected, $"'{actual ?? Null}' < '{lessThan ?? Null}' should *not* have failed the assertion.");
+            }
+        }
+
+        [Theory,
+            InlineData(0, 0, true),
+            InlineData(1, 1, true),
+            InlineData(0, 1, false),
+            InlineData(0, -1, true),
+            InlineData(-1, 0, false),
+            InlineData(1, 0, true),
+            InlineData(1, -1, true),
+            InlineData(-1, 1, false)
+            ]
+        public void GreaterThanOrEqualTo_ValueType(int actual, int greaterThanOrEqualTo, bool expected)
+        {
+            try
+            {
+                AssertExtensions.GreaterThanOrEqualTo(actual, greaterThanOrEqualTo);
+                Assert.True(expected, $"{actual} >= {greaterThanOrEqualTo} should have failed the assertion.");
+            }
+            catch (XunitException)
+            {
+                Assert.False(expected, $"{actual} >= {greaterThanOrEqualTo} should *not* have failed the assertion.");
+            }
+        }
+
+        [Theory,
+            // Null is always less than anything other than null
+            InlineData("", null, true),
+            InlineData(null, null, true),
+            InlineData(null, "", false),
+            InlineData("b", "b", true),
+            InlineData("b", "c", false),
+            InlineData("b", "a", true),
+            InlineData("a", "b", false),
+            InlineData("c", "b", true),
+            InlineData("c", "a", true),
+            InlineData("a", "c", false)
+            ]
+        public void GreaterThanOrEqualTo_ReferenceType(string actual, string greaterThanOrEqualTo, bool expected)
+        {
+            try
+            {
+                AssertExtensions.GreaterThanOrEqualTo(actual, greaterThanOrEqualTo);
+                Assert.True(expected, $"'{actual ?? Null}' >= '{greaterThanOrEqualTo ?? Null}' should have failed the assertion.");
+            }
+            catch (XunitException)
+            {
+                Assert.False(expected, $"'{actual ?? Null}' >= '{greaterThanOrEqualTo ?? Null}' should *not* have failed the assertion.");
+            }
+        }
+
+        [Theory,
+            InlineData(0, 0, true),
+            InlineData(1, 1, true),
+            InlineData(0, 1, true),
+            InlineData(0, -1, false),
+            InlineData(-1, 0, true),
+            InlineData(1, 0, false),
+            InlineData(1, -1, false),
+            InlineData(-1, 1, true)
+            ]
+        public void LessThanOrEqualTo_ValueType(int actual, int lessThanOrEqualTo, bool expected)
+        {
+            try
+            {
+                AssertExtensions.LessThanOrEqualTo(actual, lessThanOrEqualTo);
+                Assert.True(expected, $"{actual} <= {lessThanOrEqualTo} should have failed the assertion.");
+            }
+            catch (XunitException)
+            {
+                Assert.False(expected, $"{actual} <= {lessThanOrEqualTo} should *not* have failed the assertion.");
+            }
+        }
+
+        [Theory,
+            // Null is always less than anything other than null
+            InlineData("", null, false),
+            InlineData(null, null, true),
+            InlineData(null, "", true),
+            InlineData("b", "b", true),
+            InlineData("b", "c", true),
+            InlineData("b", "a", false),
+            InlineData("a", "b", true),
+            InlineData("c", "b", false),
+            InlineData("c", "a", false),
+            InlineData("a", "c", true)
+            ]
+        public void LessThanOrEqualTo_ReferenceType(string actual, string lessThanOrEqualTo, bool expected)
+        {
+            try
+            {
+                AssertExtensions.LessThanOrEqualTo(actual, lessThanOrEqualTo);
+                Assert.True(expected, $"'{actual ?? Null}' >= '{lessThanOrEqualTo ?? Null}' should have failed the assertion.");
+            }
+            catch (XunitException)
+            {
+                Assert.False(expected, $"'{actual ?? Null}' >= '{lessThanOrEqualTo ?? Null}' should *not* have failed the assertion.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Note that xunit bends over backwards when comparing in their asserts. They try to handle nullable<T>, but that should never be an issue as nullable<T> can never satisfy constraints.