### PR TITLE
Disable ComparersGenericTests.EqualityComparer_SerializationRoundtrip test for uap

### DIFF
--- a/src/System.Collections/tests/Generic/Comparers/EqualityComparer.Generic.Serialization.Tests.cs
+++ b/src/System.Collections/tests/Generic/Comparers/EqualityComparer.Generic.Serialization.Tests.cs
@@ -13,7 +13,7 @@ namespace System.Collections.Generic.Tests
     public abstract partial class ComparersGenericTests<T>
     {
         [Fact]
-        [ActiveIssue(20888, TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue(20888, TargetFrameworkMonikers.Uap)]
         public void EqualityComparer_SerializationRoundtrip()
         {
             var bf = new BinaryFormatter();


### PR DESCRIPTION
This test fails in Uap as well, with this System.Collections.Tests will be clean

cc: @danmosemsft 

FYI: @morganbr 