### PR TITLE
Updating version of UAP test tools and referencing the package from myget

### DIFF
--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -86,6 +86,16 @@
     <PackageToInclude Include="$(XUnitRunnerPackageId)" />
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(TargetGroup)' == 'uap'">
+    <UAPToolsPackageVersion>1.0.7</UAPToolsPackageVersion>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetGroup)' == 'uap'">
+    <PackageReference Include="Microsoft.DotNet.UAP.TestTools">
+      <Version>$(UAPToolsPackageVersion)</Version>
+    </PackageReference>
+  </ItemGroup>
+
   <!-- System.Data.SqlClient tests require sni.dll in the test folder -->
   <ItemGroup Condition="'$(TargetGroup)' == 'uapaot'">
     <PackageReference Include="runtime.native.System.Data.SqlClient.sni">
@@ -114,7 +124,6 @@
           Condition="'$(TargetGroup)'=='uap'" >
 
     <PropertyGroup>
-      <UAPToolsPackageVersion>1.0.2</UAPToolsPackageVersion>
       <UAPToolsPackageName>microsoft.dotnet.uap.testtools</UAPToolsPackageName>
 
       <UAPToolsFolder Condition="'$(UAPToolsFolder)'==''">$(PackagesDir)$(UAPToolsPackageName)\$(UAPToolsPackageVersion)\Tools</UAPToolsFolder>

--- a/external/test-runtime/optional.json
+++ b/external/test-runtime/optional.json
@@ -3,7 +3,6 @@
     "net45": {
       "dependencies": {
         "Microsoft.DotNet.IBCMerge": "4.6.0-alpha-00001",
-        "Microsoft.DotNet.UAP.TestTools": "1.0.2",
         "TestILC.amd64ret": "1.0.0-beta-25413-00",
         "TestILC.armret": "1.0.0-beta-25413-00",
         "TestILC.x86ret": "1.0.0-beta-25413-00"


### PR DESCRIPTION
cc: @weshaggard @danmosemsft @tarekgh @JeremyKuhne 

Fixing MemoryMappedFiles tests by referencing the new uap tools package which contains a change in the manifest that will enable codeGeneration feature for our tests. 

Also worth noting is that after this is merged, contributors will be able to run uap (UWP on CoreCLR) tests on their machines as well, which was not supported before (cc: @hughbe ). 

This PR is doing part of the work that #20956 was doing, so I will have to rebase that PR once this is merged. I did do a Helix private run with these new package and for uap we are down to ~380 failures after this. (from ~520 failures 😄)
