### PR TITLE
Minor perf improvements to Sockets

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
@@ -135,7 +135,7 @@ namespace System.Net.Sockets
                         if (_buffer != null)
                         {
                             // Can't have both set
-                            throw new ArgumentException(SR.Format(SR.net_ambiguousbuffers, "Buffer"));
+                            throw new ArgumentException(SR.Format(SR.net_ambiguousbuffers, nameof(Buffer)));
                         }
 
                         // Copy the user-provided list into our internal buffer list,
@@ -304,7 +304,7 @@ namespace System.Net.Sockets
                     // Can't have both Buffer and BufferList.
                     if (_bufferList != null)
                     {
-                        throw new ArgumentException(SR.Format(SR.net_ambiguousbuffers, "BufferList"));
+                        throw new ArgumentException(SR.Format(SR.net_ambiguousbuffers, nameof(BufferList)));
                     }
 
                     // Offset and count can't be negative and the 
@@ -484,7 +484,7 @@ namespace System.Net.Sockets
                 // Caller specified a buffer - see if it is large enough
                 if (_count < _acceptAddressBufferCount)
                 {
-                    throw new ArgumentException(SR.Format(SR.net_buffercounttoosmall, "Count"));
+                    throw new ArgumentException(SR.Format(SR.net_buffercounttoosmall, nameof(Count)));
                 }
 
                 // Buffer is already pinned if necessary.

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
@@ -455,6 +455,7 @@ namespace System.Net.Sockets
             if (_completedChanged || socket != _currentSocket)
             {
                 _completedChanged = false;
+                _currentSocket = socket;
                 _context = null;
             }
 
@@ -463,9 +464,6 @@ namespace System.Net.Sockets
             {
                 _context = ExecutionContext.Capture();
             }
-
-            // Remember current socket.
-            _currentSocket = socket;
         }
 
         internal void StartOperationAccept()

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 
 namespace System.Net.Sockets
@@ -418,13 +419,22 @@ namespace System.Net.Sockets
         private void StartConfiguring()
         {
             int status = Interlocked.CompareExchange(ref _operating, Configuring, Free);
-            if (status == InProgress || status == Configuring)
+            if (status != Free)
             {
-                throw new InvalidOperationException(SR.net_socketopinprogress);
+                ThrowForNonFreeStatus(status);
             }
-            else if (status == Disposed)
+        }
+
+        private void ThrowForNonFreeStatus(int status)
+        {
+            Debug.Assert(status == InProgress || status == Configuring || status == Disposed, $"Unexpected status: {status}");
+            if (status == Disposed)
             {
                 throw new ObjectDisposedException(GetType().FullName);
+            }
+            else
+            {
+                throw new InvalidOperationException(SR.net_socketopinprogress);
             }
         }
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
@@ -443,17 +443,10 @@ namespace System.Net.Sockets
         internal void StartOperationCommon(Socket socket)
         {
             // Change status to "in-use".
-            if (Interlocked.CompareExchange(ref _operating, InProgress, Free) != Free)
+            int status = Interlocked.CompareExchange(ref _operating, InProgress, Free);
+            if (status != Free)
             {
-                // If it was already "in-use" check if Dispose was called.
-                if (_disposeCalled)
-                {
-                    // Dispose was called - throw ObjectDisposed.
-                    throw new ObjectDisposedException(GetType().FullName);
-                }
-
-                // Only one at a time.
-                throw new InvalidOperationException(SR.net_socketopinprogress);
+                ThrowForNonFreeStatus(status);
             }
 
             // Prepare execution context for callback.

--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketAsyncEventArgsTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketAsyncEventArgsTest.cs
@@ -157,6 +157,25 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        public void SetBuffer_NoBuffer_ResetsCountOffset()
+        {
+            using (var saea = new SocketAsyncEventArgs())
+            {
+                saea.SetBuffer(42, 84);
+                Assert.Equal(0, saea.Offset);
+                Assert.Equal(0, saea.Count);
+
+                saea.SetBuffer(new byte[3], 1, 2);
+                Assert.Equal(1, saea.Offset);
+                Assert.Equal(2, saea.Count);
+
+                saea.SetBuffer(null, 1, 2);
+                Assert.Equal(0, saea.Offset);
+                Assert.Equal(0, saea.Count);
+            }
+        }
+
+        [Fact]
         public void SetBufferListWhenBufferSet_Throws()
         {
             using (var saea = new SocketAsyncEventArgs())


### PR DESCRIPTION
Shaves a few percent off various socket operations.  It's close to noise, but appears to be statistically significant and amount to around 2-3% improvement in microbenchmarks that repeatedly receive/send (in which case receives complete asynchronously) and send/receive (in which case most if not all operations complete synchronously).

(At this point most of the overhead associated with sockets (at least in the Windows build) is either in the P/Invokes to native or in peanut butter spread across lots of functions with very low exclusive amounts per function.  There's likely a decent amount more to be done on Linux, where we've done less profiling and where we know there are improvements to be made around asynchronous completion and dispatch.)

cc: @geoffkizer, @cipop, @davidsh, @vancem