### PR TITLE
Replace ActiveIssue with PlatformDetection.IsSupported

### DIFF
--- a/src/Common/tests/System/PlatformDetection.cs
+++ b/src/Common/tests/System/PlatformDetection.cs
@@ -456,5 +456,28 @@ namespace System
                 return version >= Start && (Finish == null || version <= Finish);
             }
         }
+
+        public static bool IsEnvironmentCommandLineArgsSupported => s_IsEnvironmentCommandLineArgsSupported.Value;
+
+        private static readonly Lazy<bool> s_IsEnvironmentCommandLineArgsSupported = new Lazy<bool>(
+            delegate ()
+            {
+                if (!PlatformDetection.IsNetNative)
+                    return true;
+
+                try
+                {
+                    Environment.GetCommandLineArgs();
+                }
+                catch (PlatformNotSupportedException)
+                {
+                    return false;
+                }
+                catch
+                {
+                    return true; // Hmm - threw something but not PNSE. Let the tests loose on it and report what they find...
+                }
+                return true;
+            });
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/Environment.GetCommandLineArgs.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.GetCommandLineArgs.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace System.Tests
 {
-    [ActiveIssue("https://github.com/dotnet/corert/issues/3743 - Environment.GetCommandLineArgs() returning null on .Net Native", TargetFrameworkMonikers.UapAot)]
     public class GetCommandLineArgs : RemoteExecutorTestBase
     {
         [Fact]
@@ -55,6 +54,9 @@ namespace System.Tests
 
         public static void RemoteInvoke(string[] args)
         {
+            if (!PlatformDetection.IsEnvironmentCommandLineArgsSupported)
+                return;
+
             switch (args.Length)
             {
                 case 1:


### PR DESCRIPTION
So I can close that issue. And if we ever change our mind,
the tests will light up.

Fixes https://github.com/dotnet/corert/issues/3743