### PR TITLE
Disable test in System.Net.Sockets for UAPAOT

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/NetworkStreamTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/NetworkStreamTest.cs
@@ -623,6 +623,7 @@ namespace System.Net.Sockets.Tests
         [InlineData(4096)]
         [InlineData(4095)]
         [InlineData(1024*1024)]
+        [ActiveIssue(20135, TargetFrameworkMonikers.Uap)]
         public async Task CopyToAsync_AllDataCopied(int byteCount)
         {
             await RunWithConnectedNetworkStreamsAsync(async (server, client) =>

--- a/src/System.Net.Sockets/tests/FunctionalTests/SelectTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SelectTest.cs
@@ -177,6 +177,7 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(SelectMode.SelectRead)]
         [InlineData(SelectMode.SelectError)]
+        [ActiveIssue(21057, TargetFrameworkMonikers.Uap)]
         public void Poll_NotReady(SelectMode mode)
         {
             KeyValuePair<Socket, Socket> pair = CreateConnectedSockets();

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendPacketsAsync.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendPacketsAsync.cs
@@ -81,6 +81,7 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
+        [ActiveIssue(20135, TargetFrameworkMonikers.Uap)]
         public void NullArgs_Throw(SocketImplementationType type)
         {
             int port;
@@ -116,6 +117,7 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
+        [ActiveIssue(20135, TargetFrameworkMonikers.Uap)]
         public void NullList_Throws(SocketImplementationType type)
         {
             ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() =>
@@ -130,6 +132,7 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
+        [ActiveIssue(20135, TargetFrameworkMonikers.Uap)]
         public void NullElement_Ignored(SocketImplementationType type)
         {
             SendPackets(type, (SendPacketsElement)null, 0);
@@ -139,6 +142,7 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
+        [ActiveIssue(20135, TargetFrameworkMonikers.Uap)]
         public void EmptyList_Ignored(SocketImplementationType type)
         {
             SendPackets(type, new SendPacketsElement[0], SocketError.Success, 0);
@@ -175,6 +179,7 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
+        [ActiveIssue(20135, TargetFrameworkMonikers.Uap)]
         public void EmptyBuffer_Ignored(SocketImplementationType type)
         {
             SendPackets(type, new SendPacketsElement(new byte[0]), 0);
@@ -183,6 +188,7 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
+        [ActiveIssue(20135, TargetFrameworkMonikers.Uap)]
         public void BufferZeroCount_Ignored(SocketImplementationType type)
         {
             SendPackets(type, new SendPacketsElement(new byte[10], 4, 0), 0);
@@ -205,6 +211,7 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
+        [ActiveIssue(20135, TargetFrameworkMonikers.Uap)]
         public void BufferZeroCountThenNormal_ZeroCountIgnored(SocketImplementationType type)
         {
             Assert.True(Capability.IPv6Support());

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -657,6 +657,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(20135, TargetFrameworkMonikers.Uap)]
         public async Task SendRecv_0ByteReceive_Success()
         {
             using (Socket listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))


### PR DESCRIPTION
Now all Sockets Functional tests (innerloop and outerloop) can run clean on both UAP and UAPAOT mode.

Contributes to: #20135