### PR TITLE
Move few methods from AdapterUtil.cs to Common (System.Data)

### DIFF
--- a/src/Common/src/System/Data/Common/AdapterUtil.cs
+++ b/src/Common/src/System/Data/Common/AdapterUtil.cs
@@ -34,6 +34,12 @@ namespace System.Data.Common
             TraceException("<comm.ADP.TraceException|ERR|THROW> '{0}'", e);
         }
 
+        internal static void TraceExceptionWithoutRethrow(Exception e)
+        {
+            Debug.Assert(ADP.IsCatchableExceptionType(e), "Invalid exception type, should have been re-thrown!");
+            TraceException("<comm.ADP.TraceException|ERR|CATCH> '%ls'\n", e);
+        }
+
         internal static ArgumentException Argument(string error)
         {
             ArgumentException e = new ArgumentException(error);
@@ -121,6 +127,11 @@ namespace System.Data.Common
             NotSupportedException e = new NotSupportedException(error);
             TraceExceptionAsReturnValue(e);
             return e;
+        }
+
+        internal static ArgumentOutOfRangeException NotSupportedEnumerationValue(Type type, string value, string method)
+        {
+            return ArgumentOutOfRange(SR.Format(SR.ADP_NotSupportedEnumerationValue, type.Name, value, method), type.Name);
         }
 
         internal static InvalidOperationException DataAdapter(string error)

--- a/src/System.Data.Common/src/System/Data/Common/AdapterUtil.Common.cs
+++ b/src/System.Data.Common/src/System/Data/Common/AdapterUtil.Common.cs
@@ -38,12 +38,6 @@ namespace System.Data.Common
             TraceException("<comm.ADP.TraceException|ERR|CATCH> '{0}'", e);
         }
 
-        internal static void TraceExceptionWithoutRethrow(Exception e)
-        {
-            Debug.Assert(IsCatchableExceptionType(e), "Invalid exception type, should have been re-thrown!");
-            TraceException("<comm.ADP.TraceException|ERR|CATCH> '{0}'", e);
-        }
-
         internal static DataException Data(string message)
         {
             DataException e = new DataException(message);
@@ -69,11 +63,6 @@ namespace System.Data.Common
         }
 
         // Invalid Enumeration
-
-        internal static ArgumentOutOfRangeException NotSupportedEnumerationValue(Type type, string value, string method)
-        {
-            return ArgumentOutOfRange(SR.Format(SR.ADP_NotSupportedEnumerationValue, type.Name, value, method), type.Name);
-        }
 
         internal static ArgumentOutOfRangeException InvalidAcceptRejectRule(AcceptRejectRule value)
         {

--- a/src/System.Data.Odbc/src/Common/System/Data/Common/AdapterUtil.Odbc.cs
+++ b/src/System.Data.Odbc/src/Common/System/Data/Common/AdapterUtil.Odbc.cs
@@ -50,11 +50,6 @@ namespace System.Data.Common
                 return caught;
             }
         }
-        internal static void TraceExceptionWithoutRethrow(Exception e)
-        {
-            Debug.Assert(ADP.IsCatchableExceptionType(e), "Invalid exception type, should have been re-thrown!");
-            TraceException("<comm.ADP.TraceException|ERR|CATCH> '%ls'\n", e);
-        }
 
         //
         // COM+ exceptions

--- a/src/System.Data.SqlClient/src/System/Data/Common/AdapterUtil.SqlClient.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Common/AdapterUtil.SqlClient.cs
@@ -31,12 +31,6 @@ namespace System.Data.Common
             }
         }
 
-        internal static void TraceExceptionWithoutRethrow(Exception e)
-        {
-            Debug.Assert(ADP.IsCatchableExceptionType(e), "Invalid exception type, should have been re-thrown!");
-            TraceException("<comm.ADP.TraceException|ERR|CATCH> '%ls'\n", e);
-        }
-
         //
         // COM+ exceptions
         //
@@ -880,11 +874,6 @@ namespace System.Data.Common
             {
                 throw InvalidCommandBehavior(value);
             }
-        }
-
-        internal static ArgumentOutOfRangeException NotSupportedEnumerationValue(Type type, string value, string method)
-        {
-            return ArgumentOutOfRange(SR.GetString(SR.ADP_NotSupportedEnumerationValue, type.Name, value, method), type.Name);
         }
 
         internal static ArgumentOutOfRangeException NotSupportedCommandBehavior(CommandBehavior value, string method)


### PR DESCRIPTION
Following https://github.com/dotnet/corefx/pull/18500 I moved 
```
TraceExceptionWithoutRethrow(...)
NotSupportedEnumerationValue(...)
```
methods 
to Common/AdapterUtil.cs
(from AdapterUtil.SqlClient.cs, AdapterUtil.Odbc.cs and AdapterUtil.Common.cs)
They were added after I submitted https://github.com/dotnet/corefx/pull/18500 
so now they cause compilation errors in mono
