### PR TITLE
Add option to build.cmd/sh to build projects in a directory

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -3,11 +3,26 @@ setlocal
 
 if /I [%1] == [-?] goto Usage
 
+if [%1] == [] goto Build
+
+set _rootDirectory=%CD%\
+if EXIST %_rootDirectory%%1 goto :BuildDirectory
+set _rootDirectory=%~dp0src\
+if EXIST %_rootDirectory%%1 goto :BuildDirectory
+
 :Build
 call %~dp0build-native.cmd %*
 if NOT [%ERRORLEVEL%]==[0] exit /b 1
 call %~dp0build-managed.cmd -BuildPackages=true %*
 exit /b %ERRORLEVEL%
+goto :EOF
+
+:BuildDirectory
+echo %~dp0run.cmd build-directory -directory:%_rootDirectory%%*
+call %~dp0run.cmd build-directory -directory:%_rootDirectory%%*
+exit /b %ERRORLEVEL%
+
+goto :EOF
 
 :Usage
 echo.

--- a/build.sh
+++ b/build.sh
@@ -22,6 +22,18 @@ if [ "$1" == "-?" ]; then
 fi
 
 __scriptpath=$(cd "$(dirname "$0")"; pwd -P)
+__workingDir=$(pwd -P)
+
+if [ "$1" != "" ]; then
+    if [ -d $__workingDir/$1 ]; then
+        $__scriptpath/run.sh build-directory -directory:$__workingDir/$*
+        exit $?
+    fi
+    if [ -d $__scriptpath/src/$1 ]; then
+        $__scriptpath/run.sh build-directory -directory:$__scriptpath/$*
+        exit $?
+    fi
+fi
 
 "$__scriptpath/build-native.sh" $*
 if [ $? -ne 0 ];then

--- a/config.json
+++ b/config.json
@@ -233,9 +233,78 @@
       "valueType": "target",
       "values": [],
       "defaultValue": ""
-    }
+    },
+    "DirectoryToBuild": {
+      "description": "MsBuild property used to set the directory to scope the build to things under that directory.",
+      "valueType": "property",
+      "values": [],
+      "defaultValue": "Please-Specify-A-Directory"
+    },
   },
   "commands": {
+    "build-directory": {
+      "alias":{
+        "directory": {
+           "description": "Root directory in which to scope the build from.",
+           "settings": {
+             "DirectoryToBuild": "default"
+           }
+        },
+        "debug": {
+          "description": "Sets optimization level to debug for managed build configuration. (/p:ConfigurationGroup=Debug)",
+          "settings": {
+            "ConfigurationGroup": "Debug"
+          }
+        },
+        "release": {
+          "description": "Sets optimization level to release for managed build configuration. (/p:ConfigurationGroup=Release)",
+          "settings": {
+            "ConfigurationGroup": "Release"
+          }
+        },
+        "allConfigurations": {
+          "description": "Builds all configurations instead of only those specified by framework/os.",
+          "settings": {
+            "BuildAllConfigurations":"true"
+          }
+        },
+        "framework": {
+          "description": "Sets target framework for managed build configuration and only builds the libraries applicable for that framework. (/p:TargetGroup=[value])",
+          "settings": {
+            "TargetGroup": "default"
+          }
+        },
+        "os": {
+          "description": "Sets OS for the managed build configuration and only builds the libraries applicable for that OS. (/p:OSGroup=[value])",
+          "settings": {
+            "OSGroup": "default"
+          }
+        },
+        "buildArch": {
+          "description": "Sets the architecture for the managed build confiuguration. (/p:ArchGroup=[value])",
+          "settings": {
+            "ArchGroup": "default"
+          }
+        },
+        "runtimeos": {
+          "description": "Sets runtime OS for the managed build configuration, which is used for building and restoring native OS dependent assets (i.e. RID specific binaries). (/p:RuntimeOS=[value]",
+          "settings": {
+            "RuntimeOS": "default"
+          }
+        },
+      },
+      "defaultValues": {
+        "toolName": "msbuild",
+        "settings": {
+          "Project": "src/dirs.proj",
+          "ConfigurationGroup": "default",
+          "DirectoryToBuild": "default",
+          "MsBuildLogging":"default",
+          "MsBuildWarning":"default",
+          "MsBuildError":"default"
+        }
+      }
+    },
     "build-managed": {
       "alias":{
         "packages": {

--- a/run.sh
+++ b/run.sh
@@ -8,5 +8,6 @@ __scriptpath=$(cd "$(dirname "$0")"; pwd -P)
 __toolRuntime=$__scriptpath/Tools
 __dotnet=$__toolRuntime/dotnetcli/dotnet
 
-$__dotnet $__toolRuntime/run.exe $*
+cd $__scriptpath
+$__dotnet $__toolRuntime/run.exe $__scriptpath/config.json $*
 exit $?

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -6,13 +6,17 @@
     <SerializeProjects>true</SerializeProjects>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(DirectoryToBuild)' == ''">
     <Project Include="ref.builds" />
     <Project Include="shims\shims.proj" />
     <Project Include="Native\native-binplace.proj" />
     <Project Include="src.builds" />
     <Project Include="shims\manual\*.csproj" />
     <Project Include="shims\ApiCompat.proj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(DirectoryToBuild)' != ''">
+    <Project Include="$(DirectoryToBuild)/**/*.csproj" />
   </ItemGroup>
 
   <Import Project="..\dir.targets" />


### PR DESCRIPTION
Addresses https://github.com/dotnet/corefx/issues/20827

PTAL @mellinoe @kellypleahy @ericstj @stephentoub 

After this option folks can do the following:

- Build all System.Collections projects
```
build.cmd/sh System.Collections
```
- Build System.Collection test projects (also runs tests)
```
build.cmd/sh src/System.Collections/tests
```
- While in a library directory build all projects under it.
```
cd src\System.Collections
..\..\build.cmd/sh .
```
These also support any of the standard build options like framework,
flavor, os, allconfigurations, etc. Same rules apply that you have to
have built the entire tree for that configuration before this will
succeed.