### PR TITLE
Fix Xml_TypeWithTwoDimensionalArrayProperty1.

### DIFF
--- a/src/System.Private.Xml/tests/XmlSerializer/Resources/System.Xml.XmlSerializer.Tests.rd.xml
+++ b/src/System.Private.Xml/tests/XmlSerializer/Resources/System.Xml.XmlSerializer.Tests.rd.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Library Name="System.Xml.XmlSerializer.Tests">
+    <Assembly Name="System.Xml.XmlSerializer.Tests">
+      <Namespace Name="SerializationTypes">
+        <Type Name="TypeWith2DArrayProperty1" XmlSerializer="Excluded" />
+      </Namespace>
+    </Assembly>
+  </Library>
+</Directives>

--- a/src/System.Private.Xml/tests/XmlSerializer/System.Xml.XmlSerializer.Tests.csproj
+++ b/src/System.Private.Xml/tests/XmlSerializer/System.Xml.XmlSerializer.Tests.csproj
@@ -18,5 +18,8 @@
       <Link>CommonTest\System\PlatformDetection.cs</Link>
     </Compile>
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\$(AssemblyName).rd.xml" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -1817,7 +1817,6 @@ string.Format(@"<?xml version=""1.0"" encoding=""utf-8""?>
     }
 
     [Fact]
-    [ActiveIssue("dotnet/corefx #19897", TargetFrameworkMonikers.Uap)]
     public static void Xml_TypeWithTwoDimensionalArrayProperty1()
     {
         SimpleType[][] simpleType2D = GetObjectwith2DArrayOfSimpleType();


### PR DESCRIPTION
The test failed on uapaot when using sg.exe because sg.exe couldn't pre-generate correct serializer for the test type. It's hard to fix sg.exe to make it generate proper serializer for the type.

But since the reflection-base serialization worked for the test type, the workaround is to let sg.exe not to generate serializer for the type and to use reflection-based serialization at runtime. And this would be the workaround we recommend to developers to deal with types having issues like #19897 .

Fix #19897