### PR TITLE
Fixing System.Threading.Overlapped tests in uap

### DIFF
--- a/src/System.Threading.Overlapped/tests/HandleFactory.cs
+++ b/src/System.Threading.Overlapped/tests/HandleFactory.cs
@@ -12,9 +12,9 @@ internal static partial class HandleFactory
         return new Win32Handle(handle);
     }
 
-    public static Win32Handle CreateSyncFileHandleFoWrite()
+    public static Win32Handle CreateSyncFileHandleFoWrite(string fileName = null)
     {
-        return CreateHandle(async: false);
+        return CreateHandle(async:false, fileName:fileName);
     }
 
     public static Win32Handle CreateAsyncFileHandleForWrite(string fileName = null)

--- a/src/System.Threading.Overlapped/tests/HandleFactory.cs
+++ b/src/System.Threading.Overlapped/tests/HandleFactory.cs
@@ -12,7 +12,7 @@ internal static partial class HandleFactory
         return new Win32Handle(handle);
     }
 
-    public static Win32Handle CreateSyncFileHandleFoWrite(string fileName = null)
+    public static Win32Handle CreateSyncFileHandleForWrite(string fileName = null)
     {
         return CreateHandle(async:false, fileName:fileName);
     }

--- a/src/System.Threading.Overlapped/tests/System.Threading.Overlapped.Tests.csproj
+++ b/src/System.Threading.Overlapped/tests/System.Threading.Overlapped.Tests.csproj
@@ -26,9 +26,6 @@
     <Compile Include="ThreadPoolBoundHandle_DisposeTests.cs" />
     <Compile Include="ThreadPoolBoundHandle_BindHandleTests.cs" />
     <Compile Include="OverlappedTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\IO\FileCleanupTestBase.cs">
-      <Link>Common\System\IO\FileCleanupTestBase.cs</Link>
-    </Compile>
     <Compile Include="$(CommonTestPath)\System\AssertExtensions.cs">
       <Link>Common\System\AssertExtensions.cs</Link>
     </Compile>

--- a/src/System.Threading.Overlapped/tests/System.Threading.Overlapped.Tests.csproj
+++ b/src/System.Threading.Overlapped/tests/System.Threading.Overlapped.Tests.csproj
@@ -26,6 +26,9 @@
     <Compile Include="ThreadPoolBoundHandle_DisposeTests.cs" />
     <Compile Include="ThreadPoolBoundHandle_BindHandleTests.cs" />
     <Compile Include="OverlappedTests.cs" />
+    <Compile Include="$(CommonTestPath)\System\IO\FileCleanupTestBase.cs">
+      <Link>Common\System\IO\FileCleanupTestBase.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\AssertExtensions.cs">
       <Link>Common\System\AssertExtensions.cs</Link>
     </Compile>

--- a/src/System.Threading.Overlapped/tests/ThreadPoolBoundHandle_BindHandleTests.cs
+++ b/src/System.Threading.Overlapped/tests/ThreadPoolBoundHandle_BindHandleTests.cs
@@ -54,7 +54,7 @@ public partial class ThreadPoolBoundHandleTests
     public void BindHandle_SyncHandleAsHandle_ThrowsArgumentException()
     {   // Can't bind a handle that was not opened for overlapped I/O
 
-        using(SafeHandle handle = HandleFactory.CreateSyncFileHandleFoWrite())
+        using(SafeHandle handle = HandleFactory.CreateSyncFileHandleFoWrite(GetTestFilePath()))
         {
             AssertExtensions.Throws<ArgumentException>("handle", () =>
             {
@@ -64,10 +64,11 @@ public partial class ThreadPoolBoundHandleTests
     }
 
     [Fact]
+    [ActiveIssue(21066, TargetFrameworkMonikers.Uap)]
     [PlatformSpecific(TestPlatforms.Windows)] // ThreadPoolBoundHandle.BindHandle is not supported on Unix
     public void BindHandle_ClosedSyncHandleAsHandle_ThrowsArgumentException()
     {
-        using(Win32Handle handle = HandleFactory.CreateSyncFileHandleFoWrite())
+        using(Win32Handle handle = HandleFactory.CreateSyncFileHandleFoWrite(GetTestFilePath()))
         {
             handle.CloseWithoutDisposing();
 
@@ -79,10 +80,11 @@ public partial class ThreadPoolBoundHandleTests
     }
 
     [Fact]
+    [ActiveIssue(21066, TargetFrameworkMonikers.Uap)]
     [PlatformSpecific(TestPlatforms.Windows)] // ThreadPoolBoundHandle.BindHandle is not supported on Unix
     public void BindHandle_ClosedAsyncHandleAsHandle_ThrowsArgumentException()
     {
-        using(Win32Handle handle = HandleFactory.CreateAsyncFileHandleForWrite())
+        using(Win32Handle handle = HandleFactory.CreateAsyncFileHandleForWrite(GetTestFilePath()))
         {
             handle.CloseWithoutDisposing();
 
@@ -111,7 +113,7 @@ public partial class ThreadPoolBoundHandleTests
     [PlatformSpecific(TestPlatforms.Windows)] // ThreadPoolBoundHandle.BindHandle is not supported on Unix
     public void BindHandle_DisposedAsyncHandleAsHandle_ThrowsArgumentException()
     {
-        Win32Handle handle = HandleFactory.CreateAsyncFileHandleForWrite();
+        Win32Handle handle = HandleFactory.CreateAsyncFileHandleForWrite(GetTestFilePath());
         handle.Dispose();
 
         AssertExtensions.Throws<ArgumentException>("handle", () =>
@@ -124,7 +126,7 @@ public partial class ThreadPoolBoundHandleTests
     [PlatformSpecific(TestPlatforms.Windows)] // ThreadPoolBoundHandle.BindHandle is not supported on Unix
     public void BindHandle_AlreadyBoundHandleAsHandle_ThrowsArgumentException()
     {
-        using(SafeHandle handle = HandleFactory.CreateAsyncFileHandleForWrite())
+        using(SafeHandle handle = HandleFactory.CreateAsyncFileHandleForWrite(GetTestFilePath()))
         {
             // Once
             ThreadPoolBoundHandle.BindHandle(handle);

--- a/src/System.Threading.Overlapped/tests/ThreadPoolBoundHandle_BindHandleTests.cs
+++ b/src/System.Threading.Overlapped/tests/ThreadPoolBoundHandle_BindHandleTests.cs
@@ -53,8 +53,7 @@ public partial class ThreadPoolBoundHandleTests
     [PlatformSpecific(TestPlatforms.Windows)] // ThreadPoolBoundHandle.BindHandle is not supported on Unix
     public void BindHandle_SyncHandleAsHandle_ThrowsArgumentException()
     {   // Can't bind a handle that was not opened for overlapped I/O
-
-        using(SafeHandle handle = HandleFactory.CreateSyncFileHandleFoWrite(GetTestFilePath()))
+        using(SafeHandle handle = HandleFactory.CreateSyncFileHandleForWrite(GetTestFilePath()))
         {
             AssertExtensions.Throws<ArgumentException>("handle", () =>
             {
@@ -68,7 +67,7 @@ public partial class ThreadPoolBoundHandleTests
     [PlatformSpecific(TestPlatforms.Windows)] // ThreadPoolBoundHandle.BindHandle is not supported on Unix
     public void BindHandle_ClosedSyncHandleAsHandle_ThrowsArgumentException()
     {
-        using(Win32Handle handle = HandleFactory.CreateSyncFileHandleFoWrite(GetTestFilePath()))
+        using(Win32Handle handle = HandleFactory.CreateSyncFileHandleForWrite(GetTestFilePath()))
         {
             handle.CloseWithoutDisposing();
 
@@ -99,7 +98,7 @@ public partial class ThreadPoolBoundHandleTests
     [PlatformSpecific(TestPlatforms.Windows)] // ThreadPoolBoundHandle.BindHandle is not supported on Unix
     public void BindHandle_DisposedSyncHandleAsHandle_ThrowsArgumentException()
     {
-        Win32Handle handle = HandleFactory.CreateSyncFileHandleFoWrite();
+        Win32Handle handle = HandleFactory.CreateSyncFileHandleForWrite();
         handle.Dispose();
 
         AssertExtensions.Throws<ArgumentException>("handle", () =>

--- a/src/System.Threading.Overlapped/tests/ThreadPoolBoundHandle_GetNativeOverlappedStateTests.cs
+++ b/src/System.Threading.Overlapped/tests/ThreadPoolBoundHandle_GetNativeOverlappedStateTests.cs
@@ -22,7 +22,7 @@ public partial class ThreadPoolBoundHandleTests
     [PlatformSpecific(TestPlatforms.Windows)] // ThreadPoolBoundHandle.BindHandle is not supported on Unix
     public unsafe void GetNativeOverlappedState_WhenUnderlyingStateIsNull_ReturnsNull()
     {
-        using(SafeHandle handle = HandleFactory.CreateAsyncFileHandleForWrite())
+        using(SafeHandle handle = HandleFactory.CreateAsyncFileHandleForWrite(GetTestFilePath()))
         {
             using(ThreadPoolBoundHandle boundHandle = ThreadPoolBoundHandle.BindHandle(handle))
             {
@@ -43,7 +43,7 @@ public partial class ThreadPoolBoundHandleTests
     {
         object context = new object();
 
-        using(SafeHandle handle = HandleFactory.CreateAsyncFileHandleForWrite())
+        using(SafeHandle handle = HandleFactory.CreateAsyncFileHandleForWrite(GetTestFilePath()))
         {
             using(ThreadPoolBoundHandle boundHandle = ThreadPoolBoundHandle.BindHandle(handle))
             {
@@ -66,7 +66,7 @@ public partial class ThreadPoolBoundHandleTests
 
         AsyncResult context = new AsyncResult();
 
-        using(SafeHandle handle = HandleFactory.CreateAsyncFileHandleForWrite())
+        using(SafeHandle handle = HandleFactory.CreateAsyncFileHandleForWrite(GetTestFilePath()))
         {
             using(ThreadPoolBoundHandle boundHandle = ThreadPoolBoundHandle.BindHandle(handle))
             {

--- a/src/System.Threading.Overlapped/tests/ThreadPoolBoundHandle_HandleTests.cs
+++ b/src/System.Threading.Overlapped/tests/ThreadPoolBoundHandle_HandleTests.cs
@@ -12,7 +12,7 @@ public partial class ThreadPoolBoundHandleTests
     [PlatformSpecific(TestPlatforms.Windows)] // ThreadPoolBoundHandle.BindHandle is not supported on Unix
     public void Handle_ReturnsHandle()
     {
-        using(SafeHandle handle = HandleFactory.CreateAsyncFileHandleForWrite())
+        using(SafeHandle handle = HandleFactory.CreateAsyncFileHandleForWrite(GetTestFilePath()))
         {
             using(ThreadPoolBoundHandle boundHandle = CreateThreadPoolBoundHandle(handle))
             {
@@ -25,7 +25,7 @@ public partial class ThreadPoolBoundHandleTests
     [PlatformSpecific(TestPlatforms.Windows)] // ThreadPoolBoundHandle.BindHandle is not supported on Unix
     public void Handle_AfterDisposed_DoesNotThrow()
     {
-        using(SafeHandle handle = HandleFactory.CreateAsyncFileHandleForWrite())
+        using(SafeHandle handle = HandleFactory.CreateAsyncFileHandleForWrite(GetTestFilePath()))
         {
             ThreadPoolBoundHandle boundHandle = CreateThreadPoolBoundHandle(handle);
             boundHandle.Dispose();

--- a/src/System.Threading.Overlapped/tests/ThreadPoolBoundHandle_Helpers.cs
+++ b/src/System.Threading.Overlapped/tests/ThreadPoolBoundHandle_Helpers.cs
@@ -3,11 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Xunit;
 
-public partial class ThreadPoolBoundHandleTests
+public partial class ThreadPoolBoundHandleTests : FileCleanupTestBase
 {
     struct BlittableType
     {
@@ -19,14 +20,14 @@ public partial class ThreadPoolBoundHandleTests
         public string s;
     }
 
-    private static ThreadPoolBoundHandle CreateThreadPoolBoundHandle()
+    private ThreadPoolBoundHandle CreateThreadPoolBoundHandle()
     {
         return CreateThreadPoolBoundHandle((SafeHandle)null);
     }
 
-    private static ThreadPoolBoundHandle CreateThreadPoolBoundHandle(SafeHandle handle)
+    private ThreadPoolBoundHandle CreateThreadPoolBoundHandle(SafeHandle handle)
     {
-        handle = handle ?? HandleFactory.CreateAsyncFileHandleForWrite();
+        handle = handle ?? HandleFactory.CreateAsyncFileHandleForWrite(GetTestFilePath());
 
         return ThreadPoolBoundHandle.BindHandle(handle);
     }

--- a/src/System.Threading.Overlapped/tests/ThreadPoolBoundHandle_Helpers.cs
+++ b/src/System.Threading.Overlapped/tests/ThreadPoolBoundHandle_Helpers.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Xunit;
@@ -20,14 +21,14 @@ public partial class ThreadPoolBoundHandleTests : FileCleanupTestBase
         public string s;
     }
 
-    private ThreadPoolBoundHandle CreateThreadPoolBoundHandle()
+    private ThreadPoolBoundHandle CreateThreadPoolBoundHandle([CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)
     {
-        return CreateThreadPoolBoundHandle((SafeHandle)null);
+        return CreateThreadPoolBoundHandle((SafeHandle)null, memberName, lineNumber);
     }
 
-    private ThreadPoolBoundHandle CreateThreadPoolBoundHandle(SafeHandle handle)
+    private ThreadPoolBoundHandle CreateThreadPoolBoundHandle(SafeHandle handle, [CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)
     {
-        handle = handle ?? HandleFactory.CreateAsyncFileHandleForWrite(GetTestFilePath());
+        handle = handle ?? HandleFactory.CreateAsyncFileHandleForWrite(GetTestFilePath(null, memberName, lineNumber));
 
         return ThreadPoolBoundHandle.BindHandle(handle);
     }

--- a/src/System.Threading.Overlapped/tests/ThreadPoolBoundHandle_IntegrationTests.cs
+++ b/src/System.Threading.Overlapped/tests/ThreadPoolBoundHandle_IntegrationTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Xunit;
@@ -15,7 +16,7 @@ public partial class ThreadPoolBoundHandleTests
     {
         const int DATA_SIZE = 2;
 
-        SafeHandle handle = HandleFactory.CreateAsyncFileHandleForWrite(@"SingleOverlappedOverSingleHandle.tmp");
+        SafeHandle handle = HandleFactory.CreateAsyncFileHandleForWrite(Path.Combine(TestDirectory, @"SingleOverlappedOverSingleHandle.tmp"));
         ThreadPoolBoundHandle boundHandle = ThreadPoolBoundHandle.BindHandle(handle);
 
         OverlappedContext result = new OverlappedContext();
@@ -53,7 +54,7 @@ public partial class ThreadPoolBoundHandleTests
     {
         const int DATA_SIZE = 2;
 
-        SafeHandle handle = HandleFactory.CreateAsyncFileHandleForWrite(@"MultipleOperationsOverSingleHandle.tmp");
+        SafeHandle handle = HandleFactory.CreateAsyncFileHandleForWrite(Path.Combine(TestDirectory, @"MultipleOperationsOverSingleHandle.tmp"));
         ThreadPoolBoundHandle boundHandle = ThreadPoolBoundHandle.BindHandle(handle);
 
         OverlappedContext result1 = new OverlappedContext();
@@ -111,8 +112,8 @@ public partial class ThreadPoolBoundHandleTests
     {
         const int DATA_SIZE = 2;
 
-        SafeHandle handle1 = HandleFactory.CreateAsyncFileHandleForWrite(@"MultipleOperationsOverMultipleHandle1.tmp");
-        SafeHandle handle2 = HandleFactory.CreateAsyncFileHandleForWrite(@"MultipleOperationsOverMultipleHandle2.tmp");
+        SafeHandle handle1 = HandleFactory.CreateAsyncFileHandleForWrite(Path.Combine(TestDirectory, @"MultipleOperationsOverMultipleHandle1.tmp"));
+        SafeHandle handle2 = HandleFactory.CreateAsyncFileHandleForWrite(Path.Combine(TestDirectory, @"MultipleOperationsOverMultipleHandle2.tmp"));
         ThreadPoolBoundHandle boundHandle1 = ThreadPoolBoundHandle.BindHandle(handle1);
         ThreadPoolBoundHandle boundHandle2 = ThreadPoolBoundHandle.BindHandle(handle2);
 
@@ -185,7 +186,7 @@ public partial class ThreadPoolBoundHandleTests
 
         const int DATA_SIZE = 2;
 
-        SafeHandle handle = HandleFactory.CreateAsyncFileHandleForWrite(@"AsyncLocal.tmp");
+        SafeHandle handle = HandleFactory.CreateAsyncFileHandleForWrite(Path.Combine(TestDirectory, @"AsyncLocal.tmp"));
         ThreadPoolBoundHandle boundHandle = ThreadPoolBoundHandle.BindHandle(handle);
 
         OverlappedContext context = new OverlappedContext();


### PR DESCRIPTION
cc: @stephentoub @safern @danmosemsft @kouvel 

Fixing System.Threading.Overlapped tests since they were trying to create a handle on a file in a location where uap can't access. Also disabling two tests that are failing due to issue #21066 