### PR TITLE
[release/1.0] Check for openssl version before setting cert callback.

### DIFF
--- a/src/System.Net.Http/src/Resources/Strings.resx
+++ b/src/System.Net.Http/src/Resources/Strings.resx
@@ -360,4 +360,13 @@
   <data name="net_http_response_headers_exceeded_length" xml:space="preserve">
     <value>The HTTP response headers length exceeded the set limit of {0} bytes.</value>
   </data>
+  <data name="net_http_libcurl_callback_notsupported" xml:space="preserve">
+    <value>The handler does not support custom handling of certificates with this combination of libcurl ({0}) and its SSL backend ("{1}").</value>
+  </data>
+  <data name="net_http_libcurl_clientcerts_notsupported" xml:space="preserve">
+    <value>The handler does not support client authentication certificates with this combination of libcurl ({0}) and its SSL backend ("{1}").</value>
+  </data>
+  <data name="net_http_libcurl_revocation_notsupported" xml:space="preserve">
+    <value>The handler does not support changing revocation settings with this combination of libcurl ({0}) and its SSL backend ("{1}").</value>
+  </data>
 </root>

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.SslProvider.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.SslProvider.cs
@@ -50,47 +50,80 @@ namespace System.Net.Http
                 // Register the callback with libcurl.  We need to register even if there's no user-provided
                 // server callback and even if there are no client certificates, because we support verifying
                 // server certificates against more than those known to OpenSSL.
-                CURLcode answer = easy.SetSslCtxCallback(s_sslCtxCallback, userPointer);
-                switch (answer)
+                if (CurlSslVersionDescription.IndexOf("openssl/1.0", StringComparison.OrdinalIgnoreCase) != -1)
                 {
-                    case CURLcode.CURLE_OK:
-                        // We successfully registered.  If we'll be invoking a user-provided callback to verify the server
-                        // certificate as part of that, disable libcurl's verification of the host name.  The user's callback
-                        // needs to be given the opportunity to examine the cert, and our logic will determine whether
-                        // the host name matches and will inform the callback of that.
-                        if (easy._handler.ServerCertificateValidationCallback != null)
-                        {
-                            easy.SetCurlOption(Interop.Http.CURLoption.CURLOPT_SSL_VERIFYHOST, 0); // don't verify the peer cert's hostname
-                            // We don't change the SSL_VERIFYPEER setting, as setting it to 0 will cause
-                            // SSL and libcurl to ignore the result of the server callback.
-                        }
+                    CURLcode answer = easy.SetSslCtxCallback(s_sslCtxCallback, userPointer);
+                    switch (answer)
+                    {
+                        case CURLcode.CURLE_OK:
+                            // We successfully registered.  If we'll be invoking a user-provided callback to verify the server
+                            // certificate as part of that, disable libcurl's verification of the host name.  The user's callback
+                            // needs to be given the opportunity to examine the cert, and our logic will determine whether
+                            // the host name matches and will inform the callback of that.
+                            if (easy._handler.ServerCertificateValidationCallback != null)
+                            {
+                                easy.SetCurlOption(Interop.Http.CURLoption.CURLOPT_SSL_VERIFYHOST, 0); // don't verify the peer cert's hostname
+                                // We don't change the SSL_VERIFYPEER setting, as setting it to 0 will cause
+                                // SSL and libcurl to ignore the result of the server callback.
+                            }
 
-                        // The allowed SSL protocols will be set in the configuration callback.
-                        break;
+                            // The allowed SSL protocols will be set in the configuration callback.
+                            break;
 
-                    case CURLcode.CURLE_UNKNOWN_OPTION: // Curl 7.38 and prior
-                    case CURLcode.CURLE_NOT_BUILT_IN:   // Curl 7.39 and later
-                        // It's ok if we failed to register the callback if all of the defaults are in play
-                        // with relation to handling of certificates.  But if that's not the case, failing to 
-                        // register the callback will result in those options not being factored in, which is
-                        // a significant enough error that we need to fail.
-                        EventSourceTrace("CURLOPT_SSL_CTX_FUNCTION not supported: {0}", answer, easy: easy);
-                        if (certProvider != null ||
-                            easy._handler.ServerCertificateValidationCallback != null ||
-                            easy._handler.CheckCertificateRevocationList)
-                        {
-                            throw new PlatformNotSupportedException(
-                                SR.Format(SR.net_http_unix_invalid_certcallback_option, CurlVersionDescription, CurlSslVersionDescription));
-                        }
+                        case CURLcode.CURLE_UNKNOWN_OPTION: // Curl 7.38 and prior
+                        case CURLcode.CURLE_NOT_BUILT_IN:   // Curl 7.39 and later
+                            // It's ok if we failed to register the callback if all of the defaults are in play
+                            // with relation to handling of certificates.  But if that's not the case, failing to 
+                            // register the callback will result in those options not being factored in, which is
+                            // a significant enough error that we need to fail.
+                            EventSourceTrace("CURLOPT_SSL_CTX_FUNCTION not supported: {0}", answer, easy: easy);
+                            if (certProvider != null ||
+                                easy._handler.ServerCertificateValidationCallback != null ||
+                                easy._handler.CheckCertificateRevocationList)
+                            {
+                                throw new PlatformNotSupportedException(
+                                    SR.Format(SR.net_http_unix_invalid_certcallback_option, CurlVersionDescription, CurlSslVersionDescription));
+                            }
 
-                        // Since there won't be a callback to configure the allowed SSL protocols, configure them here.
-                        SetSslVersion(easy);
+                            // Since there won't be a callback to configure the allowed SSL protocols, configure them here.
+                            SetSslVersion(easy);
 
-                        break;
+                            break;
 
-                    default:
-                        ThrowIfCURLEError(answer);
-                        break;
+                        default:
+                            ThrowIfCURLEError(answer);
+                            break;
+                    }
+                }
+                else
+                {
+                    // For newer versions of openssl throw PNSE, if default not used.
+                    if (certProvider != null)
+                    {
+                        throw new PlatformNotSupportedException(
+                            SR.Format(
+                                SR.net_http_libcurl_clientcerts_notsupported,
+                                CurlVersionDescription, CurlSslVersionDescription));
+                    }
+
+                    if (easy._handler.ServerCertificateValidationCallback != null)
+                    {
+                        throw new PlatformNotSupportedException(
+                            SR.Format(
+                                SR.net_http_libcurl_callback_notsupported,
+                                CurlVersionDescription, CurlSslVersionDescription));
+                    }
+
+                    if (easy._handler.CheckCertificateRevocationList)
+                    {
+                        throw new PlatformNotSupportedException(
+                            SR.Format(
+                                SR.net_http_libcurl_revocation_notsupported,
+                                CurlVersionDescription, CurlSslVersionDescription));
+                    }
+
+                    // In case of defaults configure the allowed SSL protocols.
+                    SetSslVersion(easy);
                 }
             }
 

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -177,6 +177,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Http.Native\Interop.Initialization.cs">
       <Link>Common\Interop\Unix\System.Net.Http.Native\Interop.Initialization.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Http.Native\Interop.VersionInfo.cs">
+      <Link>Common\Interop\Unix\System.Net.Http.Native\Interop.VersionInfo.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.cs</Link>
     </Compile>


### PR DESCRIPTION
macOS High Sierra (10.13) has changed libcurl from using SecureTransport (darwinssl) as the TLS backend to using LibreSSL.  The LibreSSL backend for libcurl handles the CURLOPT_SSL_CTX_FUNCTION setting that previously only OpenSSL did, and during the handshake we end up mixing pointers between OpenSSL (libcrypto.1.0.0.dylib) and LibreSSL (libcrypto.35.dylib), to poor effect.

Rather than blindly try the option and see if it worked, only try the option when we understand the backend to be a supported backend (OpenSSL 1.0.x).

Backport of https://github.com/dotnet/corefx/pull/19493.