### PR TITLE
Fix TextWriterTraceListener.Tests for Uap

### DIFF
--- a/src/System.Diagnostics.TextWriterTraceListener/tests/DelimiterWriteMethodTests.cs
+++ b/src/System.Diagnostics.TextWriterTraceListener/tests/DelimiterWriteMethodTests.cs
@@ -8,14 +8,14 @@ using Xunit;
 
 namespace System.Diagnostics.TextWriterTraceListenerTests
 {
-    public class DelimiterWriteMethodTests : IDisposable
+    public class DelimiterWriteMethodTests : FileCleanupTestBase
     {
         private readonly Stream _stream;
         private readonly string _fileName;
 
         public DelimiterWriteMethodTests()
         {
-            _fileName = string.Format("{0}.xml", GetType().Name);
+            _fileName = $"{GetTestFilePath(null, GetType().Name)}.xml";
             CommonUtilities.DeleteFile(_fileName);
             _stream = new FileStream(_fileName, FileMode.OpenOrCreate, FileAccess.Write);
         }
@@ -146,10 +146,10 @@ namespace System.Diagnostics.TextWriterTraceListenerTests
             Assert.Equal(expected, File.ReadAllText(_fileName));
         }
 
-        public void Dispose()
+        protected override void Dispose(bool disposing)
         {
             _stream.Dispose();
-            CommonUtilities.DeleteFile(_fileName);
+            base.Dispose(disposing);
         }
     }
 }

--- a/src/System.Diagnostics.TextWriterTraceListener/tests/DelimiterWriteMethodTests.cs
+++ b/src/System.Diagnostics.TextWriterTraceListener/tests/DelimiterWriteMethodTests.cs
@@ -15,7 +15,7 @@ namespace System.Diagnostics.TextWriterTraceListenerTests
 
         public DelimiterWriteMethodTests()
         {
-            _fileName = $"{GetTestFilePath(null, GetType().Name)}.xml";
+            _fileName = $"{GetTestFilePath()}.xml";
             CommonUtilities.DeleteFile(_fileName);
             _stream = new FileStream(_fileName, FileMode.OpenOrCreate, FileAccess.Write);
         }

--- a/src/System.Diagnostics.TextWriterTraceListener/tests/TextWriterTraceListener_WriteTests.cs
+++ b/src/System.Diagnostics.TextWriterTraceListener/tests/TextWriterTraceListener_WriteTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace System.Diagnostics.TextWriterTraceListenerTests
 {
-    public class TextWriterTraceListener_WriteTests : IDisposable
+    public class TextWriterTraceListener_WriteTests : FileCleanupTestBase
     {
         private readonly Stream _stream;
         private readonly string _fileName;
@@ -15,7 +15,7 @@ namespace System.Diagnostics.TextWriterTraceListenerTests
 
         public TextWriterTraceListener_WriteTests()
         {
-            _fileName = string.Format("{0}.xml", GetType().Name);
+            _fileName = $"{GetTestFilePath(null, GetType().Name)}.xml";
             CommonUtilities.DeleteFile(_fileName);
             _stream = new FileStream(_fileName, FileMode.OpenOrCreate, FileAccess.Write);
         }
@@ -77,10 +77,10 @@ namespace System.Diagnostics.TextWriterTraceListenerTests
             }
         }
 
-        public void Dispose()
+        protected override void Dispose(bool disposing)
         {
             _stream.Dispose();
-            CommonUtilities.DeleteFile(_fileName);
+            base.Dispose(disposing);
         }
     }
 }

--- a/src/System.Diagnostics.TextWriterTraceListener/tests/TextWriterTraceListener_WriteTests.cs
+++ b/src/System.Diagnostics.TextWriterTraceListener/tests/TextWriterTraceListener_WriteTests.cs
@@ -15,7 +15,7 @@ namespace System.Diagnostics.TextWriterTraceListenerTests
 
         public TextWriterTraceListener_WriteTests()
         {
-            _fileName = $"{GetTestFilePath(null, GetType().Name)}.xml";
+            _fileName = $"{GetTestFilePath()}.xml";
             CommonUtilities.DeleteFile(_fileName);
             _stream = new FileStream(_fileName, FileMode.OpenOrCreate, FileAccess.Write);
         }


### PR DESCRIPTION
Fixing tests to use temp path through FileCleanupTestBase class so that it is able to run inside Appx.

cc: @danmosemsft @stephentoub @brianrob 