### PR TITLE
Fix System.Net.Requests tests for ILC (UAPAOT)

### DIFF
--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -136,7 +136,7 @@ namespace System.Net.Tests
         public void ContentLength_SetNegativeOne_ThrowsArgumentOutOfRangeException(Uri remoteServer)
         {
             HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
-            Assert.Throws<ArgumentOutOfRangeException>("value", () => request.ContentLength = -1);
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => request.ContentLength = -1);
         }
 
         [Theory, MemberData(nameof(EchoServers))]
@@ -191,7 +191,7 @@ namespace System.Net.Tests
         public void MaximumResponseHeadersLength_SetNegativeTwo_ThrowsArgumentOutOfRangeException(Uri remoteServer)
         {
             HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
-            Assert.Throws<ArgumentOutOfRangeException>("value", () => request.MaximumResponseHeadersLength = -2);
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => request.MaximumResponseHeadersLength = -2);
         }
 
         [Theory, MemberData(nameof(EchoServers))]
@@ -207,8 +207,8 @@ namespace System.Net.Tests
         public void MaximumAutomaticRedirections_SetZeroOrNegative_ThrowsArgumentException(Uri remoteServer)
         {
             HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
-            Assert.Throws<ArgumentException>("value", () => request.MaximumAutomaticRedirections = 0);
-            Assert.Throws<ArgumentException>("value", () => request.MaximumAutomaticRedirections = -1);
+            AssertExtensions.Throws<ArgumentException>("value", () => request.MaximumAutomaticRedirections = 0);
+            AssertExtensions.Throws<ArgumentException>("value", () => request.MaximumAutomaticRedirections = -1);
         }
 
         [Theory, MemberData(nameof(EchoServers))]
@@ -239,7 +239,7 @@ namespace System.Net.Tests
         public void ContinueTimeout_SetNegativeTwo_ThrowsArgumentOutOfRangeException(Uri remoteServer)
         {
             HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
-            Assert.Throws<ArgumentOutOfRangeException>("value", () => request.ContinueTimeout = -2);
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => request.ContinueTimeout = -2);
         }
 
         [Theory, MemberData(nameof(EchoServers))]
@@ -262,7 +262,7 @@ namespace System.Net.Tests
         public void Timeout_SetNegativeTwo_ThrowsArgumentOutOfRangeException(Uri remoteServer)
         {
             HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
-            Assert.Throws<ArgumentOutOfRangeException>("value", () => request.Timeout = -2);
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => request.Timeout = -2);
         }
 
         [Theory, MemberData(nameof(EchoServers))]
@@ -406,7 +406,7 @@ namespace System.Net.Tests
         public void TransferEncoding_SetChunked_ThrowsArgumentException(Uri remoteServer)
         {
             HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
-            Assert.Throws<ArgumentException>("value", () => request.TransferEncoding = "chunked");
+            AssertExtensions.Throws<ArgumentException>("value", () => request.TransferEncoding = "chunked");
         }
 
         [Theory, MemberData(nameof(EchoServers))]
@@ -534,8 +534,8 @@ namespace System.Net.Tests
         public void Connection_SetKeepAliveAndClose_ThrowsArgumentException(Uri remoteServer)
         {
             HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
-            Assert.Throws<ArgumentException>("value", () => request.Connection = "keep-alive");
-            Assert.Throws<ArgumentException>("value", () => request.Connection = "close");
+            AssertExtensions.Throws<ArgumentException>("value", () => request.Connection = "keep-alive");
+            AssertExtensions.Throws<ArgumentException>("value", () => request.Connection = "close");
         }
 
         [Theory, MemberData(nameof(EchoServers))]
@@ -553,7 +553,7 @@ namespace System.Net.Tests
         public void Expect_Set100Continue_ThrowsArgumentException(Uri remoteServer)
         {
             HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
-            Assert.Throws<ArgumentException>("value", () => request.Expect = "100-continue");
+            AssertExtensions.Throws<ArgumentException>("value", () => request.Expect = "100-continue");
         }
 
         [ActiveIssue(20136, TargetFrameworkMonikers.Uap)]
@@ -706,7 +706,7 @@ namespace System.Net.Tests
         public void ClientCertificates_SetNullX509_ThrowsArgumentNullException(Uri remoteServer)
         {
             HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
-            Assert.Throws<ArgumentNullException>("value", () => request.ClientCertificates = null);
+            AssertExtensions.Throws<ArgumentNullException>("value", () => request.ClientCertificates = null);
         }
 
         [Theory, MemberData(nameof(EchoServers))]
@@ -722,7 +722,7 @@ namespace System.Net.Tests
         public void ProtocolVersion_SetInvalidHttpVersion_ThrowsArgumentException(Uri remoteServer)
         {
             HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
-            Assert.Throws<ArgumentException>("value", () => request.ProtocolVersion = new Version());
+            AssertExtensions.Throws<ArgumentException>("value", () => request.ProtocolVersion = new Version());
         }
 
         [Theory, MemberData(nameof(EchoServers))]
@@ -1080,9 +1080,9 @@ namespace System.Net.Tests
         public void Method_SetInvalidString_ThrowsArgumentException(Uri remoteServer)
         {
             HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
-            Assert.Throws<ArgumentException>("value", () => request.Method = null);
-            Assert.Throws<ArgumentException>("value", () => request.Method = string.Empty);
-            Assert.Throws<ArgumentException>("value", () => request.Method = "Method(2");
+            AssertExtensions.Throws<ArgumentException>("value", () => request.Method = null);
+            AssertExtensions.Throws<ArgumentException>("value", () => request.Method = string.Empty);
+            AssertExtensions.Throws<ArgumentException>("value", () => request.Method = "Method(2");
         }
 
         [Theory, MemberData(nameof(EchoServers))]

--- a/src/System.Net.Requests/tests/LoggingTest.cs
+++ b/src/System.Net.Requests/tests/LoggingTest.cs
@@ -11,6 +11,7 @@ namespace System.Net.Tests
     {
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core")]
+        [ActiveIssue(20136, TargetFrameworkMonikers.UapAot)]
         public void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(WebRequest).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);

--- a/src/System.Net.Requests/tests/RequestStreamTest.cs
+++ b/src/System.Net.Requests/tests/RequestStreamTest.cs
@@ -22,7 +22,7 @@ namespace System.Net.Tests
         {
             await GetRequestStream((stream) =>
             {
-                Assert.Throws<ArgumentNullException>("buffer", () => stream.Write(null, 0, 1));
+                AssertExtensions.Throws<ArgumentNullException>("buffer", () => stream.Write(null, 0, 1));
             });
         }
 
@@ -31,7 +31,7 @@ namespace System.Net.Tests
         {
             await GetRequestStream((stream) =>
             {
-                Assert.Throws<ArgumentOutOfRangeException>("offset", () => stream.Write(buffer, -1, buffer.Length));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => stream.Write(buffer, -1, buffer.Length));
             });
         }
 
@@ -58,7 +58,7 @@ namespace System.Net.Tests
         {
             await GetRequestStream((stream) =>
             {
-                Assert.Throws<ArgumentOutOfRangeException>("offset", () => stream.Write(buffer, int.MaxValue, int.MaxValue));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => stream.Write(buffer, int.MaxValue, int.MaxValue));
             });
         }
 
@@ -71,7 +71,7 @@ namespace System.Net.Tests
         {
             await GetRequestStream((stream) =>
             {
-                Assert.Throws<ArgumentNullException>("buffer", () => { Task t = stream.WriteAsync(null, 0, 1); });
+                AssertExtensions.Throws<ArgumentNullException>("buffer", () => { Task t = stream.WriteAsync(null, 0, 1); });
             });
         }
 
@@ -80,7 +80,7 @@ namespace System.Net.Tests
         {
             await GetRequestStream((stream) =>
             {
-                Assert.Throws<ArgumentOutOfRangeException>("offset", () => { Task t = stream.WriteAsync(buffer, -1, buffer.Length); });
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => { Task t = stream.WriteAsync(buffer, -1, buffer.Length); });
             });
         }
 
@@ -107,7 +107,7 @@ namespace System.Net.Tests
         {
             await GetRequestStream((stream) =>
             {
-                Assert.Throws<ArgumentOutOfRangeException>("offset", () => { Task t = stream.WriteAsync(buffer, int.MaxValue, int.MaxValue); });
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => { Task t = stream.WriteAsync(buffer, int.MaxValue, int.MaxValue); });
             });
         }
 
@@ -142,7 +142,7 @@ namespace System.Net.Tests
         {
             await GetRequestStream((stream) =>
             {
-                Assert.Throws<ArgumentNullException>("buffer", () => stream.BeginWrite(null, 0, 1, null, null));
+                AssertExtensions.Throws<ArgumentNullException>("buffer", () => stream.BeginWrite(null, 0, 1, null, null));
             });
         }
 
@@ -151,7 +151,7 @@ namespace System.Net.Tests
         {
             await GetRequestStream((stream) =>
             {
-                Assert.Throws<ArgumentOutOfRangeException>("offset", () => stream.BeginWrite(buffer, -1, buffer.Length, null, null));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => stream.BeginWrite(buffer, -1, buffer.Length, null, null));
             });
         }
 
@@ -178,7 +178,7 @@ namespace System.Net.Tests
         {
             await GetRequestStream((stream) =>
             {
-                Assert.Throws<ArgumentOutOfRangeException>("offset", () => stream.BeginWrite(buffer, int.MaxValue, int.MaxValue, null, null));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => stream.BeginWrite(buffer, int.MaxValue, int.MaxValue, null, null));
             });
         }
 


### PR DESCRIPTION
Switch From Assert.Throws to AssertExtensions.Throws to handle the
uapaot test runs which don't return string parameter name in exceptions.

Contributes to #20136