### PR TITLE
CookieContainer improvements

### DIFF
--- a/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
+++ b/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
@@ -827,14 +827,16 @@ namespace System.Net
 
                 lock (pathList.SyncRoot)
                 {
-                    foreach (DictionaryEntry entry in pathList)
+                    // Manual use of IDictionaryEnumerator instead of foreach to avoid DictionaryEntry box allocations.
+                    IDictionaryEnumerator e = pathList.GetEnumerator();
+                    while (e.MoveNext())
                     {
-                        string path = (string)entry.Key;
+                        string path = (string)e.Key;
                         if (uri.AbsolutePath.StartsWith(CookieParser.CheckQuoted(path)))
                         {
                             found = true;
 
-                            CookieCollection cc = (CookieCollection)entry.Value;
+                            CookieCollection cc = (CookieCollection)e.Value;
                             cc.TimeStamp(CookieCollection.Stamp.Set);
                             MergeUpdateCollections(ref cookies, cc, port, isSecure, matchOnlyPlainCookie);
 
@@ -1056,7 +1058,7 @@ namespace System.Net
             }
         }
 
-        public IEnumerator GetEnumerator()
+        public IDictionaryEnumerator GetEnumerator()
         {
             lock (SyncRoot)
             {

--- a/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
+++ b/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
@@ -657,11 +657,11 @@ namespace System.Net
             }
             else
             {
-                for (int i = 0; i < s_headerInfo.Length; ++i)
+                foreach (HeaderVariantInfo info in s_headerInfo)
                 {
-                    if ((String.Compare(headerName, s_headerInfo[i].Name, StringComparison.OrdinalIgnoreCase) == 0))
+                    if (string.Equals(headerName, info.Name, StringComparison.OrdinalIgnoreCase))
                     {
-                        variant = s_headerInfo[i].Variant;
+                        variant = info.Variant;
                     }
                 }
             }

--- a/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
+++ b/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
@@ -1026,32 +1026,17 @@ namespace System.Net
 
         public CookieCollection this[string s]
         {
-            get
-            {
-                lock (SyncRoot)
-                {
-                    return (CookieCollection)m_list[s];
-                }
-            }
+            get => (CookieCollection)m_list[s];
             set
             {
-                lock (SyncRoot)
-                {
-                    Debug.Assert(value != null);
-                    m_list[s] = value;
-                }
+                Debug.Assert(value != null);
+                m_list[s] = value;
             }
         }
 
-        public IDictionaryEnumerator GetEnumerator()
-        {
-            lock (SyncRoot)
-            {
-                return m_list.GetEnumerator();
-            }
-        }
+        public IDictionaryEnumerator GetEnumerator() => m_list.GetEnumerator();
 
-        public object SyncRoot => m_list;
+        public object SyncRoot => m_list.SyncRoot;
 
         [Serializable]
         [System.Runtime.CompilerServices.TypeForwardedFrom("System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]

--- a/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
+++ b/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
@@ -297,7 +297,7 @@ namespace System.Net
                 CookieCollection cookies;
                 lock (pathList.SyncRoot)
                 {
-                    cookies = (CookieCollection)pathList[cookie.Path];
+                    cookies = pathList[cookie.Path];
 
                     if (cookies == null)
                     {
@@ -854,7 +854,7 @@ namespace System.Net
 
                 if (!defaultAdded)
                 {
-                    CookieCollection cc = (CookieCollection)pathList["/"];
+                    CookieCollection cc = pathList["/"];
 
                     if (cc != null)
                     {
@@ -1039,13 +1039,13 @@ namespace System.Net
             }
         }
 
-        public object this[string s]
+        public CookieCollection this[string s]
         {
             get
             {
                 lock (SyncRoot)
                 {
-                    return m_list[s];
+                    return (CookieCollection)m_list[s];
                 }
             }
             set

--- a/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
+++ b/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
@@ -387,12 +387,14 @@ namespace System.Net
             }
             lock (m_domainTable.SyncRoot)
             {
-                foreach (DictionaryEntry entry in m_domainTable)
+                // Manual use of IDictionaryEnumerator instead of foreach to avoid DictionaryEntry box allocations.
+                IDictionaryEnumerator e = m_domainTable.GetEnumerator();
+                while (e.MoveNext())
                 {
                     if (domain == null)
                     {
-                        tempDomain = (string)entry.Key;
-                        pathList = (PathList)entry.Value; // Aliasing to trick foreach
+                        tempDomain = (string)e.Key;
+                        pathList = (PathList)e.Value; // Aliasing to trick foreach
                     }
                     else
                     {

--- a/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
+++ b/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
@@ -285,7 +285,7 @@ namespace System.Net
                     object pathValue = m_domainTable[cookie.DomainKey];
                     if (pathValue == null)
                     {
-                        m_domainTable[cookie.DomainKey] = (pathList = PathList.Create());
+                        m_domainTable[cookie.DomainKey] = (pathList = new PathList());
                     }
                     else
                     {
@@ -1000,27 +1000,13 @@ namespace System.Net
 
     [Serializable]
     [System.Runtime.CompilerServices.TypeForwardedFrom("System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    internal struct PathList
+    internal sealed class PathList
     {
         // Usage of PathList depends on it being shallowly immutable;
         // adding any mutable fields to it would result in breaks.
-        private readonly SortedList m_list; // Do not rename (binary serialization)
+        private readonly SortedList m_list = SortedList.Synchronized(new SortedList(PathListComparer.StaticInstance)); // Do not rename (binary serialization)
 
-        public static PathList Create() => new PathList(SortedList.Synchronized(new SortedList(PathListComparer.StaticInstance)));
-
-        private PathList(SortedList list)
-        {
-            Debug.Assert(list != null, $"{nameof(list)} must not be null.");
-            m_list = list;
-        }
-
-        public int Count
-        {
-            get
-            {
-                return m_list.Count;
-            }
-        }
+        public int Count => m_list.Count;
 
         public int GetCookiesCount()
         {
@@ -1065,14 +1051,7 @@ namespace System.Net
             }
         }
 
-        public object SyncRoot
-        {
-            get
-            {
-                Debug.Assert(m_list != null, $"{nameof(PathList)} should never be default initialized and only ever created with {nameof(Create)}.");
-                return m_list;
-            }
-        }
+        public object SyncRoot => m_list;
 
         [Serializable]
         [System.Runtime.CompilerServices.TypeForwardedFrom("System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]


### PR DESCRIPTION
#20870 reverted some improvements made to `CookieContainer` to enable binary serialization. This PR adds back some of the improvements while maintaining serialization compat (also some minor cleanup I noticed while making changes here). The PR is broken up into several commits to make it easier to review the changes.

cc: @ViktorHofer, @danmosemsft, @stephentoub, @davidsh, @CIPop