### PR TITLE
Fix System.Net.Security.Tests failed on armel

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamTestForUnix.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamTestForUnix.cs
@@ -109,10 +109,19 @@ namespace System.Net.Security.Tests
             // the program to be run
             startInfo.FileName = SudoCommand;
             startInfo.Arguments = string.Format("bash {0} {1}", ScriptName, args);
-            using (Process kdcSetup = Process.Start(startInfo))
+
+            try
             {
-                kdcSetup.WaitForExit();
-                return kdcSetup.ExitCode;
+                using (Process kdcSetup = Process.Start(startInfo))
+                {
+                    kdcSetup.WaitForExit();
+                    return kdcSetup.ExitCode;
+                }
+            }
+            catch
+            {
+                // Could not find the file
+                return 1;
             }
         }
     }

--- a/src/System.Net.Security/tests/Scripts/Unix/setup-kdc.sh
+++ b/src/System.Net.Security/tests/Scripts/Unix/setup-kdc.sh
@@ -66,6 +66,7 @@ clean_up()
             ;;
         *)
             echo "This is an unsupported operating system"
+            exit 1
             ;;
     esac
 
@@ -288,6 +289,7 @@ case ${OS} in
          ;;
     *)
         echo "This is an unsupported operating system"
+        exit 1
         ;;
 esac
 


### PR DESCRIPTION
Add code to care if sudo is not there on armel-rootfs
- https://github.com/dotnet/corefx/issues/21075
- add try/catch for catching a situation where there is no sudo
- return 1 if os is not specific os(ex. tizen) in setup-kdc.sh