### PR TITLE
Disable TestEtw and GetTaskSchedulersForDebugger tests for UapAot

### DIFF
--- a/src/System.Threading.Tasks.Dataflow/tests/Dataflow/EtwTests.cs
+++ b/src/System.Threading.Tasks.Dataflow/tests/Dataflow/EtwTests.cs
@@ -11,6 +11,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
     public class EtwTests : RemoteExecutorTestBase
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20592", TargetFrameworkMonikers.UapAot)]
         public void TestEtw()
         {
             RemoteInvoke(() =>

--- a/src/System.Threading.Tasks/tests/TaskScheduler/TaskSchedulerTests.cs
+++ b/src/System.Threading.Tasks/tests/TaskScheduler/TaskSchedulerTests.cs
@@ -291,6 +291,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Uses reflection to access an internal method of the TaskScheduler class.")]
         public static void GetTaskSchedulersForDebugger_ReturnsDefaultScheduler()
         {
             MethodInfo getTaskSchedulersForDebuggerMethod = typeof(TaskScheduler).GetTypeInfo().GetDeclaredMethod("GetTaskSchedulersForDebugger");
@@ -300,6 +301,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(nameof(DebuggerIsAttached))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Uses reflection to access an internal method of the TaskScheduler class.")]
         public static void GetTaskSchedulersForDebugger_DebuggerAttached_ReturnsAllSchedulers()
         {
             MethodInfo getTaskSchedulersForDebuggerMethod = typeof(TaskScheduler).GetTypeInfo().GetDeclaredMethod("GetTaskSchedulersForDebugger");
@@ -315,6 +317,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(nameof(DebuggerIsAttached))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Uses reflection to access an internal method of the TaskScheduler class.")]
         public static void GetScheduledTasksForDebugger_DebuggerAttached_ReturnsTasksFromCustomSchedulers()
         {
             var nonExecutingScheduler = new BuggyTaskScheduler(faultQueues: false);


### PR DESCRIPTION
Disable TestEtw test due to issue #20592.
Disable GetTaskSchedulersForDebugger tests due to use of reflection.