### PR TITLE
Fix System.Net.NetworkInformation.Tests for uap

### DIFF
--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/AddressParsingTests.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/AddressParsingTests.cs
@@ -3,17 +3,19 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.IO;
 using Xunit;
 
 namespace System.Net.NetworkInformation.Tests
 {
-    public class AddressParsingTests
+    public class AddressParsingTests : FileCleanupTestBase
     {
         [Fact]
-        public static void GatewayAddressParsing()
+        public void GatewayAddressParsing()
         {
-            FileUtil.NormalizeLineEndings("route", "route_normalized1");
-            List<GatewayIPAddressInformation> gatewayAddresses = StringParsingHelpers.ParseGatewayAddressesFromRouteFile("route_normalized1", "wlan0");
+            string routeNormalized = GetTestFilePath();
+            FileUtil.NormalizeLineEndings("route", routeNormalized);
+            List<GatewayIPAddressInformation> gatewayAddresses = StringParsingHelpers.ParseGatewayAddressesFromRouteFile(routeNormalized, "wlan0");
             Assert.Equal(3, gatewayAddresses.Count);
 
             Assert.Equal(StringParsingHelpers.ParseHexIPAddress("0180690A"), gatewayAddresses[0].Address);
@@ -22,20 +24,22 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        public static void DhcpServerAddressParsing()
+        public void DhcpServerAddressParsing()
         {
-            FileUtil.NormalizeLineEndings("dhclient.leases", "dhclient.leases_normalized0");
-            List<IPAddress> dhcpServerAddresses = StringParsingHelpers.ParseDhcpServerAddressesFromLeasesFile("dhclient.leases_normalized0", "wlan0");
+            string routeNormalized = GetTestFilePath();
+            FileUtil.NormalizeLineEndings("dhclient.leases", routeNormalized);
+            List<IPAddress> dhcpServerAddresses = StringParsingHelpers.ParseDhcpServerAddressesFromLeasesFile(routeNormalized, "wlan0");
             Assert.Equal(1, dhcpServerAddresses.Count);
             Assert.Equal(IPAddress.Parse("10.105.128.4"), dhcpServerAddresses[0]);
         }
 
         [Fact]
-        public static void WinsServerAddressParsing()
+        public void WinsServerAddressParsing()
         {
-            FileUtil.NormalizeLineEndings("smb.conf", "smb.conf_normalized");
+            string routeNormalized = GetTestFilePath();
+            FileUtil.NormalizeLineEndings("smb.conf", routeNormalized);
 
-            List<IPAddress> winsServerAddresses = StringParsingHelpers.ParseWinsServerAddressesFromSmbConfFile("smb.conf_normalized");
+            List<IPAddress> winsServerAddresses = StringParsingHelpers.ParseWinsServerAddressesFromSmbConfFile(routeNormalized);
             Assert.Equal(1, winsServerAddresses.Count);
             Assert.Equal(IPAddress.Parse("255.1.255.1"), winsServerAddresses[0]);
         }

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/AddressParsingTests.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/AddressParsingTests.cs
@@ -13,9 +13,9 @@ namespace System.Net.NetworkInformation.Tests
         [Fact]
         public void GatewayAddressParsing()
         {
-            string routeNormalized = GetTestFilePath();
-            FileUtil.NormalizeLineEndings("route", routeNormalized);
-            List<GatewayIPAddressInformation> gatewayAddresses = StringParsingHelpers.ParseGatewayAddressesFromRouteFile(routeNormalized, "wlan0");
+            string fileName = GetTestFilePath();
+            FileUtil.NormalizeLineEndings("route", fileName);
+            List<GatewayIPAddressInformation> gatewayAddresses = StringParsingHelpers.ParseGatewayAddressesFromRouteFile(fileName, "wlan0");
             Assert.Equal(3, gatewayAddresses.Count);
 
             Assert.Equal(StringParsingHelpers.ParseHexIPAddress("0180690A"), gatewayAddresses[0].Address);
@@ -26,9 +26,9 @@ namespace System.Net.NetworkInformation.Tests
         [Fact]
         public void DhcpServerAddressParsing()
         {
-            string routeNormalized = GetTestFilePath();
-            FileUtil.NormalizeLineEndings("dhclient.leases", routeNormalized);
-            List<IPAddress> dhcpServerAddresses = StringParsingHelpers.ParseDhcpServerAddressesFromLeasesFile(routeNormalized, "wlan0");
+            string fileName = GetTestFilePath();
+            FileUtil.NormalizeLineEndings("dhclient.leases", fileName);
+            List<IPAddress> dhcpServerAddresses = StringParsingHelpers.ParseDhcpServerAddressesFromLeasesFile(fileName, "wlan0");
             Assert.Equal(1, dhcpServerAddresses.Count);
             Assert.Equal(IPAddress.Parse("10.105.128.4"), dhcpServerAddresses[0]);
         }
@@ -36,10 +36,10 @@ namespace System.Net.NetworkInformation.Tests
         [Fact]
         public void WinsServerAddressParsing()
         {
-            string routeNormalized = GetTestFilePath();
-            FileUtil.NormalizeLineEndings("smb.conf", routeNormalized);
+            string fileName = GetTestFilePath();
+            FileUtil.NormalizeLineEndings("smb.conf", fileName);
 
-            List<IPAddress> winsServerAddresses = StringParsingHelpers.ParseWinsServerAddressesFromSmbConfFile(routeNormalized);
+            List<IPAddress> winsServerAddresses = StringParsingHelpers.ParseWinsServerAddressesFromSmbConfFile(fileName);
             Assert.Equal(1, winsServerAddresses.Count);
             Assert.Equal(IPAddress.Parse("255.1.255.1"), winsServerAddresses[0]);
         }

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/ConnectionsParsingTests.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/ConnectionsParsingTests.cs
@@ -2,38 +2,43 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.IO;
 using Xunit;
 
 namespace System.Net.NetworkInformation.Tests
 {
-    public class ConnectionsParsingTests
+    public class ConnectionsParsingTests : FileCleanupTestBase
     {
         [Fact]
-        public static void NumSocketConnectionsParsing()
+        public void NumSocketConnectionsParsing()
         {
-            FileUtil.NormalizeLineEndings("sockstat", "sockstat_normalized");
-            FileUtil.NormalizeLineEndings("sockstat6", "sockstat6_normalized");
+            string sockstatFile = $"{GetTestFilePath()}_sockstat_normalized";
+            string sockstat6File = $"{GetTestFilePath()}_sockstat6_normalized";
+            FileUtil.NormalizeLineEndings("sockstat", sockstatFile);
+            FileUtil.NormalizeLineEndings("sockstat6", sockstat6File);
 
-            int numTcp = StringParsingHelpers.ParseNumSocketConnections("sockstat_normalized", "TCP");
+            int numTcp = StringParsingHelpers.ParseNumSocketConnections(sockstatFile, "TCP");
             Assert.Equal(4, numTcp);
 
-            int numTcp6 = StringParsingHelpers.ParseNumSocketConnections("sockstat6_normalized", "TCP6");
+            int numTcp6 = StringParsingHelpers.ParseNumSocketConnections(sockstat6File, "TCP6");
             Assert.Equal(6, numTcp6);
 
-            int numUdp = StringParsingHelpers.ParseNumSocketConnections("sockstat_normalized", "UDP");
+            int numUdp = StringParsingHelpers.ParseNumSocketConnections(sockstatFile, "UDP");
             Assert.Equal(12, numUdp);
 
-            int numUdp6 = StringParsingHelpers.ParseNumSocketConnections("sockstat6_normalized", "UDP6");
+            int numUdp6 = StringParsingHelpers.ParseNumSocketConnections(sockstat6File, "UDP6");
             Assert.Equal(3, numUdp6);
         }
 
         [Fact]
-        public static void ActiveTcpConnectionsParsing()
+        public void ActiveTcpConnectionsParsing()
         {
-            FileUtil.NormalizeLineEndings("tcp", "tcp_normalized0");
-            FileUtil.NormalizeLineEndings("tcp6", "tcp6_normalized0");
+            string tcpFile = $"{GetTestFilePath()}_tcp_normalized0";
+            string tcp6File = $"{GetTestFilePath()}_tcp6_normalized0";
+            FileUtil.NormalizeLineEndings("tcp", tcpFile);
+            FileUtil.NormalizeLineEndings("tcp6", tcp6File);
 
-            TcpConnectionInformation[] infos = StringParsingHelpers.ParseActiveTcpConnectionsFromFiles("tcp_normalized0", "tcp6_normalized0");
+            TcpConnectionInformation[] infos = StringParsingHelpers.ParseActiveTcpConnectionsFromFiles(tcpFile, tcp6File);
             Assert.Equal(11, infos.Length);
             ValidateInfo(infos[0], new IPEndPoint(0xFFFFFF01L, 0x01BD), new IPEndPoint(0L, 0), TcpState.Established);
             ValidateInfo(infos[1], new IPEndPoint(0x12345678L, 0x008B), new IPEndPoint(0L, 0), TcpState.SynSent);
@@ -79,12 +84,14 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        public static void TcpListenersParsing()
+        public void TcpListenersParsing()
         {
-            FileUtil.NormalizeLineEndings("tcp", "tcp_normalized1");
-            FileUtil.NormalizeLineEndings("tcp6", "tcp6_normalized1");
+            string tcpFile = $"{GetTestFilePath()}_tcp_normalized1";
+            string tcp6File = $"{GetTestFilePath()}_tcp6_normalized1";
+            FileUtil.NormalizeLineEndings("tcp", tcpFile);
+            FileUtil.NormalizeLineEndings("tcp6", tcp6File);
 
-            IPEndPoint[] listeners = StringParsingHelpers.ParseActiveTcpListenersFromFiles("tcp_normalized1", "tcp6_normalized1");
+            IPEndPoint[] listeners = StringParsingHelpers.ParseActiveTcpListenersFromFiles(tcpFile, tcp6File);
             Assert.Equal(11, listeners.Length);
 
             Assert.Equal(new IPEndPoint(0xFFFFFF01, 0x01Bd), listeners[0]);
@@ -102,12 +109,14 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        public static void UdpListenersParsing()
+        public void UdpListenersParsing()
         {
-            FileUtil.NormalizeLineEndings("udp", "udp_normalized0");
-            FileUtil.NormalizeLineEndings("udp6", "udp6_normalized0");
+            string udpFile = $"{GetTestFilePath()}_udp_normalized0";
+            string udp6File = $"{GetTestFilePath()}_udp6_normalized0";
+            FileUtil.NormalizeLineEndings("udp", udpFile);
+            FileUtil.NormalizeLineEndings("udp6", udp6File);
 
-            IPEndPoint[] listeners = StringParsingHelpers.ParseActiveUdpListenersFromFiles("udp_normalized0", "udp6_normalized0");
+            IPEndPoint[] listeners = StringParsingHelpers.ParseActiveUdpListenersFromFiles(udpFile, udp6File);
             Assert.Equal(15, listeners.Length);
 
             Assert.Equal(listeners[0], new IPEndPoint(0x00000000, 0x8E15));

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/ConnectionsParsingTests.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/ConnectionsParsingTests.cs
@@ -12,8 +12,8 @@ namespace System.Net.NetworkInformation.Tests
         [Fact]
         public void NumSocketConnectionsParsing()
         {
-            string sockstatFile = $"{GetTestFilePath()}_sockstat_normalized";
-            string sockstat6File = $"{GetTestFilePath()}_sockstat6_normalized";
+            string sockstatFile = GetTestFilePath();
+            string sockstat6File = GetTestFilePath();
             FileUtil.NormalizeLineEndings("sockstat", sockstatFile);
             FileUtil.NormalizeLineEndings("sockstat6", sockstat6File);
 
@@ -33,8 +33,8 @@ namespace System.Net.NetworkInformation.Tests
         [Fact]
         public void ActiveTcpConnectionsParsing()
         {
-            string tcpFile = $"{GetTestFilePath()}_tcp_normalized0";
-            string tcp6File = $"{GetTestFilePath()}_tcp6_normalized0";
+            string tcpFile = GetTestFilePath();
+            string tcp6File = GetTestFilePath();
             FileUtil.NormalizeLineEndings("tcp", tcpFile);
             FileUtil.NormalizeLineEndings("tcp6", tcp6File);
 
@@ -86,8 +86,8 @@ namespace System.Net.NetworkInformation.Tests
         [Fact]
         public void TcpListenersParsing()
         {
-            string tcpFile = $"{GetTestFilePath()}_tcp_normalized1";
-            string tcp6File = $"{GetTestFilePath()}_tcp6_normalized1";
+            string tcpFile = GetTestFilePath();
+            string tcp6File = GetTestFilePath();
             FileUtil.NormalizeLineEndings("tcp", tcpFile);
             FileUtil.NormalizeLineEndings("tcp6", tcp6File);
 
@@ -111,8 +111,8 @@ namespace System.Net.NetworkInformation.Tests
         [Fact]
         public void UdpListenersParsing()
         {
-            string udpFile = $"{GetTestFilePath()}_udp_normalized0";
-            string udp6File = $"{GetTestFilePath()}_udp6_normalized0";
+            string udpFile = GetTestFilePath();
+            string udp6File = GetTestFilePath();
             FileUtil.NormalizeLineEndings("udp", udpFile);
             FileUtil.NormalizeLineEndings("udp6", udp6File);
 

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/DnsParsingTests.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/DnsParsingTests.cs
@@ -14,10 +14,10 @@ namespace System.Net.NetworkInformation.Tests
         [Theory]
         public void DnsSuffixParsing(string file)
         {
-            string normalizedFile = $"{GetTestFilePath()}_{file}_normalized0";
-            FileUtil.NormalizeLineEndings(file, normalizedFile);
+            string fileName = GetTestFilePath();
+            FileUtil.NormalizeLineEndings(file, fileName);
 
-            string suffix = StringParsingHelpers.ParseDnsSuffixFromResolvConfFile(normalizedFile);
+            string suffix = StringParsingHelpers.ParseDnsSuffixFromResolvConfFile(fileName);
             Assert.Equal("fake.suffix.net", suffix);
         }
 
@@ -26,10 +26,10 @@ namespace System.Net.NetworkInformation.Tests
         [Theory]
         public void DnsAddressesParsing(string file)
         {
-            string normalizedFile = $"{GetTestFilePath()}_{file}_normalized1";
-            FileUtil.NormalizeLineEndings(file, normalizedFile);
+            string fileName = GetTestFilePath();
+            FileUtil.NormalizeLineEndings(file, fileName);
 
-            var dnsAddresses = StringParsingHelpers.ParseDnsAddressesFromResolvConfFile(normalizedFile);
+            var dnsAddresses = StringParsingHelpers.ParseDnsAddressesFromResolvConfFile(fileName);
             Assert.Equal(1, dnsAddresses.Count);
             Assert.Equal(IPAddress.Parse("127.0.1.1"), dnsAddresses[0]);
         }

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/DnsParsingTests.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/DnsParsingTests.cs
@@ -2,31 +2,34 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.IO;
 using Xunit;
 
 namespace System.Net.NetworkInformation.Tests
 {
-    public class DnsParsingTests
+    public class DnsParsingTests : FileCleanupTestBase
     {
         [InlineData("resolv.conf")]
         [InlineData("resolv_nonewline.conf")]
         [Theory]
-        public static void DnsSuffixParsing(string file)
+        public void DnsSuffixParsing(string file)
         {
-            FileUtil.NormalizeLineEndings(file, file + "_normalized0");
+            string normalizedFile = $"{GetTestFilePath()}_{file}_normalized0";
+            FileUtil.NormalizeLineEndings(file, normalizedFile);
 
-            string suffix = StringParsingHelpers.ParseDnsSuffixFromResolvConfFile(file + "_normalized0");
+            string suffix = StringParsingHelpers.ParseDnsSuffixFromResolvConfFile(normalizedFile);
             Assert.Equal("fake.suffix.net", suffix);
         }
 
         [InlineData("resolv.conf")]
         [InlineData("resolv_nonewline.conf")]
         [Theory]
-        public static void DnsAddressesParsing(string file)
+        public void DnsAddressesParsing(string file)
         {
-            FileUtil.NormalizeLineEndings(file, file + "_normalized1");
+            string normalizedFile = $"{GetTestFilePath()}_{file}_normalized1";
+            FileUtil.NormalizeLineEndings(file, normalizedFile);
 
-            var dnsAddresses = StringParsingHelpers.ParseDnsAddressesFromResolvConfFile(file + "_normalized1");
+            var dnsAddresses = StringParsingHelpers.ParseDnsAddressesFromResolvConfFile(normalizedFile);
             Assert.Equal(1, dnsAddresses.Count);
             Assert.Equal(IPAddress.Parse("127.0.1.1"), dnsAddresses[0]);
         }

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/MiscParsingTests.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/MiscParsingTests.cs
@@ -12,18 +12,18 @@ namespace System.Net.NetworkInformation.Tests
         [Fact]
         public void NumRoutesParsing()
         {
-            string normalizedFile = GetTestFilePath();
-            FileUtil.NormalizeLineEndings("route", normalizedFile);
-            int numRoutes = StringParsingHelpers.ParseNumRoutesFromRouteFile(normalizedFile);
+            string fileName = GetTestFilePath();
+            FileUtil.NormalizeLineEndings("route", fileName);
+            int numRoutes = StringParsingHelpers.ParseNumRoutesFromRouteFile(fileName);
             Assert.Equal(4, numRoutes);
         }
 
         [Fact]
         public void DefaultTtlParsing()
         {
-            string normalizedFile = GetTestFilePath();
-            FileUtil.NormalizeLineEndings("snmp", normalizedFile);
-            int ttl = StringParsingHelpers.ParseDefaultTtlFromFile(normalizedFile);
+            string fileName = GetTestFilePath();
+            FileUtil.NormalizeLineEndings("snmp", fileName);
+            int ttl = StringParsingHelpers.ParseDefaultTtlFromFile(fileName);
             Assert.Equal(64, ttl);
         }
 

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/MiscParsingTests.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/MiscParsingTests.cs
@@ -2,25 +2,28 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.IO;
 using Xunit;
 
 namespace System.Net.NetworkInformation.Tests
 {
-    public class MiscParsingTests
+    public class MiscParsingTests : FileCleanupTestBase
     {
         [Fact]
-        public static void NumRoutesParsing()
+        public void NumRoutesParsing()
         {
-            FileUtil.NormalizeLineEndings("route", "route_normalized0");
-            int numRoutes = StringParsingHelpers.ParseNumRoutesFromRouteFile("route_normalized0");
+            string normalizedFile = GetTestFilePath();
+            FileUtil.NormalizeLineEndings("route", normalizedFile);
+            int numRoutes = StringParsingHelpers.ParseNumRoutesFromRouteFile(normalizedFile);
             Assert.Equal(4, numRoutes);
         }
 
         [Fact]
-        public static void DefaultTtlParsing()
+        public void DefaultTtlParsing()
         {
-            FileUtil.NormalizeLineEndings("snmp", "snmp_normalized0");
-            int ttl = StringParsingHelpers.ParseDefaultTtlFromFile("snmp_normalized0");
+            string normalizedFile = GetTestFilePath();
+            FileUtil.NormalizeLineEndings("snmp", normalizedFile);
+            int ttl = StringParsingHelpers.ParseDefaultTtlFromFile(normalizedFile);
             Assert.Equal(64, ttl);
         }
 

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
@@ -261,7 +261,8 @@ namespace System.Net.NetworkInformation.Tests
         [PlatformSpecific(~TestPlatforms.OSX)]
         [InlineData(false)]
         [InlineData(true)]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "https://github.com/dotnet/corefx/issues/19314")]
+        [ActiveIssue(19314, TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue(20014, TargetFrameworkMonikers.Uap)]
         public async Task NetworkInterface_LoopbackInterfaceIndex_MatchesReceivedPackets(bool ipv6)
         {
             using (var client = new Socket(SocketType.Dgram, ProtocolType.Udp))

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/StatisticsParsingTests.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/StatisticsParsingTests.cs
@@ -2,17 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.IO;
 using Xunit;
 
 namespace System.Net.NetworkInformation.Tests
 {
-    public class StatisticsParsingTests
+    public class StatisticsParsingTests : FileCleanupTestBase
     {
         [Fact]
-        public static void Icmpv4Parsing()
+        public void Icmpv4Parsing()
         {
-            FileUtil.NormalizeLineEndings("snmp", "snmp_normalized1");
-            Icmpv4StatisticsTable table = StringParsingHelpers.ParseIcmpv4FromSnmpFile("snmp_normalized1");
+            string normalizedFile = GetTestFilePath();
+            FileUtil.NormalizeLineEndings("snmp", normalizedFile);
+            Icmpv4StatisticsTable table = StringParsingHelpers.ParseIcmpv4FromSnmpFile(normalizedFile);
             Assert.Equal(1, table.InMsgs);
             Assert.Equal(2, table.InErrors);
             Assert.Equal(3, table.InCsumErrors);
@@ -43,10 +45,11 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        public static void Icmpv6Parsing()
+        public void Icmpv6Parsing()
         {
-            FileUtil.NormalizeLineEndings("snmp6", "snmp6_normalized0");
-            Icmpv6StatisticsTable table = StringParsingHelpers.ParseIcmpv6FromSnmp6File("snmp6_normalized0");
+            string normalizedFile = GetTestFilePath();
+            FileUtil.NormalizeLineEndings("snmp6", normalizedFile);
+            Icmpv6StatisticsTable table = StringParsingHelpers.ParseIcmpv6FromSnmp6File(normalizedFile);
             Assert.Equal(1, table.InMsgs);
             Assert.Equal(2, table.InErrors);
             Assert.Equal(3, table.OutMsgs);
@@ -82,10 +85,11 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        public static void TcpGlobalStatisticsParsing()
+        public void TcpGlobalStatisticsParsing()
         {
-            FileUtil.NormalizeLineEndings("snmp", "snmp_normalized2");
-            TcpGlobalStatisticsTable table = StringParsingHelpers.ParseTcpGlobalStatisticsFromSnmpFile("snmp_normalized2");
+            string normalizedFile = GetTestFilePath();
+            FileUtil.NormalizeLineEndings("snmp", normalizedFile);
+            TcpGlobalStatisticsTable table = StringParsingHelpers.ParseTcpGlobalStatisticsFromSnmpFile(normalizedFile);
             Assert.Equal(1, table.RtoAlgorithm);
             Assert.Equal(200, table.RtoMin);
             Assert.Equal(120000, table.RtoMax);
@@ -104,10 +108,11 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        public static void Udpv4GlobalStatisticsParsing()
+        public void Udpv4GlobalStatisticsParsing()
         {
-            FileUtil.NormalizeLineEndings("snmp", "snmp_normalized3");
-            UdpGlobalStatisticsTable table = StringParsingHelpers.ParseUdpv4GlobalStatisticsFromSnmpFile("snmp_normalized3");
+            string normalizedFile = GetTestFilePath();
+            FileUtil.NormalizeLineEndings("snmp", normalizedFile);
+            UdpGlobalStatisticsTable table = StringParsingHelpers.ParseUdpv4GlobalStatisticsFromSnmpFile(normalizedFile);
             Assert.Equal(7181, table.InDatagrams);
             Assert.Equal(150, table.NoPorts);
             Assert.Equal(0, table.InErrors);
@@ -118,10 +123,11 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        public static void Udpv6GlobalStatisticsParsing()
+        public void Udpv6GlobalStatisticsParsing()
         {
-            FileUtil.NormalizeLineEndings("snmp6", "snmp6_normalized1");
-            UdpGlobalStatisticsTable table = StringParsingHelpers.ParseUdpv6GlobalStatisticsFromSnmp6File("snmp6_normalized1");
+            string normalizedFile = GetTestFilePath();
+            FileUtil.NormalizeLineEndings("snmp6", normalizedFile);
+            UdpGlobalStatisticsTable table = StringParsingHelpers.ParseUdpv6GlobalStatisticsFromSnmp6File(normalizedFile);
             Assert.Equal(19, table.InDatagrams);
             Assert.Equal(0, table.NoPorts);
             Assert.Equal(0, table.InErrors);
@@ -132,10 +138,11 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        public static void Ipv4GlobalStatisticsParsing()
+        public void Ipv4GlobalStatisticsParsing()
         {
-            FileUtil.NormalizeLineEndings("snmp", "snmp_normalized4");
-            IPGlobalStatisticsTable table = StringParsingHelpers.ParseIPv4GlobalStatisticsFromSnmpFile("snmp_normalized4");
+            string normalizedFile = GetTestFilePath();
+            FileUtil.NormalizeLineEndings("snmp", normalizedFile);
+            IPGlobalStatisticsTable table = StringParsingHelpers.ParseIPv4GlobalStatisticsFromSnmpFile(normalizedFile);
 
             Assert.Equal(false, table.Forwarding);
             Assert.Equal(64, table.DefaultTtl);
@@ -159,10 +166,11 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        public static void Ipv6GlobalStatisticsParsing()
+        public void Ipv6GlobalStatisticsParsing()
         {
-            FileUtil.NormalizeLineEndings("snmp6", "snmp6_normalized2");
-            IPGlobalStatisticsTable table = StringParsingHelpers.ParseIPv6GlobalStatisticsFromSnmp6File("snmp6_normalized2");
+            string normalizedFile = GetTestFilePath();
+            FileUtil.NormalizeLineEndings("snmp6", normalizedFile);
+            IPGlobalStatisticsTable table = StringParsingHelpers.ParseIPv6GlobalStatisticsFromSnmp6File(normalizedFile);
 
             Assert.Equal(189, table.InReceives);
             Assert.Equal(0, table.InHeaderErrors);
@@ -184,10 +192,11 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        public static void IpInterfaceStatisticsParsingFirst()
+        public void IpInterfaceStatisticsParsingFirst()
         {
-            FileUtil.NormalizeLineEndings("dev", "dev_normalized0");
-            IPInterfaceStatisticsTable table = StringParsingHelpers.ParseInterfaceStatisticsTableFromFile("dev_normalized0", "wlan0");
+            string normalizedFile = GetTestFilePath();
+            FileUtil.NormalizeLineEndings("dev", normalizedFile);
+            IPInterfaceStatisticsTable table = StringParsingHelpers.ParseInterfaceStatisticsTableFromFile(normalizedFile, "wlan0");
 
             Assert.Equal(26622u, table.BytesReceived);
             Assert.Equal(394u, table.PacketsReceived);
@@ -209,10 +218,11 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        public static void IpInterfaceStatisticsParsingLast()
+        public void IpInterfaceStatisticsParsingLast()
         {
-            FileUtil.NormalizeLineEndings("dev", "dev_normalized1");
-            IPInterfaceStatisticsTable table = StringParsingHelpers.ParseInterfaceStatisticsTableFromFile("dev_normalized1", "lo");
+            string normalizedFile = GetTestFilePath();
+            FileUtil.NormalizeLineEndings("dev", normalizedFile);
+            IPInterfaceStatisticsTable table = StringParsingHelpers.ParseInterfaceStatisticsTableFromFile(normalizedFile, "lo");
 
             Assert.Equal(uint.MaxValue, table.BytesReceived);
             Assert.Equal(302u, table.PacketsReceived);

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/StatisticsParsingTests.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/StatisticsParsingTests.cs
@@ -12,9 +12,9 @@ namespace System.Net.NetworkInformation.Tests
         [Fact]
         public void Icmpv4Parsing()
         {
-            string normalizedFile = GetTestFilePath();
-            FileUtil.NormalizeLineEndings("snmp", normalizedFile);
-            Icmpv4StatisticsTable table = StringParsingHelpers.ParseIcmpv4FromSnmpFile(normalizedFile);
+            string fileName = GetTestFilePath();
+            FileUtil.NormalizeLineEndings("snmp", fileName);
+            Icmpv4StatisticsTable table = StringParsingHelpers.ParseIcmpv4FromSnmpFile(fileName);
             Assert.Equal(1, table.InMsgs);
             Assert.Equal(2, table.InErrors);
             Assert.Equal(3, table.InCsumErrors);
@@ -47,9 +47,9 @@ namespace System.Net.NetworkInformation.Tests
         [Fact]
         public void Icmpv6Parsing()
         {
-            string normalizedFile = GetTestFilePath();
-            FileUtil.NormalizeLineEndings("snmp6", normalizedFile);
-            Icmpv6StatisticsTable table = StringParsingHelpers.ParseIcmpv6FromSnmp6File(normalizedFile);
+            string fileName = GetTestFilePath();
+            FileUtil.NormalizeLineEndings("snmp6", fileName);
+            Icmpv6StatisticsTable table = StringParsingHelpers.ParseIcmpv6FromSnmp6File(fileName);
             Assert.Equal(1, table.InMsgs);
             Assert.Equal(2, table.InErrors);
             Assert.Equal(3, table.OutMsgs);
@@ -87,9 +87,9 @@ namespace System.Net.NetworkInformation.Tests
         [Fact]
         public void TcpGlobalStatisticsParsing()
         {
-            string normalizedFile = GetTestFilePath();
-            FileUtil.NormalizeLineEndings("snmp", normalizedFile);
-            TcpGlobalStatisticsTable table = StringParsingHelpers.ParseTcpGlobalStatisticsFromSnmpFile(normalizedFile);
+            string fileName = GetTestFilePath();
+            FileUtil.NormalizeLineEndings("snmp", fileName);
+            TcpGlobalStatisticsTable table = StringParsingHelpers.ParseTcpGlobalStatisticsFromSnmpFile(fileName);
             Assert.Equal(1, table.RtoAlgorithm);
             Assert.Equal(200, table.RtoMin);
             Assert.Equal(120000, table.RtoMax);
@@ -110,9 +110,9 @@ namespace System.Net.NetworkInformation.Tests
         [Fact]
         public void Udpv4GlobalStatisticsParsing()
         {
-            string normalizedFile = GetTestFilePath();
-            FileUtil.NormalizeLineEndings("snmp", normalizedFile);
-            UdpGlobalStatisticsTable table = StringParsingHelpers.ParseUdpv4GlobalStatisticsFromSnmpFile(normalizedFile);
+            string fileName = GetTestFilePath();
+            FileUtil.NormalizeLineEndings("snmp", fileName);
+            UdpGlobalStatisticsTable table = StringParsingHelpers.ParseUdpv4GlobalStatisticsFromSnmpFile(fileName);
             Assert.Equal(7181, table.InDatagrams);
             Assert.Equal(150, table.NoPorts);
             Assert.Equal(0, table.InErrors);
@@ -125,9 +125,9 @@ namespace System.Net.NetworkInformation.Tests
         [Fact]
         public void Udpv6GlobalStatisticsParsing()
         {
-            string normalizedFile = GetTestFilePath();
-            FileUtil.NormalizeLineEndings("snmp6", normalizedFile);
-            UdpGlobalStatisticsTable table = StringParsingHelpers.ParseUdpv6GlobalStatisticsFromSnmp6File(normalizedFile);
+            string fileName = GetTestFilePath();
+            FileUtil.NormalizeLineEndings("snmp6", fileName);
+            UdpGlobalStatisticsTable table = StringParsingHelpers.ParseUdpv6GlobalStatisticsFromSnmp6File(fileName);
             Assert.Equal(19, table.InDatagrams);
             Assert.Equal(0, table.NoPorts);
             Assert.Equal(0, table.InErrors);
@@ -140,9 +140,9 @@ namespace System.Net.NetworkInformation.Tests
         [Fact]
         public void Ipv4GlobalStatisticsParsing()
         {
-            string normalizedFile = GetTestFilePath();
-            FileUtil.NormalizeLineEndings("snmp", normalizedFile);
-            IPGlobalStatisticsTable table = StringParsingHelpers.ParseIPv4GlobalStatisticsFromSnmpFile(normalizedFile);
+            string fileName = GetTestFilePath();
+            FileUtil.NormalizeLineEndings("snmp", fileName);
+            IPGlobalStatisticsTable table = StringParsingHelpers.ParseIPv4GlobalStatisticsFromSnmpFile(fileName);
 
             Assert.Equal(false, table.Forwarding);
             Assert.Equal(64, table.DefaultTtl);
@@ -168,9 +168,9 @@ namespace System.Net.NetworkInformation.Tests
         [Fact]
         public void Ipv6GlobalStatisticsParsing()
         {
-            string normalizedFile = GetTestFilePath();
-            FileUtil.NormalizeLineEndings("snmp6", normalizedFile);
-            IPGlobalStatisticsTable table = StringParsingHelpers.ParseIPv6GlobalStatisticsFromSnmp6File(normalizedFile);
+            string fileName = GetTestFilePath();
+            FileUtil.NormalizeLineEndings("snmp6", fileName);
+            IPGlobalStatisticsTable table = StringParsingHelpers.ParseIPv6GlobalStatisticsFromSnmp6File(fileName);
 
             Assert.Equal(189, table.InReceives);
             Assert.Equal(0, table.InHeaderErrors);
@@ -194,9 +194,9 @@ namespace System.Net.NetworkInformation.Tests
         [Fact]
         public void IpInterfaceStatisticsParsingFirst()
         {
-            string normalizedFile = GetTestFilePath();
-            FileUtil.NormalizeLineEndings("dev", normalizedFile);
-            IPInterfaceStatisticsTable table = StringParsingHelpers.ParseInterfaceStatisticsTableFromFile(normalizedFile, "wlan0");
+            string fileName = GetTestFilePath();
+            FileUtil.NormalizeLineEndings("dev", fileName);
+            IPInterfaceStatisticsTable table = StringParsingHelpers.ParseInterfaceStatisticsTableFromFile(fileName, "wlan0");
 
             Assert.Equal(26622u, table.BytesReceived);
             Assert.Equal(394u, table.PacketsReceived);
@@ -220,9 +220,9 @@ namespace System.Net.NetworkInformation.Tests
         [Fact]
         public void IpInterfaceStatisticsParsingLast()
         {
-            string normalizedFile = GetTestFilePath();
-            FileUtil.NormalizeLineEndings("dev", normalizedFile);
-            IPInterfaceStatisticsTable table = StringParsingHelpers.ParseInterfaceStatisticsTableFromFile(normalizedFile, "lo");
+            string fileName = GetTestFilePath();
+            FileUtil.NormalizeLineEndings("dev", fileName);
+            IPInterfaceStatisticsTable table = StringParsingHelpers.ParseInterfaceStatisticsTableFromFile(fileName, "lo");
 
             Assert.Equal(uint.MaxValue, table.BytesReceived);
             Assert.Equal(302u, table.PacketsReceived);

--- a/src/System.Net.NetworkInformation/tests/UnitTests/NetworkInterfaceTest.cs
+++ b/src/System.Net.NetworkInformation/tests/UnitTests/NetworkInterfaceTest.cs
@@ -11,7 +11,8 @@ namespace System.Net.NetworkInformation.Unit.Tests
     public class NetworkInterfaceTest
     {
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework | TargetFrameworkMonikers.UapAot, "dotnet/corefx #17993")]
+        [ActiveIssue(17993, TargetFrameworkMonikers.NetFramework | TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue(20014, TargetFrameworkMonikers.Uap)]
         public void GetIsNetworkAvailable_ConnectionProfileNotPresent_ReturnsFalse()
         {
             FakeNetwork.IsConnectionProfilePresent = false;
@@ -19,7 +20,8 @@ namespace System.Net.NetworkInformation.Unit.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework | TargetFrameworkMonikers.UapAot, "dotnet/corefx #17993")]
+        [ActiveIssue(17993, TargetFrameworkMonikers.NetFramework | TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue(20014, TargetFrameworkMonikers.Uap)]
         public void GetIsNetworkAvailable_NetworkConnectivityLevelIsNone_ReturnsFalse()
         {
             FakeNetwork.IsConnectionProfilePresent = true;


### PR DESCRIPTION
This tests where writing files to the test directory and since Uap tests run inside appx this is not authorized so they where failing. 

Fixed them to use temp path. 

This brings all System.Net.NetworkInformation.*.Tests to 0 failures

cc: @danmosemsft 