### PR TITLE
EchoWebSocket supports opt-in partial message behavior

### DIFF
--- a/src/Common/tests/System/Net/Prerequisites/Servers/CoreFxNetCloudService/WebServer/WebSocket/EchoWebSocket.ashx.cs
+++ b/src/Common/tests/System/Net/Prerequisites/Servers/CoreFxNetCloudService/WebServer/WebSocket/EchoWebSocket.ashx.cs
@@ -15,7 +15,7 @@ namespace WebServer
     public class EchoWebSocket : IHttpHandler
     {
         private const int MaxBufferSize = 128 * 1024;
-        private bool _replyWithPartialMessages;
+        private bool _replyWithPartialMessages = false;
 
         public void ProcessRequest(HttpContext context)
         {

--- a/src/Common/tests/System/Net/Prerequisites/Servers/CoreFxNetCloudService/WebServer/WebSocket/EchoWebSocket.ashx.cs
+++ b/src/Common/tests/System/Net/Prerequisites/Servers/CoreFxNetCloudService/WebServer/WebSocket/EchoWebSocket.ashx.cs
@@ -15,12 +15,15 @@ namespace WebServer
     public class EchoWebSocket : IHttpHandler
     {
         private const int MaxBufferSize = 128 * 1024;
+        private bool _replyWithPartialMessages;
 
         public void ProcessRequest(HttpContext context)
         {
+            _replyWithPartialMessages = context.Request.Url.Query.Contains("replyWithPartialMessages");
+
             string subProtocol = context.Request.QueryString["subprotocol"];
 
-            if (context.Request.Url.Query == "?delay10sec")
+            if (context.Request.Url.Query.Contains("delay10sec"))
             {
                 Thread.Sleep(10000);
             }
@@ -156,7 +159,7 @@ namespace WebServer
                     await socket.SendAsync(
                             new ArraySegment<byte>(receiveBuffer, 0, offset),
                             receiveResult.MessageType,
-                            true,
+                            !_replyWithPartialMessages,
                             CancellationToken.None);
                 }
             }


### PR DESCRIPTION
In order to properly test the ClientWebSocket.ReceiveAsync behaviors
around partial WebSocket messages, we need the EchoWebSocket endpoint
to reliably reply with partial messages (endOfMessage == false). These
changes add an opt-in behavior under which EchoWebSocket will echo back
received messages without ever signaling "end of message".

This new support will be used to validate the fix for issue #21102

cc: @davidsh @CIPop 