### PR TITLE
Disabling FileSystemWatcher test on uap

### DIFF
--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.NotifyFilter.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.NotifyFilter.cs
@@ -143,6 +143,7 @@ namespace System.IO.Tests
         [Theory]
         [MemberData(nameof(FilterTypes))]
         [PlatformSpecific(TestPlatforms.Windows)]  // Uses P/Invokes to set security info
+        [ActiveIssue(21109, TargetFrameworkMonikers.Uap)]
         public void FileSystemWatcher_Directory_NotifyFilter_Security(NotifyFilters filter)
         {
             using (var testDirectory = new TempDirectory(GetTestFilePath()))


### PR DESCRIPTION
Disabling one theory that fails in uap since it can't delete a directory after calling one PInvoke.

Cc: @safern  @ianhays @danmosemsft 