### PR TITLE
Port XmlReader, XmlTextReader: ensure Readers created from a full path have an absolute BaseURI to 2.0

### DIFF
--- a/src/System.Private.Xml/src/System.Private.Xml.csproj
+++ b/src/System.Private.Xml/src/System.Private.Xml.csproj
@@ -740,6 +740,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)'=='true'">
     <Compile Include="System\Xml\Xsl\Runtime\XmlCollation.Unix.cs" />
+    <Compile Include="System\Xml\Core\XmlTextReaderImpl.Unix.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImpl.Unix.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImpl.Unix.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Xml
+{
+    internal partial class XmlTextReaderImpl
+    {
+        static partial void ConvertAbsoluteUnixPathToAbsoluteUri(ref string url, XmlResolver resolver)
+        {
+            // new Uri(uri, UriKind.RelativeOrAbsolute) returns a Relative Uri for absolute unix paths (e.g. /tmp).
+            // We convert the native unix path to a 'file://' uri string to make it an Absolute Uri.
+            if (url != null && url.Length > 0 && url[0] == '/')
+            {
+                if (resolver != null)
+                {
+                    Uri uri = resolver.ResolveUri(null, url);
+                    if (uri.IsFile)
+                    {
+                        url = uri.ToString();
+                    }
+                }
+                else
+                {
+                    url = new Uri(url).ToString();
+                }
+            }
+        }
+    }
+}

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImpl.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImpl.cs
@@ -452,6 +452,7 @@ namespace System.Xml
         }
         internal XmlTextReaderImpl(string url, Stream input, XmlNameTable nt) : this(nt)
         {
+            ConvertAbsoluteUnixPathToAbsoluteUri(ref url, resolver: null);
             _namespaceManager = new XmlNamespaceManager(nt);
             if (url == null || url.Length == 0)
             {
@@ -478,6 +479,7 @@ namespace System.Xml
         }
         internal XmlTextReaderImpl(string url, TextReader input, XmlNameTable nt) : this(nt)
         {
+            ConvertAbsoluteUnixPathToAbsoluteUri(ref url, resolver: null);
             _namespaceManager = new XmlNamespaceManager(nt);
             _reportedBaseUri = (url != null) ? url : string.Empty;
             InitTextReaderInput(_reportedBaseUri, input);
@@ -670,6 +672,7 @@ namespace System.Xml
                                     XmlParserContext context, bool closeInput)
             : this(settings.GetXmlResolver(), settings, context)
         {
+            ConvertAbsoluteUnixPathToAbsoluteUri(ref baseUriStr, settings.GetXmlResolver());
             // get BaseUri from XmlParserContext
             if (context != null)
             {
@@ -735,6 +738,7 @@ namespace System.Xml
         internal XmlTextReaderImpl(TextReader input, XmlReaderSettings settings, string baseUriStr, XmlParserContext context)
             : this(settings.GetXmlResolver(), settings, context)
         {
+            ConvertAbsoluteUnixPathToAbsoluteUri(ref baseUriStr, settings.GetXmlResolver());
             // get BaseUri from XmlParserContext
             if (context != null)
             {
@@ -9811,6 +9815,8 @@ namespace System.Xml
         {
             Buffer.BlockCopy(src, srcOffset, dst, dstOffset, count);
         }
+
+        static partial void ConvertAbsoluteUnixPathToAbsoluteUri(ref string url, XmlResolver resolver);
     }
 }
 

--- a/src/System.Private.Xml/tests/XmlReader/Tests/BaseUriTests.cs
+++ b/src/System.Private.Xml/tests/XmlReader/Tests/BaseUriTests.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace System.Xml.Tests
+{
+    public class BaseUriTests : FileCleanupTestBase
+    {
+        private const string DummyXml = @"<?xml version=""1.0""?>";
+
+        public static IEnumerable<object[]> GetXmlReaderUrlCreateMethods()
+        {
+            yield return new [] { new Func<string, XmlReader>(s => XmlReader.Create(s)) };
+            yield return new [] { new Func<string, XmlReader>(s => XmlReader.Create(File.OpenRead(s), new XmlReaderSettings { CloseInput = true }, s)) };
+            yield return new [] { new Func<string, XmlReader>(s => XmlReader.Create(new StreamReader(File.OpenRead(s)), new XmlReaderSettings { CloseInput = true }, s)) };
+            yield return new [] { new Func<string, XmlReader>(s => new XmlTextReader(s)) };
+            yield return new [] { new Func<string, XmlReader>(s => new XmlTextReader(s, File.OpenRead(s))) };
+            yield return new [] { new Func<string, XmlReader>(s => new XmlTextReader(s, new StreamReader(File.OpenRead(s)))) };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetXmlReaderUrlCreateMethods))]
+        public void CreateWithAbsolutePathGivesAbsoluteBaseUri(Func<string, XmlReader> factory)
+        {
+            string tempPath = GetTestFilePath();
+            File.WriteAllText(tempPath, DummyXml);
+            using (XmlReader reader = factory(tempPath))
+            {
+                Assert.True(new Uri(reader.BaseURI).IsAbsoluteUri);
+            }
+        }
+    }
+}

--- a/src/System.Private.Xml/tests/XmlReader/Tests/System.Xml.RW.XmlReader.Tests.csproj
+++ b/src/System.Private.Xml/tests/XmlReader/Tests/System.Xml.RW.XmlReader.Tests.csproj
@@ -12,6 +12,10 @@
   <ItemGroup>
     <Compile Include="AsyncReaderLateInitTests.cs" />
     <Compile Include="DisposeTests.cs" />
+    <Compile Include="BaseUriTests.cs" />
+    <Compile Include="$(CommonTestPath)\System\IO\FileCleanupTestBase.cs">
+      <Link>Common\System\IO\FileCleanupTestBase.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
Port 1db6c8a203ef8a752ffefd2a194fa7dd4bce59fb to 2.0.0

cc @danmosemsft @sepidehMS @stephentoub