### PR TITLE
removing two valid chars from trimming list, 0x85, 0xA0

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/PathHelpers.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/PathHelpers.Windows.cs
@@ -9,7 +9,7 @@ namespace System.IO
     internal static partial class PathHelpers
     {
 
-        internal static bool ShouldReviseDirectoryPathToCurrent(string path)
+	internal static bool ShouldReviseDirectoryPathToCurrent(string path)
         {
             // In situations where this method is invoked, "<DriveLetter>:" should be special-cased 
             // to instead go to the current directory.
@@ -78,9 +78,7 @@ namespace System.IO
         internal static string NormalizeSearchPattern(string searchPattern)
         {
             Debug.Assert(searchPattern != null);
-
-            // Win32 normalization trims only U+0020.
-            string tempSearchPattern = searchPattern.TrimEnd(PathHelpers.TrimEndChars);
+            string tempSearchPattern = searchPattern;
 
             // Make this corner case more useful, like dir
             if (tempSearchPattern.Equals("."))

--- a/src/System.IO.FileSystem/src/System/IO/PathHelpers.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/PathHelpers.Windows.cs
@@ -8,10 +8,6 @@ namespace System.IO
 {
     internal static partial class PathHelpers
     {
-        // Trim trailing whitespace, tabs etc but don't be aggressive in removing everything that has UnicodeCategory of trailing space.
-        // string.WhitespaceChars will trim more aggressively than what the underlying FS does (for ex, NTFS, FAT).    
-        internal static readonly char[] TrimEndChars = { (char)0x9, (char)0xA, (char)0xB, (char)0xC, (char)0xD, (char)0x20, (char)0x85, (char)0xA0 };
-        internal static readonly char[] TrimStartChars = { ' ' };
 
         internal static bool ShouldReviseDirectoryPathToCurrent(string path)
         {

--- a/src/System.IO.FileSystem/src/System/IO/PathHelpers.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/PathHelpers.Windows.cs
@@ -78,17 +78,13 @@ namespace System.IO
         internal static string NormalizeSearchPattern(string searchPattern)
         {
             Debug.Assert(searchPattern != null);
-            string tempSearchPattern = searchPattern;
-
-            // Make this corner case more useful, like dir
-            if (tempSearchPattern.Equals("."))
-            {
-                tempSearchPattern = "*";
-            }
-
-            CheckSearchPattern(tempSearchPattern);
-            return tempSearchPattern;
-        }
+            
+			// Make this corner case more useful, like dir
+			searchPattern = searchPattern.Equals(".") ? "*" : searchPattern;
+			
+            CheckSearchPattern(searchPattern);
+            return searchPattern;
+        }			
 
         internal static string GetFullSearchString(string fullPath, string searchPattern)
         {


### PR DESCRIPTION
As per the issue explained here
 https://github.com/dotnet/corefx/issues/21096
which is causing problems in dotnet languages like PowerShell described here
https://github.com/PowerShell/PowerShell/issues/4017
those two characters should be removed from TrimEndChars. They are valid end chars under Windows (NTFS actually)