### PR TITLE
Change PathList members from public to private

### DIFF
--- a/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
+++ b/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
@@ -820,14 +820,16 @@ namespace System.Net
 
                 lock (pathList.SyncRoot)
                 {
-                    foreach (DictionaryEntry entry in pathList)
+                    // Manual use of IDictionaryEnumerator instead of foreach to avoid DictionaryEntry box allocations.
+                    IDictionaryEnumerator e = pathList.GetEnumerator();
+                    while (e.MoveNext())
                     {
-                        string path = (string)entry.Key;
+                        string path = (string)e.Key;
                         if (uri.AbsolutePath.StartsWith(CookieParser.CheckQuoted(path)))
                         {
                             found = true;
 
-                            CookieCollection cc = (CookieCollection)entry.Value;
+                            CookieCollection cc = (CookieCollection)e.Value;
                             cc.TimeStamp(CookieCollection.Stamp.Set);
                             MergeUpdateCollections(ref cookies, cc, port, isSecure, matchOnlyPlainCookie);
 
@@ -995,9 +997,9 @@ namespace System.Net
         // adding any mutable fields to it would result in breaks.
         private readonly SortedList m_list = SortedList.Synchronized(new SortedList(PathListComparer.StaticInstance)); // Do not rename (binary serialization)
 
-        public int Count => m_list.Count;
+        internal int Count => m_list.Count;
 
-        public int GetCookiesCount()
+        internal int GetCookiesCount()
         {
             int count = 0;
             lock (SyncRoot)
@@ -1010,7 +1012,7 @@ namespace System.Net
             return count;
         }
 
-        public ICollection Values
+        internal ICollection Values
         {
             get
             {
@@ -1018,7 +1020,7 @@ namespace System.Net
             }
         }
 
-        public object this[string s]
+        internal object this[string s]
         {
             get
             {
@@ -1037,7 +1039,7 @@ namespace System.Net
             }
         }
 
-        public IEnumerator GetEnumerator()
+        internal IDictionaryEnumerator GetEnumerator()
         {
             lock (SyncRoot)
             {
@@ -1045,7 +1047,7 @@ namespace System.Net
             }
         }
 
-        public object SyncRoot => m_list.SyncRoot;
+        internal object SyncRoot => m_list.SyncRoot;
 
         [Serializable]
         private sealed class PathListComparer : IComparer


### PR DESCRIPTION
In #21133, `PathList` was made public to enable binary serialization of `CookieContainer`. `PathList` is not exposed in the reference assembly as it is an implementation detail and should not be used directly by external callers. Out of an abundance of caution, make its `public` members `internal` to prevent anyone from inadvertently taking a dependency on them, which gives us some flexibility if we want to make changes in the future.

This is a 2.1 change, so there'll be a small window between the release of 2.0 and 2.1 where someone could theoretically take a dependency on these public members, but I assume that's extremely unlikely since the type is not exposed in the reference assembly.

cc: @ViktorHofer @danmosemsft @stephentoub @krwq @weshaggard