### PR TITLE
Fix Serialization Tests for Collection Types.

### DIFF
--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -444,7 +444,9 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    [ActiveIssue("dotnet/corefx #20478", TargetFrameworkMonikers.UapAot)]
+#if ReflectionOnly
+    [ActiveIssue("dotnet/corefx #21143", TargetFrameworkMonikers.UapAot)]
+#endif
     public static void DCJS_GetOonlyDictionary_UseSimpleDictionaryFormat()
     {
         var x = new TypeWithDictionaryGenericMembers();
@@ -1504,7 +1506,6 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    [ActiveIssue("dotnet/corefx #20478", TargetFrameworkMonikers.UapAot)]
     public static void DCJS_GenericQueue()
     {
         Queue<int> value = new Queue<int>();
@@ -1518,7 +1519,6 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    [ActiveIssue("dotnet/corefx #20478", TargetFrameworkMonikers.UapAot)]
     public static void DCJS_GenericStack()
     {
         var value = new Stack<int>();
@@ -1534,7 +1534,6 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    [ActiveIssue("dotnet/corefx #20478", TargetFrameworkMonikers.UapAot)]
     public static void DCJS_Queue()
     {
         var value = new Queue();
@@ -1549,7 +1548,6 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    [ActiveIssue("dotnet/corefx #20478", TargetFrameworkMonikers.UapAot)]
     public static void DCJS_Stack()
     {
         var value = new Stack();
@@ -1565,7 +1563,6 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    [ActiveIssue("dotnet/corefx #20478", TargetFrameworkMonikers.UapAot)]
     public static void DCJS_SortedList()
     {
         var value = new SortedList();
@@ -1578,7 +1575,6 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    [ActiveIssue("dotnet/corefx #20478", TargetFrameworkMonikers.UapAot)]
     public static void DCJS_SystemVersion()
     {
         Version value = new Version(1, 2, 3, 4);
@@ -1689,7 +1685,6 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    [ActiveIssue("dotnet/corefx #20478", TargetFrameworkMonikers.UapAot)]
     public static void DCJS_ReadOnlyCollection()
     {
         List<string> list = new List<string>() { "Foo", "Bar" };
@@ -1701,7 +1696,6 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    [ActiveIssue("dotnet/corefx #20478", TargetFrameworkMonikers.UapAot)]
     public static void DCJS_ReadOnlyDictionary()
     {
         var dict = new Dictionary<string, int>();
@@ -2702,7 +2696,6 @@ public static partial class DataContractJsonSerializerTests
         Assert.Equal(4, actual2["a4"]);
     }
 
-    [ActiveIssue("dotnet/corefx #20481", TargetFrameworkMonikers.UapAot)]
     [Fact]
     public static void DCJS_VerifyDictionaryFormat()
     {
@@ -2857,7 +2850,6 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    [ActiveIssue("dotnet/corefx #20478", TargetFrameworkMonikers.UapAot)]
     public static void DCJS_ReadOnlyDictionaryCausingDuplicateInvalidDataContract()
     {
         var dict = new Dictionary<string, int>();

--- a/src/System.Runtime.Serialization.Json/tests/ReflectionOnly/Resources/System.Runtime.Serialization.Json.ReflectionOnly.Tests.rd.xml
+++ b/src/System.Runtime.Serialization.Json/tests/ReflectionOnly/Resources/System.Runtime.Serialization.Json.ReflectionOnly.Tests.rd.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Library Name="*System.Runtime.Serialization.Json.ReflectionOnly.Tests*">
+    <Namespace Name="System.Collections">
+      <Type Name="ArrayList" Dynamic="Required All" />
+      <Type Name="IList" Dynamic="Required All" />
+      <Type Name="List" Dynamic="Required All" />
+      <Type Name="Queue" Dynamic="Required All" />
+      <Type Name="Stack" Dynamic="Required All" />
+      <Type Name="SortedList" Dynamic="Required All" />       
+    </Namespace>
+    <Namespace Name="System.Collections.Generic">
+      <Type Name="Queue`1" Dynamic="Required All" />
+      <Type Name="Stack`1" Dynamic="Required All" />
+    </Namespace>
+    <Namespace Name="System.Collections.ObjectModel">
+      <Type Name="ReadOnlyCollection`1" Dynamic="Required All" />
+      <Type Name="ReadOnlyDictionary`2" Dynamic="Required All" />
+    </Namespace>
+    <Type Name="System.Version" Dynamic="Required All" />
+  </Library>
+</Directives>

--- a/src/System.Runtime.Serialization.Json/tests/ReflectionOnly/System.Runtime.Serialization.Json.ReflectionOnly.Tests.csproj
+++ b/src/System.Runtime.Serialization.Json/tests/ReflectionOnly/System.Runtime.Serialization.Json.ReflectionOnly.Tests.csproj
@@ -21,5 +21,8 @@
     <Compile Include="$(TestSourceFolder)..\DataContractJsonSerializer.CoreCLR.cs" />
     <Compile Include="$(TestSourceFolder)..\..\..\System.Runtime.Serialization.Xml\tests\SerializationTypes.CoreCLR.cs" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)'=='uapaot'">
+    <EmbeddedResource Include="$(MsBuildThisFileDirectory)Resources\$(AssemblyName).rd.xml" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -628,7 +628,6 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
-    [ActiveIssue("dotnet/corefx #20478", TargetFrameworkMonikers.UapAot)]
     public static void DCS_ListMembers()
     {
         TypeWithListMembers x = new TypeWithListMembers
@@ -1599,7 +1598,6 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
-    [ActiveIssue("dotnet/corefx #20478", TargetFrameworkMonikers.UapAot)]
     public static void DCS_GenericQueue()
     {
         Queue<int> value = new Queue<int>();
@@ -1613,7 +1611,6 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
-    [ActiveIssue("dotnet/corefx #20478", TargetFrameworkMonikers.UapAot)]
     public static void DCS_GenericStack()
     {
         var value = new Stack<int>();
@@ -1629,7 +1626,6 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
-    [ActiveIssue("dotnet/corefx #20478", TargetFrameworkMonikers.UapAot)]
     public static void DCS_Queue()
     {
         var value = new Queue();
@@ -1644,7 +1640,6 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
-    [ActiveIssue("dotnet/corefx #20478", TargetFrameworkMonikers.UapAot)]
     public static void DCS_Stack()
     {
         var value = new Stack();
@@ -1660,7 +1655,6 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
-    [ActiveIssue("dotnet/corefx #20478", TargetFrameworkMonikers.UapAot)]
     public static void DCS_SortedList()
     {
         var value = new SortedList();
@@ -1673,7 +1667,6 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
-    [ActiveIssue("dotnet/corefx #20478", TargetFrameworkMonikers.UapAot)]
     public static void DCS_SystemVersion()
     {
         Version value = new Version(1, 2, 3, 4);
@@ -1879,7 +1872,6 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
-    [ActiveIssue("dotnet/corefx #20478", TargetFrameworkMonikers.UapAot)]
     public static void DCS_ReadOnlyCollection()
     {
         List<string> list = new List<string>() { "Foo", "Bar" };
@@ -1891,7 +1883,6 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
-    [ActiveIssue("dotnet/corefx #20478", TargetFrameworkMonikers.UapAot)]
     public static void DCS_ReadOnlyDictionary()
     {
         var dict = new Dictionary<string, int>();
@@ -3050,7 +3041,6 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
-    [ActiveIssue("dotnet/corefx #20478", TargetFrameworkMonikers.UapAot)]
     public static void DCS_BasicRoundtripDCRDefaultCollections()
     {
         var defaultCollections = new SerializationTestTypes.DefaultCollections();

--- a/src/System.Runtime.Serialization.Xml/tests/ReflectionOnly/Resources/System.Runtime.Serialization.Xml.ReflectionOnly.Tests.rd.xml
+++ b/src/System.Runtime.Serialization.Xml/tests/ReflectionOnly/Resources/System.Runtime.Serialization.Xml.ReflectionOnly.Tests.rd.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Library Name="*System.Runtime.Serialization.Xml.ReflectionOnly.Tests*">
+    <Namespace Name="System.Collections">
+      <Type Name="ArrayList" Dynamic="Required All" />
+      <Type Name="IList" Dynamic="Required All" />
+      <Type Name="List" Dynamic="Required All" />
+      <Type Name="Queue" Dynamic="Required All" />
+      <Type Name="Stack" Dynamic="Required All" />
+      <Type Name="SortedList" Dynamic="Required All" />       
+    </Namespace>
+    <Namespace Name="System.Collections.Generic">
+      <Type Name="Queue`1" Dynamic="Required All" />
+      <Type Name="Stack`1" Dynamic="Required All" />
+    </Namespace>
+    <Namespace Name="System.Collections.ObjectModel">
+      <Type Name="ReadOnlyCollection`1" Dynamic="Required All" />
+      <Type Name="ReadOnlyDictionary`2" Dynamic="Required All" />
+    </Namespace>
+    <Type Name="System.Version" Dynamic="Required All" />
+  </Library>
+</Directives>

--- a/src/System.Runtime.Serialization.Xml/tests/ReflectionOnly/System.Runtime.Serialization.Xml.ReflectionOnly.Tests.csproj
+++ b/src/System.Runtime.Serialization.Xml/tests/ReflectionOnly/System.Runtime.Serialization.Xml.ReflectionOnly.Tests.csproj
@@ -38,5 +38,8 @@
     <Compile Include="$(TestSourceFolder)..\SerializationTypes.CoreCLR.cs" />
     <Compile Include="$(TestSourceFolder)..\DataContractSerializer.CoreCLR.cs" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)'=='uapaot'">
+    <EmbeddedResource Include="$(MsBuildThisFileDirectory)Resources\$(AssemblyName).rd.xml" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
Serialization tests for System.Collection types failed in ReflectionOnly mode on uapaot due to missing the metadata for the collections types.

The fix is to change the tests' rd.xml to keep the metadata for those types.

Fix #20478
Fix #20481