### PR TITLE
Fix HttpClient.MaxResponseContentBufferSize handling

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/HttpContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpContent.cs
@@ -776,23 +776,19 @@ namespace System.Net.Http
 
             private void EnsureCapacity(int value)
             {
-                if (value > _buffer.Length)
-                {
-                    Grow(value);
-                }
-                else if (value < 0) // overflow
+                if ((uint)value > (uint)_maxBufferSize) // value cast handles overflow to negative as well
                 {
                     throw CreateOverCapacityException(_maxBufferSize);
+                }
+                else if (value > _buffer.Length)
+                {
+                    Grow(value);
                 }
             }
 
             private void Grow(int value)
             {
                 Debug.Assert(value > _buffer.Length);
-                if (value > _maxBufferSize)
-                {
-                    throw CreateOverCapacityException(_maxBufferSize);
-                }
 
                 // Extract the current buffer to be replaced.
                 byte[] currentBuffer = _buffer;

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -113,13 +113,37 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "no exception throw on netfx")]
-        [Fact]
-        public async Task MaxResponseContentBufferSize_TooSmallForContent_Throws()
+        [Theory]
+        [InlineData(1, 2, true)]
+        [InlineData(1, 127, true)]
+        [InlineData(254, 255, true)]
+        [InlineData(10, 256, true)]
+        [InlineData(1, 440, true)]
+        [InlineData(2, 1, false)]
+        [InlineData(2, 2, false)]
+        [InlineData(1000, 1000, false)]
+        public async Task MaxResponseContentBufferSize_ThrowsIfTooSmallForContent(int maxSize, int contentLength, bool exceptionExpected)
         {
-            using (var client = new HttpClient())
+            using (var client = new HttpClient() { MaxResponseContentBufferSize = maxSize })
             {
-                client.MaxResponseContentBufferSize = 1;
-                await Assert.ThrowsAsync<HttpRequestException>(() => client.GetStringAsync(Configuration.Http.RemoteEchoServer));
+                await LoopbackServer.CreateServerAsync(async (server, url) =>
+                {
+                    Task<string> t = client.GetStringAsync(url);
+                    await LoopbackServer.ReadRequestAndSendResponseAsync(server,
+                        $"HTTP/1.1 200 OK\r\n" +
+                        $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
+                        $"Content-Length: {contentLength}\r\n" +
+                        "\r\n" +
+                        new string('s', contentLength));
+                    if (exceptionExpected)
+                    {
+                        await Assert.ThrowsAsync<HttpRequestException>(() => t);
+                    }
+                    else
+                    {
+                        await t;
+                    }
+                });
             }
         }
 


### PR DESCRIPTION
It's not causing failures in all cases it should, as it's comparing against a buffer size that may have grown to be larger than the desired max.

cc: @davidsh, @cipop, @geoffkizer 