### PR TITLE
Change S.DS.Protocols to AssertExtensions.Throws to fix ILC

### DIFF
--- a/src/System.DirectoryServices.Protocols/tests/AddRequestTests.cs
+++ b/src/System.DirectoryServices.Protocols/tests/AddRequestTests.cs
@@ -41,7 +41,7 @@ namespace System.DirectoryServices.Protocols.Tests
         [Fact]
         public void Ctor_NullObjectInAttributes_ThrowsArgumentException()
         {
-            Assert.Throws<ArgumentException>(null, () => new AddRequest("DistinguishedName", new DirectoryAttribute[] { null }));
+            AssertExtensions.Throws<ArgumentException>(null, () => new AddRequest("DistinguishedName", new DirectoryAttribute[] { null }));
         }
 
         [Theory]
@@ -62,7 +62,7 @@ namespace System.DirectoryServices.Protocols.Tests
         [Fact]
         public void Ctor_NullObjectClass_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>("objectClass", () => new AddRequest("DistinguishedName", (string)null));
+            AssertExtensions.Throws<ArgumentNullException>("objectClass", () => new AddRequest("DistinguishedName", (string)null));
         }
 
         [Fact]

--- a/src/System.DirectoryServices.Protocols/tests/CompareRequestTests.cs
+++ b/src/System.DirectoryServices.Protocols/tests/CompareRequestTests.cs
@@ -64,17 +64,17 @@ namespace System.DirectoryServices.Protocols.Tests
         [Fact]
         public void Ctor_NullAttributeName_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>("attributeName", () => new CompareRequest("DistinguishedName", null, "Value"));
-            Assert.Throws<ArgumentNullException>("attributeName", () => new CompareRequest("DistinguishedName", null, new byte[0]));
-            Assert.Throws<ArgumentNullException>("attributeName", () => new CompareRequest("DistinguishedName", null, new Uri("http://microsoft.com")));
+            AssertExtensions.Throws<ArgumentNullException>("attributeName", () => new CompareRequest("DistinguishedName", null, "Value"));
+            AssertExtensions.Throws<ArgumentNullException>("attributeName", () => new CompareRequest("DistinguishedName", null, new byte[0]));
+            AssertExtensions.Throws<ArgumentNullException>("attributeName", () => new CompareRequest("DistinguishedName", null, new Uri("http://microsoft.com")));
         }
 
         [Fact]
         public void Ctor_NullValue_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>("value", () => new CompareRequest("DistinguishedName", "AttributeName", (string)null));
-            Assert.Throws<ArgumentNullException>("value", () => new CompareRequest("DistinguishedName", "AttributeName", (byte[])null));
-            Assert.Throws<ArgumentNullException>("value", () => new CompareRequest("DistinguishedName", "AttributeName", (Uri)null));
+            AssertExtensions.Throws<ArgumentNullException>("value", () => new CompareRequest("DistinguishedName", "AttributeName", (string)null));
+            AssertExtensions.Throws<ArgumentNullException>("value", () => new CompareRequest("DistinguishedName", "AttributeName", (byte[])null));
+            AssertExtensions.Throws<ArgumentNullException>("value", () => new CompareRequest("DistinguishedName", "AttributeName", (Uri)null));
         }
 
         [Fact]
@@ -93,7 +93,7 @@ namespace System.DirectoryServices.Protocols.Tests
         [Fact]
         public void Ctor_NullAssertion_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>("assertion", () => new CompareRequest("DistinguishedName", null));
+            AssertExtensions.Throws<ArgumentNullException>("assertion", () => new CompareRequest("DistinguishedName", null));
         }
 
         public static IEnumerable<object[]> InvalidAssertion_TestData()
@@ -106,7 +106,7 @@ namespace System.DirectoryServices.Protocols.Tests
         [MemberData(nameof(InvalidAssertion_TestData))]
         public void Ctor_InvalidAssertion_ThrowsArgumentException(DirectoryAttribute assertion)
         {
-            Assert.Throws<ArgumentException>(null, () => new CompareRequest("DistinguishedName", assertion));
+            AssertExtensions.Throws<ArgumentException>(null, () => new CompareRequest("DistinguishedName", assertion));
         }
 
         [Fact]

--- a/src/System.DirectoryServices.Protocols/tests/DirSyncRequestControlTests.cs
+++ b/src/System.DirectoryServices.Protocols/tests/DirSyncRequestControlTests.cs
@@ -80,7 +80,7 @@ namespace System.DirectoryServices.Protocols.Tests
         [Fact]
         public void Ctor_NegativeAttributeCount_ThrowsArgumentException()
         {
-            Assert.Throws<ArgumentException>("value", () => new DirSyncRequestControl(new byte[0], DirectorySynchronizationOptions.None, -1));
+            AssertExtensions.Throws<ArgumentException>("value", () => new DirSyncRequestControl(new byte[0], DirectorySynchronizationOptions.None, -1));
         }
 
         [Fact]
@@ -94,7 +94,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void AttributeCount_SetNegative_ThrowsArgumentException()
         {
             var control = new DirSyncRequestControl();
-            Assert.Throws<ArgumentException>("value", () => control.AttributeCount = -1);
+            AssertExtensions.Throws<ArgumentException>("value", () => control.AttributeCount = -1);
         }
 
         [Fact]

--- a/src/System.DirectoryServices.Protocols/tests/DirectoryAttributeCollectionTests.cs
+++ b/src/System.DirectoryServices.Protocols/tests/DirectoryAttributeCollectionTests.cs
@@ -32,7 +32,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void Indexer_SetNull_ThrowsArgumentException()
         {
             var collection = new DirectoryAttributeCollection();
-            Assert.Throws<ArgumentException>(null, () => collection[0] = null);
+            AssertExtensions.Throws<ArgumentException>(null, () => collection[0] = null);
         }
 
         [Fact]
@@ -49,7 +49,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void Add_NullAttribute_ThrowsArgumentException()
         {
             var collection = new DirectoryAttributeCollection();
-            Assert.Throws<ArgumentException>(null, () => collection.Add(null));
+            AssertExtensions.Throws<ArgumentException>(null, () => collection.Add(null));
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void AddRange_NullAttributes_ThrowsArgumentNullException()
         {
             var collection = new DirectoryAttributeCollection();
-            Assert.Throws<ArgumentNullException>("attributes", () => collection.AddRange((DirectoryAttribute[])null));
+            AssertExtensions.Throws<ArgumentNullException>("attributes", () => collection.AddRange((DirectoryAttribute[])null));
         }
 
         [Fact]
@@ -76,7 +76,7 @@ namespace System.DirectoryServices.Protocols.Tests
             DirectoryAttribute[] attributes = new DirectoryAttribute[] { new DirectoryAttribute(), null, new DirectoryAttribute() };
             var collection = new DirectoryAttributeCollection();
 
-            Assert.Throws<ArgumentException>(null, () => collection.AddRange(attributes));
+            AssertExtensions.Throws<ArgumentException>(null, () => collection.AddRange(attributes));
             Assert.Equal(0, collection.Count);
         }
 
@@ -97,7 +97,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void AddRange_NullAttributeCollection_ThrowsArgumentNullException()
         {
             var collection = new DirectoryAttributeCollection();
-            Assert.Throws<ArgumentNullException>("attributeCollection", () => collection.AddRange((DirectoryAttributeCollection)null));
+            AssertExtensions.Throws<ArgumentNullException>("attributeCollection", () => collection.AddRange((DirectoryAttributeCollection)null));
         }
 
         [Fact]
@@ -137,7 +137,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void Insert_NullValue_ThrowsArgumentException()
         {
             var collection = new DirectoryAttributeCollection();
-            Assert.Throws<ArgumentException>(null, () => collection.Insert(0, null));
+            AssertExtensions.Throws<ArgumentException>(null, () => collection.Insert(0, null));
         }
 
         [Fact]
@@ -171,7 +171,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void Remove_InvalidValue_ThrowsArgumentException(object value, string paramName)
         {
             IList collection = new DirectoryAttributeCollection { new DirectoryAttribute() };
-            Assert.Throws<ArgumentException>(paramName, () => collection.Remove(value));
+            AssertExtensions.Throws<ArgumentException>(paramName, () => collection.Remove(value));
         }
     }
 }

--- a/src/System.DirectoryServices.Protocols/tests/DirectoryAttributeModificationCollectionTests.cs
+++ b/src/System.DirectoryServices.Protocols/tests/DirectoryAttributeModificationCollectionTests.cs
@@ -32,7 +32,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void Indexer_SetNull_ThrowsArgumentException()
         {
             var collection = new DirectoryAttributeModificationCollection();
-            Assert.Throws<ArgumentException>(null, () => collection[0] = null);
+            AssertExtensions.Throws<ArgumentException>(null, () => collection[0] = null);
         }
 
         [Fact]
@@ -49,7 +49,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void Add_NullAttribute_ThrowsArgumentException()
         {
             var collection = new DirectoryAttributeModificationCollection();
-            Assert.Throws<ArgumentException>(null, () => collection.Add(null));
+            AssertExtensions.Throws<ArgumentException>(null, () => collection.Add(null));
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void AddRange_NullAttributes_ThrowsArgumentNullException()
         {
             var collection = new DirectoryAttributeModificationCollection();
-            Assert.Throws<ArgumentNullException>("attributes", () => collection.AddRange((DirectoryAttributeModification[])null));
+            AssertExtensions.Throws<ArgumentNullException>("attributes", () => collection.AddRange((DirectoryAttributeModification[])null));
         }
 
         [Fact]
@@ -76,7 +76,7 @@ namespace System.DirectoryServices.Protocols.Tests
             DirectoryAttributeModification[] attributes = new DirectoryAttributeModification[] { new DirectoryAttributeModification(), null, new DirectoryAttributeModification() };
             var collection = new DirectoryAttributeModificationCollection();
 
-            Assert.Throws<ArgumentException>(null, () => collection.AddRange(attributes));
+            AssertExtensions.Throws<ArgumentException>(null, () => collection.AddRange(attributes));
             Assert.Equal(0, collection.Count);
         }
 
@@ -97,7 +97,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void AddRange_NullAttributeCollection_ThrowsArgumentNullException()
         {
             var collection = new DirectoryAttributeModificationCollection();
-            Assert.Throws<ArgumentNullException>("attributeCollection", () => collection.AddRange((DirectoryAttributeModificationCollection)null));
+            AssertExtensions.Throws<ArgumentNullException>("attributeCollection", () => collection.AddRange((DirectoryAttributeModificationCollection)null));
         }
 
         [Fact]
@@ -137,7 +137,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void Insert_NullValue_ThrowsArgumentException()
         {
             var collection = new DirectoryAttributeModificationCollection();
-            Assert.Throws<ArgumentException>(null, () => collection.Insert(0, null));
+            AssertExtensions.Throws<ArgumentException>(null, () => collection.Insert(0, null));
         }
 
         [Fact]
@@ -171,7 +171,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void Remove_InvalidValue_ThrowsArgumentException(object value, string paramName)
         {
             IList collection = new DirectoryAttributeModificationCollection { new DirectoryAttributeModification() };
-            Assert.Throws<ArgumentException>(paramName, () => collection.Remove(value));
+            AssertExtensions.Throws<ArgumentException>(paramName, () => collection.Remove(value));
         }
     }
 }

--- a/src/System.DirectoryServices.Protocols/tests/DirectoryAttributeModificationTests.cs
+++ b/src/System.DirectoryServices.Protocols/tests/DirectoryAttributeModificationTests.cs
@@ -31,7 +31,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void Operation_SetInvalid_InvalidEnumArgumentException(DirectoryAttributeOperation operation)
         {
             var modification = new DirectoryAttributeModification();
-            Assert.Throws<InvalidEnumArgumentException>("value", () => modification.Operation = operation);
+            AssertExtensions.Throws<InvalidEnumArgumentException>("value", () => modification.Operation = operation);
         }
     }
 }

--- a/src/System.DirectoryServices.Protocols/tests/DirectoryAttributeTests.cs
+++ b/src/System.DirectoryServices.Protocols/tests/DirectoryAttributeTests.cs
@@ -61,18 +61,18 @@ namespace System.DirectoryServices.Protocols.Tests
         [Fact]
         public void Ctor_NullName_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>("name", () => new DirectoryAttribute(null, ""));
-            Assert.Throws<ArgumentNullException>("name", () => new DirectoryAttribute(null, new byte[0]));
-            Assert.Throws<ArgumentNullException>("name", () => new DirectoryAttribute(null, new Uri("http://microsoft.com")));
-            Assert.Throws<ArgumentNullException>("name", () => new DirectoryAttribute(null, new object[0]));
+            AssertExtensions.Throws<ArgumentNullException>("name", () => new DirectoryAttribute(null, ""));
+            AssertExtensions.Throws<ArgumentNullException>("name", () => new DirectoryAttribute(null, new byte[0]));
+            AssertExtensions.Throws<ArgumentNullException>("name", () => new DirectoryAttribute(null, new Uri("http://microsoft.com")));
+            AssertExtensions.Throws<ArgumentNullException>("name", () => new DirectoryAttribute(null, new object[0]));
         }
 
         [Fact]
         public void Ctor_NullValue_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>("value", () => new DirectoryAttribute("Name", (string)null));
-            Assert.Throws<ArgumentNullException>("value", () => new DirectoryAttribute("Name", (byte[])null));
-            Assert.Throws<ArgumentNullException>("value", () => new DirectoryAttribute("Name", (Uri)null));
+            AssertExtensions.Throws<ArgumentNullException>("value", () => new DirectoryAttribute("Name", (string)null));
+            AssertExtensions.Throws<ArgumentNullException>("value", () => new DirectoryAttribute("Name", (byte[])null));
+            AssertExtensions.Throws<ArgumentNullException>("value", () => new DirectoryAttribute("Name", (Uri)null));
         }
 
         [Fact]
@@ -89,21 +89,21 @@ namespace System.DirectoryServices.Protocols.Tests
         [Fact]
         public void Ctor_NullValues_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>("values", () => new DirectoryAttribute("Name", (object[])null));
+            AssertExtensions.Throws<ArgumentNullException>("values", () => new DirectoryAttribute("Name", (object[])null));
         }
 
         [Fact]
         public void Ctor_NullObjectValues_ThrowsArgumentNullException()
         {
             string[] values = new string[] { "value1", null, "value2" };
-            Assert.Throws<ArgumentNullException>("value", () => new DirectoryAttribute("Name", values));
+            AssertExtensions.Throws<ArgumentNullException>("value", () => new DirectoryAttribute("Name", values));
         }
 
         [Fact]
         public void Ctor_InvalidObjectInValues_ThrowsArgumentException()
         {
             object[] values = new object[] { 1 };
-            Assert.Throws<ArgumentException>("value", () => new DirectoryAttribute("Name", values));
+            AssertExtensions.Throws<ArgumentException>("value", () => new DirectoryAttribute("Name", values));
         }
 
         [Fact]
@@ -117,7 +117,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void Name_SetNull_ThrowsArgumentNullException()
         {
             var attribute = new DirectoryAttribute();
-            Assert.Throws<ArgumentNullException>("value", () => attribute.Name = null);
+            AssertExtensions.Throws<ArgumentNullException>("value", () => attribute.Name = null);
         }
 
         [Fact]
@@ -143,7 +143,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void GetValues_InvalidType_ThrowsArgumentException(Type valuesType)
         {
             var attribute = new DirectoryAttribute();
-            Assert.Throws<ArgumentException>("valuesType", () => attribute.GetValues(valuesType));
+            AssertExtensions.Throws<ArgumentException>("valuesType", () => attribute.GetValues(valuesType));
         }
 
         [Fact]
@@ -167,22 +167,22 @@ namespace System.DirectoryServices.Protocols.Tests
         public void Indexer_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
         {
             var attribute = new DirectoryAttribute { "value" };
-            Assert.Throws<ArgumentOutOfRangeException>("index", () => attribute[index]);
-            Assert.Throws<ArgumentOutOfRangeException>("index", () => attribute[index] = "value");
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => attribute[index]);
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => attribute[index] = "value");
         }
 
         [Fact]
         public void Indexer_SetNull_ThrowsArgumentNullException()
         {
             var attribute = new DirectoryAttribute();
-            Assert.Throws<ArgumentNullException>("value", () => attribute[0] = null);
+            AssertExtensions.Throws<ArgumentNullException>("value", () => attribute[0] = null);
         }
 
         [Fact]
         public void Indexer_SetInvalidType_ThrowsArgumentException()
         {
             var attribute = new DirectoryAttribute();
-            Assert.Throws<ArgumentException>("value", () => attribute[0] = 1);
+            AssertExtensions.Throws<ArgumentException>("value", () => attribute[0] = 1);
         }
 
         [Fact]
@@ -197,9 +197,9 @@ namespace System.DirectoryServices.Protocols.Tests
         public void Add_NullValue_ThrowsArgumentNullException()
         {
             var attribute = new DirectoryAttribute();
-            Assert.Throws<ArgumentNullException>("value", () => attribute.Add((string)null));
-            Assert.Throws<ArgumentNullException>("value", () => attribute.Add((byte[])null));
-            Assert.Throws<ArgumentNullException>("value", () => attribute.Add((Uri)null));
+            AssertExtensions.Throws<ArgumentNullException>("value", () => attribute.Add((string)null));
+            AssertExtensions.Throws<ArgumentNullException>("value", () => attribute.Add((byte[])null));
+            AssertExtensions.Throws<ArgumentNullException>("value", () => attribute.Add((Uri)null));
         }
 
         [Fact]
@@ -236,14 +236,14 @@ namespace System.DirectoryServices.Protocols.Tests
         public void AddRange_NullValues_ThrowsArgumentNullException()
         {
             var attribute = new DirectoryAttribute();
-            Assert.Throws<ArgumentNullException>("values", () => attribute.AddRange(null));
+            AssertExtensions.Throws<ArgumentNullException>("values", () => attribute.AddRange(null));
         }
 
         [Fact]
         public void AddRange_InvalidArray_ThrowsArgumentExceptionn()
         {
             var attribute = new DirectoryAttribute();
-            Assert.Throws<ArgumentException>("values", () => attribute.AddRange(new object[0]));
+            AssertExtensions.Throws<ArgumentException>("values", () => attribute.AddRange(new object[0]));
         }
 
         [Fact]
@@ -252,7 +252,7 @@ namespace System.DirectoryServices.Protocols.Tests
             string[] objects = new string[] { "value1", null, "value2" };
             var attribute = new DirectoryAttribute();
 
-            Assert.Throws<ArgumentException>("values", () => attribute.AddRange(objects));
+            AssertExtensions.Throws<ArgumentException>("values", () => attribute.AddRange(objects));
             Assert.Equal(0, attribute.Count);
         }
 
@@ -289,9 +289,9 @@ namespace System.DirectoryServices.Protocols.Tests
         public void Insert_NullValue_ThrowsArgumentNullException()
         {
             var attribute = new DirectoryAttribute();
-            Assert.Throws<ArgumentNullException>("value", () => attribute.Insert(0, (string)null));
-            Assert.Throws<ArgumentNullException>("value", () => attribute.Insert(0, (byte[])null));
-            Assert.Throws<ArgumentNullException>("value", () => attribute.Insert(0, (Uri)null));
+            AssertExtensions.Throws<ArgumentNullException>("value", () => attribute.Insert(0, (string)null));
+            AssertExtensions.Throws<ArgumentNullException>("value", () => attribute.Insert(0, (byte[])null));
+            AssertExtensions.Throws<ArgumentNullException>("value", () => attribute.Insert(0, (Uri)null));
         }
 
         [Theory]
@@ -300,9 +300,9 @@ namespace System.DirectoryServices.Protocols.Tests
         public void Insert_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
         {
             var attribute = new DirectoryAttribute { "value2" };
-            Assert.Throws<ArgumentOutOfRangeException>("index", () => attribute.Insert(index, "value"));
-            Assert.Throws<ArgumentOutOfRangeException>("index", () => attribute.Insert(index, new byte[] { 1, 2, 3 }));
-            Assert.Throws<ArgumentOutOfRangeException>("index", () => attribute.Insert(index, new Uri("http://microsoft.com")));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => attribute.Insert(index, "value"));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => attribute.Insert(index, new byte[] { 1, 2, 3 }));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => attribute.Insert(index, new Uri("http://microsoft.com")));
         }
 
         [Fact]
@@ -326,7 +326,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void Remove_NullValue_ThrowsArgumentNullException()
         {
             var attribute = new DirectoryAttribute();
-            Assert.Throws<ArgumentNullException>("value", () => attribute.Remove(null));
+            AssertExtensions.Throws<ArgumentNullException>("value", () => attribute.Remove(null));
         }
 
         [Theory]
@@ -335,7 +335,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void Remove_InvalidValue_ThrowsArgumentException(object value, string paramName)
         {
             var attribute = new DirectoryAttribute { "value" };
-            Assert.Throws<ArgumentException>(paramName, () => attribute.Remove(value));
+            AssertExtensions.Throws<ArgumentException>(paramName, () => attribute.Remove(value));
         }
     }
 }

--- a/src/System.DirectoryServices.Protocols/tests/DirectoryConnectionTests.cs
+++ b/src/System.DirectoryServices.Protocols/tests/DirectoryConnectionTests.cs
@@ -29,7 +29,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void Timeout_SetNegative_ThrowsArgumentException()
         {
             var connection = new SubDirectoryConnection();
-            Assert.Throws<ArgumentException>("value", () => connection.Timeout = TimeSpan.FromTicks(-1));
+            AssertExtensions.Throws<ArgumentException>("value", () => connection.Timeout = TimeSpan.FromTicks(-1));
         }
 
         [Fact]

--- a/src/System.DirectoryServices.Protocols/tests/DirectoryControlCollectionTests.cs
+++ b/src/System.DirectoryServices.Protocols/tests/DirectoryControlCollectionTests.cs
@@ -32,7 +32,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void Indexer_SetNull_ThrowsArgumentException()
         {
             var collection = new DirectoryControlCollection();
-            Assert.Throws<ArgumentNullException>("value", () => collection[0] = null);
+            AssertExtensions.Throws<ArgumentNullException>("value", () => collection[0] = null);
         }
 
         [Fact]
@@ -49,7 +49,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void Add_NullControl_ThrowsArgumentNullException()
         {
             var collection = new DirectoryControlCollection();
-            Assert.Throws<ArgumentNullException>("control", () => collection.Add(null));
+            AssertExtensions.Throws<ArgumentNullException>("control", () => collection.Add(null));
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void AddRange_NullControls_ThrowsArgumentNullException()
         {
             var collection = new DirectoryControlCollection();
-            Assert.Throws<ArgumentNullException>("controls", () => collection.AddRange((DirectoryControl[])null));
+            AssertExtensions.Throws<ArgumentNullException>("controls", () => collection.AddRange((DirectoryControl[])null));
         }
 
         [Fact]
@@ -76,7 +76,7 @@ namespace System.DirectoryServices.Protocols.Tests
             DirectoryControl[] controls = new DirectoryControl[] { new AsqRequestControl(), null, new AsqRequestControl() };
             var collection = new DirectoryControlCollection();
 
-            Assert.Throws<ArgumentException>("controls", () => collection.AddRange(controls));
+            AssertExtensions.Throws<ArgumentException>("controls", () => collection.AddRange(controls));
             Assert.Equal(0, collection.Count);
         }
 
@@ -97,7 +97,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void AddRange_NullControlCollection_ThrowsArgumentNullException()
         {
             var collection = new DirectoryControlCollection();
-            Assert.Throws<ArgumentNullException>("controlCollection", () => collection.AddRange((DirectoryControlCollection)null));
+            AssertExtensions.Throws<ArgumentNullException>("controlCollection", () => collection.AddRange((DirectoryControlCollection)null));
         }
 
         [Fact]
@@ -137,7 +137,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void Insert_NullValue_ThrowsArgumentNullException()
         {
             var collection = new DirectoryControlCollection();
-            Assert.Throws<ArgumentNullException>("value", () => collection.Insert(0, null));
+            AssertExtensions.Throws<ArgumentNullException>("value", () => collection.Insert(0, null));
         }
 
         [Fact]
@@ -163,7 +163,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void Remove_NullValue_ThrowsArgumentNullException()
         {
             var collection = new DirectoryControlCollection { new AsqRequestControl() };
-            Assert.Throws<ArgumentNullException>("value", () => collection.Remove(null));
+            AssertExtensions.Throws<ArgumentNullException>("value", () => collection.Remove(null));
         }
 
         public static IEnumerable<object[]> Remove_InvalidValue_TestData()
@@ -177,7 +177,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void Remove_InvalidValue_ThrowsArgumentException(object value, string paramName)
         {
             IList collection = new DirectoryControlCollection { new AsqRequestControl() };
-            Assert.Throws<ArgumentException>(paramName, () => collection.Remove(value));
+            AssertExtensions.Throws<ArgumentException>(paramName, () => collection.Remove(value));
         }
     }
 }

--- a/src/System.DirectoryServices.Protocols/tests/DirectoryControlTests.cs
+++ b/src/System.DirectoryServices.Protocols/tests/DirectoryControlTests.cs
@@ -26,7 +26,7 @@ namespace System.DirectoryServices.Protocols.Tests
         [Fact]
         public void Ctor_NullType_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>("type", () => new DirectoryControl(null, new byte[0], false, false));
+            AssertExtensions.Throws<ArgumentNullException>("type", () => new DirectoryControl(null, new byte[0], false, false));
         }
 
         [Fact]

--- a/src/System.DirectoryServices.Protocols/tests/ExtendedDNControlTests.cs
+++ b/src/System.DirectoryServices.Protocols/tests/ExtendedDNControlTests.cs
@@ -38,7 +38,7 @@ namespace System.DirectoryServices.Protocols.Tests
         [InlineData(ExtendedDNFlag.StandardString + 1)]
         public void Ctor_InvalidFlag_ThrowsInvalidEnumArgumentException(ExtendedDNFlag flag)
         {
-            Assert.Throws<InvalidEnumArgumentException>("value", () => new ExtendedDNControl(flag));
+            AssertExtensions.Throws<InvalidEnumArgumentException>("value", () => new ExtendedDNControl(flag));
         }
     }
 }

--- a/src/System.DirectoryServices.Protocols/tests/LdapConnectionTests.cs
+++ b/src/System.DirectoryServices.Protocols/tests/LdapConnectionTests.cs
@@ -29,7 +29,7 @@ namespace System.DirectoryServices.Protocols.Tests
         [Fact]
         public void Ctor_ServerHasSpaceInName_ThrowsArgumentException()
         {
-            Assert.Throws<ArgumentException>(null, () => new LdapConnection("se rver"));
+            AssertExtensions.Throws<ArgumentException>(null, () => new LdapConnection("se rver"));
         }
 
         public static IEnumerable<object[]> Ctor_Identifier_TestData()
@@ -98,13 +98,13 @@ namespace System.DirectoryServices.Protocols.Tests
         [InlineData(AuthType.Kerberos + 1)]
         public void Ctor_InvalidAuthType_ThrowsInvalidEnumArgumentException(AuthType authType)
         {
-            Assert.Throws<InvalidEnumArgumentException>("authType", () => new LdapConnection(new LdapDirectoryIdentifier("server"), new NetworkCredential(), authType));
+            AssertExtensions.Throws<InvalidEnumArgumentException>("authType", () => new LdapConnection(new LdapDirectoryIdentifier("server"), new NetworkCredential(), authType));
         }
 
         [Fact]
         public void Ctor_InvalidAuthTypeWithCredentials_ThrowsArgumentException()
         {
-            Assert.Throws<ArgumentException>(null, () => new LdapConnection(new LdapDirectoryIdentifier("server"), new NetworkCredential("username", "password"), AuthType.Anonymous));
+            AssertExtensions.Throws<ArgumentException>(null, () => new LdapConnection(new LdapDirectoryIdentifier("server"), new NetworkCredential("username", "password"), AuthType.Anonymous));
         }
 
         [Fact]
@@ -120,7 +120,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void AuthType_SetInvalid_ThrowsInvalidEnumArgumentException(AuthType authType)
         {
             var connection = new LdapConnection("server");
-            Assert.Throws<InvalidEnumArgumentException>("value", () => connection.AuthType = authType);
+            AssertExtensions.Throws<InvalidEnumArgumentException>("value", () => connection.AuthType = authType);
         }
 
         [Fact]
@@ -143,7 +143,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void Timeout_SetInvalid_ThrowsArgumentException(long totalSeconds)
         {
             var connection = new LdapConnection("server");
-            Assert.Throws<ArgumentException>("value", () => connection.Timeout = TimeSpan.FromSeconds(totalSeconds));
+            AssertExtensions.Throws<ArgumentException>("value", () => connection.Timeout = TimeSpan.FromSeconds(totalSeconds));
         }
 
         [Fact]
@@ -180,8 +180,8 @@ namespace System.DirectoryServices.Protocols.Tests
         public void SendRequest_NullRequest_ThrowsArgumentNullException()
         {
             var connection = new LdapConnection("server");
-            Assert.Throws<ArgumentNullException>("request", () => connection.SendRequest(null));
-            Assert.Throws<ArgumentNullException>("request", () => connection.BeginSendRequest(null, PartialResultProcessing.NoPartialResultSupport, null, null));
+            AssertExtensions.Throws<ArgumentNullException>("request", () => connection.SendRequest(null));
+            AssertExtensions.Throws<ArgumentNullException>("request", () => connection.BeginSendRequest(null, PartialResultProcessing.NoPartialResultSupport, null, null));
         }
 
         [Fact]
@@ -197,7 +197,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void BeginSendRequest_InvalidPartialMode_ThrowsInvalidEnumArgumentException(PartialResultProcessing partialMode)
         {
             var connection = new LdapConnection("server");
-            Assert.Throws<InvalidEnumArgumentException>("partialMode", () => connection.BeginSendRequest(new AddRequest(), partialMode, null, null));
+            AssertExtensions.Throws<InvalidEnumArgumentException>("partialMode", () => connection.BeginSendRequest(new AddRequest(), partialMode, null, null));
         }
 
         [Theory]
@@ -213,7 +213,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void BeginSendRequest_NotifyCallbackAndNullCallback_ThrowsArgumentException()
         {
             var connection = new LdapConnection("server");
-            Assert.Throws<ArgumentException>("callback", () => connection.BeginSendRequest(new SearchRequest(), PartialResultProcessing.ReturnPartialResultsAndNotifyCallback, null, null));
+            AssertExtensions.Throws<ArgumentException>("callback", () => connection.BeginSendRequest(new SearchRequest(), PartialResultProcessing.ReturnPartialResultsAndNotifyCallback, null, null));
         }
 
         [Fact]
@@ -229,14 +229,14 @@ namespace System.DirectoryServices.Protocols.Tests
         public void EndSendRequest_NullAsyncResult_ThrowsArgumentNullException()
         {
             var connection = new LdapConnection("server");
-            Assert.Throws<ArgumentNullException>("asyncResult", () => connection.EndSendRequest(null));
+            AssertExtensions.Throws<ArgumentNullException>("asyncResult", () => connection.EndSendRequest(null));
         }
 
         [Fact]
         public void EndSendRequest_InvalidAsyncResult_ThrowsArgumentNullException()
         {
             var connection = new LdapConnection("server");
-            Assert.Throws<ArgumentException>(null, () => connection.EndSendRequest(new CustomAsyncResult()));
+            AssertExtensions.Throws<ArgumentException>(null, () => connection.EndSendRequest(new CustomAsyncResult()));
         }
 
         [Fact]
@@ -252,14 +252,14 @@ namespace System.DirectoryServices.Protocols.Tests
         public void GetPartialResults_NullAsyncResult_ThrowsArgumentNullException()
         {
             var connection = new LdapConnection("server");
-            Assert.Throws<ArgumentNullException>("asyncResult", () => connection.GetPartialResults(null));
+            AssertExtensions.Throws<ArgumentNullException>("asyncResult", () => connection.GetPartialResults(null));
         }
 
         [Fact]
         public void GetPartialResults_InvalidAsyncResult_ThrowsArgumentNullException()
         {
             var connection = new LdapConnection("server");
-            Assert.Throws<ArgumentException>(null, () => connection.GetPartialResults(new CustomAsyncResult()));
+            AssertExtensions.Throws<ArgumentException>(null, () => connection.GetPartialResults(new CustomAsyncResult()));
         }
 
         [Fact]
@@ -275,14 +275,14 @@ namespace System.DirectoryServices.Protocols.Tests
         public void Abort_NullAsyncResult_ThrowsArgumentNullException()
         {
             var connection = new LdapConnection("server");
-            Assert.Throws<ArgumentNullException>("asyncResult", () => connection.Abort(null));
+            AssertExtensions.Throws<ArgumentNullException>("asyncResult", () => connection.Abort(null));
         }
 
         [Fact]
         public void Abort_InvalidAsyncResult_ThrowsArgumentNullException()
         {
             var connection = new LdapConnection("server");
-            Assert.Throws<ArgumentException>(null, () => connection.Abort(new CustomAsyncResult()));
+            AssertExtensions.Throws<ArgumentException>(null, () => connection.Abort(new CustomAsyncResult()));
         }
 
         [Fact]

--- a/src/System.DirectoryServices.Protocols/tests/LdapDirectoryIdentifierTests.cs
+++ b/src/System.DirectoryServices.Protocols/tests/LdapDirectoryIdentifierTests.cs
@@ -78,12 +78,12 @@ namespace System.DirectoryServices.Protocols.Tests
         [Fact]
         public void Ctor_ServerHasSpaceInName_ThrowsArgumentException()
         {
-            Assert.Throws<ArgumentException>(null, () => new LdapDirectoryIdentifier("se rver"));
-            Assert.Throws<ArgumentException>(null, () => new LdapDirectoryIdentifier("se rver", 0));
-            Assert.Throws<ArgumentException>(null, () => new LdapDirectoryIdentifier("se rver", false, false));
-            Assert.Throws<ArgumentException>(null, () => new LdapDirectoryIdentifier("se rver", 0, false, false));
-            Assert.Throws<ArgumentException>(null, () => new LdapDirectoryIdentifier(new string[] { "se rver" }, false, false));
-            Assert.Throws<ArgumentException>(null, () => new LdapDirectoryIdentifier(new string[] { "se rver" }, 0, false, false));
+            AssertExtensions.Throws<ArgumentException>(null, () => new LdapDirectoryIdentifier("se rver"));
+            AssertExtensions.Throws<ArgumentException>(null, () => new LdapDirectoryIdentifier("se rver", 0));
+            AssertExtensions.Throws<ArgumentException>(null, () => new LdapDirectoryIdentifier("se rver", false, false));
+            AssertExtensions.Throws<ArgumentException>(null, () => new LdapDirectoryIdentifier("se rver", 0, false, false));
+            AssertExtensions.Throws<ArgumentException>(null, () => new LdapDirectoryIdentifier(new string[] { "se rver" }, false, false));
+            AssertExtensions.Throws<ArgumentException>(null, () => new LdapDirectoryIdentifier(new string[] { "se rver" }, 0, false, false));
         }
     }
 }

--- a/src/System.DirectoryServices.Protocols/tests/LdapSessionOptionsTests.cs
+++ b/src/System.DirectoryServices.Protocols/tests/LdapSessionOptionsTests.cs
@@ -28,7 +28,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void ReferralChasing_SetInvalid_ThrowsInvalidEnumArgumentException(ReferralChasingOptions referralChasing)
         {
             var connection = new LdapConnection("server");
-            Assert.Throws<InvalidEnumArgumentException>("value", () => connection.SessionOptions.ReferralChasing = referralChasing);
+            AssertExtensions.Throws<InvalidEnumArgumentException>("value", () => connection.SessionOptions.ReferralChasing = referralChasing);
         }
 
         [Fact]
@@ -77,7 +77,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void ReferralHopLimit_SetNegative_ThrowsArgumentException()
         {
             var connection = new LdapConnection("server");
-            Assert.Throws<ArgumentException>("value", () => connection.SessionOptions.ReferralHopLimit = -1);
+            AssertExtensions.Throws<ArgumentException>("value", () => connection.SessionOptions.ReferralHopLimit = -1);
         }
 
         [Fact]
@@ -222,7 +222,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void PingKeepAliveTimeout_InvalidTotalSeconds_ThrowsArgumentException(long seconds)
         {
             var connection = new LdapConnection("server");
-            Assert.Throws<ArgumentException>("value", () => connection.SessionOptions.PingKeepAliveTimeout = TimeSpan.FromSeconds(seconds));
+            AssertExtensions.Throws<ArgumentException>("value", () => connection.SessionOptions.PingKeepAliveTimeout = TimeSpan.FromSeconds(seconds));
         }
 
         [Fact]
@@ -249,7 +249,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void PingLimit_SetNegative_ThrowsArgumentException()
         {
             var connection = new LdapConnection("server");
-            Assert.Throws<ArgumentException>("value", () => connection.SessionOptions.PingLimit = -1);
+            AssertExtensions.Throws<ArgumentException>("value", () => connection.SessionOptions.PingLimit = -1);
         }
 
         [Fact]
@@ -278,7 +278,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void PingWaitTimeout_InvalidTotalSeconds_ThrowsArgumentException(long seconds)
         {
             var connection = new LdapConnection("server");
-            Assert.Throws<ArgumentException>("value", () => connection.SessionOptions.PingWaitTimeout = TimeSpan.FromSeconds(seconds));
+            AssertExtensions.Throws<ArgumentException>("value", () => connection.SessionOptions.PingWaitTimeout = TimeSpan.FromSeconds(seconds));
         }
 
         [Fact]
@@ -490,7 +490,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void SendTimeout_InvalidTotalSeconds_ThrowsArgumentException(long seconds)
         {
             var connection = new LdapConnection("server");
-            Assert.Throws<ArgumentException>("value", () => connection.SessionOptions.SendTimeout = TimeSpan.FromSeconds(seconds));
+            AssertExtensions.Throws<ArgumentException>("value", () => connection.SessionOptions.SendTimeout = TimeSpan.FromSeconds(seconds));
         }
 
         [Fact]

--- a/src/System.DirectoryServices.Protocols/tests/ModifyRequestTests.cs
+++ b/src/System.DirectoryServices.Protocols/tests/ModifyRequestTests.cs
@@ -40,13 +40,13 @@ namespace System.DirectoryServices.Protocols.Tests
         [Fact]
         public void Ctor_NullModifications_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>("attributes", () => new ModifyRequest("DistinguishedName", null));
+            AssertExtensions.Throws<ArgumentNullException>("attributes", () => new ModifyRequest("DistinguishedName", null));
         }
 
         [Fact]
         public void Ctor_NullObjectInAttributes_ThrowsArgumentException()
         {
-            Assert.Throws<ArgumentException>(null, () => new ModifyRequest("DistinguishedName", new DirectoryAttributeModification[] { null }));
+            AssertExtensions.Throws<ArgumentException>(null, () => new ModifyRequest("DistinguishedName", new DirectoryAttributeModification[] { null }));
         }
 
         public static IEnumerable<object[]> Ctor_DistinguishedName_Operation_AttributeName_Values_TestData()
@@ -74,19 +74,19 @@ namespace System.DirectoryServices.Protocols.Tests
         [Fact]
         public void Ctor_NullAttributeName_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>("attributeName", () => new ModifyRequest("DistinguishedName", new DirectoryAttributeOperation(), null, new object[0]));
+            AssertExtensions.Throws<ArgumentNullException>("attributeName", () => new ModifyRequest("DistinguishedName", new DirectoryAttributeOperation(), null, new object[0]));
         }
 
         [Fact]
         public void Ctor_NullObjectInValues_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>("value", () => new ModifyRequest("DistinguishedName", new DirectoryAttributeOperation(), "AttributeName", new object[] { null }));
+            AssertExtensions.Throws<ArgumentNullException>("value", () => new ModifyRequest("DistinguishedName", new DirectoryAttributeOperation(), "AttributeName", new object[] { null }));
         }
 
         [Fact]
         public void Ctor_InvalidObjectInValues_ThrowsArgumentException()
         {
-            Assert.Throws<ArgumentException>("value", () => new ModifyRequest("DistinguishedName", new DirectoryAttributeOperation(), "AttributeName", new object[] { 1 }));
+            AssertExtensions.Throws<ArgumentException>("value", () => new ModifyRequest("DistinguishedName", new DirectoryAttributeOperation(), "AttributeName", new object[] { 1 }));
         }
 
         [Fact]

--- a/src/System.DirectoryServices.Protocols/tests/PageResultRequestControlTests.cs
+++ b/src/System.DirectoryServices.Protocols/tests/PageResultRequestControlTests.cs
@@ -42,7 +42,7 @@ namespace System.DirectoryServices.Protocols.Tests
         [Fact]
         public void Ctor_NegativePageSize_ThrowsArgumentException()
         {
-            Assert.Throws<ArgumentException>("value", () => new PageResultRequestControl(-1));
+            AssertExtensions.Throws<ArgumentException>("value", () => new PageResultRequestControl(-1));
         }
 
         [Theory]

--- a/src/System.DirectoryServices.Protocols/tests/SearchOptionsControlTests.cs
+++ b/src/System.DirectoryServices.Protocols/tests/SearchOptionsControlTests.cs
@@ -38,7 +38,7 @@ namespace System.DirectoryServices.Protocols.Tests
         [InlineData(SearchOption.PhantomRoot + 1)]
         public void Ctor_InvalidFlags_ThrowsInvalidEnumArgumentException(SearchOption flag)
         {
-            Assert.Throws<InvalidEnumArgumentException>("value", () => new SearchOptionsControl(flag));
+            AssertExtensions.Throws<InvalidEnumArgumentException>("value", () => new SearchOptionsControl(flag));
         }
     }
 }

--- a/src/System.DirectoryServices.Protocols/tests/SearchRequestTests.cs
+++ b/src/System.DirectoryServices.Protocols/tests/SearchRequestTests.cs
@@ -51,7 +51,7 @@ namespace System.DirectoryServices.Protocols.Tests
         [InlineData(SearchScope.Subtree + 1)]
         public void Ctor_InvalidScope_ThrowsInvalidEnumArgumentException(SearchScope searchScope)
         {
-            Assert.Throws<InvalidEnumArgumentException>("value", () => new SearchRequest("DistinguishedName", "LdapFilter", searchScope));
+            AssertExtensions.Throws<InvalidEnumArgumentException>("value", () => new SearchRequest("DistinguishedName", "LdapFilter", searchScope));
         }
 
         [Fact]
@@ -75,7 +75,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void Filter_SetInvalid_ThrowsArgumentException()
         {
             var request = new SearchRequest();
-            Assert.Throws<ArgumentException>("value", () => request.Filter = 1);
+            AssertExtensions.Throws<ArgumentException>("value", () => request.Filter = 1);
         }
 
         [Fact]
@@ -91,7 +91,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void Aliases_SetInvalid_ThrowsInvalidEnumArgumentException(DereferenceAlias aliases)
         {
             var request = new SearchRequest();
-            Assert.Throws<InvalidEnumArgumentException>("value", () => request.Aliases = aliases);
+            AssertExtensions.Throws<InvalidEnumArgumentException>("value", () => request.Aliases = aliases);
         }
 
 
@@ -106,7 +106,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void SizeLimit_SetNegative_ThrowsArgumentException()
         {
             var request = new SearchRequest();
-            Assert.Throws<ArgumentException>("value", () => request.SizeLimit = -1);
+            AssertExtensions.Throws<ArgumentException>("value", () => request.SizeLimit = -1);
         }
 
         [Fact]
@@ -122,7 +122,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void TimeLimit_SetInvalid_ThrowsArgumentException(long totalSeconds)
         {
             var request = new SearchRequest();
-            Assert.Throws<ArgumentException>("value", () => request.TimeLimit = TimeSpan.FromSeconds(totalSeconds));
+            AssertExtensions.Throws<ArgumentException>("value", () => request.TimeLimit = TimeSpan.FromSeconds(totalSeconds));
         }
 
         [Fact]

--- a/src/System.DirectoryServices.Protocols/tests/SortKeyTests.cs
+++ b/src/System.DirectoryServices.Protocols/tests/SortKeyTests.cs
@@ -31,7 +31,7 @@ namespace System.DirectoryServices.Protocols.Tests
         [Fact]
         public void Ctor_NullAttributeName_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>("value", () => new SortKey(null, "MatchingRule", false));
+            AssertExtensions.Throws<ArgumentNullException>("value", () => new SortKey(null, "MatchingRule", false));
         }
 
         [Fact]

--- a/src/System.DirectoryServices.Protocols/tests/SortRequestControlTests.cs
+++ b/src/System.DirectoryServices.Protocols/tests/SortRequestControlTests.cs
@@ -41,13 +41,13 @@ namespace System.DirectoryServices.Protocols.Tests
         [Fact]
         public void Ctor_NullSortKeys_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>("sortKeys", () => new SortRequestControl(null));
+            AssertExtensions.Throws<ArgumentNullException>("sortKeys", () => new SortRequestControl(null));
         }
 
         [Fact]
         public void CtorNullValueInSortKeys_ThrowsArgumentException()
         {
-            Assert.Throws<ArgumentException>("sortKeys", () => new SortRequestControl(new SortKey[] { null }));
+            AssertExtensions.Throws<ArgumentException>("sortKeys", () => new SortRequestControl(new SortKey[] { null }));
         }
 
         [Fact]
@@ -103,14 +103,14 @@ namespace System.DirectoryServices.Protocols.Tests
         public void SortKeys_SetNull_ThrowsArgumentNullException()
         {
             var control = new SortRequestControl(new SortKey[0]);
-            Assert.Throws<ArgumentNullException>("value", () => control.SortKeys = null);
+            AssertExtensions.Throws<ArgumentNullException>("value", () => control.SortKeys = null);
         }
 
         [Fact]
         public void SortKeys_SetNullInValue_ThrowsArgumentException()
         {
             var control = new SortRequestControl(new SortKey[0]);
-            Assert.Throws<ArgumentException>("value", () => control.SortKeys = new SortKey[] { null });
+            AssertExtensions.Throws<ArgumentException>("value", () => control.SortKeys = new SortKey[] { null });
         }
     }
 }

--- a/src/System.DirectoryServices.Protocols/tests/VerifyNameControlTests.cs
+++ b/src/System.DirectoryServices.Protocols/tests/VerifyNameControlTests.cs
@@ -54,8 +54,8 @@ namespace System.DirectoryServices.Protocols.Tests
         [Fact]
         public void Ctor_NullServerName_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>("serverName", () => new VerifyNameControl(null));
-            Assert.Throws<ArgumentNullException>("serverName", () => new VerifyNameControl(null, 0));
+            AssertExtensions.Throws<ArgumentNullException>("serverName", () => new VerifyNameControl(null));
+            AssertExtensions.Throws<ArgumentNullException>("serverName", () => new VerifyNameControl(null, 0));
         }
 
         [Fact]
@@ -69,7 +69,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void ServerName_SetNull_ThrowsArgumentNullException()
         {
             var control = new VerifyNameControl();
-            Assert.Throws<ArgumentNullException>("value", () => control.ServerName = null);
+            AssertExtensions.Throws<ArgumentNullException>("value", () => control.ServerName = null);
         }
 
         [Fact]

--- a/src/System.DirectoryServices.Protocols/tests/VlvRequestControlTests.cs
+++ b/src/System.DirectoryServices.Protocols/tests/VlvRequestControlTests.cs
@@ -87,23 +87,23 @@ namespace System.DirectoryServices.Protocols.Tests
         [Fact]
         public void Ctor_NegativeBeforeCount_ThrowsArgumentException()
         {
-            Assert.Throws<ArgumentException>("value", () => new VlvRequestControl(-1, 0, "target"));
-            Assert.Throws<ArgumentException>("value", () => new VlvRequestControl(-1, 0, 0));
-            Assert.Throws<ArgumentException>("value", () => new VlvRequestControl(-1, 0, new byte[0]));
+            AssertExtensions.Throws<ArgumentException>("value", () => new VlvRequestControl(-1, 0, "target"));
+            AssertExtensions.Throws<ArgumentException>("value", () => new VlvRequestControl(-1, 0, 0));
+            AssertExtensions.Throws<ArgumentException>("value", () => new VlvRequestControl(-1, 0, new byte[0]));
         }
 
         [Fact]
         public void Ctor_NegativeAfterCount_ThrowsArgumentException()
         {
-            Assert.Throws<ArgumentException>("value", () => new VlvRequestControl(0, -1, "target"));
-            Assert.Throws<ArgumentException>("value", () => new VlvRequestControl(0, -1, 0));
-            Assert.Throws<ArgumentException>("value", () => new VlvRequestControl(0, -1, new byte[0]));
+            AssertExtensions.Throws<ArgumentException>("value", () => new VlvRequestControl(0, -1, "target"));
+            AssertExtensions.Throws<ArgumentException>("value", () => new VlvRequestControl(0, -1, 0));
+            AssertExtensions.Throws<ArgumentException>("value", () => new VlvRequestControl(0, -1, new byte[0]));
         }
 
         [Fact]
         public void Ctor_NegativeOffset_ThrowsArgumentException()
         {
-            Assert.Throws<ArgumentException>("value", () => new VlvRequestControl(0, 0, -1));
+            AssertExtensions.Throws<ArgumentException>("value", () => new VlvRequestControl(0, 0, -1));
         }
 
         [Fact]
@@ -117,7 +117,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public void EstimateCount_SetNegative_ThrowsArgumentException()
         {
             var control = new VlvRequestControl();
-            Assert.Throws<ArgumentException>("value", () => control.EstimateCount = -1);
+            AssertExtensions.Throws<ArgumentException>("value", () => control.EstimateCount = -1);
         }
 
         [Fact]


### PR DESCRIPTION
In ILC (native compiled) runs, ArgumentExceptions do not include the parameter name (or the message - but we should never validate that as it could be translated in future)

We should never use Assert.Throws* -- our AssertExtensions.Throws* all skip verifying the parameter name when running in ILC. This is going to keep happening so we might need to think about how to stop that eg., fork xunit's Asserts and eliminate AssertExtensions.

@hughbe fyi.