### PR TITLE
Fix System.IO.Ports.Tests for uap

### DIFF
--- a/src/System.IO.Ports/tests/SerialPort/GetPortNames.cs
+++ b/src/System.IO.Ports/tests/SerialPort/GetPortNames.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace System.IO.Ports.Tests
 {
+    [ActiveIssue("https://github.com/dotnet/corefx/issues/20588", TargetFrameworkMonikers.Uap)] // fails in both Uap and UapAot
     public class GetPortNames : PortsTest
     {
         #region Test Cases
@@ -19,7 +20,6 @@ namespace System.IO.Ports.Tests
         /// Check that all ports either open correctly or fail with UnauthorizedAccessException (which implies they're already open)
         /// </summary>
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/20588 - GetPortNames() has registry dependency.", TargetFrameworkMonikers.UapAot)]
         private void OpenEveryPortName()
         {
             foreach (string portName in SerialPort.GetPortNames())
@@ -41,7 +41,6 @@ namespace System.IO.Ports.Tests
         /// (On Windows, the latter uses a different technique to SerialPort to find ports).
         /// </summary>
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/20588 - GetPortNames() has registry dependency.", TargetFrameworkMonikers.UapAot)]
         private void AllHelperPortsAreInGetPortNames()
         {
             string[] serialPortNames = SerialPort.GetPortNames();
@@ -57,7 +56,6 @@ namespace System.IO.Ports.Tests
         /// This catches regressions in the test helpers, eg GH #18928 / #20668
         /// </summary>
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/20588 - GetPortNames() has registry dependency.", TargetFrameworkMonikers.UapAot)]
         private void AllGetPortNamesAreInHelperPorts()
         {
             string[] helperPortNames = PortHelper.GetPorts();

--- a/src/System.IO.Ports/tests/SerialPort/OpenDevices.cs
+++ b/src/System.IO.Ports/tests/SerialPort/OpenDevices.cs
@@ -13,6 +13,7 @@ namespace System.IO.Ports.Tests
     public class OpenDevices : PortsTest
     {
         [Fact]
+        [ActiveIssue(21156, TargetFrameworkMonikers.Uap)]
         public void OpenDevices01()
         {
             DosDevices dosDevices = new DosDevices();

--- a/src/System.IO.Ports/tests/SerialPort/ctor_str.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ctor_str.cs
@@ -76,7 +76,7 @@ namespace System.IO.Ports.Tests
         public void Filename()
         {
             string portName;
-            string fileName = portName = "PortNameEqualToFileName.txt";
+            string fileName = portName = GetTestFilePath();
             FileStream testFile = File.Open(fileName, FileMode.Create);
             ASCIIEncoding asciiEncd = new ASCIIEncoding();
             string testStr = "Hello World";

--- a/src/System.IO.Ports/tests/SerialPort/ctor_str_int.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ctor_str_int.cs
@@ -98,7 +98,7 @@ namespace System.IO.Ports.Tests
         {
             string portName;
             int baudRate = 9600;
-            string fileName = portName = "PortNameEqualToFileName.txt";
+            string fileName = portName = GetTestFilePath();
             FileStream testFile = File.Open(fileName, FileMode.Create);
             ASCIIEncoding asciiEncd = new ASCIIEncoding();
             string testStr = "Hello World";

--- a/src/System.IO.Ports/tests/SerialPort/ctor_str_int_parity.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ctor_str_int_parity.cs
@@ -105,7 +105,7 @@ namespace System.IO.Ports.Tests
             string portName;
             int baudRate = 9600;
             int parity = (int)Parity.Space;
-            string fileName = portName = "PortNameEqualToFileName.txt";
+            string fileName = portName = GetTestFilePath();
             FileStream testFile = File.Open(fileName, FileMode.Create);
             ASCIIEncoding asciiEncd = new ASCIIEncoding();
             string testStr = "Hello World";

--- a/src/System.IO.Ports/tests/SerialPort/ctor_str_int_parity_int.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ctor_str_int_parity_int.cs
@@ -128,7 +128,7 @@ namespace System.IO.Ports.Tests
             int baudRate = 9600;
             int parity = (int)Parity.Space;
             int dataBits = 8;
-            string fileName = portName = "PortNameEqualToFileName.txt";
+            string fileName = portName = GetTestFilePath();
             FileStream testFile = File.Open(fileName, FileMode.Create);
             ASCIIEncoding asciiEncd = new ASCIIEncoding();
             string testStr = "Hello World";

--- a/src/System.IO.Ports/tests/SerialPort/ctor_str_int_parity_int_stopbits.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ctor_str_int_parity_int_stopbits.cs
@@ -216,7 +216,7 @@ namespace System.IO.Ports.Tests
             int parity = (int)Parity.Space;
             int dataBits = 8;
             int stopBits = (int)StopBits.One;
-            string fileName = portName = "PortNameEqualToFileName.txt";
+            string fileName = portName = GetTestFilePath();
             FileStream testFile = File.Open(fileName, FileMode.Create);
             ASCIIEncoding asciiEncd = new ASCIIEncoding();
             string testStr = "Hello World";

--- a/src/System.IO.Ports/tests/Support/PortHelper.cs
+++ b/src/System.IO.Ports/tests/Support/PortHelper.cs
@@ -21,7 +21,7 @@ namespace Legacy.Support
         {
             if (PlatformDetection.IsWinRT)
             {
-                return new string[0]; // we are waiting for a Win32 new QueryDosDevice API since the current doesn't work for Uap
+                return new string[0]; // we are waiting for a Win32 new QueryDosDevice API since the current doesn't work for Uap https://github.com/dotnet/corefx/issues/21156
             }
 
             List<string> ports = new List<string>();

--- a/src/System.IO.Ports/tests/Support/PortHelper.cs
+++ b/src/System.IO.Ports/tests/Support/PortHelper.cs
@@ -19,6 +19,11 @@ namespace Legacy.Support
 
         public static string[] GetPorts()
         {
+            if (PlatformDetection.IsWinRT)
+            {
+                return new string[0]; // we are waiting for a Win32 new QueryDosDevice API since the current doesn't work for Uap
+            }
+
             List<string> ports = new List<string>();
             int returnSize = 0;
             int maxSize = 1000000;

--- a/src/System.IO.Ports/tests/Support/PortsTest.cs
+++ b/src/System.IO.Ports/tests/Support/PortsTest.cs
@@ -2,12 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.IO;
 using Legacy.Support;
 using Xunit;
 
 namespace System.IO.PortsTests
 {
-    public class PortsTest
+    public class PortsTest : FileCleanupTestBase
     {
         public static bool HasOneSerialPort => TCSupport.SufficientHardwareRequirements(TCSupport.SerialPortRequirements.OneSerialPort);
 

--- a/src/System.IO.Ports/tests/System.IO.Ports.Tests.csproj
+++ b/src/System.IO.Ports/tests/System.IO.Ports.Tests.csproj
@@ -116,9 +116,9 @@
     <Compile Include="Support\TCSupport.cs" />
     <Compile Include="Support\PortsTest.cs" />
     <Compile Include="Support\TestEventHandler.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL" />
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>CommonTest\System\PlatformDetection.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Legacy\Manual\" />


### PR DESCRIPTION
System.IO.Ports.Tests where hanging because of issue related to: https://github.com/dotnet/corefx/issues/21156

Also I've fixed tests that where trying to access common path to use TempPath and disabled a couple of more tests. 