### PR TITLE
Fix System.Xml.Xsl.XslTransformApi.Tests in uap

### DIFF
--- a/src/System.Private.Xml/tests/Xslt/XslTransformApi/CXslTArgumentList.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslTransformApi/CXslTArgumentList.cs
@@ -20,9 +20,14 @@ namespace System.Xml.Tests
     public class CArgIntegrity : XsltApiTestCaseBase
     {
         private ITestOutputHelper _output;
+        private string _xslFile;
+        private string _xmlFile;
+
         public CArgIntegrity(ITestOutputHelper output) : base(output)
         {
             _output = output;
+            _xslFile = $"{GetTestFilePath()}.xsl";
+            _xmlFile = $"{GetTestFilePath()}.xml";
         }
 
         //[Variation(Desc = "Basic Verification Test", Pri = 0)]
@@ -51,7 +56,7 @@ namespace System.Xml.Tests
   </xsl:template>
 </xsl:stylesheet>";
 
-        private static void WriteFiles(string input, string output)
+        private void WriteFiles(string input, string output)
         {
             using (XmlWriter w = XmlWriter.Create(output))
             {
@@ -62,10 +67,10 @@ namespace System.Xml.Tests
             }
         }
 
-        private static void WriteXmlAndXslFiles()
+        private void WriteXmlAndXslFiles()
         {
-            WriteFiles(s_typeXml, "type.xml");
-            WriteFiles(s_typeXsl, "type.xsl");
+            WriteFiles(s_typeXml, _xmlFile);
+            WriteFiles(s_typeXsl, _xslFile);
         }
 
         //[Variation(Desc = "Tuple.XsltArgumentList.AddParam/AddExtensionObject", Param = 1)]
@@ -94,13 +99,13 @@ namespace System.Xml.Tests
 #pragma warning disable 0618
             XslTransform xslt = new XslTransform();
 #pragma warning restore 0618
-            xslt.Load("type.xsl");
+            xslt.Load(_xslFile);
 
             XsltArgumentList xslArg = new XsltArgumentList();
             xslArg.AddParam("param", "", t);
             xslArg.AddExtensionObject("", t);
 
-            XPathDocument xpathDom = new XPathDocument("type.xml");
+            XPathDocument xpathDom = new XPathDocument(_xmlFile);
             using (StringWriter sw = new StringWriter())
             {
                 xslt.Transform(xpathDom, xslArg, sw);

--- a/src/System.Private.Xml/tests/Xslt/XslTransformApi/CXslTransform.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslTransformApi/CXslTransform.cs
@@ -2759,7 +2759,7 @@ namespace System.Xml.Tests
             {
                 if (LoadXSL("XmlResolver_Main.xsl", inputType, readerType) == 1)
                 {
-                    CallTransform(xslt, szFullFilename, "out.xml", null);
+                    CallTransform(xslt, szFullFilename, _strOutFile, null);
                     VerifyResult(expected);
                     return;
                 }
@@ -2786,7 +2786,7 @@ namespace System.Xml.Tests
 
             if (LoadXSL("xmlResolver_document_function.xsl", inputType, readerType) == 1)
             {
-                CallTransform(xslt, szFullFilename, "out.xml", null);
+                CallTransform(xslt, szFullFilename, _strOutFile, null);
                 VerifyResult(expected);
                 return;
             }
@@ -2920,7 +2920,7 @@ param2 (correct answer is 'local-param2-arg'): local-param2-arg
 
             if ((LoadXSL("Bug109644.xsl", inputType, readerType) == 1) && (Transform("foo.xml", transformType, docType) == 1))
             {
-                Assert.Equal(expected, File.ReadAllText("out.xml"));
+                Assert.Equal(expected, File.ReadAllText(_strOutFile));
                 return;
             }
             else

--- a/src/System.Private.Xml/tests/Xslt/XslTransformApi/XSLTransform.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslTransformApi/XSLTransform.cs
@@ -46,7 +46,7 @@ namespace System.Xml.Tests
     // Base class for test cases
     //
     ////////////////////////////////////////////////////////////////
-    public class XsltApiTestCaseBase
+    public class XsltApiTestCaseBase : FileCleanupTestBase
     {
         // Generic data for all derived test cases
         public String szXslNS = "http://www.w3.org/1999/XSL/Transform";
@@ -66,7 +66,7 @@ namespace System.Xml.Tests
         private bool _fTrace;            // Should we write out the results of the transform?
 
         // Other global variables
-        protected string _strOutFile = "out.xml";        // File to create when using write transforms
+        protected string _strOutFile = null;        // File to create when using write transforms
 
 #pragma warning disable 0618
         protected XslTransform xslt;                           // Main XslTransform instance
@@ -83,6 +83,7 @@ namespace System.Xml.Tests
             // Make sure that we don't cache the value of the switch to enable testing
             AppContext.SetSwitch("TestSwitch.LocalAppContext.DisableCaching", true);
             _output = output;
+            _strOutFile = GetTestFilePath();
             this.Init(null);
         }
 


### PR DESCRIPTION
This tests where crashing because they had ~1300 failures in uap and we currently dump all the failures to the app runner's UI so that 1300 stack traces where blowing up the runner and crashing. 

This PR fixes all of them and brings failures to 0. So we should stop seeing them crashing and this would bring 1546 more test that will be running :)

cc: @danmosemsft 