### PR TITLE
Add some System.DirectoryServices tests that don't require a server

### DIFF
--- a/src/System.DirectoryServices/System.DirectoryServices.sln
+++ b/src/System.DirectoryServices/System.DirectoryServices.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26430.6
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.DirectoryServices", "src\System.DirectoryServices.csproj", "{EC9B0FBC-C3A2-44E6-BFC6-51E565061C28}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -15,20 +15,42 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E89
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{EF6F08C3-2EF9-4CAC-9A25-61B55EB6583A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.DirectoryServices.Tests", "tests\System.DirectoryServices.Tests.csproj", "{297A9116-1005-499D-A895-2063D03E4C94}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		netstandard-Debug|Any CPU = netstandard-Debug|Any CPU
+		netstandard-Release|Any CPU = netstandard-Release|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{EC9B0FBC-C3A2-44E6-BFC6-51E565061C28}.Debug|Any CPU.ActiveCfg = netstandard-Windows_NT-Debug|Any CPU
 		{EC9B0FBC-C3A2-44E6-BFC6-51E565061C28}.Debug|Any CPU.Build.0 = netstandard-Windows_NT-Debug|Any CPU
+		{EC9B0FBC-C3A2-44E6-BFC6-51E565061C28}.netstandard-Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{EC9B0FBC-C3A2-44E6-BFC6-51E565061C28}.netstandard-Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{EC9B0FBC-C3A2-44E6-BFC6-51E565061C28}.netstandard-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{EC9B0FBC-C3A2-44E6-BFC6-51E565061C28}.netstandard-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
 		{EC9B0FBC-C3A2-44E6-BFC6-51E565061C28}.Release|Any CPU.ActiveCfg = netstandard-Windows_NT-Release|Any CPU
 		{EC9B0FBC-C3A2-44E6-BFC6-51E565061C28}.Release|Any CPU.Build.0 = netstandard-Windows_NT-Release|Any CPU
 		{CBCDA53B-4C01-4267-B08C-413205FE4D8D}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
 		{CBCDA53B-4C01-4267-B08C-413205FE4D8D}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{CBCDA53B-4C01-4267-B08C-413205FE4D8D}.netstandard-Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{CBCDA53B-4C01-4267-B08C-413205FE4D8D}.netstandard-Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{CBCDA53B-4C01-4267-B08C-413205FE4D8D}.netstandard-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{CBCDA53B-4C01-4267-B08C-413205FE4D8D}.netstandard-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
 		{CBCDA53B-4C01-4267-B08C-413205FE4D8D}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
 		{CBCDA53B-4C01-4267-B08C-413205FE4D8D}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{297A9116-1005-499D-A895-2063D03E4C94}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{297A9116-1005-499D-A895-2063D03E4C94}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{297A9116-1005-499D-A895-2063D03E4C94}.netstandard-Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{297A9116-1005-499D-A895-2063D03E4C94}.netstandard-Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{297A9116-1005-499D-A895-2063D03E4C94}.netstandard-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{297A9116-1005-499D-A895-2063D03E4C94}.netstandard-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{297A9116-1005-499D-A895-2063D03E4C94}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{297A9116-1005-499D-A895-2063D03E4C94}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -36,5 +58,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{EC9B0FBC-C3A2-44E6-BFC6-51E565061C28} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{CBCDA53B-4C01-4267-B08C-413205FE4D8D} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
+		{297A9116-1005-499D-A895-2063D03E4C94} = {EF6F08C3-2EF9-4CAC-9A25-61B55EB6583A}
 	EndGlobalSection
 EndGlobal

--- a/src/System.DirectoryServices/tests/Configurations.props
+++ b/src/System.DirectoryServices/tests/Configurations.props
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+        netstandard-Windows_NT;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/src/System.DirectoryServices/tests/System.DirectoryServices.Tests.csproj
+++ b/src/System.DirectoryServices/tests/System.DirectoryServices.Tests.csproj
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <ProjectGuid>{297A9116-1005-499D-A895-2063D03E4C94}</ProjectGuid>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
+  <ItemGroup>
+    <Compile Include="System\DirectoryServices\ActiveDirectorySecurityTests.cs" />
+    <Compile Include="System\DirectoryServices\DirectoryEntryTests.cs" />
+    <Compile Include="System\DirectoryServices\PropertyCollectionTests.cs" />
+    <Compile Include="System\DirectoryServices\ActiveDirectory\DirectoryContextTests.cs" />
+    <Compile Include="$(CommonTestPath)\System\AssertExtensions.cs">
+      <Link>Common\System\AssertExtensions.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>Common\System\PlatformDetection.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectory/DirectoryContextTests.cs
+++ b/src/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectory/DirectoryContextTests.cs
@@ -1,0 +1,95 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using Xunit;
+
+namespace System.DirectoryServices.ActiveDirectory.Tests
+{
+    public class DirectoryContextTests
+    {
+        [Theory]
+        [InlineData(DirectoryContextType.Domain)]
+        [InlineData(DirectoryContextType.Forest)]
+        public void Ctor_ContextType(DirectoryContextType contextType)
+        {
+            var context = new DirectoryContext(contextType);
+            Assert.Equal(contextType, context.ContextType);
+            Assert.Null(context.Name);
+            Assert.Null(context.UserName);
+        }
+
+        [Theory]
+        [InlineData(DirectoryContextType.Domain, null, null)]
+        [InlineData(DirectoryContextType.Forest, "UserName", "Password")]
+        public void Ctor_ContextType_UserName_Password(DirectoryContextType contextType, string userName, string password)
+        {
+            var context = new DirectoryContext(contextType, userName, password);
+            Assert.Equal(contextType, context.ContextType);
+            Assert.Null(context.Name);
+            Assert.Equal(userName, context.UserName);
+        }
+
+        [Theory]
+        [InlineData(DirectoryContextType.ApplicationPartition)]
+        [InlineData(DirectoryContextType.ConfigurationSet)]
+        [InlineData(DirectoryContextType.DirectoryServer)]
+        public void Ctor_NotSupportedContextType_ThrowsArgumentException(DirectoryContextType contextType)
+        {
+            AssertExtensions.Throws<ArgumentException>("contextType", () => new DirectoryContext(contextType));
+            AssertExtensions.Throws<ArgumentException>("contextType", () => new DirectoryContext(contextType, "username", "password"));
+        }
+
+        [Theory]
+        [InlineData(DirectoryContextType.ApplicationPartition, "Name")]
+        [InlineData(DirectoryContextType.ConfigurationSet, "Name")]
+        [InlineData(DirectoryContextType.DirectoryServer, "Name")]
+        [InlineData(DirectoryContextType.Domain, "Name")]
+        [InlineData(DirectoryContextType.Forest, "Name")]
+        public void Ctor_ContextType_Name(DirectoryContextType contextType, string name)
+        {
+            var context = new DirectoryContext(contextType, name);
+            Assert.Equal(contextType, context.ContextType);
+            Assert.Equal(name, context.Name);
+            Assert.Null(context.UserName);
+        }
+
+        [Theory]
+        [InlineData(DirectoryContextType.ApplicationPartition, "Name", null, null)]
+        [InlineData(DirectoryContextType.ConfigurationSet, "Name", "", "")]
+        [InlineData(DirectoryContextType.DirectoryServer, "Name", "UserName", "Password")]
+        [InlineData(DirectoryContextType.Domain, "Name", "UserName", "Password")]
+        [InlineData(DirectoryContextType.Forest, "Name", "UserName", "Password")]
+        public void Ctor_ContextType_Name_UserName_Password(DirectoryContextType contextType, string name, string userName, string password)
+        {
+            var context = new DirectoryContext(contextType, name, userName, password);
+            Assert.Equal(contextType, context.ContextType);
+            Assert.Equal(name, context.Name);
+            Assert.Equal(userName, context.UserName);
+        }
+
+        [Theory]
+        [InlineData(DirectoryContextType.Domain - 1)]
+        [InlineData(DirectoryContextType.ApplicationPartition + 1)]
+        public void Ctor_InvalidContextType_ThrowsInvalidEnumArgumentException(DirectoryContextType contextType)
+        {
+            AssertExtensions.Throws<InvalidEnumArgumentException>("contextType", () => new DirectoryContext(contextType, "name"));
+            AssertExtensions.Throws<InvalidEnumArgumentException>("contextType", () => new DirectoryContext(contextType, "name", "userName", "password"));
+        }
+
+        [Fact]
+        public void Ctor_NullName_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>("name", () => new DirectoryContext(DirectoryContextType.ConfigurationSet, null));
+            Assert.Throws<ArgumentNullException>("name", () => new DirectoryContext(DirectoryContextType.ConfigurationSet, null, "userName", "password"));
+        }
+
+        [Fact]
+        public void Ctor_EmptyName_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>("name", () => new DirectoryContext(DirectoryContextType.ConfigurationSet, string.Empty));
+            Assert.Throws<ArgumentException>("name", () => new DirectoryContext(DirectoryContextType.ConfigurationSet, string.Empty, "userName", "password"));
+        }
+    }
+}

--- a/src/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectorySecurityTests.cs
+++ b/src/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectorySecurityTests.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.DirectoryServices.Tests
+{
+    public class ActiveDirectorySecurityTests
+    {
+        [Fact]
+        public void Ctor_Default()
+        {
+            var security = new ActiveDirectorySecurity();
+            Assert.Equal(typeof(ActiveDirectoryRights), security.AccessRightType);
+            Assert.Equal(typeof(ActiveDirectoryAccessRule), security.AccessRuleType);
+            Assert.Equal(typeof(ActiveDirectoryAuditRule), security.AuditRuleType);
+        }
+    }
+}

--- a/src/System.DirectoryServices/tests/System/DirectoryServices/DirectoryEntryTests.cs
+++ b/src/System.DirectoryServices/tests/System/DirectoryServices/DirectoryEntryTests.cs
@@ -1,0 +1,235 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace System.DirectoryServices.Tests
+{
+    public class DirectoryEntryTests
+    {
+        [Fact]
+        public void Ctor_Default()
+        {
+            var entry = new DirectoryEntry();
+            Assert.Equal(string.Empty, entry.Path);
+            Assert.Null(entry.Username);
+            Assert.Equal(AuthenticationTypes.Secure, entry.AuthenticationType);
+            Assert.True(entry.UsePropertyCache);
+
+            Assert.NotNull(entry.Children);
+            Assert.NotNull(entry.Properties);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("Path")]
+        public void Ctor_Path(string path)
+        {
+            var entry = new DirectoryEntry(path);
+            Assert.Equal(path ?? string.Empty, entry.Path);
+            Assert.Null(entry.Username);
+            Assert.Equal(AuthenticationTypes.Secure, entry.AuthenticationType);
+            Assert.True(entry.UsePropertyCache);
+
+            Assert.NotNull(entry.Children);
+            Assert.NotNull(entry.Properties);
+        }
+
+        [Theory]
+        [InlineData(null, null, null)]
+        [InlineData("", "", "")]
+        [InlineData("Path", "UserName", "Password")]
+        public void Ctor_Path_UserName_Password(string path, string userName, string password)
+        {
+            var entry = new DirectoryEntry(path, userName, password);
+            Assert.Equal(path ?? string.Empty, entry.Path);
+            Assert.Equal(userName, entry.Username);
+            Assert.Equal(AuthenticationTypes.Secure, entry.AuthenticationType);
+            Assert.True(entry.UsePropertyCache);
+
+            Assert.NotNull(entry.Children);
+            Assert.NotNull(entry.Properties);
+        }
+
+        [Theory]
+        [InlineData(null, null, null, (AuthenticationTypes)int.MinValue)]
+        [InlineData("", "", "", AuthenticationTypes.Anonymous)]
+        [InlineData("Path", "UserName", "Password", AuthenticationTypes.None)]
+        public void Ctor_Path_UserName_Password_AuthenticationType(string path, string userName, string password, AuthenticationTypes authenticationType)
+        {
+            var entry = new DirectoryEntry(path, userName, password, authenticationType);
+            Assert.Equal(path ?? string.Empty, entry.Path);
+            Assert.Equal(userName, entry.Username);
+            Assert.Equal(authenticationType, entry.AuthenticationType);
+            Assert.True(entry.UsePropertyCache);
+
+            Assert.NotNull(entry.Children);
+            Assert.NotNull(entry.Properties);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(1)]
+        public void Ctor_InvalidAdsObject_ThrowsArgumentException(object adsObject)
+        {
+            AssertExtensions.Throws<ArgumentException>(null, () => new DirectoryEntry(adsObject));
+        }
+
+        [Theory]
+        [InlineData(AuthenticationTypes.Secure)]
+        [InlineData(AuthenticationTypes.Anonymous)]
+        [InlineData((AuthenticationTypes)int.MinValue)]
+        public void AuthenticationType_Set_GetReturnsExpected(AuthenticationTypes authenticationType)
+        {
+            var entry = new DirectoryEntry { AuthenticationType = authenticationType };
+            Assert.Equal(authenticationType, entry.AuthenticationType);
+        }
+
+        [Fact]
+        public void Dispose_InvokeMultipleTimes_Success()
+        {
+            var entry = new DirectoryEntry();
+            entry.Dispose();
+            entry.Dispose();
+        }
+
+        [Fact]
+        public void Dispose_GetProperties_ThrowsObjectDisposedException()
+        {
+            var entry = new DirectoryEntry("path");
+            entry.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => entry.Guid);
+            Assert.Throws<ObjectDisposedException>(() => entry.Name);
+            Assert.Throws<ObjectDisposedException>(() => entry.NativeGuid);
+            Assert.Throws<ObjectDisposedException>(() => entry.NativeObject);
+            Assert.Throws<ObjectDisposedException>(() => entry.ObjectSecurity);
+            Assert.Throws<ObjectDisposedException>(() => entry.Parent);
+            Assert.Throws<ObjectDisposedException>(() => entry.SchemaClassName);
+            Assert.Throws<ObjectDisposedException>(() => entry.SchemaEntry);
+        }
+
+        [Fact]
+        public void Dispose_InvokeMethods_ThrowsObjectDisposedException()
+        {
+            var entry = new DirectoryEntry("path");
+            entry.Dispose();
+
+            //Assert.Throws<ObjectDisposedException>(() => entry.CopyTo(new DirectoryEntry()));
+        }
+
+        [Fact]
+        public void CopyTo_NullEntry_ThrowsNullReferenceException()
+        {
+            var entry = new DirectoryEntry("path");
+            Assert.Throws<NullReferenceException>(() => entry.CopyTo(null));
+            Assert.Throws<NullReferenceException>(() => entry.CopyTo(null, "newName"));
+        }
+
+        [Fact]
+        public void CopyTo_DisposedEntry_ThrowsObjectDisposedException()
+        {
+            var entry = new DirectoryEntry("path");
+            var disposedEntry = new DirectoryEntry();
+            disposedEntry.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => entry.CopyTo(disposedEntry));
+            Assert.Throws<ObjectDisposedException>(() => entry.CopyTo(disposedEntry, "newName"));
+        }
+
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
+        public void DeleteTree_NoObject_ThrowsCOMException()
+        {
+            var entry = new DirectoryEntry("path");
+            Assert.Throws<COMException>(() => entry.DeleteTree());
+        }
+
+        [Fact]
+        public void DeleteTree_DisposedObject_ObjectDisposedException()
+        {
+            var entry = new DirectoryEntry("path");
+            entry.Dispose();
+            Assert.Throws<ObjectDisposedException>(() => entry.DeleteTree());
+        }
+
+        [Fact]
+        public void Invoke_DisposedObject_ObjectDisposedException()
+        {
+            var entry = new DirectoryEntry("path");
+            entry.Dispose();
+            Assert.Throws<ObjectDisposedException>(() => entry.Invoke(null, null));
+        }
+
+        [Fact]
+        public void InvokeGet_DisposedObject_ObjectDisposedException()
+        {
+            var entry = new DirectoryEntry("path");
+            entry.Dispose();
+            Assert.Throws<ObjectDisposedException>(() => entry.InvokeGet(null));
+        }
+
+        [Fact]
+        public void InvokeSet_DisposedObject_ObjectDisposedException()
+        {
+            var entry = new DirectoryEntry("path");
+            entry.Dispose();
+            Assert.Throws<ObjectDisposedException>(() => entry.InvokeSet(null));
+        }
+
+        [Fact]
+        public void MoveTo_NullEntry_ThrowsNullReferenceException()
+        {
+            var entry = new DirectoryEntry("path");
+            Assert.Throws<NullReferenceException>(() => entry.MoveTo(null));
+            Assert.Throws<NullReferenceException>(() => entry.MoveTo(null, "newName"));
+        }
+
+        [Fact]
+        public void MoveTo_DisposedEntry_ThrowsObjectDisposedException()
+        {
+            var entry = new DirectoryEntry("path");
+            var disposedEntry = new DirectoryEntry();
+            disposedEntry.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => entry.MoveTo(disposedEntry));
+            Assert.Throws<ObjectDisposedException>(() => entry.MoveTo(disposedEntry, "newName"));
+        }
+        
+        [Fact]
+        public void Rename_Disposed_ThrowsObjectDisposedException()
+        {
+            var entry = new DirectoryEntry("path");
+            entry.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => entry.Rename(null));
+        }
+
+        [Fact]
+        public void RefreshCache_Disposed_ThrowsObjectDisposedException()
+        {
+            var entry = new DirectoryEntry("path");
+            entry.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => entry.RefreshCache());
+            Assert.Throws<ObjectDisposedException>(() => entry.RefreshCache(null));
+        }
+
+        [Fact]
+        public void ObjectSecurity_Set_GetReturnsExpected()
+        {
+            var security = new ActiveDirectorySecurity();
+            var entry = new DirectoryEntry { ObjectSecurity = security };
+            Assert.Same(security, entry.ObjectSecurity);
+        }
+
+        [Fact]
+        public void ObjectSecurity_SetNull_ThrowsArgumentnullExceptioN()
+        {
+            var entry = new DirectoryEntry();
+            AssertExtensions.Throws<ArgumentNullException>("value", () => entry.ObjectSecurity = null);
+        }
+    }
+}

--- a/src/System.DirectoryServices/tests/System/DirectoryServices/PropertyCollectionTests.cs
+++ b/src/System.DirectoryServices/tests/System/DirectoryServices/PropertyCollectionTests.cs
@@ -1,0 +1,110 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using Xunit;
+
+namespace System.DirectoryServices.Tests
+{
+    public class PropertyCollectionTests
+    {
+        [Fact]
+        public void Indexer_NullPropertyName_ThrowsArgumentNullException()
+        {
+            using (var entry = new DirectoryEntry())
+            {
+                AssertExtensions.Throws<ArgumentNullException>("propertyName", () => entry.Properties[null]);
+                AssertExtensions.Throws<ArgumentNullException>("propertyName", () => ((IDictionary)entry.Properties)[null]);
+            }
+        }
+
+        [Fact]
+        public void Indexer_ObjectNotString_ThrowsInvalidCastException()
+        {
+            using (var entry = new DirectoryEntry())
+            {
+                IDictionary properties = entry.Properties;
+                Assert.Throws<InvalidCastException>(() => properties[1]);
+            }
+        }
+
+        [Fact]
+        public void IDictionary_ModifyDictionary_ThrowsNotSupportedException()
+        {
+            using (var entry = new DirectoryEntry())
+            {
+                IDictionary properties = entry.Properties;
+                Assert.Throws<NotSupportedException>(() => properties["name"] = 2);
+                Assert.Throws<NotSupportedException>(() => properties.Add("key", "value"));
+                Assert.Throws<NotSupportedException>(() => properties.Remove("key"));
+                Assert.Throws<NotSupportedException>(() => properties.Clear());
+            }
+        }
+
+        [Fact]
+        public void IDictionary_GetProperties_ReturnsExpected()
+        {
+            using (var entry = new DirectoryEntry())
+            {
+                IDictionary properties = entry.Properties;
+                Assert.True(properties.IsFixedSize);
+                Assert.True(properties.IsReadOnly);
+                Assert.False(properties.IsSynchronized);
+                Assert.Same(properties, properties.SyncRoot);
+            }
+        }
+
+        [Fact]
+        public void CopyTo_NullArray_ThrowsArgumentNullException()
+        {
+            using (var entry = new DirectoryEntry())
+            {
+                PropertyCollection properties = entry.Properties;
+                AssertExtensions.Throws<ArgumentNullException>("array", () => properties.CopyTo(null, 0));
+                AssertExtensions.Throws<ArgumentNullException>("array", () => ((ICollection)properties).CopyTo(null, 0));
+            }
+        }
+
+        [Fact]
+        public void CopyTo_InvalidArrayRank_ThrowsArgumentException()
+        {
+            using (var entry = new DirectoryEntry())
+            {
+                PropertyCollection properties = entry.Properties;
+                AssertExtensions.Throws<ArgumentException>("array", () => ((ICollection)properties).CopyTo(new int[1, 1], 0));
+            }
+        }
+
+        [Fact]
+        public void CopyTo_NegativeIndex_ThrowsArgumentOutOfRangeException()
+        {
+            using (var entry = new DirectoryEntry())
+            {
+                PropertyCollection properties = entry.Properties;
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("Number was less than the array's lower bound in the first dimension.", () => properties.CopyTo(new PropertyValueCollection[0], -1));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("Number was less than the array's lower bound in the first dimension.", () => ((ICollection)properties).CopyTo(new PropertyValueCollection[0], -1));
+            }
+        }
+
+        [Fact]
+        public void Values_Get_ReturnsUniqueObject()
+        {
+            using (var entry = new DirectoryEntry())
+            {
+                PropertyCollection properties = entry.Properties;
+                Assert.NotSame(properties.Values, properties.Values);
+            }
+        }
+
+        [Fact]
+        public void IDictionaryValues_Get_ReturnsUniqueObject()
+        {
+            using (var entry = new DirectoryEntry())
+            {
+                IDictionary properties = entry.Properties;
+                Assert.NotSame(properties.Values, properties.Values);
+            }
+        }
+    }
+}


### PR DESCRIPTION
I quickly realised that to properly test the library you need a server, but here's what I managed so far without one