### PR TITLE
Avoid O(N^2) in HashSetEquals and SortedSetEquals

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -9,9 +9,9 @@
        These ref versions are pulled from https://github.com/dotnet/versions.
   -->
   <PropertyGroup>
-    <CoreFxCurrentRef>f5fb8b6cb0eba67faffd6282297d8c5bf915eece</CoreFxCurrentRef>
-    <CoreClrCurrentRef>f5fb8b6cb0eba67faffd6282297d8c5bf915eece</CoreClrCurrentRef>
-    <CoreSetupCurrentRef>f5fb8b6cb0eba67faffd6282297d8c5bf915eece</CoreSetupCurrentRef>
+    <CoreFxCurrentRef>792e6aa5436af9dabbd2c2e79d586bec33b8a5f8</CoreFxCurrentRef>
+    <CoreClrCurrentRef>792e6aa5436af9dabbd2c2e79d586bec33b8a5f8</CoreClrCurrentRef>
+    <CoreSetupCurrentRef>792e6aa5436af9dabbd2c2e79d586bec33b8a5f8</CoreSetupCurrentRef>
     <ExternalCurrentRef>5a0606fccb09fce4b47545ae9896139acca547f5</ExternalCurrentRef>
     <ProjectNTfsCurrentRef>f5fb8b6cb0eba67faffd6282297d8c5bf915eece</ProjectNTfsCurrentRef>
     <ProjectNTfsTestILCCurrentRef>f5fb8b6cb0eba67faffd6282297d8c5bf915eece</ProjectNTfsTestILCCurrentRef>
@@ -22,15 +22,15 @@
   <!-- Auto-upgraded properties for each build info dependency. -->
   <PropertyGroup>
     <PlatformPackageVersion>2.1.0-preview1-25324-02</PlatformPackageVersion>
-    <CoreFxExpectedPrerelease>preview1-25409-03</CoreFxExpectedPrerelease>
-    <CoreClrPackageVersion>2.1.0-preview1-25409-01</CoreClrPackageVersion>
+    <CoreFxExpectedPrerelease>preview1-25410-01</CoreFxExpectedPrerelease>
+    <CoreClrPackageVersion>2.1.0-preview1-25409-02</CoreClrPackageVersion>
     <ExternalExpectedPrerelease>beta-25322-00</ExternalExpectedPrerelease>
     <ProjectNTfsExpectedPrerelease>beta-25409-00</ProjectNTfsExpectedPrerelease>
     <ProjectNTfsTestILCExpectedPrerelease>beta-25409-00</ProjectNTfsTestILCExpectedPrerelease>
     <ProjectNTfsTestILCPackageVersion>1.0.0-beta-25409-00</ProjectNTfsTestILCPackageVersion>
     <NETStandardPackageVersion>2.1.0-preview1-25409-01</NETStandardPackageVersion>
     <NETStandardPackageId>NETStandard.Library</NETStandardPackageId>
-    <MicrosoftNETCoreAppPackageVersion>2.1.0-preview1-25408-02</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>2.1.0-preview1-25409-04</MicrosoftNETCoreAppPackageVersion>
     <!-- Use the SNI runtime package -->
     <SniPackageVersion>4.4.0-preview2-25312-01</SniPackageVersion>
   </PropertyGroup>

--- a/src/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -949,8 +949,7 @@ namespace System.Collections.Generic
                         return false;
                     }
                 }
-                ElementCount result = CheckUniqueAndUnfoundElements(other, true);
-                return (result.uniqueCount == _count && result.unfoundCount == 0);
+                return InnerSetEquals(other);
             }
         }
 
@@ -1693,6 +1692,14 @@ namespace System.Collections.Generic
                 }
                 return true;
             }
+            else if (set1.Comparer.Equals(comparer))
+            {
+                return set1.InnerSetEquals(set2);
+            }
+            else if (set2.Comparer.Equals(comparer))
+            {
+                return set2.InnerSetEquals(set1);
+            }
             else
             {  // n^2 search because items are hashed according to their respective ECs
                 foreach (T set2Item in set2)
@@ -1713,6 +1720,12 @@ namespace System.Collections.Generic
                 }
                 return true;
             }
+        }
+
+        private bool InnerSetEquals(IEnumerable<T> other)
+        {
+            ElementCount result = CheckUniqueAndUnfoundElements(other, true);
+            return result.uniqueCount == Count && result.unfoundCount == 0;
         }
 
         /// <summary>

--- a/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
@@ -885,7 +885,14 @@ namespace System.Collections.Generic
             {
                 return set1.Count == set2.Count && set1.SetEquals(set2);
             }
-            
+            else if (set1.Comparer.Equals(comparer))
+            {
+                return set1.SetEquals(set2);
+            }
+            else if (set2.Comparer.Equals(comparer))
+            {
+                return set2.SetEquals( set1);
+            }
             bool found = false;
             foreach (T item1 in set1)
             {

--- a/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
@@ -891,7 +891,7 @@ namespace System.Collections.Generic
             }
             else if (set2.Comparer.Equals(comparer))
             {
-                return set2.SetEquals( set1);
+                return set2.SetEquals(set1);
             }
             bool found = false;
             foreach (T item1 in set1)

--- a/src/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.cs
@@ -298,9 +298,18 @@ namespace System.Collections.Tests
                 new HashSet<T> { objects[0], objects[1], objects[2] }
             };
 
+            var nonDefaultComparerSet = new HashSet<HashSet<T>>(HashSet<T>.CreateSetComparer())
+            {
+                new HashSet<T>(GetIEqualityComparer()) { objects[3], objects[4], objects[5] },
+                new HashSet<T>(GetIEqualityComparer()) { objects[0], objects[1], objects[2] }
+            };
+
             Assert.False(noComparerSet.SetEquals(set));
             Assert.True(comparerSet1.SetEquals(set));
             Assert.True(comparerSet2.SetEquals(set));
+            Assert.True(nonDefaultComparerSet.SetEquals(set));
+            Assert.True(comparerSet1.SetEquals(nonDefaultComparerSet));
+            Assert.False(set.SetEquals(nonDefaultComparerSet));
         }
 
         [Fact]

--- a/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.Tests.cs
@@ -358,9 +358,18 @@ namespace System.Collections.Tests
                 new SortedSet<T> { objects[0], objects[1], objects[2] }
             };
 
+            var nonDefaultComparerSet = new HashSet<SortedSet<T>>(SortedSet<T>.CreateSetComparer())
+            {
+                new SortedSet<T>(GetIComparer()) { objects[3], objects[4], objects[5] },
+                new SortedSet<T>(GetIComparer()) { objects[0], objects[1], objects[2] }
+            };
+
             Assert.False(noComparerSet.SetEquals(set));
             Assert.True(comparerSet1.SetEquals(set));
             Assert.True(comparerSet2.SetEquals(set));
+            Assert.True(nonDefaultComparerSet.SetEquals(set));
+            Assert.True(comparerSet1.SetEquals(nonDefaultComparerSet));
+            Assert.False(set.SetEquals(nonDefaultComparerSet));
         }
 #endregion
     }

--- a/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.Tests.cs
@@ -371,6 +371,6 @@ namespace System.Collections.Tests
             Assert.True(comparerSet1.SetEquals(nonDefaultComparerSet));
             Assert.False(set.SetEquals(nonDefaultComparerSet));
         }
-        #endregion
+#endregion
     }
 }


### PR DESCRIPTION
Avoid O(N^2) in HashSetEquals and SortedSetEquals when the two sets have different comparers, but one of them has the fallback comparer. We treat the set without the fallback comparer as just another IEnumerable, and determine equality in O(N)