### PR TITLE
Correctly handle empty strings in params of RemoteExecutorTestBase

### DIFF
--- a/src/Common/src/System/PasteArguments.cs
+++ b/src/Common/src/System/PasteArguments.cs
@@ -3,18 +3,17 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 
 namespace System
 {
-    public static class PasteArguments
+    internal static class PasteArguments
     {
          /// <summary>
         /// Repastes a set of arguments into a linear string that parses back into the originals under pre- or post-2008 VC parsing rules.
         /// The rules for parsing the executable name (argv[0]) are special, so you must indicate whether the first argument actually is argv[0].
         /// </summary>
-        public static string Paste(this IEnumerable<string> arguments, bool pasteFirstArgumentUsingArgV0Rules)
+        public static string Paste(IEnumerable<string> arguments, bool pasteFirstArgumentUsingArgV0Rules)
         {
             var stringBuilder = new StringBuilder();
 
@@ -137,7 +136,6 @@ namespace System
             return true;
         }
 
-        private const char Nul = (char)0;
         private const char Quote = '\"';
         private const char Backslash = '\\';
     }

--- a/src/Common/src/System/PasteArguments.cs
+++ b/src/Common/src/System/PasteArguments.cs
@@ -1,0 +1,144 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace System
+{
+    public static class PasteArguments
+    {
+         /// <summary>
+        /// Repastes a set of arguments into a linear string that parses back into the originals under pre- or post-2008 VC parsing rules.
+        /// The rules for parsing the executable name (argv[0]) are special, so you must indicate whether the first argument actually is argv[0].
+        /// </summary>
+        public static string Paste(this IEnumerable<string> arguments, bool pasteFirstArgumentUsingArgV0Rules)
+        {
+            var stringBuilder = new StringBuilder();
+
+            foreach (string argument in arguments)
+            {
+                if (pasteFirstArgumentUsingArgV0Rules)
+                {
+                    pasteFirstArgumentUsingArgV0Rules = false;
+
+                    // Special rules for argv[0]
+                    //   - Backslash is a normal character.
+                    //   - Quotes used to include whitespace characters.
+                    //   - Parsing ends at first whitespace outside quoted region.
+                    //   - No way to get a literal quote past the parser.
+
+                    bool hasWhitespace = false;
+                    foreach (char c in argument)
+                    {
+                        if (c == Quote)
+                        {
+                            throw new ApplicationException("The argv[0] argument cannot include a double quote.");
+                        }
+                        if (char.IsWhiteSpace(c))
+                        {
+                            hasWhitespace = true;
+                        }
+                    }
+                    if (argument.Length == 0 || hasWhitespace)
+                    {
+                        stringBuilder.Append(Quote);
+                        stringBuilder.Append(argument);
+                        stringBuilder.Append(Quote);
+                    }
+                    else
+                    {
+                        stringBuilder.Append(argument);
+                    }
+                }
+                else
+                {
+                    if (stringBuilder.Length != 0)
+                    {
+                        stringBuilder.Append(' ');
+                    }
+
+                    // Parsing rules for non-argv[0] arguments:
+                    //   - Backslash is a normal character except followed by a quote.
+                    //   - 2N backslashes followed by a quote ==> N literal backslashes followed by unescaped quote
+                    //   - 2N+1 backslashes followed by a quote ==> N literal backslashes followed by a literal quote
+                    //   - Parsing stops at first whitespace outside of quoted region.
+                    //   - (post 2008 rule): A closing quote followed by another quote ==> literal quote, and parsing remains in quoting mode.
+                    if (argument.Length != 0 && ContainsNoWhitespaceOrQuotes(argument))
+                    {
+                        // Simple case - no quoting or changes needed.
+                        stringBuilder.Append(argument);
+                    }
+                    else
+                    {
+                        stringBuilder.Append(Quote);
+                        int idx = 0;
+                        while (idx < argument.Length)
+                        {
+                            char c = argument[idx++];
+                            if (c == Backslash)
+                            {
+                                int numBackSlash = 1;
+                                while (idx < argument.Length && argument[idx] == Backslash)
+                                {
+                                    idx++;
+                                    numBackSlash++;
+                                }
+                                if (idx == argument.Length)
+                                {
+                                    // We'll emit an end quote after this so must double the number of backslashes.
+                                    stringBuilder.Append(Backslash, numBackSlash * 2);
+                                }
+                                else if (argument[idx] == Quote)
+                                {
+                                    // Backslashes will be followed by a quote. Must double the number of backslashes.
+                                    stringBuilder.Append(Backslash, numBackSlash * 2 + 1);
+                                    stringBuilder.Append(Quote);
+                                    idx++;
+                                }
+                                else
+                                {
+                                    // Backslash will not be followed by a quote, so emit as normal characters.
+                                    stringBuilder.Append(Backslash, numBackSlash);
+                                }
+                                continue;
+                            }
+                            if (c == Quote)
+                            {
+                                // Escape the quote so it appears as a literal. This also guarantees that we won't end up generating a closing quote followed
+                                // by another quote (which parses differently pre-2008 vs. post-2008.)
+                                stringBuilder.Append(Backslash);
+                                stringBuilder.Append(Quote);
+                                continue;
+                            }
+                            stringBuilder.Append(c);
+                        }
+                        stringBuilder.Append(Quote);
+                    }
+                }
+            }
+
+            return stringBuilder.ToString();
+        }
+
+        private static bool ContainsNoWhitespaceOrQuotes(string s)
+        {
+            for (int i = 0; i < s.Length; i++)
+            {
+                char c = s[i];
+                if (char.IsWhiteSpace(c) || c == Quote)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private const char Nul = (char)0;
+        private const char Quote = '\"';
+        private const char Backslash = '\\';
+    }
+}

--- a/src/CoreFx.Private.TestUtilities/src/CoreFx.Private.TestUtilities.csproj
+++ b/src/CoreFx.Private.TestUtilities/src/CoreFx.Private.TestUtilities.csproj
@@ -6,9 +6,8 @@
     <ProjectGuid>{5B7EAEC-93CB-40DF-BE40-A60BC189B737}</ProjectGuid>
     <RuntimeProjectFile>$(ProjectDir)\external\test-runtime\XUnit.Runtime.depproj</RuntimeProjectFile>
     <ClsCompliant>false</ClsCompliant>
-    <ShouldWriteSigningRequired>false</ShouldWriteSigningRequired>    
+    <ShouldWriteSigningRequired>false</ShouldWriteSigningRequired>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Debug|AnyCPU'" />
@@ -19,17 +18,18 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Windows_NT-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Windows_NT-Release|AnyCPU'" />
-
   <ItemGroup>
     <Compile Include="System\IO\FileCleanupTestBase.cs" />
     <Compile Include="System\Diagnostics\RemoteExecutorTestBase.cs" />
-    <Compile Condition="'$(TargetGroup)' == 'netcoreapp'"  Include="System\Diagnostics\RemoteExecutorTestBase.netcore.cs" />
-    <Compile Condition="'$(TargetGroup)' == 'netfx'"  Include="System\Diagnostics\RemoteExecutorTestBase.netfx.cs" />
-    <Compile Condition="'$(TargetGroup)' != 'uap'"  Include="System\Diagnostics\RemoteExecutorTestBase.Process.cs" />
-    <Compile Condition="'$(TargetGroup)' == 'uap'"  Include="System\Diagnostics\RemoteExecutorTestBase.uap.cs" />
-    <Compile Condition="'$(TargetGroup)' == 'uapaot'"  Include="System\Diagnostics\RemoteExecutorTestBase.uapaot.cs" />
+    <Compile Condition="'$(TargetGroup)' == 'netcoreapp'" Include="System\Diagnostics\RemoteExecutorTestBase.netcore.cs" />
+    <Compile Condition="'$(TargetGroup)' == 'netfx'" Include="System\Diagnostics\RemoteExecutorTestBase.netfx.cs" />
+    <Compile Condition="'$(TargetGroup)' != 'uap'" Include="System\Diagnostics\RemoteExecutorTestBase.Process.cs" />
+    <Compile Condition="'$(TargetGroup)' == 'uap'" Include="System\Diagnostics\RemoteExecutorTestBase.uap.cs" />
+    <Compile Condition="'$(TargetGroup)' == 'uapaot'" Include="System\Diagnostics\RemoteExecutorTestBase.uapaot.cs" />
+    <Compile Include="$(CommonPath)\System\PasteArguments.cs">
+      <Link>Common\System\PasteArguments.cs</Link>
+    </Compile>
   </ItemGroup>
-
   <ItemGroup>
     <Reference Include="System.Runtime" />
     <Reference Include="System.IO.FileSystem" />
@@ -38,22 +38,18 @@
     <Reference Include="System.Diagnostics.Process" />
     <Reference Include="System.ComponentModel.Primitives" />
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation" />
-
     <ReferenceFromRuntime Include="xunit.core" />
     <ReferenceFromRuntime Include="Xunit.NetCore.Extensions" />
     <ReferenceFromRuntime Include="xunit.assert" />
   </ItemGroup>
-
   <ItemGroup Condition="'$(TargetGroup)' == 'uap'">
     <Reference Include="Windows" />
     <Reference Include="mscorlib" />
     <Reference Include="System.Runtime.WindowsRuntime" />
   </ItemGroup>
-
   <ItemGroup Condition="'$(TargetGroup)' == 'netfx'">
     <Reference Include="mscorlib" />
     <Reference Include="System" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.Process.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.Process.cs
@@ -51,9 +51,9 @@ namespace System.Diagnostics
             }
 
             // If we need the host (if it exists), use it, otherwise target the console app directly.
-            string metadataArgs = PasteArguments.Paste(new string[] { ExtraParameter, a.FullName, t.FullName, method.Name }, pasteFirstArgumentUsingArgV0Rules: false);
+            string metadataArgs = PasteArguments.Paste(new string[] { a.FullName, t.FullName, method.Name }, pasteFirstArgumentUsingArgV0Rules: false);
             string passedArgs = pasteArguments ? PasteArguments.Paste(args, pasteFirstArgumentUsingArgV0Rules: false) : string.Join(" ", args);
-            string testConsoleAppArgs = metadataArgs + " " + passedArgs;
+            string testConsoleAppArgs = ExtraParameter + " " + metadataArgs + " " + passedArgs;
 
             if (!File.Exists(TestConsoleApp))
                 throw new IOException("RemoteExecutorConsoleApp test app isn't present in the test runtime directory.");

--- a/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.Process.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.Process.cs
@@ -3,8 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
+using System.Linq;
 using System.Reflection;
-using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -18,7 +19,8 @@ namespace System.Diagnostics
         /// <param name="args">The arguments to pass to the method.</param>
         /// <param name="start">true if this function should Start the Process; false if that responsibility is left up to the caller.</param>
         /// <param name="psi">The ProcessStartInfo to use, or null for a default.</param>
-        private static RemoteInvokeHandle RemoteInvoke(MethodInfo method, string[] args, RemoteInvokeOptions options)
+        /// <param name="pasteArguments">true if this function should paste the arguments (e.g. surrounding with quotes); false if that reponsibility is left up to the caller.</param>
+        private static RemoteInvokeHandle RemoteInvoke(MethodInfo method, string[] args, RemoteInvokeOptions options, bool pasteArguments = true)
         {
             options = options ?? new RemoteInvokeOptions();
 
@@ -49,13 +51,15 @@ namespace System.Diagnostics
             }
 
             // If we need the host (if it exists), use it, otherwise target the console app directly.
-            string testConsoleAppArgs = "\"" + a.FullName + "\" " + t.FullName + " " + method.Name + " " + string.Join(" ", args);
+            string metadataArgs = PasteArguments.Paste(new string[] { ExtraParameter, a.FullName, t.FullName, method.Name }, pasteFirstArgumentUsingArgV0Rules: false);
+            string passedArgs = pasteArguments ? PasteArguments.Paste(args, pasteFirstArgumentUsingArgV0Rules: false) : string.Join(" ", args);
+            string testConsoleAppArgs = metadataArgs + " " + passedArgs;
 
             if (!File.Exists(TestConsoleApp))
                 throw new IOException("RemoteExecutorConsoleApp test app isn't present in the test runtime directory.");
 
             psi.FileName = HostRunner;
-            psi.Arguments = ExtraParameter + testConsoleAppArgs;
+            psi.Arguments = testConsoleAppArgs;
 
             // Return the handle to the process, which may or not be started
             return new RemoteInvokeHandle(options.Start ?

--- a/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.cs
@@ -113,14 +113,14 @@ namespace System.Diagnostics
             return RemoteInvoke(GetMethodInfo(method), new[] { arg1, arg2, arg3, arg4, arg5 }, options);
         }
 
-        /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
+        /// <summary>Invokes the method from this assembly in another process using the specified arguments without performing any modifications to the arguments.</summary>
         /// <param name="method">The method to invoke.</param>
         /// <param name="args">The arguments to pass to the method.</param>
         /// <param name="options">Options to use for the invocation.</param>
         public static RemoteInvokeHandle RemoteInvokeRaw(Delegate method, string unparsedArg,
             RemoteInvokeOptions options = null)
         {
-            return RemoteInvoke(GetMethodInfo(method), new[] { unparsedArg }, options);
+            return RemoteInvoke(GetMethodInfo(method), new[] { unparsedArg }, options, pasteArguments: false);
         }
 
         private static MethodInfo GetMethodInfo(Delegate d)
@@ -193,7 +193,7 @@ namespace System.Diagnostics
         public bool Start { get; set; } = true;
         public ProcessStartInfo StartInfo { get; set; } = new ProcessStartInfo();
         public bool EnableProfiling { get; set; } = true;
-        public bool CheckExitCode {get; set; } = true;
+        public bool CheckExitCode { get; set; } = true;
 
         public int TimeOut {get; set; } = RemoteExecutorTestBase.FailWaitTimeoutMilliseconds;
     }

--- a/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.netcore.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.netcore.cs
@@ -13,6 +13,6 @@ namespace System.Diagnostics
         protected static readonly string HostRunnerName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dotnet.exe" : "dotnet";
         protected static readonly string HostRunner = Process.GetCurrentProcess().MainModule.FileName;
  
-        private static readonly string ExtraParameter = TestConsoleApp + " " ;
+        private static readonly string ExtraParameter = TestConsoleApp;
     }
 }

--- a/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.uap.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.uap.cs
@@ -23,7 +23,8 @@ namespace System.Diagnostics
         /// <param name="args">The arguments to pass to the method.</param>
         /// <param name="start">true if this function should Start the Process; false if that responsibility is left up to the caller.</param>
         /// <param name="psi">The ProcessStartInfo to use, or null for a default.</param>
-        private static RemoteInvokeHandle RemoteInvoke(MethodInfo method, string[] args, RemoteInvokeOptions options)
+        /// <param name="pastArguments">Unused in UAP.</param>
+        private static RemoteInvokeHandle RemoteInvoke(MethodInfo method, string[] args, RemoteInvokeOptions options, bool pasteArguments = false)
         {
             options = options ?? new RemoteInvokeOptions();
 

--- a/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.uap.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.uap.cs
@@ -23,7 +23,7 @@ namespace System.Diagnostics
         /// <param name="args">The arguments to pass to the method.</param>
         /// <param name="start">true if this function should Start the Process; false if that responsibility is left up to the caller.</param>
         /// <param name="psi">The ProcessStartInfo to use, or null for a default.</param>
-        /// <param name="pastArguments">Unused in UAP.</param>
+        /// <param name="pasteArguments">Unused in UAP.</param>
         private static RemoteInvokeHandle RemoteInvoke(MethodInfo method, string[] args, RemoteInvokeOptions options, bool pasteArguments = false)
         {
             options = options ?? new RemoteInvokeOptions();

--- a/src/System.Data.SqlClient/tests/FunctionalTests/DiagnosticTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/DiagnosticTest.cs
@@ -21,9 +21,9 @@ namespace System.Data.SqlClient.Tests
     public class DiagnosticTest : RemoteExecutorTestBase
     {
         private const string BadConnectionString = "data source = bad; initial catalog = bad; uid = bad; password = bad; connection timeout = 1;";
-        private static readonly string s_tcpConnStr = $"\"{Environment.GetEnvironmentVariable("TEST_TCP_CONN_STR")}\"";
+        private static readonly string s_tcpConnStr = Environment.GetEnvironmentVariable("TEST_TCP_CONN_STR") ?? string.Empty;
         
-        public static bool IsConnectionStringConfigured() => s_tcpConnStr != "\"\"";
+        public static bool IsConnectionStringConfigured() => s_tcpConnStr != string.Empty;
 
         [Fact]
         [ActiveIssue("dotnet/corefx #17925", TargetFrameworkMonikers.NetFramework)]

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -966,9 +966,12 @@ namespace System.Diagnostics.Tests
         [InlineData("b d \\\"\\\"a\\\"\\\"", "b,d,\"\"a\"\"")]
         public void TestArgumentParsing(string inputArguments, string expectedArgv)
         {
-            using (var handle = RemoteInvokeRaw((Func<string, string, string, int>)ConcatThreeArguments,
-                inputArguments,
-                new RemoteInvokeOptions { Start = true, StartInfo = new ProcessStartInfo { RedirectStandardOutput = true } }))
+            var options = new RemoteInvokeOptions
+            {
+                Start = true,
+                StartInfo = new ProcessStartInfo { RedirectStandardOutput = true }
+            };
+            using (RemoteInvokeHandle handle = RemoteInvokeRaw((Func<string, string, string, int>)ConcatThreeArguments, inputArguments, options))
             {
                 Assert.Equal(expectedArgv, handle.Process.StandardOutput.ReadToEnd());
             }

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrentInfo.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrentInfo.cs
@@ -26,13 +26,11 @@ namespace System.Globalization.Tests
 
             RemoteInvoke((cultureName) =>
             {
-                if (cultureName.Equals("EmptyString"))
-                    cultureName = string.Empty;
                 CultureInfo newCulture = new CultureInfo(cultureName);
                 CultureInfo.CurrentCulture = newCulture;
                 Assert.Same(newCulture.NumberFormat, NumberFormatInfo.CurrentInfo);
                 return SuccessExitCode;
-            }, newCurrentCulture.Name.Length > 0 ? newCurrentCulture.Name : "EmptyString").Dispose();
+            }, newCurrentCulture.Name).Dispose();
         }
 
         [Fact]

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CrossProcess.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CrossProcess.cs
@@ -28,7 +28,7 @@ namespace System.IO.MemoryMappedFiles.Tests
                 acc.Flush();
 
                 // Spawn and then wait for the other process, which will verify the data and write its own known pattern
-                RemoteInvoke(DataShared_OtherProcess, $"\"{file.Path}\"").Dispose();
+                RemoteInvoke(DataShared_OtherProcess, file.Path).Dispose();
 
                 // Now verify we're seeing the data from the other process
                 for (int i = 0; i < capacity; i++)

--- a/src/System.Runtime.Extensions/tests/System/Environment.GetCommandLineArgs.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.GetCommandLineArgs.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using Xunit;
@@ -11,62 +12,32 @@ namespace System.Tests
     [ActiveIssue("https://github.com/dotnet/corefx/issues/21413", TargetFrameworkMonikers.Uap)]
     public class GetCommandLineArgs : RemoteExecutorTestBase
     {
-        [Fact]
-        public void CheckCommandLineArgs_OneArg()
+        public static IEnumerable<object[]> GetCommandLineArgs_TestData()
         {
-            // 1. Check if passing no additional args work.
-            RemoteInvoke(new string[] { "singleArg" });
+            yield return new object[] { new string[] { "singleArg" } };
+            yield return new object[] { new string[] { "Arg1", "Arg2" } };
+            yield return new object[] { new string[] { "\"Arg With Quotes\"" } };
+            yield return new object[] { new string[] { "\"Arg1 With Quotes\"", "\"Arg2 With Quotes\"" } };
+            yield return new object[] { new string[] { "\"Arg1 With Quotes\"", "Arg2", "\"Arg3 With Quotes\"" } };
+            yield return new object[] { new string[] { "arg1", @"\\\\\" + "\"alpha", @"\" + "\"arg3" } };
         }
 
-        [Fact]
-        public void CheckCommandLineArgs_MultipleArgs()
-        {
-            // 1. Check if passing no additional args work.
-            RemoteInvoke(new string[] { "Arg1", "Arg2" });
-        }
-
-        [Fact]
-        public void CheckCommandLineArgs_SingleArgWithQuotes()
-        {
-            // 1. Check if passing no additional args work.
-            RemoteInvoke(new string[] { "\"Arg With Quotes\"" });
-        }
-
-        [Fact]
-        public void CheckCommandLineArgs_MultipleArgsWithQuotes()
-        {
-            // 1. Check if passing no additional args work.
-            RemoteInvoke(new string[] { "\"Arg1 With Quotes\"", "\"Arg2 With Quotes\"" });
-        }
-
-        [Fact]
-        public void CheckCommandLineArgs_MixOfQuotedUnquotedArgs()
-        {
-            // 1. Check if passing no additional args work.
-            RemoteInvoke(new string[] { "\"Arg1 With Quotes\"", "Arg2", "\"Arg3 With Quotes\"" });
-        }
-
-        [Fact]
-        public void CheckCommandLineArgs_ArgsWithEvenBackSlash()
-        {
-            //1.Check if passing no additional args work.
-            RemoteInvoke(new string[] { "arg1", @"\\\\\" + "\"alpha", @"\" + "\"arg3" });
-        }
-
-        public static void RemoteInvoke(string[] args)
+        [Theory]
+        [MemberData(nameof(GetCommandLineArgs_TestData))]
+        public void GetCommandLineArgs_Invoke_ReturnsExpected(string[] args)
         {
             switch (args.Length)
             {
                 case 1:
-                    RemoteInvoke((arg) => CheckCommandLineArgs(new string[] { arg }), args[0]);
+                    RemoteInvoke((arg) => CheckCommandLineArgs(new string[] { arg }), args[0]).Dispose();
                     break;
 
                 case 2:
-                    RemoteInvoke((arg1, arg2) => CheckCommandLineArgs(new string[] { arg1, arg2 }), args[0], args[1]);
+                    RemoteInvoke((arg1, arg2) => CheckCommandLineArgs(new string[] { arg1, arg2 }), args[0], args[1]).Dispose();
                     break;
 
                 case 3:
-                    RemoteInvoke((arg1, arg2, arg3) => CheckCommandLineArgs(new string[] { arg1, arg2, arg3 }), args[0], args[1], args[2]);
+                    RemoteInvoke((arg1, arg2, arg3) => CheckCommandLineArgs(new string[] { arg1, arg2, arg3 }), args[0], args[1], args[2]).Dispose();
                     break;
 
                 default:
@@ -81,18 +52,18 @@ namespace System.Tests
             string[] cmdLineArgs = Environment.GetCommandLineArgs();
 
             Assert.InRange(cmdLineArgs.Length, 4, int.MaxValue); /*AppName, AssemblyName, TypeName, MethodName*/
-            Assert.True(cmdLineArgs[0].Contains(TestConsoleApp)); /*The host returns the fullName*/
+            Assert.Contains(TestConsoleApp, cmdLineArgs[0]); /*The host returns the fullName*/
 
             Type t = typeof(GetCommandLineArgs);
             MethodInfo mi = t.GetMethod("CheckCommandLineArgs");
             Assembly a = t.GetTypeInfo().Assembly;
 
             Assert.Equal(cmdLineArgs[1], a.FullName);
-            Assert.True(cmdLineArgs[2].Contains(t.FullName));
-            Assert.True(cmdLineArgs[3].Contains("RemoteInvoke"));
+            Assert.Contains(t.FullName, cmdLineArgs[2]);
+            Assert.Contains("GetCommandLineArgs_Invoke_ReturnsExpected", cmdLineArgs[3]);
 
             // Check the arguments sent to the method.
-            Assert.True(cmdLineArgs.Length - 4 == args.Length);
+            Assert.Equal(args.Length, cmdLineArgs.Length - 4);
             for (int i = 0; i < args.Length; i++)
             {
                 Assert.Equal(args[i], cmdLineArgs[i + 4]);

--- a/src/System.Runtime.Extensions/tests/System/UnloadingAndProcessExitTests.netcoreapp.cs
+++ b/src/System.Runtime.Extensions/tests/System/UnloadingAndProcessExitTests.netcoreapp.cs
@@ -27,7 +27,7 @@ namespace System.Tests
                 return SuccessExitCode;
             };
 
-            using (var remote = RemoteInvoke(otherProcess, $"\"{fileName}\""))
+            using (var remote = RemoteInvoke(otherProcess, fileName))
             {
             }
 

--- a/src/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
@@ -483,7 +483,7 @@ namespace System.Runtime.Serialization.Formatters.Tests
                     b.Serialize(output, b.Deserialize(input));
                     return SuccessExitCode;
                 }
-            }, $"{outputPath}", $"{inputPath}").Dispose();
+            }, outputPath, inputPath).Dispose();
 
             // Deserialize what the other process serialized and compare it to the original
             using (FileStream fs = File.OpenRead(inputPath))

--- a/src/System.Runtime/tests/System/TypeTests.cs
+++ b/src/System.Runtime/tests/System/TypeTests.cs
@@ -20,7 +20,7 @@ internal class Outside<T>
 
 namespace System.Tests
 {
-    public static class TypeTests
+    public class TypeTests
     {
         [Theory]
         [InlineData(typeof(int), null)]
@@ -340,38 +340,19 @@ namespace System.Tests
                }, options).Dispose();
         }
 
-        [Fact]
+        [Theory]
         [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.LoadFrom() is not supported on UapAot")]
-        public static void GetTypeByNameTypeloadFailure()
+        [InlineData("System.Collections.Generic.Dictionary`2[[Program, TestLoadAssembly], [Program2, TestLoadAssembly]]")]
+        [InlineData("")]
+        public void GetTypeByName_NoSuchType_ThrowsTypeLoadException(string typeName)
         {
-            RemoteInvokeOptions options = new RemoteInvokeOptions();
-            RemoteInvoke(() =>
-               {
-                   string test1 = testtype;
-                   //Loading from the wrong path
-                   Assert.Throws<System.IO.FileNotFoundException>(() =>
-                   Type.GetType(test1,
-                     (aName) => aName.Name == "Foo" ?
-                         Assembly.LoadFrom(@".\NoSuchTestLoadAssembly.dll") : null,
-                     typeloader,
-                     true
-                  ));
+            RemoteInvoke(marshalledTypeName =>
+            {
+                Assert.Throws<TypeLoadException>(() => Type.GetType(marshalledTypeName, assemblyloader, typeloader, true));
+                Assert.Null(Type.GetType(marshalledTypeName, assemblyloader, typeloader, false));
 
-                   //Type specified 'Program2' does not exst
-                   string test2 = "System.Collections.Generic.Dictionary`2[[Program, TestLoadAssembly], [Program2, TestLoadAssembly]]";
-                   Assert.Throws<TypeLoadException>(() => Type.GetType(test2, assemblyloader, typeloader, true));
-
-                   //Api does not throw
-                   Type t1 = Type.GetType(test2,
-                                          assemblyloader,
-                                          typeloader,
-                                          false      //no throw
-                    );
-
-                   Assert.Null(t1);
-
-                   return SuccessExitCode;
-               }, options).Dispose();
+                return SuccessExitCode;
+            }, typeName).Dispose();
         }
 
         [Fact]

--- a/src/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
@@ -625,13 +625,13 @@ namespace System.Text.RegularExpressions.Tests
         public void Groups(string pattern, string input, RegexOptions options, CultureInfo cultureInfo, string[] expectedGroups)
         {
             const string EmptyPlaceholder = "-";
-            const char Seperator = ';';
+            const char Separator = ';';
 
             string outerPattern = Convert.ToBase64String(Encoding.UTF8.GetBytes(pattern));
             string outerInput = Convert.ToBase64String(Encoding.UTF8.GetBytes(input));
             string outerOptions = ((int)options).ToString();
             string outerCultureInfo = cultureInfo != null ? cultureInfo.ToString() : EmptyPlaceholder;
-            string outerExpectedGroups = expectedGroups != null && expectedGroups.Length > 0 ? "\"" + Convert.ToBase64String(Encoding.UTF8.GetBytes(string.Join(Seperator.ToString(), expectedGroups.Select(s => s == string.Empty ? EmptyPlaceholder : s).ToArray()))) + "\"" : EmptyPlaceholder;
+            string outerExpectedGroups = expectedGroups != null && expectedGroups.Length > 0 ? Convert.ToBase64String(Encoding.UTF8.GetBytes(string.Join(Separator.ToString(), expectedGroups.Select(s => s == string.Empty ? EmptyPlaceholder : s).ToArray()))) : EmptyPlaceholder;
 
             RemoteInvoke((innerPatternEnc, innerInputEnc, innerOptionsEnc, innerCultureInfoEnc, innerExpectedGroupsEnc) =>
             {
@@ -639,7 +639,7 @@ namespace System.Text.RegularExpressions.Tests
                 string innerInput = Encoding.UTF8.GetString(Convert.FromBase64String(innerInputEnc));
                 RegexOptions innerOptions = (RegexOptions)int.Parse(innerOptionsEnc);
                 CultureInfo innerCultureInfo = innerCultureInfoEnc != EmptyPlaceholder ? new CultureInfo(innerCultureInfoEnc) : null;
-                string[] innerExpectedGroups = innerExpectedGroupsEnc != EmptyPlaceholder ? Encoding.UTF8.GetString(Convert.FromBase64String(innerExpectedGroupsEnc.Trim('"'))).Split(Seperator).Select(s => s == EmptyPlaceholder ? string.Empty : s).ToArray() : new string[] { };
+                string[] innerExpectedGroups = innerExpectedGroupsEnc != EmptyPlaceholder ? Encoding.UTF8.GetString(Convert.FromBase64String(innerExpectedGroupsEnc)).Split(Separator).Select(s => s == EmptyPlaceholder ? string.Empty : s).ToArray() : new string[] { };
 
                 // In invariant culture, the unicode char matches differ from expected values provided.
                 if (CultureInfo.CurrentCulture.Equals(CultureInfo.InvariantCulture))

--- a/src/System.Threading/tests/MutexTests.cs
+++ b/src/System.Threading/tests/MutexTests.cs
@@ -248,7 +248,7 @@ namespace System.Threading.Tests
                 };
 
                 using (var mutex = new Mutex(false, mutexName))
-                using (var remote = RemoteInvoke(otherProcess, mutexName, $"\"{fileName}\""))
+                using (var remote = RemoteInvoke(otherProcess, mutexName, fileName))
                 {
                     SpinWait.SpinUntil(() => File.Exists(fileName));
 


### PR DESCRIPTION
Fixes #21181

I tested this by modifying an existing test in System.Runtime to use the empty string alongside other data.

As part of this, I noticed that one of the tests that asserts a FileNotFoundException actually originated from Assembly.LoadFrom, rather than the actual method that we were testing. We already have coverage for Assembly.LoadFrom where the path doesn't exist, so we can safely delete that test.