### PR TITLE
Remove some dead code for PngFrame

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/Icon.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Icon.cs
@@ -36,7 +36,7 @@ namespace System.Drawing
 
         // Icon data
         //
-        private byte[] _iconData;
+        private readonly byte[] _iconData;
         private int _bestImageOffset;
         private int _bestBitDepth;
         private int _bestBytesInRes;
@@ -1042,16 +1042,12 @@ namespace System.Drawing
 
         private Bitmap PngFrame()
         {
-            Bitmap bitmap = null;
-            if (_iconData != null)
+            Debug.Assert(_iconData != null);
+            using (var stream = new MemoryStream())
             {
-                using (MemoryStream stream = new MemoryStream())
-                {
-                    stream.Write(_iconData, _bestImageOffset, _bestBytesInRes);
-                    bitmap = new Bitmap(stream);
-                }
+                stream.Write(_iconData, _bestImageOffset, _bestBytesInRes);
+                return new Bitmap(stream);
             }
-            return bitmap;
         }
 
         private bool HasPngSignature()


### PR DESCRIPTION
`PngFrame` is only called from a single place - `ToBitmap`. The code for `ToBitmap` checks the following:
```cs
public Bitmap ToBitmap()
{
    if (HasPngSignature() && !LocalAppContextSwitches.DontSupportPngFramesInIcons)
    {
        return PngFrame();
    }
    else
    {
        return BmpFrame();
    }
}
```

The code for `HasPngSignature` is as follows
```cs
private bool HasPngSignature()
{
    if (!_isBestImagePng.HasValue)
    {
        if (_iconData != null && _iconData.Length >= _bestImageOffset + 8)
        {
            int iconSignature1 = BitConverter.ToInt32(_iconData, _bestImageOffset);
            int iconSignature2 = BitConverter.ToInt32(_iconData, _bestImageOffset + 4);
            _isBestImagePng = (iconSignature1 == PNGSignature1) && (iconSignature2 == PNGSignature2);
        }
        else
        {
            _isBestImagePng = false;
        }
    }

    return _isBestImagePng.Value;
}
```

Note that `_isBestImagePng` will always be false if `_iconData == null`. This means that `PngFrame()` won't be called if `_iconData == null`, so the check is dead inside `PngFrame`.

Note that `_isBestImagePng` is a cached variable, so if `_iconData` changes, then `_isBestImagePng` won't change. However, `_iconData` can be made readonly, so we know that `_iconData` and `_isBestImagePng` are fixed, so this is OK