### PR TITLE
Fixing uap pipeline builds

### DIFF
--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -381,13 +381,11 @@
       },
       "Definitions": [
         {
-          "Name": "DotNet-CoreFx-Trusted-Windows",
+          "Name": "DotNet-CoreFx-Trusted-Windows-NoTest",
           "Parameters": {
             "PB_Platform": "arm",
             "PB_BuildArguments": "-framework=uap -buildArch=arm -Debug -- /p:SignType=real /p:RuntimeOS=win10",
-            "PB_BuildTestsArguments": "-framework=uap -buildArch=arm -Debug -SkipTests -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
-            "PB_SyncArguments": "-p -- /p:ArchGroup=arm /p:RuntimeOS=win10 /p:TargetGroup=uap",
-            "PB_CreateHelixArguments": "/p:ArchGroup=arm /p:TargetGroup=uap /p:ConfigurationGroup=Debug /p:TargetQueues=Windows.10.Amd64 /p:SecondaryQueue=Windows.10.Arm64 /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/uwp/\""
+            "PB_SyncArguments": "-p -- /p:ArchGroup=arm /p:RuntimeOS=win10"
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",
@@ -431,11 +429,13 @@
           }
         },
         {
-          "Name": "DotNet-CoreFx-Trusted-Windows-NoTest",
+          "Name": "DotNet-CoreFx-Trusted-Windows",
           "Parameters": {
             "PB_Platform": "arm",
-            "PB_BuildArguments": "-framework:uapaot -buildArch=arm -Debug -- /p:SignType=real /p:RuntimeOS=win10",
-            "PB_SyncArguments": "-p -- /p:ArchGroup=arm /p:RuntimeOS=win10"
+            "PB_BuildArguments": "-framework=uapaot -buildArch=arm -Debug -- /p:SignType=real /p:RuntimeOS=win10",
+            "PB_BuildTestsArguments": "-framework=uapaot -buildArch=arm -Debug -SkipTests -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=arm /p:RuntimeOS=win10 /p:TargetGroup=uapaot",
+            "PB_CreateHelixArguments": "/p:ArchGroup=arm /p:TargetGroup=uapaot /p:ConfigurationGroup=Debug /p:TargetQueues=Windows.10.Amd64 /p:SecondaryQueue=Windows.10.Arm64 /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:\"HelixJobType=test/functional/ilc/\""
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",


### PR DESCRIPTION
cc: @MattGal @weshaggard 

Fixing two pipe build definitions which were incorrect. One wasn't queuing tests to Helix even though it should have been doing it, and the other one was queuing them even though it shouldn't. @MattGal can speak a bit more about why where we not catching all of the test runs being sent incorrectly in case folks are interested.