### PR TITLE
Make VerifyWithRevocation skip if the Online chain can't build

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
@@ -574,7 +574,14 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                     Thread.Sleep(1000); // For network flakiness
                 }
 
-                Assert.True(valid, $"Online Chain Built Validly within {RetryLimit} tries");
+                if (TestEnvironmentConfiguration.RunManualTests)
+                {
+                    Assert.True(valid, $"Online Chain Built Validly within {RetryLimit} tries");
+                }
+                else if (!valid)
+                {
+                    Console.WriteLine($"SKIP [{nameof(VerifyWithRevocation)}]: Chain failed to build within {RetryLimit} tries.");
+                }
 
                 // Since the network was enabled, we should get the whole chain.
                 Assert.Equal(3, onlineChain.ChainElements.Count);


### PR DESCRIPTION
When the system doesn't have a current CRL cached for the entirety of the chain,
and the CRL Distribution Point is offline (or there's a local network issue) then
the test fails. This is tolerable for a manual run, but not for the automated runs.

So unless the X.509 "RunManualTests" configuration is set, treat a failure of the
online chain to be a skip.  Ideally we'd throw a SkipTestException, or something
of that ilk, but xunit doesn't support it.

Fixes #21076 (in master)