### PR TITLE
Enable Reflection-based Serialization to Call Static Parse Method.

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/ReflectionJsonFormatReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/ReflectionJsonFormatReader.cs
@@ -193,7 +193,52 @@ namespace System.Runtime.Serialization.Json
                 }
                 else if (keyParseMode == KeyParseMode.UsingCustomParse)
                 {
-                    pairKey = keyDataContract.ParseMethod.Invoke(null, new object[] { keyString });
+                    TypeCode typeCode = Type.GetTypeCode(keyDataContract.UnderlyingType);
+                    switch (typeCode)
+                    {
+                        case TypeCode.Boolean:
+                            pairKey = Boolean.Parse(keyString);
+                            break;
+                        case TypeCode.Int16:
+                            pairKey = Int16.Parse(keyString);
+                            break;
+                        case TypeCode.Int32:
+                            pairKey = Int32.Parse(keyString);
+                            break;
+                        case TypeCode.Int64:
+                            pairKey = Int64.Parse(keyString);
+                            break;
+                        case TypeCode.Char:
+                            pairKey = Char.Parse(keyString);
+                            break;
+                        case TypeCode.Byte:
+                            pairKey = Byte.Parse(keyString);
+                            break;
+                        case TypeCode.SByte:
+                            pairKey = SByte.Parse(keyString);
+                            break;
+                        case TypeCode.Double:
+                            pairKey = Double.Parse(keyString);
+                            break;
+                        case TypeCode.Decimal:
+                            pairKey = Decimal.Parse(keyString);
+                            break;
+                        case TypeCode.Single:
+                            pairKey = Single.Parse(keyString);
+                            break;
+                        case TypeCode.UInt16:
+                            pairKey = UInt16.Parse(keyString);
+                            break;
+                        case TypeCode.UInt32:
+                            pairKey = UInt32.Parse(keyString);
+                            break;
+                        case TypeCode.UInt64:
+                            pairKey = UInt64.Parse(keyString);
+                            break;
+                        default:
+                            pairKey = keyDataContract.ParseMethod.Invoke(null, new object[] { keyString });
+                            break;
+                    }
                 }
                 else
                 {

--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -472,7 +472,7 @@ public static partial class DataContractJsonSerializerTests
 
 
     [Fact]
-    public static void DCJS_Dictionary_UseSimpleDictionaryFormat_KeyTypeIsInt()
+    public static void DCJS_Dictionary_UseSimpleDictionaryFormat_VariousKeyTypes()
     {
         DCJS_Dictionary_UseSimpleDictionaryFormat((int)1, 1);
         DCJS_Dictionary_UseSimpleDictionaryFormat((uint)1, 1);

--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -444,9 +444,6 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-#if ReflectionOnly
-    [ActiveIssue("dotnet/corefx #21143", TargetFrameworkMonikers.UapAot)]
-#endif
     public static void DCJS_GetOonlyDictionary_UseSimpleDictionaryFormat()
     {
         var x = new TypeWithDictionaryGenericMembers();
@@ -471,6 +468,30 @@ public static partial class DataContractJsonSerializerTests
         Assert.True(y.RO2.Count == 2);
         Assert.True(y.RO2[true] == 'a');
         Assert.True(y.RO2[false] == 'b');
+    }
+
+
+    [Fact]
+    public static void DCJS_Dictionary_UseSimpleDictionaryFormat_KeyTypeIsInt()
+    {
+        DCJS_Dictionary_UseSimpleDictionaryFormat((int)1, 1);
+        DCJS_Dictionary_UseSimpleDictionaryFormat((uint)1, 1);
+        DCJS_Dictionary_UseSimpleDictionaryFormat((short)1, 1);
+        DCJS_Dictionary_UseSimpleDictionaryFormat((long)1, 1);
+        DCJS_Dictionary_UseSimpleDictionaryFormat((byte)1, 1);
+        DCJS_Dictionary_UseSimpleDictionaryFormat((double)1.0, 1);
+        DCJS_Dictionary_UseSimpleDictionaryFormat((float)1.0, 1);
+        DCJS_Dictionary_UseSimpleDictionaryFormat((char)'a', 1);
+    }
+
+    private static void DCJS_Dictionary_UseSimpleDictionaryFormat<T>(T key, int value)
+    {
+        var settings = new DataContractJsonSerializerSettings { UseSimpleDictionaryFormat = true };
+        var dict = new Dictionary<T, int>() { { key, 1 } };
+        var actual = SerializeAndDeserialize(dict, string.Empty, settings, skipStringCompare: true);
+        Assert.NotNull(actual);
+        Assert.Equal(dict.Count, actual.Count);
+        Assert.Equal(dict[key], actual[key]);
     }
 
     [Fact]


### PR DESCRIPTION
The issue was that, on uapaot, reflection-based serialization cannot invoke primitive types's static `Parse` method due to reflection on primitive types being blocked.

Fix #21143