### PR TITLE
Fixed NullableConverter.ConvertTo(ITypeDescriptorContext, CultureInfo…

### DIFF
--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/NullableConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/NullableConverter.cs
@@ -113,7 +113,8 @@ namespace System.ComponentModel
                     return string.Empty;
                 }
             }
-            else if (UnderlyingTypeConverter != null)
+            
+            if (UnderlyingTypeConverter != null)
             {
                 return UnderlyingTypeConverter.ConvertTo(context, culture, value, destinationType);
             }


### PR DESCRIPTION
…, object) not using UnderlyingTypeConverter if the value is null