### PR TITLE
Disable an Assert.Throws that is not honored by the optimizer.

### DIFF
--- a/src/System.Numerics.Vectors/tests/Vector2Tests.cs
+++ b/src/System.Numerics.Vectors/tests/Vector2Tests.cs
@@ -18,7 +18,6 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
-        [ActiveIssue("TFS 444567 - Codegen optimization issue", TargetFrameworkMonikers.UapAot)]
         public void Vector2CopyToTest()
         {
             Vector2 v1 = new Vector2(2.0f, 3.0f);
@@ -29,7 +28,17 @@ namespace System.Numerics.Tests
             Assert.Throws<NullReferenceException>(() => v1.CopyTo(null, 0));
             Assert.Throws<ArgumentOutOfRangeException>(() => v1.CopyTo(a, -1));
             Assert.Throws<ArgumentOutOfRangeException>(() => v1.CopyTo(a, a.Length));
-            Assert.Throws<ArgumentException>(() => v1.CopyTo(a, 2));
+            
+            if (!PlatformDetection.IsNetNative)
+            {
+               Assert.Throws<ArgumentException>(() => v1.CopyTo(a, 2));
+            }
+            else
+            {
+               // The .Net Native code generation optimizer does aggressive optimizations to range checks 
+               // which result in an ArgumentOutOfRangeException exception being thrown at runtime.
+               Assert.ThrowsAny<ArgumentException>(() => v1.CopyTo(a, 2));
+            }
 
             v1.CopyTo(a, 1);
             v1.CopyTo(b);


### PR DESCRIPTION
The .Net Native code generation optimizer does aggressive optimizations to range checks which may result in not honoring the type of exceptions thrown at runtime. These "exceptions" are error conditions  and users generally don't have this in production code as they are the result of programmer logic errors not runtime behavior. We would like not to have the test preventing such optimizations so disable it here. If we are too strict about exceptions, we will not be able to remove many range checks.

More specifically for this test, when the optimizer optimizes away redundant range checks, it adjusts the exception throwing order. In the following example, the second check is being removed but the exception type ArgumentOutOfRangeException is used to replace the one thrown in the third check. 
        public void CopyTo(Single[] array, int index)
        {
            if (array == null)
            {
                // Match the JIT's exception type here. For perf, a NullReference is thrown instead of an ArgumentNull.
                throw new NullReferenceException(SR.Arg_NullArgumentNullRef);
            }
            if (index < 0 || index >= array.Length)
            {
                throw new ArgumentOutOfRangeException(nameof(index), SR.Format(SR.Arg_ArgumentOutOfRangeException, index));
            }
            if ((array.Length - index) < 2)
            {
                throw new ArgumentException(SR.Format(SR.Arg_ElementsInSourceIsGreaterThanDestination, index));
            }
            array[index] = X;
            array[index + 1] = Y;
        }