### PR TITLE
Disable uap System.IO.FileSystem tests which use CreateFile to create named pipes

### DIFF
--- a/src/System.IO.FileSystem/tests/FileStream/CopyToAsync.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/CopyToAsync.cs
@@ -238,8 +238,9 @@ namespace System.IO.Tests
             Assert.Equal<byte>(expectedData, actualData);
         }
 
-        [PlatformSpecific(TestPlatforms.Windows)] // Uses P/Invokes to create async pipe handle
         [Theory]
+        [PlatformSpecific(TestPlatforms.Windows)] // Uses P/Invokes to create async pipe handle
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Creating pipes with CreateFile is not allowed on UAP")]
         [InlineData(false, 10, 1024)]
         [InlineData(true, 10, 1024)]
         public async Task NamedPipeViaFileStream_AllDataCopied(bool useAsync, int writeSize, int numWrites)

--- a/src/System.IO.FileSystem/tests/FileStream/Pipes.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/Pipes.cs
@@ -90,8 +90,9 @@ namespace System.IO.Tests
             }
         }
 
-        [PlatformSpecific(TestPlatforms.Windows)] // Uses P/Invokes to create async pipe handle
         [Theory]
+        [PlatformSpecific(TestPlatforms.Windows)] // Uses P/Invokes to create async pipe handle
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Creating pipes with CreateFile is not allowed on UAP")]
         [InlineData(true)]
         [InlineData(false)]
         public async Task NamedPipeWriteViaAsyncFileStream(bool asyncWrites)
@@ -124,8 +125,9 @@ namespace System.IO.Tests
             }
         }
 
-        [PlatformSpecific(TestPlatforms.Windows)] // Uses P/Invokes to create async pipe handle
         [Theory]
+        [PlatformSpecific(TestPlatforms.Windows)] // Uses P/Invokes to create async pipe handle
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Creating pipes with CreateFile is not allowed on UAP")]
         [InlineData(true)]
         [InlineData(false)]
         public async Task NamedPipeReadViaAsyncFileStream(bool asyncReads)


### PR DESCRIPTION
Contributes to https://github.com/dotnet/corefx/issues/16422
Fixes https://github.com/dotnet/corefx/issues/21206