### PR TITLE
Re-enable and fix some UWP F5 tests

### DIFF
--- a/src/System.Private.Xml/tests/XmlReader/Tests/AsyncReaderLateInitTests.cs
+++ b/src/System.Private.Xml/tests/XmlReader/Tests/AsyncReaderLateInitTests.cs
@@ -67,7 +67,6 @@ namespace System.Xml.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)]  //[ActiveIssue(13121)]  // Path cannot be resolved in UWP
         public static void ReadAsyncAfterInitializationWithUriThrows()
         {
             using (XmlReader reader = XmlReader.Create("http://test.test/test.html", new XmlReaderSettings() { Async = true }))
@@ -77,7 +76,6 @@ namespace System.Xml.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)]  //[ActiveIssue(13121)]  // Path cannot be resolved in UWP
         public static void ReadAfterInitializationWithUriOnAsyncReaderTrows()
         {
             using (XmlReader reader = XmlReader.Create("http://test.test/test.html", new XmlReaderSettings() { Async = true }))

--- a/src/System.Private.Xml/tests/XmlReader/XmlResolver/System.Xml.RW.XmlSystemPathResolver.Tests.csproj
+++ b/src/System.Private.Xml/tests/XmlReader/XmlResolver/System.Xml.RW.XmlSystemPathResolver.Tests.csproj
@@ -11,6 +11,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="XmlSystemPathResolverTests.cs" />
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>Common\System\PlatformDetection.cs</Link>
+    </Compile>
     <SupplementalTestData Include="..\TestFiles\**\*.*">
       <Link>TestFiles\%(RecursiveDir)%(Filename)%(Extension)</Link>
       <DestinationDir>TestFiles\%(RecursiveDir)</DestinationDir>

--- a/src/System.Private.Xml/tests/XmlReader/XmlResolver/XmlSystemPathResolverTests.cs
+++ b/src/System.Private.Xml/tests/XmlReader/XmlResolver/XmlSystemPathResolverTests.cs
@@ -15,8 +15,9 @@ namespace System.Xml.Tests
         [Fact]
         public static void TestResolveRelativePaths()
         {
-            if (PlatformDetection.IsWinRT)  // Access to path not authorized inside an AppContainer
-                return;
+            // Workaround for System.UnauthorizedAccessException on relative path in File.Open on UWP F5
+            string curDir = Directory.GetCurrentDirectory();
+            Directory.SetCurrentDirectory(Path.GetTempPath());
 
             string path = Path.GetRandomFileName();
             bool shouldDelete = !File.Exists(path);
@@ -31,6 +32,7 @@ namespace System.Xml.Tests
                 if (shouldDelete)
                 {
                     File.Delete(path);
+                    Directory.SetCurrentDirectory(curDir);
                 }
             }
         }

--- a/src/System.Private.Xml/tests/XmlReader/XmlResolver/XmlSystemPathResolverTests.cs
+++ b/src/System.Private.Xml/tests/XmlReader/XmlResolver/XmlSystemPathResolverTests.cs
@@ -13,9 +13,11 @@ namespace System.Xml.Tests
         private const int k_getUniqueFileNameAttempts = 10;
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)]  //[ActiveIssue(13121)]  // Access to path is denied in UWP
         public static void TestResolveRelativePaths()
         {
+            if (PlatformDetection.IsWinRT)  // Access to path not authorized inside an AppContainer
+                return;
+
             string path = Path.GetRandomFileName();
             bool shouldDelete = !File.Exists(path);
             File.Open(path, FileMode.OpenOrCreate).Dispose();
@@ -86,7 +88,6 @@ namespace System.Xml.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)]    //[ActiveIssue(13121)]  // Access to path is denied in UWP
         public static void TestResolveInvalidPath()
         {
             Assert.Throws<System.Net.WebException>(() => XmlReader.Create("ftp://www.bing.com"));

--- a/src/System.Private.Xml/tests/XmlReader/XmlResolver/XmlSystemPathResolverTests.cs
+++ b/src/System.Private.Xml/tests/XmlReader/XmlResolver/XmlSystemPathResolverTests.cs
@@ -15,15 +15,14 @@ namespace System.Xml.Tests
         [Fact]
         public static void TestResolveRelativePaths()
         {
-            // Workaround for System.UnauthorizedAccessException on relative path in File.Open on UWP F5
             string curDir = Directory.GetCurrentDirectory();
-            Directory.SetCurrentDirectory(Path.GetTempPath());
-
             string path = Path.GetRandomFileName();
             bool shouldDelete = !File.Exists(path);
-            File.Open(path, FileMode.OpenOrCreate).Dispose();
             try
             {
+                Directory.SetCurrentDirectory(Path.GetTempPath()); // Workaround for System.UnauthorizedAccessException on relative path in File.Open on UWP F5
+                File.Open(path, FileMode.OpenOrCreate).Dispose();
+
                 XmlReader.Create(path).Dispose();
                 XmlReader.Create(Path.Combine(".", path)).Dispose();
             }
@@ -32,8 +31,9 @@ namespace System.Xml.Tests
                 if (shouldDelete)
                 {
                     File.Delete(path);
-                    Directory.SetCurrentDirectory(curDir);
                 }
+
+                Directory.SetCurrentDirectory(curDir);
             }
         }
 

--- a/src/System.Security.Principal.Windows/tests/WindowsIdentityTests.cs
+++ b/src/System.Security.Principal.Windows/tests/WindowsIdentityTests.cs
@@ -39,7 +39,16 @@ public class WindowsIdentityTests
             string authenticationType = "WindowsAuthentication";
             WindowsIdentity windowsIdentity2 = new WindowsIdentity(logonToken, authenticationType);
             Assert.NotNull(windowsIdentity2);
-            Assert.True(windowsIdentity2.IsAuthenticated);
+
+            if (PlatformDetection.IsWinRT)
+            {
+                Assert.False(windowsIdentity2.IsAuthenticated);
+            }
+            else
+            {
+                Assert.True(windowsIdentity2.IsAuthenticated);
+            }
+
             Assert.Equal(authenticationType, windowsIdentity2.AuthenticationType);
             CheckDispose(windowsIdentity2);
         }


### PR DESCRIPTION
Resolves https://github.com/dotnet/corefx/issues/18055, https://github.com/dotnet/corefx/issues/13121

Re-enables some tests that now pass for UWP and fixes two AppContainer issues

cc: @danmosemsft @tijoytom 