### PR TITLE
Allow file Uris to terminate the host with '\' on Unix.

### DIFF
--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -2053,7 +2053,7 @@ namespace System
                     && NotAny(Flags.ImplicitFile) && (idx + 1 < length))
                 {
                     char c;
-                    ushort i = (ushort)idx;
+                    ushort i = idx;
 
                     // V1 Compat: Allow _compression_ of > 3 slashes only for File scheme.
                     // This will skip all slashes and if their number is 2+ it sets the AuthorityFound flag
@@ -2071,10 +2071,10 @@ namespace System
                             _flags |= Flags.AuthorityFound;
                         }
                         // DOS-like path?
-                        if (i + 1 < (ushort)length && ((c = pUriString[i + 1]) == ':' || c == '|') &&
+                        if (i + 1 < length && ((c = pUriString[i + 1]) == ':' || c == '|') &&
                             UriHelper.IsAsciiLetter(pUriString[i]))
                         {
-                            if (i + 2 >= (ushort)length || ((c = pUriString[i + 2]) != '\\' && c != '/'))
+                            if (i + 2 >= length || ((c = pUriString[i + 2]) != '\\' && c != '/'))
                             {
                                 // report an error but only for a file: scheme
                                 if (_syntax.InFact(UriSyntaxFlags.FileLikeUri))
@@ -2187,22 +2187,24 @@ namespace System
                 // We must ensure that known schemes do use a server-based authority
                 {
                     ParsingError err = ParsingError.None;
-                    idx = CheckAuthorityHelper(pUriString, idx, (ushort)length, ref err, ref _flags, _syntax, ref newHost);
+                    idx = CheckAuthorityHelper(pUriString, idx, length, ref err, ref _flags, _syntax, ref newHost);
                     if (err != ParsingError.None)
                         return err;
 
-                    char hostTerminator = idx < (ushort)length ? pUriString[idx] : default(char);
-
-                    // This will disallow '\' as the host terminator for any scheme that is not implicitFile or cannot have a Dos Path
-                    if (hostTerminator == '\\' && NotAny(Flags.ImplicitFile) && _syntax.NotAny(UriSyntaxFlags.AllowDOSPath))
+                    if (idx < (ushort)length)
                     {
-                        return ParsingError.BadAuthorityTerminator;
-                    }
+                        char hostTerminator = pUriString[idx];
 
-                    // When the hostTerminator is '/' on Unix, use the UnixFile syntax (preserve backslashes)
-                    if (!IsWindowsSystem && hostTerminator == '/' && NotAny(Flags.ImplicitFile) && InFact(Flags.UncPath) && _syntax == UriParser.FileUri)
-                    {
-                        _syntax = UriParser.UnixFileUri;
+                        // This will disallow '\' as the host terminator for any scheme that is not implicitFile or cannot have a Dos Path
+                        if (hostTerminator == '\\' && NotAny(Flags.ImplicitFile) && _syntax.NotAny(UriSyntaxFlags.AllowDOSPath))
+                        {
+                            return ParsingError.BadAuthorityTerminator;
+                        }
+                        // When the hostTerminator is '/' on Unix, use the UnixFile syntax (preserve backslashes)
+                        else if (!IsWindowsSystem && hostTerminator == '/' && NotAny(Flags.ImplicitFile) && InFact(Flags.UncPath) && _syntax == UriParser.FileUri)
+                        {
+                            _syntax = UriParser.UnixFileUri;
+                        }
                     }
                 }
 

--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -2200,7 +2200,7 @@ namespace System
                     }
 
                     // When the hostTerminator is '/' on Unix, use the UnixFile syntax (preserve backslashes)
-                    if (!IsWindowsSystem && hostTerminator == '/' && _syntax == UriParser.FileUri)
+                    if (!IsWindowsSystem && hostTerminator == '/' && NotAny(Flags.ImplicitFile)  && _syntax == UriParser.FileUri)
                     {
                         _syntax = UriParser.UnixFileUri;
                     }

--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -2200,7 +2200,7 @@ namespace System
                     }
 
                     // When the hostTerminator is '/' on Unix, use the UnixFile syntax (preserve backslashes)
-                    if (!IsWindowsSystem && hostTerminator == '/' && NotAny(Flags.ImplicitFile)  && _syntax == UriParser.FileUri)
+                    if (!IsWindowsSystem && hostTerminator == '/' && NotAny(Flags.ImplicitFile) && InFact(Flags.UncPath) && _syntax == UriParser.FileUri)
                     {
                         _syntax = UriParser.UnixFileUri;
                     }

--- a/src/System.Private.Uri/tests/FunctionalTests/IriRelativeFileResolutionTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/IriRelativeFileResolutionTest.cs
@@ -73,7 +73,7 @@ namespace System.PrivateUri.Tests
         public void IriRelativeResolution_CompareImplcitAndExplicitUncWithNoUnicode_AllPropertiesTheSame()
         {
             string nonUnicodeImplicitTestUnc = @"\\c\path\path3\test.txt";
-            string nonUnicodeImplicitUncBase = s_isWindowsSystem ? @"\\c\path\file.txt" : @"\\c/path/file.txt";
+            string nonUnicodeImplicitUncBase = @"\\c/path/file.txt";
 
             string testResults;
             int errorCount = RelatavizeRestoreCompareImplicitVsExplicitFiles(nonUnicodeImplicitTestUnc,
@@ -100,7 +100,7 @@ namespace System.PrivateUri.Tests
         public void IriRelativeResolution_CompareImplcitAndExplicitUncWithUnicodeIriOn_AllPropertiesTheSame()
         {
             string unicodeImplicitTestUnc = @"\\c\path\\u30AF\path3\\u30EB\u30DE.text";
-            string nonUnicodeImplicitUncBase = s_isWindowsSystem ? @"\\c\path\file.txt" : @"\\c/path/file.txt";
+            string nonUnicodeImplicitUncBase = @"\\c\path\file.txt";
 
             string testResults;
             int errorCount = RelatavizeRestoreCompareImplicitVsExplicitFiles(unicodeImplicitTestUnc,


### PR DESCRIPTION
Reverts part of https://github.com/dotnet/corefx/pull/20623 which discards these uris as BadAuthorityTerminator.

With this change, these uris work the same as on Windows.

CC @Priya91 @stephentoub @karelz 