### PR TITLE
Disable User and Machine environment api tests inside appcontainers.

### DIFF
--- a/src/System.Runtime.Extensions/tests/System/Environment.GetEnvironmentVariable.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.GetEnvironmentVariable.cs
@@ -27,7 +27,7 @@ namespace System.Tests
             AssertExtensions.Throws<ArgumentOutOfRangeException, ArgumentException>("target", null, () => Environment.GetEnvironmentVariable("test", (EnvironmentVariableTarget)42));
             AssertExtensions.Throws<ArgumentOutOfRangeException, ArgumentException>("target", null, () => Environment.SetEnvironmentVariable("test", "test", (EnvironmentVariableTarget)(-1)));
             AssertExtensions.Throws<ArgumentOutOfRangeException, ArgumentException>("target", null, () => Environment.GetEnvironmentVariables((EnvironmentVariableTarget)(3)));
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && System.Tests.SetEnvironmentVariable.IsSupportedTarget(EnvironmentVariableTarget.User))
             {
                 AssertExtensions.Throws<ArgumentException>("variable", null, () => Environment.SetEnvironmentVariable(new string('s', 256), "value", EnvironmentVariableTarget.User));
             }

--- a/src/System.Runtime.Extensions/tests/System/Environment.SetEnvironmentVariable.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.SetEnvironmentVariable.cs
@@ -16,7 +16,7 @@ namespace System.Tests
 
         internal static bool IsSupportedTarget(EnvironmentVariableTarget target)
         {
-            return target == EnvironmentVariableTarget.Process || (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !PlatformDetection.IsWinRT && !PlatformDetection.IsNetNative);
+            return target == EnvironmentVariableTarget.Process || (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !PlatformDetection.IsUap);
         }
 
         [Fact]

--- a/src/System.Runtime.Extensions/tests/System/Environment.SetEnvironmentVariable.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.SetEnvironmentVariable.cs
@@ -14,9 +14,9 @@ namespace System.Tests
         private const int MAX_VAR_LENGTH_ALLOWED = 32767;
         private const string NullString = "\u0000";
 
-        private static bool IsSupportedTarget(EnvironmentVariableTarget target)
+        internal static bool IsSupportedTarget(EnvironmentVariableTarget target)
         {
-            return target == EnvironmentVariableTarget.Process || RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            return target == EnvironmentVariableTarget.Process || (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !PlatformDetection.IsWinRT && !PlatformDetection.IsNetNative);
         }
 
         [Fact]

--- a/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
@@ -386,24 +386,10 @@ namespace System.Tests
         private static readonly Lazy<bool> s_EnvironmentRegKeysStillAccessDenied = new Lazy<bool>(
             delegate ()
             {
-                if (!PlatformDetection.IsWindows)
-                    return false;  // On Unix, registry-based environment api's won't throw a SecurityException - they just eat all writes.
-                if (!PlatformDetection.IsWinRT)
-                    return false;  // On non-appcontainer apps, these won't throw (except writes to Target.Machine on non-elevated but that's accounted for separately.)
-
-                try
-                {
-                    Environment.GetEnvironmentVariables(EnvironmentVariableTarget.User);
-                }
-                catch (SecurityException)
-                {
-                    return true; // AppX registry exemptions not yet granted (at least on this build.)
-                }
-                catch
-                {
-                    return false; // Hmm... some other exception. We'll enable the individual tests and let them report it...
-                }
-                return false;
+                //ActiveIssue("TFS 453758" - Environment apis for User and Machine inside appcontainers should behave as "black holes" (as Unix does.)
+                // Once both CoreCLR and CoreRT work this way, get rid of s_EnvironmentRegKeysStillAccessDenied and change IsSupportedTarget to
+                // return false for IsWinRT. (and maybe IsNetNative if UAPAOT tests are still running outside appcontainer.)
+                return PlatformDetection.IsWinRT || PlatformDetection.IsNetNative;
             });
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
@@ -375,21 +375,9 @@ namespace System.Tests
             get
             {
                 yield return new object[] { EnvironmentVariableTarget.Process };
-                if (!(s_EnvironmentRegKeysStillAccessDenied.Value))
-                {
-                    yield return new object[] { EnvironmentVariableTarget.User };
-                    yield return new object[] { EnvironmentVariableTarget.Machine };
-                }
+                yield return new object[] { EnvironmentVariableTarget.User };
+                yield return new object[] { EnvironmentVariableTarget.Machine };
             }
         }
-
-        private static readonly Lazy<bool> s_EnvironmentRegKeysStillAccessDenied = new Lazy<bool>(
-            delegate ()
-            {
-                //ActiveIssue("TFS 453758" - Environment apis for User and Machine inside appcontainers should behave as "black holes" (as Unix does.)
-                // Once both CoreCLR and CoreRT work this way, get rid of s_EnvironmentRegKeysStillAccessDenied and change IsSupportedTarget to
-                // return false for IsWinRT. (and maybe IsNetNative if UAPAOT tests are still running outside appcontainer.)
-                return PlatformDetection.IsWinRT || PlatformDetection.IsNetNative;
-            });
     }
 }


### PR DESCRIPTION
These require registry apis and we don't expect to support those
inside appcontainers.