### PR TITLE
Return Linux NetworkInterface speed in bits per second, not megabits.

### DIFF
--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxNetworkInterface.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxNetworkInterface.cs
@@ -195,7 +195,10 @@ namespace System.Net.NetworkInformation
             try
             {
                 string path = Path.Combine(NetworkFiles.SysClassNetFolder, name, NetworkFiles.SpeedFileName);
-                return StringParsingHelpers.ParseRawLongFile(path);
+                long megabitsPerSecond = StringParsingHelpers.ParseRawLongFile(path);
+                return megabitsPerSecond == -1
+                    ? megabitsPerSecond
+                    : megabitsPerSecond * 1_000_000; // Value must be returned in bits per second, not megabits.
             }
             catch (Exception) // Ignore any problems accessing or parsing the file.
             {


### PR DESCRIPTION
On Linux, we retrieve the speed of a network interface "xyz" by looking at the file `/sys/class/net/xyz/speed`. This file contains the connection speed in **megabits** per second, but `NetworkInterface.Speed` specifies that it returns a value in **bits** per second. This is a small change that converts between those two units.

@stephentoub @pawelgerr

Fixes https://github.com/dotnet/corefx/issues/21226