### PR TITLE
Fix System.IO.FileSystem UAP failures (except for pipes related)

### DIFF
--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str.cs
@@ -287,7 +287,7 @@ namespace System.IO.Tests
                 Assert.NotEmpty(Directory.EnumerateFiles(Directory.GetCurrentDirectory(), "*", SearchOption.TopDirectoryOnly));
 
                 return SuccessExitCode;
-            }, $"\"{testDir}\"").Dispose();
+            }, testDir).Dispose();
         }
     }
 }

--- a/src/System.IO.FileSystem/tests/FileStream/LockUnlock.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/LockUnlock.cs
@@ -178,7 +178,7 @@ namespace System.IO.Tests
                         Assert.Throws<IOException>(() => fs2.Lock(long.Parse(secondPos), long.Parse(secondLen)));
                     }
                     return SuccessExitCode;
-                }, $"\"{path}\"", secondPosition.ToString(), secondLength.ToString()).Dispose();
+                }, path, secondPosition.ToString(), secondLength.ToString()).Dispose();
 
                 fs1.Unlock(firstPosition, firstLength);
                 RemoteInvoke((secondPath, secondPos, secondLen) =>
@@ -189,7 +189,7 @@ namespace System.IO.Tests
                         fs2.Unlock(long.Parse(secondPos), long.Parse(secondLen));
                     }
                     return SuccessExitCode;
-                }, $"\"{path}\"", secondPosition.ToString(), secondLength.ToString()).Dispose();
+                }, path, secondPosition.ToString(), secondLength.ToString()).Dispose();
             }
         }
     }


### PR DESCRIPTION
@JeremyKuhne the only thing I don't understand is how is this passing on corefx. This probably should be investigated. I manually quoted the path on netfx and APIs like GetFullPath do fail with quotes