### PR TITLE
Add test for mutex creation hang in a context where creating a global…

### DIFF
--- a/src/System.Threading/tests/EventWaitHandleTests.cs
+++ b/src/System.Threading/tests/EventWaitHandleTests.cs
@@ -176,6 +176,7 @@ namespace System.Threading.Tests
         [Theory]
         [InlineData(EventResetMode.ManualReset)]
         [InlineData(EventResetMode.AutoReset)]
+        [ActiveIssue(21275, TargetFrameworkMonikers.Uap)]
         public void PingPong(EventResetMode mode)
         {
             // Create names for the two events

--- a/src/System.Threading/tests/MutexTests.cs
+++ b/src/System.Threading/tests/MutexTests.cs
@@ -158,14 +158,16 @@ namespace System.Threading.Tests
             }
         }
 
-        private static string[] GetNamePrefixes()
+        private static IEnumerable<string> GetNamePrefixes()
         {
-            if (PlatformDetection.IsUap)
+            yield return string.Empty;
+            yield return "Local\\";
+
+            // Creating global sync objects is not allowed in UWP apps
+            if (!PlatformDetection.IsUap)
             {
-                // Creating global sync objects is not allowed in UWP apps
-                return new[] { string.Empty, "Local\\" };
+                yield return "Global\\";
             }
-            return new[] { string.Empty, "Local\\", "Global\\" };
         }
 
         public static IEnumerable<object[]> AbandonExisting_MemberData()

--- a/src/System.Threading/tests/MutexTests.cs
+++ b/src/System.Threading/tests/MutexTests.cs
@@ -75,6 +75,9 @@ namespace System.Threading.Tests
         [SkipOnTargetFramework(
             TargetFrameworkMonikers.Uap,
             "Impersonation APIs are not available and creating global sync objects is not allowed in UWP apps.")]
+        [SkipOnTargetFramework(
+            TargetFrameworkMonikers.NetFramework,
+            "The fix necessary for this test (PR https://github.com/dotnet/coreclr/pull/12381) is not in the .NET Framework.")]
         public void Ctor_ImpersonateAnonymousAndTryCreateGlobalMutexTest()
         {
             ThreadTestHelpers.RunTestInBackgroundThread(() =>

--- a/src/System.Threading/tests/SemaphoreTests.cs
+++ b/src/System.Threading/tests/SemaphoreTests.cs
@@ -278,8 +278,9 @@ namespace System.Threading.Tests
             }
         }
 
-        [PlatformSpecific(TestPlatforms.Windows)] // names aren't supported on Unix
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)] // names aren't supported on Unix
+        [ActiveIssue(21275, TargetFrameworkMonikers.Uap)]
         public void PingPong()
         {
             // Create names for the two semaphores

--- a/src/System.Threading/tests/System.Threading.Tests.csproj
+++ b/src/System.Threading/tests/System.Threading.Tests.csproj
@@ -43,6 +43,9 @@
     <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs">
       <Link>CommonTest\System\Diagnostics\Tracing\TestEventListener.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>CommonTest\System\PlatformDetection.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Threading\ThreadTestHelpers.cs">
       <Link>CommonTest\System\Threading\ThreadTestHelpers.cs</Link>
     </Compile>


### PR DESCRIPTION
… mutex is not allowed

Depends on https://github.com/dotnet/coreclr/pull/12381
Fixes dotnet/coreclr#11306

- Added test for mutex creation hang in a context where creating a global mutex is not allowed
- Modified two tests to run in a separate thread to allow them to fail rather than hang if there's a bug
- Disabled a few tests that are not working under UWP with issues filed