### PR TITLE
Enabling System.Net.Security tests and fixing/disabling tests that currently fail in UAP / UAPAOT

### DIFF
--- a/src/Common/tests/System/Net/Configuration.Certificates.cs
+++ b/src/Common/tests/System/Net/Configuration.Certificates.cs
@@ -18,8 +18,22 @@ namespace System.Net.Test.Common
         {
             private const string CertificatePassword = "testcertificate";
             private const string TestDataFolder = "TestData";
-            private static Mutex m = new Mutex(false, "Global\\CoreFXTest.Configuration.Certificates.LoadPfxCertificate");
+
+            private static Mutex m;
             private const int MutexTimeout = 120 * 1000;
+
+            static Certificates()
+            {
+                if (PlatformDetection.IsUap)
+                {
+                    // TODO: dotnet/coreclr#11306
+                    m = new Mutex(false, "Local\\CoreFXTest.Configuration.Certificates.LoadPfxCertificate");
+                }
+                else
+                {
+                    m = new Mutex(false, "Global\\CoreFXTest.Configuration.Certificates.LoadPfxCertificate");
+                }
+            }
 
             public static X509Certificate2 GetServerCertificate() => GetCertWithPrivateKey(GetServerCertificateCollection());
 

--- a/src/System.Net.Security/tests/FunctionalTests/CertificateValidationClientServer.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/CertificateValidationClientServer.cs
@@ -41,7 +41,6 @@ namespace System.Net.Security.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "https://github.com/dotnet/corefx/issues/19379")]
         public async Task CertificateValidationClientServer_EndToEnd_Ok(bool useClientSelectionCallback)
         {
             IPEndPoint endPoint = new IPEndPoint(IPAddress.IPv6Loopback, 0);

--- a/src/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
@@ -16,7 +16,6 @@ namespace System.Net.Security.Tests
     public class CertificateValidationRemoteServer
     {
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "https://github.com/dotnet/corefx/issues/19379")]
         public async Task CertificateValidationRemoteServer_EndToEnd_Ok()
         {
             using (var client = new TcpClient(AddressFamily.InterNetwork))

--- a/src/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
@@ -25,14 +25,12 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "https://github.com/dotnet/corefx/issues/19379")]
         public async Task ClientAsyncAuthenticate_ServerRequireEncryption_ConnectWithEncryption()
         {
             await ClientAsyncSslHelper(EncryptionPolicy.RequireEncryption);
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "https://github.com/dotnet/corefx/issues/19379")]
         public async Task ClientAsyncAuthenticate_ServerNoEncryption_NoConnect()
         {
             await Assert.ThrowsAsync<IOException>(() => ClientAsyncSslHelper(EncryptionPolicy.NoEncryption));

--- a/src/System.Net.Security/tests/FunctionalTests/ClientDefaultEncryptionTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ClientDefaultEncryptionTest.cs
@@ -34,7 +34,6 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "https://github.com/dotnet/corefx/issues/19379")]
         public async Task ClientDefaultEncryption_ServerRequireEncryption_ConnectWithEncryption()
         {
             using (var serverRequireEncryption = new DummyTcpServer(
@@ -76,7 +75,6 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "https://github.com/dotnet/corefx/issues/19379")]
         public async Task ClientDefaultEncryption_ServerNoEncryption_NoConnect()
         {
             using (var serverNoEncryption = new DummyTcpServer(

--- a/src/System.Net.Security/tests/FunctionalTests/LoggingTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/LoggingTest.cs
@@ -12,7 +12,7 @@ namespace System.Net.Security.Tests
     public class LoggingTest : RemoteExecutorTestBase
     {
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework | TargetFrameworkMonikers.UapAot, "NetEventSource is only part of .NET Core")] //"https://github.com/dotnet/corefx/issues/19379"
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework | TargetFrameworkMonikers.UapAot, "NetEventSource is only part of .NET Core")]
         public void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(SslStream).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);
@@ -25,6 +25,7 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
+        [ActiveIssue(19909, TargetFrameworkMonikers.Uap)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core")]
         public void EventSource_EventsRaisedAsExpected()
         {

--- a/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamStreamToStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamStreamToStreamTest.cs
@@ -21,6 +21,7 @@ namespace System.Net.Security.Tests
         protected abstract Task AuthenticateAsClientAsync(NegotiateStream client, NetworkCredential credential, string targetName);
         protected abstract Task AuthenticateAsServerAsync(NegotiateStream server);
 
+        [ActiveIssue(18760, TargetFrameworkMonikers.UapAot)] // In order to properly test this, we need UWP-AOT to run within an App Container.
         [Fact]
         public void NegotiateStream_StreamToStream_Authentication_Success()
         {
@@ -69,7 +70,7 @@ namespace System.Net.Security.Tests
 
                 if (PlatformDetection.IsUap)
                 {
-                    // TODO : UWP issue - clientIdentity.IsAuthenticated == false.
+                    // TODO #21282: UWP AppContainer issue - clientIdentity.IsAuthenticated == false.
                     Assert.Equal(false, clientIdentity.IsAuthenticated);
                 }
                 else
@@ -81,6 +82,7 @@ namespace System.Net.Security.Tests
             }
         }
 
+        [ActiveIssue(18760, TargetFrameworkMonikers.UapAot)] // In order to properly test this, we need UWP-AOT to run within an App Container.
         [Fact]
         public void NegotiateStream_StreamToStream_Authentication_TargetName_Success()
         {
@@ -132,7 +134,7 @@ namespace System.Net.Security.Tests
 
                 if (PlatformDetection.IsUap)
                 {
-                    // TODO : UWP issue - clientIdentity.IsAuthenticated == false.
+                    // TODO #21282: UWP issue - clientIdentity.IsAuthenticated == false.
                     Assert.Equal(false, clientIdentity.IsAuthenticated);
                 }
                 else

--- a/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamStreamToStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamStreamToStreamTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Linq;
 using System.Net.Test.Common;
 using System.Security.Principal;
@@ -66,13 +67,21 @@ namespace System.Net.Security.Tests
                 IIdentity clientIdentity = server.RemoteIdentity;
                 Assert.Equal("NTLM", clientIdentity.AuthenticationType);
 
-                Assert.Equal(true, clientIdentity.IsAuthenticated);
+                if (PlatformDetection.IsUap)
+                {
+                    // TODO : UWP issue - clientIdentity.IsAuthenticated == false.
+                    Assert.Equal(false, clientIdentity.IsAuthenticated);
+                }
+                else
+                {
+                    Assert.Equal(true, clientIdentity.IsAuthenticated);
+                }
+
                 IdentityValidator.AssertIsCurrentIdentity(clientIdentity);
             }
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "https://github.com/dotnet/corefx/issues/19379")]
         public void NegotiateStream_StreamToStream_Authentication_TargetName_Success()
         {
             string targetName = "testTargetName";
@@ -121,7 +130,16 @@ namespace System.Net.Security.Tests
                 IIdentity clientIdentity = server.RemoteIdentity;
                 Assert.Equal("NTLM", clientIdentity.AuthenticationType);
 
-                Assert.Equal(true, clientIdentity.IsAuthenticated);
+                if (PlatformDetection.IsUap)
+                {
+                    // TODO : UWP issue - clientIdentity.IsAuthenticated == false.
+                    Assert.Equal(false, clientIdentity.IsAuthenticated);
+                }
+                else
+                {
+                    Assert.Equal(true, clientIdentity.IsAuthenticated);
+                }
+
                 IdentityValidator.AssertIsCurrentIdentity(clientIdentity);
             }
         }

--- a/src/System.Net.Security/tests/FunctionalTests/ParameterValidationTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ParameterValidationTest.cs
@@ -23,7 +23,6 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "https://github.com/dotnet/corefx/issues/19379")]
         public async Task SslStreamConstructor_BadEncryptionPolicy_ThrowException()
         {
             using (var _remoteServer = new DummyTcpServer(

--- a/src/System.Net.Security/tests/FunctionalTests/ServerNoEncryptionTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ServerNoEncryptionTest.cs
@@ -33,7 +33,6 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "https://github.com/dotnet/corefx/issues/19379")]
         public async Task ServerNoEncryption_ClientRequireEncryption_NoConnect()
         {
             using (var serverNoEncryption = new DummyTcpServer(

--- a/src/System.Net.Security/tests/FunctionalTests/ServerRequireEncryptionTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ServerRequireEncryptionTest.cs
@@ -33,7 +33,6 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "https://github.com/dotnet/corefx/issues/19379")]
         public async Task ServerRequireEncryption_ClientRequireEncryption_ConnectWithEncryption()
         {
             using (var serverRequireEncryption = new DummyTcpServer(
@@ -54,7 +53,6 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "https://github.com/dotnet/corefx/issues/19379")]
         public async Task ServerRequireEncryption_ClientAllowNoEncryption_ConnectWithEncryption()
         {
             using (var serverRequireEncryption = new DummyTcpServer(
@@ -75,7 +73,6 @@ namespace System.Net.Security.Tests
         }
 
         [ConditionalFact(nameof(SupportsNullEncryption))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "https://github.com/dotnet/corefx/issues/19379")]
         public async Task ServerRequireEncryption_ClientNoEncryption_NoConnect()
         {
             using (var serverRequireEncryption = new DummyTcpServer(

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
@@ -38,7 +38,6 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "https://github.com/dotnet/corefx/issues/19379")]
         public void SslStream_StreamToStream_Authentication_IncorrectServerName_Fail()
         {
             VirtualNetwork network = new VirtualNetwork();
@@ -142,7 +141,6 @@ namespace System.Net.Security.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "https://github.com/dotnet/corefx/issues/19379")]
         public void SslStream_StreamToStream_LargeWrites_Sync_Success(bool randomizedData)
         {
             VirtualNetwork network = new VirtualNetwork();
@@ -189,7 +187,6 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "https://github.com/dotnet/corefx/issues/19379")]
         public async Task SslStream_StreamToStream_Successive_ClientWrite_Async_Success()
         {
             byte[] recvBuf = new byte[_sampleMsg.Length];
@@ -255,7 +252,6 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "https://github.com/dotnet/corefx/issues/19379")]
         public async Task SslStream_StreamToStream_WriteAsync_ReadByte_Success()
         {
             VirtualNetwork network = new VirtualNetwork();

--- a/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -7,6 +7,7 @@
   <PropertyGroup Condition=" '$(TargetsUnix)' == 'true' ">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Unix-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Unix-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Windows_NT-Debug|AnyCPU'" />
@@ -19,6 +20,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netcoreapp-Unix-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netcoreapp-OSX-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netcoreapp-OSX-Release|AnyCPU'" />
+
   <ItemGroup>
     <Compile Include="NotifyReadVirtualNetworkStream.cs" />
     <Compile Include="DummyTcpServer.cs" />
@@ -95,7 +97,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)'=='netcoreapp'">
-    <!-- TODO #13070: Add net463 to the condition after the TFM gets updated to the actual .Net 4.6.3.-->
+    <!-- TODO #13070: Add net463 to the condition after the TFM gets updated to the actual .Net 4.7-->
     <Compile Include="SslStreamAlertsTest.cs" />
     <Compile Include="SslStreamEKUTest.cs" />
     <Compile Include="SslStreamSchSendAuxRecordTest.cs" />

--- a/src/System.Net.Security/tests/FunctionalTests/TransportContextTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/TransportContextTest.cs
@@ -25,7 +25,6 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "https://github.com/dotnet/corefx/issues/19379")]
         public async Task TransportContext_ConnectToServerWithSsl_GetExpectedChannelBindings()
         {
             using (var testServer = new DummyTcpServer(

--- a/src/System.Net.Security/tests/UnitTests/System.Net.Security.Unit.Tests.csproj
+++ b/src/System.Net.Security/tests/UnitTests/System.Net.Security.Unit.Tests.csproj
@@ -16,6 +16,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Unix-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Windows_NT-Release|AnyCPU'" />
+
   <ItemGroup>
     <Compile Include="SslStreamAllowedProtocolsTest.cs" />
     <Compile Include="System\Security\Authentication\ExtendedProtection\ExtendedProtectionPolicyTest.cs" />


### PR DESCRIPTION
Adding workarounds for behavior differences when running in an AppContainer.

Contributes to #20033