### PR TITLE
Added a tests for ICollection`1 Types.

### DIFF
--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -3139,6 +3139,25 @@ public static partial class DataContractSerializerTests
         Assert.Equal(value.emps[1].Name, actual.emps[1].Name);
     }
 
+    [Fact]
+    public static void DCS_SampleICollectionTExplicitWithoutDC()
+    {
+        var value = new SampleICollectionTExplicitWithoutDC(true);
+        SampleICollectionTExplicitWithoutDC roundtripObject = SerializeAndDeserialize(value, string.Empty, skipStringCompare: true);
+        Assert.NotNull(roundtripObject);
+        ComparisonHelper.CompareRecursively(value, roundtripObject);
+
+        string netcorePayload = "<SampleICollectionTExplicitWithoutDC xmlns=\"http://schemas.datacontract.org/2004/07/\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><DC z:Id=\"i1\" xmlns:z=\"http://schemas.microsoft.com/2003/10/Serialization/\"><Data>Monday, January 1, 0001</Data><Next i:nil=\"true\"/></DC><DC z:Id=\"i2\" xmlns:z=\"http://schemas.microsoft.com/2003/10/Serialization/\"><Data>Monday, January 1, 0001</Data><Next i:nil=\"true\"/></DC><DC z:Ref=\"i1\" xmlns:z=\"http://schemas.microsoft.com/2003/10/Serialization/\"/></SampleICollectionTExplicitWithoutDC>";
+        var deserializedNetcoreObject = DeserializeString<SampleICollectionTExplicitWithoutDC>(netcorePayload);
+        Assert.NotNull(deserializedNetcoreObject);
+        ComparisonHelper.CompareRecursively(value, deserializedNetcoreObject);
+
+        string desktopPayload = "<SampleICollectionTExplicitWithoutDC xmlns=\"http://schemas.datacontract.org/2004/07/\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><DC z:Id=\"i1\" i:type=\"DC\" xmlns:z=\"http://schemas.microsoft.com/2003/10/Serialization/\"><Data>Monday, January 1, 0001</Data><Next i:nil=\"true\"/></DC><DC z:Id=\"i2\" i:type=\"DC\" xmlns:z=\"http://schemas.microsoft.com/2003/10/Serialization/\"><Data>Monday, January 1, 0001</Data><Next i:nil=\"true\"/></DC><DC z:Ref=\"i1\" xmlns:z=\"http://schemas.microsoft.com/2003/10/Serialization/\"/></SampleICollectionTExplicitWithoutDC>";
+        var deserializedDesktopObject = DeserializeString<SampleICollectionTExplicitWithoutDC>(desktopPayload);
+        Assert.NotNull(deserializedDesktopObject);
+        ComparisonHelper.CompareRecursively(value, deserializedDesktopObject);
+    }
+
     private static T SerializeAndDeserialize<T>(T value, string baseline, DataContractSerializerSettings settings = null, Func<DataContractSerializer> serializerFactory = null, bool skipStringCompare = false)
     {
         DataContractSerializer dcs;

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -5274,3 +5274,72 @@ public class MyArgumentException : Exception, ISerializable
         info.AddValue("ParamName", _paramName, typeof(string));
     }
 }
+
+[DataContract(IsReference = true)]
+public class DC
+{
+    [DataMember]
+    public string Data = new DateTime().ToLongDateString();
+
+    [DataMember]
+    public DC Next;
+}
+
+[CollectionDataContract(Name = "SampleICollectionTExplicitWithoutDC")]
+public class SampleICollectionTExplicitWithoutDC : ICollection<DC>
+{
+    private List<DC> _internalList = new List<DC>();
+    public SampleICollectionTExplicitWithoutDC() { }
+    public SampleICollectionTExplicitWithoutDC(bool init)
+    {
+        DC dc1 = new DC();
+        _internalList.Add(dc1);
+        _internalList.Add(new DC());
+        _internalList.Add(dc1);
+    }
+
+    void ICollection<DC>.Add(DC item)
+    {
+        _internalList.Add(item);
+    }
+
+    void ICollection<DC>.Clear()
+    {
+        _internalList.Clear();
+    }
+
+    bool ICollection<DC>.Contains(DC item)
+    {
+        return _internalList.Contains(item);
+    }
+
+    void ICollection<DC>.CopyTo(DC[] array, int arrayIndex)
+    {
+        _internalList.CopyTo(array, arrayIndex);
+    }
+
+    int ICollection<DC>.Count
+    {
+        get { return _internalList.Count; }
+    }
+
+    bool ICollection<DC>.IsReadOnly
+    {
+        get { return false; }
+    }
+
+    bool ICollection<DC>.Remove(DC item)
+    {
+        return _internalList.Remove(item);
+    }
+
+    IEnumerator<DC> IEnumerable<DC>.GetEnumerator()
+    {
+        return _internalList.GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return _internalList.GetEnumerator();
+    }
+}


### PR DESCRIPTION
DCS serialize ICollection`1 types differently on Desktop and NetCore. But DCS can de-serialize the payloads from both frameworks, so we don't need to change the behavior of either Desktop or NetCore.

Fix #21288
