### PR TITLE
[Port to 2.0] Support backslashes in Unix file URIs.

### DIFF
--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -2110,7 +2110,7 @@ namespace System
                             _flags |= Flags.UncPath;
                             idx = i;
                         }
-                        else if (!IsWindowsSystem && _syntax.InFact(UriSyntaxFlags.FileLikeUri) && pUriString[i - 1] == '/' && i - idx == 3)
+                        else if (!IsWindowsSystem && _syntax.InFact(UriSyntaxFlags.FileLikeUri) && i - idx == 3 && pUriString[i - 1] == '/')
                         {
                             _syntax = UriParser.UnixFileUri;
                             _flags |= Flags.UnixPath | Flags.AuthorityFound;

--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -4754,6 +4754,14 @@ namespace System
                         end += (_info.Offset.Query - _info.Offset.Path);
                     }
                 }
+
+                // On Unix, escape '\\' in path of file uris to '%5C' canonical form.
+                if (!IsWindowsSystem && _syntax.NotAny(UriSyntaxFlags.ConvertPathSlashes) && _syntax.InFact(UriSyntaxFlags.FileLikeUri) && !IsImplicitFile)
+                {
+                    string str = new string(dest, pos, end - pos);
+                    dest = UriHelper.EscapeString(str, 0, str.Length, dest, ref pos, true, '\\', c_DummyChar, '%');
+                    end = pos;
+                }
             }
             else
             {

--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -2053,7 +2053,7 @@ namespace System
                     && NotAny(Flags.ImplicitFile) && (idx + 1 < length))
                 {
                     char c;
-                    ushort i = (ushort)idx;
+                    ushort i = idx;
 
                     // V1 Compat: Allow _compression_ of > 3 slashes only for File scheme.
                     // This will skip all slashes and if their number is 2+ it sets the AuthorityFound flag
@@ -2071,10 +2071,10 @@ namespace System
                             _flags |= Flags.AuthorityFound;
                         }
                         // DOS-like path?
-                        if (i + 1 < (ushort)length && ((c = pUriString[i + 1]) == ':' || c == '|') &&
+                        if (i + 1 < length && ((c = pUriString[i + 1]) == ':' || c == '|') &&
                             UriHelper.IsAsciiLetter(pUriString[i]))
                         {
-                            if (i + 2 >= (ushort)length || ((c = pUriString[i + 2]) != '\\' && c != '/'))
+                            if (i + 2 >= length || ((c = pUriString[i + 2]) != '\\' && c != '/'))
                             {
                                 // report an error but only for a file: scheme
                                 if (_syntax.InFact(UriSyntaxFlags.FileLikeUri))
@@ -2187,22 +2187,24 @@ namespace System
                 // We must ensure that known schemes do use a server-based authority
                 {
                     ParsingError err = ParsingError.None;
-                    idx = CheckAuthorityHelper(pUriString, idx, (ushort)length, ref err, ref _flags, _syntax, ref newHost);
+                    idx = CheckAuthorityHelper(pUriString, idx, length, ref err, ref _flags, _syntax, ref newHost);
                     if (err != ParsingError.None)
                         return err;
 
-                    char hostTerminator = idx < (ushort)length ? pUriString[idx] : default(char);
-
-                    // This will disallow '\' as the host terminator for any scheme that is not implicitFile or cannot have a Dos Path
-                    if (hostTerminator == '\\' && NotAny(Flags.ImplicitFile) && _syntax.NotAny(UriSyntaxFlags.AllowDOSPath))
+                    if (idx < (ushort)length)
                     {
-                        return ParsingError.BadAuthorityTerminator;
-                    }
+                        char hostTerminator = pUriString[idx];
 
-                    // When the hostTerminator is '/' on Unix, use the UnixFile syntax (preserve backslashes)
-                    if (!IsWindowsSystem && hostTerminator == '/' && NotAny(Flags.ImplicitFile) && InFact(Flags.UncPath) && _syntax == UriParser.FileUri)
-                    {
-                        _syntax = UriParser.UnixFileUri;
+                        // This will disallow '\' as the host terminator for any scheme that is not implicitFile or cannot have a Dos Path
+                        if (hostTerminator == '\\' && NotAny(Flags.ImplicitFile) && _syntax.NotAny(UriSyntaxFlags.AllowDOSPath))
+                        {
+                            return ParsingError.BadAuthorityTerminator;
+                        }
+                        // When the hostTerminator is '/' on Unix, use the UnixFile syntax (preserve backslashes)
+                        else if (!IsWindowsSystem && hostTerminator == '/' && NotAny(Flags.ImplicitFile) && InFact(Flags.UncPath) && _syntax == UriParser.FileUri)
+                        {
+                            _syntax = UriParser.UnixFileUri;
+                        }
                     }
                 }
 

--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -2200,7 +2200,7 @@ namespace System
                     }
 
                     // When the hostTerminator is '/' on Unix, use the UnixFile syntax (preserve backslashes)
-                    if (!IsWindowsSystem && hostTerminator == '/' && _syntax == UriParser.FileUri)
+                    if (!IsWindowsSystem && hostTerminator == '/' && NotAny(Flags.ImplicitFile)  && _syntax == UriParser.FileUri)
                     {
                         _syntax = UriParser.UnixFileUri;
                     }

--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -2200,7 +2200,7 @@ namespace System
                     }
 
                     // When the hostTerminator is '/' on Unix, use the UnixFile syntax (preserve backslashes)
-                    if (!IsWindowsSystem && hostTerminator == '/' && NotAny(Flags.ImplicitFile)  && _syntax == UriParser.FileUri)
+                    if (!IsWindowsSystem && hostTerminator == '/' && NotAny(Flags.ImplicitFile) && InFact(Flags.UncPath) && _syntax == UriParser.FileUri)
                     {
                         _syntax = UriParser.UnixFileUri;
                     }

--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -2110,12 +2110,18 @@ namespace System
                             _flags |= Flags.UncPath;
                             idx = i;
                         }
+                        else if (!IsWindowsSystem && _syntax.InFact(UriSyntaxFlags.FileLikeUri) && i - idx == 3 && pUriString[i - 1] == '/')
+                        {
+                            _syntax = UriParser.UnixFileUri;
+                            _flags |= Flags.UnixPath | Flags.AuthorityFound;
+                            idx += 2;
+                        }
                     }
                 }
                 //
                 //STEP 1.5 decide on the Authority component
                 //
-                if ((_flags & (Flags.UncPath | Flags.DosPath)) != 0)
+                if ((_flags & (Flags.UncPath | Flags.DosPath | Flags.UnixPath)) != 0)
                 {
                 }
                 else if ((idx + 2) <= length)

--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -2191,7 +2191,7 @@ namespace System
                     if (err != ParsingError.None)
                         return err;
 
-                    if (idx < (ushort)length)
+                    if (idx < length)
                     {
                         char hostTerminator = pUriString[idx];
 

--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -2110,10 +2110,7 @@ namespace System
                             _flags |= Flags.UncPath;
                             idx = i;
 
-                            if (!IsWindowsSystem)
-                            {
-                                _syntax = UriParser.UnixFileUri;
-                            }
+                            _syntax = IsWindowsSystem ? _syntax : UriParser.UnixFileUri;
                         }
                         else if (!IsWindowsSystem && _syntax.InFact(UriSyntaxFlags.FileLikeUri) && pUriString[i - 1] == '/' && i - idx == 3)
                         {

--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -4756,7 +4756,7 @@ namespace System
                 }
 
                 // On Unix, escape '\\' in path of file uris to '%5C' canonical form.
-                if (!IsWindowsSystem && _syntax.NotAny(UriSyntaxFlags.ConvertPathSlashes) && _syntax.InFact(UriSyntaxFlags.FileLikeUri) && !IsImplicitFile)
+                if (!IsWindowsSystem && InFact(Flags.BackslashInPath) && _syntax.NotAny(UriSyntaxFlags.ConvertPathSlashes) && _syntax.InFact(UriSyntaxFlags.FileLikeUri) && !IsImplicitFile)
                 {
                     string str = new string(dest, pos, end - pos);
                     dest = UriHelper.EscapeString(str, 0, str.Length, dest, ref pos, true, '\\', c_DummyChar, '%');

--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -2109,8 +2109,13 @@ namespace System
                             // Only FILE scheme may have UNC Path flag set
                             _flags |= Flags.UncPath;
                             idx = i;
+
+                            if (!IsWindowsSystem)
+                            {
+                                _syntax = UriParser.UnixFileUri;
+                            }
                         }
-                        else if (!IsWindowsSystem && _syntax.InFact(UriSyntaxFlags.FileLikeUri) && i - idx == 3 && pUriString[i - 1] == '/')
+                        else if (!IsWindowsSystem && _syntax.InFact(UriSyntaxFlags.FileLikeUri) && pUriString[i - 1] == '/' && i - idx == 3)
                         {
                             _syntax = UriParser.UnixFileUri;
                             _flags |= Flags.UnixPath | Flags.AuthorityFound;
@@ -2193,7 +2198,8 @@ namespace System
 
                     // This will disallow '\' as the host terminator for any scheme that is not implicitFile or cannot have a Dos Path
                     if ((idx < (ushort)length && pUriString[idx] == '\\') && NotAny(Flags.ImplicitFile) &&
-                        _syntax.NotAny(UriSyntaxFlags.AllowDOSPath))
+                        (_syntax.NotAny(UriSyntaxFlags.AllowDOSPath) ||
+                        (InFact(Flags.UncPath) && _syntax.NotAny(UriSyntaxFlags.ConvertPathSlashes))))
                     {
                         return ParsingError.BadAuthorityTerminator;
                     }

--- a/src/System.Private.Uri/tests/FunctionalTests/IriRelativeFileResolutionTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/IriRelativeFileResolutionTest.cs
@@ -73,7 +73,7 @@ namespace System.PrivateUri.Tests
         public void IriRelativeResolution_CompareImplcitAndExplicitUncWithNoUnicode_AllPropertiesTheSame()
         {
             string nonUnicodeImplicitTestUnc = @"\\c\path\path3\test.txt";
-            string nonUnicodeImplicitUncBase = @"\\c\path\file.txt";
+            string nonUnicodeImplicitUncBase = s_isWindowsSystem ? @"\\c\path\file.txt" : @"\\c/path/file.txt";
 
             string testResults;
             int errorCount = RelatavizeRestoreCompareImplicitVsExplicitFiles(nonUnicodeImplicitTestUnc,
@@ -100,7 +100,7 @@ namespace System.PrivateUri.Tests
         public void IriRelativeResolution_CompareImplcitAndExplicitUncWithUnicodeIriOn_AllPropertiesTheSame()
         {
             string unicodeImplicitTestUnc = @"\\c\path\\u30AF\path3\\u30EB\u30DE.text";
-            string nonUnicodeImplicitUncBase = @"\\c\path\file.txt";
+            string nonUnicodeImplicitUncBase = s_isWindowsSystem ? @"\\c\path\file.txt" : @"\\c/path/file.txt";
 
             string testResults;
             int errorCount = RelatavizeRestoreCompareImplicitVsExplicitFiles(unicodeImplicitTestUnc,
@@ -120,7 +120,6 @@ namespace System.PrivateUri.Tests
             Uri rel = implicitBaseUri.MakeRelativeUri(implicitTestUri);
             Uri implicitResultUri = new Uri(implicitBaseUri, rel);
             Uri explicitResultUri = new Uri(explicitBaseUri, rel);
-
             Type uriType = typeof(Uri);
             PropertyInfo[] infoList = uriType.GetProperties();
             StringBuilder testResults = new StringBuilder();

--- a/src/System.Private.Uri/tests/FunctionalTests/IriRelativeFileResolutionTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/IriRelativeFileResolutionTest.cs
@@ -73,7 +73,7 @@ namespace System.PrivateUri.Tests
         public void IriRelativeResolution_CompareImplcitAndExplicitUncWithNoUnicode_AllPropertiesTheSame()
         {
             string nonUnicodeImplicitTestUnc = @"\\c\path\path3\test.txt";
-            string nonUnicodeImplicitUncBase = s_isWindowsSystem ? @"\\c\path\file.txt" : @"\\c/path/file.txt";
+            string nonUnicodeImplicitUncBase = @"\\c/path/file.txt";
 
             string testResults;
             int errorCount = RelatavizeRestoreCompareImplicitVsExplicitFiles(nonUnicodeImplicitTestUnc,
@@ -100,7 +100,7 @@ namespace System.PrivateUri.Tests
         public void IriRelativeResolution_CompareImplcitAndExplicitUncWithUnicodeIriOn_AllPropertiesTheSame()
         {
             string unicodeImplicitTestUnc = @"\\c\path\\u30AF\path3\\u30EB\u30DE.text";
-            string nonUnicodeImplicitUncBase = s_isWindowsSystem ? @"\\c\path\file.txt" : @"\\c/path/file.txt";
+            string nonUnicodeImplicitUncBase = @"\\c\path\file.txt";
 
             string testResults;
             int errorCount = RelatavizeRestoreCompareImplicitVsExplicitFiles(unicodeImplicitTestUnc,

--- a/src/System.Private.Uri/tests/FunctionalTests/UriTests.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriTests.cs
@@ -22,9 +22,9 @@ namespace System.PrivateUri.Tests
                 }
                 else
                 {
-                    yield return new object[] { @"file:///path1\path2/path3\path4", @"/path1\path2/path3\path4", @"/path1\path2/path3\path4", @"file:///path1\path2/path3\path4", "" };
+                    yield return new object[] { @"file:///path1\path2/path3\path4", @"/path1%5Cpath2/path3%5Cpath4", @"/path1\path2/path3\path4", @"file:///path1%5Cpath2/path3%5Cpath4", "" };
                     yield return new object[] { @"file:///path1%5Cpath2\path3", @"/path1%5Cpath2%5Cpath3", @"/path1\path2\path3", @"file:///path1%5Cpath2%5Cpath3", ""};
-                    yield return new object[] { @"file://localhost/path1\path2/path3\path4\", @"/path1\path2/path3\path4\", @"\\localhost\path1\path2\path3\path4\", @"file://localhost/path1\path2/path3\path4\", "localhost"};
+                    yield return new object[] { @"file://localhost/path1\path2/path3\path4\", @"/path1%5Cpath2/path3%5Cpath4%5C", @"\\localhost\path1\path2\path3\path4\", @"file://localhost/path1%5Cpath2/path3%5Cpath4%5C", "localhost"};
                     yield return new object[] { @"file://randomhost/path1%5Cpath2\path3", @"/path1%5Cpath2%5Cpath3", @"\\randomhost\path1\path2\path3", @"file://randomhost/path1%5Cpath2%5Cpath3", "randomhost"};
                 }
             }

--- a/src/System.Private.Uri/tests/FunctionalTests/UriTests.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriTests.cs
@@ -2,12 +2,45 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Xunit;
 
 namespace System.PrivateUri.Tests
 {
     public static class UriTests
     {
+        public static IEnumerable<object[]> Uri_TestData
+        {
+            get
+            {
+                if (PlatformDetection.IsWindows)
+                {
+                    yield return new object[] { @"file:///path1\path2/path3\path4", @"/path1/path2/path3/path4", @"/path1/path2/path3/path4", @"file:///path1/path2/path3/path4", "" };
+                    yield return new object[] { @"file:///path1%5Cpath2\path3", @"/path1/path2/path3", @"/path1/path2/path3", @"file:///path1/path2/path3", ""};
+                    yield return new object[] { @"file://localhost/path1\path2/path3\path4\", @"/path1/path2/path3/path4/", @"\\localhost\path1\path2\path3\path4\", @"file://localhost/path1/path2/path3/path4/", "localhost"};
+                    yield return new object[] { @"file://randomhost/path1%5Cpath2\path3", @"/path1/path2/path3", @"\\randomhost\path1\path2\path3", @"file://randomhost/path1/path2/path3", "randomhost"};
+                }
+                else
+                {
+                    yield return new object[] { @"file:///path1\path2/path3\path4", @"/path1\path2/path3\path4", @"/path1\path2/path3\path4", @"file:///path1\path2/path3\path4", "" };
+                    yield return new object[] { @"file:///path1%5Cpath2\path3", @"/path1%5Cpath2%5Cpath3", @"/path1\path2\path3", @"file:///path1%5Cpath2%5Cpath3", ""};
+                    yield return new object[] { @"file://localhost/path1\path2/path3\path4\", @"/path1\path2/path3\path4\", @"\\localhost\path1\path2\path3\path4\", @"file://localhost/path1\path2/path3\path4\", "localhost"};
+                    yield return new object[] { @"file://randomhost/path1%5Cpath2\path3", @"/path1%5Cpath2%5Cpath3", @"\\randomhost\path1\path2\path3", @"file://randomhost/path1%5Cpath2%5Cpath3", "randomhost"};
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Uri_TestData))]
+        public static void TestCtor_BackwardSlashInPath(string uri, string expectedAbsolutePath, string expectedLocalPath, string expectedAbsoluteUri, string expectedHost)
+        {
+            Uri actualUri = new Uri(uri);
+            Assert.Equal(expectedAbsolutePath, actualUri.AbsolutePath);
+            Assert.Equal(expectedLocalPath, actualUri.LocalPath);
+            Assert.Equal(expectedAbsoluteUri, actualUri.AbsoluteUri);
+            Assert.Equal(expectedHost, actualUri.Host);
+        }
+
         [Fact]
         public static void TestCtor_String()
         {

--- a/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XslTransformMultith.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XslTransformMultith.cs
@@ -29,7 +29,7 @@ namespace System.Xml.Tests
         public new void Init(object objParam)
         {
             xsltSameInstance = new XslCompiledTransform();
-            _strPath = Path.Combine(@"TestFiles\", FilePathUtil.GetTestDataPath(), @"XsltApiV2\");
+            _strPath = Path.Combine("TestFiles", FilePathUtil.GetTestDataPath(), "XsltApiV2");
             return;
         }
     }
@@ -48,7 +48,7 @@ namespace System.Xml.Tests
 
         public void Load(string _strXslFile, string _strXmlFile)
         {
-            _xrData = XmlReader.Create(_strPath + _strXmlFile);
+            _xrData = XmlReader.Create(Path.Combine(_strPath, _strXmlFile));
             _xd = new XPathDocument(_xrData, XmlSpace.Preserve);
             _xrData.Dispose();
 
@@ -56,7 +56,7 @@ namespace System.Xml.Tests
 #pragma warning disable 0618
             xrs.ProhibitDtd = false;
 #pragma warning restore 0618
-            XmlReader xrTemp = XmlReader.Create(_strPath + _strXslFile, xrs);
+            XmlReader xrTemp = XmlReader.Create(Path.Combine(_strPath, _strXslFile), xrs);
             xsltSameInstance.Load(xrTemp);
         }
 
@@ -362,7 +362,7 @@ namespace System.Xml.Tests
 
         public void Load(string _strXslFile, string _strXmlFile)
         {
-            _xrData = XmlReader.Create(_strPath + _strXmlFile);
+            _xrData = XmlReader.Create(Path.Combine(_strPath, _strXmlFile));
             _xd = new XPathDocument(_xrData, XmlSpace.Preserve);
             _xrData.Dispose();
 
@@ -370,7 +370,7 @@ namespace System.Xml.Tests
 #pragma warning disable 0618
             xrs.ProhibitDtd = false;
 #pragma warning restore 0618
-            XmlReader xrTemp = XmlReader.Create(_strPath + _strXslFile, xrs);
+            XmlReader xrTemp = XmlReader.Create(Path.Combine(_strPath, _strXslFile), xrs);
             xsltSameInstance.Load(xrTemp);
         }
 

--- a/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XsltArgumentListMultith.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XsltArgumentListMultith.cs
@@ -29,7 +29,7 @@ namespace System.Xml.Tests
         public new void Init(object objParam)
         {
             // Get parameter info
-            _strPath = Path.Combine(@"TestFiles\", FilePathUtil.GetTestDataPath(), @"XsltApiV2\");
+            _strPath = Path.Combine("TestFiles", FilePathUtil.GetTestDataPath(), "XsltApiV2");
             xsltArg1 = new XsltArgumentList();
 
             MyObject obj1 = new MyObject(1, _output);
@@ -246,9 +246,9 @@ namespace System.Xml.Tests
             string _strXmlFile = ((object[])args)[2].ToString();
 
             if (_strXslFile.Substring(0, 5) != "http:")
-                _strXslFile = _strPath + _strXslFile;
+                _strXslFile = Path.Combine(_strPath, _strXslFile);
             if (_strXmlFile.Substring(0, 5) != "http:")
-                _strXmlFile = _strPath + _strXmlFile;
+                _strXmlFile = Path.Combine(_strPath, _strXmlFile);
 
             XmlReader xrData = XmlReader.Create(_strXmlFile);
             XPathDocument xd = new XPathDocument(xrData, XmlSpace.Preserve);

--- a/src/System.Private.Xml/tests/Xslt/XslTransformApi/CXsltArgumentListMultith.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslTransformApi/CXsltArgumentListMultith.cs
@@ -31,7 +31,7 @@ namespace System.Xml.Tests
         public new void Init(object objParam)
         {
             // Get parameter info
-            _strPath = Path.Combine(@"TestFiles\", FilePathUtil.GetTestDataPath(), @"XsltApi\");
+            _strPath = Path.Combine("TestFiles", FilePathUtil.GetTestDataPath(), "XsltApi");
 
             xsltArg1 = new XsltArgumentList();
 

--- a/src/System.Runtime/tests/System/Uri.CreateStringTests.cs
+++ b/src/System.Runtime/tests/System/Uri.CreateStringTests.cs
@@ -549,8 +549,16 @@ namespace System.Tests
             // File with host
             yield return new object[] { "file://path1/path2", "/path2", "", "" };
             yield return new object[] { "file:///path1/path2", "/path1/path2", "", "" };
-            yield return new object[] { @"file:///path1\path2/path3\path4", "/path1/path2/path3/path4", "", "" };
-            yield return new object[] { @"file:///path1\path2/path3\path4\", "/path1/path2/path3/path4/", "", "" };
+            if (s_isWindowsSystem)
+            {
+                yield return new object[] { @"file:///path1\path2/path3\path4", "/path1/path2/path3/path4", "", "" };
+                yield return new object[] { @"file:///path1\path2/path3\path4\", "/path1/path2/path3/path4/", "", "" };
+            }
+            else // Unix paths preserve backslash
+            {
+                yield return new object[] { @"file:///path1\path2/path3\path4", @"/path1\path2/path3\path4", "", "" };
+                yield return new object[] { @"file:///path1\path2/path3\path4\", @"/path1\path2/path3\path4\", "", "" };
+            }
             // Implicit file with empty path
             yield return new object[] { "C:/", "C:/", "", "" };
             yield return new object[] { "C|/", "C:/", "", "" };

--- a/src/System.Runtime/tests/System/Uri.CreateStringTests.cs
+++ b/src/System.Runtime/tests/System/Uri.CreateStringTests.cs
@@ -558,9 +558,9 @@ namespace System.Tests
             }
             else // Unix paths preserve backslash
             {
-                yield return new object[] { @"file:///path1\path2/path3\path4", @"/path1\path2/path3\path4", "", "" };
+                yield return new object[] { @"file:///path1\path2/path3\path4", @"/path1%5Cpath2/path3%5Cpath4", "", "" };
                 yield return new object[] { @"file:///path1%5Cpath2\path3", @"/path1%5Cpath2%5Cpath3", "", ""};
-                yield return new object[] { @"file://localhost/path1\path2/path3\path4\", @"/path1\path2/path3\path4\", "", "" };
+                yield return new object[] { @"file://localhost/path1\path2/path3\path4\", @"/path1%5Cpath2/path3%5Cpath4%5C", "", "" };
                 yield return new object[] { @"file://localhost/path1%5Cpath2\path3", @"/path1%5Cpath2%5Cpath3", "", ""};
             }
             // Implicit file with empty path
@@ -677,7 +677,7 @@ namespace System.Tests
                 yield return new object[] { @"file:///\unchost/path1\path2/path3\path4\", "/path1/path2/path3/path4/", "", "" };
                 yield return new object[] { @"file://\/unchost/path1\path2/path3\path4\", "/path1/path2/path3/path4/", "", "" };
             }
-            else if(!s_isWindowsSystem)
+            else
             {
                 // Implicit file with path
                 yield return new object[] { "/", "/", "", "" };
@@ -687,15 +687,15 @@ namespace System.Tests
                 // Implicit file ending with backlash
                 yield return new object[] { @"/path1\path2/path3\path4\", "/path1%5Cpath2/path3%5Cpath4%5C", "", "" };
                 // Explicit UNC with backslash in path
-                yield return new object[] { @"file://\\unchost/path1\path2/path3\path4", @"/path1\path2/path3\path4", "", "" };
-                yield return new object[] { @"file:////unchost/path1\path2/path3\path4", @"/path1\path2/path3\path4", "", "" };
-                yield return new object[] { @"file:///\unchost/path1\path2/path3\path4", @"/path1\path2/path3\path4", "", "" };
-                yield return new object[] { @"file://\/unchost/path1\path2/path3\path4", @"/path1\path2/path3\path4", "", "" };
+                yield return new object[] { @"file://\\unchost/path1\path2/path3\path4", @"/path1%5Cpath2/path3%5Cpath4", "", "" };
+                yield return new object[] { @"file:////unchost/path1\path2/path3\path4", @"/path1%5Cpath2/path3%5Cpath4", "", "" };
+                yield return new object[] { @"file:///\unchost/path1\path2/path3\path4", @"/path1%5Cpath2/path3%5Cpath4", "", "" };
+                yield return new object[] { @"file://\/unchost/path1\path2/path3\path4", @"/path1%5Cpath2/path3%5Cpath4", "", "" };
                 // Explicit UNC ending with backslash
-                yield return new object[] { @"file://\\unchost/path1\path2/path3\path4\", @"/path1\path2/path3\path4\", "", "" };
-                yield return new object[] { @"file:////unchost/path1\path2/path3\path4\", @"/path1\path2/path3\path4\", "", "" };
-                yield return new object[] { @"file:///\unchost/path1\path2/path3\path4\", @"/path1\path2/path3\path4\", "", "" };
-                yield return new object[] { @"file://\/unchost/path1\path2/path3\path4\", @"/path1\path2/path3\path4\", "", "" };
+                yield return new object[] { @"file://\\unchost/path1\path2/path3\path4\", @"/path1%5Cpath2/path3%5Cpath4%5C", "", "" };
+                yield return new object[] { @"file:////unchost/path1\path2/path3\path4\", @"/path1%5Cpath2/path3%5Cpath4%5C", "", "" };
+                yield return new object[] { @"file:///\unchost/path1\path2/path3\path4\", @"/path1%5Cpath2/path3%5Cpath4%5C", "", "" };
+                yield return new object[] { @"file://\/unchost/path1\path2/path3\path4\", @"/path1%5Cpath2/path3%5Cpath4%5C", "", "" };
             }
 
             // Mailto

--- a/src/System.Runtime/tests/System/Uri.CreateStringTests.cs
+++ b/src/System.Runtime/tests/System/Uri.CreateStringTests.cs
@@ -552,12 +552,16 @@ namespace System.Tests
             if (s_isWindowsSystem)
             {
                 yield return new object[] { @"file:///path1\path2/path3\path4", "/path1/path2/path3/path4", "", "" };
-                yield return new object[] { @"file:///path1\path2/path3\path4\", "/path1/path2/path3/path4/", "", "" };
+                yield return new object[] { @"file:///path1\path2/path3%5Cpath4\", "/path1/path2/path3/path4/", "", "" };
+                yield return new object[] { @"file://localhost/path1\path2/path3\path4\", "/path1/path2/path3/path4/", "", "" };
+                yield return new object[] { @"file://localhost/path1%5Cpath2", "/path1/path2", "", ""};
             }
             else // Unix paths preserve backslash
             {
                 yield return new object[] { @"file:///path1\path2/path3\path4", @"/path1\path2/path3\path4", "", "" };
-                yield return new object[] { @"file:///path1\path2/path3\path4\", @"/path1\path2/path3\path4\", "", "" };
+                yield return new object[] { @"file:///path1%5Cpath2\path3", @"/path1%5Cpath2%5Cpath3", "", ""};
+                yield return new object[] { @"file://localhost/path1\path2/path3\path4\", @"/path1\path2/path3\path4\", "", "" };
+                yield return new object[] { @"file://localhost/path1%5Cpath2\path3", @"/path1%5Cpath2%5Cpath3", "", ""};
             }
             // Implicit file with empty path
             yield return new object[] { "C:/", "C:/", "", "" };
@@ -651,16 +655,6 @@ namespace System.Tests
             yield return new object[] { "file:////unchost/path1/path2?query#fragment", "/path1/path2", "?query", "#fragment" };
             yield return new object[] { @"file:///\unchost/path1/path2?query#fragment", "/path1/path2", "?query", "#fragment" };
             yield return new object[] { @"file://\/unchost/path1/path2?query#fragment", "/path1/path2", "?query", "#fragment" };
-            // Explicit UNC with backslash in path
-            yield return new object[] { @"file://\\unchost/path1\path2/path3\path4", "/path1/path2/path3/path4", "", "" };
-            yield return new object[] { @"file:////unchost/path1\path2/path3\path4", "/path1/path2/path3/path4", "", "" };
-            yield return new object[] { @"file:///\unchost/path1\path2/path3\path4", "/path1/path2/path3/path4", "", "" };
-            yield return new object[] { @"file://\/unchost/path1\path2/path3\path4", "/path1/path2/path3/path4", "", "" };
-            // Explicit UNC ending with backslash
-            yield return new object[] { @"file://\\unchost/path1\path2/path3\path4\", "/path1/path2/path3/path4/", "", "" };
-            yield return new object[] { @"file:////unchost/path1\path2/path3\path4\", "/path1/path2/path3/path4/", "", "" };
-            yield return new object[] { @"file:///\unchost/path1\path2/path3\path4\", "/path1/path2/path3/path4/", "", "" };
-            yield return new object[] { @"file://\/unchost/path1\path2/path3\path4\", "/path1/path2/path3/path4/", "", "" };
             // Explicit UNC with a windows drive as host
             yield return new object[] { @"file://\\C:/path1/path2", "C:/path1/path2", "", "" };
             yield return new object[] { "file:////C:/path1/path2", "C:/path1/path2", "", "" };
@@ -670,8 +664,20 @@ namespace System.Tests
             yield return new object[] { "C|/path|path/path2", "C:/path%7Cpath/path2", "", "" };
             yield return new object[] { "file://host/path?query#fragment", "/path", "?query", "#fragment" };
 
-            // Unix path
-            if (!s_isWindowsSystem)
+            if (s_isWindowsSystem)
+            {
+                // Explicit UNC with backslash in path
+                yield return new object[] { @"file://\\unchost/path1\path2/path3\path4", "/path1/path2/path3/path4", "", "" };
+                yield return new object[] { @"file:////unchost/path1\path2/path3\path4", "/path1/path2/path3/path4", "", "" };
+                yield return new object[] { @"file:///\unchost/path1\path2/path3\path4", "/path1/path2/path3/path4", "", "" };
+                yield return new object[] { @"file://\/unchost/path1\path2/path3\path4", "/path1/path2/path3/path4", "", "" };
+                // Explicit UNC ending with backslash
+                yield return new object[] { @"file://\\unchost/path1\path2/path3\path4\", "/path1/path2/path3/path4/", "", "" };
+                yield return new object[] { @"file:////unchost/path1\path2/path3\path4\", "/path1/path2/path3/path4/", "", "" };
+                yield return new object[] { @"file:///\unchost/path1\path2/path3\path4\", "/path1/path2/path3/path4/", "", "" };
+                yield return new object[] { @"file://\/unchost/path1\path2/path3\path4\", "/path1/path2/path3/path4/", "", "" };
+            }
+            else if(!s_isWindowsSystem)
             {
                 // Implicit file with path
                 yield return new object[] { "/", "/", "", "" };
@@ -680,6 +686,16 @@ namespace System.Tests
                 yield return new object[] { @"/path1\path2/path3\path4", "/path1%5Cpath2/path3%5Cpath4", "", "" };
                 // Implicit file ending with backlash
                 yield return new object[] { @"/path1\path2/path3\path4\", "/path1%5Cpath2/path3%5Cpath4%5C", "", "" };
+                // Explicit UNC with backslash in path
+                yield return new object[] { @"file://\\unchost/path1\path2/path3\path4", @"/path1\path2/path3\path4", "", "" };
+                yield return new object[] { @"file:////unchost/path1\path2/path3\path4", @"/path1\path2/path3\path4", "", "" };
+                yield return new object[] { @"file:///\unchost/path1\path2/path3\path4", @"/path1\path2/path3\path4", "", "" };
+                yield return new object[] { @"file://\/unchost/path1\path2/path3\path4", @"/path1\path2/path3\path4", "", "" };
+                // Explicit UNC ending with backslash
+                yield return new object[] { @"file://\\unchost/path1\path2/path3\path4\", @"/path1\path2/path3\path4\", "", "" };
+                yield return new object[] { @"file:////unchost/path1\path2/path3\path4\", @"/path1\path2/path3\path4\", "", "" };
+                yield return new object[] { @"file:///\unchost/path1\path2/path3\path4\", @"/path1\path2/path3\path4\", "", "" };
+                yield return new object[] { @"file://\/unchost/path1\path2/path3\path4\", @"/path1\path2/path3\path4\", "", "" };
             }
 
             // Mailto
@@ -804,6 +820,8 @@ namespace System.Tests
                     {
                         localPath = @"\\" + uri.Host + path;
                         localPath = localPath.Replace('/', '\\');
+                        // Unescape '\\'
+                        localPath = localPath.Replace("%5C", "\\");
                         if (path == "/")
                         {
                             localPath = localPath.Substring(0, localPath.Length - 1);


### PR DESCRIPTION
fixes #20628 

Master PR: #20623  #21263 #21482 

With these changes, on Unix, file paths containing backslashes will be accepted. It is legal on Unix for filenames to have \\ char. Hence, we enable support for these in .NET Core.

Cases like below will report the following on Unix.

```
file://authority\pathpart1/pathpart2?query#fragment -> file://authority/pathpart1/pathpart2?query#fragment
file://authority/pathpart1\pathpart2?query#fragment -> file://authority/pathpart1%5Cpathpart2?query#fragment
file:///pathpart1\pathpart2?query#fragment -> file:///pathpart1%5Cpathpart2?query#fragment
\\host\pathpart1\pathpart1 -> file://host/pathpart1/pathpart2
```

cc @tmds 