### PR TITLE
Disable System.ServiceProcess.ServiceController.Tests for Uap

### DIFF
--- a/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/SafeServiceControllerTests.cs
+++ b/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/SafeServiceControllerTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace System.ServiceProcess.Tests
 {
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Appx doesn't allow to access ServiceController")]
     public static class SafeServiceControllerTests
     {
         private const string KeyIsoSvcName = "KEYISO";


### PR DESCRIPTION
ServiceController is not accessible from App Container.

cc: @danmosemsft 