### PR TITLE
Add Attribute tests in System.Runtime.InteropServices

### DIFF
--- a/src/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.Tests.csproj
+++ b/src/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.Tests.csproj
@@ -14,24 +14,51 @@
   <!-- Default configurations to help VS understand the configurations -->
   <ItemGroup>
     <Compile Include="System\Runtime\InteropServices\AllowReversePInvokeCallsAttributeTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\AutomationProxyAttributeTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\BestFitMappingAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\CallingConventionTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\ClassInterfaceAttributeTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\CoClassAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\ComAliasNameAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\ComAwareEventInfoTests.cs" />
     <Compile Include="System\Runtime\InteropServices\ComAwareEventInfoTests.Windows.cs" Condition="'$(TargetsWindows)' == 'true'" />
     <Compile Include="System\Runtime\InteropServices\ComCompatibleVersionAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\ComConversionLossAttributeTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\ComDefaultInterfaceAttributeTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\ComEventInterfaceAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\ComRegisterFunctionAttributeTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\ComSourceInterfacesAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\ComUnregisterFunctionAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\ComVisibleAttributeTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\CurrencyWrapperTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\DefaultCharSetAttributeTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\DefaultDllImportSearchPathsAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\DefaultParameterValueAttributeTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\DispIdAttributeTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\DllImportAttributeTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\GuidAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\HandleCollectorTests.cs" />
     <Compile Include="System\Runtime\InteropServices\HandleRefTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\IDispatchImplAttributeTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\ImportedFromTypeLibAttributeTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\InterfaceTypeAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\LCIDConversionAttributeTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\ManagedToNativeComInteropStubAttributeTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\MarshalAsAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\MarshalTests.cs" />
     <Compile Include="System\Runtime\InteropServices\MarshalTests.Windows.cs" Condition="'$(TargetsWindows)' == 'true'" />
     <Compile Include="System\Runtime\InteropServices\PrimaryInteropAssemblyAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\ProgIdAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\RuntimeEnvironmentTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\SecureStringMarshalTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\SetWin32ContextInIDispatchAttributeTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\TypeIdentifierAttributeTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\TypeLibFuncAttributeTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\TypeLibImportClassAttributeTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\TypeLibTypeAttributeTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\TypeLibVarAttributeTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\TypeLibVersionAttributeTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\UnmanagedFunctionPointerAttributeTests.cs" />
     <Compile Include="$(CommonTestPath)\System\AssertExtensions.cs">
       <Link>Common\System\AssertExtensions.cs</Link>
     </Compile>

--- a/src/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.Tests.csproj
+++ b/src/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.Tests.csproj
@@ -30,7 +30,6 @@
     <Compile Include="System\Runtime\InteropServices\ComSourceInterfacesAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\ComUnregisterFunctionAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\ComVisibleAttributeTests.cs" />
-    <Compile Include="System\Runtime\InteropServices\CurrencyWrapperTests.cs" />
     <Compile Include="System\Runtime\InteropServices\DefaultCharSetAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\DefaultDllImportSearchPathsAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\DefaultParameterValueAttributeTests.cs" />
@@ -50,7 +49,6 @@
     <Compile Include="System\Runtime\InteropServices\PrimaryInteropAssemblyAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\ProgIdAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\RuntimeEnvironmentTests.cs" />
-    <Compile Include="System\Runtime\InteropServices\SecureStringMarshalTests.cs" />
     <Compile Include="System\Runtime\InteropServices\SetWin32ContextInIDispatchAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\TypeIdentifierAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\TypeLibFuncAttributeTests.cs" />

--- a/src/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.Tests.csproj
+++ b/src/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.Tests.csproj
@@ -14,7 +14,6 @@
   <!-- Default configurations to help VS understand the configurations -->
   <ItemGroup>
     <Compile Include="System\Runtime\InteropServices\AllowReversePInvokeCallsAttributeTests.cs" />
-    <Compile Include="System\Runtime\InteropServices\AutomationProxyAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\BestFitMappingAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\CallingConventionTests.cs" />
     <Compile Include="System\Runtime\InteropServices\ClassInterfaceAttributeTests.cs" />
@@ -39,10 +38,8 @@
     <Compile Include="System\Runtime\InteropServices\HandleCollectorTests.cs" />
     <Compile Include="System\Runtime\InteropServices\HandleRefTests.cs" />
     <Compile Include="System\Runtime\InteropServices\IDispatchImplAttributeTests.cs" />
-    <Compile Include="System\Runtime\InteropServices\ImportedFromTypeLibAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\InterfaceTypeAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\LCIDConversionAttributeTests.cs" />
-    <Compile Include="System\Runtime\InteropServices\ManagedToNativeComInteropStubAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\MarshalAsAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\MarshalTests.cs" />
     <Compile Include="System\Runtime\InteropServices\MarshalTests.Windows.cs" Condition="'$(TargetsWindows)' == 'true'" />
@@ -51,11 +48,6 @@
     <Compile Include="System\Runtime\InteropServices\RuntimeEnvironmentTests.cs" />
     <Compile Include="System\Runtime\InteropServices\SetWin32ContextInIDispatchAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\TypeIdentifierAttributeTests.cs" />
-    <Compile Include="System\Runtime\InteropServices\TypeLibFuncAttributeTests.cs" />
-    <Compile Include="System\Runtime\InteropServices\TypeLibImportClassAttributeTests.cs" />
-    <Compile Include="System\Runtime\InteropServices\TypeLibTypeAttributeTests.cs" />
-    <Compile Include="System\Runtime\InteropServices\TypeLibVarAttributeTests.cs" />
-    <Compile Include="System\Runtime\InteropServices\TypeLibVersionAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\UnmanagedFunctionPointerAttributeTests.cs" />
     <Compile Include="$(CommonTestPath)\System\AssertExtensions.cs">
       <Link>Common\System\AssertExtensions.cs</Link>
@@ -66,6 +58,16 @@
     <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
       <Link>Common\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
     </Compile>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' != 'netstandard'">
+    <Compile Include="System\Runtime\InteropServices\AutomationProxyAttributeTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\ImportedFromTypeLibAttributeTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\ManagedToNativeComInteropStubAttributeTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\TypeLibFuncAttributeTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\TypeLibImportClassAttributeTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\TypeLibTypeAttributeTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\TypeLibVarAttributeTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\TypeLibVersionAttributeTests.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/CompilerServices/IUnknownConstantAttributeTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/CompilerServices/IUnknownConstantAttributeTests.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace System.Runtime.CompilerServices.Tests
+{
+    public class IUnknownConstantAttributeTests
+    {
+        [Fact]
+        public void Ctor_Default()
+        {
+            var attribute = new IUnknownConstantAttribute();
+#pragma warning disable 0618 // UnknownWrapper is marked as Obsolete.
+            UnknownWrapper wrapper = Assert.IsType<UnknownWrapper>(attribute.Value);
+#pragma warning restore 0618
+            Assert.Null(wrapper.WrappedObject);
+        }
+    }
+}

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/AutomationProxyAttributeTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/AutomationProxyAttributeTests.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Runtime.InteropServices.Tests
+{
+    public class AutomationProxyAttributeTests
+    {
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Ctor_Val(bool val)
+        {
+            var attribute = new AutomationProxyAttribute(val);
+            Assert.Equal(val, attribute.Value);
+        }
+    }
+}

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/BestFitMappingAttributeTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/BestFitMappingAttributeTests.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Runtime.InteropServices.Tests
+{
+    public class BestFitMappingAttributeTests
+    {
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Ctor_BestFitMapping(bool bestFitMapping)
+        {
+            var attribute = new BestFitMappingAttribute(bestFitMapping);
+            Assert.Equal(bestFitMapping, attribute.BestFitMapping);
+        }
+    }
+}

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/ClassInterfaceAttributeTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/ClassInterfaceAttributeTests.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Runtime.InteropServices.Tests
+{
+    public class ClassInterfaceAttributeTests
+    {
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(4)]
+        public void Ctor_ShortClassInterfaceType(ClassInterfaceType classInterfaceType)
+        {
+            var attribute = new ClassInterfaceAttribute(classInterfaceType);
+            Assert.Equal(classInterfaceType, attribute.Value);
+        }
+
+        [Theory]
+        [InlineData((ClassInterfaceType)(-1))]
+        [InlineData(ClassInterfaceType.None)]
+        [InlineData((ClassInterfaceType)4)]
+        public void Ctor_ClassInterfaceType(ClassInterfaceType classInterfaceType)
+        {
+            var attribute = new ClassInterfaceAttribute(classInterfaceType);
+            Assert.Equal(classInterfaceType, attribute.Value);
+        }
+    }
+}

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/CoClassAttributeTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/CoClassAttributeTests.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Runtime.InteropServices.Tests
+{
+    public class CoClassAttributeTests
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData(typeof(int))]
+        public void Ctor_CoClass(Type coClass)
+        {
+            var attribute = new CoClassAttribute(coClass);
+            Assert.Equal(coClass, attribute.CoClass);
+        }
+    }
+}

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/ComDefaultInterfaceAttributeTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/ComDefaultInterfaceAttributeTests.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Runtime.InteropServices.Tests
+{
+    public class ComDefaultInterfaceAttributeTests
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData(typeof(int))]
+        public void Ctor_DefaultInterface(Type defaultInterface)
+        {
+            var attribute = new ComDefaultInterfaceAttribute(defaultInterface);
+            Assert.Equal(defaultInterface, attribute.Value);
+        }
+    }
+}

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/ComEventInterfaceAttributeTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/ComEventInterfaceAttributeTests.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Runtime.InteropServices.Tests
+{
+#pragma warning disable 0618 // ComEventInterfaceAttribute is marked as Obsolete.
+    public class ComEventInterfaceAttributeTests
+    {
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(typeof(int), typeof(string))]
+        public void Ctor_DefaultInterface(Type sourceInterface, Type eventProvider)
+        {
+            var attribute = new ComEventInterfaceAttribute(sourceInterface, eventProvider);
+            Assert.Equal(sourceInterface, attribute.SourceInterface);
+            Assert.Equal(eventProvider, attribute.EventProvider);
+        }
+    }
+#pragma warning restore 0618
+}

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/ComSourceInterfacesAttributeTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/ComSourceInterfacesAttributeTests.cs
@@ -1,0 +1,80 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Runtime.InteropServices.Tests
+{
+#pragma warning disable 0618 // ComSourceInterfacesAttribute is marked as Obsolete.
+    public class ComSourceInterfacesAttributeTests
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("SourceInterfaces")]
+        public void Ctor_SourceInterfaces(string sourceInterfaces)
+        {
+            var attribute = new ComSourceInterfacesAttribute(sourceInterfaces);
+            Assert.Equal(sourceInterfaces, attribute.Value);
+        }
+
+        [Fact]
+        public void Ctor_SourceInterface1()
+        {
+            var attribute = new ComSourceInterfacesAttribute(typeof(int));
+            Assert.Equal("System.Int32", attribute.Value);
+        }
+
+        [Fact]
+        public void Ctor_NullSourceInterfaceType1_ThrowsNullReferenceException()
+        {
+            Assert.Throws<NullReferenceException>(() => new ComSourceInterfacesAttribute((Type)null));
+            Assert.Throws<NullReferenceException>(() => new ComSourceInterfacesAttribute(null, typeof(int)));
+            Assert.Throws<NullReferenceException>(() => new ComSourceInterfacesAttribute(null, typeof(int), typeof(string)));
+            Assert.Throws<NullReferenceException>(() => new ComSourceInterfacesAttribute(null, typeof(int), typeof(string), typeof(bool)));
+        }
+
+        [Fact]
+        public void Ctor_SourceInterface1_SourceInterfaceType2()
+        {
+            var attribute = new ComSourceInterfacesAttribute(typeof(int), typeof(string));
+            Assert.Equal("System.Int32\0System.String", attribute.Value);
+        }
+
+        [Fact]
+        public void Ctor_NullSourceInterfaceType2_ThrowsNullReferenceException()
+        {
+            Assert.Throws<NullReferenceException>(() => new ComSourceInterfacesAttribute(typeof(int), null));
+            Assert.Throws<NullReferenceException>(() => new ComSourceInterfacesAttribute(typeof(int), null, typeof(string)));
+            Assert.Throws<NullReferenceException>(() => new ComSourceInterfacesAttribute(typeof(int), null, typeof(string), typeof(bool)));
+        }
+
+        [Fact]
+        public void Ctor_SourceInterface1_SourceInterfaceType2_SourceInterfaceType3()
+        {
+            var attribute = new ComSourceInterfacesAttribute(typeof(int), typeof(string), typeof(bool));
+            Assert.Equal("System.Int32\0System.String\0System.Boolean", attribute.Value);
+        }
+
+        [Fact]
+        public void Ctor_NullSourceInterfaceType3_ThrowsNullReferenceException()
+        {
+            Assert.Throws<NullReferenceException>(() => new ComSourceInterfacesAttribute(typeof(int), typeof(string), null));
+            Assert.Throws<NullReferenceException>(() => new ComSourceInterfacesAttribute(typeof(int), typeof(string), null, typeof(bool)));
+        }
+
+        [Fact]
+        public void Ctor_SourceInterface1_SourceInterfaceType2_SourceInterfaceType3_SourceInterfaceType4()
+        {
+            var attribute = new ComSourceInterfacesAttribute(typeof(int), typeof(string), typeof(bool), typeof(short));
+            Assert.Equal("System.Int32\0System.String\0System.Boolean\0System.Int16", attribute.Value);
+        }
+
+        [Fact]
+        public void Ctor_NullSourceInterfaceType4_ThrowsNullReferenceException()
+        {
+            Assert.Throws<NullReferenceException>(() => new ComSourceInterfacesAttribute(typeof(int), typeof(string), typeof(bool), null));
+        }
+    }
+#pragma warning restore 0618
+}

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/DefaultCharSetAttributeTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/DefaultCharSetAttributeTests.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Runtime.InteropServices.Tests
+{
+    public class DefaultCharSetAttributeTests
+    {
+        [Theory]
+        [InlineData((CharSet)(-1))]
+        [InlineData(CharSet.Unicode)]
+        [InlineData((CharSet)5)]
+        public void Ctor_CharSet(CharSet charSet)
+        {
+            var attribute = new DefaultCharSetAttribute(charSet);
+            Assert.Equal(charSet, attribute.CharSet);
+        }
+    }
+}

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/DefaultDllImportSearchPathsAttributeTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/DefaultDllImportSearchPathsAttributeTests.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Runtime.InteropServices.Tests
+{
+    public class DefaultDllImportSearchPathsAttributeTests
+    {
+        [Theory]
+        [InlineData((DllImportSearchPath)(-1))]
+        [InlineData(DllImportSearchPath.AssemblyDirectory)]
+        [InlineData((DllImportSearchPath)int.MaxValue)]
+        public void Ctor_Paths(DllImportSearchPath paths)
+        {
+            var attribute = new DefaultDllImportSearchPathsAttribute(paths);
+            Assert.Equal(paths, attribute.Paths);
+        }
+    }
+}

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/DispIdAttributeTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/DispIdAttributeTests.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Runtime.InteropServices
+{
+    public class DispIdAttributeTests
+    {
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(1)]
+        public static void Ctor_Value(int dispId)
+        {
+            var attribute = new DispIdAttribute(dispId);
+            Assert.Equal(dispId, attribute.Value);
+        }
+    }
+}

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/DllImportAttributeTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/DllImportAttributeTests.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Runtime.InteropServices.Tests
+{
+    public class DllImportAttributeTests
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("DllName")]
+        public void Ctor_SourceInterfaces(string dllName)
+        {
+            var attribute = new DllImportAttribute(dllName);
+            Assert.Equal(dllName, attribute.Value);
+        }
+    }
+}

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/GuidAttributeTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/GuidAttributeTests.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Runtime.InteropServices.Tests
+{
+    public class GuidAttributeTests
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("Guid")]
+        public void Ctor_Guid(string guid)
+        {
+            var attribute = new GuidAttribute(guid);
+            Assert.Equal(guid, attribute.Value);
+        }
+    }
+}

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/IDispatchImplAttributeTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/IDispatchImplAttributeTests.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+using Xunit;
+
+namespace System.Runtime.InteropServices.Tests
+{
+    public class IDispatchImplAttributeTests
+    {
+        private const string TypeName = "System.Runtime.InteropServices.IDispatchImplAttribute";
+        private const string ValueName = "Value";
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(2)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot | TargetFrameworkMonikers.NetFramework, "This has been removed from the ref in .NET Core and from the source in the .NET Framework.")]
+        public void Ctor_ImplTypeShort(short implType)
+        {
+            Type type = typeof(HandleCollector).Assembly.GetType(TypeName);
+            PropertyInfo valueProperty = type.GetProperty(ValueName);
+            Assert.NotNull(type);
+            Assert.NotNull(valueProperty);
+
+            ConstructorInfo shortConstructor = type.GetConstructor(new Type[] { typeof(short) });
+            object attribute = shortConstructor.Invoke(new object[] { implType });
+            Assert.Equal(implType, (int)valueProperty.GetValue(attribute));
+        }
+    }
+}

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/ImportedFromTypeLibAttributeTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/ImportedFromTypeLibAttributeTests.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Runtime.InteropServices.Tests
+{
+    public class ImportedFromTypeLibAttributeTests
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("Value")]
+        public void Ctor_TlbFile(string tlbFile)
+        {
+            var attribute = new ImportedFromTypeLibAttribute(tlbFile);
+            Assert.Equal(tlbFile, attribute.Value);
+        }
+    }
+}

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/InterfaceTypeAttributeTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/InterfaceTypeAttributeTests.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Runtime.InteropServices.Tests
+{
+    public class InterfaceTypeAttributeTests
+    {
+        [Theory]
+        [InlineData((ComInterfaceType)(-1))]
+        [InlineData(ComInterfaceType.InterfaceIsIInspectable)]
+        [InlineData((ComInterfaceType)5)]
+        public void Ctor_ComInterfaceType(ComInterfaceType interfaceType)
+        {
+            var attribute = new InterfaceTypeAttribute(interfaceType);
+            Assert.Equal(interfaceType, attribute.Value);
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(3)]
+        [InlineData(5)]
+        public void Ctor_ShortInterfaceType(short interfaceType)
+        {
+            var attribute = new InterfaceTypeAttribute(interfaceType);
+            Assert.Equal((ComInterfaceType)interfaceType, attribute.Value);
+        }
+    }
+}

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/ManagedToNativeComInteropStubAttributeTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/ManagedToNativeComInteropStubAttributeTests.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Runtime.InteropServices.Tests
+{
+    public class ManagedToNativeComInteropStubAttributeTests
+    {
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(typeof(int), "MethodName")]
+        public void Ctor_ClassType_MethodName(Type classType, string methodName)
+        {
+            var attribute = new ManagedToNativeComInteropStubAttribute(classType, methodName);
+            Assert.Equal(classType, attribute.ClassType);
+            Assert.Equal(methodName, attribute.MethodName);
+        }
+    }
+}

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/MarshalAsAttributeTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/MarshalAsAttributeTests.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Runtime.InteropServices.Tests
+{
+    public class MarshalAsAttributeTests
+    {
+        [Theory]
+        [InlineData((UnmanagedType)(-1))]
+        [InlineData(UnmanagedType.HString)]
+        [InlineData((UnmanagedType)int.MaxValue)]
+        public void Ctor_UmanagedTye(UnmanagedType unmanagedType)
+        {
+            var attribute = new MarshalAsAttribute(unmanagedType);
+            Assert.Equal(unmanagedType, attribute.Value);
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(47)]
+        [InlineData(short.MaxValue)]
+        public void Ctor_ShortUnmanagedType(short umanagedType)
+        {
+            var attribute = new MarshalAsAttribute(umanagedType);
+            Assert.Equal((UnmanagedType)umanagedType, attribute.Value);
+        }
+    }
+}

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/SetWin32ContextInIDispatchAttributeTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/SetWin32ContextInIDispatchAttributeTests.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+using Xunit;
+
+namespace System.Runtime.InteropServices.Tests
+{
+    public class SetWin32ContextInIDispatchAttributeTests
+    {
+        private const string TypeName = "System.Runtime.InteropServices.SetWin32ContextInIDispatchAttribute";
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot | TargetFrameworkMonikers.NetFramework, "This has been removed from the ref in .NET Core and from the source in the .NET Framework.")]
+        public void Ctor_Default_ExistsInSrc()
+        {
+            Type type = typeof(HandleCollector).Assembly.GetType(TypeName);
+            Assert.NotNull(type);
+
+            ConstructorInfo constructor = type.GetConstructor(new Type[0]);
+            object attribute = constructor.Invoke(new object[0]);
+            Assert.NotNull(attribute);
+        }
+    }
+}

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/TypeIdentifierAttributeTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/TypeIdentifierAttributeTests.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Runtime.InteropServices.Tests
+{
+    public class TypeIdentifierAttributetests
+    {
+        [Fact]
+        public void Ctor_Default()
+        {
+            var attribute = new TypeIdentifierAttribute();
+            Assert.Null(attribute.Scope);
+            Assert.Null(attribute.Identifier);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData("scope", "identifier")]
+        public void Ctor_Scope_Identifier(string scope, string identifier)
+        {
+            var attribute = new TypeIdentifierAttribute(scope, identifier);
+            Assert.Equal(scope, attribute.Scope);
+            Assert.Equal(identifier, attribute.Identifier);
+        }
+    }
+}

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/TypeLibFuncAttributeTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/TypeLibFuncAttributeTests.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Runtime.InteropServices.Tests
+{
+    public class TypeLibFuncAttributeTests
+    {
+        [Theory]
+        [InlineData((TypeLibFuncFlags)(-1))]
+        [InlineData((TypeLibFuncFlags)0)]
+        [InlineData(TypeLibFuncFlags.FBindable)]
+        public void Ctor_TypeLibFuncFlags(TypeLibFuncFlags flags)
+        {
+            var attribute = new TypeLibFuncAttribute(flags);
+            Assert.Equal(flags, attribute.Value);
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(4)]
+        public void Ctor_ShortFlags(short flags)
+        {
+            var attribute = new TypeLibFuncAttribute(flags);
+            Assert.Equal((TypeLibFuncFlags)flags, attribute.Value);
+        }
+    }
+}

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/TypeLibImportClassAttributeTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/TypeLibImportClassAttributeTests.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Runtime.InteropServices.Tests
+{
+    public class TypeLibImportClassAttributeTests
+    {
+        [Fact]
+        public void Ctor_ImportClass()
+        {
+            var attribute = new TypeLibImportClassAttribute(typeof(int));
+            Assert.Equal(typeof(int).ToString(), attribute.Value);
+        }
+
+        [Fact]
+        public void Ctor_NullImportClass_ThrowsNullReferenceException()
+        {
+            Assert.Throws<NullReferenceException>(() => new TypeLibImportClassAttribute(null));
+        }
+    }
+}

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/TypeLibTypeAttributeTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/TypeLibTypeAttributeTests.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Runtime.InteropServices.Tests
+{
+    public class TypeLibTypeAttributeTests
+    {
+        [Theory]
+        [InlineData((TypeLibTypeFlags)(-1))]
+        [InlineData((TypeLibTypeFlags)0)]
+        [InlineData(TypeLibTypeFlags.FLicensed)]
+        public void Ctor_TypeLibTypeFlags(TypeLibTypeFlags flags)
+        {
+            var attribute = new TypeLibTypeAttribute(flags);
+            Assert.Equal(flags, attribute.Value);
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(4)]
+        public void Ctor_ShortFlags(short flags)
+        {
+            var attribute = new TypeLibTypeAttribute(flags);
+            Assert.Equal((TypeLibTypeFlags)flags, attribute.Value);
+        }
+    }
+}

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/TypeLibVarAttributeTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/TypeLibVarAttributeTests.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Runtime.InteropServices.Tests
+{
+    public class TypeLibVarAttributeTests
+    {
+        [Theory]
+        [InlineData((TypeLibVarFlags)(-1))]
+        [InlineData((TypeLibVarFlags)0)]
+        [InlineData(TypeLibVarFlags.FBindable)]
+        public void Ctor_TypeLibVarFlags(TypeLibVarFlags flags)
+        {
+            var attribute = new TypeLibVarAttribute(flags);
+            Assert.Equal(flags, attribute.Value);
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(4)]
+        public void Ctor_ShortFlags(short flags)
+        {
+            var attribute = new TypeLibVarAttribute(flags);
+            Assert.Equal((TypeLibVarFlags)flags, attribute.Value);
+        }
+    }
+}

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/TypeLibVersionAttributeTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/TypeLibVersionAttributeTests.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Runtime.InteropServices.Tests
+{
+    public class TypeLibVersionAttributeTests
+    {
+        [Theory]
+        [InlineData(-1, -2)]
+        [InlineData(0, 0)]
+        [InlineData(1, 2)]
+        public void Ctor_MajorVersion_MinorVersion(int majorVersion, int minorVersion)
+        {
+            var attribute = new TypeLibVersionAttribute(majorVersion, minorVersion);
+            Assert.Equal(majorVersion, attribute.MajorVersion);
+            Assert.Equal(minorVersion, attribute.MinorVersion);
+        }
+    }
+}

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/UnmanagedFunctionPointerAttributeTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/UnmanagedFunctionPointerAttributeTests.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Runtime.InteropServices.Tests
+{
+    public class UnmanagedFunctionPointerAttributeTests
+    {
+        [Theory]
+        [InlineData((CallingConvention)(-1))]
+        [InlineData(CallingConvention.Cdecl)]
+        [InlineData((CallingConvention)int.MaxValue)]
+        public void Ctor_CallingConvention(CallingConvention callingConvention)
+        {
+            var attribute = new UnmanagedFunctionPointerAttribute(callingConvention);
+            Assert.Equal(callingConvention, attribute.CallingConvention);
+        }
+    }
+}


### PR DESCRIPTION
Had these in my backlog from last week - can now send in because it won't cause merge conflicts.

The tests are pretty basic, just added for test coverage for constructors of attributes etc. etc.