### PR TITLE
Nano only supports x64 so only test it for the x64 legs

### DIFF
--- a/buildpipeline/windows.groovy
+++ b/buildpipeline/windows.groovy
@@ -81,9 +81,12 @@ simpleNode('Windows_NT','latest') {
 
                 // Target queues
                 def targetHelixQueues = ['Windows.10.Amd64.Open',
-                                         'Windows.10.Nano.Amd64.Open',
                                          'Windows.7.Amd64.Open',
                                          'Windows.81.Amd64.Open']
+
+                if (params.AGroup == 'x64') {
+                    targetHelixQueues += ['Windows.10.Nano.Amd64.Open']
+                }
 
                 bat "\"%VS140COMNTOOLS%\\VsDevCmd.bat\" && msbuild src\\upload-tests.proj /p:ArchGroup=${params.AGroup} /p:ConfigurationGroup=${params.CGroup} /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:HelixJobType=test/functional/cli/ /p:HelixSource=${helixSource} /p:BuildMoniker=${helixBuild} /p:HelixCreator=${helixCreator} /p:CloudDropAccountName=dotnetbuilddrops /p:CloudResultsAccountName=dotnetjobresults /p:CloudDropAccessToken=%CloudDropAccessToken% /p:CloudResultsAccessToken=%OutputCloudResultsAccessToken% /p:HelixApiEndpoint=https://helix.dot.net/api/2017-04-14/jobs /p:TargetQueues=\"${targetHelixQueues.join(',')}\" /p:HelixLogFolder= /p:HelixLogFolder=${WORKSPACE}\\${logFolder}\\ /p:HelixCorrelationInfoFileName=SubmittedHelixRuns.txt"
 


### PR DESCRIPTION
@MattGal @danmosemsft this should limit the Nano test runs to just x64. 