### PR TITLE
Re-enabling CookieContainer test on uapaot

### DIFF
--- a/src/System.Net.Primitives/tests/FunctionalTests/CookieContainerTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/CookieContainerTest.cs
@@ -151,7 +151,6 @@ namespace System.Net.Primitives.Functional.Tests
 
         [Theory]
         [MemberData(nameof(SetCookiesInvalidData))]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/20482", TargetFrameworkMonikers.UapAot)]
         public static void SetCookies_InvalidData_Throws(Uri uri, string cookieHeader)
         {
             CookieContainer cc = new CookieContainer();


### PR DESCRIPTION
Reverts dotnet/corefx#20484 since test has now been fixed based on @tijoytom 's comment here: https://github.com/dotnet/corefx/issues/20482#issuecomment-309962895

