### PR TITLE
[release/2.0.0] Return Linux NetworkInterface speed as bits per second, not megabits.

### DIFF
--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxNetworkInterface.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxNetworkInterface.cs
@@ -195,7 +195,10 @@ namespace System.Net.NetworkInformation
             try
             {
                 string path = Path.Combine(NetworkFiles.SysClassNetFolder, name, NetworkFiles.SpeedFileName);
-                return StringParsingHelpers.ParseRawLongFile(path);
+                long megabitsPerSecond = StringParsingHelpers.ParseRawLongFile(path);
+                return megabitsPerSecond == -1
+                    ? megabitsPerSecond
+                    : megabitsPerSecond * 1_000_000; // Value must be returned in bits per second, not megabits.
             }
             catch (Exception) // Ignore any problems accessing or parsing the file.
             {


### PR DESCRIPTION
Direct port of #21272 to release/2.0.0.

Pending approval, do not merge.