### PR TITLE
Enabling Multifile ILC Tests for uapaot-Release-x64 configuration

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-2.0.0-prerelease-01720-02
+2.0.0-prerelease-01721-01

--- a/dir.props
+++ b/dir.props
@@ -245,6 +245,12 @@
     <SymbolPackageOutputPath Condition="'$(SymbolPackageOutputPath)'==''">$(PackageOutputPath)symbols/</SymbolPackageOutputPath>
   </PropertyGroup>
 
+  <!-- Properties related to multi-file mode for ILC tests -->
+  <PropertyGroup>
+    <!-- Only enable multi-file for Uapaot-Release-x64 for now -->
+    <EnableMultiFileILCTests Condition="'$(TargetGroup)' == 'uapaot' And '$(ConfigurationGroup)' == 'Release' And '$(ArchGroup)' == 'x64'">true</EnableMultiFileILCTests>
+  </PropertyGroup>
+
   <PropertyGroup>
     <OptionalToolingJsonPath>$(ProjectDir)\external\test-runtime\optional.json</OptionalToolingJsonPath>
   </PropertyGroup>

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -39,4 +39,10 @@
     </TraversalBuildDependsOn>
   </PropertyGroup>
 
+  <!-- Generate the shared library for running ILC tests for configuration Release-x64 -->
+  <Target Name="GenerateSharedLibraryForILC" AfterTargets="BuildAllProjects" Condition="'$(EnableMultiFileILCTests)' == 'true'">
+    <Message Importance="High" Text="Generating shared library for running ILC tests." Condition="Exists('$(TestHostRootPath)\TestILC\ilc.exe')" />
+    <Exec Command="$(TestHostRootPath)\TestILC\ilc.exe -buildSharedAssemblies -buildType ret -frameworkPath &quot;$(ILCFXInputFolder)&quot;" StandardOutputImportance="Low" Condition="Exists('$(TestHostRootPath)\TestILC\ilc.exe')" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
cc: @danmosemsft @joshfree @tijoytom @botaberg @yizhang82 

This will switch the Release-x64 configuration tests to run on multi-file mode instead of single-file.