### PR TITLE
Allow Json.NET deserialization of ObservableCollection

### DIFF
--- a/src/System.ObjectModel/src/System/Collections/ObjectModel/ObservableCollection.cs
+++ b/src/System.ObjectModel/src/System/Collections/ObjectModel/ObservableCollection.cs
@@ -375,8 +375,11 @@ namespace System.Collections.ObjectModel
         [OnDeserialized]
         private void OnDeserialized(StreamingContext context)
         {
-            _blockReentrancyCount = _monitor._busyCount;
-            _monitor._collection = this;
+            if (_monitor != null)
+            {
+                _blockReentrancyCount = _monitor._busyCount;
+                _monitor._collection = this;
+            }
         }
         #endregion Private Methods
 


### PR DESCRIPTION
Json.NET serializes the collection by enumerating it, without taking into account any of its fields like the binary serializer does, and deserializes it by adding the items back to the collection, without initializing the fields. However, it does still call the `OnSerializing`/`OnSerialized`/`OnDeserializing`/`OnDeserialized` methods.

When it calls `OnDeserialized`, a NullRef exception is thrown when we try to access the `_monitor` field because the field has not been initialized, unlike with binary deserialization, where the field would have been initialized from the serialized binary data.

A workaround is to simply check `if (_monitor != null)` before accessing it in `OnDeserialized`.

Fixes #21304

cc: @vitek-karas, @ViktorHofer