### PR TITLE
Fix HttpClientHandler.DefaultProxyCredential on NETFX

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Net46.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Net46.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Globalization;
@@ -525,8 +526,12 @@ namespace System.Net.Http
                 webRequest.ServerCertificateValidationCallback = ServerCertificateValidationCallback;
             }
 
-            if (_defaultProxyCredentials != null && webRequest.Proxy != null)
+            if (_defaultProxyCredentials != null && _useProxy && _proxy == null)
             {
+                // The HttpClientHandler has specified to use a proxy but has not
+                // set an explicit IWebProxy. That means to use the system default
+                // proxy setting object which is the default value of webRequest.Proxy.
+                Debug.Assert(webRequest.Proxy != null);
                 webRequest.Proxy.Credentials = _defaultProxyCredentials;
             }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.DefaultProxyCredentials.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.DefaultProxyCredentials.cs
@@ -12,7 +12,7 @@ namespace System.Net.Http.Functional.Tests
 {
     using Configuration = System.Net.Test.Common.Configuration;
 
-    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.NetFramework, "uap: dotnet/corefx #20010, netfx: dotnet/corefx #16805")]
+    [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
     public class HttpClientHandler_DefaultProxyCredentials_Test : RemoteExecutorTestBase
     {
         [Fact]


### PR DESCRIPTION
This bug was discovered in internal testing when this code was being
ported to .NET Framework vNext.  Due to all these tests being previously
disabled on NETFX, the bug was missed.

The HttpClientHandler.DefaultProxyCredentials property is only used when
an explicit proxy is not specified (HttpClientHandler.Proxy==null) but a
proxy is still desired (HttpClientHandler.UseProxy==true). In this case,
the semantics implied are to use the system default proxy settings to
find a proxy.  In that case, the credentials specified by
DefaultProxyCredentials should be passed to the webrequest.Proxy object
which, by default, points to the system proxy.