### PR TITLE
Fix TypeConverter tests on UAP

### DIFF
--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/CultureInfoConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/CultureInfoConverter.cs
@@ -27,6 +27,7 @@ namespace System.ComponentModel
         ///      Retrieves the "default" name for our culture.
         /// </summary>
         private string DefaultCultureString => SR.CultureInfoConverterDefaultCultureString;
+        const string DefaultInvariantCultureString = "(Default)";
 
         /// <summary>
         ///      Retrieves the Name for a input CultureInfo.
@@ -86,68 +87,58 @@ namespace System.ComponentModel
                 }
                 CultureInfo retVal = null;
 
-                CultureInfo currentUICulture = CultureInfo.CurrentUICulture;
-
+                string defaultCultureString = DefaultCultureString;
                 if (culture != null && culture.Equals(CultureInfo.InvariantCulture))
                 {
-                    CultureInfo.CurrentUICulture = culture;
+                    defaultCultureString = DefaultInvariantCultureString;
                 }
 
-                try
+                // Look for the default culture info.
+                //
+                if (text == null || text.Length == 0 || string.Compare(text, defaultCultureString, StringComparison.Ordinal) == 0)
                 {
-                    // Look for the default culture info.
-                    //
-                    if (text == null || text.Length == 0 || string.Compare(text, DefaultCultureString, StringComparison.Ordinal) == 0)
-                    {
-                        retVal = CultureInfo.InvariantCulture;
-                    }
+                    retVal = CultureInfo.InvariantCulture;
+                }
 
-                    // Now look in our set of installed cultures.
-                    //
-                    if (retVal == null)
+                // Now look in our set of installed cultures.
+                //
+                if (retVal == null)
+                {
+                    foreach (CultureInfo info in GetStandardValues(context))
                     {
-                        foreach (CultureInfo info in GetStandardValues(context))
+                        if (info != null && string.Compare(GetCultureName(info), text, StringComparison.Ordinal) == 0)
                         {
-                            if (info != null && string.Compare(GetCultureName(info), text, StringComparison.Ordinal) == 0)
-                            {
-                                retVal = info;
-                                break;
-                            }
+                            retVal = info;
+                            break;
                         }
-                       
-                    }
-
-                    // Now try to create a new culture info from this value
-                    //
-                    if (retVal == null)
-                    {
-                        try
-                        {
-                            retVal = new CultureInfo(text);
-                        }
-                        catch { }
-                    }
-
-                    // Finally, try to find a partial match
-                    //
-                    if (retVal == null)
-                    {
-                        text = text.ToLower(CultureInfo.CurrentCulture);
-                        foreach (CultureInfo info in _values)
-                        {
-                            if (info != null && GetCultureName(info).ToLower(CultureInfo.CurrentCulture).StartsWith(text))
-                            {
-                                retVal = info;
-                                break;
-                            }
-                        }
-                        
                     }
                 }
 
-                finally
+                // Now try to create a new culture info from this value
+                //
+                if (retVal == null)
                 {
-                    CultureInfo.CurrentUICulture = culture;
+                    try
+                    {
+                        retVal = new CultureInfo(text);
+                    }
+                    catch { }
+                }
+
+                // Finally, try to find a partial match
+                //
+                if (retVal == null)
+                {
+                    text = text.ToLower(CultureInfo.CurrentCulture);
+                    foreach (CultureInfo info in _values)
+                    {
+                        if (info != null && GetCultureName(info).ToLower(CultureInfo.CurrentCulture).StartsWith(text))
+                        {
+                            retVal = info;
+                            break;
+                        }
+                    }
+
                 }
 
                 // No good.  We can't support it.
@@ -179,27 +170,19 @@ namespace System.ComponentModel
             if (destinationType == typeof(string))
             {
                 string retVal;
-                CultureInfo currentUICulture = CultureInfo.CurrentUICulture;
-
+                string defaultCultureString = DefaultCultureString;
                 if (culture != null && culture.Equals(CultureInfo.InvariantCulture))
                 {
-                    CultureInfo.CurrentUICulture = culture;
+                    defaultCultureString = DefaultInvariantCultureString;
                 }
 
-                try
+                if (value == null || value == CultureInfo.InvariantCulture)
                 {
-                    if (value == null || value == CultureInfo.InvariantCulture)
-                    {
-                        retVal = DefaultCultureString;
-                    }
-                    else
-                    {
-                        retVal = GetCultureName(((CultureInfo)value));
-                    }
+                    retVal = defaultCultureString;
                 }
-                finally
+                else
                 {
-                    CultureInfo.CurrentUICulture = culture;
+                    retVal = GetCultureName(((CultureInfo)value));
                 }
 
                 return retVal;

--- a/src/System.ComponentModel.TypeConverter/tests/ConverterTestBase.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/ConverterTestBase.cs
@@ -2,12 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Globalization;
 using Xunit;
 
 namespace System.ComponentModel.Tests
 {
-    public class ConverterTestBase
+    public class ConverterTestBase : RemoteExecutorTestBase
     {
         public static void CanConvertTo_WithContext(object[,] data, TypeConverter converter)
         {

--- a/src/System.ComponentModel.TypeConverter/tests/DateTimeConverterTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/DateTimeConverterTests.cs
@@ -48,20 +48,25 @@ namespace System.ComponentModel.Tests
         [Fact]
         public static void ConvertTo_WithContext()
         {
-            DateTimeFormatInfo formatInfo = (DateTimeFormatInfo)CultureInfo.CurrentCulture.GetFormat(typeof(DateTimeFormatInfo));
-            string formatWithTime = formatInfo.ShortDatePattern + " " + formatInfo.ShortTimePattern;
-            string format = formatInfo.ShortDatePattern;
-            DateTime testDateAndTime = new DateTime(1998, 12, 5, 22, 30, 30);
+            RemoteInvoke(() => {
+                CultureInfo.CurrentCulture = new CultureInfo("pl-PL");
+                DateTimeFormatInfo formatInfo = (DateTimeFormatInfo)CultureInfo.CurrentCulture.GetFormat(typeof(DateTimeFormatInfo));
+                string formatWithTime = formatInfo.ShortDatePattern + " " + formatInfo.ShortTimePattern;
+                string format = formatInfo.ShortDatePattern;
+                DateTime testDateAndTime = new DateTime(1998, 12, 5, 22, 30, 30);
 
-            ConvertTo_WithContext(new object[5, 3]
-                {
+                ConvertTo_WithContext(new object[5, 3]
+                    {
                     { DateTimeConverterTests.s_testDate, DateTimeConverterTests.s_testDate.ToString(format, CultureInfo.CurrentCulture), null },
                     { testDateAndTime, testDateAndTime.ToString(formatWithTime, CultureInfo.CurrentCulture), null },
                     { DateTime.MinValue, string.Empty, null },
                     { DateTimeConverterTests.s_testDate, "1998-12-05", CultureInfo.InvariantCulture },
                     { testDateAndTime, "12/05/1998 22:30:30", CultureInfo.InvariantCulture }
-                },
-                DateTimeConverterTests.s_converter);
+                    },
+                    DateTimeConverterTests.s_converter);
+
+                return SuccessExitCode;
+            });
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/tests/DateTimeOffsetConverterTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/DateTimeOffsetConverterTests.cs
@@ -48,20 +48,27 @@ namespace System.ComponentModel.Tests
         [Fact]
         public static void ConvertTo_WithContext()
         {
-            DateTimeFormatInfo formatInfo = (DateTimeFormatInfo)CultureInfo.CurrentCulture.GetFormat(typeof(DateTimeFormatInfo));
-            string formatWithTime = formatInfo.ShortDatePattern + " " + formatInfo.ShortTimePattern + " zzz";
-            string format = formatInfo.ShortDatePattern + " zzz";
-            DateTimeOffset testDateAndTime = new DateTimeOffset(new DateTime(1998, 12, 5, 22, 30, 30));
+            RemoteInvoke(() =>
+            {
+                CultureInfo.CurrentCulture = new CultureInfo("pl-PL");
 
-            ConvertTo_WithContext(new object[5, 3]
-                {
+                DateTimeFormatInfo formatInfo = (DateTimeFormatInfo)CultureInfo.CurrentCulture.GetFormat(typeof(DateTimeFormatInfo));
+                string formatWithTime = formatInfo.ShortDatePattern + " " + formatInfo.ShortTimePattern + " zzz";
+                string format = formatInfo.ShortDatePattern + " zzz";
+                DateTimeOffset testDateAndTime = new DateTimeOffset(new DateTime(1998, 12, 5, 22, 30, 30));
+
+                ConvertTo_WithContext(new object[5, 3]
+                    {
                     { DateTimeOffsetConverterTests.s_testOffset, DateTimeOffsetConverterTests.s_testOffset.ToString(format, CultureInfo.CurrentCulture), null },
                     { testDateAndTime, testDateAndTime.ToString(formatWithTime, CultureInfo.CurrentCulture), null },
                     { DateTimeOffset.MinValue, string.Empty, null },
                     { DateTimeOffsetConverterTests.s_testOffset, DateTimeOffsetConverterTests.s_testOffset.ToString("yyyy-MM-dd zzz", CultureInfo.InvariantCulture), CultureInfo.InvariantCulture },
                     { testDateAndTime, testDateAndTime.ToString(CultureInfo.InvariantCulture), CultureInfo.InvariantCulture }
-                },
-                DateTimeOffsetConverterTests.s_converter);
+                    },
+                    DateTimeOffsetConverterTests.s_converter);
+
+                return SuccessExitCode;
+            });
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj
+++ b/src/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj
@@ -85,5 +85,11 @@
     <Compile Include="InstanceDescriptorTests.cs" />
     <Compile Include="Security\Authentication\ExtendedProtection\ExtendedProtectionPolicyTypeConverterTests.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
+      <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
+      <Name>RemoteExecutorConsoleApp</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.ComponentModel.TypeConverter/tests/TypeConverterTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/TypeConverterTests.cs
@@ -2,12 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Globalization;
 using Xunit;
 
 namespace System.ComponentModel.Tests
 {
-    public class TypeConverterTests : TypeConverter
+    public class TypeConverterTests : RemoteExecutorTestBase
     {
         public static TypeConverter s_converter = new TypeConverter();
         public static ITypeDescriptorContext s_context = new MyTypeDescriptorContext();
@@ -82,28 +83,34 @@ namespace System.ComponentModel.Tests
         [Fact]
         public static void ConvertTo_WithContext()
         {
-            Assert.Throws<ArgumentNullException>(
+            RemoteInvoke(() =>
+            {
+                CultureInfo.CurrentCulture = new CultureInfo("pl-PL");
+
+                Assert.Throws<ArgumentNullException>(
                 () => TypeConverterTests.s_converter.ConvertTo(TypeConverterTests.s_context, null, TypeConverterTests.c_conversionInputValue, null));
 
-            Assert.Throws<NotSupportedException>(
-                () => TypeConverterTests.s_converter.ConvertTo(TypeConverterTests.s_context, null, TypeConverterTests.c_conversionInputValue, typeof(int)));
+                Assert.Throws<NotSupportedException>(
+                    () => TypeConverterTests.s_converter.ConvertTo(TypeConverterTests.s_context, null, TypeConverterTests.c_conversionInputValue, typeof(int)));
 
-            object o = TypeConverterTests.s_converter.ConvertTo(
-                TypeConverterTests.s_context, null, TypeConverterTests.c_conversionInputValue, typeof(string));
-            TypeConverterTests.VerifyConversionToString(o);
+                object o = TypeConverterTests.s_converter.ConvertTo(
+                    TypeConverterTests.s_context, null, TypeConverterTests.c_conversionInputValue, typeof(string));
+                TypeConverterTests.VerifyConversionToString(o);
 
-            o = TypeConverterTests.s_converter.ConvertTo(
-                TypeConverterTests.s_context, CultureInfo.CurrentCulture, TypeConverterTests.c_conversionInputValue, typeof(string));
-            TypeConverterTests.VerifyConversionToString(o);
+                o = TypeConverterTests.s_converter.ConvertTo(
+                    TypeConverterTests.s_context, CultureInfo.CurrentCulture, TypeConverterTests.c_conversionInputValue, typeof(string));
+                TypeConverterTests.VerifyConversionToString(o);
 
-            o = TypeConverterTests.s_converter.ConvertTo(
-                TypeConverterTests.s_context, CultureInfo.InvariantCulture, TypeConverterTests.c_conversionInputValue, typeof(string));
-            TypeConverterTests.VerifyConversionToString(o);
+                o = TypeConverterTests.s_converter.ConvertTo(
+                    TypeConverterTests.s_context, CultureInfo.InvariantCulture, TypeConverterTests.c_conversionInputValue, typeof(string));
+                TypeConverterTests.VerifyConversionToString(o);
 
-            string s = TypeConverterTests.s_converter.ConvertTo(
-                TypeConverterTests.s_context, CultureInfo.InvariantCulture, new FormattableClass(), typeof(string)) as string;
-            Assert.NotNull(s);
-            Assert.Equal(FormattableClass.Token, s);
+                string s = TypeConverterTests.s_converter.ConvertTo(
+                    TypeConverterTests.s_context, CultureInfo.InvariantCulture, new FormattableClass(), typeof(string)) as string;
+                Assert.NotNull(s);
+                Assert.Equal(FormattableClass.Token, s);
+                return SuccessExitCode;
+            });
         }
 
         [Fact]
@@ -138,18 +145,29 @@ namespace System.ComponentModel.Tests
 
         private void RunProtectedMethods()
         {
-            Assert.Throws<NotSupportedException>(() => GetConvertFromException(null));
-            Assert.Throws<NotSupportedException>(() => GetConvertFromException("1"));
-            Assert.Throws<NotSupportedException>(() => GetConvertFromException(new BaseClass()));
-            Assert.Throws<NotSupportedException>(() => GetConvertToException(null, typeof(int)));
-            Assert.Throws<NotSupportedException>(() => GetConvertToException("1", typeof(int)));
-            Assert.Throws<NotSupportedException>(() => GetConvertToException(new BaseClass(), typeof(BaseClass)));
+            var tc = new TypeConverterHelper();
+            tc.RunProtectedMethods();
         }
 
         private static void VerifyConversionToString(object o)
         {
             Assert.True(o is string);
             Assert.Equal(TypeConverterTests.c_conversionResult, (string)o);
+        }
+
+        private class TypeConverterHelper : TypeConverter
+        {
+            public void RunProtectedMethods()
+            {
+                var tc = new TypeConverter();
+
+                Assert.Throws<NotSupportedException>(() => GetConvertFromException(null));
+                Assert.Throws<NotSupportedException>(() => GetConvertFromException("1"));
+                Assert.Throws<NotSupportedException>(() => GetConvertFromException(new BaseClass()));
+                Assert.Throws<NotSupportedException>(() => GetConvertToException(null, typeof(int)));
+                Assert.Throws<NotSupportedException>(() => GetConvertToException("1", typeof(int)));
+                Assert.Throws<NotSupportedException>(() => GetConvertToException(new BaseClass(), typeof(BaseClass)));
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/21330

Background: Tests were flaky because TypeConverter (product) is temporarily changing UI culture which is making tests fail as they expect `CultureInfo.CurrentCulture != CultureInfo.InvariantCulture`

This includes two fixes, each of them separately fixes the issue:
- product fix to not do that
- tests use RemoteExecutor and override culture from within

I recommend looking at this diff with `&w=1` / `?w=1`:
https://github.com/dotnet/corefx/commit/a246a010a20f4ecd70585527b7f15f8421fab724?w=1

cc: @tarekgh - Thank you a lot for help on this!
