### PR TITLE
Properly dispose of all resources in System.Drawing tests

### DIFF
--- a/src/System.Drawing.Common/tests/Drawing2D/MatrixTests.cs
+++ b/src/System.Drawing.Common/tests/Drawing2D/MatrixTests.cs
@@ -34,12 +34,14 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void Ctor_Default()
         {
-            var matrix = new Matrix();
-            Assert.Equal(new float[] { 1, 0, 0, 1, 0, 0 }, matrix.Elements);
-            Assert.True(matrix.IsIdentity);
-            Assert.True(matrix.IsInvertible);
-            Assert.Equal(0, matrix.OffsetX);
-            Assert.Equal(0, matrix.OffsetY);
+            using (var matrix = new Matrix())
+            {
+                Assert.Equal(new float[] { 1, 0, 0, 1, 0, 0 }, matrix.Elements);
+                Assert.True(matrix.IsIdentity);
+                Assert.True(matrix.IsInvertible);
+                Assert.Equal(0, matrix.OffsetX);
+                Assert.Equal(0, matrix.OffsetY);
+            }
         }
 
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -73,12 +75,14 @@ namespace System.Drawing.Drawing2D.Tests
         [InlineData(1.0009f, 0.0009f, -0.0009f, 0.99995f, 0, 0, false, true)]
         public void Ctor_Elements(float m11, float m12, float m21, float m22, float dx, float dy, bool isIdentity, bool isInvertible)
         {
-            var matrix = new Matrix(m11, m12, m21, m22, dx, dy);
-            Assert.Equal(new float[] { m11, m12, m21, m22, dx, dy }, matrix.Elements);
-            Assert.Equal(isIdentity, matrix.IsIdentity);
-            Assert.Equal(isInvertible, matrix.IsInvertible);
-            Assert.Equal(dx, matrix.OffsetX);
-            Assert.Equal(dy, matrix.OffsetY);
+            using (var matrix = new Matrix(m11, m12, m21, m22, dx, dy))
+            {
+                Assert.Equal(new float[] { m11, m12, m21, m22, dx, dy }, matrix.Elements);
+                Assert.Equal(isIdentity, matrix.IsIdentity);
+                Assert.Equal(isInvertible, matrix.IsInvertible);
+                Assert.Equal(dx, matrix.OffsetX);
+                Assert.Equal(dy, matrix.OffsetY);
+            }
         }
 
         public static IEnumerable<object[]> Ctor_Rectangle_Points_TestData()
@@ -93,24 +97,28 @@ namespace System.Drawing.Drawing2D.Tests
         [MemberData(nameof(Ctor_Rectangle_Points_TestData))]
         public void Ctor_Rectangle_Points(Rectangle rect, Point[] plgpnts, float[] expectedElements, bool isIdentity, bool isInvertible)
         {
-            var matrix = new Matrix(rect, plgpnts);
-            Assert.Equal(expectedElements, matrix.Elements);
-            Assert.Equal(isIdentity, matrix.IsIdentity);
-            Assert.Equal(isInvertible, matrix.IsInvertible);
-            Assert.Equal(expectedElements[4], matrix.OffsetX);
-            Assert.Equal(expectedElements[5], matrix.OffsetY);
+            using (var matrix = new Matrix(rect, plgpnts))
+            {
+                Assert.Equal(expectedElements, matrix.Elements);
+                Assert.Equal(isIdentity, matrix.IsIdentity);
+                Assert.Equal(isInvertible, matrix.IsInvertible);
+                Assert.Equal(expectedElements[4], matrix.OffsetX);
+                Assert.Equal(expectedElements[5], matrix.OffsetY);
+            }
         }
 
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [MemberData(nameof(Ctor_Rectangle_Points_TestData))]
         public void Ctor_RectangleF_Points(Rectangle rect, Point[] plgpnts, float[] expectedElements, bool isIdentity, bool isInvertible)
         {
-            var matrix = new Matrix(rect, plgpnts.Select(p => (PointF)p).ToArray());
-            Assert.Equal(expectedElements, matrix.Elements);
-            Assert.Equal(isIdentity, matrix.IsIdentity);
-            Assert.Equal(isInvertible, matrix.IsInvertible);
-            Assert.Equal(expectedElements[4], matrix.OffsetX);
-            Assert.Equal(expectedElements[5], matrix.OffsetY);
+            using (var matrix = new Matrix(rect, plgpnts.Select(p => (PointF)p).ToArray()))
+            {
+                Assert.Equal(expectedElements, matrix.Elements);
+                Assert.Equal(isIdentity, matrix.IsIdentity);
+                Assert.Equal(isInvertible, matrix.IsInvertible);
+                Assert.Equal(expectedElements[4], matrix.OffsetX);
+                Assert.Equal(expectedElements[5], matrix.OffsetY);
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -147,10 +155,12 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void Clone_Matrix_ReturnsExpected()
         {
-            var matrix = new Matrix(1, 2, 3, 4, 5, 6);
-            Matrix clone = Assert.IsType<Matrix>(matrix.Clone());
-            Assert.NotSame(matrix, clone);
-            Assert.Equal(new float[] { 1, 2, 3, 4, 5, 6 }, clone.Elements);
+            using (var matrix = new Matrix(1, 2, 3, 4, 5, 6))
+            using (Matrix clone = Assert.IsType<Matrix>(matrix.Clone()))
+            {
+                Assert.NotSame(matrix, clone);
+                Assert.Equal(new float[] { 1, 2, 3, 4, 5, 6 }, clone.Elements);
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -158,6 +168,7 @@ namespace System.Drawing.Drawing2D.Tests
         {
             var matrix = new Matrix();
             matrix.Dispose();
+
             Assert.Throws<ArgumentException>(null, () => matrix.Clone());
         }
 
@@ -173,14 +184,14 @@ namespace System.Drawing.Drawing2D.Tests
 
             var matrix = new Matrix(1, 2, 3, 4, 5, 6);
             yield return new object[] { matrix, matrix, true };
-            yield return new object[] { matrix, matrix.Clone(), true };
-            yield return new object[] { matrix, new Matrix(1, 2, 3, 4, 5, 6), true };
-            yield return new object[] { matrix, new Matrix(2, 2, 3, 4, 5, 6), false };
-            yield return new object[] { matrix, new Matrix(1, 3, 3, 4, 5, 6), false };
-            yield return new object[] { matrix, new Matrix(1, 2, 4, 4, 5, 6), false };
-            yield return new object[] { matrix, new Matrix(1, 2, 3, 5, 5, 6), false };
-            yield return new object[] { matrix, new Matrix(1, 2, 3, 4, 6, 6), false };
-            yield return new object[] { matrix, new Matrix(1, 2, 3, 4, 5, 7), false };
+            yield return new object[] { matrix.Clone(), matrix.Clone(), true };
+            yield return new object[] { matrix.Clone(), new Matrix(1, 2, 3, 4, 5, 6), true };
+            yield return new object[] { matrix.Clone(), new Matrix(2, 2, 3, 4, 5, 6), false };
+            yield return new object[] { matrix.Clone(), new Matrix(1, 3, 3, 4, 5, 6), false };
+            yield return new object[] { matrix.Clone(), new Matrix(1, 2, 4, 4, 5, 6), false };
+            yield return new object[] { matrix.Clone(), new Matrix(1, 2, 3, 5, 5, 6), false };
+            yield return new object[] { matrix.Clone(), new Matrix(1, 2, 3, 4, 6, 6), false };
+            yield return new object[] { matrix.Clone(), new Matrix(1, 2, 3, 4, 5, 7), false };
 
             yield return new object[] { new Matrix(), null, false };
             yield return new object[] { new Matrix(), new object(), false };
@@ -190,10 +201,18 @@ namespace System.Drawing.Drawing2D.Tests
         [MemberData(nameof(Equals_TestData))]
         public void Equals_Other_ReturnsExpected(Matrix matrix, object other, bool expected)
         {
-            Assert.Equal(expected, matrix.Equals(other));
-            if (other is Matrix otherMatrix)
+            try
             {
-                Assert.Equal(object.ReferenceEquals(matrix, other), matrix.GetHashCode().Equals(other.GetHashCode()));
+                Assert.Equal(expected, matrix.Equals(other));
+                if (other is Matrix otherMatrix)
+                {
+                    Assert.Equal(ReferenceEquals(matrix, other), matrix.GetHashCode().Equals(other.GetHashCode()));
+                }
+            }
+            finally
+            {
+                matrix.Dispose();
+                (other as IDisposable)?.Dispose();
             }
         }
 
@@ -202,6 +221,7 @@ namespace System.Drawing.Drawing2D.Tests
         {
             var matrix = new Matrix();
             matrix.Dispose();
+
             Assert.Throws<ArgumentException>(null, () => matrix.Equals(new Matrix()));
         }
 
@@ -210,6 +230,7 @@ namespace System.Drawing.Drawing2D.Tests
         {
             var matrix = new Matrix();
             matrix.Dispose();
+
             Assert.Throws<ArgumentException>(null, () => new Matrix().Equals(matrix));
         }
 
@@ -218,6 +239,7 @@ namespace System.Drawing.Drawing2D.Tests
         {
             var matrix = new Matrix();
             matrix.Dispose();
+
             Assert.Throws<ArgumentException>(null, () => matrix.Elements);
         }
 
@@ -232,8 +254,15 @@ namespace System.Drawing.Drawing2D.Tests
         [MemberData(nameof(Invert_TestData))]
         public void Invert_Matrix_Success(Matrix matrix, float[] expectedElements)
         {
-            matrix.Invert();
-            Assert.Equal(expectedElements, matrix.Elements);
+            try
+            {
+                matrix.Invert();
+                Assert.Equal(expectedElements, matrix.Elements);
+            }
+            finally
+            {
+                matrix.Dispose();
+            }
         }
 
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -242,13 +271,20 @@ namespace System.Drawing.Drawing2D.Tests
         [InlineData(float.NegativeInfinity)]
         public void Invert_FloatBounds_ThrowsArgumentException(float f)
         {
-            Assert.Throws<ArgumentException>(null, () => new Matrix(f, 2, 3, 4, 5, 6).Invert());
-            Assert.Throws<ArgumentException>(null, () => new Matrix(1, f, 3, 4, 5, 6).Invert());
-            Assert.Throws<ArgumentException>(null, () => new Matrix(1, 2, f, 4, 5, 6).Invert());
-            Assert.Throws<ArgumentException>(null, () => new Matrix(1, 2, 3, f, 5, 6).Invert());
-            Assert.Throws<ArgumentException>(null, () => new Matrix(1, 2, 3, 4, f, 6).Invert());
-            Assert.Throws<ArgumentException>(null, () => new Matrix(1, 2, 3, 4, 5, f).Invert());
-
+            using (var matrix1 = new Matrix(f, 2, 3, 4, 5, 6))
+            using (var matrix2 = new Matrix(1, f, 3, 4, 5, 6))
+            using (var matrix3 = new Matrix(1, 2, f, 4, 5, 6))
+            using (var matrix4 = new Matrix(1, 2, 3, f, 5, 6))
+            using (var matrix5 = new Matrix(1, 2, 3, 4, f, 6))
+            using (var matrix6 = new Matrix(1, 2, 3, 4, 5, f))
+            {
+                Assert.Throws<ArgumentException>(null, () => matrix1.Invert());
+                Assert.Throws<ArgumentException>(null, () => matrix2.Invert());
+                Assert.Throws<ArgumentException>(null, () => matrix3.Invert());
+                Assert.Throws<ArgumentException>(null, () => matrix4.Invert());
+                Assert.Throws<ArgumentException>(null, () => matrix5.Invert());
+                Assert.Throws<ArgumentException>(null, () => matrix6.Invert());
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -256,6 +292,7 @@ namespace System.Drawing.Drawing2D.Tests
         {
             var matrix = new Matrix();
             matrix.Dispose();
+
             Assert.Throws<ArgumentException>(null, () => matrix.Invert());
         }
 
@@ -264,6 +301,7 @@ namespace System.Drawing.Drawing2D.Tests
         {
             var matrix = new Matrix();
             matrix.Dispose();
+
             Assert.Throws<ArgumentException>(null, () => matrix.IsIdentity);
         }
 
@@ -272,6 +310,7 @@ namespace System.Drawing.Drawing2D.Tests
         {
             var matrix = new Matrix();
             matrix.Dispose();
+
             Assert.Throws<ArgumentException>(null, () => matrix.IsInvertible);
         }
 
@@ -306,22 +345,34 @@ namespace System.Drawing.Drawing2D.Tests
         [MemberData(nameof(Multiply_TestData))]
         public void Multiply_Matrix_Success(Matrix matrix, Matrix multiple, MatrixOrder order, float[] expected)
         {
-            if (order == MatrixOrder.Prepend)
+            try
             {
-                Matrix clone1 = matrix.Clone();
-                clone1.Multiply(multiple);
-                Assert.Equal(expected, clone1.Elements);
+                if (order == MatrixOrder.Prepend)
+                {
+                    using (Matrix clone1 = matrix.Clone())
+                    {
+                        clone1.Multiply(multiple);
+                        Assert.Equal(expected, clone1.Elements);
+                    }
+                }
+                matrix.Multiply(multiple, order);
+                Assert.Equal(expected, matrix.Elements);
             }
-            matrix.Multiply(multiple, order);
-            Assert.Equal(expected, matrix.Elements);
+            finally
+            {
+                matrix.Dispose();
+                multiple.Dispose();
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void Multiply_NullMatrix_ThrowsArgumentNullException()
         {
-            var matrix = new Matrix();
-            Assert.Throws<ArgumentNullException>("matrix", () => matrix.Multiply(null));
-            Assert.Throws<ArgumentNullException>("matrix", () => matrix.Multiply(null, MatrixOrder.Prepend));
+            using (var matrix = new Matrix())
+            {
+                Assert.Throws<ArgumentNullException>("matrix", () => matrix.Multiply(null));
+                Assert.Throws<ArgumentNullException>("matrix", () => matrix.Multiply(null, MatrixOrder.Prepend));
+            }
         }
 
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -329,8 +380,11 @@ namespace System.Drawing.Drawing2D.Tests
         [InlineData(MatrixOrder.Append + 1)]
         public void Multiply_InvalidMatrixOrder_ThrowsArgumentException(MatrixOrder order)
         {
-            var matrix = new Matrix();
-            Assert.Throws<ArgumentException>(null, () => matrix.Multiply(new Matrix(), order));
+            using (var matrix = new Matrix())
+            using (var other = new Matrix())
+            {
+                Assert.Throws<ArgumentException>(null, () => matrix.Multiply(other, order));
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -338,28 +392,38 @@ namespace System.Drawing.Drawing2D.Tests
         {
             var matrix = new Matrix();
             matrix.Dispose();
-            Assert.Throws<ArgumentException>(null, () => matrix.Multiply(new Matrix()));
-            Assert.Throws<ArgumentException>(null, () => matrix.Multiply(new Matrix(), MatrixOrder.Prepend));
+
+            using (var other = new Matrix())
+            {
+                Assert.Throws<ArgumentException>(null, () => matrix.Multiply(other));
+                Assert.Throws<ArgumentException>(null, () => matrix.Multiply(other, MatrixOrder.Prepend));
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void Multiply_DisposedMatrix_ThrowsArgumentException()
         {
-            var matrix = new Matrix();
-            matrix.Dispose();
-            Assert.Throws<ArgumentException>(null, () => new Matrix().Multiply(matrix));
-            Assert.Throws<ArgumentException>(null, () => new Matrix().Multiply(matrix, MatrixOrder.Prepend));
+            using (var matrix = new Matrix())
+            {
+                var other = new Matrix();
+                other.Dispose();
+
+                Assert.Throws<ArgumentException>(null, () => matrix.Multiply(other));
+                Assert.Throws<ArgumentException>(null, () => matrix.Multiply(other, MatrixOrder.Prepend));
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void Reset_Matrix_ReturnsExpected()
         {
-            var matrix = new Matrix(1, 2, 3, 4, 5, 6);
-            matrix.Reset();
-            Assert.Equal(new float[] { 1, 0, 0, 1, 0, 0 }, matrix.Elements);
+            using (var matrix = new Matrix(1, 2, 3, 4, 5, 6))
+            {
+                matrix.Reset();
+                Assert.Equal(new float[] { 1, 0, 0, 1, 0, 0 }, matrix.Elements);
 
-            matrix.Reset();
-            Assert.Equal(new float[] { 1, 0, 0, 1, 0, 0 }, matrix.Elements);
+                matrix.Reset();
+                Assert.Equal(new float[] { 1, 0, 0, 1, 0, 0 }, matrix.Elements);
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -367,6 +431,7 @@ namespace System.Drawing.Drawing2D.Tests
         {
             var matrix = new Matrix();
             matrix.Dispose();
+
             Assert.Throws<ArgumentException>(null, () => matrix.Reset());
         }
 
@@ -383,16 +448,16 @@ namespace System.Drawing.Drawing2D.Tests
 
             var rotated45 = new Matrix();
             rotated45.Rotate(45);
-            yield return new object[] { rotated45, 135, PointF.Empty, MatrixOrder.Prepend, new float[] { -1, 0, 0, -1, 0, 0 }, null, false };
-            yield return new object[] { rotated45, 135, PointF.Empty, MatrixOrder.Append, new float[] { -1, 0, 0, -1, 0, 0 }, null, false };
+            yield return new object[] { rotated45.Clone(), 135, PointF.Empty, MatrixOrder.Prepend, new float[] { -1, 0, 0, -1, 0, 0 }, null, false };
+            yield return new object[] { rotated45.Clone(), 135, PointF.Empty, MatrixOrder.Append, new float[] { -1, 0, 0, -1, 0, 0 }, null, false };
 
             yield return new object[] { new Matrix(), 90, PointF.Empty, MatrixOrder.Prepend, new float[] { 0, 1, -1, 0, 0, 0 }, null, false };
             yield return new object[] { new Matrix(), 90, PointF.Empty, MatrixOrder.Append, new float[] { 0, 1, -1, 0, 0, 0 }, null, false };
 
             var rotated90 = new Matrix();
             rotated90.Rotate(90);
-            yield return new object[] { rotated90, 270, PointF.Empty, MatrixOrder.Prepend, new float[] { 1, 0, 0, 1, 0, 0 }, null, true };
-            yield return new object[] { rotated90, 270, PointF.Empty, MatrixOrder.Append, new float[] { 1, 0, 0, 1, 0, 0 }, null, true };
+            yield return new object[] { rotated90.Clone(), 270, PointF.Empty, MatrixOrder.Prepend, new float[] { 1, 0, 0, 1, 0, 0 }, null, true };
+            yield return new object[] { rotated90.Clone(), 270, PointF.Empty, MatrixOrder.Append, new float[] { 1, 0, 0, 1, 0, 0 }, null, true };
 
             yield return new object[] { new Matrix(10, 20, 30, 40, 50, 60), 180, new PointF(10, 10), MatrixOrder.Prepend, new float[] { -10, -20, -30, -40, 850, 1260 }, null, false };
             yield return new object[] { new Matrix(10, 20, 30, 40, 50, 60), 180, new PointF(10, 10), MatrixOrder.Append, new float[] { -10, -20, -30, -40, -30, -40 }, null, false };
@@ -411,34 +476,49 @@ namespace System.Drawing.Drawing2D.Tests
         [MemberData(nameof(Rotate_TestData))]
         public void Rotate_Matrix_Success(Matrix matrix, float angle, PointF point, MatrixOrder order, float[] expectedElements, float[] expectedElementsRotateAt, bool isIdentity)
         {
-            if (order == MatrixOrder.Prepend)
+            try
             {
-                if (point == Point.Empty)
+                if (order == MatrixOrder.Prepend)
                 {
-                    Matrix clone1 = matrix.Clone();
-                    clone1.Rotate(angle);
-                    AssertEqualFloatArray(expectedElements, clone1.Elements);
-                    Assert.Equal(isIdentity, clone1.IsIdentity);
+                    if (point == Point.Empty)
+                    {
+                        using (Matrix clone1 = matrix.Clone())
+                        {
+                            clone1.Rotate(angle);
+                            AssertEqualFloatArray(expectedElements, clone1.Elements);
+                            Assert.Equal(isIdentity, clone1.IsIdentity);
+                        }
+                    }
+
+                    using (Matrix clone2 = matrix.Clone())
+                    {
+                        clone2.RotateAt(angle, point);
+                        AssertEqualFloatArray(expectedElementsRotateAt ?? expectedElements, clone2.Elements);
+                        Assert.False(clone2.IsIdentity);
+                    }
                 }
 
-                Matrix clone2 = matrix.Clone();
-                clone2.RotateAt(angle, point);
-                AssertEqualFloatArray(expectedElementsRotateAt ?? expectedElements, clone2.Elements);
-                Assert.False(clone2.IsIdentity);
-            }
+                if (point == Point.Empty)
+                {
+                    using (Matrix clone3 = matrix.Clone())
+                    {
+                        clone3.Rotate(angle, order);
+                        AssertEqualFloatArray(expectedElements, clone3.Elements);
+                        Assert.Equal(isIdentity, clone3.IsIdentity);
+                    }
+                }
 
-            if (point == Point.Empty)
+                using (Matrix clone4 = matrix.Clone())
+                {
+                    clone4.RotateAt(angle, point, order);
+                    AssertEqualFloatArray(expectedElementsRotateAt ?? expectedElements, clone4.Elements);
+                    Assert.False(clone4.IsIdentity);
+                }
+            }
+            finally
             {
-                Matrix clone3 = matrix.Clone();
-                clone3.Rotate(angle, order);
-                AssertEqualFloatArray(expectedElements, clone3.Elements);
-                Assert.Equal(isIdentity, clone3.IsIdentity);
+                matrix.Dispose();
             }
-
-            Matrix clone4 = matrix.Clone();
-            clone4.RotateAt(angle, point, order);
-            AssertEqualFloatArray(expectedElementsRotateAt ?? expectedElements, clone4.Elements);
-            Assert.False(clone4.IsIdentity);
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -446,6 +526,7 @@ namespace System.Drawing.Drawing2D.Tests
         {
             var matrix = new Matrix();
             matrix.Dispose();
+
             Assert.Throws<ArgumentException>(null, () => matrix.Rotate(1, MatrixOrder.Append));
         }
 
@@ -454,8 +535,10 @@ namespace System.Drawing.Drawing2D.Tests
         [InlineData(MatrixOrder.Append + 1)]
         public void Rotate_InvalidMatrixOrder_ThrowsArgumentException(MatrixOrder order)
         {
-            var matrix = new Matrix();
-            Assert.Throws<ArgumentException>(null, () => matrix.Rotate(1, order));
+            using (var matrix = new Matrix())
+            {
+                Assert.Throws<ArgumentException>(null, () => matrix.Rotate(1, order));
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -463,6 +546,7 @@ namespace System.Drawing.Drawing2D.Tests
         {
             var matrix = new Matrix();
             matrix.Dispose();
+
             Assert.Throws<ArgumentException>(null, () => matrix.RotateAt(1, PointF.Empty));
             Assert.Throws<ArgumentException>(null, () => matrix.RotateAt(1, PointF.Empty, MatrixOrder.Append));
         }
@@ -472,8 +556,10 @@ namespace System.Drawing.Drawing2D.Tests
         [InlineData(MatrixOrder.Append + 1)]
         public void RotateAt_InvalidMatrixOrder_ThrowsArgumentException(MatrixOrder order)
         {
-            var matrix = new Matrix();
-            Assert.Throws<ArgumentException>(null, () => matrix.RotateAt(1, PointF.Empty, order));
+            using (var matrix = new Matrix())
+            {
+                Assert.Throws<ArgumentException>(null, () => matrix.RotateAt(1, PointF.Empty, order));
+            }
         }
 
         public static IEnumerable<object[]> Scale_TestData()
@@ -510,15 +596,24 @@ namespace System.Drawing.Drawing2D.Tests
         [MemberData(nameof(Scale_TestData))]
         public void Scale_Matrix_Succss(Matrix matrix, float scaleX, float scaleY, MatrixOrder order, float[] expectedElements)
         {
-            if (order == MatrixOrder.Prepend)
+            try
             {
-                Matrix clone = matrix.Clone();
-                clone.Scale(scaleX, scaleY);
-                Assert.Equal(expectedElements, clone.Elements);
-            }
+                if (order == MatrixOrder.Prepend)
+                {
+                    using (Matrix clone = matrix.Clone())
+                    {
+                        clone.Scale(scaleX, scaleY);
+                        Assert.Equal(expectedElements, clone.Elements);
+                    }
+                }
 
-            matrix.Scale(scaleX, scaleY, order);
-            Assert.Equal(expectedElements, matrix.Elements);
+                matrix.Scale(scaleX, scaleY, order);
+                Assert.Equal(expectedElements, matrix.Elements);
+            }
+            finally
+            {
+                matrix.Dispose();
+            }
         }
 
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -526,8 +621,10 @@ namespace System.Drawing.Drawing2D.Tests
         [InlineData(MatrixOrder.Append + 1)]
         public void Scale_InvalidMatrixOrder_ThrowsArgumentException(MatrixOrder order)
         {
-            var matrix = new Matrix();
-            Assert.Throws<ArgumentException>(null, () => matrix.Shear(1, 2, order));
+            using (var matrix = new Matrix())
+            {
+                Assert.Throws<ArgumentException>(null, () => matrix.Shear(1, 2, order));
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -535,6 +632,7 @@ namespace System.Drawing.Drawing2D.Tests
         {
             var matrix = new Matrix();
             matrix.Dispose();
+
             Assert.Throws<ArgumentException>(null, () => matrix.Scale(1, 2));
             Assert.Throws<ArgumentException>(null, () => matrix.Scale(1, 2, MatrixOrder.Append));
         }
@@ -573,15 +671,24 @@ namespace System.Drawing.Drawing2D.Tests
         [MemberData(nameof(Shear_TestData))]
         public void Shear_Matrix_Succss(Matrix matrix, float shearX, float shearY, MatrixOrder order, float[] expectedElements)
         {
-            if (order == MatrixOrder.Prepend)
+            try
             {
-                Matrix clone = matrix.Clone();
-                clone.Shear(shearX, shearY);
-                Assert.Equal(expectedElements, clone.Elements);
-            }
+                if (order == MatrixOrder.Prepend)
+                {
+                    using (Matrix clone = matrix.Clone())
+                    {
+                        clone.Shear(shearX, shearY);
+                        Assert.Equal(expectedElements, clone.Elements);
+                    }
+                }
 
-            matrix.Shear(shearX, shearY, order);
-            Assert.Equal(expectedElements, matrix.Elements);
+                matrix.Shear(shearX, shearY, order);
+                Assert.Equal(expectedElements, matrix.Elements);
+            }
+            finally
+            {
+                matrix.Dispose();
+            }
         }
 
 
@@ -590,8 +697,10 @@ namespace System.Drawing.Drawing2D.Tests
         [InlineData(MatrixOrder.Append + 1)]
         public void Shear_InvalidMatrixOrder_ThrowsArgumentException(MatrixOrder order)
         {
-            var matrix = new Matrix();
-            Assert.Throws<ArgumentException>(null, () => matrix.Shear(1, 2, order));
+            using (var matrix = new Matrix())
+            {
+                Assert.Throws<ArgumentException>(null, () => matrix.Shear(1, 2, order));
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -599,6 +708,7 @@ namespace System.Drawing.Drawing2D.Tests
         {
             var matrix = new Matrix();
             matrix.Dispose();
+
             Assert.Throws<ArgumentException>(null, () => matrix.Shear(1, 2));
             Assert.Throws<ArgumentException>(null, () => matrix.Shear(1, 2, MatrixOrder.Append));
         }
@@ -628,15 +738,24 @@ namespace System.Drawing.Drawing2D.Tests
         [MemberData(nameof(Translate_TestData))]
         public void Translate_Matrix_Success(Matrix matrix, float offsetX, float offsetY, MatrixOrder order, float[] expectedElements)
         {
-            if (order == MatrixOrder.Prepend)
+            try
             {
-                Matrix clone = matrix.Clone();
-                clone.Translate(offsetX, offsetY);
-                AssertEqualFloatArray(expectedElements, clone.Elements);
-            }
+                if (order == MatrixOrder.Prepend)
+                {
+                    using (Matrix clone = matrix.Clone())
+                    {
+                        clone.Translate(offsetX, offsetY);
+                        AssertEqualFloatArray(expectedElements, clone.Elements);
+                    }
+                }
 
-            matrix.Translate(offsetX, offsetY, order);
-            AssertEqualFloatArray(expectedElements, matrix.Elements);
+                matrix.Translate(offsetX, offsetY, order);
+                AssertEqualFloatArray(expectedElements, matrix.Elements);
+            }
+            finally
+            {
+                matrix.Dispose();
+            }
         }
 
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -644,8 +763,10 @@ namespace System.Drawing.Drawing2D.Tests
         [InlineData(MatrixOrder.Append + 1)]
         public void Translate_InvalidMatrixOrder_ThrowsArgumentException(MatrixOrder order)
         {
-            var matrix = new Matrix();
-            Assert.Throws<ArgumentException>(null, () => matrix.Translate(1, 2, order));
+            using (var matrix = new Matrix())
+            {
+                Assert.Throws<ArgumentException>(null, () => matrix.Translate(1, 2, order));
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -653,6 +774,7 @@ namespace System.Drawing.Drawing2D.Tests
         {
             var matrix = new Matrix();
             matrix.Dispose();
+
             Assert.Throws<ArgumentException>(null, () => matrix.Translate(1, 2));
             Assert.Throws<ArgumentException>(null, () => matrix.Translate(1, 2, MatrixOrder.Append));
         }
@@ -668,33 +790,51 @@ namespace System.Drawing.Drawing2D.Tests
         [MemberData(nameof(TransformPoints_TestData))]
         public void TransformPoints_Point_Success(Matrix matrix, Point[] points, Point[] expectedPoints)
         {
-            matrix.TransformPoints(points);
-            Assert.Equal(expectedPoints, points);
+            try
+            {
+                matrix.TransformPoints(points);
+                Assert.Equal(expectedPoints, points);
+            }
+            finally
+            {
+                matrix.Dispose();
+            }
         }
 
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [MemberData(nameof(TransformPoints_TestData))]
         public void TransformPoints_PointF_Success(Matrix matrix, Point[] points, Point[] expectedPoints)
         {
-            PointF[] pointFs = points.Select(p => (PointF)p).ToArray();
-            matrix.TransformPoints(pointFs);
-            Assert.Equal(expectedPoints.Select(p => (PointF)p), pointFs);
+            try
+            {
+                PointF[] pointFs = points.Select(p => (PointF)p).ToArray();
+                matrix.TransformPoints(pointFs);
+                Assert.Equal(expectedPoints.Select(p => (PointF)p), pointFs);
+            }
+            finally
+            {
+                matrix.Dispose();
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void TransformPoints_NullPoints_ThrowsArgumentNullException()
         {
-            var matrix = new Matrix();
-            Assert.Throws<ArgumentNullException>("pts", () => matrix.TransformPoints((Point[])null));
-            Assert.Throws<ArgumentNullException>("pts", () => matrix.TransformPoints((PointF[])null));
+            using (var matrix = new Matrix())
+            {
+                Assert.Throws<ArgumentNullException>("pts", () => matrix.TransformPoints((Point[])null));
+                Assert.Throws<ArgumentNullException>("pts", () => matrix.TransformPoints((PointF[])null));
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void TransformPoints_EmptyPoints_ThrowsArgumentException()
         {
-            var matrix = new Matrix();
-            Assert.Throws<ArgumentException>(null, () => matrix.TransformPoints(new Point[0]));
-            Assert.Throws<ArgumentException>(null, () => matrix.TransformPoints(new PointF[0]));
+            using (var matrix = new Matrix())
+            {
+                Assert.Throws<ArgumentException>(null, () => matrix.TransformPoints(new Point[0]));
+                Assert.Throws<ArgumentException>(null, () => matrix.TransformPoints(new PointF[0]));
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -718,43 +858,68 @@ namespace System.Drawing.Drawing2D.Tests
         [MemberData(nameof(TransformVectors_TestData))]
         public void TransformVectors_Point_Success(Matrix matrix, Point[] points, Point[] expectedPoints)
         {
-            matrix.TransformVectors(points);
-            Assert.Equal(expectedPoints, points);
+            try
+            {
+                matrix.TransformVectors(points);
+                Assert.Equal(expectedPoints, points);
+            }
+            finally
+            {
+                matrix.Dispose();
+            }
         }
 
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [MemberData(nameof(TransformVectors_TestData))]
         public void TransformVectors_PointF_Success(Matrix matrix, Point[] points, Point[] expectedPoints)
         {
-            PointF[] pointFs = points.Select(p => (PointF)p).ToArray();
-            matrix.TransformVectors(pointFs);
-            Assert.Equal(expectedPoints.Select(p => (PointF)p), pointFs);
+            try
+            {
+                PointF[] pointFs = points.Select(p => (PointF)p).ToArray();
+                matrix.TransformVectors(pointFs);
+                Assert.Equal(expectedPoints.Select(p => (PointF)p), pointFs);
+            }
+            finally
+            {
+                matrix.Dispose();
+            }
         }
 
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [MemberData(nameof(TransformVectors_TestData))]
         public void VectorTransformPoints_Points_Success(Matrix matrix, Point[] points, Point[] expectedPoints)
         {
-            matrix.VectorTransformPoints(points);
-            Assert.Equal(expectedPoints, points);
+            try
+            {
+                matrix.VectorTransformPoints(points);
+                Assert.Equal(expectedPoints, points);
+            }
+            finally
+            {
+                matrix.Dispose();
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void TransformVectors_NullPoints_ThrowsArgumentNullException()
         {
-            var matrix = new Matrix();
-            Assert.Throws<ArgumentNullException>("pts", () => matrix.VectorTransformPoints(null));
-            Assert.Throws<ArgumentNullException>("pts", () => matrix.TransformVectors((Point[])null));
-            Assert.Throws<ArgumentNullException>("pts", () => matrix.TransformVectors((PointF[])null));
+            using (var matrix = new Matrix())
+            {
+                Assert.Throws<ArgumentNullException>("pts", () => matrix.VectorTransformPoints(null));
+                Assert.Throws<ArgumentNullException>("pts", () => matrix.TransformVectors((Point[])null));
+                Assert.Throws<ArgumentNullException>("pts", () => matrix.TransformVectors((PointF[])null));
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void TransformVectors_EmptyPoints_ThrowsArgumentException()
         {
-            var matrix = new Matrix();
-            Assert.Throws<ArgumentException>(null, () => matrix.VectorTransformPoints(new Point[0]));
-            Assert.Throws<ArgumentException>(null, () => matrix.TransformVectors(new Point[0]));
-            Assert.Throws<ArgumentException>(null, () => matrix.TransformVectors(new PointF[0]));
+            using (var matrix = new Matrix())
+            {
+                Assert.Throws<ArgumentException>(null, () => matrix.VectorTransformPoints(new Point[0]));
+                Assert.Throws<ArgumentException>(null, () => matrix.TransformVectors(new Point[0]));
+                Assert.Throws<ArgumentException>(null, () => matrix.TransformVectors(new PointF[0]));
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]

--- a/src/System.Drawing.Common/tests/IconTests.cs
+++ b/src/System.Drawing.Common/tests/IconTests.cs
@@ -41,10 +41,12 @@ namespace System.Drawing.Tests
         [InlineData("256x256_seven_entries_multiple_bits.ico")]
         public void Ctor_FilePath(string name)
         {
-            var icon = new Icon(Helpers.GetTestBitmapPath(name));
-            Assert.Equal(32, icon.Width);
-            Assert.Equal(32, icon.Height);
-            Assert.Equal(new Size(32, 32), icon.Size);
+            using (var icon = new Icon(Helpers.GetTestBitmapPath(name)))
+            {
+                Assert.Equal(32, icon.Width);
+                Assert.Equal(32, icon.Height);
+                Assert.Equal(new Size(32, 32), icon.Size);
+            }
         }
 
         public static IEnumerable<object[]> Size_TestData()
@@ -71,20 +73,24 @@ namespace System.Drawing.Tests
         [MemberData(nameof(Size_TestData))]
         public void Ctor_FilePath_Width_Height(string fileName, Size size, Size expectedSize)
         {
-            var icon = new Icon(Helpers.GetTestBitmapPath(fileName), size.Width, size.Height);
-            Assert.Equal(expectedSize.Width, icon.Width);
-            Assert.Equal(expectedSize.Height, icon.Height);
-            Assert.Equal(expectedSize, icon.Size);
+            using (var icon = new Icon(Helpers.GetTestBitmapPath(fileName), size.Width, size.Height))
+            {
+                Assert.Equal(expectedSize.Width, icon.Width);
+                Assert.Equal(expectedSize.Height, icon.Height);
+                Assert.Equal(expectedSize, icon.Size);
+            }
         }
 
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [MemberData(nameof(Size_TestData))]
         public void Ctor_FilePath_Size(string fileName, Size size, Size expectedSize)
         {
-            var icon = new Icon(Helpers.GetTestBitmapPath(fileName), size);
-            Assert.Equal(expectedSize.Width, icon.Width);
-            Assert.Equal(expectedSize.Height, icon.Height);
-            Assert.Equal(expectedSize, icon.Size);
+            using (var icon = new Icon(Helpers.GetTestBitmapPath(fileName), size))
+            {
+                Assert.Equal(expectedSize.Width, icon.Width);
+                Assert.Equal(expectedSize.Height, icon.Height);
+                Assert.Equal(expectedSize, icon.Size);
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -112,8 +118,8 @@ namespace System.Drawing.Tests
         public void Ctor_Stream_Width_Height(string fileName, Size size, Size expectedSize)
         {
             using (var stream = new FileStream(Helpers.GetTestBitmapPath(fileName), FileMode.Open))
+            using (var icon = new Icon(stream, size.Width, size.Height))
             {
-                var icon = new Icon(stream, size.Width, size.Height);
                 Assert.Equal(expectedSize.Width, icon.Width);
                 Assert.Equal(expectedSize.Height, icon.Height);
                 Assert.Equal(expectedSize, icon.Size);
@@ -125,8 +131,8 @@ namespace System.Drawing.Tests
         public void Ctor_Stream_Size(string fileName, Size size, Size expectedSize)
         {
             using (var stream = new FileStream(Helpers.GetTestBitmapPath(fileName), FileMode.Open))
+            using (var icon = new Icon(stream, size))
             {
-                var icon = new Icon(stream, size);
                 Assert.Equal(expectedSize.Width, icon.Width);
                 Assert.Equal(expectedSize.Height, icon.Height);
                 Assert.Equal(expectedSize, icon.Size);
@@ -202,24 +208,28 @@ namespace System.Drawing.Tests
         [MemberData(nameof(Size_TestData))]
         public void Ctor_Icon_Width_Height(string fileName, Size size, Size expectedSize)
         {
-            var sourceIcon = new Icon(Helpers.GetTestBitmapPath(fileName));
-            var icon = new Icon(sourceIcon, size.Width, size.Height);
-            Assert.Equal(expectedSize.Width, icon.Width);
-            Assert.Equal(expectedSize.Height, icon.Height);
-            Assert.Equal(expectedSize, icon.Size);
-            Assert.NotSame(sourceIcon.Handle, icon.Handle);
+            using (var sourceIcon = new Icon(Helpers.GetTestBitmapPath(fileName)))
+            using (var icon = new Icon(sourceIcon, size.Width, size.Height))
+            {
+                Assert.Equal(expectedSize.Width, icon.Width);
+                Assert.Equal(expectedSize.Height, icon.Height);
+                Assert.Equal(expectedSize, icon.Size);
+                Assert.NotSame(sourceIcon.Handle, icon.Handle);
+            }
         }
 
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [MemberData(nameof(Size_TestData))]
         public void Ctor_Icon_Size(string fileName, Size size, Size expectedSize)
         {
-            var sourceIcon = new Icon(Helpers.GetTestBitmapPath(fileName));
-            var icon = new Icon(sourceIcon, size);
-            Assert.Equal(expectedSize.Width, icon.Width);
-            Assert.Equal(expectedSize.Height, icon.Height);
-            Assert.Equal(expectedSize, icon.Size);
-            Assert.NotSame(sourceIcon.Handle, icon.Handle);
+            using (var sourceIcon = new Icon(Helpers.GetTestBitmapPath(fileName)))
+            using (var icon = new Icon(sourceIcon, size))
+            {
+                Assert.Equal(expectedSize.Width, icon.Width);
+                Assert.Equal(expectedSize.Height, icon.Height);
+                Assert.Equal(expectedSize, icon.Size);
+                Assert.NotSame(sourceIcon.Handle, icon.Handle);
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -243,9 +253,11 @@ namespace System.Drawing.Tests
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void Ctor_Type_Resource()
         {
-            var icon = new Icon(typeof(IconTests), "48x48_multiple_entries_4bit.ico");
-            Assert.Equal(32, icon.Height);
-            Assert.Equal(32, icon.Width);
+            using (var icon = new Icon(typeof(IconTests), "48x48_multiple_entries_4bit.ico"))
+            {
+                Assert.Equal(32, icon.Height);
+                Assert.Equal(32, icon.Width);
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -267,25 +279,29 @@ namespace System.Drawing.Tests
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void Clone_ConstructedIcon_Success()
         {
-            var icon = new Icon(Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico"));
-            Icon clone = (Icon)icon.Clone();
-            Assert.NotSame(icon, clone);
-            Assert.NotSame(icon.Handle, clone.Handle);
-            Assert.Equal(32, clone.Width);
-            Assert.Equal(32, clone.Height);
-            Assert.Equal(new Size(32, 32), clone.Size);
+            using (var icon = new Icon(Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico")))
+            using (Icon clone = Assert.IsType<Icon>(icon.Clone()))
+            {
+                Assert.NotSame(icon, clone);
+                Assert.NotSame(icon.Handle, clone.Handle);
+                Assert.Equal(32, clone.Width);
+                Assert.Equal(32, clone.Height);
+                Assert.Equal(new Size(32, 32), clone.Size);
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void Clone_IconFromHandle_Success()
         {
-            var icon = Icon.FromHandle(SystemIcons.Hand.Handle);
-            Icon clone = (Icon)icon.Clone();
-            Assert.NotSame(icon, clone);
-            Assert.NotSame(icon.Handle, clone.Handle);
-            Assert.Equal(SystemIcons.Hand.Width, clone.Width);
-            Assert.Equal(SystemIcons.Hand.Height, clone.Height);
-            Assert.Equal(SystemIcons.Hand.Size, clone.Size);
+            using (var icon = Icon.FromHandle(SystemIcons.Hand.Handle))
+            using (Icon clone = Assert.IsType<Icon>(icon.Clone()))
+            {
+                Assert.NotSame(icon, clone);
+                Assert.NotSame(icon.Handle, clone.Handle);
+                Assert.Equal(SystemIcons.Hand.Width, clone.Width);
+                Assert.Equal(SystemIcons.Hand.Height, clone.Height);
+                Assert.Equal(SystemIcons.Hand.Size, clone.Size);
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -309,14 +325,15 @@ namespace System.Drawing.Tests
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void Dispose_DoesNotOwnHandle_DoesNotDestroyHandle()
         {
-            var source = new Icon(Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico"));
-            var icon = Icon.FromHandle(source.Handle);
+            using (var source = new Icon(Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico")))
+            using (var icon = Icon.FromHandle(source.Handle))
+            {
+                IntPtr handle = icon.Handle;
+                Assert.NotEqual(IntPtr.Zero, handle);
 
-            IntPtr handle = icon.Handle;
-            Assert.NotEqual(IntPtr.Zero, handle);
-
-            icon.Dispose();
-            Assert.Equal(handle, icon.Handle);
+                icon.Dispose();
+                Assert.Equal(handle, icon.Handle);
+            }
         }
 
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -325,23 +342,29 @@ namespace System.Drawing.Tests
         [InlineData(48)]
         public void XpIcon_ToBitmap_Success(int size)
         {
-            var icon = new Icon(Helpers.GetTestBitmapPath("48x48_multiple_entries_32bit.ico"), size, size);
-            Assert.Equal(size, icon.Width);
-            Assert.Equal(size, icon.Height);
-            Assert.Equal(new Size(size, size), icon.Size);
+            using (var icon = new Icon(Helpers.GetTestBitmapPath("48x48_multiple_entries_32bit.ico"), size, size))
+            {
+                Assert.Equal(size, icon.Width);
+                Assert.Equal(size, icon.Height);
+                Assert.Equal(new Size(size, size), icon.Size);
 
-            Bitmap bitmap = icon.ToBitmap();
-            Assert.Equal(size, bitmap.Width);
-            Assert.Equal(size, bitmap.Height);
-            Assert.Equal(new Size(size, size), bitmap.Size);
+                using (Bitmap bitmap = icon.ToBitmap())
+                {
+                    Assert.Equal(size, bitmap.Width);
+                    Assert.Equal(size, bitmap.Height);
+                    Assert.Equal(new Size(size, size), bitmap.Size);
+                }
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void ExtractAssociatedIcon_FilePath_Success()
         {
-            Icon icon = Icon.ExtractAssociatedIcon(Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico"));
-            Assert.Equal(32, icon.Width);
-            Assert.Equal(32, icon.Height);
+            using (Icon icon = Icon.ExtractAssociatedIcon(Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico")))
+            {
+                Assert.Equal(32, icon.Width);
+                Assert.Equal(32, icon.Height);
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -381,7 +404,7 @@ namespace System.Drawing.Tests
         public void Save_OutputStream_ProducesIdenticalBytes()
         {
             string filePath = Helpers.GetTestBitmapPath("256x256_seven_entries_multiple_bits.ico");
-            var icon = new Icon(filePath);
+            using (var icon = new Icon(filePath))
             using (var outputStream = new MemoryStream())
             {
                 icon.Save(outputStream);
@@ -405,39 +428,47 @@ namespace System.Drawing.Tests
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void Save_NullOutputStreamIconData_ThrowsNullReferenceException()
         {
-            var icon = new Icon(Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico"));
-            Assert.Throws<NullReferenceException>(() => icon.Save(null));
+            using (var icon = new Icon(Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico")))
+            {
+                Assert.Throws<NullReferenceException>(() => icon.Save(null));
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void Save_NullOutputStreamNoIconData_ThrowsArgumentNullException()
         {
-            var source = new Icon(Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico"));
-            var icon = Icon.FromHandle(source.Handle);
-            icon.Dispose();
+            using (var source = new Icon(Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico")))
+            {
+                var icon = Icon.FromHandle(source.Handle);
+                icon.Dispose();
 
-            Assert.Throws<ArgumentNullException>("dataStream", () => icon.Save(null));
+                Assert.Throws<ArgumentNullException>("dataStream", () => icon.Save(null));
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void Save_ClosedOutputStreamIconData_ThrowsException()
         {
-            var icon = new Icon(Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico"));
-            var stream = new MemoryStream();
-            stream.Close();
+            using (var icon = new Icon(Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico")))
+            {
+                var stream = new MemoryStream();
+                stream.Close();
 
-            Assert.Throws<ObjectDisposedException>(() => icon.Save(stream));
+                Assert.Throws<ObjectDisposedException>(() => icon.Save(stream));
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void Save_ClosedOutputStreamNoIconData_DoesNothing()
         {
-            var source = new Icon(Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico"));
-            var icon = Icon.FromHandle(source.Handle);
-            var stream = new MemoryStream();
-            stream.Close();
+            using (var source = new Icon(Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico")))
+            using (var icon = Icon.FromHandle(source.Handle))
+            {
+                var stream = new MemoryStream();
+                stream.Close();
 
-            icon.Save(stream);
+                icon.Save(stream);
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -613,13 +644,11 @@ namespace System.Drawing.Tests
         public void FromHandle_IconHandleOneTime_Success()
         {
             using (var icon1 = new Icon(Helpers.GetTestBitmapPath("16x16_one_entry_4bit.ico")))
+            using (Icon icon2 = Icon.FromHandle(icon1.Handle))
             {
-                using (Icon icon2 = Icon.FromHandle(icon1.Handle))
-                {
-                    Assert.Equal(icon1.Handle, icon2.Handle);
-                    Assert.Equal(icon1.Size, icon2.Size);
-                    SaveAndCompare(icon2, false);
-                }
+                Assert.Equal(icon1.Handle, icon2.Handle);
+                Assert.Equal(icon1.Size, icon2.Size);
+                SaveAndCompare(icon2, false);
             }
         }
 
@@ -711,24 +740,28 @@ namespace System.Drawing.Tests
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void Serialize_RoundtripFromData_Success()
         {
-            var icon = new Icon(Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico"));
-            Roundtrip(icon);
+            using (var icon = new Icon(Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico")))
+            {
+                Roundtrip(icon);
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void Serialize_RoundtripWithSize_Success()
         {
-            var icon = new Icon(Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico"));
-            Assert.Equal(new Size(32, 32), icon.Size);
-            Roundtrip(icon);
+            using (var icon = new Icon(Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico")))
+            {
+                Assert.Equal(new Size(32, 32), icon.Size);
+                Roundtrip(icon);
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void Serialize_RoundtripWithUnownedHandle_Success()
         {
             using (var sourceIcon = new Icon(Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico")))
+            using (var icon = Icon.FromHandle(sourceIcon.Handle))
             {
-                var icon = Icon.FromHandle(sourceIcon.Handle);
                 Roundtrip(icon);
             }
         }

--- a/src/System.Drawing.Common/tests/StringFormatTests.cs
+++ b/src/System.Drawing.Common/tests/StringFormatTests.cs
@@ -17,14 +17,16 @@ namespace System.Drawing.Tests
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void Ctor_Default()
         {
-            var format = new StringFormat();
-            Assert.Equal(StringAlignment.Near, format.Alignment);
-            Assert.Equal(0, format.DigitSubstitutionLanguage);
-            Assert.Equal(StringDigitSubstitute.User, format.DigitSubstitutionMethod);
-            Assert.Equal((StringFormatFlags)0, format.FormatFlags);
-            Assert.Equal(HotkeyPrefix.None, format.HotkeyPrefix);
-            Assert.Equal(StringAlignment.Near, format.LineAlignment);
-            Assert.Equal(StringTrimming.Character, format.Trimming);
+            using (var format = new StringFormat())
+            {
+                Assert.Equal(StringAlignment.Near, format.Alignment);
+                Assert.Equal(0, format.DigitSubstitutionLanguage);
+                Assert.Equal(StringDigitSubstitute.User, format.DigitSubstitutionMethod);
+                Assert.Equal((StringFormatFlags)0, format.FormatFlags);
+                Assert.Equal(HotkeyPrefix.None, format.HotkeyPrefix);
+                Assert.Equal(StringAlignment.Near, format.LineAlignment);
+                Assert.Equal(StringTrimming.Character, format.Trimming);
+            }
         }
 
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -32,14 +34,16 @@ namespace System.Drawing.Tests
         [InlineData((StringFormatFlags)(-1))]
         public void Ctor_Options(StringFormatFlags options)
         {
-            var format = new StringFormat(options);
-            Assert.Equal(StringAlignment.Near, format.Alignment);
-            Assert.Equal(0, format.DigitSubstitutionLanguage);
-            Assert.Equal(StringDigitSubstitute.User, format.DigitSubstitutionMethod);
-            Assert.Equal(options, format.FormatFlags);
-            Assert.Equal(HotkeyPrefix.None, format.HotkeyPrefix);
-            Assert.Equal(StringAlignment.Near, format.LineAlignment);
-            Assert.Equal(StringTrimming.Character, format.Trimming);
+            using (var format = new StringFormat(options))
+            {
+                Assert.Equal(StringAlignment.Near, format.Alignment);
+                Assert.Equal(0, format.DigitSubstitutionLanguage);
+                Assert.Equal(StringDigitSubstitute.User, format.DigitSubstitutionMethod);
+                Assert.Equal(options, format.FormatFlags);
+                Assert.Equal(HotkeyPrefix.None, format.HotkeyPrefix);
+                Assert.Equal(StringAlignment.Near, format.LineAlignment);
+                Assert.Equal(StringTrimming.Character, format.Trimming);
+            }
         }
 
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -48,32 +52,36 @@ namespace System.Drawing.Tests
         [InlineData((StringFormatFlags)(-1), -1)]
         public void Ctor_Options_Language(StringFormatFlags options, int language)
         {
-            var format = new StringFormat(options, language);
-            Assert.Equal(StringAlignment.Near, format.Alignment);
-            Assert.Equal(0, format.DigitSubstitutionLanguage);
-            Assert.Equal(StringDigitSubstitute.User, format.DigitSubstitutionMethod);
-            Assert.Equal(options, format.FormatFlags);
-            Assert.Equal(HotkeyPrefix.None, format.HotkeyPrefix);
-            Assert.Equal(StringAlignment.Near, format.LineAlignment);
-            Assert.Equal(StringTrimming.Character, format.Trimming);
+            using (var format = new StringFormat(options, language))
+            {
+                Assert.Equal(StringAlignment.Near, format.Alignment);
+                Assert.Equal(0, format.DigitSubstitutionLanguage);
+                Assert.Equal(StringDigitSubstitute.User, format.DigitSubstitutionMethod);
+                Assert.Equal(options, format.FormatFlags);
+                Assert.Equal(HotkeyPrefix.None, format.HotkeyPrefix);
+                Assert.Equal(StringAlignment.Near, format.LineAlignment);
+                Assert.Equal(StringTrimming.Character, format.Trimming);
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void Ctor_Format()
         {
-            var original = new StringFormat(StringFormatFlags.NoClip, EnglishLanguageCode);
-            var format = new StringFormat(original);
-            Assert.Equal(StringAlignment.Near, format.Alignment);
-            Assert.Equal(0, format.DigitSubstitutionLanguage);
-            Assert.Equal(StringDigitSubstitute.User, format.DigitSubstitutionMethod);
-            Assert.Equal(StringFormatFlags.NoClip, format.FormatFlags);
-            Assert.Equal(HotkeyPrefix.None, format.HotkeyPrefix);
-            Assert.Equal(StringAlignment.Near, format.LineAlignment);
-            Assert.Equal(StringTrimming.Character, format.Trimming);
+            using (var original = new StringFormat(StringFormatFlags.NoClip, EnglishLanguageCode))
+            using (var format = new StringFormat(original))
+            {
+                Assert.Equal(StringAlignment.Near, format.Alignment);
+                Assert.Equal(0, format.DigitSubstitutionLanguage);
+                Assert.Equal(StringDigitSubstitute.User, format.DigitSubstitutionMethod);
+                Assert.Equal(StringFormatFlags.NoClip, format.FormatFlags);
+                Assert.Equal(HotkeyPrefix.None, format.HotkeyPrefix);
+                Assert.Equal(StringAlignment.Near, format.LineAlignment);
+                Assert.Equal(StringTrimming.Character, format.Trimming);
 
-            // The new format is a clone.
-            original.FormatFlags = StringFormatFlags.NoFontFallback;
-            Assert.Equal(StringFormatFlags.NoClip, format.FormatFlags);
+                // The new format is a clone.
+                original.FormatFlags = StringFormatFlags.NoFontFallback;
+                Assert.Equal(StringFormatFlags.NoClip, format.FormatFlags);
+            }
         }
 
         [Fact]
@@ -87,6 +95,7 @@ namespace System.Drawing.Tests
         {
             var format = new StringFormat();
             format.Dispose();
+
             Assert.Throws<ArgumentException>(null, () => new StringFormat(format));
         }
 
@@ -101,19 +110,21 @@ namespace System.Drawing.Tests
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void Clone_Valid_Success()
         {
-            var original = new StringFormat(StringFormatFlags.NoClip, EnglishLanguageCode);
-            var format = (StringFormat)original.Clone();
-            Assert.Equal(StringAlignment.Near, format.Alignment);
-            Assert.Equal(0, format.DigitSubstitutionLanguage);
-            Assert.Equal(StringDigitSubstitute.User, format.DigitSubstitutionMethod);
-            Assert.Equal(StringFormatFlags.NoClip, format.FormatFlags);
-            Assert.Equal(HotkeyPrefix.None, format.HotkeyPrefix);
-            Assert.Equal(StringAlignment.Near, format.LineAlignment);
-            Assert.Equal(StringTrimming.Character, format.Trimming);
+            using (var original = new StringFormat(StringFormatFlags.NoClip, EnglishLanguageCode))
+            using (StringFormat format = Assert.IsType<StringFormat>(original.Clone()))
+            {
+                Assert.Equal(StringAlignment.Near, format.Alignment);
+                Assert.Equal(0, format.DigitSubstitutionLanguage);
+                Assert.Equal(StringDigitSubstitute.User, format.DigitSubstitutionMethod);
+                Assert.Equal(StringFormatFlags.NoClip, format.FormatFlags);
+                Assert.Equal(HotkeyPrefix.None, format.HotkeyPrefix);
+                Assert.Equal(StringAlignment.Near, format.LineAlignment);
+                Assert.Equal(StringTrimming.Character, format.Trimming);
 
-            // The new format is a clone.
-            original.FormatFlags = StringFormatFlags.NoFontFallback;
-            Assert.Equal(StringFormatFlags.NoClip, format.FormatFlags);
+                // The new format is a clone.
+                original.FormatFlags = StringFormatFlags.NoFontFallback;
+                Assert.Equal(StringFormatFlags.NoClip, format.FormatFlags);
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -121,6 +132,7 @@ namespace System.Drawing.Tests
         {
             var format = new StringFormat();
             format.Dispose();
+
             Assert.Throws<ArgumentException>(null, () => format.Clone());
         }
 
@@ -131,10 +143,12 @@ namespace System.Drawing.Tests
         [InlineData(-1, StringDigitSubstitute.User - 1, 65535)]
         public void SetDigitSubstitution_Invoke_SetsProperties(int language, StringDigitSubstitute substitute, int expectedLanguage)
         {
-            var format = new StringFormat();
-            format.SetDigitSubstitution(language, substitute);
-            Assert.Equal(expectedLanguage, format.DigitSubstitutionLanguage);
-            Assert.Equal(substitute, format.DigitSubstitutionMethod);
+            using (var format = new StringFormat())
+            {
+                format.SetDigitSubstitution(language, substitute);
+                Assert.Equal(expectedLanguage, format.DigitSubstitutionLanguage);
+                Assert.Equal(substitute, format.DigitSubstitutionMethod);
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -142,6 +156,7 @@ namespace System.Drawing.Tests
         {
             var format = new StringFormat();
             format.Dispose();
+
             Assert.Throws<ArgumentException>(null, () => format.SetDigitSubstitution(0, StringDigitSubstitute.None));
         }
 
@@ -150,32 +165,40 @@ namespace System.Drawing.Tests
         [InlineData(10, new float[] { 1, 2.3f, 4, float.PositiveInfinity, float.NaN })]
         public void SetTabStops_GetTabStops_ReturnsExpected(float firstTabOffset, float[] tabStops)
         {
-            var format = new StringFormat();
-            format.SetTabStops(firstTabOffset, tabStops);
+            using (var format = new StringFormat())
+            {
+                format.SetTabStops(firstTabOffset, tabStops);
 
-            Assert.Equal(tabStops, format.GetTabStops(out float actualFirstTabOffset));
-            Assert.Equal(firstTabOffset, actualFirstTabOffset);
+                Assert.Equal(tabStops, format.GetTabStops(out float actualFirstTabOffset));
+                Assert.Equal(firstTabOffset, actualFirstTabOffset);
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void SetTabStops_NullTabStops_ThrowsNullReferenceException()
         {
-            var format = new StringFormat();
-            Assert.Throws<NullReferenceException>(() => format.SetTabStops(0, null));
+            using (var format = new StringFormat())
+            {
+                Assert.Throws<NullReferenceException>(() => format.SetTabStops(0, null));
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void SetTabStops_NegativeFirstTabOffset_ThrowsArgumentException()
         {
-            var format = new StringFormat();
-            Assert.Throws<ArgumentException>(null, () => format.SetTabStops(-1, new float[0]));
+            using (var format = new StringFormat())
+            {
+                Assert.Throws<ArgumentException>(null, () => format.SetTabStops(-1, new float[0]));
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void SetTabStops_NegativeInfinityInTabStops_ThrowsNotImplementedException()
         {
-            var format = new StringFormat();
-            Assert.Throws<NotImplementedException>(() => format.SetTabStops(0, new float[] { float.NegativeInfinity }));
+            using (var format = new StringFormat())
+            {
+                Assert.Throws<NotImplementedException>(() => format.SetTabStops(0, new float[] { float.NegativeInfinity }));
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -183,6 +206,7 @@ namespace System.Drawing.Tests
         {
             var format = new StringFormat();
             format.Dispose();
+
             Assert.Throws<ArgumentException>(null, () => format.SetTabStops(0, new float[0]));
         }
 
@@ -191,6 +215,7 @@ namespace System.Drawing.Tests
         {
             var format = new StringFormat();
             format.Dispose();
+
             Assert.Throws<ArgumentException>(null, () => format.GetTabStops(out float firstTabOffset));
         }
 
@@ -206,22 +231,28 @@ namespace System.Drawing.Tests
         [MemberData(nameof(SetMeasurableCharacterRanges_TestData))]
         public void SetMeasurableCharacterRanges_Valid_Success(CharacterRange[] ranges)
         {
-            var format = new StringFormat();
-            format.SetMeasurableCharacterRanges(ranges);
+            using (var format = new StringFormat())
+            {
+                format.SetMeasurableCharacterRanges(ranges);
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void SetMeasurableCharacterRanges_NullRanges_ThrowsNullReferenceException()
         {
-            var format = new StringFormat();
-            Assert.Throws<NullReferenceException>(() => format.SetMeasurableCharacterRanges(null));
+            using (var format = new StringFormat())
+            {
+                Assert.Throws<NullReferenceException>(() => format.SetMeasurableCharacterRanges(null));
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void SetMeasurableCharacterRanges_RangesTooLarge_ThrowsOverflowException()
         {
-            var format = new StringFormat();
-            Assert.Throws<OverflowException>(() => format.SetMeasurableCharacterRanges(new CharacterRange[33]));
+            using (var format = new StringFormat())
+            {
+                Assert.Throws<OverflowException>(() => format.SetMeasurableCharacterRanges(new CharacterRange[33]));
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -229,6 +260,7 @@ namespace System.Drawing.Tests
         {
             var format = new StringFormat();
             format.Dispose();
+
             Assert.Throws<ArgumentException>(null, () => format.SetMeasurableCharacterRanges(new CharacterRange[0]));
         }
 
@@ -238,8 +270,10 @@ namespace System.Drawing.Tests
         [InlineData(StringAlignment.Near)]
         public void Alignment_SetValid_GetReturnsExpected(StringAlignment alignment)
         {
-            var format = new StringFormat { Alignment = alignment };
-            Assert.Equal(alignment, format.Alignment);
+            using (var format = new StringFormat { Alignment = alignment })
+            {
+                Assert.Equal(alignment, format.Alignment);
+            }
         }
 
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -247,8 +281,10 @@ namespace System.Drawing.Tests
         [InlineData(StringAlignment.Far + 1)]
         public void Alignment_SetInvalid_ThrowsInvalidEnumArgumentException(StringAlignment alignment)
         {
-            var format = new StringFormat();
-            Assert.Throws<InvalidEnumArgumentException>("value", () => format.Alignment = alignment);
+            using (var format = new StringFormat())
+            {
+                Assert.Throws<InvalidEnumArgumentException>("value", () => format.Alignment = alignment);
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -256,6 +292,7 @@ namespace System.Drawing.Tests
         {
             var format = new StringFormat();
             format.Dispose();
+
             Assert.Throws<ArgumentException>(null, () => format.Alignment);
             Assert.Throws<ArgumentException>(null, () => format.Alignment = StringAlignment.Center);
         }
@@ -265,6 +302,7 @@ namespace System.Drawing.Tests
         {
             var format = new StringFormat();
             format.Dispose();
+
             Assert.Throws<ArgumentException>(null, () => format.DigitSubstitutionMethod);
         }
 
@@ -273,6 +311,7 @@ namespace System.Drawing.Tests
         {
             var format = new StringFormat();
             format.Dispose();
+
             Assert.Throws<ArgumentException>(null, () => format.DigitSubstitutionLanguage);
         }
 
@@ -282,8 +321,10 @@ namespace System.Drawing.Tests
         [InlineData((StringFormatFlags)int.MaxValue)]
         public void FormatFlags_Set_GetReturnsExpected(StringFormatFlags formatFlags)
         {
-            var format = new StringFormat { FormatFlags = formatFlags };
-            Assert.Equal(formatFlags, format.FormatFlags);
+            using (var format = new StringFormat { FormatFlags = formatFlags })
+            {
+                Assert.Equal(formatFlags, format.FormatFlags);
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -291,6 +332,7 @@ namespace System.Drawing.Tests
         {
             var format = new StringFormat();
             format.Dispose();
+
             Assert.Throws<ArgumentException>(null, () => format.FormatFlags);
             Assert.Throws<ArgumentException>(null, () => format.FormatFlags = StringFormatFlags.NoClip);
         }
@@ -301,8 +343,10 @@ namespace System.Drawing.Tests
         [InlineData(StringAlignment.Near)]
         public void LineAlignment_SetValid_GetReturnsExpected(StringAlignment alignment)
         {
-            var format = new StringFormat { LineAlignment = alignment };
-            Assert.Equal(alignment, format.LineAlignment);
+            using (var format = new StringFormat { LineAlignment = alignment })
+            {
+                Assert.Equal(alignment, format.LineAlignment);
+            }
         }
 
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -310,8 +354,10 @@ namespace System.Drawing.Tests
         [InlineData(StringAlignment.Far + 1)]
         public void LineAlignment_SetInvalid_ThrowsInvalidEnumArgumentException(StringAlignment alignment)
         {
-            var format = new StringFormat();
-            Assert.Throws<InvalidEnumArgumentException>("value", () => format.LineAlignment = alignment);
+            using (var format = new StringFormat())
+            {
+                Assert.Throws<InvalidEnumArgumentException>("value", () => format.LineAlignment = alignment);
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -319,6 +365,7 @@ namespace System.Drawing.Tests
         {
             var format = new StringFormat();
             format.Dispose();
+
             Assert.Throws<ArgumentException>(null, () => format.LineAlignment);
             Assert.Throws<ArgumentException>(null, () => format.LineAlignment = StringAlignment.Center);
         }
@@ -329,8 +376,10 @@ namespace System.Drawing.Tests
         [InlineData(HotkeyPrefix.Show)]
         public void HotKeyPrefix_SetValid_GetReturnsExpected(HotkeyPrefix prefix)
         {
-            var format = new StringFormat { HotkeyPrefix = prefix };
-            Assert.Equal(prefix, format.HotkeyPrefix);
+            using (var format = new StringFormat { HotkeyPrefix = prefix })
+            {
+                Assert.Equal(prefix, format.HotkeyPrefix);
+            }
         }
 
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -338,8 +387,10 @@ namespace System.Drawing.Tests
         [InlineData(HotkeyPrefix.Hide + 1)]
         public void HotKeyPrefix_SetInvalid_ThrowsInvalidEnumArgumentException(HotkeyPrefix prefix)
         {
-            var format = new StringFormat();
-            Assert.Throws<InvalidEnumArgumentException>("value", () => format.HotkeyPrefix = prefix);
+            using (var format = new StringFormat())
+            {
+                Assert.Throws<InvalidEnumArgumentException>("value", () => format.HotkeyPrefix = prefix);
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -347,6 +398,7 @@ namespace System.Drawing.Tests
         {
             var format = new StringFormat();
             format.Dispose();
+
             Assert.Throws<ArgumentException>(null, () => format.HotkeyPrefix);
             Assert.Throws<ArgumentException>(null, () => format.HotkeyPrefix = HotkeyPrefix.Hide);
         }
@@ -355,8 +407,10 @@ namespace System.Drawing.Tests
         [InlineData(StringTrimming.Word)]
         public void Trimming_SetValid_GetReturnsExpected(StringTrimming trimming)
         {
-            var format = new StringFormat { Trimming = trimming };
-            Assert.Equal(trimming, format.Trimming);
+            using (var format = new StringFormat { Trimming = trimming })
+            {
+                Assert.Equal(trimming, format.Trimming);
+            }
         }
 
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -364,8 +418,10 @@ namespace System.Drawing.Tests
         [InlineData(StringTrimming.EllipsisPath + 1)]
         public void Trimming_SetInvalid_ThrowsInvalidEnumArgumentException(StringTrimming trimming)
         {
-            var format = new StringFormat();
-            Assert.Throws<InvalidEnumArgumentException>("value", () => format.Trimming = trimming);
+            using (var format = new StringFormat())
+            {
+                Assert.Throws<InvalidEnumArgumentException>("value", () => format.Trimming = trimming);
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -373,6 +429,8 @@ namespace System.Drawing.Tests
         {
             var format = new StringFormat();
             format.Dispose();
+
+
             Assert.Throws<ArgumentException>(null, () => format.Trimming);
             Assert.Throws<ArgumentException>(null, () => format.Trimming = StringTrimming.Word);
         }
@@ -410,8 +468,10 @@ namespace System.Drawing.Tests
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void ToString_Flags_ReturnsExpected()
         {
-            var format = new StringFormat(StringFormatFlags.DirectionVertical);
-            Assert.Equal("[StringFormat, FormatFlags=DirectionVertical]", format.ToString());
+            using (var format = new StringFormat(StringFormatFlags.DirectionVertical))
+            {
+                Assert.Equal("[StringFormat, FormatFlags=DirectionVertical]", format.ToString());
+            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -419,6 +479,7 @@ namespace System.Drawing.Tests
         {
             var format = new StringFormat(StringFormatFlags.DirectionVertical);
             format.Dispose();
+
             Assert.Throws<ArgumentException>(null, () => format.ToString());
         }
     }


### PR DESCRIPTION
I think the resources will be finalized, but this is good practice and it was mentioned this should be done