### PR TITLE
Reenable test in System.Runtime.InteropServices for ILC

### DIFF
--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/RuntimeEnvironmentTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/RuntimeEnvironmentTests.cs
@@ -16,7 +16,6 @@ namespace System.Runtime.InteropServices
         }
 
         [Fact]
-        [ActiveIssue(20600, TargetFrameworkMonikers.UapAot)]
         public void RuntimeEnvironmentSysVersion()
         {            
             Assert.NotEmpty(RuntimeEnvironment.GetSystemVersion());


### PR DESCRIPTION
Api is now implemented.

Fixes https://github.com/dotnet/corefx/issues/20600