### PR TITLE
Disable DirectoryServices test for UAPAOT

### DIFF
--- a/src/System.DirectoryServices/tests/System/DirectoryServices/DirectoryEntryTests.cs
+++ b/src/System.DirectoryServices/tests/System/DirectoryServices/DirectoryEntryTests.cs
@@ -141,6 +141,7 @@ namespace System.DirectoryServices.Tests
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
+        [ActiveIssue(21346, TargetFrameworkMonikers.UapAot)]
         public void DeleteTree_NoObject_ThrowsCOMException()
         {
             var entry = new DirectoryEntry("path");


### PR DESCRIPTION
Relates to https://github.com/dotnet/corefx/issues/21346

@hughbe I think we missed this one in https://github.com/dotnet/corefx/pull/21349 