### PR TITLE
Fix DefaultProxyCredentials edge case on NETFX

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Net46.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Net46.cs
@@ -526,12 +526,13 @@ namespace System.Net.Http
                 webRequest.ServerCertificateValidationCallback = ServerCertificateValidationCallback;
             }
 
-            if (_defaultProxyCredentials != null && _useProxy && _proxy == null)
+            if (_defaultProxyCredentials != null && _useProxy && _proxy == null && webRequest.Proxy != null)
             {
-                // The HttpClientHandler has specified to use a proxy but has not
-                // set an explicit IWebProxy. That means to use the system default
-                // proxy setting object which is the default value of webRequest.Proxy.
-                Debug.Assert(webRequest.Proxy != null);
+                // The HttpClientHandler has specified to use a proxy but has not set an explicit IWebProxy.
+                // That means to use the default proxy on the underlying webrequest object. The initial value
+                // of the webrequest.Proxy when first created comes from the static WebRequest.DefaultWebProxy.
+                // In the default case, this value is non-null. But can be set later to null. That is why the
+                // 'if' check above validates for a non-null webRequest.Proxy.
                 webRequest.Proxy.Credentials = _defaultProxyCredentials;
             }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.DefaultProxyCredentials.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.DefaultProxyCredentials.cs
@@ -109,5 +109,23 @@ namespace System.Net.Http.Functional.Tests
             Assert.Equal($"{ExpectedUsername}:{ExpectedPassword}", proxyTask.Result.AuthenticationHeaderValue);
         }
 
+        // The purpose of this test is mainly to validate the .NET Framework OOB System.Net.Http implementation
+        // since it has an underlying dependency to WebRequest. While .NET Core implementations of System.Net.Http
+        // are not using any WebRequest code, the test is still useful to validate correctness.
+        [OuterLoop] // TODO: Issue #11345
+        [Fact]
+        public async Task ProxyNotExplicitlyProvided_DefaultCredentialsSet_DefaultWebProxySetToNull_Success()
+        {
+            WebRequest.DefaultWebProxy = null;
+
+            using (var handler = new HttpClientHandler())
+            using (var client = new HttpClient(handler))
+            {
+                handler.DefaultProxyCredentials = new NetworkCredential("UsernameNotUsed", "PasswordNotUsed");
+                HttpResponseMessage response = await client.GetAsync(Configuration.Http.RemoteEchoServer);
+
+                Assert.Equal(response.StatusCode, HttpStatusCode.OK);
+            }
+        }
     }
 }


### PR DESCRIPTION
After my PR #21325, I discovered an edge case where we need to check for
a non-null Proxy property in the underlying WebRequest.

On .NET Framework, System.Net.Http is built on WebRequest
(HttpWebRequest) and is subject to side-affects from it. The static
property WebRequest.DefaultWebProxy affects the initial value of
WebRequest.Proxy. So, it's possible that a developer may have set
WebRequest.DefaultWebProxy to null prior to using System.Net.Http in the
app.

The net affect of this is that there won't be any proxy used as the
system default proxy and thus the
HttpClientHandler.DefaultProxyCredentials is ignored.

On .NET Core, there is no relationship between System.Net.Http and
System.Net.WebRequest.  So, in all cases on .NET Core, where a developer
has specified HttpClientHander.UseProxy=true and HttpClientHandler.Proxy
= null (default values), the handler will always try to use the system
default proxy (if configured).