### PR TITLE
Enable Debug x86 uapaot test runs to be multifile

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -246,9 +246,9 @@
   </PropertyGroup>
 
   <!-- Properties related to multi-file mode for ILC tests -->
-  <PropertyGroup>
-    <!-- Only enable multi-file for Uapaot-Release-x64 for now -->
-    <EnableMultiFileILCTests Condition="'$(TargetGroup)' == 'uapaot' And '$(ConfigurationGroup)' == 'Release' And '$(ArchGroup)' == 'x64'">true</EnableMultiFileILCTests>
+  <PropertyGroup Condition="'$(TargetGroup)' == 'uapaot'">
+    <!-- Only enable multi-file for Release-x64 and Debug-x86 for now -->
+    <EnableMultiFileILCTests Condition="'$(ConfigurationGroup)|$(ArchGroup)' == 'Release|x64' Or '$(ConfigurationGroup)|$(ArchGroup)' == 'Debug|x86'">true</EnableMultiFileILCTests>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
FYI: @weshaggard @danmosemsft @tijoytom @joshfree @sergiy-k @botaberg @yizhang82 

Given that we verified that multifile runs didn't produce different results to single-file, with this I'm turning on multi-file mode on Debug-x86 runs as well to have more coverage.