### PR TITLE
Fix failing System.Runtime.Interop.Tests on ILC

### DIFF
--- a/src/System.Runtime.InteropServices/src/System/Runtime/InteropServices/ComAwareEventInfo.cs
+++ b/src/System.Runtime.InteropServices/src/System/Runtime/InteropServices/ComAwareEventInfo.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Reflection;
 using System.Security;
 
@@ -54,6 +55,8 @@ namespace System.Runtime.InteropServices
 
         public override MethodInfo GetAddMethod(bool nonPublic) => _innerEventInfo.GetAddMethod(nonPublic);
 
+        public override MethodInfo[] GetOtherMethods(bool nonPublic) => _innerEventInfo.GetOtherMethods(nonPublic);
+
         public override MethodInfo GetRaiseMethod(bool nonPublic) => _innerEventInfo.GetRaiseMethod(nonPublic);
 
         public override MethodInfo GetRemoveMethod(bool nonPublic) => _innerEventInfo.GetRemoveMethod(nonPublic);
@@ -70,10 +73,16 @@ namespace System.Runtime.InteropServices
             return _innerEventInfo.GetCustomAttributes(inherit);
         }
 
+        public override IList<CustomAttributeData> GetCustomAttributesData() => _innerEventInfo.GetCustomAttributesData();
+
         public override bool IsDefined(Type attributeType, bool inherit)
         {
             return _innerEventInfo.IsDefined(attributeType, inherit);
         }
+
+        public override int MetadataToken => _innerEventInfo.MetadataToken;
+
+        public override Module Module => _innerEventInfo.Module;
 
         public override string Name => _innerEventInfo.Name;
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/21348

Override all the remaining Reflection apis whose default
implementation is "throw". This will increase the chance
of success in the cases where the two CoreLib's have
different dependencies on Reflection objects passed into them.
We actually try very hard to avoid these but there are
some cases where the cost of doing that is too high -
CustomAttributeExtensions being one of them.