### PR TITLE
Fix RuntimeInformation.FrameworkName for Uap and UapAot

### DIFF
--- a/src/Common/tests/System/PlatformDetection.cs
+++ b/src/Common/tests/System/PlatformDetection.cs
@@ -428,7 +428,7 @@ namespace System
 
         // System.Security.Cryptography.Xml.XmlDsigXsltTransform.GetOutput() relies on XslCompiledTransform which relies
         // heavily on Reflection.Emit
-        public static bool IsXmlDsigXsltTransformSupported => PlatformDetection.IsReflectionEmitSupported;
+        public static bool IsXmlDsigXsltTransformSupported => !PlatformDetection.IsUap;
 
         public static Range[] FrameworkRanges => new Range[]{
           new Range(new Version(4, 7, 2500, 0), null, new Version(4, 7, 1)),

--- a/src/System.Runtime.InteropServices.RuntimeInformation/src/Configurations.props
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/src/Configurations.props
@@ -9,6 +9,7 @@
       net462-Windows_NT;
       net47-Windows_NT;
       uap-Windows_NT;
+      uapaot-Windows_NT;
       netstandard1.1-AnyOS;
       netstandard1.1-Unix;
       netstandard1.1-Windows_NT;

--- a/src/System.Runtime.InteropServices.RuntimeInformation/src/System.Runtime.InteropServices.RuntimeInformation.csproj
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/src/System.Runtime.InteropServices.RuntimeInformation.csproj
@@ -10,6 +10,7 @@
     <DefineConstants Condition="'$(TargetGroup)'=='wpa81'">$(DefineConstants);wpa81</DefineConstants>
     <DefineConstants Condition="'$(TargetGroup)'=='win8'">$(DefineConstants);win8</DefineConstants>
     <DefineConstants Condition="'$(TargetGroup)'=='uap'">$(DefineConstants);uap</DefineConstants>
+    <DefineConstants Condition="'$(TargetGroup)'=='uapaot'">$(DefineConstants);uapaot</DefineConstants>
     <DefineConstants Condition="'$(TargetGroup)'=='netstandard1.1'">$(DefineConstants);netstandard11</DefineConstants>
     <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetGroup)'=='netstandard1.1' AND '$(OSGroup)'=='AnyOS'">SR.PlatformNotSupported_RuntimeInformation</GeneratePlatformNotSupportedAssemblyMessage>
     <!-- use netstandard1.1 refs for win8 and wpa81 -->
@@ -66,7 +67,7 @@
     </Compile>
     <Compile Include="System\Runtime\InteropServices\RuntimeInformation\RuntimeInformation.Unix.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetsWindows)'=='true' And ('$(TargetGroup)' != 'win8' AND '$(TargetGroup)' != 'wpa81' and '$(TargetGroup)' != 'netstandard1.1' and '$(TargetGroup)' != 'uap')">
+  <ItemGroup Condition="'$(TargetsWindows)'=='true' And ('$(TargetGroup)' != 'win8' AND '$(TargetGroup)' != 'wpa81' and '$(TargetGroup)' != 'netstandard1.1' and '$(TargetGroup)' != 'uap' and '$(TargetGroup)' != 'uapaot')">
     <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.RtlGetVersion.cs">
       <Link>Common\Interop\Windows\NtDll\Interop.RtlGetVersion.cs</Link>
     </Compile>

--- a/src/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Windows.cs
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Windows.cs
@@ -25,7 +25,7 @@ namespace System.Runtime.InteropServices
             {
                 if (null == s_osDescription)
                 {
-#if uap || win8 || netstandard11 // all these are subject to WACK
+#if uap || win8 || netstandard11 || uapaot // all these are subject to WACK
                     s_osDescription = "Microsoft Windows";
 #elif wpa81
                     s_osDescription = "Microsoft Windows Phone";

--- a/src/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.cs
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.cs
@@ -9,7 +9,7 @@ namespace System.Runtime.InteropServices
 {
     public static partial class RuntimeInformation
     {
-#if uap
+#if uapaot
         private const string FrameworkName = ".NET Native";
 #elif netfx || win8
         private const string FrameworkName = ".NET Framework";

--- a/src/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
@@ -50,7 +50,7 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
         public void VerifyRuntimeDebugNameOnNetCoreUwp()
         {
             AssemblyFileVersionAttribute attr = (AssemblyFileVersionAttribute)(typeof(object).GetTypeInfo().Assembly.GetCustomAttribute(typeof(AssemblyFileVersionAttribute)));
-            string expected = string.Format(".NET Native {0}", attr.Version);
+            string expected = string.Format(PlatformDetection.IsNetNative ? ".NET Native {0}" : ".NET Core {0}", attr.Version);
             Assert.Equal(expected, RuntimeInformation.FrameworkDescription);
             Assert.Same(RuntimeInformation.FrameworkDescription, RuntimeInformation.FrameworkDescription);
         }


### PR DESCRIPTION
@sepidehMS found this while investigating System.ObjectModel.Tests which is caused by this. 

Fixes: https://github.com/dotnet/corefx/issues/18973

When refactoring from netcore50 to uap and netcore50aot in: https://github.com/dotnet/corefx/pull/16704
this was changed from netcore50aot to uap instead of uapaot.