### PR TITLE
Fix HttpClientHandler PreAuthenticate property for UAP

### DIFF
--- a/src/System.Net.Http/src/netcore50/System/Net/HttpClientHandler.cs
+++ b/src/System.Net.Http/src/netcore50/System/Net/HttpClientHandler.cs
@@ -161,14 +161,6 @@ namespace System.Net.Http
             get { return true; }
             set
             {
-                /*
-                TODO:#18104
-                if (value != PreAuthenticate)
-                {
-                    throw new PlatformNotSupportedException(String.Format(CultureInfo.InvariantCulture,
-                        SR.net_http_value_not_supported, value, nameof(PreAuthenticate)));
-                }
-                */
                 CheckDisposedOrStarted();
             }
         }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -25,7 +25,6 @@ namespace System.Net.Http.Functional.Tests
 
     // Note:  Disposing the HttpClient object automatically disposes the handler within. So, it is not necessary
     // to separately Dispose (or have a 'using' statement) for the handler.
-    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "dotnet/corefx #20010")]
     public class HttpClientHandlerTest
     {
         readonly ITestOutputHelper _output;
@@ -99,7 +98,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ActiveIssue("dotnet/corefx #20010", TargetFrameworkMonikers.Uap)]
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [Fact]
         public void Ctor_ExpectedDefaultPropertyValues()
         {
@@ -132,7 +131,16 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ActiveIssue("dotnet/corefx #20010", TargetFrameworkMonikers.Uap)]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsUap))]
+        public void Ctor_ExpectedDefaultPropertyValues_UapPlatform()
+        {
+            using (var handler = new HttpClientHandler())
+            {
+                Assert.True(handler.PreAuthenticate);
+            }
+        }
+
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "MaxRequestContentBufferSize not used on .NET Core due to architecture differences")]
         [Fact]
         public void MaxRequestContentBufferSize_Get_ReturnsZero()
@@ -143,7 +151,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ActiveIssue("dotnet/corefx #20010", TargetFrameworkMonikers.Uap)]
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "MaxRequestContentBufferSize not used on .NET Core due to architecture differences")]
         [Fact]
         public void MaxRequestContentBufferSize_Set_ThrowsPlatformNotSupportedException()
@@ -154,6 +162,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
@@ -200,6 +209,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(EchoServers))]
         public async Task SendAsync_SimpleGet_Success(Uri remoteServer)
@@ -217,6 +227,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(GetAsync_IPBasedUri_Success_MemberData))]
@@ -245,6 +256,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task SendAsync_MultipleRequestsReusingSameClient_Success()
@@ -261,6 +273,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task GetAsync_ResponseContentAfterClientAndHandlerDispose_Success()
@@ -276,6 +289,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task SendAsync_Cancel_CancellationTokenPropagates()
@@ -296,6 +310,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(CompressedServers))]
         public async Task GetAsync_SetAutomaticDecompression_ContentDecompressed(Uri server)
@@ -318,6 +333,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(CompressedServers))]
         public async Task GetAsync_SetAutomaticDecompression_HeadersRemoved(Uri server)
@@ -334,6 +350,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task GetAsync_ServerNeedsBasicAuthAndSetDefaultCredentials_StatusCodeUnauthorized()
@@ -350,6 +367,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task GetAsync_ServerNeedsAuthAndSetCredential_StatusCodeOK()
@@ -366,6 +384,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task GetAsync_ServerNeedsAuthAndNoCredential_StatusCodeUnauthorized()
@@ -380,6 +399,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData("WWW-Authenticate: CustomAuth\r\n")]
@@ -407,6 +427,7 @@ namespace System.Net.Http.Functional.Tests
             });
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(RedirectStatusCodes))]
         public async Task GetAsync_AllowAutoRedirectFalse_RedirectFromHttpToHttp_StatusCodeRedirect(int statusCode)
@@ -429,6 +450,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(RedirectStatusCodes))]
         public async Task GetAsync_AllowAutoRedirectTrue_RedirectFromHttpToHttp_StatusCodeOK(int statusCode)
@@ -451,6 +473,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task GetAsync_AllowAutoRedirectTrue_RedirectFromHttpToHttps_StatusCodeOK()
@@ -473,7 +496,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ActiveIssue("dotnet/corefx #20010", TargetFrameworkMonikers.Uap)]
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Framework allows HTTPS to HTTP redirection")]
         [OuterLoop] // TODO: Issue #11345
         [Fact]
@@ -497,6 +520,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task GetAsync_AllowAutoRedirectTrue_RedirectToUriWithParams_RequestMsgUriSet()
@@ -520,7 +544,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ActiveIssue("dotnet/corefx #20010", TargetFrameworkMonikers.Uap)]
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(3, 2)]
@@ -565,6 +589,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task GetAsync_AllowAutoRedirectTrue_RedirectWithRelativeLocation()
@@ -587,6 +612,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(200)]
@@ -622,6 +648,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(IsNotWindows7))] // Skip test on Win7 since WinHTTP has bugs w/ fragments.
         [InlineData("#origFragment", "", "#origFragment", false)]
@@ -667,6 +694,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task GetAsync_CredentialIsNetworkCredentialUriRedirect_StatusCodeUnauthorized()
@@ -687,6 +715,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(RedirectStatusCodes))]
         public async Task GetAsync_CredentialIsCredentialCacheUriRedirect_StatusCodeOK(int statusCode)
@@ -714,6 +743,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task GetAsync_DefaultCoookieContainer_NoCookieSent()
@@ -729,6 +759,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData("cookieName1", "cookieValue1")]
@@ -750,7 +781,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ActiveIssue("dotnet/corefx #20010", TargetFrameworkMonikers.Uap)]
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData("cookieName1", "cookieValue1")]
@@ -775,6 +806,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(HeaderValueAndUris))]
         public async Task GetAsync_RequestHeadersAddCustomHeaders_HeaderAndValueSent(string name, string value, Uri uri)
@@ -837,6 +869,7 @@ namespace System.Net.Http.Functional.Tests
             }
         };
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(CookieNameValues))]
@@ -874,6 +907,7 @@ namespace System.Net.Http.Functional.Tests
             });
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [ActiveIssue(17174, TestPlatforms.AnyUnix)] // https://github.com/curl/curl/issues/1354
         [Theory]
@@ -912,6 +946,7 @@ namespace System.Net.Http.Functional.Tests
             });
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task GetAsync_ResponseHeadersRead_ReadFromEachIterativelyDoesntDeadlock()
@@ -937,6 +972,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task SendAsync_HttpRequestMsgResponseHeadersRead_StatusCodeOK()
@@ -957,6 +993,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "netfx's ConnectStream.ReadAsync tries to read beyond data already buffered, causing hangs #18864")]
         [OuterLoop] // TODO: Issue #11345
         [Fact]
@@ -995,6 +1032,7 @@ namespace System.Net.Http.Functional.Tests
             });
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task Dispose_DisposingHandlerCancelsActiveOperationsWithoutResponses()
@@ -1060,6 +1098,7 @@ namespace System.Net.Http.Functional.Tests
             });
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(200)]
@@ -1086,7 +1125,7 @@ namespace System.Net.Http.Functional.Tests
             });
         }
 
-        [ActiveIssue("dotnet/corefx #20010", TargetFrameworkMonikers.Uap)]
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(99)]
@@ -1110,6 +1149,7 @@ namespace System.Net.Http.Functional.Tests
 
         #region Post Methods Tests
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(VerifyUploadServers))]
         public async Task PostAsync_CallMethodTwice_StringContent(Uri remoteServer)
@@ -1135,6 +1175,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(VerifyUploadServers))]
         public async Task PostAsync_CallMethod_UnicodeStringContent(Uri remoteServer)
@@ -1152,6 +1193,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(VerifyUploadServersStreamsAndExpectedData))]
         public async Task PostAsync_CallMethod_StreamContent(Uri remoteServer, HttpContent content, byte[] expectedData)
@@ -1293,6 +1335,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(EchoServers))]
         public async Task PostAsync_CallMethod_NullContent(Uri remoteServer)
@@ -1314,6 +1357,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(EchoServers))]
         public async Task PostAsync_CallMethod_EmptyContent(Uri remoteServer)
@@ -1336,6 +1380,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(false)]
@@ -1360,6 +1405,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // takes several seconds
         [Theory]
         [InlineData(302, false)]
@@ -1388,8 +1434,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-
-
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(EchoServers))] // NOTE: will not work for in-box System.Net.Http.dll due to disposal of request content
         public async Task PostAsync_ReuseRequestContent_Success(Uri remoteServer)
@@ -1428,6 +1473,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [PlatformSpecific(TestPlatforms.Windows)] // CopyToAsync(Stream, TransportContext) isn't used on unix
         [Fact]
@@ -1452,6 +1498,7 @@ namespace System.Net.Http.Functional.Tests
 
         #region Various HTTP Method Tests
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(HttpMethods))]
         public async Task SendAsync_SendRequestUsingMethodToEchoServerWithNoContent_MethodCorrectlySent(
@@ -1510,6 +1557,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData("12345678910", 0)]
@@ -1544,6 +1592,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(HttpMethodsThatDontAllowContent))]
         public async Task SendAsync_SendRequestUsingNoBodyMethodToEchoServerWithContent_NoBodySent(
@@ -1591,7 +1640,7 @@ namespace System.Net.Http.Functional.Tests
         #endregion
 
         #region Version tests
-        [ActiveIssue("dotnet/corefx #20010", TargetFrameworkMonikers.Uap)]
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task SendAsync_RequestVersion10_ServerReceivesVersion10Request()
@@ -1673,6 +1722,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Specifying Version(2,0) throws exception on netfx")]
         [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(IsWindows10Version1607OrGreater)), MemberData(nameof(Http2NoPushServers))]
@@ -1735,6 +1785,7 @@ namespace System.Net.Http.Functional.Tests
         #endregion
 
         #region Proxy tests
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(CredentialsForProxy))]
@@ -1778,6 +1829,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(BypassedProxies))]
@@ -1794,6 +1846,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void Proxy_HaveNoCredsAndUseAuthenticatedCustomProxy_ProxyAuthenticationRequiredStatusCode()
@@ -1835,6 +1888,7 @@ namespace System.Net.Http.Functional.Tests
         #endregion
 
         #region Uri wire transmission encoding tests
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task SendRequest_UriPathHasReservedChars_ServerReceivedExpectedPath()


### PR DESCRIPTION
The HttpClientHandler for UAP does not properly implement the PreAuthenticate
property. This is because on UAP, HttpClientHandler is built on the WinRT
APIs which in turn are built on WinInet. And WinInet always uses authentication
caching internally and this results in the net effect of PreAuthenticate always
being "true".

The default for .NET Framework and .NET Core (non-UAP) is "false".

When this property was first added to .NET Core 1.1, the UAP version defaulted
to true and the setter would throw PNSE.

As part of .NET Core 2.0, API surface for networking APIs was expanded. This
resulted in HttpWebRequest exposing and implementing a "PreAuthenticate" property,
which is what it has historically done in .NET Framework. On .NET Core, HttpWebRequest
is built on top of HttpClient. And so, HttpWebRequest was enhanced in .NET Core 2.0
to set the default of PreAuthenticate to false. But this later caused the PNSE
exception to surface and this exception was caught in UWP app-compat testing.
Essentially, we had now created the default HttpWebRequest to always throw an
exception.

So, in PR #18105, the PNSE in HttpClientHandler.PreAuthenticate was commented out
and thus the setter became a no-op.

This PR basically acknowledges this situation and removes the TODO from this change.
Since there is no good way to implement the actual HttpClientHandler.PreAuthenticate
property, I left the getter default to return "true" which is closer to reality of
what happens on UAP (even though this default value is different from .NET Framework
or the rest of .NET Core). And, in terms of the setter for the property, I opted to
leave it as a no-op. This seems like the best compromise outcome for now and will
generate less distraction for developers rather than throwing an exception all the
time.

The rest of this PR moves the ActiveIssue's from the class level to the method level
as part of eventually solving all of them. In addition, I added a new test case to
validate the HttpClientHandler constructor defaults that are different on the UAP
platform.

Fixes #18104