### PR TITLE
Miscellaneous cleanup in ManagedHandler

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Managed/AuthenticationHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/AuthenticationHandler.cs
@@ -50,7 +50,7 @@ namespace System.Net.Http
                 TrySetBasicAuthToken(request);
             }
 
-            HttpResponseMessage response = await _innerHandler.SendAsync(request, cancellationToken);
+            HttpResponseMessage response = await _innerHandler.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
             if (!_preAuthenticate && response.StatusCode == HttpStatusCode.Unauthorized)
             {
@@ -67,7 +67,7 @@ namespace System.Net.Http
                         }
 
                         response.Dispose();
-                        response = await _innerHandler.SendAsync(request, cancellationToken);
+                        response = await _innerHandler.SendAsync(request, cancellationToken).ConfigureAwait(false);
                         break;
                     }
                 }

--- a/src/System.Net.Http/src/System/Net/Http/Managed/AuthenticationHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/AuthenticationHandler.cs
@@ -16,19 +16,9 @@ namespace System.Net.Http
 
         public AuthenticationHandler(bool preAuthenticate, ICredentials credentials, HttpMessageHandler innerHandler)
         {
-            if (innerHandler == null)
-            {
-                throw new ArgumentNullException(nameof(innerHandler));
-            }
-
-            if (credentials == null)
-            {
-                throw new ArgumentNullException(nameof(credentials));
-            }
-
             _preAuthenticate = preAuthenticate;
-            _credentials = credentials;
-            _innerHandler = innerHandler;
+            _credentials = credentials ?? throw new ArgumentNullException(nameof(credentials));
+            _innerHandler = innerHandler ?? throw new ArgumentNullException(nameof(innerHandler));
         }
 
         private bool TrySetBasicAuthToken(HttpRequestMessage request)

--- a/src/System.Net.Http/src/System/Net/Http/Managed/AutoRedirectHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/AutoRedirectHandler.cs
@@ -14,18 +14,13 @@ namespace System.Net.Http
 
         public AutoRedirectHandler(int maxAutomaticRedirections, HttpMessageHandler innerHandler)
         {
-            if (innerHandler == null)
-            {
-                throw new ArgumentNullException(nameof(innerHandler));
-            }
+            _innerHandler = innerHandler ?? throw new ArgumentNullException(nameof(innerHandler));
 
             if (maxAutomaticRedirections < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(maxAutomaticRedirections));
             }
-
             _maxAutomaticRedirections = maxAutomaticRedirections;
-            _innerHandler = innerHandler;
         }
 
         protected internal override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)

--- a/src/System.Net.Http/src/System/Net/Http/Managed/AutoRedirectHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/AutoRedirectHandler.cs
@@ -30,7 +30,7 @@ namespace System.Net.Http
 
         protected internal override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            HttpResponseMessage response = await _innerHandler.SendAsync(request, cancellationToken);
+            HttpResponseMessage response = await _innerHandler.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
             int redirectCount = 0;
             while (true)
@@ -101,7 +101,7 @@ namespace System.Net.Http
 
                 // Do the redirect.
                 response.Dispose();
-                response = await _innerHandler.SendAsync(request, cancellationToken);
+                response = await _innerHandler.SendAsync(request, cancellationToken).ConfigureAwait(false);
             }
 
             return response;

--- a/src/System.Net.Http/src/System/Net/Http/Managed/ConnectHelper.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/ConnectHelper.cs
@@ -9,7 +9,7 @@ namespace System.Net.Http
 {
     internal static class ConnectHelper
     {
-        public static async Task<NetworkStream> ConnectAsync(string host, int port)
+        public static async ValueTask<NetworkStream> ConnectAsync(string host, int port)
         {
             TcpClient client;
             try

--- a/src/System.Net.Http/src/System/Net/Http/Managed/ConnectHelper.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/ConnectHelper.cs
@@ -25,12 +25,12 @@ namespace System.Net.Http
                 if (IPAddress.TryParse(host, out ipAddress))
                 {
                     client = new TcpClient(ipAddress.AddressFamily);
-                    await client.ConnectAsync(ipAddress, port);
+                    await client.ConnectAsync(ipAddress, port).ConfigureAwait(false);
                 }
                 else
                 {
                     client = new TcpClient();
-                    await client.ConnectAsync(host, port);
+                    await client.ConnectAsync(host, port).ConfigureAwait(false);
                 }
             }
             catch (SocketException se)

--- a/src/System.Net.Http/src/System/Net/Http/Managed/CookieHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/CookieHandler.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace System.Net.Http
 {
-    internal class CookieHandler : HttpMessageHandler
+    internal sealed class CookieHandler : HttpMessageHandler
     {
         private readonly HttpMessageHandler _innerHandler;
         private readonly CookieContainer _cookieContainer;

--- a/src/System.Net.Http/src/System/Net/Http/Managed/CookieHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/CookieHandler.cs
@@ -15,18 +15,8 @@ namespace System.Net.Http
 
         public CookieHandler(CookieContainer cookieContainer, HttpMessageHandler innerHandler)
         {
-            if (innerHandler == null)
-            {
-                throw new ArgumentNullException(nameof(innerHandler));
-            }
-
-            if (cookieContainer == null)
-            {
-                throw new ArgumentNullException(nameof(cookieContainer));
-            }
-
-            _innerHandler = innerHandler;
-            _cookieContainer = cookieContainer;
+            _innerHandler = innerHandler ?? throw new ArgumentNullException(nameof(innerHandler));
+            _cookieContainer = cookieContainer ?? throw new ArgumentNullException(nameof(cookieContainer));
         }
 
         protected internal override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)

--- a/src/System.Net.Http/src/System/Net/Http/Managed/CookieHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/CookieHandler.cs
@@ -38,7 +38,7 @@ namespace System.Net.Http
                 request.Headers.Add("Cookie", cookieHeader);
             }
 
-            HttpResponseMessage response = await _innerHandler.SendAsync(request, cancellationToken);
+            HttpResponseMessage response = await _innerHandler.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
             // Handle Set-Cookie
             IEnumerable<string> setCookies;

--- a/src/System.Net.Http/src/System/Net/Http/Managed/DecompressionHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/DecompressionHandler.cs
@@ -51,7 +51,7 @@ namespace System.Net.Http
                 request.Headers.AcceptEncoding.Add(s_deflateHeaderValue);
             }
 
-            HttpResponseMessage response = await _innerHandler.SendAsync(request, cancellationToken);
+            HttpResponseMessage response = await _innerHandler.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
             while (true)
             {
@@ -127,8 +127,8 @@ namespace System.Net.Http
 
             protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
             {
-                Stream decompressedStream = await CreateContentReadStreamAsync();
-                await decompressedStream.CopyToAsync(stream);
+                Stream decompressedStream = await CreateContentReadStreamAsync().ConfigureAwait(false);
+                await decompressedStream.CopyToAsync(stream).ConfigureAwait(false);
                 decompressedStream.Dispose();
             }
 
@@ -141,7 +141,7 @@ namespace System.Net.Http
 
                 _contentConsumed = true;
 
-                Stream originalStream = await _originalContent.ReadAsStreamAsync();
+                Stream originalStream = await _originalContent.ReadAsStreamAsync().ConfigureAwait(false);
                 return GetDecompressedStream(originalStream);
             }
 

--- a/src/System.Net.Http/src/System/Net/Http/Managed/DecompressionHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/DecompressionHandler.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 
 namespace System.Net.Http
 {
-    internal class DecompressionHandler : HttpMessageHandler
+    internal sealed class DecompressionHandler : HttpMessageHandler
     {
         private readonly HttpMessageHandler _innerHandler;
         private readonly DecompressionMethods _decompressionMethods;

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
@@ -198,7 +198,7 @@ namespace System.Net.Http
                 _chunkBytesRemaining = 0;
             }
 
-            private async Task<bool> TryGetNextChunk(CancellationToken cancellationToken)
+            private async ValueTask<bool> TryGetNextChunk(CancellationToken cancellationToken)
             {
                 Debug.Assert(_chunkBytesRemaining == 0);
 
@@ -564,7 +564,7 @@ namespace System.Net.Http
             }
         }
 
-        private async Task<HttpResponseMessage> ParseResponseAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        private async ValueTask<HttpResponseMessage> ParseResponseAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             HttpResponseMessage response = new HttpResponseMessage();
             response.RequestMessage = request;
@@ -757,7 +757,7 @@ namespace System.Net.Http
             }
         }
 
-        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+        public async ValueTask<HttpResponseMessage> SendAsync(HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
             if (request.Version.Major != 1 || request.Version.Minor != 1)
@@ -966,7 +966,7 @@ namespace System.Net.Http
             _readLength = await _stream.ReadAsync(_readBuffer, 0, BufferSize, cancellationToken).ConfigureAwait(false);
         }
 
-        private async Task<byte> ReadByteSlowAsync(CancellationToken cancellationToken)
+        private async ValueTask<byte> ReadByteSlowAsync(CancellationToken cancellationToken)
         {
             await FillAsync(cancellationToken).ConfigureAwait(false);
 
@@ -987,10 +987,10 @@ namespace System.Net.Http
                 return new ValueTask<byte>(_readBuffer[_readOffset++]);
             }
 
-            return new ValueTask<byte>(ReadByteSlowAsync(cancellationToken));
+            return ReadByteSlowAsync(cancellationToken);
         }
 
-        private async Task<char> ReadCharSlowAsync(CancellationToken cancellationToken)
+        private async ValueTask<char> ReadCharSlowAsync(CancellationToken cancellationToken)
         {
             await FillAsync(cancellationToken).ConfigureAwait(false);
 
@@ -1022,7 +1022,7 @@ namespace System.Net.Http
                 return new ValueTask<char>((char)b);
             }
 
-            return new ValueTask<char>(ReadCharSlowAsync(cancellationToken));
+            return ReadCharSlowAsync(cancellationToken);
         }
 
         private void ReadFromBuffer(byte[] buffer, int offset, int count)
@@ -1033,7 +1033,7 @@ namespace System.Net.Http
             _readOffset += count;
         }
 
-        private async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        private async ValueTask<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             // This is called when reading the response body
 

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
@@ -67,11 +67,11 @@ namespace System.Net.Http
             {
                 Debug.Assert(stream != null);
 
-                HttpContentReadStream contentStream = ConsumeStream();
-
-                const int BufferSize = 8192;
-                await contentStream.CopyToAsync(stream, BufferSize, _cancellationToken).ConfigureAwait(false);
-                contentStream.Dispose();
+                using (HttpContentReadStream contentStream = ConsumeStream())
+                {
+                    const int BufferSize = 8192;
+                    await contentStream.CopyToAsync(stream, BufferSize, _cancellationToken).ConfigureAwait(false);
+                }
             }
 
             protected internal override bool TryComputeLength(out long length)
@@ -80,10 +80,8 @@ namespace System.Net.Http
                 return false;
             }
 
-            protected override Task<Stream> CreateContentReadStreamAsync()
-            {
-                return Task.FromResult<Stream>(ConsumeStream());
-            }
+            protected override Task<Stream> CreateContentReadStreamAsync() =>
+                Task.FromResult<Stream>(ConsumeStream());
 
             protected override void Dispose(bool disposing)
             {

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
@@ -70,7 +70,7 @@ namespace System.Net.Http
                 HttpContentReadStream contentStream = ConsumeStream();
 
                 const int BufferSize = 8192;
-                await contentStream.CopyToAsync(stream, BufferSize, _cancellationToken);
+                await contentStream.CopyToAsync(stream, BufferSize, _cancellationToken).ConfigureAwait(false);
                 contentStream.Dispose();
             }
 
@@ -146,7 +146,7 @@ namespace System.Net.Http
 
                 count = (int)Math.Min(count, _contentBytesRemaining);
 
-                int bytesRead = await _connection.ReadAsync(buffer, offset, count, cancellationToken);
+                int bytesRead = await _connection.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
 
                 if (bytesRead == 0)
                 {
@@ -180,7 +180,7 @@ namespace System.Net.Http
                     return;
                 }
 
-                await _connection.CopyChunkToAsync(destination, _contentBytesRemaining, cancellationToken);
+                await _connection.CopyChunkToAsync(destination, _contentBytesRemaining, cancellationToken).ConfigureAwait(false);
 
                 _contentBytesRemaining = 0;
                 _connection.PutConnectionInPool();
@@ -204,7 +204,7 @@ namespace System.Net.Http
 
                 // Start of chunk, read chunk size
                 int chunkSize = 0;
-                char c = await _connection.ReadCharAsync(cancellationToken);
+                char c = await _connection.ReadCharAsync(cancellationToken).ConfigureAwait(false);
                 while (true)
                 {
                     // Get hex digit
@@ -225,10 +225,10 @@ namespace System.Net.Http
                         throw new IOException("Invalid chunk size in response stream");
                     }
 
-                    c = await _connection.ReadCharAsync(cancellationToken);
+                    c = await _connection.ReadCharAsync(cancellationToken).ConfigureAwait(false);
                     if (c == '\r')
                     {
-                        if (await _connection.ReadCharAsync(cancellationToken) != '\n')
+                        if (await _connection.ReadCharAsync(cancellationToken).ConfigureAwait(false) != '\n')
                         {
                             throw new IOException("Saw CR without LF while parsing chunk size");
                         }
@@ -243,8 +243,8 @@ namespace System.Net.Http
                     // Indicates end of response body
 
                     // We expect final CRLF after this
-                    if (await _connection.ReadByteAsync(cancellationToken) != (byte)'\r' ||
-                        await _connection.ReadByteAsync(cancellationToken) != (byte)'\n')
+                    if (await _connection.ReadByteAsync(cancellationToken).ConfigureAwait(false) != (byte)'\r' ||
+                        await _connection.ReadByteAsync(cancellationToken).ConfigureAwait(false) != (byte)'\n')
                     {
                         throw new IOException("missing final CRLF for chunked encoding");
                     }
@@ -265,8 +265,8 @@ namespace System.Net.Http
                 if (_chunkBytesRemaining == 0)
                 {
                     // Parse CRLF at end of chunk
-                    if (await _connection.ReadCharAsync(cancellationToken) != '\r' ||
-                        await _connection.ReadCharAsync(cancellationToken) != '\n')
+                    if (await _connection.ReadCharAsync(cancellationToken).ConfigureAwait(false) != '\r' ||
+                        await _connection.ReadCharAsync(cancellationToken).ConfigureAwait(false) != '\n')
                     {
                         throw new IOException("missing CRLF for end of chunk");
                     }
@@ -298,7 +298,7 @@ namespace System.Net.Http
 
                 if (_chunkBytesRemaining == 0)
                 {
-                    if (!await TryGetNextChunk(cancellationToken))
+                    if (!await TryGetNextChunk(cancellationToken).ConfigureAwait(false))
                     {
                         // End of response body
                         return 0;
@@ -307,7 +307,7 @@ namespace System.Net.Http
 
                 count = Math.Min(count, _chunkBytesRemaining);
 
-                int bytesRead = await _connection.ReadAsync(buffer, offset, count, cancellationToken);
+                int bytesRead = await _connection.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
 
                 if (bytesRead == 0)
                 {
@@ -315,7 +315,7 @@ namespace System.Net.Http
                     throw new IOException("Unexpected end of content stream while processing chunked response body");
                 }
 
-                await ConsumeChunkBytes(bytesRead, cancellationToken);
+                await ConsumeChunkBytes(bytesRead, cancellationToken).ConfigureAwait(false);
 
                 return bytesRead;
             }
@@ -335,14 +335,14 @@ namespace System.Net.Http
 
                 if (_chunkBytesRemaining > 0)
                 {
-                    await _connection.CopyChunkToAsync(destination, _chunkBytesRemaining, cancellationToken);
-                    await ConsumeChunkBytes(_chunkBytesRemaining, cancellationToken);
+                    await _connection.CopyChunkToAsync(destination, _chunkBytesRemaining, cancellationToken).ConfigureAwait(false);
+                    await ConsumeChunkBytes(_chunkBytesRemaining, cancellationToken).ConfigureAwait(false);
                 }
 
-                while (await TryGetNextChunk(cancellationToken))
+                while (await TryGetNextChunk(cancellationToken).ConfigureAwait(false))
                 {
-                    await _connection.CopyChunkToAsync(destination, _chunkBytesRemaining, cancellationToken);
-                    await ConsumeChunkBytes(_chunkBytesRemaining, cancellationToken);
+                    await _connection.CopyChunkToAsync(destination, _chunkBytesRemaining, cancellationToken).ConfigureAwait(false);
+                    await ConsumeChunkBytes(_chunkBytesRemaining, cancellationToken).ConfigureAwait(false);
                 }
             }
         }
@@ -377,7 +377,7 @@ namespace System.Net.Http
                     return 0;
                 }
 
-                int bytesRead = await _connection.ReadAsync(buffer, offset, count, cancellationToken);
+                int bytesRead = await _connection.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
 
                 if (bytesRead == 0)
                 {
@@ -403,7 +403,7 @@ namespace System.Net.Http
                     return;
                 }
 
-                await _connection.CopyToAsync(destination, cancellationToken);
+                await _connection.CopyToAsync(destination, cancellationToken).ConfigureAwait(false);
 
                 // We cannot reuse this connection, so close it.
                 _connection.Dispose();
@@ -451,18 +451,18 @@ namespace System.Net.Http
                     int digit = (count & mask) >> shift;
                     if (digitWritten || digit != 0)
                     {
-                        await _connection.WriteCharAsync((char)(digit < 10 ? '0' + digit : 'A' + digit - 10), cancellationToken);
+                        await _connection.WriteCharAsync((char)(digit < 10 ? '0' + digit : 'A' + digit - 10), cancellationToken).ConfigureAwait(false);
                         digitWritten = true;
                     }
                 }
 
-                await _connection.WriteCharAsync('\r', cancellationToken);
-                await _connection.WriteCharAsync('\n', cancellationToken);
+                await _connection.WriteCharAsync('\r', cancellationToken).ConfigureAwait(false);
+                await _connection.WriteCharAsync('\n', cancellationToken).ConfigureAwait(false);
 
                 // Write chunk contents
-                await _connection.WriteAsync(buffer, offset, count, cancellationToken);
-                await _connection.WriteCharAsync('\r', cancellationToken);
-                await _connection.WriteCharAsync('\n', cancellationToken);
+                await _connection.WriteAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+                await _connection.WriteCharAsync('\r', cancellationToken).ConfigureAwait(false);
+                await _connection.WriteCharAsync('\n', cancellationToken).ConfigureAwait(false);
             }
 
             public override Task FlushAsync(CancellationToken cancellationToken)
@@ -473,13 +473,13 @@ namespace System.Net.Http
             public override async Task FinishAsync(CancellationToken cancellationToken)
             {
                 // Send 0 byte chunk to indicate end
-                await _connection.WriteCharAsync('0', cancellationToken);
-                await _connection.WriteCharAsync('\r', cancellationToken);
-                await _connection.WriteCharAsync('\n', cancellationToken);
+                await _connection.WriteCharAsync('0', cancellationToken).ConfigureAwait(false);
+                await _connection.WriteCharAsync('\r', cancellationToken).ConfigureAwait(false);
+                await _connection.WriteCharAsync('\n', cancellationToken).ConfigureAwait(false);
 
                 // Send final _CRLF
-                await _connection.WriteCharAsync('\r', cancellationToken);
-                await _connection.WriteCharAsync('\n', cancellationToken);
+                await _connection.WriteCharAsync('\r', cancellationToken).ConfigureAwait(false);
+                await _connection.WriteCharAsync('\n', cancellationToken).ConfigureAwait(false);
 
                 _connection = null;
             }
@@ -569,26 +569,26 @@ namespace System.Net.Http
             HttpResponseMessage response = new HttpResponseMessage();
             response.RequestMessage = request;
 
-            if (await ReadCharAsync(cancellationToken) != 'H' ||
-                await ReadCharAsync(cancellationToken) != 'T' ||
-                await ReadCharAsync(cancellationToken) != 'T' ||
-                await ReadCharAsync(cancellationToken) != 'P' ||
-                await ReadCharAsync(cancellationToken) != '/' ||
-                await ReadCharAsync(cancellationToken) != '1' ||
-                await ReadCharAsync(cancellationToken) != '.' ||
-                await ReadCharAsync(cancellationToken) != '1')
+            if (await ReadCharAsync(cancellationToken).ConfigureAwait(false) != 'H' ||
+                await ReadCharAsync(cancellationToken).ConfigureAwait(false) != 'T' ||
+                await ReadCharAsync(cancellationToken).ConfigureAwait(false) != 'T' ||
+                await ReadCharAsync(cancellationToken).ConfigureAwait(false) != 'P' ||
+                await ReadCharAsync(cancellationToken).ConfigureAwait(false) != '/' ||
+                await ReadCharAsync(cancellationToken).ConfigureAwait(false) != '1' ||
+                await ReadCharAsync(cancellationToken).ConfigureAwait(false) != '.' ||
+                await ReadCharAsync(cancellationToken).ConfigureAwait(false) != '1')
             {
                 throw new HttpRequestException("could not read response HTTP version");
             }
 
-            if (await ReadCharAsync(cancellationToken) != ' ')
+            if (await ReadCharAsync(cancellationToken).ConfigureAwait(false) != ' ')
             {
                 throw new HttpRequestException("Invalid characters in response");
             }
 
-            char status1 = await ReadCharAsync(cancellationToken);
-            char status2 = await ReadCharAsync(cancellationToken);
-            char status3 = await ReadCharAsync(cancellationToken);
+            char status1 = await ReadCharAsync(cancellationToken).ConfigureAwait(false);
+            char status2 = await ReadCharAsync(cancellationToken).ConfigureAwait(false);
+            char status3 = await ReadCharAsync(cancellationToken).ConfigureAwait(false);
 
             if (!char.IsDigit(status1) ||
                 !char.IsDigit(status2) ||
@@ -600,7 +600,7 @@ namespace System.Net.Http
             int status = 100 * (status1 - '0') + 10 * (status2 - '0') + (status3 - '0');
             response.StatusCode = (HttpStatusCode)status;
 
-            if (await ReadCharAsync(cancellationToken) != ' ')
+            if (await ReadCharAsync(cancellationToken).ConfigureAwait(false) != ' ')
             {
                 throw new HttpRequestException("Invalid characters in response line");
             }
@@ -608,14 +608,14 @@ namespace System.Net.Http
             _sb.Clear();
 
             // Parse reason phrase
-            char c = await ReadCharAsync(cancellationToken);
+            char c = await ReadCharAsync(cancellationToken).ConfigureAwait(false);
             while (c != '\r')
             {
                 _sb.Append(c);
-                c = await ReadCharAsync(cancellationToken);
+                c = await ReadCharAsync(cancellationToken).ConfigureAwait(false);
             }
 
-            if (await ReadCharAsync(cancellationToken) != '\n')
+            if (await ReadCharAsync(cancellationToken).ConfigureAwait(false) != '\n')
             {
                 throw new HttpRequestException("Saw CR without LF while parsing response line");
             }
@@ -626,12 +626,12 @@ namespace System.Net.Http
 
             // Parse headers
             _sb.Clear();
-            c = await ReadCharAsync(cancellationToken);
+            c = await ReadCharAsync(cancellationToken).ConfigureAwait(false);
             while (true)
             {
                 if (c == '\r')
                 {
-                    if (await ReadCharAsync(cancellationToken) != '\n')
+                    if (await ReadCharAsync(cancellationToken).ConfigureAwait(false) != '\n')
                     {
                         throw new HttpRequestException("Saw CR without LF while parsing headers");
                     }
@@ -643,7 +643,7 @@ namespace System.Net.Http
                 while (c != ':')
                 {
                     _sb.Append(c);
-                    c = await ReadCharAsync(cancellationToken);
+                    c = await ReadCharAsync(cancellationToken).ConfigureAwait(false);
                 }
 
                 string headerName = _sb.ToString();
@@ -651,19 +651,19 @@ namespace System.Net.Http
                 _sb.Clear();
 
                 // Get header value
-                c = await ReadCharAsync(cancellationToken);
+                c = await ReadCharAsync(cancellationToken).ConfigureAwait(false);
                 while (c == ' ')
                 {
-                    c = await ReadCharAsync(cancellationToken);
+                    c = await ReadCharAsync(cancellationToken).ConfigureAwait(false);
                 }
 
                 while (c != '\r')
                 {
                     _sb.Append(c);
-                    c = await ReadCharAsync(cancellationToken);
+                    c = await ReadCharAsync(cancellationToken).ConfigureAwait(false);
                 }
 
-                if (await ReadCharAsync(cancellationToken) != '\n')
+                if (await ReadCharAsync(cancellationToken).ConfigureAwait(false) != '\n')
                 {
                     throw new HttpRequestException("Saw CR without LF while parsing headers");
                 }
@@ -689,7 +689,7 @@ namespace System.Net.Http
 
                 _sb.Clear();
 
-                c = await ReadCharAsync(cancellationToken);
+                c = await ReadCharAsync(cancellationToken).ConfigureAwait(false);
             }
 
             // Instantiate responseStream
@@ -731,9 +731,9 @@ namespace System.Net.Http
         {
             foreach (KeyValuePair<string, IEnumerable<string>> header in headers)
             {
-                await WriteStringAsync(header.Key, cancellationToken);
-                await WriteCharAsync(':', cancellationToken);
-                await WriteCharAsync(' ', cancellationToken);
+                await WriteStringAsync(header.Key, cancellationToken).ConfigureAwait(false);
+                await WriteCharAsync(':', cancellationToken).ConfigureAwait(false);
+                await WriteCharAsync(' ', cancellationToken).ConfigureAwait(false);
 
                 bool first = true;
                 foreach (string headerValue in header.Value)
@@ -744,16 +744,16 @@ namespace System.Net.Http
                     }
                     else
                     {
-                        await WriteCharAsync(',', cancellationToken);
-                        await WriteCharAsync(' ', cancellationToken);
+                        await WriteCharAsync(',', cancellationToken).ConfigureAwait(false);
+                        await WriteCharAsync(' ', cancellationToken).ConfigureAwait(false);
                     }
-                    await WriteStringAsync(headerValue, cancellationToken);
+                    await WriteStringAsync(headerValue, cancellationToken).ConfigureAwait(false);
                 }
 
                 Debug.Assert(!first, "No values for header??");
 
-                await WriteCharAsync('\r', cancellationToken);
-                await WriteCharAsync('\n', cancellationToken);
+                await WriteCharAsync('\r', cancellationToken).ConfigureAwait(false);
+                await WriteCharAsync('\n', cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -803,32 +803,32 @@ namespace System.Net.Http
             }
 
             // Write request line
-            await WriteStringAsync(request.Method.Method, cancellationToken);
-            await WriteCharAsync(' ', cancellationToken);
+            await WriteStringAsync(request.Method.Method, cancellationToken).ConfigureAwait(false);
+            await WriteCharAsync(' ', cancellationToken).ConfigureAwait(false);
 
             if (_usingProxy)
             {
-                await WriteStringAsync(request.RequestUri.AbsoluteUri, cancellationToken);
+                await WriteStringAsync(request.RequestUri.AbsoluteUri, cancellationToken).ConfigureAwait(false);
             }
             else
             {
-                await WriteStringAsync(request.RequestUri.PathAndQuery, cancellationToken);
+                await WriteStringAsync(request.RequestUri.PathAndQuery, cancellationToken).ConfigureAwait(false);
             }
 
-            await WriteCharAsync(' ', cancellationToken);
-            await WriteCharAsync('H', cancellationToken);
-            await WriteCharAsync('T', cancellationToken);
-            await WriteCharAsync('T', cancellationToken);
-            await WriteCharAsync('P', cancellationToken);
-            await WriteCharAsync('/', cancellationToken);
-            await WriteCharAsync('1', cancellationToken);
-            await WriteCharAsync('.', cancellationToken);
-            await WriteCharAsync('1', cancellationToken);
-            await WriteCharAsync('\r', cancellationToken);
-            await WriteCharAsync('\n', cancellationToken);
+            await WriteCharAsync(' ', cancellationToken).ConfigureAwait(false);
+            await WriteCharAsync('H', cancellationToken).ConfigureAwait(false);
+            await WriteCharAsync('T', cancellationToken).ConfigureAwait(false);
+            await WriteCharAsync('T', cancellationToken).ConfigureAwait(false);
+            await WriteCharAsync('P', cancellationToken).ConfigureAwait(false);
+            await WriteCharAsync('/', cancellationToken).ConfigureAwait(false);
+            await WriteCharAsync('1', cancellationToken).ConfigureAwait(false);
+            await WriteCharAsync('.', cancellationToken).ConfigureAwait(false);
+            await WriteCharAsync('1', cancellationToken).ConfigureAwait(false);
+            await WriteCharAsync('\r', cancellationToken).ConfigureAwait(false);
+            await WriteCharAsync('\n', cancellationToken).ConfigureAwait(false);
 
             // Write request headers
-            await WriteHeadersAsync(request.Headers, cancellationToken);
+            await WriteHeadersAsync(request.Headers, cancellationToken).ConfigureAwait(false);
 
             if (requestContent == null)
             {
@@ -837,18 +837,18 @@ namespace System.Net.Http
                 if (request.Method != HttpMethod.Get &&
                     request.Method != HttpMethod.Head)
                 {
-                    await WriteStringAsync("Content-Length: 0\r\n", cancellationToken);
+                    await WriteStringAsync("Content-Length: 0\r\n", cancellationToken).ConfigureAwait(false);
                 }
             }
             else
             {
                 // Write content headers
-                await WriteHeadersAsync(requestContent.Headers, cancellationToken);
+                await WriteHeadersAsync(requestContent.Headers, cancellationToken).ConfigureAwait(false);
             }
 
             // CRLF for end of headers.
-            await WriteCharAsync('\r', cancellationToken);
-            await WriteCharAsync('\n', cancellationToken);
+            await WriteCharAsync('\r', cancellationToken).ConfigureAwait(false);
+            await WriteCharAsync('\n', cancellationToken).ConfigureAwait(false);
 
             // Write body, if any
             if (requestContent != null)
@@ -858,13 +858,13 @@ namespace System.Net.Http
                     (HttpContentWriteStream)new ContentLengthWriteStream(this));
 
                 // TODO: CopyToAsync doesn't take a CancellationToken, how do we deal with Cancellation here?
-                await request.Content.CopyToAsync(stream, _transportContext);
-                await stream.FinishAsync(cancellationToken);
+                await request.Content.CopyToAsync(stream, _transportContext).ConfigureAwait(false);
+                await stream.FinishAsync(cancellationToken).ConfigureAwait(false);
             }
 
-            await FlushAsync(cancellationToken);
+            await FlushAsync(cancellationToken).ConfigureAwait(false);
 
-            return await ParseResponseAsync(request, cancellationToken);
+            return await ParseResponseAsync(request, cancellationToken).ConfigureAwait(false);
         }
 
         private void WriteToBuffer(byte[] buffer, int offset, int count)
@@ -890,7 +890,7 @@ namespace System.Net.Http
             {
                 // Fit what we can in the current write buffer and flush it.
                 WriteToBuffer(buffer, offset, remaining);
-                await FlushAsync(cancellationToken);
+                await FlushAsync(cancellationToken).ConfigureAwait(false);
 
                 // Update offset and count to reflect the write we just did.
                 offset += remaining;
@@ -901,7 +901,7 @@ namespace System.Net.Http
             {
                 // Large write.  No sense buffering this.  Write directly to stream.
                 // CONSIDER: May want to be a bit smarter here?  Think about how large writes should work...
-                await _stream.WriteAsync(buffer, offset, count, cancellationToken);
+                await _stream.WriteAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
             }
             else
             {
@@ -933,7 +933,7 @@ namespace System.Net.Http
 
         private async Task<bool> WriteByteSlowAsync(byte b, CancellationToken cancellationToken)
         {
-            await _stream.WriteAsync(_writeBuffer, 0, BufferSize, cancellationToken);
+            await _stream.WriteAsync(_writeBuffer, 0, BufferSize, cancellationToken).ConfigureAwait(false);
 
             _writeBuffer[0] = b;
             _writeOffset = 1;
@@ -945,7 +945,7 @@ namespace System.Net.Http
         {
             for (int i = 0; i < s.Length; i++)
             {
-                await WriteCharAsync(s[i], cancellationToken);
+                await WriteCharAsync(s[i], cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -953,7 +953,7 @@ namespace System.Net.Http
         {
             if (_writeOffset > 0)
             { 
-                await _stream.WriteAsync(_writeBuffer, 0, _writeOffset, cancellationToken);
+                await _stream.WriteAsync(_writeBuffer, 0, _writeOffset, cancellationToken).ConfigureAwait(false);
                 _writeOffset = 0;
             }
         }
@@ -963,12 +963,12 @@ namespace System.Net.Http
             Debug.Assert(_readOffset == _readLength);
 
             _readOffset = 0;
-            _readLength = await _stream.ReadAsync(_readBuffer, 0, BufferSize, cancellationToken);
+            _readLength = await _stream.ReadAsync(_readBuffer, 0, BufferSize, cancellationToken).ConfigureAwait(false);
         }
 
         private async Task<byte> ReadByteSlowAsync(CancellationToken cancellationToken)
         {
-            await FillAsync(cancellationToken);
+            await FillAsync(cancellationToken).ConfigureAwait(false);
 
             if (_readLength == 0)
             {
@@ -992,7 +992,7 @@ namespace System.Net.Http
 
         private async Task<char> ReadCharSlowAsync(CancellationToken cancellationToken)
         {
-            await FillAsync(cancellationToken);
+            await FillAsync(cancellationToken).ConfigureAwait(false);
 
             if (_readLength == 0)
             {
@@ -1051,7 +1051,7 @@ namespace System.Net.Http
             {
                 // Caller requested a small read size (less than half the read buffer size).
                 // Read into the buffer, so that we read as much as possible, hopefully.
-                await FillAsync(cancellationToken);
+                await FillAsync(cancellationToken).ConfigureAwait(false);
 
                 count = Math.Min(count, _readLength);
                 ReadFromBuffer(buffer, offset, count);
@@ -1060,7 +1060,7 @@ namespace System.Net.Http
 
             // Large read size, and no buffered data.
             // Do an unbuffered read directly against the underlying stream.
-            count = await _stream.ReadAsync(buffer, offset, count, cancellationToken);
+            count = await _stream.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
             return count;
         }
 
@@ -1068,7 +1068,7 @@ namespace System.Net.Http
         {
             Debug.Assert(count <= _readLength - _readOffset);
 
-            await destination.WriteAsync(_readBuffer, _readOffset, count, cancellationToken);
+            await destination.WriteAsync(_readBuffer, _readOffset, count, cancellationToken).ConfigureAwait(false);
             _readOffset += count;
         }
 
@@ -1079,19 +1079,19 @@ namespace System.Net.Http
             int remaining = _readLength - _readOffset;
             if (remaining > 0)
             {
-                await CopyFromBuffer(destination, remaining, cancellationToken);
+                await CopyFromBuffer(destination, remaining, cancellationToken).ConfigureAwait(false);
             }
 
             while (true)
             {
-                await FillAsync(cancellationToken);
+                await FillAsync(cancellationToken).ConfigureAwait(false);
                 if (_readLength == 0)
                 {
                     // End of stream
                     break;
                 }
 
-                await CopyFromBuffer(destination, _readLength, cancellationToken);
+                await CopyFromBuffer(destination, _readLength, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -1105,7 +1105,7 @@ namespace System.Net.Http
             if (remaining > 0)
             {
                 remaining = (int)Math.Min(remaining, length);
-                await CopyFromBuffer(destination, remaining, cancellationToken);
+                await CopyFromBuffer(destination, remaining, cancellationToken).ConfigureAwait(false);
 
                 length -= remaining;
                 if (length == 0)
@@ -1116,14 +1116,14 @@ namespace System.Net.Http
 
             while (true)
             {
-                await FillAsync(cancellationToken);
+                await FillAsync(cancellationToken).ConfigureAwait(false);
                 if (_readLength == 0)
                 {
                     throw new HttpRequestException("unexpected end of stream");
                 }
 
                 remaining = (int)Math.Min(_readLength, length);
-                await CopyFromBuffer(destination, remaining, cancellationToken);
+                await CopyFromBuffer(destination, remaining, cancellationToken).ConfigureAwait(false);
 
                 length -= remaining;
                 if (length == 0)

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
@@ -206,15 +206,15 @@ namespace System.Net.Http
                 while (true)
                 {
                     // Get hex digit
-                    if (c >= '0' && c <= '9')
+                    if ((uint)(c - '0') <= '9' - '0')
                     {
                         chunkSize = chunkSize * 16 + (c - '0');
                     }
-                    else if (c >= 'a' && c <= 'f')
+                    else if ((uint)(c - 'a') <= ('f' - 'a'))
                     {
                         chunkSize = chunkSize * 16 + (c - 'a' + 10);
                     }
-                    else if (c >= 'A' && c <= 'F')
+                    else if ((uint)(c - 'A') <= ('F' - 'A'))
                     {
                         chunkSize = chunkSize * 16 + (c - 'A' + 10);
                     }

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionHandler.cs
@@ -57,7 +57,7 @@ namespace System.Net.Http
             return await connection.SendAsync(request, cancellationToken).ConfigureAwait(false);
         }
 
-        private async Task<SslStream> EstablishSslConnection(string host, HttpRequestMessage request, Stream stream)
+        private async ValueTask<SslStream> EstablishSslConnection(string host, HttpRequestMessage request, Stream stream)
         {
             RemoteCertificateValidationCallback callback = null;
             if (_serverCertificateCustomValidationCallback != null)
@@ -96,7 +96,7 @@ namespace System.Net.Http
             return sslStream;
         }
 
-        private async Task<HttpConnection> CreateConnection(HttpRequestMessage request, HttpConnectionKey key, HttpConnectionPool pool)
+        private async ValueTask<HttpConnection> CreateConnection(HttpRequestMessage request, HttpConnectionKey key, HttpConnectionPool pool)
         {
             Uri uri = request.RequestUri;
 

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionHandler.cs
@@ -51,10 +51,10 @@ namespace System.Net.Http
             if (connection == null)
             {
                 // No connection available in pool.  Create a new one.
-                connection = await CreateConnection(request, key, pool);
+                connection = await CreateConnection(request, key, pool).ConfigureAwait(false);
             }
 
-            return await connection.SendAsync(request, cancellationToken);
+            return await connection.SendAsync(request, cancellationToken).ConfigureAwait(false);
         }
 
         private async Task<SslStream> EstablishSslConnection(string host, HttpRequestMessage request, Stream stream)
@@ -73,7 +73,7 @@ namespace System.Net.Http
             try
             {
                 // TODO: No cancellationToken?
-                await sslStream.AuthenticateAsClientAsync(host, _clientCertificates, _sslProtocols, _checkCertificateRevocationList);
+                await sslStream.AuthenticateAsClientAsync(host, _clientCertificates, _sslProtocols, _checkCertificateRevocationList).ConfigureAwait(false);
             }
             catch (AuthenticationException ae)
             {
@@ -100,13 +100,13 @@ namespace System.Net.Http
         {
             Uri uri = request.RequestUri;
 
-            Stream stream = await ConnectHelper.ConnectAsync(uri.Host, uri.Port);
+            Stream stream = await ConnectHelper.ConnectAsync(uri.Host, uri.Port).ConfigureAwait(false);
 
             TransportContext transportContext = null;
 
             if (uri.Scheme == "https")
             {
-                SslStream sslStream = await EstablishSslConnection(uri.Host, request, stream);
+                SslStream sslStream = await EstablishSslConnection(uri.Host, request, stream).ConfigureAwait(false);
 
                 stream = sslStream;
                 transportContext = sslStream.TransportContext;

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionKey.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionKey.cs
@@ -12,51 +12,29 @@ namespace System.Net.Http
 
         public HttpConnectionKey(Uri uri)
         {
-            if (uri.Scheme == "http")
-            {
-                UsingSSL = false;
-            }
-            else if (uri.Scheme == "https")
-            {
-                UsingSSL = true;
-            }
-            else
-            {
+            UsingSSL = 
+                uri.Scheme == "http" ? false :
+                uri.Scheme == "https" ? true :
                 throw new ArgumentException("Invalid Uri scheme", nameof(uri));
-            }
 
             Host = uri.Host;
             Port = uri.Port;
         }
 
-        public override int GetHashCode()
-        {
-            return UsingSSL.GetHashCode() ^ Host.GetHashCode() ^ Port.GetHashCode();
-        }
+        public override int GetHashCode() =>
+            UsingSSL.GetHashCode() ^ Host.GetHashCode() ^ Port.GetHashCode();
 
-        public override bool Equals(object obj)
-        {
-            if (obj == null || obj.GetType() != typeof(HttpConnectionKey))
-            {
-                return false;
-            }
+        public override bool Equals(object obj) =>
+            obj != null &&
+            obj is HttpConnectionKey &&
+            Equals((HttpConnectionKey)obj);
 
-            return Equals((HttpConnectionKey)obj);
-        }
+        public bool Equals(HttpConnectionKey other) =>
+            UsingSSL == other.UsingSSL &&
+            Host == other.Host &&
+            Port == other.Port;
 
-        public bool Equals(HttpConnectionKey other)
-        {
-            return (UsingSSL == other.UsingSSL && Host == other.Host && Port == other.Port);
-        }
-
-        public static bool operator ==(HttpConnectionKey key1, HttpConnectionKey key2)
-        {
-            return key1.Equals(key2);
-        }
-
-        public static bool operator !=(HttpConnectionKey key1, HttpConnectionKey key2)
-        {
-            return !key1.Equals(key2);
-        }
+        public static bool operator ==(HttpConnectionKey key1, HttpConnectionKey key2) => key1.Equals(key2);
+        public static bool operator !=(HttpConnectionKey key1, HttpConnectionKey key2) => !key1.Equals(key2);
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionPool.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionPool.cs
@@ -8,9 +8,9 @@ namespace System.Net.Http
 {
     internal sealed class HttpConnectionPool : IDisposable
     {
-        ConcurrentDictionary<HttpConnection, HttpConnection> _activeConnections;
-        ConcurrentBag<HttpConnection> _idleConnections;
-        bool _disposed;
+        private readonly ConcurrentDictionary<HttpConnection, HttpConnection> _activeConnections;
+        private readonly ConcurrentBag<HttpConnection> _idleConnections;
+        private bool _disposed;
 
         public HttpConnectionPool()
         {

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpContentReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpContentReadStream.cs
@@ -4,7 +4,6 @@
 
 using System.IO;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace System.Net.Http
 {
@@ -18,15 +17,10 @@ namespace System.Net.Http
         }
 
         public override bool CanRead => true;
-
         public override bool CanSeek => false;
-
         public override bool CanWrite => false;
 
-        public override long Length
-        {
-            get { throw new NotSupportedException(); }
-        }
+        public override long Length => throw new NotSupportedException();
 
         public override long Position
         {
@@ -34,39 +28,22 @@ namespace System.Net.Http
             set { throw new NotSupportedException(); }
         }
 
-        public override void Flush()
-        {
-            throw new NotSupportedException();
-        }
+        public override void Flush() => throw new NotSupportedException();
 
-        public override long Seek(long offset, SeekOrigin origin)
-        {
-            throw new NotSupportedException();
-        }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
 
-        public override void SetLength(long value)
-        {
-            throw new NotSupportedException();
-        }
+        public override void SetLength(long value) => throw new NotSupportedException();
 
-        public override void Write(byte[] buffer, int offset, int count)
-        {
-            throw new NotSupportedException();
-        }
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
 
-        public override int Read(byte[] buffer, int offset, int count)
-        {
-            return ReadAsync(buffer, offset, count, CancellationToken.None).Result;
-        }
+        public override int Read(byte[] buffer, int offset, int count) =>
+            ReadAsync(buffer, offset, count, CancellationToken.None).Result;
 
         // TODO: Restore this once we address unit test build's target
         //public override void CopyTo(Stream destination, int bufferSize)
         //{
         //    CopyToAsync(destination, bufferSize, CancellationToken.None).Wait();
         //}
-
-        public abstract override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken);
-        public abstract override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken);
 
         protected override void Dispose(bool disposing)
         {

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpContentWriteStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpContentWriteStream.cs
@@ -20,15 +20,10 @@ namespace System.Net.Http
         }
 
         public override bool CanRead => false;
-
         public override bool CanSeek => false;
-
         public override bool CanWrite => true;
 
-        public override long Length
-        {
-            get { throw new NotSupportedException(); }
-        }
+        public override long Length => throw new NotSupportedException();
 
         public override long Position
         {
@@ -36,33 +31,17 @@ namespace System.Net.Http
             set { throw new NotSupportedException(); }
         }
 
-        public override void Flush()
-        {
-            FlushAsync().Wait();
-        }
+        public override void Flush() => FlushAsync().GetAwaiter().GetResult();
 
-        public override long Seek(long offset, SeekOrigin origin)
-        {
-            throw new NotSupportedException();
-        }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
 
-        public override void SetLength(long value)
-        {
-            throw new NotSupportedException();
-        }
+        public override void SetLength(long value) => throw new NotSupportedException();
 
-        public override int Read(byte[] buffer, int offset, int count)
-        {
-            throw new NotSupportedException();
-        }
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
 
-        public override void Write(byte[] buffer, int offset, int count)
-        {
-            WriteAsync(buffer, offset, count, CancellationToken.None).Wait();
-        }
+        public override void Write(byte[] buffer, int offset, int count) =>
+            WriteAsync(buffer, offset, count, CancellationToken.None).GetAwaiter().GetResult();
 
-        public abstract override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken);
-        public abstract override Task FlushAsync(CancellationToken cancellationToken);
         public abstract Task FinishAsync(CancellationToken cancellationToken);
 
         protected override void Dispose(bool disposing)

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpProxyConnectionHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpProxyConnectionHandler.cs
@@ -101,7 +101,7 @@ namespace System.Net.Http
             return response;
         }
 
-        private async Task<HttpConnection> GetOrCreateConnection(HttpRequestMessage request, Uri proxyUri)
+        private async ValueTask<HttpConnection> GetOrCreateConnection(HttpRequestMessage request, Uri proxyUri)
         {
             HttpConnectionKey key = new HttpConnectionKey(proxyUri);
 

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpProxyConnectionHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpProxyConnectionHandler.cs
@@ -20,19 +20,8 @@ namespace System.Net.Http
 
         public HttpProxyConnectionHandler(IWebProxy proxy, HttpMessageHandler innerHandler)
         {
-            if (proxy == null)
-            {
-                throw new ArgumentNullException(nameof(proxy));
-            }
-
-            if (innerHandler == null)
-            {
-                throw new ArgumentNullException(nameof(innerHandler));
-            }
-
-            _proxy = proxy;
-            _innerHandler = innerHandler;
-
+            _proxy = proxy ?? throw new ArgumentNullException(nameof(proxy));
+            _innerHandler = innerHandler ?? throw new ArgumentNullException(nameof(innerHandler));
             _connectionPoolTable = new ConcurrentDictionary<HttpConnectionKey, HttpConnectionPool>();
         }
 
@@ -119,7 +108,7 @@ namespace System.Net.Http
 
             if (pool == null)
             {
-                pool = _connectionPoolTable.GetOrAdd(key, new HttpConnectionPool());
+                pool = _connectionPoolTable.GetOrAdd(key, _ => new HttpConnectionPool());
             }
 
             return new HttpConnection(pool, key, stream, null, true);

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpProxyConnectionHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpProxyConnectionHandler.cs
@@ -54,7 +54,7 @@ namespace System.Net.Http
 
             if (proxyUri == null)
             {
-                return await _innerHandler.SendAsync(request, cancellationToken);
+                return await _innerHandler.SendAsync(request, cancellationToken).ConfigureAwait(false);
             }
 
             if (proxyUri.Scheme != "http")
@@ -68,9 +68,9 @@ namespace System.Net.Http
                 throw new NotImplementedException("no support for SSL tunneling through proxy");
             }
 
-            HttpConnection connection = await GetOrCreateConnection(request, proxyUri);
+            HttpConnection connection = await GetOrCreateConnection(request, proxyUri).ConfigureAwait(false);
 
-            HttpResponseMessage response = await connection.SendAsync(request, cancellationToken);
+            HttpResponseMessage response = await connection.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
             // Handle proxy authentication
             if (response.StatusCode == HttpStatusCode.ProxyAuthenticationRequired &&
@@ -89,8 +89,8 @@ namespace System.Net.Http
                             request.Headers.ProxyAuthorization = new AuthenticationHeaderValue("Basic",
                                 BasicAuthenticationHelper.GetBasicTokenForCredential(credential));
 
-                            connection = await GetOrCreateConnection(request, proxyUri);
-                            response = await connection.SendAsync(request, cancellationToken);
+                            connection = await GetOrCreateConnection(request, proxyUri).ConfigureAwait(false);
+                            response = await connection.SendAsync(request, cancellationToken).ConfigureAwait(false);
                         }
 
                         break;
@@ -115,7 +115,7 @@ namespace System.Net.Http
                 }
             }
 
-            Stream stream = await ConnectHelper.ConnectAsync(proxyUri.Host, proxyUri.Port);
+            Stream stream = await ConnectHelper.ConnectAsync(proxyUri.Host, proxyUri.Port).ConfigureAwait(false);
 
             if (pool == null)
             {


### PR DESCRIPTION
Just some easy to fix things in a quick perusal:
- Added ConfigureAwait to all awaits
- Changed some `Task<T>`s to `ValueTask<T>`s
- Changed some .Waits to .GetAwaiter.GetResults
- Fixed several calls to GetOrAdd to not aggressively allocate unnecessarily
- Sealed several classes, marked several fields as readonly
- Applied some auto-IDE fixes
- Use throw expressions in a few places
- Removed some unnecessary overrides and using

cc: @geoffkizer 