### PR TITLE
Fix System.IO.Pipes.Tests for Uap

### DIFF
--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CreateServer.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CreateServer.cs
@@ -56,12 +56,14 @@ namespace System.IO.Pipes.Tests
             AssertExtensions.Throws<ArgumentOutOfRangeException>("pipeName", () => new NamedPipeServerStream(reservedName, direction, 1, PipeTransmissionMode.Byte, PipeOptions.None, 0, 0));}
 
         [Fact]
+        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public static void Create_PipeName()
         {
             new NamedPipeServerStream(GetUniquePipeName()).Dispose();
         }
 
         [Fact]
+        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public static void Create_PipeName_Direction_MaxInstances()
         {
             new NamedPipeServerStream(GetUniquePipeName(), PipeDirection.Out, 1).Dispose();
@@ -69,6 +71,7 @@ namespace System.IO.Pipes.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // can't access SafePipeHandle on Unix until after connection created
+        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public static void CreateWithNegativeOneServerInstances_DefaultsToMaxServerInstances()
         {
             // When passed -1 as the maxnumberofserverisntances, the NamedPipeServerStream.Windows class
@@ -196,6 +199,7 @@ namespace System.IO.Pipes.Tests
         [InlineData(PipeDirection.Out)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "This scenario is not handled with System.ArgumentException on Full Framework")]
         [PlatformSpecific(TestPlatforms.Windows)] // accessing SafePipeHandle on Unix fails for a non-connected stream
+        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public static void Windows_CreateFromDisposedServerHandle_Throws_ObjectDisposedException(PipeDirection direction)
         {
             // The pipe is closed when we try to make a new Stream with it
@@ -237,6 +241,7 @@ namespace System.IO.Pipes.Tests
         [InlineData(PipeDirection.Out)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET framework handles this scenario by throwing ApplicationException instead")]
         [PlatformSpecific(TestPlatforms.Windows)] // accessing SafePipeHandle on Unix fails for a non-connected stream
+        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public static void Windows_CreateFromAlreadyBoundHandle_Throws_ArgumentException(PipeDirection direction)
         {
             // The pipe is already bound
@@ -248,6 +253,7 @@ namespace System.IO.Pipes.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // NumberOfServerInstances > 1 isn't supported and has undefined behavior on Unix
+        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public static void ServerCountOverMaxServerInstances_Throws_IOException()
         {
             string uniqueServerName = GetUniquePipeName();
@@ -259,6 +265,7 @@ namespace System.IO.Pipes.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // NumberOfServerInstances > 1 isn't supported and has undefined behavior on Unix
+        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public static void Windows_ServerCloneWithDifferentDirection_Throws_UnauthorizedAccessException()
         {
             string uniqueServerName = GetUniquePipeName();

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CrossProcess.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CrossProcess.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace System.IO.Pipes.Tests
 {
+    [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
     public sealed class NamedPipeTest_CrossProcess : RemoteExecutorTestBase
     {
         [Fact]

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Read.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Read.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace System.IO.Pipes.Tests
 {
+    [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
     public class NamedPipeTest_Read_ServerOut_ClientIn : PipeTest_Read
     {
         protected override ServerClientPair CreateServerClientPair()
@@ -27,6 +28,7 @@ namespace System.IO.Pipes.Tests
         }
     }
 
+    [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
     public class NamedPipeTest_Read_ServerIn_ClientOut : PipeTest_Read
     {
         protected override ServerClientPair CreateServerClientPair()
@@ -46,6 +48,7 @@ namespace System.IO.Pipes.Tests
         }
     }
 
+    [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
     public class NamedPipeTest_Read_ServerInOut_ClientInOut : PipeTest_Read
     {
         protected override ServerClientPair CreateServerClientPair()
@@ -68,6 +71,7 @@ namespace System.IO.Pipes.Tests
         public override void WriteToReadOnlyPipe_Throws_NotSupportedException() { }
     }
 
+    [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
     public class NamedPipeTest_Read_ServerInOut_ClientInOut_APMWaitForConnection : PipeTest_Read
     {
         protected override ServerClientPair CreateServerClientPair()

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.RunAsClient.Windows.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.RunAsClient.Windows.cs
@@ -15,6 +15,7 @@ namespace System.IO.Pipes.Tests
     {
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]  // Uses P/Invokes
+        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public async Task RunAsClient_Windows()
         {
             string pipeName = Path.GetRandomFileName();

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Simple.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Simple.cs
@@ -754,6 +754,7 @@ namespace System.IO.Pipes.Tests
         }
     }
 
+    [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
     public class NamedPipeTest_Simple_ServerInOutRead_ClientInOutWrite : NamedPipeTest_Simple
     {
         protected override NamedPipePair CreateNamedPipePair(PipeOptions serverOptions, PipeOptions clientOptions)
@@ -767,6 +768,7 @@ namespace System.IO.Pipes.Tests
         }
     }
 
+    [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
     public class NamedPipeTest_Simple_ServerInOutWrite_ClientInOutRead : NamedPipeTest_Simple
     {
         protected override NamedPipePair CreateNamedPipePair(PipeOptions serverOptions, PipeOptions clientOptions)
@@ -780,6 +782,7 @@ namespace System.IO.Pipes.Tests
         }
     }
 
+    [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
     public class NamedPipeTest_Simple_ServerInOut_ClientIn : NamedPipeTest_Simple
     {
         protected override NamedPipePair CreateNamedPipePair(PipeOptions serverOptions, PipeOptions clientOptions)
@@ -793,6 +796,7 @@ namespace System.IO.Pipes.Tests
         }
     }
 
+    [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
     public class NamedPipeTest_Simple_ServerInOut_ClientOut : NamedPipeTest_Simple
     {
         protected override NamedPipePair CreateNamedPipePair(PipeOptions serverOptions, PipeOptions clientOptions)
@@ -806,6 +810,7 @@ namespace System.IO.Pipes.Tests
         }
     }
 
+    [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
     public class NamedPipeTest_Simple_ServerOut_ClientIn : NamedPipeTest_Simple
     {
         protected override NamedPipePair CreateNamedPipePair(PipeOptions serverOptions, PipeOptions clientOptions)
@@ -819,6 +824,7 @@ namespace System.IO.Pipes.Tests
         }
     }
 
+    [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
     public class NamedPipeTest_Simple_ServerIn_ClientOut : NamedPipeTest_Simple
     {
         protected override NamedPipePair CreateNamedPipePair(PipeOptions serverOptions, PipeOptions clientOptions)

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Specific.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Specific.cs
@@ -56,6 +56,7 @@ namespace System.IO.Pipes.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // Unix implementation uses bidirectional sockets
+        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public void ConnectWithConflictingDirections_Throws_UnauthorizedAccessException()
         {
             string serverName1 = GetUniquePipeName();
@@ -79,6 +80,7 @@ namespace System.IO.Pipes.Tests
         [InlineData(PipeOptions.None)]
         [InlineData(PipeOptions.Asynchronous)]
         [PlatformSpecific(TestPlatforms.Windows)] // Unix currently doesn't support message mode
+        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public async Task Windows_MessagePipeTransissionMode(PipeOptions serverOptions)
         {
             byte[] msg1 = new byte[] { 5, 7, 9, 10 };
@@ -168,6 +170,7 @@ namespace System.IO.Pipes.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // Unix doesn't support MaxNumberOfServerInstances
+        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public async Task Windows_Get_NumberOfServerInstances_Succeed()
         {
             string pipeName = GetUniquePipeName();
@@ -190,6 +193,7 @@ namespace System.IO.Pipes.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // Win32 P/Invokes to verify the user name
+        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public async Task Windows_GetImpersonationUserName_Succeed()
         {
             string pipeName = GetUniquePipeName();
@@ -277,6 +281,7 @@ namespace System.IO.Pipes.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // Unix implementation uses bidirectional sockets
+        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public static void Windows_BufferSizeRoundtripping()
         {
             int desiredBufferSize = 10;
@@ -305,6 +310,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public void PipeTransmissionMode_Returns_Byte()
         {
             using (ServerClientPair pair = CreateServerClientPair())
@@ -316,6 +322,7 @@ namespace System.IO.Pipes.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // Unix doesn't currently support message mode
+        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public void Windows_SetReadModeTo__PipeTransmissionModeByte()
         {
             string pipeName = GetUniquePipeName();
@@ -397,6 +404,7 @@ namespace System.IO.Pipes.Tests
         [Theory]
         [InlineData(PipeDirection.Out, PipeDirection.In)]
         [InlineData(PipeDirection.In, PipeDirection.Out)]
+        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public void InvalidReadMode_Throws_ArgumentOutOfRangeException(PipeDirection serverDirection, PipeDirection clientDirection)
         {
             string pipeName = GetUniquePipeName();

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Write.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Write.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace System.IO.Pipes.Tests
 {
+    [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
     public class NamedPipeTest_Write_ServerOut_ClientIn : PipeTest_Write
     {
         protected override ServerClientPair CreateServerClientPair()
@@ -27,6 +28,7 @@ namespace System.IO.Pipes.Tests
         }
     }
 
+    [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
     public class NamedPipeTest_Write_ServerIn_ClientOut : PipeTest_Write
     {
         protected override ServerClientPair CreateServerClientPair()
@@ -46,6 +48,7 @@ namespace System.IO.Pipes.Tests
         }
     }
 
+    [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
     public class NamedPipeTest_Write_ServerInOut_ClientInOut : PipeTest_Write
     {
         protected override ServerClientPair CreateServerClientPair()


### PR DESCRIPTION
This brings failures to 1 which is not related to CreateNamedPipe. It is failing in RemoteExecutor with exit code = -4. 

This is the test: https://github.com/dotnet/corefx/blob/master/src/System.IO.Pipes/tests/AnonymousPipeTests/AnonymousPipeTest.CrossProcess.cs#L13

I'm currently investigating that test. If I don't find anything I will disable it tomorrow so that we get it to green.

