### PR TITLE
Disable System.IO.FileSystem NamedPipe for UAP

### DIFF
--- a/src/System.IO.FileSystem/tests/FileStream/CopyToAsync.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/CopyToAsync.cs
@@ -242,6 +242,7 @@ namespace System.IO.Tests
         [Theory]
         [InlineData(false, 10, 1024)]
         [InlineData(true, 10, 1024)]
+        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public async Task NamedPipeViaFileStream_AllDataCopied(bool useAsync, int writeSize, int numWrites)
         {
             long totalLength = writeSize * numWrites;

--- a/src/System.IO.FileSystem/tests/FileStream/Pipes.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/Pipes.cs
@@ -94,6 +94,7 @@ namespace System.IO.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public async Task NamedPipeWriteViaAsyncFileStream(bool asyncWrites)
         {
             string name = Guid.NewGuid().ToString("N");
@@ -128,6 +129,7 @@ namespace System.IO.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public async Task NamedPipeReadViaAsyncFileStream(bool asyncReads)
         {
             string name = Guid.NewGuid().ToString("N");


### PR DESCRIPTION
This cleans System.IO.FileSystem in UAP.