### PR TITLE
Disable System.IO.Pipes.AccessControl.Tests for UAP

### DIFF
--- a/src/System.IO.Pipes.AccessControl/tests/NamedPipeTests/NamedPipeTest.AclExtensions.cs
+++ b/src/System.IO.Pipes.AccessControl/tests/NamedPipeTests/NamedPipeTest.AclExtensions.cs
@@ -28,6 +28,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public void SetAccessControl_NamedPipeStream()
         {
             string pipeName = GetUniquePipeName();
@@ -45,6 +46,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public void SetAccessControl_NamedPipeStream_BeforeWaitingToConnect()
         {
             string pipeName = GetUniquePipeName();
@@ -59,6 +61,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public void SetAccessControl_NamedPipeStream_ClientDisposed()
         {
             string pipeName = GetUniquePipeName();
@@ -79,6 +82,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public void SetAccessControl_NamedPipeStream_ClientHandleClosed()
         {
             string pipeName = GetUniquePipeName();
@@ -99,6 +103,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public void SetAccessControl_NamedPipeStream_ServerDisconnected()
         {
             string pipeName = GetUniquePipeName();
@@ -119,6 +124,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public void SetAccessControl_NamedPipeStream_ServerDisposed()
         {
             string pipeName = GetUniquePipeName();
@@ -139,6 +145,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public void SetAccessControl_NamedPipeStream_ServerHandleClosed()
         {
             string pipeName = GetUniquePipeName();

--- a/src/System.IO.Pipes.AccessControl/tests/PipeTest.AclExtensions.cs
+++ b/src/System.IO.Pipes.AccessControl/tests/PipeTest.AclExtensions.cs
@@ -15,6 +15,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public void GetAccessControl_DisposedStream()
         {
             using (var pair = CreateServerClientPair())
@@ -28,6 +29,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public void GetAccessControl_ConnectedStream()
         {
             using (var pair = CreateServerClientPair())
@@ -44,6 +46,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public void SetAccessControl_NullPipeSecurity()
         {
             using (var pair = CreateServerClientPair())
@@ -59,6 +62,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public void SetAccessControl_DisposedStream()
         {
             using (var pair = CreateServerClientPair())
@@ -72,6 +76,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public void SetAccessControl_ConnectedStream()
         {
             using (var pair = CreateServerClientPair())


### PR DESCRIPTION
Disabling NamedPipes tests. This cleans System.IO.Pipes,AccessControl.Tests in UAP.