### PR TITLE
[release/2.0] Fix temp keychain lifetime with macOS CopyWithPrivateKey

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/PrivateKeyAssociationTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/PrivateKeyAssociationTests.cs
@@ -240,9 +240,15 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                 DateTimeOffset now = DateTimeOffset.UtcNow;
 
                 using (X509Certificate2 cert = request.CreateSelfSigned(now, now.AddDays(1)))
-                using (RSA rsa = cert.GetRSAPrivateKey())
                 {
-                    signature = rsa.SignData(data, hashAlgorithm, RSASignaturePadding.Pkcs1);
+                    using (RSA rsa = cert.GetRSAPrivateKey())
+                    {
+                        signature = rsa.SignData(data, hashAlgorithm, RSASignaturePadding.Pkcs1);
+                    }
+
+                    // RSAOther is exportable, so ensure PFX export succeeds
+                    byte[] pfxBytes = cert.Export(X509ContentType.Pkcs12, request.SubjectName.Name);
+                    Assert.InRange(pfxBytes.Length, 100, int.MaxValue);
                 }
 
                 Assert.True(rsaOther.VerifyData(data, signature, hashAlgorithm, RSASignaturePadding.Pkcs1));
@@ -444,9 +450,15 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
 
                 using (X509Certificate2 cert = request.Create(request.SubjectName, dsaGen, now, now.AddDays(1), new byte[1]))
                 using (X509Certificate2 certWithPrivateKey = cert.CopyWithPrivateKey(dsaOther))
-                using (DSA dsa = certWithPrivateKey.GetDSAPrivateKey())
                 {
-                    signature = dsa.SignData(data, hashAlgorithm);
+                    using (DSA dsa = certWithPrivateKey.GetDSAPrivateKey())
+                    {
+                        signature = dsa.SignData(data, hashAlgorithm);
+                    }
+
+                    // DSAOther is exportable, so ensure PFX export succeeds
+                    byte[] pfxBytes = certWithPrivateKey.Export(X509ContentType.Pkcs12, request.SubjectName.Name);
+                    Assert.InRange(pfxBytes.Length, 100, int.MaxValue);
                 }
 
                 Assert.True(dsaOther.VerifyData(data, signature, hashAlgorithm));
@@ -523,9 +535,15 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                 DateTimeOffset now = DateTimeOffset.UtcNow;
 
                 using (X509Certificate2 cert = request.CreateSelfSigned(now, now.AddDays(1)))
-                using (ECDsa ecdsa = cert.GetECDsaPrivateKey())
                 {
-                    signature = ecdsa.SignData(data, hashAlgorithm);
+                    using (ECDsa ecdsa = cert.GetECDsaPrivateKey())
+                    {
+                        signature = ecdsa.SignData(data, hashAlgorithm);
+                    }
+
+                    // ECDsaOther is exportable, so ensure PFX export succeeds
+                    byte[] pfxBytes = cert.Export(X509ContentType.Pkcs12, request.SubjectName.Name);
+                    Assert.InRange(pfxBytes.Length, 100, int.MaxValue);
                 }
 
                 Assert.True(ecdsaOther.VerifyData(data, signature, hashAlgorithm));


### PR DESCRIPTION
Because macOS is the only platform that doesn't allow ephemeral keys to be
associated with certificates we have a straightforward-yet-complex temporary
keychain management system.

In the new CopyWithPrivateKey methods, we end up messing with the refcounts
and deleting too early because the input certificate got mutated by the call -- it
believes it belongs to the keychain, even though it was subsequently removed
from it.  So when that cert handle disposes we DangerousRelease our shared
lifetime handle even though we never did a DangerousAddRef.

Since the new method is supposed to have no lasting side effects, and we've
found one, change to use the Windows PAL approach: first clone the cert to
disassociate it from mutation operations.

The existing tests noticed this problem, which got the incorrect fix of a
persisted field for the private key.  But since PFX exporting is done within the
keychain itself, if the keychain was deleted PFX export isn't possible.

With the addition of PFX export tests from CopyWithPrivateKey we now have
better ways of tracking that the keychain isn't deleted too early.

Port of https://github.com/dotnet/corefx/pull/21334 to release/2.0
Fixes #20272.