### PR TITLE
Fix System.Runtime.InteropServices.Tests from crashing in uap

### DIFF
--- a/src/System.Runtime.InteropServices/tests/Configurations.props
+++ b/src/System.Runtime.InteropServices/tests/Configurations.props
@@ -5,6 +5,7 @@
       netstandard;
       netcoreapp-Windows_NT;
       netfx-Windows_NT;
+      uap-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.Tests.csproj
+++ b/src/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.Tests.csproj
@@ -47,7 +47,7 @@
     <Compile Include="System\Runtime\InteropServices\MarshalAsAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\MarshalTests.cs" />
     <Compile Include="System\Runtime\InteropServices\MarshalTests.Windows.cs" Condition="'$(TargetsWindows)' == 'true'" />
-    <Compile Include="System\Runtime\InteropServices\PrimaryInteropAssemblyAttributeTests.cs" />
+    <Compile Condition="'$(TargetGroup)' != 'uap'" Include="System\Runtime\InteropServices\PrimaryInteropAssemblyAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\ProgIdAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\RuntimeEnvironmentTests.cs" />
     <Compile Include="System\Runtime\InteropServices\SetWin32ContextInIDispatchAttributeTests.cs" />


### PR DESCRIPTION
System.Runtime.InteropServices are crashing in uap with error: 

```
System.IO.FileLoadException: Could not load file or assembly 'System.Runtime.InteropServices.Tests, Version=4.2.1.0, Culture=neutral, PublicKeyToken=9d77cc7ad39b68eb'. Operation is not supported. (Exception from HRESULT: 0x80131515)
File name: 'System.Runtime.InteropServices.Tests, Version=4.2.1.0, Culture=neutral, PublicKeyToken=9d77cc7ad39b68eb' ---> System.NotSupportedException: A Primary Interop Assembly is not supported in AppX.
```

@yizhang82 explained: _PrimaryInteropAssemblyAttributeTests.cs has PrimaryInteropAssemblyAttribute in it which makes the entire test assembly a PrimaryInteropAssembly that can’t be loaded under AppX. This test needs to be disabled under AppX and also excluded from build._ 

With this change they run fine but there are 7 tests failing with error: 
```
System.Runtime.InteropServices.Tests.ComAwareEventInfoTests.AddEventHandler_NullSourceTypeEventInterface_ThrowsNullReferenceException [FAIL]
        System.Runtime.InteropServices.COMException : Creating an instance of the COM component with CLSID {7B9E38B0-A97C-11D0-8534-00C04FD8D503} using CoCreateInstanceFromApp
  failed due to the following error: 80040154 Class not registered (Exception from HRESULT: 0x80040154 (REGDB_E_CLASSNOTREG)). Please make sure your COM object is in the allowe
  d list of CoCreateInstanceFromApp.
```

@yizhang82 once my PR is merged could you take a look? Or should this tests be disabled?

@weshaggard is this the best way to exclude it from the build or is there a better way than adding a build configuration?

cc: @danmosemsft  @tijoytom 