### PR TITLE
Removing serialization tests for lazy as we stripped the type from th…

### DIFF
--- a/src/System.Runtime/tests/System/LazyTests.cs
+++ b/src/System.Runtime/tests/System/LazyTests.cs
@@ -3,12 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.IO;
 using System.Reflection;
-using System.Runtime.Serialization.Formatters.Binary;
-using System.Runtime.Serialization.Formatters.Tests;
 using System.Threading;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace System.Tests
@@ -362,24 +358,6 @@ namespace System.Tests
         {
             var e = Assert.ThrowsAny<Exception>(() => x.Value);
             Assert.NotSame(e, Assert.ThrowsAny<Exception>(() => x.Value));
-        }
-
-        [Fact]
-        [ActiveIssue(19119, TargetFrameworkMonikers.Netcoreapp)]
-        public static void Serialization_ValueType()
-        {
-            Lazy<int> fortytwo = BinaryFormatterHelpers.Clone(new Lazy<int>(() => 42));
-            Assert.True(fortytwo.IsValueCreated);
-            Assert.Equal(fortytwo.Value, 42);
-        }
-
-        [Fact]
-        [ActiveIssue(19119, TargetFrameworkMonikers.Netcoreapp)]
-        public static void Serialization_RefType()
-        {
-            Lazy<string> fortytwo = BinaryFormatterHelpers.Clone(new Lazy<string>(() => "42"));
-            Assert.True(fortytwo.IsValueCreated);
-            Assert.Equal(fortytwo.Value, "42");
         }
 
         [Theory]


### PR DESCRIPTION
…e serialization bucket and it won't come back soon. Before I just disabled them with an ActiveIssue but it's better to remove them completely (Stephen also suggested that back then).

Fixes https://github.com/dotnet/corefx/issues/21421

cc @danmosemsft 