### PR TITLE
Fixed System.Runtime.Extensions uap/uapaot/netfx tests (combined with Viktor's PR)

### DIFF
--- a/src/System.Runtime.Extensions/tests/System/AppDomainTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/AppDomainTests.cs
@@ -383,7 +383,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "")]
         public void MonitoringIsEnabled()
         {
             RemoteInvoke(() => {

--- a/src/System.Runtime.Extensions/tests/System/AppDomainTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/AppDomainTests.cs
@@ -2,19 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Resources;
 using System.Runtime.ExceptionServices;
 using Xunit;
-using Xunit.NetCore.Extensions;
 
 namespace System.Tests
 {
-    // No appdomain in UWP or CoreRT
-    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot | TargetFrameworkMonikers.NetFramework, "dotnet/corefx #18718")]
     public class AppDomainTests : RemoteExecutorTestBase
     {
         [Fact]
@@ -40,7 +36,6 @@ namespace System.Tests
         {
             Assert.Null(AppDomain.CurrentDomain.RelativeSearchPath);
         } 
-
 
         [Fact]
         public void UnhandledException_Add_Remove()
@@ -99,7 +94,7 @@ namespace System.Tests
 
         static void MyHandler(object sender, UnhandledExceptionEventArgs args) 
         {
-            System.IO.File.Create("success.txt");
+            File.Create("success.txt");
         }
 
         [Fact]
@@ -115,7 +110,7 @@ namespace System.Tests
             Assert.NotNull(s);
             string expected = Assembly.GetEntryAssembly().GetName().Name;
             Assert.Equal(expected, s);
-        }        
+        }
 
         //[Fact]
         public void Id()
@@ -173,7 +168,6 @@ namespace System.Tests
                 Assert.True(flag, "FirstChanceHandler not called");
                 return SuccessExitCode;
             }).Dispose();
-
         }
 
         class FirstChanceTestException : Exception

--- a/src/System.Runtime.Extensions/tests/System/AppDomainTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/AppDomainTests.cs
@@ -677,7 +677,6 @@ namespace System.Tests
         private void CopyTestAssemblies()
         {
             string destTestAssemblyPath = Path.Combine(Environment.CurrentDirectory, "AssemblyResolveTests", "AssemblyResolveTests.dll");
-            Console.WriteLine($"destinationPat={destTestAssemblyPath}");
             if (!File.Exists(destTestAssemblyPath) && File.Exists("AssemblyResolveTests.dll"))
             {
                 Directory.CreateDirectory(Path.GetDirectoryName(destTestAssemblyPath));

--- a/src/System.Runtime.Extensions/tests/System/AppDomainTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/AppDomainTests.cs
@@ -150,6 +150,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue(21680, TargetFrameworkMonikers.UapAot)]
         public void FirstChanceException_Called()
         {
             RemoteInvoke(() => {
@@ -240,6 +241,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue(21680, TargetFrameworkMonikers.UapAot)]
         public void ExecuteAssemblyByName()
         {
             RemoteInvoke(() => {
@@ -290,6 +292,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue(21680, TargetFrameworkMonikers.UapAot)]
         public void SetData_SameKeyMultipleTimes_ReplacesOldValue()
         {
             RemoteInvoke(() => {
@@ -608,6 +611,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue(21680, TargetFrameworkMonikers.UapAot)]
         public void TypeResolve()
         {
             RemoteInvoke(() => {
@@ -635,6 +639,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue(21680, TargetFrameworkMonikers.UapAot)]
         public void ResourceResolve()
         {
             RemoteInvoke(() => {

--- a/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
@@ -269,6 +269,7 @@ namespace System.Tests
 
         // The commented out folders aren't set on all systems.
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))] // https://github.com/dotnet/corefx/issues/19110
+        [ActiveIssue(20782, TargetFrameworkMonikers.Uap)]
         [InlineData(Environment.SpecialFolder.ApplicationData, false)]
         [InlineData(Environment.SpecialFolder.CommonApplicationData, false)]
         [InlineData(Environment.SpecialFolder.LocalApplicationData, true)]

--- a/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
@@ -269,59 +269,67 @@ namespace System.Tests
 
         // The commented out folders aren't set on all systems.
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))] // https://github.com/dotnet/corefx/issues/19110
-        [InlineData(Environment.SpecialFolder.ApplicationData)]
-        [InlineData(Environment.SpecialFolder.CommonApplicationData)]
-        [InlineData(Environment.SpecialFolder.LocalApplicationData)]
-        [InlineData(Environment.SpecialFolder.Cookies)]
-        [InlineData(Environment.SpecialFolder.Desktop)]
-        [InlineData(Environment.SpecialFolder.Favorites)]
-        [InlineData(Environment.SpecialFolder.History)]
-        [InlineData(Environment.SpecialFolder.InternetCache)]
-        [InlineData(Environment.SpecialFolder.Programs)]
+        [InlineData(Environment.SpecialFolder.ApplicationData, false)]
+        [InlineData(Environment.SpecialFolder.CommonApplicationData, false)]
+        [InlineData(Environment.SpecialFolder.LocalApplicationData, true)]
+        [InlineData(Environment.SpecialFolder.Cookies, true)]
+        [InlineData(Environment.SpecialFolder.Desktop, false)]
+        [InlineData(Environment.SpecialFolder.Favorites, false)]
+        [InlineData(Environment.SpecialFolder.History, true)]
+        [InlineData(Environment.SpecialFolder.InternetCache, true)]
+        [InlineData(Environment.SpecialFolder.Programs, true)]
         // [InlineData(Environment.SpecialFolder.MyComputer)]
-        [InlineData(Environment.SpecialFolder.MyMusic)]
-        [InlineData(Environment.SpecialFolder.MyPictures)]
-        [InlineData(Environment.SpecialFolder.MyVideos)]
-        [InlineData(Environment.SpecialFolder.Recent)]
-        [InlineData(Environment.SpecialFolder.SendTo)]
-        [InlineData(Environment.SpecialFolder.StartMenu)]
-        [InlineData(Environment.SpecialFolder.Startup)]
-        [InlineData(Environment.SpecialFolder.System)]
-        [InlineData(Environment.SpecialFolder.Templates)]
-        [InlineData(Environment.SpecialFolder.DesktopDirectory)]
-        [InlineData(Environment.SpecialFolder.Personal)]
-        [InlineData(Environment.SpecialFolder.ProgramFiles)]
-        [InlineData(Environment.SpecialFolder.CommonProgramFiles)]
-        [InlineData(Environment.SpecialFolder.AdminTools)]
-        [InlineData(Environment.SpecialFolder.CDBurning)]
-        [InlineData(Environment.SpecialFolder.CommonAdminTools)]
-        [InlineData(Environment.SpecialFolder.CommonDocuments)]
-        [InlineData(Environment.SpecialFolder.CommonMusic)]
+        [InlineData(Environment.SpecialFolder.MyMusic, false)]
+        [InlineData(Environment.SpecialFolder.MyPictures, false)]
+        [InlineData(Environment.SpecialFolder.MyVideos, false)]
+        [InlineData(Environment.SpecialFolder.Recent, false)]
+        [InlineData(Environment.SpecialFolder.SendTo, false)]
+        [InlineData(Environment.SpecialFolder.StartMenu, false)]
+        [InlineData(Environment.SpecialFolder.Startup, true)]
+        [InlineData(Environment.SpecialFolder.System, true)]
+        [InlineData(Environment.SpecialFolder.Templates, false)]
+        [InlineData(Environment.SpecialFolder.DesktopDirectory, false)]
+        [InlineData(Environment.SpecialFolder.Personal, false)]
+        [InlineData(Environment.SpecialFolder.ProgramFiles, true)]
+        [InlineData(Environment.SpecialFolder.CommonProgramFiles, true)]
+        [InlineData(Environment.SpecialFolder.AdminTools, true)]
+        [InlineData(Environment.SpecialFolder.CDBurning, false)]
+        [InlineData(Environment.SpecialFolder.CommonAdminTools, false)]
+        [InlineData(Environment.SpecialFolder.CommonDocuments, false)]
+        [InlineData(Environment.SpecialFolder.CommonMusic, false)]
         // [InlineData(Environment.SpecialFolder.CommonOemLinks)]
-        [InlineData(Environment.SpecialFolder.CommonPictures)]
-        [InlineData(Environment.SpecialFolder.CommonStartMenu)]
-        [InlineData(Environment.SpecialFolder.CommonPrograms)]
-        [InlineData(Environment.SpecialFolder.CommonStartup)]
-        [InlineData(Environment.SpecialFolder.CommonDesktopDirectory)]
-        [InlineData(Environment.SpecialFolder.CommonTemplates)]
-        [InlineData(Environment.SpecialFolder.CommonVideos)]
-        [InlineData(Environment.SpecialFolder.Fonts)]
-        [InlineData(Environment.SpecialFolder.NetworkShortcuts)]
+        [InlineData(Environment.SpecialFolder.CommonPictures, false)]
+        [InlineData(Environment.SpecialFolder.CommonStartMenu, false)]
+        [InlineData(Environment.SpecialFolder.CommonPrograms, false)]
+        [InlineData(Environment.SpecialFolder.CommonStartup, false)]
+        [InlineData(Environment.SpecialFolder.CommonDesktopDirectory, false)]
+        [InlineData(Environment.SpecialFolder.CommonTemplates, false)]
+        [InlineData(Environment.SpecialFolder.CommonVideos, false)]
+        [InlineData(Environment.SpecialFolder.Fonts, true)]
+        [InlineData(Environment.SpecialFolder.NetworkShortcuts, false)]
         // [InlineData(Environment.SpecialFolder.PrinterShortcuts)]
-        [InlineData(Environment.SpecialFolder.UserProfile)]
-        [InlineData(Environment.SpecialFolder.CommonProgramFilesX86)]
-        [InlineData(Environment.SpecialFolder.ProgramFilesX86)]
-        [InlineData(Environment.SpecialFolder.Resources)]
+        [InlineData(Environment.SpecialFolder.UserProfile, false)]
+        [InlineData(Environment.SpecialFolder.CommonProgramFilesX86, true)]
+        [InlineData(Environment.SpecialFolder.ProgramFilesX86, true)]
+        [InlineData(Environment.SpecialFolder.Resources, true)]
         // [InlineData(Environment.SpecialFolder.LocalizedResources)]
-        [InlineData(Environment.SpecialFolder.SystemX86)]
-        [InlineData(Environment.SpecialFolder.Windows)]
+        [InlineData(Environment.SpecialFolder.SystemX86, true)]
+        [InlineData(Environment.SpecialFolder.Windows, true)]
         [PlatformSpecific(TestPlatforms.Windows)]  // Tests OS-specific environment
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/18048", TargetFrameworkMonikers.Uap)]
-        public unsafe void GetFolderPath_Windows(Environment.SpecialFolder folder)
+        public unsafe void GetFolderPath_Windows(Environment.SpecialFolder folder, bool existsInAppContainer = true)
         {
             string knownFolder = Environment.GetFolderPath(folder);
-
-            Assert.NotEmpty(knownFolder);
+            // If you are not executing inside an AppContainer or the folder is allowed in it the path must not be empty.
+            if (!PlatformDetection.IsWinRT || existsInAppContainer)
+            {
+                Assert.NotEmpty(knownFolder);
+            }
+            else
+            {
+                // If you hit this assert it means that SHGetFolderPath inside a UWP has been fixed. 
+                // Check the value is reasonable and update the test data to expect a path from now on.
+                Assert.Empty(knownFolder);
+            }
 
             // Call the older folder API to compare our results.
             char* buffer = stackalloc char[260];


### PR DESCRIPTION
Contributes to: https://github.com/dotnet/corefx/issues/18718
This is resolving conflicts with mostly overlapping changes with @danmosemsft's PR: https://github.com/dotnet/corefx/pull/21412
I've left original PR for comparison: https://github.com/dotnet/corefx/pull/19866

We might want to revert changes to src/System.Runtime.Extensions/tests/System/AppDomainTests.cs

cc: @ViktorHofer 

Testing in progress so may fail CI