### PR TITLE
Improve code coverage of System.IO.FileSystem.AccessControl (55.8%)

### DIFF
--- a/src/System.IO.FileSystem.AccessControl/tests/FileSystemAccessRuleTests.cs
+++ b/src/System.IO.FileSystem.AccessControl/tests/FileSystemAccessRuleTests.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Security.AccessControl;
+using System.Security.Principal;
+using Xunit;
+
+namespace System.IO
+{
+    public class FileSystemAccessRuleTests
+    {
+        [Fact]
+        public void FileSystemAccessRule_Returns_Valid_Object()
+        {
+            var identity = new SecurityIdentifier(WellKnownSidType.WorldSid, null);
+            var accessRule = new FileSystemAccessRule(identity, FileSystemRights.AppendData, AccessControlType.Allow);
+            var expectedFileSystemRights = FileSystemRights.AppendData | FileSystemRights.Synchronize;
+            Assert.Equal(identity, accessRule.IdentityReference);
+            Assert.Equal(expectedFileSystemRights, accessRule.FileSystemRights);
+            Assert.Equal(AccessControlType.Allow, accessRule.AccessControlType);
+            Assert.Equal(PropagationFlags.None, accessRule.PropagationFlags);
+            Assert.Equal(InheritanceFlags.None, accessRule.InheritanceFlags);
+        }
+
+        [Fact]
+        public void FileSystemAccessRule_InvalidFileSystemRights()
+        {
+            var identity = new SecurityIdentifier(WellKnownSidType.WorldSid, null);
+            Assert.Throws<ArgumentOutOfRangeException>("fileSystemRights", () =>
+            new FileSystemAccessRule(identity, (FileSystemRights)(-1), AccessControlType.Allow));
+        }
+
+        [Fact]
+        public void FileSystemAccessRule_AcessControlTypeDeny_Returns_Valid_Object()
+        {
+            var identity = new SecurityIdentifier(WellKnownSidType.WorldSid, null);
+            var accessRule = new FileSystemAccessRule(identity, FileSystemRights.AppendData, AccessControlType.Deny);
+            var expectedFileSystemRights = FileSystemRights.AppendData & ~FileSystemRights.Synchronize;
+            Assert.Equal(expectedFileSystemRights, accessRule.FileSystemRights);
+            Assert.Equal(AccessControlType.Deny, accessRule.AccessControlType);
+        }
+
+        [Fact]
+        public void FileSystemAccessRule_FileSystemRightsFullControl_Returns_Valid_Object()
+        {
+            var identity = new SecurityIdentifier(WellKnownSidType.WorldSid, null);
+            var accessRule = new FileSystemAccessRule(identity, FileSystemRights.FullControl, AccessControlType.Deny);
+            Assert.Equal(FileSystemRights.FullControl, accessRule.FileSystemRights);
+            Assert.Equal(AccessControlType.Deny, accessRule.AccessControlType);
+        }
+
+        [Fact]
+        public void FileSystemAccessRule_IdentityAsString_Returns_Valid_Object()
+        {
+            var accessRule = new FileSystemAccessRule(@"MYDOMAIN\MyAccount", FileSystemRights.AppendData,
+                AccessControlType.Allow);
+            var expectedFileSystemRights = FileSystemRights.AppendData | FileSystemRights.Synchronize;
+            Assert.Equal(new NTAccount(@"MYDOMAIN\MyAccount"), accessRule.IdentityReference);
+            Assert.Equal(expectedFileSystemRights, accessRule.FileSystemRights);
+            Assert.Equal(AccessControlType.Allow, accessRule.AccessControlType);
+            Assert.Equal(PropagationFlags.None, accessRule.PropagationFlags);
+            Assert.Equal(InheritanceFlags.None, accessRule.InheritanceFlags);
+        }
+
+        [Fact]
+        public void FileSystemAccessRule_InhertianceFlag_PropagationFlag_Returns_Valid_Object()
+        {
+            var identity = new SecurityIdentifier(WellKnownSidType.WorldSid, null);
+            var accessRule = new FileSystemAccessRule(identity, FileSystemRights.AppendData,
+                InheritanceFlags.ContainerInherit, PropagationFlags.NoPropagateInherit,
+                AccessControlType.Allow);
+
+            Assert.Equal(PropagationFlags.NoPropagateInherit, accessRule.PropagationFlags);
+            Assert.Equal(InheritanceFlags.ContainerInherit, accessRule.InheritanceFlags);
+        }
+
+        [Fact]
+        public void FileSystemAccessRule_InhertianceFlag_PropagationFlag_IdentityAsString_Returns_Valid_Object()
+        {
+            var accessRule = new FileSystemAccessRule(@"MYDOMAIN\MyAccount", FileSystemRights.AppendData,
+                InheritanceFlags.ObjectInherit, PropagationFlags.InheritOnly,
+                AccessControlType.Allow);
+
+            Assert.Equal(new NTAccount(@"MYDOMAIN\MyAccount"), accessRule.IdentityReference);
+            Assert.Equal(PropagationFlags.InheritOnly, accessRule.PropagationFlags);
+            Assert.Equal(InheritanceFlags.ObjectInherit, accessRule.InheritanceFlags);
+        }
+    }
+}

--- a/src/System.IO.FileSystem.AccessControl/tests/FileSystemSecurityTests.cs
+++ b/src/System.IO.FileSystem.AccessControl/tests/FileSystemSecurityTests.cs
@@ -1,0 +1,411 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.AccessControl;
+using System.Security.Principal;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.IO
+{
+    public class FileSystemSecurityTests
+    {
+        [Fact]
+        public void AddAccessRule_InvalidFileSystemAccessRule()
+        {
+            var fileSecurity = new FileSecurity();
+            Assert.Throws<ArgumentNullException>("rule", () => fileSecurity.AddAccessRule(null));
+        }
+
+        [Fact]
+        public void AddAccessRule_Succeeds()
+        {
+            var accessRule = new FileSystemAccessRule(@"NT AUTHORITY\SYSTEM",
+                FileSystemRights.AppendData, AccessControlType.Allow);
+            var fileSecurity = new FileSecurity();
+            fileSecurity.AddAccessRule(accessRule);
+            AuthorizationRuleCollection rules =
+                fileSecurity.GetAccessRules(true, true, typeof(System.Security.Principal.NTAccount));
+            Assert.Equal(1, rules.Count);
+            var actualAddedRule = (FileSystemAccessRule)rules[0];
+            Assert.Equal(accessRule.IdentityReference, actualAddedRule.IdentityReference);
+            Assert.Equal(accessRule.FileSystemRights, actualAddedRule.FileSystemRights);
+            Assert.Equal(accessRule.AccessControlType, actualAddedRule.AccessControlType);
+        }
+
+        [Fact]
+        public void SetAccessRule_InvalidFileSystemAccessRule()
+        {
+            var fileSecurity = new FileSecurity();
+            Assert.Throws<ArgumentNullException>("rule", () => fileSecurity.SetAccessRule(null));
+        }
+
+        [Fact]
+        public void SetAccessRule_Succeeds()
+        {
+            var accessRuleRead = new FileSystemAccessRule(@"NT AUTHORITY\SYSTEM",
+                FileSystemRights.Read, AccessControlType.Allow);
+            var fileSecurity = new FileSecurity();
+            fileSecurity.AddAccessRule(accessRuleRead);
+            var accessRuleWrite = new FileSystemAccessRule(@"NT AUTHORITY\SYSTEM",
+                FileSystemRights.Write, AccessControlType.Allow);
+            //Changing the value of file system rights from "read" to "write".
+            fileSecurity.SetAccessRule(accessRuleWrite);
+
+            AuthorizationRuleCollection rules =
+                fileSecurity.GetAccessRules(true, true, typeof(System.Security.Principal.NTAccount));
+
+            Assert.Equal(1, rules.Count);
+            var existingAccessRule = (FileSystemAccessRule)rules[0];
+            Assert.Equal(accessRuleWrite.FileSystemRights, existingAccessRule.FileSystemRights);
+        }
+
+        [Fact]
+        public void SetAccessRule_IgnoreExistingRule_Succeeds()
+        {
+            var accessRuleRead = new FileSystemAccessRule(@"NT AUTHORITY\SYSTEM",
+                FileSystemRights.Read, AccessControlType.Allow);
+            var fileSecurity = new FileSecurity();
+            fileSecurity.AddAccessRule(accessRuleRead);
+            var newAccessRule = new FileSystemAccessRule(@"NT AUTHORITY\Network Service",
+                FileSystemRights.Write, AccessControlType.Allow);
+            fileSecurity.SetAccessRule(newAccessRule);
+
+            AuthorizationRuleCollection rules =
+                fileSecurity.GetAccessRules(true, true, typeof(System.Security.Principal.NTAccount));
+
+            Assert.Equal(2, rules.Count);
+            var existingAccessRule = (FileSystemAccessRule)rules[0];
+            Assert.Equal(new NTAccount(@"NT AUTHORITY\SYSTEM"), existingAccessRule.IdentityReference);
+            existingAccessRule = (FileSystemAccessRule)rules[1];
+            Assert.Equal(new NTAccount(@"NT AUTHORITY\Network Service"), existingAccessRule.IdentityReference);
+        }
+
+        [Fact]
+        public void ResetAccessRule_InvalidFileSystemAccessRule()
+        {
+            var fileSecurity = new FileSecurity();
+            Assert.Throws<ArgumentNullException>("rule", () => fileSecurity.ResetAccessRule(null));
+        }
+
+        [Fact]
+        public void ResetSetAccessRule_Succeeds()
+        {
+            var accessRuleRead = new FileSystemAccessRule(@"NT AUTHORITY\SYSTEM",
+                FileSystemRights.Read, AccessControlType.Allow);
+            var accessRuleAppendData = new FileSystemAccessRule(@"NT AUTHORITY\SYSTEM",
+                FileSystemRights.AppendData, AccessControlType.Deny);
+            var accessRuleWrite = new FileSystemAccessRule(@"NT AUTHORITY\SYSTEM",
+                FileSystemRights.Write, AccessControlType.Allow);
+
+            var fileSecurity = new FileSecurity();
+            fileSecurity.AddAccessRule(accessRuleRead);
+            fileSecurity.AddAccessRule(accessRuleAppendData);
+            AuthorizationRuleCollection rules =
+                fileSecurity.GetAccessRules(true, true, typeof(System.Security.Principal.NTAccount));
+            Assert.Equal(2, rules.Count);
+            //Resetting the access rules.
+            fileSecurity.ResetAccessRule(accessRuleWrite);
+            rules = fileSecurity.GetAccessRules(true, true, typeof(System.Security.Principal.NTAccount));
+            Assert.Equal(1, rules.Count);
+            var existingAccessRule = (FileSystemAccessRule)rules[0];
+            Assert.Equal(accessRuleWrite.FileSystemRights, existingAccessRule.FileSystemRights);
+            Assert.Equal(AccessControlType.Allow, existingAccessRule.AccessControlType);
+        }
+
+        [Fact]
+        public void RemoveAccessRule_InvalidFileSystemAccessRule()
+        {
+            var fileSecurity = new FileSecurity();
+            Assert.Throws<ArgumentNullException>("rule", () => fileSecurity.RemoveAccessRule(null));
+        }
+
+        [Fact]
+        public void RemoveAccessRule_Succeeds()
+        {
+            var accessRule = new FileSystemAccessRule(@"NT AUTHORITY\SYSTEM",
+                FileSystemRights.Read | FileSystemRights.Write,
+                AccessControlType.Allow);
+            var fileSecurity = new FileSecurity();
+            fileSecurity.AddAccessRule(accessRule);
+            AuthorizationRuleCollection rules =
+               fileSecurity.GetAccessRules(true, true, typeof(System.Security.Principal.NTAccount));
+            Assert.Equal(1, rules.Count);
+            //Removing the "write" access right.
+            Assert.True(fileSecurity.RemoveAccessRule(new FileSystemAccessRule(@"NT AUTHORITY\SYSTEM",
+                 FileSystemRights.Write,
+                AccessControlType.Allow)));
+            rules = fileSecurity.GetAccessRules(true, true, typeof(System.Security.Principal.NTAccount));
+            Assert.Equal(1, rules.Count);
+            var remainingRule = (FileSystemAccessRule)rules[0];
+            Assert.Equal(FileSystemRights.Read | FileSystemRights.Synchronize, remainingRule.FileSystemRights);
+        }
+
+        [Fact]
+        public void RemoveAccessRule_IdenticalRule_Succeeds()
+        {
+            var accessRule = new FileSystemAccessRule(@"NT AUTHORITY\SYSTEM",
+                FileSystemRights.Read | FileSystemRights.Write,
+                AccessControlType.Allow);
+            var fileSecurity = new FileSecurity();
+            fileSecurity.AddAccessRule(accessRule);
+            Assert.True(fileSecurity.RemoveAccessRule(new FileSystemAccessRule(@"NT AUTHORITY\SYSTEM",
+                 FileSystemRights.Read | FileSystemRights.Write,
+                AccessControlType.Allow)));
+            var rules = fileSecurity.GetAccessRules(true, true, typeof(System.Security.Principal.NTAccount));
+            Assert.Equal(0, rules.Count);
+        }
+
+        [Fact]
+        public void RemoveAccessRule_NoMatchableRules_Succeeds()
+        {
+            var accessRuleAppendData = new FileSystemAccessRule(@"NT AUTHORITY\SYSTEM", FileSystemRights.AppendData,
+                AccessControlType.Allow);
+            var accessRuleWrite = new FileSystemAccessRule(@"NT AUTHORITY\SYSTEM",
+                FileSystemRights.Write, AccessControlType.Deny);
+
+            var fileSecurity = new FileSecurity();
+            fileSecurity.AddAccessRule(accessRuleAppendData);
+            Assert.True(fileSecurity.RemoveAccessRule(accessRuleWrite));
+            AuthorizationRuleCollection rules =
+                fileSecurity.GetAccessRules(true, true, typeof(System.Security.Principal.NTAccount));
+            Assert.Equal(1, rules.Count);
+            var remainingRule = (FileSystemAccessRule)rules[0];
+            Assert.Equal(new NTAccount(@"NT AUTHORITY\SYSTEM"), accessRuleAppendData.IdentityReference);
+            Assert.Equal(accessRuleAppendData.FileSystemRights,remainingRule.FileSystemRights);
+            Assert.Equal(AccessControlType.Allow, remainingRule.AccessControlType);
+        }
+
+        [Fact]
+        public void RemoveAccessRuleSpecific_Invalid_FileSystemAccessRule()
+        {
+            var fileSecurity = new FileSecurity();
+            Assert.Throws<ArgumentNullException>("rule", () => fileSecurity.RemoveAccessRuleSpecific(null));
+        }
+
+        [Fact]
+        public void RemoveAccessRuleSpecific_NoMatchingRules_Succeeds()
+        {
+            var accessRuleReadWrite = new FileSystemAccessRule(@"NT AUTHORITY\SYSTEM",
+                FileSystemRights.Read | FileSystemRights.Write,
+                AccessControlType.Allow);
+            var accessRuleWrite = new FileSystemAccessRule(@"NT AUTHORITY\SYSTEM",
+                FileSystemRights.Write, AccessControlType.Allow);
+
+            var fileSecurity = new FileSecurity();
+            fileSecurity.AddAccessRule(accessRuleReadWrite);
+            fileSecurity.RemoveAccessRuleSpecific(accessRuleWrite);
+            AuthorizationRuleCollection rules =
+                fileSecurity.GetAccessRules(true, true, typeof(System.Security.Principal.NTAccount));
+            Assert.Equal(1, rules.Count);
+            var remainingRule = (FileSystemAccessRule)rules[0];
+            Assert.Equal(FileSystemRights.Write | FileSystemRights.Read | FileSystemRights.Synchronize,
+                remainingRule.FileSystemRights);
+        }
+
+        [Fact]
+        public void RemoveAccessRuleSpecific_Succeeds()
+        {
+            var accessRule = new FileSystemAccessRule(@"NT AUTHORITY\SYSTEM", FileSystemRights.AppendData
+                | FileSystemRights.Write, AccessControlType.Allow);
+            var fileSecurity = new FileSecurity();
+            fileSecurity.AddAccessRule(accessRule);
+            AuthorizationRuleCollection rules =
+               fileSecurity.GetAccessRules(true, true, typeof(System.Security.Principal.NTAccount));
+            Assert.Equal(1, rules.Count);
+            fileSecurity.RemoveAccessRuleSpecific(accessRule);
+            rules = fileSecurity.GetAccessRules(true, true, typeof(System.Security.Principal.NTAccount));
+            Assert.Equal(0, rules.Count);
+        }
+
+        [Fact]
+        public void RemoveAccessRuleAll_InvalidFileSystemAccessRule()
+        {
+            var fileSecurity = new FileSecurity();
+            Assert.Throws<ArgumentNullException>("rule", () => fileSecurity.RemoveAccessRuleAll(null));
+        }
+
+        [Fact]
+        public void RemoveAccessRuleAll_Succeeds()
+        {
+            var accessRuleAppendData = new FileSystemAccessRule(@"NT AUTHORITY\SYSTEM", FileSystemRights.AppendData,
+                AccessControlType.Allow);
+            var accessRuleRead = new FileSystemAccessRule(@"NT AUTHORITY\SYSTEM",
+                FileSystemRights.Read, AccessControlType.Allow);
+            var accessRuleWrite = new FileSystemAccessRule(@"NT AUTHORITY\SYSTEM",
+                FileSystemRights.Write, AccessControlType.Allow);
+            var accessRuleReadPermissionDeny = new FileSystemAccessRule(@"NT AUTHORITY\SYSTEM",
+              FileSystemRights.ReadPermissions, AccessControlType.Deny);
+            var accessRuleReadNetworkService = new FileSystemAccessRule(@"NT AUTHORITY\Network Service",
+                FileSystemRights.Read, AccessControlType.Allow);
+
+            var fileSecurity = new FileSecurity();
+            fileSecurity.AddAccessRule(accessRuleAppendData);
+            fileSecurity.AddAccessRule(accessRuleRead);
+            fileSecurity.AddAccessRule(accessRuleReadPermissionDeny);
+            fileSecurity.AddAccessRule(accessRuleReadNetworkService);
+            //Removing all the access rules of the "System" user with the access control type "allow".
+            fileSecurity.RemoveAccessRuleAll(accessRuleWrite);
+            AuthorizationRuleCollection rules =
+                fileSecurity.GetAccessRules(true, true, typeof(System.Security.Principal.NTAccount));
+
+            Assert.Equal(2, rules.Count);
+            var existingAccessRule = (FileSystemAccessRule)rules[0];
+            Assert.Equal(new NTAccount(@"NT AUTHORITY\SYSTEM"), existingAccessRule.IdentityReference);
+            Assert.Equal(AccessControlType.Deny, existingAccessRule.AccessControlType);
+            Assert.Equal(FileSystemRights.ReadPermissions, existingAccessRule.FileSystemRights);
+            existingAccessRule = (FileSystemAccessRule)rules[1];
+            Assert.Equal(new NTAccount(@"NT AUTHORITY\Network Service"), existingAccessRule.IdentityReference);
+            Assert.Equal(AccessControlType.Allow, existingAccessRule.AccessControlType);
+        }
+
+        [Fact]
+        public void AccessRuleType_Returns_Valid_Object()
+        {
+            var accessRule = new FileSystemAccessRule(@"NT AUTHORITY\SYSTEM", FileSystemRights.AppendData,
+             AccessControlType.Allow);
+            var fileSecurity = new FileSecurity();
+            fileSecurity.AddAccessRule(accessRule);
+            Type accessRuleType = fileSecurity.AccessRuleType;
+            Assert.Equal(typeof(FileSystemAccessRule), accessRuleType);
+        }
+
+        [Fact]
+        public void AddAuditRule_Succeeds()
+        {
+            var auditRule = new FileSystemAuditRule(@"NT AUTHORITY\SYSTEM",
+                FileSystemRights.AppendData, AuditFlags.Success);
+            var fileSecurity = new FileSecurity();
+            fileSecurity.AddAuditRule(auditRule);
+            AuthorizationRuleCollection auditRules =
+                fileSecurity.GetAuditRules(true, true, typeof(System.Security.Principal.NTAccount));
+            Assert.Equal(1, auditRules.Count);
+            var actualAddedRule = (FileSystemAuditRule)auditRules[0];
+            Assert.Equal(new NTAccount(@"NT AUTHORITY\SYSTEM"), actualAddedRule.IdentityReference);
+            Assert.Equal(AuditFlags.Success, actualAddedRule.AuditFlags);
+            Assert.Equal(FileSystemRights.AppendData, actualAddedRule.FileSystemRights);
+        }
+
+        [Fact]
+        public void SetAuditRule_Succeeds()
+        {
+            var auditRuleAppendData = new FileSystemAuditRule(@"NT AUTHORITY\SYSTEM",
+                FileSystemRights.AppendData, AuditFlags.Success);
+            var auditRuleNetworkService = new FileSystemAuditRule(@"NT AUTHORITY\Network Service",
+                FileSystemRights.CreateFiles, AuditFlags.Failure);
+            var auditRuleDelete = new FileSystemAuditRule(@"NT AUTHORITY\SYSTEM",
+                FileSystemRights.Delete, AuditFlags.Success);
+
+            var fileSecurity = new FileSecurity();
+            fileSecurity.AddAuditRule(auditRuleNetworkService);
+            fileSecurity.AddAuditRule(auditRuleAppendData);
+            fileSecurity.SetAuditRule(auditRuleDelete);
+            var auditRules = fileSecurity.GetAuditRules(true, true, typeof(System.Security.Principal.NTAccount));
+
+            Assert.Equal(2, auditRules.Count);
+            var firstAuditRule = (FileSystemAuditRule)auditRules[0];
+            Assert.Equal(new NTAccount(@"NT AUTHORITY\SYSTEM"), firstAuditRule.IdentityReference);
+            Assert.Equal(AuditFlags.Success, firstAuditRule.AuditFlags);
+            Assert.Equal(FileSystemRights.Delete, firstAuditRule.FileSystemRights);
+            var secondAuditRule = (FileSystemAuditRule)auditRules[1];
+            Assert.Equal(new NTAccount(@"NT AUTHORITY\Network Service"), secondAuditRule.IdentityReference);
+            Assert.Equal(AuditFlags.Failure, secondAuditRule.AuditFlags);
+            Assert.Equal(FileSystemRights.CreateFiles, secondAuditRule.FileSystemRights);
+        }
+
+        [Fact]
+        public void RemoveAuditRule_Succeeds()
+        {
+            var auditRule = new FileSystemAuditRule(@"NT AUTHORITY\SYSTEM",
+                FileSystemRights.Read | FileSystemRights.Write,
+                AuditFlags.Failure);
+            var fileSecurity = new FileSecurity();
+            fileSecurity.AddAuditRule(auditRule);
+            AuthorizationRuleCollection rules =
+               fileSecurity.GetAuditRules(true, true, typeof(System.Security.Principal.NTAccount));
+            Assert.Equal(1, rules.Count);
+            Assert.True(fileSecurity.RemoveAuditRule(new FileSystemAuditRule(@"NT AUTHORITY\SYSTEM",
+                FileSystemRights.Write, AuditFlags.Failure)));
+
+            rules = fileSecurity.GetAuditRules(true, true, typeof(System.Security.Principal.NTAccount));
+            Assert.Equal(1, rules.Count);
+            var existingRule = (FileSystemAuditRule)rules[0];
+            Assert.Equal(FileSystemRights.Read, existingRule.FileSystemRights);
+            Assert.Equal(AuditFlags.Failure, existingRule.AuditFlags);
+            Assert.Equal(new NTAccount(@"NT AUTHORITY\SYSTEM"), existingRule.IdentityReference);
+        }
+
+        [Fact]
+        public void RemoveAuditRuleSpecific_Succeeds()
+        {
+            var auditRuleReadWrite = new FileSystemAuditRule(@"NT AUTHORITY\SYSTEM",
+               FileSystemRights.Write | FileSystemRights.Read, AuditFlags.Success);
+            var auditRuleNetworkService = new FileSystemAuditRule(@"NT AUTHORITY\Network Service",
+                FileSystemRights.Read, AuditFlags.Failure);
+
+            var fileSecurity = new FileSecurity();
+            fileSecurity.AddAuditRule(auditRuleReadWrite);
+            fileSecurity.AddAuditRule(auditRuleNetworkService);
+            fileSecurity.RemoveAuditRuleSpecific(auditRuleReadWrite);
+            AuthorizationRuleCollection rules =
+              fileSecurity.GetAuditRules(true, true, typeof(System.Security.Principal.NTAccount));
+            Assert.Equal(1, rules.Count);
+            var existingAuditRule = (FileSystemAuditRule)rules[0];
+            Assert.Equal(new NTAccount(@"NT AUTHORITY\Network Service"), existingAuditRule.IdentityReference);
+            Assert.Equal(FileSystemRights.Read, existingAuditRule.FileSystemRights);
+            Assert.Equal(AuditFlags.Failure, existingAuditRule.AuditFlags);
+        }
+
+        [Fact]
+        public void RemoveAuditRuleSpecific_NoMatchingRules_Succeeds()
+        {
+            var auditRuleReadWrite = new FileSystemAuditRule(@"NT AUTHORITY\SYSTEM",
+              FileSystemRights.Write | FileSystemRights.Read, AuditFlags.Success);
+            var fileSecurity = new FileSecurity();
+            fileSecurity.AddAuditRule(auditRuleReadWrite);
+            fileSecurity.RemoveAuditRuleSpecific(new FileSystemAuditRule(@"NT AUTHORITY\SYSTEM",
+              FileSystemRights.Write, AuditFlags.Success));
+            AuthorizationRuleCollection rules =
+              fileSecurity.GetAuditRules(true, true, typeof(System.Security.Principal.NTAccount));
+            Assert.Equal(1, rules.Count);
+            var existingRule = (FileSystemAuditRule)rules[0];
+            Assert.Equal(FileSystemRights.Write | FileSystemRights.Read, existingRule.FileSystemRights);
+        }
+
+        [Fact]
+        public void RemoveAuditRuleAll_Succeeds()
+        {
+            var auditRuleAppend = new FileSystemAuditRule(@"NT AUTHORITY\SYSTEM", FileSystemRights.AppendData,
+                AuditFlags.Success);
+            var auditRuleWrite = new FileSystemAuditRule(@"NT AUTHORITY\SYSTEM",
+                FileSystemRights.Write, AuditFlags.Success);
+            var auditRuleNetworkService = new FileSystemAuditRule(@"NT AUTHORITY\Network Service",
+                FileSystemRights.Read, AuditFlags.Failure);
+
+            var fileSecurity = new FileSecurity();
+            fileSecurity.AddAuditRule(auditRuleAppend);
+            fileSecurity.AddAuditRule(auditRuleNetworkService);
+            fileSecurity.RemoveAuditRuleAll(auditRuleWrite);
+            AuthorizationRuleCollection rules =
+                fileSecurity.GetAuditRules(true, true, typeof(System.Security.Principal.NTAccount));
+
+            Assert.Equal(1, rules.Count);
+            var existingAuditRule = (FileSystemAuditRule)rules[0];
+            Assert.Equal(new NTAccount(@"NT AUTHORITY\Network Service"), existingAuditRule.IdentityReference);
+            Assert.Equal(FileSystemRights.Read, existingAuditRule.FileSystemRights);
+            Assert.Equal(AuditFlags.Failure, existingAuditRule.AuditFlags);
+        }
+
+        [Fact]
+        public void AuditRuleType_Returns_Valid_Object()
+        {
+            var fileSecurity = new FileSecurity();
+            Type type = fileSecurity.AuditRuleType;
+            Assert.Equal(typeof(FileSystemAuditRule), type);
+        }
+    }
+}

--- a/src/System.IO.FileSystem.AccessControl/tests/System.IO.FileSystem.AccessControl.Tests.csproj
+++ b/src/System.IO.FileSystem.AccessControl/tests/System.IO.FileSystem.AccessControl.Tests.csproj
@@ -10,6 +10,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="DirectoryObjectSecurityTests.cs" />
+    <Compile Include="FileSystemAccessRuleTests.cs" />
     <Compile Include="FileSystemAclExtensionsTests.cs" />
     <Compile Include="$(CommonTestPath)\System\AssertExtensions.cs">
       <Link>Common\System\AssertExtensions.cs</Link>
@@ -21,6 +22,7 @@
       <Link>Common\System\IO\TempDirectory.cs</Link>
     </Compile>
     <Compile Include="FileSystemAuditRuleTests.cs" />
+    <Compile Include="FileSystemSecurityTests.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
A new pull request for the issue #15808 to increase the code coverage: 
I added two new classes to handle the tests for the following types: "FileSystemAccessRule",  "FileSystmSecurity". 
I have also run the "CodeFormatter" tool on the new classes.
 