### PR TITLE
Make Named Pipe test Windows Specific

### DIFF
--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/MARSTest/MARSTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/MARSTest/MARSTest.cs
@@ -14,6 +14,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         private static readonly string _connStr = (new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr) { MultipleActiveResultSets = true }).ConnectionString;
 
         [CheckConnStrSetupFact]
+        [PlatformSpecific(TestPlatforms.Windows)]
         public static void NamedPipesMARSTest()
         {
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(DataTestUtility.NpConnStr);


### PR DESCRIPTION
`NamedPipesMARSTest` was being executed on Linux / MacOS.
Disabling the test since its not expected to work on platforms other than Windows.

cc @corivera 