### PR TITLE
Escape '\' on Unix file uris to '%5C' for canonical form.

### DIFF
--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -4754,6 +4754,14 @@ namespace System
                         end += (_info.Offset.Query - _info.Offset.Path);
                     }
                 }
+
+                // On Unix, escape '\\' in path of file uris to '%5C' canonical form.
+                if (!IsWindowsSystem && _syntax.NotAny(UriSyntaxFlags.ConvertPathSlashes) && _syntax.InFact(UriSyntaxFlags.FileLikeUri) && !IsImplicitFile)
+                {
+                    string str = new string(dest, pos, end - pos);
+                    dest = UriHelper.EscapeString(str, 0, str.Length, dest, ref pos, true, '\\', c_DummyChar, '%');
+                    end = pos;
+                }
             }
             else
             {

--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -4756,7 +4756,7 @@ namespace System
                 }
 
                 // On Unix, escape '\\' in path of file uris to '%5C' canonical form.
-                if (!IsWindowsSystem && _syntax.NotAny(UriSyntaxFlags.ConvertPathSlashes) && _syntax.InFact(UriSyntaxFlags.FileLikeUri) && !IsImplicitFile)
+                if (!IsWindowsSystem && InFact(Flags.BackslashInPath) && _syntax.NotAny(UriSyntaxFlags.ConvertPathSlashes) && _syntax.InFact(UriSyntaxFlags.FileLikeUri) && !IsImplicitFile)
                 {
                     string str = new string(dest, pos, end - pos);
                     dest = UriHelper.EscapeString(str, 0, str.Length, dest, ref pos, true, '\\', c_DummyChar, '%');

--- a/src/System.Private.Uri/tests/FunctionalTests/UriTests.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriTests.cs
@@ -22,9 +22,9 @@ namespace System.PrivateUri.Tests
                 }
                 else
                 {
-                    yield return new object[] { @"file:///path1\path2/path3\path4", @"/path1\path2/path3\path4", @"/path1\path2/path3\path4", @"file:///path1\path2/path3\path4", "" };
+                    yield return new object[] { @"file:///path1\path2/path3\path4", @"/path1%5Cpath2/path3%5Cpath4", @"/path1\path2/path3\path4", @"file:///path1%5Cpath2/path3%5Cpath4", "" };
                     yield return new object[] { @"file:///path1%5Cpath2\path3", @"/path1%5Cpath2%5Cpath3", @"/path1\path2\path3", @"file:///path1%5Cpath2%5Cpath3", ""};
-                    yield return new object[] { @"file://localhost/path1\path2/path3\path4\", @"/path1\path2/path3\path4\", @"\\localhost\path1\path2\path3\path4\", @"file://localhost/path1\path2/path3\path4\", "localhost"};
+                    yield return new object[] { @"file://localhost/path1\path2/path3\path4\", @"/path1%5Cpath2/path3%5Cpath4%5C", @"\\localhost\path1\path2\path3\path4\", @"file://localhost/path1%5Cpath2/path3%5Cpath4%5C", "localhost"};
                     yield return new object[] { @"file://randomhost/path1%5Cpath2\path3", @"/path1%5Cpath2%5Cpath3", @"\\randomhost\path1\path2\path3", @"file://randomhost/path1%5Cpath2%5Cpath3", "randomhost"};
                 }
             }

--- a/src/System.Runtime/tests/System/Uri.CreateStringTests.cs
+++ b/src/System.Runtime/tests/System/Uri.CreateStringTests.cs
@@ -558,9 +558,9 @@ namespace System.Tests
             }
             else // Unix paths preserve backslash
             {
-                yield return new object[] { @"file:///path1\path2/path3\path4", @"/path1\path2/path3\path4", "", "" };
+                yield return new object[] { @"file:///path1\path2/path3\path4", @"/path1%5Cpath2/path3%5Cpath4", "", "" };
                 yield return new object[] { @"file:///path1%5Cpath2\path3", @"/path1%5Cpath2%5Cpath3", "", ""};
-                yield return new object[] { @"file://localhost/path1\path2/path3\path4\", @"/path1\path2/path3\path4\", "", "" };
+                yield return new object[] { @"file://localhost/path1\path2/path3\path4\", @"/path1%5Cpath2/path3%5Cpath4%5C", "", "" };
                 yield return new object[] { @"file://localhost/path1%5Cpath2\path3", @"/path1%5Cpath2%5Cpath3", "", ""};
             }
             // Implicit file with empty path
@@ -677,7 +677,7 @@ namespace System.Tests
                 yield return new object[] { @"file:///\unchost/path1\path2/path3\path4\", "/path1/path2/path3/path4/", "", "" };
                 yield return new object[] { @"file://\/unchost/path1\path2/path3\path4\", "/path1/path2/path3/path4/", "", "" };
             }
-            else if(!s_isWindowsSystem)
+            else
             {
                 // Implicit file with path
                 yield return new object[] { "/", "/", "", "" };
@@ -687,15 +687,15 @@ namespace System.Tests
                 // Implicit file ending with backlash
                 yield return new object[] { @"/path1\path2/path3\path4\", "/path1%5Cpath2/path3%5Cpath4%5C", "", "" };
                 // Explicit UNC with backslash in path
-                yield return new object[] { @"file://\\unchost/path1\path2/path3\path4", @"/path1\path2/path3\path4", "", "" };
-                yield return new object[] { @"file:////unchost/path1\path2/path3\path4", @"/path1\path2/path3\path4", "", "" };
-                yield return new object[] { @"file:///\unchost/path1\path2/path3\path4", @"/path1\path2/path3\path4", "", "" };
-                yield return new object[] { @"file://\/unchost/path1\path2/path3\path4", @"/path1\path2/path3\path4", "", "" };
+                yield return new object[] { @"file://\\unchost/path1\path2/path3\path4", @"/path1%5Cpath2/path3%5Cpath4", "", "" };
+                yield return new object[] { @"file:////unchost/path1\path2/path3\path4", @"/path1%5Cpath2/path3%5Cpath4", "", "" };
+                yield return new object[] { @"file:///\unchost/path1\path2/path3\path4", @"/path1%5Cpath2/path3%5Cpath4", "", "" };
+                yield return new object[] { @"file://\/unchost/path1\path2/path3\path4", @"/path1%5Cpath2/path3%5Cpath4", "", "" };
                 // Explicit UNC ending with backslash
-                yield return new object[] { @"file://\\unchost/path1\path2/path3\path4\", @"/path1\path2/path3\path4\", "", "" };
-                yield return new object[] { @"file:////unchost/path1\path2/path3\path4\", @"/path1\path2/path3\path4\", "", "" };
-                yield return new object[] { @"file:///\unchost/path1\path2/path3\path4\", @"/path1\path2/path3\path4\", "", "" };
-                yield return new object[] { @"file://\/unchost/path1\path2/path3\path4\", @"/path1\path2/path3\path4\", "", "" };
+                yield return new object[] { @"file://\\unchost/path1\path2/path3\path4\", @"/path1%5Cpath2/path3%5Cpath4%5C", "", "" };
+                yield return new object[] { @"file:////unchost/path1\path2/path3\path4\", @"/path1%5Cpath2/path3%5Cpath4%5C", "", "" };
+                yield return new object[] { @"file:///\unchost/path1\path2/path3\path4\", @"/path1%5Cpath2/path3%5Cpath4%5C", "", "" };
+                yield return new object[] { @"file://\/unchost/path1\path2/path3\path4\", @"/path1%5Cpath2/path3%5Cpath4%5C", "", "" };
             }
 
             // Mailto


### PR DESCRIPTION
On Unix it is valid for filenames to have char '\\'. According to URI RFC, on the wire, the backslash needs to be in percent-encoded form as %5C. Hence we are converting all '\\' and '%5C' in unix file uris to be '%5C' in Uri.AbsolutePath and Uri.AbsoluteUri. These return the canonical URI values. Also note, the Uri.LocalPath will return these unescaped as before.

cc @tmds @CIPop @wfurt @karelz 