### PR TITLE
Disable UAP console tests related to output encoding

### DIFF
--- a/src/System.Console/tests/ConsoleEncoding.Windows.cs
+++ b/src/System.Console/tests/ConsoleEncoding.Windows.cs
@@ -11,6 +11,7 @@ public partial class ConsoleEncoding
 {
     [Fact]
     [PlatformSpecific(TestPlatforms.Windows)]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "https://github.com/dotnet/corefx/issues/21483")]
     public void InputEncoding_SetDefaultEncoding_Success()
     {
         RemoteInvoke(() =>
@@ -44,6 +45,7 @@ public partial class ConsoleEncoding
 
     [Fact]
     [PlatformSpecific(TestPlatforms.Windows)]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "https://github.com/dotnet/corefx/issues/21483")]
     public void OutputEncoding_SetDefaultEncoding_Success()
     {
         RemoteInvoke(() =>

--- a/src/System.Console/tests/ConsoleEncoding.cs
+++ b/src/System.Console/tests/ConsoleEncoding.cs
@@ -79,6 +79,7 @@ public partial class ConsoleEncoding : RemoteExecutorTestBase
     }
 
     [Fact]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "https://github.com/dotnet/corefx/issues/21483")]
     public void TestValidEncodings()
     {
         Action<Encoding> check = encoding =>

--- a/src/System.Console/tests/ReadAndWrite.cs
+++ b/src/System.Console/tests/ReadAndWrite.cs
@@ -261,6 +261,7 @@ public class ReadAndWrite
     [Fact]
     // On the full framework it is not guaranteed to eat the preamble bytes
     [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "https://github.com/dotnet/corefx/issues/21483")]
     public static unsafe void OutputEncodingPreamble()
     {
         Encoding curEncoding = Console.OutputEncoding;
@@ -283,6 +284,7 @@ public class ReadAndWrite
     }
 
     [Fact]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "https://github.com/dotnet/corefx/issues/21483")]
     public static unsafe void OutputEncoding()
     {
         Encoding curEncoding = Console.OutputEncoding;


### PR DESCRIPTION
Related to: https://github.com/dotnet/corefx/issues/21483

still working on the rest of System.Console.Tests but they are different buckets

Disabling because those are not available pre RS3

```
kernel32!SetConsoleOutputCP
kernel32!GetConsoleOutputCP
```