### PR TITLE
Qualify Table types with Schema names

### DIFF
--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/DateTimeVariantTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/DateTimeVariantTest.cs
@@ -178,7 +178,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                 {
                     conn.Open();
                     DropType(conn, tvpTypeName);
-                    xsql(conn, string.Format("create type {0} as table (f1 {1})", tvpTypeName, expectedBaseTypeName));
+                    xsql(conn, string.Format("create type dbo.{0} as table (f1 {1})", tvpTypeName, expectedBaseTypeName));
 
                     // Send TVP using SqlMetaData.
                     SqlMetaData[] metadata = new SqlMetaData[1];
@@ -232,7 +232,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                 {
                     conn.Open();
                     DropType(conn, tvpTypeName);
-                    xsql(conn, string.Format("create type {0} as table (f1 sql_variant)", tvpTypeName));
+                    xsql(conn, string.Format("create type dbo.{0} as table (f1 sql_variant)", tvpTypeName));
 
                     // Send TVP using SqlMetaData.
                     SqlMetaData[] metadata = new SqlMetaData[1];
@@ -284,7 +284,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                 {
                     conn.Open();
                     DropType(conn, tvpTypeName);
-                    xsql(conn, string.Format("create type {0} as table (f1 {1})", tvpTypeName, expectedBaseTypeName));
+                    xsql(conn, string.Format("create type dbo.{0} as table (f1 {1})", tvpTypeName, expectedBaseTypeName));
 
                     // Send TVP using SqlDataReader.
                     SqlConnection connInput = new SqlConnection(s_connStr);
@@ -346,7 +346,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                 {
                     conn.Open();
                     DropType(conn, tvpTypeName);
-                    xsql(conn, string.Format("create type {0} as table (f1 sql_variant)", tvpTypeName));
+                    xsql(conn, string.Format("create type dbo.{0} as table (f1 sql_variant)", tvpTypeName));
 
                     // Send TVP using SqlDataReader.
                     SqlConnection connInput = new SqlConnection(s_connStr);
@@ -412,9 +412,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                     DropStoredProcedure(conn, ProcName);
                     DropTable(conn, InputTableName);
                     DropTable(conn, OutputTableName);
-                    DropType(conn, tvpTypeName);
+                    DropType(conn, $"dbo.{tvpTypeName}");
 
-                    xsql(conn, string.Format("create type {0} as table (f1 {1})", tvpTypeName, expectedBaseTypeName));
+                    xsql(conn, string.Format("create type dbo.{0} as table (f1 {1})", tvpTypeName, expectedBaseTypeName));
                     xsql(conn, string.Format("create table {0} (f1 {1})", InputTableName, expectedBaseTypeName));
                     xsql(conn, string.Format("create table {0} (f1 {1})", OutputTableName, expectedBaseTypeName));
 

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/SqlVariantParam.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/SqlVariantParam.cs
@@ -122,7 +122,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                 {
                     connBulk.Open();
 
-                    ExecuteSQL(connBulk, "create table {0} (f1 sql_variant)", bulkCopyTableName);
+                    ExecuteSQL(connBulk, "create table dbo.{0} (f1 sql_variant)", bulkCopyTableName);
                     try
                     {
                         // Perform bulk copy to target.
@@ -215,7 +215,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             {
                 connTvp.Open();
 
-                ExecuteSQL(connTvp, "create type {0} as table (f1 sql_variant)", tvpTypeName);
+                ExecuteSQL(connTvp, "create type dbo.{0} as table (f1 sql_variant)", tvpTypeName);
                 try
                 {
                     // Send TVP using SqlMetaData.


### PR DESCRIPTION
While creating the Table types in the parameter test, we need to qualify it with the schema name as well.
The errors can happen when we change the default schema of the DB resulting in omission of dbo. as a prefix from the database artifacts. 
Since Notification test need some schema modifications, on the test database, parameter tests start failing because they try to query a type prefixed with dbo. which doesn't exist in the database.

During the creation of the Table types, it should be qualified with a schema name.