### PR TITLE
Make DirectoryServices.AccountManagement project usable with corefx infra

### DIFF
--- a/src/System.DirectoryServices.AccountManagement/System.DirectoryServices.AccountManagement.sln
+++ b/src/System.DirectoryServices.AccountManagement/System.DirectoryServices.AccountManagement.sln
@@ -2,7 +2,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.DirectoryServices.AccountManagement.Tests", "tests\System.DirectoryServices.AccountManagement.Tests.csproj", "{57E8F8D4-0766-4CC7-B3F9-B243B81DB6A5}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.DirectoryServices.AccountManagement.Tests", "tests\System.DirectoryServices.AccountManagement.Tests.csproj", "{297A9116-1005-499D-A895-2063D03E4C94}"
 	ProjectSection(ProjectDependencies) = postProject
 		{879C23DC-D828-4DFB-8E92-ABBC11B71035} = {879C23DC-D828-4DFB-8E92-ABBC11B71035}
 	EndProjectSection
@@ -26,10 +26,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{57E8F8D4-0766-4CC7-B3F9-B243B81DB6A5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{57E8F8D4-0766-4CC7-B3F9-B243B81DB6A5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{57E8F8D4-0766-4CC7-B3F9-B243B81DB6A5}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{57E8F8D4-0766-4CC7-B3F9-B243B81DB6A5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{297A9116-1005-499D-A895-2063D03E4C94}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{297A9116-1005-499D-A895-2063D03E4C94}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{297A9116-1005-499D-A895-2063D03E4C94}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{297A9116-1005-499D-A895-2063D03E4C94}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
 		{879C23DC-D828-4DFB-8E92-ABBC11B71035}.Debug|Any CPU.ActiveCfg = netstandard-Windows_NT-Debug|Any CPU
 		{879C23DC-D828-4DFB-8E92-ABBC11B71035}.Debug|Any CPU.Build.0 = netstandard-Windows_NT-Debug|Any CPU
 		{879C23DC-D828-4DFB-8E92-ABBC11B71035}.Release|Any CPU.ActiveCfg = netstandard-Windows_NT-Release|Any CPU
@@ -43,7 +43,7 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
-		{57E8F8D4-0766-4CC7-B3F9-B243B81DB6A5} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{297A9116-1005-499D-A895-2063D03E4C94} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{879C23DC-D828-4DFB-8E92-ABBC11B71035} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{404455B6-466C-4F78-9DCC-C37DCC0B75DA} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 	EndGlobalSection

--- a/src/System.DirectoryServices.AccountManagement/tests/System.DirectoryServices.AccountManagement.Tests.csproj
+++ b/src/System.DirectoryServices.AccountManagement/tests/System.DirectoryServices.AccountManagement.Tests.csproj
@@ -1,29 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
-  <PropertyGroup>
-    <Configuration Condition="'$(Configuration)'==''">Windows_Debug</Configuration>
-  </PropertyGroup>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
-    <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
-    <ProjectGuid>{57E8F8D4-0766-4CC7-B3F9-B243B81DB6A5}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AssemblyName>System.DirectoryServices.AccountManagement.Tests</AssemblyName>
+    <ProjectGuid>{297A9116-1005-499D-A895-2063D03E4C94}</ProjectGuid>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
+  <!-- Default configurations to help VS understand the configurations -->
   <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'==''">
     <Compile Include="ComputerPrincipalTest.cs" />
     <Compile Include="ExtendedUserPrincipal.cs" />
     <Compile Include="GroupPrincipalTest.cs" />
     <Compile Include="PrincipalTest.cs" />
     <Compile Include="UserPrincipalTest.cs" />
-    <Content Include="AuthoringTests.txt" />
-    <ProjectReference Include="..\..\System.DirectoryServices\ref\System.DirectoryServices.csproj" />
-    <ProjectReference Include="..\..\System.DirectoryServices.Protocols\ref\System.DirectoryServices.Protocols.csproj" />
-    <ProjectReference Include="..\ref\System.DirectoryServices.AccountManagement.csproj" />
+    <Compile Include="$(CommonTestPath)\System\AssertExtensions.cs">
+      <Link>Common\System\AssertExtensions.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
Previously these tests would not compile with `msbuild /T:BuildAndTest`. Now they do