### PR TITLE
Fix some HttpClientHandler properties for UAP

### DIFF
--- a/src/System.Net.Http/src/netcore50/System/Net/HttpClientHandler.cs
+++ b/src/System.Net.Http/src/netcore50/System/Net/HttpClientHandler.cs
@@ -273,20 +273,11 @@ namespace System.Net.Http
             }
         }
 
-        // WinINet limit
         public int MaxAutomaticRedirections
         {
-            get { return 10; }
+            get { return 10; } // WinRT Windows.Web.Http constant via use of native WinINet.
             set
             {
-                /*
-                 * TODO:#17812
-                if (value != MaxAutomaticRedirections)
-                {
-                    throw new PlatformNotSupportedException(String.Format(CultureInfo.InvariantCulture,
-                        SR.net_http_value_not_supported, value, nameof(MaxAutomaticRedirections)));
-                }
-                */
                 CheckDisposedOrStarted();
             }
         }
@@ -326,11 +317,7 @@ namespace System.Net.Http
 
             set
             {
-                /*
-                 * TODO:#18036
-                throw new PlatformNotSupportedException(String.Format(CultureInfo.InvariantCulture,
-                    SR.net_http_value_not_supported, value, nameof(MaxResponseHeadersLength)));
-                */
+                CheckDisposedOrStarted();
             }
         }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxResponseHeadersLength.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxResponseHeadersLength.cs
@@ -15,18 +15,9 @@ namespace System.Net.Http.Functional.Tests
 {
     using Configuration = System.Net.Test.Common.Configuration;
 
-    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "dotnet/corefx #20010")]
     public class HttpClientHandler_MaxResponseHeadersLength_Test : RemoteExecutorTestBase
     {
-        [Fact]
-        public void Default_MaxResponseHeadersLength()
-        {
-            using (var handler = new HttpClientHandler())
-            {
-                Assert.Equal(64, handler.MaxResponseHeadersLength);
-            }
-        }
-
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Not currently supported on UAP")]
         [Theory]
         [InlineData(0)]
         [InlineData(-1)]
@@ -38,6 +29,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Not currently supported on UAP")]
         [Theory]
         [InlineData(1)]
         [InlineData(65)]
@@ -63,6 +55,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Not currently supported on UAP")]
         [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(ResponseWithManyHeadersData))]
         public async Task ThresholdExceeded_ThrowsException(string responseHeaders, int maxResponseHeadersLength, bool shouldSucceed)

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -115,13 +115,17 @@ namespace System.Net.Http.Functional.Tests
                 Assert.Equal(null, handler.Proxy);
                 Assert.True(handler.SupportsAutomaticDecompression);
                 Assert.True(handler.UseCookies);
-
-                if (!PlatformDetection.IsUap) // TODO https://github.com/dotnet/corefx/issues/21510
-                {
-                    Assert.False(handler.UseDefaultCredentials);
-                }
-
                 Assert.True(handler.UseProxy);
+            }
+        }
+
+        [ActiveIssue(21510, TargetFrameworkMonikers.Uap)]
+        [Fact]
+        public void UseDefaultCredentials_Ctor_ExpectedValue()
+        {
+            using (var handler = new HttpClientHandler())
+            {
+                Assert.False(handler.UseDefaultCredentials);
             }
         }
 
@@ -139,7 +143,7 @@ namespace System.Net.Http.Functional.Tests
                 Assert.True(handler.SupportsRedirectConfiguration);
                 
                 // Changes from .NET Framework (Desktop).
-                if (!PlatformDetection.IsFullFramework) // TODO Issue #17691
+                if (!PlatformDetection.IsFullFramework)
                 {
                     Assert.Equal(0, handler.MaxRequestContentBufferSize);
                 }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -98,9 +98,8 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [Fact]
-        public void Ctor_ExpectedDefaultPropertyValues()
+        public void Ctor_ExpectedDefaultPropertyValues_CommonPlatform()
         {
             using (var handler = new HttpClientHandler())
             {
@@ -112,22 +111,38 @@ namespace System.Net.Http.Functional.Tests
                 Assert.NotNull(cookies);
                 Assert.Equal(0, cookies.Count);
                 Assert.Null(handler.Credentials);
-                Assert.Equal(50, handler.MaxAutomaticRedirections);
-                Assert.False(handler.PreAuthenticate);
+                Assert.NotNull(handler.Properties);
                 Assert.Equal(null, handler.Proxy);
                 Assert.True(handler.SupportsAutomaticDecompression);
+                Assert.True(handler.UseCookies);
+
+                if (!PlatformDetection.IsUap) // TODO https://github.com/dotnet/corefx/issues/21510
+                {
+                    Assert.False(handler.UseDefaultCredentials);
+                }
+
+                Assert.True(handler.UseProxy);
+            }
+        }
+
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)]
+        [Fact]
+        public void Ctor_ExpectedDefaultPropertyValues_NotUapPlatform()
+        {
+            using (var handler = new HttpClientHandler())
+            {
+                // Same as .NET Framework (Desktop).
+                Assert.Equal(50, handler.MaxAutomaticRedirections);
+                Assert.Equal(64, handler.MaxResponseHeadersLength);
+                Assert.False(handler.PreAuthenticate);
                 Assert.True(handler.SupportsProxy);
                 Assert.True(handler.SupportsRedirectConfiguration);
-                Assert.True(handler.UseCookies);
-                Assert.False(handler.UseDefaultCredentials);
-                Assert.True(handler.UseProxy);
-
+                
                 // Changes from .NET Framework (Desktop).
                 if (!PlatformDetection.IsFullFramework) // TODO Issue #17691
                 {
                     Assert.Equal(0, handler.MaxRequestContentBufferSize);
                 }
-                Assert.NotNull(handler.Properties);
             }
         }
 
@@ -136,7 +151,11 @@ namespace System.Net.Http.Functional.Tests
         {
             using (var handler = new HttpClientHandler())
             {
+                Assert.Equal(10, handler.MaxAutomaticRedirections);
+                Assert.Equal(-1, handler.MaxResponseHeadersLength);
                 Assert.True(handler.PreAuthenticate);
+                Assert.False(handler.SupportsProxy);
+                Assert.False(handler.SupportsRedirectConfiguration);
             }
         }
 
@@ -544,7 +563,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Not currently supported on UAP")]
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(3, 2)]


### PR DESCRIPTION
Due to platform differences on UAP and the current use of WinRT APIs to
implement that HTTP stack, a few properties won't have the same defaults
or behavior.

Similar to the decision made in PR #21403, don't throw PNSE. Instead
just no-op.

Fixes #18036 #17812