### PR TITLE
Allow local execution of RemoteInvoke for debugging purposes

### DIFF
--- a/src/CoreFx.Private.TestUtilities/src/CoreFx.Private.TestUtilities.csproj
+++ b/src/CoreFx.Private.TestUtilities/src/CoreFx.Private.TestUtilities.csproj
@@ -31,6 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Reference Condition="'$(TargetGroup)' != 'uap'" Include="System.Console" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.IO.FileSystem" />
     <Reference Include="System.Threading.Thread" />


### PR DESCRIPTION
When debugging a test that does RemoteInvoke, it is necessary to find the child process and attach to it; and if you want to debug the rest of the test, attach to the parent process.

With this, setting FORCE_LOCAL_INVOKE=1 does the RemoteInvoke inproc so you can conveniently debug just one process. (Not all tests work this way, but many work perfectly well)