### PR TITLE
Fix occasional 'The data area passed to a system call is too small.' 

### DIFF
--- a/src/Common/src/Interop/Windows/kernel32/Interop.GetConsoleTitle.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.GetConsoleTitle.cs
@@ -39,7 +39,7 @@ internal partial class Interop
 
             while (true)
             {
-                // If capacity is insufficient, sometimes it returns length,
+                // If capacity is insufficient, sometimes it returns length (in chars, w/o null terminator),
                 // and sometimes it returns 0 with an error ERROR_INSUFFICIENT_BUFFER
                 int len = GetConsoleTitle(sb, sb.Capacity + 1); // +1 for null which marshaler adds
 
@@ -61,8 +61,9 @@ internal partial class Interop
                     titleLength = len;
                     return 0;
                 }
-                else
+                else if (sb.Capacity >= len)
                 {
+                    // Success
                     title = sb.ToString();
                     titleLength = title.Length;
                     return 0;

--- a/src/Common/src/Interop/Windows/kernel32/Interop.GetConsoleTitle.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.GetConsoleTitle.cs
@@ -69,7 +69,7 @@ internal partial class Interop
                 }
 
                 // We need to increase the sb capacity and retry.
-                sb.Capacity = CharCountToByteCount(len == 0 ? Math.Min(sb.Capacity * 2, MaxAllowedBufferSizeInChars) : len + 1);
+                sb.Capacity = CharCountToByteCount(len == 0 ? Math.Min(sb.Capacity * 2, MaxAllowedBufferSizeInChars) : len);
             }
         }
     }

--- a/src/Common/src/Interop/Windows/kernel32/Interop.GetConsoleTitle.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.GetConsoleTitle.cs
@@ -19,49 +19,43 @@ internal partial class Interop
         // Although msdn states that the max allowed limit is 65K,
         // desktop limits this to 24500 as buffer sizes greater than it
         // throw.
-        private const int MaxAllowedBufferSizeInChars = 24500;
-
-        // GetConsoleTitle sometimes interprets the second parameter (nSize) as number of bytes and sometimes as the number of chars.
-        // Instead of doing complicated and dangerous logic to determine if this may or may not occur,
-        // we simply assume the worst and reserve a bigger buffer. This way we may use a bit more memory,
-        // but we will always be safe.
-        private static int CharCountToByteCount(int numChars)
-        {
-            return numChars * 2;
-        }
+        // See note below for why we're pessimistically setting the capacity as if it was bytes, even though it's in chars.
+        private const int MaxAllowedBufferSizeInChars = 24500 * sizeof(char);
 
         // 1. We first try to call the GetConsoleTitle with an InitialBufferSizeInChars of 256.
         // 2. Then based on the return value either increase the capacity or return failure.
         internal static int GetConsoleTitle(out string title, out int titleLength)
         {
             int lastError = 0;
-            StringBuilder sb = new StringBuilder(CharCountToByteCount(InitialBufferSizeInChars + 1));
+
+            // See note below for why we're pessimistically setting the capacity as if it was bytes, even though it's in chars.
+            StringBuilder sb = new StringBuilder(InitialBufferSizeInChars * sizeof(char));
 
             while (true)
             {
-                // If capacity is insufficient, sometimes it returns length (in chars, w/o null terminator),
-                // and sometimes it returns 0 with an error ERROR_INSUFFICIENT_BUFFER
-                int len = GetConsoleTitle(sb, sb.Capacity + 1); // +1 for null which marshaler adds
+                // If capacity is insufficient, sometimes this function returns length,
+                // and sometimes (Windows 10 RS2) it returns 0 with either ERROR_INSUFFICIENT_BUFFER or ERROR_SUCCESS.
+                // In either of those latter cases, try again hopefully with a larger buffer.
+                //
+                // In some cases (Windows 7, perhaps depending on codepage) it interprets the second parameter as bytes. 
+                // Give it characters, pssimistically, but make sure that the number of characters we offer is twice what it claims it needs.
+                //
+                // In some cases (Windows 10 RS2), the returned length includes null, in others (Windows 7) it does not. 
+                // Pessimistically assume it does not.
+                int len = GetConsoleTitle(sb, sb.Capacity);
 
                 if (len <= 0)
                 {
                     lastError = Marshal.GetLastWin32Error();
 
-                    if (len < 0 || lastError != Errors.ERROR_INSUFFICIENT_BUFFER)
+                    if (len < 0 || (lastError != Errors.ERROR_INSUFFICIENT_BUFFER && lastError != Errors.ERROR_SUCCESS))
                     {
                         title = string.Empty;
                         titleLength = title.Length;
                         return lastError;
                     }
                 }
-                else if (sb.Capacity > MaxAllowedBufferSizeInChars)
-                {
-                    // Title is greater than the allowed buffer so we do not read the title and only pass the length to the caller.
-                    title = string.Empty;
-                    titleLength = len;
-                    return 0;
-                }
-                else if (sb.Capacity >= len)
+                else if (sb.Capacity >= (len + 1) * sizeof(char))
                 {
                     // Success
                     title = sb.ToString();
@@ -70,7 +64,26 @@ internal partial class Interop
                 }
 
                 // We need to increase the sb capacity and retry.
-                sb.Capacity = CharCountToByteCount(len == 0 ? Math.Min(sb.Capacity * 2, MaxAllowedBufferSizeInChars) : len);
+                if (sb.Capacity >= MaxAllowedBufferSizeInChars)
+                {
+                    // No more room to grow.
+                    // Title is greater than the allowed buffer so we do not read the title and only pass the length to the caller.
+                    title = string.Empty;
+                    titleLength = len;
+                    return 0;
+                }
+
+                if (len > 0)
+                {
+                    // Add one for the null terminator in case length doesn't include it
+                    // Double the length requested, in case it will interpret sb.Capacity as bytes
+                    sb.Capacity = Math.Min((len + 1) * sizeof(char), MaxAllowedBufferSizeInChars);
+                }
+                else
+                {
+                    // Don't know what length is needed: just double
+                    sb.Capacity = Math.Min(sb.Capacity * 2, MaxAllowedBufferSizeInChars);
+                }
             }
         }
     }

--- a/src/Common/src/Interop/Windows/kernel32/Interop.GetConsoleTitle.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.GetConsoleTitle.cs
@@ -19,8 +19,7 @@ internal partial class Interop
         // Although msdn states that the max allowed limit is 65K,
         // desktop limits this to 24500 as buffer sizes greater than it
         // throw.
-        // See note below for why we're pessimistically setting the capacity as if it was bytes, even though it's in chars.
-        private const int MaxAllowedBufferSizeInChars = 24500 * sizeof(char);
+        private const int MaxAllowedBufferSizeInChars = 24500;
 
         // 1. We first try to call the GetConsoleTitle with an InitialBufferSizeInChars of 256.
         // 2. Then based on the return value either increase the capacity or return failure.
@@ -64,7 +63,7 @@ internal partial class Interop
                 }
 
                 // We need to increase the sb capacity and retry.
-                if (sb.Capacity >= MaxAllowedBufferSizeInChars)
+                if (sb.Capacity >= MaxAllowedBufferSizeInChars * sizeof(char))
                 {
                     // No more room to grow.
                     // Title is greater than the allowed buffer so we do not read the title and only pass the length to the caller.
@@ -77,12 +76,12 @@ internal partial class Interop
                 {
                     // Add one for the null terminator in case length doesn't include it
                     // Double the length requested, in case it will interpret sb.Capacity as bytes
-                    sb.Capacity = Math.Min((len + 1) * sizeof(char), MaxAllowedBufferSizeInChars);
+                    sb.Capacity = Math.Min((len + 1) * sizeof(char), MaxAllowedBufferSizeInChars * sizeof(char));
                 }
                 else
                 {
                     // Don't know what length is needed: just double
-                    sb.Capacity = Math.Min(sb.Capacity * 2, MaxAllowedBufferSizeInChars);
+                    sb.Capacity = Math.Min(sb.Capacity * 2, MaxAllowedBufferSizeInChars * sizeof(char));
                 }
             }
         }

--- a/src/System.Console/tests/WindowAndCursorProps.cs
+++ b/src/System.Console/tests/WindowAndCursorProps.cs
@@ -142,9 +142,12 @@ public class WindowAndCursorProps : RemoteExecutorTestBase
     [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))] // Nano currently ignores set title
     [InlineData(0)]
     [InlineData(1)]
+    [InlineData(10)]
     [InlineData(255)]
     [InlineData(256)]
+    [InlineData(257)]
     [InlineData(1024)]
+    [InlineData(24_000)]
     [PlatformSpecific(TestPlatforms.Windows)]  // Expected behavior specific to Windows
     [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)] // In appcontainer, the stream cannot be opened: there is no Console
     public static void Title_Set_Windows(int lengthOfTitle)


### PR DESCRIPTION
When running Console tests on one of my machines I sometimes get this error when it tries to get a console title of >1000 characters. GetConsoleTitle, is supposed to return the length of the buffer it wants, but sometimes instead it returns 0 and ERROR_INSUFFICIENT_BUFFER. I don't know why: I found mention on the web of this also. To fix this, in such a case, progressively try larger buffers until we hit our limit or it works. This makes the test pass on my laptop.

Also I added +1 when we pass in the length of the StringBuilder. @JeremyKuhne pointed out (also documented [here](https://docs.microsoft.com/en-us/dotnet/framework/interop/default-marshaling-for-strings)) that .Capacity does not include the trailing null that the marshaler includes in the buffer it passes to the native call.