### PR TITLE
Re-enable some System.Net.Mail tests for UAPAOT

### DIFF
--- a/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -297,7 +297,6 @@ namespace System.Net.Mail.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Crashes or hangs: https://github.com/dotnet/corefx/issues/19604")]
         public async Task TestMailDeliveryAsync()
         {
             SmtpServer server = new SmtpServer();
@@ -323,7 +322,6 @@ namespace System.Net.Mail.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Crashes or hangs: https://github.com/dotnet/corefx/issues/19604")]
         public async Task TestCredentialsCopyInAsyncContext()
         {
             SmtpServer server = new SmtpServer();

--- a/src/System.Net.Mail/tests/Functional/SmtpExceptionTest.cs
+++ b/src/System.Net.Mail/tests/Functional/SmtpExceptionTest.cs
@@ -9,7 +9,6 @@
 // (C) 2008 Gert Driesen
 //
 
-
 using System.Collections;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters;
@@ -86,13 +85,6 @@ namespace System.Net.Mail.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/19585 - System.Exception not serializable - NotImplemented", TargetFrameworkMonikers.UapAot)]
-        public void TestConstructorThrowsNull()
-        {
-            Assert.Throws<ArgumentNullException>(() => new MySmtpException((SerializationInfo)null, new StreamingContext()));
-        }
-
-        [Fact]
         public void TestConstructorWithStatusCodeAndStringArgument()
         {
             string msg;
@@ -162,13 +154,4 @@ namespace System.Net.Mail.Tests
             Assert.Equal(SmtpStatusCode.GeneralFailure, se.StatusCode);
         }
     }
-
-    class MySmtpException : SmtpException
-    {
-        public MySmtpException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
-        {
-        }
-    }
 }
-


### PR DESCRIPTION
With the recent implementation of System.Net.NetworkInformation for UWP,
we can re-enable some tests.

Also, the latest plan of record for serialization support in .NET Core
is such that serializing these exception types are not supported. So,
removing the test for that.  FYI, the actual implementation of the
serialization overrides in the SmtpException class are already no-ops in
the code and simply call the base method.

Fixes #19604