### PR TITLE
Disable WinHttpHandler tests on UAP/UAPAOT

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/ServerCertificateTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/ServerCertificateTest.cs
@@ -17,6 +17,7 @@ using Xunit.Abstractions;
 
 namespace System.Net.Http.WinHttpHandlerFunctional.Tests
 {
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "WinHttpHandler not supported on UAP")]
     public class ServerCertificateTest
     {
         private readonly ITestOutputHelper _output;

--- a/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/WinHttpHandlerTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/WinHttpHandlerTest.cs
@@ -18,6 +18,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
 {
     // Note:  Disposing the HttpClient object automatically disposes the handler within. So, it is not necessary
     // to separately Dispose (or have a 'using' statement) for the handler.
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "WinHttpHandler not supported on UAP")]
     public class WinHttpHandlerTest
     {
         // TODO: This is a placeholder until GitHub Issue #2383 gets resolved.


### PR DESCRIPTION
System.Net.Http.WinHttpHandler is only meant for use on .NET Framework
and .NET Core but not for UWP apps.

Fixes #21438