### PR TITLE
Disable Pipes, Threading, and String tests for UAP

### DIFF
--- a/src/System.IO.Pipes/tests/AnonymousPipeTests/AnonymousPipeTest.CrossProcess.cs
+++ b/src/System.IO.Pipes/tests/AnonymousPipeTests/AnonymousPipeTest.CrossProcess.cs
@@ -10,6 +10,7 @@ namespace System.IO.Pipes.Tests
     public class AnonymousPipeTest_CrossProcess : RemoteExecutorTestBase
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/21275", TargetFrameworkMonikers.Uap)]
         public void PingPong()
         {
             // Create two anonymous pipes, one for each direction of communication.

--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -1291,6 +1291,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/21541", TargetFrameworkMonikers.Uap)]
         public static void IndexOf_TurkishI()
         {
             RemoteInvoke(() =>

--- a/src/System.Threading.Overlapped/tests/ThreadPoolBoundHandle_AllocateNativeOverlappedTests.cs
+++ b/src/System.Threading.Overlapped/tests/ThreadPoolBoundHandle_AllocateNativeOverlappedTests.cs
@@ -200,6 +200,7 @@ public partial class ThreadPoolBoundHandleTests
 
     [Fact]
     [PlatformSpecific(TestPlatforms.Windows)] // ThreadPoolBoundHandle.BindHandle is not supported on Unix
+    [ActiveIssue("https://github.com/dotnet/corefx/issues/18058", TargetFrameworkMonikers.Uap)]
     public unsafe void AllocateNativeOverlapped_PreAllocated_ReusedReturnedNativeOverlapped_OffsetLowAndOffsetHighSetToZero()
     {   // The CLR reuses NativeOverlapped underneath, check to make sure that they reset fields back to zero
 


### PR DESCRIPTION
This just leaves a hang in Regex tests, and various DirectoryServices tests, as the only remaining UAP failures.