### PR TITLE
Fix System.DirectoryServices.Tests for Uap

### DIFF
--- a/src/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectory/ActiveDirectoryInterSiteTransportTests.cs
+++ b/src/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectory/ActiveDirectoryInterSiteTransportTests.cs
@@ -22,12 +22,18 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
             Assert.Throws<ActiveDirectoryOperationException>(() => ActiveDirectoryInterSiteTransport.FindByTransportType(context, ActiveDirectoryTransportType.Rpc));
         }
 
-        [Theory]
-        [InlineData("\0")]
-        [InlineData("server:port")]
-        public void FindByTransportType_ForestNoDomainAssociatedWithName_ThrowsActiveDirectoryOperationException(string name)
+        [Fact]
+        public void FindByTransportType_ForestNoDomainAssociatedWithName_ThrowsActiveDirectoryOperationException()
         {
-            var context = new DirectoryContext(DirectoryContextType.Forest, name);
+            var context = new DirectoryContext(DirectoryContextType.Forest, "server:port");
+            AssertExtensions.Throws<ArgumentException>("context", () => ActiveDirectoryInterSiteTransport.FindByTransportType(context, ActiveDirectoryTransportType.Rpc));
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Not approved COM object for app")]
+        public void FindByTransportType_ForestNoDomainAssociatedWithName_ThrowsActiveDirectoryOperationException_NoUap()
+        {
+            var context = new DirectoryContext(DirectoryContextType.Forest, "\0");
             AssertExtensions.Throws<ArgumentException>("context", () => ActiveDirectoryInterSiteTransport.FindByTransportType(context, ActiveDirectoryTransportType.Rpc));
         }
 
@@ -42,6 +48,7 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
         [InlineData(DirectoryContextType.ApplicationPartition)]
         [InlineData(DirectoryContextType.DirectoryServer)]
         [InlineData(DirectoryContextType.Domain)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Access to common path is denied inside App")]
         public void FindByTransportType_InvalidContextTypeWithName_ThrowsArgumentException(DirectoryContextType type)
         {
             var context = new DirectoryContext(type, "Name");

--- a/src/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectory/DomainControllerTests.cs
+++ b/src/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectory/DomainControllerTests.cs
@@ -30,6 +30,7 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
         [InlineData("\0")]
         [InlineData("server:port")]
         [InlineData("[")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Access to path is denied when in App container")]
         public void GetDomainController_InvalidName_ThrowsActiveDirectoryObjectNotFoundException(string name)
         {
             var context = new DirectoryContext(DirectoryContextType.DirectoryServer, name);
@@ -37,6 +38,7 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Access to path is denied when in App container")]
         public void GetDomainController_InvalidIPV6_ThrowsInvalidCastException()
         {
             var context = new DirectoryContext(DirectoryContextType.DirectoryServer, "[::1]:port");
@@ -103,6 +105,7 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Not approved COM object for app")]
         public void FindAll_NoSuchName_ReturnsEmpty()
         {
             var context = new DirectoryContext(DirectoryContextType.Domain, "\0");

--- a/src/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectory/ForestTests.cs
+++ b/src/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectory/ForestTests.cs
@@ -25,6 +25,7 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Not approved COM object for app")]
         public void GetForest_NullNameAndNotRootedDomain_ThrowsActiveDirectoryOperationException()
         {
             var context = new DirectoryContext(DirectoryContextType.Forest);
@@ -33,10 +34,21 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
 
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [InlineData(DirectoryContextType.DirectoryServer, "\0")]
-        [InlineData(DirectoryContextType.DirectoryServer, "server:port")]
-        [InlineData(DirectoryContextType.Forest, "\0")]
         [InlineData(DirectoryContextType.Forest, "server:port")]
         public void GetForest_NonNullNameAndNotRootedDomain_ThrowsActiveDirectoryObjectNotFoundException(DirectoryContextType type, string name)
+        {
+            var context = new DirectoryContext(type, name);
+            Assert.Throws<ActiveDirectoryObjectNotFoundException>(() => Forest.GetForest(context));
+
+            // The result of validation is cached, so repeat this to make sure it's cached properly.
+            Assert.Throws<ActiveDirectoryObjectNotFoundException>(() => Forest.GetForest(context));
+        }
+
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
+        [InlineData(DirectoryContextType.Forest, "\0")]
+        [InlineData(DirectoryContextType.DirectoryServer, "server:port")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Not approved COM object for app")]
+        public void GetForest_NonNullNameAndNotRootedDomain_ThrowsActiveDirectoryObjectNotFoundException_NonUap(DirectoryContextType type, string name)
         {
             var context = new DirectoryContext(type, name);
             Assert.Throws<ActiveDirectoryObjectNotFoundException>(() => Forest.GetForest(context));

--- a/src/System.DirectoryServices/tests/System/DirectoryServices/DirectoryEntryTests.cs
+++ b/src/System.DirectoryServices/tests/System/DirectoryServices/DirectoryEntryTests.cs
@@ -220,6 +220,7 @@ namespace System.DirectoryServices.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "PNE in UAP")]
         public void ObjectSecurity_Set_GetReturnsExpected()
         {
             var security = new ActiveDirectorySecurity();

--- a/src/System.DirectoryServices/tests/System/DirectoryServices/DirectoryEntryTests.cs
+++ b/src/System.DirectoryServices/tests/System/DirectoryServices/DirectoryEntryTests.cs
@@ -220,7 +220,7 @@ namespace System.DirectoryServices.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "PNE in UAP")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "PNSE in UAP")]
         public void ObjectSecurity_Set_GetReturnsExpected()
         {
             var security = new ActiveDirectorySecurity();


### PR DESCRIPTION
With this the only remaining failures is the Text.Expressions tests which I couldn't repro locally, they seem to be timing out because they take a long time to execute. They took about 3 minutes in my local box. 