### PR TITLE
Fix invalid icon tests

### DIFF
--- a/src/System.Drawing.Common/tests/IconTests.cs
+++ b/src/System.Drawing.Common/tests/IconTests.cs
@@ -240,13 +240,41 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
-        [ActiveIssue(21360)]
-        public void Ctor_InvalidIconHandle_SetsHandleToZero()
+        public void Ctor_InvalidHandle_Success()
         {
-            using (Icon source = Icon.FromHandle((IntPtr)100))
-            using (var icon = new Icon(source, 10, 10))
+            var random = new Random();
+
+            // First, generate a random handle. There are 2^32 numbers in the range, so it's likely that
+            // there will be no such icon associated with this handle.
+            // However, if there is an icon associated with this handle, the test will fail.
+            // Instead, repeat 100 times with another random number. The chance of an icon existing 100 times
+            // with a random handle is minimal.
+            for (int i = 0; i < 100; i++)
             {
-                Assert.Throws<ObjectDisposedException>(() => icon.Handle);
+                IntPtr handle = (IntPtr)random.Next();
+
+                try
+                {
+                    using (Icon icon = Icon.FromHandle(handle))
+                    using (var stream = new MemoryStream())
+                    {
+                        Exception ex = Assert.ThrowsAny<Exception>(() => icon.Save(stream));
+                        Assert.True(ex is COMException || ex is ObjectDisposedException, $"{ex.GetType().ToString()} was thrown.");
+
+                        Assert.Throws<ArgumentException>(null, () => icon.ToBitmap());
+                        Assert.Equal(Size.Empty, icon.Size);
+
+                        using (var newIcon = new Icon(icon, 10, 10))
+                        {
+                            Assert.Throws<ObjectDisposedException>(() => newIcon.Handle);
+                        }
+
+                        return;
+                    }
+                }
+                catch (Exception) when (i < 99)
+                {
+                }
             }
         }
 
@@ -485,28 +513,6 @@ namespace System.Drawing.Tests
             Assert.Throws<ObjectDisposedException>(() => icon.Save(new MemoryStream()));
         }
 
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
-        [ActiveIssue(21360)]
-        public void Save_InvalidHandle_ThrowsCOMOrObjectDisposedException()
-        {
-            using (Icon icon = Icon.FromHandle((IntPtr)100))
-            using (var stream = new MemoryStream())
-            {
-                Exception ex = Assert.ThrowsAny<Exception>(() => icon.Save(stream));
-                Assert.True(ex is COMException || ex is ObjectDisposedException, $"{ex.GetType().ToString()} was thrown.");
-            }
-        }
-
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
-        [ActiveIssue(21360)]
-        public void ToBitmap_InvalidHandle_ThrowsArgumentException()
-        {
-            using (Icon icon = Icon.FromHandle((IntPtr)100))
-            {
-                Assert.Throws<ArgumentException>(null, () => icon.ToBitmap());
-            }
-        }
-
         public static IEnumerable<object[]> ToBitmap_TestData()
         {
             yield return new object[] { new Icon(Helpers.GetTestBitmapPath("16x16_one_entry_4bit.ico")) };
@@ -719,16 +725,6 @@ namespace System.Drawing.Tests
         public void FromHandle_Zero_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(null, () => Icon.FromHandle(IntPtr.Zero));
-        }
-
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
-        [ActiveIssue(21360)]
-        public void Size_GetFromInvalidHandle_ReturnsZeroSize()
-        {
-            using (Icon icon = Icon.FromHandle((IntPtr)100))
-            {
-                Assert.Equal(Size.Empty, icon.Size);
-            }
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]


### PR DESCRIPTION
Fixes #21360

Firstly, generate a random handle first - this gives us 4 billion different values of the handle instead of the 1 previously.

But if we're *really* unlucky, then keep going and repeat 100 times. Quite simply, if my analysis of the cause of the issue is correct, this should never fail.

