### PR TITLE
Enabling CI for UWP F5 runs

### DIFF
--- a/buildpipeline/windows.groovy
+++ b/buildpipeline/windows.groovy
@@ -8,7 +8,7 @@
 // TestOuter - If true, runs outerloop, if false runs just innerloop
 
 def submittedHelixJson = null
-def submitToHelix = (params.TGroup == 'netcoreapp')
+def submitToHelix = (params.TGroup == 'netcoreapp' || params.TGroup == 'uap')
 
 simpleNode('Windows_NT','latest') {
     stage ('Checkout source') {
@@ -61,7 +61,7 @@ simpleNode('Windows_NT','latest') {
             if (submitToHelix) {
                 archiveTests = 'true'
             }
-            if (submitToHelix || params.TGroup == 'uap' || params.TGroup == 'uapaot') {
+            if (submitToHelix || params.TGroup == 'uapaot') {
                 additionalArgs += ' -SkipTests'
             }
             bat ".\\build-tests.cmd ${framework} -buildArch=${params.AGroup} -${params.CGroup}${additionalArgs} -- /p:RuntimeOS=win10 /p:ArchiveTests=${archiveTests}"
@@ -80,15 +80,21 @@ simpleNode('Windows_NT','latest') {
                 def helixCreator = getUser()
 
                 // Target queues
-                def targetHelixQueues = ['Windows.10.Amd64.Open',
+                def targetHelixQueues = []
+                if (params.TGroup == 'netcoreapp')
+                {
+                    targetHelixQueues = ['Windows.10.Amd64.Open',
                                          'Windows.7.Amd64.Open',
                                          'Windows.81.Amd64.Open']
+                } else if (params.TGroup == 'uap') {
+                    targetHelixQueues = ['Windows.10.Amd64.ClientRS2.Open']
+                }
 
                 if (params.AGroup == 'x64') {
                     targetHelixQueues += ['Windows.10.Nano.Amd64.Open']
                 }
 
-                bat "\"%VS140COMNTOOLS%\\VsDevCmd.bat\" && msbuild src\\upload-tests.proj /p:ArchGroup=${params.AGroup} /p:ConfigurationGroup=${params.CGroup} /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:HelixJobType=test/functional/cli/ /p:HelixSource=${helixSource} /p:BuildMoniker=${helixBuild} /p:HelixCreator=${helixCreator} /p:CloudDropAccountName=dotnetbuilddrops /p:CloudResultsAccountName=dotnetjobresults /p:CloudDropAccessToken=%CloudDropAccessToken% /p:CloudResultsAccessToken=%OutputCloudResultsAccessToken% /p:HelixApiEndpoint=https://helix.dot.net/api/2017-04-14/jobs /p:TargetQueues=\"${targetHelixQueues.join(',')}\" /p:HelixLogFolder= /p:HelixLogFolder=${WORKSPACE}\\${logFolder}\\ /p:HelixCorrelationInfoFileName=SubmittedHelixRuns.txt"
+                bat "\"%VS140COMNTOOLS%\\VsDevCmd.bat\" && msbuild src\\upload-tests.proj /p:TargetGroup=${params.TGroup} /p:ArchGroup=${params.AGroup} /p:ConfigurationGroup=${params.CGroup} /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:HelixJobType=test/functional/cli/ /p:HelixSource=${helixSource} /p:BuildMoniker=${helixBuild} /p:HelixCreator=${helixCreator} /p:CloudDropAccountName=dotnetbuilddrops /p:CloudResultsAccountName=dotnetjobresults /p:CloudDropAccessToken=%CloudDropAccessToken% /p:CloudResultsAccessToken=%OutputCloudResultsAccessToken% /p:HelixApiEndpoint=https://helix.dot.net/api/2017-04-14/jobs /p:TargetQueues=\"${targetHelixQueues.join(',')}\" /p:HelixLogFolder= /p:HelixLogFolder=${WORKSPACE}\\${logFolder}\\ /p:HelixCorrelationInfoFileName=SubmittedHelixRuns.txt"
 
                 submittedHelixJson = readJSON file: "${logFolder}\\SubmittedHelixRuns.txt"
             }
@@ -100,10 +106,10 @@ if (submitToHelix) {
     stage ('Execute Tests') {
         def contextBase
         if (params.TestOuter) {
-            contextBase = "Win tests w/outer - ${params.AGroup} ${params.CGroup}"
+            contextBase = "Win tests w/outer - ${params.TGroup} ${params.AGroup} ${params.CGroup}"
         }
         else {
-            contextBase = "Win tests - ${params.AGroup} ${params.CGroup}"
+            contextBase = "Win tests - ${params.TGroup} ${params.AGroup} ${params.CGroup}"
         }
         waitForHelixRuns(submittedHelixJson, contextBase)
     }

--- a/buildpipeline/windows.groovy
+++ b/buildpipeline/windows.groovy
@@ -86,12 +86,11 @@ simpleNode('Windows_NT','latest') {
                     targetHelixQueues = ['Windows.10.Amd64.Open',
                                          'Windows.7.Amd64.Open',
                                          'Windows.81.Amd64.Open']
+                    if (params.AGroup == 'x64') {
+                        targetHelixQueues += ['Windows.10.Nano.Amd64.Open']
+                    }
                 } else if (params.TGroup == 'uap') {
                     targetHelixQueues = ['Windows.10.Amd64.ClientRS2.Open']
-                }
-
-                if (params.AGroup == 'x64') {
-                    targetHelixQueues += ['Windows.10.Nano.Amd64.Open']
                 }
 
                 bat "\"%VS140COMNTOOLS%\\VsDevCmd.bat\" && msbuild src\\upload-tests.proj /p:TargetGroup=${params.TGroup} /p:ArchGroup=${params.AGroup} /p:ConfigurationGroup=${params.CGroup} /p:TestProduct=corefx /p:TimeoutInSeconds=1200 /p:TargetOS=Windows_NT /p:HelixJobType=test/functional/cli/ /p:HelixSource=${helixSource} /p:BuildMoniker=${helixBuild} /p:HelixCreator=${helixCreator} /p:CloudDropAccountName=dotnetbuilddrops /p:CloudResultsAccountName=dotnetjobresults /p:CloudDropAccessToken=%CloudDropAccessToken% /p:CloudResultsAccessToken=%OutputCloudResultsAccessToken% /p:HelixApiEndpoint=https://helix.dot.net/api/2017-04-14/jobs /p:TargetQueues=\"${targetHelixQueues.join(',')}\" /p:HelixLogFolder= /p:HelixLogFolder=${WORKSPACE}\\${logFolder}\\ /p:HelixCorrelationInfoFileName=SubmittedHelixRuns.txt"

--- a/src/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectory/ActiveDirectoryInterSiteTransportTests.cs
+++ b/src/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectory/ActiveDirectoryInterSiteTransportTests.cs
@@ -16,6 +16,7 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Getting information about domain is denied inside App")]
         public void FindByTransportType_ForestNoDomainAssociatedWithoutName_ThrowsActiveDirectoryOperationException()
         {
             var context = new DirectoryContext(DirectoryContextType.Forest);
@@ -56,6 +57,7 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Getting information about domain is denied inside App")]
         public void FindByTransportType_ConfigurationSetTypeWithName_Throws()
         {
             var context = new DirectoryContext(DirectoryContextType.ConfigurationSet, "Name");

--- a/src/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectory/DomainControllerTests.cs
+++ b/src/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectory/DomainControllerTests.cs
@@ -114,6 +114,7 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Getting information about domain is denied inside App")]
         public void FindAll_NullName_ThrowsActiveDirectoryOperationException()
         {
             var context = new DirectoryContext(DirectoryContextType.Domain);

--- a/src/System.Text.RegularExpressions/tests/Configurations.props
+++ b/src/System.Text.RegularExpressions/tests/Configurations.props
@@ -4,6 +4,7 @@
     <BuildConfigurations>
       netcoreapp;
       netstandard;
+      uap;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
@@ -11,7 +11,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
-  <ItemGroup>
+  <!-- [ActiveIssue(https://github.com/dotnet/corefx/issues/21547)] -- times out in uap. -->
+  <ItemGroup Condition="'$(TargetGroup)' != 'uap'">
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
       <Link>Common\tests\System\PlatformDetection.cs</Link>
     </Compile>

--- a/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
@@ -11,7 +11,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
-  <!-- [ActiveIssue(https://github.com/dotnet/corefx/issues/21547)] -- times out in uap. -->
+  <!-- [ActiveIssue(https://github.com/dotnet/corefx/issues/21547)] times out in uap. -->
   <ItemGroup Condition="'$(TargetGroup)' != 'uap'">
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
       <Link>Common\tests\System\PlatformDetection.cs</Link>


### PR DESCRIPTION
cc: @weshaggard @mmitche @danmosemsft @safern 

Now that our UWP F5 test run is clean, we are ready for adding this CI leg for uap tests. The only thing missing now is that the actual open target queue for ClientRS2 doesn't exist yet, but should be created very soon. Once that queue is ready, this PR will be ready to merge.