### PR TITLE
improve SslStream read buffering

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -231,15 +231,21 @@ internal static partial class Interop
             return retVal;
         }
 
-        internal static int Decrypt(SafeSslHandle context, byte[] outBuffer, int count, out Ssl.SslErrorCode errorCode)
+        internal static int Decrypt(SafeSslHandle context, byte[] outBuffer, int offset, int count, out Ssl.SslErrorCode errorCode)
         {
             errorCode = Ssl.SslErrorCode.SSL_ERROR_NONE;
 
-            int retVal = BioWrite(context.InputBio, outBuffer, 0, count);
+            int retVal = BioWrite(context.InputBio, outBuffer, offset, count);
 
             if (retVal == count)
             {
-                retVal = Ssl.SslRead(context, outBuffer, outBuffer.Length);
+                unsafe
+                {
+                    fixed (byte* fixedBuffer = outBuffer)
+                    {
+                        retVal = Ssl.SslRead(context, fixedBuffer + offset, outBuffer.Length);
+                    }
+                }
 
                 if (retVal > 0)
                 {

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -74,7 +74,7 @@ internal static partial class Interop
         internal static extern unsafe int SslWrite(SafeSslHandle ssl, byte* buf, int num);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslRead")]
-        internal static extern int SslRead(SafeSslHandle ssl, byte[] buf, int num);
+        internal static extern unsafe int SslRead(SafeSslHandle ssl, byte* buf, int num);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_IsSslRenegotiatePending")]
         [return: MarshalAs(UnmanagedType.Bool)]

--- a/src/System.Net.Security/src/System/Net/Security/SslState.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslState.cs
@@ -239,14 +239,6 @@ namespace System.Net.Security
             }
         }
 
-        internal bool DataAvailable
-        {
-            get
-            {
-                return IsAuthenticated && (SecureStream.DataAvailable || _queuedReadCount != 0);
-            }
-        }
-
         internal CipherAlgorithmType CipherAlgorithm
         {
             get
@@ -894,7 +886,7 @@ namespace System.Net.Security
                 _Framing = DetectFraming(buffer, readBytes);
             }
 
-            int restBytes = GetRemainingFrameSize(buffer, readBytes);
+            int restBytes = GetRemainingFrameSize(buffer, 0, readBytes);
 
             if (restBytes < 0)
             {
@@ -1676,9 +1668,9 @@ namespace System.Net.Security
 
         //
         // This is called from SslStream class too.
-        internal int GetRemainingFrameSize(byte[] buffer, int dataSize)
+        internal int GetRemainingFrameSize(byte[] buffer, int offset, int dataSize)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, buffer, dataSize);
+            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, buffer, offset, dataSize);
 
             int payloadSize = -1;
             switch (_Framing)
@@ -1691,16 +1683,16 @@ namespace System.Net.Security
                     }
                     // Note: Cannot detect version mismatch for <= SSL2
 
-                    if ((buffer[0] & 0x80) != 0)
+                    if ((buffer[offset] & 0x80) != 0)
                     {
                         // Two bytes
-                        payloadSize = (((buffer[0] & 0x7f) << 8) | buffer[1]) + 2;
+                        payloadSize = (((buffer[offset] & 0x7f) << 8) | buffer[offset + 1]) + 2;
                         payloadSize -= dataSize;
                     }
                     else
                     {
                         // Three bytes
-                        payloadSize = (((buffer[0] & 0x3f) << 8) | buffer[1]) + 3;
+                        payloadSize = (((buffer[offset] & 0x3f) << 8) | buffer[offset + 1]) + 3;
                         payloadSize -= dataSize;
                     }
 
@@ -1711,7 +1703,7 @@ namespace System.Net.Security
                         throw new System.IO.IOException(SR.net_ssl_io_frame);
                     }
 
-                    payloadSize = ((buffer[3] << 8) | buffer[4]) + 5;
+                    payloadSize = ((buffer[offset + 3] << 8) | buffer[offset + 4]) + 5;
                     payloadSize -= dataSize;
                     break;
                 default:

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.cs
@@ -608,6 +608,7 @@ namespace System.Net.Security
 
         private void ConsumeBufferedBytes(int byteCount)
         {
+            Debug.Assert(byteCount >= 0);
             Debug.Assert(byteCount <= _internalBufferCount);
 
             _internalOffset += byteCount;

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.cs
@@ -42,6 +42,9 @@ namespace System.Net.Security
         private int _internalOffset;
         private int _internalBufferCount;
 
+        private int _decryptedBytesOffset;
+        private int _decryptedBytesCount;
+
         internal SslStreamInternal(SslState sslState)
         {
             if (PinnableBufferCacheEventSource.Log.IsEnabled())
@@ -50,6 +53,9 @@ namespace System.Net.Security
             }
 
             _sslState = sslState;
+
+            _decryptedBytesOffset = 0;
+            _decryptedBytesCount = 0;
         }
 
         // If we have a read buffer from the pinnable cache, return it.
@@ -96,10 +102,10 @@ namespace System.Net.Security
             // If there's any data in the buffer, take one byte, and we're done.
             try
             {
-                if (InternalBufferCount > 0)
+                if (_decryptedBytesCount > 0)
                 {
-                    int b = InternalBuffer[InternalOffset];
-                    SkipBytes(1);
+                    int b = InternalBuffer[_decryptedBytesOffset++];
+                    _decryptedBytesCount--;
                     return b;
                 }
             }
@@ -210,11 +216,6 @@ namespace System.Net.Security
             }
         }
 
-        internal bool DataAvailable
-        {
-            get { return InternalBufferCount != 0; }
-        }
-
         private byte[] InternalBuffer
         {
             get
@@ -223,40 +224,13 @@ namespace System.Net.Security
             }
         }
 
-        private int InternalOffset
+        private void EnsureInternalBufferSize(int newSize)
         {
-            get
-            {
-                return _internalOffset;
-            }
-        }
-
-        private int InternalBufferCount
-        {
-            get
-            {
-                return _internalBufferCount;
-            }
-        }
-
-        private void SkipBytes(int decrCount)
-        {
-            _internalOffset += decrCount;
-            _internalBufferCount -= decrCount;
-        }
-
-        //
-        // This will set the internal offset to "curOffset" and ensure internal buffer.
-        // If not enough, reallocate and copy up to "curOffset".
-        //
-        private void EnsureInternalBufferSize(int curOffset, int addSize)
-        {
-            if (_internalBuffer == null || _internalBuffer.Length < addSize + curOffset)
+            if (_internalBuffer == null || _internalBuffer.Length < newSize)
             {
                 bool wasPinnable = _internalBufferFromPinnableCache;
                 byte[] saved = _internalBuffer;
 
-                int newSize = addSize + curOffset;
                 if (newSize <= PinnableReadBufferSize)
                 {
                     if (PinnableBufferCacheEventSource.Log.IsEnabled())
@@ -278,9 +252,9 @@ namespace System.Net.Security
                     _internalBuffer = new byte[newSize];
                 }
 
-                if (saved != null && curOffset != 0)
+                if (saved != null && _internalBufferCount != 0)
                 {
-                    Buffer.BlockCopy(saved, 0, _internalBuffer, 0, curOffset);
+                    Buffer.BlockCopy(saved, _internalOffset, _internalBuffer, 0, _internalBufferCount);
                 }
 
                 if (wasPinnable)
@@ -288,8 +262,15 @@ namespace System.Net.Security
                     s_PinnableReadBufferCache.FreeBuffer(saved);
                 }
             }
-            _internalOffset = curOffset;
-            _internalBufferCount = curOffset + addSize;
+            else if (_internalOffset > 0 && _internalBufferCount > 0)
+            {
+                // We have buffered data at a non-zero offset.
+                // To maximize the buffer space available for the next read,
+                // copy the existing data down to the beginning of the buffer.
+                Buffer.BlockCopy(_internalBuffer, _internalOffset, _internalBuffer, 0, _internalBufferCount);
+            }
+
+            _internalOffset = 0;
         }
 
         //
@@ -497,6 +478,154 @@ namespace System.Net.Security
             }
         }
 
+        // Fill the buffer up to the minimum specified size (or more, if possible).
+        // Returns 0 if EOF on initial read, otherwise throws on EOF.
+        // Returns minSize on success.
+        private int FillBuffer(int minSize)
+        {
+            Debug.Assert(_internalOffset == 0);
+            Debug.Assert(minSize > _internalBufferCount);
+
+            int initialCount = _internalBufferCount;
+            do
+            {
+                int bytes = _sslState.InnerStream.Read(InternalBuffer, _internalBufferCount, InternalBuffer.Length - _internalBufferCount);
+                if (bytes == 0)
+                {
+                    if (_internalBufferCount != initialCount)
+                    {
+                        // We read some bytes, but not as many as we expected, so throw.
+                        throw new IOException(SR.net_io_eof);
+                    }
+
+                    return 0;
+                }
+
+                _internalBufferCount += bytes;
+            } while (_internalBufferCount < minSize);
+
+            return minSize;
+        }
+
+        // Fill the buffer up to the minimum specified size (or more, if possible).
+        // Returns 0 if EOF on initial read, otherwise throws on EOF.
+        // Returns minSize on success.
+        public async Task<int> FillBufferAsync(int minSize)
+        {
+            Debug.Assert(_internalOffset == 0);
+            Debug.Assert(minSize > _internalBufferCount);
+
+            int initialCount = _internalBufferCount;
+            do
+            {
+                int bytes = await _sslState.InnerStream.ReadAsync(InternalBuffer, _internalBufferCount, InternalBuffer.Length - _internalBufferCount, CancellationToken.None).ConfigureAwait(false);
+                if (bytes == 0)
+                {
+                    if (_internalBufferCount != initialCount)
+                    {
+                        // We read some bytes, but not as many as we expected, so throw.
+                        throw new IOException(SR.net_io_eof);
+                    }
+
+                    return 0;
+                }
+
+                _internalBufferCount += bytes;
+            } while (_internalBufferCount < minSize);
+
+            return minSize;
+        }
+
+        private static async void TaskToAsyncProtocolRequest2(Task<int> task, AsyncProtocolRequest asyncRequest)
+        {
+            try
+            {
+                asyncRequest.CompleteRequest(await task.ConfigureAwait(false));
+            }
+            catch (Exception e)
+            {
+                asyncRequest.CompleteUserWithError(e);
+            }
+        }
+
+        // Returns true if pending, false if completed
+        private static bool TaskToAsyncProtocolRequest(Task<int> task, AsyncProtocolRequest asyncRequest, AsyncProtocolCallback asyncCallback, out int result)
+        {
+            // Parameters other than asyncCallback are not used
+            asyncRequest.SetNextRequest(null, 0, 0, asyncCallback);
+
+            TaskToAsyncProtocolRequest2(task, asyncRequest);
+
+            if (asyncRequest.MustCompleteSynchronously)
+            {
+                result = asyncRequest.Result;
+                return false;
+            }
+
+            result = 0;
+            return true;
+        }
+
+        private int EnsureBufferedBytes(int minSize, AsyncProtocolRequest asyncRequest, AsyncProtocolCallback asyncCallback)
+        {
+            if (_internalBufferCount >= minSize)
+            {
+                return minSize;
+            }
+
+            EnsureInternalBufferSize(minSize);
+
+            int bytesRead;
+            if (asyncRequest != null)
+            {
+                if (TaskToAsyncProtocolRequest(
+                        FillBufferAsync(minSize),
+                        asyncRequest,
+                        asyncCallback,
+                        out bytesRead))
+                {
+                    return -1;
+                }
+            }
+            else
+            {
+                bytesRead = FillBuffer(minSize);
+            }
+
+            Debug.Assert(bytesRead == 0 || bytesRead == minSize);
+            return bytesRead;
+        }
+
+        private void ConsumeBufferedBytes(int byteCount)
+        {
+            Debug.Assert(byteCount <= _internalBufferCount);
+
+            _internalOffset += byteCount;
+            _internalBufferCount -= byteCount;
+
+            if (_internalBufferCount == 0)
+            {
+                // No remaining buffered bytes, so reset the offset to the beginning for the next read.
+                _internalOffset = 0;
+            }
+        }
+
+        private int CopyDecryptedData(byte[] buffer, int offset, int count)
+        {
+            Debug.Assert(_decryptedBytesCount > 0);
+
+            int copyBytes = _decryptedBytesCount > count ? count : _decryptedBytesCount;
+            if (copyBytes != 0)
+            {
+                Buffer.BlockCopy(InternalBuffer, _decryptedBytesOffset, buffer, offset, copyBytes);
+
+                _decryptedBytesOffset += copyBytes;
+                _decryptedBytesCount -= copyBytes;
+            }
+
+            return copyBytes;
+        }
+
         //
         // Combined sync/async read method. For sync request asyncRequest==null.
         //
@@ -517,15 +646,9 @@ namespace System.Net.Security
 
             try
             {
-                int copyBytes;
-                if (InternalBufferCount != 0)
+                if (_decryptedBytesCount != 0)
                 {
-                    copyBytes = InternalBufferCount > count ? count : InternalBufferCount;
-                    if (copyBytes != 0)
-                    {
-                        Buffer.BlockCopy(InternalBuffer, InternalOffset, buffer, offset, copyBytes);
-                        SkipBytes(copyBytes);
-                    }
+                    int copyBytes = CopyDecryptedData(buffer, offset, count);
                     
                     asyncRequest?.CompleteUser(copyBytes);
                     
@@ -562,9 +685,9 @@ namespace System.Net.Security
         {
             int result = 0;
 
-            if (InternalBufferCount != 0)
+            if (_decryptedBytesCount != 0)
             {
-                NetEventSource.Fail(this, $"Previous frame was not consumed. InternalBufferCount: {InternalBufferCount}");
+                NetEventSource.Fail(this, $"Previous frame was not consumed. _decryptedBytesCount: {_decryptedBytesCount}");
             }
 
             do
@@ -597,33 +720,13 @@ namespace System.Net.Security
 
         private int StartFrameHeader(byte[] buffer, int offset, int count, AsyncProtocolRequest asyncRequest)
         {
-            int readBytes = 0;
-
-            //
-            // Always pass InternalBuffer for SSPI "in place" decryption.
-            // A user buffer can be shared by many threads in that case decryption/integrity check may fail cause of data corruption.
-            //
-
-            // Reset internal buffer for a new frame.
-            EnsureInternalBufferSize(0, SecureChannel.ReadHeaderSize);
-
-            if (asyncRequest != null)
+            int readBytes = EnsureBufferedBytes(SecureChannel.ReadHeaderSize, asyncRequest, s_readHeaderCallback);
+            if (readBytes == -1)
             {
-                asyncRequest.SetNextRequest(InternalBuffer, 0, SecureChannel.ReadHeaderSize, s_readHeaderCallback);
-                FixedSizeReader.ReadPacketAsync(_sslState.InnerStream, asyncRequest);
-
-                if (!asyncRequest.MustCompleteSynchronously)
-                {
-                    return 0;
-                }
-
-                readBytes = asyncRequest.Result;
+                Debug.Assert(asyncRequest != null);
+                return 0;
             }
-            else
-            {
-                readBytes = FixedSizeReader.ReadPacket(_sslState.InnerStream, InternalBuffer, 0, SecureChannel.ReadHeaderSize);
-            }
-
+            
             return StartFrameBody(readBytes, buffer, offset, count, asyncRequest);
         }
 
@@ -631,40 +734,27 @@ namespace System.Net.Security
         {
             if (readBytes == 0)
             {
-                //EOF : Reset the buffer as we did not read anything into it.
-                SkipBytes(InternalBufferCount);
+                // EOF 
                 asyncRequest?.CompleteUser(0);
-                
                 return 0;
             }
 
-            // Now readBytes is a payload size.
-            readBytes = _sslState.GetRemainingFrameSize(InternalBuffer, readBytes);
+            Debug.Assert(readBytes == SecureChannel.ReadHeaderSize);
 
-            if (readBytes < 0)
+            int payloadBytes = _sslState.GetRemainingFrameSize(InternalBuffer, _internalOffset, readBytes);
+            if (payloadBytes < 0)
             {
                 throw new IOException(SR.net_frame_read_size);
             }
 
-            EnsureInternalBufferSize(SecureChannel.ReadHeaderSize, readBytes);
-
-            if (asyncRequest != null)
+            readBytes = EnsureBufferedBytes(SecureChannel.ReadHeaderSize + payloadBytes, asyncRequest, s_readFrameCallback);
+            if (readBytes == -1)
             {
-                asyncRequest.SetNextRequest(InternalBuffer, SecureChannel.ReadHeaderSize, readBytes, s_readFrameCallback);
-
-                FixedSizeReader.ReadPacketAsync(_sslState.InnerStream, asyncRequest);
-
-                if (!asyncRequest.MustCompleteSynchronously)
-                {
-                    return 0;
-                }
-                
-                readBytes = asyncRequest.Result;
+                Debug.Assert(asyncRequest != null);
+                return 0;
             }
-            else
-            {
-                readBytes = FixedSizeReader.ReadPacket(_sslState.InnerStream, InternalBuffer, SecureChannel.ReadHeaderSize, readBytes);
-            }
+
+            Debug.Assert(readBytes == 0 || readBytes == SecureChannel.ReadHeaderSize + payloadBytes);
             
             return ProcessFrameBody(readBytes, buffer, offset, count, asyncRequest);
         }
@@ -680,57 +770,46 @@ namespace System.Net.Security
                 throw new IOException(SR.net_io_eof);
             }
 
-            // Set readBytes to total number of received bytes.
-            readBytes += SecureChannel.ReadHeaderSize;
+            // At this point, readBytes contains the size of the header plus body.
+            // Set _decrytpedBytesOffset/Count to the current frame we have (including header)
+            // DecryptData will decrypt in-place and modify these to point to the actual decrypted data, which may be smaller.
+            _decryptedBytesOffset = _internalOffset;
+            _decryptedBytesCount = readBytes;
+            SecurityStatusPal status = _sslState.DecryptData(InternalBuffer, ref _decryptedBytesOffset, ref _decryptedBytesCount);
 
-            // Decrypt into internal buffer, change "readBytes" to count now _Decrypted Bytes_.
-            int data_offset = 0;
-
-            SecurityStatusPal status = _sslState.DecryptData(InternalBuffer, ref data_offset, ref readBytes);
+            // Treat the bytes we just decrypted as consumed
+            // Note, we won't do another buffer read until the decrypted bytes are processed
+            ConsumeBufferedBytes(readBytes);
 
             if (status.ErrorCode != SecurityStatusPalErrorCode.OK)
             {
                 byte[] extraBuffer = null;
-                if (readBytes != 0)
+                if (_decryptedBytesCount != 0)
                 {
-                    extraBuffer = new byte[readBytes];
-                    Buffer.BlockCopy(InternalBuffer, data_offset, extraBuffer, 0, readBytes);
+                    extraBuffer = new byte[_decryptedBytesCount];
+                    Buffer.BlockCopy(InternalBuffer, _decryptedBytesOffset, extraBuffer, 0, _decryptedBytesCount);
+
+                    _decryptedBytesCount = 0;
                 }
 
-                // Reset internal buffer count.
-                SkipBytes(InternalBufferCount);
-                return ProcessReadErrorCode(status, buffer, offset, count, asyncRequest, extraBuffer);
+                return ProcessReadErrorCode(status, asyncRequest, extraBuffer);
             }
 
-
-            if (readBytes == 0 && count != 0)
+            if (_decryptedBytesCount == 0)
             {
                 // Read again since remote side has sent encrypted 0 bytes.
-                SkipBytes(InternalBufferCount);
                 return -1;
             }
 
-            // Decrypted data start from "data_offset" offset, the total count can be shrunk after decryption.
-            EnsureInternalBufferSize(0, data_offset + readBytes);
-            SkipBytes(data_offset);
-
-            if (readBytes > count)
-            {
-                readBytes = count;
-            }
-
-            Buffer.BlockCopy(InternalBuffer, InternalOffset, buffer, offset, readBytes);
-
-            // This will adjust both the remaining internal buffer count and the offset.
-            SkipBytes(readBytes);
+            int copyBytes = CopyDecryptedData(buffer, offset, count);
 
             _sslState.FinishRead(null);
-            asyncRequest?.CompleteUser(readBytes);
+            asyncRequest?.CompleteUser(copyBytes);
 
-            return readBytes;
+            return copyBytes;
         }
 
-        private int ProcessReadErrorCode(SecurityStatusPal status, byte[] buffer, int offset, int count, AsyncProtocolRequest asyncRequest, byte[] extraBuffer)
+        private int ProcessReadErrorCode(SecurityStatusPal status, AsyncProtocolRequest asyncRequest, byte[] extraBuffer)
         {
             ProtocolToken message = new ProtocolToken(null, status);
             if (NetEventSource.IsEnabled) NetEventSource.Info(null, $"***Processing an error Status = {message.Status}");

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.cs
@@ -540,11 +540,17 @@ namespace System.Net.Security
         {
             Debug.Assert(task.IsCompleted);
             if (task.IsCompletedSuccessfully)
+            {
                 asyncRequest.CompleteRequest(task.Result);
+            }
             else if (task.IsFaulted)
+            {
                 asyncRequest.CompleteUserWithError(task.Exception.InnerException);
+            }
             else
+            {
                 asyncRequest.CompleteUserWithError(new OperationCanceledException());
+            }
         }
 
         // Returns true if pending, false if completed

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
@@ -156,7 +156,7 @@ namespace System.Net.Security
                 {
                     Debug.Assert(offset == 0, "Expected offset 0 when decrypting");
                     Debug.Assert(ReferenceEquals(input, output), "Expected input==output when decrypting");
-                    resultSize = Interop.OpenSsl.Decrypt(scHandle, input, size, out errorCode);
+                    resultSize = Interop.OpenSsl.Decrypt(scHandle, input, offset, size, out errorCode);
                 }
 
                 switch (errorCode)


### PR DESCRIPTION
SslStream is currently reading from the underlying stream piece-wise; that is, it first does a 5 byte read to get the frame header, then a second read to get the frame body, whose size is defined in the header.  This results in multiple kernel calls to receive socket data.

Add some smarter read buffering logic to improve this.  Now, we try to read as much as we can at once into the read buffer, and then process it until we run out of data.

Contributes to #21371

@stephentoub @CIPop 