### PR TITLE
Fix some more low-hanging fruit in ManagedHandler

### DIFF
--- a/src/Common/src/System/Net/HttpKnownHeaderNames.TryGetHeaderName.cs
+++ b/src/Common/src/System/Net/HttpKnownHeaderNames.TryGetHeaderName.cs
@@ -8,6 +8,9 @@ namespace System.Net
 {
     internal static partial class HttpKnownHeaderNames
     {
+        private const string Gzip = "gzip";
+        private const string Deflate = "deflate";
+
         /// <summary>
         /// Gets a known header name string from a matching char[] array segment, using a case-sensitive
         /// ordinal comparison. Used to avoid allocating new strings for known header names.
@@ -45,6 +48,36 @@ namespace System.Net
                 (buf, index) => (char)((byte*)buf)[index],
                 (known, buf, start, len) => EqualsOrdinal(known, buf, len),
                 out name);
+        }
+
+        public static string GetHeaderValue(string name, char[] array, int startIndex, int length)
+        {
+            Debug.Assert(name != null);
+            CharArrayHelpers.DebugAssertArrayInputs(array, startIndex, length);
+
+            if (length == 0)
+            {
+                return string.Empty;
+            }
+
+            // If it's a known header value, use the known value instead of allocating a new string.
+
+            // Do a really quick reference equals check to see if name is the same object as
+            // HttpKnownHeaderNames.ContentEncoding, in which case the value is very likely to
+            // be either "gzip" or "deflate".
+            if (ReferenceEquals(name, ContentEncoding))
+            {
+                if (CharArrayHelpers.EqualsOrdinalAsciiIgnoreCase(Gzip, array, startIndex, length))
+                {
+                    return Gzip;
+                }
+                else if (CharArrayHelpers.EqualsOrdinalAsciiIgnoreCase(Deflate, array, startIndex, length))
+                {
+                    return Deflate;
+                }
+            }
+
+            return new string(array, startIndex, length);
         }
 
         private static bool TryGetHeaderName<T>(

--- a/src/Common/src/System/Net/UriScheme.cs
+++ b/src/Common/src/System/Net/UriScheme.cs
@@ -4,7 +4,7 @@
 
 namespace System.Net
 {
-    internal class UriScheme
+    internal static class UriScheme
     {
         public const string File = "file";
         public const string Ftp = "ftp";

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseHeaderReader.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseHeaderReader.cs
@@ -11,9 +11,6 @@ namespace System.Net.Http
     /// </summary>
     internal struct WinHttpResponseHeaderReader
     {
-        private const string Gzip = "gzip";
-        private const string Deflate = "deflate";
-
         private readonly char[] _buffer;
         private readonly int _length;
         private int _position;
@@ -65,7 +62,7 @@ namespace System.Net.Http
                 int valueLength = startIndex + length - colonIndex - 1;
                 CharArrayHelpers.Trim(_buffer, ref valueStartIndex, ref valueLength);
 
-                value = GetHeaderValue(name, _buffer, valueStartIndex, valueLength);
+                value = HttpKnownHeaderNames.GetHeaderValue(name, _buffer, valueStartIndex, valueLength);
 
                 return true;
             }
@@ -126,36 +123,6 @@ namespace System.Net.Http
             startIndex = 0;
             length = 0;
             return false;
-        }
-
-        private static string GetHeaderValue(string name, char[] array, int startIndex, int length)
-        {
-            Debug.Assert(name != null);
-            CharArrayHelpers.DebugAssertArrayInputs(array, startIndex, length);
-
-            if (length == 0)
-            {
-                return string.Empty;
-            }
-
-            // If it's a known header value, use the known value instead of allocating a new string.
-
-            // Do a really quick reference equals check to see if name is the same object as
-            // HttpKnownHeaderNames.ContentEncoding, in which case the value is very likely to
-            // be either "gzip" or "deflate".
-            if (object.ReferenceEquals(name, HttpKnownHeaderNames.ContentEncoding))
-            {
-                if (CharArrayHelpers.EqualsOrdinalAsciiIgnoreCase(Gzip, array, startIndex, length))
-                {
-                    return Gzip;
-                }
-                else if (CharArrayHelpers.EqualsOrdinalAsciiIgnoreCase(Deflate, array, startIndex, length))
-                {
-                    return Deflate;
-                }
-            }
-
-            return new string(array, startIndex, length);
         }
     }
 }

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -217,6 +217,9 @@
     <Compile Include="$(CommonPath)\System\Net\SecurityProtocol.cs">
       <Link>Common\System\Net\SecurityProtocol.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Net\UriScheme.cs">
+      <Link>Common\System\Net\UriScheme.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Errors.cs">
       <Link>Common\Interop\Unix\Interop.Errors.cs</Link>
     </Compile>

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
@@ -63,14 +63,7 @@ namespace System.Net.Http
             if (disposing && !_disposed)
             {
                 _disposed = true;
-                if (_winHttpHandler != null)
-                {
-                    _winHttpHandler.Dispose();
-                }
-                else
-                {
-                    _managedHandler.Dispose();
-                }
+                ((HttpMessageHandler)_winHttpHandler ?? _managedHandler).Dispose();
             }
 
             base.Dispose(disposing);

--- a/src/System.Net.Http/src/System/Net/Http/Managed/AuthenticationHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/AuthenticationHandler.cs
@@ -10,6 +10,7 @@ namespace System.Net.Http
 {
     internal sealed class AuthenticationHandler : HttpMessageHandler
     {
+        private const string Basic = "Basic";
         private readonly HttpMessageHandler _innerHandler;
         private readonly bool _preAuthenticate;
         private readonly ICredentials _credentials;
@@ -23,13 +24,13 @@ namespace System.Net.Http
 
         private bool TrySetBasicAuthToken(HttpRequestMessage request)
         {
-            NetworkCredential credential = _credentials.GetCredential(request.RequestUri, "Basic");
+            NetworkCredential credential = _credentials.GetCredential(request.RequestUri, Basic);
             if (credential == null)
             {
                 return false;
             }
 
-            request.Headers.Authorization = new AuthenticationHeaderValue("Basic", BasicAuthenticationHelper.GetBasicTokenForCredential(credential));
+            request.Headers.Authorization = new AuthenticationHeaderValue(Basic, BasicAuthenticationHelper.GetBasicTokenForCredential(credential));
             return true;
         }
 
@@ -49,7 +50,7 @@ namespace System.Net.Http
                 foreach (AuthenticationHeaderValue h in authenticateValues)
                 {
                     // We only support Basic auth, ignore others
-                    if (h.Scheme == "Basic")
+                    if (h.Scheme == Basic)
                     {
                         if (!TrySetBasicAuthToken(request))
                         {

--- a/src/System.Net.Http/src/System/Net/Http/Managed/AutoRedirectHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/AutoRedirectHandler.cs
@@ -27,7 +27,7 @@ namespace System.Net.Http
         {
             HttpResponseMessage response = await _innerHandler.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
-            int redirectCount = 0;
+            uint redirectCount = 0;
             while (true)
             {
                 bool needRedirect = false;

--- a/src/System.Net.Http/src/System/Net/Http/Managed/AutoRedirectHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/AutoRedirectHandler.cs
@@ -72,8 +72,8 @@ namespace System.Net.Http
 
                 // Disallow automatic redirection from https to http
                 bool allowed =
-                    (request.RequestUri.Scheme == "http" && (location.Scheme == "http" || location.Scheme == "https")) ||
-                    (request.RequestUri.Scheme == "https" && location.Scheme == "https");
+                    (request.RequestUri.Scheme == UriScheme.Http && (location.Scheme == UriScheme.Http || location.Scheme == UriScheme.Https)) ||
+                    (request.RequestUri.Scheme == UriScheme.Https && location.Scheme == UriScheme.Https);
                 if (!allowed)
                 {
                     break;

--- a/src/System.Net.Http/src/System/Net/Http/Managed/CookieHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/CookieHandler.cs
@@ -25,14 +25,14 @@ namespace System.Net.Http
             string cookieHeader = _cookieContainer.GetCookieHeader(request.RequestUri);
             if (!string.IsNullOrEmpty(cookieHeader))
             {
-                request.Headers.Add("Cookie", cookieHeader);
+                request.Headers.Add(HttpKnownHeaderNames.Cookie, cookieHeader);
             }
 
             HttpResponseMessage response = await _innerHandler.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
             // Handle Set-Cookie
             IEnumerable<string> setCookies;
-            if (response.Headers.TryGetValues("Set-Cookie", out setCookies))
+            if (response.Headers.TryGetValues(HttpKnownHeaderNames.SetCookie, out setCookies))
             {
                 foreach (string setCookie in setCookies)
                 {

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
@@ -641,7 +641,7 @@ namespace System.Net.Http
             }
 
             string knownReasonPhrase = HttpStatusDescription.Get(response.StatusCode);
-            response.ReasonPhrase = CharArrayHelpers.EqualsOrdinal(knownReasonPhrase, _sb.Chars, 0, _sb.Offset) ?
+            response.ReasonPhrase = CharArrayHelpers.EqualsOrdinal(knownReasonPhrase, _sb.Chars, 0, _sb.Length) ?
                 knownReasonPhrase :
                 _sb.ToString();
 
@@ -670,7 +670,7 @@ namespace System.Net.Http
                 }
 
                 string headerName;
-                if (!HttpKnownHeaderNames.TryGetHeaderName(_sb.Chars, 0, _sb.Offset, out headerName))
+                if (!HttpKnownHeaderNames.TryGetHeaderName(_sb.Chars, 0, _sb.Length, out headerName))
                 {
                     headerName = _sb.ToString();
                 }
@@ -695,7 +695,7 @@ namespace System.Net.Http
                     throw new HttpRequestException("Saw CR without LF while parsing headers");
                 }
 
-                string headerValue = HttpKnownHeaderNames.GetHeaderValue(headerName, _sb.Chars, 0, _sb.Offset);
+                string headerValue = HttpKnownHeaderNames.GetHeaderValue(headerName, _sb.Chars, 0, _sb.Length);
 
                 // TryAddWithoutValidation will fail if the header name has trailing whitespace.
                 // So, trim it here.
@@ -1262,28 +1262,28 @@ namespace System.Net.Http
         private struct ValueStringBuilder
         {
             public char[] Chars;
-            public int Offset;
+            public int Length;
 
             public ValueStringBuilder(int initialCapacity)
             {
                 Chars = new char[initialCapacity];
-                Offset = 0;
+                Length = 0;
             }
 
             public void Append(char c)
             {
-                if (Offset == Chars.Length)
+                if (Length == Chars.Length)
                 {
                     Grow();
                 }
-                Chars[Offset++] = c;
+                Chars[Length++] = c;
             }
 
             private void Grow() => Array.Resize(ref Chars, Chars.Length * 2);
 
-            public void Clear() => Offset = 0;
+            public void Clear() => Length = 0;
 
-            public override string ToString() => new string(Chars, 0, Offset);
+            public override string ToString() => new string(Chars, 0, Length);
         }
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
@@ -780,7 +780,7 @@ namespace System.Net.Http
             await WriteTwoBytesAsync((byte)'\r', (byte)'\n', cancellationToken).ConfigureAwait(false);
         }
 
-        public async ValueTask<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
             if (request.Version.Major != 1 || request.Version.Minor != 1)

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
@@ -980,7 +980,7 @@ namespace System.Net.Http
                 _writeOffset += toCopy;
                 offset += toCopy;
 
-                Debug.Assert(offset <= BufferSize, $"Expected {nameof(offset)} to be <= {bytes.Length}, got {offset}");
+                Debug.Assert(offset <= bytes.Length, $"Expected {nameof(offset)} to be <= {bytes.Length}, got {offset}");
                 Debug.Assert(_writeOffset <= BufferSize, $"Expected {nameof(_writeOffset)} to be <= {BufferSize}, got {_writeOffset}");
                 if (offset == bytes.Length)
                 {

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
@@ -1151,7 +1151,7 @@ namespace System.Net.Http
             return count;
         }
 
-        private async Task CopyFromBuffer(Stream destination, int count, CancellationToken cancellationToken)
+        private async Task CopyFromBufferAsync(Stream destination, int count, CancellationToken cancellationToken)
         {
             Debug.Assert(count <= _readLength - _readOffset);
 
@@ -1166,7 +1166,7 @@ namespace System.Net.Http
             int remaining = _readLength - _readOffset;
             if (remaining > 0)
             {
-                await CopyFromBuffer(destination, remaining, cancellationToken).ConfigureAwait(false);
+                await CopyFromBufferAsync(destination, remaining, cancellationToken).ConfigureAwait(false);
             }
 
             while (true)
@@ -1178,7 +1178,7 @@ namespace System.Net.Http
                     break;
                 }
 
-                await CopyFromBuffer(destination, _readLength, cancellationToken).ConfigureAwait(false);
+                await CopyFromBufferAsync(destination, _readLength, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -1192,7 +1192,7 @@ namespace System.Net.Http
             if (remaining > 0)
             {
                 remaining = (int)Math.Min(remaining, length);
-                await CopyFromBuffer(destination, remaining, cancellationToken).ConfigureAwait(false);
+                await CopyFromBufferAsync(destination, remaining, cancellationToken).ConfigureAwait(false);
 
                 length -= remaining;
                 if (length == 0)
@@ -1210,7 +1210,7 @@ namespace System.Net.Http
                 }
 
                 remaining = (int)Math.Min(_readLength, length);
-                await CopyFromBuffer(destination, remaining, cancellationToken).ConfigureAwait(false);
+                await CopyFromBufferAsync(destination, remaining, cancellationToken).ConfigureAwait(false);
 
                 length -= remaining;
                 if (length == 0)

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
@@ -1021,13 +1021,15 @@ namespace System.Net.Http
             return WriteStringAsync(s, cancellationToken);
         }
 
-        private async Task FlushAsync(CancellationToken cancellationToken)
+        private Task FlushAsync(CancellationToken cancellationToken)
         {
             if (_writeOffset > 0)
-            { 
-                await _stream.WriteAsync(_writeBuffer, 0, _writeOffset, cancellationToken).ConfigureAwait(false);
+            {
+                Task t = _stream.WriteAsync(_writeBuffer, 0, _writeOffset, cancellationToken);
                 _writeOffset = 0;
+                return t;
             }
+            return Task.CompletedTask;
         }
 
         private Task FillAsync(CancellationToken cancellationToken)

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
@@ -692,11 +692,8 @@ namespace System.Net.Http
                 // Don't ask me why this is the right API to call, but apparently it is
                 if (!response.Headers.TryAddWithoutValidation(headerName, headerValue))
                 {
-                    if (!responseContent.Headers.TryAddWithoutValidation(headerName, headerValue))
-                    {
-                        // Header name or value validation failed.
-                        throw new HttpRequestException($"invalid response header, {headerName}: {headerValue}");
-                    }
+                    // The existing handlers ignore headers that couldn't be added.  Do the same here.
+                    responseContent.Headers.TryAddWithoutValidation(headerName, headerValue);
                 }
 
                 _sb.Clear();

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionHandler.cs
@@ -100,7 +100,7 @@ namespace System.Net.Http
 
             TransportContext transportContext = null;
 
-            if (uri.Scheme == "https")
+            if (uri.Scheme == UriScheme.Https)
             {
                 SslStream sslStream = await EstablishSslConnection(uri.Host, request, stream).ConfigureAwait(false);
 

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionHandler.cs
@@ -36,7 +36,7 @@ namespace System.Net.Http
             _connectionPoolTable = new ConcurrentDictionary<HttpConnectionKey, HttpConnectionPool>();
         }
 
-        protected internal override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        protected internal override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             HttpConnection connection = null;
 
@@ -47,12 +47,16 @@ namespace System.Net.Http
                 connection = pool.GetConnection();
             }
 
-            if (connection == null)
-            {
-                // No connection available in pool.  Create a new one.
-                connection = await CreateConnection(request, key, pool).ConfigureAwait(false);
-            }
+            return connection != null ?
+                connection.SendAsync(request, cancellationToken) :
+                SendAsyncWithNewConnection(key, pool, request, cancellationToken);
+        }
 
+        private async Task<HttpResponseMessage> SendAsyncWithNewConnection(
+            HttpConnectionKey key, HttpConnectionPool pool,
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var connection = await CreateConnection(request, key, pool).ConfigureAwait(false);
             return await connection.SendAsync(request, cancellationToken).ConfigureAwait(false);
         }
 

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionHandler.cs
@@ -116,7 +116,7 @@ namespace System.Net.Http
 
         protected override void Dispose(bool disposing)
         {
-            if (disposing && !!_disposed)
+            if (disposing && !_disposed)
             {
                 _disposed = true;
 

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionKey.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionKey.cs
@@ -22,7 +22,7 @@ namespace System.Net.Http
         }
 
         public override int GetHashCode() =>
-            UsingSSL.GetHashCode() ^ Host.GetHashCode() ^ Port.GetHashCode();
+            UsingSSL.GetHashCode() << 16 ^ Host.GetHashCode() ^ Port.GetHashCode();
 
         public override bool Equals(object obj) =>
             obj != null &&

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionKey.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionKey.cs
@@ -13,8 +13,8 @@ namespace System.Net.Http
         public HttpConnectionKey(Uri uri)
         {
             UsingSSL = 
-                uri.Scheme == "http" ? false :
-                uri.Scheme == "https" ? true :
+                uri.Scheme == UriScheme.Http ? false :
+                uri.Scheme == UriScheme.Https ? true :
                 throw new ArgumentException("Invalid Uri scheme", nameof(uri));
 
             Host = uri.Host;

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpProxyConnectionHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpProxyConnectionHandler.cs
@@ -116,7 +116,7 @@ namespace System.Net.Http
 
         protected override void Dispose(bool disposing)
         {
-            if (disposing && !!_disposed)
+            if (disposing && !_disposed)
             {
                 _disposed = true;
 

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpProxyConnectionHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpProxyConnectionHandler.cs
@@ -49,12 +49,12 @@ namespace System.Net.Http
         private async Task<HttpResponseMessage> SendWithProxyAsync(
             Uri proxyUri, HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            if (proxyUri.Scheme != "http")
+            if (proxyUri.Scheme != UriScheme.Http)
             {
                 throw new InvalidOperationException($"invalid scheme {proxyUri.Scheme} for proxy");
             }
 
-            if (request.RequestUri.Scheme == "https")
+            if (request.RequestUri.Scheme == UriScheme.Https)
             {
                 // TODO: Implement SSL tunneling through proxy
                 throw new NotImplementedException("no support for SSL tunneling through proxy");
@@ -71,14 +71,15 @@ namespace System.Net.Http
                 foreach (AuthenticationHeaderValue h in response.Headers.ProxyAuthenticate)
                 {
                     // We only support Basic auth, ignore others
-                    if (h.Scheme == "Basic")
+                    const string Basic = "Basic";
+                    if (h.Scheme == Basic)
                     {
-                        NetworkCredential credential = _proxy.Credentials.GetCredential(proxyUri, "Basic");
+                        NetworkCredential credential = _proxy.Credentials.GetCredential(proxyUri, Basic);
                         if (credential != null)
                         {
                             response.Dispose();
 
-                            request.Headers.ProxyAuthorization = new AuthenticationHeaderValue("Basic",
+                            request.Headers.ProxyAuthorization = new AuthenticationHeaderValue(Basic,
                                 BasicAuthenticationHelper.GetBasicTokenForCredential(credential));
 
                             connection = await GetOrCreateConnection(request, proxyUri).ConfigureAwait(false);

--- a/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -51,6 +51,9 @@
     <Compile Include="$(CommonPath)\System\Net\Logging\NetEventSource.Common.cs">
       <Link>ProductionCode\Common\System\Net\Logging\NetEventSource.Common.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Net\SecurityProtocol.cs">
+      <Link>Common\System\Net\SecurityProtocol.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Net\UriScheme.cs">
       <Link>Common\System\Net\UriScheme.cs</Link>
     </Compile>

--- a/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -51,6 +51,9 @@
     <Compile Include="$(CommonPath)\System\Net\Logging\NetEventSource.Common.cs">
       <Link>ProductionCode\Common\System\Net\Logging\NetEventSource.Common.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Net\UriScheme.cs">
+      <Link>Common\System\Net\UriScheme.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\ShouldNotBeInvokedException.cs">
       <Link>Common\System\ShouldNotBeInvokedException.cs</Link>
     </Compile>


### PR DESCRIPTION
- Setting the Host header in the request object incurs a variety of allocations.  We can skip that and just write the header directly to the output.
- Rather than writing strings char by char, if the whole string fits in the output buffer, we can just store the chars rather than doing an async write for each.
- Use cached header name strings, reason phrases, and some value strings, rather than always allocating a string for each
- Remove several of the intermediary async methods in the handler chain (though we should really try to remove them all... SendAsync is pretty much always going to yield, so this is adding measurable allocations on every call, even if it results in cleaner code)
- Use ContinueWith instead of async/await in a few places where ContinueWith results in less allocation
- Clean up the ManagedHandler class a bit, including ensuring arg validation is happening the same as in CurlHandler
- Fix several issues from the initial PR feedback

cc: @geoffkizer 