### PR TITLE
Disable  GetActivationFactory negative test on UAPAOT

### DIFF
--- a/src/System.Runtime.InteropServices.WindowsRuntime/tests/System/Runtime/InteropServices/WindowsRuntime/WindowsRuntimeMarshalTests.cs
+++ b/src/System.Runtime.InteropServices.WindowsRuntime/tests/System/Runtime/InteropServices/WindowsRuntime/WindowsRuntimeMarshalTests.cs
@@ -312,6 +312,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "No reliable way to check if a type is WinRT in AOT")]
         public void GetActivationFactory_NotExportedType_ThrowsArgumentException()
         {
             AssertExtensions.Throws<ArgumentException>("type", () => WindowsRuntimeMarshal.GetActivationFactory(typeof(int)));


### PR DESCRIPTION
We dont have a way to check if a type is WinRT reliably in
AOT without reflection enabling the type in question.
@yizhang82 