### PR TITLE
Fix use of Cookie.InternalSetName

### DIFF
--- a/src/Common/src/System/Net/CookieParser.cs
+++ b/src/Common/src/System/Net/CookieParser.cs
@@ -544,6 +544,12 @@ namespace System.Net
             return _tokenizer.GetCookieString();
         }
 
+#if SYSTEM_NET_PRIMITIVES_DLL
+        private static bool InternalSetNameMethod(Cookie cookie, string value)
+        {
+            return cookie.InternalSetName(value);
+        }
+#else
         private static Func<Cookie, string, bool> s_internalSetNameMethod;
         private static Func<Cookie, string, bool> InternalSetNameMethod
         {
@@ -568,6 +574,7 @@ namespace System.Net
                 return s_internalSetNameMethod;
             }
         }
+#endif
 
         private static FieldInfo s_isQuotedDomainField = null;
         private static FieldInfo IsQuotedDomainField

--- a/src/System.Net.Primitives/tests/FunctionalTests/CookieContainerTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/CookieContainerTest.cs
@@ -151,7 +151,6 @@ namespace System.Net.Primitives.Functional.Tests
 
         [Theory]
         [MemberData(nameof(SetCookiesInvalidData))]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/20482", TargetFrameworkMonikers.UapAot)]
         public static void SetCookies_InvalidData_Throws(Uri uri, string cookieHeader)
         {
             CookieContainer cc = new CookieContainer();


### PR DESCRIPTION
The System.Net.Primitives UAPAOT test run was failing in
SetCookies_InvalidData_Throws. The reflection wasn't working as
expected.  However, this same CookieParser.cs file is included in the
System.Net.HttpListener library.  And that reflection was working.

It seems that reflecting on a type (Cookie) from within the same library
(System.Net.Primitives) doesn't work from another type in that same
library (CookieParser).

It turns out that we can optimize this anyways and not use reflection
when the file is included directly in System.Net.Primitives.

Fixes #20482