### PR TITLE
Fix System.Threading tests hang in uapaot

### DIFF
--- a/src/System.Threading/tests/ReaderWriterLockSlimTests.cs
+++ b/src/System.Threading/tests/ReaderWriterLockSlimTests.cs
@@ -383,7 +383,7 @@ namespace System.Threading.Tests
 
         [Fact]
         [OuterLoop]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #3364 and #5839")] // Hangs in desktop
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework | TargetFrameworkMonikers.UapAot, "dotnet/corefx #3364, #5839 and #21585")] // Hangs in desktop and in UapAot
         public static void ReleaseReadersWhenWaitingWriterTimesOut()
         {
             using (var rwls = new ReaderWriterLockSlim())


### PR DESCRIPTION
cc: @kouvel @MattGal @danmosemsft 

I have verified in an ARM machine that without this test, the test execution finishes.