### PR TITLE
Remove outdated TODO in HttpClientHandler for UAP

### DIFF
--- a/src/System.Net.Http/src/netcore50/System/Net/HttpHandlerToFilter.cs
+++ b/src/System.Net.Http/src/netcore50/System/Net/HttpHandlerToFilter.cs
@@ -85,11 +85,6 @@ namespace System.Net.Http
                 }
                 else
                 {
-                    // TODO (#7878): We need to throw an exception here similar to .NET Desktop
-                    // throw new ArgumentException(SR.GetString(SR.net_wrongversion), "value");
-                    //
-                    // But we need to do that checking in the HttpClientHandler object itself.
-                    // and we have that bug as well for the WinHttpHandler version also.
                     maxVersion = RTHttpVersion.Http11;
                 }
                 


### PR DESCRIPTION
The current behavior for .NET Core (Windows, *Nix, and UAP) is to use a
default HTTP version if none or an illegal version is specified on the HttpRequestMessage.Version

On .NET Framework, an exception is thrown in these cases, "Only HTTP/1.0
and HTTP/1.1 version requests are currently supported." This error
message wouldn't make sense now anyways since HTTP/2 is supported in
.NET Core. So, it is better to use a default version than to throw an
exception.

This difference between .NET Core and .NET Framework will be document here:
https://github.com/dotnet/corefx/wiki/ApiCompat

Fixes #7878