### PR TITLE
Standardize all XML comments in System.Drawing & minor formatting fixes

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/BufferedGraphics.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/BufferedGraphics.cs
@@ -2,19 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
 namespace System.Drawing
 {
-    using System.Diagnostics;
-    using System.Runtime.InteropServices;
-
-    /// <include file='doc\BufferedGraphics.uex' path='docs/doc[@for="BufferedGraphics"]/*' />
-    /// <devdoc>
-    ///         The BufferedGraphics class can be thought of as a "Token" or "Reference" to the
-    ///         buffer that a BufferedGraphicsContext creates. While a BufferedGraphics is 
-    ///         outstanding, the memory associated with the buffer is locked. The general design
-    ///         is such that under normal conditions a single BufferedGraphics will be in use at
-    ///         one time for a given BufferedGraphicsContext.
-    /// </devdoc>
+    /// <summary>
+    /// The BufferedGraphics class can be thought of as a "Token" or "Reference" to the buffer that a
+    /// BufferedGraphicsContext creates. While a BufferedGraphics is outstanding, the memory associated with the
+    /// buffer is locked. The general designis such that under normal conditions a single BufferedGraphics will be in
+    /// use at one time for a given BufferedGraphicsContext.
+    /// </summary>
     public sealed class BufferedGraphics : IDisposable
     {
         private Graphics _bufferedGraphicsSurface;
@@ -26,10 +24,9 @@ namespace System.Drawing
         private bool _disposeContext;
         private static int s_rop = 0xcc0020; // RasterOp.SOURCE.GetRop();
 
-        /// <include file='doc\BufferedGraphics.uex' path='docs/doc[@for="BufferedGraphics.BufferedGraphics"]/*' />
-        /// <devdoc>
-        ///         Internal constructor, this class is created by the BufferedGraphicsContext.
-        /// </devdoc>
+        /// <summary>
+        /// Internal constructor, this class is created by the BufferedGraphicsContext.
+        /// </summary>
         internal BufferedGraphics(Graphics bufferedGraphicsSurface, BufferedGraphicsContext context, Graphics targetGraphics,
                                   IntPtr targetDC, Point targetLoc, Size virtualSize)
         {
@@ -46,10 +43,9 @@ namespace System.Drawing
             Dispose(false);
         }
 
-        /// <include file='doc\BufferedGraphics.uex' path='docs/doc[@for="BufferedGraphics.Dispose"]/*' />
-        /// <devdoc>
-        ///         Disposes the object and releases the lock on the memory.
-        /// </devdoc>
+        /// <summary>
+        /// Disposes the object and releases the lock on the memory.
+        /// </summary>
         public void Dispose()
         {
             Dispose(true);
@@ -77,10 +73,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\BufferedGraphics.uex' path='docs/doc[@for="BufferedGraphics.DisposeContext"]/*' />
-        /// <devdoc>
-        ///         Internal property - determines if we need to dispose of the Context when this is disposed
-        /// </devdoc>
+        /// <summary>
+        /// Determines if we need to dispose of the Context when this is disposed
+        /// </summary>
         internal bool DisposeContext
         {
             get
@@ -93,10 +88,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\BufferedGraphics.uex' path='docs/doc[@for="BufferedGraphics.Graphics"]/*' />
-        /// <devdoc>
-        ///         Allows access to the Graphics wrapper for the buffer.
-        /// </devdoc>
+        /// <summary>
+        /// Allows access to the Graphics wrapper for the buffer.
+        /// </summary>
         public Graphics Graphics
         {
             get
@@ -106,10 +100,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\BufferedGraphics.uex' path='docs/doc[@for="BufferedGraphics.Render"]/*' />
-        /// <devdoc>
-        ///         Renders the buffer to the original graphics used to allocate the buffer.
-        /// </devdoc>
+        /// <summary>
+        /// Renders the buffer to the original graphics used to allocate the buffer.
+        /// </summary>
         public void Render()
         {
             if (_targetGraphics != null)
@@ -122,10 +115,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\BufferedGraphics.uex' path='docs/doc[@for="BufferedGraphics.Render1"]/*' />
-        /// <devdoc>
-        ///         Renders the buffer to the specified target graphics.
-        /// </devdoc>
+        /// <summary>
+        /// Renders the buffer to the specified target graphics.
+        /// </summary>
         public void Render(Graphics target)
         {
             if (target != null)
@@ -143,19 +135,17 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\BufferedGraphics.uex' path='docs/doc[@for="BufferedGraphics.Render2"]/*' />
-        /// <devdoc>
-        ///         Renders the buffer to the specified target HDC.
-        /// </devdoc>
+        /// <summary>
+        /// Renders the buffer to the specified target HDC.
+        /// </summary>
         public void Render(IntPtr targetDC)
         {
             RenderInternal(new HandleRef(null, targetDC), this);
         }
 
-        /// <include file='doc\BufferedGraphics.uex' path='docs/doc[@for="BufferedGraphics.RenderInternal"]/*' />
-        /// <devdoc>
-        ///         Internal method that renders the specified buffer into the target.
-        /// </devdoc>
+        /// <summary>
+        /// Internal method that renders the specified buffer into the target.
+        /// </summary>
         private void RenderInternal(HandleRef refTargetDC, BufferedGraphics buffer)
         {
             IntPtr sourceDC = buffer.Graphics.GetHdc();

--- a/src/System.Drawing.Common/src/System/Drawing/BufferedGraphicsContext.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/BufferedGraphicsContext.cs
@@ -2,19 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using System.Threading;
+
 namespace System.Drawing
 {
-    using System.ComponentModel;
-    using System.Diagnostics;
-    using System.Runtime.InteropServices;
-    using System.Security.Permissions;
-    using System.Threading;
-
-    /// <include file='doc\BufferedGraphicsContext.uex' path='docs/doc[@for="BufferedGraphicsContext"]/*' />
-    /// <devdoc>
-    ///         The BufferedGraphicsContext class can be used to perform standard double buffer
-    ///         rendering techniques.
-    /// </devdoc>
+    /// <summary>
+    /// The BufferedGraphicsContext class can be used to perform standard double buffer rendering techniques.
+    /// </summary>
     public sealed class BufferedGraphicsContext : IDisposable
     {
         private Size _maximumBuffer;
@@ -39,10 +37,9 @@ namespace System.Drawing
         private string _stackAtBusy;
 #endif
 
-        /// <include file='doc\BufferedGraphicsContext.uex' path='docs/doc[@for="BufferedGraphicsContext.BufferedGraphicsContext"]/*' />
-        /// <devdoc>
-        ///         Basic constructor.
-        /// </devdoc>
+        /// <summary>
+        /// Basic constructor.
+        /// </summary>
         public BufferedGraphicsContext()
         {
             //by defualt, the size of our maxbuffer will be 3 x standard button size
@@ -52,17 +49,12 @@ namespace System.Drawing
             _bufferSize = Size.Empty;
         }
 
-        /// <include file='doc\BufferedGraphicsContext.uex' path='docs/doc[@for="BufferedGraphicsContext.Finalizer"]/*' />
-        /// <devdoc>
-        ///         Destructor.
-        /// </devdoc>
         ~BufferedGraphicsContext()
         {
             Dispose(false);
         }
 
         //Internal trace switch for debugging
-        //
         internal static TraceSwitch DoubleBuffering
         {
             get
@@ -75,13 +67,12 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\BufferedGraphicsContext.uex' path='docs/doc[@for="BufferedGraphicsContext.MaximumBuffer"]/*' />
-        /// <devdoc>
-        ///         Allows you to set the maximum width and height of the buffer that will be retained in memory.
-        ///         You can allocate a buffer of any size, however any request for a buffer that would have a total
-        ///         memory footprint larger that the maximum size will be allocated temporarily and then discarded 
-        ///         with the BufferedGraphics is released.
-        /// </devdoc>
+        /// <summary>
+        /// Allows you to set the maximum width and height of the buffer that will be retained in memory.
+        /// You can allocate a buffer of any size, however any request for a buffer that would have a total
+        /// memory footprint larger that the maximum size will be allocated temporarily and then discarded 
+        /// with the BufferedGraphics is released.
+        /// </summary>
         public Size MaximumBuffer
         {
             get
@@ -108,10 +99,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\BufferedGraphicsContext.uex' path='docs/doc[@for="BufferedGraphicsContext.Allocate"]/*' />
-        /// <devdoc>
-        ///         Returns a BufferedGraphics that is matched for the specified target Graphics object.
-        /// </devdoc>
+        /// <summary>
+        /// Returns a BufferedGraphics that is matched for the specified target Graphics object.
+        /// </summary>
         public BufferedGraphics Allocate(Graphics targetGraphics, Rectangle targetRectangle)
         {
             if (ShouldUseTempManager(targetRectangle))
@@ -122,10 +112,9 @@ namespace System.Drawing
             return AllocBuffer(targetGraphics, IntPtr.Zero, targetRectangle);
         }
 
-        /// <include file='doc\BufferedGraphicsContext.uex' path='docs/doc[@for="BufferedGraphicsContext.Allocate1"]/*' />
-        /// <devdoc>
-        ///         Returns a BufferedGraphics that is matched for the specified target HDC object.
-        /// </devdoc>
+        /// <summary>
+        /// Returns a BufferedGraphics that is matched for the specified target HDC object.
+        /// </summary>
         [SecurityPermission(SecurityAction.LinkDemand, Flags = SecurityPermissionFlag.UnmanagedCode)]
         public BufferedGraphics Allocate(IntPtr targetDC, Rectangle targetRectangle)
         {
@@ -137,10 +126,9 @@ namespace System.Drawing
             return AllocBuffer(null, targetDC, targetRectangle);
         }
 
-        /// <include file='doc\BufferedGraphicsContext.uex' path='docs/doc[@for="BufferedGraphicsContext.AllocBuffer"]/*' />
-        /// <devdoc>
-        ///         Returns a BufferedGraphics that is matched for the specified target HDC object.
-        /// </devdoc>
+        /// <summary>
+        /// Returns a BufferedGraphics that is matched for the specified target HDC object.
+        /// </summary>
         private BufferedGraphics AllocBuffer(Graphics targetGraphics, IntPtr targetDC, Rectangle targetRectangle)
         {
             int oldBusy = Interlocked.CompareExchange(ref _busy, BUFFER_BUSY_PAINTING, BUFFER_FREE);
@@ -194,10 +182,9 @@ namespace System.Drawing
             return _buffer;
         }
 
-        /// <include file='doc\BufferedGraphicsContext.uex' path='docs/doc[@for="BufferedGraphicsContext.AllocBufferInTempManager"]/*' />
-        /// <devdoc>
-        ///         Returns a BufferedGraphics that is matched for the specified target HDC object.
-        /// </devdoc>
+        /// <summary>
+        /// Returns a BufferedGraphics that is matched for the specified target HDC object.
+        /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:DisposeObjectsBeforeLosingScope")]
         private BufferedGraphics AllocBufferInTempManager(Graphics targetGraphics, IntPtr targetDC, Rectangle targetRectangle)
         {
@@ -225,31 +212,30 @@ namespace System.Drawing
         }
 
 
-        /// <include file='doc\BufferedGraphicsContext.uex' path='docs/doc[@for="BufferedGraphicsContext.bFillBitmapInfo"]/*' />
-        /// <devdoc>
-        // bFillBitmapInfo
-        //
-        // Fills in the fields of a BITMAPINFO so that we can create a bitmap
-        // that matches the format of the display.
-        //
-        // This is done by creating a compatible bitmap and calling GetDIBits
-        // to return the color masks.  This is done with two calls.  The first
-        // call passes in biBitCount = 0 to GetDIBits which will fill in the
-        // base BITMAPINFOHEADER data.  The second call to GetDIBits (passing
-        // in the BITMAPINFO filled in by the first call) will return the color
-        // table or bitmasks, as appropriate.
-        //
-        // Returns:
-        //   TRUE if successful, FALSE otherwise.
-        //
-        // History:
-        //  07-Jun-1995 -by- Gilman Wong [Microsoft]
-        // Wrote it.
-        //
-        //  15-Nov-2000 -by- Chris Anderson [Microsoft]
-        // Ported it to C#
-        //
-        /// </devdoc>
+        /// <summary>
+        /// bFillBitmapInfo
+        ///
+        /// Fills in the fields of a BITMAPINFO so that we can create a bitmap
+        /// that matches the format of the display.
+        /// 
+        /// This is done by creating a compatible bitmap and calling GetDIBits
+        /// to return the color masks.  This is done with two calls.  The first
+        /// call passes in biBitCount = 0 to GetDIBits which will fill in the
+        /// base BITMAPINFOHEADER data.  The second call to GetDIBits (passing
+        /// in the BITMAPINFO filled in by the first call) will return the color
+        /// table or bitmasks, as appropriate.
+        /// 
+        /// Returns:
+        ///   TRUE if successful, FALSE otherwise.
+        /// 
+        /// History:
+        ///  07-Jun-1995 -by- Gilman Wong [Microsoft]
+        /// Wrote it.
+        /// 
+        ///  15-Nov-2000 -by- Chris Anderson [Microsoft]
+        /// Ported it to C#
+        ///
+        /// </summary>
         private bool bFillBitmapInfo(IntPtr hdc, IntPtr hpal, ref NativeMethods.BITMAPINFO_FLAT pbmi)
         {
             IntPtr hbm = IntPtr.Zero;
@@ -315,26 +301,25 @@ namespace System.Drawing
             return bRet;
         }
 
-        /// <include file='doc\BufferedGraphicsContext.uex' path='docs/doc[@for="BufferedGraphicsContext.bFillColorTable"]/*' />
-        /// <devdoc>
-        // bFillColorTable
-        //
-        // Initialize the color table of the BITMAPINFO pointed to by pbmi.  Colors
-        // are set to the current system palette.
-        //
-        // Note: call only valid for displays of 8bpp or less.
-        //
-        // Returns:
-        //   TRUE if successful, FALSE otherwise.
-        //
-        // History:
-        //  23-Jan-1996 -by- Gilman Wong [Microsoft]
-        // Wrote it.
-        //
-        //  15-Nov-2000 -by- Chris Anderson [Microsoft]
-        // Ported it to C#
-        //
-        /// </devdoc>
+        /// <summary>
+        /// bFillColorTable
+        ///
+        /// Initialize the color table of the BITMAPINFO pointed to by pbmi.  Colors
+        /// are set to the current system palette.
+        ///
+        /// Note: call only valid for displays of 8bpp or less.
+        ///
+        /// Returns:
+        ///   TRUE if successful, FALSE otherwise.
+        ///
+        /// History:
+        ///  23-Jan-1996 -by- Gilman Wong [Microsoft]
+        /// Wrote it.
+        ///
+        ///  15-Nov-2000 -by- Chris Anderson [Microsoft]
+        /// Ported it to C#
+        ///
+        /// </summary>
         private unsafe bool bFillColorTable(IntPtr hdc, IntPtr hpal, ref NativeMethods.BITMAPINFO_FLAT pbmi)
         {
             bool bRet = false;
@@ -389,10 +374,9 @@ namespace System.Drawing
             return bRet;
         }
 
-        /// <include file='doc\BufferedGraphicsContext.uex' path='docs/doc[@for="BufferedGraphicsContext.CreateBuffer"]/*' />
-        /// <devdoc>
-        ///         Returns a Graphics object representing a buffer.
-        /// </devdoc>
+        /// <summary>
+        /// Returns a Graphics object representing a buffer.
+        /// </summary>
         private Graphics CreateBuffer(IntPtr src, int offsetX, int offsetY, int width, int height)
         {
             //create the compat DC
@@ -430,33 +414,32 @@ namespace System.Drawing
             return _compatGraphics;
         }
 
-        /// <include file='doc\BufferedGraphicsContext.uex' path='docs/doc[@for="BufferedGraphicsContext.CreateCompatibleDIB"]/*' />
-        /// <devdoc>
-        // CreateCompatibleDIB
-        //
-        // Create a DIB section with an optimal format w.r.t. the specified hdc.
-        //
-        // If DIB <= 8bpp, then the DIB color table is initialized based on the
-        // specified palette.  If the palette handle is NULL, then the system
-        // palette is used.
-        //
-        // Note: The hdc must be a direct DC (not an info or memory DC).
-        //
-        // Note: On palettized displays, if the system palette changes the
-        //       UpdateDIBColorTable function should be called to maintain
-        //       the identity palette mapping between the DIB and the display.
-        //
-        // Returns:
-        //   Valid bitmap handle if successful, NULL if error.
-        //
-        // History:
-        //  23-Jan-1996 -by- Gilman Wong [Microsoft]
-        // Wrote it.
-        //
-        //  15-Nov-2000 -by- Chris Anderson [Microsoft]
-        // Ported it to C#.
-        //
-        /// </devdoc>        
+        /// <summary>
+        /// CreateCompatibleDIB
+        ///
+        /// Create a DIB section with an optimal format w.r.t. the specified hdc.
+        ///
+        /// If DIB <= 8bpp, then the DIB color table is initialized based on the
+        /// specified palette.  If the palette handle is NULL, then the system
+        /// palette is used.
+        ///
+        /// Note: The hdc must be a direct DC (not an info or memory DC).
+        ///
+        /// Note: On palettized displays, if the system palette changes the
+        ///       UpdateDIBColorTable function should be called to maintain
+        ///       the identity palette mapping between the DIB and the display.
+        ///
+        /// Returns:
+        ///   Valid bitmap handle if successful, NULL if error.
+        ///
+        /// History:
+        ///  23-Jan-1996 -by- Gilman Wong [Microsoft]
+        /// Wrote it.
+        ///
+        ///  15-Nov-2000 -by- Chris Anderson [Microsoft]
+        /// Ported it to C#.
+        ///
+        /// </summary>        
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Interoperability", "CA1404:CallGetLastErrorImmediatelyAfterPInvoke")]
         private IntPtr CreateCompatibleDIB(IntPtr hdc, IntPtr hpal, int ulWidth, int ulHeight, ref IntPtr ppvBits)
         {
@@ -468,9 +451,7 @@ namespace System.Drawing
             IntPtr hbmRet = IntPtr.Zero;
             NativeMethods.BITMAPINFO_FLAT pbmi = new NativeMethods.BITMAPINFO_FLAT();
 
-            //
             // Validate hdc.
-            //
             int objType = UnsafeNativeMethods.GetObjectType(new HandleRef(null, hdc));
 
             switch (objType)
@@ -486,9 +467,7 @@ namespace System.Drawing
 
             if (bFillBitmapInfo(hdc, hpal, ref pbmi))
             {
-                //
                 // Change bitmap size to match specified dimensions.
-                //
 
                 pbmi.bmiHeader_biWidth = ulWidth;
                 pbmi.bmiHeader_biHeight = ulHeight;
@@ -508,10 +487,8 @@ namespace System.Drawing
                 pbmi.bmiHeader_biClrUsed = 0;
                 pbmi.bmiHeader_biClrImportant = 0;
 
-                //
                 // Create the DIB section.  Let Win32 allocate the memory and return
                 // a pointer to the bitmap surface.
-                //
 
                 hbmRet = SafeNativeMethods.CreateDIBSection(new HandleRef(null, hdc), ref pbmi, NativeMethods.DIB_RGB_COLORS, ref ppvBits, IntPtr.Zero, 0);
                 Win32Exception ex = null;
@@ -537,19 +514,15 @@ namespace System.Drawing
             return hbmRet;
         }
 
-        /// <include file='doc\BufferedGraphicsContext.uex' path='docs/doc[@for="BufferedGraphicsContext.Dispose"]/*' />
-        /// <devdoc>
-        ///     Disposes of native handles.
-        /// </devdoc>
         public void Dispose()
         {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
 
-        /// <devdoc>
-        ///         Disposes the DC, but leaves the bitmap alone.
-        /// </devdoc>
+        /// <summary>
+        /// Disposes the DC, but leaves the bitmap alone.
+        /// </summary>
         private void DisposeDC()
         {
             if (_oldBitmap != IntPtr.Zero && _compatDC != IntPtr.Zero)
@@ -566,10 +539,9 @@ namespace System.Drawing
             }
         }
 
-        /// <devdoc>
-        ///         Disposes the bitmap, will ASSERT if bitmap is being used (checks oldbitmap).
-        ///         if ASSERTed, call DisposeDC() first.
-        /// </devdoc>
+        /// <summary>
+        /// Disposes the bitmap, will ASSERT if bitmap is being used (checks oldbitmap). if ASSERTed, call DisposeDC() first.
+        /// </summary>
         private void DisposeBitmap()
         {
             if (_dib != IntPtr.Zero)
@@ -582,10 +554,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\BufferedGraphicsContext.uex' path='docs/doc[@for="BufferedGraphicsContext.Dispose1"]/*' />
-        /// <devdoc>
-        ///     Disposes of the Graphics buffer.
-        /// </devdoc>
+        /// <summary>
+        /// Disposes of the Graphics buffer.
+        /// </summary>
         private void Dispose(bool disposing)
         {
             Debug.WriteLineIf(DoubleBuffering.TraceInfo, "Dispose(" + disposing + ") {");
@@ -636,36 +607,23 @@ namespace System.Drawing
 #if DEBUG
         private void DumpBitmapInfo(ref NativeMethods.BITMAPINFO_FLAT pbmi)
         {
-            //Debug.WriteLine("biSize --> " + pbmi.bmiHeader_biSize);
             Debug.WriteLine("biWidth --> " + pbmi.bmiHeader_biWidth);
             Debug.WriteLine("biHeight --> " + pbmi.bmiHeader_biHeight);
             Debug.WriteLine("biPlanes --> " + pbmi.bmiHeader_biPlanes);
             Debug.WriteLine("biBitCount --> " + pbmi.bmiHeader_biBitCount);
-            //Debug.WriteLine("biCompression --> " + pbmi.bmiHeader_biCompression);
-            //Debug.WriteLine("biSizeImage --> " + pbmi.bmiHeader_biSizeImage);
-            //Debug.WriteLine("biXPelsPerMeter --> " + pbmi.bmiHeader_biXPelsPerMeter);
-            //Debug.WriteLine("biYPelsPerMeter --> " + pbmi.bmiHeader_biYPelsPerMeter);
-            //Debug.WriteLine("biClrUsed --> " + pbmi.bmiHeader_biClrUsed);
-            //Debug.WriteLine("biClrImportant --> " + pbmi.bmiHeader_biClrImportant);
-            //Debug.Write("bmiColors --> ");
-            //for (int i=0; i<pbmi.bmiColors.Length; i++) {
-            //    Debug.Write(pbmi.bmiColors[i].ToString("X"));
-            //}
             Debug.WriteLine("");
         }
 #endif
 
-        /// <include file='doc\BufferedGraphicsContext.uex' path='docs/doc[@for="BufferedGraphicsContext.Invalidate"]/*' />
-        /// <devdoc>
-        ///         Invalidates the cached graphics buffer.
-        /// </devdoc>
+        /// <summary>
+        /// Invalidates the cached graphics buffer.
+        /// </summary>
         public void Invalidate()
         {
             int oldBusy = Interlocked.CompareExchange(ref _busy, BUFFER_BUSY_DISPOSING, BUFFER_FREE);
 
             //if we're not busy with our buffer, lets
             //clean it up now
-            //
             if (oldBusy == BUFFER_FREE)
             {
                 Dispose();
@@ -680,10 +638,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\BufferedGraphicsContext.uex' path='docs/doc[@for="BufferedGraphicsContext.ReleaseBuffer"]/*' />
-        /// <devdoc>
-        ///         Returns a Graphics object representing a buffer.
-        /// </devdoc>
+        /// <summary>
+        /// Returns a Graphics object representing a buffer.
+        /// </summary>
         internal void ReleaseBuffer(BufferedGraphics buffer)
         {
             Debug.Assert(buffer == _buffer, "Tried to release a bogus buffer");
@@ -703,14 +660,13 @@ namespace System.Drawing
             _busy = BUFFER_FREE;
         }
 
-        /// <include file='doc\BufferedGraphicsContext.uex' path='docs/doc[@for="BufferedGraphicsContext.ShouldUseTempManager"]/*' />
-        /// <devdoc>
-        ///         This routine allows us to control the point were we start using throw away
-        ///         managers for painting. Since the buffer manager stays around (by default)
-        ///         for the life of the app, we don't want to consume too much memory
-        ///         in the buffer. However, re-allocating the buffer for small things (like
-        ///         buttons, labels, etc) will hit us on runtime performance.
-        /// </devdoc>
+        /// <summary>
+        /// This routine allows us to control the point were we start using throw away
+        /// managers for painting. Since the buffer manager stays around (by default)
+        /// for the life of the app, we don't want to consume too much memory
+        /// in the buffer. However, re-allocating the buffer for small things (like
+        /// buttons, labels, etc) will hit us on runtime performance.
+        /// </summary>
         private bool ShouldUseTempManager(Rectangle targetBounds)
         {
             return (targetBounds.Width * targetBounds.Height) > (MaximumBuffer.Width * MaximumBuffer.Height);

--- a/src/System.Drawing.Common/src/System/Drawing/BufferedGraphicsManager.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/BufferedGraphicsManager.cs
@@ -2,30 +2,27 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.ConstrainedExecution;
+
 namespace System.Drawing
 {
-    using System.Runtime.ConstrainedExecution;
-
-    /// <include file='doc\BufferedGraphicsManager.uex' path='docs/doc[@for="BufferedGraphicsManager"]/*' />
-    /// <devdoc>
-    ///         The BufferedGraphicsManager is used for accessing a BufferedGraphicsContext.
-    /// </devdoc>
+    /// <summary>
+    /// The BufferedGraphicsManager is used for accessing a BufferedGraphicsContext.
+    /// </summary>
     public sealed class BufferedGraphicsManager
     {
         private static BufferedGraphicsContext s_bufferedGraphicsContext;
 
-        /// <include file='doc\BufferedGraphicsManager.uex' path='docs/doc[@for="BufferedGraphicsManager.BufferedGraphicsManager"]/*' />
-        /// <devdoc>
-        ///         Private constructor.
-        /// </devdoc>
+        /// <summary>
+        /// Private constructor.
+        /// </summary>
         private BufferedGraphicsManager()
         {
         }
 
-        /// <include file='doc\BufferedGraphicsManager.uex' path='docs/doc[@for="BufferedGraphicsManager.BufferedGraphicsManager"]/*' />
-        /// <devdoc>
-        ///         Static constructor.  Here, we hook the exit & unload events so we can clean up our context buffer.
-        /// </devdoc>
+        /// <summary>
+        /// Static constructor.  Here, we hook the exit & unload events so we can clean up our context buffer.
+        /// </summary>
         static BufferedGraphicsManager()
         {
             AppDomain.CurrentDomain.ProcessExit += new EventHandler(BufferedGraphicsManager.OnShutdown);
@@ -33,10 +30,9 @@ namespace System.Drawing
             s_bufferedGraphicsContext = new BufferedGraphicsContext();
         }
 
-        /// <include file='doc\BufferedGraphicsManager.uex' path='docs/doc[@for="BufferedGraphicsManager.Current"]/*' />
-        /// <devdoc>
-        ///         Retrieves the context associated with the app domain.
-        /// </devdoc>
+        /// <summary>
+        /// Retrieves the context associated with the app domain.
+        /// </summary>
         public static BufferedGraphicsContext Current
         {
             get
@@ -45,10 +41,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\BufferedGraphicsManager.uex' path='docs/doc[@for="BufferedGraphicsManager.OnProcessExit"]/*' />
-        /// <devdoc>
-        ///         Called on process exit
-        /// </devdoc>
+        /// <summary>
+        /// Called on process exit
+        /// </summary>
         [PrePrepareMethod]
         private static void OnShutdown(object sender, EventArgs e)
         {

--- a/src/System.Drawing.Common/src/System/Drawing/ColorTranslator.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/ColorTranslator.cs
@@ -2,15 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
+using System.Globalization;
+
 namespace System.Drawing
 {
-    using System.Collections;
-    using System.Globalization;
-
-    /// <include file='doc\ColorTranslator.uex' path='docs/doc[@for="ColorTranslator"]/*' />
-    /// <devdoc>
-    ///    Translates colors to and from GDI+ <see cref='System.Drawing.Color'/> objects.
-    /// </devdoc>
+    /// <summary>
+    /// Translates colors to and from GDI+ <see cref='Color'/> objects.
+    /// </summary>
     public sealed class ColorTranslator
     {
         private const int Win32RedShift = 0;
@@ -19,21 +18,17 @@ namespace System.Drawing
 
         private static Hashtable s_htmlSysColorTable;
 
-        /// <include file='doc\ColorTranslator.uex' path='docs/doc[@for="ColorTranslator.ToWin32"]/*' />
-        /// <devdoc>
-        ///    Translates the specified <see cref='System.Drawing.Color'/> to a
-        ///    Win32 color.
-        /// </devdoc>
+        /// <summary>
+        /// Translates the specified <see cref='Color'/> to a Win32 color.
+        /// </summary>
         public static int ToWin32(Color c)
         {
             return c.R << Win32RedShift | c.G << Win32GreenShift | c.B << Win32BlueShift;
         }
 
-        /// <include file='doc\ColorTranslator.uex' path='docs/doc[@for="ColorTranslator.ToOle"]/*' />
-        /// <devdoc>
-        ///    Translates the specified <see cref='System.Drawing.Color'/> to
-        ///    an Ole color.
-        /// </devdoc>
+        /// <summary>
+        /// Translates the specified <see cref='Color'/> to an Ole color.
+        /// </summary>
         public static int ToOle(Color c)
         {
             //    WARNING!!! WARNING!!! WARNING!!! WARNING!!! 
@@ -116,18 +111,17 @@ namespace System.Drawing
 
             return ToWin32(c);
         }
-        /// <include file='doc\ColorTranslator.uex' path='docs/doc[@for="ColorTranslator.FromOle"]/*' />
-        /// <devdoc>
-        ///    Translates an Ole color value to a GDI+
-        /// <see cref='System.Drawing.Color'/>.
-        /// </devdoc>
+
+        /// <summary>
+        /// Translates an Ole color value to a GDI+ <see cref='Color'/>.
+        /// </summary>
         public static Color FromOle(int oleColor)
         {
             //    WARNING!!! WARNING!!! WARNING!!! WARNING!!! 
             //    WARNING!!! WARNING!!! WARNING!!! WARNING!!!
             //    We must never have another method called ToOle() with a different signature.
             //    This is so that we can push into the runtime a custom marshaller for OLE_COLOR to Color.
-            
+
             switch (oleColor)
             {
                 case unchecked((int)0x8000000A):
@@ -199,21 +193,17 @@ namespace System.Drawing
             return KnownColorTable.ArgbToKnownColor(color.ToArgb());
         }
 
-        /// <include file='doc\ColorTranslator.uex' path='docs/doc[@for="ColorTranslator.FromWin32"]/*' />
-        /// <devdoc>
-        ///    Translates an Win32 color value to a
-        ///    GDI+ <see cref='System.Drawing.Color'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Translates an Win32 color value to a GDI+ <see cref='Color'/>.
+        /// </summary>
         public static Color FromWin32(int win32Color)
         {
             return FromOle(win32Color);
         }
 
-        /// <include file='doc\ColorTranslator.uex' path='docs/doc[@for="ColorTranslator.FromHtml"]/*' />
-        /// <devdoc>
-        ///    Translates an Html color representation to
-        ///    a GDI+ <see cref='System.Drawing.Color'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Translates an Html color representation to a GDI+ <see cref='Color'/>.
+        /// </summary>
         public static Color FromHtml(string htmlColor)
         {
             Color c = Color.Empty;
@@ -274,12 +264,9 @@ namespace System.Drawing
             return c;
         }
 
-        /// <include file='doc\ColorTranslator.uex' path='docs/doc[@for="ColorTranslator.ToHtml"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Translates the specified <see cref='System.Drawing.Color'/> to an Html string color representation.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Translates the specified <see cref='Color'/> to an Html string color representation.
+        /// </summary>
         public static string ToHtml(Color c)
         {
             string colorString = String.Empty;
@@ -291,36 +278,86 @@ namespace System.Drawing
             {
                 switch (c.ToKnownColor())
                 {
-                    case KnownColor.ActiveBorder: colorString = "activeborder"; break;
+                    case KnownColor.ActiveBorder:
+                        colorString = "activeborder";
+                        break;
                     case KnownColor.GradientActiveCaption:
-                    case KnownColor.ActiveCaption: colorString = "activecaption"; break;
-                    case KnownColor.AppWorkspace: colorString = "appworkspace"; break;
-                    case KnownColor.Desktop: colorString = "background"; break;
-                    case KnownColor.Control: colorString = "buttonface"; break;
-                    case KnownColor.ControlLight: colorString = "buttonface"; break;
-                    case KnownColor.ControlDark: colorString = "buttonshadow"; break;
-                    case KnownColor.ControlText: colorString = "buttontext"; break;
-                    case KnownColor.ActiveCaptionText: colorString = "captiontext"; break;
-                    case KnownColor.GrayText: colorString = "graytext"; break;
+                    case KnownColor.ActiveCaption:
+                        colorString = "activecaption";
+                        break;
+                    case KnownColor.AppWorkspace:
+                        colorString = "appworkspace";
+                        break;
+                    case KnownColor.Desktop:
+                        colorString = "background";
+                        break;
+                    case KnownColor.Control:
+                        colorString = "buttonface";
+                        break;
+                    case KnownColor.ControlLight:
+                        colorString = "buttonface";
+                        break;
+                    case KnownColor.ControlDark:
+                        colorString = "buttonshadow";
+                        break;
+                    case KnownColor.ControlText:
+                        colorString = "buttontext";
+                        break;
+                    case KnownColor.ActiveCaptionText:
+                        colorString = "captiontext";
+                        break;
+                    case KnownColor.GrayText:
+                        colorString = "graytext";
+                        break;
                     case KnownColor.HotTrack:
-                    case KnownColor.Highlight: colorString = "highlight"; break;
+                    case KnownColor.Highlight:
+                        colorString = "highlight";
+                        break;
                     case KnownColor.MenuHighlight:
-                    case KnownColor.HighlightText: colorString = "highlighttext"; break;
-                    case KnownColor.InactiveBorder: colorString = "inactiveborder"; break;
+                    case KnownColor.HighlightText:
+                        colorString = "highlighttext";
+                        break;
+                    case KnownColor.InactiveBorder:
+                        colorString = "inactiveborder";
+                        break;
                     case KnownColor.GradientInactiveCaption:
-                    case KnownColor.InactiveCaption: colorString = "inactivecaption"; break;
-                    case KnownColor.InactiveCaptionText: colorString = "inactivecaptiontext"; break;
-                    case KnownColor.Info: colorString = "infobackground"; break;
-                    case KnownColor.InfoText: colorString = "infotext"; break;
+                    case KnownColor.InactiveCaption:
+                        colorString = "inactivecaption";
+                        break;
+                    case KnownColor.InactiveCaptionText:
+                        colorString = "inactivecaptiontext";
+                        break;
+                    case KnownColor.Info:
+                        colorString = "infobackground";
+                        break;
+                    case KnownColor.InfoText:
+                        colorString = "infotext";
+                        break;
                     case KnownColor.MenuBar:
-                    case KnownColor.Menu: colorString = "menu"; break;
-                    case KnownColor.MenuText: colorString = "menutext"; break;
-                    case KnownColor.ScrollBar: colorString = "scrollbar"; break;
-                    case KnownColor.ControlDarkDark: colorString = "threeddarkshadow"; break;
-                    case KnownColor.ControlLightLight: colorString = "buttonhighlight"; break;
-                    case KnownColor.Window: colorString = "window"; break;
-                    case KnownColor.WindowFrame: colorString = "windowframe"; break;
-                    case KnownColor.WindowText: colorString = "windowtext"; break;
+                    case KnownColor.Menu:
+                        colorString = "menu";
+                        break;
+                    case KnownColor.MenuText:
+                        colorString = "menutext";
+                        break;
+                    case KnownColor.ScrollBar:
+                        colorString = "scrollbar";
+                        break;
+                    case KnownColor.ControlDarkDark:
+                        colorString = "threeddarkshadow";
+                        break;
+                    case KnownColor.ControlLightLight:
+                        colorString = "buttonhighlight";
+                        break;
+                    case KnownColor.Window:
+                        colorString = "window";
+                        break;
+                    case KnownColor.WindowFrame:
+                        colorString = "windowframe";
+                        break;
+                    case KnownColor.WindowText:
+                        colorString = "windowtext";
+                        break;
                 }
             }
             else if (c.IsNamedColor)

--- a/src/System.Drawing.Common/src/System/Drawing/ContentAlignment.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/ContentAlignment.cs
@@ -4,83 +4,46 @@
 
 namespace System.Drawing
 {
-    /// <include file='doc\ContentAlignment.uex' path='docs/doc[@for="ContentAlignment"]/*' />
-    /// <devdoc>
-    ///    <para>
-    ///       Specifies alignment of content on the drawing surface.
-    ///    </para>
-    /// </devdoc>
+    /// <summary>
+    /// Specifies alignment of content on the drawing surface.
+    /// </summary>
     public enum ContentAlignment
     {
-        /// <include file='doc\ContentAlignment.uex' path='docs/doc[@for="ContentAlignment.TopLeft"]/*' />
-        /// <devdoc>
-        ///    Content is vertically aligned at the top, and horizontally
-        ///    aligned on the left.
-        /// </devdoc>
+        /// <summary>
+        /// Content is vertically aligned at the top, and horizontally aligned on the left.
+        /// </summary>
         TopLeft = 0x001,
-        /// <include file='doc\ContentAlignment.uex' path='docs/doc[@for="ContentAlignment.TopCenter"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Content is vertically aligned at the top, and
-        ///       horizontally aligned at the center.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Content is vertically aligned at the top, and horizontally aligned at the center.
+        /// </summary>
         TopCenter = 0x002,
-        /// <include file='doc\ContentAlignment.uex' path='docs/doc[@for="ContentAlignment.TopRight"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Content is vertically aligned at the top, and
-        ///       horizontally aligned on the right.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Content is vertically aligned at the top, and horizontally aligned on the right.
+        /// </summary>
         TopRight = 0x004,
-        /// <include file='doc\ContentAlignment.uex' path='docs/doc[@for="ContentAlignment.MiddleLeft"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Content is vertically aligned in the middle, and
-        ///       horizontally aligned on the left.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Content is vertically aligned in the middle, and horizontally aligned on the left.
+        /// </summary>
         MiddleLeft = 0x010,
-        /// <include file='doc\ContentAlignment.uex' path='docs/doc[@for="ContentAlignment.MiddleCenter"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Content is vertically aligned in the middle, and
-        ///       horizontally aligned at the center.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Content is vertically aligned in the middle, and horizontally aligned at the center.
+        /// </summary>
         MiddleCenter = 0x020,
-        /// <include file='doc\ContentAlignment.uex' path='docs/doc[@for="ContentAlignment.MiddleRight"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Content is vertically aligned in the middle, and horizontally aligned on the
-        ///       right.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Content is vertically aligned in the middle, and horizontally aligned on the right.
+        /// </summary>
         MiddleRight = 0x040,
-        /// <include file='doc\ContentAlignment.uex' path='docs/doc[@for="ContentAlignment.BottomLeft"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Content is vertically aligned at the bottom, and horizontally aligned on the
-        ///       left.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Content is vertically aligned at the bottom, and horizontally aligned on the left.
+        /// </summary>
         BottomLeft = 0x100,
-        /// <include file='doc\ContentAlignment.uex' path='docs/doc[@for="ContentAlignment.BottomCenter"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Content is vertically aligned at the bottom, and horizontally aligned at the
-        ///       center.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Content is vertically aligned at the bottom, and horizontally aligned at the center.
+        /// </summary>
         BottomCenter = 0x200,
-        /// <include file='doc\ContentAlignment.uex' path='docs/doc[@for="ContentAlignment.BottomRight"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Content is vertically aligned at the bottom, and horizontally aligned on the
-        ///       right.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Content is vertically aligned at the bottom, and horizontally aligned on the right.
+        /// </summary>
         BottomRight = 0x400,
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/CopyPixelOperation.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/CopyPixelOperation.cs
@@ -4,158 +4,34 @@
 
 namespace System.Drawing
 {
-    /// <include file='doc\CopyPixelOperation.uex' path='docs/doc[@for="CopyPixelOperation"]/*' />
-    /// <devdoc>
-    ///    <para>
-    ///       Specifies the
-    ///       Copy Pixel (ROP) operation.
-    ///    </para>
-    /// </devdoc>
+    /// <summary>
+    /// Specifies the Copy Pixel (ROP) operation.
+    /// </summary>
     [System.Runtime.InteropServices.ComVisible(true)]
     public enum CopyPixelOperation
     {
-        /// <include file='doc\CopyPixelOperation.uex' path='docs/doc[@for="CopyPixelOperation.Blackness"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Fills the Destination Rectangle using the color associated with the index 0 in the physical palette.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Fills the Destination Rectangle using the color associated with the index 0 in the physical palette.
+        /// </summary>
         Blackness = SafeNativeMethods.BLACKNESS,
-
-        /// <include file='doc\CopyPixelOperation.uex' path='docs/doc[@for="CopyPixelOperation.CaptureBlt"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Includes any windows that are Layered on Top.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Includes any windows that are Layered on Top.
+        /// </summary>
         CaptureBlt = SafeNativeMethods.CAPTUREBLT,
-
-        /// <include file='doc\CopyPixelOperation.uex' path='docs/doc[@for="CopyPixelOperation.DestinationInvert"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       DestinationInvert.
-        ///    </para>
-        /// </devdoc>
         DestinationInvert = SafeNativeMethods.DSTINVERT,
-
-        /// <include file='doc\CopyPixelOperation.uex' path='docs/doc[@for="CopyPixelOperation.MergeCopy"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       MergeCopy.
-        ///    </para>
-        /// </devdoc>
         MergeCopy = SafeNativeMethods.MERGECOPY,
-
-        /// <include file='doc\CopyPixelOperation.uex' path='docs/doc[@for="CopyPixelOperation.MergePaint"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       MergePaint.
-        ///    </para>
-        /// </devdoc>
         MergePaint = SafeNativeMethods.MERGEPAINT,
-
-
-        /// <include file='doc\CopyPixelOperation.uex' path='docs/doc[@for="CopyPixelOperation.NoMirrorBitmap"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       NoMirrorBitmap.
-        ///    </para>
-        /// </devdoc>
         NoMirrorBitmap = SafeNativeMethods.NOMIRRORBITMAP,
-
-
-        /// <include file='doc\CopyPixelOperation.uex' path='docs/doc[@for="CopyPixelOperation.NotSourceCopy"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       NotSourceCopy.
-        ///    </para>
-        /// </devdoc>
         NotSourceCopy = SafeNativeMethods.NOTSRCCOPY,
-
-
-        /// <include file='doc\CopyPixelOperation.uex' path='docs/doc[@for="CopyPixelOperation.NotSourceErase"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       NotSourceErase.
-        ///    </para>
-        /// </devdoc>
         NotSourceErase = SafeNativeMethods.NOTSRCERASE,
-
-
-
-        /// <include file='doc\CopyPixelOperation.uex' path='docs/doc[@for="CopyPixelOperation.PatCopy"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       PatCopy.
-        ///    </para>
-        /// </devdoc>
         PatCopy = SafeNativeMethods.PATCOPY,
-
-
-
-        /// <include file='doc\CopyPixelOperation.uex' path='docs/doc[@for="CopyPixelOperation.PatInvert"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       PatInvert.
-        ///    </para>
-        /// </devdoc>
         PatInvert = SafeNativeMethods.PATINVERT,
-
-
-        /// <include file='doc\CopyPixelOperation.uex' path='docs/doc[@for="CopyPixelOperation.PatPaint"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       PatPaint.
-        ///    </para>
-        /// </devdoc>
         PatPaint = SafeNativeMethods.PATPAINT,
-
-        /// <include file='doc\CopyPixelOperation.uex' path='docs/doc[@for="CopyPixelOperation.SourceAnd"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       SourceAnd.
-        ///    </para>
-        /// </devdoc>
         SourceAnd = SafeNativeMethods.SRCAND,
-
-        /// <include file='doc\CopyPixelOperation.uex' path='docs/doc[@for="CopyPixelOperation.SourceCopy"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       SourceCopy.
-        ///    </para>
-        /// </devdoc>
         SourceCopy = SafeNativeMethods.SRCCOPY,
-
-        /// <include file='doc\CopyPixelOperation.uex' path='docs/doc[@for="CopyPixelOperation.SourceErase"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       SourceErase.
-        ///    </para>
-        /// </devdoc>
         SourceErase = SafeNativeMethods.SRCERASE,
-
-        /// <include file='doc\CopyPixelOperation.uex' path='docs/doc[@for="CopyPixelOperation.SourceInvert"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       SourceInvert.
-        ///    </para>
-        /// </devdoc>
         SourceInvert = SafeNativeMethods.SRCINVERT,
-
-        /// <include file='doc\CopyPixelOperation.uex' path='docs/doc[@for="CopyPixelOperation.SourcePaint"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       SourcePaint.
-        ///    </para>
-        /// </devdoc>
         SourcePaint = SafeNativeMethods.SRCPAINT,
-
-        /// <include file='doc\CopyPixelOperation.uex' path='docs/doc[@for="CopyPixelOperation.Whiteness"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Whiteness.
-        ///    </para>
-        /// </devdoc>
         Whiteness = SafeNativeMethods.WHITENESS,
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/DashCap.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/DashCap.cs
@@ -4,30 +4,13 @@
 
 namespace System.Drawing.Drawing2D
 {
-    /**
-     * Line cap constants
-     */
-    /// <include file='doc\DashCap.uex' path='docs/doc[@for="DashCap"]/*' />
-    /// <devdoc>
-    ///    Specifies the available dash cap
-    ///    styles with which a <see cref='System.Drawing.Pen'/> can end a line.
-    /// </devdoc>
+    /// <summary>
+    /// Specifies the available dash cap styles with which a <see cref='Pen'/> can end a line.
+    /// </summary>
     public enum DashCap
     {
-        /// <include file='doc\DashCap.uex' path='docs/doc[@for="DashCap.Flat"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         Flat = 0,
-        /// <include file='doc\DashCap.uex' path='docs/doc[@for="DashCap.Round"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         Round = 2,
-        /// <include file='doc\DashCap.uex' path='docs/doc[@for="DashCap.Triangle"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         Triangle = 3
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/Design/CategoryNameCollection.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Design/CategoryNameCollection.cs
@@ -2,45 +2,37 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
+
 namespace System.Drawing.Design
 {
-    using System.Collections;
-
-    /// <include file='doc\CategoryNameCollection.uex' path='docs/doc[@for="CategoryNameCollection"]/*' />
-    /// <devdoc>
-    ///     <para>
-    ///       A collection that stores <see cref='System.String'/> objects.
-    ///    </para>
-    /// </devdoc>
+    /// <summary>
+    /// A collection that stores <see cref='string'/> objects.
+    /// </summary>
     [System.Security.Permissions.PermissionSetAttribute(System.Security.Permissions.SecurityAction.LinkDemand, Name = "FullTrust")]
     public sealed class CategoryNameCollection : ReadOnlyCollectionBase
     {
-        /// <include file='doc\CategoryNameCollection.uex' path='docs/doc[@for="CategoryNameCollection.CategoryNameCollection"]/*' />
-        /// <devdoc>
-        ///     <para>
-        ///       Initializes a new instance of <see cref='System.Drawing.Design.CategoryNameCollection'/> based on another <see cref='System.Drawing.Design.CategoryNameCollection'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of <see cref='CategoryNameCollection'/> based on another
+        /// <see cref='CategoryNameCollection'/>.
+        /// </summary>
         public CategoryNameCollection(CategoryNameCollection value)
         {
             InnerList.AddRange(value);
         }
 
-        /// <include file='doc\CategoryNameCollection.uex' path='docs/doc[@for="CategoryNameCollection.CategoryNameCollection1"]/*' />
-        /// <devdoc>
-        ///     <para>
-        ///       Initializes a new instance of <see cref='System.Drawing.Design.CategoryNameCollection'/> containing any array of <see cref='System.String'/> objects.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of <see cref='CategoryNameCollection'/> containing any array of
+        /// <see cref='string'/> objects.
+        /// </summary>
         public CategoryNameCollection(String[] value)
         {
             InnerList.AddRange(value);
         }
 
-        /// <include file='doc\CategoryNameCollection.uex' path='docs/doc[@for="CategoryNameCollection.this"]/*' />
-        /// <devdoc>
-        /// <para>Represents the entry at the specified index of the <see cref='System.String'/>.</para>
-        /// </devdoc>
+        /// <summary>
+        /// Represents the entry at the specified index of the <see cref='string'/>.
+        /// </summary>
         public string this[int index]
         {
             get
@@ -49,35 +41,30 @@ namespace System.Drawing.Design
             }
         }
 
-        /// <include file='doc\CategoryNameCollection.uex' path='docs/doc[@for="CategoryNameCollection.Contains"]/*' />
-        /// <devdoc>
-        /// <para>Gets a value indicating whether the 
-        ///    <see cref='System.Drawing.Design.CategoryNameCollection'/> contains the specified <see cref='System.String'/>.</para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets a value indicating whether the  <see cref='CategoryNameCollection'/> contains the specified
+        /// <see cref='string'/>.
+        /// </summary>
         public bool Contains(string value)
         {
             return InnerList.Contains(value);
         }
 
-        /// <include file='doc\CategoryNameCollection.uex' path='docs/doc[@for="CategoryNameCollection.CopyTo"]/*' />
-        /// <devdoc>
-        /// <para>Copies the <see cref='System.Drawing.Design.CategoryNameCollection'/> values to a one-dimensional <see cref='System.Array'/> instance at the 
-        ///    specified index.</para>
-        /// </devdoc>
+        /// <summary>
+        /// Copies the <see cref='CategoryNameCollection'/> values to a one-dimensional <see cref='Array'/> instance
+        /// at the specified index.
+        /// </summary>
         public void CopyTo(String[] array, int index)
         {
             InnerList.CopyTo(array, index);
         }
 
-        /// <include file='doc\CategoryNameCollection.uex' path='docs/doc[@for="CategoryNameCollection.IndexOf"]/*' />
-        /// <devdoc>
-        ///    <para>Returns the index of a <see cref='System.String'/> in 
-        ///       the <see cref='System.Drawing.Design.CategoryNameCollection'/> .</para>
-        /// </devdoc>
+        /// <summary>
+        /// Returns the index of a <see cref='string'/> in  the <see cref='CategoryNameCollection'/> .
+        /// </summary>
         public int IndexOf(string value)
         {
             return InnerList.IndexOf(value);
         }
     }
 }
-

--- a/src/System.Drawing.Common/src/System/Drawing/Font.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Font.cs
@@ -2,23 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Drawing.Internal;
+using System.Globalization;
+using System.Runtime.InteropServices;
+
 namespace System.Drawing
 {
-    using System.ComponentModel;
-    using System.Diagnostics;
-    using System.Drawing.Internal;
-    using System.Globalization;
-    using System.Runtime.InteropServices;
-
-    /*
-    * Represent a font object
-    */
-
-    /// <include file='doc\Font.uex' path='docs/doc[@for="Font"]/*' />
-    /// <devdoc>
-    ///    Defines a particular format for text,
-    ///    including font face, size, and style attributes.
-    /// </devdoc>
+    /// <summary>
+    /// Defines a particular format for text, including font face, size, and style attributes.
+    /// </summary>
     [ComVisible(true)]
     public sealed partial class Font : MarshalByRefObject, ICloneable, IDisposable
     {
@@ -35,9 +29,9 @@ namespace System.Drawing
         private string _systemFontName = "";
         private string _originalFontName;
 
-        ///<devdoc>
-        ///     Creates the GDI+ native font object.
-        ///</devdoc>
+        ///<summary>
+        /// Creates the GDI+ native font object.
+        ///</summary>
         private void CreateNativeFont()
         {
             Debug.Assert(_nativeFont == IntPtr.Zero, "nativeFont already initialized, this will generate a handle leak.");
@@ -63,13 +57,10 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.Font"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Font'/> class from
-        ///       the specified existing <see cref='System.Drawing.Font'/> and <see cref='System.Drawing.FontStyle'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Font'/> class from the specified existing <see cref='Font'/>
+        /// and <see cref='FontStyle'/>.
+        /// </summary>
         public Font(Font prototype, FontStyle newStyle)
         {
             // Copy over the originalFontName because it won't get initialized
@@ -77,52 +68,42 @@ namespace System.Drawing
             Initialize(prototype.FontFamily, prototype.Size, newStyle, prototype.Unit, SafeNativeMethods.DEFAULT_CHARSET, false);
         }
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.Font1"]/*' />
-        /// <devdoc>
-        ///    Initializes a new instance of the <see cref='System.Drawing.Font'/> class with
-        ///    the specified attributes.
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Font'/> class with the specified attributes.
+        /// </summary>
         public Font(FontFamily family, float emSize, FontStyle style, GraphicsUnit unit)
         {
             Initialize(family, emSize, style, unit, SafeNativeMethods.DEFAULT_CHARSET, false);
         }
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.Font9"]/*' />
-        /// <devdoc>
-        ///    Initializes a new instance of the <see cref='System.Drawing.Font'/> class with
-        ///    the specified attributes.
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Font'/> class with the specified attributes.
+        /// </summary>
         public Font(FontFamily family, float emSize, FontStyle style, GraphicsUnit unit, byte gdiCharSet)
         {
             Initialize(family, emSize, style, unit, gdiCharSet, false);
         }
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.Font11"]/*' />
-        /// <devdoc>
-        ///    Initializes a new instance of the <see cref='System.Drawing.Font'/> class with
-        ///    the specified attributes.
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Font'/> class with the specified attributes.
+        /// </summary>
         public Font(FontFamily family, float emSize, FontStyle style, GraphicsUnit unit, byte gdiCharSet, bool gdiVerticalFont)
         {
             Initialize(family, emSize, style, unit, gdiCharSet, gdiVerticalFont);
         }
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.Font10"]/*' />
-        /// <devdoc>
-        ///    Initializes a new instance of the <see cref='System.Drawing.Font'/> class with
-        ///    the specified attributes.
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Font'/> class with the specified attributes.
+        /// </summary>
         public Font(string familyName, float emSize, FontStyle style, GraphicsUnit unit, byte gdiCharSet)
         {
             Initialize(familyName, emSize, style, unit, gdiCharSet, IsVerticalName(familyName));
         }
 
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.Font12"]/*' />
-        /// <devdoc>
-        ///    Initializes a new instance of the <see cref='System.Drawing.Font'/> class with
-        ///    the specified attributes.
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Font'/> class with the specified attributes.
+        /// </summary>
         public Font(string familyName, float emSize, FontStyle style, GraphicsUnit unit, byte gdiCharSet, bool gdiVerticalFont)
         {
             if (float.IsNaN(emSize) || float.IsInfinity(emSize) || emSize <= 0)
@@ -133,83 +114,65 @@ namespace System.Drawing
             Initialize(familyName, emSize, style, unit, gdiCharSet, gdiVerticalFont);
         }
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.Font2"]/*' />
-        /// <devdoc>
-        ///    Initializes a new instance of the <see cref='System.Drawing.Font'/> class with
-        ///    the specified attributes.
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Font'/> class with the specified attributes.
+        /// </summary>
         public Font(FontFamily family, float emSize, FontStyle style)
         {
             Initialize(family, emSize, style, GraphicsUnit.Point, SafeNativeMethods.DEFAULT_CHARSET, false);
         }
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.Font3"]/*' />
-        /// <devdoc>
-        ///    Initializes a new instance of the <see cref='System.Drawing.Font'/> class with
-        ///    the specified attributes.
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Font'/> class with the specified attributes.
+        /// </summary>
         public Font(FontFamily family, float emSize, GraphicsUnit unit)
         {
             Initialize(family, emSize, FontStyle.Regular, unit, SafeNativeMethods.DEFAULT_CHARSET, false);
         }
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.Font4"]/*' />
-        /// <devdoc>
-        ///    Initializes a new instance of the <see cref='System.Drawing.Font'/> class with
-        ///    the specified attributes.
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Font'/> class with the specified attributes.
+        /// </summary>
         public Font(FontFamily family, float emSize)
         {
             Initialize(family, emSize, FontStyle.Regular, GraphicsUnit.Point, SafeNativeMethods.DEFAULT_CHARSET, false);
         }
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.Font5"]/*' />
-        /// <devdoc>
-        ///    Initializes a new instance of the <see cref='System.Drawing.Font'/> class with
-        ///    the specified attributes.
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Font'/> class with the specified attributes.
+        /// </summary>
         public Font(string familyName, float emSize, FontStyle style, GraphicsUnit unit)
         {
             Initialize(familyName, emSize, style, unit, SafeNativeMethods.DEFAULT_CHARSET, IsVerticalName(familyName));
         }
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.Font6"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Font'/> class with
-        ///       the specified
-        ///       attributes.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Font'/> class with the specified attributes.
+        /// </summary>
         public Font(string familyName, float emSize, FontStyle style)
         {
             Initialize(familyName, emSize, style, GraphicsUnit.Point, SafeNativeMethods.DEFAULT_CHARSET, IsVerticalName(familyName));
         }
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.Font7"]/*' />
-        /// <devdoc>
-        ///    Initializes a new instance of the <see cref='System.Drawing.Font'/> class with
-        ///    the specified attributes.
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Font'/> class with the specified attributes.
+        /// </summary>
         public Font(string familyName, float emSize, GraphicsUnit unit)
         {
             Initialize(familyName, emSize, FontStyle.Regular, unit, SafeNativeMethods.DEFAULT_CHARSET, IsVerticalName(familyName));
         }
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.Font8"]/*' />
-        /// <devdoc>
-        ///    Initializes a new instance of the <see cref='System.Drawing.Font'/> class with
-        ///    the specified attributes.
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Font'/> class with the specified attributes.
+        /// </summary>
         public Font(string familyName, float emSize)
         {
             Initialize(familyName, emSize, FontStyle.Regular, GraphicsUnit.Point, SafeNativeMethods.DEFAULT_CHARSET, IsVerticalName(familyName));
         }
 
-        /// <devdoc>
-        ///     Constructor to initialize fields from an exisiting native GDI+ object reference.
-        ///     Used by ToLogFont.
-        /// </devdoc>
+        /// <summary>
+        /// Constructor to initialize fields from an exisiting native GDI+ object reference. Used by ToLogFont.
+        /// </summary>
         private Font(IntPtr nativeFont, byte gdiCharSet, bool gdiVerticalFont)
         {
             Debug.Assert(_nativeFont == IntPtr.Zero, "GDI+ native font already initialized, this will generate a handle leak");
@@ -248,9 +211,9 @@ namespace System.Drawing
             Initialize(_fontFamily, size, style, unit, gdiCharSet, gdiVerticalFont);
         }
 
-        /// <devdoc>
-        ///     Initializes this object's fields.
-        /// </devdoc>
+        /// <summary>
+        /// Initializes this object's fields.
+        /// </summary>
         private void Initialize(string familyName, float emSize, FontStyle style, GraphicsUnit unit, byte gdiCharSet, bool gdiVerticalFont)
         {
             _originalFontName = familyName;
@@ -259,9 +222,9 @@ namespace System.Drawing
             Initialize(_fontFamily, emSize, style, unit, gdiCharSet, gdiVerticalFont);
         }
 
-        /// <devdoc>
-        ///     Initializes this object's fields.
-        /// </devdoc>
+        /// <summary>
+        /// Initializes this object's fields.
+        /// </summary>
         private void Initialize(FontFamily family, float emSize, FontStyle style, GraphicsUnit unit, byte gdiCharSet, bool gdiVerticalFont)
         {
             if (family == null)
@@ -300,11 +263,9 @@ namespace System.Drawing
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.FromHfont"]/*' />
-        /// <devdoc>
-        ///    Creates a <see cref='System.Drawing.Font'/> from the specified Windows
-        ///    handle.
-        /// </devdoc>
+        /// <summary>
+        /// Creates a <see cref='System.Drawing.Font'/> from the specified Windows handle.
+        /// </summary>
         public static Font FromHfont(IntPtr hfont)
         {
             SafeNativeMethods.LOGFONT lf = new SafeNativeMethods.LOGFONT();
@@ -324,11 +285,6 @@ namespace System.Drawing
             return result;
         }
 
-
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.FromLogFont"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public static Font FromLogFont(object lf)
         {
             IntPtr screenDC = UnsafeNativeMethods.GetDC(NativeMethods.NullHandleRef);
@@ -344,10 +300,6 @@ namespace System.Drawing
             return result;
         }
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.FromLogFont1"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public static Font FromLogFont(object lf, IntPtr hdc)
         {
             IntPtr font = IntPtr.Zero;
@@ -369,11 +321,9 @@ namespace System.Drawing
 #pragma warning restore 0618
         }
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.FromHdc"]/*' />
-        /// <devdoc>
-        ///    Creates a Font from the specified Windows
-        ///    handle to a device context.
-        /// </devdoc>
+        /// <summary>
+        /// Creates a Font from the specified Windows handle to a device context.
+        /// </summary>
         public static Font FromHdc(IntPtr hdc)
         {
             IntPtr font = IntPtr.Zero;
@@ -390,10 +340,9 @@ namespace System.Drawing
         }
 
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.Clone"]/*' />
-        /// <devdoc>
-        ///    Creates an exact copy of this <see cref='System.Drawing.Font'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Creates an exact copy of this <see cref='Font'/>.
+        /// </summary>
         public object Clone()
         {
             IntPtr cloneFont = IntPtr.Zero;
@@ -409,10 +358,9 @@ namespace System.Drawing
         }
 
 
-        /// <devdoc>
-        ///     Get native GDI+ object pointer.
-        ///     This property triggers the creation of the GDI+ native object if not initialized yet.
-        /// </devdoc>
+        /// <summary>
+        /// Get native GDI+ object pointer. This property triggers the creation of the GDI+ native object if not initialized yet.
+        /// </summary>
         internal IntPtr NativeFont
         {
             get
@@ -422,10 +370,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.FontFamily"]/*' />
-        /// <devdoc>
-        ///    Gets the <see cref='System.Drawing.FontFamily'/> of this <see cref='System.Drawing.Font'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets the <see cref='Drawing.FontFamily'/> of this <see cref='Font'/>.
+        /// </summary>
         [Browsable(false)]
         public FontFamily FontFamily
         {
@@ -447,19 +394,17 @@ namespace System.Drawing
             GC.SuppressFinalize(_fontFamily);
         }
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.Finalize"]/*' />
-        /// <devdoc>
-        ///    Cleans up Windows resources for this <see cref='System.Drawing.Font'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Cleans up Windows resources for this <see cref='Font'/>.
+        /// </summary>
         ~Font()
         {
             Dispose(false);
         }
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.Dispose"]/*' />
-        /// <devdoc>
-        ///    Cleans up Windows resources for this <see cref='System.Drawing.Font'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Cleans up Windows resources for this <see cref='Font'/>.
+        /// </summary>
         public void Dispose()
         {
             Dispose(true);
@@ -501,12 +446,9 @@ namespace System.Drawing
             return familyName != null && familyName.Length > 0 && familyName[0] == '@';
         }
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.Bold"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets a value indicating whether this <see cref='System.Drawing.Font'/> is bold.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets a value indicating whether this <see cref='System.Drawing.Font'/> is bold.
+        /// </summary>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool Bold
         {
@@ -516,15 +458,14 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.GdiCharSet"]/*' />
-        /// <devdoc>
+        /// <summary>
         ///     Returns the GDI char set for this instance of a font. This will only
         ///     be valid if this font was created from a classic GDI font definition,
         ///     like a LOGFONT or HFONT, or it was passed into the constructor.
         ///
         ///     This is here for compatability with native Win32 intrinsic controls
         ///     on non-Unicode platforms.
-        /// </devdoc>
+        /// </summary>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public byte GdiCharSet
         {
@@ -534,16 +475,12 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.GdiVerticalFont"]/*' />
-        /// <devdoc>
-        ///     Determines if this font was created to represt a GDI vertical font.
-        ///     his will only be valid if this font was created from a classic GDI
-        ///     font definition, like a LOGFONT or HFONT, or it was passed into the 
-        ///     constructor.
+        /// <summary>
+        /// Determines if this font was created to represt a GDI vertical font. This will only be valid if this font
+        /// was created from a classic GDIfont definition, like a LOGFONT or HFONT, or it was passed into the constructor.
         ///
-        ///     This is here for compatability with native Win32 intrinsic controls
-        ///     on non-Unicode platforms.
-        /// </devdoc>
+        /// This is here for compatability with native Win32 intrinsic controls on non-Unicode platforms.
+        /// </summary>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool GdiVerticalFont
         {
@@ -553,12 +490,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.Italic"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets a value indicating whether this <see cref='System.Drawing.Font'/> is Italic.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets a value indicating whether this <see cref='Font'/> is Italic.
+        /// </summary>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool Italic
         {
@@ -568,37 +502,27 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.Name"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets the face name of this <see cref='System.Drawing.Font'/> .
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets the face name of this <see cref='Font'/> .
+        /// </summary>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string Name
         {
             get { return FontFamily.Name; }
         }
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.OriginalFontName"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       This property is required by the framework and not intended to be used directly.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// This property is required by the framework and not intended to be used directly.
+        /// </summary>
         [Browsable(false)]
         public string OriginalFontName
         {
             get { return _originalFontName; }
         }
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.Strikeout"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets a value indicating whether this <see cref='System.Drawing.Font'/> is strikeout (has a line
-        ///       through it).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets a value indicating whether this <see cref='Font'/> is strikeout (has a line through it).
+        /// </summary>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool Strikeout
         {
@@ -608,12 +532,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.Underline"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets a value indicating whether this <see cref='System.Drawing.Font'/> is underlined.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets a value indicating whether this <see cref='Font'/> is underlined.
+        /// </summary>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool Underline
         {
@@ -623,11 +544,10 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.Equals"]/*' />
-        /// <devdoc>
-        ///    Returns a value indicating whether the
-        ///    specified object is a <see cref='System.Drawing.Font'/> equivalent to this <see cref='System.Drawing.Font'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Returns a value indicating whether the specified object is a <see cref='Font'/> equivalent to this
+        /// <see cref='Font'/>.
+        /// </summary>
         public override bool Equals(object obj)
         {
             if (obj == this)
@@ -657,10 +577,9 @@ namespace System.Drawing
 
 
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.GetHashCode"]/*' />
-        /// <devdoc>
-        ///    Gets the hash code for this <see cref='System.Drawing.Font'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets the hash code for this <see cref='Font'/>.
+        /// </summary>
         public override int GetHashCode()
         {
             return unchecked((int)((((UInt32)_fontStyle << 13) | ((UInt32)_fontStyle >> 19)) ^
@@ -677,11 +596,9 @@ namespace System.Drawing
             return familyName;
         }
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.ToString"]/*' />
-        /// <devdoc>
-        ///    Returns a human-readable string
-        ///    representation of this <see cref='System.Drawing.Font'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Returns a human-readable string representation of this <see cref='Font'/>.
+        /// </summary>
         public override string ToString()
         {
             return string.Format(CultureInfo.CurrentCulture, "[{0}: Name={1}, Size={2}, Units={3}, GdiCharSet={4}, GdiVerticalFont={5}]",
@@ -693,14 +610,6 @@ namespace System.Drawing
                                     _gdiVerticalFont);
         }
 
-
-
-        // Operations
-
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.ToLogFont"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void ToLogFont(object logFont)
         {
             IntPtr screenDC = UnsafeNativeMethods.GetDC(NativeMethods.NullHandleRef);
@@ -723,10 +632,6 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.ToLogFont1"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public unsafe void ToLogFont(object logFont, Graphics graphics)
         {
             if (graphics == null)
@@ -759,10 +664,9 @@ namespace System.Drawing
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.ToHfont"]/*' />
-        /// <devdoc>
-        ///    Returns a handle to this <see cref='System.Drawing.Font'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Returns a handle to this <see cref='Font'/>.
+        /// </summary>
         public IntPtr ToHfont()
         {
             SafeNativeMethods.LOGFONT lf = new SafeNativeMethods.LOGFONT();
@@ -779,11 +683,9 @@ namespace System.Drawing
             return handle;
         }
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.GetHeight"]/*' />
-        /// <devdoc>
-        ///    Returns the height of this Font in the
-        ///    specified graphics context.
-        /// </devdoc>
+        /// <summary>
+        /// Returns the height of this Font in the specified graphics context.
+        /// </summary>
         public float GetHeight(Graphics graphics)
         {
             if (graphics == null)
@@ -799,9 +701,6 @@ namespace System.Drawing
             return ht;
         }
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.GetHeight1"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public float GetHeight()
         {
             IntPtr screenDC = UnsafeNativeMethods.GetDC(NativeMethods.NullHandleRef);
@@ -821,10 +720,6 @@ namespace System.Drawing
             return height;
         }
 
-
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.GetHeight2"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public float GetHeight(float dpi)
         {
             float ht;
@@ -837,11 +732,9 @@ namespace System.Drawing
             return ht;
         }
 
-
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.Style"]/*' />
-        /// <devdoc>
-        ///    Gets style information for this <see cref='System.Drawing.Font'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets style information for this <see cref='Font'/>.
+        /// </summary>
         [
         Browsable(false)
         ]
@@ -854,10 +747,9 @@ namespace System.Drawing
         }
 
         // Return value is in Unit (the unit the font was created in)
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.Size"]/*' />
-        /// <devdoc>
-        ///    Gets the size of this <see cref='System.Drawing.Font'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets the size of this <see cref='Font'/>.
+        /// </summary>
         public float Size
         {
             get
@@ -866,10 +758,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.SizeInPoints"]/*' />
-        /// <devdoc>
-        ///    Gets the size, in points, of this <see cref='System.Drawing.Font'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets the size, in points, of this <see cref='Font'/>.
+        /// </summary>
         [Browsable(false)]
         public float SizeInPoints
         {
@@ -904,10 +795,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.Unit"]/*' />
-        /// <devdoc>
-        ///    Gets the unit of measure for this <see cref='System.Drawing.Font'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets the unit of measure for this <see cref='Font'/>.
+        /// </summary>
         public GraphicsUnit Unit
         {
             get
@@ -916,10 +806,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.Height"]/*' />
-        /// <devdoc>
-        ///    Gets the height of this <see cref='System.Drawing.Font'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets the height of this <see cref='Font'/>.
+        /// </summary>
         [
         Browsable(false)
         ]
@@ -931,10 +820,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.IsSystemFont"]/*' />
-        /// <devdoc>
-        ///    Returns true if this <see cref='System.Drawing.Font'/> is a SystemFont.
-        /// </devdoc>
+        /// <summary>
+        /// Returns true if this <see cref='Font'/> is a SystemFont.
+        /// </summary>
         [
         Browsable(false)
         ]
@@ -946,10 +834,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Font.uex' path='docs/doc[@for="Font.SystemFontName"]/*' />
-        /// <devdoc>
-        ///    Gets the name of this <see cref='System.Drawing.SystemFont'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets the name of this <see cref='Drawing.SystemFont'/>.
+        /// </summary>
         [
         Browsable(false)
         ]
@@ -968,4 +855,3 @@ namespace System.Drawing
         }
     }
 }
-

--- a/src/System.Drawing.Common/src/System/Drawing/FontFamily.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/FontFamily.cs
@@ -2,26 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-/*
-* font family object (sdkinc\GDIplusFontFamily.h)
-*/
+using System.Diagnostics;
+using System.Drawing.Text;
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Text;
 
 namespace System.Drawing
 {
-    using System.Diagnostics;
-    using System.Drawing.Text;
-    using System.Globalization;
-    using System.Runtime.InteropServices;
-    using System.Text;
-
-    /**
-     * Represent a FontFamily object
-     */
-    /// <include file='doc\FontFamily.uex' path='docs/doc[@for="FontFamily"]/*' />
-    /// <devdoc>
-    ///    Abstracts a group of type faces having a
-    ///    similar basic design but having certain variation in styles.
-    /// </devdoc>
+    /// <summary>
+    /// Abstracts a group of type faces having a similar basic design but having certain variation in styles.
+    /// </summary>
     public sealed class FontFamily : MarshalByRefObject, IDisposable
     {
         private const int LANG_NEUTRAL = 0;
@@ -34,9 +25,9 @@ namespace System.Drawing
         private int _id;
 #endif
 
-        /// <devdoc>
-        ///     Sets the GDI+ native family.
-        /// </devdoc>
+        /// <summary>
+        /// Sets the GDI+ native family.
+        /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2106:SecureAsserts")]
         private void SetNativeFamily(IntPtr family)
         {
@@ -52,59 +43,49 @@ namespace System.Drawing
 #endif
         }
 
-        ///<devdoc>
-        ///     Internal constructor to initialize the native GDI+ font to an existing one.
-        ///     Used to create generic fonts and by FontCollection class.
-        ///</devdoc>
+        ///<summary>
+        /// Internal constructor to initialize the native GDI+ font to an existing one. Used to create generic fonts
+        /// and by FontCollection class.
+        ///</summary>
         internal FontFamily(IntPtr family)
         {
             SetNativeFamily(family);
         }
 
-        /// <include file='doc\FontFamily.uex' path='docs/doc[@for="FontFamily.FontFamily3"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.FontFamily'/>
-        ///       class with the specified name.
+        /// <summary>
+        /// Initializes a new instance of the <see cref='FontFamily'/> class with the specified name.
         ///
-        ///       The <paramref name="createDefaultOnFail"/> parameter determines how errors are
-        ///       handled when creating a font based on a font family that does not exist on the
-        ///       end user's system at run time. If this parameter is true, then a fall-back font
-        ///       will always be used instead. If this parameter is false, an exception will be thrown.
-        ///    </para>
-        /// </devdoc>
+        /// The <paramref name="createDefaultOnFail"/> parameter determines how errors are handled when creating a
+        /// font based on a font family that does not exist on the end user's system at run time. If this parameter is
+        /// true, then a fall-back fontwill always be used instead. If this parameter is false, an exception will be thrown.
+        /// </summary>
         internal FontFamily(string name, bool createDefaultOnFail)
         {
             _createDefaultOnFail = createDefaultOnFail;
             CreateFontFamily(name, null);
         }
 
-        /// <include file='doc\FontFamily.uex' path='docs/doc[@for="FontFamily.FontFamily"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.FontFamily'/>
-        ///       class with the specified name.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='FontFamily'/> class with the specified name.
+        /// </summary>
         public FontFamily(string name)
         {
             CreateFontFamily(name, null);
         }
 
-        /// <include file='doc\FontFamily.uex' path='docs/doc[@for="FontFamily.FontFamily1"]/*' />
-        /// <devdoc>
-        ///    Initializes a new instance of the <see cref='System.Drawing.FontFamily'/>
-        ///    class in the specified <see cref='System.Drawing.Text.FontCollection'/> and with the specified name.
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='FontFamily'/> class in the specified
+        /// <see cref='FontCollection'/> and with the specified name.
+        /// </summary>
         public FontFamily(string name, FontCollection fontCollection)
         {
             CreateFontFamily(name, fontCollection);
         }
 
-        /// <devdoc>
-        ///     Creates the native font family object.  
-        ///     Note: GDI+ creates singleton font family objects (from the corresponding font file) and reference count them.
-        /// </devdoc>
+        /// <summary>
+        /// Creates the native font family object. Note: GDI+ creates singleton font family objects (from the
+        /// corresponding font file) and reference count them.
+        /// </summary>
         private void CreateFontFamily(string name, FontCollection fontCollection)
         {
             IntPtr fontfamily = IntPtr.Zero;
@@ -139,11 +120,9 @@ namespace System.Drawing
             SetNativeFamily(fontfamily);
         }
 
-        /// <include file='doc\FontFamily.uex' path='docs/doc[@for="FontFamily.FontFamily2"]/*' />
-        /// <devdoc>
-        ///    Initializes a new instance of the <see cref='System.Drawing.FontFamily'/>
-        ///    class from the specified generic font family.
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='FontFamily'/> class from the specified generic font family.
+        /// </summary>
         public FontFamily(GenericFontFamilies genericFamily)
         {
             IntPtr fontfamily = IntPtr.Zero;
@@ -175,26 +154,18 @@ namespace System.Drawing
             SetNativeFamily(fontfamily);
         }
 
-        /// <include file='doc\FontFamily.uex' path='docs/doc[@for="FontFamily.Finalize"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Allows an object to free resources before the object is reclaimed by the
-        ///       Garbage Collector (<see langword='GC'/>).
-        ///    </para>
-        /// </devdoc>
         ~FontFamily()
         {
             Dispose(false);
         }
 
-        /// <devdoc>
-        ///     The GDI+ native font family.  It is shared by all FontFamily objects with same family name.
-        /// </devdoc>
+        /// <summary>
+        /// The GDI+ native font family. It is shared by all FontFamily objects with same family name.
+        /// </summary>
         internal IntPtr NativeFamily
         {
             get
             {
-                //Debug.Assert( this.nativeFamily != IntPtr.Zero, "this.nativeFamily == IntPtr.Zero." );
                 return _nativeFamily;
             }
         }
@@ -203,10 +174,6 @@ namespace System.Drawing
         // than AddRef (it doesn't copy the underlying GpFont), and in a garbage collected
         // world, that's not very useful.
 
-        /// <include file='doc\FontFamily.uex' path='docs/doc[@for="FontFamily.Equals"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public override bool Equals(object obj)
         {
             if (obj == this)
@@ -222,20 +189,17 @@ namespace System.Drawing
             return ff.NativeFamily == NativeFamily;
         }
 
-        /// <include file='doc\FontFamily.uex' path='docs/doc[@for="FontFamily.ToString"]/*' />
-        /// <devdoc>
-        ///    Converts this <see cref='System.Drawing.FontFamily'/> to a
-        ///    human-readable string.
-        /// </devdoc>
+        /// <summary>
+        /// Converts this <see cref='FontFamily'/> to a human-readable string.
+        /// </summary>
         public override string ToString()
         {
             return string.Format(CultureInfo.CurrentCulture, "[{0}: Name={1}]", GetType().Name, Name);
         }
 
-        /// <include file='doc\FontFamily.uex' path='docs/doc[@for="FontFamily.GetHashCode"]/*' />
-        /// <devdoc>
-        ///    Gets a hash code for this <see cref='System.Drawing.FontFamily'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets a hash code for this <see cref='FontFamily'/>.
+        /// </summary>
         public override int GetHashCode()
         {
             return GetName(LANG_NEUTRAL).GetHashCode();
@@ -249,10 +213,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\FontFamily.uex' path='docs/doc[@for="FontFamily.Dispose"]/*' />
-        /// <devdoc>
-        ///    Disposes of this <see cref='System.Drawing.FontFamily'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Disposes of this <see cref='FontFamily'/>.
+        /// </summary>
         public void Dispose()
         {
             Dispose(true);
@@ -289,10 +252,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\FontFamily.uex' path='docs/doc[@for="FontFamily.Name"]/*' />
-        /// <devdoc>
-        ///    Gets the name of this <see cref='System.Drawing.FontFamily'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets the name of this <see cref='FontFamily'/>.
+        /// </summary>
         public String Name
         {
             get
@@ -301,13 +263,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\FontFamily.uex' path='docs/doc[@for="FontFamily.GetName"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Retuns the name of this <see cref='System.Drawing.FontFamily'/> in
-        ///       the specified language.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Retuns the name of this <see cref='FontFamily'/> in the specified language.
+        /// </summary>
         public String GetName(int language)
         {
             // LF_FACESIZE is 32
@@ -322,12 +280,10 @@ namespace System.Drawing
         }
 
 
-        /// <include file='doc\FontFamily.uex' path='docs/doc[@for="FontFamily.Families"]/*' />
-        /// <devdoc>
-        ///    Returns an array that contains all of the
-        /// <see cref='System.Drawing.FontFamily'/> objects associated with the current graphics 
-        ///    context.
-        /// </devdoc>
+        /// <summary>
+        /// Returns an array that contains all of the <see cref='FontFamily'/> objects associated with the current
+        /// graphics context.
+        /// </summary>
         public static FontFamily[] Families
         {
             get
@@ -336,12 +292,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\FontFamily.uex' path='docs/doc[@for="FontFamily.GenericSansSerif"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets a generic SansSerif <see cref='System.Drawing.FontFamily'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets a generic SansSerif <see cref='FontFamily'/>.
+        /// </summary>
         public static FontFamily GenericSansSerif
         {
             get
@@ -362,10 +315,9 @@ namespace System.Drawing
             return fontfamily;
         }
 
-        /// <include file='doc\FontFamily.uex' path='docs/doc[@for="FontFamily.GenericSerif"]/*' />
-        /// <devdoc>
-        ///    Gets a generic Serif <see cref='System.Drawing.FontFamily'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets a generic Serif <see cref='FontFamily'/>.
+        /// </summary>
         public static FontFamily GenericSerif
         {
             get
@@ -386,10 +338,9 @@ namespace System.Drawing
             return fontfamily;
         }
 
-        /// <include file='doc\FontFamily.uex' path='docs/doc[@for="FontFamily.GenericMonospace"]/*' />
-        /// <devdoc>
-        ///    Gets a generic monospace <see cref='System.Drawing.FontFamily'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets a generic monospace <see cref='FontFamily'/>.
+        /// </summary>
         public static FontFamily GenericMonospace
         {
             get
@@ -410,16 +361,10 @@ namespace System.Drawing
             return fontfamily;
         }
 
-        // No longer support in FontFamily
-        // Obsolete API and need to be removed later
-        //
-        /// <include file='doc\FontFamily.uex' path='docs/doc[@for="FontFamily.GetFamilies"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Returns an array that contains all of the <see cref='System.Drawing.FontFamily'/> objects associated with
-        ///       the specified graphics context.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Returns an array that contains all of the <see cref='FontFamily'/> objects associated with the specified
+        /// graphics context.
+        /// </summary>
         [Obsolete("Do not use method GetFamilies, use property Families instead")]
         public static FontFamily[] GetFamilies(Graphics graphics)
         {
@@ -429,11 +374,9 @@ namespace System.Drawing
             return new InstalledFontCollection().Families;
         }
 
-        /// <include file='doc\FontFamily.uex' path='docs/doc[@for="FontFamily.IsStyleAvailable"]/*' />
-        /// <devdoc>
-        ///    Indicates whether the specified <see cref='System.Drawing.FontStyle'/> is
-        ///    available.
-        /// </devdoc>
+        /// <summary>
+        /// Indicates whether the specified <see cref='FontStyle'/> is available.
+        /// </summary>
         public bool IsStyleAvailable(FontStyle style)
         {
             int bresult;
@@ -446,11 +389,9 @@ namespace System.Drawing
             return bresult != 0;
         }
 
-        /// <include file='doc\FontFamily.uex' path='docs/doc[@for="FontFamily.GetEmHeight"]/*' />
-        /// <devdoc>
-        ///    Gets the size of the Em square for the
-        ///    specified style in font design units.
-        /// </devdoc>
+        /// <summary>
+        /// Gets the size of the Em square for the specified style in font design units.
+        /// </summary>
         public int GetEmHeight(FontStyle style)
         {
             int result = 0;
@@ -464,12 +405,9 @@ namespace System.Drawing
         }
 
 
-        /// <include file='doc\FontFamily.uex' path='docs/doc[@for="FontFamily.GetCellAscent"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Returns the ascender metric for Windows.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Returns the ascender metric for Windows.
+        /// </summary>
         public int GetCellAscent(FontStyle style)
         {
             int result = 0;
@@ -482,12 +420,9 @@ namespace System.Drawing
             return result;
         }
 
-        /// <include file='doc\FontFamily.uex' path='docs/doc[@for="FontFamily.GetCellDescent"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Returns the descender metric for Windows.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Returns the descender metric for Windows.
+        /// </summary>
         public int GetCellDescent(FontStyle style)
         {
             int result = 0;
@@ -500,11 +435,10 @@ namespace System.Drawing
             return result;
         }
 
-        /// <include file='doc\FontFamily.uex' path='docs/doc[@for="FontFamily.GetLineSpacing"]/*' />
-        /// <devdoc>
-        ///    Returns the distance between two
-        ///    consecutive lines of text for this <see cref='System.Drawing.FontFamily'/> with the specified <see cref='System.Drawing.FontStyle'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Returns the distance between two consecutive lines of text for this <see cref='FontFamily'/> with the
+        /// specified <see cref='FontStyle'/>.
+        /// </summary>
         public int GetLineSpacing(FontStyle style)
         {
             int result = 0;

--- a/src/System.Drawing.Common/src/System/Drawing/FontStyle.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/FontStyle.cs
@@ -2,49 +2,33 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-/*
-* font style constants (sdkinc\GDIplusEnums.h)
-*/
-
 namespace System.Drawing
 {
-    /// <include file='doc\FontStyle.uex' path='docs/doc[@for="FontStyle"]/*' />
-    /// <devdoc>
-    ///    <para>
-    ///       Specifies style information applied to
-    ///       text.
-    ///    </para>
-    /// </devdoc>
-    [
-    Flags
-    ]
+    /// <summary>
+    /// Specifies style information applied to text.
+    /// </summary>
+    [Flags]
     public enum FontStyle
     {
-        /// <include file='doc\FontStyle.uex' path='docs/doc[@for="FontStyle.Regular"]/*' />
-        /// <devdoc>
-        ///    Normal text.
-        /// </devdoc>
+        /// <summary>
+        /// Normal text.
+        /// </summary>
         Regular = 0,
-        /// <include file='doc\FontStyle.uex' path='docs/doc[@for="FontStyle.Bold"]/*' />
-        /// <devdoc>
-        ///    Bold text.
-        /// </devdoc>
+        /// <summary>
+        /// Bold text.
+        /// </summary>
         Bold = 1,
-        /// <include file='doc\FontStyle.uex' path='docs/doc[@for="FontStyle.Italic"]/*' />
-        /// <devdoc>
-        ///    Italic text.
-        /// </devdoc>
+        /// <summary>
+        /// Italic text.
+        /// </summary>
         Italic = 2,
-        /// <include file='doc\FontStyle.uex' path='docs/doc[@for="FontStyle.Underline"]/*' />
-        /// <devdoc>
-        ///    Underlined text.
-        /// </devdoc>
+        /// <summary>
+        /// Underlined text.
+        /// </summary>
         Underline = 4,
-        /// <include file='doc\FontStyle.uex' path='docs/doc[@for="FontStyle.Strikeout"]/*' />
-        /// <devdoc>
-        ///    Text with a line through the middle.
-        /// </devdoc>
+        /// <summary>
+        /// Text with a line through the middle.
+        /// </summary>
         Strikeout = 8,
     }
 }
-

--- a/src/System.Drawing.Common/src/System/Drawing/Gdiplus.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Gdiplus.cs
@@ -2,6 +2,28 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Internal;
+using System.Text;
+using System.Collections;
+using System.Runtime.InteropServices;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System;
+using System.IO;
+using Microsoft.Win32;
+using System.Drawing;
+using System.Drawing.Internal;
+using System.Drawing.Imaging;
+using System.Drawing.Text;
+using System.Drawing.Drawing2D;
+using System.Threading;
+using System.Security.Permissions;
+using System.Security;
+using System.Runtime.ConstrainedExecution;
+using System.Globalization;
+using System.Runtime.Versioning;
+
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources", Scope = "member", Target = "System.Drawing.SafeNativeMethods+BITMAP.bmBits")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources", Scope = "member", Target = "System.Drawing.SafeNativeMethods+DIBSECTION.dshSection")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources", Scope = "member", Target = "System.Drawing.SafeNativeMethods+Gdip.initToken")]
@@ -45,34 +67,8 @@
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "System.Drawing.SafeNativeMethods+Gdip")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "System.Drawing.SafeNativeMethods+ENHMETAHEADER..ctor()")]
 
-
-
-
-
 namespace System.Drawing
 {
-    using System.Internal;
-    using System.Text;
-    using System.Collections;
-    using System.Runtime.InteropServices;
-    using System.ComponentModel;
-    using System.Diagnostics;
-    using System.Diagnostics.CodeAnalysis;
-    using System;
-    using System.IO;
-    using Microsoft.Win32;
-    using System.Drawing;
-    using System.Drawing.Internal;
-    using System.Drawing.Imaging;
-    using System.Drawing.Text;
-    using System.Drawing.Drawing2D;
-    using System.Threading;
-    using System.Security.Permissions;
-    using System.Security;
-    using System.Runtime.ConstrainedExecution;
-    using System.Globalization;
-    using System.Runtime.Versioning;
-
     [System.Security.SuppressUnmanagedCodeSecurityAttribute()]
     internal class SafeNativeMethods
     {
@@ -90,9 +86,9 @@ namespace System.Drawing
                 Initialize();
             }
 
-            /// <devdoc>
-            ///      Returns true if GDI+ has been started, but not shut down
-            /// </devdoc>
+            /// <summary>
+            /// Returns true if GDI+ has been started, but not shut down
+            /// </summary>
             private static bool Initialized
             {
                 get
@@ -101,12 +97,11 @@ namespace System.Drawing
                 }
             }
 
-            /// <devdoc>
-            ///      This property will give us back a hashtable we can use to store
-            ///      all of our static brushes and pens on a per-thread basis.  This way   
-            ///      we can avoid 'object in use' crashes when different threads are
-            ///      referencing the same drawing object.
-            /// </devdoc>
+            /// <summary>
+            /// This property will give us back a hashtable we can use to store all of our static brushes and pens on
+            /// a per-thread basis. This way we can avoid 'object in use' crashes when different threads are
+            /// referencing the same drawing object.
+            /// </summary>
             internal static IDictionary ThreadData
             {
                 get
@@ -123,7 +118,6 @@ namespace System.Drawing
             }
 
             // Clean up thread data
-            //
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
             private static void ClearThreadData()
             {
@@ -132,10 +126,10 @@ namespace System.Drawing
                 Thread.SetData(slot, null);
             }
 
-            /// <devdoc>
-            ///      Initializes GDI+
-            ///      This should only be called by our constructor (static), we do not expect multiple calls per domain
-            /// </devdoc>
+            /// <summary>
+            /// Initializes GDI+
+            /// This should only be called by our constructor (static), we do not expect multiple calls per domain
+            /// </summary>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1804:RemoveUnusedLocals")]
             private static void Initialize()
             {
@@ -170,9 +164,9 @@ namespace System.Drawing
                 }
             }
 
-            /// <devdoc>
-            ///      Shutsdown GDI+
-            /// </devdoc>            
+            /// <summary>
+            /// Shutsdown GDI+
+            /// </summary>            
             private static void Shutdown()
             {
                 Debug.WriteLineIf(s_gdiPlusInitialization.TraceVerbose, "Shutdown GDI+ [" + AppDomain.CurrentDomain.FriendlyName + "]");
@@ -229,9 +223,7 @@ namespace System.Drawing
                 Shutdown();
             }
 
-            // Fix for Dev10 560430. When we call it in static constructor of other classes,
-            // JIT will make sure the static constructor of Gdip has been called before, 
-            // and GDI+ has been initialized.
+            // Used to ensure static constructor has run.
             internal static void DummyFunction()
             {
             }
@@ -3411,37 +3403,12 @@ namespace System.Drawing
             return System.Internal.HandleCollector.Add(IntCreateBitmap(width, height, planes, bpp, bitmapData), SafeNativeMethods.CommonHandles.GDI);
         }
 
-
-        // FxCop rule 'AvoidBuildingNonCallableCode' - Left here in case it is needed in the future.
-        //[DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling=true, EntryPoint="CreatePatternBrush", CharSet=System.Runtime.InteropServices.CharSet.Auto)]
-        //private static extern IntPtr /*HBRUSH*/ IntCreatePatternBrush(HandleRef hbmp);
-        //public static IntPtr /*HBRUSH*/ CreatePatternBrush(HandleRef hbmp) {
-        //    return System.Internal.HandleCollector.Add(IntCreatePatternBrush(hbmp), SafeNativeMethods.CommonHandles.GDI);
-        //}
-
-        /* FxCop rule 'AvoidBuildingNonCallableCode' - Left here in case it is needed in the future.
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling=true, CharSet=CharSet.Auto)]
-        public static extern long GetBitmapBits(HandleRef hbmp, long nBytes, byte[] buffer);
-        */
-
         [DllImport(ExternDll.Gdi32, SetLastError = true, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
         public static extern int BitBlt(HandleRef hDC, int x, int y, int nWidth, int nHeight,
                                          HandleRef hSrcDC, int xSrc, int ySrc, int dwRop);
-        /* FxCop rule 'AvoidBuildingNonCallableCode' - Left here in case it is needed in the future.        
-        [DllImport(ExternDll.Gdi32)]
-        public static extern IntPtr GetDIBits(HandleRef hdc, HandleRef hbm, int arg1, int arg2, IntPtr arg3, NativeMethods.BITMAPINFOHEADER bmi, int arg5);
-        */
 
         [DllImport(ExternDll.Gdi32)]
         public static extern int GetDIBits(HandleRef hdc, HandleRef hbm, int arg1, int arg2, IntPtr arg3, ref NativeMethods.BITMAPINFO_FLAT bmi, int arg5);
-
-        /* FxCop rule 'AvoidBuildingNonCallableCode' - Left here in case it is needed in the future.        
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling=true, CharSet=System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern int GetPaletteEntries(HandleRef hpal, int iStartIndex, int nEntries, int[] lppe);
-
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling=true, CharSet=System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern int GetPaletteEntries(HandleRef hpal, int iStartIndex, int nEntries, IntPtr lppe);
-        */
 
         [DllImport(ExternDll.Gdi32)]
         public static extern uint GetPaletteEntries(HandleRef hpal, int iStartIndex, int nEntries, byte[] lppe);
@@ -3473,11 +3440,6 @@ namespace System.Drawing
         [DllImport(ExternDll.Comdlg32, SetLastError = true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
         public static extern bool PrintDlg([In, Out] PRINTDLGX86 lppd);
 
-        /* FxCop rule 'AvoidBuildingNonCallableCode' - Left here in case it is needed in the future.                
-        [DllImport(ExternDll.Comdlg32, SetLastError=true, CharSet=System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern int PageSetupDlg([In, Out] PAGESETUPDLG lppsd);
-        */
-
         [DllImport(ExternDll.Winspool, SetLastError = true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
         public static extern int DeviceCapabilities(string pDevice, string pPort, short fwCapabilities, IntPtr pOutput, IntPtr /*DEVMODE*/ pDevMode);
 
@@ -3486,17 +3448,6 @@ namespace System.Drawing
 
         [DllImport(ExternDll.Winspool, SetLastError = true, CharSet = System.Runtime.InteropServices.CharSet.Auto, BestFitMapping = false)]
         public static extern int DocumentProperties(HandleRef hwnd, HandleRef hPrinter, string pDeviceName, IntPtr /*DEVMODE*/ pDevModeOutput, IntPtr /*DEVMODE*/ pDevModeInput, int fMode);
-
-        /* FxCop rule 'AvoidBuildingNonCallableCode' - Left here in case it is needed in the future.        
-        [DllImport(ExternDll.Winspool, SetLastError=true, CharSet=System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern int GetPrinter(HandleRef hPrinter, int level, HandleRef pPrinter, int cbBuf, int[] pcbNeeded);
-
-        [DllImport(ExternDll.Winspool, SetLastError=true, CharSet=System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern bool OpenPrinter(string pPrinterName, HandleRef [] phPrinter, HandleRef pDefault);
-        
-        [DllImport(ExternDll.Winspool, SetLastError=true, ExactSpelling=true, CharSet=System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern int ClosePrinter(HandleRef hPrinter);
-        */
 
         [DllImport(ExternDll.Winspool, SetLastError = true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
         public static extern int EnumPrinters(int flags, string name, int level, IntPtr pPrinterEnum/*buffer*/,
@@ -3528,53 +3479,6 @@ namespace System.Drawing
         {
             return AddFontResourceEx(fileName, /*FR_PRIVATE*/ 0x10, IntPtr.Zero);
         }
-
-
-        /* FxCop rule 'AvoidBuildingNonCallableCode' - Left here in case it is needed in the future.        
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling=true, CharSet=System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern int ExcludeClipRect(HandleRef hDC, int nLeftRect, int nTopRect, int nRightRect, int nBottomRect);
-
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling=true, CharSet=System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern int SaveDC(HandleRef hDC);
-
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling=true, CharSet=System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern bool RestoreDC(HandleRef hDC, int nSavedDC);        
-       
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling=true, CharSet=System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern bool SetWorldTransform(HandleRef hDC, NativeMethods.XFORM xform);
-
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling=true, CharSet=System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern bool ModifyWorldTransform( HandleRef hdc, NativeMethods.XFORM lpXform, int iMode );
-
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling=true, CharSet=System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern bool GetWorldTransform( HandleRef hdc, NativeMethods.XFORM lpXform );
-
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling=true, CharSet=System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern int SetGraphicsMode(HandleRef hDC, int iMode);
-
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling=true, CharSet=System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern int GetGraphicsMode(HandleRef hDC);
-
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling=true, CharSet=System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern int GetNearestColor(HandleRef hDC, int color);
-
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling=true, CharSet=System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern int GetRgnBox(HandleRef hRegion, ref RECT clipRect);
-
-
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling=true, EntryPoint="CreateCompatibleDC", CharSet=CharSet.Auto)]
-        public static extern IntPtr IntCreateCompatibleDC(HandleRef hDC);
-        public static IntPtr CreateCompatibleDC(HandleRef hDC) {
-            return System.Internal.HandleCollector.Add(IntCreateCompatibleDC(hDC), SafeNativeMethods.CommonHandles.GDI);
-        }
-        
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling=true, CharSet=System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern bool Polygon(HandleRef hDC, SafeNativeMethods.POINT[] points, int nCount);
-
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling=true, CharSet=System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern int SetPolyFillMode(HandleRef hDC, int nPolyFillMode);
-        */
-
 
         internal static IntPtr SaveClipRgn(IntPtr hDC)
         {
@@ -3626,19 +3530,6 @@ namespace System.Drawing
         }
         [DllImport(ExternDll.Kernel32)]
         static internal extern void ZeroMemory(IntPtr destination, UIntPtr length);
-
-        //
-        // WARNING: Don't uncomment this code unless you absolutelly need it.  Use instead Marshal.GetLastWin32Error
-        // and mark your PInvoke [DllImport(..., SetLastError=true)]
-        // From MSDN:
-        // GetLastWin32Error exposes the Win32 GetLastError API method from Kernel32.DLL. This method exists because 
-        // it is not safe to make a direct platform invoke call to GetLastError to obtain this information. If you 
-        // want to access this error code, you must call GetLastWin32Error rather than writing your own platform invoke 
-        // definition for GetLastError and calling it. The common language runtime can make internal calls to APIs that 
-        // overwrite the operating system maintained GetLastError.
-        //
-        //[DllImport(ExternDll.Kernel32, SetLastError=true, ExactSpelling=true, CharSet=System.Runtime.InteropServices.CharSet.Auto)]
-        //public extern static int GetLastError();
 
         public const int ERROR_ACCESS_DENIED = 5;
         public const int ERROR_INVALID_PARAMETER = 87;
@@ -3758,23 +3649,6 @@ namespace System.Drawing
             public int top;
             public int right;
             public int bottom;
-
-            /* FxCop rule 'AvoidBuildingNonCallableCode' - Left here in case it is needed in the future.        
-            public static RECT FromXYWH(int x, int y, int width, int height) {
-                return new RECT(x,
-                                y,
-                                x + width,
-                                y + height);
-            }
-
-            public Size Size 
-            {
-                get 
-                {
-                    return new Size(this.right - this.left, this.bottom - this.top);
-                }
-            }
-            */
         }
 
         [StructLayout(LayoutKind.Sequential)]
@@ -3988,18 +3862,6 @@ namespace System.Drawing
             internal int union2;
             internal int union3;
 
-            /* FxCop rule 'AvoidBuildingNonCallableCode' - Left here in case it is needed in the future.        
-            public static PICTDESC CreateBitmapPICTDESC(IntPtr hbitmap, IntPtr hpal) {
-                PICTDESC pictdesc = new PICTDESC();
-                pictdesc.cbSizeOfStruct = 16;
-                pictdesc.picType = Ole.PICTYPE_BITMAP;
-                pictdesc.union1 = hbitmap;
-                pictdesc.union2 = unchecked((int)(((long)hpal) & 0xffffffff));
-                pictdesc.union3 = (int)(((long)hpal) >> 32);
-                return pictdesc;
-            }
-            */
-
             public static PICTDESC CreateIconPICTDESC(IntPtr hicon)
             {
                 PICTDESC pictdesc = new PICTDESC();
@@ -4009,39 +3871,10 @@ namespace System.Drawing
                 return pictdesc;
             }
 
-            /* FxCop rule 'AvoidBuildingNonCallableCode' - Left here in case it is needed in the future.        
-            public static PICTDESC CreateEnhMetafilePICTDESC(IntPtr hEMF) {
-                PICTDESC pictdesc = new PICTDESC();
-                pictdesc.cbSizeOfStruct = 12;
-                pictdesc.picType = Ole.PICTYPE_ENHMETAFILE;
-                pictdesc.union1 = hEMF;
-                return pictdesc;
-            }
-
-            public static PICTDESC CreateWinMetafilePICTDESC(IntPtr hmetafile, int x, int y) {
-                PICTDESC pictdesc = new PICTDESC();
-                pictdesc.cbSizeOfStruct = 20;
-                pictdesc.picType = Ole.PICTYPE_METAFILE;
-                pictdesc.union1 = hmetafile;
-                pictdesc.union2 = x;
-                pictdesc.union3 = y;
-                return pictdesc;
-            }
-            */
-
             public virtual IntPtr GetHandle()
             {
                 return union1;
             }
-
-            /*public virtual IntPtr GetHPal() {
-                Debug.Assert((union2 >= 0) && (union3 >= 0));
-
-                long u2 = union2;
-                long u3 = union3;
-                if (picType == Ole.PICTYPE_BITMAP)
-                    return (IntPtr)(u2 | (u3 << 32));
-            */
         }
 
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
@@ -4138,65 +3971,55 @@ namespace System.Drawing
 #endif
             }
 
-            /// <include file='doc\SafeNativeMethods.uex' path='docs/doc[@for="SafeNativeMethods.CommonHandles.Accelerator"]/*' />
-            /// <devdoc>
-            ///     Handle type for accelerator tables.
-            /// </devdoc>
+            /// <summary>
+            /// Handle type for accelerator tables.
+            /// </summary>
             public static readonly int Accelerator = System.Internal.HandleCollector.RegisterType("Accelerator", 80, 50);
 
-            /// <include file='doc\SafeNativeMethods.uex' path='docs/doc[@for="SafeNativeMethods.CommonHandles.Cursor"]/*' />
-            /// <devdoc>
-            ///     handle type for cursors.
-            /// </devdoc>
+            /// <summary>
+            /// Handle type for cursors.
+            /// </summary>
             public static readonly int Cursor = System.Internal.HandleCollector.RegisterType("Cursor", 20, 500);
 
-            /// <include file='doc\SafeNativeMethods.uex' path='docs/doc[@for="SafeNativeMethods.CommonHandles.EMF"]/*' />
-            /// <devdoc>
-            ///     Handle type for enhanced metafiles.
-            /// </devdoc>
+            /// <summary>
+            /// Handle type for enhanced metafiles.
+            /// </summary>
             public static readonly int EMF = System.Internal.HandleCollector.RegisterType("EnhancedMetaFile", 20, 500);
 
-            /// <include file='doc\SafeNativeMethods.uex' path='docs/doc[@for="SafeNativeMethods.CommonHandles.Find"]/*' />
-            /// <devdoc>
-            ///     Handle type for file find handles.
-            /// </devdoc>
+            /// <summary>
+            /// Handle type for file find handles.
+            /// </summary>
             public static readonly int Find = System.Internal.HandleCollector.RegisterType("Find", 0, 1000);
 
-            /// <include file='doc\SafeNativeMethods.uex' path='docs/doc[@for="SafeNativeMethods.CommonHandles.GDI"]/*' />
-            /// <devdoc>
-            ///     Handle type for GDI objects.
-            /// </devdoc>
+            /// <summary>
+            /// Handle type for GDI objects.
+            /// </summary>
             public static readonly int GDI = System.Internal.HandleCollector.RegisterType("GDI", 50, 500);
 
-            /// <include file='doc\SafeNativeMethods.uex' path='docs/doc[@for="SafeNativeMethods.CommonHandles.HDC"]/*' />
-            /// <devdoc>
-            ///     Handle type for HDC's that count against the Win98 limit of five DC's.  HDC's
-            ///     which are not scarce, such as HDC's for bitmaps, are counted as GDIHANDLE's.
-            /// </devdoc>
+            /// <summary>
+            /// Handle type for HDC's that count against the Win98 limit of five DC's. 
+            /// HDC's which are not scarce, such as HDC's for bitmaps, are counted as GDIHANDLE's.
+            /// </summary>
             public static readonly int HDC = System.Internal.HandleCollector.RegisterType("HDC", 100, 2); // wait for 2 dc's before collecting
 
-            /// <include file='doc\SafeNativeMethods.uex' path='docs/doc[@for="SafeNativeMethods.CommonHandles.Icon"]/*' />
-            /// <devdoc>
-            ///     Handle type for icons.
-            /// </devdoc>
+            /// <summary>
+            /// Handle type for icons.
+            /// </summary>
             public static readonly int Icon = System.Internal.HandleCollector.RegisterType("Icon", 20, 500);
 
-            /// <include file='doc\SafeNativeMethods.uex' path='docs/doc[@for="SafeNativeMethods.CommonHandles.Kernel"]/*' />
-            /// <devdoc>
-            ///     Handle type for kernel objects.
-            /// </devdoc>
+            /// <summary>
+            /// Handle type for kernel objects.
+            /// </summary>
             public static readonly int Kernel = System.Internal.HandleCollector.RegisterType("Kernel", 0, 1000);
 
-            /// <include file='doc\SafeNativeMethods.uex' path='docs/doc[@for="SafeNativeMethods.CommonHandles.Menu"]/*' />
-            /// <devdoc>
-            ///     Handle type for files.
-            /// </devdoc>
+            /// <summary>
+            /// Handle type for files.
+            /// </summary>
             public static readonly int Menu = System.Internal.HandleCollector.RegisterType("Menu", 30, 1000);
 
-            /// <include file='doc\SafeNativeMethods.uex' path='docs/doc[@for="SafeNativeMethods.CommonHandles.Window"]/*' />
-            /// <devdoc>
-            ///     Handle type for windows.
-            /// </devdoc>
+            /// <summary>
+            /// Handle type for windows.
+            /// </summary>
             public static readonly int Window = System.Internal.HandleCollector.RegisterType("Window", 5, 1000);
 
 #if DEBUG
@@ -4238,26 +4061,8 @@ namespace System.Drawing
             return IntDeleteObject(hObject);
         }
 
-        /* FxCop rule 'AvoidBuildingNonCallableCode' - Left here in case it is needed in the future.
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling = true, EntryPoint = "DeleteDC", CharSet = System.Runtime.InteropServices.CharSet.Auto)]
-        internal static extern bool IntDeleteDC(HandleRef hDC);
-        public static bool DeleteDC(HandleRef hDC)
-        {
-            System.Internal.HandleCollector.Remove((IntPtr)hDC, SafeNativeMethods.CommonHandles.GDI);
-            return IntDeleteDC(hDC);
-        }
-        */
-
         [DllImport(ExternDll.Gdi32, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern IntPtr SelectObject(HandleRef hdc, HandleRef obj);
-
-        /* FxCop rule 'AvoidBuildingNonCallableCode' - Left here in case it is needed in the future.
-        [DllImport(ExternDll.User32, SetLastError=true, EntryPoint="CreateIconIndirect")]
-        private static extern IntPtr IntCreateIconIndirect(SafeNativeMethods.ICONINFO piconinfo);
-        public static IntPtr CreateIconIndirect(SafeNativeMethods.ICONINFO piconinfo) {
-            return System.Internal.HandleCollector.Add(IntCreateIconIndirect(piconinfo), SafeNativeMethods.CommonHandles.Icon);
-        }
-        */
 
         [DllImport(ExternDll.User32, SetLastError = true, EntryPoint = "CreateIconFromResourceEx")]
         private unsafe static extern IntPtr IntCreateIconFromResourceEx(byte* pbIconBits, int cbIconBits, bool fIcon, int dwVersion, int csDesired, int cyDesired, int flags);
@@ -4325,51 +4130,14 @@ namespace System.Drawing
             return GetObject(hObject, System.Runtime.InteropServices.Marshal.SizeOf(typeof(SafeNativeMethods.LOGFONT)), lp);
         }
 
-        /* FxCop rule 'AvoidBuildingNonCallableCode' - Left here in case it is needed in the future.        
-        [DllImport(ExternDll.Gdi32, SetLastError=true, CharSet=System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern int GetObject(HandleRef hObject, int nSize, [In, Out] SafeNativeMethods.DIBSECTION ds);
-        
-        [DllImport(ExternDll.Gdi32, SetLastError=true, CharSet=System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern int GetObject(HandleRef hObject, int nSize, [In, Out] SafeNativeMethods.LOGPEN lp);
-        public static int GetObject(HandleRef hObject, SafeNativeMethods.LOGPEN lp) {
-            return GetObject(hObject, System.Runtime.InteropServices.Marshal.SizeOf(typeof(SafeNativeMethods.LOGPEN)), lp);
-        }
-        [DllImport(ExternDll.Gdi32, SetLastError=true, CharSet=System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern int GetObject(HandleRef hObject, int nSize, [In, Out] SafeNativeMethods.LOGBRUSH lb);
-        public static int GetObject(HandleRef hObject, SafeNativeMethods.LOGBRUSH lb) {
-            return GetObject(hObject, System.Runtime.InteropServices.Marshal.SizeOf(typeof(SafeNativeMethods.LOGBRUSH)), lb);
-        }
-        
-        //HPALETTE
-        [DllImport(ExternDll.Gdi32, SetLastError=true, CharSet=System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern int GetObject(HandleRef hObject, int nSize, ref int nEntries);
-        
-        [DllImport(ExternDll.Gdi32, SetLastError=true, CharSet=System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern int GetObject(HandleRef hObject, int nSize, int[] nEntries);
-        */
-
         [DllImport(ExternDll.User32, SetLastError = true, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
         public static extern bool GetIconInfo(HandleRef hIcon, [In, Out] SafeNativeMethods.ICONINFO info);
 
         [DllImport(ExternDll.User32, SetLastError = true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
         public static extern int GetSysColor(int nIndex);
 
-        /* FxCop rule 'AvoidBuildingNonCallableCode' - Left here in case it is needed in the future.        
-        [DllImport(ExternDll.User32, SetLastError=true, ExactSpelling=true, CharSet=System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern bool DrawIcon(HandleRef hDC, int x, int y, HandleRef hIcon);
-        */
-
         [DllImport(ExternDll.User32, SetLastError = true, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
         public static extern bool DrawIconEx(HandleRef hDC, int x, int y, HandleRef hIcon, int width, int height, int iStepIfAniCursor, HandleRef hBrushFlickerFree, int diFlags);
-
-        /* FxCop rule 'AvoidBuildingNonCallableCode' - Left here in case it is needed in the future.               
-        [DllImport(ExternDll.Oleaut32, PreserveSig=false)]
-        public static extern IPicture OleLoadPicture(UnsafeNativeMethods.IStream pStream, int lSize, bool fRunmode, ref Guid refiid);
-        
-        [DllImport(ExternDll.Oleaut32, PreserveSig=false)]
-        public static extern IPicture OleLoadPictureEx(UnsafeNativeMethods.IStream pStream, int lSize, bool fRunmode, ref Guid refiid, int width, int height, int dwFlags);
-        */
-
 
 #if CUSTOM_MARSHALING_ISTREAM
         [DllImport(ExternDll.Oleaut32, PreserveSig=false)]
@@ -4523,170 +4291,6 @@ namespace System.Drawing
             TRANSPARENT = 1,
             OPAQUE = 2
         }
-
-        // FxCop rule 'AvoidBuildingNonCallableCode' - Left here in case it is needed in the future.        
-        //[DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
-        //public static extern int /*COLORREF*/ SetTextColor(HandleRef hDC, int crColor);
-
-        // FxCop rule 'AvoidBuildingNonCallableCode' - Left here in case it is needed in the future.        
-        //[DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
-        //public static extern int /*COLORREF*/ GetTextColor(HandleRef hDC);
-
-        /* FxCop rule 'AvoidBuildingNonCallableCode' - Left here in case it is needed in the future.
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern int SetBkColor(HandleRef hDC, int clr);
-
-
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern int SetBkMode(HandleRef hDC, int nBkMode);
-
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern int GetBkColor(HandleRef hDC);
-
-        [DllImport(ExternDll.User32, SetLastError=true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern int DrawText(HandleRef hDC, string lpszString, int nCount, ref SafeNativeMethods.RECT lpRect, int nFormat);
-
-        [DllImport(ExternDll.Gdi32, SetLastError=true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern int GetTextExtentPoint32(HandleRef hDC, string str, int len, [In, Out] SafeNativeMethods.SIZE size);
-    
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern bool LineTo(HandleRef hdc, int x, int y);
-
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern bool MoveToEx(HandleRef hdc, int x, int y, SafeNativeMethods.POINT pt);
-
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern bool Rectangle(HandleRef hdc, int left, int top, int right, int bottom);
-
-        [DllImport(ExternDll.User32, SetLastError=true, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern int FillRect(HandleRef hdc, [In] ref SafeNativeMethods.RECT rect, HandleRef hbrush);
-
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling = true, EntryPoint = "CreateSolidBrush", CharSet = System.Runtime.InteropServices.CharSet.Auto)]
-        private static extern IntPtr IntCreateSolidBrush(int crColor);
-        public static IntPtr CreateSolidBrush(int crColor) 
-        {
-            return System.Internal.HandleCollector.Add(IntCreateSolidBrush(crColor), SafeNativeMethods.CommonHandles.GDI);
-        }
-
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling = true, EntryPoint = "CreateHatchBrush", CharSet = System.Runtime.InteropServices.CharSet.Auto)]
-        private static extern IntPtr IntCreateHatchBrush(int fnStyle, int crColor);
-        public static IntPtr CreateHatchBrush(int fnStyle, int crColor) 
-        {
-            return System.Internal.HandleCollector.Add(IntCreateHatchBrush(fnStyle, crColor), SafeNativeMethods.CommonHandles.GDI);
-        }
-
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling = true, EntryPoint = "CreatePen", CharSet = System.Runtime.InteropServices.CharSet.Auto)]
-        private static extern IntPtr IntCreatePen(int fnStyle, int nWidth, int crColor);
-        public static IntPtr CreatePen(int fnStyle, int nWidth, int crColor)
-        {
-            return System.Internal.HandleCollector.Add(IntCreatePen(fnStyle, nWidth, crColor), SafeNativeMethods.CommonHandles.GDI);
-        }
-
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling = true, EntryPoint = "ExtCreatePen", CharSet = System.Runtime.InteropServices.CharSet.Auto)]
-        private static extern IntPtr IntExtCreatePen(int fnStyle, int dwWidth, SafeNativeMethods.LOGBRUSH lplb, int dwStyleCount, [MarshalAs(UnmanagedType.LPArray)] int[] lpStyle);
-        public static IntPtr ExtCreatePen(int fnStyle, int dwWidth, SafeNativeMethods.LOGBRUSH lplb, int dwStyleCount, int[] lpStyle)
-        {
-            return System.Internal.HandleCollector.Add(IntExtCreatePen(fnStyle, dwWidth, lplb, dwStyleCount, lpStyle), SafeNativeMethods.CommonHandles.GDI);
-        }
-
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern int SetROP2(HandleRef hDC, int nDrawMode);
-
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern int SetMapMode(HandleRef hDC, int nMapMode);
-
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern IntPtr GetCurrentObject(HandleRef hDC, uint uObjectType);
-
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling=true, CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
-        public static extern int GetTextMetricsW(HandleRef hDC, [In, Out] ref SafeNativeMethods.TEXTMETRIC lptm);
-
-        public static int GetTextMetrics(HandleRef hDC, ref SafeNativeMethods.TEXTMETRIC lptm) {
-            return SafeNativeMethods.GetTextMetricsW(hDC, ref lptm);
-        }
-
-        [DllImport(ExternDll.Kernel32, SetLastError=true, CharSet=System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern int FormatMessage(int dwFlags, HandleRef lpSource, int dwMessageId, int dwLanguageId, StringBuilder lpBuffer, int nSize, HandleRef arguments);
-    
-        [DllImport(ExternDll.Kernel32, SetLastError=true, CharSet=System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern int GetUserDefaultLCID();
-
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern int SetTextAlign(HandleRef hDC, int nMode);
-
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern int GetSystemPaletteUse(HandleRef hDc);
-
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern int GetSystemPaletteUse(HandleRef hDc, int iStartIndex, int nEntries, HandleRef lppe);
-        */
-
-        // FxCop rule 'AvoidBuildingNonCallableCode' - Left here in case it is needed in the future.
-        //[DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling=true, EntryPoint="CreatePalette", CharSet=System.Runtime.InteropServices.CharSet.Auto)]
-        //private static extern IntPtr /*HPALETTE*/ IntCreatePalette(HandleRef lplgpl);
-        //public static IntPtr /*HPALETTE*/ CreatePalette(HandleRef lplgpl) {
-        //    IntPtr result = IntCreatePalette(lplgpl);
-        //    if(result == IntPtr.Zero) {
-        //        Debug.WriteLine("IntCreatePalette failed : " + DbgUtil.GetLastErrorStr());
-        //        throw new Win32Exception();
-        //    }
-        //    return System.Internal.HandleCollector.Add(result, SafeNativeMethods.CommonHandles.GDI);
-        //}
-
-
-        /* FxCop rule 'AvoidBuildingNonCallableCode' - Left here in case it is needed in the future.
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern int SetPixel(HandleRef hDc, int x, int y, int color);
-
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern bool Ellipse(HandleRef hDc, int x1, int y1, int x2, int y2);
-
-        [DllImport(ExternDll.User32, SetLastError=true, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern bool DrawFocusRect(HandleRef hDc, ref SafeNativeMethods.RECT lpRect);
-
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern bool GdiFlush();
-
-        [DllImport(ExternDll.Gdi32, SetLastError=true, CharSet=CharSet.Auto)]
-        public static extern int GetObject(HandleRef hObject, int nSize, [In, Out] NativeMethods.BITMAP bm);
-
-
-        
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling=true, EntryPoint="CreateDIBSection", CharSet=CharSet.Auto)]
-        public static extern IntPtr IntCreateDIBSection(HandleRef hdc, ref NativeMethods.BITMAPINFO bmi, int iUsage, ref IntPtr ppvBits, IntPtr hSection, int dwOffset);
-        public static IntPtr CreateDIBSection(HandleRef hdc, ref NativeMethods.BITMAPINFO bmi, int iUsage, ref IntPtr ppvBits, IntPtr hSection, int dwOffset) {
-            return System.Internal.HandleCollector.Add(IntCreateDIBSection(hdc, ref bmi, iUsage, ref ppvBits, hSection, dwOffset), SafeNativeMethods.CommonHandles.GDI);
-        }
-
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling=true, CharSet=System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern bool DPtoLP(HandleRef hDC, [In, Out] ref POINT lpRect, int nCount);       
-
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling=true, CharSet=System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern int GetMapMode(HandleRef hDC);
-        
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling=true, CharSet=System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern bool BeginPath(HandleRef hDC);
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling=true, CharSet=System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern bool EndPath(HandleRef hDC);
-
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling=true, CharSet=System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern bool StrokePath(HandleRef hDC);
-
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling=true, CharSet=System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern bool AngleArc(HandleRef hDC, int x, int y, int radius, float startAngle, float endAngle);
-
-        [DllImport(ExternDll.Gdi32, SetLastError=true, ExactSpelling=true, CharSet=System.Runtime.InteropServices.CharSet.Auto)]
-        public static extern bool Arc(HandleRef hDC, int nLeftRect,   // x-coord of rectangle's upper-left corner
-                                  int nTopRect,    // y-coord of rectangle's upper-left corner
-                                  int nRightRect,  // x-coord of rectangle's lower-right corner
-                                  int nBottomRect, // y-coord of rectangle's lower-right corner
-                                  int nXStartArc,  // x-coord of first radial ending point
-                                  int nYStartArc,  // y-coord of first radial ending point
-                                  int nXEndArc,    // x-coord of second radial ending point
-                                  int nYEndArc     // y-coord of second radial ending point
-                                );
-     
-        */
     }
 }
 

--- a/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
@@ -2,27 +2,23 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Diagnostics.Contracts;
+using System.Drawing.Drawing2D;
+using System.Drawing.Imaging;
+using System.Drawing.Internal;
+using System.Drawing.Text;
+using System.Globalization;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+
 namespace System.Drawing
 {
-    using System.ComponentModel;
-    using System.Diagnostics;
-    using System.Diagnostics.Contracts;
-    using System.Drawing.Drawing2D;
-    using System.Drawing.Imaging;
-    using System.Drawing.Internal;
-    using System.Drawing.Text;
-    using System.Globalization;
-    using System.Runtime.ConstrainedExecution;
-    using System.Runtime.InteropServices;
-    using System.Security.Permissions;
-
-    /**
-     * Represent a graphics drawing context
-     */
-    /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics"]/*' />
-    /// <devdoc>
-    ///    Encapsulates a GDI+ drawing surface.
-    /// </devdoc>
+    /// <summary>
+    /// Encapsulates a GDI+ drawing surface.
+    /// </summary>
     public sealed class Graphics : MarshalByRefObject, IDisposable, IDeviceContext
     {
 #if FINALIZATION_WATCH
@@ -38,27 +34,24 @@ namespace System.Drawing
         private string allocationSite = Graphics.GetAllocationStack();
 #endif
 
-        /// <devdoc>
-        ///     The context state previous to the current Graphics context (the head of the stack).
-        ///     We don't keep a GraphicsContext for the current context since it is available at any time from GDI+ and
-        ///     we don't want to keep track of changes in it.
-        /// </devdoc>
+        /// <summary>
+        /// The context state previous to the current Graphics context (the head of the stack).
+        /// We don't keep a GraphicsContext for the current context since it is available at any time from GDI+ and
+        /// we don't want to keep track of changes in it.
+        /// </summary>
         private GraphicsContext _previousContext;
-
-        /// <devdoc>
-        ///     Object to lock on for static methods. 
 
         private static readonly object s_syncObject = new Object();
 
-        /// <devdoc>
-        ///     Handle to native GDI+ graphics object.  This object is created on demand.
-        /// </devdoc>
+        /// <summary>
+        /// Handle to native GDI+ graphics object.  This object is created on demand.
+        /// </summary>
         private IntPtr _nativeGraphics;
 
-        /// <devdoc>
-        ///     Handle to native DC - obtained from the GDI+ graphics object.
-        ///     We need to cache it to implement IDeviceContext interface.
-        /// </devdoc>
+        /// <summary>
+        /// Handle to native DC - obtained from the GDI+ graphics object. We need to cache it to implement
+        /// IDeviceContext interface.
+        /// </summary>
         private IntPtr _nativeHdc;
 
         // Object reference used for printing; it could point to a PrintPreviewGraphics to obtain the VisibleClipBounds, or 
@@ -72,25 +65,22 @@ namespace System.Drawing
         private Image _backingImage;
 
         /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawImageAbort"]/*' />
-        /// <devdoc>
-        /// </devdoc>
+        /// <summary>
+        /// </summary>
         public delegate bool DrawImageAbort(IntPtr callbackdata);
 
         // Callback for EnumerateMetafile methods.  The parameters are:
 
-        //      recordType      (if >= MinRecordType, it's an EMF+ record)
-        //      flags           (always 0 for EMF records)
-        //      dataSize        size of the data, or 0 if no data
-        //      data            pointer to the data, or NULL if no data (UINT32 aligned)
-        //      callbackData    pointer to callbackData, if any
+        // recordType      (if >= MinRecordType, it's an EMF+ record)
+        // flags           (always 0 for EMF records)
+        // dataSize        size of the data, or 0 if no data
+        // data            pointer to the data, or NULL if no data (UINT32 aligned)
+        // callbackData    pointer to callbackData, if any
 
         // This method can then call Metafile.PlayRecord to play the
         // record that was just enumerated.  If this method  returns
         // FALSE, the enumeration process is aborted.  Otherwise, it continues.        
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EnumerateMetafileProc"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public delegate bool EnumerateMetafileProc(EmfPlusRecordType recordType,
                                                    int flags,
                                                    int dataSize,
@@ -98,9 +88,9 @@ namespace System.Drawing
                                                    PlayRecordCallback callbackData);
 
 
-        /// <devdoc>
-        ///     Constructor to initialize this object from a native GDI+ Graphics pointer.
-        /// </devdoc>
+        /// <summary>
+        /// Constructor to initialize this object from a native GDI+ Graphics pointer.
+        /// </summary>
         private Graphics(IntPtr gdipNativeGraphics)
         {
             if (gdipNativeGraphics == IntPtr.Zero)
@@ -110,13 +100,9 @@ namespace System.Drawing
             _nativeGraphics = gdipNativeGraphics;
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.FromHdc"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Creates a new instance of the <see cref='System.Drawing.Graphics'/> class from the specified
-        ///       handle to a device context.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Creates a new instance of the <see cref='Graphics'/> class from the specified handle to a device context.
+        /// </summary>
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public static Graphics FromHdc(IntPtr hdc)
         {
@@ -128,7 +114,6 @@ namespace System.Drawing
             return FromHdcInternal(hdc);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.FromHdcInternal"]/*' />
         [SecurityPermission(SecurityAction.LinkDemand, Flags = SecurityPermissionFlag.UnmanagedCode)]
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public static Graphics FromHdcInternal(IntPtr hdc)
@@ -145,13 +130,9 @@ namespace System.Drawing
             return new Graphics(nativeGraphics);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.FromHdc1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Creates a new instance of the Graphics class from the specified handle to 
-        ///       a device context and handle to a device.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Creates a new instance of the Graphics class from the specified handle to a device context and handle to a device.
+        /// </summary>
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public static Graphics FromHdc(IntPtr hdc, IntPtr hdevice)
         {
@@ -166,21 +147,15 @@ namespace System.Drawing
             return new Graphics(gdipNativeGraphics);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.FromHwnd"]/*' />
-        /// <devdoc>
-        ///    Creates a new instance of the <see cref='System.Drawing.Graphics'/> class
-        ///    from a window handle.
-        /// </devdoc>
+        /// <summary>
+        /// Creates a new instance of the <see cref='Graphics'/> class from a window handle.
+        /// </summary>
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public static Graphics FromHwnd(IntPtr hwnd)
         {
             return FromHwndInternal(hwnd);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.FromHwndInternal"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         [SecurityPermission(SecurityAction.LinkDemand, Flags = SecurityPermissionFlag.UnmanagedCode)]
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public static Graphics FromHwndInternal(IntPtr hwnd)
@@ -197,11 +172,9 @@ namespace System.Drawing
             return new Graphics(nativeGraphics);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.FromImage"]/*' />
-        /// <devdoc>
-        ///    Creates an instance of the <see cref='System.Drawing.Graphics'/> class
-        ///    from an existing <see cref='System.Drawing.Image'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Creates an instance of the <see cref='Graphics'/> class from an existing <see cref='Image'/>.
+        /// </summary>
         public static Graphics FromImage(Image image)
         {
             if (image == null)
@@ -231,9 +204,6 @@ namespace System.Drawing
 
         internal IntPtr NativeGraphics => _nativeGraphics;
 
-        /// <devdoc>
-        ///     Implementation of IDeviceContext.GetHdc().
-        /// </devdoc>
         [SecurityPermission(SecurityAction.LinkDemand, Flags = SecurityPermissionFlag.UnmanagedCode)]
         public IntPtr GetHdc()
         {
@@ -271,24 +241,15 @@ namespace System.Drawing
             _nativeHdc = IntPtr.Zero;
         }
 
-        /**
-         * Dispose of resources associated with the graphics context
-         *
-         * @notes How do we set up delegates to notice others
-         *  when a Graphics object is disposed.
-         */
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.Dispose"]/*' />
-        /// <devdoc>
-        ///    Deletes this <see cref='System.Drawing.Graphics'/>, and
-        ///    frees the memory allocated for it.
-        /// </devdoc>        
+        /// <summary>
+        /// Deletes this <see cref='Graphics'/>, and frees the memory allocated for it.
+        /// </summary>        
         public void Dispose()
         {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.Dispose2"]/*' />
         private void Dispose(bool disposing)
         {
 #if DEBUG
@@ -356,33 +317,22 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.Finalize"]/*' />
-        /// <devdoc>
-        ///    Deletes this <see cref='System.Drawing.Graphics'/>, and
-        ///    frees the memory allocated for it.
-        /// </devdoc>
         ~Graphics()
         {
             Dispose(false);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.Flush"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Forces immediate execution of all operations currently on the stack.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Forces immediate execution of all operations currently on the stack.
+        /// </summary>
         public void Flush()
         {
             Flush(FlushIntention.Flush);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.Flush1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Forces execution of all operations currently on the stack.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Forces execution of all operations currently on the stack.
+        /// </summary>
         public void Flush(FlushIntention intention)
         {
             int status = SafeNativeMethods.Gdip.GdipFlush(new HandleRef(this, NativeGraphics), intention);
@@ -394,20 +344,9 @@ namespace System.Drawing
         }
 
 
-        /*
-        * Methods for setting/getting:
-        *  compositing mode
-        *  rendering quality hint
-        *
-        * @notes We should probably separate rendering hints
-        *  into several categories, e.g. antialiasing, image
-        *  filtering, etc.
-        */
-
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.CompositingMode"]/*' />
-        /// <devdoc>
-        ///    Gets or sets the <see cref='System.Drawing.Drawing2D.CompositingMode'/> associated with this <see cref='System.Drawing.Graphics'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the <see cref='Drawing2D.CompositingMode'/> associated with this <see cref='Graphics'/>.
+        /// </summary>
         public CompositingMode CompositingMode
         {
             get
@@ -441,10 +380,6 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.RenderingOrigin"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public Point RenderingOrigin
         {
             get
@@ -471,10 +406,6 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.CompositingQuality"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public CompositingQuality CompositingQuality
         {
             get
@@ -508,14 +439,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.TextRenderingHint"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets or sets the rendering mode for text associated with
-        ///       this <see cref='System.Drawing.Graphics'/>
-        ///       .
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the rendering mode for text associated with this <see cref='Graphics'/>.
+        /// </summary>
         public TextRenderingHint TextRenderingHint
         {
             get
@@ -548,10 +474,6 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.TextContrast"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public int TextContrast
         {
             get
@@ -578,10 +500,6 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.SmoothingMode"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public SmoothingMode SmoothingMode
         {
             get
@@ -614,10 +532,6 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.PixelOffsetMode"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public PixelOffsetMode PixelOffsetMode
         {
             get
@@ -650,10 +564,10 @@ namespace System.Drawing
             }
         }
 
-        /// <devdoc>
-        ///    Represents an object used in conection with the printing API, it is used to hold a reference to a PrintPreviewGraphics (fake graphics)
-        ///    or a printer DeviceContext (and maybe more in the future).
-        /// </devdoc>
+        /// <summary>
+        /// Represents an object used in conection with the printing API, it is used to hold a reference to a
+        /// PrintPreviewGraphics (fake graphics) or a printer DeviceContext (and maybe more in the future).
+        /// </summary>
         internal object PrintingHelper
         {
             get
@@ -667,11 +581,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.InterpolationMode"]/*' />
-        /// <devdoc>
-        ///    Gets or sets the interpolation mode
-        ///    associated with this Graphics.
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the interpolation mode associated with this Graphics.
+        /// </summary>
         public InterpolationMode InterpolationMode
         {
             get
@@ -705,14 +617,9 @@ namespace System.Drawing
             }
         }
 
-        /**
-         * Return the current world transform
-         */
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.Transform"]/*' />
-        /// <devdoc>
-        ///    Gets or sets the world transform
-        ///    for this <see cref='System.Drawing.Graphics'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the world transform for this <see cref='Graphics'/>.
+        /// </summary>
         public Matrix Transform
         {
             get
@@ -742,13 +649,6 @@ namespace System.Drawing
         }
 
 
-        /**
-         * Retrieve the current page transform information
-         * notes @ these are atomic
-         */
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.PageUnit"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public GraphicsUnit PageUnit
         {
             get
@@ -781,9 +681,6 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.PageScale"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public float PageScale
         {
             get
@@ -811,9 +708,6 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DpiX"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public float DpiX
         {
             get
@@ -831,9 +725,6 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DpiY"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public float DpiY
         {
             get
@@ -852,41 +743,35 @@ namespace System.Drawing
         }
 
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.CopyFromScreen"]/*' />
-        /// <devdoc>
-        ///     CopyPixels will perform a gdi "bitblt" operation to the source from the destination
-        ///     with the given size.
-        /// </devdoc>
+        /// <summary>
+        /// CopyPixels will perform a gdi "bitblt" operation to the source from the destination with the given size.
+        /// </summary>
         public void CopyFromScreen(Point upperLeftSource, Point upperLeftDestination, Size blockRegionSize)
         {
             CopyFromScreen(upperLeftSource.X, upperLeftSource.Y, upperLeftDestination.X, upperLeftDestination.Y, blockRegionSize);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.CopyFromScreen1"]/*' />
-        /// <devdoc>
-        ///     CopyPixels will perform a gdi "bitblt" operation to the source from the destination
-        ///     with the given size.
-        /// </devdoc>
+        /// <summary>
+        /// CopyPixels will perform a gdi "bitblt" operation to the source from the destination with the given size.
+        /// </summary>
         public void CopyFromScreen(int sourceX, int sourceY, int destinationX, int destinationY, Size blockRegionSize)
         {
             CopyFromScreen(sourceX, sourceY, destinationX, destinationY, blockRegionSize, CopyPixelOperation.SourceCopy);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.CopyFromScreen2"]/*' />
-        /// <devdoc>
-        ///     CopyPixels will perform a gdi "bitblt" operation to the source from the destination
-        ///     with the given size and specified raster operation.
-        /// </devdoc>
+        /// <summary>
+        /// CopyPixels will perform a gdi "bitblt" operation to the source from the destination with the given size
+        /// and specified raster operation.
+        /// </summary>
         public void CopyFromScreen(Point upperLeftSource, Point upperLeftDestination, Size blockRegionSize, CopyPixelOperation copyPixelOperation)
         {
             CopyFromScreen(upperLeftSource.X, upperLeftSource.Y, upperLeftDestination.X, upperLeftDestination.Y, blockRegionSize, copyPixelOperation);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.CopyFromScreen3"]/*' />
-        /// <devdoc>
-        ///     CopyPixels will perform a gdi "bitblt" operation to the source from the destination
-        ///     with the given size and specified raster operation.
-        /// </devdoc>        
+        /// <summary>
+        /// CopyPixels will perform a gdi "bitblt" operation to the source from the destination with the given size
+        /// and specified raster operation.
+        /// </summary>        
         public void CopyFromScreen(int sourceX, int sourceY, int destinationX, int destinationY, Size blockRegionSize, CopyPixelOperation copyPixelOperation)
         {
             switch (copyPixelOperation)
@@ -939,17 +824,9 @@ namespace System.Drawing
             }
         }
 
-        /*
-         * Manipulate the current transform
-         *
-         * @notes For get methods, we return copies of our internal objects.
-         *  For set methods, we make copies of the objects passed in.
-         */
-
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.ResetTransform"]/*' />
-        /// <devdoc>
-        ///    Resets the world transform to identity.
-        /// </devdoc>
+        /// <summary>
+        /// Resets the world transform to identity.
+        /// </summary>
         public void ResetTransform()
         {
             int status = SafeNativeMethods.Gdip.GdipResetWorldTransform(new HandleRef(this, NativeGraphics));
@@ -960,23 +837,17 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.MultiplyTransform"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Multiplies the <see cref='System.Drawing.Drawing2D.Matrix'/> that
-        ///       represents the world transform and <paramref term="matrix"/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Multiplies the <see cref='Matrix'/> that represents the world transform and <paramref name="matrix"/>.
+        /// </summary>
         public void MultiplyTransform(Matrix matrix)
         {
             MultiplyTransform(matrix, MatrixOrder.Prepend);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.MultiplyTransform1"]/*' />
-        /// <devdoc>
-        ///    Multiplies the <see cref='System.Drawing.Drawing2D.Matrix'/> that
-        ///    represents the world transform and <paramref term="matrix"/>.
-        /// </devdoc>
+        /// <summary>
+        /// Multiplies the <see cref='Matrix'/> that represents the world transform and <paramref name="matrix"/>.
+        /// </summary>
         public void MultiplyTransform(Matrix matrix, MatrixOrder order)
         {
             if (matrix == null)
@@ -993,17 +864,11 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.TranslateTransform"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public void TranslateTransform(float dx, float dy)
         {
             TranslateTransform(dx, dy, MatrixOrder.Prepend);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.TranslateTransform1"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public void TranslateTransform(float dx, float dy, MatrixOrder order)
         {
             int status = SafeNativeMethods.Gdip.GdipTranslateWorldTransform(new HandleRef(this, NativeGraphics), dx, dy, order);
@@ -1014,26 +879,11 @@ namespace System.Drawing
             }
         }
 
-        // can be called during the creation of NativeGraphics
-        /*private void TranslateTransform(float dx, float dy, MatrixOrder order, IntPtr nativeGraphics) {
-            int status = SafeNativeMethods.Gdip.GdipTranslateWorldTransform(new HandleRef(this, nativeGraphics), dx, dy, order);
-
-            if (status != SafeNativeMethods.Gdip.Ok) {
-                throw SafeNativeMethods.Gdip.StatusException(status);
-            }
-        }*/
-
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.ScaleTransform"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public void ScaleTransform(float sx, float sy)
         {
             ScaleTransform(sx, sy, MatrixOrder.Prepend);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.ScaleTransform1"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public void ScaleTransform(float sx, float sy, MatrixOrder order)
         {
             int status = SafeNativeMethods.Gdip.GdipScaleWorldTransform(new HandleRef(this, NativeGraphics), sx, sy, order);
@@ -1044,17 +894,11 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.RotateTransform"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public void RotateTransform(float angle)
         {
             RotateTransform(angle, MatrixOrder.Prepend);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.RotateTransform1"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public void RotateTransform(float angle, MatrixOrder order)
         {
             int status = SafeNativeMethods.Gdip.GdipRotateWorldTransform(new HandleRef(this, NativeGraphics), angle, order);
@@ -1065,13 +909,6 @@ namespace System.Drawing
             }
         }
 
-        /*
-         * Transform points in the current graphics context
-         */
-        // float version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.TransformPoints"]/*' />
-        /// <devdoc>
-        /// </devdoc
         public void TransformPoints(CoordinateSpace destSpace,
                                      CoordinateSpace srcSpace,
                                      PointF[] pts)
@@ -1106,10 +943,6 @@ namespace System.Drawing
             }
         }
 
-        // int version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.TransformPoints1"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void TransformPoints(CoordinateSpace destSpace,
                                     CoordinateSpace srcSpace,
@@ -1144,9 +977,6 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.GetNearestColor"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public Color GetNearestColor(Color color)
         {
             int nearest = color.ToArgb();
@@ -1161,21 +991,9 @@ namespace System.Drawing
             return Color.FromArgb(nearest);
         }
 
-        /*
-         * Vector drawing methods
-         *
-         * @notes Do we need a set of methods that take
-         *  integer coordinate parameters?
-         */
-
-        // float version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawLine"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws a line connecting the two
-        ///       specified points.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws a line connecting the two specified points.
+        /// </summary>
         public void DrawLine(Pen pen, float x1, float y1, float x2, float y2)
         {
             if (pen == null)
@@ -1187,25 +1005,17 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawLine1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws a line connecting the two
-        ///       specified points.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws a line connecting the two specified points.
+        /// </summary>
         public void DrawLine(Pen pen, PointF pt1, PointF pt2)
         {
             DrawLine(pen, pt1.X, pt1.Y, pt2.X, pt2.Y);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawLines"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws a series of line segments that
-        ///       connect an array of points.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws a series of line segments that connect an array of points.
+        /// </summary>
         public void DrawLines(Pen pen, PointF[] points)
         {
             if (pen == null)
@@ -1224,14 +1034,9 @@ namespace System.Drawing
         }
 
 
-        // int version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawLine2"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws a line connecting the two
-        ///       specified points.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws a line connecting the two specified points.
+        /// </summary>
         public void DrawLine(Pen pen, int x1, int y1, int x2, int y2)
         {
             if (pen == null)
@@ -1243,25 +1048,17 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawLine3"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws a line connecting the two
-        ///       specified points.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws a line connecting the two specified points.
+        /// </summary>
         public void DrawLine(Pen pen, Point pt1, Point pt2)
         {
             DrawLine(pen, pt1.X, pt1.Y, pt2.X, pt2.Y);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawLines1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws a series of line segments that connect an array of
-        ///       points.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws a series of line segments that connect an array of points.
+        /// </summary>
         public void DrawLines(Pen pen, Point[] points)
         {
             if (pen == null)
@@ -1279,13 +1076,9 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        // float version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawArc"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws an arc from the specified ellipse.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws an arc from the specified ellipse.
+        /// </summary>
         public void DrawArc(Pen pen, float x, float y, float width, float height,
                             float startAngle, float sweepAngle)
         {
@@ -1299,25 +1092,17 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawArc1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws an arc from the specified
-        ///       ellipse.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws an arc from the specified ellipse.
+        /// </summary>
         public void DrawArc(Pen pen, RectangleF rect, float startAngle, float sweepAngle)
         {
             DrawArc(pen, rect.X, rect.Y, rect.Width, rect.Height, startAngle, sweepAngle);
         }
 
-        // int version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawArc2"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws an arc from the specified ellipse.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws an arc from the specified ellipse.
+        /// </summary>
         public void DrawArc(Pen pen, int x, int y, int width, int height,
                             int startAngle, int sweepAngle)
         {
@@ -1331,24 +1116,17 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawArc3"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws an arc from the specified ellipse.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws an arc from the specified ellipse.
+        /// </summary>
         public void DrawArc(Pen pen, Rectangle rect, float startAngle, float sweepAngle)
         {
             DrawArc(pen, rect.X, rect.Y, rect.Width, rect.Height, startAngle, sweepAngle);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawBezier"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws a cubic bezier curve defined by
-        ///       four ordered pairs that represent points.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws a cubic bezier curve defined by four ordered pairs that represent points.
+        /// </summary>
         public void DrawBezier(Pen pen, float x1, float y1, float x2, float y2,
                                float x3, float y3, float x4, float y4)
         {
@@ -1362,26 +1140,17 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        // float version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawBezier1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws a cubic bezier curve defined by
-        ///       four points.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws a cubic bezier curve defined by four points.
+        /// </summary>
         public void DrawBezier(Pen pen, PointF pt1, PointF pt2, PointF pt3, PointF pt4)
         {
             DrawBezier(pen, pt1.X, pt1.Y, pt2.X, pt2.Y, pt3.X, pt3.Y, pt4.X, pt4.Y);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawBeziers"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws a series of cubic Bezier curves
-        ///       from an array of points.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws a series of cubic Bezier curves from an array of points.
+        /// </summary>
         public void DrawBeziers(Pen pen, PointF[] points)
         {
             if (pen == null)
@@ -1399,25 +1168,17 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        // int version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawBezier2"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws a cubic bezier curve defined by four points.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws a cubic bezier curve defined by four points.
+        /// </summary>
         public void DrawBezier(Pen pen, Point pt1, Point pt2, Point pt3, Point pt4)
         {
             DrawBezier(pen, pt1.X, pt1.Y, pt2.X, pt2.Y, pt3.X, pt3.Y, pt4.X, pt4.Y);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawBeziers1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws a series of cubic Bezier curves from an array of
-        ///       points.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws a series of cubic Bezier curves from an array of points.
+        /// </summary>
         public void DrawBeziers(Pen pen, Point[] points)
         {
             if (pen == null)
@@ -1434,26 +1195,17 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawRectangle"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws the outline of a rectangle specified by
-        ///    <paramref term="rect"/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws the outline of a rectangle specified by <paramref name="rect"/>.
+        /// </summary>
         public void DrawRectangle(Pen pen, Rectangle rect)
         {
             DrawRectangle(pen, rect.X, rect.Y, rect.Width, rect.Height);
         }
 
-        // float version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawRectangle1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws the outline of the specified
-        ///       rectangle.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws the outline of the specified rectangle.
+        /// </summary>
         public void DrawRectangle(Pen pen, float x, float y, float width, float height)
         {
             if (pen == null)
@@ -1468,13 +1220,9 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        // int version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawRectangle2"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws the outline of the specified rectangle.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws the outline of the specified rectangle.
+        /// </summary>
         public void DrawRectangle(Pen pen, int x, int y, int width, int height)
         {
             if (pen == null)
@@ -1488,13 +1236,9 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawRectangles"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws the outlines of a series of
-        ///       rectangles.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws the outlines of a series of rectangles.
+        /// </summary>
         public void DrawRectangles(Pen pen, RectangleF[] rects)
         {
             if (pen == null)
@@ -1516,12 +1260,9 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawRectangles1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws the outlines of a series of rectangles.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws the outlines of a series of rectangles.
+        /// </summary>
         public void DrawRectangles(Pen pen, Rectangle[] rects)
         {
             if (pen == null)
@@ -1543,26 +1284,17 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        // float version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawEllipse"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws the outline of an
-        ///       ellipse defined by a bounding rectangle.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws the outline of an ellipse defined by a bounding rectangle.
+        /// </summary>
         public void DrawEllipse(Pen pen, RectangleF rect)
         {
             DrawEllipse(pen, rect.X, rect.Y, rect.Width, rect.Height);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawEllipse1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws the outline of an
-        ///       ellipse defined by a bounding rectangle.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws the outline of an ellipse defined by a bounding rectangle.
+        /// </summary>
         public void DrawEllipse(Pen pen, float x, float y, float width, float height)
         {
             if (pen == null)
@@ -1575,25 +1307,17 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        // int version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawEllipse2"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws the outline of an ellipse specified by a bounding
-        ///       rectangle.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws the outline of an ellipse specified by a bounding rectangle.
+        /// </summary>
         public void DrawEllipse(Pen pen, Rectangle rect)
         {
             DrawEllipse(pen, rect.X, rect.Y, rect.Width, rect.Height);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawEllipse3"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws the outline of an ellipse defined by a bounding rectangle.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws the outline of an ellipse defined by a bounding rectangle.
+        /// </summary>
         public void DrawEllipse(Pen pen, int x, int y, int width, int height)
         {
             if (pen == null)
@@ -1606,27 +1330,18 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        // float version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawPie"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws the outline of a pie section
-        ///       defined by an ellipse and two radial lines.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws the outline of a pie section defined by an ellipse and two radial lines.
+        /// </summary>
         public void DrawPie(Pen pen, RectangleF rect, float startAngle, float sweepAngle)
         {
             DrawPie(pen, rect.X, rect.Y, rect.Width, rect.Height, startAngle,
                     sweepAngle);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawPie1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws the outline of a pie section
-        ///       defined by an ellipse and two radial lines.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws the outline of a pie section defined by an ellipse and two radial lines.
+        /// </summary>
         public void DrawPie(Pen pen, float x, float y, float width,
                             float height, float startAngle, float sweepAngle)
         {
@@ -1640,27 +1355,18 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        // int version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawPie2"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws the outline of a pie section defined by an ellipse
-        ///       and two radial lines.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws the outline of a pie section defined by an ellipse and two radial lines.
+        /// </summary>
         public void DrawPie(Pen pen, Rectangle rect, float startAngle, float sweepAngle)
         {
             DrawPie(pen, rect.X, rect.Y, rect.Width, rect.Height, startAngle,
                     sweepAngle);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawPie3"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws the outline of a pie section defined by an ellipse and two radial
-        ///       lines.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws the outline of a pie section defined by an ellipse and two radial lines.
+        /// </summary>
         public void DrawPie(Pen pen, int x, int y, int width, int height,
                             int startAngle, int sweepAngle)
         {
@@ -1674,12 +1380,9 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        // float version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawPolygon"]/*' />
-        /// <devdoc>
-        ///    Draws the outline of a polygon defined
-        ///    by an array of points.
-        /// </devdoc>
+        /// <summary>
+        /// Draws the outline of a polygon defined by an array of points.
+        /// </summary>
         public void DrawPolygon(Pen pen, PointF[] points)
         {
             if (pen == null)
@@ -1697,12 +1400,9 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        // int version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawPolygon1"]/*' />
-        /// <devdoc>
-        ///    Draws the outline of a polygon defined
-        ///    by an array of points.
-        /// </devdoc>
+        /// <summary>
+        /// Draws the outline of a polygon defined by an array of points.
+        /// </summary>
         public void DrawPolygon(Pen pen, Point[] points)
         {
             if (pen == null)
@@ -1720,13 +1420,9 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawPath"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws the lines and curves defined by a
-        ///    <see cref='System.Drawing.Drawing2D.GraphicsPath'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws the lines and curves defined by a <see cref='GraphicsPath'/>.
+        /// </summary>
         public void DrawPath(Pen pen, GraphicsPath path)
         {
             if (pen == null)
@@ -1741,14 +1437,9 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        // float version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawCurve"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws a curve defined by an array of
-        ///       points.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws a curve defined by an array of points.
+        /// </summary>
         public void DrawCurve(Pen pen, PointF[] points)
         {
             if (pen == null)
@@ -1766,13 +1457,9 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawCurve1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws a curve defined by an array of
-        ///       points.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws a curve defined by an array of points.
+        /// </summary>
         public void DrawCurve(Pen pen, PointF[] points, float tension)
         {
             if (pen == null)
@@ -1790,22 +1477,14 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawCurve2"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void DrawCurve(Pen pen, PointF[] points, int offset, int numberOfSegments)
         {
             DrawCurve(pen, points, offset, numberOfSegments, 0.5f);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawCurve3"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws a curve defined by an array of
-        ///       points.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws a curve defined by an array of points.
+        /// </summary>
         public void DrawCurve(Pen pen, PointF[] points, int offset, int numberOfSegments,
                               float tension)
         {
@@ -1825,13 +1504,9 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        // int version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawCurve4"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws a curve defined by an array of points.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws a curve defined by an array of points.
+        /// </summary>
         public void DrawCurve(Pen pen, Point[] points)
         {
             if (pen == null)
@@ -1849,12 +1524,9 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawCurve5"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws a curve defined by an array of points.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws a curve defined by an array of points.
+        /// </summary>
         public void DrawCurve(Pen pen, Point[] points, float tension)
         {
             if (pen == null)
@@ -1872,12 +1544,9 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawCurve6"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws a curve defined by an array of points.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws a curve defined by an array of points.
+        /// </summary>
         public void DrawCurve(Pen pen, Point[] points, int offset, int numberOfSegments,
                               float tension)
         {
@@ -1897,14 +1566,9 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        // float version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawClosedCurve"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws a closed curve defined by an
-        ///       array of points.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws a closed curve defined by an array of points.
+        /// </summary>
         public void DrawClosedCurve(Pen pen, PointF[] points)
         {
             if (pen == null)
@@ -1922,13 +1586,9 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawClosedCurve1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws a closed curve defined by an
-        ///       array of points.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws a closed curve defined by an array of points.
+        /// </summary>
         public void DrawClosedCurve(Pen pen, PointF[] points, float tension, FillMode fillmode)
         {
             if (pen == null)
@@ -1946,13 +1606,9 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        // int version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawClosedCurve2"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws a closed curve defined by an array of points.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws a closed curve defined by an array of points.
+        /// </summary>
         public void DrawClosedCurve(Pen pen, Point[] points)
         {
             if (pen == null)
@@ -1970,12 +1626,9 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawClosedCurve3"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws a closed curve defined by an array of points.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws a closed curve defined by an array of points.
+        /// </summary>
         public void DrawClosedCurve(Pen pen, Point[] points, float tension, FillMode fillmode)
         {
             if (pen == null)
@@ -1993,11 +1646,9 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.Clear"]/*' />
-        /// <devdoc>
-        ///    Fills the entire drawing surface with the
-        ///    specified color.
-        /// </devdoc>
+        /// <summary>
+        /// Fills the entire drawing surface with the specified color.
+        /// </summary>
         public void Clear(Color color)
         {
             int status = SafeNativeMethods.Gdip.GdipGraphicsClear(new HandleRef(this, NativeGraphics), color.ToArgb());
@@ -2008,25 +1659,17 @@ namespace System.Drawing
             }
         }
 
-        // float version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.FillRectangle"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Fills the interior of a rectangle with a <see cref='System.Drawing.Brush'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Fills the interior of a rectangle with a <see cref='Brush'/>.
+        /// </summary>
         public void FillRectangle(Brush brush, RectangleF rect)
         {
             FillRectangle(brush, rect.X, rect.Y, rect.Width, rect.Height);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.FillRectangle1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Fills the interior of a rectangle with a
-        ///    <see cref='System.Drawing.Brush'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Fills the interior of a rectangle with a <see cref='Brush'/>.
+        /// </summary>
         public void FillRectangle(Brush brush, float x, float y, float width, float height)
         {
             if (brush == null)
@@ -2041,24 +1684,17 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        // int version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.FillRectangle2"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Fills the interior of a rectangle with a <see cref='System.Drawing.Brush'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Fills the interior of a rectangle with a <see cref='Brush'/>.
+        /// </summary>
         public void FillRectangle(Brush brush, Rectangle rect)
         {
             FillRectangle(brush, rect.X, rect.Y, rect.Width, rect.Height);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.FillRectangle3"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Fills the interior of a rectangle with a <see cref='System.Drawing.Brush'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Fills the interior of a rectangle with a <see cref='Brush'/>.
+        /// </summary>
         public void FillRectangle(Brush brush, int x, int y, int width, int height)
         {
             if (brush == null)
@@ -2072,13 +1708,9 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.FillRectangles"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Fills the interiors of a series of
-        ///       rectangles with a <see cref='System.Drawing.Brush'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Fills the interiors of a series of rectangles with a <see cref='Brush'/>.
+        /// </summary>
         public void FillRectangles(Brush brush, RectangleF[] rects)
         {
             if (brush == null)
@@ -2100,12 +1732,9 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.FillRectangles1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Fills the interiors of a series of rectangles with a <see cref='System.Drawing.Brush'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Fills the interiors of a series of rectangles with a <see cref='Brush'/>.
+        /// </summary>
         public void FillRectangles(Brush brush, Rectangle[] rects)
         {
             if (brush == null)
@@ -2127,25 +1756,17 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        // float version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.FillPolygon"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Fills the interior of a polygon defined
-        ///       by an array of points.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Fills the interior of a polygon defined by an array of points.
+        /// </summary>
         public void FillPolygon(Brush brush, PointF[] points)
         {
             FillPolygon(brush, points, FillMode.Alternate);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.FillPolygon1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Fills the interior of a polygon defined by an array of points.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Fills the interior of a polygon defined by an array of points.
+        /// </summary>
         public void FillPolygon(Brush brush, PointF[] points, FillMode fillMode)
         {
             if (brush == null)
@@ -2163,24 +1784,17 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        // int version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.FillPolygon2"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Fills the interior of a polygon defined by an array of points.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Fills the interior of a polygon defined by an array of points.
+        /// </summary>
         public void FillPolygon(Brush brush, Point[] points)
         {
             FillPolygon(brush, points, FillMode.Alternate);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.FillPolygon3"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Fills the interior of a polygon defined by an array of points.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Fills the interior of a polygon defined by an array of points.
+        /// </summary>
         public void FillPolygon(Brush brush, Point[] points, FillMode fillMode)
         {
             if (brush == null)
@@ -2198,25 +1812,17 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        // float version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.FillEllipse"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Fills the interior of an ellipse
-        ///       defined by a bounding rectangle.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Fills the interior of an ellipse defined by a bounding rectangle.
+        /// </summary>
         public void FillEllipse(Brush brush, RectangleF rect)
         {
             FillEllipse(brush, rect.X, rect.Y, rect.Width, rect.Height);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.FillEllipse1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Fills the interior of an ellipse defined by a bounding rectangle.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Fills the interior of an ellipse defined by a bounding rectangle.
+        /// </summary>
         public void FillEllipse(Brush brush, float x, float y, float width,
                                 float height)
         {
@@ -2230,25 +1836,17 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        // int version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.FillEllipse2"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Fills the interior of an ellipse defined by a bounding rectangle.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Fills the interior of an ellipse defined by a bounding rectangle.
+        /// </summary>
         public void FillEllipse(Brush brush, Rectangle rect)
         {
             FillEllipse(brush, rect.X, rect.Y, rect.Width, rect.Height);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.FillEllipse3"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Fills the interior of an ellipse defined by a bounding
-        ///       rectangle.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Fills the interior of an ellipse defined by a bounding rectangle.
+        /// </summary>
         public void FillEllipse(Brush brush, int x, int y, int width, int height)
         {
             if (brush == null)
@@ -2261,13 +1859,9 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.FillPie"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Fills the interior of a pie section defined by an ellipse and two radial
-        ///       lines.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Fills the interior of a pie section defined by an ellipse and two radial lines.
+        /// </summary>
         public void FillPie(Brush brush, Rectangle rect, float startAngle,
                             float sweepAngle)
         {
@@ -2275,14 +1869,9 @@ namespace System.Drawing
                     sweepAngle);
         }
 
-        // float verison
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.FillPie1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Fills the interior of a pie section defined by an ellipse and two radial
-        ///       lines.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Fills the interior of a pie section defined by an ellipse and two radial lines.
+        /// </summary>
         public void FillPie(Brush brush, float x, float y, float width,
                             float height, float startAngle, float sweepAngle)
         {
@@ -2296,14 +1885,9 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        // int verison
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.FillPie2"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Fills the interior of a pie section defined by an ellipse
-        ///       and two radial lines.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Fills the interior of a pie section defined by an ellipse and two radial lines.
+        /// </summary>
         public void FillPie(Brush brush, int x, int y, int width,
                             int height, int startAngle, int sweepAngle)
         {
@@ -2317,12 +1901,9 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.FillPath"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Fills the interior of a path.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Fills the interior of a path.
+        /// </summary>
         public void FillPath(Brush brush, GraphicsPath path)
         {
             if (brush == null)
@@ -2337,15 +1918,9 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        // float version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.FillClosedCurve"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Fills the interior a closed
-        ///       curve defined by an
-        ///       array of points.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Fills the interior a closed curve defined by an array of points.
+        /// </summary>
         public void FillClosedCurve(Brush brush, PointF[] points)
         {
             if (brush == null)
@@ -2363,22 +1938,14 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.FillClosedCurve1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Fills the
-        ///       interior of a closed curve defined by an array of points.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Fills the interior of a closed curve defined by an array of points.
+        /// </summary>
         public void FillClosedCurve(Brush brush, PointF[] points, FillMode fillmode)
         {
             FillClosedCurve(brush, points, fillmode, 0.5f);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.FillClosedCurve2"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void FillClosedCurve(Brush brush, PointF[] points, FillMode fillmode, float tension)
         {
             if (brush == null)
@@ -2397,13 +1964,9 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        // int version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.FillClosedCurve3"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Fills the interior a closed curve defined by an array of points.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Fills the interior a closed curve defined by an array of points.
+        /// </summary>
         public void FillClosedCurve(Brush brush, Point[] points)
         {
             if (brush == null)
@@ -2421,19 +1984,11 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.FillClosedCurve4"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void FillClosedCurve(Brush brush, Point[] points, FillMode fillmode)
         {
             FillClosedCurve(brush, points, fillmode, 0.5f);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.FillClosedCurve5"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void FillClosedCurve(Brush brush, Point[] points, FillMode fillmode, float tension)
         {
             if (brush == null)
@@ -2452,12 +2007,9 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.FillRegion"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Fills the interior of a <see cref='System.Drawing.Region'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Fills the interior of a <see cref='Region'/>.
+        /// </summary>
         public void FillRegion(Brush brush, Region region)
         {
             if (brush == null)
@@ -2473,66 +2025,42 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        /*
-         * Text drawing methods
-         *
-         * @notes Should there be integer versions, also?
-         */
-
-        // Without clipping rectangle
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawString"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws a string with the specified font.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws a string with the specified font.
+        /// </summary>
         public void DrawString(String s, Font font, Brush brush, float x, float y)
         {
             DrawString(s, font, brush, new RectangleF(x, y, 0, 0), null);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawString1"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public void DrawString(String s, Font font, Brush brush, PointF point)
         {
             DrawString(s, font, brush, new RectangleF(point.X, point.Y, 0, 0), null);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawString2"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public void DrawString(String s, Font font, Brush brush, float x, float y, StringFormat format)
         {
             DrawString(s, font, brush, new RectangleF(x, y, 0, 0), format);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawString3"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public void DrawString(String s, Font font, Brush brush, PointF point, StringFormat format)
         {
             DrawString(s, font, brush, new RectangleF(point.X, point.Y, 0, 0), format);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawString4"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public void DrawString(String s, Font font, Brush brush, RectangleF layoutRectangle)
         {
             DrawString(s, font, brush, layoutRectangle, null);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawString5"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public void DrawString(String s, Font font, Brush brush,
                                RectangleF layoutRectangle, StringFormat format)
         {
             if (brush == null)
                 throw new ArgumentNullException("brush");
 
-            if (s == null || s.Length == 0) return;
+            if (s == null || s.Length == 0)
+                return;
             if (font == null)
                 throw new ArgumentNullException("font");
 
@@ -2544,11 +2072,6 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        // MeasureString
-
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.MeasureString"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public SizeF MeasureString(String text, Font font, SizeF layoutArea, StringFormat stringFormat,
                                    out int charactersFitted, out int linesFilled)
         {
@@ -2578,9 +2101,6 @@ namespace System.Drawing
             return grfboundingBox.SizeF;
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.MeasureString1"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public SizeF MeasureString(String text, Font font, PointF origin, StringFormat stringFormat)
         {
             if (text == null || text.Length == 0)
@@ -2610,17 +2130,11 @@ namespace System.Drawing
             return grfboundingBox.SizeF;
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.MeasureString2"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public SizeF MeasureString(String text, Font font, SizeF layoutArea)
         {
             return MeasureString(text, font, layoutArea, null);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.MeasureString3"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public SizeF MeasureString(String text, Font font, SizeF layoutArea, StringFormat stringFormat)
         {
             if (text == null || text.Length == 0)
@@ -2650,33 +2164,21 @@ namespace System.Drawing
             return grfboundingBox.SizeF;
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.MeasureString4"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public SizeF MeasureString(String text, Font font)
         {
             return MeasureString(text, font, new SizeF(0, 0));
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.MeasureString5"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public SizeF MeasureString(String text, Font font, int width)
         {
             return MeasureString(text, font, new SizeF(width, 999999));
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.MeasureString6"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public SizeF MeasureString(String text, Font font, int width, StringFormat format)
         {
             return MeasureString(text, font, new SizeF(width, 999999), format);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.MeasureCharacterRanges"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public Region[] MeasureCharacterRanges(String text, Font font, RectangleF layoutRect,
                                           StringFormat stringFormat)
         {
@@ -2723,9 +2225,6 @@ namespace System.Drawing
             return regions;
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawIcon"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public void DrawIcon(Icon icon, int x, int y)
         {
             if (icon == null)
@@ -2746,13 +2245,12 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawIcon1"]/*' />
-        /// <devdoc>
-        ///    Draws this image to a graphics object.  The drawing command originates on the graphics
-        ///    object, but a graphics object generally has no idea how to render a given image.  So,
-        ///    it passes the call to the actual image.  This version crops the image to the given
-        ///    dimensions and allows the user to specify a rectangle within the image to draw.
-        /// </devdoc>
+        /// <summary>
+        /// Draws this image to a graphics object.  The drawing command originates on the graphics
+        /// object, but a graphics object generally has no idea how to render a given image.  So,
+        /// it passes the call to the actual image.  This version crops the image to the given
+        /// dimensions and allows the user to specify a rectangle within the image to draw.
+        /// </summary>
         public void DrawIcon(Icon icon, Rectangle targetRect)
         {
             if (icon == null)
@@ -2773,13 +2271,12 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawIconUnstretched"]/*' />
-        /// <devdoc>
-        ///    Draws this image to a graphics object.  The drawing command originates on the graphics
-        ///    object, but a graphics object generally has no idea how to render a given image.  So,
-        ///    it passes the call to the actual image.  This version stretches the image to the given
-        ///    dimensions and allows the user to specify a rectangle within the image to draw.
-        /// </devdoc>
+        /// <summary>
+        /// Draws this image to a graphics object.  The drawing command originates on the graphics
+        /// object, but a graphics object generally has no idea how to render a given image.  So,
+        /// it passes the call to the actual image.  This version stretches the image to the given
+        /// dimensions and allows the user to specify a rectangle within the image to draw.
+        /// </summary>
         public void DrawIconUnstretched(Icon icon, Rectangle targetRect)
         {
             if (icon == null)
@@ -2797,25 +2294,15 @@ namespace System.Drawing
             }
         }
 
-        /**
-         * Draw images (both bitmap and vector)
-         */
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawImage"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draws the specified image at the
-        ///       specified location.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draws the specified image at the specified location.
+        /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, PointF point)
         {
             DrawImage(image, point.X, point.Y);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawImage1"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, float x, float y)
         {
@@ -2832,18 +2319,12 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawImage2"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, RectangleF rect)
         {
             DrawImage(image, rect.X, rect.Y, rect.Width, rect.Height);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawImage3"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, float x, float y, float width,
                               float height)
@@ -2863,19 +2344,12 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        // int version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawImage4"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, Point point)
         {
             DrawImage(image, point.X, point.Y);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawImage5"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, int x, int y)
         {
@@ -2892,18 +2366,12 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawImage6"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, Rectangle rect)
         {
             DrawImage(image, rect.X, rect.Y, rect.Width, rect.Height);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawImage7"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, int x, int y, int width, int height)
         {
@@ -2926,42 +2394,26 @@ namespace System.Drawing
 
 
 
-        // unscaled versions
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawImageUnscaled"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public void DrawImageUnscaled(Image image, Point point)
         {
             DrawImage(image, point.X, point.Y);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawImageUnscaled1"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public void DrawImageUnscaled(Image image, int x, int y)
         {
             DrawImage(image, x, y);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawImageUnscaled2"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public void DrawImageUnscaled(Image image, Rectangle rect)
         {
             DrawImage(image, rect.X, rect.Y);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawImageUnscaled3"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public void DrawImageUnscaled(Image image, int x, int y, int width, int height)
         {
             DrawImage(image, x, y);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawImageUnscaledAndClipped"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public void DrawImageUnscaledAndClipped(Image image, Rectangle rect)
         {
             if (image == null)
@@ -2987,9 +2439,6 @@ namespace System.Drawing
          *
          *  @notes Perspective blt only works for bitmap images.
          */
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawImage8"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, PointF[] destPoints)
         {
@@ -3017,10 +2466,6 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        // int version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawImage9"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, Point[] destPoints)
         {
@@ -3048,15 +2493,6 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        /*
-         * We need another set of methods similar to the ones above
-         * that take an additional Rectangle parameter to specify the
-         * portion of the source image to be drawn.
-         */
-        // float version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawImage10"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, float x, float y, RectangleF srcRect,
                               GraphicsUnit srcUnit)
@@ -3082,10 +2518,6 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        // int version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawImage11"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, int x, int y, Rectangle srcRect,
                               GraphicsUnit srcUnit)
@@ -3111,10 +2543,6 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        // float version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawImage12"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, RectangleF destRect, RectangleF srcRect,
                               GraphicsUnit srcUnit)
@@ -3146,10 +2574,6 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        // int version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawImage13"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, Rectangle destRect, Rectangle srcRect,
                               GraphicsUnit srcUnit)
@@ -3180,8 +2604,6 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        // float version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawImage14"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, PointF[] destPoints, RectangleF srcRect,
                               GraphicsUnit srcUnit)
@@ -3221,7 +2643,6 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawImage15"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, PointF[] destPoints, RectangleF srcRect,
                               GraphicsUnit srcUnit, ImageAttributes imageAttr)
@@ -3229,7 +2650,6 @@ namespace System.Drawing
             DrawImage(image, destPoints, srcRect, srcUnit, imageAttr, null, 0);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawImage16"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, PointF[] destPoints, RectangleF srcRect,
                               GraphicsUnit srcUnit, ImageAttributes imageAttr,
@@ -3238,7 +2658,6 @@ namespace System.Drawing
             DrawImage(image, destPoints, srcRect, srcUnit, imageAttr, callback, 0);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawImage17"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, PointF[] destPoints, RectangleF srcRect,
                               GraphicsUnit srcUnit, ImageAttributes imageAttr,
@@ -3279,15 +2698,12 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        // int version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawImage18"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, Point[] destPoints, Rectangle srcRect, GraphicsUnit srcUnit)
         {
             DrawImage(image, destPoints, srcRect, srcUnit, null, null, 0);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawImage19"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, Point[] destPoints, Rectangle srcRect,
                               GraphicsUnit srcUnit, ImageAttributes imageAttr)
@@ -3295,7 +2711,6 @@ namespace System.Drawing
             DrawImage(image, destPoints, srcRect, srcUnit, imageAttr, null, 0);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawImage20"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, Point[] destPoints, Rectangle srcRect,
                               GraphicsUnit srcUnit, ImageAttributes imageAttr,
@@ -3304,7 +2719,6 @@ namespace System.Drawing
             DrawImage(image, destPoints, srcRect, srcUnit, imageAttr, callback, 0);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawImage21"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, Point[] destPoints, Rectangle srcRect,
                               GraphicsUnit srcUnit, ImageAttributes imageAttr,
@@ -3345,8 +2759,6 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        // float version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawImage22"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, Rectangle destRect, float srcX, float srcY,
                               float srcWidth, float srcHeight, GraphicsUnit srcUnit)
@@ -3354,7 +2766,6 @@ namespace System.Drawing
             DrawImage(image, destRect, srcX, srcY, srcWidth, srcHeight, srcUnit, null);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawImage23"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, Rectangle destRect, float srcX, float srcY,
                               float srcWidth, float srcHeight, GraphicsUnit srcUnit,
@@ -3363,7 +2774,6 @@ namespace System.Drawing
             DrawImage(image, destRect, srcX, srcY, srcWidth, srcHeight, srcUnit, imageAttrs, null);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawImage24"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, Rectangle destRect, float srcX, float srcY,
                               float srcWidth, float srcHeight, GraphicsUnit srcUnit,
@@ -3373,7 +2783,6 @@ namespace System.Drawing
         }
 
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawImage25"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, Rectangle destRect, float srcX, float srcY,
                               float srcWidth, float srcHeight, GraphicsUnit srcUnit, ImageAttributes imageAttrs,
@@ -3405,8 +2814,6 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        // int version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawImage26"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, Rectangle destRect, int srcX, int srcY,
                               int srcWidth, int srcHeight, GraphicsUnit srcUnit)
@@ -3414,7 +2821,6 @@ namespace System.Drawing
             DrawImage(image, destRect, srcX, srcY, srcWidth, srcHeight, srcUnit, null);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawImage27"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, Rectangle destRect, int srcX, int srcY,
                               int srcWidth, int srcHeight, GraphicsUnit srcUnit,
@@ -3423,7 +2829,6 @@ namespace System.Drawing
             DrawImage(image, destRect, srcX, srcY, srcWidth, srcHeight, srcUnit, imageAttr, null);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawImage28"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, Rectangle destRect, int srcX, int srcY,
                               int srcWidth, int srcHeight, GraphicsUnit srcUnit,
@@ -3432,7 +2837,6 @@ namespace System.Drawing
             DrawImage(image, destRect, srcX, srcY, srcWidth, srcHeight, srcUnit, imageAttr, callback, IntPtr.Zero);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.DrawImage29"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, Rectangle destRect, int srcX, int srcY,
                               int srcWidth, int srcHeight, GraphicsUnit srcUnit, ImageAttributes imageAttrs,
@@ -3464,7 +2868,6 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EnumerateMetafile"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, PointF destPoint,
                                       EnumerateMetafileProc callback)
@@ -3472,7 +2875,6 @@ namespace System.Drawing
             EnumerateMetafile(metafile, destPoint, callback, IntPtr.Zero);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EnumerateMetafile1"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, PointF destPoint,
                                       EnumerateMetafileProc callback, IntPtr callbackData)
@@ -3480,7 +2882,6 @@ namespace System.Drawing
             EnumerateMetafile(metafile, destPoint, callback, callbackData, null);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EnumerateMetafile2"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
         public void EnumerateMetafile(Metafile metafile, PointF destPoint,
@@ -3503,7 +2904,6 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EnumerateMetafile3"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, Point destPoint,
                                       EnumerateMetafileProc callback)
@@ -3511,7 +2911,6 @@ namespace System.Drawing
             EnumerateMetafile(metafile, destPoint, callback, IntPtr.Zero);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EnumerateMetafile4"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, Point destPoint,
                                       EnumerateMetafileProc callback, IntPtr callbackData)
@@ -3519,7 +2918,6 @@ namespace System.Drawing
             EnumerateMetafile(metafile, destPoint, callback, callbackData, null);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EnumerateMetafile5"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
         public void EnumerateMetafile(Metafile metafile, Point destPoint,
@@ -3542,7 +2940,6 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EnumerateMetafile6"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, RectangleF destRect,
                                       EnumerateMetafileProc callback)
@@ -3550,7 +2947,6 @@ namespace System.Drawing
             EnumerateMetafile(metafile, destRect, callback, IntPtr.Zero);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EnumerateMetafile7"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, RectangleF destRect,
                                       EnumerateMetafileProc callback, IntPtr callbackData)
@@ -3558,7 +2954,6 @@ namespace System.Drawing
             EnumerateMetafile(metafile, destRect, callback, callbackData, null);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EnumerateMetafile8"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
         public void EnumerateMetafile(Metafile metafile, RectangleF destRect,
@@ -3584,7 +2979,6 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EnumerateMetafile9"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, Rectangle destRect,
                                       EnumerateMetafileProc callback)
@@ -3592,7 +2986,6 @@ namespace System.Drawing
             EnumerateMetafile(metafile, destRect, callback, IntPtr.Zero);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EnumerateMetafile10"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, Rectangle destRect,
                                       EnumerateMetafileProc callback, IntPtr callbackData)
@@ -3600,7 +2993,6 @@ namespace System.Drawing
             EnumerateMetafile(metafile, destRect, callback, callbackData, null);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EnumerateMetafile11"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
         public void EnumerateMetafile(Metafile metafile, Rectangle destRect,
@@ -3624,7 +3016,6 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EnumerateMetafile12"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, PointF[] destPoints,
                                       EnumerateMetafileProc callback)
@@ -3632,7 +3023,6 @@ namespace System.Drawing
             EnumerateMetafile(metafile, destPoints, callback, IntPtr.Zero);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EnumerateMetafile13"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, PointF[] destPoints,
                                       EnumerateMetafileProc callback, IntPtr callbackData)
@@ -3640,7 +3030,6 @@ namespace System.Drawing
             EnumerateMetafile(metafile, destPoints, callback, IntPtr.Zero, null);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EnumerateMetafile14"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
         public void EnumerateMetafile(Metafile metafile, PointF[] destPoints,
@@ -3675,7 +3064,6 @@ namespace System.Drawing
         }
 
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EnumerateMetafile15"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, Point[] destPoints,
                                       EnumerateMetafileProc callback)
@@ -3683,7 +3071,6 @@ namespace System.Drawing
             EnumerateMetafile(metafile, destPoints, callback, IntPtr.Zero);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EnumerateMetafile16"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, Point[] destPoints,
                                       EnumerateMetafileProc callback, IntPtr callbackData)
@@ -3691,7 +3078,6 @@ namespace System.Drawing
             EnumerateMetafile(metafile, destPoints, callback, callbackData, null);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EnumerateMetafile17"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
         public void EnumerateMetafile(Metafile metafile, Point[] destPoints,
@@ -3725,7 +3111,6 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EnumerateMetafile18"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, PointF destPoint,
                                       RectangleF srcRect, GraphicsUnit srcUnit,
@@ -3734,7 +3119,6 @@ namespace System.Drawing
             EnumerateMetafile(metafile, destPoint, srcRect, srcUnit, callback, IntPtr.Zero);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EnumerateMetafile19"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, PointF destPoint,
                                       RectangleF srcRect, GraphicsUnit srcUnit,
@@ -3743,7 +3127,6 @@ namespace System.Drawing
             EnumerateMetafile(metafile, destPoint, srcRect, srcUnit, callback, callbackData, null);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EnumerateMetafile20"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
         public void EnumerateMetafile(Metafile metafile, PointF destPoint,
@@ -3771,7 +3154,6 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EnumerateMetafile21"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, Point destPoint,
                                       Rectangle srcRect, GraphicsUnit srcUnit,
@@ -3780,7 +3162,6 @@ namespace System.Drawing
             EnumerateMetafile(metafile, destPoint, srcRect, srcUnit, callback, IntPtr.Zero);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EnumerateMetafile22"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, Point destPoint,
                                       Rectangle srcRect, GraphicsUnit srcUnit,
@@ -3789,7 +3170,6 @@ namespace System.Drawing
             EnumerateMetafile(metafile, destPoint, srcRect, srcUnit, callback, callbackData, null);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EnumerateMetafile23"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
         public void EnumerateMetafile(Metafile metafile, Point destPoint,
@@ -3818,7 +3198,6 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EnumerateMetafile24"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, RectangleF destRect,
                                       RectangleF srcRect, GraphicsUnit srcUnit,
@@ -3827,7 +3206,6 @@ namespace System.Drawing
             EnumerateMetafile(metafile, destRect, srcRect, srcUnit, callback, IntPtr.Zero);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EnumerateMetafile25"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, RectangleF destRect,
                                       RectangleF srcRect, GraphicsUnit srcUnit,
@@ -3836,7 +3214,6 @@ namespace System.Drawing
             EnumerateMetafile(metafile, destRect, srcRect, srcUnit, callback, callbackData, null);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EnumerateMetafile26"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
         public void EnumerateMetafile(Metafile metafile, RectangleF destRect,
@@ -3866,7 +3243,6 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EnumerateMetafile27"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, Rectangle destRect,
                                       Rectangle srcRect, GraphicsUnit srcUnit,
@@ -3875,7 +3251,6 @@ namespace System.Drawing
             EnumerateMetafile(metafile, destRect, srcRect, srcUnit, callback, IntPtr.Zero);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EnumerateMetafile28"]/*' />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, Rectangle destRect,
                                       Rectangle srcRect, GraphicsUnit srcUnit,
@@ -3884,10 +3259,6 @@ namespace System.Drawing
             EnumerateMetafile(metafile, destRect, srcRect, srcUnit, callback, callbackData, null);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EnumerateMetafile29"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, Rectangle destRect,
@@ -3916,10 +3287,6 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EnumerateMetafile30"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, PointF[] destPoints,
                                       RectangleF srcRect, GraphicsUnit srcUnit,
@@ -3928,10 +3295,6 @@ namespace System.Drawing
             EnumerateMetafile(metafile, destPoints, srcRect, srcUnit, callback, IntPtr.Zero);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EnumerateMetafile31"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, PointF[] destPoints,
                                       RectangleF srcRect, GraphicsUnit srcUnit,
@@ -3940,10 +3303,6 @@ namespace System.Drawing
             EnumerateMetafile(metafile, destPoints, srcRect, srcUnit, callback, callbackData, null);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EnumerateMetafile32"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, PointF[] destPoints,
@@ -3982,11 +3341,6 @@ namespace System.Drawing
             }
         }
 
-
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EnumerateMetafile33"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, Point[] destPoints,
                                       Rectangle srcRect, GraphicsUnit srcUnit,
@@ -3995,10 +3349,6 @@ namespace System.Drawing
             EnumerateMetafile(metafile, destPoints, srcRect, srcUnit, callback, IntPtr.Zero);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EnumerateMetafile34"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, Point[] destPoints,
                                       Rectangle srcRect, GraphicsUnit srcUnit,
@@ -4007,10 +3357,6 @@ namespace System.Drawing
             EnumerateMetafile(metafile, destPoints, srcRect, srcUnit, callback, callbackData, null);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EnumerateMetafile35"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, Point[] destPoints,
@@ -4050,23 +3396,11 @@ namespace System.Drawing
         }
 
 
-        /*
-         * Clipping region operations
-         *
-         * @notes Simply incredible redundancy here.
-         */
-
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.SetClip"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public void SetClip(Graphics g)
         {
             SetClip(g, CombineMode.Replace);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.SetClip1"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public void SetClip(Graphics g, CombineMode combineMode)
         {
             if (g == null)
@@ -4082,17 +3416,11 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.SetClip2"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public void SetClip(Rectangle rect)
         {
             SetClip(rect, CombineMode.Replace);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.SetClip3"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public void SetClip(Rectangle rect, CombineMode combineMode)
         {
             int status = SafeNativeMethods.Gdip.GdipSetClipRectI(new HandleRef(this, NativeGraphics), rect.X, rect.Y,
@@ -4104,17 +3432,11 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.SetClip4"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public void SetClip(RectangleF rect)
         {
             SetClip(rect, CombineMode.Replace);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.SetClip5"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public void SetClip(RectangleF rect, CombineMode combineMode)
         {
             int status = SafeNativeMethods.Gdip.GdipSetClipRect(new HandleRef(this, NativeGraphics), rect.X, rect.Y,
@@ -4126,17 +3448,11 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.SetClip6"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public void SetClip(GraphicsPath path)
         {
             SetClip(path, CombineMode.Replace);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.SetClip7"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public void SetClip(GraphicsPath path, CombineMode combineMode)
         {
             if (path == null)
@@ -4151,9 +3467,6 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.SetClip8"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public void SetClip(Region region, CombineMode combineMode)
         {
             if (region == null)
@@ -4169,9 +3482,6 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.IntersectClip"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public void IntersectClip(Rectangle rect)
         {
             int status = SafeNativeMethods.Gdip.GdipSetClipRectI(new HandleRef(this, NativeGraphics), rect.X, rect.Y,
@@ -4183,9 +3493,6 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.IntersectClip1"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public void IntersectClip(RectangleF rect)
         {
             int status = SafeNativeMethods.Gdip.GdipSetClipRect(new HandleRef(this, NativeGraphics), rect.X, rect.Y,
@@ -4197,9 +3504,6 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.IntersectClip2"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public void IntersectClip(Region region)
         {
             if (region == null)
@@ -4214,9 +3518,6 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.ExcludeClip"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public void ExcludeClip(Rectangle rect)
         {
             int status = SafeNativeMethods.Gdip.GdipSetClipRectI(new HandleRef(this, NativeGraphics), rect.X, rect.Y,
@@ -4228,9 +3529,6 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.ExcludeClip1"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public void ExcludeClip(Region region)
         {
             if (region == null)
@@ -4246,9 +3544,6 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.ResetClip"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public void ResetClip()
         {
             int status = SafeNativeMethods.Gdip.GdipResetClip(new HandleRef(this, NativeGraphics));
@@ -4259,9 +3554,6 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.TranslateClip"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public void TranslateClip(float dx, float dy)
         {
             int status = SafeNativeMethods.Gdip.GdipTranslateClip(new HandleRef(this, NativeGraphics), dx, dy);
@@ -4272,9 +3564,6 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.TranslateClip1"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public void TranslateClip(int dx, int dy)
         {
             int status = SafeNativeMethods.Gdip.GdipTranslateClip(new HandleRef(this, NativeGraphics), dx, dy);
@@ -4285,17 +3574,17 @@ namespace System.Drawing
             }
         }
 
-        /// <devdoc>
-        ///     Combines current Graphics context with all previous contexts.
-        ///     When BeginContainer() is called, a copy of the current context is pushed into the GDI+ context stack, it keeps track of the
-        ///     absolute clipping and transform but reset the public properties so it looks like a brand new context.
-        ///     When Save() is called, a copy of the current context is also pushed in the GDI+ stack but the public clipping and transform
-        ///     properties are not reset (cumulative).  Consecutive Save context are ignored with the exception of the top one which contains 
-        ///     all previous information.
-        ///     The return value is an object array where the first element contains the cumulative clip region and the second the cumulative
-        ///     translate transform matrix.
-        ///     WARNING: This method is for internal FX support only.
-        ///     </devdoc>
+        /// <summary>
+        /// Combines current Graphics context with all previous contexts.
+        /// When BeginContainer() is called, a copy of the current context is pushed into the GDI+ context stack, it keeps track of the
+        /// absolute clipping and transform but reset the public properties so it looks like a brand new context.
+        /// When Save() is called, a copy of the current context is also pushed in the GDI+ stack but the public clipping and transform
+        /// properties are not reset (cumulative).  Consecutive Save context are ignored with the exception of the top one which contains 
+        /// all previous information.
+        /// The return value is an object array where the first element contains the cumulative clip region and the second the cumulative
+        /// translate transform matrix.
+        /// WARNING: This method is for internal FX support only.
+        /// </summary>
         [StrongNameIdentityPermissionAttribute(SecurityAction.LinkDemand, Name = "System.Windows.Forms", PublicKey = "0x00000000000000000400000000000000")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public object GetContextInfo()
@@ -4361,12 +3650,6 @@ namespace System.Drawing
         }
 
 
-        /**
-         *  GetClip region from graphics context
-         */
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.Clip"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public Region Clip
         {
             get
@@ -4388,9 +3671,6 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.ClipBounds"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public RectangleF ClipBounds
         {
             get
@@ -4408,9 +3688,6 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.IsClipEmpty"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public bool IsClipEmpty
         {
             get
@@ -4428,12 +3705,6 @@ namespace System.Drawing
             }
         }
 
-        /**
-         * Hit testing operations
-         */
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.VisibleClipBounds"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public RectangleF VisibleClipBounds
         {
             get
@@ -4460,12 +3731,6 @@ namespace System.Drawing
             }
         }
 
-        /**
-          * @notes atomic operation?  status needed?
-          */
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.IsVisibleClipEmpty"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public bool IsVisibleClipEmpty
         {
             get
@@ -4484,17 +3749,11 @@ namespace System.Drawing
         }
 
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.IsVisible"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public bool IsVisible(int x, int y)
         {
             return IsVisible(new Point(x, y));
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.IsVisible1"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public bool IsVisible(Point point)
         {
             int isVisible;
@@ -4509,17 +3768,11 @@ namespace System.Drawing
             return isVisible != 0;
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.IsVisible2"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public bool IsVisible(float x, float y)
         {
             return IsVisible(new PointF(x, y));
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.IsVisible3"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public bool IsVisible(PointF point)
         {
             int isVisible;
@@ -4534,17 +3787,11 @@ namespace System.Drawing
             return isVisible != 0;
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.IsVisible4"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public bool IsVisible(int x, int y, int width, int height)
         {
             return IsVisible(new Rectangle(x, y, width, height));
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.IsVisible5"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public bool IsVisible(Rectangle rect)
         {
             int isVisible;
@@ -4560,17 +3807,11 @@ namespace System.Drawing
             return isVisible != 0;
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.IsVisible6"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public bool IsVisible(float x, float y, float width, float height)
         {
             return IsVisible(new RectangleF(x, y, width, height));
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.IsVisible7"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public bool IsVisible(RectangleF rect)
         {
             int isVisible;
@@ -4586,9 +3827,9 @@ namespace System.Drawing
             return isVisible != 0;
         }
 
-        /// <devdoc>
-        ///     Saves the current context into the context stack.
-        /// </devdoc>
+        /// <summary>
+        /// Saves the current context into the context stack.
+        /// </summary>
         private void PushContext(GraphicsContext context)
         {
             Debug.Assert(context != null && context.State != 0, "GraphicsContext object is null or not valid.");
@@ -4602,9 +3843,9 @@ namespace System.Drawing
             _previousContext = context;
         }
 
-        /// <devdoc>
-        ///     Pops all contexts from the specified one included.  The specified context is becoming the current context.
-        /// </devdoc>
+        /// <summary>
+        /// Pops all contexts from the specified one included.  The specified context is becoming the current context.
+        /// </summary>
         private void PopContext(int currentContextState)
         {
             Debug.Assert(_previousContext != null, "Trying to restore a context when the stack is empty");
@@ -4624,12 +3865,6 @@ namespace System.Drawing
             Debug.Fail("Warning: context state not found!");
         }
 
-        /**
-         * Save/restore graphics state
-         */
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.Save"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public GraphicsState Save()
         {
             GraphicsContext context = new GraphicsContext(this);
@@ -4650,9 +3885,6 @@ namespace System.Drawing
             return new GraphicsState(state);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.Restore"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public void Restore(GraphicsState gstate)
         {
             int status = SafeNativeMethods.Gdip.GdipRestoreGraphics(new HandleRef(this, NativeGraphics), gstate.nativeState);
@@ -4665,14 +3897,6 @@ namespace System.Drawing
             PopContext(gstate.nativeState);
         }
 
-        /*
-         * Begin and end container drawing
-         */
-        // float version
-
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.BeginContainer"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public GraphicsContainer BeginContainer(RectangleF dstrect, RectangleF srcrect, GraphicsUnit unit)
         {
             GraphicsContext context = new GraphicsContext(this);
@@ -4696,9 +3920,6 @@ namespace System.Drawing
             return new GraphicsContainer(state);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.BeginContainer1"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public GraphicsContainer BeginContainer()
         {
             GraphicsContext context = new GraphicsContext(this);
@@ -4718,9 +3939,6 @@ namespace System.Drawing
             return new GraphicsContainer(state);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.EndContainer"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public void EndContainer(GraphicsContainer container)
         {
             if (container == null)
@@ -4738,10 +3956,6 @@ namespace System.Drawing
             PopContext(container.nativeGraphicsContainer);
         }
 
-        // int version
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.BeginContainer2"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public GraphicsContainer BeginContainer(Rectangle dstrect, Rectangle srcrect, GraphicsUnit unit)
         {
             GraphicsContext context = new GraphicsContext(this);
@@ -4765,9 +3979,6 @@ namespace System.Drawing
             return new GraphicsContainer(state);
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.AddMetafileComment"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public void AddMetafileComment(byte[] data)
         {
             if (data == null)
@@ -4783,9 +3994,6 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Graphics.uex' path='docs/doc[@for="Graphics.GetHalftonePalette"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         public static IntPtr GetHalftonePalette()
         {
             if (s_halftonePalette == IntPtr.Zero)
@@ -4816,19 +4024,19 @@ namespace System.Drawing
         }
 
 
-        /// <devdoc>
-        ///     GDI+ will return a 'generic error' with specific win32 last error codes when
-        ///     a terminal server session has been closed, minimized, etc...  We don't want 
-        ///     to throw when this happens, so we'll guard against this by looking at the
-        ///     'last win32 error code' and checking to see if it is either 1) access denied
-        ///     or 2) proc not found and then ignore it.
+        /// <summary>
+        /// GDI+ will return a 'generic error' with specific win32 last error codes when
+        /// a terminal server session has been closed, minimized, etc...  We don't want 
+        /// to throw when this happens, so we'll guard against this by looking at the
+        /// 'last win32 error code' and checking to see if it is either 1) access denied
+        /// or 2) proc not found and then ignore it.
         /// 
-        ///     The problem is that when you lock the machine, the secure desktop is enabled and 
-        ///     rendering fails which is expected (since the app doesn't have permission to draw 
-        ///     on the secure desktop). Not sure if there's anything you can do, short of catching 
-        ///     the desktop switch message and absorbing all the exceptions that get thrown while 
-        ///     it's the secure desktop.
-        /// </devdoc>
+        /// The problem is that when you lock the machine, the secure desktop is enabled and 
+        /// rendering fails which is expected (since the app doesn't have permission to draw 
+        /// on the secure desktop). Not sure if there's anything you can do, short of catching 
+        /// the desktop switch message and absorbing all the exceptions that get thrown while 
+        /// it's the secure desktop.
+        /// </summary>
         private void CheckErrorStatus(int status)
         {
             if (status != SafeNativeMethods.Gdip.Ok)
@@ -4850,13 +4058,13 @@ namespace System.Drawing
             }
         }
 
-        /// <devdoc>
-        ///     GDI+ will return a 'generic error' when we attempt to draw an Emf 
-        ///     image with width/height == 1.  Here, we will hack around this by 
-        ///     resetting the errorstatus.  Note that we don't do simple arg checking
-        ///     for height || width == 1 here because transforms can be applied to
-        ///     the Graphics object making it difficult to identify this scenario.
-        /// </devdoc>
+        /// <summary>
+        /// GDI+ will return a 'generic error' when we attempt to draw an Emf 
+        /// image with width/height == 1.  Here, we will hack around this by 
+        /// resetting the errorstatus.  Note that we don't do simple arg checking
+        /// for height || width == 1 here because transforms can be applied to
+        /// the Graphics object making it difficult to identify this scenario.
+        /// </summary>
         private void IgnoreMetafileErrors(Image image, ref int errorStatus)
         {
             if (errorStatus != SafeNativeMethods.Gdip.Ok)

--- a/src/System.Drawing.Common/src/System/Drawing/GraphicsContext.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/GraphicsContext.cs
@@ -2,52 +2,49 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Drawing.Drawing2D;
+
 namespace System.Drawing
 {
-    using System.Drawing.Drawing2D;
-
-    /// <devdoc>
-    ///     Contains information about the context of a Graphics object.
-    /// </devdoc>
+    /// <summary>
+    /// Contains information about the context of a Graphics object.
+    /// </summary>
     internal class GraphicsContext : IDisposable
     {
-        /// <devdoc>
-        ///     The state that identifies the context.
-        /// </devdoc>
+        /// <summary>
+        /// The state that identifies the context.
+        /// </summary>
         private int _contextState;
 
-        /// <devdoc>
-        ///     The context's translate transform.
-        /// </devdoc>
+        /// <summary>
+        /// The context's translate transform.
+        /// </summary>
         private PointF _transformOffset;
 
-        /// <devdoc>
-        ///     The context's clip region.
-        /// </devdoc>
+        /// <summary>
+        /// The context's clip region.
+        /// </summary>
         private Region _clipRegion;
 
-        /// <devdoc>
-        ///     The next context up the stack.
-        /// </devdoc>
+        /// <summary>
+        /// The next context up the stack.
+        /// </summary>
         private GraphicsContext _nextContext;
 
-        /// <devdoc>
-        ///     The previous context down the stack.
-        /// </devdoc>
+        /// <summary>
+        /// The previous context down the stack.
+        /// </summary>
         private GraphicsContext _prevContext;
 
-        /// <devdoc>
-        ///     Flags that determines whether the context was created for a Graphics.Save() operation.
-        ///     This kind of contexts are cumulative across subsequent Save() calls so the top context
-        ///     info is cumulative.  This is not the same for contexts created for a Graphics.BeginContainer()
-        ///     operation, in this case the new context information is reset.  See Graphics.BeginContainer()
-        ///     and Graphics.Save() for more information.
-        /// </devdoc>
+        /// <summary>
+        /// Flags that determines whether the context was created for a Graphics.Save() operation.
+        /// This kind of contexts are cumulative across subsequent Save() calls so the top context
+        /// info is cumulative.  This is not the same for contexts created for a Graphics.BeginContainer()
+        /// operation, in this case the new context information is reset.  See Graphics.BeginContainer()
+        /// and Graphics.Save() for more information.
+        /// </summary>
         private bool _isCumulative;
 
-        /// <devdoc>
-        ///     Private constructor disallowed.
-        /// </devdoc>
         private GraphicsContext()
         {
         }
@@ -74,18 +71,18 @@ namespace System.Drawing
             }
         }
 
-        /// <devdoc>
-        ///     Disposes this and all contexts up the stack.
-        /// </devdoc>
+        /// <summary>
+        /// Disposes this and all contexts up the stack.
+        /// </summary>
         public void Dispose()
         {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
 
-        /// <devdoc>
-        ///     Disposes this and all contexts up the stack.
-        /// </devdoc>
+        /// <summary>
+        /// Disposes this and all contexts up the stack.
+        /// </summary>
         public void Dispose(bool disposing)
         {
             if (_nextContext != null)
@@ -102,9 +99,9 @@ namespace System.Drawing
             }
         }
 
-        /// <devdoc>
-        ///     The state id representing the GraphicsContext.
-        /// </devdoc>
+        /// <summary>
+        /// The state id representing the GraphicsContext.
+        /// </summary>
         public int State
         {
             get
@@ -117,9 +114,9 @@ namespace System.Drawing
             }
         }
 
-        /// <devdoc>
-        ///     The translate transform in the GraphicsContext.
-        /// </devdoc>
+        /// <summary>
+        /// The translate transform in the GraphicsContext.
+        /// </summary>
         public PointF TransformOffset
         {
             get
@@ -128,9 +125,9 @@ namespace System.Drawing
             }
         }
 
-        /// <devdoc>
+        /// <summary>
         ///     The clipping region the GraphicsContext.
-        /// </devdoc>
+        /// </summary>
         public Region Clip
         {
             get
@@ -139,9 +136,9 @@ namespace System.Drawing
             }
         }
 
-        /// <devdoc>
-        ///     The next GraphicsContext object in the stack.
-        /// </devdoc>
+        /// <summary>
+        /// The next GraphicsContext object in the stack.
+        /// </summary>
         public GraphicsContext Next
         {
             get
@@ -154,9 +151,9 @@ namespace System.Drawing
             }
         }
 
-        /// <devdoc>
-        ///     The previous GraphicsContext object in the stack.
-        /// </devdoc>
+        /// <summary>
+        /// The previous GraphicsContext object in the stack.
+        /// </summary>
         public GraphicsContext Previous
         {
             get
@@ -169,9 +166,9 @@ namespace System.Drawing
             }
         }
 
-        /// <devdoc>
-        ///     Determines whether this context is cumulative or not.  See filed for more info.
-        /// </devdoc>
+        /// <summary>
+        /// Determines whether this context is cumulative or not.  See filed for more info.
+        /// </summary>
         public bool IsCumulative
         {
             get

--- a/src/System.Drawing.Common/src/System/Drawing/IDeviceContext.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/IDeviceContext.cs
@@ -4,21 +4,20 @@
 
 namespace System.Drawing
 {
-    /// <include file='doc\IDeviceContext.uex' path='docs/doc[@for="IDeviceContext"]/*' />
-    /// <devdoc>
-    ///       This interface defines methods for obtaining a display/window device context handle (Win32 hdc).
-    ///       Note: Display and window dc handles are obtained and released using BeginPaint/EndPaint and
-    ///       GetDC/ReleaseDC; this interface is intended to be used with the last method only.  
-    ///       
-    ///       Warning to implementors: Creating and releasing non-display dc handles using this interface needs
-    ///       special care, for instance using other Win32 functions like CreateDC or CreateCompatibleDC require 
-    ///       DeleteDC instead of ReleaseDC to properly free the dc handle.  
-    ///       
-    ///       See the DeviceContext class for an implemenation of this interface, it uses the Dispose method
-    ///       for freeing non-display dc handles.
-    ///       
-    ///       This is a low-level API that is expected to be used with TextRenderer or PInvoke calls.
-    /// </devdoc>
+    /// <summary>
+    /// This interface defines methods for obtaining a display/window device context handle (Win32 hdc).
+    /// Note: Display and window dc handles are obtained and released using BeginPaint/EndPaint and
+    /// GetDC/ReleaseDC; this interface is intended to be used with the last method only.  
+    /// 
+    /// Warning to implementors: Creating and releasing non-display dc handles using this interface needs
+    /// special care, for instance using other Win32 functions like CreateDC or CreateCompatibleDC require 
+    /// DeleteDC instead of ReleaseDC to properly free the dc handle.  
+    /// 
+    /// See the DeviceContext class for an implemenation of this interface, it uses the Dispose method
+    /// for freeing non-display dc handles.
+    /// 
+    /// This is a low-level API that is expected to be used with TextRenderer or PInvoke calls.
+    /// </summary>
     public interface IDeviceContext : IDisposable
     {
         IntPtr GetHdc();
@@ -26,4 +25,3 @@ namespace System.Drawing
         void ReleaseHdc();
     }
 }
-

--- a/src/System.Drawing.Common/src/System/Drawing/Image.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Image.cs
@@ -2,26 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Drawing.Imaging;
+using System.Drawing.Internal;
+using System.Globalization;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Runtime.Serialization;
+using System.Security.Permissions;
+
 namespace System.Drawing
 {
-    using System.ComponentModel;
-    using System.Diagnostics;
-    using System.Drawing.Imaging;
-    using System.Drawing.Internal;
-    using System.Globalization;
-    using System.IO;
-    using System.Runtime.InteropServices;
-    using System.Runtime.Serialization;
-    using System.Security.Permissions;
-
-    /**
-     * Represent an image object (could be bitmap or vector)
-     */
-    /// <include file='doc\Image.uex' path='docs/doc[@for="Image"]/*' />
-    /// <devdoc>
-    ///    An abstract base class that provides
-    ///    functionality for 'Bitmap', 'Icon', 'Cursor', and 'Metafile' descended classes.
-    /// </devdoc>
+    /// <summary>
+    /// An abstract base class that provides functionality for 'Bitmap', 'Icon', 'Cursor', and 'Metafile' descended classes.
+    /// </summary>
     [ImmutableObject(true)]
     [ComVisible(true)]
     public abstract partial class Image : MarshalByRefObject, ICloneable, IDisposable
@@ -30,11 +25,6 @@ namespace System.Drawing
         private string allocationSite = Graphics.GetAllocationStack();
 #endif
 
-
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.GetThumbnailImageAbort"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         // The signature of this delegate is incorrect. The signature of the corresponding 
         // native callback function is:
         // extern "C" {
@@ -43,29 +33,21 @@ namespace System.Drawing
         //     typedef ImageAbort GetThumbnailImageAbort;
         // }
         // However, as this delegate is not used in both GDI 1.0 and 1.1, we choose not
-        // to modify it in Dev10, in order not to break exsiting code
+        // to modify it, in order to preserve compatibility.
         public delegate bool GetThumbnailImageAbort();
 
-        /*
-         * Handle to native image object
-         */
         internal IntPtr nativeImage;
 
         // used to work around lack of animated gif encoder... rarely set...
-        //
         private byte[] _rawData;
 
         //userData : so that user can use TAGS with IMAGES..
         private object _userData;
 
-        /**
-         * Constructor can't be invoked directly
-         */
         internal Image()
         {
         }
 
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.Tag"]/*' />
         [
         Localizable(false),
         DefaultValue(null),
@@ -82,23 +64,14 @@ namespace System.Drawing
             }
         }
 
-        /**
-        * Create an image object from a URL
-        */
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.FromFile"]/*' />
-        /// <devdoc>
-        ///    Creates an <see cref='System.Drawing.Image'/> from the specified file.
-        /// </devdoc>
-        // [Obsolete("Use Image.FromFile(string, useEmbeddedColorManagement)")]
+        /// <summary>
+        /// Creates an <see cref='Image'/> from the specified file.
+        /// </summary>
         public static Image FromFile(String filename)
         {
             return Image.FromFile(filename, false);
         }
 
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.FromFile1"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public static Image FromFile(String filename,
                                      bool useEmbeddedColorManagement)
         {
@@ -142,34 +115,20 @@ namespace System.Drawing
         }
 
 
-        /**
-         * Create an image object from a data stream
-         */
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.FromStream"]/*' />
-        /// <devdoc>
-        ///    Creates an <see cref='System.Drawing.Image'/> from the specified data
-        ///    stream.
-        /// </devdoc>
-        // [Obsolete("Use Image.FromStream(stream, useEmbeddedColorManagement)")]
+        /// <summary>
+        /// Creates an <see cref='Image'/> from the specified data stream.
+        /// </summary>
         public static Image FromStream(Stream stream)
         {
             return Image.FromStream(stream, false);
         }
 
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.FromStream1"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public static Image FromStream(Stream stream,
                                        bool useEmbeddedColorManagement)
         {
             return FromStream(stream, useEmbeddedColorManagement, true);
         }
 
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.FromStream2"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public static Image FromStream(Stream stream, bool useEmbeddedColorManagement, bool validateImageData)
         {
             if (stream == null)
@@ -247,13 +206,9 @@ namespace System.Drawing
             SetNativeImage(nativeImage);
         }
 
-        /**
-         * Make a copy of the image object
-         */
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.Clone"]/*' />
-        /// <devdoc>
-        ///    Creates an exact copy of this <see cref='System.Drawing.Image'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Creates an exact copy of this <see cref='Image'/>.
+        /// </summary>
         public object Clone()
         {
             IntPtr cloneImage = IntPtr.Zero;
@@ -274,21 +229,15 @@ namespace System.Drawing
             return CreateImageObject(cloneImage);
         }
 
-        /**
-         * Dispose of resources associated with the Image object
-         */
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.Dispose"]/*' />
-        /// <devdoc>
-        ///    Cleans up Windows resources for this
-        /// <see cref='System.Drawing.Image'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Cleans up Windows resources for this <see cref='Image'/>.
+        /// </summary>
         public void Dispose()
         {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
 
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.Dispose2"]/*' />
         protected virtual void Dispose(bool disposing)
         {
 #if FINALIZATION_WATCH
@@ -323,11 +272,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.Finalize"]/*' />
-        /// <devdoc>
-        ///    Cleans up Windows resources for this
-        /// <see cref='System.Drawing.Image'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Cleans up Windows resources for this <see cref='Image'/>.
+        /// </summary>
         ~Image()
         {
             Dispose(false);
@@ -416,22 +363,6 @@ namespace System.Drawing
             Metafile = 2,
         }
 
-        /* FxCop rule 'AvoidBuildingNonCallableCode' - Left here in case it is needed in the future.
-        private ImageTypeEnum ImageType
-        {
-            get { 
-                int type = -1;
-
-                int status = SafeNativeMethods.Gdip.GdipGetImageType(new HandleRef(this, nativeImage), out type);
-
-                if (status != SafeNativeMethods.Gdip.Ok)
-                    throw SafeNativeMethods.Gdip.StatusException(status);
-
-                return(ImageTypeEnum) type;
-            }
-        }
-        */
-
         internal static Image CreateImageObject(IntPtr nativeImage)
         {
             Image image;
@@ -460,11 +391,9 @@ namespace System.Drawing
             return image;
         }
 
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.GetEncoderParameterList"]/*' />
-        /// <devdoc>
-        ///    Returns information about the codecs used
-        ///    for this <see cref='System.Drawing.Image'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Returns information about the codecs used for this <see cref='Image'/>.
+        /// </summary>
         public EncoderParameters GetEncoderParameterList(Guid encoder)
         {
             EncoderParameters p;
@@ -503,20 +432,17 @@ namespace System.Drawing
             return p;
         }
 
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.Save"]/*' />
-        /// <devdoc>
-        ///    Saves this <see cref='System.Drawing.Image'/> to the specified file.
-        /// </devdoc>
+        /// <summary>
+        /// Saves this <see cref='Image'/> to the specified file.
+        /// </summary>
         public void Save(string filename)
         {
             Save(filename, RawFormat);
         }
 
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.Save1"]/*' />
-        /// <devdoc>
-        ///    Saves this <see cref='System.Drawing.Image'/> to the specified file in the
-        ///    specified format.
-        /// </devdoc>
+        /// <summary>
+        /// Saves this <see cref='Image'/> to the specified file in the specified format.
+        /// </summary>
         public void Save(string filename, ImageFormat format)
         {
             if (format == null)
@@ -530,13 +456,9 @@ namespace System.Drawing
             Save(filename, codec, null);
         }
 
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.Save2"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Saves this <see cref='System.Drawing.Image'/> to the specified file in the specified format
-        ///       and with the specified encoder parameters.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Saves this <see cref='Image'/> to the specified file in the specified format and with the specified encoder parameters.
+        /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void Save(string filename, ImageCodecInfo encoder, EncoderParameters encoderParams)
         {
@@ -597,7 +519,6 @@ namespace System.Drawing
         internal void Save(MemoryStream stream)
         {
             // Jpeg loses data, so we don't want to use it to serialize...
-            //
             ImageFormat dest = RawFormat;
             if (dest == ImageFormat.Jpeg)
             {
@@ -607,7 +528,6 @@ namespace System.Drawing
 
             // If we don't find an Encoder (for things like Icon), we
             // just switch back to PNG...
-            //
             if (codec == null)
             {
                 codec = ImageFormat.Png.FindEncoder();
@@ -615,13 +535,9 @@ namespace System.Drawing
             Save(stream, codec, null);
         }
 
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.Save3"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Saves this <see cref='System.Drawing.Image'/> to the specified stream in the specified
-        ///       format.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Saves this <see cref='Image'/> to the specified stream in the specified format.
+        /// </summary>
         public void Save(Stream stream, ImageFormat format)
         {
             if (format == null)
@@ -631,13 +547,9 @@ namespace System.Drawing
             Save(stream, codec, null);
         }
 
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.Save4"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Saves this <see cref='System.Drawing.Image'/> to the specified stream in the specified
-        ///       format.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Saves this <see cref='Image'/> to the specified stream in the specified format.
+        /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void Save(Stream stream, ImageCodecInfo encoder, EncoderParameters encoderParams)
         {
@@ -697,13 +609,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.SaveAdd"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Adds an <see cref='System.Drawing.Imaging.EncoderParameters'/> to this
-        ///    <see cref='System.Drawing.Image'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Adds an <see cref='EncoderParameters'/> to this <see cref='Image'/>.
+        /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void SaveAdd(EncoderParameters encoderParams)
         {
@@ -726,13 +634,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.SaveAdd1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Adds an <see cref='System.Drawing.Imaging.EncoderParameters'/> to the
-        ///       specified <see cref='System.Drawing.Image'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Adds an <see cref='EncoderParameters'/> to the specified <see cref='Image'/>.
+        /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void SaveAdd(Image image, EncoderParameters encoderParams)
         {
@@ -760,9 +664,6 @@ namespace System.Drawing
             }
         }
 
-        /**
-         * Return; image size information
-         */
         private SizeF _GetPhysicalDimension()
         {
             float width;
@@ -776,24 +677,17 @@ namespace System.Drawing
             return new SizeF(width, height);
         }
 
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.PhysicalDimension"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets the width and height of this
-        ///    <see cref='System.Drawing.Image'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets the width and height of this <see cref='Image'/>.
+        /// </summary>
         public SizeF PhysicalDimension
         {
             get { return _GetPhysicalDimension(); }
         }
 
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.Size"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets the width and height of this <see cref='System.Drawing.Image'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets the width and height of this <see cref='Image'/>.
+        /// </summary>
         public Size Size
         {
             get
@@ -802,10 +696,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.Width"]/*' />
-        /// <devdoc>
-        ///    Gets the width of this <see cref='System.Drawing.Image'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets the width of this <see cref='Image'/>.
+        /// </summary>
         [
         DefaultValue(false),
         Browsable(false),
@@ -826,10 +719,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.Height"]/*' />
-        /// <devdoc>
-        ///    Gets the height of this <see cref='System.Drawing.Image'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets the height of this <see cref='Image'/>.
+        /// </summary>
         [
         DefaultValue(false),
         Browsable(false),
@@ -850,11 +742,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.HorizontalResolution"]/*' />
-        /// <devdoc>
-        ///    Gets the horizontal resolution, in
-        ///    pixels-per-inch, of this <see cref='System.Drawing.Image'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets the horizontal resolution, in pixels-per-inch, of this <see cref='Image'/>.
+        /// </summary>
         public float HorizontalResolution
         {
             get
@@ -870,11 +760,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.VerticalResolution"]/*' />
-        /// <devdoc>
-        ///    Gets the vertical resolution, in
-        ///    pixels-per-inch, of this <see cref='System.Drawing.Image'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets the vertical resolution, in pixels-per-inch, of this <see cref='Image'/>.
+        /// </summary>
         public float VerticalResolution
         {
             get
@@ -890,10 +778,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.Flags"]/*' />
-        /// <devdoc>
-        ///    Gets attribute flags for this <see cref='System.Drawing.Image'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets attribute flags for this <see cref='Image'/>.
+        /// </summary>
         [Browsable(false)]
         public int Flags
         {
@@ -910,10 +797,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.RawFormat"]/*' />
-        /// <devdoc>
-        ///    Gets the format of this <see cref='System.Drawing.Image'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets the format of this <see cref='Image'/>.
+        /// </summary>
         public ImageFormat RawFormat
         {
             get
@@ -930,10 +816,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.PixelFormat"]/*' />
-        /// <devdoc>
-        ///    Gets the pixel format for this <see cref='System.Drawing.Image'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets the pixel format for this <see cref='Image'/>.
+        /// </summary>
         public PixelFormat PixelFormat
         {
             get
@@ -949,11 +834,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.GetBounds"]/*' />
-        /// <devdoc>
-        ///    Gets a bounding rectangle in
-        ///    the specified units for this <see cref='System.Drawing.Image'/>.
-        /// </devdoc>        
+        /// <summary>
+        /// Gets a bounding rectangle in the specified units for this <see cref='Image'/>.
+        /// </summary>        
         public RectangleF GetBounds(ref GraphicsUnit pageUnit)
         {
             GPRECTF gprectf = new GPRECTF();
@@ -1023,11 +906,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.Palette"]/*' />
-        /// <devdoc>
-        ///    Gets or sets the color
-        ///    palette used for this <see cref='System.Drawing.Image'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the color palette used for this <see cref='Image'/>.
+        /// </summary>
         [Browsable(false)]
         public ColorPalette Palette
         {
@@ -1043,10 +924,9 @@ namespace System.Drawing
 
         // Thumbnail support
 
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.GetThumbnailImage"]/*' />
-        /// <devdoc>
-        ///    Returns the thumbnail for this <see cref='System.Drawing.Image'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Returns the thumbnail for this <see cref='Image'/>.
+        /// </summary>
         public Image GetThumbnailImage(int thumbWidth, int thumbHeight,
                                        GetThumbnailImageAbort callback, IntPtr callbackData)
         {
@@ -1062,13 +942,9 @@ namespace System.Drawing
 
         // Multi-frame support
 
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.FrameDimensionsList"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets an array of GUIDs that represent the
-        ///       dimensions of frames within this <see cref='System.Drawing.Image'/>.
-        ///    </para>
-        /// </devdoc>        
+        /// <summary>
+        /// Gets an array of GUIDs that represent the dimensions of frames within this <see cref='Image'/>.
+        /// </summary>        
         [Browsable(false)]
         public Guid[] FrameDimensionsList
         {
@@ -1123,13 +999,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.GetFrameCount"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Returns the number of frames of the given
-        ///       dimension.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Returns the number of frames of the given dimension.
+        /// </summary>
         public int GetFrameCount(FrameDimension dimension)
         {
             int[] count = new int[] { 0 };
@@ -1143,13 +1015,9 @@ namespace System.Drawing
             return count[0];
         }
 
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.SelectActiveFrame"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Selects the frame specified by the given
-        ///       dimension and index.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Selects the frame specified by the given dimension and index.
+        /// </summary>
         public int SelectActiveFrame(FrameDimension dimension, int frameIndex)
         {
             int[] count = new int[] { 0 };
@@ -1163,11 +1031,6 @@ namespace System.Drawing
             return count[0];
         }
 
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.RotateFlip"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///    </para>
-        /// </devdoc>
         public void RotateFlip(RotateFlipType rotateFlipType)
         {
             int status = SafeNativeMethods.Gdip.GdipImageRotateFlip(new HandleRef(this, nativeImage), unchecked((int)rotateFlipType));
@@ -1176,11 +1039,9 @@ namespace System.Drawing
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.PropertyIdList"]/*' />
-        /// <devdoc>
-        ///    Gets an array of the property IDs stored in
-        ///    this <see cref='System.Drawing.Image'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets an array of the property IDs stored in this <see cref='Image'/>.
+        /// </summary>
         [Browsable(false)]
         public int[] PropertyIdList
         {
@@ -1208,11 +1069,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.GetPropertyItem"]/*' />
-        /// <devdoc>
-        ///    Gets the specified property item from this
-        /// <see cref='System.Drawing.Image'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets the specified property item from this <see cref='Image'/>.
+        /// </summary>
         public PropertyItem GetPropertyItem(int propid)
         {
             PropertyItem propitem;
@@ -1250,11 +1109,9 @@ namespace System.Drawing
             return propitem;
         }
 
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.RemovePropertyItem"]/*' />
-        /// <devdoc>
-        ///    Removes the specified property item from
-        ///    this <see cref='System.Drawing.Image'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Removes the specified property item from this <see cref='Image'/>.
+        /// </summary>
         public void RemovePropertyItem(int propid)
         {
             int status = SafeNativeMethods.Gdip.GdipRemovePropertyItem(new HandleRef(this, nativeImage), propid);
@@ -1262,13 +1119,9 @@ namespace System.Drawing
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.SetPropertyItem"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Sets the specified property item to the
-        ///       specified value.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Sets the specified property item to the specified value.
+        /// </summary>
         public void SetPropertyItem(PropertyItem propitem)
         {
             PropertyItemInternal propItemInternal = PropertyItemInternal.ConvertFromPropertyItem(propitem);
@@ -1281,10 +1134,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.PropertyItems"]/*' />
-        /// <devdoc>
-        ///    Gets an array of <see cref='System.Drawing.Imaging.PropertyItem'/> objects that describe this <see cref='System.Drawing.Image'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets an array of <see cref='PropertyItem'/> objects that describe this <see cref='Image'/>.
+        /// </summary>
         [Browsable(false)]
         public PropertyItem[] PropertyItems
         {
@@ -1338,23 +1190,17 @@ namespace System.Drawing
             nativeImage = handle;
         }
 
-        // !! Ambiguous to offer constructor for 'FromHbitmap'
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.FromHbitmap"]/*' />
-        /// <devdoc>
-        ///    Creates a <see cref='System.Drawing.Bitmap'/> from a Windows handle.
-        /// </devdoc>
+        /// <summary>
+        /// Creates a <see cref='Bitmap'/> from a Windows handle.
+        /// </summary>
         public static Bitmap FromHbitmap(IntPtr hbitmap)
         {
             return FromHbitmap(hbitmap, IntPtr.Zero);
         }
 
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.FromHbitmap1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Creates a <see cref='System.Drawing.Bitmap'/> from the specified Windows
-        ///       handle with the specified color palette.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Creates a <see cref='Bitmap'/> from the specified Windows handle with the specified color palette.
+        /// </summary>
         public static Bitmap FromHbitmap(IntPtr hbitmap, IntPtr hpalette)
         {
             IntPtr bitmap = IntPtr.Zero;
@@ -1366,44 +1212,25 @@ namespace System.Drawing
             return Bitmap.FromGDIplus(bitmap);
         }
 
-        /*
-         * Return the pixel size for the specified format (in bits)
-         */
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.GetPixelFormatSize"]/*' />
-        /// <devdoc>
-        ///    Returns the size of the specified pixel
-        ///    format.
-        /// </devdoc>
+        /// <summary>
+        /// Returns the size of the specified pixel format.
+        /// </summary>
         public static int GetPixelFormatSize(PixelFormat pixfmt)
         {
             return (unchecked((int)pixfmt) >> 8) & 0xFF;
         }
 
-        /*
-         * Determine if the pixel format can have alpha channel
-         */
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.IsAlphaPixelFormat"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Returns a value indicating whether the
-        ///       pixel format contains alpha information.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Returns a value indicating whether the pixel format contains alpha information.
+        /// </summary>
         public static bool IsAlphaPixelFormat(PixelFormat pixfmt)
         {
             return (pixfmt & PixelFormat.Alpha) != 0;
         }
 
-        /*
-         * Determine if the pixel format is an extended format,
-         * i.e. supports 16-bit per channel
-         */
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.IsExtendedPixelFormat"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Returns a value indicating whether the pixel format is extended.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Returns a value indicating whether the pixel format is extended.
+        /// </summary>
         public static bool IsExtendedPixelFormat(PixelFormat pixfmt)
         {
             return (pixfmt & PixelFormat.Extended) != 0;
@@ -1416,12 +1243,9 @@ namespace System.Drawing
          *   PixelFormat64bppARGB
          *   PixelFormat64bppPARGB
          */
-        /// <include file='doc\Image.uex' path='docs/doc[@for="Image.IsCanonicalPixelFormat"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Returns a value indicating whether the pixel format is canonical.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Returns a value indicating whether the pixel format is canonical.
+        /// </summary>
         public static bool IsCanonicalPixelFormat(PixelFormat pixfmt)
         {
             return (pixfmt & PixelFormat.Canonical) != 0;

--- a/src/System.Drawing.Common/src/System/Drawing/ImageAnimator.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/ImageAnimator.cs
@@ -9,7 +9,7 @@ namespace System.Drawing
     using System.Drawing.Imaging;
     using System.Threading;
 
-    /// <devdoc>
+    /// <summary>
     ///     Animates one or more images that have time-based frames.
     ///     See the ImageInfo.cs file for the helper nested ImageInfo class.
     ///     
@@ -31,35 +31,35 @@ namespace System.Drawing
     ///     section lock using the image ref the image access is not from the same thread that executes ImageAnimator
     ///     code.  If the user code locks on the image ref forever a deadlock will happen preventing the animiation 
     ///     from occurring.
-    /// </devdoc>                                
+    /// </summary>                                
     public sealed partial class ImageAnimator
     {
-        /// <devdoc>
+        /// <summary>
         ///     A list of images to be animated.    
-        /// </devdoc>
+        /// </summary>
         private static List<ImageInfo> s_imageInfoList;
 
-        /// <devdoc>
+        /// <summary>
         ///     A variable to flag when an image or images need to be updated due to the selection of a new frame
         ///     in an image.  We don't need to synchronize access to this variable, in the case it is true we don't
         ///     do anything, otherwise the worse case is where a thread attempts to update the image's frame after
         ///     another one did which is harmless.
-        /// </devdoc>
+        /// </summary>
         private static bool s_anyFrameDirty;
 
-        /// <devdoc>
+        /// <summary>
         ///     The thread used for animating the images.
-        /// </devdoc>
+        /// </summary>
         private static Thread s_animationThread;
 
-        /// <devdoc>
+        /// <summary>
         ///     Lock that allows either concurrent read-access to the images list for multiple threads, or write- 
         ///     access to it for a single thread.  Observe that synchronization access to image objects are done
         ///     with critical sections (lock).
-        /// </devdoc>
+        /// </summary>
         private static ReaderWriterLock s_rwImgListLock = new ReaderWriterLock();
 
-        /// <devdoc>
+        /// <summary>
         ///     Flag to avoid a deadlock when waiting on a write-lock and a an attemp to acquire a read-lock is 
         ///     made in the same thread. If RWLock is currently owned by another thread, the current thread is going to wait on an 
         ///     event using CoWaitForMultipleHandles while pumps message. 
@@ -75,7 +75,7 @@ namespace System.Drawing
         ///     a reader lock while pumping message, the thread is blocked forever.
         ///     This TLS variable is used to flag the above situation and avoid the deadlock, it is ThreadStatic so each
         ///     thread calling into ImageAnimator is garded against this problem.
-		/// </devdoc>
+		/// </summary>
 
 
 
@@ -83,16 +83,16 @@ namespace System.Drawing
         [ThreadStatic]
         private static int t_threadWriterLockWaitCount;
 
-        /// <devdoc>
+        /// <summary>
         ///     Prevent instantiation of this class.
-        /// </devdoc>
+        /// </summary>
         private ImageAnimator()
         {
         }
 
-        /// <devdoc>
+        /// <summary>
         ///     Advances the frame in the specified image. The new frame is drawn the next time the image is rendered.
-        /// </devdoc>
+        /// </summary>
         public static void UpdateFrames(Image image)
         {
             if (!s_anyFrameDirty || image == null || s_imageInfoList == null)
@@ -153,9 +153,9 @@ namespace System.Drawing
             }
         }
 
-        /// <devdoc>
+        /// <summary>
         ///     Advances the frame in all images currently being animated. The new frame is drawn the next time the image is rendered.
-        /// </devdoc>
+        /// </summary>
         public static void UpdateFrames()
         {
             if (!s_anyFrameDirty || s_imageInfoList == null)
@@ -190,10 +190,10 @@ namespace System.Drawing
             }
         }
 
-        /// <devdoc>
+        /// <summary>
         ///     Adds an image to the image manager.  If the image does not support animation this method does nothing.
         ///     This method creates the image list and spawns the animation thread the first time it is called.
-        /// </devdoc>
+        /// </summary>
         public static void Animate(Image image, EventHandler onFrameChangedHandler)
         {
             if (image == null)
@@ -282,9 +282,9 @@ namespace System.Drawing
             }
         }
 
-        /// <devdoc>
+        /// <summary>
         ///    Whether or not the image has multiple time-based frames.
-        /// </devdoc>
+        /// </summary>
         public static bool CanAnimate(Image image)
         {
             if (image == null)
@@ -312,9 +312,9 @@ namespace System.Drawing
             return false;
         }
 
-        /// <devdoc>
+        /// <summary>
         ///     Removes an image from the image manager so it is no longer animated.
-        /// </devdoc>
+        /// </summary>
         public static void StopAnimate(Image image, EventHandler onFrameChangedHandler)
         {
             // Make sure we have a list of images                       
@@ -378,13 +378,13 @@ namespace System.Drawing
         }
 
 
-        /// <devdoc>
+        /// <summary>
         ///     Worker thread procedure which implements the main animation loop.
         ///     NOTE: This is the ONLY code the worker thread executes, keeping it in one method helps better understand 
         ///     any synchronization issues.  
         ///     WARNING: Also, this is the only place where ImageInfo objects (not the contained image object) are modified,
         ///     so no access synchronization is required to modify them.
-        /// </devdoc>
+        /// </summary>
         private static void AnimateImages50ms()
         {
             Debug.Assert(s_imageInfoList != null, "Null images list");

--- a/src/System.Drawing.Common/src/System/Drawing/ImageInfo.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/ImageInfo.cs
@@ -2,20 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+using System.Drawing.Imaging;
+
 namespace System.Drawing
 {
-    using System.Diagnostics;
-    using System.Drawing.Imaging;
-
-    /// <devdoc>
-    ///     Animates one or more images that have time-based frames.
-    ///     This file contains the nested ImageInfo class - See ImageAnimator.cs for the definition of the outer class.
-    /// </devdoc>                                   
+    /// <summary>
+    /// Animates one or more images that have time-based frames. This file contains the nested ImageInfo class
+    /// - See ImageAnimator.cs for the definition of the outer class.
+    /// </summary>
     public sealed partial class ImageAnimator
     {
-        /// <devdoc> 
-        ///     ImageAnimator nested helper class used to store extra image state info.
-        /// </devdoc>  
+        /// <summary>
+        /// ImageAnimator nested helper class used to store extra image state info.
+        /// </summary>
         private class ImageInfo
         {
             private const int PropertyTagFrameDelay = 0x5100;
@@ -29,8 +29,6 @@ namespace System.Drawing
             private int[] _frameDelay;
             private int _frameTimer;
 
-            /// <devdoc> 
-            /// </devdoc>  
             public ImageInfo(Image image)
             {
                 _image = image;
@@ -67,9 +65,9 @@ namespace System.Drawing
                 }
             }
 
-            /// <devdoc> 
-            ///     Whether the image supports animation.
-            /// </devdoc>  
+            /// <summary>
+            /// Whether the image supports animation.
+            /// </summary>
             public bool Animated
             {
                 get
@@ -78,9 +76,9 @@ namespace System.Drawing
                 }
             }
 
-            /// <devdoc> 
-            ///     The current frame.
-            /// </devdoc> 
+            /// <summary>
+            /// The current frame.
+            /// </summary>
             public int Frame
             {
                 get
@@ -107,9 +105,9 @@ namespace System.Drawing
                 }
             }
 
-            /// <devdoc> 
-            ///     The current frame has not been updated.
-            /// </devdoc> 
+            /// <summary>
+            /// The current frame has not been updated.
+            /// </summary>
             public bool FrameDirty
             {
                 get
@@ -118,8 +116,6 @@ namespace System.Drawing
                 }
             }
 
-            /// <devdoc> 
-            /// </devdoc> 
             public EventHandler FrameChangedHandler
             {
                 get
@@ -132,9 +128,9 @@ namespace System.Drawing
                 }
             }
 
-            /// <devdoc> 
-            ///     The number of frames in the image.
-            /// </devdoc> 
+            /// <summary>
+            /// The number of frames in the image.
+            /// </summary>
             public int FrameCount
             {
                 get
@@ -143,16 +139,14 @@ namespace System.Drawing
                 }
             }
 
-            /// <devdoc> 
-            ///     The delay associated with the frame at the specified index.
-            /// </devdoc> 
+            /// <summary>
+            /// The delay associated with the frame at the specified index.
+            /// </summary>
             public int FrameDelay(int frame)
             {
                 return _frameDelay[frame];
             }
 
-            /// <devdoc> 
-            /// </devdoc> 
             internal int FrameTimer
             {
                 get
@@ -165,9 +159,9 @@ namespace System.Drawing
                 }
             }
 
-            /// <devdoc> 
-            ///     The image this object wraps.
-            /// </devdoc> 
+            /// <summary>
+            /// The image this object wraps.
+            /// </summary>
             internal Image Image
             {
                 get
@@ -176,9 +170,9 @@ namespace System.Drawing
                 }
             }
 
-            /// <devdoc> 
-            ///     Selects the current frame as the active frame in the image.
-            /// </devdoc> 
+            /// <summary>
+            /// Selects the current frame as the active frame in the image.
+            /// </summary>
             internal void UpdateFrame()
             {
                 if (_frameDirty)
@@ -188,9 +182,9 @@ namespace System.Drawing
                 }
             }
 
-            /// <devdoc> 
-            ///     Raises the FrameChanged event.
-            /// </devdoc> 
+            /// <summary>
+            /// Raises the FrameChanged event.
+            /// </summary>
             protected void OnFrameChanged(EventArgs e)
             {
                 if (_onFrameChangedHandler != null)

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/BitmapData.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/BitmapData.cs
@@ -2,14 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
+
 namespace System.Drawing.Imaging
 {
-    using System.Runtime.InteropServices;
-
-    /// <include file='doc\BitmapData.uex' path='docs/doc[@for="BitmapData"]/*' />
-    /// <devdoc>
-    ///    Specifies the attributes of a bitmap image.
-    /// </devdoc>
+    /// <summary>
+    /// Specifies the attributes of a bitmap image.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public sealed class BitmapData
     {
@@ -20,41 +19,36 @@ namespace System.Drawing.Imaging
         private IntPtr _scan0;
         private int _reserved;
 
-        /// <include file='doc\BitmapData.uex' path='docs/doc[@for="BitmapData.Width"]/*' />
-        /// <devdoc>
-        ///    Specifies the pixel width of the <see cref='System.Drawing.Bitmap'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies the pixel width of the <see cref='Bitmap'/>.
+        /// </summary>
         public int Width
         {
             get { return _width; }
             set { _width = value; }
         }
 
-        /// <include file='doc\BitmapData.uex' path='docs/doc[@for="BitmapData.Height"]/*' />
-        /// <devdoc>
-        ///    Specifies the pixel height of the <see cref='System.Drawing.Bitmap'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies the pixel height of the <see cref='Bitmap'/>.
+        /// </summary>
         public int Height
         {
             get { return _height; }
             set { _height = value; }
         }
 
-        /// <include file='doc\BitmapData.uex' path='docs/doc[@for="BitmapData.Stride"]/*' />
-        /// <devdoc>
-        ///    Specifies the stride width of the <see cref='System.Drawing.Bitmap'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies the stride width of the <see cref='Bitmap'/>.
+        /// </summary>
         public int Stride
         {
             get { return _stride; }
             set { _stride = value; }
         }
 
-        /// <include file='doc\BitmapData.uex' path='docs/doc[@for="BitmapData.PixelFormat"]/*' />
-        /// <devdoc>
-        ///    Specifies the format of the pixel
-        ///    information in this <see cref='System.Drawing.Bitmap'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies the format of the pixel information in this <see cref='Bitmap'/>.
+        /// </summary>
         public PixelFormat PixelFormat
         {
             get { return (PixelFormat)_pixelFormat; }
@@ -95,24 +89,20 @@ namespace System.Drawing.Imaging
             }
         }
 
-        /// <include file='doc\BitmapData.uex' path='docs/doc[@for="BitmapData.Scan0"]/*' />
-        /// <devdoc>
-        ///    Specifies the address of the pixel data.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies the address of the pixel data.
+        /// </summary>
         public IntPtr Scan0
         {
             get { return _scan0; }
             set { _scan0 = value; }
         }
 
-        /// <include file='doc\BitmapData.uex' path='docs/doc[@for="BitmapData.Reserved"]/*' />
-        /// <devdoc>
-        ///    Reserved. Do not use.
-        /// </devdoc>
+        /// <summary>
+        /// Reserved. Do not use.
+        /// </summary>
         public int Reserved
         {
-            // why make public??
-            //
             get { return _reserved; }
             set { _reserved = value; }
         }

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/ColorAdjustType.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/ColorAdjustType.cs
@@ -4,63 +4,40 @@
 
 namespace System.Drawing.Imaging
 {
-    /**
-     * Color adjust type constants
-     */
-    /// <include file='doc\ColorAdjustType.uex' path='docs/doc[@for="ColorAdjustType"]/*' />
-    /// <devdoc>
-    ///    Specifies which GDI+ objects use color
-    ///    adjustment information.
-    /// </devdoc>
+    /// <summary>
+    /// Specifies which GDI+ objects use color adjustment information.
+    /// </summary>
     public enum ColorAdjustType
     {
-        /// <include file='doc\ColorAdjustType.uex' path='docs/doc[@for="ColorAdjustType.Default"]/*' />
-        /// <devdoc>
-        ///    Defines color adjustment information that is
-        ///    used by all GDI+ objects that do not have their own color adjustment
-        ///    information.
-        /// </devdoc>
+        /// <summary>
+        /// Defines color adjustment information that is used by all GDI+ objects that do not have their own color
+        /// adjustment information.
+        /// </summary>
         Default = 0,
-        /// <include file='doc\ColorAdjustType.uex' path='docs/doc[@for="ColorAdjustType.Bitmap"]/*' />
-        /// <devdoc>
-        ///    Defines color adjustment information for
-        /// <see cref='System.Drawing.Bitmap'/> 
+        /// <summary>
+        /// Defines color adjustment information for <see cref='Drawing.Bitmap'/> 
         /// objects.
-        /// </devdoc>
+        /// </summary>
         Bitmap,
-        /// <include file='doc\ColorAdjustType.uex' path='docs/doc[@for="ColorAdjustType.Brush"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Defines color adjustment information for <see cref='System.Drawing.Brush'/> objects.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Defines color adjustment information for <see cref='Drawing.Brush'/> objects.
+        /// </summary>
         Brush,
-        /// <include file='doc\ColorAdjustType.uex' path='docs/doc[@for="ColorAdjustType.Pen"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Defines color adjustment information for <see cref='System.Drawing.Pen'/> objects.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Defines color adjustment information for <see cref='Drawing.Pen'/> objects.
+        /// </summary>
         Pen,
-        /// <include file='doc\ColorAdjustType.uex' path='docs/doc[@for="ColorAdjustType.Text"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Defines color adjustment information for text.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Defines color adjustment information for text.
+        /// </summary>
         Text,
-        /// <include file='doc\ColorAdjustType.uex' path='docs/doc[@for="ColorAdjustType.Count"]/*' />
-        /// <devdoc>
-        ///    Specifies the number of types specified.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies the number of types specified.
+        /// </summary>
         Count,
-        /// <include file='doc\ColorAdjustType.uex' path='docs/doc[@for="ColorAdjustType.Any"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Specifies the number of types specified.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Specifies the number of types specified.
+        /// </summary>
         Any
     }
 }
-

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/ColorChannelFlags.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/ColorChannelFlags.cs
@@ -4,42 +4,30 @@
 
 namespace System.Drawing.Imaging
 {
-    /**
-     * Color channel flag constants
-     */
-    /// <include file='doc\ColorChannelFlags.uex' path='docs/doc[@for="ColorChannelFlag"]/*' />
-    /// <devdoc>
-    ///    Specifies a range of CMYK channels.
-    /// </devdoc>
+    /// <summary>
+    /// Specifies a range of CMYK channels.
+    /// </summary>
     public enum ColorChannelFlag
     {
-        /// <include file='doc\ColorChannelFlags.uex' path='docs/doc[@for="ColorChannelFlag.ColorChannelC"]/*' />
-        /// <devdoc>
-        ///    Specifies the Cyan color channel.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies the Cyan color channel.
+        /// </summary>
         ColorChannelC = 0,
-        /// <include file='doc\ColorChannelFlags.uex' path='docs/doc[@for="ColorChannelFlag.ColorChannelM"]/*' />
-        /// <devdoc>
-        ///    Specifies the Magenta color channel.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies the Magenta color channel.
+        /// </summary>
         ColorChannelM,
-        /// <include file='doc\ColorChannelFlags.uex' path='docs/doc[@for="ColorChannelFlag.ColorChannelY"]/*' />
-        /// <devdoc>
-        ///    Specifies the Yellow color channel.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies the Yellow color channel.
+        /// </summary>
         ColorChannelY,
-        /// <include file='doc\ColorChannelFlags.uex' path='docs/doc[@for="ColorChannelFlag.ColorChannelK"]/*' />
-        /// <devdoc>
-        ///    Specifies the Black color channel.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies the Black color channel.
+        /// </summary>
         ColorChannelK,
-        /// <include file='doc\ColorChannelFlags.uex' path='docs/doc[@for="ColorChannelFlag.ColorChannelLast"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       This element specifies to leave the color
-        ///       channel unchanged from the last selected channel.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// This element specifies to leave the color channel unchanged from the last selected channel.
+        /// </summary>
         ColorChannelLast
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/ColorMap.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/ColorMap.cs
@@ -4,45 +4,34 @@
 
 namespace System.Drawing.Imaging
 {
-    /// <include file='doc\ColorMap.uex' path='docs/doc[@for="ColorMap"]/*' />
-    /// <devdoc>
-    ///    Defines a map for converting colors.
-    /// </devdoc>
+    /// <summary>
+    /// Defines a map for converting colors.
+    /// </summary>
     public sealed class ColorMap
     {
         private Color _oldColor;
         private Color _newColor;
 
-        /// <include file='doc\ColorMap.uex' path='docs/doc[@for="ColorMap.ColorMap"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.ColorMap'/> class.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='ColorMap'/> class.
+        /// </summary>
         public ColorMap()
         {
             _oldColor = new Color();
             _newColor = new Color();
         }
 
-        /// <include file='doc\ColorMap.uex' path='docs/doc[@for="ColorMap.OldColor"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Specifies the existing <see cref='System.Drawing.Color'/> to be
-        ///       converted.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Specifies the existing <see cref='Color'/> to be converted.
+        /// </summary>
         public Color OldColor
         {
             get { return _oldColor; }
             set { _oldColor = value; }
         }
-        /// <include file='doc\ColorMap.uex' path='docs/doc[@for="ColorMap.NewColor"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Specifes the new <see cref='System.Drawing.Color'/> to which to convert.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Specifes the new <see cref='Color'/> to which to convert.
+        /// </summary>
         public Color NewColor
         {
             get { return _newColor; }

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/ColorMapType.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/ColorMapType.cs
@@ -4,24 +4,18 @@
 
 namespace System.Drawing.Imaging
 {
-    /**
-     * Color Map type constants
-     */
-    /// <include file='doc\ColorMapType.uex' path='docs/doc[@for="ColorMapType"]/*' />
-    /// <devdoc>
-    ///    Specifies the types of color maps.
-    /// </devdoc>
+    /// <summary>
+    /// Specifies the types of color maps.
+    /// </summary>
     public enum ColorMapType
     {
-        /// <include file='doc\ColorMapType.uex' path='docs/doc[@for="ColorMapType.Default"]/*' />
-        /// <devdoc>
-        ///    A default color map.
-        /// </devdoc>
+        /// <summary>
+        /// A default color map.
+        /// </summary>
         Default = 0,
-        /// <include file='doc\ColorMapType.uex' path='docs/doc[@for="ColorMapType.Brush"]/*' />
-        /// <devdoc>
-        ///    Specifies a color map for a <see cref='System.Drawing.Brush'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies a color map for a <see cref='Drawing.Brush'/>.
+        /// </summary>
         Brush
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/ColorMatrix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/ColorMatrix.cs
@@ -2,15 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
+
 namespace System.Drawing.Imaging
 {
-    using System.Runtime.InteropServices;
-
-    /// <include file='doc\ColorMatrix.uex' path='docs/doc[@for="ColorMatrix"]/*' />
-    /// <devdoc>
-    ///    Defines a 5 x 5 matrix that that
-    ///    contains the homogenous coordinates for the RGBA space.
-    /// </devdoc>
+    /// <summary>
+    /// Defines a 5 x 5 matrix that that contains the homogenous coordinates for the RGBA space.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public sealed class ColorMatrix
     {
@@ -40,12 +38,9 @@ namespace System.Drawing.Imaging
         private float _matrix43;
         private float _matrix44;
 
-        /// <include file='doc\ColorMatrix.uex' path='docs/doc[@for="ColorMatrix.ColorMatrix"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.ColorMatrix'/> class.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='ColorMatrix'/> class.
+        /// </summary>
         public ColorMatrix()
         {
             /*
@@ -79,297 +74,224 @@ namespace System.Drawing.Imaging
             _matrix44 = 1.0f;
         }
 
-        /// <include file='doc\ColorMatrix.uex' path='docs/doc[@for="ColorMatrix.Matrix00"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Represents the element at the
-        ///       0th row and 0th column of this <see cref='System.Drawing.Imaging.ColorMatrix'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Represents the element at the 0th row and 0th column of this <see cref='ColorMatrix'/>.
+        /// </summary>
         public float Matrix00
         {
             get { return _matrix00; }
             set { _matrix00 = value; }
         }
-        /// <include file='doc\ColorMatrix.uex' path='docs/doc[@for="ColorMatrix.Matrix01"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Represents the element at the 0th row and 1st column of this <see cref='System.Drawing.Imaging.ColorMatrix'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Represents the element at the 0th row and 1st column of this <see cref='ColorMatrix'/>.
+        /// </summary>
         public float Matrix01
         {
             get { return _matrix01; }
             set { _matrix01 = value; }
         }
 
-        /// <include file='doc\ColorMatrix.uex' path='docs/doc[@for="ColorMatrix.Matrix02"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Represents the element at the 0th row and 2nd column of this <see cref='System.Drawing.Imaging.ColorMatrix'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Represents the element at the 0th row and 2nd column of this <see cref='ColorMatrix'/>.
+        /// </summary>
         public float Matrix02
         {
             get { return _matrix02; }
             set { _matrix02 = value; }
         }
 
-        /// <include file='doc\ColorMatrix.uex' path='docs/doc[@for="ColorMatrix.Matrix03"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Represents the element at the 0th row and 3rd column of this <see cref='System.Drawing.Imaging.ColorMatrix'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Represents the element at the 0th row and 3rd column of this <see cref='ColorMatrix'/>.
+        /// </summary>
         public float Matrix03
         {
             get { return _matrix03; }
             set { _matrix03 = value; }
         }
 
-        /// <include file='doc\ColorMatrix.uex' path='docs/doc[@for="ColorMatrix.Matrix04"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Represents the element at the 0th row and 4th column of this <see cref='System.Drawing.Imaging.ColorMatrix'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Represents the element at the 0th row and 4th column of this <see cref='ColorMatrix'/>.
+        /// </summary>
         public float Matrix04
         {
             get { return _matrix04; }
             set { _matrix04 = value; }
         }
 
-        /// <include file='doc\ColorMatrix.uex' path='docs/doc[@for="ColorMatrix.Matrix10"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Represents the element at the 1st row and 0th column of this <see cref='System.Drawing.Imaging.ColorMatrix'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Represents the element at the 1st row and 0th column of this <see cref='ColorMatrix'/>.
+        /// </summary>
         public float Matrix10
         {
             get { return _matrix10; }
             set { _matrix10 = value; }
         }
 
-        /// <include file='doc\ColorMatrix.uex' path='docs/doc[@for="ColorMatrix.Matrix11"]/*' />
-        /// <devdoc>
-        ///    Represents the element at the 1st row and
-        ///    1st column of this <see cref='System.Drawing.Imaging.ColorMatrix'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Represents the element at the 1st row and 1st column of this <see cref='ColorMatrix'/>.
+        /// </summary>
         public float Matrix11
         {
             get { return _matrix11; }
             set { _matrix11 = value; }
         }
 
-        /// <include file='doc\ColorMatrix.uex' path='docs/doc[@for="ColorMatrix.Matrix12"]/*' />
-        /// <devdoc>
-        ///    Represents the element at the 1st row
-        ///    and 2nd column of this <see cref='System.Drawing.Imaging.ColorMatrix'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Represents the element at the 1st row and 2nd column of this <see cref='ColorMatrix'/>.
+        /// </summary>
         public float Matrix12
         {
             get { return _matrix12; }
             set { _matrix12 = value; }
         }
 
-        /// <include file='doc\ColorMatrix.uex' path='docs/doc[@for="ColorMatrix.Matrix13"]/*' />
-        /// <devdoc>
-        ///    Represents the element at the 1st row
-        ///    and 3rd column of this <see cref='System.Drawing.Imaging.ColorMatrix'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Represents the element at the 1st row and 3rd column of this <see cref='ColorMatrix'/>.
+        /// </summary>
         public float Matrix13
         {
             get { return _matrix13; }
             set { _matrix13 = value; }
         }
 
-        /// <include file='doc\ColorMatrix.uex' path='docs/doc[@for="ColorMatrix.Matrix14"]/*' />
-        /// <devdoc>
-        ///    Represents the element at the 1st row
-        ///    and 4th column of this <see cref='System.Drawing.Imaging.ColorMatrix'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Represents the element at the 1st row and 4th column of this <see cref='ColorMatrix'/>.
+        /// </summary>
         public float Matrix14
         {
             get { return _matrix14; }
             set { _matrix14 = value; }
         }
 
-        /// <include file='doc\ColorMatrix.uex' path='docs/doc[@for="ColorMatrix.Matrix20"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Represents the element at the 2nd row and
-        ///       0th column of this <see cref='System.Drawing.Imaging.ColorMatrix'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Represents the element at the 2nd row and 0th column of this <see cref='ColorMatrix'/>.
+        /// </summary>
         public float Matrix20
         {
             get { return _matrix20; }
             set { _matrix20 = value; }
         }
 
-        /// <include file='doc\ColorMatrix.uex' path='docs/doc[@for="ColorMatrix.Matrix21"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Represents the element at the 2nd row and 1st column of this <see cref='System.Drawing.Imaging.ColorMatrix'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Represents the element at the 2nd row and 1st column of this <see cref='ColorMatrix'/>.
+        /// </summary>
         public float Matrix21
         {
             get { return _matrix21; }
             set { _matrix21 = value; }
         }
 
-        /// <include file='doc\ColorMatrix.uex' path='docs/doc[@for="ColorMatrix.Matrix22"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Represents the element at the 2nd row and 2nd column of this <see cref='System.Drawing.Imaging.ColorMatrix'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Represents the element at the 2nd row and 2nd column of this <see cref='ColorMatrix'/>.
+        /// </summary>
         public float Matrix22
         {
             get { return _matrix22; }
             set { _matrix22 = value; }
         }
 
-        /// <include file='doc\ColorMatrix.uex' path='docs/doc[@for="ColorMatrix.Matrix23"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Represents the element at the 2nd row and 3rd column of this <see cref='System.Drawing.Imaging.ColorMatrix'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Represents the element at the 2nd row and 3rd column of this <see cref='ColorMatrix'/>.
+        /// </summary>
         public float Matrix23
         {
             get { return _matrix23; }
             set { _matrix23 = value; }
         }
 
-        /// <include file='doc\ColorMatrix.uex' path='docs/doc[@for="ColorMatrix.Matrix24"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Represents the element at the 2nd row and 4th column of this <see cref='System.Drawing.Imaging.ColorMatrix'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Represents the element at the 2nd row and 4th column of this <see cref='ColorMatrix'/>.
+        /// </summary>
         public float Matrix24
         {
             get { return _matrix24; }
             set { _matrix24 = value; }
         }
 
-        /// <include file='doc\ColorMatrix.uex' path='docs/doc[@for="ColorMatrix.Matrix30"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Represents the element at the 3rd row and 0th column of this <see cref='System.Drawing.Imaging.ColorMatrix'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Represents the element at the 3rd row and 0th column of this <see cref='ColorMatrix'/>.
+        /// </summary>
         public float Matrix30
         {
             get { return _matrix30; }
             set { _matrix30 = value; }
         }
 
-        /// <include file='doc\ColorMatrix.uex' path='docs/doc[@for="ColorMatrix.Matrix31"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Represents the element at the 3rd row and 1st column of this <see cref='System.Drawing.Imaging.ColorMatrix'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Represents the element at the 3rd row and 1st column of this <see cref='ColorMatrix'/>.
+        /// </summary>
         public float Matrix31
         {
             get { return _matrix31; }
             set { _matrix31 = value; }
         }
 
-        /// <include file='doc\ColorMatrix.uex' path='docs/doc[@for="ColorMatrix.Matrix32"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Represents the element at the 3rd row and 2nd column of this <see cref='System.Drawing.Imaging.ColorMatrix'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Represents the element at the 3rd row and 2nd column of this <see cref='ColorMatrix'/>.
+        /// </summary>
         public float Matrix32
         {
             get { return _matrix32; }
             set { _matrix32 = value; }
         }
 
-        /// <include file='doc\ColorMatrix.uex' path='docs/doc[@for="ColorMatrix.Matrix33"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Represents the element at the 3rd row and 3rd column of this <see cref='System.Drawing.Imaging.ColorMatrix'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Represents the element at the 3rd row and 3rd column of this <see cref='ColorMatrix'/>.
+        /// </summary>
         public float Matrix33
         {
             get { return _matrix33; }
             set { _matrix33 = value; }
         }
 
-        /// <include file='doc\ColorMatrix.uex' path='docs/doc[@for="ColorMatrix.Matrix34"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Represents the element at the 3rd row and 4th column of this <see cref='System.Drawing.Imaging.ColorMatrix'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Represents the element at the 3rd row and 4th column of this <see cref='ColorMatrix'/>.
+        /// </summary>
         public float Matrix34
         {
             get { return _matrix34; }
             set { _matrix34 = value; }
         }
 
-        /// <include file='doc\ColorMatrix.uex' path='docs/doc[@for="ColorMatrix.Matrix40"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Represents the element at the 4th row and 0th column of this <see cref='System.Drawing.Imaging.ColorMatrix'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Represents the element at the 4th row and 0th column of this <see cref='ColorMatrix'/>.
+        /// </summary>
         public float Matrix40
         {
             get { return _matrix40; }
             set { _matrix40 = value; }
         }
 
-        /// <include file='doc\ColorMatrix.uex' path='docs/doc[@for="ColorMatrix.Matrix41"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Represents the element at the 4th row and 1st column of this <see cref='System.Drawing.Imaging.ColorMatrix'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Represents the element at the 4th row and 1st column of this <see cref='ColorMatrix'/>.
+        /// </summary>
         public float Matrix41
         {
             get { return _matrix41; }
             set { _matrix41 = value; }
         }
 
-        /// <include file='doc\ColorMatrix.uex' path='docs/doc[@for="ColorMatrix.Matrix42"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Represents the element at the 4th row and 2nd column of this <see cref='System.Drawing.Imaging.ColorMatrix'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Represents the element at the 4th row and 2nd column of this <see cref='ColorMatrix'/>.
+        /// </summary>
         public float Matrix42
         {
             get { return _matrix42; }
             set { _matrix42 = value; }
         }
 
-        /// <include file='doc\ColorMatrix.uex' path='docs/doc[@for="ColorMatrix.Matrix43"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Represents the element at the 4th row and 3rd column of this <see cref='System.Drawing.Imaging.ColorMatrix'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Represents the element at the 4th row and 3rd column of this <see cref='ColorMatrix'/>.
+        /// </summary>
         public float Matrix43
         {
             get { return _matrix43; }
             set { _matrix43 = value; }
         }
 
-        /// <include file='doc\ColorMatrix.uex' path='docs/doc[@for="ColorMatrix.Matrix44"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Represents the element at the 4th row and 4th column of this <see cref='System.Drawing.Imaging.ColorMatrix'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Represents the element at the 4th row and 4th column of this <see cref='ColorMatrix'/>.
+        /// </summary>
         public float Matrix44
         {
             get { return _matrix44; }
@@ -377,13 +299,9 @@ namespace System.Drawing.Imaging
         }
 
 
-        /// <include file='doc\ColorMatrix.uex' path='docs/doc[@for="ColorMatrix.ColorMatrix1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.ColorMatrix'/> class with the
-        ///       elements in the specified matrix.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='ColorMatrix'/> class with the elements in the specified matrix.
+        /// </summary>
         [CLSCompliant(false)]
         public ColorMatrix(float[][] newColorMatrix)
         {
@@ -455,12 +373,9 @@ namespace System.Drawing.Imaging
             return returnMatrix;
         }
 
-        /// <include file='doc\ColorMatrix.uex' path='docs/doc[@for="ColorMatrix.this"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets or sets the value of the specified element of this <see cref='System.Drawing.Imaging.ColorMatrix'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the value of the specified element of this <see cref='ColorMatrix'/>.
+        /// </summary>
         public float this[int row, int column]
         {
             get

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/ColorMatrixFlags.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/ColorMatrixFlags.cs
@@ -4,33 +4,22 @@
 
 namespace System.Drawing.Imaging
 {
-    /**
-     * Color matrix flag constants
-     */
-    /// <include file='doc\ColorMatrixFlags.uex' path='docs/doc[@for="ColorMatrixFlag"]/*' />
-    /// <devdoc>
-    ///    Specifies available options for
-    ///    color-adjusting. GDI+ can adjust color data only, grayscale data only,
-    ///    or both.
-    /// </devdoc>
+    /// <summary>
+    /// Specifies available options for color-adjusting. GDI+ can adjust color data only, grayscale data only, or both.
+    /// </summary>
     public enum ColorMatrixFlag
     {
-        /// <include file='doc\ColorMatrixFlags.uex' path='docs/doc[@for="ColorMatrixFlag.Default"]/*' />
-        /// <devdoc>
-        ///    Both colors and grayscale are
-        ///    color-adjusted.
-        /// </devdoc>
+        /// <summary>
+        /// Both colors and grayscale are color-adjusted.
+        /// </summary>
         Default = 0,
-        /// <include file='doc\ColorMatrixFlags.uex' path='docs/doc[@for="ColorMatrixFlag.SkipGrays"]/*' />
-        /// <devdoc>
-        ///    Grascale values are not color-adjusted.
-        /// </devdoc>
+        /// <summary>
+        /// Grascale values are not color-adjusted.
+        /// </summary>
         SkipGrays = 1,
-        /// <include file='doc\ColorMatrixFlags.uex' path='docs/doc[@for="ColorMatrixFlag.AltGrays"]/*' />
-        /// <devdoc>
-        ///    Only grascale values are color-adjusted.
-        /// </devdoc>
+        /// <summary>
+        /// Only grascale values are color-adjusted.
+        /// </summary>
         AltGrays = 2
     }
 }
-

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/ColorMode.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/ColorMode.cs
@@ -4,31 +4,18 @@
 
 namespace System.Drawing.Imaging
 {
-    /**
-     * Color mode constants
-     */
-    /// <include file='doc\ColorMode.uex' path='docs/doc[@for="ColorMode"]/*' />
-    /// <devdoc>
-    ///    <para>
-    ///       Specifies two modes for color component
-    ///       values.
-    ///    </para>
-    /// </devdoc>
+    /// <summary>
+    /// Specifies two modes for color component values.
+    /// </summary>
     public enum ColorMode
     {
-        /// <include file='doc\ColorMode.uex' path='docs/doc[@for="ColorMode.Argb32Mode"]/*' />
-        /// <devdoc>
-        ///    Specifies that integer values supplied are
-        ///    32-bit values.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies that integer values supplied are 32-bit values.
+        /// </summary>
         Argb32Mode = 0,
-        /// <include file='doc\ColorMode.uex' path='docs/doc[@for="ColorMode.Argb64Mode"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Specifies that integer values supplied are
-        ///       64-bit values.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Specifies that integer values supplied are 64-bit values.
+        /// </summary>
         Argb64Mode = 1
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/ColorPalette.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/ColorPalette.cs
@@ -2,32 +2,26 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
+
 namespace System.Drawing.Imaging
 {
-    using System.Runtime.InteropServices;
-
-    /// <include file='doc\ColorPalette.uex' path='docs/doc[@for="ColorPalette"]/*' />
-    /// <devdoc>
-    ///    Defines an array of colors that make up a
-    ///    color palette.
-    /// </devdoc>
+    /// <summary>
+    /// Defines an array of colors that make up a color palette.
+    /// </summary>
     public sealed class ColorPalette
     {
-        ///    Note (From VSWhidbey#444618): We don't provide a public constructor for ColorPalette because if we allow 
-        ///    arbitrary creation of color palettes you could in theroy not only change the color entries, but the size 
-        ///    of the palette and that is not valid for an image (meaning you cannot change the palette size for an image).  
-        ///    ColorPalettes are only valid for "indexed" images like GIFs.
+        // We don't provide a public constructor for ColorPalette because if we allow 
+        // arbitrary creation of color palettes you could in theroy not only change the color entries, but the size 
+        // of the palette and that is not valid for an image (meaning you cannot change the palette size for an image).  
+        // ColorPalettes are only valid for "indexed" images like GIFs.
 
         private int _flags;
         private Color[] _entries;
 
-        /// <include file='doc\ColorPalette.uex' path='docs/doc[@for="ColorPalette.Flags"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Specifies how to interpret the color
-        ///       information in the array of colors.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Specifies how to interpret the color information in the array of colors.
+        /// </summary>
         public int Flags
         {
             get
@@ -36,10 +30,9 @@ namespace System.Drawing.Imaging
             }
         }
 
-        /// <include file='doc\ColorPalette.uex' path='docs/doc[@for="ColorPalette.Entries"]/*' />
-        /// <devdoc>
-        ///    Specifies an array of <see cref='System.Drawing.Color'/> objects.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies an array of <see cref='Color'/> objects.
+        /// </summary>
         public Color[] Entries
         {
             get

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/EmfPlusRecordType.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/EmfPlusRecordType.cs
@@ -4,994 +4,209 @@
 
 namespace System.Drawing.Imaging
 {
-    /*
-     * EmfPlusRecordType constants
-     */
-
-    /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType"]/*' />
-    /// <devdoc>
-    ///    <para>
-    ///       Specifies the methods available in a metafile to read and write graphic
-    ///       commands.
-    ///    </para>
-    /// </devdoc>    
+    /// <summary>
+    /// Specifies the methods available in a metafile to read and write graphic commands.
+    /// </summary>    
     public enum EmfPlusRecordType
     {
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfRecordBase"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfRecordBase = 0x00010000,
-
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfSetBkColor"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfSetBkColor = WmfRecordBase | 0x201,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfSetBkMode"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfSetBkMode = WmfRecordBase | 0x102,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfSetMapMode"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfSetMapMode = WmfRecordBase | 0x103,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfSetROP2"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfSetROP2 = WmfRecordBase | 0x104,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfSetRelAbs"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfSetRelAbs = WmfRecordBase | 0x105,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfSetPolyFillMode"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfSetPolyFillMode = WmfRecordBase | 0x106,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfSetStretchBltMode"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfSetStretchBltMode = WmfRecordBase | 0x107,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfSetTextCharExtra"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfSetTextCharExtra = WmfRecordBase | 0x108,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfSetTextColor"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfSetTextColor = WmfRecordBase | 0x209,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfSetTextJustification"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfSetTextJustification = WmfRecordBase | 0x20A,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfSetWindowOrg"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfSetWindowOrg = WmfRecordBase | 0x20B,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfSetWindowExt"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfSetWindowExt = WmfRecordBase | 0x20C,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfSetViewportOrg"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfSetViewportOrg = WmfRecordBase | 0x20D,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfSetViewportExt"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfSetViewportExt = WmfRecordBase | 0x20E,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfOffsetWindowOrg"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfOffsetWindowOrg = WmfRecordBase | 0x20F,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfScaleWindowExt"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfScaleWindowExt = WmfRecordBase | 0x410,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfOffsetViewportOrg"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfOffsetViewportOrg = WmfRecordBase | 0x211,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfScaleViewportExt"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfScaleViewportExt = WmfRecordBase | 0x412,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfLineTo"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfLineTo = WmfRecordBase | 0x213,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfMoveTo"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfMoveTo = WmfRecordBase | 0x214,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfExcludeClipRect"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfExcludeClipRect = WmfRecordBase | 0x415,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfIntersectClipRect"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfIntersectClipRect = WmfRecordBase | 0x416,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfArc"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfArc = WmfRecordBase | 0x817,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfEllipse"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfEllipse = WmfRecordBase | 0x418,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfFloodFill"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfFloodFill = WmfRecordBase | 0x419,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfPie"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfPie = WmfRecordBase | 0x81A,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfRectangle"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfRectangle = WmfRecordBase | 0x41B,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfRoundRect"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfRoundRect = WmfRecordBase | 0x61C,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfPatBlt"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfPatBlt = WmfRecordBase | 0x61D,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfSaveDC"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfSaveDC = WmfRecordBase | 0x01E,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfSetPixel"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfSetPixel = WmfRecordBase | 0x41F,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfOffsetCilpRgn"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfOffsetCilpRgn = WmfRecordBase | 0x220,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfTextOut"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfTextOut = WmfRecordBase | 0x521,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfBitBlt"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfBitBlt = WmfRecordBase | 0x922,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfStretchBlt"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfStretchBlt = WmfRecordBase | 0xB23,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfPolygon"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfPolygon = WmfRecordBase | 0x324,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfPolyline"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfPolyline = WmfRecordBase | 0x325,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfEscape"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfEscape = WmfRecordBase | 0x626,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfRestoreDC"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfRestoreDC = WmfRecordBase | 0x127,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfFillRegion"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfFillRegion = WmfRecordBase | 0x228,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfFrameRegion"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfFrameRegion = WmfRecordBase | 0x429,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfInvertRegion"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfInvertRegion = WmfRecordBase | 0x12A,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfPaintRegion"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfPaintRegion = WmfRecordBase | 0x12B,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfSelectClipRegion"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfSelectClipRegion = WmfRecordBase | 0x12C,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfSelectObject"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfSelectObject = WmfRecordBase | 0x12D,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfSetTextAlign"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfSetTextAlign = WmfRecordBase | 0x12E,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfChord"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfChord = WmfRecordBase | 0x830,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfSetMapperFlags"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfSetMapperFlags = WmfRecordBase | 0x231,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfExtTextOut"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfExtTextOut = WmfRecordBase | 0xA32,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfSetDibToDev"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfSetDibToDev = WmfRecordBase | 0xD33,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfSelectPalette"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfSelectPalette = WmfRecordBase | 0x234,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfRealizePalette"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfRealizePalette = WmfRecordBase | 0x035,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfAnimatePalette"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfAnimatePalette = WmfRecordBase | 0x436,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfSetPalEntries"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfSetPalEntries = WmfRecordBase | 0x037,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfPolyPolygon"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfPolyPolygon = WmfRecordBase | 0x538,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfResizePalette"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfResizePalette = WmfRecordBase | 0x139,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfDibBitBlt"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfDibBitBlt = WmfRecordBase | 0x940,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfDibStretchBlt"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfDibStretchBlt = WmfRecordBase | 0xb41,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfDibCreatePatternBrush"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfDibCreatePatternBrush = WmfRecordBase | 0x142,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfStretchDib"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfStretchDib = WmfRecordBase | 0xf43,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfExtFloodFill"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfExtFloodFill = WmfRecordBase | 0x548,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfSetLayout"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfSetLayout = WmfRecordBase | 0x149, // META_SETLAYOUT
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfDeleteObject"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfDeleteObject = WmfRecordBase | 0x1f0,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfCreatePalette"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfCreatePalette = WmfRecordBase | 0x0f7,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfCreatePatternBrush"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfCreatePatternBrush = WmfRecordBase | 0x1f9,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfCreatePenIndirect"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfCreatePenIndirect = WmfRecordBase | 0x2fa,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfCreateFontIndirect"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfCreateFontIndirect = WmfRecordBase | 0x2fb,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfCreateBrushIndirect"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfCreateBrushIndirect = WmfRecordBase | 0x2fc,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.WmfCreateRegion"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         WmfCreateRegion = WmfRecordBase | 0x6ff,
 
         // Since we have to enumerate GDI records right along with GDI+ records,
         // we list all the GDI records here so that they can be part of the
         // same enumeration type which is used in the enumeration callback.
 
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfHeader"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfHeader = 1,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfPolyBezier"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfPolyBezier = 2,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfPolygon"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfPolygon = 3,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfPolyline"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfPolyline = 4,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfPolyBezierTo"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfPolyBezierTo = 5,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfPolyLineTo"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfPolyLineTo = 6,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfPolyPolyline"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfPolyPolyline = 7,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfPolyPolygon"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfPolyPolygon = 8,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfSetWindowExtEx"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfSetWindowExtEx = 9,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfSetWindowOrgEx"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfSetWindowOrgEx = 10,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfSetViewportExtEx"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfSetViewportExtEx = 11,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfSetViewportOrgEx"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfSetViewportOrgEx = 12,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfSetBrushOrgEx"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfSetBrushOrgEx = 13,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfEof"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfEof = 14,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfSetPixelV"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfSetPixelV = 15,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfSetMapperFlags"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfSetMapperFlags = 16,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfSetMapMode"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfSetMapMode = 17,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfSetBkMode"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfSetBkMode = 18,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfSetPolyFillMode"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfSetPolyFillMode = 19,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfSetROP2"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfSetROP2 = 20,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfSetStretchBltMode"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfSetStretchBltMode = 21,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfSetTextAlign"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfSetTextAlign = 22,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfSetColorAdjustment"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfSetColorAdjustment = 23,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfSetTextColor"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfSetTextColor = 24,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfSetBkColor"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfSetBkColor = 25,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfOffsetClipRgn"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfOffsetClipRgn = 26,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfMoveToEx"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfMoveToEx = 27,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfSetMetaRgn"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfSetMetaRgn = 28,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfExcludeClipRect"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfExcludeClipRect = 29,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfIntersectClipRect"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfIntersectClipRect = 30,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfScaleViewportExtEx"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfScaleViewportExtEx = 31,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfScaleWindowExtEx"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfScaleWindowExtEx = 32,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfSaveDC"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfSaveDC = 33,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfRestoreDC"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfRestoreDC = 34,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfSetWorldTransform"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfSetWorldTransform = 35,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfModifyWorldTransform"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfModifyWorldTransform = 36,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfSelectObject"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfSelectObject = 37,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfCreatePen"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfCreatePen = 38,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfCreateBrushIndirect"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfCreateBrushIndirect = 39,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfDeleteObject"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfDeleteObject = 40,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfAngleArc"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfAngleArc = 41,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfEllipse"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfEllipse = 42,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfRectangle"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfRectangle = 43,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfRoundRect"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfRoundRect = 44,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfRoundArc"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfRoundArc = 45,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfChord"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfChord = 46,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfPie"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfPie = 47,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfSelectPalette"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfSelectPalette = 48,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfCreatePalette"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfCreatePalette = 49,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfSetPaletteEntries"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfSetPaletteEntries = 50,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfResizePalette"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfResizePalette = 51,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfRealizePalette"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfRealizePalette = 52,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfExtFloodFill"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfExtFloodFill = 53,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfLineTo"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfLineTo = 54,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfArcTo"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfArcTo = 55,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfPolyDraw"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfPolyDraw = 56,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfSetArcDirection"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfSetArcDirection = 57,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfSetMiterLimit"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfSetMiterLimit = 58,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfBeginPath"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfBeginPath = 59,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfEndPath"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfEndPath = 60,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfCloseFigure"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfCloseFigure = 61,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfFillPath"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfFillPath = 62,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfStrokeAndFillPath"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfStrokeAndFillPath = 63,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfStrokePath"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfStrokePath = 64,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfFlattenPath"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfFlattenPath = 65,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfWidenPath"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfWidenPath = 66,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfSelectClipPath"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfSelectClipPath = 67,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfAbortPath"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfAbortPath = 68,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfReserved069"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfReserved069 = 69,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfGdiComment"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfGdiComment = 70,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfFillRgn"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfFillRgn = 71,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfFrameRgn"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfFrameRgn = 72,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfInvertRgn"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfInvertRgn = 73,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfPaintRgn"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfPaintRgn = 74,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfExtSelectClipRgn"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfExtSelectClipRgn = 75,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfBitBlt"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfBitBlt = 76,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfStretchBlt"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfStretchBlt = 77,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfMaskBlt"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfMaskBlt = 78,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfPlgBlt"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfPlgBlt = 79,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfSetDIBitsToDevice"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfSetDIBitsToDevice = 80,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfStretchDIBits"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfStretchDIBits = 81,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfExtCreateFontIndirect"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfExtCreateFontIndirect = 82,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfExtTextOutA"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfExtTextOutA = 83,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfExtTextOutW"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfExtTextOutW = 84,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfPolyBezier16"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfPolyBezier16 = 85,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfPolygon16"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfPolygon16 = 86,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfPolyline16"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfPolyline16 = 87,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfPolyBezierTo16"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfPolyBezierTo16 = 88,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfPolylineTo16"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfPolylineTo16 = 89,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfPolyPolyline16"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfPolyPolyline16 = 90,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfPolyPolygon16"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfPolyPolygon16 = 91,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfPolyDraw16"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfPolyDraw16 = 92,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfCreateMonoBrush"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfCreateMonoBrush = 93,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfCreateDibPatternBrushPt"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfCreateDibPatternBrushPt = 94,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfExtCreatePen"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfExtCreatePen = 95,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfPolyTextOutA"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfPolyTextOutA = 96,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfPolyTextOutW"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfPolyTextOutW = 97,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfSetIcmMode"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfSetIcmMode = 98,  // EMR_SETICMMODE,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfCreateColorSpace"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfCreateColorSpace = 99,  // EMR_CREATECOLORSPACE,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfSetColorSpace"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfSetColorSpace = 100, // EMR_SETCOLORSPACE,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfDeleteColorSpace"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfDeleteColorSpace = 101, // EMR_DELETECOLORSPACE,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfGlsRecord"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfGlsRecord = 102, // EMR_GLSRECORD,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfGlsBoundedRecord"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfGlsBoundedRecord = 103, // EMR_GLSBOUNDEDRECORD,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfPixelFormat"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfPixelFormat = 104, // EMR_PIXELFORMAT,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfDrawEscape"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfDrawEscape = 105, // EMR_RESERVED_105,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfExtEscape"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfExtEscape = 106, // EMR_RESERVED_106,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfStartDoc"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfStartDoc = 107, // EMR_RESERVED_107,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfSmallTextOut"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfSmallTextOut = 108, // EMR_RESERVED_108,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfForceUfiMapping"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfForceUfiMapping = 109, // EMR_RESERVED_109,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfNamedEscpae"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfNamedEscpae = 110, // EMR_RESERVED_110,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfColorCorrectPalette"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfColorCorrectPalette = 111, // EMR_COLORCORRECTPALETTE,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfSetIcmProfileA"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfSetIcmProfileA = 112, // EMR_SETICMPROFILEA,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfSetIcmProfileW"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfSetIcmProfileW = 113, // EMR_SETICMPROFILEW,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfAlphaBlend"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfAlphaBlend = 114, // EMR_ALPHABLEND,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfSetLayout"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfSetLayout = 115, // EMR_SETLAYOUT,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfTransparentBlt"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfTransparentBlt = 116, // EMR_TRANSPARENTBLT,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfReserved117"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfReserved117 = 117,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfGradientFill"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfGradientFill = 118, // EMR_GRADIENTFILL,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfSetLinkedUfis"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfSetLinkedUfis = 119, // EMR_RESERVED_119,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfSetTextJustification"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfSetTextJustification = 120, // EMR_RESERVED_120,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfColorMatchToTargetW"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfColorMatchToTargetW = 121, // EMR_COLORMATCHTOTARGETW,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfCreateColorSpaceW"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfCreateColorSpaceW = 122, // EMR_CREATECOLORSPACEW,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfMax"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfMax = 122,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfMin"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfMin = 1,
 
         // That is the END of the GDI EMF records.
@@ -1000,312 +215,76 @@ namespace System.Drawing.Imaging
         // a bit of room here for the addition of any new GDI
         // records that may be added later.
 
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EmfPlusRecordBase"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EmfPlusRecordBase = 0x00004000,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.Invalid"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         Invalid = EmfPlusRecordBase,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.Header"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         Header,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EndOfFile"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EndOfFile,
 
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.Comment"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         Comment,
 
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.GetDC"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         GetDC,    // the application grabbed the metafile dc
 
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.MultiFormatStart"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         MultiFormatStart,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.MultiFormatSection"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         MultiFormatSection,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.MultiFormatEnd"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         MultiFormatEnd,
 
         // For all Persistent Objects
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.Object"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         Object,
         // Drawing Records
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.Clear"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         Clear,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.FillRects"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         FillRects,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.DrawRects"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         DrawRects,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.FillPolygon"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         FillPolygon,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.DrawLines"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         DrawLines,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.FillEllipse"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         FillEllipse,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.DrawEllipse"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         DrawEllipse,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.FillPie"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         FillPie,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.DrawPie"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         DrawPie,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.DrawArc"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         DrawArc,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.FillRegion"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         FillRegion,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.FillPath"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         FillPath,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.DrawPath"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         DrawPath,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.FillClosedCurve"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         FillClosedCurve,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.DrawClosedCurve"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         DrawClosedCurve,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.DrawCurve"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         DrawCurve,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.DrawBeziers"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         DrawBeziers,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.DrawImage"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         DrawImage,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.DrawImagePoints"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         DrawImagePoints,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.DrawString"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         DrawString,
 
         // Graphics State Records
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.SetRenderingOrigin"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         SetRenderingOrigin,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.SetAntiAliasMode"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         SetAntiAliasMode,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.SetTextRenderingHint"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         SetTextRenderingHint,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.SetTextContrast"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         SetTextContrast,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.SetInterpolationMode"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         SetInterpolationMode,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.SetPixelOffsetMode"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         SetPixelOffsetMode,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.SetCompositingMode"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         SetCompositingMode,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.SetCompositingQuality"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         SetCompositingQuality,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.Save"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         Save,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.Restore"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         Restore,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.BeginContainer"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         BeginContainer,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.BeginContainerNoParams"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         BeginContainerNoParams,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.EndContainer"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         EndContainer,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.SetWorldTransform"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         SetWorldTransform,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.ResetWorldTransform"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         ResetWorldTransform,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.MultiplyWorldTransform"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         MultiplyWorldTransform,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.TranslateWorldTransform"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         TranslateWorldTransform,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.ScaleWorldTransform"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         ScaleWorldTransform,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.RotateWorldTransform"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         RotateWorldTransform,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.SetPageTransform"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         SetPageTransform,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.ResetClip"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         ResetClip,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.SetClipRect"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         SetClipRect,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.SetClipPath"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         SetClipPath,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.SetClipRegion"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         SetClipRegion,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.OffsetClip"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         OffsetClip,
 
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.DrawDriverString"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         DrawDriverString,
 
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.Total"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         Total,
 
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.Max"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         Max = Total - 1,
-        /// <include file='doc\EmfPlusRecordType.uex' path='docs/doc[@for="EmfPlusRecordType.Min"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         Min = Header
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/EmfType.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/EmfType.cs
@@ -4,40 +4,22 @@
 
 namespace System.Drawing.Imaging
 {
-    /**
-     * EmfType Type
-     */
-    /// <include file='doc\EmfType.uex' path='docs/doc[@for="EmfType"]/*' />
-    /// <devdoc>
-    ///    <para>
-    ///       Specifies the metafile type.
-    ///    </para>
-    /// </devdoc>
+    /// <summary>
+    /// Specifies the metafile type.
+    /// </summary>
     public enum EmfType
     {
-        /// <include file='doc\EmfType.uex' path='docs/doc[@for="EmfType.EmfOnly"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Windows enhanced metafile. Contains GDI commands. Metafiles of this type are
-        ///       refered to as an EMF file.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Windows enhanced metafile. Contains GDI commands. Metafiles of this type are refered to as an EMF file.
+        /// </summary>
         EmfOnly = MetafileType.Emf,
-        /// <include file='doc\EmfType.uex' path='docs/doc[@for="EmfType.EmfPlusOnly"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Windows enhanced metafile plus. Contains GDI+ commands. Metafiles of this
-        ///       type are refered to as an EMF+ file.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Windows enhanced metafile plus. Contains GDI+ commands. Metafiles of this type are refered to as an EMF+ file.
+        /// </summary>
         EmfPlusOnly = MetafileType.EmfPlusOnly,
-        /// <include file='doc\EmfType.uex' path='docs/doc[@for="EmfType.EmfPlusDual"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Dual Windows enhanced metafile. Contains equivalent GDI and GDI+ commands.
-        ///       Metafiles of this type are refered to as an EMF+ file.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Dual Windows enhanced metafile. Contains equivalent GDI and GDI+ commands. Metafiles of this type are refered to as an EMF+ file.
+        /// </summary>
         EmfPlusDual = MetafileType.EmfPlusDual
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/Encoder.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/Encoder.cs
@@ -4,82 +4,26 @@
 
 namespace System.Drawing.Imaging
 {
-    /**
-     * Encoder Parameter types
-     */
-    // note : READONLY ARE USELESS HERE, but since we shipped like that already, might as well leave it there...
-    /// <include file='doc\Encoder.uex' path='docs/doc[@for="Encoder"]/*' />
-    /// <devdoc>
-    ///    <para>[To be supplied.]</para>
-    /// </devdoc>
     public sealed class Encoder
     {
-        /// <include file='doc\Encoder.uex' path='docs/doc[@for="Encoder.Compression"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>        
         public static readonly Encoder Compression = new Encoder(new Guid(unchecked((int)0xe09d739d), unchecked((short)0xccd4), unchecked((short)0x44ee), new byte[] { 0x8e, 0xba, 0x3f, 0xbf, 0x8b, 0xe4, 0xfc, 0x58 }));
-        /// <include file='doc\Encoder.uex' path='docs/doc[@for="Encoder.ColorDepth"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public static readonly Encoder ColorDepth = new Encoder(new Guid(0x66087055, unchecked((short)0xad66), unchecked((short)0x4c7c), new byte[] { 0x9a, 0x18, 0x38, 0xa2, 0x31, 0x0b, 0x83, 0x37 }));
-        /// <include file='doc\Encoder.uex' path='docs/doc[@for="Encoder.ScanMethod"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public static readonly Encoder ScanMethod = new Encoder(new Guid(0x3a4e2661, (short)0x3109, (short)0x4e56, new byte[] { 0x85, 0x36, 0x42, 0xc1, 0x56, 0xe7, 0xdc, 0xfa }));
-        /// <include file='doc\Encoder.uex' path='docs/doc[@for="Encoder.Version"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public static readonly Encoder Version = new Encoder(new Guid(0x24d18c76, unchecked((short)0x814a), unchecked((short)0x41a4), new byte[] { 0xbf, 0x53, 0x1c, 0x21, 0x9c, 0xcc, 0xf7, 0x97 }));
-        /// <include file='doc\Encoder.uex' path='docs/doc[@for="Encoder.RenderMethod"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public static readonly Encoder RenderMethod = new Encoder(new Guid(0x6d42c53a, (short)0x229a, (short)0x4825, new byte[] { 0x8b, 0xb7, 0x5c, 0x99, 0xe2, 0xb9, 0xa8, 0xb8 }));
-        /// <include file='doc\Encoder.uex' path='docs/doc[@for="Encoder.Quality"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public static readonly Encoder Quality = new Encoder(new Guid(0x1d5be4b5, unchecked((short)0xfa4a), unchecked((short)0x452d), new byte[] { 0x9c, 0xdd, 0x5d, 0xb3, 0x51, 0x05, 0xe7, 0xeb }));
-        /// <include file='doc\Encoder.uex' path='docs/doc[@for="Encoder.Transformation"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public static readonly Encoder Transformation = new Encoder(new Guid(unchecked((int)0x8d0eb2d1), unchecked((short)0xa58e), unchecked((short)0x4ea8), new byte[] { 0xaa, 0x14, 0x10, 0x80, 0x74, 0xb7, 0xb6, 0xf9 }));
-        /// <include file='doc\Encoder.uex' path='docs/doc[@for="Encoder.LuminanceTable"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>        
         public static readonly Encoder LuminanceTable = new Encoder(new Guid(unchecked((int)0xedb33bce), unchecked((short)0x0266), unchecked((short)0x4a77), new byte[] { 0xb9, 0x04, 0x27, 0x21, 0x60, 0x99, 0xe7, 0x17 }));
-        /// <include file='doc\Encoder.uex' path='docs/doc[@for="Encoder.ChrominanceTable"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public static readonly Encoder ChrominanceTable = new Encoder(new Guid(unchecked((int)0xf2e455dc), unchecked((short)0x09b3), unchecked((short)0x4316), new byte[] { 0x82, 0x60, 0x67, 0x6a, 0xda, 0x32, 0x48, 0x1c }));
-        /// <include file='doc\Encoder.uex' path='docs/doc[@for="Encoder.SaveFlag"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public static readonly Encoder SaveFlag = new Encoder(new Guid(unchecked((int)0x292266fc), unchecked((short)0xac40), unchecked((short)0x47bf), new byte[] { 0x8c, 0xfc, 0xa8, 0x5b, 0x89, 0xa6, 0x55, 0xde }));
 
         private Guid _guid;
 
-        /// <include file='doc\Encoder.uex' path='docs/doc[@for="Encoder.Encoder"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public Encoder(Guid guid)
         {
             _guid = guid;
         }
 
-        /// <include file='doc\Encoder.uex' path='docs/doc[@for="Encoder.Guid"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public Guid Guid
         {
             get { return _guid; }

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/EncoderParameter.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/EncoderParameter.cs
@@ -2,14 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
+
 namespace System.Drawing.Imaging
 {
-    using System.Runtime.InteropServices;
-
-    /// <include file='doc\EncoderParameter.uex' path='docs/doc[@for="EncoderParameter"]/*' />
-    /// <devdoc>
-    ///    <para>[To be supplied.]</para>
-    /// </devdoc>
     [StructLayout(LayoutKind.Sequential)]
     public sealed class EncoderParameter : IDisposable
     {
@@ -21,16 +17,14 @@ namespace System.Drawing.Imaging
         private EncoderParameterValueType _parameterValueType;   // Value type, like ValueTypeLONG  etc.
         private IntPtr _parameterValue;                 // A pointer to the parameter values
 
-        /// <include file='doc\EncoderParameter.uex' path='docs/doc[@for="EncoderParameter.Finalize"]/*' />
         ~EncoderParameter()
         {
             Dispose(false);
         }
 
-        /// <include file='doc\EncoderParameter.uex' path='docs/doc[@for="EncoderParameter.Encoder"]/*' />
-        /// <devdoc>
-        ///    Gets/Sets the Encoder for the EncoderPameter.
-        /// </devdoc>
+        /// <summary>
+        /// Gets/Sets the Encoder for the EncoderPameter.
+        /// </summary>
         public Encoder Encoder
         {
             get
@@ -43,10 +37,9 @@ namespace System.Drawing.Imaging
             }
         }
 
-        /// <include file='doc\EncoderParameter.uex' path='docs/doc[@for="EncoderParameter.Type"]/*' />
-        /// <devdoc>
-        ///    Gets the EncoderParameterValueType object from the EncoderParameter.
-        /// </devdoc>
+        /// <summary>
+        /// Gets the EncoderParameterValueType object from the EncoderParameter.
+        /// </summary>
         public EncoderParameterValueType Type
         {
             get
@@ -55,10 +48,9 @@ namespace System.Drawing.Imaging
             }
         }
 
-        /// <include file='doc\EncoderParameter.uex' path='docs/doc[@for="EncoderParameter.ValueType"]/*' />
-        /// <devdoc>
-        ///    Gets the EncoderParameterValueType object from the EncoderParameter.
-        /// </devdoc>
+        /// <summary>
+        /// Gets the EncoderParameterValueType object from the EncoderParameter.
+        /// </summary>
         public EncoderParameterValueType ValueType
         {
             get
@@ -67,10 +59,9 @@ namespace System.Drawing.Imaging
             }
         }
 
-        /// <include file='doc\EncoderParameter.uex' path='docs/doc[@for="EncoderParameter.NumberOfValues"]/*' />
-        /// <devdoc>
-        ///    Gets the NumberOfValues from the EncoderParameter.
-        /// </devdoc>
+        /// <summary>
+        /// Gets the NumberOfValues from the EncoderParameter.
+        /// </summary>
         public int NumberOfValues
         {
             get
@@ -79,11 +70,6 @@ namespace System.Drawing.Imaging
             }
         }
 
-
-        /// <include file='doc\EncoderParameter.uex' path='docs/doc[@for="EncoderParameter.Dispose"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void Dispose()
         {
             Dispose(true);
@@ -98,10 +84,6 @@ namespace System.Drawing.Imaging
             _parameterValue = IntPtr.Zero;
         }
 
-        /// <include file='doc\EncoderParameter.uex' path='docs/doc[@for="EncoderParameter.EncoderParameter"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public EncoderParameter(Encoder encoder, byte value)
         {
             _parameterGuid = encoder.Guid;
@@ -117,10 +99,6 @@ namespace System.Drawing.Imaging
             GC.KeepAlive(this);
         }
 
-        /// <include file='doc\EncoderParameter.uex' path='docs/doc[@for="EncoderParameter.EncoderParameter1"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public EncoderParameter(Encoder encoder, byte value, bool undefined)
         {
             _parameterGuid = encoder.Guid;
@@ -139,10 +117,6 @@ namespace System.Drawing.Imaging
             GC.KeepAlive(this);
         }
 
-        /// <include file='doc\EncoderParameter.uex' path='docs/doc[@for="EncoderParameter.EncoderParameter2"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public EncoderParameter(Encoder encoder, short value)
         {
             _parameterGuid = encoder.Guid;
@@ -158,10 +132,6 @@ namespace System.Drawing.Imaging
             GC.KeepAlive(this);
         }
 
-        /// <include file='doc\EncoderParameter.uex' path='docs/doc[@for="EncoderParameter.EncoderParameter3"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public EncoderParameter(Encoder encoder, long value)
         {
             _parameterGuid = encoder.Guid;
@@ -177,11 +147,6 @@ namespace System.Drawing.Imaging
             GC.KeepAlive(this);
         }
 
-        // Consider supporting a 'float' and converting to numerator/denominator                               
-        /// <include file='doc\EncoderParameter.uex' path='docs/doc[@for="EncoderParameter.EncoderParameter4"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public EncoderParameter(Encoder encoder, int numerator, int denominator)
         {
             _parameterGuid = encoder.Guid;
@@ -199,11 +164,6 @@ namespace System.Drawing.Imaging
             GC.KeepAlive(this);
         }
 
-        // Consider supporting a 'float' and converting to numerator/denominator                               
-        /// <include file='doc\EncoderParameter.uex' path='docs/doc[@for="EncoderParameter.EncoderParameter5"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public EncoderParameter(Encoder encoder, long rangebegin, long rangeend)
         {
             _parameterGuid = encoder.Guid;
@@ -221,11 +181,6 @@ namespace System.Drawing.Imaging
             GC.KeepAlive(this);
         }
 
-        // Consider supporting a 'float' and converting to numerator/denominator                               
-        /// <include file='doc\EncoderParameter.uex' path='docs/doc[@for="EncoderParameter.EncoderParameter6"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public EncoderParameter(Encoder encoder,
                                 int numerator1, int demoninator1,
                                 int numerator2, int demoninator2)
@@ -247,10 +202,6 @@ namespace System.Drawing.Imaging
             GC.KeepAlive(this);
         }
 
-        /// <include file='doc\EncoderParameter.uex' path='docs/doc[@for="EncoderParameter.EncoderParameter7"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public EncoderParameter(Encoder encoder, string value)
         {
             _parameterGuid = encoder.Guid;
@@ -264,10 +215,6 @@ namespace System.Drawing.Imaging
                 throw SafeNativeMethods.Gdip.StatusException(SafeNativeMethods.Gdip.OutOfMemory);
         }
 
-        /// <include file='doc\EncoderParameter.uex' path='docs/doc[@for="EncoderParameter.EncoderParameter8"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public EncoderParameter(Encoder encoder, byte[] value)
         {
             _parameterGuid = encoder.Guid;
@@ -284,10 +231,6 @@ namespace System.Drawing.Imaging
             GC.KeepAlive(this);
         }
 
-        /// <include file='doc\EncoderParameter.uex' path='docs/doc[@for="EncoderParameter.EncoderParameter9"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public EncoderParameter(Encoder encoder, byte[] value, bool undefined)
         {
             _parameterGuid = encoder.Guid;
@@ -307,10 +250,6 @@ namespace System.Drawing.Imaging
             GC.KeepAlive(this);
         }
 
-        /// <include file='doc\EncoderParameter.uex' path='docs/doc[@for="EncoderParameter.EncoderParameter10"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public EncoderParameter(Encoder encoder, short[] value)
         {
             _parameterGuid = encoder.Guid;
@@ -328,10 +267,6 @@ namespace System.Drawing.Imaging
             GC.KeepAlive(this);
         }
 
-        /// <include file='doc\EncoderParameter.uex' path='docs/doc[@for="EncoderParameter.EncoderParameter11"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public unsafe EncoderParameter(Encoder encoder, long[] value)
         {
             _parameterGuid = encoder.Guid;
@@ -356,11 +291,6 @@ namespace System.Drawing.Imaging
             GC.KeepAlive(this);
         }
 
-        // Consider supporting a 'float' and converting to numerator/denominator                               
-        /// <include file='doc\EncoderParameter.uex' path='docs/doc[@for="EncoderParameter.EncoderParameter12"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public EncoderParameter(Encoder encoder, int[] numerator, int[] denominator)
         {
             _parameterGuid = encoder.Guid;
@@ -385,11 +315,6 @@ namespace System.Drawing.Imaging
             GC.KeepAlive(this);
         }
 
-        // Consider supporting a 'float' and converting to numerator/denominator                               
-        /// <include file='doc\EncoderParameter.uex' path='docs/doc[@for="EncoderParameter.EncoderParameter13"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public EncoderParameter(Encoder encoder, long[] rangebegin, long[] rangeend)
         {
             _parameterGuid = encoder.Guid;
@@ -414,11 +339,6 @@ namespace System.Drawing.Imaging
             GC.KeepAlive(this);
         }
 
-        // Consider supporting a 'float' and converting to numerator/denominator                               
-        /// <include file='doc\EncoderParameter.uex' path='docs/doc[@for="EncoderParameter.EncoderParameter14"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public EncoderParameter(Encoder encoder,
                                 int[] numerator1, int[] denominator1,
                                 int[] numerator2, int[] denominator2)
@@ -449,11 +369,6 @@ namespace System.Drawing.Imaging
             GC.KeepAlive(this);
         }
 
-        // Consider supporting a 'float' and converting to numerator/denominator                               
-        /// <include file='doc\EncoderParameter.uex' path='docs/doc[@for="EncoderParameter.EncoderParameter15"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         [Obsolete("This constructor has been deprecated. Use EncoderParameter(Encoder encoder, int numberValues, EncoderParameterValueType type, IntPtr value) instead.  http://go.microsoft.com/fwlink/?linkid=14202")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public EncoderParameter(Encoder encoder, int NumberOfValues, int Type, int Value)
@@ -463,13 +378,25 @@ namespace System.Drawing.Imaging
             switch ((EncoderParameterValueType)Type)
             {
                 case EncoderParameterValueType.ValueTypeByte:
-                case EncoderParameterValueType.ValueTypeAscii: size = 1; break;
-                case EncoderParameterValueType.ValueTypeShort: size = 2; break;
-                case EncoderParameterValueType.ValueTypeLong: size = 4; break;
+                case EncoderParameterValueType.ValueTypeAscii:
+                    size = 1;
+                    break;
+                case EncoderParameterValueType.ValueTypeShort:
+                    size = 2;
+                    break;
+                case EncoderParameterValueType.ValueTypeLong:
+                    size = 4;
+                    break;
                 case EncoderParameterValueType.ValueTypeRational:
-                case EncoderParameterValueType.ValueTypeLongRange: size = 2 * 4; break;
-                case EncoderParameterValueType.ValueTypeUndefined: size = 1; break;
-                case EncoderParameterValueType.ValueTypeRationalRange: size = 2 * 2 * 4; break;
+                case EncoderParameterValueType.ValueTypeLongRange:
+                    size = 2 * 4;
+                    break;
+                case EncoderParameterValueType.ValueTypeUndefined:
+                    size = 1;
+                    break;
+                case EncoderParameterValueType.ValueTypeRationalRange:
+                    size = 2 * 2 * 4;
+                    break;
                 default:
                     throw SafeNativeMethods.Gdip.StatusException(SafeNativeMethods.Gdip.WrongState);
             }
@@ -492,10 +419,6 @@ namespace System.Drawing.Imaging
             GC.KeepAlive(this);
         }
 
-        /// <include file='doc\EncoderParameter.uex' path='docs/doc[@for="EncoderParameter.EncoderParameter16"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2004:RemoveCallsToGCKeepAlive")]
         public EncoderParameter(Encoder encoder, int numberValues, EncoderParameterValueType type, IntPtr value)
         {
@@ -504,13 +427,25 @@ namespace System.Drawing.Imaging
             switch (type)
             {
                 case EncoderParameterValueType.ValueTypeByte:
-                case EncoderParameterValueType.ValueTypeAscii: size = 1; break;
-                case EncoderParameterValueType.ValueTypeShort: size = 2; break;
-                case EncoderParameterValueType.ValueTypeLong: size = 4; break;
+                case EncoderParameterValueType.ValueTypeAscii:
+                    size = 1;
+                    break;
+                case EncoderParameterValueType.ValueTypeShort:
+                    size = 2;
+                    break;
+                case EncoderParameterValueType.ValueTypeLong:
+                    size = 4;
+                    break;
                 case EncoderParameterValueType.ValueTypeRational:
-                case EncoderParameterValueType.ValueTypeLongRange: size = 2 * 4; break;
-                case EncoderParameterValueType.ValueTypeUndefined: size = 1; break;
-                case EncoderParameterValueType.ValueTypeRationalRange: size = 2 * 2 * 4; break;
+                case EncoderParameterValueType.ValueTypeLongRange:
+                    size = 2 * 4;
+                    break;
+                case EncoderParameterValueType.ValueTypeUndefined:
+                    size = 1;
+                    break;
+                case EncoderParameterValueType.ValueTypeRationalRange:
+                    size = 2 * 2 * 4;
+                    break;
                 default:
                     throw SafeNativeMethods.Gdip.StatusException(SafeNativeMethods.Gdip.WrongState);
             }

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/EncoderParameterValueType.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/EncoderParameterValueType.cs
@@ -4,72 +4,46 @@
 
 namespace System.Drawing.Imaging
 {
-    /**
-     * EncoderParameter Value Type
-     */
-    /// <include file='doc\EncoderParameterValueType.uex' path='docs/doc[@for="EncoderParameterValueType"]/*' />
-    /// <devdoc>
-    ///    Specifies a EncoderParameter data type.
-    /// </devdoc>    
+    /// <summary>
+    /// Specifies a EncoderParameter data type.
+    /// </summary>    
     public enum EncoderParameterValueType
     {
-        /// <include file='doc\EncoderParameterValueType.uex' path='docs/doc[@for="EncoderParameterValueType.ValueTypeByte"]/*' />
-        /// <devdoc>
-        ///    The data is an 8-bit unsigned value.
-        /// </devdoc>
-        ValueTypeByte = 1,   // 8-bit unsigned int
-        /// <include file='doc\EncoderParameterValueType.uex' path='docs/doc[@for="EncoderParameterValueType.ValueTypeAscii"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       The data is an 8-bit ASCII value.
-        ///    </para>
-        /// </devdoc>
-        ValueTypeAscii = 2,   // 8-bit byte containing one 7-bit ASCII
-                              // code. NULL terminated.
-                              /// <include file='doc\EncoderParameterValueType.uex' path='docs/doc[@for="EncoderParameterValueType.ValueTypeShort"]/*' />
-                              /// <devdoc>
-                              ///    <para>
-                              ///       The data is a 16-bit unsigned value.
-                              ///    </para>
-                              /// </devdoc>
-        ValueTypeShort = 3,   // 16-bit unsigned int
-        /// <include file='doc\EncoderParameterValueType.uex' path='docs/doc[@for="EncoderParameterValueType.ValueTypeLong"]/*' />
-        /// <devdoc>
-        ///    The data is a 32-bit unsigned value.
-        /// </devdoc>
-        ValueTypeLong = 4,   // 32-bit unsigned int
-        /// <include file='doc\EncoderParameterValueType.uex' path='docs/doc[@for="EncoderParameterValueType.ValueTypeRational"]/*' />
-        /// <devdoc>
-        ///    The data is two long integers, specifying
-        ///    the numerator and the denominator of a rational number, respectively.
-        /// </devdoc>
-        ValueTypeRational = 5,   // Two Longs. The first Long is the
-                                 // numerator, the second Long expresses the
-                                 // denomintor.
-                                 /// <include file='doc\EncoderParameterValueType.uex' path='docs/doc[@for="EncoderParameterValueType.ValueTypeLongRange"]/*' />
-                                 /// <devdoc>
-                                 ///    Two values that specify a range of numbers.
-                                 /// </devdoc>
-        ValueTypeLongRange = 6,   // Two longs which specify a range of
-                                  // integer values. The first Long specifies
-                                  // the lower end and the second one
-                                  // specifies the higher end. All values 
-                                  // are inclusive at both ends
-                                  /// <include file='doc\EncoderParameterValueType.uex' path='docs/doc[@for="EncoderParameterValueType.ValueTypeUndefined"]/*' />
-                                  /// <devdoc>
-                                  ///    An 8-bit undefined value.
-                                  /// </devdoc>
-        ValueTypeUndefined = 7,   // 8-bit byte that can take any value
-                                  // depending on field definition
-                                  /// <include file='doc\EncoderParameterValueType.uex' path='docs/doc[@for="EncoderParameterValueType.ValueTypeRationalRange"]/*' />
-                                  /// <devdoc>
-                                  ///    A range of rational numbers.
-                                  /// </devdoc>
-        ValueTypeRationalRange = 8    // Two Rationals. The first Rational
-                                      // specifies the lower end and the second
-                                      // specifies the higher end. All values 
-                                      // are inclusive at both ends
+        /// <summary>
+        /// The data is an 8-bit unsigned value.
+        /// </summary>
+        ValueTypeByte = 1,
+        /// <summary>
+        /// The data is an 8-bit ASCII value.
+        /// </summary>
+        ValueTypeAscii = 2, // 8-bit byte containing one 7-bit ASCII code. NULL terminated.
+        /// <summary>
+        /// The data is a 16-bit unsigned value.
+        /// </summary>
+        ValueTypeShort = 3,
+        /// <summary>
+        /// The data is a 32-bit unsigned value.
+        /// </summary>
+        ValueTypeLong = 4,
+        /// <summary>
+        /// The data is two long integers, specifying the numerator and the denominator of a rational number, respectively.
+        /// </summary>
+        ValueTypeRational = 5,   // Two Longs. The first Long is the numerator, the second Long expresses the denomintor.
+
+        /// <summary>
+        /// Two longs which specify a range of integer values.
+        /// The first Long specifies the lower end and the second one specifies the higher end.
+        /// All values are inclusive at both ends.
+        /// </summary>
+        ValueTypeLongRange = 6,
+        /// <summary>
+        /// An 8-bit undefined value that can take any value depending on field definition.
+        /// </summary>
+        ValueTypeUndefined = 7,
+        /// <summary>
+        /// Two Rationals. The first Rational specifies the lower end and the second specifies the higher end.
+        /// All values are inclusive at both ends
+        /// </summary>
+        ValueTypeRationalRange = 8
     }
 }
-
-

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/EncoderParameters.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/EncoderParameters.cs
@@ -2,41 +2,24 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
+
 namespace System.Drawing.Imaging
 {
-    using Marshal = System.Runtime.InteropServices.Marshal;
-
-    //[StructLayout(LayoutKind.Sequential)]
-    /// <include file='doc\EncoderParameters.uex' path='docs/doc[@for="EncoderParameters"]/*' />
-    /// <devdoc>
-    ///    <para>[To be supplied.]</para>
-    /// </devdoc>
     public sealed class EncoderParameters : IDisposable
     {
         private EncoderParameter[] _param;
 
-        /// <include file='doc\EncoderParameters.uex' path='docs/doc[@for="EncoderParameters.EncoderParameters"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public EncoderParameters(int count)
         {
             _param = new EncoderParameter[count];
         }
 
-        /// <include file='doc\EncoderParameters.uex' path='docs/doc[@for="EncoderParameters.EncoderParameters1"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public EncoderParameters()
         {
             _param = new EncoderParameter[1];
         }
 
-        /// <include file='doc\EncoderParameters.uex' path='docs/doc[@for="EncoderParameters.Param"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public EncoderParameter[] Param
         {
             get
@@ -49,25 +32,25 @@ namespace System.Drawing.Imaging
             }
         }
 
-        /// <devdoc>
-        ///     Copy the EncoderParameters data into a chunk of memory to be consumed by native GDI+ code.
-        ///     
-        ///     We need to marshal the EncoderParameters info from/to native GDI+ ourselve since the definition of the managed/unmanaged classes 
-        ///     are different and the native class is a bit weird. The native EncoderParameters class is defined in GDI+ as follows:
+        /// <summary>
+        /// Copy the EncoderParameters data into a chunk of memory to be consumed by native GDI+ code.
+        ///
+        /// We need to marshal the EncoderParameters info from/to native GDI+ ourselve since the definition of the managed/unmanaged classes
+        /// are different and the native class is a bit weird. The native EncoderParameters class is defined in GDI+ as follows:
         /// 
-        ///      class EncoderParameters {
-        ///          UINT Count;                      // Number of parameters in this structure
-        ///          EncoderParameter Parameter[1];   // Parameter values
-        ///      };
-        /// 
-        ///     We don't have the 'Count' field since the managed array contains it. In order for this structure to work with more than one 
-        ///     EncoderParameter we need to preallocate memory for the extra n-1 elements, something like this:
-        ///     
-        ///         EncoderParameters* pEncoderParameters = (EncoderParameters*) malloc(sizeof(EncoderParameters) + (n-1) * sizeof(EncoderParameter));
-        ///         
-        ///     Also, in 64-bit platforms, 'Count' is aligned in 8 bytes (4 extra padding bytes) so we use IntPtr instead of Int32 to account for 
-        ///     that.
-        /// </devdoc>
+        /// class EncoderParameters {
+        ///     UINT Count;                      // Number of parameters in this structure
+        ///     EncoderParameter Parameter[1];   // Parameter values
+        /// };
+        ///
+        /// We don't have the 'Count' field since the managed array contains it. In order for this structure to work with more than one
+        /// EncoderParameter we need to preallocate memory for the extra n-1 elements, something like this:
+        ///
+        /// EncoderParameters* pEncoderParameters = (EncoderParameters*) malloc(sizeof(EncoderParameters) + (n-1) * sizeof(EncoderParameter));
+        ///
+        /// Also, in 64-bit platforms, 'Count' is aligned in 8 bytes (4 extra padding bytes) so we use IntPtr instead of Int32 to account for
+        /// that.
+        /// </summary>
         internal IntPtr ConvertToMemory()
         {
             int size = Marshal.SizeOf(typeof(EncoderParameter));
@@ -92,10 +75,10 @@ namespace System.Drawing.Imaging
             return memory;
         }
 
-        /// <devdoc>
-        ///     Copy the native GDI+ EncoderParameters data from a chunk of memory into a managed EncoderParameters object.
-        ///     See ConvertToMemory for more info.
-        /// </devdoc>
+        /// <summary>
+        /// Copy the native GDI+ EncoderParameters data from a chunk of memory into a managed EncoderParameters object.
+        /// See ConvertToMemory for more info.
+        /// </summary>
         internal static EncoderParameters ConvertFromMemory(IntPtr memory)
         {
             if (memory == IntPtr.Zero)
@@ -122,7 +105,6 @@ namespace System.Drawing.Imaging
             return p;
         }
 
-        /// <include file='doc\EncoderParameters.uex' path='docs/doc[@for="EncoderParameters.Dispose"]/*' />
         public void Dispose()
         {
             foreach (EncoderParameter p in _param)
@@ -136,4 +118,3 @@ namespace System.Drawing.Imaging
         }
     }
 }
-

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/EncoderValue.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/EncoderValue.cs
@@ -4,136 +4,106 @@
 
 namespace System.Drawing.Imaging
 {
-    /**
-     * EncoderParameter Value Type
-     */
-    /// <include file='doc\EncoderValue.uex' path='docs/doc[@for="EncoderValue"]/*' />
-    /// <devdoc>
-    ///    <para>
-    ///       The EncoderValue enum.
-    ///    </para>
-    /// </devdoc>
+    /// <summary>
+    /// The EncoderValue enum.
+    /// </summary>
     public enum EncoderValue
     {
-        /// <include file='doc\EncoderValue.uex' path='docs/doc[@for="EncoderValue.ColorTypeCMYK"]/*' />
-        /// <devdoc>
-        ///    Specifies the CMYK color space.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies the CMYK color space.
+        /// </summary>
         ColorTypeCMYK,
-        /// <include file='doc\EncoderValue.uex' path='docs/doc[@for="EncoderValue.ColorTypeYCCK"]/*' />
-        /// <devdoc>
-        ///    Specifies the YCCK color space.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies the YCCK color space.
+        /// </summary>
         ColorTypeYCCK,
-        /// <include file='doc\EncoderValue.uex' path='docs/doc[@for="EncoderValue.CompressionLZW"]/*' />
-        /// <devdoc>
-        ///    Specifies the LZW compression method.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies the LZW compression method.
+        /// </summary>
         CompressionLZW,
-        /// <include file='doc\EncoderValue.uex' path='docs/doc[@for="EncoderValue.CompressionCCITT3"]/*' />
-        /// <devdoc>
-        ///    For a TIFF image, specifies the CCITT3 compression method.
-        /// </devdoc>
+        /// <summary>
+        /// For a TIFF image, specifies the CCITT3 compression method.
+        /// </summary>
         CompressionCCITT3,
-        /// <include file='doc\EncoderValue.uex' path='docs/doc[@for="EncoderValue.CompressionCCITT4"]/*' />
-        /// <devdoc>
-        ///    For a TIFF image, specifies the CCITT4 compression method.
-        /// </devdoc>
+        /// <summary>
+        /// For a TIFF image, specifies the CCITT4 compression method.
+        /// </summary>
         CompressionCCITT4,
-        /// <include file='doc\EncoderValue.uex' path='docs/doc[@for="EncoderValue.CompressionRle"]/*' />
-        /// <devdoc>
-        ///    For a TIFF image, specifies the RLE compression method.
-        /// </devdoc>
+        /// <summary>
+        /// For a TIFF image, specifies the RLE compression method.
+        /// </summary>
         CompressionRle,
-        /// <include file='doc\EncoderValue.uex' path='docs/doc[@for="EncoderValue.CompressionNone"]/*' />
-        /// <devdoc>
-        ///    For a TIFF image, specifies no compression.
-        /// </devdoc>
+        /// <summary>
+        /// For a TIFF image, specifies no compression.
+        /// </summary>
         CompressionNone,
-        /// <include file='doc\EncoderValue.uex' path='docs/doc[@for="EncoderValue.ScanMethodInterlaced"]/*' />
-        /// <devdoc>
-        ///    Specifies interlaced mode.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies interlaced mode.
+        /// </summary>
         ScanMethodInterlaced,
-        /// <include file='doc\EncoderValue.uex' path='docs/doc[@for="EncoderValue.ScanMethodNonInterlaced"]/*' />
-        /// <devdoc>
-        ///    Specifies non-interlaced mode.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies non-interlaced mode.
+        /// </summary>
         ScanMethodNonInterlaced,
-        /// <include file='doc\EncoderValue.uex' path='docs/doc[@for="EncoderValue.VersionGif87"]/*' />
-        /// <devdoc>
-        ///    For a GIF image, specifies version 87.
-        /// </devdoc>
+        /// <summary>
+        /// For a GIF image, specifies version 87.
+        /// </summary>
         VersionGif87,
-        /// <include file='doc\EncoderValue.uex' path='docs/doc[@for="EncoderValue.VersionGif89"]/*' />
-        /// <devdoc>
-        ///    For a GIF images, specifies version 89a.
-        /// </devdoc>
+        /// <summary>
+        /// For a GIF images, specifies version 89a.
+        /// </summary>
         VersionGif89,
-        /// <include file='doc\EncoderValue.uex' path='docs/doc[@for="EncoderValue.RenderProgressive"]/*' />
-        /// <devdoc>
-        ///    Specifies progressive mode.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies progressive mode.
+        /// </summary>
         RenderProgressive,
-        /// <include file='doc\EncoderValue.uex' path='docs/doc[@for="EncoderValue.RenderNonProgressive"]/*' />
-        /// <devdoc>
-        ///    Specifies non-progressive mode.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies non-progressive mode.
+        /// </summary>
         RenderNonProgressive,
-        /// <include file='doc\EncoderValue.uex' path='docs/doc[@for="EncoderValue.TransformRotate90"]/*' />
-        /// <devdoc>
-        ///    For a JPEG image, specifies lossless 90-degree clockwise rotation.
-        /// </devdoc>
+        /// <summary>
+        /// For a JPEG image, specifies lossless 90-degree clockwise rotation.
+        /// </summary>
         TransformRotate90,
-        /// <include file='doc\EncoderValue.uex' path='docs/doc[@for="EncoderValue.TransformRotate180"]/*' />
-        /// <devdoc>
-        ///    For a JPEG image, specifies lossless 180-degree rotation.
-        /// </devdoc>
+        /// <summary>
+        /// For a JPEG image, specifies lossless 180-degree rotation.
+        /// </summary>
         TransformRotate180,
-        /// <include file='doc\EncoderValue.uex' path='docs/doc[@for="EncoderValue.TransformRotate270"]/*' />
-        /// <devdoc>
-        ///    For a JPEG image, specifies lossless 270-degree clockwise rotation.
-        /// </devdoc>
+        /// <summary>
+        /// For a JPEG image, specifies lossless 270-degree clockwise rotation.
+        /// </summary>
         TransformRotate270,
-        /// <include file='doc\EncoderValue.uex' path='docs/doc[@for="EncoderValue.TransformFlipHorizontal"]/*' />
-        /// <devdoc>
-        ///    For a JPEG image, specifies a lossless horizontal flip.
-        /// </devdoc>
+        /// <summary>
+        /// For a JPEG image, specifies a lossless horizontal flip.
+        /// </summary>
         TransformFlipHorizontal,
-        /// <include file='doc\EncoderValue.uex' path='docs/doc[@for="EncoderValue.TransformFlipVertical"]/*' />
-        /// <devdoc>
-        ///    For a JPEG image, specifies a lossless vertical flip.
-        /// </devdoc>
+        /// <summary>
+        /// For a JPEG image, specifies a lossless vertical flip.
+        /// </summary>
         TransformFlipVertical,
-        /// <include file='doc\EncoderValue.uex' path='docs/doc[@for="EncoderValue.MultiFrame"]/*' />
-        /// <devdoc>
-        ///    Specifies multiframe encoding.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies multiframe encoding.
+        /// </summary>
         MultiFrame,
-        /// <include file='doc\EncoderValue.uex' path='docs/doc[@for="EncoderValue.LastFrame"]/*' />
-        /// <devdoc>
-        ///    Specifies the last frame of a multi-frame image.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies the last frame of a multi-frame image.
+        /// </summary>
         LastFrame,
-        /// <include file='doc\EncoderValue.uex' path='docs/doc[@for="EncoderValue.Flush"]/*' />
-        /// <devdoc>
-        ///    Specifies that the encoder object is to be closed. 
-        /// </devdoc>
+        /// <summary>
+        /// Specifies that the encoder object is to be closed. 
+        /// </summary>
         Flush,
-        /// <include file='doc\EncoderValue.uex' path='docs/doc[@for="EncoderValue.FrameDimensionTime"]/*' />
-        /// <devdoc>
-        ///    For a GIF image, specifies the time frame dimension.
-        /// </devdoc>
+        /// <summary>
+        /// For a GIF image, specifies the time frame dimension.
+        /// </summary>
         FrameDimensionTime,
-        /// <include file='doc\EncoderValue.uex' path='docs/doc[@for="EncoderValue.FrameDimensionResolution"]/*' />
-        /// <devdoc>
-        ///    Specifies the resolution frame dimension.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies the resolution frame dimension.
+        /// </summary>
         FrameDimensionResolution,
-        /// <include file='doc\EncoderValue.uex' path='docs/doc[@for="EncoderValue.FrameDimensionPage"]/*' />
-        /// <devdoc>
-        ///    For a TIFF image, specifies the page frame dimension
-        /// </devdoc>
+        /// <summary>
+        /// For a TIFF image, specifies the page frame dimension
+        /// </summary>
         FrameDimensionPage
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/FrameDimension.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/FrameDimension.cs
@@ -4,14 +4,6 @@
 
 namespace System.Drawing.Imaging
 {
-    /**
-     * frame dimension constants (used with Bitmap.FrameDimensionsList)
-     */
-    /// <include file='doc\FrameDimension.uex' path='docs/doc[@for="FrameDimension"]/*' />
-    /// <devdoc>
-    ///    
-    /// </devdoc>
-    // [TypeConverterAttribute(typeof(FrameDimensionConverter))]
     public sealed class FrameDimension
     {
         // Frame dimension GUIDs, from sdkinc\imgguids.h
@@ -21,56 +13,49 @@ namespace System.Drawing.Imaging
 
         private Guid _guid;
 
-        /// <include file='doc\FrameDimension.uex' path='docs/doc[@for="FrameDimension.FrameDimension"]/*' />
-        /// <devdoc>
-        ///    Initializes a new instance of the <see cref='System.Drawing.Imaging.FrameDimension'/> class with the specified GUID.
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='FrameDimension'/> class with the specified GUID.
+        /// </summary>
         public FrameDimension(Guid guid)
         {
             _guid = guid;
         }
 
-        /// <include file='doc\FrameDimension.uex' path='docs/doc[@for="FrameDimension.Guid"]/*' />
-        /// <devdoc>
-        ///    Specifies a global unique identifier (GUID)
-        ///    that represents this <see cref='System.Drawing.Imaging.FrameDimension'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies a global unique identifier (GUID) that represents this <see cref='FrameDimension'/>.
+        /// </summary>
         public Guid Guid
         {
             get { return _guid; }
         }
 
-        /// <include file='doc\FrameDimension.uex' path='docs/doc[@for="FrameDimension.Time"]/*' />
-        /// <devdoc>
-        ///    The time dimension.
-        /// </devdoc>
+        /// <summary>
+        /// The time dimension.
+        /// </summary>
         public static FrameDimension Time
         {
             get { return s_time; }
         }
 
-        /// <include file='doc\FrameDimension.uex' path='docs/doc[@for="FrameDimension.Resolution"]/*' />
-        /// <devdoc>
-        ///    The resolution dimension.
-        /// </devdoc>
+        /// <summary>
+        /// The resolution dimension.
+        /// </summary>
         public static FrameDimension Resolution
         {
             get { return s_resolution; }
         }
 
-        /// <include file='doc\FrameDimension.uex' path='docs/doc[@for="FrameDimension.Page"]/*' />
-        /// <devdoc>
-        ///    The page dimension.
-        /// </devdoc>
+        /// <summary>
+        /// The page dimension.
+        /// </summary>
         public static FrameDimension Page
         {
             get { return s_page; }
         }
-        /// <include file='doc\FrameDimension.uex' path='docs/doc[@for="FrameDimension.Equals"]/*' />
-        /// <devdoc>
-        ///    Returns a value indicating whether the
-        ///    specified object is an <see cref='System.Drawing.Imaging.FrameDimension'/> equivalent to this <see cref='System.Drawing.Imaging.FrameDimension'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Returns a value indicating whether the specified object is an <see cref='FrameDimension'/> equivalent to
+        /// this <see cref='FrameDimension'/>.
+        /// </summary>
         public override bool Equals(object o)
         {
             FrameDimension format = o as FrameDimension;
@@ -79,19 +64,14 @@ namespace System.Drawing.Imaging
             return _guid == format._guid;
         }
 
-        /// <include file='doc\FrameDimension.uex' path='docs/doc[@for="FrameDimension.GetHashCode"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public override int GetHashCode()
         {
             return _guid.GetHashCode();
         }
 
-        /// <include file='doc\FrameDimension.uex' path='docs/doc[@for="FrameDimension.ToString"]/*' />
-        /// <devdoc>
-        ///    Converts this <see cref='System.Drawing.Imaging.FrameDimension'/> to a human-readable string.
-        /// </devdoc>
+        /// <summary>
+        /// Converts this <see cref='FrameDimension'/> to a human-readable string.
+        /// </summary>
         public override string ToString()
         {
             if (this == s_time) return "Time";

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/ImageAttributes.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/ImageAttributes.cs
@@ -2,13 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
+using System.Diagnostics;
+using System.Drawing.Drawing2D;
+using System.Globalization;
+
 namespace System.Drawing.Imaging
 {
-    using System.Runtime.InteropServices;
-    using System.Diagnostics;
-    using System.Drawing.Drawing2D;
-    using System.Globalization;
-
     // sdkinc\GDIplusImageAttributes.h
 
     // There are 5 possible sets of color adjustments:
@@ -29,22 +29,15 @@ namespace System.Drawing.Imaging
     // have no color adjustments at all, regardless of what previous adjustments
     // have been set for the defaults or for that type.
 
-    /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes"]/*' />
-    /// <devdoc>
-    ///    Contains information about how image colors
-    ///    are manipulated during rendering.
-    /// </devdoc>
+    /// <summary>
+    /// Contains information about how image colors are manipulated during rendering.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public sealed class ImageAttributes : ICloneable, IDisposable
     {
 #if FINALIZATION_WATCH
         private string allocationSite = Graphics.GetAllocationStack();
 #endif                                                         
-
-
-        /*
-         * Handle to native image attributes object
-         */
 
         internal IntPtr nativeImageAttributes;
 
@@ -56,10 +49,9 @@ namespace System.Drawing.Imaging
             nativeImageAttributes = handle;
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.ImageAttributes"]/*' />
-        /// <devdoc>
-        ///    Initializes a new instance of the <see cref='System.Drawing.Imaging.ImageAttributes'/> class.
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='ImageAttributes'/> class.
+        /// </summary>
         public ImageAttributes()
         {
             IntPtr newImageAttributes = IntPtr.Zero;
@@ -77,11 +69,9 @@ namespace System.Drawing.Imaging
             SetNativeImageAttributes(newNativeImageAttributes);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.Dispose"]/*' />
-        /// <devdoc>
-        ///    Cleans up Windows resources for this
-        /// <see cref='System.Drawing.Imaging.ImageAttributes'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Cleans up Windows resources for this <see cref='ImageAttributes'/>.
+        /// </summary>
         public void Dispose()
         {
             Dispose(true);
@@ -122,22 +112,17 @@ namespace System.Drawing.Imaging
             }
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.Finalize"]/*' />
-        /// <devdoc>
-        ///    Cleans up Windows resources for this
-        /// <see cref='System.Drawing.Imaging.ImageAttributes'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Cleans up Windows resources for this <see cref='ImageAttributes'/>.
+        /// </summary>
         ~ImageAttributes()
         {
             Dispose(false);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.Clone"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Creates an exact copy of this <see cref='System.Drawing.Imaging.ImageAttributes'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Creates an exact copy of this <see cref='ImageAttributes'/>.
+        /// </summary>
         public object Clone()
         {
             IntPtr clone = IntPtr.Zero;
@@ -152,64 +137,25 @@ namespace System.Drawing.Imaging
             return new ImageAttributes(clone);
         }
 
-        /* FxCop rule 'AvoidBuildingNonCallableCode' - Left here in case it is needed in the future.
-        void SetToIdentity()
-        {
-            SetToIdentity(ColorAdjustType.Default);
-        }
-
-        void SetToIdentity(ColorAdjustType type) 
-        {
-            int status = SafeNativeMethods.Gdip.GdipSetImageAttributesToIdentity(new HandleRef(this, nativeImageAttributes), type);
-
-                if (status != SafeNativeMethods.Gdip.Ok)
-                        throw SafeNativeMethods.Gdip.StatusException(status);
-        }
-        
-        void Reset()
-        {
-            Reset(ColorAdjustType.Default);
-        }
-
-        void Reset(ColorAdjustType type)
-        {
-            int status = SafeNativeMethods.Gdip.GdipResetImageAttributes(new HandleRef(this, nativeImageAttributes), type);
-
-            if (status != SafeNativeMethods.Gdip.Ok)
-                    throw SafeNativeMethods.Gdip.StatusException(status);
-        }
-        */
-
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.SetColorMatrix"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Sets the 5 X 5 color adjust matrix to the
-        ///       specified <see cref='System.Drawing.Drawing2D.Matrix'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Sets the 5 X 5 color adjust matrix to the specified <see cref='Matrix'/>.
+        /// </summary>
         public void SetColorMatrix(ColorMatrix newColorMatrix)
         {
             SetColorMatrix(newColorMatrix, ColorMatrixFlag.Default, ColorAdjustType.Default);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.SetColorMatrix1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Sets the 5 X 5 color adjust matrix to the specified 'Matrix' with the specified 'ColorMatrixFlags'.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Sets the 5 X 5 color adjust matrix to the specified 'Matrix' with the specified 'ColorMatrixFlags'.
+        /// </summary>
         public void SetColorMatrix(ColorMatrix newColorMatrix, ColorMatrixFlag flags)
         {
             SetColorMatrix(newColorMatrix, flags, ColorAdjustType.Default);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.SetColorMatrix2"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Sets the 5 X 5 color adjust matrix to the specified 'Matrix' with the 
-        ///       specified 'ColorMatrixFlags'.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Sets the 5 X 5 color adjust matrix to the specified 'Matrix' with the  specified 'ColorMatrixFlags'.
+        /// </summary>
         public void SetColorMatrix(ColorMatrix newColorMatrix, ColorMatrixFlag mode, ColorAdjustType type)
         {
             int status = SafeNativeMethods.Gdip.GdipSetImageAttributesColorMatrix(
@@ -224,22 +170,17 @@ namespace System.Drawing.Imaging
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.ClearColorMatrix"]/*' />
-        /// <devdoc>
-        ///    Clears the color adjust matrix to all
-        ///    zeroes.
-        /// </devdoc>
+        /// <summary>
+        /// Clears the color adjust matrix to all zeroes.
+        /// </summary>
         public void ClearColorMatrix()
         {
             ClearColorMatrix(ColorAdjustType.Default);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.ClearColorMatrix1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Clears the color adjust matrix.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Clears the color adjust matrix.
+        /// </summary>
         public void ClearColorMatrix(ColorAdjustType type)
         {
             int status = SafeNativeMethods.Gdip.GdipSetImageAttributesColorMatrix(
@@ -254,31 +195,19 @@ namespace System.Drawing.Imaging
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.SetColorMatrices"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Sets a color adjust matrix for image colors
-        ///       and a separate gray scale adjust matrix for gray scale values.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Sets a color adjust matrix for image colors and a separate gray scale adjust matrix for gray scale values.
+        /// </summary>
         public void SetColorMatrices(ColorMatrix newColorMatrix, ColorMatrix grayMatrix)
         {
             SetColorMatrices(newColorMatrix, grayMatrix, ColorMatrixFlag.Default, ColorAdjustType.Default);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.SetColorMatrices1"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void SetColorMatrices(ColorMatrix newColorMatrix, ColorMatrix grayMatrix, ColorMatrixFlag flags)
         {
             SetColorMatrices(newColorMatrix, grayMatrix, flags, ColorAdjustType.Default);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.SetColorMatrices2"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void SetColorMatrices(ColorMatrix newColorMatrix, ColorMatrix grayMatrix, ColorMatrixFlag mode,
                                      ColorAdjustType type)
         {
@@ -294,19 +223,11 @@ namespace System.Drawing.Imaging
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.SetThreshold"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void SetThreshold(float threshold)
         {
             SetThreshold(threshold, ColorAdjustType.Default);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.SetThreshold1"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void SetThreshold(float threshold, ColorAdjustType type)
         {
             int status = SafeNativeMethods.Gdip.GdipSetImageAttributesThreshold(
@@ -319,19 +240,11 @@ namespace System.Drawing.Imaging
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.ClearThreshold"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void ClearThreshold()
         {
             ClearThreshold(ColorAdjustType.Default);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.ClearThreshold1"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void ClearThreshold(ColorAdjustType type)
         {
             int status = SafeNativeMethods.Gdip.GdipSetImageAttributesThreshold(
@@ -344,19 +257,11 @@ namespace System.Drawing.Imaging
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.SetGamma"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void SetGamma(float gamma)
         {
             SetGamma(gamma, ColorAdjustType.Default);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.SetGamma1"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void SetGamma(float gamma, ColorAdjustType type)
         {
             int status = SafeNativeMethods.Gdip.GdipSetImageAttributesGamma(
@@ -369,19 +274,11 @@ namespace System.Drawing.Imaging
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.ClearGamma"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void ClearGamma()
         {
             ClearGamma(ColorAdjustType.Default);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.ClearGamma1"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void ClearGamma(ColorAdjustType type)
         {
             int status = SafeNativeMethods.Gdip.GdipSetImageAttributesGamma(
@@ -394,19 +291,11 @@ namespace System.Drawing.Imaging
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.SetNoOp"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void SetNoOp()
         {
             SetNoOp(ColorAdjustType.Default);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.SetNoOp1"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void SetNoOp(ColorAdjustType type)
         {
             int status = SafeNativeMethods.Gdip.GdipSetImageAttributesNoOp(
@@ -418,19 +307,11 @@ namespace System.Drawing.Imaging
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.ClearNoOp"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void ClearNoOp()
         {
             ClearNoOp(ColorAdjustType.Default);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.ClearNoOp1"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void ClearNoOp(ColorAdjustType type)
         {
             int status = SafeNativeMethods.Gdip.GdipSetImageAttributesNoOp(
@@ -442,19 +323,11 @@ namespace System.Drawing.Imaging
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.SetColorKey"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void SetColorKey(Color colorLow, Color colorHigh)
         {
             SetColorKey(colorLow, colorHigh, ColorAdjustType.Default);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.SetColorKey1"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void SetColorKey(Color colorLow, Color colorHigh, ColorAdjustType type)
         {
             int lowInt = colorLow.ToArgb();
@@ -471,19 +344,11 @@ namespace System.Drawing.Imaging
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.ClearColorKey"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void ClearColorKey()
         {
             ClearColorKey(ColorAdjustType.Default);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.ClearColorKey1"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void ClearColorKey(ColorAdjustType type)
         {
             int zero = 0;
@@ -498,19 +363,11 @@ namespace System.Drawing.Imaging
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.SetOutputChannel"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void SetOutputChannel(ColorChannelFlag flags)
         {
             SetOutputChannel(flags, ColorAdjustType.Default);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.SetOutputChannel1"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void SetOutputChannel(ColorChannelFlag flags, ColorAdjustType type)
         {
             int status = SafeNativeMethods.Gdip.GdipSetImageAttributesOutputChannel(
@@ -523,19 +380,11 @@ namespace System.Drawing.Imaging
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.ClearOutputChannel"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void ClearOutputChannel()
         {
             ClearOutputChannel(ColorAdjustType.Default);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.ClearOutputChannel1"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void ClearOutputChannel(ColorAdjustType type)
         {
             int status = SafeNativeMethods.Gdip.GdipSetImageAttributesOutputChannel(
@@ -548,19 +397,11 @@ namespace System.Drawing.Imaging
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.SetOutputChannelColorProfile"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void SetOutputChannelColorProfile(String colorProfileFilename)
         {
             SetOutputChannelColorProfile(colorProfileFilename, ColorAdjustType.Default);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.SetOutputChannelColorProfile1"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void SetOutputChannelColorProfile(String colorProfileFilename,
                                                  ColorAdjustType type)
         {
@@ -574,19 +415,11 @@ namespace System.Drawing.Imaging
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.ClearOutputChannelColorProfile"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void ClearOutputChannelColorProfile()
         {
             ClearOutputChannel(ColorAdjustType.Default);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.ClearOutputChannelColorProfile1"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void ClearOutputChannelColorProfile(ColorAdjustType type)
         {
             int status = SafeNativeMethods.Gdip.GdipSetImageAttributesOutputChannel(
@@ -599,19 +432,11 @@ namespace System.Drawing.Imaging
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.SetRemapTable"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void SetRemapTable(ColorMap[] map)
         {
             SetRemapTable(map, ColorAdjustType.Default);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.SetRemapTable1"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void SetRemapTable(ColorMap[] map, ColorAdjustType type)
         {
             int index = 0;
@@ -645,19 +470,11 @@ namespace System.Drawing.Imaging
             }
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.ClearRemapTable"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void ClearRemapTable()
         {
             ClearRemapTable(ColorAdjustType.Default);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.ClearRemapTable1"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void ClearRemapTable(ColorAdjustType type)
         {
             int status = SafeNativeMethods.Gdip.GdipSetImageAttributesRemapTable(
@@ -671,46 +488,26 @@ namespace System.Drawing.Imaging
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.SetBrushRemapTable"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void SetBrushRemapTable(ColorMap[] map)
         {
             SetRemapTable(map, ColorAdjustType.Brush);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.ClearBrushRemapTable"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void ClearBrushRemapTable()
         {
             ClearRemapTable(ColorAdjustType.Brush);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.SetWrapMode"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void SetWrapMode(WrapMode mode)
         {
             SetWrapMode(mode, new Color(), false);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.SetWrapMode1"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void SetWrapMode(WrapMode mode, Color color)
         {
             SetWrapMode(mode, color, false);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.SetWrapMode2"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void SetWrapMode(WrapMode mode, Color color, bool clamp)
         {
             int status = SafeNativeMethods.Gdip.GdipSetImageAttributesWrapMode(
@@ -723,10 +520,6 @@ namespace System.Drawing.Imaging
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        /// <include file='doc\ImageAttributes.uex' path='docs/doc[@for="ImageAttributes.GetAdjustedPalette"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void GetAdjustedPalette(ColorPalette palette, ColorAdjustType type)
         {
             // does inplace adjustment

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/ImageCodecFlags.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/ImageCodecFlags.cs
@@ -4,61 +4,17 @@
 
 namespace System.Drawing.Imaging
 {
-    /**
-     * Color channel flag constants
-     */
-    /// <include file='doc\ImageCodecFlags.uex' path='docs/doc[@for="ImageCodecFlags"]/*' />
-    /// <devdoc>
-    ///    <para>[To be supplied.]</para>
-    /// </devdoc>
-    [Flags()]
+    [Flags]
     public enum ImageCodecFlags
     {
-        /// <include file='doc\ImageCodecFlags.uex' path='docs/doc[@for="ImageCodecFlags.Encoder"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         Encoder = 0x00000001,
-        /// <include file='doc\ImageCodecFlags.uex' path='docs/doc[@for="ImageCodecFlags.Decoder"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         Decoder = 0x00000002,
-        /// <include file='doc\ImageCodecFlags.uex' path='docs/doc[@for="ImageCodecFlags.SupportBitmap"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         SupportBitmap = 0x00000004,
-        /// <include file='doc\ImageCodecFlags.uex' path='docs/doc[@for="ImageCodecFlags.SupportVector"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         SupportVector = 0x00000008,
-        /// <include file='doc\ImageCodecFlags.uex' path='docs/doc[@for="ImageCodecFlags.SeekableEncode"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         SeekableEncode = 0x00000010,
-        /// <include file='doc\ImageCodecFlags.uex' path='docs/doc[@for="ImageCodecFlags.BlockingDecode"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         BlockingDecode = 0x00000020,
-
-        /// <include file='doc\ImageCodecFlags.uex' path='docs/doc[@for="ImageCodecFlags.Builtin"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         Builtin = 0x00010000,
-        /// <include file='doc\ImageCodecFlags.uex' path='docs/doc[@for="ImageCodecFlags.System"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         System = 0x00020000,
-        /// <include file='doc\ImageCodecFlags.uex' path='docs/doc[@for="ImageCodecFlags.User"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         User = 0x00040000
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/ImageCodecInfo.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/ImageCodecInfo.cs
@@ -2,15 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
+
 namespace System.Drawing.Imaging
 {
-    using System.Runtime.InteropServices;
-
     // sdkinc\imaging.h
-    /// <include file='doc\ImageCodecInfo.uex' path='docs/doc[@for="ImageCodecInfo"]/*' />
-    /// <devdoc>
-    ///    <para>[To be supplied.]</para>
-    /// </devdoc>
     public sealed class ImageCodecInfo
     {
         private Guid _clsid;
@@ -29,37 +25,24 @@ namespace System.Drawing.Imaging
         {
         }
 
-        /// <include file='doc\ImageCodecInfo.uex' path='docs/doc[@for="ImageCodecInfo.Clsid"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public Guid Clsid
         {
             get { return _clsid; }
             set { _clsid = value; }
         }
-        /// <include file='doc\ImageCodecInfo.uex' path='docs/doc[@for="ImageCodecInfo.FormatID"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
+
         public Guid FormatID
         {
             get { return _formatID; }
             set { _formatID = value; }
         }
-        /// <include file='doc\ImageCodecInfo.uex' path='docs/doc[@for="ImageCodecInfo.CodecName"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
+
         public string CodecName
         {
             get { return _codecName; }
             set { _codecName = value; }
         }
-        /// <include file='doc\ImageCodecInfo.uex' path='docs/doc[@for="ImageCodecInfo.DllName"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
+
         public string DllName
         {
             get
@@ -71,65 +54,44 @@ namespace System.Drawing.Imaging
                 _dllName = value;
             }
         }
-        /// <include file='doc\ImageCodecInfo.uex' path='docs/doc[@for="ImageCodecInfo.FormatDescription"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
+
         public string FormatDescription
         {
             get { return _formatDescription; }
             set { _formatDescription = value; }
         }
-        /// <include file='doc\ImageCodecInfo.uex' path='docs/doc[@for="ImageCodecInfo.FilenameExtension"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
+
         public string FilenameExtension
         {
             get { return _filenameExtension; }
             set { _filenameExtension = value; }
         }
-        /// <include file='doc\ImageCodecInfo.uex' path='docs/doc[@for="ImageCodecInfo.MimeType"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
+
         public string MimeType
         {
             get { return _mimeType; }
             set { _mimeType = value; }
         }
-        /// <include file='doc\ImageCodecInfo.uex' path='docs/doc[@for="ImageCodecInfo.Flags"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
+
         public ImageCodecFlags Flags
         {
             get { return _flags; }
             set { _flags = value; }
         }
-        /// <include file='doc\ImageCodecInfo.uex' path='docs/doc[@for="ImageCodecInfo.Version"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
+
         public int Version
         {
             get { return _version; }
             set { _version = value; }
         }
-        /// <include file='doc\ImageCodecInfo.uex' path='docs/doc[@for="ImageCodecInfo.SignaturePatterns"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
+
         [CLSCompliant(false)]
         public byte[][] SignaturePatterns
         {
             get { return _signaturePatterns; }
             set { _signaturePatterns = value; }
         }
-        /// <include file='doc\ImageCodecInfo.uex' path='docs/doc[@for="ImageCodecInfo.SignatureMasks"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
+
         [CLSCompliant(false)]
         public byte[][] SignatureMasks
         {
@@ -139,10 +101,6 @@ namespace System.Drawing.Imaging
 
         // Encoder/Decoder selection APIs
 
-        /// <include file='doc\ImageCodecInfo.uex' path='docs/doc[@for="ImageCodecInfo.GetImageDecoders"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public static ImageCodecInfo[] GetImageDecoders()
         {
             ImageCodecInfo[] imageCodecs;
@@ -177,10 +135,6 @@ namespace System.Drawing.Imaging
             return imageCodecs;
         }
 
-        /// <include file='doc\ImageCodecInfo.uex' path='docs/doc[@for="ImageCodecInfo.GetImageEncoders"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public static ImageCodecInfo[] GetImageEncoders()
         {
             ImageCodecInfo[] imageCodecs;
@@ -214,55 +168,6 @@ namespace System.Drawing.Imaging
 
             return imageCodecs;
         }
-
-        /* FxCop rule 'AvoidBuildingNonCallableCode' - Left here in case it is needed in the future.
-         internal static ImageCodecInfoPrivate ConvertToMemory(ImageCodecInfo imagecs)
-         {
-             ImageCodecInfoPrivate imagecsp = new ImageCodecInfoPrivate();
-             
-             imagecsp.Clsid = imagecs.Clsid;
-             imagecsp.FormatID = imagecs.FormatID;
-             
-             imagecsp.CodecName = Marshal.StringToHGlobalUni(imagecs.CodecName);
-             imagecsp.DllName = Marshal.StringToHGlobalUni(imagecs.DllName);
-             imagecsp.FormatDescription = Marshal.StringToHGlobalUni(imagecs.FormatDescription);
-             imagecsp.FilenameExtension = Marshal.StringToHGlobalUni(imagecs.FilenameExtension);
-             imagecsp.MimeType = Marshal.StringToHGlobalUni(imagecs.MimeType);
-             
-             imagecsp.Flags = (int)imagecs.Flags;
-             imagecsp.Version = (int)imagecs.Version;
-             imagecsp.SigCount = imagecs.SignaturePatterns.Length;
-             imagecsp.SigSize = imagecs.SignaturePatterns[0].Length;
-             
-             imagecsp.SigPattern = Marshal.AllocHGlobal(imagecsp.SigCount*imagecsp.SigSize);
-             imagecsp.SigMask = Marshal.AllocHGlobal(imagecsp.SigCount*imagecsp.SigSize);
-             
-             for (int i=0; i<imagecsp.SigCount; i++)
-             {
-                 Marshal.Copy(imagecs.SignaturePatterns[i], 
-                              0, 
-                              (IntPtr)((long)imagecsp.SigPattern + i*imagecsp.SigSize), 
-                              imagecsp.SigSize);
-                                  
-                 Marshal.Copy(imagecs.SignatureMasks[i], 
-                              0, 
-                              (IntPtr)((long)imagecsp.SigMask + i*imagecsp.SigSize), 
-                              imagecsp.SigSize);
-             }
-                          
-             return imagecsp;
-         }
-
-         internal static void FreeMemory(ImageCodecInfoPrivate imagecodecp)
-         {
-             Marshal.FreeHGlobal(imagecodecp.CodecName);
-             Marshal.FreeHGlobal(imagecodecp.FormatDescription);
-             Marshal.FreeHGlobal(imagecodecp.FilenameExtension);
-             Marshal.FreeHGlobal(imagecodecp.MimeType);
-             Marshal.FreeHGlobal(imagecodecp.SigPattern);
-             Marshal.FreeHGlobal(imagecodecp.SigMask);
-         }
-         */
 
         private static ImageCodecInfo[] ConvertFromMemory(IntPtr memoryStart, int numCodecs)
         {

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/ImageFlags.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/ImageFlags.cs
@@ -4,99 +4,58 @@
 
 namespace System.Drawing.Imaging
 {
-    /**
-     * Color channel flag constants
-     */
-    /// <include file='doc\ImageFlags.uex' path='docs/doc[@for="ImageFlags"]/*' />
-    /// <devdoc>
-    ///    Specifies the attributes of the pixel data
-    ///    contained in an <see langword='Image'/> object.
-    /// </devdoc>
-    [Flags()]
+    /// <summary>
+    /// Specifies the attributes of the pixel data contained in an <see cref='Image'/> object.
+    /// </summary>
+    [Flags]
     public enum ImageFlags
     {
-        /// <include file='doc\ImageFlags.uex' path='docs/doc[@for="ImageFlags.None"]/*' />
-        /// <devdoc>
-        ///    There is no format information.
-        /// </devdoc>
+        /// <summary>
+        /// There is no format information.
+        /// </summary>
         None = 0,
 
         // Low-word: shared with SINKFLAG_x
 
-        /// <include file='doc\ImageFlags.uex' path='docs/doc[@for="ImageFlags.Scalable"]/*' />
-        /// <devdoc>
-        ///    Pixel data is scalable.
-        /// </devdoc>
+        /// <summary>
+        /// Pixel data is scalable.
+        /// </summary>
         Scalable = 0x0001,
-        /// <include file='doc\ImageFlags.uex' path='docs/doc[@for="ImageFlags.HasAlpha"]/*' />
-        /// <devdoc>
-        ///    Pixel data contains alpha information.
-        /// </devdoc>
+        /// <summary>
+        /// Pixel data contains alpha information.
+        /// </summary>
         HasAlpha = 0x0002,
-        /// <include file='doc\ImageFlags.uex' path='docs/doc[@for="ImageFlags.HasTranslucent"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         HasTranslucent = 0x0004,
-        /// <include file='doc\ImageFlags.uex' path='docs/doc[@for="ImageFlags.PartiallyScalable"]/*' />
-        /// <devdoc>
-        ///    Pixel data is partially scalable, but there
-        ///    are some limitations.
-        /// </devdoc>
+        /// <summary>
+        /// Pixel data is partially scalable, but there are some limitations.
+        /// </summary>
         PartiallyScalable = 0x0008,
 
         // Low-word: color space definition
 
-        /// <include file='doc\ImageFlags.uex' path='docs/doc[@for="ImageFlags.ColorSpaceRgb"]/*' />
-        /// <devdoc>
-        ///    Pixel data uses an RGB color space.
-        /// </devdoc>
+        /// <summary>
+        /// Pixel data uses an RGB color space.
+        /// </summary>
         ColorSpaceRgb = 0x0010,
-        /// <include file='doc\ImageFlags.uex' path='docs/doc[@for="ImageFlags.ColorSpaceCmyk"]/*' />
-        /// <devdoc>
-        ///    Pixel data uses a CMYK color space.
-        /// </devdoc>
+        /// <summary>
+        /// Pixel data uses a CMYK color space.
+        /// </summary>
         ColorSpaceCmyk = 0x0020,
-        /// <include file='doc\ImageFlags.uex' path='docs/doc[@for="ImageFlags.ColorSpaceGray"]/*' />
-        /// <devdoc>
-        ///    Pixel data is grayscale.
-        /// </devdoc>
+        /// <summary>
+        /// Pixel data is grayscale.
+        /// </summary>
         ColorSpaceGray = 0x0040,
-        /// <include file='doc\ImageFlags.uex' path='docs/doc[@for="ImageFlags.ColorSpaceYcbcr"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         ColorSpaceYcbcr = 0x0080,
-        /// <include file='doc\ImageFlags.uex' path='docs/doc[@for="ImageFlags.ColorSpaceYcck"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         ColorSpaceYcck = 0x0100,
 
         // Low-word: image size info
 
-        /// <include file='doc\ImageFlags.uex' path='docs/doc[@for="ImageFlags.HasRealDpi"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         HasRealDpi = 0x1000,
-        /// <include file='doc\ImageFlags.uex' path='docs/doc[@for="ImageFlags.HasRealPixelSize"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         HasRealPixelSize = 0x2000,
 
         // High-word
 
-        /// <include file='doc\ImageFlags.uex' path='docs/doc[@for="ImageFlags.ReadOnly"]/*' />
-        /// <devdoc>
-        ///    Pixel data is read-only.
-        /// </devdoc>
         ReadOnly = 0x00010000,
-        /// <include file='doc\ImageFlags.uex' path='docs/doc[@for="ImageFlags.Caching"]/*' />
-        /// <devdoc>
-        ///    Pixel data can be cached for faster access.
-        /// </devdoc>
         Caching = 0x00020000
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/ImageFormat.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/ImageFormat.cs
@@ -4,13 +4,9 @@
 
 namespace System.Drawing.Imaging
 {
-    /**
-     * Image format constants
-     */
-    /// <include file='doc\ImageFormat.uex' path='docs/doc[@for="ImageFormat"]/*' />
-    /// <devdoc>
-    ///    Specifies the format of the image.
-    /// </devdoc>
+    /// <summary>
+    /// Specifies the format of the image.
+    /// </summary>
     public sealed class ImageFormat
     {
         // Format IDs
@@ -28,131 +24,108 @@ namespace System.Drawing.Imaging
         private static ImageFormat s_flashPIX = new ImageFormat(new Guid("{b96b3cb4-0728-11d3-9d7b-0000f81ef32e}"));
         private static ImageFormat s_icon = new ImageFormat(new Guid("{b96b3cb5-0728-11d3-9d7b-0000f81ef32e}"));
 
-
         private Guid _guid;
 
-        /// <include file='doc\ImageFormat.uex' path='docs/doc[@for="ImageFormat.ImageFormat"]/*' />
-        /// <devdoc>
-        ///    Initializes a new instance of the <see cref='System.Drawing.Imaging.ImageFormat'/> class with the specified GUID.
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='ImageFormat'/> class with the specified GUID.
+        /// </summary>
         public ImageFormat(Guid guid)
         {
             _guid = guid;
         }
 
-        /// <include file='doc\ImageFormat.uex' path='docs/doc[@for="ImageFormat.Guid"]/*' />
-        /// <devdoc>
-        ///    Specifies a global unique identifier (GUID)
-        ///    that represents this <see cref='System.Drawing.Imaging.ImageFormat'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies a global unique identifier (GUID) that represents this <see cref='ImageFormat'/>.
+        /// </summary>
         public Guid Guid
         {
             get { return _guid; }
         }
 
-        /// <include file='doc\ImageFormat.uex' path='docs/doc[@for="ImageFormat.MemoryBmp"]/*' />
-        /// <devdoc>
-        ///    Specifies a memory bitmap image format.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies a memory bitmap image format.
+        /// </summary>
         public static ImageFormat MemoryBmp
         {
             get { return s_memoryBMP; }
         }
 
-        /// <include file='doc\ImageFormat.uex' path='docs/doc[@for="ImageFormat.Bmp"]/*' />
-        /// <devdoc>
-        ///    Specifies the bitmap image format.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies the bitmap image format.
+        /// </summary>
         public static ImageFormat Bmp
         {
             get { return s_bmp; }
         }
 
-        /// <include file='doc\ImageFormat.uex' path='docs/doc[@for="ImageFormat.Emf"]/*' />
-        /// <devdoc>
-        ///    Specifies the enhanced Windows metafile
-        ///    image format.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies the enhanced Windows metafile image format.
+        /// </summary>
         public static ImageFormat Emf
         {
             get { return s_emf; }
         }
 
-        /// <include file='doc\ImageFormat.uex' path='docs/doc[@for="ImageFormat.Wmf"]/*' />
-        /// <devdoc>
-        ///    Specifies the Windows metafile image
-        ///    format.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies the Windows metafile image format.
+        /// </summary>
         public static ImageFormat Wmf
         {
             get { return s_wmf; }
         }
 
-        /// <include file='doc\ImageFormat.uex' path='docs/doc[@for="ImageFormat.Gif"]/*' />
-        /// <devdoc>
-        ///    Specifies the GIF image format.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies the GIF image format.
+        /// </summary>
         public static ImageFormat Gif
         {
             get { return s_gif; }
         }
 
-        /// <include file='doc\ImageFormat.uex' path='docs/doc[@for="ImageFormat.Jpeg"]/*' />
-        /// <devdoc>
-        ///    Specifies the JPEG image format.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies the JPEG image format.
+        /// </summary>
         public static ImageFormat Jpeg
         {
             get { return s_jpeg; }
         }
 
-        /// <include file='doc\ImageFormat.uex' path='docs/doc[@for="ImageFormat.Png"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Specifies the W3C PNG image format.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Specifies the W3C PNG image format.
+        /// </summary>
         public static ImageFormat Png
         {
             get { return s_png; }
         }
 
-        /// <include file='doc\ImageFormat.uex' path='docs/doc[@for="ImageFormat.Tiff"]/*' />
-        /// <devdoc>
-        ///    Specifies the Tag Image File
-        ///    Format (TIFF) image format.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies the Tag Image File Format (TIFF) image format.
+        /// </summary>
         public static ImageFormat Tiff
         {
             get { return s_tiff; }
         }
 
-        /// <include file='doc\ImageFormat.uex' path='docs/doc[@for="ImageFormat.Exif"]/*' />
-        /// <devdoc>
-        ///    Specifies the Exchangable Image Format
-        ///    (EXIF).
-        /// </devdoc>
+        /// <summary>
+        /// Specifies the Exchangable Image Format (EXIF).
+        /// </summary>
         public static ImageFormat Exif
         {
             get { return s_exif; }
         }
 
-        /// <include file='doc\ImageFormat.uex' path='docs/doc[@for="ImageFormat.Icon"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Specifies the Windows icon image format.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Specifies the Windows icon image format.
+        /// </summary>
         public static ImageFormat Icon
         {
             get { return s_icon; }
         }
 
-        /// <include file='doc\ImageFormat.uex' path='docs/doc[@for="ImageFormat.Equals"]/*' />
-        /// <devdoc>
-        ///    Returns a value indicating whether the
-        ///    specified object is an <see cref='System.Drawing.Imaging.ImageFormat'/> equivalent to this <see cref='System.Drawing.Imaging.ImageFormat'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Returns a value indicating whether the specified object is an <see cref='ImageFormat'/> equivalent to this
+        /// <see cref='ImageFormat'/>.
+        /// </summary>
         public override bool Equals(object o)
         {
             ImageFormat format = o as ImageFormat;
@@ -161,12 +134,9 @@ namespace System.Drawing.Imaging
             return _guid == format._guid;
         }
 
-        /// <include file='doc\ImageFormat.uex' path='docs/doc[@for="ImageFormat.GetHashCode"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Returns a hash code.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Returns a hash code.
+        /// </summary>
         public override int GetHashCode()
         {
             return _guid.GetHashCode();
@@ -186,10 +156,9 @@ namespace System.Drawing.Imaging
         }
 #endif
 
-        /// <include file='doc\ImageFormat.uex' path='docs/doc[@for="ImageFormat.ToString"]/*' />
-        /// <devdoc>
-        ///    Converts this <see cref='System.Drawing.Imaging.ImageFormat'/> to a human-readable string.
-        /// </devdoc>
+        /// <summary>
+        /// Converts this <see cref='System.Drawing.Imaging.ImageFormat'/> to a human-readable string.
+        /// </summary>
         public override string ToString()
         {
             if (this == s_memoryBMP) return "MemoryBMP";

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/ImageLockMode.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/ImageLockMode.cs
@@ -4,43 +4,27 @@
 
 namespace System.Drawing.Imaging
 {
-    //
     // Access modes used when calling IImage::LockBits
-    //
-    /// <include file='doc\ImageLockMode.uex' path='docs/doc[@for="ImageLockMode"]/*' />
-    /// <devdoc>
-    ///    Indicates the access mode for an <see cref='System.Drawing.Image'/>.
-    /// </devdoc>
+    /// <summary>
+    /// Indicates the access mode for an <see cref='Image'/>.
+    /// </summary>
     public enum ImageLockMode
     {
-        /// <include file='doc\ImageLockMode.uex' path='docs/doc[@for="ImageLockMode.ReadOnly"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Specifies the image is read-only.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Specifies the image is read-only.
+        /// </summary>
         ReadOnly = 0x0001,
-        /// <include file='doc\ImageLockMode.uex' path='docs/doc[@for="ImageLockMode.WriteOnly"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Specifies the image is
-        ///       write-only.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Specifies the image is write-only.
+        /// </summary>
         WriteOnly = 0x0002,
-        /// <include file='doc\ImageLockMode.uex' path='docs/doc[@for="ImageLockMode.ReadWrite"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Specifies the image is
-        ///       read-write.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Specifies the image is read-write.
+        /// </summary>
         ReadWrite = ReadOnly | WriteOnly,
-        /// <include file='doc\ImageLockMode.uex' path='docs/doc[@for="ImageLockMode.UserInputBuffer"]/*' />
-        /// <devdoc>
-        ///    Indicates the image resides in a user input
-        ///    buffer, to which the user controls access.
-        /// </devdoc>
+        /// <summary>
+        /// Indicates the image resides in a user input buffer, to which the user controls access.
+        /// </summary>
         UserInputBuffer = 0x0004,
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/METAHEADER.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/METAHEADER.cs
@@ -2,21 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace System.Drawing.Imaging
-{
     using System.Runtime.InteropServices;
 
-    /// <include file='doc\METAHEADER.uex' path='docs/doc[@for="MetaHeader"]/*' />
-    /// <devdoc>
-    ///    <para>[To be supplied.]</para>
-    /// </devdoc>
+namespace System.Drawing.Imaging
+{
     [StructLayout(LayoutKind.Sequential, Pack = 2)]
     public sealed class MetaHeader
     {
-        /// The ENHMETAHEADER structure is defined natively as a union with WmfHeader.  
-        /// Extreme care should be taken if changing the layout of the corresponding managaed 
-        /// structures to minimize the risk of buffer overruns.  The affected managed classes 
-        /// are the following: ENHMETAHEADER, MetaHeader, MetafileHeaderWmf, MetafileHeaderEmf.
+        // The ENHMETAHEADER structure is defined natively as a union with WmfHeader.  
+        // Extreme care should be taken if changing the layout of the corresponding managaed 
+        // structures to minimize the risk of buffer overruns.  The affected managed classes 
+        // are the following: ENHMETAHEADER, MetaHeader, MetafileHeaderWmf, MetafileHeaderEmf.
         private short _type;
         private short _headerSize;
         private short _version;
@@ -25,68 +21,54 @@ namespace System.Drawing.Imaging
         private int _maxRecord;
         private short _noParameters;
 
-        /// <include file='doc\METAHEADER.uex' path='docs/doc[@for="MetaHeader.Type"]/*' />
-        /// <devdoc>
-        ///    Represents the type of the associated
-        /// <see cref='System.Drawing.Imaging.Metafile'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Represents the type of the associated <see cref='Metafile'/>.
+        /// </summary>
         public short Type
         {
             get { return _type; }
             set { _type = value; }
         }
-        /// <include file='doc\METAHEADER.uex' path='docs/doc[@for="MetaHeader.HeaderSize"]/*' />
-        /// <devdoc>
-        ///    Represents the sizi, in bytes, of the
-        ///    header file.
-        /// </devdoc>
+
+        /// <summary>
+        /// Represents the sizi, in bytes, of the header file.
+        /// </summary>
         public short HeaderSize
         {
             get { return _headerSize; }
             set { _headerSize = value; }
         }
-        /// <include file='doc\METAHEADER.uex' path='docs/doc[@for="MetaHeader.Version"]/*' />
-        /// <devdoc>
-        ///    Represents the version number of the header
-        ///    format.
-        /// </devdoc>
+
+        /// <summary>
+        /// Represents the version number of the header format.
+        /// </summary>
         public short Version
         {
             get { return _version; }
             set { _version = value; }
         }
-        /// <include file='doc\METAHEADER.uex' path='docs/doc[@for="MetaHeader.Size"]/*' />
-        /// <devdoc>
-        ///    Represents the sizi, in bytes, of the
-        ///    associated <see cref='System.Drawing.Imaging.Metafile'/>.
-        /// </devdoc>
+
+        /// <summary>
+        /// Represents the size, in bytes, of the associated <see cref='Metafile'/>.
+        /// </summary>
         public int Size
         {
             get { return _size; }
             set { _size = value; }
         }
-        /// <include file='doc\METAHEADER.uex' path='docs/doc[@for="MetaHeader.NoObjects"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
+
         public short NoObjects
         {
             get { return _noObjects; }
             set { _noObjects = value; }
         }
-        /// <include file='doc\METAHEADER.uex' path='docs/doc[@for="MetaHeader.MaxRecord"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
+
         public int MaxRecord
         {
             get { return _maxRecord; }
             set { _maxRecord = value; }
         }
-        /// <include file='doc\METAHEADER.uex' path='docs/doc[@for="MetaHeader.NoParameters"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
+
         public short NoParameters
         {
             get { return _noParameters; }

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/Metafile.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/Metafile.cs
@@ -2,45 +2,30 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
+using System.IO;
+using System.Drawing.Internal;
+
 namespace System.Drawing.Imaging
 {
-    using System.Runtime.InteropServices;
-    using System.IO;
-    using System.Drawing.Internal;
-
-    /**
-     * Represent a metafile image
-     */
-    /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile"]/*' />
-    /// <devdoc>
-    ///    Defines a graphic metafile. A metafile
-    ///    contains records that describe a sequence of graphics operations that can be
-    ///    recorded and played back.
-    /// </devdoc>
+    /// <summary>
+    /// Defines a graphic metafile. A metafile contains records that describe a sequence of graphics operations that
+    /// can be recorded and played back.
+    /// </summary>
     public sealed partial class Metafile : Image
     {
-        /*
-         * Create a new metafile object from a metafile handle (WMF)
-         */
-
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class from the specified handle and
-        ///    <see cref='System.Drawing.Imaging.WmfPlaceableFileHeader'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class from the specified handle and
+        /// <see cref='WmfPlaceableFileHeader'/>.
+        /// </summary>
         public Metafile(IntPtr hmetafile, WmfPlaceableFileHeader wmfHeader) :
         this(hmetafile, wmfHeader, false)
         { }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class from the specified handle and
-        ///    <see cref='System.Drawing.Imaging.WmfPlaceableFileHeader'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class from the specified handle and
+        /// <see cref='WmfPlaceableFileHeader'/>.
+        /// </summary>
         public Metafile(IntPtr hmetafile, WmfPlaceableFileHeader wmfHeader, bool deleteWmf)
         {
             IntPtr metafile = IntPtr.Zero;
@@ -53,17 +38,10 @@ namespace System.Drawing.Imaging
             SetNativeImage(metafile);
         }
 
-        /*
-         * Create a new metafile object from an enhanced metafile handle
-         */
-
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile2"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class from the
-        ///       specified handle and <see cref='System.Drawing.Imaging.WmfPlaceableFileHeader'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class from the specified handle and
+        /// <see cref='WmfPlaceableFileHeader'/>.
+        /// </summary>
         public Metafile(IntPtr henhmetafile, bool deleteEmf)
         {
             IntPtr metafile = IntPtr.Zero;
@@ -76,13 +54,9 @@ namespace System.Drawing.Imaging
             SetNativeImage(metafile);
         }
 
-        /**
-         * Create a new metafile object from a file
-         */
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile3"]/*' />
-        /// <devdoc>
-        ///    Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class from the specified filename.
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class from the specified filename.
+        /// </summary>
         public Metafile(string filename)
         {
             IntPtr metafile = IntPtr.Zero;
@@ -95,13 +69,9 @@ namespace System.Drawing.Imaging
             SetNativeImage(metafile);
         }
 
-        /**
-         * Create a new metafile object from a stream
-         */
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile4"]/*' />
-        /// <devdoc>
-        ///    Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class from the specified stream.
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class from the specified stream.
+        /// </summary>
         public Metafile(Stream stream)
         {
             if (stream == null)
@@ -119,22 +89,16 @@ namespace System.Drawing.Imaging
             SetNativeImage(metafile);
         }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile5"]/*' />
-        /// <devdoc>
-        ///    Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class from the specified handle to a
-        ///    device context.
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class from the specified handle to a device context.
+        /// </summary>
         public Metafile(IntPtr referenceHdc, EmfType emfType) :
         this(referenceHdc, emfType, null)
         { }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile6"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class from the
-        ///       specified handle to a device context.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class from the specified handle to a device context.
+        /// </summary>
         public Metafile(IntPtr referenceHdc, EmfType emfType, String description)
         {
             IntPtr metafile = IntPtr.Zero;
@@ -152,46 +116,34 @@ namespace System.Drawing.Imaging
             SetNativeImage(metafile);
         }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile7"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class from the specified device context,
-        ///       bounded by the specified rectangle.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class from the specified device context, bounded
+        /// by the specified rectangle.
+        /// </summary>
         public Metafile(IntPtr referenceHdc, RectangleF frameRect) :
         this(referenceHdc, frameRect, MetafileFrameUnit.GdiCompatible)
         { }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile8"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class from the specified device context,
-        ///       bounded by the specified rectangle.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class from the specified device context, bounded
+        /// by the specified rectangle.
+        /// </summary>
         public Metafile(IntPtr referenceHdc, RectangleF frameRect, MetafileFrameUnit frameUnit) :
         this(referenceHdc, frameRect, frameUnit, EmfType.EmfPlusDual)
         { }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile9"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class from the
-        ///       specified device context, bounded by the specified rectangle.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class from the specified device context, bounded
+        /// by the specified rectangle.
+        /// </summary>
         public Metafile(IntPtr referenceHdc, RectangleF frameRect, MetafileFrameUnit frameUnit, EmfType type) :
         this(referenceHdc, frameRect, frameUnit, type, null)
         { }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile10"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class from the specified device context,
-        ///       bounded by the specified rectangle.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class from the specified device context, bounded
+        /// by the specified rectangle.
+        /// </summary>
         public Metafile(IntPtr referenceHdc, RectangleF frameRect, MetafileFrameUnit frameUnit, EmfType type, String description)
         {
             IntPtr metafile = IntPtr.Zero;
@@ -209,46 +161,34 @@ namespace System.Drawing.Imaging
             SetNativeImage(metafile);
         }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile11"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class from the
-        ///       specified device context, bounded by the specified rectangle.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class from the specified device context, bounded
+        /// by the specified rectangle.
+        /// </summary>
         public Metafile(IntPtr referenceHdc, Rectangle frameRect) :
         this(referenceHdc, frameRect, MetafileFrameUnit.GdiCompatible)
         { }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile12"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class from the
-        ///       specified device context, bounded by the specified rectangle.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class from the specified device context, bounded
+        /// by the specified rectangle.
+        /// </summary>
         public Metafile(IntPtr referenceHdc, Rectangle frameRect, MetafileFrameUnit frameUnit) :
         this(referenceHdc, frameRect, frameUnit, EmfType.EmfPlusDual)
         { }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile13"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class from the
-        ///       specified device context, bounded by the specified rectangle.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class from the specified device context, bounded
+        /// by the specified rectangle.
+        /// </summary>
         public Metafile(IntPtr referenceHdc, Rectangle frameRect, MetafileFrameUnit frameUnit, EmfType type) :
         this(referenceHdc, frameRect, frameUnit, type, null)
         { }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile14"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class from the
-        ///       specified device context, bounded by the specified rectangle.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class from the specified device context, bounded
+        /// by the specified rectangle.
+        /// </summary>
         public Metafile(IntPtr referenceHdc, Rectangle frameRect, MetafileFrameUnit frameUnit, EmfType type, string desc)
         {
             IntPtr metafile = IntPtr.Zero;
@@ -281,32 +221,23 @@ namespace System.Drawing.Imaging
             SetNativeImage(metafile);
         }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile15"]/*' />
-        /// <devdoc>
-        ///    Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class with the specified
-        ///    filename.
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class with the specified filename.
+        /// </summary>
         public Metafile(string fileName, IntPtr referenceHdc) :
         this(fileName, referenceHdc, EmfType.EmfPlusDual, null)
         { }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile16"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class with the specified
-        ///       filename.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class with the specified filename.
+        /// </summary>
         public Metafile(string fileName, IntPtr referenceHdc, EmfType type) :
         this(fileName, referenceHdc, type, null)
         { }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile17"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class with the specified filename.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class with the specified filename.
+        /// </summary>
         public Metafile(string fileName, IntPtr referenceHdc, EmfType type, String description)
         {
             IntPtr metafile = IntPtr.Zero;
@@ -324,56 +255,39 @@ namespace System.Drawing.Imaging
             SetNativeImage(metafile);
         }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile18"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class with the specified filename.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class with the specified filename.
+        /// </summary>
         public Metafile(string fileName, IntPtr referenceHdc, RectangleF frameRect) :
         this(fileName, referenceHdc, frameRect, MetafileFrameUnit.GdiCompatible)
         { }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile19"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class with the specified filename.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class with the specified filename.
+        /// </summary>
         public Metafile(string fileName, IntPtr referenceHdc, RectangleF frameRect,
                         MetafileFrameUnit frameUnit) :
         this(fileName, referenceHdc, frameRect, frameUnit, EmfType.EmfPlusDual)
         { }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile20"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class with the specified filename.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class with the specified filename.
+        /// </summary>
         public Metafile(string fileName, IntPtr referenceHdc, RectangleF frameRect,
                         MetafileFrameUnit frameUnit, EmfType type) :
         this(fileName, referenceHdc, frameRect, frameUnit, type, null)
         { }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile21"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class with the
-        ///       specified filename.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class with the specified filename.
+        /// </summary>
         public Metafile(string fileName, IntPtr referenceHdc, RectangleF frameRect, MetafileFrameUnit frameUnit, string desc) :
         this(fileName, referenceHdc, frameRect, frameUnit, EmfType.EmfPlusDual, desc)
         { }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile22"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class with the
-        ///       specified filename.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class with the specified filename.
+        /// </summary>
         public Metafile(string fileName, IntPtr referenceHdc, RectangleF frameRect,
                         MetafileFrameUnit frameUnit, EmfType type, String description)
         {
@@ -394,59 +308,39 @@ namespace System.Drawing.Imaging
             SetNativeImage(metafile);
         }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile23"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class with the
-        ///       specified filename.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class with the specified filename.
+        /// </summary>
         public Metafile(string fileName, IntPtr referenceHdc, Rectangle frameRect) :
         this(fileName, referenceHdc, frameRect, MetafileFrameUnit.GdiCompatible)
         { }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile24"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class with the
-        ///       specified filename.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class with the specified filename.
+        /// </summary>
         public Metafile(string fileName, IntPtr referenceHdc, Rectangle frameRect,
                         MetafileFrameUnit frameUnit) :
         this(fileName, referenceHdc, frameRect, frameUnit, EmfType.EmfPlusDual)
         { }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile25"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class with the
-        ///       specified filename.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class with the specified filename.
+        /// </summary>
         public Metafile(string fileName, IntPtr referenceHdc, Rectangle frameRect,
                         MetafileFrameUnit frameUnit, EmfType type) :
         this(fileName, referenceHdc, frameRect, frameUnit, type, null)
         { }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile26"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class with the
-        ///       specified filename.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class with the specified filename.
+        /// </summary>
         public Metafile(string fileName, IntPtr referenceHdc, Rectangle frameRect, MetafileFrameUnit frameUnit, string description) :
         this(fileName, referenceHdc, frameRect, frameUnit, EmfType.EmfPlusDual, description)
         { }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile27"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class with the
-        ///       specified filename.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class with the specified filename.
+        /// </summary>
         public Metafile(string fileName, IntPtr referenceHdc, Rectangle frameRect, MetafileFrameUnit frameUnit, EmfType type, string description)
         {
             IntPtr metafile = IntPtr.Zero;
@@ -481,34 +375,23 @@ namespace System.Drawing.Imaging
             SetNativeImage(metafile);
         }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile28"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class from the specified data
-        ///       stream.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class from the specified data stream.
+        /// </summary>
         public Metafile(Stream stream, IntPtr referenceHdc) :
         this(stream, referenceHdc, EmfType.EmfPlusDual, null)
         { }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile29"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class from the specified data
-        ///       stream.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class from the specified data stream.
+        /// </summary>
         public Metafile(Stream stream, IntPtr referenceHdc, EmfType type) :
         this(stream, referenceHdc, type, null)
         { }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile30"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class from the specified data stream.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class from the specified data stream.
+        /// </summary>
         public Metafile(Stream stream, IntPtr referenceHdc, EmfType type, string description)
         {
             IntPtr metafile = IntPtr.Zero;
@@ -527,47 +410,32 @@ namespace System.Drawing.Imaging
             SetNativeImage(metafile);
         }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile31"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class from the specified data stream.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class from the specified data stream.
+        /// </summary>
         public Metafile(Stream stream, IntPtr referenceHdc, RectangleF frameRect) :
         this(stream, referenceHdc, frameRect, MetafileFrameUnit.GdiCompatible)
         { }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile32"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class with the
-        ///       specified filename.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class with the specified filename.
+        /// </summary>
         public Metafile(Stream stream, IntPtr referenceHdc, RectangleF frameRect,
                         MetafileFrameUnit frameUnit) :
         this(stream, referenceHdc, frameRect, frameUnit, EmfType.EmfPlusDual)
         { }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile33"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class with the
-        ///       specified filename.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class with the specified filename.
+        /// </summary>
         public Metafile(Stream stream, IntPtr referenceHdc, RectangleF frameRect,
                         MetafileFrameUnit frameUnit, EmfType type) :
         this(stream, referenceHdc, frameRect, frameUnit, type, null)
         { }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile34"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class with the
-        ///       specified filename.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class with the specified filename.
+        /// </summary>
         public Metafile(Stream stream, IntPtr referenceHdc, RectangleF frameRect,
                         MetafileFrameUnit frameUnit, EmfType type, string description)
         {
@@ -588,48 +456,32 @@ namespace System.Drawing.Imaging
             SetNativeImage(metafile);
         }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile35"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class from the
-        ///       specified data stream.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class from the specified data stream.
+        /// </summary>
         public Metafile(Stream stream, IntPtr referenceHdc, Rectangle frameRect) :
         this(stream, referenceHdc, frameRect, MetafileFrameUnit.GdiCompatible)
         { }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile36"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class with the
-        ///       specified filename.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class with the specified filename.
+        /// </summary>
         public Metafile(Stream stream, IntPtr referenceHdc, Rectangle frameRect,
                         MetafileFrameUnit frameUnit) :
         this(stream, referenceHdc, frameRect, frameUnit, EmfType.EmfPlusDual)
         { }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile37"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class with the
-        ///       specified filename.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class with the specified filename.
+        /// </summary>
         public Metafile(Stream stream, IntPtr referenceHdc, Rectangle frameRect,
                         MetafileFrameUnit frameUnit, EmfType type) :
         this(stream, referenceHdc, frameRect, frameUnit, type, null)
         { }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.Metafile38"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Imaging.Metafile'/> class with the
-        ///       specified filename.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Metafile'/> class with the specified filename.
+        /// </summary>
         public Metafile(Stream stream, IntPtr referenceHdc, Rectangle frameRect, MetafileFrameUnit frameUnit,
                         EmfType type, string description)
         {
@@ -665,12 +517,9 @@ namespace System.Drawing.Imaging
             SetNativeImage(metafile);
         }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.GetMetafileHeader"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Returns the <see cref='System.Drawing.Imaging.MetafileHeader'/> associated with the specified <see cref='System.Drawing.Imaging.Metafile'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Returns the <see cref='MetafileHeader'/> associated with the specified <see cref='Metafile'/>.
+        /// </summary>
         public static MetafileHeader GetMetafileHeader(IntPtr hmetafile, WmfPlaceableFileHeader wmfHeader)
         {
             MetafileHeader header = new MetafileHeader();
@@ -685,12 +534,9 @@ namespace System.Drawing.Imaging
             return header;
         }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.GetMetafileHeader1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Returns the <see cref='System.Drawing.Imaging.MetafileHeader'/> associated with the specified <see cref='System.Drawing.Imaging.Metafile'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Returns the <see cref='MetafileHeader'/> associated with the specified <see cref='Metafile'/>.
+        /// </summary>
         public static MetafileHeader GetMetafileHeader(IntPtr henhmetafile)
         {
             MetafileHeader header = new MetafileHeader();
@@ -704,12 +550,9 @@ namespace System.Drawing.Imaging
             return header;
         }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.GetMetafileHeader2"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Returns the <see cref='System.Drawing.Imaging.MetafileHeader'/> associated with the specified <see cref='System.Drawing.Imaging.Metafile'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Returns the <see cref='MetafileHeader'/> associated with the specified <see cref='Metafile'/>.
+        /// </summary>
         public static MetafileHeader GetMetafileHeader(string fileName)
         {
             MetafileHeader header = new MetafileHeader();
@@ -753,12 +596,9 @@ namespace System.Drawing.Imaging
             return header;
         }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.GetMetafileHeader3"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Returns the <see cref='System.Drawing.Imaging.MetafileHeader'/> associated with the specified <see cref='System.Drawing.Imaging.Metafile'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Returns the <see cref='MetafileHeader'/> associated with the specified <see cref='Metafile'/>.
+        /// </summary>
         public static MetafileHeader GetMetafileHeader(Stream stream)
         {
             MetafileHeader header;
@@ -804,12 +644,9 @@ namespace System.Drawing.Imaging
             return header;
         }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.GetMetafileHeader4"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Returns the <see cref='System.Drawing.Imaging.MetafileHeader'/> associated with this <see cref='System.Drawing.Imaging.Metafile'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Returns the <see cref='MetafileHeader'/> associated with this <see cref='Metafile'/>.
+        /// </summary>
         public MetafileHeader GetMetafileHeader()
         {
             MetafileHeader header;
@@ -855,11 +692,9 @@ namespace System.Drawing.Imaging
             return header;
         }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.GetHenhmetafile"]/*' />
-        /// <devdoc>
-        ///    Returns a Windows handle to an enhanced
-        /// <see cref='System.Drawing.Imaging.Metafile'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Returns a Windows handle to an enhanced <see cref='Metafile'/>.
+        /// </summary>
         public IntPtr GetHenhmetafile()
         {
             IntPtr hEmf = IntPtr.Zero;
@@ -872,10 +707,9 @@ namespace System.Drawing.Imaging
             return hEmf;
         }
 
-        /// <include file='doc\Metafile.uex' path='docs/doc[@for="Metafile.PlayRecord"]/*' />
-        /// <devdoc>
-        ///    Plays an EMF+ file.
-        /// </devdoc>
+        /// <summary>
+        /// Plays an EMF+ file.
+        /// </summary>
         public void PlayRecord(EmfPlusRecordType recordType,
                                int flags,
                                int dataSize,

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/MetafileFrameUnit.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/MetafileFrameUnit.cs
@@ -4,58 +4,35 @@
 
 namespace System.Drawing.Imaging
 {
-    /**
-     * Page unit constants
-     */
-    /// <include file='doc\MetafileFrameUnit.uex' path='docs/doc[@for="MetafileFrameUnit"]/*' />
-    /// <devdoc>
-    ///    <para>
-    ///       Specifies the unit of measurement for the
-    ///       rectangle used to size and position a metafile. This is specified during the
-    ///       creation of the <see cref='System.Drawing.Imaging.Metafile'/>.
-    ///    </para>
-    /// </devdoc>    
+    /// <summary>
+    /// Specifies the unit of measurement for the rectangle used to size and position a metafile.
+    /// This is specified during the creation of the <see cref='Metafile'/>.
+    /// </summary>    
     public enum MetafileFrameUnit
     {
-        /// <include file='doc\MetafileFrameUnit.uex' path='docs/doc[@for="MetafileFrameUnit.Pixel"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Specifies a pixel as the unit of measure.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Specifies a pixel as the unit of measure.
+        /// </summary>
         Pixel = GraphicsUnit.Pixel,
-        /// <include file='doc\MetafileFrameUnit.uex' path='docs/doc[@for="MetafileFrameUnit.Point"]/*' />
-        /// <devdoc>
-        ///    Specifies a printer's point as
-        ///    the unit of measure.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies a printer's point as the unit of measure.
+        /// </summary>
         Point = GraphicsUnit.Point,
-        /// <include file='doc\MetafileFrameUnit.uex' path='docs/doc[@for="MetafileFrameUnit.Inch"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Specifies an inch as the unit of measure.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Specifies an inch as the unit of measure.
+        /// </summary>
         Inch = GraphicsUnit.Inch,
-        /// <include file='doc\MetafileFrameUnit.uex' path='docs/doc[@for="MetafileFrameUnit.Document"]/*' />
-        /// <devdoc>
-        ///    Specifies 1/300 of an inch as the unit of
-        ///    measure.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies 1/300 of an inch as the unit of measure.
+        /// </summary>
         Document = GraphicsUnit.Document,
-        /// <include file='doc\MetafileFrameUnit.uex' path='docs/doc[@for="MetafileFrameUnit.Millimeter"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Specifies a millimeter as the unit of
-        ///       measure.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Specifies a millimeter as the unit of measure.
+        /// </summary>
         Millimeter = GraphicsUnit.Millimeter,
-        /// <include file='doc\MetafileFrameUnit.uex' path='docs/doc[@for="MetafileFrameUnit.GdiCompatible"]/*' />
-        /// <devdoc>
-        ///    Specifies .01 millimeter as the unit of
-        ///    measure. Provided for compatibility with GDI.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies .01 millimeter as the unit of measure. Provided for compatibility with GDI.
+        /// </summary>
         GdiCompatible
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/MetafileHeader.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/MetafileHeader.cs
@@ -2,15 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
+
 namespace System.Drawing.Imaging
 {
-    using System.Runtime.InteropServices;
-
-    /// <include file='doc\MetafileHeader.uex' path='docs/doc[@for="MetafileHeader"]/*' />
-    /// <devdoc>
-    ///    Contains attributes of an
-    ///    associated <see cref='System.Drawing.Imaging.Metafile'/>.
-    /// </devdoc>
+    /// <summary>
+    /// Contains attributes of an associated <see cref='Metafile'/>.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public sealed class MetafileHeader
     {
@@ -22,10 +20,9 @@ namespace System.Drawing.Imaging
         {
         }
 
-        /// <include file='doc\MetafileHeader.uex' path='docs/doc[@for="MetafileHeader.Type"]/*' />
-        /// <devdoc>
-        ///    Gets the type of the associated <see cref='System.Drawing.Imaging.Metafile'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets the type of the associated <see cref='Metafile'/>.
+        /// </summary>
         public MetafileType Type
         {
             get
@@ -34,13 +31,9 @@ namespace System.Drawing.Imaging
             }
         }
 
-        /// <include file='doc\MetafileHeader.uex' path='docs/doc[@for="MetafileHeader.MetafileSize"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets the size, in bytes, of the associated
-        ///    <see cref='System.Drawing.Imaging.Metafile'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets the size, in bytes, of the associated <see cref='Metafile'/>.
+        /// </summary>
         public int MetafileSize
         {
             get
@@ -49,11 +42,9 @@ namespace System.Drawing.Imaging
             }
         }
 
-        /// <include file='doc\MetafileHeader.uex' path='docs/doc[@for="MetafileHeader.Version"]/*' />
-        /// <devdoc>
-        ///    Gets the version number of the associated
-        /// <see cref='System.Drawing.Imaging.Metafile'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets the version number of the associated <see cref='Metafile'/>.
+        /// </summary>
         public int Version
         {
             get
@@ -62,21 +53,9 @@ namespace System.Drawing.Imaging
             }
         }
 
-        /* FxCop rule 'AvoidBuildingNonCallableCode' - Left here in case it is needed in the future.
-         private EmfPlusFlags EmfPlusFlags
-         {
-             get
-             {
-                 return IsWmf() ? wmf.emfPlusFlags : emf.emfPlusFlags;
-             }
-         }
-         */
-
-        /// <include file='doc\MetafileHeader.uex' path='docs/doc[@for="MetafileHeader.DpiX"]/*' />
-        /// <devdoc>
-        ///    Gets the horizontal resolution, in
-        ///    dots-per-inch, of the associated <see cref='System.Drawing.Imaging.Metafile'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets the horizontal resolution, in dots-per-inch, of the associated <see cref='Metafile'/>.
+        /// </summary>
         public float DpiX
         {
             get
@@ -85,11 +64,9 @@ namespace System.Drawing.Imaging
             }
         }
 
-        /// <include file='doc\MetafileHeader.uex' path='docs/doc[@for="MetafileHeader.DpiY"]/*' />
-        /// <devdoc>
-        ///    Gets the vertical resolution, in
-        ///    dots-per-inch, of the associated <see cref='System.Drawing.Imaging.Metafile'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets the vertical resolution, in dots-per-inch, of the associated <see cref='Metafile'/>.
+        /// </summary>
         public float DpiY
         {
             get
@@ -98,11 +75,9 @@ namespace System.Drawing.Imaging
             }
         }
 
-        /// <include file='doc\MetafileHeader.uex' path='docs/doc[@for="MetafileHeader.Bounds"]/*' />
-        /// <devdoc>
-        ///    Gets a <see cref='System.Drawing.Rectangle'/> that bounds the associated
-        /// <see cref='System.Drawing.Imaging.Metafile'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets a <see cref='Rectangle'/> that bounds the associated <see cref='Metafile'/>.
+        /// </summary>
         public Rectangle Bounds
         {
             get
@@ -113,12 +88,9 @@ namespace System.Drawing.Imaging
             }
         }
 
-        /// <include file='doc\MetafileHeader.uex' path='docs/doc[@for="MetafileHeader.IsWmf"]/*' />
-        /// <devdoc>
-        ///    Returns a value indicating whether the
-        ///    associated <see cref='System.Drawing.Imaging.Metafile'/> is in the Windows metafile
-        ///    format.
-        /// </devdoc>
+        /// <summary>
+        /// Returns a value indicating whether the associated <see cref='Metafile'/> is in the Windows metafile format.
+        /// </summary>
         public bool IsWmf()
         {
             if ((wmf == null) && (emf == null))
@@ -132,14 +104,9 @@ namespace System.Drawing.Imaging
                 return false;
         }
 
-        /// <include file='doc\MetafileHeader.uex' path='docs/doc[@for="MetafileHeader.IsWmfPlaceable"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Returns a value indicating whether the
-        ///       associated <see cref='System.Drawing.Imaging.Metafile'/> is in the Windows Placeable metafile
-        ///       format.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Returns a value indicating whether the associated <see cref='Metafile'/> is in the Windows Placeable metafile format.
+        /// </summary>
         public bool IsWmfPlaceable()
         {
             if (wmf == null && emf == null)
@@ -148,12 +115,9 @@ namespace System.Drawing.Imaging
             return ((wmf != null) && (wmf.type == MetafileType.WmfPlaceable));
         }
 
-        /// <include file='doc\MetafileHeader.uex' path='docs/doc[@for="MetafileHeader.IsEmf"]/*' />
-        /// <devdoc>
-        ///    Returns a value indicating whether the
-        ///    associated <see cref='System.Drawing.Imaging.Metafile'/> is in the Windows enhanced metafile
-        ///    format.
-        /// </devdoc>
+        /// <summary>
+        /// Returns a value indicating whether the associated <see cref='Metafile'/> is in the Windows enhanced metafile format.
+        /// </summary>
         public bool IsEmf()
         {
             if (wmf == null && emf == null)
@@ -162,12 +126,10 @@ namespace System.Drawing.Imaging
             return ((emf != null) && (emf.type == MetafileType.Emf));
         }
 
-        /// <include file='doc\MetafileHeader.uex' path='docs/doc[@for="MetafileHeader.IsEmfOrEmfPlus"]/*' />
-        /// <devdoc>
-        ///    Returns a value indicating whether the
-        ///    associated <see cref='System.Drawing.Imaging.Metafile'/> is in the Windows enhanced metafile
-        ///    format or the Windows enhanced metafile plus.
-        /// </devdoc>
+        /// <summary>
+        /// Returns a value indicating whether the associated <see cref='Metafile'/> is in the Windows enhanced
+        /// metafile format or the Windows enhanced metafile plus.
+        /// </summary>
         public bool IsEmfOrEmfPlus()
         {
             if (wmf == null && emf == null)
@@ -176,12 +138,10 @@ namespace System.Drawing.Imaging
             return ((emf != null) && (emf.type >= MetafileType.Emf));
         }
 
-        /// <include file='doc\MetafileHeader.uex' path='docs/doc[@for="MetafileHeader.IsEmfPlus"]/*' />
-        /// <devdoc>
-        ///    Returns a value indicating whether the
-        ///    associated <see cref='System.Drawing.Imaging.Metafile'/> is in the Windows enhanced metafile
-        ///    plus format.
-        /// </devdoc>
+        /// <summary>
+        /// Returns a value indicating whether the associated <see cref='Metafile'/> is in the Windows enhanced
+        /// metafile plus format.
+        /// </summary>
         public bool IsEmfPlus()
         {
             if (wmf == null && emf == null)
@@ -190,13 +150,10 @@ namespace System.Drawing.Imaging
             return ((emf != null) && (emf.type >= MetafileType.EmfPlusOnly));
         }
 
-        /// <include file='doc\MetafileHeader.uex' path='docs/doc[@for="MetafileHeader.IsEmfPlusDual"]/*' />
-        /// <devdoc>
-        ///    Returns a value indicating whether the
-        ///    associated <see cref='System.Drawing.Imaging.Metafile'/> is in the Dual enhanced
-        ///    metafile format. This format supports both the enhanced and the enhanced
-        ///    plus format.
-        /// </devdoc>
+        /// <summary>
+        /// Returns a value indicating whether the associated <see cref='Metafile'/> is in the Dual enhanced metafile
+        /// format. This format supports both the enhanced and the enhanced plus format.
+        /// </summary>
         public bool IsEmfPlusDual()
         {
             if (wmf == null && emf == null)
@@ -205,13 +162,10 @@ namespace System.Drawing.Imaging
             return ((emf != null) && (emf.type == MetafileType.EmfPlusDual));
         }
 
-        /// <include file='doc\MetafileHeader.uex' path='docs/doc[@for="MetafileHeader.IsEmfPlusOnly"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Returns a value indicating whether the associated <see cref='System.Drawing.Imaging.Metafile'/> supports only the Windows
-        ///       enhanced metafile plus format.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Returns a value indicating whether the associated <see cref='Metafile'/> supports only the Windows
+        /// enhanced metafile plus format.
+        /// </summary>
         public bool IsEmfPlusOnly()
         {
             if (wmf == null && emf == null)
@@ -220,23 +174,18 @@ namespace System.Drawing.Imaging
             return ((emf != null) && (emf.type == MetafileType.EmfPlusOnly));
         }
 
-        /// <include file='doc\MetafileHeader.uex' path='docs/doc[@for="MetafileHeader.IsDisplay"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Returns a value indicating whether the associated <see cref='System.Drawing.Imaging.Metafile'/> is device-dependent.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Returns a value indicating whether the associated <see cref='Metafile'/> is device-dependent.
+        /// </summary>
         public bool IsDisplay()
         {
             return IsEmfPlus() &&
                (((unchecked((int)emf.emfPlusFlags)) & ((int)EmfPlusFlags.Display)) != 0);
         }
 
-        /// <include file='doc\MetafileHeader.uex' path='docs/doc[@for="MetafileHeader.WmfHeader"]/*' />
-        /// <devdoc>
-        ///    Gets the WMF header file for the associated
-        /// <see cref='System.Drawing.Imaging.Metafile'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets the WMF header file for the associated <see cref='Metafile'/>.
+        /// </summary>
         public MetaHeader WmfHeader
         {
             get
@@ -248,31 +197,9 @@ namespace System.Drawing.Imaging
             }
         }
 
-
-        /// <include file='doc\MetafileHeader.uex' path='docs/doc[@for="MetafileHeader.EmfHeader"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets the WMF header file for the associated <see cref='System.Drawing.Imaging.Metafile'/>.
-        ///    </para>
-        /// </devdoc>
-        /* FxCop rule 'AvoidBuildingNonCallableCode' - Left here in case it is needed in the future.
-         internal SafeNativeMethods.ENHMETAHEADER EmfHeader
-         {
-             get
-             {
-                 if (emf == null)
-                     throw SafeNativeMethods.Gdip.StatusException(SafeNativeMethods.Gdip.InvalidParameter);
-
-                 return emf.EmfHeader;
-              }
-          }
-        */
-
-        /// <include file='doc\MetafileHeader.uex' path='docs/doc[@for="MetafileHeader.EmfPlusHeaderSize"]/*' />
-        /// <devdoc>
-        ///    Gets the size, in bytes, of the
-        ///    enhanced metafile plus header file.
-        /// </devdoc>
+        /// <summary>
+        /// Gets the size, in bytes, of the enhanced metafile plus header file.
+        /// </summary>
         public int EmfPlusHeaderSize
         {
             get
@@ -284,13 +211,9 @@ namespace System.Drawing.Imaging
             }
         }
 
-        /// <include file='doc\MetafileHeader.uex' path='docs/doc[@for="MetafileHeader.LogicalDpiX"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets the logical horizontal resolution, in
-        ///       dots-per-inch, of the associated <see cref='System.Drawing.Imaging.Metafile'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets the logical horizontal resolution, in dots-per-inch, of the associated <see cref='Metafile'/>.
+        /// </summary>
         public int LogicalDpiX
         {
             get
@@ -302,11 +225,9 @@ namespace System.Drawing.Imaging
             }
         }
 
-        /// <include file='doc\MetafileHeader.uex' path='docs/doc[@for="MetafileHeader.LogicalDpiY"]/*' />
-        /// <devdoc>
-        ///    Gets the logical vertical resolution, in
-        ///    dots-per-inch, of the associated <see cref='System.Drawing.Imaging.Metafile'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets the logical vertical resolution, in dots-per-inch, of the associated <see cref='Metafile'/>.
+        /// </summary>
         public int LogicalDpiY
         {
             get

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/MetafileType.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/MetafileType.cs
@@ -4,47 +4,34 @@
 
 namespace System.Drawing.Imaging
 {
-    /**
-     * MetafileType Type
-     */
-    /// <include file='doc\MetafileType.uex' path='docs/doc[@for="MetafileType"]/*' />
-    /// <devdoc>
-    ///    <para>
-    ///       Specifies the format of a <see cref='System.Drawing.Imaging.Metafile'/>.
-    ///    </para>
-    /// </devdoc>
+    /// <summary>
+    /// Specifies the format of a <see cref='Metafile'/>.
+    /// </summary>
     public enum MetafileType
     {
-        /// <include file='doc\MetafileType.uex' path='docs/doc[@for="MetafileType.Invalid"]/*' />
-        /// <devdoc>
-        ///    Specifies an invalid type.
-        /// </devdoc>
-        Invalid,            // Invalid metafile
-                            /// <include file='doc\MetafileType.uex' path='docs/doc[@for="MetafileType.Wmf"]/*' />
-                            /// <devdoc>
-                            ///    Specifies a standard Windows metafile.
-                            /// </devdoc>
-        Wmf,                // Standard WMF
-                            /// <include file='doc\MetafileType.uex' path='docs/doc[@for="MetafileType.WmfPlaceable"]/*' />
-                            /// <devdoc>
-                            ///    Specifies a Windows Placeable metafile.
-                            /// </devdoc>
-        WmfPlaceable,           // Placeable Metafile format
-                                /// <include file='doc\MetafileType.uex' path='docs/doc[@for="MetafileType.Emf"]/*' />
-                                /// <devdoc>
-                                ///    Specifies a Windows enhanced metafile.
-                                /// </devdoc>
-        Emf,                // EMF (not EMF+)
-                            /// <include file='doc\MetafileType.uex' path='docs/doc[@for="MetafileType.EmfPlusOnly"]/*' />
-                            /// <devdoc>
-                            ///    Specifies a Windows enhanced metafile plus.
-                            /// </devdoc>
-        EmfPlusOnly,        // EMF+ without dual, down-level records
-                            /// <include file='doc\MetafileType.uex' path='docs/doc[@for="MetafileType.EmfPlusDual"]/*' />
-                            /// <devdoc>
-                            ///    Specifies both enhanced and enhanced plus
-                            ///    commands in the same file.
-                            /// </devdoc>
-        EmfPlusDual,        // EMF+ with dual, down-level records
+        /// <summary>
+        /// Specifies an invalid type.
+        /// </summary>
+        Invalid,
+        /// <summary>
+        /// Specifies a standard Windows metafile.
+        /// </summary>
+        Wmf,
+        /// <summary>
+        /// Specifies a Windows Placeable metafile.
+        /// </summary>
+        WmfPlaceable,
+        /// <summary>
+        /// Specifies a Windows enhanced metafile.
+        /// </summary>
+        Emf,
+        /// <summary>
+        /// Specifies a Windows enhanced metafile plus.
+        /// </summary>
+        EmfPlusOnly,
+        /// <summary>
+        /// Specifies both enhanced and enhanced plus commands in the same file.
+        /// </summary>
+        EmfPlusDual,
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/PaletteFlags.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/PaletteFlags.cs
@@ -4,30 +4,24 @@
 
 namespace System.Drawing.Imaging
 {
-    /// <include file='doc\PaletteFlags.uex' path='docs/doc[@for="PaletteFlags"]/*' />
-    /// <devdoc>
-    ///    Specifies the type of color data in the
-    ///    system palette. The data can be color data with alpha, grayscale only, or
-    ///    halftone data.
-    /// </devdoc>
+    /// <summary>
+    /// Specifies the type of color data in the system palette. The data can be color data with alpha, grayscale only,
+    /// or halftone data.
+    /// </summary>
     [Flags]
     public enum PaletteFlags
     {
-        /// <include file='doc\PaletteFlags.uex' path='docs/doc[@for="PaletteFlags.HasAlpha"]/*' />
-        /// <devdoc>
-        ///    Specifies alpha data.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies alpha data.
+        /// </summary>
         HasAlpha = 0x0001,
-        /// <include file='doc\PaletteFlags.uex' path='docs/doc[@for="PaletteFlags.GrayScale"]/*' />
-        /// <devdoc>
-        ///    Specifies grayscale data.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies grayscale data.
+        /// </summary>
         GrayScale = 0x0002,
-        /// <include file='doc\PaletteFlags.uex' path='docs/doc[@for="PaletteFlags.Halftone"]/*' />
-        /// <devdoc>
-        ///    Specifies halftone data.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies halftone data.
+        /// </summary>
         Halftone = 0x0004
     }
 }
-

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/PixelFormat.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/PixelFormat.cs
@@ -12,202 +12,109 @@ namespace System.Drawing.Imaging
      *  bits 24-31 = reserved
      */
 
-    //
-    // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-    // XX                                                                         XX
-    // XX  If you modify this file, please update Image.GetColorDepth()           XX
-    // XX                                                                         XX
-    // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-    //
-    /// <include file='doc\PixelFormat.uex' path='docs/doc[@for="PixelFormat"]/*' />
-    /// <devdoc>
-    ///    Specifies the format of the color data for
-    ///    each pixel in the image.
-    /// </devdoc>
+    // If you modify this file, please update Image.GetColorDepth()
+
+    /// <summary>
+    /// Specifies the format of the color data for each pixel in the image.
+    /// </summary>
     public enum PixelFormat
     {
-        /// <include file='doc\PixelFormat.uex' path='docs/doc[@for="PixelFormat.Indexed"]/*' />
-        /// <devdoc>
-        ///    Specifies that pixel data contains
-        ///    color indexed values which means they are an index to colors in the system color
-        ///    table, as opposed to individual color values.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies that pixel data contains color indexed values which means they are an index to colors in the
+        /// system color table, as opposed to individual color values.
+        /// </summary>
         Indexed = 0x00010000,
-        /// <include file='doc\PixelFormat.uex' path='docs/doc[@for="PixelFormat.Gdi"]/*' />
-        /// <devdoc>
-        ///    Specifies that pixel data contains GDI
-        ///    colors.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies that pixel data contains GDI colors.
+        /// </summary>
         Gdi = 0x00020000,
-        /// <include file='doc\PixelFormat.uex' path='docs/doc[@for="PixelFormat.Alpha"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Specifies that pixel data contains alpha values that are
-        ///       not pre-multiplied.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Specifies that pixel data contains alpha values that are not pre-multiplied.
+        /// </summary>
         Alpha = 0x00040000,
-        /// <include file='doc\PixelFormat.uex' path='docs/doc[@for="PixelFormat.PAlpha"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Specifies that pixel format contains pre-multipled alpha values.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Specifies that pixel format contains pre-multipled alpha values.
+        /// </summary>
         PAlpha = 0x00080000, // What's this?
-        /// <include file='doc\PixelFormat.uex' path='docs/doc[@for="PixelFormat.Extended"]/*' />
-        /// <devdoc>
-        ///    Specifies that
-        /// </devdoc>
         Extended = 0x00100000,
-        /// <include file='doc\PixelFormat.uex' path='docs/doc[@for="PixelFormat.Canonical"]/*' />
-        /// <devdoc>
-        ///    Specifies that
-        /// </devdoc>
         Canonical = 0x00200000,
-        /// <include file='doc\PixelFormat.uex' path='docs/doc[@for="PixelFormat.Undefined"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Specifies that pixel format is undefined.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Specifies that pixel format is undefined.
+        /// </summary>
         Undefined = 0,
-        /// <include file='doc\PixelFormat.uex' path='docs/doc[@for="PixelFormat.DontCare"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Specifies that pixel format is a don't care.
-        ///    </para>
-        /// </devdoc>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
+        /// <summary>
+        /// Specifies that pixel format is a don't care.
+        /// </summary>
         DontCare = 0,
         // makes it into devtools, we can change this.
-        /// <include file='doc\PixelFormat.uex' path='docs/doc[@for="PixelFormat.Format1bppIndexed"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Specifies thatpixel format is 1 bit per pixel indexed
-        ///       color. The color table therefore has two colors in it.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Specifies thatpixel format is 1 bit per pixel indexed color. The color table therefore has two colors in it.
+        /// </summary>
         Format1bppIndexed = 1 | (1 << 8) | (int)Indexed | (int)Gdi,
-        /// <include file='doc\PixelFormat.uex' path='docs/doc[@for="PixelFormat.Format4bppIndexed"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Specifies that pixel format is 4 bits per pixel indexed
-        ///       color. The color table therefore has 16 colors in it.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Specifies that pixel format is 4 bits per pixel indexed color. The color table therefore has 16 colors in it.
+        /// </summary>
         Format4bppIndexed = 2 | (4 << 8) | (int)Indexed | (int)Gdi,
-        /// <include file='doc\PixelFormat.uex' path='docs/doc[@for="PixelFormat.Format8bppIndexed"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Specifies that pixel format is 8 bits per pixel indexed
-        ///       color. The color table therefore has 256 colors in it.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Specifies that pixel format is 8 bits per pixel indexed color. The color table therefore has 256 colors in it.
+        /// </summary>
         Format8bppIndexed = 3 | (8 << 8) | (int)Indexed | (int)Gdi,
-        /// <include file='doc\PixelFormat.uex' path='docs/doc[@for="PixelFormat.Format16bppGrayScale"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         Format16bppGrayScale = 4 | (16 << 8) | (int)Extended,
-        /// <include file='doc\PixelFormat.uex' path='docs/doc[@for="PixelFormat.Format16bppRgb555"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Specifies that pixel format is 16 bits per pixel. The
-        ///       color information specifies 65536 shades of gray.
-        ///    </para>
-        /// </devdoc>                              
+        /// <summary>
+        /// Specifies that pixel format is 16 bits per pixel. The color information specifies 65536 shades of gray.
+        /// </summary>                              
         Format16bppRgb555 = 5 | (16 << 8) | (int)Gdi,
-        /// <include file='doc\PixelFormat.uex' path='docs/doc[@for="PixelFormat.Format16bppRgb565"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Specifies that pixel format is 16 bits per pixel. The
-        ///       color information specifies 32768 shades of color of which 5 bits are red, 5
-        ///       bits are green and 5 bits are blue.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Specifies that pixel format is 16 bits per pixel. The color information specifies 32768 shades of color of
+        /// which 5 bits are red, 5 bits are green and 5 bits are blue.
+        /// </summary>
         Format16bppRgb565 = 6 | (16 << 8) | (int)Gdi,
-        /// <include file='doc\PixelFormat.uex' path='docs/doc[@for="PixelFormat.Format16bppArgb1555"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Specifies that pixel format
-        ///       is 16 bits per pixel. The color information specifies 32768
-        ///       shades of color of which 5 bits are red, 5 bits are green, 5
-        ///       bits are blue and 1 bit is alpha.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Specifies that pixel format is 16 bits per pixel. The color information specifies 32768 shades of color of
+        /// which 5 bits are red, 5 bits are green, 5 bits are blue and 1 bit is alpha.
+        /// </summary>
         Format16bppArgb1555 = 7 | (16 << 8) | (int)Alpha | (int)Gdi,
-        /// <include file='doc\PixelFormat.uex' path='docs/doc[@for="PixelFormat.Format24bppRgb"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Specifies that pixel format is 24 bits per pixel. The
-        ///       color information specifies 16777216 shades of color of which 8 bits are red, 8
-        ///       bits are green and 8 bits are blue.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Specifies that pixel format is 24 bits per pixel. The color information specifies 16777216 shades of color
+        /// of which 8 bits are red, 8 bits are green and 8 bits are blue.
+        /// </summary>
         Format24bppRgb = 8 | (24 << 8) | (int)Gdi,
-        /// <include file='doc\PixelFormat.uex' path='docs/doc[@for="PixelFormat.Format32bppRgb"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Specifies that pixel format is 24 bits per pixel. The
-        ///       color information specifies 16777216 shades of color of which 8 bits are red, 8
-        ///       bits are green and 8 bits are blue.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Specifies that pixel format is 24 bits per pixel. The color information specifies 16777216 shades of color
+        /// of which 8 bits are red, 8 bits are green and 8 bits are blue.
+        /// </summary>
         Format32bppRgb = 9 | (32 << 8) | (int)Gdi,
-        /// <include file='doc\PixelFormat.uex' path='docs/doc[@for="PixelFormat.Format32bppArgb"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Specifies that pixel format is 32 bits per pixel. The
-        ///       color information specifies 16777216 shades of color of which 8 bits are red, 8
-        ///       bits are green and 8 bits are blue. The 8 additional bits are alpha bits.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Specifies that pixel format is 32 bits per pixel. The color information specifies 16777216 shades of color
+        /// of which 8 bits are red, 8 bits are green and 8 bits are blue. The 8 additional bits are alpha bits.
+        /// </summary>
         Format32bppArgb = 10 | (32 << 8) | (int)Alpha | (int)Gdi | (int)Canonical,
-        /// <include file='doc\PixelFormat.uex' path='docs/doc[@for="PixelFormat.Format32bppPArgb"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Specifies that
-        ///       pixel format is 32 bits per pixel. The color information
-        ///       specifies 16777216 shades of color of which 8 bits are red, 8 bits are
-        ///       green and 8 bits are blue. The 8 additional bits are pre-multiplied alpha bits. .
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Specifies that pixel format is 32 bits per pixel. The color information specifies 16777216 shades of color
+        /// of which 8 bits are red, 8 bits are green and 8 bits are blue. The 8 additional bits are pre-multiplied alpha bits.
+        /// </summary>
         Format32bppPArgb = 11 | (32 << 8) | (int)Alpha | (int)PAlpha | (int)Gdi,
-        /// <include file='doc\PixelFormat.uex' path='docs/doc[@for="PixelFormat.Format48bppRgb"]/*' />
-        /// <devdoc>
-        ///    Specifies that pixel format is 48 bits per pixel.
-        ///    The color information specifies 16777216 shades of color of which 8 bits are
-        ///    red, 8 bits are green and 8 bits are blue. The 8 additional bits are alpha bits.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies that pixel format is 48 bits per pixel. The color information specifies 16777216 shades of color
+        /// of which 8 bits are red, 8 bits are green and 8 bits are blue. The 8 additional bits are alpha bits.
+        /// </summary>
         Format48bppRgb = 12 | (48 << 8) | (int)Extended,
-        /// <include file='doc\PixelFormat.uex' path='docs/doc[@for="PixelFormat.Format64bppArgb"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Specifies pixel format is 64 bits per pixel. The
-        ///       color information specifies 16777216 shades of color of which 16 bits are red, 16
-        ///       bits are green and 16 bits are blue. The 16 additional bits are alpha bits.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Specifies pixel format is 64 bits per pixel. The color information specifies 16777216 shades of color of
+        /// which 16 bits are red, 16 bits are green and 16 bits are blue. The 16 additional bits are alpha bits.
+        /// </summary>
         Format64bppArgb = 13 | (64 << 8) | (int)Alpha | (int)Canonical | (int)Extended,
-        /// <include file='doc\PixelFormat.uex' path='docs/doc[@for="PixelFormat.Format64bppPArgb"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Specifies that pixel format is 64 bits per pixel. The
-        ///       color information specifies 16777216 shades of color of which 16 bits are red,
-        ///       16 bits are green and 16 bits are blue. The 16 additional bits are
-        ///       pre-multiplied alpha bits.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Specifies that pixel format is 64 bits per pixel. The color information specifies 16777216 shades of color
+        /// of which 16 bits are red, 16 bits are green and 16 bits are blue. The 16 additional bits are pre-multiplied
+        /// alpha bits.
+        /// </summary>
         Format64bppPArgb = 14 | (64 << 8) | (int)Alpha | (int)PAlpha | (int)Extended,
 
-        /// <include file='doc\PixelFormat.uex' path='docs/doc[@for="PixelFormat.Max"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Specifies that pixel format is 64 bits per pixel. The
-        ///       color information specifies 16777216 shades of color of which 16 bits are red,
-        ///       16 bits are green and 16 bits are blue. The 16 additional bits are alpha bits.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Specifies that pixel format is 64 bits per pixel. The color information specifies 16777216 shades of color
+        /// of which 16 bits are red, 16 bits are green and 16 bits are blue. The 16 additional bits are alpha bits.
+        /// </summary>
         Max = 15,
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/PlayRecordCallback.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/PlayRecordCallback.cs
@@ -4,13 +4,5 @@
 
 namespace System.Drawing.Imaging
 {
-    /// <include file='doc\PlayRecordCAllback.uex' path='docs/doc[@for="PlayRecodCallBack"]/*' />
-    /// <devdoc>
-    /// </devdoc>
-    public delegate void PlayRecordCallback(EmfPlusRecordType recordType,
-                                            int flags,
-                                            int dataSize,
-                                            IntPtr recordData);
+    public delegate void PlayRecordCallback(EmfPlusRecordType recordType, int flags, int dataSize, IntPtr recordData);
 }
-
-

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/PropertyItem.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/PropertyItem.cs
@@ -5,11 +5,9 @@
 namespace System.Drawing.Imaging
 {
     // sdkinc\imaging.h
-    /// <include file='doc\PropertyItem.uex' path='docs/doc[@for="PropertyItem"]/*' />
-    /// <devdoc>
-    ///    Encapsulates a metadata property to be
-    ///    included in an image file.
-    /// </devdoc>
+    /// <summary>
+    /// Encapsulates a metadata property to be included in an image file.
+    /// </summary>
     public sealed class PropertyItem
     {
         private int _id;
@@ -21,37 +19,33 @@ namespace System.Drawing.Imaging
         {
         }
 
-        /// <include file='doc\PropertyItem.uex' path='docs/doc[@for="PropertyItem.Id"]/*' />
-        /// <devdoc>
-        ///    Represents the ID of the property.
-        /// </devdoc>
+        /// <summary>
+        /// Represents the ID of the property.
+        /// </summary>
         public int Id
         {
             get { return _id; }
             set { _id = value; }
         }
-        /// <include file='doc\PropertyItem.uex' path='docs/doc[@for="PropertyItem.Len"]/*' />
-        /// <devdoc>
-        ///    Represents the length of the property.
-        /// </devdoc>
+        /// <summary>
+        /// Represents the length of the property.
+        /// </summary>
         public int Len
         {
             get { return _len; }
             set { _len = value; }
         }
-        /// <include file='doc\PropertyItem.uex' path='docs/doc[@for="PropertyItem.Type"]/*' />
-        /// <devdoc>
-        ///    Represents the type of the property.
-        /// </devdoc>
+        /// <summary>
+        /// Represents the type of the property.
+        /// </summary>
         public short Type
         {
             get { return _type; }
             set { _type = value; }
         }
-        /// <include file='doc\PropertyItem.uex' path='docs/doc[@for="PropertyItem.Value"]/*' />
-        /// <devdoc>
-        ///    Contains the property value.
-        /// </devdoc>
+        /// <summary>
+        /// Contains the property value.
+        /// </summary>
         public byte[] Value
         {
             get { return _value; }
@@ -59,4 +53,3 @@ namespace System.Drawing.Imaging
         }
     }
 }
-

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/WmfPlaceableFileHeader.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/WmfPlaceableFileHeader.cs
@@ -2,14 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
+
 namespace System.Drawing.Imaging
 {
-    using System.Runtime.InteropServices;
-
-    /// <include file='doc\WmfPlaceableFileHeader.uex' path='docs/doc[@for="WmfPlaceableFileHeader"]/*' />
-    /// <devdoc>
-    ///    Defines an Placeable Metafile.
-    /// </devdoc>
+    /// <summary>
+    /// Defines an Placeable Metafile.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public sealed class WmfPlaceableFileHeader
     {
@@ -23,105 +22,81 @@ namespace System.Drawing.Imaging
         private int _reserved;
         private short _checksum;
 
-        /// <include file='doc\WmfPlaceableFileHeader.uex' path='docs/doc[@for="WmfPlaceableFileHeader.Key"]/*' />
-        /// <devdoc>
-        ///    Indicates the presence of a placeable
-        ///    metafile header.
-        /// </devdoc>
+        /// <summary>
+        /// Indicates the presence of a placeable metafile header.
+        /// </summary>
         public int Key
         {
             get { return _key; }
             set { _key = value; }
         }
 
-        /// <include file='doc\WmfPlaceableFileHeader.uex' path='docs/doc[@for="WmfPlaceableFileHeader.Hmf"]/*' />
-        /// <devdoc>
-        ///    Stores the handle of the metafile in
-        ///    memory.
-        /// </devdoc>
+        /// <summary>
+        /// Stores the handle of the metafile in memory.
+        /// </summary>
         public short Hmf
         {
             get { return _hmf; }
             set { _hmf = value; }
         }
 
-        /// <include file='doc\WmfPlaceableFileHeader.uex' path='docs/doc[@for="WmfPlaceableFileHeader.BboxLeft"]/*' />
-        /// <devdoc>
-        ///    The x-coordinate of the upper-left corner
-        ///    of the bounding rectangle of the metafile image on the output device.
-        /// </devdoc>
+        /// <summary>
+        /// The x-coordinate of the upper-left corner of the bounding rectangle of the metafile image on the output device.
+        /// </summary>
         public short BboxLeft
         {
             get { return _bboxLeft; }
             set { _bboxLeft = value; }
         }
 
-        /// <include file='doc\WmfPlaceableFileHeader.uex' path='docs/doc[@for="WmfPlaceableFileHeader.BboxTop"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       The y-coordinate of the upper-left corner of the bounding rectangle of the
-        ///       metafile image on the output device.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// The y-coordinate of the upper-left corner of the bounding rectangle of the metafile image on the output device.
+        /// </summary>
         public short BboxTop
         {
             get { return _bboxTop; }
             set { _bboxTop = value; }
         }
 
-        /// <include file='doc\WmfPlaceableFileHeader.uex' path='docs/doc[@for="WmfPlaceableFileHeader.BboxRight"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       The x-coordinate of the lower-right corner of the bounding rectangle of the
-        ///       metafile image on the output device.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// The x-coordinate of the lower-right corner of the bounding rectangle of the metafile image on the output device.
+        /// </summary>
         public short BboxRight
         {
             get { return _bboxRight; }
             set { _bboxRight = value; }
         }
 
-        /// <include file='doc\WmfPlaceableFileHeader.uex' path='docs/doc[@for="WmfPlaceableFileHeader.BboxBottom"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       The y-coordinate of the lower-right corner of the bounding rectangle of the
-        ///       metafile image on the output device.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// The y-coordinate of the lower-right corner of the bounding rectangle of the metafile image on the output device.
+        /// </summary>
         public short BboxBottom
         {
             get { return _bboxBottom; }
             set { _bboxBottom = value; }
         }
 
-        /// <include file='doc\WmfPlaceableFileHeader.uex' path='docs/doc[@for="WmfPlaceableFileHeader.Inch"]/*' />
-        /// <devdoc>
-        ///    Indicates the number of twips per inch.
-        /// </devdoc>
+        /// <summary>
+        /// Indicates the number of twips per inch.
+        /// </summary>
         public short Inch
         {
             get { return _inch; }
             set { _inch = value; }
         }
 
-        /// <include file='doc\WmfPlaceableFileHeader.uex' path='docs/doc[@for="WmfPlaceableFileHeader.Reserved"]/*' />
-        /// <devdoc>
-        ///    Reserved. Do not use.
-        /// </devdoc>
+        /// <summary>
+        ///  Reserved. Do not use.
+        /// </summary>
         public int Reserved
         {
             get { return _reserved; }
             set { _reserved = value; }
         }
 
-        /// <include file='doc\WmfPlaceableFileHeader.uex' path='docs/doc[@for="WmfPlaceableFileHeader.Checksum"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Indicates the checksum value for the
-        ///       previous ten WORDs in the header.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Indicates the checksum value for the previous ten WORDs in the header.
+        /// </summary>
         public short Checksum
         {
             get { return _checksum; }

--- a/src/System.Drawing.Common/src/System/Drawing/Pen.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Pen.cs
@@ -2,21 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Drawing.Drawing2D;
+using System.Drawing.Internal;
+using System.Globalization;
+using System.Runtime.InteropServices;
+
 namespace System.Drawing
 {
-    using System.ComponentModel;
-    using System.Diagnostics;
-    using System.Drawing.Drawing2D;
-    using System.Drawing.Internal;
-    using System.Globalization;
-    using System.Runtime.InteropServices;
-
-    /// <include file='doc\Pen.uex' path='docs/doc[@for="Pen"]/*' />
-    /// <devdoc>
-    ///     <para>
-    ///         Defines an object used to draw lines and curves.
-    ///     </para>
-    /// </devdoc>
+    /// <summary>
+    /// Defines an object used to draw lines and curves.
+    /// </summary>
     public sealed class Pen : MarshalByRefObject, ISystemColorTracker, ICloneable, IDisposable
     {
 #if FINALIZATION_WATCH
@@ -30,9 +27,9 @@ namespace System.Drawing
         private Color _color;
         private bool _immutable;
 
-        /// <devdoc>
-        ///     Creates a Pen from a native GDI+ object.
-        /// </devdoc>
+        /// <summary>
+        /// Creates a Pen from a native GDI+ object.
+        /// </summary>
         private Pen(IntPtr nativePen)
         {
             SetNativePen(nativePen);
@@ -44,24 +41,17 @@ namespace System.Drawing
             _immutable = immutable;
         }
 
-        /// <include file='doc\Pen.uex' path='docs/doc[@for="Pen.Pen"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the Pen
-        ///       class with the specified <see cref='System.Drawing.Pen.Color'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the Pen class with the specified <see cref='Color'/>.
+        /// </summary>
         public Pen(Color color) : this(color, (float)1.0)
         {
         }
 
-        /// <include file='doc\Pen.uex' path='docs/doc[@for="Pen.Pen1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Pen'/>  class with the specified 
-        ///       <see cref='System.Drawing.Pen.Color'/> and <see cref='System.Drawing.Pen.Width'/>.
-        /// </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Pen'/> class with the specified
+        /// <see cref='Color'/> and <see cref='Width'/>.
+        /// </summary>
         public Pen(Color color, float width)
         {
             _color = color;
@@ -85,24 +75,16 @@ namespace System.Drawing
 #endif
         }
 
-        /// <include file='doc\Pen.uex' path='docs/doc[@for="Pen.Pen2"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the Pen class with the
-        ///       specified <see cref='System.Drawing.Pen.Brush'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the Pen class with the specified <see cref='Brush'/>.
+        /// </summary>
         public Pen(Brush brush) : this(brush, (float)1.0)
         {
         }
 
-        /// <include file='doc\Pen.uex' path='docs/doc[@for="Pen.Pen3"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Pen'/> class with
-        ///       the specified <see cref='System.Drawing.Brush'/> and width.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='Pen'/> class with the specified <see cref='Drawing.Brush'/> and width.
+        /// </summary>
         public Pen(Brush brush, float width)
         {
             IntPtr pen = IntPtr.Zero;
@@ -131,9 +113,9 @@ namespace System.Drawing
             _nativePen = nativePen;
         }
 
-        /// <devdoc>
-        ///    Gets the GDI+ native object.
-        /// </devdoc>
+        /// <summary>
+        /// Gets the GDI+ native object.
+        /// </summary>
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
         internal IntPtr NativePen
         {
@@ -145,13 +127,9 @@ namespace System.Drawing
             }
         }
 
-        /**
-         * Create a copy of the pen object
-         */
-        /// <include file='doc\Pen.uex' path='docs/doc[@for="Pen.Clone"]/*' />
-        /// <devdoc>
-        ///     Creates an exact copy of this <see cref='System.Drawing.Pen'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Creates an exact copy of this <see cref='System.Drawing.Pen'/>.
+        /// </summary>
         public object Clone()
         {
             IntPtr clonePen = IntPtr.Zero;
@@ -166,13 +144,9 @@ namespace System.Drawing
             return new Pen(clonePen);
         }
 
-        /**
-         * Dispose of resources associated with the Pen object
-         */
-        /// <include file='doc\Pen.uex' path='docs/doc[@for="Pen.Dispose"]/*' />
-        /// <devdoc>
-        ///    Cleans up Windows resources for this <see cref='System.Drawing.Pen'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Cleans up Windows resources for this <see cref='System.Drawing.Pen'/>.
+        /// </summary>
         public void Dispose()
         {
             Dispose(true);
@@ -227,22 +201,17 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Pen.uex' path='docs/doc[@for="Pen.Finalize"]/*' />
-        /// <devdoc>
-        ///    Cleans up Windows resources for this <see cref='System.Drawing.Pen'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Cleans up Windows resources for this <see cref='System.Drawing.Pen'/>.
+        /// </summary>
         ~Pen()
         {
             Dispose(false);
         }
 
-        /**
-         * Set/get pen width
-         */
-        /// <include file='doc\Pen.uex' path='docs/doc[@for="Pen.Width"]/*' />
-        /// <devdoc>
-        ///    Gets or sets the width of this <see cref='System.Drawing.Pen'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the width of this <see cref='System.Drawing.Pen'/>.
+        /// </summary>
         public float Width
         {
             get
@@ -269,16 +238,9 @@ namespace System.Drawing
             }
         }
 
-        /**
-         * Set/get line caps: start, end, and dash
-         */
-        /// <include file='doc\Pen.uex' path='docs/doc[@for="Pen.SetLineCap"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Sets the values that determine the style of
-        ///       cap used to end lines drawn by this <see cref='System.Drawing.Pen'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Sets the values that determine the style of cap used to end lines drawn by this <see cref='Pen'/>.
+        /// </summary>
         public void SetLineCap(LineCap startCap, LineCap endCap, DashCap dashCap)
         {
             if (_immutable)
@@ -290,13 +252,9 @@ namespace System.Drawing
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        /// <include file='doc\Pen.uex' path='docs/doc[@for="Pen.StartCap"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets or sets the cap style used at the
-        ///       beginning of lines drawn with this <see cref='System.Drawing.Pen'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the cap style used at the beginning of lines drawn with this <see cref='Pen'/>.
+        /// </summary>
         public LineCap StartCap
         {
             get
@@ -339,13 +297,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Pen.uex' path='docs/doc[@for="Pen.EndCap"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets or sets the cap style used at the end of
-        ///       lines drawn with this <see cref='System.Drawing.Pen'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the cap style used at the end of lines drawn with this <see cref='Pen'/>.
+        /// </summary>
         public LineCap EndCap
         {
             get
@@ -389,11 +343,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Pen.uex' path='docs/doc[@for="Pen.DashCap"]/*' />
-        /// <devdoc>
-        ///    Gets or sets the cap style used at the
-        ///    beginning or end of dashed lines drawn with this <see cref='System.Drawing.Pen'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the cap style used at the beginning or end of dashed lines drawn with this <see cref='Pen'/>.
+        /// </summary>
         public DashCap DashCap
         {
             get
@@ -428,14 +380,9 @@ namespace System.Drawing
             }
         }
 
-        /**
-        * Set/get line join
-        */
-        /// <include file='doc\Pen.uex' path='docs/doc[@for="Pen.LineJoin"]/*' />
-        /// <devdoc>
-        ///    Gets or sets the join style for the ends of
-        ///    two overlapping lines drawn with this <see cref='System.Drawing.Pen'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the join style for the ends of two overlapping lines drawn with this <see cref='Pen'/>.
+        /// </summary>
         public LineJoin LineJoin
         {
             get
@@ -467,16 +414,9 @@ namespace System.Drawing
             }
         }
 
-        /**
-         * Set/get custom start line cap
-         */
-        /// <include file='doc\Pen.uex' path='docs/doc[@for="Pen.CustomStartCap"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets or sets a custom cap style to use at the beginning of lines
-        ///       drawn with this <see cref='System.Drawing.Pen'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets a custom cap style to use at the beginning of lines drawn with this <see cref='Pen'/>.
+        /// </summary>
         public CustomLineCap CustomStartCap
         {
             get
@@ -503,16 +443,9 @@ namespace System.Drawing
             }
         }
 
-        /**
-         * Set/get custom end line cap
-         */
-        /// <include file='doc\Pen.uex' path='docs/doc[@for="Pen.CustomEndCap"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets or sets a custom cap style to use at the end of lines
-        ///       drawn with this <see cref='System.Drawing.Pen'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets a custom cap style to use at the end of lines drawn with this <see cref='Pen'/>.
+        /// </summary>
         public CustomLineCap CustomEndCap
         {
             get
@@ -539,11 +472,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Pen.uex' path='docs/doc[@for="Pen.MiterLimit"]/*' />
-        /// <devdoc>
-        ///    Gets or sets the limit of the thickness of
-        ///    the join on a mitered corner.
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the limit of the thickness of the join on a mitered corner.
+        /// </summary>
         public float MiterLimit
         {
             get
@@ -569,16 +500,9 @@ namespace System.Drawing
             }
         }
 
-        /**
-         * Pen Mode
-         */
-        /// <include file='doc\Pen.uex' path='docs/doc[@for="Pen.Alignment"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets or sets
-        ///       the alignment for objects drawn with this <see cref='System.Drawing.Pen'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the alignment for objects drawn with this <see cref='Pen'/>.
+        /// </summary>
         public PenAlignment Alignment
         {
             get
@@ -611,16 +535,9 @@ namespace System.Drawing
             }
         }
 
-        /**
-         * Set/get pen transform
-         */
-        /// <include file='doc\Pen.uex' path='docs/doc[@for="Pen.Transform"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets
-        ///       or sets the geometrical transform for objects drawn with this <see cref='System.Drawing.Pen'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the geometrical transform for objects drawn with this <see cref='Pen'/>.
+        /// </summary>
         public Matrix Transform
         {
             get
@@ -652,12 +569,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Pen.uex' path='docs/doc[@for="Pen.ResetTransform"]/*' />
-        /// <devdoc>
-        ///    Resets the geometric transform for this
-        /// <see cref='System.Drawing.Pen'/> to 
-        ///    identity.
-        /// </devdoc>
+        /// <summary>
+        /// Resets the geometric transform for this <see cref='Pen'/> to identity.
+        /// </summary>
         public void ResetTransform()
         {
             int status = SafeNativeMethods.Gdip.GdipResetPenTransform(new HandleRef(this, NativePen));
@@ -666,27 +580,17 @@ namespace System.Drawing
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        /// <include file='doc\Pen.uex' path='docs/doc[@for="Pen.MultiplyTransform"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Multiplies the transform matrix for this
-        ///    <see cref='System.Drawing.Pen'/> by 
-        ///       the specified <see cref='System.Drawing.Drawing2D.Matrix'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Multiplies the transform matrix for this <see cref='Pen'/> by the specified <see cref='Matrix'/>.
+        /// </summary>
         public void MultiplyTransform(Matrix matrix)
         {
             MultiplyTransform(matrix, MatrixOrder.Prepend);
         }
 
-        /// <include file='doc\Pen.uex' path='docs/doc[@for="Pen.MultiplyTransform1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Multiplies the transform matrix for this
-        ///    <see cref='System.Drawing.Pen'/> by 
-        ///       the specified <see cref='System.Drawing.Drawing2D.Matrix'/> in the specified order.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Multiplies the transform matrix for this <see cref='Pen'/> by the specified <see cref='Matrix'/> in the specified order.
+        /// </summary>
         public void MultiplyTransform(Matrix matrix, MatrixOrder order)
         {
             int status = SafeNativeMethods.Gdip.GdipMultiplyPenTransform(new HandleRef(this, NativePen),
@@ -697,24 +601,18 @@ namespace System.Drawing
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        /// <include file='doc\Pen.uex' path='docs/doc[@for="Pen.TranslateTransform"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Translates the local geometrical transform
-        ///       by the specified dimmensions. This method prepends the translation to the
-        ///       transform.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Translates the local geometrical transform by the specified dimmensions. This method prepends the translation
+        /// to the transform.
+        /// </summary>
         public void TranslateTransform(float dx, float dy)
         {
             TranslateTransform(dx, dy, MatrixOrder.Prepend);
         }
 
-        /// <include file='doc\Pen.uex' path='docs/doc[@for="Pen.TranslateTransform1"]/*' />
-        /// <devdoc>
-        ///    Translates the local geometrical transform
-        ///    by the specified dimmensions in the specified order.
-        /// </devdoc>
+        /// <summary>
+        /// Translates the local geometrical transform by the specified dimmensions in the specified order.
+        /// </summary>
         public void TranslateTransform(float dx, float dy, MatrixOrder order)
         {
             int status = SafeNativeMethods.Gdip.GdipTranslatePenTransform(new HandleRef(this, NativePen),
@@ -724,23 +622,17 @@ namespace System.Drawing
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        /// <include file='doc\Pen.uex' path='docs/doc[@for="Pen.ScaleTransform"]/*' />
-        /// <devdoc>
-        ///    Scales the local geometric transform by the
-        ///    specified amounts. This method prepends the scaling matrix to the transform.
-        /// </devdoc>
+        /// <summary>
+        /// Scales the local geometric transform by the specified amounts. This method prepends the scaling matrix to the transform.
+        /// </summary>
         public void ScaleTransform(float sx, float sy)
         {
             ScaleTransform(sx, sy, MatrixOrder.Prepend);
         }
 
-        /// <include file='doc\Pen.uex' path='docs/doc[@for="Pen.ScaleTransform1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Scales the local geometric transform by the
-        ///       specified amounts in the specified order.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Scales the local geometric transform by the specified amounts in the specified order.
+        /// </summary>
         public void ScaleTransform(float sx, float sy, MatrixOrder order)
         {
             int status = SafeNativeMethods.Gdip.GdipScalePenTransform(new HandleRef(this, NativePen),
@@ -750,23 +642,17 @@ namespace System.Drawing
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        /// <include file='doc\Pen.uex' path='docs/doc[@for="Pen.RotateTransform"]/*' />
-        /// <devdoc>
-        ///    Rotates the local geometric transform by the
-        ///    specified amount. This method prepends the rotation to the transform.
-        /// </devdoc>
+        /// <summary>
+        /// Rotates the local geometric transform by the specified amount. This method prepends the rotation to the transform.
+        /// </summary>
         public void RotateTransform(float angle)
         {
             RotateTransform(angle, MatrixOrder.Prepend);
         }
 
-        /// <include file='doc\Pen.uex' path='docs/doc[@for="Pen.RotateTransform1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Rotates the local geometric transform by the specified
-        ///       amount in the specified order.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Rotates the local geometric transform by the specified amount in the specified order.
+        /// </summary>
         public void RotateTransform(float angle, MatrixOrder order)
         {
             int status = SafeNativeMethods.Gdip.GdipRotatePenTransform(new HandleRef(this, NativePen),
@@ -775,13 +661,6 @@ namespace System.Drawing
             if (status != SafeNativeMethods.Gdip.Ok)
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
-
-        /**
-         * Set/get pen type (color, line texture, or brush)
-         *
-         * @notes GetLineFill returns either a Brush object
-         *  or a LineTexture object.
-         */
 
         private void InternalSetColor(Color value)
         {
@@ -793,11 +672,9 @@ namespace System.Drawing
             _color = value;
         }
 
-        /// <include file='doc\Pen.uex' path='docs/doc[@for="Pen.PenType"]/*' />
-        /// <devdoc>
-        ///    Gets the style of lines drawn with this
-        /// <see cref='System.Drawing.Pen'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets the style of lines drawn with this <see cref='Pen'/>.
+        /// </summary>
         public PenType PenType
         {
             get
@@ -813,12 +690,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Pen.uex' path='docs/doc[@for="Pen.Color"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets or sets the color of this <see cref='System.Drawing.Pen'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the color of this <see cref='Pen'/>.
+        /// </summary>
         public Color Color
         {
             get
@@ -861,11 +735,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Pen.uex' path='docs/doc[@for="Pen.Brush"]/*' />
-        /// <devdoc>
-        ///    Gets or sets the <see cref='System.Drawing.Brush'/> that
-        ///    determines attributes of this <see cref='System.Drawing.Pen'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the <see cref='Drawing.Brush'/> that determines attributes of this <see cref='Pen'/>.
+        /// </summary>
         public Brush Brush
         {
             get
@@ -929,14 +801,9 @@ namespace System.Drawing
             return nativeBrush;
         }
 
-        /**
-         * Set/get dash attributes
-         */
-        /// <include file='doc\Pen.uex' path='docs/doc[@for="Pen.DashStyle"]/*' />
-        /// <devdoc>
-        ///    Gets or sets the style used for dashed
-        ///    lines drawn with this <see cref='System.Drawing.Pen'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the style used for dashed lines drawn with this <see cref='Pen'/>.
+        /// </summary>
         public DashStyle DashStyle
         {
             get
@@ -979,11 +846,10 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Pen.uex' path='docs/doc[@for="Pen.EnsureValidDashPattern"]/*' />
-        /// <devdoc>
-        ///    This method is called after the user sets the pen's dash style to custom.
-        ///    Here, we make sure that there is a default value set for the custom pattern.
-        /// </devdoc>
+        /// <summary>
+        /// This method is called after the user sets the pen's dash style to custom. Here, we make sure that there
+        /// is a default value set for the custom pattern.
+        /// </summary>
         private void EnsureValidDashPattern()
         {
             int retval = 0;
@@ -999,11 +865,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Pen.uex' path='docs/doc[@for="Pen.DashOffset"]/*' />
-        /// <devdoc>
-        ///    Gets or sets the distance from the start of
-        ///    a line to the beginning of a dash pattern.
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the distance from the start of a line to the beginning of a dash pattern.
+        /// </summary>
         public float DashOffset
         {
             get
@@ -1029,13 +893,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Pen.uex' path='docs/doc[@for="Pen.DashPattern"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets or sets an array of cutom dashes and
-        ///       spaces. The dashes are made up of line segments.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets an array of cutom dashes and spaces. The dashes are made up of line segments.
+        /// </summary>
         public float[] DashPattern
         {
             get
@@ -1111,11 +971,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Pen.uex' path='docs/doc[@for="Pen.CompoundArray"]/*' />
-        /// <devdoc>
-        ///    Gets or sets an array of cutom dashes and
-        ///    spaces. The dashes are made up of line segments.
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets an array of cutom dashes and spaces. The dashes are made up of line segments.
+        /// </summary>
         public float[] CompoundArray
         {
             get
@@ -1147,8 +1005,6 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\Pen.uex' path='docs/doc[@for="Pen.ISystemColorTracker.OnSystemColorChanged"]/*' />
-        /// <internalonly/>
         void ISystemColorTracker.OnSystemColorChanged()
         {
             if (NativePen != IntPtr.Zero)

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/DefaultPrintController.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/DefaultPrintController.cs
@@ -2,29 +2,24 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Drawing.Internal;
+using System.Runtime.InteropServices;
+
 namespace System.Drawing.Printing
 {
-    using System.ComponentModel;
-    using System.Diagnostics;
-    using System.Drawing.Internal;
-    using System.Runtime.InteropServices;
-
-    /// <include file='doc\DefaultPrintController.uex' path='docs/doc[@for="StandardPrintController"]/*' />
-    /// <devdoc>
-    ///    <para>Specifies a print controller that sends information to a printer.
-    ///       </para>
-    /// </devdoc>
+    /// <summary>
+    /// Specifies a print controller that sends information to a printer.
+    /// </summary>
     public class StandardPrintController : PrintController
     {
         private DeviceContext _dc;
         private Graphics _graphics;
 
-        /// <include file='doc\DefaultPrintController.uex' path='docs/doc[@for="StandardPrintController.OnStartPrint"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Implements StartPrint for printing to a physical printer.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Implements StartPrint for printing to a physical printer.
+        /// </summary>
         public override void OnStartPrint(PrintDocument document, PrintEventArgs e)
         {
             Debug.Assert(_dc == null && _graphics == null, "PrintController methods called in the wrong order?");
@@ -59,12 +54,9 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\DefaultPrintController.uex' path='docs/doc[@for="StandardPrintController.OnStartPage"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Implements StartPage for printing to a physical printer.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Implements StartPage for printing to a physical printer.
+        /// </summary>
         public override Graphics OnStartPage(PrintDocument document, PrintPageEventArgs e)
         {
             Debug.Assert(_dc != null && _graphics == null, "PrintController methods called in the wrong order?");
@@ -110,12 +102,9 @@ namespace System.Drawing.Printing
             return _graphics;
         }
 
-        /// <include file='doc\DefaultPrintController.uex' path='docs/doc[@for="StandardPrintController.OnEndPage"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Implements EndPage for printing to a physical printer.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Implements EndPage for printing to a physical printer.
+        /// </summary>
         public override void OnEndPage(PrintDocument document, PrintPageEventArgs e)
         {
             Debug.Assert(_dc != null && _graphics != null, "PrintController methods called in the wrong order?");
@@ -134,12 +123,9 @@ namespace System.Drawing.Printing
             base.OnEndPage(document, e);
         }
 
-        /// <include file='doc\DefaultPrintController.uex' path='docs/doc[@for="StandardPrintController.OnEndPrint"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Implements EndPrint for printing to a physical printer.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Implements EndPrint for printing to a physical printer.
+        /// </summary>
         public override void OnEndPrint(PrintDocument document, PrintEventArgs e)
         {
             Debug.Assert(_dc != null && _graphics == null, "PrintController methods called in the wrong order?");

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/Duplex.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/Duplex.cs
@@ -4,44 +4,29 @@
 
 namespace System.Drawing.Printing
 {
-    /// <include file='doc\Duplex.uex' path='docs/doc[@for="Duplex"]/*' />
-    /// <devdoc>
-    ///    <para>Specifies the printer's duplex setting.</para>
-    /// </devdoc>
+    /// <summary>
+    /// Specifies the printer's duplex setting.
+    /// </summary>
     public enum Duplex
     {
-        /// <include file='doc\Duplex.uex' path='docs/doc[@for="Duplex.Default"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       The printer's default duplex setting.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// The printer's default duplex setting.
+        /// </summary>
         Default = -1,
 
-        /// <include file='doc\Duplex.uex' path='docs/doc[@for="Duplex.Simplex"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Single-sided printing.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Single-sided printing.
+        /// </summary>
         Simplex = SafeNativeMethods.DMDUP_SIMPLEX,
 
-        /// <include file='doc\Duplex.uex' path='docs/doc[@for="Duplex.Horizontal"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Double-sided, horizontal printing.
-        ///       
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Double-sided, horizontal printing.
+        /// </summary>
         Horizontal = SafeNativeMethods.DMDUP_HORIZONTAL,
 
-        /// <include file='doc\Duplex.uex' path='docs/doc[@for="Duplex.Vertical"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Double-sided, vertical printing.
-        ///       
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Double-sided, vertical printing.
+        /// </summary>
         Vertical = SafeNativeMethods.DMDUP_VERTICAL,
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/InvalidPrinterException.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/InvalidPrinterException.cs
@@ -2,28 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Security;
+
 namespace System.Drawing.Printing
 {
-    using System.Security;
-
-    /// <include file='doc\InvalidPrinterException.uex' path='docs/doc[@for="InvalidPrinterException"]/*' />
-    /// <devdoc>
-    ///    <para>
-    ///       Represents
-    ///       the
-    ///       exception that is thrown when trying to access a printer using invalid printer settings.
-    ///    </para>
-    /// </devdoc>
+    /// <summary>
+    /// Represents the exception that is thrown when trying to access a printer using invalid printer settings.
+    /// </summary>
     public partial class InvalidPrinterException : SystemException
     {
         private PrinterSettings _settings;
 
-        /// <include file='doc\InvalidPrinterException.uex' path='docs/doc[@for="InvalidPrinterException.InvalidPrinterException"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Printing.InvalidPrinterException'/> class.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='InvalidPrinterException'/> class.
+        /// </summary>
         public InvalidPrinterException(PrinterSettings settings)
         : base(GenerateMessage(settings))
         {

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/Margins.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/Margins.cs
@@ -2,23 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Globalization;
+using System.Runtime.Serialization;
+
 namespace System.Drawing.Printing
 {
-    using System.Globalization;
-    using System.Runtime.Serialization;
-
-    /// <include file='doc\Margins.uex' path='docs/doc[@for="Margins"]/*' />
-    /// <devdoc>
-    ///    <para>
-    ///       Specifies the margins of a printed page.
-    ///    </para>
-    /// </devdoc>
+    /// <summary>
+    /// Specifies the margins of a printed page.
+    /// </summary>
     public partial class Margins : ICloneable
     {
         private int _left;
         private int _right;
-        private int _top;
         private int _bottom;
+        private int _top;
 
         [OptionalField]
         private double _doubleLeft;
@@ -29,23 +26,16 @@ namespace System.Drawing.Printing
         [OptionalField]
         private double _doubleBottom;
 
-        /// <include file='doc\Margins.uex' path='docs/doc[@for="Margins.Margins"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of a the <see cref='System.Drawing.Printing.Margins'/> class with one-inch margins.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of a the <see cref='Margins'/> class with one-inch margins.
+        /// </summary>
         public Margins() : this(100, 100, 100, 100)
         {
         }
 
-        /// <include file='doc\Margins.uex' path='docs/doc[@for="Margins.Margins1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of a the <see cref='System.Drawing.Printing.Margins'/> class with the specified left, right, top, and bottom
-        ///       margins.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of a the <see cref='Margins'/> class with the specified left, right, top, and bottom margins.
+        /// </summary>
         public Margins(int left, int right, int top, int bottom)
         {
             CheckMargin(left, "left");
@@ -64,12 +54,9 @@ namespace System.Drawing.Printing
             _doubleBottom = (double)bottom;
         }
 
-        /// <include file='doc\Margins.uex' path='docs/doc[@for="Margins.Left"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets or sets the left margin, in hundredths of an inch.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the left margin, in hundredths of an inch.
+        /// </summary>
         public int Left
         {
             get { return _left; }
@@ -81,12 +68,9 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\Margins.uex' path='docs/doc[@for="Margins.Right"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets or sets the right margin, in hundredths of an inch.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the right margin, in hundredths of an inch.
+        /// </summary>
         public int Right
         {
             get { return _right; }
@@ -98,12 +82,9 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\Margins.uex' path='docs/doc[@for="Margins.Top"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets or sets the top margin, in hundredths of an inch.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the top margin, in hundredths of an inch.
+        /// </summary>
         public int Top
         {
             get { return _top; }
@@ -115,12 +96,9 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\Margins.uex' path='docs/doc[@for="Margins.Bottom"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets or sets the bottom margin, in hundredths of an inch.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the bottom margin, in hundredths of an inch.
+        /// </summary>
         public int Bottom
         {
             get { return _bottom; }
@@ -132,14 +110,11 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\Margins.uex' path='docs/doc[@for="Margins.DoubleLeft"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets or sets the left margin with double value, in hundredths of an inch.
-        ///       When use the setter, the ranger of setting double value should between
-        ///       0 to Int.MaxValue;
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the left margin with double value, in hundredths of an inch.
+        /// When use the setter, the ranger of setting double value should between
+        /// 0 to Int.MaxValue;
+        /// </summary>
         internal double DoubleLeft
         {
             get { return _doubleLeft; }
@@ -150,14 +125,11 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\Margins.uex' path='docs/doc[@for="Margins.DoubleRight"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets or sets the right margin with double value, in hundredths of an inch.
-        ///       When use the setter, the ranger of setting double value should between
-        ///       0 to Int.MaxValue;
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the right margin with double value, in hundredths of an inch.
+        /// When use the setter, the ranger of setting double value should between
+        /// 0 to Int.MaxValue;
+        /// </summary>
         internal double DoubleRight
         {
             get { return _doubleRight; }
@@ -168,14 +140,11 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\Margins.uex' path='docs/doc[@for="Margins.DoubleTop"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets or sets the top margin with double value, in hundredths of an inch.
-        ///       When use the setter, the ranger of setting double value should between
-        ///       0 to Int.MaxValue;
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the top margin with double value, in hundredths of an inch.
+        /// When use the setter, the ranger of setting double value should between
+        /// 0 to Int.MaxValue;
+        /// </summary>
         internal double DoubleTop
         {
             get { return _doubleTop; }
@@ -186,14 +155,11 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\Margins.uex' path='docs/doc[@for="Margins.DoubleBottom"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets or sets the bottom margin with double value, in hundredths of an inch.
-        ///       When use the setter, the ranger of setting double value should between
-        ///       0 to Int.MaxValue;
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the bottom margin with double value, in hundredths of an inch.
+        /// When use the setter, the ranger of setting double value should between
+        /// 0 to Int.MaxValue;
+        /// </summary>
         internal double DoubleBottom
         {
             get { return _doubleBottom; }
@@ -210,29 +176,25 @@ namespace System.Drawing.Printing
                 throw new ArgumentException(SR.Format(SR.InvalidLowBoundArgumentEx, name, margin, "0"));
         }
 
-        /// <include file='doc\Margins.uex' path='docs/doc[@for="Margins.Clone"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Retrieves a duplicate of this object, member by member.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Retrieves a duplicate of this object, member by member.
+        /// </summary>
         public object Clone()
         {
             return MemberwiseClone();
         }
 
-        /// <include file='doc\Margins.uex' path='docs/doc[@for="Margins.Equals"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Compares this <see cref='System.Drawing.Printing.Margins'/> to a specified <see cref='System.Drawing.Printing.Margins'/> to see whether they
-        ///       are equal.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Compares this <see cref='Margins'/> to a specified <see cref='Margins'/> to see whether they
+        /// are equal.
+        /// </summary>
         public override bool Equals(object obj)
         {
             Margins margins = obj as Margins;
-            if (margins == this) return true;
-            if (margins == null) return false;
+            if (margins == this)
+                return true;
+            if (margins == null)
+                return false;
 
             return margins.Left == Left
             && margins.Right == Right
@@ -240,13 +202,9 @@ namespace System.Drawing.Printing
             && margins.Bottom == Bottom;
         }
 
-        /// <include file='doc\Margins.uex' path='docs/doc[@for="Margins.GetHashCode"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Calculates and retrieves a hash code based on the left, right, top, and bottom
-        ///       margins.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Calculates and retrieves a hash code based on the left, right, top, and bottom margins.
+        /// </summary>
         public override int GetHashCode()
         {
             // return HashCodes.Combine(left, right, top, bottom);
@@ -263,11 +221,9 @@ namespace System.Drawing.Printing
             return unchecked((int)result);
         }
 
-        /// <include file='doc\Margins.uex' path='docs/doc[@for="Margins.operator=="]/*' />
-        /// <devdoc>
-        ///    Tests whether two <see cref='System.Drawing.Printing.Margins'/> objects
-        ///    are identical.
-        /// </devdoc>
+        /// <summary>
+        /// Tests whether two <see cref='Margins'/> objects are identical.
+        /// </summary>
         public static bool operator ==(Margins m1, Margins m2)
         {
             if (object.ReferenceEquals(m1, null) != object.ReferenceEquals(m2, null))
@@ -281,25 +237,17 @@ namespace System.Drawing.Printing
             return true;
         }
 
-        /// <include file='doc\Margins.uex' path='docs/doc[@for="Margins.operator!="]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Tests whether two <see cref='System.Drawing.Printing.Margins'/> objects are different.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Tests whether two <see cref='Margins'/> objects are different.
+        /// </summary>
         public static bool operator !=(Margins m1, Margins m2)
         {
             return !(m1 == m2);
         }
 
-        /// <include file='doc\Margins.uex' path='docs/doc[@for="Margins.ToString"]/*' />
-        /// <internalonly/>
-        /// <devdoc>
-        ///    <para>
-        ///       Provides some interesting information for the Margins in
-        ///       String form.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Provides some interesting information for the Margins in String form.
+        /// </summary>
         public override string ToString()
         {
             return "[Margins"

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PageSettings.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PageSettings.cs
@@ -2,19 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+using System.Drawing.Internal;
+using System.Runtime.InteropServices;
+
 namespace System.Drawing.Printing
 {
-    using System.Diagnostics;
-    using System.Drawing.Internal;
-    using System.Runtime.InteropServices;
-
-    /// <include file='doc\PageSettings.uex' path='docs/doc[@for="PageSettings"]/*' />
-    /// <devdoc>
-    ///    <para>
-    ///       Specifies
-    ///       settings that apply to a single page.
-    ///    </para>
-    /// </devdoc>
+    /// <summary>
+    /// Specifies settings that apply to a single page.
+    /// </summary>
     public partial class PageSettings : ICloneable
     {
         internal PrinterSettings printerSettings;
@@ -26,34 +22,25 @@ namespace System.Drawing.Printing
         private TriState _landscape = TriState.Default;
         private Margins _margins = new Margins();
 
-        /// <include file='doc\PageSettings.uex' path='docs/doc[@for="PageSettings.PageSettings"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Printing.PageSettings'/> class using
-        ///       the default printer.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='PageSettings'/> class using the default printer.
+        /// </summary>
         public PageSettings() : this(new PrinterSettings())
         {
         }
 
-        /// <include file='doc\PageSettings.uex' path='docs/doc[@for="PageSettings.PageSettings1"]/*' />
-        /// <devdoc>
-        /// <para>Initializes a new instance of the <see cref='System.Drawing.Printing.PageSettings'/> class using
-        ///    the specified printer.</para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='PageSettings'/> class using the specified printer.
+        /// </summary>
         public PageSettings(PrinterSettings printerSettings)
         {
             Debug.Assert(printerSettings != null, "printerSettings == null");
             this.printerSettings = printerSettings;
         }
 
-        /// <include file='doc\PageSettings.uex' path='docs/doc[@for="PageSettings.Bounds"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets the bounds of the page, taking into account the Landscape property.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets the bounds of the page, taking into account the Landscape property.
+        /// </summary>
         public Rectangle Bounds
         {
             get
@@ -67,12 +54,9 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PageSettings.uex' path='docs/doc[@for="PageSettings.Color"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets or sets a value indicating whether the page is printed in color.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets a value indicating whether the page is printed in color.
+        /// </summary>
         public bool Color
         {
             get
@@ -85,10 +69,9 @@ namespace System.Drawing.Printing
             set { _color = value; }
         }
 
-        /// <include file='doc\PageSettings.uex' path='docs/doc[@for="PageSettings.HardMarginX"]/*' />
-        /// <devdoc>
-        ///    <para>Returns the x dimension of the hard margin</para>
-        /// </devdoc>
+        /// <summary>
+        /// Returns the x dimension of the hard margin
+        /// </summary>
         public float HardMarginX
         {
             get
@@ -111,10 +94,9 @@ namespace System.Drawing.Printing
         }
 
 
-        /// <include file='doc\PageSettings.uex' path='docs/doc[@for="PageSettings.HardMarginY"]/*' />
-        /// <devdoc>
-        ///    <para>Returns the y dimension of the hard margin</para>
-        /// </devdoc>
+        /// <summary>
+        /// Returns the y dimension of the hard margin.
+        /// </summary>
         public float HardMarginY
         {
             get
@@ -136,12 +118,9 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PageSettings.uex' path='docs/doc[@for="PageSettings.Landscape"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets or sets a value indicating whether the page should be printed in landscape or portrait orientation.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets a value indicating whether the page should be printed in landscape or portrait orientation.
+        /// </summary>
         public bool Landscape
         {
             get
@@ -154,25 +133,18 @@ namespace System.Drawing.Printing
             set { _landscape = value; }
         }
 
-        /// <include file='doc\PageSettings.uex' path='docs/doc[@for="PageSettings.Margins"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets or sets a value indicating the margins for this page.
-        ///       
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets a value indicating the margins for this page.
+        /// </summary>
         public Margins Margins
         {
             get { return _margins; }
             set { _margins = value; }
         }
 
-        /// <include file='doc\PageSettings.uex' path='docs/doc[@for="PageSettings.PaperSize"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets or sets the paper size.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the paper size.
+        /// </summary>
         public PaperSize PaperSize
         {
             get
@@ -182,13 +154,9 @@ namespace System.Drawing.Printing
             set { _paperSize = value; }
         }
 
-        /// <include file='doc\PageSettings.uex' path='docs/doc[@for="PageSettings.PaperSource"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets or sets a value indicating the paper source (i.e. upper bin).
-        ///       
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets a value indicating the paper source (i.e. upper bin).
+        /// </summary>
         public PaperSource PaperSource
         {
             get
@@ -212,12 +180,9 @@ namespace System.Drawing.Printing
             set { _paperSource = value; }
         }
 
-        /// <include file='doc\PageSettings.uex' path='docs/doc[@for="PageSettings.PrintableArea"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets the PrintableArea for the printer. Units = 100ths of an inch.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets the PrintableArea for the printer. Units = 100ths of an inch.
+        /// </summary>
         public RectangleF PrintableArea
         {
             get
@@ -258,12 +223,9 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PageSettings.uex' path='docs/doc[@for="PageSettings.PrinterResolution"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets or sets the printer resolution for the page.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the printer resolution for the page.
+        /// </summary>
         public PrinterResolution PrinterResolution
         {
             get
@@ -290,13 +252,9 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PageSettings.uex' path='docs/doc[@for="PageSettings.PrinterSettings"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets or sets the
-        ///       associated printer settings.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the associated printer settings.
+        /// </summary>
         public PrinterSettings PrinterSettings
         {
             get { return printerSettings; }
@@ -308,10 +266,9 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PageSettings.uex' path='docs/doc[@for="PageSettings.Clone"]/*' />
-        /// <devdoc>
-        ///     Copies the settings and margins.
-        /// </devdoc>
+        /// <summary>
+        /// Copies the settings and margins.
+        /// </summary>
         public object Clone()
         {
             PageSettings result = (PageSettings)MemberwiseClone();
@@ -319,12 +276,9 @@ namespace System.Drawing.Printing
             return result;
         }
 
-        /// <include file='doc\PageSettings.uex' path='docs/doc[@for="PageSettings.CopyToHdevmode"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Copies the relevant information out of the PageSettings and into the handle.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Copies the relevant information out of the PageSettings and into the handle.
+        /// </summary>
         public void CopyToHdevmode(IntPtr hdevmode)
         {
             IntPtr modePointer = SafeNativeMethods.GlobalLock(new HandleRef(null, hdevmode));
@@ -549,12 +503,9 @@ namespace System.Drawing.Printing
                                          mode.dmPrintQuality, mode.dmYResolution);
         }
 
-        /// <include file='doc\PageSettings.uex' path='docs/doc[@for="PageSettings.SetHdevmode"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Copies the relevant information out of the handle and into the PageSettings.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Copies the relevant information out of the handle and into the PageSettings.
+        /// </summary>
         public void SetHdevmode(IntPtr hdevmode)
         {
             if (hdevmode == IntPtr.Zero)
@@ -580,14 +531,9 @@ namespace System.Drawing.Printing
             SafeNativeMethods.GlobalUnlock(new HandleRef(null, hdevmode));
         }
 
-        /// <include file='doc\PageSettings.uex' path='docs/doc[@for="PageSettings.ToString"]/*' />
-        /// <internalonly/>
-        /// <devdoc>
-        ///    <para>
-        ///       Provides some interesting information about the PageSettings in
-        ///       String form.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Provides some interesting information about the PageSettings in String form.
+        /// </summary>
         public override string ToString()
         {
             return "[PageSettings:"
@@ -601,4 +547,3 @@ namespace System.Drawing.Printing
         }
     }
 }
-

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PaperKinds.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PaperKinds.cs
@@ -4,20 +4,14 @@
 
 namespace System.Drawing.Printing
 {
-    /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind"]/*' />
-    /// <devdoc>
-    ///    <para>
-    ///       Specifies the standard paper sizes.
-    ///    </para>
-    /// </devdoc>
+    /// <summary>
+    /// Specifies the standard paper sizes.
+    /// </summary>
     public enum PaperKind
     {
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.Custom"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       The paper size is defined by the user.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// The paper size is defined by the user.
+        /// </summary>
         Custom = 0,
 
         // I got this information from two places: MSDN's writeup of DEVMODE 
@@ -25,974 +19,473 @@ namespace System.Drawing.Printing
         // and the raw C++ header file (wingdi.h).  Beyond that, your guess
         // is as good as mine as to what these members mean.
 
-
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.Letter"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Letter paper (8.5 in.
-        ///       by 11 in.).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Letter paper (8.5 in. by 11 in.).
+        /// </summary>
         Letter = SafeNativeMethods.DMPAPER_LETTER,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.Legal"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Legal paper (8.5 in.
-        ///       by 14
-        ///       in.).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Legal paper (8.5 in. by 14 in.).
+        /// </summary>
         Legal = SafeNativeMethods.DMPAPER_LEGAL,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.A4"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       A4 paper (210
-        ///       mm by 297
-        ///       mm).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// A4 paper (210 mm by 297 mm).
+        /// </summary>
         A4 = SafeNativeMethods.DMPAPER_A4,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.CSheet"]/*' />
-        /// <devdoc>
-        ///    C paper (17 in. by 22 in.).
-        /// </devdoc>
+        /// <summary>
+        /// C paper (17 in. by 22 in.).
+        /// </summary>
         CSheet = SafeNativeMethods.DMPAPER_CSHEET,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.DSheet"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       D paper (22
-        ///       in. by 34 in.).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// D paper (22 in. by 34 in.).
+        /// </summary>
         DSheet = SafeNativeMethods.DMPAPER_DSHEET,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.ESheet"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       E paper (34
-        ///       in. by 44 in.).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// E paper (34 in. by 44 in.).
+        /// </summary>
         ESheet = SafeNativeMethods.DMPAPER_ESHEET,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.LetterSmall"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Letter small paper (8.5 in. by 11 in.).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Letter small paper (8.5 in. by 11 in.).
+        /// </summary>
         LetterSmall = SafeNativeMethods.DMPAPER_LETTERSMALL,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.Tabloid"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Tabloid paper (11
-        ///       in. by 17 in.).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Tabloid paper (11 in. by 17 in.).
+        /// </summary>
         Tabloid = SafeNativeMethods.DMPAPER_TABLOID,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.Ledger"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Ledger paper (17
-        ///       in. by 11 in.).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Ledger paper (17 in. by 11 in.).
+        /// </summary>
         Ledger = SafeNativeMethods.DMPAPER_LEDGER,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.Statement"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Statement paper (5.5
-        ///       in. by 8.5 in.).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Statement paper (5.5 in. by 8.5 in.).
+        /// </summary>
         Statement = SafeNativeMethods.DMPAPER_STATEMENT,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.Executive"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Executive paper (7.25
-        ///       in. by 10.5
-        ///       in.).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Executive paper (7.25 in. by 10.5 in.).
+        /// </summary>
         Executive = SafeNativeMethods.DMPAPER_EXECUTIVE,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.A3"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       A3 paper
-        ///       (297 mm by 420 mm).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// A3 paper (297 mm by 420 mm).
+        /// </summary>
         A3 = SafeNativeMethods.DMPAPER_A3,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.A4Small"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       A4 small paper
-        ///       (210 mm by 297 mm).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// A4 small paper (210 mm by 297 mm).
+        /// </summary>
         A4Small = SafeNativeMethods.DMPAPER_A4SMALL,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.A5"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       A5 paper (148
-        ///       mm by 210
-        ///       mm).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// A5 paper (148 mm by 210 mm).
+        /// </summary>
         A5 = SafeNativeMethods.DMPAPER_A5,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.B4"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       B4 paper (250 mm by 353 mm).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// B4 paper (250 mm by 353 mm).
+        /// </summary>
         B4 = SafeNativeMethods.DMPAPER_B4,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.B5"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       B5 paper (176
-        ///       mm by 250 mm).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// B5 paper (176 mm by 250 mm).
+        /// </summary>
         B5 = SafeNativeMethods.DMPAPER_B5,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.Folio"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Folio paper (8.5
-        ///       in. by 13 in.).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Folio paper (8.5 in. by 13 in.).
+        /// </summary>
         Folio = SafeNativeMethods.DMPAPER_FOLIO,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.Quarto"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Quarto paper (215
-        ///       mm by 275 mm).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Quarto paper (215 mm by 275 mm).
+        /// </summary>
         Quarto = SafeNativeMethods.DMPAPER_QUARTO,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.Standard10x14"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       10-by-14-inch paper.
-        ///       
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// 10-by-14-inch paper.
+        /// </summary>
         Standard10x14 = SafeNativeMethods.DMPAPER_10X14,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.Standard11x17"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       11-by-17-inch paper.
-        ///       
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// 11-by-17-inch paper.
+        /// </summary>
         Standard11x17 = SafeNativeMethods.DMPAPER_11X17,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.Note"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Note paper (8.5 in.
-        ///       by 11 in.).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Note paper (8.5 in. by 11 in.).
+        /// </summary>
         Note = SafeNativeMethods.DMPAPER_NOTE,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.Number9Envelope"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       #9 envelope (3.875
-        ///       in. by 8.875 in.).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// #9 envelope (3.875 in. by 8.875 in.).
+        /// </summary>
         Number9Envelope = SafeNativeMethods.DMPAPER_ENV_9,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.Number10Envelope"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       #10 envelope
-        ///       (4.125 in. by 9.5 in.).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// #10 envelope (4.125 in. by 9.5 in.).
+        /// </summary>
         Number10Envelope = SafeNativeMethods.DMPAPER_ENV_10,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.Number11Envelope"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       #11 envelope (4.5
-        ///       in. by 10.375 in.).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// #11 envelope (4.5 in. by 10.375 in.).
+        /// </summary>
         Number11Envelope = SafeNativeMethods.DMPAPER_ENV_11,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.Number12Envelope"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       #12 envelope (4.75
-        ///       in. by 11 in.).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// #12 envelope (4.75 in. by 11 in.).
+        /// </summary>
         Number12Envelope = SafeNativeMethods.DMPAPER_ENV_12,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.Number14Envelope"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       #14 envelope (5 in. by 11.5 in.).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// #14 envelope (5 in. by 11.5 in.).
+        /// </summary>
         Number14Envelope = SafeNativeMethods.DMPAPER_ENV_14,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.DLEnvelope"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       DL envelope
-        ///       (110 mm by 220 mm).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// DL envelope (110 mm by 220 mm).
+        /// </summary>
         DLEnvelope = SafeNativeMethods.DMPAPER_ENV_DL,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.C5Envelope"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       C5 envelope
-        ///       (162 mm by 229 mm).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// C5 envelope (162 mm by 229 mm).
+        /// </summary>
         C5Envelope = SafeNativeMethods.DMPAPER_ENV_C5,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.C3Envelope"]/*' />
-        /// <devdoc>
-        ///    C3 envelope (324 mm by 458 mm).
-        /// </devdoc>
+        /// <summary>
+        /// C3 envelope (324 mm by 458 mm).
+        /// </summary>
         C3Envelope = SafeNativeMethods.DMPAPER_ENV_C3,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.C4Envelope"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       C4 envelope (229
-        ///       mm by 324 mm).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// C4 envelope (229 mm by 324 mm).
+        /// </summary>
         C4Envelope = SafeNativeMethods.DMPAPER_ENV_C4,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.C6Envelope"]/*' />
-        /// <devdoc>
-        ///    C6 envelope (114 mm by 162 mm).
-        /// </devdoc>
+        /// <summary>
+        /// C6 envelope (114 mm by 162 mm).
+        /// </summary>
         C6Envelope = SafeNativeMethods.DMPAPER_ENV_C6,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.C65Envelope"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       C65 envelope (114
-        ///       mm by 229 mm).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// C65 envelope (114 mm by 229 mm).
+        /// </summary>
         C65Envelope = SafeNativeMethods.DMPAPER_ENV_C65,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.B4Envelope"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       B4 envelope (250 mm by 353 mm).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// B4 envelope (250 mm by 353 mm).
+        /// </summary>
         B4Envelope = SafeNativeMethods.DMPAPER_ENV_B4,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.B5Envelope"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       B5 envelope (176
-        ///       mm by 250 mm).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// B5 envelope (176 mm by 250 mm).
+        /// </summary>
         B5Envelope = SafeNativeMethods.DMPAPER_ENV_B5,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.B6Envelope"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       B6 envelope (176
-        ///       mm by 125 mm).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// B6 envelope (176 mm by 125 mm).
+        /// </summary>
         B6Envelope = SafeNativeMethods.DMPAPER_ENV_B6,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.ItalyEnvelope"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Italy envelope (110 mm by 230 mm).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Italy envelope (110 mm by 230 mm).
+        /// </summary>
         ItalyEnvelope = SafeNativeMethods.DMPAPER_ENV_ITALY,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.MonarchEnvelope"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Monarch envelope (3.875
-        ///       in. by 7.5 in.).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Monarch envelope (3.875 in. by 7.5 in.).
+        /// </summary>
         MonarchEnvelope = SafeNativeMethods.DMPAPER_ENV_MONARCH,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.PersonalEnvelope"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       6 3/4 envelope
-        ///       (3.625 in. by 6.5 in.).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// 6 3/4 envelope (3.625 in. by 6.5 in.).
+        /// </summary>
         PersonalEnvelope = SafeNativeMethods.DMPAPER_ENV_PERSONAL,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.USStandardFanfold"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       US standard
-        ///       fanfold (14.875 in. by 11 in.).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// US standard fanfold (14.875 in. by 11 in.).
+        /// </summary>
         USStandardFanfold = SafeNativeMethods.DMPAPER_FANFOLD_US,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.GermanStandardFanfold"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       German standard fanfold
-        ///       (8.5 in. by 12 in.).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// German standard fanfold (8.5 in. by 12 in.).
+        /// </summary>
         GermanStandardFanfold = SafeNativeMethods.DMPAPER_FANFOLD_STD_GERMAN,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.GermanLegalFanfold"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       German legal fanfold
-        ///       (8.5 in. by 13 in.).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// German legal fanfold (8.5 in. by 13 in.).
+        /// </summary>
         GermanLegalFanfold = SafeNativeMethods.DMPAPER_FANFOLD_LGL_GERMAN,
-
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.IsoB4"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       ISO B4 (250 mm by 353 mm).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// ISO B4 (250 mm by 353 mm).
+        /// </summary>
         IsoB4 = SafeNativeMethods.DMPAPER_ISO_B4,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.JapanesePostcard"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Japanese postcard (100 mm by 148 mm).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Japanese postcard (100 mm by 148 mm).
+        /// </summary>
         JapanesePostcard = SafeNativeMethods.DMPAPER_JAPANESE_POSTCARD,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.Standard9x11"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       9-by-11-inch
-        ///       paper.
-        ///       
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// 9-by-11-inch paper.
+        /// </summary>
         Standard9x11 = SafeNativeMethods.DMPAPER_9X11,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.Standard10x11"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       10-by-11-inch paper.
-        ///       
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// 10-by-11-inch paper.
+        /// </summary>
         Standard10x11 = SafeNativeMethods.DMPAPER_10X11,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.Standard15x11"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       15-by-11-inch paper.
-        ///       
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// 15-by-11-inch paper.
+        /// </summary>
         Standard15x11 = SafeNativeMethods.DMPAPER_15X11,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.InviteEnvelope"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Invite envelope (220
-        ///       mm by 220 mm).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Invite envelope (220 mm by 220 mm).
+        /// </summary>
         InviteEnvelope = SafeNativeMethods.DMPAPER_ENV_INVITE,
-        //= SafeNativeMethods.DMPAPER_RESERVED_48,
-        //= SafeNativeMethods.DMPAPER_RESERVED_49,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.LetterExtra"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Letter extra paper
-        ///       (9.275 in. by
-        ///       12 in.). This value is specific to the PostScript driver and is used only
-        ///       by Linotronic printers in order to conserve paper.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Letter extra paper (9.275 in. by 12 in.).
+        /// This value is specific to the PostScript driver and is used only by Linotronic printers in order to conserve paper.
+        /// </summary>
         LetterExtra = SafeNativeMethods.DMPAPER_LETTER_EXTRA,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.LegalExtra"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Legal extra
-        ///       paper (9.275 in.
-        ///       by 15 in.). This value is specific to the PostScript driver, and is used
-        ///       only by Linotronic printers in order to conserve paper.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Legal extra paper (9.275 in. by 15 in.).
+        /// This value is specific to the PostScript driver and is used only by Linotronic printers in order to conserve paper.
+        /// </summary>
         LegalExtra = SafeNativeMethods.DMPAPER_LEGAL_EXTRA,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.TabloidExtra"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Tabloid extra paper
-        ///       (11.69 in. by 18 in.). This
-        ///       value is specific to the PostScript driver and is used only by Linotronic printers in order to conserve paper.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Tabloid extra paper (11.69 in. by 18 in.).
+        /// This value is specific to the PostScript driver and is used only by Linotronic printers in order to conserve paper.
+        /// </summary>
         TabloidExtra = SafeNativeMethods.DMPAPER_TABLOID_EXTRA,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.A4Extra"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       A4 extra
-        ///       paper
-        ///       (236 mm by 322 mm). This value is specific to the PostScript driver and is used only
-        ///       by Linotronic printers to help save paper.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// A4 extra paper (236 mm by 322 mm).
+        /// This value is specific to the PostScript driver and is used only by Linotronic printers in order to conserve paper.
+        /// </summary>
         A4Extra = SafeNativeMethods.DMPAPER_A4_EXTRA,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.LetterTransverse"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Letter transverse paper
-        ///       (8.275 in. by 11 in.).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Letter transverse paper (8.275 in. by 11 in.).
+        /// </summary>
         LetterTransverse = SafeNativeMethods.DMPAPER_LETTER_TRANSVERSE,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.A4Transverse"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       A4 transverse paper
-        ///       (210 mm by 297 mm).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// A4 transverse paper (210 mm by 297 mm).
+        /// </summary>
         A4Transverse = SafeNativeMethods.DMPAPER_A4_TRANSVERSE,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.LetterExtraTransverse"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Letter extra transverse
-        ///       paper (9.275 in. by 12
-        ///       in.).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Letter extra transverse paper (9.275 in. by 12 in.).
+        /// </summary>
         LetterExtraTransverse = SafeNativeMethods.DMPAPER_LETTER_EXTRA_TRANSVERSE,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.APlus"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       SuperA/SuperA/A4 paper (227
-        ///       mm by 356 mm).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// SuperA/SuperA/A4 paper (227 mm by 356 mm).
+        /// </summary>
         APlus = SafeNativeMethods.DMPAPER_A_PLUS,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.BPlus"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       SuperB/SuperB/A3 paper (305
-        ///       mm by 487 mm).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// SuperB/SuperB/A3 paper (305 mm by 487 mm).
+        /// </summary>
         BPlus = SafeNativeMethods.DMPAPER_B_PLUS,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.LetterPlus"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Letter plus paper
-        ///       (8.5 in. by 12.69 in.).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Letter plus paper (8.5 in. by 12.69 in.).
+        /// </summary>
         LetterPlus = SafeNativeMethods.DMPAPER_LETTER_PLUS,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.A4Plus"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       A4 plus paper
-        ///       (210 mm by 330 mm).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// A4 plus paper (210 mm by 330 mm).
+        /// </summary>
         A4Plus = SafeNativeMethods.DMPAPER_A4_PLUS,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.A5Transverse"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       A5 transverse paper
-        ///       (148 mm by 210
-        ///       mm).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// A5 transverse paper (148 mm by 210 mm).
+        /// </summary>
         A5Transverse = SafeNativeMethods.DMPAPER_A5_TRANSVERSE,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.B5Transverse"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       JIS B5 transverse
-        ///       paper (182 mm by 257 mm).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// JIS B5 transverse paper (182 mm by 257 mm).
+        /// </summary>
         B5Transverse = SafeNativeMethods.DMPAPER_B5_TRANSVERSE,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.A3Extra"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       A3 extra paper
-        ///       (322 mm by 445 mm).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// A3 extra paper (322 mm by 445 mm).
+        /// </summary>
         A3Extra = SafeNativeMethods.DMPAPER_A3_EXTRA,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.A5Extra"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       A5 extra paper
-        ///       (174 mm by 235 mm).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// A5 extra paper (174 mm by 235 mm).
+        /// </summary>
         A5Extra = SafeNativeMethods.DMPAPER_A5_EXTRA,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.B5Extra"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       ISO B5 extra
-        ///       paper (201 mm by 276 mm).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// ISO B5 extra paper (201 mm by 276 mm).
+        /// </summary>
         B5Extra = SafeNativeMethods.DMPAPER_B5_EXTRA,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.A2"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       A2 paper
-        ///       (420
-        ///       mm by 594 mm).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// A2 paper (420 mm by 594 mm).
+        /// </summary>
         A2 = SafeNativeMethods.DMPAPER_A2,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.A3Transverse"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       A3 transverse paper
-        ///       (297 mm by 420 mm).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// A3 transverse paper (297 mm by 420 mm).
+        /// </summary>
         A3Transverse = SafeNativeMethods.DMPAPER_A3_TRANSVERSE,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.A3ExtraTransverse"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       A3 extra transverse
-        ///       paper (322 mm by 445 mm).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// A3 extra transverse paper (322 mm by 445 mm).
+        /// </summary>
         A3ExtraTransverse = SafeNativeMethods.DMPAPER_A3_EXTRA_TRANSVERSE,
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.JapaneseDoublePostcard"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Japanese double postcard
-        ///       (200 mm by 148
-        ///       mm). Requires Windows
-        ///       98, Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        JapaneseDoublePostcard = SafeNativeMethods.DMPAPER_DBL_JAPANESE_POSTCARD, /* Japanese Double Postcard 200 x 148 mm */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.A6"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       A6 paper (105
-        ///       mm by 148 mm). Requires
-        ///       Windows 98,
-        ///       Windows
-        ///       NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        A6 = SafeNativeMethods.DMPAPER_A6,  /* A6 105 x 148 mm                 */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.JapaneseEnvelopeKakuNumber2"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Japanese Kaku #2 envelope. Requires Windows
-        ///       98, Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        JapaneseEnvelopeKakuNumber2 = SafeNativeMethods.DMPAPER_JENV_KAKU2,  /* Japanese Envelope Kaku #2       */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.JapaneseEnvelopeKakuNumber3"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Japanese Kaku #3 envelope. Requires Windows 98, Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        JapaneseEnvelopeKakuNumber3 = SafeNativeMethods.DMPAPER_JENV_KAKU3,  /* Japanese Envelope Kaku #3       */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.JapaneseEnvelopeChouNumber3"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Japanese Chou #3 envelope. Requires Windows
-        ///       98, Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        JapaneseEnvelopeChouNumber3 = SafeNativeMethods.DMPAPER_JENV_CHOU3,  /* Japanese Envelope Chou #3       */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.JapaneseEnvelopeChouNumber4"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Japanese Chou #4 envelope. Requires Windows
-        ///       98, Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        JapaneseEnvelopeChouNumber4 = SafeNativeMethods.DMPAPER_JENV_CHOU4,  /* Japanese Envelope Chou #4       */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.LetterRotated"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Letter rotated paper (11
-        ///       in. by
-        ///       8.5 in.).
-        ///    </para>
-        /// </devdoc>
-        LetterRotated = SafeNativeMethods.DMPAPER_LETTER_ROTATED,  /* Letter Rotated 11 x 8 1/2 11 in */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.A3Rotated"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       A3
-        ///       rotated paper (420mm by 297 mm).
-        ///    </para>
-        /// </devdoc>
-        A3Rotated = SafeNativeMethods.DMPAPER_A3_ROTATED,  /* A3 Rotated 420 x 297 mm         */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.A4Rotated"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       A4 rotated paper
-        ///       (297 mm by 210 mm).
-        ///       Requires Windows
-        ///       98, Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        A4Rotated = SafeNativeMethods.DMPAPER_A4_ROTATED,  /* A4 Rotated 297 x 210 mm         */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.A5Rotated"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       A5 rotated paper
-        ///       (210 mm by 148 mm).
-        ///       Requires Windows
-        ///       98, Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        A5Rotated = SafeNativeMethods.DMPAPER_A5_ROTATED,  /* A5 Rotated 210 x 148 mm         */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.B4JisRotated"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       JIS B4 rotated
-        ///       paper (364 mm by 257
-        ///       mm). Requires Windows
-        ///       98, Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        B4JisRotated = SafeNativeMethods.DMPAPER_B4_JIS_ROTATED,  /* B4 (JIS) Rotated 364 x 257 mm   */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.B5JisRotated"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       JIS B5 rotated
-        ///       paper (257 mm by 182
-        ///       mm). Requires Windows
-        ///       98, Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        B5JisRotated = SafeNativeMethods.DMPAPER_B5_JIS_ROTATED,  /* B5 (JIS) Rotated 257 x 182 mm   */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.JapanesePostcardRotated"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Japanese rotated postcard
-        ///       (148 mm by 100
-        ///       mm). Requires Windows
-        ///       98,
-        ///       Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        JapanesePostcardRotated = SafeNativeMethods.DMPAPER_JAPANESE_POSTCARD_ROTATED, /* Japanese Postcard Rotated 148 x 100 mm */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.JapaneseDoublePostcardRotated"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Japanese rotated double
-        ///       postcard (148 mm by
-        ///       200 mm). Requires
-        ///       Windows 98, Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        JapaneseDoublePostcardRotated = SafeNativeMethods.DMPAPER_DBL_JAPANESE_POSTCARD_ROTATED, /* Double Japanese Postcard Rotated 148 x 200 mm */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.A6Rotated"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       A6
-        ///       rotated paper
-        ///       (148 mm by 105 mm).
-        ///       Requires Windows
-        ///       98, Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        A6Rotated = SafeNativeMethods.DMPAPER_A6_ROTATED,  /* A6 Rotated 148 x 105 mm         */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.JapaneseEnvelopeKakuNumber2Rotated"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Japanese rotated Kaku #2 envelope. Requires
-        ///       Windows 98, Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        JapaneseEnvelopeKakuNumber2Rotated = SafeNativeMethods.DMPAPER_JENV_KAKU2_ROTATED,  /* Japanese Envelope Kaku #2 Rotated */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.JapaneseEnvelopeKakuNumber3Rotated"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Japanese rotated Kaku #3 envelope. Requires
-        ///       Windows 98, Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        JapaneseEnvelopeKakuNumber3Rotated = SafeNativeMethods.DMPAPER_JENV_KAKU3_ROTATED,  /* Japanese Envelope Kaku #3 Rotated */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.JapaneseEnvelopeChouNumber3Rotated"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Japanese rotated Chou #3 envelope. Requires
-        ///       Windows 98, Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        JapaneseEnvelopeChouNumber3Rotated = SafeNativeMethods.DMPAPER_JENV_CHOU3_ROTATED,  /* Japanese Envelope Chou #3 Rotated */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.JapaneseEnvelopeChouNumber4Rotated"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Japanese rotated Chou #4 envelope. Requires
-        ///       Windows 98, Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        JapaneseEnvelopeChouNumber4Rotated = SafeNativeMethods.DMPAPER_JENV_CHOU4_ROTATED,  /* Japanese Envelope Chou #4 Rotated */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.B6Jis"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       JIS B6 paper
-        ///       (128 mm by 182 mm).
-        ///       Requires Windows 98,
-        ///       Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        B6Jis = SafeNativeMethods.DMPAPER_B6_JIS,  /* B6 (JIS) 128 x 182 mm           */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.B6JisRotated"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       JIS B6
-        ///       rotated paper (182 mm by 128
-        ///       mm). Requires Windows
-        ///       98, Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        B6JisRotated = SafeNativeMethods.DMPAPER_B6_JIS_ROTATED,  /* B6 (JIS) Rotated 182 x 128 mm   */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.Standard12x11"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       12-by-11-inch paper. Requires Windows 98,
-        ///       Windows
-        ///       NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        Standard12x11 = SafeNativeMethods.DMPAPER_12X11,  /* 12 x 11 in                      */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.JapaneseEnvelopeYouNumber4"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Japanese You #4 envelope. Requires Windows
-        ///       98, Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        JapaneseEnvelopeYouNumber4 = SafeNativeMethods.DMPAPER_JENV_YOU4,  /* Japanese Envelope You #4        */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.JapaneseEnvelopeYouNumber4Rotated"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Japanese You #4 rotated envelope. Requires
-        ///       Windows 98, Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        JapaneseEnvelopeYouNumber4Rotated = SafeNativeMethods.DMPAPER_JENV_YOU4_ROTATED,  /* Japanese Envelope You #4 Rotated*/
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.Prc16K"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       PRC 16K paper (146 mm
-        ///       by 215
-        ///       mm). Requires Windows
-        ///       98, Windows NT 4.0,
-        ///       or later.
-        ///    </para>
-        /// </devdoc>
-        Prc16K = SafeNativeMethods.DMPAPER_P16K,  /* PRC 16K 146 x 215 mm            */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.Prc32K"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       PRC 32K paper (97 mm
-        ///       by 151
-        ///       mm). Requires Windows 98, Windows
-        ///       NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        Prc32K = SafeNativeMethods.DMPAPER_P32K,  /* PRC 32K 97 x 151 mm             */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.Prc32KBig"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       PRC 32K big paper (97
-        ///       mm by
-        ///       151 mm). Requires Windows 98, Windows
-        ///       NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        Prc32KBig = SafeNativeMethods.DMPAPER_P32KBIG,  /* PRC 32K(Big) 97 x 151 mm        */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.PrcEnvelopeNumber1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       PRC #1 envelope (102 mm
-        ///       by 165
-        ///       mm). Requires Windows 98, Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        PrcEnvelopeNumber1 = SafeNativeMethods.DMPAPER_PENV_1,  /* PRC Envelope #1 102 x 165 mm    */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.PrcEnvelopeNumber2"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       PRC #2 envelope (102 mm
-        ///       by 176
-        ///       mm). Requires Windows 98, Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        PrcEnvelopeNumber2 = SafeNativeMethods.DMPAPER_PENV_2,  /* PRC Envelope #2 102 x 176 mm    */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.PrcEnvelopeNumber3"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       PRC #3 envelope (125 mm
-        ///       by 176
-        ///       mm). Requires Windows 98, Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        PrcEnvelopeNumber3 = SafeNativeMethods.DMPAPER_PENV_3,  /* PRC Envelope #3 125 x 176 mm    */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.PrcEnvelopeNumber4"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       PRC #4 envelope (110 mm
-        ///       by 208
-        ///       mm). Requires Windows 98, Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        PrcEnvelopeNumber4 = SafeNativeMethods.DMPAPER_PENV_4,  /* PRC Envelope #4 110 x 208 mm    */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.PrcEnvelopeNumber5"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       PRC #5 envelope (110 mm by 220 mm). Requires Windows 98, Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        PrcEnvelopeNumber5 = SafeNativeMethods.DMPAPER_PENV_5, /* PRC Envelope #5 110 x 220 mm    */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.PrcEnvelopeNumber6"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       PRC #6 envelope (120 mm by 230 mm). Requires Windows 98, Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        PrcEnvelopeNumber6 = SafeNativeMethods.DMPAPER_PENV_6, /* PRC Envelope #6 120 x 230 mm    */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.PrcEnvelopeNumber7"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       PRC #7 envelope (160 mm
-        ///       by 230
-        ///       mm). Requires Windows 98, Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        PrcEnvelopeNumber7 = SafeNativeMethods.DMPAPER_PENV_7, /* PRC Envelope #7 160 x 230 mm    */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.PrcEnvelopeNumber8"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       PRC #8 envelope (120 mm
-        ///       by 309
-        ///       mm). Requires Windows 98, Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        PrcEnvelopeNumber8 = SafeNativeMethods.DMPAPER_PENV_8, /* PRC Envelope #8 120 x 309 mm    */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.PrcEnvelopeNumber9"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       PRC #9 envelope (229 mm by 324 mm). Requires Windows 98, Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        PrcEnvelopeNumber9 = SafeNativeMethods.DMPAPER_PENV_9, /* PRC Envelope #9 229 x 324 mm    */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.PrcEnvelopeNumber10"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       PRC #10 envelope (324 mm
-        ///       by 458
-        ///       mm). Requires Windows 98, Windows NT 4.0, or
-        ///       later.
-        ///    </para>
-        /// </devdoc>
-        PrcEnvelopeNumber10 = SafeNativeMethods.DMPAPER_PENV_10, /* PRC Envelope #10 324 x 458 mm   */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.Prc16KRotated"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       PRC 16K rotated paper (146 mm by 215 mm). Requires Windows 98, Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        Prc16KRotated = SafeNativeMethods.DMPAPER_P16K_ROTATED, /* PRC 16K Rotated                 */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.Prc32KRotated"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       PRC 32K rotated paper (97 mm by 151
-        ///       mm). Requires Windows 98, Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        Prc32KRotated = SafeNativeMethods.DMPAPER_P32K_ROTATED, /* PRC 32K Rotated                 */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.Prc32KBigRotated"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       PRC 32K big rotated paper (97 mm by 151 mm). Requires Windows 98, Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        Prc32KBigRotated = SafeNativeMethods.DMPAPER_P32KBIG_ROTATED, /* PRC 32K(Big) Rotated            */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.PrcEnvelopeNumber1Rotated"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       PRC #1 rotated envelope (165 mm by 102 mm). Requires Windows 98, Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        PrcEnvelopeNumber1Rotated = SafeNativeMethods.DMPAPER_PENV_1_ROTATED, /* PRC Envelope #1 Rotated 165 x 102 mm */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.PrcEnvelopeNumber2Rotated"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       PRC #2 rotated envelope
-        ///       (176 mm by
-        ///       102 mm). Requires Windows 98, Windows NT 4.0, or
-        ///       later.
-        ///    </para>
-        /// </devdoc>
-        PrcEnvelopeNumber2Rotated = SafeNativeMethods.DMPAPER_PENV_2_ROTATED, /* PRC Envelope #2 Rotated 176 x 102 mm */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.PrcEnvelopeNumber3Rotated"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       PRC #3 rotated envelope
-        ///       (176 mm by
-        ///       125 mm). Requires Windows 98, Windows NT 4.0, or
-        ///       later.
-        ///    </para>
-        /// </devdoc>
-        PrcEnvelopeNumber3Rotated = SafeNativeMethods.DMPAPER_PENV_3_ROTATED, /* PRC Envelope #3 Rotated 176 x 125 mm */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.PrcEnvelopeNumber4Rotated"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       PRC #4 rotated envelope (208 mm by 110 mm). Requires Windows 98, Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        PrcEnvelopeNumber4Rotated = SafeNativeMethods.DMPAPER_PENV_4_ROTATED, /* PRC Envelope #4 Rotated 208 x 110 mm */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.PrcEnvelopeNumber5Rotated"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       PRC #5 rotated envelope (220 mm by 110 mm). Requires Windows 98, Windows NT 4.0, or
-        ///       later.
-        ///    </para>
-        /// </devdoc>
-        PrcEnvelopeNumber5Rotated = SafeNativeMethods.DMPAPER_PENV_5_ROTATED, /* PRC Envelope #5 Rotated 220 x 110 mm */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.PrcEnvelopeNumber6Rotated"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       PRC #6 rotated envelope (230 mm by 120 mm). Requires Windows 98, Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        PrcEnvelopeNumber6Rotated = SafeNativeMethods.DMPAPER_PENV_6_ROTATED, /* PRC Envelope #6 Rotated 230 x 120 mm */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.PrcEnvelopeNumber7Rotated"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       PRC #7 rotated envelope (230 mm by 160 mm). Requires Windows 98, Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        PrcEnvelopeNumber7Rotated = SafeNativeMethods.DMPAPER_PENV_7_ROTATED, /* PRC Envelope #7 Rotated 230 x 160 mm */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.PrcEnvelopeNumber8Rotated"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       PRC #8 rotated
-        ///       envelope (309 mm
-        ///       by 120
-        ///       mm). Requires Windows 98, Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        PrcEnvelopeNumber8Rotated = SafeNativeMethods.DMPAPER_PENV_8_ROTATED, /* PRC Envelope #8 Rotated 309 x 120 mm */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.PrcEnvelopeNumber9Rotated"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       PRC #9 rotated envelope (324 mm by 229 mm). Requires Windows 98, Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        PrcEnvelopeNumber9Rotated = SafeNativeMethods.DMPAPER_PENV_9_ROTATED, /* PRC Envelope #9 Rotated 324 x 229 mm */
-        /// <include file='doc\PaperKinds.uex' path='docs/doc[@for="PaperKind.PrcEnvelopeNumber10Rotated"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       PRC #10 rotated envelope (458 mm by 324 mm). Requires Windows 98, Windows NT 4.0, or later.
-        ///    </para>
-        /// </devdoc>
-        PrcEnvelopeNumber10Rotated = SafeNativeMethods.DMPAPER_PENV_10_ROTATED, /* PRC Envelope #10 Rotated 458 x 324 mm */
-
-        // Other useful values: SafeNativeMethods.DMPAPER_LAST, SafeNativeMethods.DMPAPER_USER
+        /// <summary>
+        /// Japanese double postcard (200 mm by 148mm).
+        /// </summary>
+        JapaneseDoublePostcard = SafeNativeMethods.DMPAPER_DBL_JAPANESE_POSTCARD,
+        /// <summary>
+        /// A6 paper (105 mm by 148 mm).
+        /// </summary>
+        A6 = SafeNativeMethods.DMPAPER_A6,
+        /// <summary>
+        /// Japanese Kaku #2 envelope.
+        /// </summary>
+        JapaneseEnvelopeKakuNumber2 = SafeNativeMethods.DMPAPER_JENV_KAKU2,
+        /// <summary>
+        /// Japanese Kaku #3 envelope.
+        /// </summary>
+        JapaneseEnvelopeKakuNumber3 = SafeNativeMethods.DMPAPER_JENV_KAKU3,
+        /// <summary>
+        /// Japanese Chou #3 envelope.
+        /// </summary>
+        JapaneseEnvelopeChouNumber3 = SafeNativeMethods.DMPAPER_JENV_CHOU3,
+        /// <summary>
+        /// Japanese Chou #4 envelope.
+        /// </summary>
+        JapaneseEnvelopeChouNumber4 = SafeNativeMethods.DMPAPER_JENV_CHOU4,
+        /// <summary>
+        /// Letter rotated paper (11 in. by 8.5 in.).
+        /// </summary>
+        LetterRotated = SafeNativeMethods.DMPAPER_LETTER_ROTATED,
+        /// <summary>
+        /// A3 rotated paper (420mm by 297 mm).
+        /// </summary>
+        A3Rotated = SafeNativeMethods.DMPAPER_A3_ROTATED,
+        /// <summary>
+        /// A4 rotated paper (297 mm by 210 mm).
+        /// </summary>
+        A4Rotated = SafeNativeMethods.DMPAPER_A4_ROTATED,
+        /// <summary>
+        /// A5 rotated paper (210 mm by 148 mm).
+        /// </summary>
+        A5Rotated = SafeNativeMethods.DMPAPER_A5_ROTATED,
+        /// <summary>
+        /// JIS B4 rotated paper (364 mm by 257 mm).
+        /// </summary>
+        B4JisRotated = SafeNativeMethods.DMPAPER_B4_JIS_ROTATED,
+        /// <summary>
+        /// JIS B5 rotated paper (257 mm by 182 mm).
+        /// </summary>
+        B5JisRotated = SafeNativeMethods.DMPAPER_B5_JIS_ROTATED,
+        /// <summary>
+        /// Japanese rotated postcard (148 mm by 100 mm).
+        /// </summary>
+        JapanesePostcardRotated = SafeNativeMethods.DMPAPER_JAPANESE_POSTCARD_ROTATED,
+        /// <summary>
+        /// Japanese rotated double postcard (148 mm by 200 mm).
+        /// </summary>
+        JapaneseDoublePostcardRotated = SafeNativeMethods.DMPAPER_DBL_JAPANESE_POSTCARD_ROTATED,
+        /// <summary>
+        /// A6 rotated paper (148 mm by 105 mm).
+        /// </summary>
+        A6Rotated = SafeNativeMethods.DMPAPER_A6_ROTATED,
+        /// <summary>
+        /// Japanese rotated Kaku #2 envelope.
+        /// </summary>
+        JapaneseEnvelopeKakuNumber2Rotated = SafeNativeMethods.DMPAPER_JENV_KAKU2_ROTATED,
+        /// <summary>
+        /// Japanese rotated Kaku #3 envelope.
+        /// </summary>
+        JapaneseEnvelopeKakuNumber3Rotated = SafeNativeMethods.DMPAPER_JENV_KAKU3_ROTATED,
+        /// <summary>
+        /// Japanese rotated Chou #3 envelope.
+        /// </summary>
+        JapaneseEnvelopeChouNumber3Rotated = SafeNativeMethods.DMPAPER_JENV_CHOU3_ROTATED,
+        /// <summary>
+        /// Japanese rotated Chou #4 envelope.
+        /// </summary>
+        JapaneseEnvelopeChouNumber4Rotated = SafeNativeMethods.DMPAPER_JENV_CHOU4_ROTATED,
+        /// <summary>
+        /// JIS B6 paper (128 mm by 182 mm).
+        /// </summary>
+        B6Jis = SafeNativeMethods.DMPAPER_B6_JIS,
+        /// <summary>
+        /// JIS B6 rotated paper (182 mm by 128 mm).
+        /// </summary>
+        B6JisRotated = SafeNativeMethods.DMPAPER_B6_JIS_ROTATED,
+        /// <summary>
+        /// 12-by-11-inch paper.
+        /// </summary>
+        Standard12x11 = SafeNativeMethods.DMPAPER_12X11,
+        /// <summary>
+        /// Japanese You #4 envelope.
+        /// </summary>
+        JapaneseEnvelopeYouNumber4 = SafeNativeMethods.DMPAPER_JENV_YOU4,
+        /// <summary>
+        /// Japanese You #4 rotated envelope.
+        /// </summary>
+        JapaneseEnvelopeYouNumber4Rotated = SafeNativeMethods.DMPAPER_JENV_YOU4_ROTATED,
+        /// <summary>
+        /// PRC 16K paper (146 mm by 215 mm).
+        /// </summary>
+        Prc16K = SafeNativeMethods.DMPAPER_P16K,
+        /// <summary>
+        /// PRC 32K paper (97 mm by 151 mm).
+        /// </summary>
+        Prc32K = SafeNativeMethods.DMPAPER_P32K,
+        /// <summary>
+        /// PRC 32K big paper (97 mm by 151 mm).
+        /// </summary>
+        Prc32KBig = SafeNativeMethods.DMPAPER_P32KBIG,
+        /// <summary>
+        /// PRC #1 envelope (102 mm by 165 mm).
+        /// </summary>
+        PrcEnvelopeNumber1 = SafeNativeMethods.DMPAPER_PENV_1,
+        /// <summary>
+        /// PRC #2 envelope (102 mm by 176 mm).
+        /// </summary>
+        PrcEnvelopeNumber2 = SafeNativeMethods.DMPAPER_PENV_2,
+        /// <summary>
+        /// PRC #3 envelope (125 mm by 176 mm).
+        /// </summary>
+        PrcEnvelopeNumber3 = SafeNativeMethods.DMPAPER_PENV_3,
+        /// <summary>
+        /// PRC #4 envelope (110 mm by 208 mm).
+        /// </summary>
+        PrcEnvelopeNumber4 = SafeNativeMethods.DMPAPER_PENV_4,
+        /// <summary>
+        /// PRC #5 envelope (110 mm by 220 mm).
+        /// </summary>
+        PrcEnvelopeNumber5 = SafeNativeMethods.DMPAPER_PENV_5,
+        /// <summary>
+        /// PRC #6 envelope (120 mm by 230 mm).
+        /// </summary>
+        PrcEnvelopeNumber6 = SafeNativeMethods.DMPAPER_PENV_6,
+        /// <summary>
+        /// PRC #7 envelope (160 mm by 230 mm).
+        /// </summary>
+        PrcEnvelopeNumber7 = SafeNativeMethods.DMPAPER_PENV_7,
+        /// <summary>
+        /// PRC #8 envelope (120 mm by 309 mm).
+        /// </summary>
+        PrcEnvelopeNumber8 = SafeNativeMethods.DMPAPER_PENV_8,
+        /// <summary>
+        /// PRC #9 envelope (229 mm by 324 mm).
+        /// </summary>
+        PrcEnvelopeNumber9 = SafeNativeMethods.DMPAPER_PENV_9,
+        /// <summary>
+        /// PRC #10 envelope (324 mm by 458 mm).
+        /// </summary>
+        PrcEnvelopeNumber10 = SafeNativeMethods.DMPAPER_PENV_10,
+        /// <summary>
+        /// PRC 16K rotated paper (146 mm by 215 mm).
+        /// </summary>
+        Prc16KRotated = SafeNativeMethods.DMPAPER_P16K_ROTATED,
+        /// <summary>
+        /// PRC 32K rotated paper (97 mm by 151 mm).
+        /// </summary>
+        Prc32KRotated = SafeNativeMethods.DMPAPER_P32K_ROTATED,
+        /// <summary>
+        /// PRC 32K big rotated paper (97 mm by 151 mm).
+        /// </summary>
+        Prc32KBigRotated = SafeNativeMethods.DMPAPER_P32KBIG_ROTATED,
+        /// <summary>
+        /// PRC #1 rotated envelope (165 mm by 102 mm).
+        /// </summary>
+        PrcEnvelopeNumber1Rotated = SafeNativeMethods.DMPAPER_PENV_1_ROTATED,
+        /// <summary>
+        /// PRC #2 rotated envelope (176 mm by 102 mm).
+        /// </summary>
+        PrcEnvelopeNumber2Rotated = SafeNativeMethods.DMPAPER_PENV_2_ROTATED,
+        /// <summary>
+        /// PRC #3 rotated envelope (176 mm by 125 mm).
+        /// </summary>
+        PrcEnvelopeNumber3Rotated = SafeNativeMethods.DMPAPER_PENV_3_ROTATED,
+        /// <summary>
+        /// PRC #4 rotated envelope (208 mm by 110 mm).
+        /// </summary>
+        PrcEnvelopeNumber4Rotated = SafeNativeMethods.DMPAPER_PENV_4_ROTATED,
+        /// <summary>
+        /// PRC #5 rotated envelope (220 mm by 110 mm).
+        /// </summary>
+        PrcEnvelopeNumber5Rotated = SafeNativeMethods.DMPAPER_PENV_5_ROTATED,
+        /// <summary>
+        /// PRC #6 rotated envelope (230 mm by 120 mm).
+        /// </summary>
+        PrcEnvelopeNumber6Rotated = SafeNativeMethods.DMPAPER_PENV_6_ROTATED,
+        /// <summary>
+        /// PRC #7 rotated envelope (230 mm by 160 mm).
+        /// </summary>
+        PrcEnvelopeNumber7Rotated = SafeNativeMethods.DMPAPER_PENV_7_ROTATED,
+        /// <summary>
+        /// PRC #8 rotated envelope (309 mm by 120 mm).
+        /// </summary>
+        PrcEnvelopeNumber8Rotated = SafeNativeMethods.DMPAPER_PENV_8_ROTATED,
+        /// <summary>
+        /// PRC #9 rotated envelope (324 mm by 229 mm).
+        /// </summary>
+        PrcEnvelopeNumber9Rotated = SafeNativeMethods.DMPAPER_PENV_9_ROTATED,
+        /// <summary>
+        /// PRC #10 rotated envelope (458 mm by 324 mm).
+        /// </summary>
+        PrcEnvelopeNumber10Rotated = SafeNativeMethods.DMPAPER_PENV_10_ROTATED,
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PaperSize.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PaperSize.cs
@@ -2,17 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Globalization;
+
 namespace System.Drawing.Printing
 {
-    using System.Globalization;
-
-    /// <include file='doc\PaperSize.uex' path='docs/doc[@for="PaperSize"]/*' />
-    /// <devdoc>
-    ///    <para>
-    ///       Specifies
-    ///       the size of a piece of paper.
-    ///    </para>
-    /// </devdoc>
+    /// <summary>
+    /// Specifies the size of a piece of paper.
+    /// </summary>
     public partial class PaperSize
     {
         private PaperKind _kind;
@@ -23,13 +19,9 @@ namespace System.Drawing.Printing
         private int _height;
         private bool _createdByDefaultConstructor;
 
-        /// <include file='doc\PaperSize.uex' path='docs/doc[@for="PaperSize.PaperSize2"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Printing.PaperSize'/> class with default properties.
-        ///       This constructor is required for the serialization of the <see cref='System.Drawing.Printing.PaperSize'/> class.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='PaperSize'/> class with default properties.
+        /// </summary>
         public PaperSize()
         {
             _kind = PaperKind.Custom;
@@ -45,12 +37,9 @@ namespace System.Drawing.Printing
             _height = height;
         }
 
-        /// <include file='doc\PaperSize.uex' path='docs/doc[@for="PaperSize.PaperSize"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Printing.PaperSize'/> class.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='System.Drawing.Printing.PaperSize'/> class.
+        /// </summary>
         public PaperSize(string name, int width, int height)
         {
             _kind = PaperKind.Custom;
@@ -59,11 +48,9 @@ namespace System.Drawing.Printing
             _height = height;
         }
 
-        /// <include file='doc\PaperSize.uex' path='docs/doc[@for="PaperSize.Height"]/*' />
-        /// <devdoc>
-        ///    <para>Gets or sets
-        ///       the height of the paper, in hundredths of an inch.</para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the height of the paper, in hundredths of an inch.
+        /// </summary>
         public int Height
         {
             get
@@ -73,18 +60,15 @@ namespace System.Drawing.Printing
 
             set
             {
-                if (_kind != PaperKind.Custom && !_createdByDefaultConstructor) throw new ArgumentException(SR.Format(SR.PSizeNotCustom));
+                if (_kind != PaperKind.Custom && !_createdByDefaultConstructor)
+                    throw new ArgumentException(SR.Format(SR.PSizeNotCustom));
                 _height = value;
             }
         }
 
-        /// <include file='doc\PaperSize.uex' path='docs/doc[@for="PaperSize.Kind"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets the type of paper.
-        ///       
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets the type of paper.
+        /// </summary>
         public PaperKind Kind
         {
             get
@@ -97,40 +81,33 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PaperSize.uex' path='docs/doc[@for="PaperSize.PaperName"]/*' />
-        /// <devdoc>
-        ///    <para>Gets
-        ///       or sets the name of the type of paper.</para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the name of the type of paper.
+        /// </summary>
         public string PaperName
         {
             get { return _name; }
 
             set
             {
-                if (_kind != PaperKind.Custom && !_createdByDefaultConstructor) throw new ArgumentException(SR.Format(SR.PSizeNotCustom));
+                if (_kind != PaperKind.Custom && !_createdByDefaultConstructor)
+                    throw new ArgumentException(SR.Format(SR.PSizeNotCustom));
                 _name = value;
             }
         }
 
-        /// <include file='doc\PaperSize.uex' path='docs/doc[@for="PaperSize.RawKind"]/*' />
-        /// <devdoc>
-        /// <para>
+        /// <summary>
         /// Same as Kind, but values larger than or equal to DMPAPER_LAST do not map to PaperKind.Custom.
-        /// This property is needed for serialization of the PrinterSettings object.
-        /// </para>
-        /// </devdoc>
+        /// </summary>
         public int RawKind
         {
             get { return unchecked((int)_kind); }
             set { _kind = unchecked((PaperKind)value); }
         }
 
-        /// <include file='doc\PaperSize.uex' path='docs/doc[@for="PaperSize.Width"]/*' />
-        /// <devdoc>
-        ///    <para>Gets or sets
-        ///       the width of the paper, in hundredths of an inch.</para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the width of the paper, in hundredths of an inch.
+        /// </summary>
         public int Width
         {
             get
@@ -140,19 +117,15 @@ namespace System.Drawing.Printing
 
             set
             {
-                if (_kind != PaperKind.Custom && !_createdByDefaultConstructor) throw new ArgumentException(SR.Format(SR.PSizeNotCustom));
+                if (_kind != PaperKind.Custom && !_createdByDefaultConstructor)
+                    throw new ArgumentException(SR.Format(SR.PSizeNotCustom));
                 _width = value;
             }
         }
 
-        /// <include file='doc\PaperSize.uex' path='docs/doc[@for="PaperSize.ToString"]/*' />
-        /// <internalonly/>
-        /// <devdoc>
-        ///    <para>
-        ///       Provides some interesting information about the PaperSize in
-        ///       String form.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Provides some interesting information about the PaperSize in String form.
+        /// </summary>
         public override string ToString()
         {
             return "[PaperSize " + PaperName

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PaperSource.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PaperSource.cs
@@ -4,24 +4,17 @@
 
 namespace System.Drawing.Printing
 {
-    /// <include file='doc\PaperSource.uex' path='docs/doc[@for="PaperSource"]/*' />
-    /// <devdoc>
-    ///    <para>
-    ///       Specifies the paper tray from which the printer gets paper.
-    ///    </para>
-    /// </devdoc>
+    /// <summary>
+    /// Specifies the paper tray from which the printer gets paper.
+    /// </summary>
     public partial class PaperSource
     {
         private string _name;
         private PaperSourceKind _kind;
 
-        /// <include file='doc\PaperSource.uex' path='docs/doc[@for="PaperSource.PaperSource"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Printing.PaperSource'/> class with default properties.
-        ///       This constructor is required for the serialization of the <see cref='System.Drawing.Printing.PaperSource'/> class.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='PaperSource'/> class with default properties.
+        /// </summary>
         public PaperSource()
         {
             _kind = PaperSourceKind.Custom;
@@ -34,14 +27,9 @@ namespace System.Drawing.Printing
             _name = name;
         }
 
-        /// <include file='doc\PaperSource.uex' path='docs/doc[@for="PaperSource.Kind"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets
-        ///       a value indicating the type of paper source.
-        ///       
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets a value indicating the type of paper source.
+        /// </summary>
         public PaperSourceKind Kind
         {
             get
@@ -53,40 +41,27 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PaperSource.uex' path='docs/doc[@for="PaperSource.RawKind"]/*' />
-        /// <devdoc>
-        ///    <para>
+        /// <summary>
         /// Same as Kind, but values larger than DMBIN_USER do not map to PaperSourceKind.Custom.
-        /// This property is needed for serialization of the PrinterSettings object.
-        ///    </para>
-        /// </devdoc>
+        /// </summary>
         public int RawKind
         {
             get { return unchecked((int)_kind); }
             set { _kind = unchecked((PaperSourceKind)value); }
         }
 
-        /// <include file='doc\PaperSource.uex' path='docs/doc[@for="PaperSource.SourceName"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets the name of the paper source.
-        ///       Setter is added for serialization of the PrinterSettings object.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets the name of the paper source.
+        /// </summary>
         public string SourceName
         {
             get { return _name; }
             set { _name = value; }
         }
 
-        /// <include file='doc\PaperSource.uex' path='docs/doc[@for="PaperSource.ToString"]/*' />
-        /// <internalonly/>
-        /// <devdoc>
-        ///    <para>
-        ///       Provides some interesting information about the PaperSource in
-        ///       String form.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Provides some interesting information about the PaperSource in String form.
+        /// </summary>
         public override string ToString()
         {
             return "[PaperSource " + SourceName

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PaperSourceKind.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PaperSourceKind.cs
@@ -4,127 +4,78 @@
 
 namespace System.Drawing.Printing
 {
-    /// <include file='doc\PaperSourceKind.uex' path='docs/doc[@for="PaperSourceKind"]/*' />
-    /// <devdoc>
-    ///    <para>
-    ///       Standard paper sources.
-    ///    </para>
-    /// </devdoc>
+    /// <summary>
+    /// Standard paper sources.
+    /// </summary>
     public enum PaperSourceKind
     {
         // Please keep these in SafeNativeMethods.cs order
 
-        /// <include file='doc\PaperSourceKind.uex' path='docs/doc[@for="PaperSourceKind.Upper"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       The upper bin of a printer (or, if the printer only has one bin, the only bin).
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// The upper bin of a printer (or, if the printer only has one bin, the only bin).
+        /// </summary>
         Upper = SafeNativeMethods.DMBIN_UPPER,
 
-        /// <include file='doc\PaperSourceKind.uex' path='docs/doc[@for="PaperSourceKind.Lower"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       The lower bin of a printer.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// The lower bin of a printer.
+        /// </summary>
         Lower = SafeNativeMethods.DMBIN_LOWER,
 
-        /// <include file='doc\PaperSourceKind.uex' path='docs/doc[@for="PaperSourceKind.Middle"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       The middle bin of a printer.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// The middle bin of a printer.
+        /// </summary>
         Middle = SafeNativeMethods.DMBIN_MIDDLE,
 
-        /// <include file='doc\PaperSourceKind.uex' path='docs/doc[@for="PaperSourceKind.Manual"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Manually-fed paper.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Manually-fed paper.
+        /// </summary>
         Manual = SafeNativeMethods.DMBIN_MANUAL,
 
-        /// <include file='doc\PaperSourceKind.uex' path='docs/doc[@for="PaperSourceKind.Envelope"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       An envelope.
-        ///       
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// An envelope.
+        /// </summary>
         Envelope = SafeNativeMethods.DMBIN_ENVELOPE,
 
-        /// <include file='doc\PaperSourceKind.uex' path='docs/doc[@for="PaperSourceKind.ManualFeed"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       A manually-fed envelope.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// A manually-fed envelope.
+        /// </summary>
         ManualFeed = SafeNativeMethods.DMBIN_ENVMANUAL,
 
-        /// <include file='doc\PaperSourceKind.uex' path='docs/doc[@for="PaperSourceKind.AutomaticFeed"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Automatic-fed paper.
-        ///       
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Automatic-fed paper.
+        /// </summary>
         AutomaticFeed = SafeNativeMethods.DMBIN_AUTO,
 
-        /// <include file='doc\PaperSourceKind.uex' path='docs/doc[@for="PaperSourceKind.TractorFeed"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       A tractor feed.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// A tractor feed.
+        /// </summary>
         TractorFeed = SafeNativeMethods.DMBIN_TRACTOR,
 
-        /// <include file='doc\PaperSourceKind.uex' path='docs/doc[@for="PaperSourceKind.SmallFormat"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Small-format paper.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Small-format paper.
+        /// </summary>
         SmallFormat = SafeNativeMethods.DMBIN_SMALLFMT,
 
-        /// <include file='doc\PaperSourceKind.uex' path='docs/doc[@for="PaperSourceKind.LargeFormat"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Large-format paper.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Large-format paper.
+        /// </summary>
         LargeFormat = SafeNativeMethods.DMBIN_LARGEFMT,
 
-        /// <include file='doc\PaperSourceKind.uex' path='docs/doc[@for="PaperSourceKind.LargeCapacity"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       A large-capacity
-        ///       bin a printer.
-        ///       
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// A large-capacity bin printer.
+        /// </summary>
         LargeCapacity = SafeNativeMethods.DMBIN_LARGECAPACITY,
 
-        /// <include file='doc\PaperSourceKind.uex' path='docs/doc[@for="PaperSourceKind.Cassette"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       A paper cassette.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// A paper cassette.
+        /// </summary>
         Cassette = SafeNativeMethods.DMBIN_CASSETTE,
 
-        /// <include file='doc\PaperSourceKind.uex' path='docs/doc[@for="PaperSourceKind.FormSource"]/*' />
-        /// <devdoc>
-        /// </devdoc>
         FormSource = SafeNativeMethods.DMBIN_FORMSOURCE,
 
-        /// <include file='doc\PaperSourceKind.uex' path='docs/doc[@for="PaperSourceKind.Custom"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       A printer-specific paper source.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// A printer-specific paper source.
+        /// </summary>
         Custom = SafeNativeMethods.DMBIN_USER + 1,
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PreviewPageInfo.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PreviewPageInfo.cs
@@ -4,13 +4,9 @@
 
 namespace System.Drawing.Printing
 {
-    /// <include file='doc\PreviewPageInfo.uex' path='docs/doc[@for="PreviewPageInfo"]/*' />
-    /// <devdoc>
-    ///    <para>
-    ///       Specifies print preview information for
-    ///       a single page. This class cannot be inherited.
-    ///    </para>
-    /// </devdoc>
+    /// <summary>
+    /// Specifies print preview information for a single page. This class cannot be inherited.
+    /// </summary>
     public sealed class PreviewPageInfo
     {
         private Image _image;
@@ -18,33 +14,26 @@ namespace System.Drawing.Printing
         // Physical measures in hundredths of an inch
         private Size _physicalSize = Size.Empty;
 
-        /// <include file='doc\PreviewPageInfo.uex' path='docs/doc[@for="PreviewPageInfo.PreviewPageInfo"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Printing.PreviewPageInfo'/>
-        ///       class.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='PreviewPageInfo'/> class.
+        /// </summary>
         public PreviewPageInfo(Image image, Size physicalSize)
         {
             _image = image;
             _physicalSize = physicalSize;
         }
 
-        /// <include file='doc\PreviewPageInfo.uex' path='docs/doc[@for="PreviewPageInfo.Image"]/*' />
-        /// <devdoc>
-        ///    <para>Gets the image of the printed page.</para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets the image of the printed page.
+        /// </summary>
         public Image Image
         {
             get { return _image; }
         }
 
-        // Physical measures in hundredths of an inch
-        /// <include file='doc\PreviewPageInfo.uex' path='docs/doc[@for="PreviewPageInfo.PhysicalSize"]/*' />
-        /// <devdoc>
-        ///    <para> Gets the size of the printed page, in hundredths of an inch.</para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets the size of the printed page, in hundredths of an inch.
+        /// </summary>
         public Size PhysicalSize
         {
             get { return _physicalSize; }

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PreviewPrintController.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PreviewPrintController.cs
@@ -2,20 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
+using System.Diagnostics;
+using System.Drawing.Drawing2D;
+using System.Drawing.Imaging;
+using System.Drawing.Internal;
+using System.Drawing.Text;
+using System.Runtime.InteropServices;
+
 namespace System.Drawing.Printing
 {
-    using System.Collections;
-    using System.Diagnostics;
-    using System.Drawing.Drawing2D;
-    using System.Drawing.Imaging;
-    using System.Drawing.Internal;
-    using System.Drawing.Text;
-    using System.Runtime.InteropServices;
-
-    /// <include file='doc\PreviewPrintController.uex' path='docs/doc[@for="PreviewPrintController"]/*' />
-    /// <devdoc>
-    ///     A PrintController which "prints" to a series of images.
-    /// </devdoc>
+    /// <summary>
+    /// A PrintController which "prints" to a series of images.
+    /// </summary>
     public class PreviewPrintController : PrintController
     {
         private IList _list = new ArrayList(); // list of PreviewPageInfo
@@ -27,12 +26,9 @@ namespace System.Drawing.Printing
         {
         }
 
-        /// <include file='doc\PreviewPrintController.uex' path='docs/doc[@for="PreviewPrintController.IsPreview"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       This is new public property which notifies if this controller is used for PrintPreview.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// This is new public property which notifies if this controller is used for PrintPreview.
+        /// </summary>
         public override bool IsPreview
         {
             get
@@ -41,12 +37,9 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PreviewPrintController.uex' path='docs/doc[@for="PreviewPrintController.OnStartPrint"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Implements StartPrint for generating print preview information.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Implements StartPrint for generating print preview information.
+        /// </summary>
         public override void OnStartPrint(PrintDocument document, PrintEventArgs e)
         {
             Debug.Assert(_dc == null && _graphics == null, "PrintController methods called in the wrong order?");
@@ -64,12 +57,9 @@ namespace System.Drawing.Printing
             _dc = document.PrinterSettings.CreateInformationContext(modeHandle);
         }
 
-        /// <include file='doc\PreviewPrintController.uex' path='docs/doc[@for="PreviewPrintController.OnStartPage"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Implements StartEnd for generating print preview information.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Implements StartEnd for generating print preview information.
+        /// </summary>
         public override Graphics OnStartPage(PrintDocument document, PrintPageEventArgs e)
         {
             Debug.Assert(_dc != null && _graphics == null, "PrintController methods called in the wrong order?");
@@ -134,12 +124,9 @@ namespace System.Drawing.Printing
             return _graphics;
         }
 
-        /// <include file='doc\PreviewPrintController.uex' path='docs/doc[@for="PreviewPrintController.OnEndPage"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Implements EndPage for generating print preview information.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Implements EndPage for generating print preview information.
+        /// </summary>
         public override void OnEndPage(PrintDocument document, PrintPageEventArgs e)
         {
             Debug.Assert(_dc != null && _graphics != null, "PrintController methods called in the wrong order?");
@@ -153,12 +140,9 @@ namespace System.Drawing.Printing
             base.OnEndPage(document, e);
         }
 
-        /// <include file='doc\PreviewPrintController.uex' path='docs/doc[@for="PreviewPrintController.OnEndPrint"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Implements EndPrint for generating print preview information.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Implements EndPrint for generating print preview information.
+        /// </summary>
         public override void OnEndPrint(PrintDocument document, PrintEventArgs e)
         {
             Debug.Assert(_dc != null && _graphics == null, "PrintController methods called in the wrong order?");
@@ -172,12 +156,6 @@ namespace System.Drawing.Printing
             base.OnEndPrint(document, e);
         }
 
-        /// <include file='doc\PreviewPrintController.uex' path='docs/doc[@for="PreviewPrintController.GetPreviewPageInfo"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       The "printout".
-        ///    </para>
-        /// </devdoc>
         public PreviewPageInfo[] GetPreviewPageInfo()
         {
             // For security purposes, don't assume our public methods methods are called in any particular order
@@ -188,7 +166,6 @@ namespace System.Drawing.Printing
             return temp;
         }
 
-        /// <include file='doc\PreviewPrintController.uex' path='docs/doc[@for="PreviewPrintController.UseAntiAlias"]/*' />
         public virtual bool UseAntiAlias
         {
             get
@@ -202,4 +179,3 @@ namespace System.Drawing.Printing
         }
     }
 }
-

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PrintAction.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PrintAction.cs
@@ -4,34 +4,22 @@
 
 namespace System.Drawing.Printing
 {
-    /// <include file='doc\PrintAction.uex' path='docs/doc[@for="PrintAction"]/*' />
-    /// <devdoc>
-    ///    <para>
-    ///       Specifies the type of action for the <see cref='System.Drawing.Printing.PrintEventArgs'/>.
-    ///    </para>
-    /// </devdoc>
+    /// <summary>
+    /// Specifies the type of action for the <see cref='PrintEventArgs'/>.
+    /// </summary>
     public enum PrintAction
     {
-        /// <include file='doc\PrintAction.uex' path='docs/doc[@for="PrintAction.PrintToFile"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Printing to a file.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Printing to a file.
+        /// </summary>
         PrintToFile,
-        /// <include file='doc\PrintAction.uex' path='docs/doc[@for="PrintAction.PrintToPreview"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Printing to a preview.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Printing to a preview.
+        /// </summary>
         PrintToPreview,
-        /// <include file='doc\PrintAction.uex' path='docs/doc[@for="PrintAction.PrintToPrinter"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Printing to a printer.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Printing to a printer.
+        /// </summary>
         PrintToPrinter
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PrintController.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PrintController.cs
@@ -2,16 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Security;
+
 namespace System.Drawing.Printing
 {
-    using System.Diagnostics;
-    using System.Runtime.InteropServices;
-    using System.Security;
-
-    /// <include file='doc\PrintController.uex' path='docs/doc[@for="PrintController"]/*' />
-    /// <devdoc>
-    ///    <para>Controls how a document is printed.</para>
-    /// </devdoc>
+    /// <summary>
+    /// Controls how a document is printed.
+    /// </summary>
     public abstract class PrintController
     {
         // DEVMODEs are pretty expensive, so we cache one here and share it with the 
@@ -21,11 +20,8 @@ namespace System.Drawing.Printing
         #region SafeDeviceModeHandle Class
 
         /// <summary>
-        ///     Represents a SafeHandle for a Printer's Device Mode struct handle (DEVMODE)
+        /// Represents a SafeHandle for a Printer's Device Mode struct handle (DEVMODE)
         /// </summary>
-        /// <SecurityNote>
-        ///     Critical: base class SafeHandle is critical
-        /// </SecurityNote>
         [SecurityCritical]
         internal sealed class SafeDeviceModeHandle : SafeHandle
         {
@@ -76,23 +72,17 @@ namespace System.Drawing.Printing
 
         internal SafeDeviceModeHandle modeHandle = null;
 
-        /// <include file='doc\PrintController.uex' path='docs/doc[@for="PrintController.PrintController"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Printing.PrintController'/> class.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='PrintController'/> class.
+        /// </summary>
         protected PrintController()
         {
         }
 
 
-        /// <include file='doc\PrintController.uex' path='docs/doc[@for="PrintController.IsPreview"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       This is new public property which notifies if this controller is used for PrintPreview.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// This is new public property which notifies if this controller is used for PrintPreview.
+        /// </summary>
         public virtual bool IsPreview
         {
             get
@@ -280,39 +270,32 @@ namespace System.Drawing.Printing
         }
 
 
-        /// <include file='doc\PrintController.uex' path='docs/doc[@for="PrintController.OnStartPrint"]/*' />
-        /// <devdoc>
-        ///    <para>When overridden in a derived class, begins the control sequence of when and how to print a document.</para>
-        /// </devdoc>
+        /// <summary>
+        /// When overridden in a derived class, begins the control sequence of when and how to print a document.
+        /// </summary>
         public virtual void OnStartPrint(PrintDocument document, PrintEventArgs e)
         {
             modeHandle = (SafeDeviceModeHandle)document.PrinterSettings.GetHdevmode(document.DefaultPageSettings);
         }
 
-        /// <include file='doc\PrintController.uex' path='docs/doc[@for="PrintController.OnStartPage"]/*' />
-        /// <devdoc>
-        ///    <para>When overridden in a derived class, begins the control 
-        ///       sequence of when and how to print a page in a document.</para>
-        /// </devdoc>
+        /// <summary>
+        /// When overridden in a derived class, begins the control sequence of when and how to print a page in a document.
+        /// </summary>
         public virtual Graphics OnStartPage(PrintDocument document, PrintPageEventArgs e)
         {
             return null;
         }
 
-        /// <include file='doc\PrintController.uex' path='docs/doc[@for="PrintController.OnEndPage"]/*' />
-        /// <devdoc>
-        ///    <para>When overridden in a derived class, completes the control sequence of when and how 
-        ///       to print a page in a document.</para>
-        /// </devdoc>
+        /// <summary>
+        /// When overridden in a derived class, completes the control sequence of when and how to print a page in a document.
+        /// </summary>
         public virtual void OnEndPage(PrintDocument document, PrintPageEventArgs e)
         {
         }
 
-        /// <include file='doc\PrintController.uex' path='docs/doc[@for="PrintController.OnEndPrint"]/*' />
-        /// <devdoc>
-        ///    <para>When overridden in a derived class, completes the 
-        ///       control sequence of when and how to print a document.</para>
-        /// </devdoc>
+        /// <summary>
+        /// When overridden in a derived class, completes the control sequence of when and how to print a document.
+        /// </summary>
         public virtual void OnEndPrint(PrintDocument document, PrintEventArgs e)
         {
             Debug.Assert((modeHandle != null), "modeHandle is null.  Someone must have forgot to call base.StartPrint");
@@ -323,4 +306,3 @@ namespace System.Drawing.Printing
         }
     }
 }
-

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PrintDocument.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PrintDocument.cs
@@ -2,15 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
+
 namespace System.Drawing.Printing
 {
-    using System.ComponentModel;
-
-    /// <include file='doc\PrintDocument.uex' path='docs/doc[@for="PrintDocument"]/*' />
-    /// <devdoc>
-    ///    <para>Defines a reusable object that sends output to the
-    ///       printer.</para>
-    /// </devdoc>
+    /// <summary>
+    /// Defines a reusable object that sends output to the printer.
+    /// </summary>
     [SRDescription(nameof(SR.PrintDocumentDesc))]
     public class PrintDocument : Component
     {
@@ -29,22 +27,17 @@ namespace System.Drawing.Printing
         private bool _originAtMargins;
         private bool _userSetPageSettings;
 
-        /// <include file='doc\PrintDocument.uex' path='docs/doc[@for="PrintDocument.PrintDocument"]/*' />
-        /// <devdoc>
-        /// <para>Initializes a new instance of the <see cref='System.Drawing.Printing.PrintDocument'/>
-        /// class.</para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='PrintDocument'/> class.
+        /// </summary>
         public PrintDocument()
         {
             _defaultPageSettings = new PageSettings(_printerSettings);
         }
 
-        /// <include file='doc\PrintDocument.uex' path='docs/doc[@for="PrintDocument.DefaultPageSettings"]/*' />
-        /// <devdoc>
-        ///    <para>Gets or sets the
-        ///       default
-        ///       page settings for the document being printed.</para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the default page settings for the document being printed.
+        /// </summary>
         [
         Browsable(false),
         DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden),
@@ -62,12 +55,10 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PrintDocument.uex' path='docs/doc[@for="PrintDocument.DocumentName"]/*' />
-        /// <devdoc>
-        ///    <para>Gets or sets the name to display to the user while printing the document;
-        ///       for example, in a print status dialog or a printer
-        ///       queue.</para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the name to display to the user while printing the document; for example, in a print status
+        /// dialog or a printer queue.
+        /// </summary>
         [
         DefaultValue("document"),
         SRDescription(nameof(SR.PDOCdocumentNameDescr))
@@ -84,13 +75,11 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PrintDocument.uex' path='docs/doc[@for="PrintDocument.OriginAtMargins"]/*' />
         // If true, positions the origin of the graphics object 
         // associated with the page at the point just inside
         // the user-specified margins of the page.
         // If false, the graphics origin is at the top-left
         // corner of the printable area of the page.
-        //
         [
         DefaultValue(false),
         SRDescription(nameof(SR.PDOCoriginAtMarginsDescr))
@@ -107,11 +96,9 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PrintDocument.uex' path='docs/doc[@for="PrintDocument.PrintController"]/*' />
-        /// <devdoc>
-        /// <para>Gets or sets the <see cref='System.Drawing.Printing.PrintController'/> 
-        /// that guides the printing process.</para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the <see cref='Printing.PrintController'/>  that guides the printing process.
+        /// </summary>
         [
         Browsable(false),
         DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden),
@@ -133,11 +120,9 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PrintDocument.uex' path='docs/doc[@for="PrintDocument.PrinterSettings"]/*' />
-        /// <devdoc>
-        ///    <para> Gets or sets the printer on which the
-        ///       document is printed.</para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the printer on which the document is printed.
+        /// </summary>
         [
         Browsable(false),
         DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden),
@@ -159,12 +144,9 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PrintDocument.uex' path='docs/doc[@for="PrintDocument.BeginPrint"]/*' />
-        /// <devdoc>
-        /// <para>Occurs when the <see cref='System.Drawing.Printing.PrintDocument.Print'/> method is called, before 
-        ///    the
-        ///    first page prints.</para>
-        /// </devdoc>
+        /// <summary>
+        /// Occurs when the <see cref='Print'/> method is called, before the first page prints.
+        /// </summary>
         [SRDescription(nameof(SR.PDOCbeginPrintDescr))]
         public event PrintEventHandler BeginPrint
         {
@@ -178,11 +160,9 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PrintDocument.uex' path='docs/doc[@for="PrintDocument.EndPrint"]/*' />
-        /// <devdoc>
-        /// <para>Occurs when <see cref='System.Drawing.Printing.PrintDocument.Print'/> is
-        ///    called, after the last page is printed.</para>
-        /// </devdoc>
+        /// <summary>
+        /// Occurs when <see cref='Print'/> is called, after the last page is printed.
+        /// </summary>
         [SRDescription(nameof(SR.PDOCendPrintDescr))]
         public event PrintEventHandler EndPrint
         {
@@ -196,10 +176,9 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PrintDocument.uex' path='docs/doc[@for="PrintDocument.PrintPage"]/*' />
-        /// <devdoc>
-        ///    <para>Occurs when a page is printed. </para>
-        /// </devdoc>
+        /// <summary>
+        /// Occurs when a page is printed.
+        /// </summary>
         [SRDescription(nameof(SR.PDOCprintPageDescr))]
         public event PrintPageEventHandler PrintPage
         {
@@ -213,10 +192,6 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PrintDocument.uex' path='docs/doc[@for="PrintDocument.QueryPageSettings"]/*' />
-        /// <devdoc>
-        ///    <para>Occurs</para>
-        /// </devdoc>
         [SRDescription(nameof(SR.PDOCqueryPageSettingsDescr))]
         public event QueryPageSettingsEventHandler QueryPageSettings
         {
@@ -235,11 +210,9 @@ namespace System.Drawing.Printing
             OnBeginPrint(e);
         }
 
-        /// <include file='doc\PrintDocument.uex' path='docs/doc[@for="PrintDocument.OnBeginPrint"]/*' />
-        /// <devdoc>
-        /// <para>Raises the <see cref='E:System.Drawing.Printing.PrintDocument.BeginPrint'/>
-        /// event.</para>
-        /// </devdoc>
+        /// <summary>
+        /// Raises the <see cref='BeginPrint'/> event.
+        /// </summary>
         protected virtual void OnBeginPrint(PrintEventArgs e)
         {
             if (_beginPrintHandler != null)
@@ -251,11 +224,9 @@ namespace System.Drawing.Printing
             OnEndPrint(e);
         }
 
-        /// <include file='doc\PrintDocument.uex' path='docs/doc[@for="PrintDocument.OnEndPrint"]/*' />
-        /// <devdoc>
-        /// <para>Raises the <see cref='E:System.Drawing.Printing.PrintDocument.EndPrint'/>
-        /// event.</para>
-        /// </devdoc>
+        /// <summary>
+        /// Raises the <see cref='EndPrint'/> event.
+        /// </summary>
         protected virtual void OnEndPrint(PrintEventArgs e)
         {
             if (_endPrintHandler != null)
@@ -267,11 +238,9 @@ namespace System.Drawing.Printing
             OnPrintPage(e);
         }
 
-        /// <include file='doc\PrintDocument.uex' path='docs/doc[@for="PrintDocument.OnPrintPage"]/*' />
-        /// <devdoc>
-        /// <para>Raises the <see cref='E:System.Drawing.Printing.PrintDocument.PrintPage'/>
-        /// event.</para>
-        /// </devdoc>
+        /// <summary>
+        /// Raises the <see cref='PrintPage'/> event.
+        /// </summary>
         protected virtual void OnPrintPage(PrintPageEventArgs e)
         {
             if (_printPageHandler != null)
@@ -283,40 +252,30 @@ namespace System.Drawing.Printing
             OnQueryPageSettings(e);
         }
 
-        /// <include file='doc\PrintDocument.uex' path='docs/doc[@for="PrintDocument.OnQueryPageSettings"]/*' />
-        /// <devdoc>
-        /// <para>Raises the <see cref='E:System.Drawing.Printing.PrintDocument.QueryPageSettings'/> event.</para>
-        /// </devdoc>
+        /// <summary>
+        /// Raises the <see cref='QueryPageSettings'/> event.
+        /// </summary>
         protected virtual void OnQueryPageSettings(QueryPageSettingsEventArgs e)
         {
             if (_queryHandler != null)
                 _queryHandler(this, e);
         }
 
-        /// <include file='doc\PrintDocument.uex' path='docs/doc[@for="PrintDocument.Print"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Prints the document.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Prints the document.
+        /// </summary>
         public void Print()
         {
             PrintController controller = PrintController;
             controller.Print(this);
         }
 
-        /// <include file='doc\PrintDocument.uex' path='docs/doc[@for="PrintDocument.ToString"]/*' />
-        /// <internalonly/>
-        /// <devdoc>
-        ///    <para>
-        ///       Provides some interesting information about the PrintDocument in
-        ///       String form.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Provides some interesting information about the PrintDocument in String form.
+        /// </summary>
         public override string ToString()
         {
             return "[PrintDocument " + DocumentName + "]";
         }
     }
 }
-

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PrintEvent.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PrintEvent.cs
@@ -2,46 +2,35 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
+
 namespace System.Drawing.Printing
 {
-    using System.ComponentModel;
-
-    /// <include file='doc\PrintEvent.uex' path='docs/doc[@for="PrintEventArgs"]/*' />    
-    /// <devdoc>
-    /// <para>Provides data for the <see cref='E:System.Drawing.Printing.PrintDocument.BeginPrint'/> and
-    /// <see cref='E:System.Drawing.Printing.PrintDocument.EndPrint'/> events.</para>
-    /// </devdoc>
+    /// <summary>
+    /// Provides data for the <see cref='PrintDocument.BeginPrint'/> and <see cref='PrintDocument.EndPrint'/> events.
+    /// </summary>
     public class PrintEventArgs : CancelEventArgs
     {
         private PrintAction _printAction;
 
-        /// <include file='doc\PrintEvent.uex' path='docs/doc[@for="PrintEventArgs.PrintEventArgs"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Printing.PrintEventArgs'/> class.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='PrintEventArgs'/> class.
+        /// </summary>
         public PrintEventArgs()
         {
         }
 
-        /// <include file='doc\PrintEvent.uex' path='docs/doc[@for="PrintEventArgs.PrintEventArgs1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Printing.PrintEventArgs'/> class.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='PrintEventArgs'/> class.
+        /// </summary>
         internal PrintEventArgs(PrintAction action)
         {
             _printAction = action;
         }
 
-        /// <include file='doc\PrintEvent.uex' path='docs/doc[@for="PrintEventArgs.PrintAction"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Specifies which <see cref='System.Drawing.Printing.PrintAction'/> is causing this event.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Specifies which <see cref='Printing.PrintAction'/> is causing this event.
+        /// </summary>
         public PrintAction PrintAction
         {
             get

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PrintEventHandler.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PrintEventHandler.cs
@@ -4,13 +4,11 @@
 
 namespace System.Drawing.Printing
 {
-    /// <include file='doc\PrintEventHandler.uex' path='docs/doc[@for="PrintEventHandler"]/*' />
-    /// <devdoc>
-    ///    <para>
-    ///       Represents the method that will handle the <see cref='E:System.Drawing.Printing.PrintDocument.BeginPrint'/>,
-    ///    <see cref='E:System.Drawing.Printing.PrintDocument.EndPrint'/>, or <see cref='E:System.Drawing.Printing.PrintDocument.QueryPageSettings'/> event of a <see cref='System.Drawing.Printing.PrintDocument'/>.
-    ///    </para>
-    /// </devdoc>
+    /// <summary>
+    /// Represents the method that will handle the <see cref='PrintDocument.BeginPrint'/>,
+    /// <see cref='PrintDocument.EndPrint'/>, or <see cref='PrintDocument.QueryPageSettings'/>
+    /// event of a <see cref='PrintDocument'/>.
+    /// </summary>
     public delegate void PrintEventHandler(object sender, PrintEventArgs e);
 }
 

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PrintPageEvent.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PrintPageEvent.cs
@@ -4,11 +4,9 @@
 
 namespace System.Drawing.Printing
 {
-    /// <include file='doc\PrintPageEvent.uex' path='docs/doc[@for="PrintPageEventArgs"]/*' />
-    /// <devdoc>
-    /// <para>Provides data for the <see cref='E:System.Drawing.Printing.PrintDocument.PrintPage'/>
-    /// event.</para>
-    /// </devdoc>
+    /// <summary>
+    /// Provides data for the <see cref='PrintDocument.PrintPage'/> event.
+    /// </summary>
     // NOTE: Please keep this class consistent with PaintEventArgs.
     public class PrintPageEventArgs : EventArgs
     {
@@ -24,10 +22,9 @@ namespace System.Drawing.Printing
         internal bool CopySettingsToDevMode = true;
 
 
-        /// <include file='doc\PrintPageEvent.uex' path='docs/doc[@for="PrintPageEventArgs.PrintPageEventArgs"]/*' />
-        /// <devdoc>
-        /// <para>Initializes a new instance of the <see cref='System.Drawing.Printing.PrintPageEventArgs'/> class.</para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='PrintPageEventArgs'/> class.
+        /// </summary>
         public PrintPageEventArgs(Graphics graphics, Rectangle marginBounds, Rectangle pageBounds, PageSettings pageSettings)
         {
             _graphics = graphics; // may be null, see PrintController
@@ -36,24 +33,18 @@ namespace System.Drawing.Printing
             _pageSettings = pageSettings;
         }
 
-        /// <include file='doc\PrintPageEvent.uex' path='docs/doc[@for="PrintPageEventArgs.Cancel"]/*' />
-        /// <devdoc>
-        ///    <para>Gets or sets a value indicating whether the print job should be canceled.</para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets a value indicating whether the print job should be canceled.
+        /// </summary>
         public bool Cancel
         {
             get { return _cancel; }
             set { _cancel = value; }
         }
 
-        /// <include file='doc\PrintPageEvent.uex' path='docs/doc[@for="PrintPageEventArgs.Graphics"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets the <see cref='System.Drawing.Graphics'/>
-        ///       used to paint the
-        ///       item.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets the <see cref='System.Drawing.Graphics'/> used to paint the item.
+        /// </summary>
         public Graphics Graphics
         {
             get
@@ -62,21 +53,18 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PrintPageEvent.uex' path='docs/doc[@for="PrintPageEventArgs.HasMorePages"]/*' />
-        /// <devdoc>
-        ///    <para> Gets or sets a value indicating whether an additional page should
-        ///       be printed.</para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets a value indicating whether an additional page should be printed.
+        /// </summary>
         public bool HasMorePages
         {
             get { return _hasMorePages; }
             set { _hasMorePages = value; }
         }
 
-        /// <include file='doc\PrintPageEvent.uex' path='docs/doc[@for="PrintPageEventArgs.MarginBounds"]/*' />
-        /// <devdoc>
-        ///    <para>Gets the rectangular area that represents the portion of the page between the margins.</para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets the rectangular area that represents the portion of the page between the margins.
+        /// </summary>
         public Rectangle MarginBounds
         {
             get
@@ -85,12 +73,9 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PrintPageEvent.uex' path='docs/doc[@for="PrintPageEventArgs.PageBounds"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets the rectangular area that represents the total area of the page.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets the rectangular area that represents the total area of the page.
+        /// </summary>
         public Rectangle PageBounds
         {
             get
@@ -99,11 +84,9 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PrintPageEvent.uex' path='docs/doc[@for="PrintPageEventArgs.PageSettings"]/*' />
-        /// <devdoc>
-        ///    <para>Gets
-        ///       the page settings for the current page.</para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets the page settings for the current page.
+        /// </summary>
         public PageSettings PageSettings
         {
             get
@@ -112,14 +95,9 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PrintPageEvent.uex' path='docs/doc[@for="PrintPageEventArgs.Dispose"]/*' />
-        /// <devdoc>
-        ///    <para>Disposes
-        ///       of the resources (other than memory) used by
-        ///       the <see cref='System.Drawing.Printing.PrintPageEventArgs'/>.</para>
-        /// </devdoc>
-        // We want a way to dispose the GDI+ Graphics, but we don't want to create one
-        // simply to dispose it
+        /// <summary>
+        /// Disposes of the resources (other than memory) used by the <see cref='PrintPageEventArgs'/>.
+        /// </summary>
         internal void Dispose()
         {
             _graphics.Dispose();

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PrintPageEventHandler.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PrintPageEventHandler.cs
@@ -4,11 +4,8 @@
 
 namespace System.Drawing.Printing
 {
-    /// <include file='doc\PrintPageEventHandler.uex' path='docs/doc[@for="PrintPageEventHandler"]/*' />
-    /// <devdoc>
-    ///    <para>
-    ///       Represents the method that will handle the <see cref='E:System.Drawing.Printing.PrintDocument.PrintPage'/> event of a <see cref='System.Drawing.Printing.PrintDocument'/>.
-    ///    </para>
-    /// </devdoc>
+    /// <summary>
+    /// Represents the method that will handle the <see cref='PrintDocument.PrintPage'/> event of a <see cref='PrintDocument'/>.
+    /// </summary>
     public delegate void PrintPageEventHandler(object sender, PrintPageEventArgs e);
 }

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PrintPreviewGraphics.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PrintPreviewGraphics.cs
@@ -2,16 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Drawing.Internal;
+using System.Drawing.Printing;
+using System.Runtime.InteropServices;
+
 namespace System.Drawing
 {
-    using System.Drawing.Internal;
-    using System.Drawing.Printing;
-    using System.Runtime.InteropServices;
-
-    /// <include file='doc\PrintPreviewGraphics.uex' path='docs/doc[@for="PrintPreviewGraphics"]/*' />
-    /// <devdoc>
-    ///    <para> Retrives the printer graphics during preview.</para>
-    /// </devdoc>
+    /// <summary>
+    /// Retrives the printer graphics during preview.
+    /// </summary>
     internal class PrintPreviewGraphics
     {
         private PrintPageEventArgs _printPageEventArgs;
@@ -23,10 +22,9 @@ namespace System.Drawing
             _printDocument = document;
         }
 
-        /// <include file='doc\PrintPreviewGraphics.uex' path='docs/doc[@for="PrintPreviewGraphics.VisibleClipBounds"]/*' />
-        /// <devdoc>
-        ///     Gets the Visible bounds of this graphics object. Used during print preview.    
-        /// </devdoc>
+        /// <summary>
+        /// Gets the Visible bounds of this graphics object. Used during print preview.
+        /// </summary>
         public RectangleF VisibleClipBounds
         {
             get

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PrintRange.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PrintRange.cs
@@ -4,50 +4,29 @@
 
 namespace System.Drawing.Printing
 {
-    /// <include file='doc\PrintRange.uex' path='docs/doc[@for="PrintRange"]/*' />
-    /// <devdoc>
-    ///    <para>
-    ///       Specifies the option buttons in the print dialog box that
-    ///       designate the part of the document to print.
-    ///    </para>
-    /// </devdoc>
+    /// <summary>
+    /// Specifies the option buttons in the print dialog box that designate the part of the document to print.
+    /// </summary>
     public enum PrintRange
     {
-        /// <include file='doc\PrintRange.uex' path='docs/doc[@for="PrintRange.AllPages"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       All pages are printed.
-        ///       
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// All pages are printed.
+        /// </summary>
         AllPages = SafeNativeMethods.PD_ALLPAGES,
 
-        /// <include file='doc\PrintRange.uex' path='docs/doc[@for="PrintRange.SomePages"]/*' />
-        /// <devdoc>
-        /// <para> The pages between <see cref='System.Drawing.Printing.PrinterSettings.FromPage'/> and
-        /// <see cref='System.Drawing.Printing.PrinterSettings.ToPage'/>
-        /// are
-        /// printed.</para>
-        /// </devdoc>
+        /// <summary>
+        /// The pages between <see cref='PrinterSettings.FromPage'/> and <see cref='PrinterSettings.ToPage'/> are printed.
+        /// </summary>
         SomePages = SafeNativeMethods.PD_PAGENUMS,
 
-        /// <include file='doc\PrintRange.uex' path='docs/doc[@for="PrintRange.Selection"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       The selected pages are printed.
-        ///       
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// The selected pages are printed.
+        /// </summary>
         Selection = SafeNativeMethods.PD_SELECTION,
 
-        /// <internalonly/>
         /// <summary>
-        ///    <para>
-        ///       The
-        ///       current page is printed. The print dialog box requires Windows 2000 or
-        ///       later for this setting; if used with an earlier operating system, all pages will be printed.
-        ///       
-        ///    </para>
+        /// The current page is printed. The print dialog box requires Windows 2000 or later for this setting; if used
+        /// with an earlier operating system, all pages will be printed.
         /// </summary>
         CurrentPage = SafeNativeMethods.PD_CURRENTPAGE,
 

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PrinterResolution.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PrinterResolution.cs
@@ -2,29 +2,23 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
+using System.Globalization;
+
 namespace System.Drawing.Printing
 {
-    using System.ComponentModel;
-    using System.Globalization;
-
-    /// <include file='doc\PrinterResolution.uex' path='docs/doc[@for="PrinterResolution"]/*' />
-    /// <devdoc>
-    ///    <para> Retrieves
-    ///       the resolution supported by a printer.</para>
-    /// </devdoc>
+    /// <summary>
+    /// Retrieves the resolution supported by a printer.
+    /// </summary>
     public partial class PrinterResolution
     {
         private int _x;
         private int _y;
         private PrinterResolutionKind _kind;
 
-        /// <include file='doc\PrinterResolution.uex' path='docs/doc[@for="PrinterResolution.PrinterResolution"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Printing.PrinterResolution'/> class with default properties.
-        ///       This constructor is required for the serialization of the <see cref='System.Drawing.Printing.PrinterResolution'/> class.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='PrinterResolution'/> class with default properties.
+        /// </summary>
         public PrinterResolution()
         {
             _kind = PrinterResolutionKind.Custom;
@@ -37,14 +31,9 @@ namespace System.Drawing.Printing
             _y = y;
         }
 
-        /// <include file='doc\PrinterResolution.uex' path='docs/doc[@for="PrinterResolution.Kind"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets
-        ///       a value indicating the kind of printer resolution.
-        ///       Setter added to enable serialization of the PrinterSettings object.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets a value indicating the kind of printer resolution.
+        /// </summary>
         public PrinterResolutionKind Kind
         {
             get { return _kind; }
@@ -60,14 +49,9 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PrinterResolution.uex' path='docs/doc[@for="PrinterResolution.X"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets the printer resolution in the horizontal direction,
-        ///       in dots per inch.
-        ///       Setter added to enable serialization of the PrinterSettings object.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets the printer resolution in the horizontal direction, in dots per inch.
+        /// </summary>
         public int X
         {
             get
@@ -80,13 +64,9 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PrinterResolution.uex' path='docs/doc[@for="PrinterResolution.Y"]/*' />
-        /// <devdoc>
-        ///    <para> Gets the printer resolution in the vertical direction,
-        ///       in dots per inch.
-        ///       Setter added to enable serialization of the PrinterSettings object.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets the printer resolution in the vertical direction, in dots per inch.
+        /// </summary>
         public int Y
         {
             get
@@ -99,14 +79,9 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PrinterResolution.uex' path='docs/doc[@for="PrinterResolution.ToString"]/*' />
-        /// <internalonly/>
-        /// <devdoc>
-        ///    <para>
-        ///       Provides some interesting information about the PrinterResolution in
-        ///       String form.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Provides some interesting information about the PrinterResolution in String form.
+        /// </summary>
         public override string ToString()
         {
             if (_kind != PrinterResolutionKind.Custom)

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PrinterResolutionKind.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PrinterResolutionKind.cs
@@ -4,51 +4,30 @@
 
 namespace System.Drawing.Printing
 {
-    /// <include file='doc\PrinterResolutionKind.uex' path='docs/doc[@for="PrinterResolutionKind"]/*' />
-    /// <devdoc>
-    ///    <para>Specifies a printer resolution.</para>
-    /// </devdoc>
+    /// <summary>
+    /// Specifies a printer resolution.
+    /// </summary>
     public enum PrinterResolutionKind
     {
-        /// <include file='doc\PrinterResolutionKind.uex' path='docs/doc[@for="PrinterResolutionKind.High"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       High resolution.
-        ///       
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// High resolution.
+        /// </summary>
         High = SafeNativeMethods.DMRES_HIGH,
-        /// <include file='doc\PrinterResolutionKind.uex' path='docs/doc[@for="PrinterResolutionKind.Medium"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Medium resolution.
-        ///       
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Medium resolution.
+        /// </summary>
         Medium = SafeNativeMethods.DMRES_MEDIUM,
-        /// <include file='doc\PrinterResolutionKind.uex' path='docs/doc[@for="PrinterResolutionKind.Low"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Low resolution.
-        ///       
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Low resolution.
+        /// </summary>
         Low = SafeNativeMethods.DMRES_LOW,
-        /// <include file='doc\PrinterResolutionKind.uex' path='docs/doc[@for="PrinterResolutionKind.Draft"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Draft-quality resolution.
-        ///       
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Draft-quality resolution.
+        /// </summary>
         Draft = SafeNativeMethods.DMRES_DRAFT,
-        /// <include file='doc\PrinterResolutionKind.uex' path='docs/doc[@for="PrinterResolutionKind.Custom"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Custom resolution.
-        ///       
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Custom resolution.
+        /// </summary>
         Custom = 0,
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PrinterSettings.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PrinterSettings.cs
@@ -2,22 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Drawing.Imaging;
+using System.Drawing.Internal;
+using System.Globalization;
+using System.IO;
+using System.Runtime.InteropServices;
+
 namespace System.Drawing.Printing
 {
-    using System.Collections;
-    using System.ComponentModel;
-    using System.Diagnostics;
-    using System.Drawing.Imaging;
-    using System.Drawing.Internal;
-    using System.Globalization;
-    using System.IO;
-    using System.Runtime.InteropServices;
-
-    /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings"]/*' />
-    /// <devdoc>
-    ///    Information about how a document should be printed, including which printer
-    ///    to print it on.
-    /// </devdoc>
+    /// <summary>
+    /// Information about how a document should be printed, including which printer to print it on.
+    /// </summary>
     public partial class PrinterSettings : ICloneable
     {
         // All read/write data is stored in managed code, and whenever we need to call Win32,
@@ -51,34 +49,25 @@ namespace System.Drawing.Printing
         private short _devmodebytes;
         private byte[] _cachedDevmode;
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PrinterSettings"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Printing.PrinterSettings'/> class.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='PrinterSettings'/> class.
+        /// </summary>
         public PrinterSettings()
         {
             _defaultPageSettings = new PageSettings(this);
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.CanDuplex"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets a value indicating whether the printer supports duplex (double-sided) printing.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets a value indicating whether the printer supports duplex (double-sided) printing.
+        /// </summary>
         public bool CanDuplex
         {
             get { return DeviceCapabilities(SafeNativeMethods.DC_DUPLEX, IntPtr.Zero, 0) == 1; }
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.Copies"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets or sets the number of copies to print.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the number of copies to print.
+        /// </summary>
         public short Copies
         {
             get
@@ -95,22 +84,19 @@ namespace System.Drawing.Printing
                                                              "value", value.ToString(CultureInfo.CurrentCulture),
                                                              (0).ToString(CultureInfo.CurrentCulture)));
                 /*
-                We shouldnt allow copies to be set since the copies can be a large number 
-                and can be reflected in PrintDialog. So for the Copies property,
-                we prefer that for SafePrinting, copied cannot be set programmatically 
-                but through the print dialog. 
-                Any lower security could set copies to anything. Vs Whidbey 93475*/
+                    We shouldnt allow copies to be set since the copies can be a large number 
+                    and can be reflected in PrintDialog. So for the Copies property,
+                    we prefer that for SafePrinting, copied cannot be set programmatically 
+                    but through the print dialog. 
+                    Any lower security could set copies to anything.
+                */
                 _copies = value;
             }
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.Collate"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets or sets
-        ///       a value indicating whether the print out is collated.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets a value indicating whether the print out is collated.
+        /// </summary>
         public bool Collate
         {
             get
@@ -123,12 +109,9 @@ namespace System.Drawing.Printing
             set { _collate = value; }
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.DefaultPageSettings"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets the default page settings for this printer.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets the default page settings for this printer.
+        /// </summary>
         public PageSettings DefaultPageSettings
         {
             get { return _defaultPageSettings; }
@@ -139,31 +122,11 @@ namespace System.Drawing.Printing
         internal string DriverName
         {
             get { return _driverName; }
-            // set { driverName = value;}
         }
 
-        /* // No point in having a driver version if you can't get the driver name
         /// <summary>
-        ///    <para>
-        ///       Gets the printer driver version number.
-        ///    </para>
+        /// Gets or sets the printer's duplex setting.
         /// </summary>
-        /// <value>
-        ///    <para>
-        ///       The printer driver version number.
-        ///    </para>
-        /// </value>
-        public int DriverVersion {
-            get { return DeviceCapabilities(SafeNativeMethods.DC_DRIVER, 0, -1);}
-        }
-        */
-
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.Duplex"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets or sets the printer's duplex setting.
-        ///    </para>
-        /// </devdoc>
         public Duplex Duplex
         {
             get
@@ -184,10 +147,9 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.FromPage"]/*' />
-        /// <devdoc>
-        ///    <para>Gets or sets the first page to print.</para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the first page to print.
+        /// </summary>
         public int FromPage
         {
             get { return _fromPage; }
@@ -203,12 +165,9 @@ namespace System.Drawing.Printing
 
 
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.InstalledPrinters"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets the names of all printers installed on the machine.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets the names of all printers installed on the machine.
+        /// </summary>
         public static StringCollection InstalledPrinters
         {
             get
@@ -256,13 +215,9 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.IsDefaultPrinter"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets a value indicating whether the <see cref='System.Drawing.Printing.PrinterSettings.PrinterName'/>
-        ///       property designates the default printer.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets a value indicating whether the <see cref='PrinterName'/> property designates the default printer.
+        /// </summary>
         public bool IsDefaultPrinter
         {
             get
@@ -271,12 +226,9 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.IsPlotter"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets a value indicating whether the printer is a plotter, as opposed to a raster printer.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets a value indicating whether the printer is a plotter, as opposed to a raster printer.
+        /// </summary>
         public bool IsPlotter
         {
             get
@@ -285,13 +237,9 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.IsValid"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets a value indicating whether the <see cref='System.Drawing.Printing.PrinterSettings.PrinterName'/>
-        ///       property designates a valid printer.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets a value indicating whether the <see cref='PrinterName'/> property designates a valid printer.
+        /// </summary>
         public bool IsValid
         {
             get
@@ -300,36 +248,25 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.LandscapeAngle"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets the angle, in degrees, which the portrait orientation is rotated
-        ///       to produce the landscape orientation.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets the angle, in degrees, which the portrait orientation is rotated to produce the landscape orientation.
+        /// </summary>
         public int LandscapeAngle
         {
             get { return DeviceCapabilities(SafeNativeMethods.DC_ORIENTATION, IntPtr.Zero, 0); }
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.MaximumCopies"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets the maximum number of copies allowed by the printer.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets the maximum number of copies allowed by the printer.
+        /// </summary>
         public int MaximumCopies
         {
             get { return DeviceCapabilities(SafeNativeMethods.DC_COPIES, IntPtr.Zero, 1); }
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.MaximumPage"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets or sets the highest <see cref='System.Drawing.Printing.PrinterSettings.FromPage'/> or <see cref='System.Drawing.Printing.PrinterSettings.ToPage'/>
-        ///       which may be selected in a print dialog box.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the highest <see cref='FromPage'/> or <see cref='ToPage'/> which may be selected in a print dialog box.
+        /// </summary>
         public int MaximumPage
         {
             get { return _maxPage; }
@@ -343,11 +280,9 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.MinimumPage"]/*' />
-        /// <devdoc>
-        /// <para>Gets or sets the lowest <see cref='System.Drawing.Printing.PrinterSettings.FromPage'/> or <see cref='System.Drawing.Printing.PrinterSettings.ToPage'/>
-        /// which may be selected in a print dialog box.</para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the lowest <see cref='FromPage'/> or <see cref='ToPage'/> which may be selected in a print dialog box.
+        /// </summary>
         public int MinimumPage
         {
             get { return _minPage; }
@@ -373,12 +308,9 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PrintFileName"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Indicates the name of the printerfile.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Indicates the name of the printerfile.
+        /// </summary>
         public string PrintFileName
         {
             get
@@ -396,42 +328,31 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PaperSizes"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets the paper sizes supported by this printer.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets the paper sizes supported by this printer.
+        /// </summary>
         public PaperSizeCollection PaperSizes
         {
             get { return new PaperSizeCollection(Get_PaperSizes()); }
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PaperSources"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets the paper sources available on this printer.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets the paper sources available on this printer.
+        /// </summary>
         public PaperSourceCollection PaperSources
         {
             get { return new PaperSourceCollection(Get_PaperSources()); }
         }
 
-        /// <devdoc>
-        ///    <para>
-        ///        Whether the print dialog has been displayed.  In SafePrinting mode,
-        ///        a print dialog is required to print.  After printing,
-        ///        this property is set to false if the program does not have AllPrinting;
-        ///        this guarantees a document is only printed once each time the print dialog is shown.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Whether the print dialog has been displayed.  In SafePrinting mode, a print dialog is required to print.
+        /// After printing, this property is set to false if the program does not have AllPrinting; this guarantees
+        /// a document is only printed once each time the print dialog is shown.
+        /// </summary>
         internal bool PrintDialogDisplayed
         {
             get
             {
-                // no security check
-
                 return _printDialogDisplayed;
             }
 
@@ -441,11 +362,9 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PrintRange"]/*' />
-        /// <devdoc>
-        ///    <para> 
-        ///       Gets or sets the pages the user has asked to print.</para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the pages the user has asked to print.
+        /// </summary>
         public PrintRange PrintRange
         {
             get { return _printRange; }
@@ -458,10 +377,9 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PrintToFile"]/*' />
-        /// <devdoc>
-        ///       Indicates whether to print to a file instead of a port.
-        /// </devdoc>
+        /// <summary>
+        /// Indicates whether to print to a file instead of a port.
+        /// </summary>
         public bool PrintToFile
         {
             get
@@ -474,12 +392,9 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PrinterName"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets or sets the name of the printer.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the name of the printer.
+        /// </summary>
         public string PrinterName
         {
             get
@@ -508,28 +423,24 @@ namespace System.Drawing.Printing
                 _cachedDevmode = null;
                 _extrainfo = null;
                 _printerName = value;
-                // VsWhidbey : 235920: PrinterName can be set through a fulltrusted assembly without using  the PrintDialog. 
+                // PrinterName can be set through a fulltrusted assembly without using  the PrintDialog. 
                 // So dont set this variable here.
                 //PrintDialogDisplayed = true;
             }
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PrinterResolutions"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets the resolutions supported by this printer.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets the resolutions supported by this printer.
+        /// </summary>
         public PrinterResolutionCollection PrinterResolutions
         {
             get { return new PrinterResolutionCollection(Get_PrinterResolutions()); }
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.IsDirectPrintingSupported"]/*' />
-        /// <devdoc>
-        ///     If the image is a JPEG or a PNG (Image.RawFormat) and the printer returns true
-        ///     from ExtEscape(CHECKJPEGFORMAT) or ExtEscape(CHECKPNGFORMAT) then this function returns true.
-        /// </devdoc>
+        /// <summary>
+        /// If the image is a JPEG or a PNG (Image.RawFormat) and the printer returns true from
+        /// ExtEscape(CHECKJPEGFORMAT) or ExtEscape(CHECKPNGFORMAT) then this function returns true.
+        /// </summary>
         public bool IsDirectPrintingSupported(ImageFormat imageFormat)
         {
             bool isDirectPrintingSupported = false;
@@ -551,18 +462,13 @@ namespace System.Drawing.Printing
             return isDirectPrintingSupported;
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.IsDirectPrintingSupported"]/*' />
-        /// <devdoc>
-        ///    <para>
+        /// <summary>
         /// This method utilizes the CHECKJPEGFORMAT/CHECKPNGFORMAT printer escape functions
         /// to determine whether the printer can handle a JPEG image.
-        /// See http://msdn.microsoft.com/library/default.asp?url=/library/en-us/gdi/prntspol_51ys.asp
-        /// for more information on this printer escape function.
         ///
         /// If the image is a JPEG or a PNG (Image.RawFormat) and the printer returns true
         /// from ExtEscape(CHECKJPEGFORMAT) or ExtEscape(CHECKPNGFORMAT) then this function returns true.
-        ///    </para>
-        /// </devdoc>
+        /// </summary>
         public bool IsDirectPrintingSupported(Image image)
         {
             bool isDirectPrintingSupported = false;
@@ -608,13 +514,9 @@ namespace System.Drawing.Printing
             return isDirectPrintingSupported;
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.SupportsColor"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets a
-        ///       value indicating whether the printer supports color printing.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets a value indicating whether the printer supports color printing.
+        /// </summary>
         public bool SupportsColor
         {
             get
@@ -623,10 +525,9 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.ToPage"]/*' />
-        /// <devdoc>
-        ///    Gets or sets the last page to print.
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the last page to print.
+        /// </summary>
         public int ToPage
         {
             get { return _toPage; }
@@ -640,19 +541,16 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.Clone"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Creates an identical copy of this object.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Creates an identical copy of this object.
+        /// </summary>
         public object Clone()
         {
             PrinterSettings clone = (PrinterSettings)MemberwiseClone();
             clone._printDialogDisplayed = false;
             return clone;
         }
- // what is done in copytohdevmode cannot give unwanted access AllPrinting permission
+        // what is done in copytohdevmode cannot give unwanted access AllPrinting permission
         internal DeviceContext CreateDeviceContext(PageSettings pageSettings)
         {
             IntPtr modeHandle = GetHdevmodeInternal();
@@ -679,7 +577,8 @@ namespace System.Drawing.Printing
             return dc;
         }
 
-        // A read-only DC, which is faster than CreateHdc         // what is done in copytohdevmode cannot give unwanted access AllPrinting permission
+        // A read-only DC, which is faster than CreateHdc
+        // what is done in copytohdevmode cannot give unwanted access AllPrinting permission
         internal DeviceContext CreateInformationContext(PageSettings pageSettings)
         {
             IntPtr modeHandle = GetHdevmodeInternal();
@@ -707,13 +606,12 @@ namespace System.Drawing.Printing
             return dc;
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.CreateMeasurementGraphics"]/*' />
         public Graphics CreateMeasurementGraphics()
         {
             return CreateMeasurementGraphics(DefaultPageSettings);
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.CreateMeasurementGraphics2"]/*' /> //whatever the call stack calling HardMarginX and HardMarginY here is safe
+        //whatever the call stack calling HardMarginX and HardMarginY here is safe
         public Graphics CreateMeasurementGraphics(bool honorOriginAtMargins)
         {
             Graphics g = CreateMeasurementGraphics();
@@ -725,7 +623,6 @@ namespace System.Drawing.Printing
             return g;
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.CreateMeasurementGraphics3"]/*' />
         public Graphics CreateMeasurementGraphics(PageSettings pageSettings)
         {
             // returns the Graphics object for the printer
@@ -735,7 +632,7 @@ namespace System.Drawing.Printing
             return g;
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.CreateMeasurementGraphics4"]/*' /> //whatever the call stack calling HardMarginX and HardMarginY here is safe
+        //whatever the call stack calling HardMarginX and HardMarginY here is safe
         public Graphics CreateMeasurementGraphics(PageSettings pageSettings, bool honorOriginAtMargins)
         {
             Graphics g = CreateMeasurementGraphics();
@@ -952,13 +849,12 @@ namespace System.Drawing.Printing
             return result;
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.GetHdevmode"]/*' />
-        /// <devdoc>
-        ///    <para>Creates a handle to a DEVMODE structure which correspond too the printer settings.
-        ///       When you are done with the handle, you must deallocate it yourself:
-        ///       Windows.GlobalFree(handle);
-        ///       Where "handle" is the return value from this method.</para>
-        /// </devdoc>
+        /// <summary>
+        /// Creates a handle to a DEVMODE structure which correspond too the printer settings.When you are done with the
+        /// handle, you must deallocate it yourself:
+        ///   Windows.GlobalFree(handle);
+        ///   Where "handle" is the return value from this method.
+        /// </summary>
         public IntPtr GetHdevmode()
         {
             // Don't assert unmanaged code -- anyone using handles should have unmanaged code permission
@@ -1014,12 +910,14 @@ namespace System.Drawing.Printing
             }
             if ((mode.dmFields & SafeNativeMethods.DM_COPIES) == SafeNativeMethods.DM_COPIES)
             {
-                if (_copies != -1) mode.dmCopies = _copies;
+                if (_copies != -1)
+                    mode.dmCopies = _copies;
             }
 
             if ((mode.dmFields & SafeNativeMethods.DM_DUPLEX) == SafeNativeMethods.DM_DUPLEX)
             {
-                if (unchecked((int)_duplex) != -1) mode.dmDuplex = unchecked((short)_duplex);
+                if (unchecked((int)_duplex) != -1)
+                    mode.dmDuplex = unchecked((short)_duplex);
             }
 
             if ((mode.dmFields & SafeNativeMethods.DM_COLLATE) == SafeNativeMethods.DM_COLLATE)
@@ -1043,36 +941,28 @@ namespace System.Drawing.Printing
             return handle;
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.GetHdevmode1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Creates a handle to a DEVMODE structure which correspond to the printer
-        ///       and page settings.
-        ///       When you are done with the handle, you must deallocate it yourself:
-        ///       Windows.GlobalFree(handle);
-        ///       Where "handle" is the return value from this method.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Creates a handle to a DEVMODE structure which correspond to the printer and page settings.
+        /// When you are done with the handle, you must deallocate it yourself:
+        ///   Windows.GlobalFree(handle);
+        ///   Where "handle" is the return value from this method.
+        /// </summary>
         public IntPtr GetHdevmode(PageSettings pageSettings)
         {
-            // Don't assert unmanaged code -- anyone using handles should have unmanaged code permission
             IntPtr modeHandle = GetHdevmodeInternal();
             pageSettings.CopyToHdevmode(modeHandle);
 
             return modeHandle;
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.GetHdevnames"]/*' />
-        /// <devdoc>
-        ///    Creates a handle to a DEVNAMES structure which correspond to the printer settings.
-        ///    When you are done with the handle, you must deallocate it yourself:
-        ///    Windows.GlobalFree(handle);
-        ///    Where "handle" is the return value from this method.
-        /// </devdoc>
+        /// <summary>
+        /// Creates a handle to a DEVNAMES structure which correspond to the printer settings.
+        /// When you are done with the handle, you must deallocate it yourself:
+        ///   Windows.GlobalFree(handle);
+        ///   Where "handle" is the return value from this method.
+        /// </summary>
         public IntPtr GetHdevnames()
         {
-            // Don't assert unmanaged code -- anyone using handles should have unmanaged code permission
-
             string printerName = PrinterName; // the PrinterName property is slow when using the default printer
             string driver = DriverName;  // make sure we are writing out exactly the same string as we got the length of
             string outPort = OutputPort;
@@ -1128,18 +1018,42 @@ namespace System.Drawing.Printing
                 SafeNativeMethods.DEVMODE mode = (SafeNativeMethods.DEVMODE)UnsafeNativeMethods.PtrToStructure(modePointer, typeof(SafeNativeMethods.DEVMODE));
                 switch (field)
                 {
-                    case ModeField.Orientation: result = mode.dmOrientation; break;
-                    case ModeField.PaperSize: result = mode.dmPaperSize; break;
-                    case ModeField.PaperLength: result = mode.dmPaperLength; break;
-                    case ModeField.PaperWidth: result = mode.dmPaperWidth; break;
-                    case ModeField.Copies: result = mode.dmCopies; break;
-                    case ModeField.DefaultSource: result = mode.dmDefaultSource; break;
-                    case ModeField.PrintQuality: result = mode.dmPrintQuality; break;
-                    case ModeField.Color: result = mode.dmColor; break;
-                    case ModeField.Duplex: result = mode.dmDuplex; break;
-                    case ModeField.YResolution: result = mode.dmYResolution; break;
-                    case ModeField.TTOption: result = mode.dmTTOption; break;
-                    case ModeField.Collate: result = mode.dmCollate; break;
+                    case ModeField.Orientation:
+                        result = mode.dmOrientation;
+                        break;
+                    case ModeField.PaperSize:
+                        result = mode.dmPaperSize;
+                        break;
+                    case ModeField.PaperLength:
+                        result = mode.dmPaperLength;
+                        break;
+                    case ModeField.PaperWidth:
+                        result = mode.dmPaperWidth;
+                        break;
+                    case ModeField.Copies:
+                        result = mode.dmCopies;
+                        break;
+                    case ModeField.DefaultSource:
+                        result = mode.dmDefaultSource;
+                        break;
+                    case ModeField.PrintQuality:
+                        result = mode.dmPrintQuality;
+                        break;
+                    case ModeField.Color:
+                        result = mode.dmColor;
+                        break;
+                    case ModeField.Duplex:
+                        result = mode.dmDuplex;
+                        break;
+                    case ModeField.YResolution:
+                        result = mode.dmYResolution;
+                        break;
+                    case ModeField.TTOption:
+                        result = mode.dmTTOption;
+                        break;
+                    case ModeField.Collate:
+                        result = mode.dmCollate;
+                        break;
                     default:
                         Debug.Fail("Invalid field in GetModeField");
                         result = defaultValue;
@@ -1285,12 +1199,9 @@ namespace System.Drawing.Printing
             return result;
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.SetHdevmode"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Copies the relevant information out of the handle and into the PrinterSettings.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Copies the relevant information out of the handle and into the PrinterSettings.
+        /// </summary>
         public void SetHdevmode(IntPtr hdevmode)
         {
             if (hdevmode == IntPtr.Zero)
@@ -1333,10 +1244,9 @@ namespace System.Drawing.Printing
             SafeNativeMethods.GlobalUnlock(new HandleRef(null, hdevmode));
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.SetHdevnames"]/*' />
-        /// <devdoc>
-        ///    <para>Copies the relevant information out of the handle and into the PrinterSettings.</para>
-        /// </devdoc>
+        /// <summary>
+        /// Copies the relevant information out of the handle and into the PrinterSettings.
+        /// </summary>
         public void SetHdevnames(IntPtr hdevnames)
         {
             if (hdevnames == IntPtr.Zero)
@@ -1353,14 +1263,9 @@ namespace System.Drawing.Printing
             SafeNativeMethods.GlobalUnlock(new HandleRef(null, hdevnames));
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.ToString"]/*' />
-        /// <internalonly/>
-        /// <devdoc>
-        ///    <para>
-        ///       Provides some interesting information about the PrinterSettings in
-        ///       String form.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Provides some interesting information about the PrinterSettings in String form.
+        /// </summary>
         public override string ToString()
         {
             string printerName = PrinterName;
@@ -1368,8 +1273,6 @@ namespace System.Drawing.Printing
             + printerName
             + " Copies=" + Copies.ToString(CultureInfo.InvariantCulture)
             + " Collate=" + Collate.ToString(CultureInfo.InvariantCulture)
-            //            + " DriverName=" + DriverName.ToString(CultureInfo.InvariantCulture)
-            //            + " DriverVersion=" + DriverVersion.ToString(CultureInfo.InvariantCulture)
             + " Duplex=" + Duplex.ToString()
             + " FromPage=" + FromPage.ToString(CultureInfo.InvariantCulture)
             + " LandscapeAngle=" + LandscapeAngle.ToString(CultureInfo.InvariantCulture)
@@ -1382,7 +1285,8 @@ namespace System.Drawing.Printing
         // Write null terminated string, return length of string in characters (including null)
         private short WriteOneDEVNAME(string str, IntPtr bufferStart, int index)
         {
-            if (str == null) str = "";
+            if (str == null)
+                str = "";
             IntPtr address = (IntPtr)(checked((long)bufferStart + index * Marshal.SystemDefaultCharSize));
 
             char[] data = str.ToCharArray();
@@ -1392,33 +1296,24 @@ namespace System.Drawing.Printing
             return checked((short)(str.Length + 1));
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PaperSizeCollection"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Collection of PaperSize's...
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Collection of PaperSize's...
+        /// </summary>
         public class PaperSizeCollection : ICollection
         {
             private PaperSize[] _array;
 
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PaperSizeCollection.PaperSizeCollection"]/*' />
-            /// <devdoc>
-            ///    <para>
-            ///       Initializes a new instance of the <see cref='System.Drawing.Printing.PrinterSettings.PaperSizeCollection'/> class.
-            ///    </para>
-            /// </devdoc>
+            /// <summary>
+            /// Initializes a new instance of the <see cref='System.Drawing.Printing.PrinterSettings.PaperSizeCollection'/> class.
+            /// </summary>
             public PaperSizeCollection(PaperSize[] array)
             {
                 _array = array;
             }
 
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PaperSizeCollection.Count"]/*' />
-            /// <devdoc>
-            ///    <para>
-            ///       Gets a value indicating the number of paper sizes.
-            ///    </para>
-            /// </devdoc>
+            /// <summary>
+            /// Gets a value indicating the number of paper sizes.
+            /// </summary>
             public int Count
             {
                 get
@@ -1427,12 +1322,9 @@ namespace System.Drawing.Printing
                 }
             }
 
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PaperSizeCollection.this"]/*' />
-            /// <devdoc>
-            ///    <para>
-            ///       Retrieves the PaperSize with the specified index.
-            ///    </para>
-            /// </devdoc>
+            /// <summary>
+            /// Retrieves the PaperSize with the specified index.
+            /// </summary>
             public virtual PaperSize this[int index]
             {
                 get
@@ -1441,19 +1333,11 @@ namespace System.Drawing.Printing
                 }
             }
 
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PaperSizeCollection.GetEnumerator"]/*' />
-            /// <devdoc>
-            /// </devdoc>
             public IEnumerator GetEnumerator()
             {
                 return new ArrayEnumerator(_array, 0, Count);
             }
 
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PaperSizeCollection.ICollection.Count"]/*' />
-            /// <devdoc>        
-            ///    ICollection private interface implementation.        
-            /// </devdoc>
-            /// <internalonly/>
             int ICollection.Count
             {
                 get
@@ -1463,11 +1347,6 @@ namespace System.Drawing.Printing
             }
 
 
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PaperSizeCollection.ICollection.IsSynchronized"]/*' />
-            /// <devdoc>        
-            ///    ICollection private interface implementation.        
-            /// </devdoc>
-            /// <internalonly/>
             bool ICollection.IsSynchronized
             {
                 get
@@ -1476,11 +1355,6 @@ namespace System.Drawing.Printing
                 }
             }
 
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PaperSizeCollection.ICollection.SyncRoot"]/*' />
-            /// <devdoc>        
-            ///    ICollection private interface implementation.        
-            /// </devdoc>
-            /// <internalonly/>
             object ICollection.SyncRoot
             {
                 get
@@ -1489,11 +1363,6 @@ namespace System.Drawing.Printing
                 }
             }
 
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PaperSizeCollection.ICollection.CopyTo"]/*' />
-            /// <devdoc>        
-            /// ICollection private interface implementation.        
-            /// </devdoc>
-            /// <internalonly/>
             void ICollection.CopyTo(Array array, int index)
             {
                 Array.Copy(_array, index, array, 0, _array.Length);
@@ -1504,21 +1373,11 @@ namespace System.Drawing.Printing
                 Array.Copy(_array, index, paperSizes, 0, _array.Length);
             }
 
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PaperSizeCollection.IEnumerable.GetEnumerator"]/*' />
-            /// <devdoc>        
-            ///    IEnumerable private interface implementation.        
-            /// </devdoc>
-            /// <internalonly/>
             IEnumerator IEnumerable.GetEnumerator()
             {
                 return GetEnumerator();
             }
 
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PaperSizeCollection.Add"]/*' />
-            /// <devdoc>        
-            /// Empty implementation required for serialization of PrinterSettings object.
-            /// </devdoc>
-            /// <internalonly/>
             [
                 EditorBrowsable(EditorBrowsableState.Never)
             ]
@@ -1532,33 +1391,21 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PaperSourceCollection"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Collection of PaperSource's...
-        ///    </para>
-        /// </devdoc>
         public class PaperSourceCollection : ICollection
         {
             private PaperSource[] _array;
 
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PaperSourceCollection.PaperSourceCollection"]/*' />
-            /// <devdoc>
-            ///    <para>
-            ///       Initializes a new instance of the <see cref='System.Drawing.Printing.PrinterSettings.PaperSourceCollection'/> class.
-            ///    </para>
-            /// </devdoc>
+            /// <summary>
+            /// Initializes a new instance of the <see cref='PaperSourceCollection'/> class.
+            /// </summary>
             public PaperSourceCollection(PaperSource[] array)
             {
                 _array = array;
             }
 
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PaperSourceCollection.Count"]/*' />
-            /// <devdoc>
-            ///    <para>
-            ///       Gets a value indicating the number of paper sources.
-            ///    </para>
-            /// </devdoc>
+            /// <summary>
+            /// Gets a value indicating the number of paper sources.
+            /// </summary>
             public int Count
             {
                 get
@@ -1567,12 +1414,9 @@ namespace System.Drawing.Printing
                 }
             }
 
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PaperSourceCollection.this"]/*' />
-            /// <devdoc>
-            ///    <para>
-            ///       Gets the PaperSource with the specified index.
-            ///    </para>
-            /// </devdoc>
+            /// <summary>
+            /// Gets the PaperSource with the specified index.
+            /// </summary>
             public virtual PaperSource this[int index]
             {
                 get
@@ -1581,23 +1425,11 @@ namespace System.Drawing.Printing
                 }
             }
 
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PaperSourceCollection.GetEnumerator"]/*' />
-            /// <devdoc>
-            /// </devdoc>
-            /// <devdoc>
-            /// </devdoc>
-            /// <devdoc>
-            /// </devdoc>
             public IEnumerator GetEnumerator()
             {
                 return new ArrayEnumerator(_array, 0, Count);
             }
 
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PaperSourceCollection.ICollection.Count"]/*' />
-            /// <devdoc>        
-            ///    ICollection private interface implementation.        
-            /// </devdoc>
-            /// <internalonly/>
             int ICollection.Count
             {
                 get
@@ -1607,11 +1439,6 @@ namespace System.Drawing.Printing
             }
 
 
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PaperSourceCollection.ICollection.IsSynchronized"]/*' />
-            /// <devdoc>        
-            ///    ICollection private interface implementation.        
-            /// </devdoc>
-            /// <internalonly/>
             bool ICollection.IsSynchronized
             {
                 get
@@ -1620,11 +1447,6 @@ namespace System.Drawing.Printing
                 }
             }
 
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PaperSourceCollection.ICollection.SyncRoot"]/*' />
-            /// <devdoc>        
-            ///    ICollection private interface implementation.        
-            /// </devdoc>
-            /// <internalonly/>
             object ICollection.SyncRoot
             {
                 get
@@ -1633,11 +1455,6 @@ namespace System.Drawing.Printing
                 }
             }
 
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PaperSourceCollection.ICollection.CopyTo"]/*' />
-            /// <devdoc>        
-            /// ICollection private interface implementation.        
-            /// </devdoc>
-            /// <internalonly/>
             void ICollection.CopyTo(Array array, int index)
             {
                 Array.Copy(_array, index, array, 0, _array.Length);
@@ -1648,24 +1465,12 @@ namespace System.Drawing.Printing
                 Array.Copy(_array, index, paperSources, 0, _array.Length);
             }
 
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PaperSourceCollection.IEnumerable.GetEnumerator"]/*' />
-            /// <devdoc>        
-            ///    IEnumerable private interface implementation.        
-            /// </devdoc>
-            /// <internalonly/>
             IEnumerator IEnumerable.GetEnumerator()
             {
                 return GetEnumerator();
             }
 
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PaperSourceCollection.Add"]/*' />
-            /// <devdoc>        
-            /// Empty implementation required for serialization of PrinterSettings object.
-            /// </devdoc>
-            /// <internalonly/>
-            [
-                EditorBrowsable(EditorBrowsableState.Never)
-            ]
+            [EditorBrowsable(EditorBrowsableState.Never)]
             public Int32 Add(PaperSource paperSource)
             {
                 PaperSource[] newArray = new PaperSource[Count + 1];
@@ -1676,34 +1481,21 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PrinterResolutionCollection"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Collection of PrinterResolution's...
-        ///    </para>
-        /// </devdoc>
         public class PrinterResolutionCollection : ICollection
         {
             private PrinterResolution[] _array;
 
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PrinterResolutionCollection.PrinterResolutionCollection"]/*' />
-            /// <devdoc>
-            ///    <para>
-            ///       Initializes a new instance of the <see cref='System.Drawing.Printing.PrinterSettings.PrinterResolutionCollection'/> class.
-            ///    </para>
-            /// </devdoc>
+            /// <summary>
+            /// Initializes a new instance of the <see cref='PrinterResolutionCollection'/> class.
+            /// </summary>
             public PrinterResolutionCollection(PrinterResolution[] array)
             {
                 _array = array;
             }
 
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PrinterResolutionCollection.Count"]/*' />
-            /// <devdoc>
-            ///    <para>
-            ///       Gets a
-            ///       value indicating the number of available printer resolutions.
-            ///    </para>
-            /// </devdoc>
+            /// <summary>
+            /// Gets a value indicating the number of available printer resolutions.
+            /// </summary>
             public int Count
             {
                 get
@@ -1712,12 +1504,9 @@ namespace System.Drawing.Printing
                 }
             }
 
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PrinterResolutionCollection.this"]/*' />
-            /// <devdoc>
-            ///    <para>
-            ///       Retrieves the PrinterResolution with the specified index.
-            ///    </para>
-            /// </devdoc>
+            /// <summary>
+            /// Retrieves the PrinterResolution with the specified index.
+            /// </summary>
             public virtual PrinterResolution this[int index]
             {
                 get
@@ -1726,23 +1515,11 @@ namespace System.Drawing.Printing
                 }
             }
 
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PrinterResolutionCollection.GetEnumerator"]/*' />
-            /// <devdoc>
-            /// </devdoc>
-            /// <devdoc>
-            /// </devdoc>
-            /// <devdoc>
-            /// </devdoc>
             public IEnumerator GetEnumerator()
             {
                 return new ArrayEnumerator(_array, 0, Count);
             }
 
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PrinterResolutionCollection.ICollection.Count"]/*' />
-            /// <devdoc>        
-            ///    ICollection private interface implementation.        
-            /// </devdoc>
-            /// <internalonly/>
             int ICollection.Count
             {
                 get
@@ -1751,12 +1528,6 @@ namespace System.Drawing.Printing
                 }
             }
 
-
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PrinterResolutionCollection.ICollection.IsSynchronized"]/*' />
-            /// <devdoc>        
-            ///    ICollection private interface implementation.        
-            /// </devdoc>
-            /// <internalonly/>
             bool ICollection.IsSynchronized
             {
                 get
@@ -1765,11 +1536,6 @@ namespace System.Drawing.Printing
                 }
             }
 
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PrinterResolutionCollection.ICollection.SyncRoot"]/*' />
-            /// <devdoc>        
-            ///    ICollection private interface implementation.        
-            /// </devdoc>
-            /// <internalonly/>
             object ICollection.SyncRoot
             {
                 get
@@ -1778,11 +1544,6 @@ namespace System.Drawing.Printing
                 }
             }
 
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterResolutionCollection.ICollection.CopyTo"]/*' />
-            /// <devdoc>        
-            /// ICollection private interface implementation.        
-            /// </devdoc>
-            /// <internalonly/>
             void ICollection.CopyTo(Array array, int index)
             {
                 Array.Copy(_array, index, array, 0, _array.Length);
@@ -1793,24 +1554,12 @@ namespace System.Drawing.Printing
                 Array.Copy(_array, index, printerResolutions, 0, _array.Length);
             }
 
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PrinterResolutionCollection.IEnumerable.GetEnumerator"]/*' />
-            /// <devdoc>        
-            ///    IEnumerable private interface implementation.        
-            /// </devdoc>
-            /// <internalonly/>
             IEnumerator IEnumerable.GetEnumerator()
             {
                 return GetEnumerator();
             }
 
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.PrinterResolutionCollection.Add"]/*' />
-            /// <devdoc>        
-            /// Empty implementation required for serialization of PrinterSettings object.
-            /// </devdoc>
-            /// <internalonly/>
-            [
-                EditorBrowsable(EditorBrowsableState.Never)
-            ]
+            [EditorBrowsable(EditorBrowsableState.Never)]
             public Int32 Add(PrinterResolution printerResolution)
             {
                 PrinterResolution[] newArray = new PrinterResolution[Count + 1];
@@ -1821,34 +1570,21 @@ namespace System.Drawing.Printing
             }
         }
 
-        /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.StringCollection"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Collection of String's...
-        ///    </para>
-        /// </devdoc>
-        /// <internalonly/>
         public class StringCollection : ICollection
         {
             private String[] _array;
 
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.StringCollection.StringCollection"]/*' />
-            /// <devdoc>
-            ///    <para>
-            ///       Initializes a new instance of the <see cref='System.Drawing.Printing.PrinterSettings.StringCollection'/> class.
-            ///    </para>
-            /// </devdoc>
+            /// <summary>
+            /// Initializes a new instance of the <see cref='StringCollection'/> class.
+            /// </summary>
             public StringCollection(String[] array)
             {
                 _array = array;
             }
 
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.StringCollection.Count"]/*' />
-            /// <devdoc>
-            ///    <para>
-            ///       Gets a value indicating the number of strings.
-            ///    </para>
-            /// </devdoc>
+            /// <summary>
+            /// Gets a value indicating the number of strings.
+            /// </summary>
             public int Count
             {
                 get
@@ -1857,12 +1593,9 @@ namespace System.Drawing.Printing
                 }
             }
 
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.StringCollection.this"]/*' />
-            /// <devdoc>
-            ///    <para>
-            ///       Gets the string with the specified index.
-            ///    </para>
-            /// </devdoc>
+            /// <summary>
+            /// Gets the string with the specified index.
+            /// </summary>
             public virtual String this[int index]
             {
                 get
@@ -1871,23 +1604,11 @@ namespace System.Drawing.Printing
                 }
             }
 
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.StringCollection.GetEnumerator"]/*' />
-            /// <devdoc>
-            /// </devdoc>
-            /// <devdoc>
-            /// </devdoc>
-            /// <devdoc>
-            /// </devdoc>
             public IEnumerator GetEnumerator()
             {
                 return new ArrayEnumerator(_array, 0, Count);
             }
 
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.StringCollection.ICollection.Count"]/*' />
-            /// <devdoc>        
-            ///    ICollection private interface implementation.        
-            /// </devdoc>
-            /// <internalonly/>
             int ICollection.Count
             {
                 get
@@ -1896,12 +1617,6 @@ namespace System.Drawing.Printing
                 }
             }
 
-
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.StringCollection.ICollection.IsSynchronized"]/*' />
-            /// <devdoc>        
-            ///    ICollection private interface implementation.        
-            /// </devdoc>
-            /// <internalonly/>
             bool ICollection.IsSynchronized
             {
                 get
@@ -1910,11 +1625,6 @@ namespace System.Drawing.Printing
                 }
             }
 
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="PrinterSettings.StringCollection.ICollection.SyncRoot"]/*' />
-            /// <devdoc>        
-            ///    ICollection private interface implementation.        
-            /// </devdoc>
-            /// <internalonly/>
             object ICollection.SyncRoot
             {
                 get
@@ -1923,11 +1633,6 @@ namespace System.Drawing.Printing
                 }
             }
 
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="StringCollection.ICollection.CopyTo"]/*' />
-            /// <devdoc>        
-            /// ICollection private interface implementation.        
-            /// </devdoc>
-            /// <internalonly/>
             void ICollection.CopyTo(Array array, int index)
             {
                 Array.Copy(_array, index, array, 0, _array.Length);
@@ -1939,23 +1644,11 @@ namespace System.Drawing.Printing
                 Array.Copy(_array, index, strings, 0, _array.Length);
             }
 
-
-
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="StringCollection.IEnumerable.GetEnumerator"]/*' />
-            /// <devdoc>        
-            /// IEnumerable private interface implementation.        
-            /// </devdoc>
-            /// <internalonly/>
             IEnumerator IEnumerable.GetEnumerator()
             {
                 return GetEnumerator();
             }
 
-            /// <include file='doc\PrinterSettings.uex' path='docs/doc[@for="StringCollection.Add"]/*' />
-            /// <devdoc>        
-            /// Empty implementation required for serialization of PrinterSettings object.
-            /// </devdoc>
-            /// <internalonly/>
             [
                 EditorBrowsable(EditorBrowsableState.Never)
             ]
@@ -1997,7 +1690,8 @@ namespace System.Drawing.Printing
 
             public bool MoveNext()
             {
-                if (_index >= _endIndex) return false;
+                if (_index >= _endIndex)
+                    return false;
                 _item = _array[_index++];
                 return true;
             }
@@ -2012,5 +1706,3 @@ namespace System.Drawing.Printing
         }
     }
 }
-
-

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PrinterUnit.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PrinterUnit.cs
@@ -4,44 +4,32 @@
 
 namespace System.Drawing.Printing
 {
-    /// <include file='doc\PrinterUnit.uex' path='docs/doc[@for="PrinterUnit"]/*' />
-    /// <devdoc>
-    ///    <para>Specifies several of
-    ///       the units of measure Microsoft Win32 uses for printing.</para>
-    /// </devdoc>
+    /// <summary>
+    /// Specifies several of the units of measure Microsoft Win32 uses for printing.
+    /// </summary>
     public enum PrinterUnit
     {
-        /// <include file='doc\PrinterUnit.uex' path='docs/doc[@for="PrinterUnit.Display"]/*' />
-        /// <devdoc>
-        ///    <para>The default unit (0.01 in.).</para>
-        /// </devdoc>
-        // Our default units, as well as GDI+'s
+        /// <summary>
+        /// The default unit (0.01 in.).
+        /// </summary>
         Display = 0,
 
-        /// <include file='doc\PrinterUnit.uex' path='docs/doc[@for="PrinterUnit.ThousandthsOfAnInch"]/*' />
-        /// <devdoc>
-        ///    <para>One
-        ///       thousandth of an inch
-        ///       (0.001 in.).</para>
-        /// </devdoc>
+        /// <summary>
+        /// One thousandth of an inch (0.001 in.).
+        /// </summary>
         // Used by PAGESETUPDLG.rtMargin and rtMinMargin
         ThousandthsOfAnInch = 1,
 
-        /// <include file='doc\PrinterUnit.uex' path='docs/doc[@for="PrinterUnit.HundredthsOfAMillimeter"]/*' />
-        /// <devdoc>
-        ///    <para>One hundredth of a millimeter
-        ///       (0.01 mm).</para>
-        /// </devdoc>
+        /// <summary>
+        /// One hundredth of a millimeter (0.01 mm).
+        /// </summary>
         // Used by PAGESETUPDLG.rtMargin and rtMinMargin
         HundredthsOfAMillimeter = 2,
 
-        /// <include file='doc\PrinterUnit.uex' path='docs/doc[@for="PrinterUnit.TenthsOfAMillimeter"]/*' />
-        /// <devdoc>
-        ///    <para>One tenth of a millimeter
-        ///       (0.1 mm).</para>
-        /// </devdoc>
+        /// <summary>
+        /// One tenth of a millimeter (0.1 mm).
+        /// </summary>
         // DeviceCapabilities(DC_PAPERSIZE)
         TenthsOfAMillimeter = 3,
     }
 }
-

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PrinterUnitConvert.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PrinterUnitConvert.cs
@@ -2,30 +2,23 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+
 namespace System.Drawing.Printing
 {
-    using System.Diagnostics;
-
-    /// <include file='doc\PrinterUnitConvert.uex' path='docs/doc[@for="PrinterUnitConvert"]/*' />
-    /// <devdoc>
-    ///    <para>
-    ///       Specifies a series of conversion methods that are
-    ///       useful when interoperating with the raw Win32 printing API.
-    ///       This class cannot be inherited.
-    ///    </para>
-    /// </devdoc>
+    /// <summary>
+    /// Specifies a series of conversion methods that are useful when interoperating with the raw Win32 printing API.
+    /// This class cannot be inherited.
+    /// </summary>
     public sealed class PrinterUnitConvert
     {
         private PrinterUnitConvert()
         {
         }
 
-        /// <include file='doc\PrinterUnitConvert.uex' path='docs/doc[@for="PrinterUnitConvert.Convert"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Converts the value, in fromUnit units, to toUnit units.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Converts the value, in fromUnit units, to toUnit units.
+        /// </summary>
         public static double Convert(double value, PrinterUnit fromUnit, PrinterUnit toUnit)
         {
             double fromUnitsPerDisplay = UnitsPerDisplay(fromUnit);
@@ -33,23 +26,17 @@ namespace System.Drawing.Printing
             return value * toUnitsPerDisplay / fromUnitsPerDisplay;
         }
 
-        /// <include file='doc\PrinterUnitConvert.uex' path='docs/doc[@for="PrinterUnitConvert.Convert1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Converts the value, in fromUnit units, to toUnit units.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Converts the value, in fromUnit units, to toUnit units.
+        /// </summary>
         public static int Convert(int value, PrinterUnit fromUnit, PrinterUnit toUnit)
         {
             return (int)Math.Round(Convert((double)value, fromUnit, toUnit));
         }
 
-        /// <include file='doc\PrinterUnitConvert.uex' path='docs/doc[@for="PrinterUnitConvert.Convert2"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Converts the value, in fromUnit units, to toUnit units.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Converts the value, in fromUnit units, to toUnit units.
+        /// </summary>
         public static Point Convert(Point value, PrinterUnit fromUnit, PrinterUnit toUnit)
         {
             return new Point(
@@ -58,12 +45,9 @@ namespace System.Drawing.Printing
                             );
         }
 
-        /// <include file='doc\PrinterUnitConvert.uex' path='docs/doc[@for="PrinterUnitConvert.Convert3"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Converts the value, in fromUnit units, to toUnit units.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Converts the value, in fromUnit units, to toUnit units.
+        /// </summary>
         public static Size Convert(Size value, PrinterUnit fromUnit, PrinterUnit toUnit)
         {
             return new Size(
@@ -72,12 +56,9 @@ namespace System.Drawing.Printing
                            );
         }
 
-        /// <include file='doc\PrinterUnitConvert.uex' path='docs/doc[@for="PrinterUnitConvert.Convert4"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Converts the value, in fromUnit units, to toUnit units.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Converts the value, in fromUnit units, to toUnit units.
+        /// </summary>
         public static Rectangle Convert(Rectangle value, PrinterUnit fromUnit, PrinterUnit toUnit)
         {
             return new Rectangle(
@@ -88,12 +69,9 @@ namespace System.Drawing.Printing
                                 );
         }
 
-        /// <include file='doc\PrinterUnitConvert.uex' path='docs/doc[@for="PrinterUnitConvert.Convert5"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Converts the value, in fromUnit units, to toUnit units.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Converts the value, in fromUnit units, to toUnit units.
+        /// </summary>
         public static Margins Convert(Margins value, PrinterUnit fromUnit, PrinterUnit toUnit)
         {
             Margins result = new Margins();

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/QueryPageSettingsEventArgs.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/QueryPageSettingsEventArgs.cs
@@ -4,12 +4,9 @@
 
 namespace System.Drawing.Printing
 {
-    /// <include file='doc\QueryPageSettingsEventArgs.uex' path='docs/doc[@for="QueryPageSettingsEventArgs"]/*' />
-    /// <devdoc>
-    ///    <para>
-    ///       Provides data for the <see cref='E:System.Drawing.Printing.PrintDocument.QueryPageSettings'/> event.
-    ///    </para>
-    /// </devdoc>
+    /// <summary>
+    /// Provides data for the <see cref='PrintDocument.QueryPageSettings'/> event.
+    /// </summary>
     public class QueryPageSettingsEventArgs : PrintEventArgs
     {
         private PageSettings _pageSettings;
@@ -22,23 +19,17 @@ namespace System.Drawing.Printing
         /// used often.
         internal bool PageSettingsChanged;
 
-        /// <include file='doc\QueryPageSettingsEventArgs.uex' path='docs/doc[@for="QueryPageSettingsEventArgs.QueryPageSettingsEventArgs"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Printing.QueryPageSettingsEventArgs'/> class.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='QueryPageSettingsEventArgs'/> class.
+        /// </summary>
         public QueryPageSettingsEventArgs(PageSettings pageSettings) : base()
         {
             _pageSettings = pageSettings;
         }
 
-        /// <include file='doc\QueryPageSettingsEventArgs.uex' path='docs/doc[@for="QueryPageSettingsEventArgs.PageSettings"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets or sets the page settings for the page to be printed.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the page settings for the page to be printed.
+        /// </summary>
         public PageSettings PageSettings
         {
             get

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/QueryPageSettingsEventHandler.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/QueryPageSettingsEventHandler.cs
@@ -4,11 +4,9 @@
 
 namespace System.Drawing.Printing
 {
-    /// <include file='doc\QueryPageSettingsEventHandler.uex' path='docs/doc[@for="QueryPageSettingsEventHandler"]/*' />
-    /// <devdoc>
-    ///    <para>
-    ///       Represents the method that will handle the <see cref='E:System.Drawing.Printing.PrintDocument.QueryPageSettings'/> event of a <see cref='System.Drawing.Printing.PrintDocument'/>.
-    ///    </para>
-    /// </devdoc>
+    /// <summary>
+    /// Represents the method that will handle the <see cref='PrintDocument.QueryPageSettings'/> event of a
+    /// <see cref='PrintDocument'/>.
+    /// </summary>
     public delegate void QueryPageSettingsEventHandler(object sender, QueryPageSettingsEventArgs e);
 }

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/TriState.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/TriState.cs
@@ -71,14 +71,9 @@ namespace System.Drawing.Printing
                 return (value == TriState.True);
         }
 
-        /// <include file='doc\TriState.uex' path='docs/doc[@for="TriState.ToString"]/*' />
-        /// <internalonly/>
-        /// <devdoc>
-        ///    <para>
-        ///       Provides some interesting information about the TriState in
-        ///       String form.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Provides some interesting information about the TriState in String form.
+        /// </summary>
         public override string ToString()
         {
             if (this == Default) return "Default";

--- a/src/System.Drawing.Common/src/System/Drawing/RotateFlipType.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/RotateFlipType.cs
@@ -4,95 +4,26 @@
 
 namespace System.Drawing
 {
-    /// <include file='doc\RotateFlipType.uex' path='docs/doc[@for="RotateFlipType"]/*' />
-    /// <devdoc>
-    ///    Specifies the different patterns available 'RotateFlipType' objects.
-    /// </devdoc>
-
+    /// <summary>
+    /// Specifies the different patterns available 'RotateFlipType' objects.
+    /// </summary>
     public enum RotateFlipType
     {
-        /// <include file='doc\RotateFlipType.uex' path='docs/doc[@for="RotateFlipType.RotateNoneFlipNone"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         RotateNoneFlipNone = 0,
-        /// <include file='doc\RotateFlipType.uex' path='docs/doc[@for="RotateFlipType.Rotate90FlipNone"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         Rotate90FlipNone = 1,
-        /// <include file='doc\RotateFlipType.uex' path='docs/doc[@for="RotateFlipType.Rotate180FlipNone"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         Rotate180FlipNone = 2,
-        /// <include file='doc\RotateFlipType.uex' path='docs/doc[@for="RotateFlipType.Rotate270FlipNone"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         Rotate270FlipNone = 3,
-
-        /// <include file='doc\RotateFlipType.uex' path='docs/doc[@for="RotateFlipType.RotateNoneFlipX"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         RotateNoneFlipX = 4,
-        /// <include file='doc\RotateFlipType.uex' path='docs/doc[@for="RotateFlipType.Rotate90FlipX"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         Rotate90FlipX = 5,
-        /// <include file='doc\RotateFlipType.uex' path='docs/doc[@for="RotateFlipType.Rotate180FlipX"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         Rotate180FlipX = 6,
-        /// <include file='doc\RotateFlipType.uex' path='docs/doc[@for="RotateFlipType.Rotate270FlipX"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         Rotate270FlipX = 7,
-
-        /// <include file='doc\RotateFlipType.uex' path='docs/doc[@for="RotateFlipType.RotateNoneFlipY"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         RotateNoneFlipY = Rotate180FlipX,
-        /// <include file='doc\RotateFlipType.uex' path='docs/doc[@for="RotateFlipType.Rotate90FlipY"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         Rotate90FlipY = Rotate270FlipX,
-        /// <include file='doc\RotateFlipType.uex' path='docs/doc[@for="RotateFlipType.Rotate180FlipY"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         Rotate180FlipY = RotateNoneFlipX,
-        /// <include file='doc\RotateFlipType.uex' path='docs/doc[@for="RotateFlipType.Rotate270FlipY"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         Rotate270FlipY = Rotate90FlipX,
-
-        /// <include file='doc\RotateFlipType.uex' path='docs/doc[@for="RotateFlipType.RotateNoneFlipXY"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         RotateNoneFlipXY = Rotate180FlipNone,
-        /// <include file='doc\RotateFlipType.uex' path='docs/doc[@for="RotateFlipType.Rotate90FlipXY"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         Rotate90FlipXY = Rotate270FlipNone,
-        /// <include file='doc\RotateFlipType.uex' path='docs/doc[@for="RotateFlipType.Rotate180FlipXY"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         Rotate180FlipXY = RotateNoneFlipNone,
-        /// <include file='doc\RotateFlipType.uex' path='docs/doc[@for="RotateFlipType.Rotate270FlipXY"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         Rotate270FlipXY = Rotate90FlipNone
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/StringAlignment.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/StringAlignment.cs
@@ -4,42 +4,28 @@
 
 namespace System.Drawing
 {
-    /**
-     * used for both vertical and horizontal alignment.
-     */
-    /// <include file='doc\StringAlignment.uex' path='docs/doc[@for="StringAlignment"]/*' />
-    /// <devdoc>
-    ///    Specifies the alignment of a text string
-    ///    relative to its layout rectangle.
-    /// </devdoc>
+    /// <summary>
+    /// Specifies the alignment of a text string relative to its layout rectangle.
+    /// </summary>
     public enum StringAlignment
     {
         // left or top in English
-        /// <include file='doc\StringAlignment.uex' path='docs/doc[@for="StringAlignment.Near"]/*' />
-        /// <devdoc>
-        ///    Specifies the text be aligned near the
-        ///    layout. In a left-to-right layout, the near position is left. In a right-to-left
-        ///    layout, the near position is right.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies the text be aligned near the layout. In a left-to-right layout, the near position is left. In a
+        /// right-to-left layout, the near position is right.
+        /// </summary>
         Near = 0,
 
-        /// <include file='doc\StringAlignment.uex' path='docs/doc[@for="StringAlignment.Center"]/*' />
-        /// <devdoc>
-        ///    Specifies that text is aligned in the
-        ///    center of the layout rectangle.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies that text is aligned in the center of the layout rectangle.
+        /// </summary>
         Center = 1,
 
-        // NO ALTERNATE SPELLINGS!
-        // Centre      = 1,
-
         // right or bottom in English
-        /// <include file='doc\StringAlignment.uex' path='docs/doc[@for="StringAlignment.Far"]/*' />
-        /// <devdoc>
-        ///    Specifies that text is aligned far from the
-        ///    origin position of the layout rectangle. In a left-to-right layout, the far
-        ///    position is right. In a right-to-left layout, the far position is left.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies that text is aligned far from the origin position of the layout rectangle. In a left-to-right
+        /// layout, the far position is right. In a right-to-left layout, the far position is left.
+        /// </summary>
         Far = 2
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/StringDigitSubstitute.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/StringDigitSubstitute.cs
@@ -6,34 +6,14 @@
 
 namespace System.Drawing
 {
-    /// <include file='doc\StringDigitSubstitute.uex' path='docs/doc[@for="StringDigitSubstitute"]/*' />
-    /// <devdoc>
-    ///    <para>
-    ///       Specifies style information applied to
-    ///       String Digit Substitute.
-    ///    </para>
-    /// </devdoc>
+    /// <summary>
+    /// Specifies style information applied to String Digit Substitute.
+    /// </summary>
     public enum StringDigitSubstitute
     {
-        /// <include file='doc\StringDigitSubstitute.uex' path='docs/doc[@for="StringDigitSubstitute.User"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         User = 0,  // As NLS setting
-        /// <include file='doc\StringDigitSubstitute.uex' path='docs/doc[@for="StringDigitSubstitute.None"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         None = 1,
-        /// <include file='doc\StringDigitSubstitute.uex' path='docs/doc[@for="StringDigitSubstitute.National"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         National = 2,
-        /// <include file='doc\StringDigitSubstitute.uex' path='docs/doc[@for="StringDigitSubstitute.Traditional"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         Traditional = 3
     };
 }

--- a/src/System.Drawing.Common/src/System/Drawing/StringFormat.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/StringFormat.cs
@@ -10,23 +10,15 @@ namespace System.Drawing
     using System.Runtime.InteropServices;
     using System.Globalization;
 
-    /// <include file='doc\StringFormat.uex' path='docs/doc[@for="CharacterRange"]/*' />
     [StructLayout(LayoutKind.Sequential)]
     public struct CharacterRange
     {
         private int _first;
         private int _length;
 
-        /**
-        * Create a new CharacterRange object
-        */
-        /// <include file='doc\StringFormat.uex' path='docs/doc[@for="CharacterRange.CharacterRange"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.CharacterRange'/> class
-        ///       with the specified coordinates.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='CharacterRange'/> class with the specifiedcoordinates.
+        /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public CharacterRange(int First, int Length)
         {
@@ -34,10 +26,9 @@ namespace System.Drawing
             _length = Length;
         }
 
-        /// <include file='doc\StringFormat.uex' path='docs/doc[@for="CharacterRange.First"]/*' />
-        /// <devdoc>
-        ///    Gets the First character position of this <see cref='System.Drawing.CharacterRange'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets the First character position of this <see cref='CharacterRange'/>.
+        /// </summary>
         public int First
         {
             get
@@ -50,12 +41,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\StringFormat.uex' path='docs/doc[@for="CharacterRange.Length"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets the Length of this <see cref='System.Drawing.CharacterRange'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets the Length of this <see cref='CharacterRange'/>.
+        /// </summary>
         public int Length
         {
             get
@@ -77,34 +65,26 @@ namespace System.Drawing
             return ((_first == cr.First) && (_length == cr.Length));
         }
 
-        /// <include file='doc\StringFormat.uex' path='docs/doc[@for="CharacterRange.EqualOperator"]/*' />
         public static bool operator ==(CharacterRange cr1, CharacterRange cr2)
         {
             return ((cr1.First == cr2.First) && (cr1.Length == cr2.Length));
         }
 
-        /// <include file='doc\StringFormat.uex' path='docs/doc[@for="CharacterRange.InequalOperator"]/*' />
         public static bool operator !=(CharacterRange cr1, CharacterRange cr2)
         {
             return !(cr1 == cr2);
         }
 
-        /// <include file='doc\StringFormat.uex' path='docs/doc[@for="CharacterRange.GetHashCode"]/*' />
         public override int GetHashCode()
         {
             return unchecked(_first << 8 + _length);
         }
     }
 
-    /**
-     * Represent a Stringformat object
-     */
-    /// <include file='doc\StringFormat.uex' path='docs/doc[@for="StringFormat"]/*' />
-    /// <devdoc>
-    ///    Encapsulates text layout information (such
-    ///    as alignment and linespacing), display manipulations (such as ellipsis insertion
-    ///    and national digit substitution) and OpenType features.
-    /// </devdoc>
+    /// <summary>
+    /// Encapsulates text layout information (such as alignment and linespacing), display manipulations (such as
+    /// ellipsis insertion and national digit substitution) and OpenType features.
+    /// </summary>
     public sealed class StringFormat : MarshalByRefObject, ICloneable, IDisposable
     {
         internal IntPtr nativeFormat;
@@ -114,30 +94,25 @@ namespace System.Drawing
             nativeFormat = format;
         }
 
-        /// <include file='doc\StringFormat.uex' path='docs/doc[@for="StringFormat.StringFormat"]/*' />
-        /// <devdoc>
-        ///    Initializes a new instance of the <see cref='System.Drawing.StringFormat'/>
-        ///    class.
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='StringFormat'/> class.
+        /// </summary>
         public StringFormat() : this(0, 0)
         {
         }
 
-        /// <include file='doc\StringFormat.uex' path='docs/doc[@for="StringFormat.StringFormat1"]/*' />
-        /// <devdoc>
-        ///    Initializes a new instance of the <see cref='System.Drawing.StringFormat'/>
-        ///    class with the specified <see cref='System.Drawing.StringFormatFlags'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='StringFormat'/> class with the specified <see cref='System.Drawing.StringFormatFlags'/>.
+        /// </summary>
         public StringFormat(StringFormatFlags options) :
         this(options, 0)
         {
         }
 
-        /// <include file='doc\StringFormat.uex' path='docs/doc[@for="StringFormat.StringFormat2"]/*' />
-        /// <devdoc>
-        ///    Initializes a new instance of the <see cref='System.Drawing.StringFormat'/>
-        ///    class with the specified <see cref='System.Drawing.StringFormatFlags'/> and language.
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='StringFormat'/> class with the specified
+        /// <see cref='System.Drawing.StringFormatFlags'/> and language.
+        /// </summary>
         public StringFormat(StringFormatFlags options, int language)
         {
             int status = SafeNativeMethods.Gdip.GdipCreateStringFormat(options, language, out nativeFormat);
@@ -146,13 +121,10 @@ namespace System.Drawing
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        /// <include file='doc\StringFormat.uex' path='docs/doc[@for="StringFormat.StringFormat3"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.StringFormat'/> class from the specified
-        ///       existing <see cref='System.Drawing.StringFormat'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='StringFormat'/> class from the specified
+        /// existing <see cref='System.Drawing.StringFormat'/>.
+        /// </summary>
         public StringFormat(StringFormat format)
         {
             if (format == null)
@@ -166,18 +138,15 @@ namespace System.Drawing
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        /// <include file='doc\StringFormat.uex' path='docs/doc[@for="StringFormat.Dispose"]/*' />
-        /// <devdoc>
-        ///    Cleans up Windows resources for this
-        /// <see cref='System.Drawing.StringFormat'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Cleans up Windows resources for this <see cref='StringFormat'/>.
+        /// </summary>
         public void Dispose()
         {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
 
-        /// <include file='doc\StringFormat.uex' path='docs/doc[@for="StringFormat.Dispose2"]/*' />
         private void Dispose(bool disposing)
         {
             if (nativeFormat != IntPtr.Zero)
@@ -208,10 +177,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\StringFormat.uex' path='docs/doc[@for="StringFormat.Clone"]/*' />
-        /// <devdoc>
-        ///    Creates an exact copy of this <see cref='System.Drawing.StringFormat'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Creates an exact copy of this <see cref='StringFormat'/>.
+        /// </summary>
         public object Clone()
         {
             IntPtr cloneFormat = IntPtr.Zero;
@@ -227,10 +195,9 @@ namespace System.Drawing
         }
 
 
-        /// <include file='doc\StringFormat.uex' path='docs/doc[@for="StringFormat.FormatFlags"]/*' />
-        /// <devdoc>
-        ///    Gets or sets a <see cref='System.Drawing.StringFormatFlags'/> that contains formatting information.
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets a <see cref='StringFormatFlags'/> that contains formatting information.
+        /// </summary>
         public StringFormatFlags FormatFlags
         {
             get
@@ -253,13 +220,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\StringFormat.uex' path='docs/doc[@for="StringFormat.SetMeasurableCharacterRanges"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Sets the measure of characters to the specified
-        ///       range.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Sets the measure of characters to the specified range.
+        /// </summary>
         public void SetMeasurableCharacterRanges(CharacterRange[] ranges)
         {
             int status = SafeNativeMethods.Gdip.GdipSetStringFormatMeasurableCharacterRanges(new HandleRef(this, nativeFormat), ranges.Length, ranges);
@@ -269,10 +232,9 @@ namespace System.Drawing
         }
 
         // For English, this is horizontal alignment
-        /// <include file='doc\StringFormat.uex' path='docs/doc[@for="StringFormat.Alignment"]/*' />
-        /// <devdoc>
-        ///    Specifies text alignment information.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies text alignment information.
+        /// </summary>
         public StringAlignment Alignment
         {
             get
@@ -301,10 +263,9 @@ namespace System.Drawing
         }
 
         // For English, this is vertical alignment
-        /// <include file='doc\StringFormat.uex' path='docs/doc[@for="StringFormat.LineAlignment"]/*' />
-        /// <devdoc>
-        ///    Gets or sets the line alignment.
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the line alignment.
+        /// </summary>
         public StringAlignment LineAlignment
         {
             get
@@ -331,12 +292,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\StringFormat.uex' path='docs/doc[@for="StringFormat.HotkeyPrefix"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets or sets the <see cref='System.Drawing.StringFormat.HotkeyPrefix'/> for this <see cref='System.Drawing.StringFormat'/> .
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the <see cref='HotkeyPrefix'/> for this <see cref='StringFormat'/> .
+        /// </summary>
         public HotkeyPrefix HotkeyPrefix
         {
             get
@@ -364,10 +322,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\StringFormat.uex' path='docs/doc[@for="StringFormat.SetTabStops"]/*' />
-        /// <devdoc>
-        ///    Sets tab stops for this <see cref='System.Drawing.StringFormat'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Sets tab stops for this <see cref='StringFormat'/>.
+        /// </summary>
         public void SetTabStops(float firstTabOffset, float[] tabStops)
         {
             if (firstTabOffset < 0)
@@ -379,10 +336,9 @@ namespace System.Drawing
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        /// <include file='doc\StringFormat.uex' path='docs/doc[@for="StringFormat.GetTabStops"]/*' />
-        /// <devdoc>
-        ///    Gets the tab stops for this <see cref='System.Drawing.StringFormat'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets the tab stops for this <see cref='StringFormat'/>.
+        /// </summary>
         public float[] GetTabStops(out float firstTabOffset)
         {
             int count = 0;
@@ -404,11 +360,9 @@ namespace System.Drawing
         // String trimming. How to handle more text than can be displayed
         // in the limits available.
 
-        /// <include file='doc\StringFormat.uex' path='docs/doc[@for="StringFormat.Trimming"]/*' />
-        /// <devdoc>
-        ///    Gets or sets the <see cref='System.Drawing.StringTrimming'/>
-        ///    for this <see cref='System.Drawing.StringFormat'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets the <see cref='StringTrimming'/> for this <see cref='StringFormat'/>.
+        /// </summary>
         public StringTrimming Trimming
         {
             get
@@ -436,18 +390,17 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\StringFormat.uex' path='docs/doc[@for="StringFormat.GenericDefault"]/*' />
-        /// <devdoc>
-        ///    Gets a generic default <see cref='System.Drawing.StringFormat'/>.
-        ///    Remarks from MSDN: A generic, default StringFormat object has the following characteristics: 
-        ///         - No string format flags are set. 
-        ///         - Character alignment and line alignment are set to StringAlignmentNear. 
-        ///         - Language ID is set to neutral language, which means that the current language associated with the calling thread is used. 
-        ///         - String digit substitution is set to StringDigitSubstituteUser. 
-        ///         - Hot key prefix is set to HotkeyPrefixNone. 
-        ///         - Number of tab stops is set to zero. 
-        ///         - String trimming is set to StringTrimmingCharacter. 
-        /// </devdoc>
+        /// <summary>
+        /// Gets a generic default <see cref='StringFormat'/>.
+        /// Remarks from MSDN: A generic, default StringFormat object has the following characteristics: 
+        /// - No string format flags are set. 
+        /// - Character alignment and line alignment are set to StringAlignmentNear. 
+        /// - Language ID is set to neutral language, which means that the current language associated with the calling thread is used. 
+        /// - String digit substitution is set to StringDigitSubstituteUser. 
+        /// - Hot key prefix is set to HotkeyPrefixNone. 
+        /// - Number of tab stops is set to zero. 
+        /// - String trimming is set to StringTrimmingCharacter. 
+        /// </summary>
         public static StringFormat GenericDefault
         {
             get
@@ -462,18 +415,17 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\StringFormat.uex' path='docs/doc[@for="StringFormat.GenericTypographic"]/*' />
-        /// <devdoc>
-        ///    Gets a generic typographic <see cref='System.Drawing.StringFormat'/>.
-        ///    Remarks from MSDN: A generic, typographic StringFormat object has the following characteristics: 
-        ///         - String format flags StringFormatFlagsLineLimit, StringFormatFlagsNoClip, and StringFormatFlagsNoFitBlackBox are set. 
-        ///         - Character alignment and line alignment are set to StringAlignmentNear. 
-        ///         - Language ID is set to neutral language, which means that the current language associated with the calling thread is used.
-        ///         - String digit substitution is set to StringDigitSubstituteUser. 
-        ///         - Hot key prefix is set to HotkeyPrefixNone. 
-        ///         - Number of tab stops is set to zero. 
-        ///         - String trimming is set to StringTrimmingNone. 
-        /// </devdoc>
+        /// <summary>
+        /// Gets a generic typographic <see cref='StringFormat'/>.
+        /// Remarks from MSDN: A generic, typographic StringFormat object has the following characteristics: 
+        /// - String format flags StringFormatFlagsLineLimit, StringFormatFlagsNoClip, and StringFormatFlagsNoFitBlackBox are set. 
+        /// - Character alignment and line alignment are set to StringAlignmentNear. 
+        /// - Language ID is set to neutral language, which means that the current language associated with the calling thread is used.
+        /// - String digit substitution is set to StringDigitSubstituteUser. 
+        /// - Hot key prefix is set to HotkeyPrefixNone. 
+        /// - Number of tab stops is set to zero. 
+        /// - String trimming is set to StringTrimmingNone. 
+        /// </summary>
         public static StringFormat GenericTypographic
         {
             get
@@ -488,10 +440,6 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\StringFormat.uex' path='docs/doc[@for="StringFormat.SetDigitSubstitution"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public void SetDigitSubstitution(int language, StringDigitSubstitute substitute)
         {
             int status = SafeNativeMethods.Gdip.GdipSetStringFormatDigitSubstitution(new HandleRef(this, nativeFormat), language, substitute);
@@ -500,11 +448,9 @@ namespace System.Drawing
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        /// <include file='doc\StringFormat.uex' path='docs/doc[@for="StringFormat.DigitSubstitutionMethod"]/*' />
-        /// <devdoc>
-        ///    Gets the <see cref='System.Drawing.StringDigitSubstitute'/>
-        ///    for this <see cref='System.Drawing.StringFormat'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets the <see cref='StringDigitSubstitute'/> for this <see cref='StringFormat'/>.
+        /// </summary>
         public StringDigitSubstitute DigitSubstitutionMethod
         {
             get
@@ -521,11 +467,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\StringFormat.uex' path='docs/doc[@for="StringFormat.DigitSubstitutionLanguage"]/*' />
-        /// <devdoc>
-        ///    Gets the language of <see cref='System.Drawing.StringDigitSubstitute'/>
-        ///    for this <see cref='System.Drawing.StringFormat'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Gets the language of <see cref='StringDigitSubstitute'/> for this <see cref='StringFormat'/>.
+        /// </summary>
         public int DigitSubstitutionLanguage
         {
             get
@@ -541,24 +485,17 @@ namespace System.Drawing
             }
         }
 
-        /**
-          * Object cleanup
-          */
-        /// <include file='doc\StringFormat.uex' path='docs/doc[@for="StringFormat.Finalize"]/*' />
-        /// <devdoc>
-        ///    Cleans up Windows resources for this
-        /// <see cref='System.Drawing.StringFormat'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Cleans up Windows resources for this <see cref='StringFormat'/>.
+        /// </summary>
         ~StringFormat()
         {
             Dispose(false);
         }
 
-        /// <include file='doc\StringFormat.uex' path='docs/doc[@for="StringFormat.ToString"]/*' />
-        /// <devdoc>
-        ///    Converts this <see cref='System.Drawing.StringFormat'/> to
-        ///    a human-readable string.
-        /// </devdoc>
+        /// <summary>
+        /// Converts this <see cref='StringFormat'/> to a human-readable string.
+        /// </summary>
         public override string ToString()
         {
             return "[StringFormat, FormatFlags=" + FormatFlags.ToString() + "]";

--- a/src/System.Drawing.Common/src/System/Drawing/StringFormatFlags.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/StringFormatFlags.cs
@@ -4,98 +4,81 @@
 
 namespace System.Drawing
 {
-    /// <include file='doc\StringFormatFlags.uex' path='docs/doc[@for="StringFormatFlags"]/*' />
-    /// <devdoc>
-    ///    Specifies the display and layout
-    ///    information for text strings.
-    /// </devdoc>
-    [Flags()]
+    /// <summary>
+    /// Specifies the display and layout information for text strings.
+    /// </summary>
+    [Flags]
     public enum StringFormatFlags
     {
-        /// <include file='doc\StringFormatFlags.uex' path='docs/doc[@for="StringFormatFlags.DirectionRightToLeft"]/*' />
-        /// <devdoc>
-        ///    Specifies that text is right to left.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies that text is right to left.
+        /// </summary>
         DirectionRightToLeft = 0x00000001,
 
-        /// <include file='doc\StringFormatFlags.uex' path='docs/doc[@for="StringFormatFlags.DirectionVertical"]/*' />
-        /// <devdoc>
-        ///    Specifies that text is vertical.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies that text is vertical.
+        /// </summary>
         DirectionVertical = 0x00000002,
 
-        /// <include file='doc\StringFormatFlags.uex' path='docs/doc[@for="StringFormatFlags.FitBlackBox"]/*' />
-        /// <devdoc>
-        ///    Specifies that no part of any glyph
-        ///    overhangs the bounding rectangle. By default some glyphs overhang the rectangle
-        ///    slightly where necessary to appear at the edge visually. For example when an
-        ///    italic lower case letter f in a font such as Garamond is aligned at the far left
-        ///    of a rectangle, the lower part of the f will reach slightly further left than
-        ///    the left edge of the rectangle. Setting this flag will ensure no painting
-        ///    outside the rectangle but will cause the aligned edges of adjacent lines of text
-        ///    to appear uneven.
-        ///    
-        ///    WARNING:
-        ///    The GDI+ equivalent for this is StringFormatFlags::StringFormatFlagsNoFitBlackBox,
-        ///    which is defined as 0x4.  This was a mistake introduced since the first version of
-        ///    the product and fixing it at this point would be a breaking change.
-        ///    http://msdn.microsoft.com/library/default.asp?url=/library/en-us/gdicpp/GDIPlus/GDIPlusreference/enumerations/stringformatflags.asp, 
-        ///    See also VSWhidbey#434198.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies that no part of any glyph overhangs the bounding rectangle. By default some glyphs
+        /// overhang the rectangle slightly where necessary to appear at the edge visually. For example
+        /// when an italic lower case letter f in a font such as Garamond is aligned at the far left
+        /// of a rectangle, the lower part of the f will reach slightly further left thanthe left edge
+        /// of the rectangle. Setting this flag will ensure no painting outside the rectangle but will
+        /// cause the aligned edges of adjacent lines of text to appear uneven.
+        /// 
+        /// WARNING:
+        /// The GDI+ equivalent for this is StringFormatFlags::StringFormatFlagsNoFitBlackBox,
+        /// which is defined as 0x4.  This was a mistake introduced since the first version of
+        /// the product and fixing it at this point would be a breaking change.
+        /// http://msdn.microsoft.com/library/default.asp?url=/library/en-us/gdicpp/GDIPlus/GDIPlusreference/enumerations/stringformatflags.asp, 
+        /// </summary>
         FitBlackBox = 0x00000004,
 
-        /// <include file='doc\StringFormatFlags.uex' path='docs/doc[@for="StringFormatFlags.DisplayFormatControl"]/*' />
-        /// <devdoc>
-        ///    Causes control characters such as the
-        ///    left-to-right mark to be shown in the output with a representative glyph.
-        /// </devdoc>
+        /// <summary>
+        /// Causes control characters such as the left-to-right mark to be shown in the output with a representative glyph.
+        /// </summary>
         DisplayFormatControl = 0x00000020,
 
-        /// <include file='doc\StringFormatFlags.uex' path='docs/doc[@for="StringFormatFlags.NoFontFallback"]/*' />
-        /// <devdoc>
-        ///    Disables fallback to alternate fonts for
-        ///    characters not supported in the requested font. Any missing characters are
-        ///    displayed with the fonts missing glyph, usually an open square.
-        /// </devdoc>
+        /// <summary>
+        /// Disables fallback to alternate fonts for characters not supported in the requested font. Any missing characters are
+        /// displayed with the fonts missing glyph, usually an open square.
+        /// </summary>
         NoFontFallback = 0x00000400,
 
-        /// <include file='doc\StringFormatFlags.uex' path='docs/doc[@for="StringFormatFlags.MeasureTrailingSpaces"]/*' />
-        /// <devdoc>
-        ///    Specifies that the space at the end of each line is included in a string measurement.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies that the space at the end of each line is included in a string measurement.
+        /// </summary>
         MeasureTrailingSpaces = 0x00000800,
 
-        /// <include file='doc\StringFormatFlags.uex' path='docs/doc[@for="StringFormatFlags.NoWrap"]/*' />
-        /// <devdoc>
-        ///    Specifies that the wrapping of text to the next line is disabled. NoWrap is implied 
-        ///    when a point of origin is used instead of a layout rectangle. When drawing text within 
-        ///    a rectangle, by default, text is broken at the last word boundary that is inside the 
-        ///    rectangle's boundary and wrapped to the next line. 
-        /// </devdoc>
+        /// <summary>
+        /// Specifies that the wrapping of text to the next line is disabled. NoWrap is implied when a point of origin
+        /// is used instead of a layout rectangle. When drawing text within a rectangle, by default, text is broken at
+        /// the last word boundary that is inside the rectangle's boundary and wrapped to the next line. 
+        /// </summary>
         NoWrap = 0x00001000,
 
-        /// <include file='doc\StringFormatFlags.uex' path='docs/doc[@for="StringFormatFlags.LineLimit"]/*' />
-        /// <devdoc>
-        ///    Specifies that only entire lines are laid out in the layout rectangle. By default, layout 
-        ///    continues until the end of the text or until no more lines are visible as a result of clipping, 
-        ///    whichever comes first. The default settings allow the last line to be partially obscured by a 
-        ///    layout rectangle that is not a whole multiple of the line height. 
-        ///    To ensure that only whole lines are seen, set this flag and be careful to provide a layout 
-        ///    rectangle at least as tall as the height of one line. 
-        /// </devdoc>
+        /// <summary>
+        /// Specifies that only entire lines are laid out in the layout rectangle. By default, layout 
+        /// continues until the end of the text or until no more lines are visible as a result of clipping, 
+        /// whichever comes first. The default settings allow the last line to be partially obscured by a 
+        /// layout rectangle that is not a whole multiple of the line height. 
+        /// To ensure that only whole lines are seen, set this flag and be careful to provide a layout 
+        /// rectangle at least as tall as the height of one line. 
+        /// </summary>
         LineLimit = 0x00002000,
 
-        /// <include file='doc\StringFormatFlags.uex' path='docs/doc[@for="StringFormatFlags.NoClip"]/*' />
-        /// <devdoc>
-        ///    Specifies that characters overhanging the layout rectangle and text extending outside the layout 
-        ///    rectangle are allowed to show. By default, all overhanging characters and text that extends outside 
-        ///    the layout rectangle are clipped. Any trailing spaces (spaces that are at the end of a line) that 
-        ///    extend outside the layout rectangle are clipped. Therefore, the setting of this flag will have an 
-        ///    effect on a string measurement if trailing spaces are being included in the measurement. 
-        ///    If clipping is enabled, trailing spaces that extend outside the layout rectangle are not included 
-        ///    in the measurement. If clipping is disabled, all trailing spaces are included in the measurement, 
-        ///    regardless of whether they are outside the layout rectangle. 
-        /// </devdoc>
+        /// <summary>
+        /// Specifies that characters overhanging the layout rectangle and text extending outside the layout 
+        /// rectangle are allowed to show. By default, all overhanging characters and text that extends outside 
+        /// the layout rectangle are clipped. Any trailing spaces (spaces that are at the end of a line) that 
+        /// extend outside the layout rectangle are clipped. Therefore, the setting of this flag will have an 
+        /// effect on a string measurement if trailing spaces are being included in the measurement. 
+        /// If clipping is enabled, trailing spaces that extend outside the layout rectangle are not included 
+        /// in the measurement. If clipping is disabled, all trailing spaces are included in the measurement, 
+        /// regardless of whether they are outside the layout rectangle. 
+        /// </summary>
         NoClip = 0x00004000
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/StringTrimming.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/StringTrimming.cs
@@ -4,52 +4,43 @@
 
 namespace System.Drawing
 {
-    /// <include file='doc\StringTrimming.uex' path='docs/doc[@for="StringTrimming"]/*' />
-    /// <devdoc>
-    ///    Specifies how to trim characters from a
-    ///    string that does not completely fit into a layout shape.
-    /// </devdoc>
+    /// <summary>
+    /// Specifies how to trim characters from a string that does not completely fit into a layout shape.
+    /// </summary>
     public enum StringTrimming
     {
-        /// <include file='doc\StringTrimming.uex' path='docs/doc[@for="StringTrimming.None"]/*' />
-        /// <devdoc>
-        ///    Specifies no trimming.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies no trimming.
+        /// </summary>
         None = 0,
 
-        /// <include file='doc\StringTrimming.uex' path='docs/doc[@for="StringTrimming.Character"]/*' />
-        /// <devdoc>
-        ///    Specifies that the string is broken at the boundary of the last character that is 
-        ///    inside the layout rectangle. This is the default.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies that the string is broken at the boundary of the last character
+        /// that is inside the layout rectangle. This is the default.
+        /// </summary>
         Character = 1,
 
-        /// <include file='doc\StringTrimming.uex' path='docs/doc[@for="StringTrimming.Word"]/*' />
-        /// <devdoc>
-        ///    Specifies that the string is broken at the boundary of the last word that is inside 
-        ///    the layout rectangle.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies that the string is broken at the boundary of the last word that is inside the layout rectangle.
+        /// </summary>
         Word = 2,
 
-        /// <include file='doc\StringTrimming.uex' path='docs/doc[@for="StringTrimming.EllipsisCharacter"]/*' />
-        /// <devdoc>
-        ///    Specifies that the string is broken at the boundary of the last character that is inside 
-        ///    the layout rectangle and an ellipsis (...) is inserted after the character. 
-        /// </devdoc>
+        /// <summary>
+        /// Specifies that the string is broken at the boundary of the last character that is inside 
+        /// the layout rectangle and an ellipsis (...) is inserted after the character. 
+        /// </summary>
         EllipsisCharacter = 3,
 
-        /// <include file='doc\StringTrimming.uex' path='docs/doc[@for="StringTrimming.EllipsisWord"]/*' />
-        /// <devdoc>
-        ///    Specifies that the string is broken at the boundary of the last word that is inside the 
-        ///    layout rectangle and an ellipsis (...) is inserted after the word.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies that the string is broken at the boundary of the last word that is inside the 
+        /// layout rectangle and an ellipsis (...) is inserted after the word.
+        /// </summary>
         EllipsisWord = 4,
 
-        /// <include file='doc\StringTrimming.uex' path='docs/doc[@for="StringTrimming.EllipsisPath"]/*' />
-        /// <devdoc>
-        ///    Specifies that the center is removed from the string and replaced by an ellipsis. 
-        ///    The algorithm keeps as much of the last portion of the string as possible. 
-        /// </devdoc>
+        /// <summary>
+        /// Specifies that the center is removed from the string and replaced by an ellipsis. 
+        /// The algorithm keeps as much of the last portion of the string as possible. 
+        /// </summary>
         EllipsisPath = 5
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/StringUnit.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/StringUnit.cs
@@ -4,65 +4,42 @@
 
 namespace System.Drawing
 {
-    /**
-     * used for both vertical and horizontal alignment.
-     */
-    /// <include file='doc\StringUnit.uex' path='docs/doc[@for="StringUnit"]/*' />
-    /// <devdoc>
-    ///    Specifies the units of measure for a text
-    ///    string.
-    /// </devdoc>
+    /// <summary>
+    /// Specifies the units of measure for a text string.
+    /// </summary>
     public enum StringUnit
     {
-        /// <include file='doc\StringUnit.uex' path='docs/doc[@for="StringUnit.World"]/*' />
-        /// <devdoc>
-        ///    Specifies world units as the unit of
-        ///    measure.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies world units as the unit of measure.
+        /// </summary>
         World = GraphicsUnit.World,
-        /// <include file='doc\StringUnit.uex' path='docs/doc[@for="StringUnit.Display"]/*' />
-        /// <devdoc>
-        ///    Specifies the device unit as the unit of
-        ///    measure.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies the device unit as the unit of measure.
+        /// </summary>
         Display = GraphicsUnit.Display,
-        /// <include file='doc\StringUnit.uex' path='docs/doc[@for="StringUnit.Pixel"]/*' />
-        /// <devdoc>
-        ///    Specifies a pixel as the unit of measure.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies a pixel as the unit of measure.
+        /// </summary>
         Pixel = GraphicsUnit.Pixel,
-        /// <include file='doc\StringUnit.uex' path='docs/doc[@for="StringUnit.Point"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Specifies a printer's point as the unit of measure.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Specifies a printer's point as the unit of measure.
+        /// </summary>
         Point = GraphicsUnit.Point,
-        /// <include file='doc\StringUnit.uex' path='docs/doc[@for="StringUnit.Inch"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Specifies an inch as the unit of measure.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Specifies an inch as the unit of measure.
+        /// </summary>
         Inch = GraphicsUnit.Inch,
-        /// <include file='doc\StringUnit.uex' path='docs/doc[@for="StringUnit.Document"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Specifies 1/300 of an inch as the unit of measure.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Specifies 1/300 of an inch as the unit of measure.
+        /// </summary>
         Document = GraphicsUnit.Document,
-        /// <include file='doc\StringUnit.uex' path='docs/doc[@for="StringUnit.Millimeter"]/*' />
-        /// <devdoc>
-        ///    Specifies a millimeter as the unit of
-        ///    measure
-        /// </devdoc>
+        /// <summary>
+        /// Specifies a millimeter as the unit of measure
+        /// </summary>
         Millimeter = GraphicsUnit.Millimeter,
-        /// <include file='doc\StringUnit.uex' path='docs/doc[@for="StringUnit.Em"]/*' />
-        /// <devdoc>
-        ///    Specifies a printer's em size of 32 as the
-        ///    unit of measure.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies a printer's em size of 32 as the unit of measure.
+        /// </summary>
         Em = 32
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/Text/FontCollection.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Text/FontCollection.cs
@@ -7,11 +7,9 @@ namespace System.Drawing.Text
     using System.Diagnostics;
     using System.Runtime.InteropServices;
 
-    /// <include file='doc\FontCollection.uex' path='docs/doc[@for="FontCollection"]/*' />
-    /// <devdoc>
-    ///    When inherited, enumerates the FontFamily
-    ///    objects in a collection of fonts.
-    /// </devdoc>
+    /// <summary>
+    /// When inherited, enumerates the FontFamily objects in a collection of fonts.
+    /// </summary>
     public abstract class FontCollection : IDisposable
     {
         internal IntPtr nativeFontCollection;
@@ -22,29 +20,23 @@ namespace System.Drawing.Text
             nativeFontCollection = IntPtr.Zero;
         }
 
-        /// <include file='doc\FontCollection.uex' path='docs/doc[@for="FontCollection.Dispose"]/*' />
-        /// <devdoc>
-        ///    Disposes of this <see cref='System.Drawing.Text.FontCollection'/>
-        /// </devdoc>
+        /// <summary>
+        /// Disposes of this <see cref='System.Drawing.Text.FontCollection'/>
+        /// </summary>
         public void Dispose()
         {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
 
-        /// <include file='doc\FontCollection.uex' path='docs/doc[@for="FontCollection.Dispose2"]/*' />
         protected virtual void Dispose(bool disposing)
         {
-            // nothing...
         }
 
-        /// <include file='doc\FontCollection.uex' path='docs/doc[@for="FontCollection.Families"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets the array of <see cref='System.Drawing.FontFamily'/>
-        ///       objects associated with this <see cref='System.Drawing.Text.FontCollection'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets the array of <see cref='System.Drawing.FontFamily'/> objects associated
+        /// with this <see cref='System.Drawing.Text.FontCollection'/>.
+        /// </summary>
         public FontFamily[] Families
         {
             get
@@ -80,16 +72,6 @@ namespace System.Drawing.Text
             }
         }
 
-        /**
-         * Object cleanup
-         */
-        /// <include file='doc\FontCollection.uex' path='docs/doc[@for="FontCollection.Finalize"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Allows an object to free resources before the object is
-        ///       reclaimed by the Garbage Collector (<see langword='GC'/>).
-        ///    </para>
-        /// </devdoc>
         ~FontCollection()
         {
             Dispose(false);

--- a/src/System.Drawing.Common/src/System/Drawing/Text/GenericFontFamilies.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Text/GenericFontFamilies.cs
@@ -4,29 +4,22 @@
 
 namespace System.Drawing.Text
 {
-    /**
-     * GenericFontFamilies
-     */
-    /// <include file='doc\GenericFontFamilies.uex' path='docs/doc[@for="GenericFontFamilies"]/*' />
-    /// <devdoc>
-    ///    Specifies a generic <see cref='System.Drawing.FontFamily'/>.
-    /// </devdoc>
+    /// <summary>
+    /// Specifies a generic <see cref='System.Drawing.FontFamily'/>.
+    /// </summary>
     public enum GenericFontFamilies
     {
-        /// <include file='doc\GenericFontFamilies.uex' path='docs/doc[@for="GenericFontFamilies.Serif"]/*' />
-        /// <devdoc>
-        ///    A generic Serif <see cref='System.Drawing.FontFamily'/>.
-        /// </devdoc>
+        /// <summary>
+        /// A generic Serif <see cref='System.Drawing.FontFamily'/>.
+        /// </summary>
         Serif,
-        /// <include file='doc\GenericFontFamilies.uex' path='docs/doc[@for="GenericFontFamilies.SansSerif"]/*' />
-        /// <devdoc>
-        ///    A generic SansSerif <see cref='System.Drawing.FontFamily'/>.
-        /// </devdoc>
+        /// <summary>
+        /// A generic SansSerif <see cref='System.Drawing.FontFamily'/>.
+        /// </summary>
         SansSerif,
-        /// <include file='doc\GenericFontFamilies.uex' path='docs/doc[@for="GenericFontFamilies.Monospace"]/*' />
-        /// <devdoc>
-        ///    A generic Monospace <see cref='System.Drawing.FontFamily'/>.
-        /// </devdoc>
+        /// <summary>
+        /// A generic Monospace <see cref='System.Drawing.FontFamily'/>.
+        /// </summary>
         Monospace
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/Text/HotkeyPrefix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Text/HotkeyPrefix.cs
@@ -4,34 +4,22 @@
 
 namespace System.Drawing.Text
 {
-    /// <include file='doc\HotkeyPrefix.uex' path='docs/doc[@for="HotkeyPrefix"]/*' />
-    /// <devdoc>
-    ///    <para>
-    ///       Specifies the type of display for hotkey prefixes for text.
-    ///    </para>
-    /// </devdoc>
+    /// <summary>
+    /// Specifies the type of display for hotkey prefixes for text.
+    /// </summary>
     public enum HotkeyPrefix
     {
-        /// <include file='doc\HotkeyPrefix.uex' path='docs/doc[@for="HotkeyPrefix.None"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       No hotkey prefix.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// No hotkey prefix.
+        /// </summary>
         None = 0,
-        /// <include file='doc\HotkeyPrefix.uex' path='docs/doc[@for="HotkeyPrefix.Show"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Display the hotkey prefix.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Display the hotkey prefix.
+        /// </summary>
         Show = 1,
-        /// <include file='doc\HotkeyPrefix.uex' path='docs/doc[@for="HotkeyPrefix.Hide"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Do not display the hotkey prefix.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Do not display the hotkey prefix.
+        /// </summary>
         Hide = 2
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/Text/InstalledFontCollection.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Text/InstalledFontCollection.cs
@@ -4,19 +4,14 @@
 
 namespace System.Drawing.Text
 {
-    /// <include file='doc\InstalledFontCollection.uex' path='docs/doc[@for="InstalledFontCollection"]/*' />
-    /// <devdoc>
-    ///    <para>
-    ///       Represents the fonts installed on the
-    ///       system.
-    ///    </para>
-    /// </devdoc>
+    /// <summary>
+    /// Represents the fonts installed on the system.
+    /// </summary>
     public sealed class InstalledFontCollection : FontCollection
     {
-        /// <include file='doc\InstalledFontCollection.uex' path='docs/doc[@for="InstalledFontCollection.InstalledFontCollection"]/*' />
-        /// <devdoc>
-        ///    Initializes a new instance of the <see cref='System.Drawing.Text.InstalledFontCollection'/> class.
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='System.Drawing.Text.InstalledFontCollection'/> class.
+        /// </summary>
         public InstalledFontCollection()
         {
             nativeFontCollection = IntPtr.Zero;

--- a/src/System.Drawing.Common/src/System/Drawing/Text/PrivateFontCollection.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Text/PrivateFontCollection.cs
@@ -8,18 +8,14 @@ namespace System.Drawing.Text
     using System.Runtime.InteropServices;
     using System.Globalization;
 
-    /// <include file='doc\PrivateFontCollection.uex' path='docs/doc[@for="PrivateFontCollection"]/*' />
-    /// <devdoc>
-    ///    Encapsulates a collection of <see cref='System.Drawing.Font'/> objecs.
-    /// </devdoc>
+    /// <summary>
+    /// Encapsulates a collection of <see cref='System.Drawing.Font'/> objecs.
+    /// </summary>
     public sealed class PrivateFontCollection : FontCollection
     {
-        /// <include file='doc\PrivateFontCollection.uex' path='docs/doc[@for="PrivateFontCollection.PrivateFontCollection"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.Text.PrivateFontCollection'/> class.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='System.Drawing.Text.PrivateFontCollection'/> class.
+        /// </summary>
         public PrivateFontCollection()
         {
             nativeFontCollection = IntPtr.Zero;
@@ -30,13 +26,9 @@ namespace System.Drawing.Text
                 throw SafeNativeMethods.Gdip.StatusException(status);
         }
 
-        /// <include file='doc\PrivateFontCollection.uex' path='docs/doc[@for="PrivateFontCollection.Dispose"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Cleans up Windows resources for this
-        ///    <see cref='System.Drawing.Text.PrivateFontCollection'/> .
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Cleans up Windows resources for this <see cref='System.Drawing.Text.PrivateFontCollection'/>.
+        /// </summary>
         protected override void Dispose(bool disposing)
         {
             if (nativeFontCollection != IntPtr.Zero)
@@ -69,13 +61,9 @@ namespace System.Drawing.Text
             base.Dispose(disposing);
         }
 
-        /// <include file='doc\PrivateFontCollection.uex' path='docs/doc[@for="PrivateFontCollection.AddFontFile"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Adds a font from the specified file to
-        ///       this <see cref='System.Drawing.Text.PrivateFontCollection'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Adds a font from the specified file to this <see cref='System.Drawing.Text.PrivateFontCollection'/>.
+        /// </summary>
         public void AddFontFile(string filename)
         {
             int status = SafeNativeMethods.Gdip.GdipPrivateAddFontFile(new HandleRef(this, nativeFontCollection), filename);
@@ -87,11 +75,9 @@ namespace System.Drawing.Text
             SafeNativeMethods.AddFontFile(filename);
         }
 
-        /// <include file='doc\PrivateFontCollection.uex' path='docs/doc[@for="PrivateFontCollection.AddMemoryFont"]/*' />
-        /// <devdoc>
-        ///    Adds a font contained in system memory to
-        ///    this <see cref='System.Drawing.Text.PrivateFontCollection'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Adds a font contained in system memory to this <see cref='System.Drawing.Text.PrivateFontCollection'/>.
+        /// </summary>
         public void AddMemoryFont(IntPtr memory, int length)
         {
             int status = SafeNativeMethods.Gdip.GdipPrivateAddMemoryFont(new HandleRef(this, nativeFontCollection), new HandleRef(null, memory), length);

--- a/src/System.Drawing.Common/src/System/Drawing/Text/TextRenderingHint.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Text/TextRenderingHint.cs
@@ -4,42 +4,16 @@
 
 namespace System.Drawing.Text
 {
-    /// <include file='doc\TextRenderingHint.uex' path='docs/doc[@for="TextRenderingHint"]/*' />
-    /// <devdoc>
-    ///    Specifies the quality of text rendering.
-    /// </devdoc>
+    /// <summary>
+    /// Specifies the quality of text rendering.
+    /// </summary>
     public enum TextRenderingHint
     {
-        /// <include file='doc\TextRenderingHint.uex' path='docs/doc[@for="TextRenderingHint.SystemDefault"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         SystemDefault = 0,        // Glyph with system default rendering hint
-        /// <include file='doc\TextRenderingHint.uex' path='docs/doc[@for="TextRenderingHint.SingleBitPerPixelGridFit"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         SingleBitPerPixelGridFit, // Glyph bitmap with hinting
-        /// <include file='doc\TextRenderingHint.uex' path='docs/doc[@for="TextRenderingHint.SingleBitPerPixel"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         SingleBitPerPixel,        // Glyph bitmap without hinting
-        /// <include file='doc\TextRenderingHint.uex' path='docs/doc[@for="TextRenderingHint.AntiAliasGridFit"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
-        AntiAliasGridFit,         //Anti-aliasing with hinting
-        /// <include file='doc\TextRenderingHint.uex' path='docs/doc[@for="TextRenderingHint.AntiAlias"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
+        AntiAliasGridFit,         // Anti-aliasing with hinting
         AntiAlias,                // Glyph anti-alias bitmap without hinting
-        // Glyph anti-alias bitmap without hinting  
-        /// <include file='doc\TextRenderingHint.uex' path='docs/doc[@for="TextRenderingHint.ClearTypeGridFit"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         ClearTypeGridFit          // Glyph CT bitmap with hinting
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/TextureBrush.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/TextureBrush.cs
@@ -2,62 +2,36 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
+using System.Diagnostics;
+using System.ComponentModel;
+using System.Drawing.Drawing2D;
+using System.Drawing.Imaging;
+
 namespace System.Drawing
 {
-    using System.Runtime.InteropServices;
-    using System.Diagnostics;
-    using System.ComponentModel;
-    using System.Drawing.Drawing2D;
-    using System.Drawing.Imaging;
-
-    /**
-     * Represent a Texture brush object
-     */
-    /// <include file='doc\TextureBrush.uex' path='docs/doc[@for="TextureBrush"]/*' />
-    /// <devdoc>
-    ///    Encapsulates a <see cref='System.Drawing.Brush'/> that uses an fills the
-    ///    interior of a shape with an image.
-    /// </devdoc>
+    /// <summary>
+    /// Encapsulates a <see cref='System.Drawing.Brush'/> that fills the interior of a shape with an image.
+    /// </summary>
     public sealed class TextureBrush : Brush
     {
-        /**
-         * Create a new texture brush object
-         *
-         * @notes Should the rectangle parameter be Rectangle or RectF?
-         *  We'll use Rectangle to specify pixel unit source image
-         *  rectangle for now. Eventually, we'll need a mechanism
-         *  to specify areas of an image in a resolution-independent way.
-         *
-         * @notes We'll make a copy of the bitmap object passed in.
-         */
-
         // When creating a texture brush from a metafile image, the dstRect
         // is used to specify the size that the metafile image should be
         // rendered at in the device units of the destination graphics.
         // It is NOT used to crop the metafile image, so only the width 
         // and height values matter for metafiles.
-        /// <include file='doc\TextureBrush.uex' path='docs/doc[@for="TextureBrush.TextureBrush"]/*' />
-        /// <devdoc>
-        ///    Initializes a new instance of the <see cref='System.Drawing.TextureBrush'/>
-        ///    class with the specified image.
-        /// </devdoc>
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref='System.Drawing.TextureBrush'/> class with the specified image.
+        /// </summary>
         public TextureBrush(Image bitmap)
             : this(bitmap, System.Drawing.Drawing2D.WrapMode.Tile)
         {
         }
 
-        // When creating a texture brush from a metafile image, the dstRect
-        // is used to specify the size that the metafile image should be
-        // rendered at in the device units of the destination graphics.
-        // It is NOT used to crop the metafile image, so only the width 
-        // and height values matter for metafiles.
-        /// <include file='doc\TextureBrush.uex' path='docs/doc[@for="TextureBrush.TextureBrush1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.TextureBrush'/>
-        ///       class with the specified image and wrap mode.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='System.Drawing.TextureBrush'/> class with the specified image and wrap mode.
+        /// </summary>
         public TextureBrush(Image image, WrapMode wrapMode)
         {
             if (image == null)
@@ -82,19 +56,10 @@ namespace System.Drawing
             SetNativeBrushInternal(brush);
         }
 
-        // When creating a texture brush from a metafile image, the dstRect
-        // is used to specify the size that the metafile image should be
-        // rendered at in the device units of the destination graphics.
-        // It is NOT used to crop the metafile image, so only the width 
-        // and height values matter for metafiles.
-        // float version
-        /// <include file='doc\TextureBrush.uex' path='docs/doc[@for="TextureBrush.TextureBrush2"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.TextureBrush'/>
-        ///       class with the specified image, wrap mode, and bounding rectangle.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='System.Drawing.TextureBrush'/> class with the specified image,
+        /// wrap mode, and bounding rectangle.
+        /// </summary>
         public TextureBrush(Image image, WrapMode wrapMode, RectangleF dstRect)
         {
             if (image == null)
@@ -123,19 +88,10 @@ namespace System.Drawing
             SetNativeBrushInternal(brush);
         }
 
-        // int version
-        // When creating a texture brush from a metafile image, the dstRect
-        // is used to specify the size that the metafile image should be
-        // rendered at in the device units of the destination graphics.
-        // It is NOT used to crop the metafile image, so only the width 
-        // and height values matter for metafiles.
-        /// <include file='doc\TextureBrush.uex' path='docs/doc[@for="TextureBrush.TextureBrush3"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.TextureBrush'/>
-        ///       class with the specified image, wrap mode, and bounding rectangle.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='System.Drawing.TextureBrush'/> class with the specified image,
+        /// wrap mode, and bounding rectangle.
+        /// </summary>
         public TextureBrush(Image image, WrapMode wrapMode, Rectangle dstRect)
         {
             if (image == null)
@@ -167,36 +123,19 @@ namespace System.Drawing
         }
 
 
-        // When creating a texture brush from a metafile image, the dstRect
-        // is used to specify the size that the metafile image should be
-        // rendered at in the device units of the destination graphics.
-        // It is NOT used to crop the metafile image, so only the width 
-        // and height values matter for metafiles.
-        /// <include file='doc\TextureBrush.uex' path='docs/doc[@for="TextureBrush.TextureBrush4"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.TextureBrush'/> class with the specified image
-        ///       and bounding rectangle.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='System.Drawing.TextureBrush'/> class with the specified image
+        /// and bounding rectangle.
+        /// </summary>
         public TextureBrush(Image image, RectangleF dstRect)
-        : this(image, dstRect, (ImageAttributes)null)
+            : this(image, dstRect, (ImageAttributes)null)
         { }
 
-        // When creating a texture brush from a metafile image, the dstRect
-        // is used to specify the size that the metafile image should be
-        // rendered at in the device units of the destination graphics.
-        // It is NOT used to crop the metafile image, so only the width 
-        // and height values matter for metafiles.
-        /// <include file='doc\TextureBrush.uex' path='docs/doc[@for="TextureBrush.TextureBrush5"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.TextureBrush'/> class with the specified
-        ///       image, bounding rectangle, and image attributes.
-        ///    </para>
-        /// </devdoc>
-        public TextureBrush(Image image, RectangleF dstRect,
-                            ImageAttributes imageAttr)
+        /// <summary>
+        /// Initializes a new instance of the <see cref='System.Drawing.TextureBrush'/> class with the specified image,
+        /// bounding rectangle, and image attributes.
+        /// </summary>
+        public TextureBrush(Image image, RectangleF dstRect, ImageAttributes imageAttr)
         {
             if (image == null)
                 throw new ArgumentNullException("image");
@@ -220,36 +159,19 @@ namespace System.Drawing
             SetNativeBrushInternal(brush);
         }
 
-        // When creating a texture brush from a metafile image, the dstRect
-        // is used to specify the size that the metafile image should be
-        // rendered at in the device units of the destination graphics.
-        // It is NOT used to crop the metafile image, so only the width 
-        // and height values matter for metafiles.
-        /// <include file='doc\TextureBrush.uex' path='docs/doc[@for="TextureBrush.TextureBrush6"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.TextureBrush'/> class with the specified image
-        ///       and bounding rectangle.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Initializes a new instance of the <see cref='System.Drawing.TextureBrush'/> class with the specified image
+        /// and bounding rectangle.
+        /// </summary>
         public TextureBrush(Image image, Rectangle dstRect)
-        : this(image, dstRect, (ImageAttributes)null)
+            : this(image, dstRect, (ImageAttributes)null)
         { }
 
-        // When creating a texture brush from a metafile image, the dstRect
-        // is used to specify the size that the metafile image should be
-        // rendered at in the device units of the destination graphics.
-        // It is NOT used to crop the metafile image, so only the width 
-        // and height values matter for metafiles.
-        /// <include file='doc\TextureBrush.uex' path='docs/doc[@for="TextureBrush.TextureBrush7"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Initializes a new instance of the <see cref='System.Drawing.TextureBrush'/> class with the specified
-        ///       image, bounding rectangle, and image attributes.
-        ///    </para>
-        /// </devdoc>
-        public TextureBrush(Image image, Rectangle dstRect,
-                            ImageAttributes imageAttr)
+        /// <summary>
+        /// Initializes a new instance of the <see cref='System.Drawing.TextureBrush'/> class with the specified
+        /// image, bounding rectangle, and image attributes.
+        /// </summary>
+        public TextureBrush(Image image, Rectangle dstRect, ImageAttributes imageAttr)
         {
             if (image == null)
                 throw new ArgumentNullException("image");
@@ -273,19 +195,18 @@ namespace System.Drawing
             SetNativeBrushInternal(brush);
         }
 
-        /// <devdoc>
-        ///     Constructor to initialized this object to be owned by GDI+.
-        /// </devdoc>
+        /// <summary>
+        /// Constructor to initialize this object to be owned by GDI+.
+        /// </summary>
         internal TextureBrush(IntPtr nativeBrush)
         {
             Debug.Assert(nativeBrush != IntPtr.Zero, "Initializing native brush with null.");
             SetNativeBrushInternal(nativeBrush);
         }
 
-        /// <include file='doc\TextureBrush.uex' path='docs/doc[@for="TextureBrush.Clone"]/*' />
-        /// <devdoc>
-        ///    Creates an exact copy of this <see cref='System.Drawing.TextureBrush'/>.
-        /// </devdoc>
+        /// <summary>
+        /// Creates an exact copy of this <see cref='System.Drawing.TextureBrush'/>.
+        /// </summary>
         public override Object Clone()
         {
             IntPtr cloneBrush = IntPtr.Zero;
@@ -299,9 +220,6 @@ namespace System.Drawing
         }
 
 
-        /**
-         * Set/get brush transform
-         */
         private void _SetTransform(Matrix matrix)
         {
             int status = SafeNativeMethods.Gdip.GdipSetTextureTransform(new HandleRef(this, NativeBrush), new HandleRef(matrix, matrix.nativeMatrix));
@@ -324,13 +242,10 @@ namespace System.Drawing
             return matrix;
         }
 
-        /// <include file='doc\TextureBrush.uex' path='docs/doc[@for="TextureBrush.Transform"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets or sets a <see cref='System.Drawing.Drawing2D.Matrix'/> that defines a local geometrical
-        ///       transform for this <see cref='System.Drawing.TextureBrush'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets a <see cref='System.Drawing.Drawing2D.Matrix'/> that defines a local geometrical
+        /// transform for this <see cref='System.Drawing.TextureBrush'/>.
+        /// </summary>
         public Matrix Transform
         {
             get { return _GetTransform(); }
@@ -345,9 +260,6 @@ namespace System.Drawing
             }
         }
 
-        /**
-         * Set/get brush wrapping mode
-         */
         private void _SetWrapMode(WrapMode wrapMode)
         {
             int status = SafeNativeMethods.Gdip.GdipSetTextureWrapMode(new HandleRef(this, NativeBrush), unchecked((int)wrapMode));
@@ -372,13 +284,10 @@ namespace System.Drawing
             return (WrapMode)mode;
         }
 
-        /// <include file='doc\TextureBrush.uex' path='docs/doc[@for="TextureBrush.WrapMode"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets or sets a <see cref='System.Drawing.Drawing2D.WrapMode'/> that indicates the wrap mode for this
-        ///    <see cref='System.Drawing.TextureBrush'/>. 
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets or sets a <see cref='System.Drawing.Drawing2D.WrapMode'/> that indicates the wrap mode for this
+        /// <see cref='System.Drawing.TextureBrush'/>. 
+        /// </summary>
         public WrapMode WrapMode
         {
             get
@@ -398,12 +307,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\TextureBrush.uex' path='docs/doc[@for="TextureBrush.Image"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Gets the <see cref='System.Drawing.Image'/> associated with this <see cref='System.Drawing.TextureBrush'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Gets the <see cref='System.Drawing.Image'/> associated with this <see cref='System.Drawing.TextureBrush'/>.
+        /// </summary>
         public Image Image
         {
             get
@@ -421,13 +327,9 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\TextureBrush.uex' path='docs/doc[@for="TextureBrush.ResetTransform"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Resets the <see cref='System.Drawing.Drawing2D.LinearGradientBrush.Transform'/> property to
-        ///       identity.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Resets the <see cref='System.Drawing.Drawing2D.LinearGradientBrush.Transform'/> property to identity.
+        /// </summary>
         public void ResetTransform()
         {
             int status = SafeNativeMethods.Gdip.GdipResetTextureTransform(new HandleRef(this, NativeBrush));
@@ -438,23 +340,19 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\TextureBrush.uex' path='docs/doc[@for="TextureBrush.MultiplyTransform"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Multiplies the <see cref='System.Drawing.Drawing2D.Matrix'/> that represents the local geometrical
-        ///       transform of this <see cref='System.Drawing.TextureBrush'/> by the specified <see cref='System.Drawing.Drawing2D.Matrix'/> by prepending the specified <see cref='System.Drawing.Drawing2D.Matrix'/>.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Multiplies the <see cref='System.Drawing.Drawing2D.Matrix'/> that represents the local geometrical
+        /// transform of this <see cref='System.Drawing.TextureBrush'/> by the specified <see cref='System.Drawing.Drawing2D.Matrix'/>
+        /// by prepending the specified <see cref='System.Drawing.Drawing2D.Matrix'/>.
+        /// </summary>
         public void MultiplyTransform(Matrix matrix)
         { MultiplyTransform(matrix, MatrixOrder.Prepend); }
 
-        /// <include file='doc\TextureBrush.uex' path='docs/doc[@for="TextureBrush.MultiplyTransform1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Multiplies the <see cref='System.Drawing.Drawing2D.Matrix'/> that represents the local geometrical
-        ///       transform of this <see cref='System.Drawing.TextureBrush'/> by the specified <see cref='System.Drawing.Drawing2D.Matrix'/> in the specified order.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Multiplies the <see cref='System.Drawing.Drawing2D.Matrix'/> that represents the local geometrical
+        /// transform of this <see cref='System.Drawing.TextureBrush'/> by the specified <see cref='System.Drawing.Drawing2D.Matrix'/>
+        /// in the specified order.
+        /// </summary>
         public void MultiplyTransform(Matrix matrix, MatrixOrder order)
         {
             if (matrix == null)
@@ -472,23 +370,16 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\TextureBrush.uex' path='docs/doc[@for="TextureBrush.TranslateTransform"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Translates the local geometrical transform by the specified dimmensions. This
-        ///       method prepends the translation to the transform.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Translates the local geometrical transform by the specified dimmensions. This
+        /// method prepends the translation to the transform.
+        /// </summary>
         public void TranslateTransform(float dx, float dy)
         { TranslateTransform(dx, dy, MatrixOrder.Prepend); }
 
-        /// <include file='doc\TextureBrush.uex' path='docs/doc[@for="TextureBrush.TranslateTransform1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Translates the local geometrical transform by the specified dimmensions in
-        ///       the specified order.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Translates the local geometrical transform by the specified dimmensions in the specified order.
+        /// </summary>
         public void TranslateTransform(float dx, float dy, MatrixOrder order)
         {
             int status = SafeNativeMethods.Gdip.GdipTranslateTextureTransform(new HandleRef(this, NativeBrush),
@@ -502,23 +393,16 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\TextureBrush.uex' path='docs/doc[@for="TextureBrush.ScaleTransform"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Scales the local geometric transform by the specified amounts. This method
-        ///       prepends the scaling matrix to the transform.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Scales the local geometric transform by the specified amounts. This method
+        /// prepends the scaling matrix to the transform.
+        /// </summary>
         public void ScaleTransform(float sx, float sy)
         { ScaleTransform(sx, sy, MatrixOrder.Prepend); }
 
-        /// <include file='doc\TextureBrush.uex' path='docs/doc[@for="TextureBrush.ScaleTransform1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Scales the local geometric transform by the specified amounts in the
-        ///       specified order.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Scales the local geometric transform by the specified amounts in the specified order.
+        /// </summary>
         public void ScaleTransform(float sx, float sy, MatrixOrder order)
         {
             int status = SafeNativeMethods.Gdip.GdipScaleTextureTransform(new HandleRef(this, NativeBrush),
@@ -532,23 +416,15 @@ namespace System.Drawing
             }
         }
 
-        /// <include file='doc\TextureBrush.uex' path='docs/doc[@for="TextureBrush.RotateTransform"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Rotates the local geometric transform by the specified amount. This method
-        ///       prepends the rotation to the transform.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Rotates the local geometric transform by the specified amount. This method prepends the rotation to the transform.
+        /// </summary>
         public void RotateTransform(float angle)
         { RotateTransform(angle, MatrixOrder.Prepend); }
 
-        /// <include file='doc\TextureBrush.uex' path='docs/doc[@for="TextureBrush.RotateTransform1"]/*' />
-        /// <devdoc>
-        ///    <para>
-        ///       Rotates the local geometric transform by the specified amount in the
-        ///       specified order.
-        ///    </para>
-        /// </devdoc>
+        /// <summary>
+        /// Rotates the local geometric transform by the specified amount in the specified order.
+        /// </summary>
         public void RotateTransform(float angle, MatrixOrder order)
         {
             int status = SafeNativeMethods.Gdip.GdipRotateTextureTransform(new HandleRef(this, NativeBrush),

--- a/src/System.Drawing.Common/src/System/Drawing/ToolboxBitmapAttribute.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/ToolboxBitmapAttribute.cs
@@ -9,92 +9,69 @@ namespace System.Drawing
     using System.IO;
     using DpiHelper = System.Windows.Forms.DpiHelper;
 
-    /// <include file='doc\ToolboxBitmapAttribute.uex' path='docs/doc[@for="ToolboxBitmapAttribute"]/*' />
-    /// <devdoc>
-    ///     ToolboxBitmapAttribute defines the images associated with
-    ///     a specified component. The component can offer a small
-    ///     and large image (large is optional).
-    ///
-    /// </devdoc>
+    /// <summary>
+    /// ToolboxBitmapAttribute defines the images associated with a specified component.
+    /// The component can offer a small and large image (large is optional).
+    /// </summary>
     [AttributeUsage(AttributeTargets.Class)]
     public class ToolboxBitmapAttribute : Attribute
     {
-        /// <include file='doc\ToolboxBitmapAttribute.uex' path='docs/doc[@for="ToolboxBitmapAttribute.smallImage"]/*' />
-        /// <devdoc>
-        ///     The small image for this component
-        /// </devdoc>
+        /// <summary>
+        /// The small image for this component
+        /// </summary>
         private Image _smallImage;
 
-        /// <include file='doc\ToolboxBitmapAttribute.uex' path='docs/doc[@for="ToolboxBitmapAttribute.largeImage"]/*' />
-        /// <devdoc>
-        ///     The large image for this component.
-        /// </devdoc>
+        /// <summary>
+        /// The large image for this component.
+        /// </summary>
         private Image _largeImage;
 
-        /// <include file='doc\ToolboxBitmapAttribute.uex' path='docs/doc[@for="ToolboxBitmapAttribute.originalBitmap"]/*' />
-        /// <devdoc>
-        ///     The original small image for this component, before scaling per DPI.
-        /// </devdoc>
+        /// <summary>
+        /// The original small image for this component, before scaling per DPI.
+        /// </summary>
         private Bitmap _originalBitmap;
 
-        /// <include file='doc\ToolboxBitmapAttribute.uex' path='docs/doc[@for="ToolboxBitmapAttribute.imageFile"]/*' />
-        /// <devdoc>
-        ///     The path to the image file for this toolbox item, if any.
-        /// </devdoc>
+        /// <summary>
+        /// The path to the image file for this toolbox item, if any.
+        /// </summary>
         private string _imageFile;
 
-        /// <include file='doc\ToolboxBitmapAttribute.uex' path='docs/doc[@for="ToolboxBitmapAttribute.imagetype"]/*' />
-        /// <devdoc>
-        ///     The Type used to retrieve the toolbox image for this component, if provided upon initialization of this class.
-        /// </devdoc>
+        /// <summary>
+        /// The Type used to retrieve the toolbox image for this component, if provided upon initialization of this class.
+        /// </summary>
         private Type _imageType;
 
-        /// <include file='doc\ToolboxBitmapAttribute.uex' path='docs/doc[@for="ToolboxBitmapAttribute.imageName"]/*' />
-        /// <devdoc>
-        ///     The resource name of the toolbox image for the component, if provided upon initialization of this class.
-        /// </devdoc>
+        /// <summary>
+        /// The resource name of the toolbox image for the component, if provided upon initialization of this class.
+        /// </summary>
         private string _imageName;
 
-        /// <include file='doc\ToolboxBitmapAttribute.uex' path='docs/doc[@for="ToolboxBitmapAttribute.largeSize"]/*' />
-        /// <devdoc>
-        ///     The default size of the large image.
-        /// </devdoc>
+        /// <summary>
+        /// The default size of the large image.
+        /// </summary>
         private static readonly Size s_largeSize = new Size(32, 32);
 
-        /// <include file='doc\ToolboxBitmapAttribute.uex' path='docs/doc[@for="ToolboxBitmapAttribute.smallSize"]/*' />
-        /// <devdoc>
-        ///     The default size of the large image.
-        /// </devdoc>
+        /// <summary>
+        /// The default size of the large image.
+        /// </summary>
         private static readonly Size s_smallSize = new Size(16, 16);
 
         // Used to help cache the last result of BitmapSelector.GetFileName
         private static string s_lastOriginalFileName;
         private static string s_lastUpdatedFileName;
 
-        /// <include file='doc\ToolboxBitmapAttribute.uex' path='docs/doc[@for="ToolboxBitmapAttribute.ToolboxBitmapAttribute"]/*' />
-        /// <devdoc>
-        ///     Constructs a new ToolboxBitmapAttribute.
-        /// </devdoc>
         public ToolboxBitmapAttribute(string imageFile)
             : this(GetImageFromFile(imageFile, false), GetImageFromFile(imageFile, true))
         {
             _imageFile = imageFile;
         }
 
-        /// <include file='doc\ToolboxBitmapAttribute.uex' path='docs/doc[@for="ToolboxBitmapAttribute.ToolboxBitmapAttribute1"]/*' />
-        /// <devdoc>
-        ///     Constructs a new ToolboxBitmapAttribute.
-        /// </devdoc>
         public ToolboxBitmapAttribute(Type t)
             : this(GetImageFromResource(t, null, false), GetImageFromResource(t, null, true))
         {
             _imageType = t;
         }
 
-        /// <include file='doc\ToolboxBitmapAttribute.uex' path='docs/doc[@for="ToolboxBitmapAttribute.ToolboxBitmapAttribute2"]/*' />
-        /// <devdoc>
-        ///     Constructs a new ToolboxBitmapAttribute.
-        /// </devdoc>
         public ToolboxBitmapAttribute(Type t, string name)
             : this(GetImageFromResource(t, name, false), GetImageFromResource(t, name, true))
         {
@@ -102,21 +79,12 @@ namespace System.Drawing
             _imageName = name;
         }
 
-
-        /// <include file='doc\ToolboxBitmapAttribute.uex' path='docs/doc[@for="ToolboxBitmapAttribute.ToolboxBitmapAttribute3"]/*' />
-        /// <devdoc>
-        ///     Constructs a new ToolboxBitmapAttribute.
-        /// </devdoc>
         private ToolboxBitmapAttribute(Image smallImage, Image largeImage)
         {
             _smallImage = smallImage;
             _largeImage = largeImage;
         }
 
-        /// <include file='doc\ToolboxBitmapAttribute.uex' path='docs/doc[@for="ToolboxBitmapAttribute.Equals"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public override bool Equals(object value)
         {
             if (value == this)
@@ -133,27 +101,16 @@ namespace System.Drawing
             return false;
         }
 
-        /// <include file='doc\ToolboxBitmapAttribute.uex' path='docs/doc[@for="ToolboxBitmapAttribute.GetHashCode"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public override int GetHashCode()
         {
             return base.GetHashCode();
         }
 
-        /// <include file='doc\ToolboxBitmapAttribute.uex' path='docs/doc[@for="ToolboxBitmapAttribute.GetImage"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public Image GetImage(object component)
         {
             return GetImage(component, true);
         }
-        /// <include file='doc\ToolboxBitmapAttribute.uex' path='docs/doc[@for="ToolboxBitmapAttribute.GetImage1"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
+
         public Image GetImage(object component, bool large)
         {
             if (component != null)
@@ -162,28 +119,17 @@ namespace System.Drawing
             }
             return null;
         }
-        /// <include file='doc\ToolboxBitmapAttribute.uex' path='docs/doc[@for="ToolboxBitmapAttribute.GetImage2"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
+
         public Image GetImage(Type type)
         {
             return GetImage(type, false);
         }
 
-        /// <include file='doc\ToolboxBitmapAttribute.uex' path='docs/doc[@for="ToolboxBitmapAttribute.GetImage3"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public Image GetImage(Type type, bool large)
         {
             return GetImage(type, null, large);
         }
 
-        /// <include file='doc\ToolboxBitmapAttribute.uex' path='docs/doc[@for="ToolboxBitmapAttribute.GetImage4"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public Image GetImage(Type type, string imgName, bool large)
         {
             if ((large && _largeImage == null) ||
@@ -367,7 +313,6 @@ namespace System.Drawing
             Image img = null;
 
             // load the image from the manifest resources. 
-            //
             Stream stream = BitmapSelector.GetResourceStream(t, bitmapname);
             if (stream != null)
             {
@@ -398,19 +343,11 @@ namespace System.Drawing
             return GetIconFromStream(BitmapSelector.GetResourceStream(t, bitmapname), large, scaled);
         }
 
-        /// <include file='doc\ToolboxBitmapAttribute.uex' path='docs/doc[@for="ToolboxBitmapAttribute.GetImageFromResource"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         public static Image GetImageFromResource(Type t, string imageName, bool large)
         {
             return GetImageFromResource(t, imageName, large, true /*scaled*/);
         }
 
-        /// <include file='doc\ToolboxBitmapAttribute.uex' path='docs/doc[@for="ToolboxBitmapAttribute.GetImageFromResource"]/*' />
-        /// <devdoc>
-        ///    <para>[To be supplied.]</para>
-        /// </devdoc>
         internal static Image GetImageFromResource(Type t, string imageName, bool large, bool scaled)
         {
             Image img = null;
@@ -491,16 +428,12 @@ namespace System.Drawing
             img.SetPixel(0, img.Height - 1, newBottomLeft);
         }
 
-        /// <include file='doc\ToolboxBitmapAttribute.uex' path='docs/doc[@for="ToolboxBitmapAttribute.Default"]/*' />
-        /// <devdoc>
-        ///     Default name is null
-        /// </devdoc>        
         public static readonly ToolboxBitmapAttribute Default = new ToolboxBitmapAttribute((Image)null, (Image)null);
 
         private static readonly ToolboxBitmapAttribute s_defaultComponent;
         static ToolboxBitmapAttribute()
         {
-            //Fix for Dev10 560430. When we call Gdip.DummyFunction, JIT will make sure Gdip..cctor will be called before
+            // Ensure Gdip type initializer has run.
             SafeNativeMethods.Gdip.DummyFunction();
 
             Bitmap bitmap = null;

--- a/src/System.Drawing.Common/src/System/Drawing/Unit.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Unit.cs
@@ -4,53 +4,39 @@
 
 namespace System.Drawing
 {
-    /// <include file='doc\Unit.uex' path='docs/doc[@for="GraphicsUnit"]/*' />
-    /// <devdoc>
-    ///    Specifies the unit of measure for the given
-    ///    data.
-    /// </devdoc>
+    /// <summary>
+    /// Specifies the unit of measure for the given data.
+    /// </summary>
     public enum GraphicsUnit
     {
-        /// <include file='doc\Unit.uex' path='docs/doc[@for="GraphicsUnit.World"]/*' />
-        /// <devdoc>
-        ///    Specifies the world unit as the unit of
-        ///    measure.
-        /// </devdoc>
-        World = 0,     // 0 -- World coordinate (non-physical unit)
-        /// <include file='doc\Unit.uex' path='docs/doc[@for="GraphicsUnit.Display"]/*' />
-        /// <devdoc>
-        ///    Specifies 1/75 inch as the unit of measure.
-        /// </devdoc>
-        Display = 1,    // 1 -- Variable - for PageTransform only
-        /// <include file='doc\Unit.uex' path='docs/doc[@for="GraphicsUnit.Pixel"]/*' />
-        /// <devdoc>
-        ///    Specifies a device pixel as the unit of
-        ///    measure.
-        /// </devdoc>
-        Pixel = 2,      // 2 -- Each unit is one device pixel.
-        /// <include file='doc\Unit.uex' path='docs/doc[@for="GraphicsUnit.Point"]/*' />
-        /// <devdoc>
-        ///    Specifies a printer's point (1/72 inch) as
-        ///    the unit of measure.
-        /// </devdoc>
-        Point = 3,      // 3 -- Each unit is a printer's point, or 1/72 inch.
-        /// <include file='doc\Unit.uex' path='docs/doc[@for="GraphicsUnit.Inch"]/*' />
-        /// <devdoc>
-        ///    Specifies the inch as the unit of measure.
-        /// </devdoc>
-        Inch = 4,       // 4 -- Each unit is 1 inch.
-        /// <include file='doc\Unit.uex' path='docs/doc[@for="GraphicsUnit.Document"]/*' />
-        /// <devdoc>
-        ///    Specifes the document unit (1/300 inch) as
-        ///    the unit of measure.
-        /// </devdoc>
-        Document = 5,   // 5 -- Each unit is 1/300 inch.
-        /// <include file='doc\Unit.uex' path='docs/doc[@for="GraphicsUnit.Millimeter"]/*' />
-        /// <devdoc>
-        ///    Specifies the millimeter as the unit of
-        ///    measure.
-        /// </devdoc>
-        Millimeter = 6  // 6 -- Each unit is 1 millimeter.
+        /// <summary>
+        /// Specifies the world unit as the unit of measure.
+        /// </summary>
+        World = 0,
+        /// <summary>
+        /// Specifies 1/75 inch as the unit of measure.
+        /// </summary>
+        Display = 1,
+        /// <summary>
+        /// Specifies a device pixel as the unit of measure.
+        /// </summary>
+        Pixel = 2,
+        /// <summary>
+        /// Specifies a printer's point (1/72 inch) as the unit of measure.
+        /// </summary>
+        Point = 3,
+        /// <summary>
+        /// Specifies the inch as the unit of measure.
+        /// </summary>
+        Inch = 4,
+        /// <summary>
+        /// Specifes the document unit (1/300 inch) as the unit of measure.
+        /// </summary>
+        Document = 5,
+        /// <summary>
+        /// Specifies the millimeter as the unit of measure.
+        /// </summary>
+        Millimeter = 6
     }
 }
 

--- a/src/System.Drawing.Common/src/misc/ClientUtils.cs
+++ b/src/System.Drawing.Common/src/misc/ClientUtils.cs
@@ -2,12 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
+using System.Diagnostics;
+using System.Globalization;
+
 namespace System.Drawing
 {
-    using System.Collections;
-    using System.Diagnostics;
-    using System.Globalization;
-
     // Miscellaneous utilities
     internal static class ClientUtils
     {
@@ -90,10 +90,6 @@ namespace System.Drawing
 
             return valid;
         }
-
-
-
-
 
         // Useful for cases where you have discontiguous members of the enum.
         // Valid example: AutoComplete source.
@@ -212,22 +208,22 @@ namespace System.Drawing
         }
 #endif
 
-        /// <devdoc>
-        ///   WeakRefCollection - a collection that holds onto weak references
+        /// <summary>
+        /// WeakRefCollection - a collection that holds onto weak references
         ///
-        ///   Essentially you pass in the object as it is, and under the covers
-        ///   we only hold a weak reference to the object.
+        /// Essentially you pass in the object as it is, and under the covers
+        /// we only hold a weak reference to the object.
         ///
-        ///   -----------------------------------------------------------------
-        ///   !!!IMPORTANT USAGE NOTE!!!        
-        ///   Users of this class should set the RefCheckThreshold property 
-        ///   explicitly or call ScavengeReferences every once in a while to 
-        ///   remove dead references.
-        ///   Also avoid calling Remove(item).  Instead call RemoveByHashCode(item)
-        ///   to make sure dead refs are removed.
-        ///   -----------------------------------------------------------------
+        /// -----------------------------------------------------------------
+        /// !!!IMPORTANT USAGE NOTE!!!        
+        /// Users of this class should set the RefCheckThreshold property 
+        /// explicitly or call ScavengeReferences every once in a while to 
+        /// remove dead references.
+        /// Also avoid calling Remove(item).  Instead call RemoveByHashCode(item)
+        /// to make sure dead refs are removed.
+        /// -----------------------------------------------------------------
         ///
-        /// </devdoc>        
+        /// </summary>        
         internal class WeakRefCollection : IList
         {
             private int _refCheckThreshold = Int32.MaxValue; // this means this is disabled by default.
@@ -249,11 +245,10 @@ namespace System.Drawing
             }
 
             /// <summary>
-            ///     Indicates the value where the collection should check its items to remove dead weakref left over.
-            ///     Note: When GC collects weak refs from this collection the WeakRefObject identity changes since its 
-            ///           Target becomes null.  This makes the item unrecognizable by the collection and cannot be
-            ///           removed - Remove(item) and Contains(item) will not find it anymore.
-            ///           
+            /// Indicates the value where the collection should check its items to remove dead weakref left over.
+            /// Note: When GC collects weak refs from this collection the WeakRefObject identity changes since its 
+            ///       Target becomes null.  This makes the item unrecognizable by the collection and cannot be
+            ///       removed - Remove(item) and Contains(item) will not find it anymore.
             /// </summary>
             public int RefCheckThreshold
             {
@@ -371,10 +366,10 @@ namespace System.Drawing
             }
 
             /// <summary>
-            ///     Removes the value using its hash code as its identity.  
-            ///     This is needed because the underlying item in the collection may have already been collected
-            ///     changing the identity of the WeakRefObject making it impossible for the collection to identify
-            ///     it.  See WeakRefObject for more info.
+            /// Removes the value using its hash code as its identity.  
+            /// This is needed because the underlying item in the collection may have already been collected changing
+            /// the identity of the WeakRefObject making it impossible for the collection to identify it.
+            /// See WeakRefObject for more info.
             /// </summary>
             public void RemoveByHashCode(object value)
             {
@@ -414,7 +409,6 @@ namespace System.Drawing
             #endregion
 
             #region ICollection Members
-            /// <include file='doc\ArrangedElementCollection.uex' path='docs/doc[@for="ArrangedElementCollection.Count"]/*' />
             public int Count { get { return InnerList.Count; } }
             object ICollection.SyncRoot { get { return InnerList.SyncRoot; } }
             public bool IsReadOnly { get { return InnerList.IsReadOnly; } }
@@ -430,11 +424,11 @@ namespace System.Drawing
             #endregion
 
             /// <summary>
-            ///     Wraps a weak ref object.
-            ///     WARNING: Use this class carefully!  
-            ///     When the weak ref is collected, this object looses its identity. This is bad when the object
-            ///     has been added to a collection since Contains(WeakRef(item)) and Remove(WeakRef(item)) would 
-            ///     not be able to identify the item.
+            /// Wraps a weak ref object.
+            /// WARNING: Use this class carefully!  
+            /// When the weak ref is collected, this object looses its identity. This is bad when the object has been
+            /// added to a collection since Contains(WeakRef(item)) and Remove(WeakRef(item)) would not be able to
+            /// identify the item.
             /// </summary>
             internal class WeakRefObject
             {

--- a/src/System.Drawing.Common/src/misc/DbgUtil.cs
+++ b/src/System.Drawing.Common/src/misc/DbgUtil.cs
@@ -2,20 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+using System.Globalization;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using System.Text;
+
 namespace System.Drawing.Internal
 {
-    using System.Diagnostics;
-    using System.Globalization;
-    using System.Reflection;
-    using System.Runtime.InteropServices;
-    using System.Security.Permissions;
-    using System.Text;
-
-
-    /// <include file='doc\DbgUtil.uex' path='docs/doc[@for="DbgUtil"]/*' />
-    /// <devdoc>
+    /// <summary>
     /// Debug help utility.
-    /// </devdoc>
+    /// </summary>
     [
     ReflectionPermission(SecurityAction.Assert, MemberAccess = true),
     EnvironmentPermission(SecurityAction.Assert, Unrestricted = true),
@@ -43,13 +41,10 @@ namespace System.Drawing.Internal
         public static int finalizeMaxFrameCount = 5;
 #pragma warning restore 0414
 
-        // Methods
-
-
-        /// <devdoc>
-        ///   Call this method from your Dispose(bool) to assert that unmanaged resources has been explicitly disposed.
-        /// </devdoc>
-        [Conditional("DEBUG")] // This code will be compiled into the assembly anyways, it is up to the compiler to ignore the call.
+        /// <summary>
+        /// Call this method from your Dispose(bool) to assert that unmanaged resources has been explicitly disposed.
+        /// </summary>
+        [Conditional("DEBUG")]
         public static void AssertFinalization(object obj, bool disposing)
         {
 #if GDI_FINALIZATION_WATCH
@@ -86,8 +81,6 @@ namespace System.Drawing.Internal
 #endif
         }
 
-        /// <devdoc>
-        /// </devdoc>
         [Conditional("DEBUG")]
         public static void AssertWin32(bool expression, string message)
         {
@@ -99,8 +92,6 @@ namespace System.Drawing.Internal
 #endif
         }
 
-        /// <devdoc>
-        /// </devdoc>
         [Conditional("DEBUG")]
         public static void AssertWin32(bool expression, string format, object arg1)
         {
@@ -113,8 +104,6 @@ namespace System.Drawing.Internal
 #endif
         }
 
-        /// <devdoc>
-        /// </devdoc>
         [Conditional("DEBUG")]
         public static void AssertWin32(bool expression, string format, object arg1, object arg2)
         {
@@ -127,8 +116,6 @@ namespace System.Drawing.Internal
 #endif
         }
 
-        /// <devdoc>
-        /// </devdoc>
         [Conditional("DEBUG")]
         public static void AssertWin32(bool expression, string format, object arg1, object arg2, object arg3)
         {
@@ -141,8 +128,6 @@ namespace System.Drawing.Internal
 #endif
         }
 
-        /// <devdoc>
-        /// </devdoc>
         [Conditional("DEBUG")]
         public static void AssertWin32(bool expression, string format, object arg1, object arg2, object arg3, object arg4)
         {
@@ -155,8 +140,6 @@ namespace System.Drawing.Internal
 #endif
         }
 
-        /// <devdoc>
-        /// </devdoc>
         [Conditional("DEBUG")]
         public static void AssertWin32(bool expression, string format, object arg1, object arg2, object arg3, object arg4, object arg5)
         {
@@ -169,9 +152,7 @@ namespace System.Drawing.Internal
 #endif
         }
 
-        /// <devdoc>
-        /// </devdoc>
-        [Conditional("DEBUG")] // This code will be compiled into the assembly anyways, it is up to the compiler to ignore the call.
+        [Conditional("DEBUG")]
         private static void AssertWin32Impl(bool expression, string format, object[] args)
         {
 #if DEBUG
@@ -183,7 +164,6 @@ namespace System.Drawing.Internal
 #endif
         }
 
-        //
         // WARNING: Your PInvoke function needs to have the DllImport.SetLastError=true for this method
         // to work properly.  From the MSDN:
         // GetLastWin32Error exposes the Win32 GetLastError API method from Kernel32.DLL. This method exists 
@@ -194,7 +174,6 @@ namespace System.Drawing.Internal
         //
         // You can only use this method to obtain error codes if you apply the System.Runtime.InteropServices.DllImportAttribute
         // to the method signature and set the SetLastError field to true.
-        //              
         public static string GetLastErrorStr()
         {
             int MAX_SIZE = 255;
@@ -229,21 +208,18 @@ namespace System.Drawing.Internal
             return String.Format(CultureInfo.CurrentCulture, "0x{0:x8} - {1}", err, message);
         }
 
-        /// <devdoc>
-        ///   Duplicated here from ClientUtils not to depend on that code because this class is to be
-        ///   compiled into System.Drawing and System.Windows.Forms.
-        /// </devdoc>
+        /// <summary>
+        /// Duplicated here from ClientUtils not to depend on that code because this class is to be compiled into
+        /// System.Drawing and System.Windows.Forms.
+        /// </summary>
         private static bool IsCriticalException(Exception ex)
         {
             return
-                //ex is NullReferenceException ||
                 ex is StackOverflowException ||
                 ex is OutOfMemoryException ||
                 ex is System.Threading.ThreadAbortException;
         }
 
-        /// <devdoc>
-        /// </devdoc>
         public static string StackTrace
         {
             get
@@ -252,10 +228,10 @@ namespace System.Drawing.Internal
             }
         }
 
-        /// <devdoc>
-        ///   Returns information about the top stack frames in a string format.  The input param determines the number of
-        ///   frames to include.
-        /// </devdoc>
+        /// <summary>
+        /// Returns information about the top stack frames in a string format.  The input param determines the number of
+        /// frames to include.
+        /// </summary>
         public static string StackFramesToStr(int maxFrameCount)
         {
             string trace = String.Empty;
@@ -329,7 +305,7 @@ namespace System.Drawing.Internal
             }
             catch (Exception ex)
             {
-                if (DbgUtil.IsCriticalException(ex))
+                if (IsCriticalException(ex))
                 {
                     throw;  //rethrow critical exception.
                 }
@@ -339,26 +315,26 @@ namespace System.Drawing.Internal
             return trace.ToString();
         }
 
-        /// <devdoc>
-        ///   Returns information about the top stack frames in a string format.
-        /// </devdoc>
+        /// <summary>
+        /// Returns information about the top stack frames in a string format.
+        /// </summary>
         public static string StackFramesToStr()
         {
-            return StackFramesToStr(DbgUtil.gdipInitMaxFrameCount);
+            return StackFramesToStr(gdipInitMaxFrameCount);
         }
 
-        /// <devdoc>
-        ///   Returns information about the top stack frames in a string format.  The input param determines the number of
-        ///   frames to include.  The 'message' parameter is used as the header of the returned string.
-        /// </devdoc>
+        /// <summary>
+        /// Returns information about the top stack frames in a string format.  The input param determines the number of
+        /// frames to include. The 'message' parameter is used as the header of the returned string.
+        /// </summary>
         public static string StackTraceToStr(string message, int frameCount)
         {
             return String.Format(CultureInfo.CurrentCulture, "{0}\r\nTop Stack Trace:\r\n{1}", message, DbgUtil.StackFramesToStr(frameCount));
         }
 
-        /// <devdoc>
-        ///   Returns information about the top stack frames in a string format. The 'message' parameter is used as the header of the returned string.
-        /// </devdoc>
+        /// <summary>
+        /// Returns information about the top stack frames in a string format. The 'message' parameter is used as the header of the returned string.
+        /// </summary>
         public static string StackTraceToStr(string message)
         {
             return StackTraceToStr(message, DbgUtil.gdipInitMaxFrameCount);

--- a/src/System.Drawing.Common/src/misc/DebugHandleTracker.cs
+++ b/src/System.Drawing.Common/src/misc/DebugHandleTracker.cs
@@ -2,28 +2,23 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
+using System.Diagnostics;
+
+using Hashtable = System.Collections.Hashtable;
+
 namespace System.Internal
 {
-    using System.ComponentModel;
-    using System.Diagnostics;
-
-    using Hashtable = System.Collections.Hashtable;
-
-    /// <include file='doc\DebugHandleTracker.uex' path='docs/doc[@for="DebugHandleTracker"]/*' />
-    /// <devdoc>
-    ///     The job of this class is to collect and track handle usage in
-    ///     windows forms.  Ideally, a developer should never have to call dispose() on
-    ///     any windows forms object.  The problem in making this happen is in objects that
-    ///     are very small to the VM garbage collector, but take up huge amounts
-    ///     of resources to the system.  A good example of this is a Win32 region
-    ///     handle.  To the VM, a Region object is a small six ubyte object, so there
-    ///     isn't much need to garbage collect it anytime soon.  To Win32, however,
-    ///     a region handle consumes expensive USER and GDI resources.  Ideally we
-    ///     would like to be able to mark an object as "expensive" so it uses a different
-    ///     garbage collection algorithm.  In absence of that, we use the HandleCollector class, which
-    ///     runs a daemon thread to garbage collect when handle usage goes up.
-    /// </devdoc>
-    /// <internalonly/>
+    /// <summary>
+    /// The job of this class is to collect and track handle usage in windows forms. Ideally, a developer should never
+    /// have to call dispose() on any windows forms object. The problem in making this happen is in objects that are
+    /// very small to the VM garbage collector, but take up huge amounts of resources to the system. A good example of
+    /// this is a Win32 region handle. To the VM, a Region object is a small six ubyte object, so there isn't much need
+    /// to garbage collect it anytime soon. To Win32, however, a region handle consumes expensive USER and GDI
+    /// resources. Ideally we would like to be able to mark an object as "expensive" so it uses a different garbage
+    /// collection algorithm. In absence of that, we use the HandleCollector class, which runs a daemon thread to
+    /// garbage collect when handle usage goes up.
+    /// </summary>
     internal class DebugHandleTracker
     {
         private static Hashtable s_handleTypes = new Hashtable();
@@ -46,12 +41,9 @@ namespace System.Internal
 
         private static object s_internalSyncObject = new object();
 
-        /// <include file='doc\DebugHandleTracker.uex' path='docs/doc[@for="DebugHandleTracker.IgnoreCurrentHandlesAsLeaks"]/*' />
-        /// <devdoc>
-        ///     All handles available at this time will be not be considered as leaks
-        ///     when CheckLeaks is called to report leaks.
-        /// </devdoc>
-        /** @conditional(DEBUG) */
+        /// <summary>
+        /// All handles available at this time will be not be considered as leaks when CheckLeaks is called to report leaks.
+        /// </summary>
         public static void IgnoreCurrentHandlesAsLeaks()
         {
             lock (s_internalSyncObject)
@@ -72,13 +64,10 @@ namespace System.Internal
             }
         }
 
-        /// <include file='doc\DebugHandleTracker.uex' path='docs/doc[@for="DebugHandleTracker.CheckLeaks"]/*' />
-        /// <devdoc>
-        ///     Called at shutdown to check for handles that are currently allocated.
-        ///     Normally, there should be none.  This will print a list of all
-        ///     handle leaks.
-        /// </devdoc>
-        /** @conditional(DEBUG) */
+        /// <summary>
+        /// Called at shutdown to check for handles that are currently allocated. Normally, there should be none. 
+        /// This will print a list of all handle leaks.
+        /// </summary>
         public static void CheckLeaks()
         {
             lock (s_internalSyncObject)
@@ -103,22 +92,18 @@ namespace System.Internal
             }
         }
 
-        /// <include file='doc\DebugHandleTracker.uex' path='docs/doc[@for="DebugHandleTracker.Initialize"]/*' />
-        /// <devdoc>
-        ///     Ensures leak detection has been initialized.
-        /// </devdoc>
-        /** @conditional(DEBUG) */
+        /// <summary>
+        /// Ensures leak detection has been initialized.
+        /// </summary>
         public static void Initialize()
         {
             // Calling this method forces the class to be loaded, thus running the
             // static constructor which does all the work.
         }
 
-        /// <include file='doc\DebugHandleTracker.uex' path='docs/doc[@for="DebugHandleTracker.OnHandleAdd"]/*' />
-        /// <devdoc>
-        ///     Called by the Win32 handle collector when a new handle is created.
-        /// </devdoc>
-        /** @conditional(DEBUG) */
+        /// <summary>
+        /// Called by the Win32 handle collector when a new handle is created.
+        /// </summary>
         private void OnHandleAdd(string handleName, IntPtr handle, int handleCount)
         {
             HandleType type = (HandleType)s_handleTypes[handleName];
@@ -130,11 +115,9 @@ namespace System.Internal
             type.Add(handle);
         }
 
-        /// <include file='doc\DebugHandleTracker.uex' path='docs/doc[@for="DebugHandleTracker.OnHandleRemove"]/*' />
-        /// <devdoc>
-        ///     Called by the Win32 handle collector when a new handle is created.
-        /// </devdoc>
-        /** @conditional(DEBUG) */
+        /// <summary>
+        /// Called by the Win32 handle collector when a new handle is created.
+        /// </summary>
         private void OnHandleRemove(string handleName, IntPtr handle, int HandleCount)
         {
             HandleType type = (HandleType)s_handleTypes[handleName];
@@ -161,10 +144,9 @@ namespace System.Internal
             }
         }
 
-        /// <include file='doc\DebugHandleTracker.uex' path='docs/doc[@for="DebugHandleTracker.HandleType"]/*' />
-        /// <devdoc>
-        ///     Represents a specific type of handle.
-        /// </devdoc>
+        /// <summary>
+        /// Represents a specific type of handle.
+        /// </summary>
         private class HandleType
         {
             public readonly string name;
@@ -174,20 +156,18 @@ namespace System.Internal
 
             private const int BUCKETS = 10;
 
-            /// <include file='doc\DebugHandleTracker.uex' path='docs/doc[@for="DebugHandleTracker.HandleType.HandleType"]/*' />
-            /// <devdoc>
-            ///     Creates a new handle type.
-            /// </devdoc>
+            /// <summary>
+            /// Creates a new handle type.
+            /// </summary>
             public HandleType(string name)
             {
                 this.name = name;
                 _buckets = new HandleEntry[BUCKETS];
             }
 
-            /// <include file='doc\DebugHandleTracker.uex' path='docs/doc[@for="DebugHandleTracker.HandleType.Add"]/*' />
-            /// <devdoc>
-            ///     Adds a handle to this handle type for monitoring.
-            /// </devdoc>
+            /// <summary>
+            /// Adds a handle to this handle type for monitoring.
+            /// </summary>
             public void Add(IntPtr handle)
             {
                 lock (this)
@@ -215,10 +195,9 @@ namespace System.Internal
                 }
             }
 
-            /// <include file='doc\DebugHandleTracker.uex' path='docs/doc[@for="DebugHandleTracker.HandleType.CheckLeaks"]/*' />
-            /// <devdoc>
-            ///     Checks and reports leaks for handle monitoring.
-            /// </devdoc>
+            /// <summary>
+            /// Checks and reports leaks for handle monitoring.
+            /// </summary>
             public void CheckLeaks()
             {
                 lock (this)
@@ -247,10 +226,9 @@ namespace System.Internal
                 }
             }
 
-            /// <include file='doc\DebugHandleTracker.uex' path='docs/doc[@for="DebugHandleTracker.HandleType.IgnoreCurrentHandlesAsLeaks"]/*' />
-            /// <devdoc>
-            ///     Marks all the handles currently stored, as ignorable, so that they will not be reported as leaks later.
-            /// </devdoc>
+            /// <summary>
+            /// Marks all the handles currently stored, as ignorable, so that they will not be reported as leaks later.
+            /// </summary>
             public void IgnoreCurrentHandlesAsLeaks()
             {
                 lock (this)
@@ -270,19 +248,17 @@ namespace System.Internal
                 }
             }
 
-            /// <include file='doc\DebugHandleTracker.uex' path='docs/doc[@for="DebugHandleTracker.HandleType.ComputeHash"]/*' />
-            /// <devdoc>
-            ///     Computes the hash bucket for this handle.
-            /// </devdoc>
+            /// <summary>
+            /// Computes the hash bucket for this handle.
+            /// </summary>
             private int ComputeHash(IntPtr handle)
             {
                 return (unchecked((int)handle) & 0xFFFF) % BUCKETS;
             }
 
-            /// <include file='doc\DebugHandleTracker.uex' path='docs/doc[@for="DebugHandleTracker.HandleType.Remove"]/*' />
-            /// <devdoc>
-            ///     Removes the given handle from our monitor list.
-            /// </devdoc>
+            /// <summary>
+            /// Removes the given handle from our monitor list.
+            /// </summary>
             public bool Remove(IntPtr handle)
             {
                 lock (this)
@@ -320,10 +296,9 @@ namespace System.Internal
                 }
             }
 
-            /// <include file='doc\DebugHandleTracker.uex' path='docs/doc[@for="DebugHandleTracker.HandleType.HandleEntry"]/*' />
-            /// <devdoc>
-            ///     Denotes a single entry in our handle list.
-            /// </devdoc>
+            /// <summary>
+            /// Denotes a single entry in our handle list.
+            /// </summary>
             private class HandleEntry
             {
                 public readonly IntPtr handle;
@@ -331,10 +306,9 @@ namespace System.Internal
                 public readonly string callStack;
                 public bool ignorableAsLeak;
 
-                /// <include file='doc\DebugHandleTracker.uex' path='docs/doc[@for="DebugHandleTracker.HandleType.HandleEntry.HandleEntry"]/*' />
-                /// <devdoc>
-                ///     Creates a new handle entry
-                /// </devdoc>
+                /// <summary>
+                /// Creates a new handle entry
+                /// </summary>
                 public HandleEntry(HandleEntry next, IntPtr handle)
                 {
                     this.handle = handle;
@@ -350,57 +324,31 @@ namespace System.Internal
                     }
                 }
 
-                /// <include file='doc\DebugHandleTracker.uex' path='docs/doc[@for="DebugHandleTracker.HandleType.HandleEntry.ToString"]/*' />
-                /// <devdoc>
-                ///     Converts this handle to a printable string.  the string consists
-                ///     of the handle value along with the callstack for it's
-                ///     allocation.
-                /// </devdoc>
+                /// <summary>
+                /// Converts this handle to a printable string.  the string consists of the handle value along with
+                /// the callstack for it's allocation.
+                /// </summary>
                 public string ToString(HandleType type)
                 {
                     StackParser sp = new StackParser(callStack);
 
                     // Discard all of the stack up to and including the "Handle.create" call
-                    //
                     sp.DiscardTo("HandleCollector.Add");
 
                     // Skip the next call as it is always a debug wrapper
-                    //
                     sp.DiscardNext();
 
                     // Now recreate the leak list with a lot of stack entries
-                    //
                     sp.Truncate(40);
 
                     string description = "";
-                    /*if (type.name.Equals("GDI") || type.name.Equals("HDC")) {
-                        int objectType = UnsafeNativeMethods.GetObjectType(new HandleRef(null, handle));
-                        switch (objectType) {
-                            case NativeMethods.OBJ_DC: description = "normal DC"; break;
-                            case NativeMethods.OBJ_MEMDC: description = "memory DC"; break;
-                            case NativeMethods.OBJ_METADC: description = "metafile DC"; break;
-                            case NativeMethods.OBJ_ENHMETADC: description = "enhanced metafile DC"; break;
-
-                            case NativeMethods.OBJ_PEN: description = "Pen"; break;
-                            case NativeMethods.OBJ_BRUSH: description = "Brush"; break;
-                            case NativeMethods.OBJ_PAL: description = "Palette"; break;
-                            case NativeMethods.OBJ_FONT: description = "Font"; break;
-                            case NativeMethods.OBJ_BITMAP: description = "Bitmap"; break;
-                            case NativeMethods.OBJ_REGION: description = "Region"; break;
-                            case NativeMethods.OBJ_METAFILE: description = "Metafile"; break;
-                            case NativeMethods.OBJ_EXTPEN: description = "Extpen"; break;
-                            default: description = "?"; break;
-                        }
-                        description = " (" + description + ")";
-                    }*/
 
                     return Convert.ToString(unchecked((int)handle), 16) + description + ": " + sp.ToString();
                 }
 
-                /// <include file='doc\DebugHandleTracker.uex' path='docs/doc[@for="DebugHandleTracker.HandleType.HandleEntry.StackParser"]/*' />
-                /// <devdoc>
-                ///     Simple stack parsing class to manipulate our callstack.
-                /// </devdoc>
+                /// <summary>
+                /// Simple stack parsing class to manipulate our callstack.
+                /// </summary>
                 private class StackParser
                 {
                     internal string releventStack;
@@ -408,21 +356,18 @@ namespace System.Internal
                     internal int endIndex;
                     internal int length;
 
-                    /// <include file='doc\DebugHandleTracker.uex' path='docs/doc[@for="DebugHandleTracker.HandleType.HandleEntry.StackParser.StackParser"]/*' />
-                    /// <devdoc>
-                    ///     Creates a new stackparser with the given callstack
-                    /// </devdoc>
+                    /// <summary>
+                    /// Creates a new stackparser with the given callstack
+                    /// </summary>
                     public StackParser(string callStack)
                     {
                         releventStack = callStack;
                         length = releventStack.Length;
                     }
 
-                    /// <include file='doc\DebugHandleTracker.uex' path='docs/doc[@for="DebugHandleTracker.HandleType.HandleEntry.StackParser.ContainsString"]/*' />
-                    /// <devdoc>
-                    ///     Determines if the given string contains token.  This is a case
-                    ///     sensitive match.
-                    /// </devdoc>
+                    /// <summary>
+                    /// Determines if the given string contains token.  This is a case sensitive match.
+                    /// </summary>
                     private static bool ContainsString(string str, string token)
                     {
                         int stringLength = str.Length;
@@ -443,20 +388,17 @@ namespace System.Internal
                         return false;
                     }
 
-                    /// <include file='doc\DebugHandleTracker.uex' path='docs/doc[@for="DebugHandleTracker.HandleType.HandleEntry.StackParser.DiscardNext"]/*' />
-                    /// <devdoc>
-                    ///     Discards the next line of the stack trace.
-                    /// </devdoc>
+                    /// <summary>
+                    /// Discards the next line of the stack trace.
+                    /// </summary>
                     public void DiscardNext()
                     {
                         GetLine();
                     }
 
-                    /// <include file='doc\DebugHandleTracker.uex' path='docs/doc[@for="DebugHandleTracker.HandleType.HandleEntry.StackParser.DiscardTo"]/*' />
-                    /// <devdoc>
-                    ///     Discards all lines up to and including the line that contains
-                    ///     discardText.
-                    /// </devdoc>
+                    /// <summary>
+                    /// Discards all lines up to and including the line that contains discardText.
+                    /// </summary>
                     public void DiscardTo(string discardText)
                     {
                         while (startIndex < length)
@@ -469,10 +411,9 @@ namespace System.Internal
                         }
                     }
 
-                    /// <include file='doc\DebugHandleTracker.uex' path='docs/doc[@for="DebugHandleTracker.HandleType.HandleEntry.StackParser.GetLine"]/*' />
-                    /// <devdoc>
-                    ///     Retrieves the next line of the stack.
-                    /// </devdoc>
+                    /// <summary>
+                    /// Retrieves the next line of the stack.
+                    /// </summary>
                     private string GetLine()
                     {
                         endIndex = releventStack.IndexOf('\r', startIndex);
@@ -494,19 +435,17 @@ namespace System.Internal
                         return line;
                     }
 
-                    /// <include file='doc\DebugHandleTracker.uex' path='docs/doc[@for="DebugHandleTracker.HandleType.HandleEntry.StackParser.ToString"]/*' />
-                    /// <devdoc>
-                    ///     Rereives the string of the parsed stack trace
-                    /// </devdoc>
+                    /// <summary>
+                    /// Rereives the string of the parsed stack trace
+                    /// </summary>
                     public override string ToString()
                     {
                         return releventStack.Substring(startIndex);
                     }
 
-                    /// <include file='doc\DebugHandleTracker.uex' path='docs/doc[@for="DebugHandleTracker.HandleType.HandleEntry.StackParser.Truncate"]/*' />
-                    /// <devdoc>
-                    ///     Truncates the stack trace, saving the given # of lines.
-                    /// </devdoc>
+                    /// <summary>
+                    /// Truncates the stack trace, saving the given # of lines.
+                    /// </summary>
                     public void Truncate(int lines)
                     {
                         string truncatedStack = "";
@@ -532,7 +471,5 @@ namespace System.Internal
                 }
             }
         }
-
-        //#endif // DEBUG
     }
 }

--- a/src/System.Drawing.Common/src/misc/GDI/ApplyGraphicsProperties.cs
+++ b/src/System.Drawing.Common/src/misc/GDI/ApplyGraphicsProperties.cs
@@ -4,10 +4,10 @@
 
 namespace System.Drawing.Internal
 {
-    /// <devdoc>
-    ///     Enumeration defining the different Graphics properties to apply to a WindowsGraphics when creating it
-    ///     from a Graphics object.
-    /// </devdoc>
+    /// <summary>
+    /// Enumeration defining the different Graphics properties to apply to a WindowsGraphics when creating it from a
+    /// Graphics object.
+    /// </summary>
     [Flags]
     internal enum ApplyGraphicsProperties
     {

--- a/src/System.Drawing.Common/src/misc/GDI/DeviceContext.cs
+++ b/src/System.Drawing.Common/src/misc/GDI/DeviceContext.cs
@@ -2,61 +2,60 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
 namespace System.Drawing.Internal
 {
-    using System.Collections;
-    using System.Diagnostics;
-    using System.Runtime.InteropServices;
-
-    /// <include file='doc\IDeviceContext.uex' path='docs/doc[@for="DeviceContext"]/*' />
-    /// <devdoc>
-    ///     Represents a Win32 device context.  Provides operations for setting some of the properties
-    ///     of a device context.  It's the managed wrapper for an HDC.
-    ///     
-    ///     This class is divided into two files separating the code that needs to be compiled into
-    ///     reatail builds and debugging code.
-    /// </devdoc>
+    /// <summary>
+    /// Represents a Win32 device context.  Provides operations for setting some of the properties of a device context.
+    /// It's the managed wrapper for an HDC.
+    ///
+    /// This class is divided into two files separating the code that needs to be compiled into reatail builds and
+    /// debugging code.
+    /// </summary>
     internal sealed partial class DeviceContext : MarshalByRefObject, IDeviceContext, IDisposable
     {
-        /// <devdoc>
-        ///     This class is a wrapper to a Win32 device context, and the Hdc property is the way to get a 
-        ///     handle to it.
-        ///     
-        ///     The hDc is released/deleted only when owned by the object, meaning it was created internally; 
-        ///     in this case, the object is responsible for releasing/deleting it. 
-        ///     In the case the object is created from an exisiting hdc, it is not released; this is consistent 
-        ///     with the Win32 guideline that says if you call GetDC/CreateDC/CreatIC/CreateEnhMetafile, you are 
-        ///     responsible for calling ReleaseDC/DeleteDC/DeleteEnhMetafile respectivelly.
-        ///     
-        ///     This class implements some of the operations commonly performed on the properties of a dc in WinForms, 
-        ///     specially for interacting with GDI+, like clipping and coordinate transformation.  
-        ///     Several properties are not persisted in the dc but instead they are set/reset during a more comprehensive
-        ///     operation like text rendering or painting; for instance text alignment is set and reset during DrawText (GDI), 
-        ///     DrawString (GDI+).  
-        ///     
-        ///     Other properties are persisted from operation to operation until they are reset, like clipping, 
-        ///     one can make several calls to Graphics or WindowsGraphics obect after setting the dc clip area and 
-        ///     before resetting it; these kinds of properties are the ones implemented in this class.
-        ///     This kind of properties place an extra chanllenge in the scenario where a DeviceContext is obtained 
-        ///     from a Graphics object that has been used with GDI+, because GDI+ saves the hdc internally, rendering the 
-        ///     DeviceContext underlying hdc out of sync.  DeviceContext needs to support these kind of properties to 
-        ///     be able to keep the GDI+ and GDI HDCs in sync.
-        ///     
-        ///     A few other persisting properties have been implemented in DeviceContext2, among them:
-        ///     1. Window origin.
-        ///     2. Bounding rectangle.
-        ///     3. DC origin.
-        ///     4. View port extent.
-        ///     5. View port origin.
-        ///     6. Window extent
-        ///     
-        ///     Other non-persisted properties just for information: Background/Forground color, Palette, Color adjustment,
-        ///     Color space, ICM mode and profile, Current pen position, Binary raster op (not supported by GDI+), 
-        ///     Background mode, Logical Pen, DC pen color, ARc direction, Miter limit, Logical brush, DC brush color,
-        ///     Brush origin, Polygon filling mode, Bitmap stretching mode, Logical font, Intercharacter spacing, 
-        ///     Font mapper flags, Text alignment, Test justification, Layout, Path, Meta region.
-        ///     See book "Windows Graphics Programming - Feng Yuang", P315 - Device Context Attributes.
-        /// </devdoc>
+        /// <summary>
+        /// This class is a wrapper to a Win32 device context, and the Hdc property is the way to get a 
+        /// handle to it.
+        /// 
+        /// The hDc is released/deleted only when owned by the object, meaning it was created internally; 
+        /// in this case, the object is responsible for releasing/deleting it. 
+        /// In the case the object is created from an exisiting hdc, it is not released; this is consistent 
+        /// with the Win32 guideline that says if you call GetDC/CreateDC/CreatIC/CreateEnhMetafile, you are 
+        /// responsible for calling ReleaseDC/DeleteDC/DeleteEnhMetafile respectivelly.
+        /// 
+        /// This class implements some of the operations commonly performed on the properties of a dc in WinForms, 
+        /// specially for interacting with GDI+, like clipping and coordinate transformation.  
+        /// Several properties are not persisted in the dc but instead they are set/reset during a more comprehensive
+        /// operation like text rendering or painting; for instance text alignment is set and reset during DrawText (GDI), 
+        /// DrawString (GDI+).  
+        /// 
+        /// Other properties are persisted from operation to operation until they are reset, like clipping, 
+        /// one can make several calls to Graphics or WindowsGraphics obect after setting the dc clip area and 
+        /// before resetting it; these kinds of properties are the ones implemented in this class.
+        /// This kind of properties place an extra chanllenge in the scenario where a DeviceContext is obtained 
+        /// from a Graphics object that has been used with GDI+, because GDI+ saves the hdc internally, rendering the 
+        /// DeviceContext underlying hdc out of sync.  DeviceContext needs to support these kind of properties to 
+        /// be able to keep the GDI+ and GDI HDCs in sync.
+        /// 
+        /// A few other persisting properties have been implemented in DeviceContext2, among them:
+        /// 1. Window origin.
+        /// 2. Bounding rectangle.
+        /// 3. DC origin.
+        /// 4. View port extent.
+        /// 5. View port origin.
+        /// 6. Window extent
+        /// 
+        /// Other non-persisted properties just for information: Background/Forground color, Palette, Color adjustment,
+        /// Color space, ICM mode and profile, Current pen position, Binary raster op (not supported by GDI+), 
+        /// Background mode, Logical Pen, DC pen color, ARc direction, Miter limit, Logical brush, DC brush color,
+        /// Brush origin, Polygon filling mode, Bitmap stretching mode, Logical font, Intercharacter spacing, 
+        /// Font mapper flags, Text alignment, Test justification, Layout, Path, Meta region.
+        /// See book "Windows Graphics Programming - Feng Yuang", P315 - Device Context Attributes.
+        /// </summary>
 
         private IntPtr _hDC;
         private DeviceContextType _dcType;
@@ -86,17 +85,14 @@ namespace System.Drawing.Internal
         private string DeAllocationSite = "";
 #endif
 
-        ///
-        /// Class properties...
-        ///
+        /// <summary>
+        /// Specifies whether a modification has been applied to the dc, like setting the clipping area or a coordinate
+        /// transform.
+        /// </summary>
 
-        /// <devdoc>
-        ///     Specifies whether a modification has been applied to the dc, like setting the clipping area or a coordinate transform.
-        /// </devdoc>
-
-        /// <devdoc>
-        ///     The device type the context refers to.
-        /// </devdoc>
+        /// <summary>
+        /// The device type the context refers to.
+        /// </summary>
         public DeviceContextType DeviceContextType
         {
             get
@@ -105,11 +101,10 @@ namespace System.Drawing.Internal
             }
         }
 
-        /// <devdoc>
-        ///     This object's hdc.  If this property is called, then the object will be used as an HDC wrapper,
-        ///     so the hdc is cached and calls to GetHdc/ReleaseHdc won't PInvoke into GDI.
-        ///     Call Dispose to properly release the hdc.
-        /// </devdoc>
+        /// <summary>
+        /// This object's hdc.  If this property is called, then the object will be used as an HDC wrapper, so the hdc
+        /// is cached and calls to GetHdc/ReleaseHdc won't PInvoke into GDI. Call Dispose to properly release the hdc.
+        /// </summary>
         public IntPtr Hdc
         {
             get
@@ -139,12 +134,9 @@ namespace System.Drawing.Internal
             }
         }
 
-        // VSWhidbey 536325
-        // Due to a problem with calling DeleteObject() on currently selected GDI objects,
-        // we now track the initial set of objects when a DeviceContext is created.  Then,
-        // we also track which objects are currently selected in the DeviceContext.  When 
-        // a currently selected object is disposed, it is first replaced in the DC and then
-        // deleted.
+        // Due to a problem with calling DeleteObject() on currently selected GDI objects, we now track the initial set
+        // of objects when a DeviceContext is created. Then, we also track which objects are currently selected in the
+        // DeviceContext. When a currently selected object is disposed, it is first replaced in the DC and then deleted.
         private void CacheInitialState()
         {
             Debug.Assert(_hDC != IntPtr.Zero, "Cannot get initial state without a valid HDC");
@@ -191,13 +183,9 @@ namespace System.Drawing.Internal
             IntUnsafeNativeMethods.DeleteObject(new HandleRef(this, handleToDelete));
         }
 
-        //
-        // object construction API.  Publicly constructable from static methods only.
-        //
-
-        /// <devdoc>
-        ///     Constructor to contruct a DeviceContext object from an window handle.
-        /// </devdoc>
+        /// <summary>
+        /// Constructor to contruct a DeviceContext object from an window handle.
+        /// </summary>
         private DeviceContext(IntPtr hWnd)
         {
             _hWnd = hWnd;
@@ -212,9 +200,9 @@ namespace System.Drawing.Internal
 #endif
         }
 
-        /// <devdoc>
-        ///     Constructor to contruct a DeviceContext object from an existing Win32 device context handle.
-        /// </devdoc>
+        /// <summary>
+        /// Constructor to contruct a DeviceContext object from an existing Win32 device context handle.
+        /// </summary>
         private DeviceContext(IntPtr hDC, DeviceContextType dcType)
         {
             _hDC = hDC;
@@ -234,9 +222,9 @@ namespace System.Drawing.Internal
 
 
 
-        /// <devdoc>
-        ///     CreateDC creates a DeviceContext object wrapping an hdc created with the Win32 CreateDC function.
-        /// </devdoc>
+        /// <summary>
+        /// CreateDC creates a DeviceContext object wrapping an hdc created with the Win32 CreateDC function.
+        /// </summary>
         public static DeviceContext CreateDC(string driverName, string deviceName, string fileName, HandleRef devMode)
         {
             // Note: All input params can be null but not at the same time.  See MSDN for information.
@@ -245,9 +233,9 @@ namespace System.Drawing.Internal
             return new DeviceContext(hdc, DeviceContextType.NamedDevice);
         }
 
-        /// <devdoc>
-        ///     CreateIC creates a DeviceContext object wrapping an hdc created with the Win32 CreateIC function.
-        /// </devdoc>
+        /// <summary>
+        /// CreateIC creates a DeviceContext object wrapping an hdc created with the Win32 CreateIC function.
+        /// </summary>
         public static DeviceContext CreateIC(string driverName, string deviceName, string fileName, HandleRef devMode)
         {
             // Note: All input params can be null but not at the same time.  See MSDN for information.
@@ -256,9 +244,9 @@ namespace System.Drawing.Internal
             return new DeviceContext(hdc, DeviceContextType.Information);
         }
 
-        /// <devdoc>
-        ///     Creates a DeviceContext object wrapping a memory DC compatible with the specified device.
-        /// </devdoc>
+        /// <summary>
+        /// Creates a DeviceContext object wrapping a memory DC compatible with the specified device.
+        /// </summary>
         public static DeviceContext FromCompatibleDC(IntPtr hdc)
         {
             // If hdc is null, the function creates a memory DC compatible with the application's current screen.
@@ -270,41 +258,36 @@ namespace System.Drawing.Internal
             return new DeviceContext(compatibleDc, DeviceContextType.Memory);
         }
 
-        /// <include file='doc\IDeviceContext.uex' path='docs/doc[@for="DeviceContext.FromHdc"]/*' />
-        /// <devdoc>
-        ///     Used for wrapping an existing hdc.  In this case, this object doesn't own the hdc
-        ///     so calls to GetHdc/ReleaseHdc don't PInvoke into GDI.
-        /// </devdoc>
+        /// <summary>
+        /// Used for wrapping an existing hdc.  In this case, this object doesn't own the hdc so calls to
+        /// GetHdc/ReleaseHdc don't PInvoke into GDI.
+        /// </summary>
         public static DeviceContext FromHdc(IntPtr hdc)
         {
             Debug.Assert(hdc != IntPtr.Zero, "hdc == 0");
             return new DeviceContext(hdc, DeviceContextType.Unknown);
         }
 
-        /// <include file='doc\IDeviceContext.uex' path='docs/doc[@for="DeviceContext.FromHwnd"]/*' />
-        /// <devdoc>
-        ///     When hwnd is null, we are getting the screen DC.
-        /// </devdoc>
+        /// <summary>
+        /// When hwnd is null, we are getting the screen DC.
+        /// </summary>
         public static DeviceContext FromHwnd(IntPtr hwnd)
         {
             return new DeviceContext(hwnd);
         }
 
 
-        /// <include file='doc\IDeviceContext.uex' path='docs/doc[@for="DeviceContext.Finalize"]/*' />
         ~DeviceContext()
         {
             Dispose(false);
         }
 
-        /// <include file='doc\IDeviceContext.uex' path='docs/doc[@for="DeviceContext.Dispose"]/*' />
         public void Dispose()
         {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
 
-        /// <include file='doc\IDeviceContext.uex' path='docs/doc[@for="DeviceContext.Dispose1"]/*' />
         internal void Dispose(bool disposing)
         {
             if (_disposed)
@@ -364,12 +347,11 @@ namespace System.Drawing.Internal
             DbgUtil.AssertFinalization(this, disposing);
         }
 
-        /// <include file='doc\IDeviceContext.uex' path='docs/doc[@for="DeviceContext.GetHdc"]/*' />
-        /// <devdoc>
-        ///     Explicit interface method implementation to hide them a bit for usability reasons so the object is seen 
-        ///     as a wrapper around an hdc that is always available, and for performance reasons since it caches the hdc 
-        ///     if used in this way.
-        /// </devdoc>
+        /// <summary>
+        /// Explicit interface method implementation to hide them a bit for usability reasons so the object is seen as
+        /// a wrapper around an hdc that is always available, and for performance reasons since it caches the hdc if
+        /// used in this way.
+        /// </summary>
         IntPtr IDeviceContext.GetHdc()
         {
             if (_hDC == IntPtr.Zero)
@@ -388,11 +370,9 @@ namespace System.Drawing.Internal
         }
 
 
-        /// <include file='doc\IDeviceContext.uex' path='docs/doc[@for="DeviceContext.ReleaseHdc"]/*' />
-        ///<devdoc>
-        ///     If the object was created from a DC, this object doesn't 'own' the dc so we just ignore 
-        ///     this call.
-        ///</devdoc>
+        ///<summary>
+        /// If the object was created from a DC, this object doesn't 'own' the dc so we just ignore this call.
+        ///</summary>
         void IDeviceContext.ReleaseHdc()
         {
             if (_hDC != IntPtr.Zero && _dcType == DeviceContextType.Display)
@@ -410,10 +390,10 @@ namespace System.Drawing.Internal
         }
 
 
-        /// <devdoc>
-        ///     Specifies whether the DC is in GM_ADVANCE mode (supported only in NT platforms).  
-        ///     If false, it is in GM_COMPATIBLE mode.
-        /// </devdoc>
+        /// <summary>
+        /// Specifies whether the DC is in GM_ADVANCE mode (supported only in NT platforms). If false, it is in
+        /// GM_COMPATIBLE mode.
+        /// </summary>
         public DeviceContextGraphicsMode GraphicsMode
         {
             get
@@ -422,25 +402,25 @@ namespace System.Drawing.Internal
             }
         }
 
-        /// <devdoc>
-        ///     Sets the dc graphics mode and returns the old value.
-        /// </devdoc>
+        /// <summary>
+        /// Sets the dc graphics mode and returns the old value.
+        /// </summary>
         public DeviceContextGraphicsMode SetGraphicsMode(DeviceContextGraphicsMode newMode)
         {
             return (DeviceContextGraphicsMode)IntUnsafeNativeMethods.SetGraphicsMode(new HandleRef(this, _hDC), unchecked((int)newMode));
         }
 
-        /// <devdoc>
-        ///     Restores the device context to the specified state. The DC is restored by popping state information off a 
-        ///     stack created by earlier calls to the SaveHdc function. 
-        ///     The stack can contain the state information for several instances of the DC. If the state specified by the 
-        ///     specified parameter is not at the top of the stack, RestoreDC deletes all state information between the top 
-        ///     of the stack and the specified instance. 
-        ///     Specifies the saved state to be restored. If this parameter is positive, nSavedDC represents a specific 
-        ///     instance of the state to be restored. If this parameter is negative, nSavedDC represents an instance relative 
-        ///     to the current state. For example, -1 restores the most recently saved state. 
-        ///     See MSDN for more info.
-        /// </devdoc>
+        /// <summary>
+        /// Restores the device context to the specified state. The DC is restored by popping state information off a 
+        /// stack created by earlier calls to the SaveHdc function. 
+        /// The stack can contain the state information for several instances of the DC. If the state specified by the 
+        /// specified parameter is not at the top of the stack, RestoreDC deletes all state information between the top 
+        /// of the stack and the specified instance. 
+        /// Specifies the saved state to be restored. If this parameter is positive, nSavedDC represents a specific 
+        /// instance of the state to be restored. If this parameter is negative, nSavedDC represents an instance relative 
+        /// to the current state. For example, -1 restores the most recently saved state. 
+        /// See MSDN for more info.
+        /// </summary>
         public void RestoreHdc()
         {
 #if TRACK_HDC
@@ -472,14 +452,14 @@ namespace System.Drawing.Internal
 #endif        
         }
 
-        /// <devdoc>
-        ///     Saves the current state of the device context by copying data describing selected objects and graphic 
-        ///     modes (such as the bitmap, brush, palette, font, pen, region, drawing mode, and mapping mode) to a 
-        ///     context stack. 
-        ///     The SaveDC function can be used any number of times to save any number of instances of the DC state. 
-        ///     A saved state can be restored by using the RestoreHdc method.
-        ///     See MSDN for more details. 
-        /// </devdoc>
+        /// <summary>
+        /// Saves the current state of the device context by copying data describing selected objects and graphic 
+        /// modes (such as the bitmap, brush, palette, font, pen, region, drawing mode, and mapping mode) to a 
+        /// context stack. 
+        /// The SaveDC function can be used any number of times to save any number of instances of the DC state. 
+        /// A saved state can be restored by using the RestoreHdc method.
+        /// See MSDN for more details. 
+        /// </summary>
         public int SaveHdc()
         {
             HandleRef hdc = new HandleRef(this, _hDC);
@@ -505,13 +485,13 @@ namespace System.Drawing.Internal
             return state;
         }
 
-        /// <devdoc>
-        ///     Selects a region as the current clipping region for the device context.
-        ///     Remarks (From MSDN):
-        ///         - Only a copy of the selected region is used. The region itself can be selected for any number of other device contexts or it can be deleted. 
-        ///         - The SelectClipRgn function assumes that the coordinates for a region are specified in device units. 
-        ///         - To remove a device-context's clipping region, specify a NULL region handle. 
-        /// </devdoc>
+        /// <summary>
+        /// Selects a region as the current clipping region for the device context.
+        /// Remarks (From MSDN):
+        /// - Only a copy of the selected region is used. The region itself can be selected for any number of other device contexts or it can be deleted. 
+        /// - The SelectClipRgn function assumes that the coordinates for a region are specified in device units. 
+        /// - To remove a device-context's clipping region, specify a NULL region handle. 
+        /// </summary>
         public void SetClip(WindowsRegion region)
         {
             HandleRef hdc = new HandleRef(this, _hDC);
@@ -520,10 +500,9 @@ namespace System.Drawing.Internal
             IntUnsafeNativeMethods.SelectClipRgn(hdc, hRegion);
         }
 
-        ///<devdoc>
-        ///     Creates a new clipping region from the intersection of the current clipping region and 
-        ///     the specified rectangle. 
-        ///</devdoc>
+        ///<summary>
+        /// Creates a new clipping region from the intersection of the current clipping region and the specified rectangle. 
+        ///</summary>
         public void IntersectClip(WindowsRegion wr)
         {
             //if the incoming windowsregion is infinite, there is no need to do any intersecting.
@@ -552,9 +531,10 @@ namespace System.Drawing.Internal
             }
         }
 
-        /// <devdoc>
-        ///     Modifies the viewport origin for a device context using the specified horizontal and vertical offsets in logical units.
-        /// </devdoc>
+        /// <summary>
+        ///  Modifies the viewport origin for a device context using the specified horizontal and vertical offsets in
+        ///  logical units.
+        /// </summary>
         public void TranslateTransform(int dx, int dy)
         {
             IntNativeMethods.POINT orgn = new IntNativeMethods.POINT();
@@ -582,7 +562,7 @@ namespace System.Drawing.Internal
         }
 
         /// <summary>
-        ///     This allows collections to treat DeviceContext objects wrapping the same HDC as the same objects.
+        /// This allows collections to treat DeviceContext objects wrapping the same HDC as the same objects.
         /// </summary>
         public override int GetHashCode()
         {

--- a/src/System.Drawing.Common/src/misc/GDI/DeviceContextGraphicsMode.cs
+++ b/src/System.Drawing.Common/src/misc/GDI/DeviceContextGraphicsMode.cs
@@ -4,9 +4,9 @@
 
 namespace System.Drawing.Internal
 {
-    /// <devdoc>
-    ///    Specifies the graphics mode of a device context.
-    /// </devdoc>
+    /// <summary>
+    /// Specifies the graphics mode of a device context.
+    /// </summary>
     internal enum DeviceContextGraphicsMode
     {
         /*
@@ -35,14 +35,5 @@ namespace System.Drawing.Internal
         the XFORM structure pointed to by lpXform is ignored. 
         */
         ModifyWorldIdentity = 1
-
-        /*
-        GM_COMPATIBLE       = 1,
-        GM_ADVANCED         = 2,
-        
-        MWT_IDENTITY        = 1,
-        MWT_LEFTMULTIPLY  // Multiplies the current transformation by the data in the XFORM structure. (The data in the XFORM structure becomes the left multiplicand, and the data for the current transformation becomes the right multiplicand.) 
-        MWT_RIGHTMULTIPLY // Multiplies the current transformation by the data in the XFORM structure. (The data in the XFORM structure becomes the right multiplicand, and the data for the current transformation becomes the left multiplicand.) 
-        */
     }
 }

--- a/src/System.Drawing.Common/src/misc/GDI/DeviceContextType.cs
+++ b/src/System.Drawing.Common/src/misc/GDI/DeviceContextType.cs
@@ -4,9 +4,9 @@
 
 namespace System.Drawing.Internal
 {
-    /// <devdoc>
-    ///     Represent the device type the context refers to.
-    /// </devdoc>
+    /// <summary>
+    /// Represent the device type the context refers to.
+    /// </summary>
     internal enum DeviceContextType
     {
         // Unknown device
@@ -31,4 +31,3 @@ namespace System.Drawing.Internal
         Metafile = 0x06 // currently not supported.
     }
 }
-

--- a/src/System.Drawing.Common/src/misc/GDI/DeviceContexts.cs
+++ b/src/System.Drawing.Common/src/misc/GDI/DeviceContexts.cs
@@ -4,20 +4,18 @@
 
 namespace System.Drawing.Internal
 {
-    /// <devdoc>
-    ///     Keeps a cache of some graphics primitives.
-    ///     Created to improve performance of TextRenderer.MeasureText methods that don't receive a WindowsGraphics.
-    ///     This class mantains a cache of MRU WindowsFont objects in the process.
-    /// </devdoc>
+    /// <summary>
+    /// Keeps a cache of some graphics primitives. Created to improve performance of TextRenderer.MeasureText methods
+    /// that don't receive a WindowsGraphics. This class mantains a cache of MRU WindowsFont objects in the process.
+    /// </summary>
     internal static class DeviceContexts
     {
         [ThreadStatic]
         private static ClientUtils.WeakRefCollection t_activeDeviceContexts;
 
-        /// <devdoc>
-        /// WindowsGraphicsCacheManager needs to track DeviceContext
-        /// objects so it can ask them if a font is in use before they 
-        /// it's deleted.  
+        /// <summary>
+        /// WindowsGraphicsCacheManager needs to track DeviceContext objects so it can ask them if a font is in use
+        /// before they it's deleted.  
         internal static void AddDeviceContext(DeviceContext dc)
         {
             if (t_activeDeviceContexts == null)

--- a/src/System.Drawing.Common/src/misc/GDI/GdiObjectType.cs
+++ b/src/System.Drawing.Common/src/misc/GDI/GdiObjectType.cs
@@ -4,9 +4,9 @@
 
 namespace System.Drawing.Internal
 {
-    /// <devdoc>
-    ///    Specifies the the type of a GDI object.
-    /// </devdoc>
+    /// <summary>
+    /// Specifies the the type of a GDI object.
+    /// </summary>
     internal enum GdiObjectType
     {
         Pen = 1,
@@ -23,17 +23,5 @@ namespace System.Drawing.Internal
         EnhancedMetafileDC = 12,
         EnhMetafile = 13,
         ColorSpace = 14
-
-        /*
-        OBJ_PEN       = 1,
-        OBJ_BRUSH     = 2,
-        OBJ_FONT      = 6,
-        OBJ_EXTPEN    = 11,
-            
-        OBJ_DC        = 3,
-        OBJ_METADC    = 4,
-        OBJ_MEMDC     = 10,
-        OBJ_ENHMETADC = 12,
-    */
     }
 }

--- a/src/System.Drawing.Common/src/misc/GDI/SafeNativeMethods.cs
+++ b/src/System.Drawing.Common/src/misc/GDI/SafeNativeMethods.cs
@@ -6,11 +6,10 @@ namespace System.Drawing.Internal
 {
     using System.Runtime.InteropServices;
 
-    /// <devdoc>
-    ///   This is an extract of the System.Drawing IntNativeMethods in the CommonUI tree.
-    ///   This is done to be able to compile the GDI code in both assemblies System.Drawing
-    ///   and System.Windows.Forms.
-    /// </devdoc>
+    /// <summary>
+    /// This is an extract of the System.Drawing IntNativeMethods in the CommonUI tree.
+    /// This is done to be able to compile the GDI code in both assemblies System.Drawing and System.Windows.Forms.
+    /// </summary>
     [System.Security.SuppressUnmanagedCodeSecurityAttribute()]
     internal static partial class IntSafeNativeMethods
     {
@@ -18,20 +17,20 @@ namespace System.Drawing.Internal
         {
             static CommonHandles() { }
 
-            /// <devdoc>
-            ///     Handle type for enhanced metafiles.
-            /// </devdoc>
+            /// <summary>
+            /// Handle type for enhanced metafiles.
+            /// </summary>
             public static readonly int EMF = System.Internal.HandleCollector.RegisterType("EnhancedMetaFile", 20, 500);
 
-            /// <devdoc>
-            ///     Handle type for GDI objects.
-            /// </devdoc>
+            /// <summary>
+            /// Handle type for GDI objects.
+            /// </summary>
             public static readonly int GDI = System.Internal.HandleCollector.RegisterType("GDI", 90, 50);
 
-            /// <devdoc>
-            ///     Handle type for HDC's that count against the Win98 limit of five DC's.  HDC's
-            ///     which are not scarce, such as HDC's for bitmaps, are counted as GDIHANDLE's.
-            /// </devdoc>
+            /// <summary>
+            /// Handle type for HDC's that count against the Win98 limit of five DC's. HDC's which are not scarce,
+            /// such as HDC's for bitmaps, are counted as GDIHANDLE's.
+            /// </summary>
             public static readonly int HDC = System.Internal.HandleCollector.RegisterType("HDC", 100, 2); // wait for 2 dc's before collecting
         }
 

--- a/src/System.Drawing.Common/src/misc/GDI/UnsafeNativeMethods.cs
+++ b/src/System.Drawing.Common/src/misc/GDI/UnsafeNativeMethods.cs
@@ -2,11 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
 namespace System.Drawing.Internal
 {
-    using System.Diagnostics;
-    using System.Runtime.InteropServices;
-
     [System.Security.SuppressUnmanagedCodeSecurityAttribute]
     internal static partial class IntUnsafeNativeMethods
     {
@@ -19,10 +19,10 @@ namespace System.Drawing.Internal
             return hdc;
         }
 
-        /// <devdoc>
-        ///     NOTE: DeleteDC is to be used to delete the hdc created from CreateCompatibleDC ONLY.  All other hdcs should be
-        ///     deleted with DeleteHDC.
-        /// </devdoc>
+        /// <summary>
+        /// NOTE: DeleteDC is to be used to delete the hdc created from CreateCompatibleDC ONLY. All other hdcs shoul
+        /// be deleted with DeleteHDC.
+        /// </summary>
         [DllImport(ExternDll.Gdi32, SetLastError = true, ExactSpelling = true, EntryPoint = "DeleteDC", CharSet = CharSet.Auto)]
         public static extern bool IntDeleteDC(HandleRef hDC);
         public static bool DeleteDC(HandleRef hDC)
@@ -67,10 +67,10 @@ namespace System.Drawing.Internal
             return hdc;
         }
 
-        /// <devdoc>
-        ///     CreateCompatibleDC requires to add a GDI handle instead of an HDC handle to avoid perf penalty in HandleCollector.
-        ///     The hdc obtained from this method needs to be deleted with DeleteDC instead of DeleteHDC.
-        /// </devdoc>
+        /// <summary>
+        /// CreateCompatibleDC requires to add a GDI handle instead of an HDC handle to avoid perf penalty in HandleCollector.
+        /// The hdc obtained from this method needs to be deleted with DeleteDC instead of DeleteHDC.
+        /// </summary>
         [DllImport(ExternDll.Gdi32, SetLastError = true, ExactSpelling = true, EntryPoint = "CreateCompatibleDC", CharSet = CharSet.Auto)]
         public static extern IntPtr IntCreateCompatibleDC(HandleRef hDC);
         public static IntPtr CreateCompatibleDC(HandleRef hDC)

--- a/src/System.Drawing.Common/src/misc/GDI/WindowsGraphics.cs
+++ b/src/System.Drawing.Common/src/misc/GDI/WindowsGraphics.cs
@@ -5,24 +5,20 @@
 // THIS PARTIAL CLASS CONTAINS THE BASE METHODS FOR CREATING AND DISPOSING A WINDOWSGRAPHICS AS WELL
 // GETTING, DISPOSING AND WORKING WITH A DC.
 
+using System.Diagnostics;
+using System.Drawing.Drawing2D;
+
 namespace System.Drawing.Internal
 {
-    using System.Diagnostics;
-    using System.Drawing.Drawing2D;
-
-    /// <include file='doc\WindowsGraphics.uex' path='docs/doc[@for="WindowsGraphics"]/*' />
-    /// <devdoc>
-    ///     WindowsGraphics is a library for rendering text and drawing using GDI; it was
-    ///     created to address performance and compatibility issues found in GDI+ Graphics
-    ///     class.
-    ///     
-    ///     Note: WindowsGraphics is a stateful component, DC properties are persisted from 
-    ///     method calls, as opposed to Graphics (GDI+) which performs attomic operations and 
-    ///     always restores the hdc.
-    ///     The underlying hdc is always saved and restored on dispose so external HDCs won't
-    ///     be modified by WindowsGraphics.  So we don't need to restore previous objects into 
-    ///     the dc in method calls.
-    ///</devdoc>
+    /// <summary>
+    /// WindowsGraphics is a library for rendering text and drawing using GDI; it was created to address performance
+    /// and compatibility issues found in GDI+ Graphics class.
+    ///
+    /// Note: WindowsGraphics is a stateful component, DC properties are persisted from method calls, as opposed to
+    /// Graphics (GDI+) which performs attomic operations and always restores the hdc. The underlying hdc is always
+    /// saved and restored on dispose so external HDCs won't be modified by WindowsGraphics. So we don't need to
+    /// restore previous objects into the dc in method calls.
+    ///</summary>
     internal sealed partial class WindowsGraphics : MarshalByRefObject, IDisposable, IDeviceContext
     {
         // Wrapper around the window dc this object refers to.
@@ -35,22 +31,18 @@ namespace System.Drawing.Internal
         private string AllocationSite = DbgUtil.StackTrace;
 #endif
 
-        // Construction/destruction API
-
-        /// <include file='doc\WindowsGraphics.uex' path='docs/doc[@for="WindowsGraphics.WindowsGraphics"]/*' />
         public WindowsGraphics(DeviceContext dc)
         {
             Debug.Assert(dc != null, "null dc!");
             _dc = dc;
             _dc.SaveHdc();
-            //this.disposeDc = false; // the dc is not owned by this object.
         }
 
-        /// <devdoc>
-        ///     Creates a WindowsGraphics from a memory DeviceContext object compatible with the primary screen device.
-        ///     This object is suitable for performing text measuring but not for drawing into it because it does 
-        ///     not have a backup bitmap.
-        /// </devdoc>
+        /// <summary>
+        /// Creates a WindowsGraphics from a memory DeviceContext object compatible with the primary screen device.
+        /// This object is suitable for performing text measuring but not for drawing into it because it does not have
+        /// a backup bitmap.
+        /// </summary>
         public static WindowsGraphics CreateMeasurementWindowsGraphics()
         {
             DeviceContext dc = DeviceContext.FromCompatibleDC(IntPtr.Zero);
@@ -60,7 +52,6 @@ namespace System.Drawing.Internal
             return wg;
         }
 
-        /// <include file='doc\WindowsGraphics.uex' path='docs/doc[@for="WindowsGraphics.FromHwnd"]/*' />
         public static WindowsGraphics FromHwnd(IntPtr hWnd)
         {
             DeviceContext dc = DeviceContext.FromHwnd(hWnd);
@@ -70,7 +61,6 @@ namespace System.Drawing.Internal
             return wg;
         }
 
-        /// <include file='doc\WindowsGraphics.uex' path='docs/doc[@for="WindowsGraphics.FromHwnd"]/*' />
         public static WindowsGraphics FromHdc(IntPtr hDc)
         {
             Debug.Assert(hDc != IntPtr.Zero, "null hDc");
@@ -82,29 +72,29 @@ namespace System.Drawing.Internal
             return wg;
         }
 
-        /// <devdoc>
-        ///     Creates a WindowsGraphics object from a Graphics object.  Clipping and coordinate transforms
-        ///     are preserved.
-        ///     
-        ///     Notes: 
-        ///     - The passed Graphics object cannot be used until the WindowsGraphics is disposed
-        ///     since it borrows the hdc from the Graphics object locking it.
-        ///     - Changes to the hdc using the WindowsGraphics object are not preserved into the Graphics object;
-        ///     the hdc is returned to the Graphics object intact.
-        ///     
-        ///     Some background about how Graphics uses the internal hdc when created from an existing one
-        ///     (mail from GillesK from GDI+ team):
-        ///     User has an HDC with a particular state:
-        ///     Graphics object gets created based on that HDC. We query the HDC for its state and apply it to the Graphics. 
-        ///     At this stage, we do a SaveHDC and clear everything out of it.
-        ///     User calls GetHdc. We restore the HDC to the state it was in and give it to the user.
-        ///     User calls ReleaseHdc, we save the current state of the HDC and clear everything 
-        ///     (so that the graphics state gets applied next time we use it).
-        ///     Next time the user calls GetHdc we give him back the state after the second ReleaseHdc. 
-        ///     (But the state changes between the GetHdc and ReleaseHdc are not applied to the Graphics).
-        ///     Please note that this only applies the HDC created graphics, for Bitmap derived graphics, GetHdc creates a new DIBSection and 
-        ///     things get a lot more complicated.
-        /// </devdoc>
+        /// <summary>
+        /// Creates a WindowsGraphics object from a Graphics object.  Clipping and coordinate transforms
+        /// are preserved.
+        /// 
+        /// Notes: 
+        /// - The passed Graphics object cannot be used until the WindowsGraphics is disposed
+        /// since it borrows the hdc from the Graphics object locking it.
+        /// - Changes to the hdc using the WindowsGraphics object are not preserved into the Graphics object;
+        /// the hdc is returned to the Graphics object intact.
+        /// 
+        /// Some background about how Graphics uses the internal hdc when created from an existing one
+        /// (mail from GillesK from GDI+ team):
+        /// User has an HDC with a particular state:
+        /// Graphics object gets created based on that HDC. We query the HDC for its state and apply it to the Graphics. 
+        /// At this stage, we do a SaveHDC and clear everything out of it.
+        /// User calls GetHdc. We restore the HDC to the state it was in and give it to the user.
+        /// User calls ReleaseHdc, we save the current state of the HDC and clear everything 
+        /// (so that the graphics state gets applied next time we use it).
+        /// Next time the user calls GetHdc we give him back the state after the second ReleaseHdc. 
+        /// (But the state changes between the GetHdc and ReleaseHdc are not applied to the Graphics).
+        /// Please note that this only applies the HDC created graphics, for Bitmap derived graphics, GetHdc creates a new DIBSection and 
+        /// things get a lot more complicated.
+        /// </summary>
         public static WindowsGraphics FromGraphics(Graphics g)
         {
             ApplyGraphicsProperties properties = ApplyGraphicsProperties.All;
@@ -114,7 +104,6 @@ namespace System.Drawing.Internal
         public static WindowsGraphics FromGraphics(Graphics g, ApplyGraphicsProperties properties)
         {
             Debug.Assert(g != null, "null Graphics object.");
-            //Debug.Assert( properties != ApplyGraphicsProperties.None, "Consider using other WindowsGraphics constructor if not preserving Graphics properties." );
 
             WindowsRegion wr = null;
             float[] elements = null;
@@ -182,7 +171,6 @@ namespace System.Drawing.Internal
             return wg;
         }
 
-        /// <include file='doc\WindowsGraphics.uex' path='docs/doc[@for="WindowsGraphics.Finalize"]/*' />
         ~WindowsGraphics()
         {
             Dispose(false);
@@ -197,11 +185,10 @@ namespace System.Drawing.Internal
         }
 
 
-        /// <include file='doc\WindowsGraphics.uex' path='docs/doc[@for="WindowsGraphics.Dispose"]/*' />
         // Okay to suppress.
-        //"WindowsGraphics object does not own the Graphics object.  For instance in a control’s Paint event we pass the 
-        //GraphicsContainer object to TextRenderer, which uses WindowsGraphics; 
-        //if the Graphics object is disposed then further painting will be broken."
+        // "WindowsGraphics object does not own the Graphics object.  For instance in a control’s Paint event we pass
+        // the GraphicsContainer object to TextRenderer, which uses WindowsGraphics; if the Graphics object is disposed
+        // then further painting will be broken."
         public void Dispose()
         {
             Dispose(true);
@@ -245,13 +232,11 @@ namespace System.Drawing.Internal
             }
         }
 
-        /// <include file='doc\WindowsGraphics.uex' path='docs/doc[@for="WindowsGraphics.GetHdc"]/*' />
         public IntPtr GetHdc()
         {
             return _dc.Hdc;
         }
 
-        /// <include file='doc\WindowsGraphics.uex' path='docs/doc[@for="WindowsGraphics.ReleaseHdc"]/*' />
         public void ReleaseHdc()
         {
             _dc.Dispose();

--- a/src/System.Drawing.Common/src/misc/GDI/WindowsRegion.cs
+++ b/src/System.Drawing.Common/src/misc/GDI/WindowsRegion.cs
@@ -2,17 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
 namespace System.Drawing.Internal
 {
-    using System.Diagnostics;
-    using System.Runtime.InteropServices;
-
-    /// <devdoc>
-    ///     <para>
-    ///         Encapsulates a GDI Region object.
-    ///     </para>
-    /// </devdoc>
-
+    /// <summary>
+    /// Encapsulates a GDI Region object.
+    /// </summary>
     internal sealed partial class WindowsRegion : MarshalByRefObject, ICloneable, IDisposable
     {
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
@@ -23,32 +20,24 @@ namespace System.Drawing.Internal
         private string AllocationSite = DbgUtil.StackTrace;
 #endif
 
-        /// <devdoc>
-        /// </devdoc>
         private WindowsRegion()
         {
         }
 
-        /// <devdoc>
-        /// </devdoc>
         public WindowsRegion(Rectangle rect)
         {
             CreateRegion(rect);
         }
 
-        /// <devdoc>
-        /// </devdoc>
         public WindowsRegion(int x, int y, int width, int height)
         {
             CreateRegion(new Rectangle(x, y, width, height));
         }
 
-        // Consider implementing a constructor that calls ExtCreateRegion(XFORM lpXform, DWORD nCount, RGNDATA lpRgnData) if needed.
-
-        /// <devdoc>
-        ///     Creates a WindowsRegion from a region handle, if 'takeOwnership' is true, the handle is added to the HandleCollector
-        ///     and is removed & destroyed on dispose. 
-        /// </devdoc>
+        /// <summary>
+        /// Creates a WindowsRegion from a region handle, if 'takeOwnership' is true, the handle is added to the
+        /// HandleCollector and is removed & destroyed on dispose. 
+        /// </summary>
         public static WindowsRegion FromHregion(IntPtr hRegion, bool takeOwnership)
         {
             WindowsRegion wr = new WindowsRegion();
@@ -68,9 +57,9 @@ namespace System.Drawing.Internal
             return wr;
         }
 
-        /// <devdoc>
-        ///     Creates a WindowsRegion from a System.Drawing.Region. 
-        /// </devdoc>
+        /// <summary>
+        /// Creates a WindowsRegion from a System.Drawing.Region. 
+        /// </summary>
         public static WindowsRegion FromRegion(Region region, Graphics g)
         {
             if (region.IsInfinite(g))
@@ -89,8 +78,6 @@ namespace System.Drawing.Internal
             return WindowsRegion.FromHregion(region.GetHrgn(g), true);
         }
 
-        /// <devdoc>
-        /// </devdoc>
         public object Clone()
         {
             // WARNING: WindowsRegion currently supports rectangulare regions only, if the WindowsRegion was created
@@ -101,17 +88,15 @@ namespace System.Drawing.Internal
                 new WindowsRegion(ToRectangle());
         }
 
-        /// <devdoc>
-        ///     Combines region1 & region2 into this region.   The regions cannot be null. 
-        ///     The three regions need not be distinct. For example, the sourceRgn1 can equal this region. 
-        /// </devdoc>
+        /// <summary>
+        /// Combines region1 & region2 into this region. The regions cannot be null. The three regions need not be
+        /// distinct. For example, the sourceRgn1 can equal this region. 
+        /// </summary>
         public IntNativeMethods.RegionFlags CombineRegion(WindowsRegion region1, WindowsRegion region2, RegionCombineMode mode)
         {
             return IntUnsafeNativeMethods.CombineRgn(new HandleRef(this, HRegion), new HandleRef(region1, region1.HRegion), new HandleRef(region2, region2.HRegion), mode);
         }
 
-        /// <devdoc>
-        /// </devdoc>
         private void CreateRegion(Rectangle rect)
         {
             Debug.Assert(_nativeHandle == IntPtr.Zero, "nativeHandle should be null, we're leaking handle");
@@ -119,15 +104,11 @@ namespace System.Drawing.Internal
             _ownHandle = true;
         }
 
-        /// <devdoc>
-        /// </devdoc>
         public void Dispose()
         {
             Dispose(true);
         }
 
-        /// <devdoc>
-        /// </devdoc>
         public void Dispose(bool disposing)
         {
             if (_nativeHandle != IntPtr.Zero)
@@ -148,16 +129,14 @@ namespace System.Drawing.Internal
             }
         }
 
-        /// <devdoc>
-        /// </devdoc>
         ~WindowsRegion()
         {
             Dispose(false);
         }
 
-        /// <devdoc>
-        ///     The native region handle. 
-        /// </devdoc>
+        /// <summary>
+        /// The native region handle. 
+        /// </summary>
         public IntPtr HRegion
         {
             get
@@ -166,8 +145,6 @@ namespace System.Drawing.Internal
             }
         }
 
-        /// <devdoc>
-        /// </devdoc>
         public bool IsInfinite
         {
             get
@@ -176,9 +153,9 @@ namespace System.Drawing.Internal
             }
         }
 
-        /// <devdoc>
-        ///     A rectangle representing the window region set with the SetWindowRgn function. 
-        /// </devdoc>
+        /// <summary>
+        /// A rectangle representing the window region set with the SetWindowRgn function. 
+        /// </summary>
         public Rectangle ToRectangle()
         {
             if (IsInfinite)
@@ -192,4 +169,3 @@ namespace System.Drawing.Internal
         }
     }
 }
-

--- a/src/System.Drawing.Common/src/misc/GDI/WindowsRegionCombineMode.cs
+++ b/src/System.Drawing.Common/src/misc/GDI/WindowsRegionCombineMode.cs
@@ -4,8 +4,6 @@
 
 namespace System.Drawing.Internal
 {
-    /// <devdoc>
-    /// </devdoc>
     internal enum RegionCombineMode
     {
         AND = 1,

--- a/src/System.Drawing.Common/src/misc/HandleCollector.cs
+++ b/src/System.Drawing.Common/src/misc/HandleCollector.cs
@@ -23,22 +23,19 @@ namespace System.Internal
 
         private static object s_internalSyncObject = new object();
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.HandleCollector.Add"]/*' />
-        /// <devdoc>
-        ///     Adds the given handle to the handle collector.  This keeps the
-        ///     handle on a "hot list" of objects that may need to be garbage
-        ///     collected.
-        /// </devdoc>
+        /// <summary>
+        /// Adds the given handle to the handle collector. This keeps the handle on a "hot list" of objects that may
+        /// need to be garbage collected.
+        /// </summary>
         internal static IntPtr Add(IntPtr handle, int type)
         {
             s_handleTypes[type - 1].Add(handle);
             return handle;
         }
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.HandleCollector.Add"]/*' />
-        /// <devdoc>
-        ///     Suspends GC.Collect
-        /// </devdoc>
+        /// <summary>
+        /// Suspends GC.Collect
+        /// </summary>
         internal static void SuspendCollect()
         {
             lock (s_internalSyncObject)
@@ -47,10 +44,9 @@ namespace System.Internal
             }
         }
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.HandleCollector.Add"]/*' />
-        /// <devdoc>
-        ///     Resumes GC.Collect
-        /// </devdoc>        
+        /// <summary>
+        /// Resumes GC.Collect
+        /// </summary>        
         internal static void ResumeCollect()
         {
             bool performCollect = false;
@@ -82,10 +78,9 @@ namespace System.Internal
             }
         }
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.HandleCollector.RegisterType"]/*' />
-        /// <devdoc>
-        ///     Registers a new type of handle with the handle collector.
-        /// </devdoc>
+        /// <summary>
+        /// Registers a new type of handle with the handle collector.
+        /// </summary>
         internal static int RegisterType(string typeName, int expense, int initialThreshold)
         {
             lock (s_internalSyncObject)
@@ -105,21 +100,18 @@ namespace System.Internal
             }
         }
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.HandleCollector.Remove"]/*' />
-        /// <devdoc>
-        ///     Removes the given handle from the handle collector.  Removing a
-        ///     handle removes it from our "hot list" of objects that should be
-        ///     frequently garbage collected.
-        /// </devdoc>
+        /// <summary>
+        /// Removes the given handle from the handle collector. Removing a handle removes it from our "hot list" of
+        /// objects that should be frequently garbage collected.
+        /// </summary>
         internal static IntPtr Remove(IntPtr handle, int type)
         {
             return s_handleTypes[type - 1].Remove(handle);
         }
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.HandleCollector.HandleType"]/*' />
-        /// <devdoc>
-        ///     Represents a specific type of handle.
-        /// </devdoc>
+        /// <summary>
+        /// Represents a specific type of handle.
+        /// </summary>
         private class HandleType
         {
             internal readonly string name;
@@ -133,10 +125,9 @@ namespace System.Internal
             private List<IntPtr> handles = new List<IntPtr>();
 #endif
 
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.HandleCollector.HandleType.HandleType"]/*' />
-            /// <devdoc>
-            ///     Creates a new handle type.
-            /// </devdoc>
+            /// <summary>
+            /// Creates a new handle type.
+            /// </summary>
             internal HandleType(string name, int expense, int initialThreshHold)
             {
                 this.name = name;
@@ -145,10 +136,9 @@ namespace System.Internal
                 _deltaPercent = 100 - expense;
             }
 
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.HandleCollector.HandleType.Add"]/*' />
-            /// <devdoc>
-            ///     Adds a handle to this handle type for monitoring.
-            /// </devdoc>            
+            /// <summary>
+            /// Adds a handle to this handle type for monitoring.
+            /// </summary>            
             internal void Add(IntPtr handle)
             {
                 if (handle == IntPtr.Zero)
@@ -207,11 +197,9 @@ namespace System.Internal
             }
 
 
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.HandleCollector.HandleType.GetHandleCount"]/*' />
-            /// <devdoc>
-            ///     Retrieves the outstanding handle count for this
-            ///     handle type.
-            /// </devdoc>
+            /// <summary>
+            /// Retrieves the outstanding handle count for this handle type.
+            /// </summary>
             internal int GetHandleCount()
             {
                 lock (this)
@@ -220,10 +208,9 @@ namespace System.Internal
                 }
             }
 
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.HandleCollector.HandleType.NeedCollection"]/*' />
-            /// <devdoc>
-            ///     Determines if this handle type needs a garbage collection pass.
-            /// </devdoc>
+            /// <summary>
+            /// Determines if this handle type needs a garbage collection pass.
+            /// </summary>
             internal bool NeedCollection()
             {
                 if (s_suspendCount > 0)
@@ -243,7 +230,6 @@ namespace System.Internal
                 // need to collect, but if it 10% below the next lowest threshhold we
                 // will bump down a rung.  We need to choose a percentage here or else
                 // we will oscillate.
-                //
                 int oldThreshHold = (100 * _threshHold) / (100 + _deltaPercent);
                 if (oldThreshHold >= _initialThreshHold && _handleCount < (int)(oldThreshHold * .9F))
                 {
@@ -256,10 +242,9 @@ namespace System.Internal
                 return false;
             }
 
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.HandleCollector.HandleType.Remove"]/*' />
-            /// <devdoc>
-            ///     Removes the given handle from our monitor list.
-            /// </devdoc>
+            /// <summary>
+            /// Removes the given handle from our monitor list.
+            /// </summary>
             internal IntPtr Remove(IntPtr handle)
             {
                 if (handle == IntPtr.Zero)


### PR DESCRIPTION
This is part of #20706 
> * Clean up the formatting of the XML doc comments. They are using some defunct syntax that doesn't work or make sense anymore.
> * Normalize comment style (lots of weird "block-style" header comments, weird comment spacing, etc.)

This was a very rote cleanup. I just went through all of the files and did the following:

* Change all XML comments to be of normal form, with `<summary>` tags, etc. There were a TON of comments that were empty, or just contained junk. I removed those. Others were of the correct form, but were formatted really strangely -- I fixed those up, too.
* Removed duplicate comments. There were lots of comments right above the XML comment blocks which essentially said the exact same thing. I just removed these when I saw them.
* Inside methods: cleaned up weird comment blocks where I saw them, deleted useless comments, empty comments, etc.
* As I went, I also moved the "using" blocks up outside of the namespace, like all of the other files in corefx. This isn't related to the comments -- I just figured I would clean that up at the same time.

There are no functional changes here. This is all code style cleanup.

@hughbe @stephentoub Could you give this a quick look over? I know that it is quite large, but the changes are all very straightforward and formulaic. I've only touched comment blocks, so I don't think the entire thing needs to be examined, just a small section to make sure it looks reasonable.