### PR TITLE
Enable some System.Net.Requests tests for UAP/UAPAOT

### DIFF
--- a/src/System.Net.Requests/tests/AuthenticationManagerTest.cs
+++ b/src/System.Net.Requests/tests/AuthenticationManagerTest.cs
@@ -26,7 +26,6 @@ namespace System.Net.Tests
             Assert.Throws<ArgumentNullException>(() => AuthenticationManager.Register(null));
         }
 
-        [ActiveIssue(20136, TargetFrameworkMonikers.Uap)]
         [Fact]
         public void Register_Unregister_ModuleCountUnchanged()
         {
@@ -42,7 +41,6 @@ namespace System.Net.Tests
             }).Dispose();           
         }
 
-        [ActiveIssue(20136, TargetFrameworkMonikers.Uap)]
         public void Register_UnregisterByScheme_ModuleCountUnchanged()
         {
             RemoteInvoke(() =>
@@ -66,7 +64,6 @@ namespace System.Net.Tests
             Assert.Equal(PlatformDetection.IsFullFramework ? 5 : 0, count);
         }
 
-        [ActiveIssue(20136, TargetFrameworkMonikers.Uap)]
         [Fact]
         public void CredentialPolicy_Roundtrip()
         {
@@ -85,7 +82,6 @@ namespace System.Net.Tests
             }).Dispose();
         }
 
-        [ActiveIssue(20136, TargetFrameworkMonikers.Uap)]
         [Fact]
         public void CustomTargetNameDictionary_ValidCollection()
         {

--- a/src/System.Net.Requests/tests/GlobalProxySelectionTest.cs
+++ b/src/System.Net.Requests/tests/GlobalProxySelectionTest.cs
@@ -38,7 +38,6 @@ namespace System.Net.Tests
             }
         }
 
-        [ActiveIssue(20136, TargetFrameworkMonikers.Uap)]
         [Fact]
         public void Select_Success()
         {

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -556,7 +556,6 @@ namespace System.Net.Tests
             AssertExtensions.Throws<ArgumentException>("value", () => request.Expect = "100-continue");
         }
 
-        [ActiveIssue(20136, TargetFrameworkMonikers.Uap)]
         [Fact]
         public void DefaultMaximumResponseHeadersLength_SetAndGetLength_ValuesMatch()
         {
@@ -579,7 +578,6 @@ namespace System.Net.Tests
             }).Dispose();
         }
 
-        [ActiveIssue(20136, TargetFrameworkMonikers.Uap)]
         [Fact]
         public void DefaultMaximumErrorResponseLength_SetAndGetLength_ValuesMatch()
         {
@@ -602,7 +600,6 @@ namespace System.Net.Tests
             }).Dispose();
         }
 
-        [ActiveIssue(20136, TargetFrameworkMonikers.Uap)]
         [Fact]
         public void DefaultCachePolicy_SetAndGetPolicyReload_ValuesMatch()
         {


### PR DESCRIPTION
Tests that use RemoteExecutor are now working on both UAP and UAPAOT.

Contributes to #20136