### PR TITLE
Fix GetEnvironmentVariable test for UAPAOT

### DIFF
--- a/src/System.Runtime.Extensions/tests/System/Environment.GetEnvironmentVariable.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.GetEnvironmentVariable.cs
@@ -219,7 +219,11 @@ namespace System.Tests
         [MemberData(nameof(EnvironmentTests.EnvironmentVariableTargets), MemberType = typeof(EnvironmentTests))]
         public void EnumerateEnvironmentVariables(EnvironmentVariableTarget target)
         {
-            bool lookForSetValue = (target == EnvironmentVariableTarget.Process) || PlatformDetection.IsWindowsAndElevated;
+            bool lookForSetValue = (target == EnvironmentVariableTarget.Process) ||
+                                    // On the Project N corelib, it doesn't attempt to set machine/user environment variables;
+                                    // it just returns silently. So don't try.
+                                    (PlatformDetection.IsWindowsAndElevated && !PlatformDetection.IsNetNative);
+
 
             string key = $"EnumerateEnvironmentVariables ({target})";
             string value = Path.GetRandomFileName();


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/21302

After debugging laboriously I remembered that @AtsushiKan made SetEnvironmentVariable skip on AOT for machine/user scope.