### PR TITLE
Fix uapaot threading test

### DIFF
--- a/src/Common/tests/System/PlatformDetection.cs
+++ b/src/Common/tests/System/PlatformDetection.cs
@@ -153,6 +153,7 @@ namespace System
             }
         }
 
+        public static bool IsNotWinRT => !IsWinRT;
         public static bool IsWinRTSupported => IsWinRT || (IsWindows && !IsWindows7);
         public static bool IsNotWinRTSupported => !IsWinRTSupported;
 

--- a/src/System.Threading/tests/MutexTests.cs
+++ b/src/System.Threading/tests/MutexTests.cs
@@ -70,11 +70,8 @@ namespace System.Threading.Tests
             }
         }
 
-        [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]
-        [SkipOnTargetFramework(
-            TargetFrameworkMonikers.Uap,
-            "Impersonation APIs are not available and creating global sync objects is not allowed in UWP apps.")]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWinRT))] // Can't create global objects in appcontainer
         [SkipOnTargetFramework(
             TargetFrameworkMonikers.NetFramework,
             "The fix necessary for this test (PR https://github.com/dotnet/coreclr/pull/12381) is not in the .NET Framework.")]
@@ -93,7 +90,7 @@ namespace System.Threading.Tests
             });
         }
 
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsUap))]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsWinRT))] // Can't create global objects in appcontainer
         [PlatformSpecific(TestPlatforms.Windows)]
         public void Ctor_TryCreateGlobalMutexTest_Uwp()
         {


### PR DESCRIPTION
Fix https://github.com/dotnet/corefx/issues/21609

It should have been disabled for appcontainer (aka IsWinRT) not for all UAP