### PR TITLE
Fixing VisualBasic ResourceManager loading and enabling test

### DIFF
--- a/src/Common/src/System/SR.vb
+++ b/src/Common/src/System/SR.vb
@@ -25,7 +25,7 @@ Namespace System
 
                     ' The following constructor ResourceManager(Type) is going to be replaced by the private constructor ResourceManager(String)
                     ' we'll pass s_resourcesName to this constructor
-                    SR.s_resourceManager = New ResourceManager(GetType(SR))
+                    SR.s_resourceManager = New ResourceManager(SR.ResourceType)
                 End If
                 Return SR.s_resourceManager
             End Get

--- a/src/Microsoft.VisualBasic/tests/OperatorsTests.cs
+++ b/src/Microsoft.VisualBasic/tests/OperatorsTests.cs
@@ -238,7 +238,6 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
 
         [Theory]
         [MemberData(nameof(IncompatibleAddObject_TestData))]
-        [ActiveIssue(21088)]
         public void AddObject_Incompatible_ThrowsInvalidCastException(object left, object right)
         {
             Assert.Throws<InvalidCastException>(() => Operators.AddObject(left, right));


### PR DESCRIPTION
ResourceManager was broken in VisualBasic which resulted in NullReferenceExceptions when exceptions with strings should be thrown.

Fixes https://github.com/dotnet/corefx/issues/21088

@danmosemsft should the production code fix be ported into release/2.0.0?