### PR TITLE
Reenable EnumeratePastEndThenModify collection test

### DIFF
--- a/src/Common/tests/System/Collections/IEnumerableTest.cs
+++ b/src/Common/tests/System/Collections/IEnumerableTest.cs
@@ -339,7 +339,6 @@ namespace Tests.Collections
         }
 
         [Fact]
-        [ActiveIssue(1170)]
         public void EnumeratePastEndThenModify()
         {
             object[] items = GenerateItems(EnumerableSize);
@@ -354,7 +353,7 @@ namespace Tests.Collections
             VerifyModifiedEnumerator(
                 enumerator,
                 DefaultValue,
-                true,
+                false,
                 true);
         }
 


### PR DESCRIPTION
Fixes #1170 (is already closed but the code was never cleaned up)

According to the changes in MSDN accessing the `Enumerator.Current` after the collection is modified does not result in an exception. Therefore changing the test.