### PR TITLE
Reenabling equality comparers tests after corert src change

### DIFF
--- a/src/System.Collections/tests/Generic/Comparers/Comparer.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/Comparers/Comparer.Generic.Tests.cs
@@ -35,7 +35,6 @@ namespace System.Collections.Generic.Tests
         }
 
         [Fact]
-        [ActiveIssue("dotnet/corert#1736", TargetFrameworkMonikers.Uap)]
         public void Comparer_EqualsShouldBeOverriddenAndWorkForDifferentInstances_cloned()
         {
             var comparer = Comparer<T>.Default;
@@ -62,7 +61,6 @@ namespace System.Collections.Generic.Tests
         }
 
         [Fact]
-        [ActiveIssue("dotnet/corert#1736", TargetFrameworkMonikers.Uap)]
         public void Comparer_GetHashCodeShouldBeOverriddenAndBeTheSameAsLongAsTheTypeIsTheSame_cloned()
         {
             var comparer = Comparer<T>.Default;

--- a/src/System.Collections/tests/Generic/Comparers/EqualityComparer.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/Comparers/EqualityComparer.Generic.Tests.cs
@@ -31,7 +31,6 @@ namespace System.Collections.Generic.Tests
         }
 
         [Fact]
-        [ActiveIssue("dotnet/corert#1736", TargetFrameworkMonikers.Uap)]
         public void EqualityComparer_EqualsShouldBeOverriddenAndWorkForDifferentInstances_cloned()
         {
             var comparer = EqualityComparer<T>.Default;
@@ -58,7 +57,6 @@ namespace System.Collections.Generic.Tests
         }
 
         [Fact]
-        [ActiveIssue("dotnet/corert#1736", TargetFrameworkMonikers.Uap)]
         public void EqualityComparer_GetHashCodeShouldBeOverriddenAndBeTheSameAsLongAsTheTypeIsTheSame_cloned()
         {
             var comparer = EqualityComparer<T>.Default;


### PR DESCRIPTION
Fixes https://github.com/dotnet/corert/issues/1736

Passes locally for me.