### PR TITLE
Fix some TLS related HttpClientHandler properties for UAP

### DIFF
--- a/src/System.Net.Http/src/netcore50/System/Net/HttpClientHandler.cs
+++ b/src/System.Net.Http/src/netcore50/System/Net/HttpClientHandler.cs
@@ -362,37 +362,23 @@ namespace System.Net.Http
 
         public bool CheckCertificateRevocationList
         {
-            // We can't get this property to actually work yet since the current WinRT Windows.Web.Http APIs don't have a setting for this.
-            // FYI: The WinRT API always checks for certificate revocation. If the revocation status can't be determined completely, i.e.
-            // the revocation server is offline, then the request is still allowed.
+            // The WinRT API always checks for certificate revocation. If the revocation status is indeterminate
+            // (such as revocation server is offline), then the WinRT API will indicate "success" and not fail
+            // the request.
             get { return true; }
             set
             {
                 CheckDisposedOrStarted();
-                /*TODO#18116
-                if (!value)
-                {
-                    throw new PlatformNotSupportedException(String.Format(CultureInfo.InvariantCulture,
-                        SR.net_http_value_not_supported, value, nameof(CheckCertificateRevocationList)));
-                }
-                */
             }
         }
 
         public SslProtocols SslProtocols
         {
+            // The WinRT API does not expose a property to control this. It always uses the system default.
             get { return SslProtocols.None; }
             set
             {
                 CheckDisposedOrStarted();
-                if (value != SslProtocols.None)
-                {
-                    /*
-                    TODO:#18116
-                    throw new PlatformNotSupportedException(String.Format(CultureInfo.InvariantCulture,
-                        SR.net_http_value_not_supported, value, nameof(SslProtocols)));
-                   */
-                }
             }
         }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
@@ -16,7 +16,8 @@ namespace System.Net.Http.Functional.Tests
 {
     using Configuration = System.Net.Test.Common.Configuration;
 
-    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.NetFramework, "netfx: dotnet/corefx #16805, uap: dotnet/corefx #20010")]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "SslProtocols not supported on UAP")]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "dotnet/corefx #16805")]
     public partial class HttpClientHandler_SslProtocols_Test
     {
         [Fact]

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -10,6 +10,7 @@ using System.Net.Sockets;
 using System.Net.Security;
 using System.Net.Test.Common;
 using System.Runtime.InteropServices;
+using System.Security.Authentication;
 using System.Security.Authentication.ExtendedProtection;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -145,7 +146,9 @@ namespace System.Net.Http.Functional.Tests
                 // Changes from .NET Framework (Desktop).
                 if (!PlatformDetection.IsFullFramework)
                 {
+                    Assert.False(handler.CheckCertificateRevocationList);
                     Assert.Equal(0, handler.MaxRequestContentBufferSize);
+                    Assert.Equal(SslProtocols.None, handler.SslProtocols);
                 }
             }
         }
@@ -155,9 +158,11 @@ namespace System.Net.Http.Functional.Tests
         {
             using (var handler = new HttpClientHandler())
             {
+                Assert.True(handler.CheckCertificateRevocationList);
                 Assert.Equal(10, handler.MaxAutomaticRedirections);
                 Assert.Equal(-1, handler.MaxResponseHeadersLength);
                 Assert.True(handler.PreAuthenticate);
+                Assert.Equal(SslProtocols.None, handler.SslProtocols);
                 Assert.False(handler.SupportsProxy);
                 Assert.False(handler.SupportsRedirectConfiguration);
             }


### PR DESCRIPTION
Due to platform differences on UAP and the current use of WinRT APIs to
implement that HTTP stack, a few properties won't have the same defaults
or behavior.

CheckCertificateRevocationList default value is true for UAP and can't
be changed. However, on UAP, revocation checking that results in an
indeterminate status (i.e. revocation server offline) is treated the
same as a valid result. This is the behavior of the underlying WinRT
APIs.

SslProtocols default value is SslProtocols.None which is the same as the
rest of .NET Core. 'None' means to use the system default. However, changes
to this property value will be ignored.

Similar to the decision made in PR #21403, we don't throw PNSE for these
differences. Instead we just no-op on the property setter.

The behavior differences will be documented in:
https://github.com/dotnet/corefx/wiki/ApiCompat

Contributes to #18116.