### PR TITLE
Fix cryptography errors on macOS 10.13

### DIFF
--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_symmetric.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_symmetric.cpp
@@ -131,6 +131,10 @@ extern "C" int32_t AppleCryptoNative_CryptorReset(CCCryptorRef cryptor, const ui
     if (cryptor == nullptr)
         return -1;
 
+    // 10.13 Beta reports an error when resetting ECB, which is the only mode which has a null IV.
+    if (pbIv == nullptr)
+        return 1;
+
     CCStatus status = CCCryptorReset(cryptor, pbIv);
     *pccStatus = status;
     return status == kCCSuccess;

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509chain.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509chain.cpp
@@ -174,7 +174,12 @@ static void MergeStatusCodes(CFTypeRef key, CFTypeRef value, void* context)
         // (On Windows CERT_CHAIN_PARA.pStrongSignPara is NULL, so "strongness" checks
         // are not performed).
     }
-
+    else if (CFEqual(keyString, CFSTR("StatusCodes")))
+    {
+        // 10.13 added a StatusCodes value which may be a numeric rehashing of the string data.
+        // It doesn't represent a new error code, and we're still getting the old ones, so
+        // just ignore it for now.
+    }
     else
     {
 #ifdef DEBUGGING_UNKNOWN_VALUE

--- a/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
@@ -165,6 +165,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        // Crashing on macOS 10.13 Beta
+        [ActiveIssue(21436, TestPlatforms.OSX)]
         public static void TestResetMethod()
         {
             using (var sampleCert = new X509Certificate2(TestData.DssCer))


### PR DESCRIPTION
This provides a long-term workaround for the behavior change in CCCryptorReset for ECB transforms (should the workaround be inadequate we'd catch it in testing at a future point... but since ECB is stateless it's fine).

It provides a stable workaround for the appearance of a new status info field in the trust results.  Unless "StatusCodes" became used to represent some new type of distinct error at a later date it seems ignorable.

The TestResetMethod chain test is being disabled because it's segfaulting.  It appears to be the sole test testing DSA-based certificate chains, which might indicate a DSA-based regression in the new OS version.  Investigation will continue.