### PR TITLE
Re-enable tests blocked by RemoteExecutor for Uap and UapAot

### DIFF
--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CrossProcess.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CrossProcess.cs
@@ -10,7 +10,6 @@ namespace System.IO.MemoryMappedFiles.Tests
     public class CrossProcessTests : RemoteExecutorTestBase
     {
         [Fact]
-        [ActiveIssue(19909, TargetFrameworkMonikers.Uap)] // Remote executor in Uap and Process.Start() in UapAot
         public void DataShared()
         {
             // Create a new file and load it into an MMF
@@ -28,7 +27,7 @@ namespace System.IO.MemoryMappedFiles.Tests
                 acc.Flush();
 
                 // Spawn and then wait for the other process, which will verify the data and write its own known pattern
-                RemoteInvoke(DataShared_OtherProcess, $"\"{file.Path}\"").Dispose();
+                RemoteInvoke(DataShared_OtherProcess, $"{file.Path}").Dispose();
 
                 // Now verify we're seeing the data from the other process
                 for (int i = 0; i < capacity; i++)

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CrossProcess.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CrossProcess.cs
@@ -27,7 +27,7 @@ namespace System.IO.MemoryMappedFiles.Tests
                 acc.Flush();
 
                 // Spawn and then wait for the other process, which will verify the data and write its own known pattern
-                RemoteInvoke(DataShared_OtherProcess, $"{file.Path}").Dispose();
+                RemoteInvoke(DataShared_OtherProcess, file.Path).Dispose();
 
                 // Now verify we're seeing the data from the other process
                 for (int i = 0; i < capacity; i++)

--- a/src/System.Net.Primitives/tests/FunctionalTests/LoggingTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/LoggingTest.cs
@@ -25,7 +25,6 @@ namespace System.Net.Primitives.Functional.Tests
         }
 
         [Fact]
-        [ActiveIssue(19909, TargetFrameworkMonikers.Uap)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetFramework: NetEventSource is only part of .NET Core;")]
         public void EventSource_EventsRaisedAsExpected()
         {

--- a/src/System.Net.Primitives/tests/FunctionalTests/LoggingTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/LoggingTest.cs
@@ -25,6 +25,7 @@ namespace System.Net.Primitives.Functional.Tests
         }
 
         [Fact]
+        [ActiveIssue(20470, TargetFrameworkMonikers.UapAot)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetFramework: NetEventSource is only part of .NET Core;")]
         public void EventSource_EventsRaisedAsExpected()
         {

--- a/src/System.Net.Security/tests/FunctionalTests/LoggingTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/LoggingTest.cs
@@ -25,7 +25,6 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
-        [ActiveIssue(19909, TargetFrameworkMonikers.Uap)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core")]
         public void EventSource_EventsRaisedAsExpected()
         {

--- a/src/System.Net.Security/tests/FunctionalTests/LoggingTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/LoggingTest.cs
@@ -25,6 +25,7 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
+        [ActiveIssue(20470, TargetFrameworkMonikers.UapAot)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core")]
         public void EventSource_EventsRaisedAsExpected()
         {


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/19909

No need to leave them disabled for Uap only as RemoteExecutor is fixed now. 