### PR TITLE
Fix ILC compilation failure for S.R.InteropServices.Test

### DIFF
--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/MarshalTests.Windows.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/MarshalTests.Windows.cs
@@ -24,21 +24,21 @@ namespace System.Runtime.InteropServices
         {
             Assert.Equal(expected, Marshal.IsComObject(value));
         }
-
-        [ComImport]
-        [Guid("927971f5-0939-11d1-8be1-00c04fd8d503")]
-        public interface IComImportObject { }
-
-        public class InterfaceComImportObject : IComImportObject { }
-
-        [ComImport]
-        [Guid("927971f5-0939-11d1-8be1-00c04fd8d503")]
-        public class InterfaceAndComImportObject : IComImportObject { }
-
-        [ComImport]
-        [Guid("927971f5-0939-11d1-8be1-00c04fd8d503")]
-        public class ComImportObject { }
-
-        public class SubComImportObject : ComImportObject { }
     }
+
+    [ComImport]
+    [Guid("927971f5-0939-11d1-8be1-00c04fd8d503")]
+    public interface IComImportObject { }
+
+    public class InterfaceComImportObject : IComImportObject { }
+
+    [ComImport]
+    [Guid("927971f5-0939-11d1-8be1-00c04fd8d503")]
+    public class InterfaceAndComImportObject : IComImportObject { }
+
+    [ComImport]
+    [Guid("927971f5-0939-11d1-8be1-00c04fd8d503")]
+    public class ComImportObject { }
+
+    public class SubComImportObject : ComImportObject { }
 }


### PR DESCRIPTION
CCI trips over casting nested typedef to INamespaceTypeDefintion , this
is a CCI bug since NestedTypeDefintion should implement INamespaceTypeDefintion.
Fixing the CCI is involved  since CCI is used widely , the simple work-around is
to make the test class non nested.