### PR TITLE
add apfs to the filesystem  list

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.MountPoints.FormatInfo.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.MountPoints.FormatInfo.cs
@@ -145,6 +145,7 @@ internal static partial class Interop
 
                 case "adfs":
                 case "affs":
+                case "apfs":
                 case "befs":
                 case "bfs":
                 case "btrfs":


### PR DESCRIPTION
https://github.com/dotnet/corefx/issues/21597

Tests will pass on 10.13 as long as we recognize the name. 
OSX supports that via statfs() and adding Magic number does not seems needed. 
According to notes in the code, that is internal glibc code and it does not reflect type of the partition anyway. 


src/Native/Unix/System.Native/pal_mount.cpp:

int result = statfs(name, &stats);

#if HAVE_STATFS_FSTYPENAME || HAVE_STATVFS_FSTYPENAME
#ifdef VFS_NAMELEN
        if (bufferLength < VFS_NAMELEN)
#else
        if (bufferLength < MFSNAMELEN)
#endif
        {
            result = ERANGE;
            *formatType = 0;
        }
        else
        {
            SafeStringCopy(formatNameBuffer, bufferLength, stats.f_fstypename);
            *formatType = -1;
        }
#else
        assert(formatType != nullptr);
        *formatType = SignedCast(stats.f_type);
        SafeStringCopy(formatNameBuffer, bufferLength, "");
#endif


