### PR TITLE
Fix the three System.Data.SqlClient tests that were failing on arm due to sni.dll not being available on arm

### DIFF
--- a/src/Common/tests/System/PlatformDetection.cs
+++ b/src/Common/tests/System/PlatformDetection.cs
@@ -36,6 +36,9 @@ namespace System
             GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 14393;
         public static bool IsWindows10Version1703OrGreater => IsWindows &&
             GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 15063;
+        public static bool IsArmProcess => RuntimeInformation.ProcessArchitecture == Architecture.Arm;
+        public static bool IsNotArmProcess => !IsArmProcess;
+        public static bool IsNotArmProcessAndIsNotWindowsNanoServer => IsNotArmProcess && IsNotWindowsNanoServer;
 
         // Windows OneCoreUAP SKU doesn't have httpapi.dll
         public static bool IsNotOneCoreUAP => (!IsWindows || 

--- a/src/Common/tests/System/PlatformDetection.cs
+++ b/src/Common/tests/System/PlatformDetection.cs
@@ -38,7 +38,6 @@ namespace System
             GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 15063;
         public static bool IsArmProcess => RuntimeInformation.ProcessArchitecture == Architecture.Arm;
         public static bool IsNotArmProcess => !IsArmProcess;
-        public static bool IsNotArmProcessAndIsNotWindowsNanoServer => IsNotArmProcess && IsNotWindowsNanoServer;
 
         // Windows OneCoreUAP SKU doesn't have httpapi.dll
         public static bool IsNotOneCoreUAP => (!IsWindows || 

--- a/src/System.Data.SqlClient/tests/FunctionalTests/AmbientTransactionFailureTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/AmbientTransactionFailureTest.cs
@@ -72,7 +72,7 @@ namespace System.Data.SqlClient.Tests
             new object[] { EnlistConnectionInTransaction, s_connectionStringWithEnlistOff }
         };
 
-        [Theory]
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotArmProcess))] // https://github.com/dotnet/corefx/issues/21598
         [MemberData(nameof(ExceptionTestDataForSqlException))]
         public void TestSqlException(Action<string> connectAction, string connectionString)
         {

--- a/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionTest.cs
@@ -26,7 +26,7 @@ namespace System.Data.SqlClient.Tests
 
 
         [PlatformSpecific(TestPlatforms.Windows)]  // Integ auth on Test server is supported on Windows right now
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))] // https://github.com/dotnet/corefx/issues/19218
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotArmProcessAndIsNotWindowsNanoServer))] // https://github.com/dotnet/corefx/issues/19218 And https://github.com/dotnet/corefx/issues/21598
         [ActiveIssue("https://github.com/dotnet/corefx/issues/20718", TargetFrameworkMonikers.UapAot)]
         public void IntegratedAuthConnectionTest()
         {

--- a/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionTest.cs
@@ -26,7 +26,7 @@ namespace System.Data.SqlClient.Tests
 
 
         [PlatformSpecific(TestPlatforms.Windows)]  // Integ auth on Test server is supported on Windows right now
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotArmProcessAndIsNotWindowsNanoServer))] // https://github.com/dotnet/corefx/issues/19218 And https://github.com/dotnet/corefx/issues/21598
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer), nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotArmProcess))] // https://github.com/dotnet/corefx/issues/19218 And https://github.com/dotnet/corefx/issues/21598
         [ActiveIssue("https://github.com/dotnet/corefx/issues/20718", TargetFrameworkMonikers.UapAot)]
         public void IntegratedAuthConnectionTest()
         {


### PR DESCRIPTION
cc: @saurabh500 @danmosemsft @stephentoub 

Disabling few tests that are failing on our arm runs. Note that I couldn't find any logic in place to skip tests for ARM so I added some to PlatformDetection but please feel free to comment if there was already a way to do this.