### PR TITLE
Disable test for UAPAOT that interns empty strings

### DIFF
--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -2733,7 +2733,8 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void InternalTestAotSubset()
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, ".NetNative does not even intern empty string in multifile")]
+        public static void InternEmptyStringTest()
         {
             string emptyFromField = string.Empty;
             string emptyFromInternTable = string.IsInterned(emptyFromField);


### PR DESCRIPTION
Fix https://github.com/dotnet/corefx/issues/21377

@AtsushiKan @morganbr since the tests don't have a way to tell whether it's a multifile configuration or not, I have to disable this test for AOT. Whether or not it interns empty string seems a small matter.