### PR TITLE
Changing System.Security.Principal.Windows to PInvoke to LsaNtStatusToWinError

### DIFF
--- a/src/Common/src/Interop/Windows/advapi32/Interop.LsaNtStatusToWinError.cs
+++ b/src/Common/src/Interop/Windows/advapi32/Interop.LsaNtStatusToWinError.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Advapi32
+    {
+        [DllImport(Interop.Libraries.Advapi32, SetLastError = false)]
+        internal static extern uint LsaNtStatusToWinError(uint status);
+    }
+}

--- a/src/System.Security.Principal.Windows/src/PinvokeAnalyzerExceptionList.analyzerdata.netcoreapp
+++ b/src/System.Security.Principal.Windows/src/PinvokeAnalyzerExceptionList.analyzerdata.netcoreapp
@@ -1,0 +1,1 @@
+advapi32.dll!LsaNtStatusToWinError

--- a/src/System.Security.Principal.Windows/src/PinvokeAnalyzerExceptionList.analyzerdata.uap
+++ b/src/System.Security.Principal.Windows/src/PinvokeAnalyzerExceptionList.analyzerdata.uap
@@ -3,6 +3,7 @@ advapi32.dll!LsaClose
 advapi32.dll!LsaFreeMemory
 advapi32.dll!LsaLookupNames2
 advapi32.dll!LsaLookupSids
+advapi32.dll!LsaNtStatusToWinError
 advapi32.dll!LsaOpenPolicy
 advapi32.dll!OpenProcessToken
 ntdll.dll!RtlNtStatusToDosError

--- a/src/System.Security.Principal.Windows/src/System.Security.Principal.Windows.csproj
+++ b/src/System.Security.Principal.Windows/src/System.Security.Principal.Windows.csproj
@@ -125,8 +125,8 @@
     <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.ImpersonateLoggedOnUser.cs">
       <Link>Common\Interop\Interop.ImpersonateLoggedOnUser.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.RtlNtStatusToDosError.cs">
-      <Link>Common\Interop\Interop.RtlNtStatusToDosError.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.LsaNtStatusToWinError.cs">
+      <Link>Common\Interop\Interop.LsaNtStatusToWinError.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.LocalFree.cs">
       <Link>Common\Interop\Interop.LocalFree.cs</Link>

--- a/src/System.Security.Principal.Windows/src/System/Security/Principal/NTAccount.cs
+++ b/src/System.Security.Principal.Windows/src/System/Security/Principal/NTAccount.cs
@@ -316,14 +316,14 @@ namespace System.Security.Principal
                 }
                 else if (ReturnCode != 0)
                 {
-                    int win32ErrorCode = Interop.NtDll.RtlNtStatusToDosError(unchecked((int)ReturnCode));
+                    uint win32ErrorCode = Interop.Advapi32.LsaNtStatusToWinError(ReturnCode);
 
-                    if (win32ErrorCode != Interop.Errors.ERROR_TRUSTED_RELATIONSHIP_FAILURE)
+                    if (unchecked((int)win32ErrorCode) != Interop.Errors.ERROR_TRUSTED_RELATIONSHIP_FAILURE)
                     {
                         Debug.Assert(false, string.Format(CultureInfo.InvariantCulture, "Interop.LsaLookupNames(2) returned unrecognized error {0}", win32ErrorCode));
                     }
 
-                    throw new Win32Exception(win32ErrorCode);
+                    throw new Win32Exception(unchecked((int)win32ErrorCode));
                 }
 
                 //

--- a/src/System.Security.Principal.Windows/src/System/Security/Principal/SID.cs
+++ b/src/System.Security.Principal.Windows/src/System/Security/Principal/SID.cs
@@ -1104,10 +1104,10 @@ nameof(binaryForm));
                 }
                 else if (ReturnCode != 0)
                 {
-                    int win32ErrorCode = Interop.NtDll.RtlNtStatusToDosError(unchecked((int)ReturnCode));
+                    uint win32ErrorCode = Interop.Advapi32.LsaNtStatusToWinError(ReturnCode);
 
                     Debug.Assert(false, string.Format(CultureInfo.InvariantCulture, "Interop.LsaLookupSids returned {0}", win32ErrorCode));
-                    throw new Win32Exception(win32ErrorCode);
+                    throw new Win32Exception(unchecked((int)win32ErrorCode));
                 }
 
 

--- a/src/System.Security.Principal.Windows/src/System/Security/Principal/Win32.cs
+++ b/src/System.Security.Principal.Windows/src/System/Security/Principal/Win32.cs
@@ -66,9 +66,9 @@ namespace System.Security.Principal
             }
             else
             {
-                int win32ErrorCode = Interop.NtDll.RtlNtStatusToDosError(unchecked((int)ReturnCode));
+                uint win32ErrorCode = Interop.Advapi32.LsaNtStatusToWinError(ReturnCode);
 
-                throw new Win32Exception(win32ErrorCode);
+                throw new Win32Exception(unchecked((int)win32ErrorCode));
             }
         }
 

--- a/src/System.Security.Principal.Windows/src/System/Security/Principal/WindowsIdentity.cs
+++ b/src/System.Security.Principal.Windows/src/System/Security/Principal/WindowsIdentity.cs
@@ -720,8 +720,8 @@ namespace System.Security.Principal
             if ((uint)status == Interop.StatusOptions.STATUS_INSUFFICIENT_RESOURCES || (uint)status == Interop.StatusOptions.STATUS_NO_MEMORY)
                 return new OutOfMemoryException();
 
-            int win32ErrorCode = Interop.NtDll.RtlNtStatusToDosError(status);
-            return new SecurityException(new Win32Exception(win32ErrorCode).Message);
+            uint win32ErrorCode = Interop.Advapi32.LsaNtStatusToWinError((uint)status);
+            return new SecurityException(new Win32Exception(unchecked((int)win32ErrorCode)).Message);
         }
         
         private static SafeAccessTokenHandle GetCurrentToken(TokenAccessLevels desiredAccess, bool threadOnly, out bool isImpersonating, out int hr)


### PR DESCRIPTION
cc: @danmosemsft @stephentoub @JeremyKuhne 

Fixes #18293

Moving calls from GetExceptionFromNtStatus to LsaNtStatusToWinError