### PR TITLE
Move Entries from Library Rd.xml to Test Rd.xml.

### DIFF
--- a/src/System.Private.DataContractSerialization/src/Resources/System.Private.DataContractSerialization.rd.xml
+++ b/src/System.Private.DataContractSerialization/src/Resources/System.Private.DataContractSerialization.rd.xml
@@ -8,7 +8,6 @@
             <TypeParameter Name="type" DataContractSerializer="Public"/>
             <TypeEnumerableParameter Name="knownTypes" DataContractSerializer="Public"/>
           </Method>
-          <Property Name="Option" Dynamic="Required" />
         </Type>
         <Type Name="KeyValuePairAdapter`2" Dynamic="Required All" />
         <!-- Reflection-based serialization requires the entries below. -->

--- a/src/System.Private.Xml/src/Resources/System.Private.Xml.rd.xml
+++ b/src/System.Private.Xml/src/Resources/System.Private.Xml.rd.xml
@@ -14,8 +14,6 @@
           </Method>
         </Type>
         <Type Name="ReflectionXmlSerializationReaderHelper" Dynamic="Required All" />
-          <!--<Method Name="GetSetMemberValueDelegateWithType{TObj, TParam}" Dynamic="Required" />
-        </Type>-->
       </Namespace>
       <Namespace Name="System.Xml.Schema" Dynamic="Public" />
     </Assembly>

--- a/src/System.Private.Xml/src/Resources/System.Private.Xml.rd.xml
+++ b/src/System.Private.Xml/src/Resources/System.Private.Xml.rd.xml
@@ -12,7 +12,6 @@
             <TypeParameter Name="type" XmlSerializer="Public"/>
             <TypeEnumerableParameter Name="extraTypes" Dynamic="Public"/>
           </Method>
-          <Property Name="Mode" Dynamic="Required" />
         </Type>
         <Type Name="ReflectionXmlSerializationReaderHelper" Dynamic="Required All" />
           <!--<Method Name="GetSetMemberValueDelegateWithType{TObj, TParam}" Dynamic="Required" />

--- a/src/System.Private.Xml/tests/XmlSerializer/ReflectionOnly/Resources/System.Xml.XmlSerializer.ReflectionOnly.Tests.rd.xml
+++ b/src/System.Private.Xml/tests/XmlSerializer/ReflectionOnly/Resources/System.Xml.XmlSerializer.ReflectionOnly.Tests.rd.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Library Name="System.Xml.XmlSerializer.ReflectionOnly.Tests">
+    <Assembly Name="System.Private.Xml">
+      <Namespace Name="System.Xml.Serialization">
+        <Type Name="XmlSerializer">
+          <Property Name="Mode" Dynamic="Required" />
+        </Type>
+      </Namespace>
+    </Assembly>
+  </Library>
+</Directives>

--- a/src/System.Private.Xml/tests/XmlSerializer/ReflectionOnly/System.Xml.XmlSerializer.ReflectionOnly.Tests.csproj
+++ b/src/System.Private.Xml/tests/XmlSerializer/ReflectionOnly/System.Xml.XmlSerializer.ReflectionOnly.Tests.csproj
@@ -23,5 +23,8 @@
       <Link>CommonTest\System\PlatformDetection.cs</Link>
     </Compile>
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\$(AssemblyName).rd.xml" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime.Serialization.Json/tests/ReflectionOnly/Resources/System.Runtime.Serialization.Json.ReflectionOnly.Tests.rd.xml
+++ b/src/System.Runtime.Serialization.Json/tests/ReflectionOnly/Resources/System.Runtime.Serialization.Json.ReflectionOnly.Tests.rd.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
   <Library Name="*System.Runtime.Serialization.Json.ReflectionOnly.Tests*">
+    <Assembly Name="System.Private.DataContractSerialization">
+      <Namespace Name="System.Runtime.Serialization">
+        <Type Name="DataContractSerializer">
+          <Property Name="Option" Dynamic="Required" />
+        </Type>
+      </Namespace>
+    </Assembly>
     <Namespace Name="System.Collections">
       <Type Name="ArrayList" Dynamic="Required All" />
       <Type Name="IList" Dynamic="Required All" />

--- a/src/System.Runtime.Serialization.Xml/tests/ReflectionOnly/Resources/System.Runtime.Serialization.Xml.ReflectionOnly.Tests.rd.xml
+++ b/src/System.Runtime.Serialization.Xml/tests/ReflectionOnly/Resources/System.Runtime.Serialization.Xml.ReflectionOnly.Tests.rd.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
   <Library Name="*System.Runtime.Serialization.Xml.ReflectionOnly.Tests*">
+    <Assembly Name="System.Private.DataContractSerialization">
+      <Namespace Name="System.Runtime.Serialization">
+        <Type Name="DataContractSerializer">
+          <Property Name="Option" Dynamic="Required" />
+        </Type>
+      </Namespace>
+    </Assembly>
     <Namespace Name="System.Collections">
       <Type Name="ArrayList" Dynamic="Required All" />
       <Type Name="IList" Dynamic="Required All" />


### PR DESCRIPTION
XmlSerializer.Mode iss marked as required by the System.Private.Xml.rd.xml.
Unfortunately, it pulls in the XmlSerializer type itself (has to), which
in turn pulls in a whole lot of code through its static ctor dependencies.
This caused some size-on-disk regressions.

As the property is used by our test project only, the fix is to move the
entry from the library rd.xml to the test rd.xml. The fix also made the 
similar changes to DCS/DCJS.

Fix #21667