### PR TITLE
Add converter from IEnumerable to TheoryData

### DIFF
--- a/referenceFromRuntime.targets
+++ b/referenceFromRuntime.targets
@@ -12,8 +12,8 @@
   <Target Name="AddRuntimeProjectReference"
           BeforeTargets="AddProjectReferencesDynamically"
           Condition="'$(IsTestProject)'!='true' AND '@(ReferenceFromRuntime)' != ''">
-    <Error Condition="'$(IsReferenceAssembly)' != 'true' AND '$(RuntimeProjectFile)' == ''" Text="RuntimeProjectFile must be specified when using ReferenceFromRuntime from source projects." />
-    <Error Condition="'$(IsReferenceAssembly)' == 'true'" Text="ReferenceFromRuntime may not be used from reference assemblies." />
+    <Error Condition="('$(IsReferenceAssembly)' != 'true' OR '$(AllowReferenceFromRuntime)' == 'true') AND '$(RuntimeProjectFile)' == ''" Text="RuntimeProjectFile must be specified when using ReferenceFromRuntime from source projects." />
+    <Error Condition="'$(IsReferenceAssembly)' == 'true' AND '$(AllowReferenceFromRuntime)' != 'true'" Text="ReferenceFromRuntime may not be used from reference assemblies." />
 
     <ItemGroup>
       <ProjectReference Include="$(RuntimeProjectFile)">

--- a/src/CoreFx.Private.TestUtilities/CoreFx.Private.TestUtilities.sln
+++ b/src/CoreFx.Private.TestUtilities/CoreFx.Private.TestUtilities.sln
@@ -1,7 +1,12 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26430.14
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoreFx.Private.TestUtilities.Tests", "tests\CoreFx.Private.TestUtilities.Tests.csproj", "{5E0DB390-A45E-41BE-8304-B840327FE597}"
+	ProjectSection(ProjectDependencies) = postProject
+		{EBDB0247-CA43-4226-B7A1-8FEF21061D09} = {EBDB0247-CA43-4226-B7A1-8FEF21061D09}
+	EndProjectSection
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoreFx.Private.TestUtilities", "src\CoreFx.Private.TestUtilities.csproj", "{EBDB0247-CA43-4226-B7A1-8FEF21061D09}"
 	ProjectSection(ProjectDependencies) = postProject
 		{E2E59C98-998F-9965-991D-99411166AF6F} = {E2E59C98-998F-9965-991D-99411166AF6F}
@@ -9,123 +14,37 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoreFx.Private.TestUtilitie
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoreFx.Private.TestUtilities", "ref\CoreFx.Private.TestUtilities.csproj", "{E2E59C98-998F-9965-991D-99411166AF6F}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{1A2F9F4A-A032-433E-B914-ADD5992BB178}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E893-4E87-987E-04EF0DCEAEFD}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0695C735-1077-425E-8A4B-78CF2DB33EED}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoreFx.Private.TestUtilities.Tests", "tests\CoreFx.Private.TestUtilities.Tests.csproj", "{5E0DB390-A45E-41BE-8304-B840327FE597}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		netcoreapp-Unix-Debug|Any CPU = netcoreapp-Unix-Debug|Any CPU
-		netcoreapp-Unix-Release|Any CPU = netcoreapp-Unix-Release|Any CPU
-		netcoreapp-Windows_NT-Debug|Any CPU = netcoreapp-Windows_NT-Debug|Any CPU
-		netcoreapp-Windows_NT-Release|Any CPU = netcoreapp-Windows_NT-Release|Any CPU
-		netfx-Windows_NT-Debug|Any CPU = netfx-Windows_NT-Debug|Any CPU
-		netfx-Windows_NT-Release|Any CPU = netfx-Windows_NT-Release|Any CPU
-		netstandard-Debug|Any CPU = netstandard-Debug|Any CPU
-		netstandard-Release|Any CPU = netstandard-Release|Any CPU
 		Release|Any CPU = Release|Any CPU
-		uapaot-Windows_NT-Debug|Any CPU = uapaot-Windows_NT-Debug|Any CPU
-		uapaot-Windows_NT-Release|Any CPU = uapaot-Windows_NT-Release|Any CPU
-		uap-Windows_NT-Debug|Any CPU = uap-Windows_NT-Debug|Any CPU
-		uap-Windows_NT-Release|Any CPU = uap-Windows_NT-Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.Debug|Any CPU.ActiveCfg = netfx-Windows_NT-Debug|Any CPU
-		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.Debug|Any CPU.Build.0 = netfx-Windows_NT-Debug|Any CPU
-		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.netcoreapp-Unix-Debug|Any CPU.ActiveCfg = netcoreapp-Unix-Debug|Any CPU
-		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.netcoreapp-Unix-Debug|Any CPU.Build.0 = netcoreapp-Unix-Debug|Any CPU
-		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.netcoreapp-Unix-Release|Any CPU.ActiveCfg = netcoreapp-Unix-Release|Any CPU
-		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.netcoreapp-Unix-Release|Any CPU.Build.0 = netcoreapp-Unix-Release|Any CPU
-		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.netcoreapp-Windows_NT-Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
-		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.netcoreapp-Windows_NT-Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
-		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.netcoreapp-Windows_NT-Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
-		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.netcoreapp-Windows_NT-Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
-		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.netfx-Windows_NT-Debug|Any CPU.ActiveCfg = netfx-Windows_NT-Debug|Any CPU
-		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.netfx-Windows_NT-Debug|Any CPU.Build.0 = netfx-Windows_NT-Debug|Any CPU
-		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.netfx-Windows_NT-Release|Any CPU.ActiveCfg = netfx-Windows_NT-Release|Any CPU
-		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.netfx-Windows_NT-Release|Any CPU.Build.0 = netfx-Windows_NT-Release|Any CPU
-		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.netstandard-Debug|Any CPU.ActiveCfg = netfx-Windows_NT-Release|Any CPU
-		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.netstandard-Debug|Any CPU.Build.0 = netfx-Windows_NT-Release|Any CPU
-		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.netstandard-Release|Any CPU.ActiveCfg = netfx-Windows_NT-Release|Any CPU
-		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.netstandard-Release|Any CPU.Build.0 = netfx-Windows_NT-Release|Any CPU
-		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.Release|Any CPU.ActiveCfg = netfx-Windows_NT-Release|Any CPU
-		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.Release|Any CPU.Build.0 = netfx-Windows_NT-Release|Any CPU
-		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.uapaot-Windows_NT-Debug|Any CPU.ActiveCfg = uapaot-Windows_NT-Debug|Any CPU
-		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.uapaot-Windows_NT-Debug|Any CPU.Build.0 = uapaot-Windows_NT-Debug|Any CPU
-		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.uapaot-Windows_NT-Release|Any CPU.ActiveCfg = uapaot-Windows_NT-Release|Any CPU
-		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.uapaot-Windows_NT-Release|Any CPU.Build.0 = uapaot-Windows_NT-Release|Any CPU
-		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.uap-Windows_NT-Debug|Any CPU.ActiveCfg = uap-Windows_NT-Debug|Any CPU
-		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.uap-Windows_NT-Debug|Any CPU.Build.0 = uap-Windows_NT-Debug|Any CPU
-		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.uap-Windows_NT-Release|Any CPU.ActiveCfg = uap-Windows_NT-Release|Any CPU
-		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.uap-Windows_NT-Release|Any CPU.Build.0 = uap-Windows_NT-Release|Any CPU
-		{E2E59C98-998F-9965-991D-99411166AF6F}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{E2E59C98-998F-9965-991D-99411166AF6F}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{E2E59C98-998F-9965-991D-99411166AF6F}.netcoreapp-Unix-Debug|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{E2E59C98-998F-9965-991D-99411166AF6F}.netcoreapp-Unix-Debug|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{E2E59C98-998F-9965-991D-99411166AF6F}.netcoreapp-Unix-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{E2E59C98-998F-9965-991D-99411166AF6F}.netcoreapp-Unix-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{E2E59C98-998F-9965-991D-99411166AF6F}.netcoreapp-Windows_NT-Debug|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{E2E59C98-998F-9965-991D-99411166AF6F}.netcoreapp-Windows_NT-Debug|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{E2E59C98-998F-9965-991D-99411166AF6F}.netcoreapp-Windows_NT-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{E2E59C98-998F-9965-991D-99411166AF6F}.netcoreapp-Windows_NT-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{E2E59C98-998F-9965-991D-99411166AF6F}.netfx-Windows_NT-Debug|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{E2E59C98-998F-9965-991D-99411166AF6F}.netfx-Windows_NT-Debug|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{E2E59C98-998F-9965-991D-99411166AF6F}.netfx-Windows_NT-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{E2E59C98-998F-9965-991D-99411166AF6F}.netfx-Windows_NT-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{E2E59C98-998F-9965-991D-99411166AF6F}.netstandard-Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{E2E59C98-998F-9965-991D-99411166AF6F}.netstandard-Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{E2E59C98-998F-9965-991D-99411166AF6F}.netstandard-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{E2E59C98-998F-9965-991D-99411166AF6F}.netstandard-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{E2E59C98-998F-9965-991D-99411166AF6F}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{E2E59C98-998F-9965-991D-99411166AF6F}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{E2E59C98-998F-9965-991D-99411166AF6F}.uapaot-Windows_NT-Debug|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{E2E59C98-998F-9965-991D-99411166AF6F}.uapaot-Windows_NT-Debug|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{E2E59C98-998F-9965-991D-99411166AF6F}.uapaot-Windows_NT-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{E2E59C98-998F-9965-991D-99411166AF6F}.uapaot-Windows_NT-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{E2E59C98-998F-9965-991D-99411166AF6F}.uap-Windows_NT-Debug|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{E2E59C98-998F-9965-991D-99411166AF6F}.uap-Windows_NT-Debug|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{E2E59C98-998F-9965-991D-99411166AF6F}.uap-Windows_NT-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{E2E59C98-998F-9965-991D-99411166AF6F}.uap-Windows_NT-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
 		{5E0DB390-A45E-41BE-8304-B840327FE597}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
 		{5E0DB390-A45E-41BE-8304-B840327FE597}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{5E0DB390-A45E-41BE-8304-B840327FE597}.netcoreapp-Unix-Debug|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{5E0DB390-A45E-41BE-8304-B840327FE597}.netcoreapp-Unix-Debug|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{5E0DB390-A45E-41BE-8304-B840327FE597}.netcoreapp-Unix-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{5E0DB390-A45E-41BE-8304-B840327FE597}.netcoreapp-Unix-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{5E0DB390-A45E-41BE-8304-B840327FE597}.netcoreapp-Windows_NT-Debug|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{5E0DB390-A45E-41BE-8304-B840327FE597}.netcoreapp-Windows_NT-Debug|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{5E0DB390-A45E-41BE-8304-B840327FE597}.netcoreapp-Windows_NT-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{5E0DB390-A45E-41BE-8304-B840327FE597}.netcoreapp-Windows_NT-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{5E0DB390-A45E-41BE-8304-B840327FE597}.netfx-Windows_NT-Debug|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{5E0DB390-A45E-41BE-8304-B840327FE597}.netfx-Windows_NT-Debug|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{5E0DB390-A45E-41BE-8304-B840327FE597}.netfx-Windows_NT-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{5E0DB390-A45E-41BE-8304-B840327FE597}.netfx-Windows_NT-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{5E0DB390-A45E-41BE-8304-B840327FE597}.netstandard-Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{5E0DB390-A45E-41BE-8304-B840327FE597}.netstandard-Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{5E0DB390-A45E-41BE-8304-B840327FE597}.netstandard-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{5E0DB390-A45E-41BE-8304-B840327FE597}.netstandard-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
 		{5E0DB390-A45E-41BE-8304-B840327FE597}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
 		{5E0DB390-A45E-41BE-8304-B840327FE597}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{5E0DB390-A45E-41BE-8304-B840327FE597}.uapaot-Windows_NT-Debug|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{5E0DB390-A45E-41BE-8304-B840327FE597}.uapaot-Windows_NT-Debug|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{5E0DB390-A45E-41BE-8304-B840327FE597}.uapaot-Windows_NT-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{5E0DB390-A45E-41BE-8304-B840327FE597}.uapaot-Windows_NT-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{5E0DB390-A45E-41BE-8304-B840327FE597}.uap-Windows_NT-Debug|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{5E0DB390-A45E-41BE-8304-B840327FE597}.uap-Windows_NT-Debug|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{5E0DB390-A45E-41BE-8304-B840327FE597}.uap-Windows_NT-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{5E0DB390-A45E-41BE-8304-B840327FE597}.uap-Windows_NT-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
+		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
+		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
+		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
+		{E2E59C98-998F-9965-991D-99411166AF6F}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{E2E59C98-998F-9965-991D-99411166AF6F}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{E2E59C98-998F-9965-991D-99411166AF6F}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{E2E59C98-998F-9965-991D-99411166AF6F}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
+		{5E0DB390-A45E-41BE-8304-B840327FE597} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{EBDB0247-CA43-4226-B7A1-8FEF21061D09} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{E2E59C98-998F-9965-991D-99411166AF6F} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
-		{5E0DB390-A45E-41BE-8304-B840327FE597} = {0695C735-1077-425E-8A4B-78CF2DB33EED}
 	EndGlobalSection
 EndGlobal

--- a/src/CoreFx.Private.TestUtilities/CoreFx.Private.TestUtilities.sln
+++ b/src/CoreFx.Private.TestUtilities/CoreFx.Private.TestUtilities.sln
@@ -1,8 +1,8 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26430.14
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoreFx.Private.TestUtilities", "src\CoreFx.Private.TestUtilities.csproj", "{5B7EAEC-93CB-40DF-BE40-A60BC189B737}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoreFx.Private.TestUtilities", "src\CoreFx.Private.TestUtilities.csproj", "{EBDB0247-CA43-4226-B7A1-8FEF21061D09}"
 	ProjectSection(ProjectDependencies) = postProject
 		{E2E59C98-998F-9965-991D-99411166AF6F} = {E2E59C98-998F-9965-991D-99411166AF6F}
 	EndProjectSection
@@ -13,26 +13,119 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E89
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0695C735-1077-425E-8A4B-78CF2DB33EED}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoreFx.Private.TestUtilities.Tests", "tests\CoreFx.Private.TestUtilities.Tests.csproj", "{5E0DB390-A45E-41BE-8304-B840327FE597}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		netcoreapp-Unix-Debug|Any CPU = netcoreapp-Unix-Debug|Any CPU
+		netcoreapp-Unix-Release|Any CPU = netcoreapp-Unix-Release|Any CPU
+		netcoreapp-Windows_NT-Debug|Any CPU = netcoreapp-Windows_NT-Debug|Any CPU
+		netcoreapp-Windows_NT-Release|Any CPU = netcoreapp-Windows_NT-Release|Any CPU
+		netfx-Windows_NT-Debug|Any CPU = netfx-Windows_NT-Debug|Any CPU
+		netfx-Windows_NT-Release|Any CPU = netfx-Windows_NT-Release|Any CPU
+		netstandard-Debug|Any CPU = netstandard-Debug|Any CPU
+		netstandard-Release|Any CPU = netstandard-Release|Any CPU
 		Release|Any CPU = Release|Any CPU
+		uapaot-Windows_NT-Debug|Any CPU = uapaot-Windows_NT-Debug|Any CPU
+		uapaot-Windows_NT-Release|Any CPU = uapaot-Windows_NT-Release|Any CPU
+		uap-Windows_NT-Debug|Any CPU = uap-Windows_NT-Debug|Any CPU
+		uap-Windows_NT-Release|Any CPU = uap-Windows_NT-Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{5B7EAEC-93CB-40DF-BE40-A60BC189B737}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
-		{5B7EAEC-93CB-40DF-BE40-A60BC189B737}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
-		{5B7EAEC-93CB-40DF-BE40-A60BC189B737}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
-		{5B7EAEC-93CB-40DF-BE40-A60BC189B737}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
+		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.Debug|Any CPU.ActiveCfg = netfx-Windows_NT-Debug|Any CPU
+		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.Debug|Any CPU.Build.0 = netfx-Windows_NT-Debug|Any CPU
+		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.netcoreapp-Unix-Debug|Any CPU.ActiveCfg = netcoreapp-Unix-Debug|Any CPU
+		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.netcoreapp-Unix-Debug|Any CPU.Build.0 = netcoreapp-Unix-Debug|Any CPU
+		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.netcoreapp-Unix-Release|Any CPU.ActiveCfg = netcoreapp-Unix-Release|Any CPU
+		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.netcoreapp-Unix-Release|Any CPU.Build.0 = netcoreapp-Unix-Release|Any CPU
+		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.netcoreapp-Windows_NT-Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
+		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.netcoreapp-Windows_NT-Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
+		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.netcoreapp-Windows_NT-Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
+		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.netcoreapp-Windows_NT-Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
+		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.netfx-Windows_NT-Debug|Any CPU.ActiveCfg = netfx-Windows_NT-Debug|Any CPU
+		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.netfx-Windows_NT-Debug|Any CPU.Build.0 = netfx-Windows_NT-Debug|Any CPU
+		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.netfx-Windows_NT-Release|Any CPU.ActiveCfg = netfx-Windows_NT-Release|Any CPU
+		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.netfx-Windows_NT-Release|Any CPU.Build.0 = netfx-Windows_NT-Release|Any CPU
+		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.netstandard-Debug|Any CPU.ActiveCfg = netfx-Windows_NT-Release|Any CPU
+		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.netstandard-Debug|Any CPU.Build.0 = netfx-Windows_NT-Release|Any CPU
+		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.netstandard-Release|Any CPU.ActiveCfg = netfx-Windows_NT-Release|Any CPU
+		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.netstandard-Release|Any CPU.Build.0 = netfx-Windows_NT-Release|Any CPU
+		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.Release|Any CPU.ActiveCfg = netfx-Windows_NT-Release|Any CPU
+		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.Release|Any CPU.Build.0 = netfx-Windows_NT-Release|Any CPU
+		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.uapaot-Windows_NT-Debug|Any CPU.ActiveCfg = uapaot-Windows_NT-Debug|Any CPU
+		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.uapaot-Windows_NT-Debug|Any CPU.Build.0 = uapaot-Windows_NT-Debug|Any CPU
+		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.uapaot-Windows_NT-Release|Any CPU.ActiveCfg = uapaot-Windows_NT-Release|Any CPU
+		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.uapaot-Windows_NT-Release|Any CPU.Build.0 = uapaot-Windows_NT-Release|Any CPU
+		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.uap-Windows_NT-Debug|Any CPU.ActiveCfg = uap-Windows_NT-Debug|Any CPU
+		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.uap-Windows_NT-Debug|Any CPU.Build.0 = uap-Windows_NT-Debug|Any CPU
+		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.uap-Windows_NT-Release|Any CPU.ActiveCfg = uap-Windows_NT-Release|Any CPU
+		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.uap-Windows_NT-Release|Any CPU.Build.0 = uap-Windows_NT-Release|Any CPU
 		{E2E59C98-998F-9965-991D-99411166AF6F}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
 		{E2E59C98-998F-9965-991D-99411166AF6F}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{E2E59C98-998F-9965-991D-99411166AF6F}.netcoreapp-Unix-Debug|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{E2E59C98-998F-9965-991D-99411166AF6F}.netcoreapp-Unix-Debug|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{E2E59C98-998F-9965-991D-99411166AF6F}.netcoreapp-Unix-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{E2E59C98-998F-9965-991D-99411166AF6F}.netcoreapp-Unix-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{E2E59C98-998F-9965-991D-99411166AF6F}.netcoreapp-Windows_NT-Debug|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{E2E59C98-998F-9965-991D-99411166AF6F}.netcoreapp-Windows_NT-Debug|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{E2E59C98-998F-9965-991D-99411166AF6F}.netcoreapp-Windows_NT-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{E2E59C98-998F-9965-991D-99411166AF6F}.netcoreapp-Windows_NT-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{E2E59C98-998F-9965-991D-99411166AF6F}.netfx-Windows_NT-Debug|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{E2E59C98-998F-9965-991D-99411166AF6F}.netfx-Windows_NT-Debug|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{E2E59C98-998F-9965-991D-99411166AF6F}.netfx-Windows_NT-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{E2E59C98-998F-9965-991D-99411166AF6F}.netfx-Windows_NT-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{E2E59C98-998F-9965-991D-99411166AF6F}.netstandard-Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{E2E59C98-998F-9965-991D-99411166AF6F}.netstandard-Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{E2E59C98-998F-9965-991D-99411166AF6F}.netstandard-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{E2E59C98-998F-9965-991D-99411166AF6F}.netstandard-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
 		{E2E59C98-998F-9965-991D-99411166AF6F}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
 		{E2E59C98-998F-9965-991D-99411166AF6F}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{E2E59C98-998F-9965-991D-99411166AF6F}.uapaot-Windows_NT-Debug|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{E2E59C98-998F-9965-991D-99411166AF6F}.uapaot-Windows_NT-Debug|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{E2E59C98-998F-9965-991D-99411166AF6F}.uapaot-Windows_NT-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{E2E59C98-998F-9965-991D-99411166AF6F}.uapaot-Windows_NT-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{E2E59C98-998F-9965-991D-99411166AF6F}.uap-Windows_NT-Debug|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{E2E59C98-998F-9965-991D-99411166AF6F}.uap-Windows_NT-Debug|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{E2E59C98-998F-9965-991D-99411166AF6F}.uap-Windows_NT-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{E2E59C98-998F-9965-991D-99411166AF6F}.uap-Windows_NT-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{5E0DB390-A45E-41BE-8304-B840327FE597}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{5E0DB390-A45E-41BE-8304-B840327FE597}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{5E0DB390-A45E-41BE-8304-B840327FE597}.netcoreapp-Unix-Debug|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{5E0DB390-A45E-41BE-8304-B840327FE597}.netcoreapp-Unix-Debug|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{5E0DB390-A45E-41BE-8304-B840327FE597}.netcoreapp-Unix-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{5E0DB390-A45E-41BE-8304-B840327FE597}.netcoreapp-Unix-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{5E0DB390-A45E-41BE-8304-B840327FE597}.netcoreapp-Windows_NT-Debug|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{5E0DB390-A45E-41BE-8304-B840327FE597}.netcoreapp-Windows_NT-Debug|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{5E0DB390-A45E-41BE-8304-B840327FE597}.netcoreapp-Windows_NT-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{5E0DB390-A45E-41BE-8304-B840327FE597}.netcoreapp-Windows_NT-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{5E0DB390-A45E-41BE-8304-B840327FE597}.netfx-Windows_NT-Debug|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{5E0DB390-A45E-41BE-8304-B840327FE597}.netfx-Windows_NT-Debug|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{5E0DB390-A45E-41BE-8304-B840327FE597}.netfx-Windows_NT-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{5E0DB390-A45E-41BE-8304-B840327FE597}.netfx-Windows_NT-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{5E0DB390-A45E-41BE-8304-B840327FE597}.netstandard-Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{5E0DB390-A45E-41BE-8304-B840327FE597}.netstandard-Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{5E0DB390-A45E-41BE-8304-B840327FE597}.netstandard-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{5E0DB390-A45E-41BE-8304-B840327FE597}.netstandard-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{5E0DB390-A45E-41BE-8304-B840327FE597}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{5E0DB390-A45E-41BE-8304-B840327FE597}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{5E0DB390-A45E-41BE-8304-B840327FE597}.uapaot-Windows_NT-Debug|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{5E0DB390-A45E-41BE-8304-B840327FE597}.uapaot-Windows_NT-Debug|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{5E0DB390-A45E-41BE-8304-B840327FE597}.uapaot-Windows_NT-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{5E0DB390-A45E-41BE-8304-B840327FE597}.uapaot-Windows_NT-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{5E0DB390-A45E-41BE-8304-B840327FE597}.uap-Windows_NT-Debug|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{5E0DB390-A45E-41BE-8304-B840327FE597}.uap-Windows_NT-Debug|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{5E0DB390-A45E-41BE-8304-B840327FE597}.uap-Windows_NT-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{5E0DB390-A45E-41BE-8304-B840327FE597}.uap-Windows_NT-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
-		{5B7EAEC-93CB-40DF-BE40-A60BC189B737} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
+		{EBDB0247-CA43-4226-B7A1-8FEF21061D09} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{E2E59C98-998F-9965-991D-99411166AF6F} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
+		{5E0DB390-A45E-41BE-8304-B840327FE597} = {0695C735-1077-425E-8A4B-78CF2DB33EED}
 	EndGlobalSection
 EndGlobal

--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
@@ -5,7 +5,17 @@
 using System.IO;
 using System.Threading.Tasks;
 using System.Runtime.CompilerServices;
+using System.Collections.Generic;
+using Xunit;
 
+namespace System
+{
+    public static class TheoryExtensions
+    {
+        [CLSCompliant(false)]
+        public static TheoryData ToTheoryData<T>(this IEnumerable<T> data) { throw null; }
+    }
+}
 namespace System.Diagnostics
 {
     public abstract partial class RemoteExecutorTestBase : System.IO.FileCleanupTestBase

--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.csproj
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.csproj
@@ -3,13 +3,15 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{E2E59C98-998F-9965-991D-99411166AF6F}</ProjectGuid>
-    <ShouldWriteSigningRequired>false</ShouldWriteSigningRequired>    
+    <ShouldWriteSigningRequired>false</ShouldWriteSigningRequired>
+    <AllowReferenceFromRuntime>true</AllowReferenceFromRuntime>
+    <RuntimeProjectFile>$(ProjectDir)\external\test-runtime\XUnit.Runtime.depproj</RuntimeProjectFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="CoreFx.Private.TestUtilities.cs" />
+    <ReferenceFromRuntime Include="xunit.core" />
   </ItemGroup>
-  
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/CoreFx.Private.TestUtilities/src/CoreFx.Private.TestUtilities.csproj
+++ b/src/CoreFx.Private.TestUtilities/src/CoreFx.Private.TestUtilities.csproj
@@ -52,6 +52,7 @@
   <ItemGroup Condition="'$(TargetGroup)' == 'netfx'">
     <Reference Include="mscorlib" />
     <Reference Include="System" />
+    <Reference Include="System.Core" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/CoreFx.Private.TestUtilities/src/CoreFx.Private.TestUtilities.csproj
+++ b/src/CoreFx.Private.TestUtilities/src/CoreFx.Private.TestUtilities.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>CoreFx.Private.TestUtilities</AssemblyName>
-    <ProjectGuid>{5B7EAEC-93CB-40DF-BE40-A60BC189B737}</ProjectGuid>
+    <ProjectGuid>{EBDB0247-CA43-4226-B7A1-8FEF21061D09}</ProjectGuid>
     <RuntimeProjectFile>$(ProjectDir)\external\test-runtime\XUnit.Runtime.depproj</RuntimeProjectFile>
     <ClsCompliant>false</ClsCompliant>
     <ShouldWriteSigningRequired>false</ShouldWriteSigningRequired>
@@ -29,10 +29,12 @@
     <Compile Include="$(CommonPath)\System\PasteArguments.cs">
       <Link>Common\System\PasteArguments.cs</Link>
     </Compile>
+    <Compile Include="System\TheoryExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Runtime" />
     <Reference Include="System.IO.FileSystem" />
+    <Reference Include="System.Linq" />
     <Reference Include="System.Threading.Thread" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Diagnostics.Process" />

--- a/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.cs
@@ -3,9 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
-using System.Diagnostics;
 using System.Reflection;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Xunit;
 

--- a/src/CoreFx.Private.TestUtilities/src/System/TheoryExtensions.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/TheoryExtensions.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace System
+{
+    public static class TheoryExtensions
+    {
+        /// <summary>
+        /// Converts an IEnumerable<typeparamref name="T"/> into an Xunit theory compatible enumerable.
+        /// </summary>
+        public static TheoryData ToTheoryData<T>(this IEnumerable<T> data)
+        {
+            // Returning TheoryData rather than IEnumerable<object> directly should
+            // encourage discover and usage of TheoryData<T1, ..> classes for more
+            // complicated theories. Slightly easier to type as well.
+            return new TheoryDataAdapter(data.Select(d => new object[] { d }));
+        }
+
+        private class TheoryDataAdapter : TheoryData, IEnumerable<object[]>
+        {
+            private IEnumerable<object[]> _data;
+
+            public TheoryDataAdapter(IEnumerable<object[]> data)
+            {
+                _data = data;
+            }
+
+            public new IEnumerator<object[]> GetEnumerator() => _data.GetEnumerator();
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+    }
+}

--- a/src/CoreFx.Private.TestUtilities/tests/Configurations.props
+++ b/src/CoreFx.Private.TestUtilities/tests/Configurations.props
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+      netstandard;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/src/CoreFx.Private.TestUtilities/tests/CoreFx.Private.TestUtilities.Tests.csproj
+++ b/src/CoreFx.Private.TestUtilities/tests/CoreFx.Private.TestUtilities.Tests.csproj
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <ProjectGuid>{5E0DB390-A45E-41BE-8304-B840327FE597}</ProjectGuid>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Release|AnyCPU'" />
+  <PropertyGroup>
+    <RootNamespace>CoreFx.Private.TestUtilities.Tests</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="TheoryExtensionTests.cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/CoreFx.Private.TestUtilities/tests/TheoryExtensionTests.cs
+++ b/src/CoreFx.Private.TestUtilities/tests/TheoryExtensionTests.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace CoreFx.Private.TestUtilities.Tests
+{
+    public class TheoryExtensionTests : IClassFixture<TheoryExtensionTests.TheoryDataFixture>
+    {
+        public class TheoryDataFixture : IDisposable
+        {
+            private static List<string> s_receivedTheoryData = new List<string>();
+
+            public void AddValue(string value)
+            {
+                s_receivedTheoryData.Add(value);
+            }
+
+            public void Dispose()
+            {
+                Assert.Equal(3, s_receivedTheoryData.Count);
+                Assert.Equal(new string[] { "one", "two", "three" }, s_receivedTheoryData);
+            }
+        }
+
+        private TheoryDataFixture _fixture;
+
+        public TheoryExtensionTests(TheoryDataFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Theory,
+            MemberData(nameof(ToTheoryDataData))]
+        public void ToTheoryData_Basic(string data)
+        {
+            _fixture.AddValue(data);
+        }
+
+        public static TheoryData ToTheoryDataData
+        {
+            get
+            {
+                List<string> data = new List<string>
+                {
+                    "one", "two", "three"
+                };
+
+                return data.ToTheoryData();
+            }
+        }
+    }
+}

--- a/src/System.DirectoryServices.Protocols/System.DirectoryServices.Protocols.sln
+++ b/src/System.DirectoryServices.Protocols/System.DirectoryServices.Protocols.sln
@@ -2,7 +2,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.DirectoryServices.Protocols.Tests", "tests\System.DirectoryServices.Protocols.Tests.csproj", "{297A9116-1005-499D-A895-2063D03E4C94}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.DirectoryServices.Protocols.Tests", "tests\System.DirectoryServices.Protocols.Tests.csproj", "{6638C675-CD62-408F-AB3B-AAFD8A906A96}"
 	ProjectSection(ProjectDependencies) = postProject
 		{135980AC-4583-44EC-894E-CB3B1A481920} = {135980AC-4583-44EC-894E-CB3B1A481920}
 	EndProjectSection
@@ -26,10 +26,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{297A9116-1005-499D-A895-2063D03E4C94}.Debug|Any CPU.ActiveCfg = netstandard-Windows_NT-Debug|Any CPU
-		{297A9116-1005-499D-A895-2063D03E4C94}.Debug|Any CPU.Build.0 = netstandard-Windows_NT-Debug|Any CPU
-		{297A9116-1005-499D-A895-2063D03E4C94}.Release|Any CPU.ActiveCfg = netstandard-Windows_NT-Release|Any CPU
-		{297A9116-1005-499D-A895-2063D03E4C94}.Release|Any CPU.Build.0 = netstandard-Windows_NT-Release|Any CPU
+		{6638C675-CD62-408F-AB3B-AAFD8A906A96}.Debug|Any CPU.ActiveCfg = netstandard-Windows_NT-Debug|Any CPU
+		{6638C675-CD62-408F-AB3B-AAFD8A906A96}.Debug|Any CPU.Build.0 = netstandard-Windows_NT-Debug|Any CPU
+		{6638C675-CD62-408F-AB3B-AAFD8A906A96}.Release|Any CPU.ActiveCfg = netstandard-Windows_NT-Release|Any CPU
+		{6638C675-CD62-408F-AB3B-AAFD8A906A96}.Release|Any CPU.Build.0 = netstandard-Windows_NT-Release|Any CPU
 		{135980AC-4583-44EC-894E-CB3B1A481920}.Debug|Any CPU.ActiveCfg = netstandard-Windows_NT-Debug|Any CPU
 		{135980AC-4583-44EC-894E-CB3B1A481920}.Debug|Any CPU.Build.0 = netstandard-Windows_NT-Debug|Any CPU
 		{135980AC-4583-44EC-894E-CB3B1A481920}.Release|Any CPU.ActiveCfg = netstandard-Windows_NT-Release|Any CPU
@@ -43,7 +43,7 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
-		{297A9116-1005-499D-A895-2063D03E4C94} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{6638C675-CD62-408F-AB3B-AAFD8A906A96} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{135980AC-4583-44EC-894E-CB3B1A481920} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{7DEA4539-9A0D-4801-B229-3824710EBCEE} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 	EndGlobalSection

--- a/src/System.DirectoryServices.Protocols/tests/System.DirectoryServices.Protocols.Tests.csproj
+++ b/src/System.DirectoryServices.Protocols/tests/System.DirectoryServices.Protocols.Tests.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <ProjectGuid>{297A9116-1005-499D-A895-2063D03E4C94}</ProjectGuid>
+    <ProjectGuid>{6638C675-CD62-408F-AB3B-AAFD8A906A96}</ProjectGuid>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Release|AnyCPU'" />

--- a/src/System.DirectoryServices/System.DirectoryServices.sln
+++ b/src/System.DirectoryServices/System.DirectoryServices.sln
@@ -1,7 +1,12 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26430.6
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.DirectoryServices.Tests", "tests\System.DirectoryServices.Tests.csproj", "{DDE3838B-0EEA-4D9A-A120-9D72CB33F250}"
+	ProjectSection(ProjectDependencies) = postProject
+		{EC9B0FBC-C3A2-44E6-BFC6-51E565061C28} = {EC9B0FBC-C3A2-44E6-BFC6-51E565061C28}
+	EndProjectSection
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.DirectoryServices", "src\System.DirectoryServices.csproj", "{EC9B0FBC-C3A2-44E6-BFC6-51E565061C28}"
 	ProjectSection(ProjectDependencies) = postProject
 		{CBCDA53B-4C01-4267-B08C-413205FE4D8D} = {CBCDA53B-4C01-4267-B08C-413205FE4D8D}
@@ -9,53 +14,37 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.DirectoryServices", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.DirectoryServices", "ref\System.DirectoryServices.csproj", "{CBCDA53B-4C01-4267-B08C-413205FE4D8D}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{1A2F9F4A-A032-433E-B914-ADD5992BB178}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E893-4E87-987E-04EF0DCEAEFD}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{EF6F08C3-2EF9-4CAC-9A25-61B55EB6583A}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.DirectoryServices.Tests", "tests\System.DirectoryServices.Tests.csproj", "{297A9116-1005-499D-A895-2063D03E4C94}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		netstandard-Debug|Any CPU = netstandard-Debug|Any CPU
-		netstandard-Release|Any CPU = netstandard-Release|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{DDE3838B-0EEA-4D9A-A120-9D72CB33F250}.Debug|Any CPU.ActiveCfg = netstandard-Windows_NT-Debug|Any CPU
+		{DDE3838B-0EEA-4D9A-A120-9D72CB33F250}.Debug|Any CPU.Build.0 = netstandard-Windows_NT-Debug|Any CPU
+		{DDE3838B-0EEA-4D9A-A120-9D72CB33F250}.Release|Any CPU.ActiveCfg = netstandard-Windows_NT-Release|Any CPU
+		{DDE3838B-0EEA-4D9A-A120-9D72CB33F250}.Release|Any CPU.Build.0 = netstandard-Windows_NT-Release|Any CPU
 		{EC9B0FBC-C3A2-44E6-BFC6-51E565061C28}.Debug|Any CPU.ActiveCfg = netstandard-Windows_NT-Debug|Any CPU
 		{EC9B0FBC-C3A2-44E6-BFC6-51E565061C28}.Debug|Any CPU.Build.0 = netstandard-Windows_NT-Debug|Any CPU
-		{EC9B0FBC-C3A2-44E6-BFC6-51E565061C28}.netstandard-Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{EC9B0FBC-C3A2-44E6-BFC6-51E565061C28}.netstandard-Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{EC9B0FBC-C3A2-44E6-BFC6-51E565061C28}.netstandard-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{EC9B0FBC-C3A2-44E6-BFC6-51E565061C28}.netstandard-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
 		{EC9B0FBC-C3A2-44E6-BFC6-51E565061C28}.Release|Any CPU.ActiveCfg = netstandard-Windows_NT-Release|Any CPU
 		{EC9B0FBC-C3A2-44E6-BFC6-51E565061C28}.Release|Any CPU.Build.0 = netstandard-Windows_NT-Release|Any CPU
 		{CBCDA53B-4C01-4267-B08C-413205FE4D8D}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
 		{CBCDA53B-4C01-4267-B08C-413205FE4D8D}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{CBCDA53B-4C01-4267-B08C-413205FE4D8D}.netstandard-Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{CBCDA53B-4C01-4267-B08C-413205FE4D8D}.netstandard-Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{CBCDA53B-4C01-4267-B08C-413205FE4D8D}.netstandard-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{CBCDA53B-4C01-4267-B08C-413205FE4D8D}.netstandard-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
 		{CBCDA53B-4C01-4267-B08C-413205FE4D8D}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
 		{CBCDA53B-4C01-4267-B08C-413205FE4D8D}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{297A9116-1005-499D-A895-2063D03E4C94}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{297A9116-1005-499D-A895-2063D03E4C94}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{297A9116-1005-499D-A895-2063D03E4C94}.netstandard-Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{297A9116-1005-499D-A895-2063D03E4C94}.netstandard-Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{297A9116-1005-499D-A895-2063D03E4C94}.netstandard-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{297A9116-1005-499D-A895-2063D03E4C94}.netstandard-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{297A9116-1005-499D-A895-2063D03E4C94}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{297A9116-1005-499D-A895-2063D03E4C94}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
+		{DDE3838B-0EEA-4D9A-A120-9D72CB33F250} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{EC9B0FBC-C3A2-44E6-BFC6-51E565061C28} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{CBCDA53B-4C01-4267-B08C-413205FE4D8D} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
-		{297A9116-1005-499D-A895-2063D03E4C94} = {EF6F08C3-2EF9-4CAC-9A25-61B55EB6583A}
 	EndGlobalSection
 EndGlobal

--- a/src/System.DirectoryServices/tests/System.DirectoryServices.Tests.csproj
+++ b/src/System.DirectoryServices/tests/System.DirectoryServices.Tests.csproj
@@ -2,11 +2,10 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <ProjectGuid>{297A9116-1005-499D-A895-2063D03E4C94}</ProjectGuid>
+    <ProjectGuid>{DDE3838B-0EEA-4D9A-A120-9D72CB33F250}</ProjectGuid>
   </PropertyGroup>
-  <!-- Default configurations to help VS understand the configurations -->
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="System\DirectoryServices\ActiveDirectorySecurityTests.cs" />
     <Compile Include="System\DirectoryServices\ActiveDirectory\DomainControllerTests.cs" />

--- a/src/System.Drawing.Common/tests/System.Drawing.Common.Tests.csproj
+++ b/src/System.Drawing.Common/tests/System.Drawing.Common.Tests.csproj
@@ -4,9 +4,10 @@
   <PropertyGroup>
     <ProjectGuid>{4B93E684-0630-45F4-8F63-6C7788C9892F}</ProjectGuid>
   </PropertyGroup>
-  <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="BitmapTests.cs" />
     <Compile Include="BrushTests.cs" />

--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -110,20 +110,16 @@ namespace System.IO.Tests
             Assert.Equal(IOServices.AddTrailingSlashIfNeeded(TestDirectory), result.FullName);
         }
 
-        [Fact]
-        public void ValidPathWithTrailingSlash()
+        [Theory, MemberData(nameof(ValidPathComponentNames))]
+        public void ValidPathWithTrailingSlash(string component)
         {
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
 
-            var components = IOInputs.GetValidPathComponentNames();
-            Assert.All(components, (component) =>
-            {
-                string path = IOServices.AddTrailingSlashIfNeeded(Path.Combine(testDir.FullName, component));
-                DirectoryInfo result = Create(path);
+            string path = IOServices.AddTrailingSlashIfNeeded(Path.Combine(testDir.FullName, component));
+            DirectoryInfo result = Create(path);
 
-                Assert.Equal(path, result.FullName);
-                Assert.True(result.Exists);
-            });
+            Assert.Equal(path, result.FullName);
+            Assert.True(result.Exists);
         }
 
         [ConditionalFact(nameof(UsingNewNormalization))]

--- a/src/System.IO.FileSystem/tests/FileSystemTest.cs
+++ b/src/System.IO.FileSystem/tests/FileSystemTest.cs
@@ -23,6 +23,7 @@ namespace System.IO.Tests
         public static TheoryData<string> PathsWithInvalidColons = TestData.PathsWithInvalidColons;
         public static TheoryData<string> PathsWithInvalidCharacters = TestData.PathsWithInvalidCharacters;
         public static TheoryData<char> TrailingCharacters = TestData.TrailingCharacters;
+        public static TheoryData ValidPathComponentNames = IOInputs.GetValidPathComponentNames().ToTheoryData();
 
         /// <summary>
         /// In some cases (such as when running without elevated privileges),

--- a/src/System.IO.FileSystem/tests/Performance/System.IO.FileSystem.Performance.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/Performance/System.IO.FileSystem.Performance.Tests.csproj
@@ -16,6 +16,11 @@
     <Compile Include="..\PortedCommon\ReparsePointUtilities.cs" />
     <Compile Include="..\TestData.cs" />
     <Compile Include="..\FileSystemTest.cs" />
+    <Compile Include="..\PortedCommon\CommonUtilities.cs" />
+    <Compile Include="..\PortedCommon\DllImports.cs" />
+    <Compile Include="..\PortedCommon\IOInputs.cs" />
+    <Compile Include="..\PortedCommon\IOServices.cs" />
+    <Compile Include="..\PortedCommon\PathInfo.cs" />
     <Compile Include="Perf.Directory.cs" />
     <Compile Include="Perf.File.cs" />
     <Compile Include="Perf.FileInfo.cs" />
@@ -25,6 +30,9 @@
     </Compile>
     <Compile Include="$(CommonTestPath)\System\IO\PathFeatures.cs">
       <Link>Common\System\IO\PathFeatures.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>Common\System\PlatformDetection.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Net.NetworkInformation/System.Net.NetworkInformation.sln
+++ b/src/System.Net.NetworkInformation/System.Net.NetworkInformation.sln
@@ -7,11 +7,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Net.NetworkInformati
 		{3CA89D6C-F8D1-4813-9775-F8D249686E31} = {3CA89D6C-F8D1-4813-9775-F8D249686E31}
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Net.NetworkInformation.WinRT.Unit.Tests", "tests\UnitTests\System.Net.NetworkInformation.WinRT.Unit.Tests.csproj", "{2194D6A2-1A35-46B5-8233-AEEBCBD31EF9}"
-	ProjectSection(ProjectDependencies) = postProject
-		{3CA89D6C-F8D1-4813-9775-F8D249686E31} = {3CA89D6C-F8D1-4813-9775-F8D249686E31}
-	EndProjectSection
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Net.NetworkInformation", "src\System.Net.NetworkInformation.csproj", "{3CA89D6C-F8D1-4813-9775-F8D249686E31}"
 	ProjectSection(ProjectDependencies) = postProject
 		{B897C3BE-7162-44BB-8B81-7A2464C082A7} = {B897C3BE-7162-44BB-8B81-7A2464C082A7}
@@ -35,10 +30,6 @@ Global
 		{DCBB8805-4658-44BF-B5E8-B6714EC8936B}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
 		{DCBB8805-4658-44BF-B5E8-B6714EC8936B}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
 		{DCBB8805-4658-44BF-B5E8-B6714EC8936B}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{2194D6A2-1A35-46B5-8233-AEEBCBD31EF9}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
-		{2194D6A2-1A35-46B5-8233-AEEBCBD31EF9}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
-		{2194D6A2-1A35-46B5-8233-AEEBCBD31EF9}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
-		{2194D6A2-1A35-46B5-8233-AEEBCBD31EF9}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
 		{3CA89D6C-F8D1-4813-9775-F8D249686E31}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
 		{3CA89D6C-F8D1-4813-9775-F8D249686E31}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
 		{3CA89D6C-F8D1-4813-9775-F8D249686E31}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
@@ -53,7 +44,6 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{DCBB8805-4658-44BF-B5E8-B6714EC8936B} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
-		{2194D6A2-1A35-46B5-8233-AEEBCBD31EF9} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{3CA89D6C-F8D1-4813-9775-F8D249686E31} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{B897C3BE-7162-44BB-8B81-7A2464C082A7} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 	EndGlobalSection

--- a/src/System.Runtime.InteropServices.RuntimeInformation/src/System.Runtime.InteropServices.RuntimeInformation.csproj
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/src/System.Runtime.InteropServices.RuntimeInformation.csproj
@@ -42,6 +42,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.1-Windows_NT-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Windows_NT-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'win8-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'win8-Windows_NT-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'wpa81-Windows_NT-Debug|AnyCPU'" />

--- a/src/System.Runtime.InteropServices.WindowsRuntime/System.Runtime.InteropServices.WindowsRuntime.sln
+++ b/src/System.Runtime.InteropServices.WindowsRuntime/System.Runtime.InteropServices.WindowsRuntime.sln
@@ -1,7 +1,12 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26430.6
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.InteropServices.WindowsRuntime.Tests", "tests\System.Runtime.InteropServices.WindowsRuntime.Tests.csproj", "{27F624C8-06E3-455D-B5D1-C0FEB343EFAA}"
+	ProjectSection(ProjectDependencies) = postProject
+		{5655C5E4-9B76-489B-87AF-42BD60570A00} = {5655C5E4-9B76-489B-87AF-42BD60570A00}
+	EndProjectSection
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.InteropServices.WindowsRuntime", "src\System.Runtime.InteropServices.WindowsRuntime.csproj", "{5655C5E4-9B76-489B-87AF-42BD60570A00}"
 	ProjectSection(ProjectDependencies) = postProject
 		{DC485335-D0D7-4E28-9593-445B7B6BEFA7} = {DC485335-D0D7-4E28-9593-445B7B6BEFA7}
@@ -9,53 +14,37 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.InteropServi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.InteropServices.WindowsRuntime", "ref\System.Runtime.InteropServices.WindowsRuntime.csproj", "{DC485335-D0D7-4E28-9593-445B7B6BEFA7}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{1A2F9F4A-A032-433E-B914-ADD5992BB178}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E893-4E87-987E-04EF0DCEAEFD}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{9C47C6BC-98A1-4C52-B80F-9607F80E7EB2}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.InteropServices.WindowsRuntime.Tests", "tests\System.Runtime.InteropServices.WindowsRuntime.Tests.csproj", "{9B4D1DA9-AA4C-428F-9F66-D45C924025A5}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		netstandard-Debug|Any CPU = netstandard-Debug|Any CPU
-		netstandard-Release|Any CPU = netstandard-Release|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{27F624C8-06E3-455D-B5D1-C0FEB343EFAA}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
+		{27F624C8-06E3-455D-B5D1-C0FEB343EFAA}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
+		{27F624C8-06E3-455D-B5D1-C0FEB343EFAA}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
+		{27F624C8-06E3-455D-B5D1-C0FEB343EFAA}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
 		{5655C5E4-9B76-489B-87AF-42BD60570A00}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
 		{5655C5E4-9B76-489B-87AF-42BD60570A00}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
-		{5655C5E4-9B76-489B-87AF-42BD60570A00}.netstandard-Debug|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
-		{5655C5E4-9B76-489B-87AF-42BD60570A00}.netstandard-Debug|Any CPU.Build.0 = netcoreapp-Release|Any CPU
-		{5655C5E4-9B76-489B-87AF-42BD60570A00}.netstandard-Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
-		{5655C5E4-9B76-489B-87AF-42BD60570A00}.netstandard-Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
 		{5655C5E4-9B76-489B-87AF-42BD60570A00}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
 		{5655C5E4-9B76-489B-87AF-42BD60570A00}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
 		{DC485335-D0D7-4E28-9593-445B7B6BEFA7}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
 		{DC485335-D0D7-4E28-9593-445B7B6BEFA7}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
-		{DC485335-D0D7-4E28-9593-445B7B6BEFA7}.netstandard-Debug|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
-		{DC485335-D0D7-4E28-9593-445B7B6BEFA7}.netstandard-Debug|Any CPU.Build.0 = netcoreapp-Release|Any CPU
-		{DC485335-D0D7-4E28-9593-445B7B6BEFA7}.netstandard-Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
-		{DC485335-D0D7-4E28-9593-445B7B6BEFA7}.netstandard-Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
 		{DC485335-D0D7-4E28-9593-445B7B6BEFA7}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
 		{DC485335-D0D7-4E28-9593-445B7B6BEFA7}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
-		{9B4D1DA9-AA4C-428F-9F66-D45C924025A5}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
-		{9B4D1DA9-AA4C-428F-9F66-D45C924025A5}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
-		{9B4D1DA9-AA4C-428F-9F66-D45C924025A5}.netstandard-Debug|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
-		{9B4D1DA9-AA4C-428F-9F66-D45C924025A5}.netstandard-Debug|Any CPU.Build.0 = netcoreapp-Release|Any CPU
-		{9B4D1DA9-AA4C-428F-9F66-D45C924025A5}.netstandard-Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
-		{9B4D1DA9-AA4C-428F-9F66-D45C924025A5}.netstandard-Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
-		{9B4D1DA9-AA4C-428F-9F66-D45C924025A5}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
-		{9B4D1DA9-AA4C-428F-9F66-D45C924025A5}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
+		{27F624C8-06E3-455D-B5D1-C0FEB343EFAA} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{5655C5E4-9B76-489B-87AF-42BD60570A00} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{DC485335-D0D7-4E28-9593-445B7B6BEFA7} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
-		{9B4D1DA9-AA4C-428F-9F66-D45C924025A5} = {9C47C6BC-98A1-4C52-B80F-9607F80E7EB2}
 	EndGlobalSection
 EndGlobal

--- a/src/System.Runtime.InteropServices.WindowsRuntime/tests/System.Runtime.InteropServices.WindowsRuntime.Tests.csproj
+++ b/src/System.Runtime.InteropServices.WindowsRuntime/tests/System.Runtime.InteropServices.WindowsRuntime.Tests.csproj
@@ -3,13 +3,16 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <ProjectGuid>{9B4D1DA9-AA4C-428F-9F66-D45C924025A5}</ProjectGuid>
+    <ProjectGuid>{27F624C8-06E3-455D-B5D1-C0FEB343EFAA}</ProjectGuid>
   </PropertyGroup>
-  <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Windows_NT-Release|AnyCPU'" />
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
     <Compile Include="System\Runtime\InteropServices\WindowsRuntime\DefaultInterfaceAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\WindowsRuntime\EmptyAttributeTests.cs" />

--- a/src/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.Tests.csproj
+++ b/src/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.Tests.csproj
@@ -12,7 +12,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Windows_NT-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
-  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="System\Runtime\InteropServices\AllowReversePInvokeCallsAttributeTests.cs" />
     <Compile Include="System\Runtime\InteropServices\ArrayWithOffsetTests.cs" />

--- a/src/System.Runtime.WindowsRuntime.UI.Xaml/System.Runtime.WindowsRuntime.UI.Xaml.sln
+++ b/src/System.Runtime.WindowsRuntime.UI.Xaml/System.Runtime.WindowsRuntime.UI.Xaml.sln
@@ -1,7 +1,12 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26430.6
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.WindowsRuntime.UI.Xaml.Tests", "tests\System.Runtime.WindowsRuntime.UI.Xaml.Tests.csproj", "{69FC7EB5-64FD-4464-88B1-B8ADD3870640}"
+	ProjectSection(ProjectDependencies) = postProject
+		{263DA4F1-C3BC-4B43-98E7-9F38B419A131} = {263DA4F1-C3BC-4B43-98E7-9F38B419A131}
+	EndProjectSection
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.WindowsRuntime.UI.Xaml", "src\System.Runtime.WindowsRuntime.UI.Xaml.csproj", "{263DA4F1-C3BC-4B43-98E7-9F38B419A131}"
 	ProjectSection(ProjectDependencies) = postProject
 		{AA1600B8-C4D3-42A9-A28A-04D0C8282566} = {AA1600B8-C4D3-42A9-A28A-04D0C8282566}
@@ -9,53 +14,37 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.WindowsRunti
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.WindowsRuntime.UI.Xaml", "ref\System.Runtime.WindowsRuntime.UI.Xaml.csproj", "{AA1600B8-C4D3-42A9-A28A-04D0C8282566}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{1A2F9F4A-A032-433E-B914-ADD5992BB178}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E893-4E87-987E-04EF0DCEAEFD}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{67CF07C4-6F36-4BF6-A5F6-2E537BFE0FC6}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.WindowsRuntime.UI.Xaml.Tests", "tests\System.Runtime.WindowsRuntime.UI.Xaml.Tests.csproj", "{30CAB353-089E-4294-B23B-F2DD1D945654}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
-		uap-Release|Any CPU = uap-Release|Any CPU
-		uap-Windows_NT-Debug|Any CPU = uap-Windows_NT-Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{69FC7EB5-64FD-4464-88B1-B8ADD3870640}.Debug|Any CPU.ActiveCfg = uap-Windows_NT-Debug|Any CPU
+		{69FC7EB5-64FD-4464-88B1-B8ADD3870640}.Debug|Any CPU.Build.0 = uap-Windows_NT-Debug|Any CPU
+		{69FC7EB5-64FD-4464-88B1-B8ADD3870640}.Release|Any CPU.ActiveCfg = uap-Windows_NT-Release|Any CPU
+		{69FC7EB5-64FD-4464-88B1-B8ADD3870640}.Release|Any CPU.Build.0 = uap-Windows_NT-Release|Any CPU
 		{263DA4F1-C3BC-4B43-98E7-9F38B419A131}.Debug|Any CPU.ActiveCfg = uap-Windows_NT-Debug|Any CPU
 		{263DA4F1-C3BC-4B43-98E7-9F38B419A131}.Debug|Any CPU.Build.0 = uap-Windows_NT-Debug|Any CPU
 		{263DA4F1-C3BC-4B43-98E7-9F38B419A131}.Release|Any CPU.ActiveCfg = uap-Windows_NT-Release|Any CPU
 		{263DA4F1-C3BC-4B43-98E7-9F38B419A131}.Release|Any CPU.Build.0 = uap-Windows_NT-Release|Any CPU
-		{263DA4F1-C3BC-4B43-98E7-9F38B419A131}.uap-Release|Any CPU.ActiveCfg = uap-Windows_NT-Release|Any CPU
-		{263DA4F1-C3BC-4B43-98E7-9F38B419A131}.uap-Release|Any CPU.Build.0 = uap-Windows_NT-Release|Any CPU
-		{263DA4F1-C3BC-4B43-98E7-9F38B419A131}.uap-Windows_NT-Debug|Any CPU.ActiveCfg = uap-Windows_NT-Debug|Any CPU
-		{263DA4F1-C3BC-4B43-98E7-9F38B419A131}.uap-Windows_NT-Debug|Any CPU.Build.0 = uap-Windows_NT-Debug|Any CPU
 		{AA1600B8-C4D3-42A9-A28A-04D0C8282566}.Debug|Any CPU.ActiveCfg = uap-Debug|Any CPU
 		{AA1600B8-C4D3-42A9-A28A-04D0C8282566}.Debug|Any CPU.Build.0 = uap-Debug|Any CPU
 		{AA1600B8-C4D3-42A9-A28A-04D0C8282566}.Release|Any CPU.ActiveCfg = uap-Release|Any CPU
 		{AA1600B8-C4D3-42A9-A28A-04D0C8282566}.Release|Any CPU.Build.0 = uap-Release|Any CPU
-		{AA1600B8-C4D3-42A9-A28A-04D0C8282566}.uap-Release|Any CPU.ActiveCfg = uap-Release|Any CPU
-		{AA1600B8-C4D3-42A9-A28A-04D0C8282566}.uap-Release|Any CPU.Build.0 = uap-Release|Any CPU
-		{AA1600B8-C4D3-42A9-A28A-04D0C8282566}.uap-Windows_NT-Debug|Any CPU.ActiveCfg = uap-Release|Any CPU
-		{AA1600B8-C4D3-42A9-A28A-04D0C8282566}.uap-Windows_NT-Debug|Any CPU.Build.0 = uap-Release|Any CPU
-		{30CAB353-089E-4294-B23B-F2DD1D945654}.Debug|Any CPU.ActiveCfg = uap-Windows_NT-Debug|Any CPU
-		{30CAB353-089E-4294-B23B-F2DD1D945654}.Debug|Any CPU.Build.0 = uap-Windows_NT-Debug|Any CPU
-		{30CAB353-089E-4294-B23B-F2DD1D945654}.Release|Any CPU.ActiveCfg = uap-Release|Any CPU
-		{30CAB353-089E-4294-B23B-F2DD1D945654}.Release|Any CPU.Build.0 = uap-Release|Any CPU
-		{30CAB353-089E-4294-B23B-F2DD1D945654}.uap-Release|Any CPU.ActiveCfg = uap-Release|Any CPU
-		{30CAB353-089E-4294-B23B-F2DD1D945654}.uap-Release|Any CPU.Build.0 = uap-Release|Any CPU
-		{30CAB353-089E-4294-B23B-F2DD1D945654}.uap-Windows_NT-Debug|Any CPU.ActiveCfg = uap-Windows_NT-Debug|Any CPU
-		{30CAB353-089E-4294-B23B-F2DD1D945654}.uap-Windows_NT-Debug|Any CPU.Build.0 = uap-Windows_NT-Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
+		{69FC7EB5-64FD-4464-88B1-B8ADD3870640} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{263DA4F1-C3BC-4B43-98E7-9F38B419A131} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{AA1600B8-C4D3-42A9-A28A-04D0C8282566} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
-		{30CAB353-089E-4294-B23B-F2DD1D945654} = {67CF07C4-6F36-4BF6-A5F6-2E537BFE0FC6}
 	EndGlobalSection
 EndGlobal

--- a/src/System.Runtime.WindowsRuntime.UI.Xaml/tests/System.Runtime.WindowsRuntime.UI.Xaml.Tests.csproj
+++ b/src/System.Runtime.WindowsRuntime.UI.Xaml/tests/System.Runtime.WindowsRuntime.UI.Xaml.Tests.csproj
@@ -2,10 +2,10 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <ProjectGuid>{30CAB353-089E-4294-B23B-F2DD1D945654}</ProjectGuid>
+    <ProjectGuid>{69FC7EB5-64FD-4464-88B1-B8ADD3870640}</ProjectGuid>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="Windows\UI\Xaml\CornerRadiusTests.cs" />
     <Compile Include="Windows\UI\Xaml\DurationTests.cs" />

--- a/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
@@ -5,12 +5,12 @@
     <ProjectGuid>{94B106C2-D574-4392-80AB-3EE308A078DF}</ProjectGuid>
     <AppDesignerFolder>Properties</AppDesignerFolder>
   </PropertyGroup>
-  <!-- Default configurations to help VS understand the configurations -->
-  <!-- Compiled Source Files -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Release|AnyCPU'" />
   <!-- [ActiveIssue(https://github.com/dotnet/corefx/issues/21547)] times out in uap. -->
   <ItemGroup Condition="'$(TargetGroup)' != 'uap'">
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">


### PR DESCRIPTION
Manipulating test input data in IEnumerable format is
desirable, but a bit awkward to get into IEnumerable<object[]> format that [Theory] expects.

Add test project to new test project. :)  Change a test in
System.IO.FileSystem to theory with new extension.