### PR TITLE
Clarify default credentials usage for HttpClientHandler on UAP

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.DefaultProxyCredentials.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.DefaultProxyCredentials.cs
@@ -12,7 +12,6 @@ namespace System.Net.Http.Functional.Tests
 {
     using Configuration = System.Net.Test.Common.Configuration;
 
-    [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
     public class HttpClientHandler_DefaultProxyCredentials_Test : RemoteExecutorTestBase
     {
         [Fact]
@@ -30,6 +29,10 @@ namespace System.Net.Http.Functional.Tests
             using (var handler = new HttpClientHandler())
             {
                 var creds = new NetworkCredential("username", "password", "domain");
+
+                handler.DefaultProxyCredentials = null;
+                Assert.Null(handler.DefaultProxyCredentials);
+
                 handler.DefaultProxyCredentials = creds;
                 Assert.Same(creds, handler.DefaultProxyCredentials);
 
@@ -38,6 +41,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void ProxyExplicitlyProvided_DefaultCredentials_Ignored()

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -116,17 +116,8 @@ namespace System.Net.Http.Functional.Tests
                 Assert.Equal(null, handler.Proxy);
                 Assert.True(handler.SupportsAutomaticDecompression);
                 Assert.True(handler.UseCookies);
-                Assert.True(handler.UseProxy);
-            }
-        }
-
-        [ActiveIssue(21510, TargetFrameworkMonikers.Uap)]
-        [Fact]
-        public void UseDefaultCredentials_Ctor_ExpectedValue()
-        {
-            using (var handler = new HttpClientHandler())
-            {
                 Assert.False(handler.UseDefaultCredentials);
+                Assert.True(handler.UseProxy);
             }
         }
 
@@ -165,6 +156,24 @@ namespace System.Net.Http.Functional.Tests
                 Assert.Equal(SslProtocols.None, handler.SslProtocols);
                 Assert.False(handler.SupportsProxy);
                 Assert.False(handler.SupportsRedirectConfiguration);
+            }
+        }
+
+        [Fact]
+        public void Credentials_SetGet_Roundtrips()
+        {
+            using (var handler = new HttpClientHandler())
+            {
+                var creds = new NetworkCredential("username", "password", "domain");
+
+                handler.Credentials = null;
+                Assert.Null(handler.Credentials);
+
+                handler.Credentials = creds;
+                Assert.Same(creds, handler.Credentials);
+
+                handler.Credentials = CredentialCache.DefaultCredentials;
+                Assert.Same(CredentialCache.DefaultCredentials, handler.Credentials);
             }
         }
 


### PR DESCRIPTION
This PR clarifies how credential handling and specifically default
logged-on credentials actually works on the UAP platform.

First, "default credentials" are the current credentials of the
logged-on user, typically on an enterprise network joined to an
Active Directory domain. When these credentials are sent to a
proxy or server, only Negotiate, Kerberos, or NTLM schemes are
used. Those credentials can never be sent via other schemes
like basic or digest.

.NET Framework traditionally has two ways for developers to specify
using default logged-on credentials to send to the server. Either
set the .UseDefaultCredentials property to true or specify
CredentialCache.DefaultCredentials to the .Credentials property.

For proxy credentials, the developer could pass DefaultCredentials
via the custom IProxy object or via the .DefaultProxyCredentials
property.

.NET Framework would send default credentials anywhere (intranet
or internet) if specified by the developer.

The UAP platform implementation of System.Net.Http uses a different
set of rules for sending default credentials. It is based on whether
the app has Enterprise Authentication capability as well as if the
endpoint is specified in an intranet zone. This design is part of
the base native WinInet and WinHTTP stacks. It was a design choice
to provide optimum security as well as convenience for developers
writing apps for enterprise scenarios.

This PR does a few things. First, it keeps the .NET ICredentials
properties stored separately so that they correctly round-trip
on get and set. .NET NetworkCredential has 3 parameters (domain,
user, password). But WinRT PasswordCredential only has 2 parameters
(user, password). We now convert to the WinRT objects only when
we need to use them.

Second, this PR clarifies that the .UseDefaultCredentials property
is basically a no-op because the API models of default credentials
handling is different on the UAP platform as described above.

These platform differences will be documented here:
https://github.com/dotnet/corefx/wiki/ApiCompat

Fixes #19642
Fixes #21510