### PR TITLE
Several allocation improvements for HttpClient/ManagedHandler

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/ByteArrayContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/ByteArrayContent.cs
@@ -62,9 +62,13 @@ namespace System.Net.Http
             return true;
         }
 
-        protected override Task<Stream> CreateContentReadStreamAsync()
-        {
-            return Task.FromResult<Stream>(new MemoryStream(_content, _offset, _count, writable: false));
-        }
+        protected override Task<Stream> CreateContentReadStreamAsync() =>
+            Task.FromResult<Stream>(CreateMemoryStreamForByteArray());
+
+        internal override ValueTask<Stream> CreateContentReadStreamValueAsync() =>
+            GetType() == typeof(ByteArrayContent) ? new ValueTask<Stream>(CreateMemoryStreamForByteArray()) :
+            base.CreateContentReadStreamValueAsync();
+
+        internal MemoryStream CreateMemoryStreamForByteArray() => new MemoryStream(_content, _offset, _count, writable: false);
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/ByteArrayContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/ByteArrayContent.cs
@@ -65,9 +65,9 @@ namespace System.Net.Http
         protected override Task<Stream> CreateContentReadStreamAsync() =>
             Task.FromResult<Stream>(CreateMemoryStreamForByteArray());
 
-        internal override ValueTask<Stream> CreateContentReadStreamValueAsync() =>
-            GetType() == typeof(ByteArrayContent) ? new ValueTask<Stream>(CreateMemoryStreamForByteArray()) :
-            base.CreateContentReadStreamValueAsync();
+        internal override Stream TryCreateContentReadStream() =>
+            GetType() == typeof(ByteArrayContent) ? CreateMemoryStreamForByteArray() : // type check ensures we use possible derived type's CreateContentReadStreamAsync override
+            null;
 
         internal MemoryStream CreateMemoryStreamForByteArray() => new MemoryStream(_content, _offset, _count, writable: false);
     }

--- a/src/System.Net.Http/src/System/Net/Http/FormUrlEncodedContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/FormUrlEncodedContent.cs
@@ -53,5 +53,9 @@ namespace System.Net.Http
             // Escape spaces as '+'.
             return Uri.EscapeDataString(data).Replace("%20", "+");
         }
+
+        internal override ValueTask<Stream> CreateContentReadStreamValueAsync() =>
+            GetType() == typeof(FormUrlEncodedContent) ? new ValueTask<Stream>(CreateMemoryStreamForByteArray()) :
+            base.CreateContentReadStreamValueAsync();
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/FormUrlEncodedContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/FormUrlEncodedContent.cs
@@ -54,8 +54,8 @@ namespace System.Net.Http
             return Uri.EscapeDataString(data).Replace("%20", "+");
         }
 
-        internal override ValueTask<Stream> CreateContentReadStreamValueAsync() =>
-            GetType() == typeof(FormUrlEncodedContent) ? new ValueTask<Stream>(CreateMemoryStreamForByteArray()) :
-            base.CreateContentReadStreamValueAsync();
+        internal override Stream TryCreateContentReadStream() =>
+            GetType() == typeof(FormUrlEncodedContent) ? CreateMemoryStreamForByteArray() : // type check ensures we use possible derived type's CreateContentReadStreamAsync override
+            null;
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/Headers/HttpGeneralHeaders.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/HttpGeneralHeaders.cs
@@ -109,30 +109,38 @@ namespace System.Net.Http.Headers
             get { return TransferEncodingCore; }
         }
 
+        internal static bool? GetTransferEncodingChunked(HttpHeaders parent, HttpGeneralHeaders headers)
+        {
+            // If we've already initialized the transfer encoding header value collection
+            // and it contains the special value, or if we haven't and the headers contain
+            // the parsed special value, return true.  We don't just access TransferEncodingCore,
+            // as doing so will unnecessarily initialize the collection even if it's not needed.
+            if (headers != null && headers._transferEncoding != null)
+            {
+                if (headers._transferEncoding.IsSpecialValueSet)
+                {
+                    return true;
+                }
+            }
+            else if (parent.ContainsParsedValue(HttpKnownHeaderNames.TransferEncoding, HeaderUtilities.TransferEncodingChunked))
+            {
+                return true;
+            }
+            if (headers != null && headers._transferEncodingChunkedSet)
+            {
+                return false;
+            }
+            return null;
+        }
+
         public bool? TransferEncodingChunked
         {
             get
             {
-                // If we've already initialized the transfer encoding header value collection
-                // and it contains the special value, or if we haven't and the headers contain
-                // the parsed special value, return true.  We don't just access TransferEncodingCore,
-                // as doing so will unnecessarily initialize the collection even if it's not needed.
-                if (_transferEncoding != null)
-                {
-                    if (_transferEncoding.IsSpecialValueSet)
-                    {
-                        return true;
-                    }
-                }
-                else if (_parent.ContainsParsedValue(HttpKnownHeaderNames.TransferEncoding, HeaderUtilities.TransferEncodingChunked))
-                {
-                    return true;
-                }
-                if (_transferEncodingChunkedSet)
-                {
-                    return false;
-                }
-                return null;
+                // Separated out into a static to enable access to TransferEncodingChunked
+                // without the caller needing to force the creation of HttpGeneralHeaders
+                // if it wasn't created for other reasons.
+                return GetTransferEncodingChunked(_parent, this);
             }
             set
             {

--- a/src/System.Net.Http/src/System/Net/Http/Headers/HttpRequestHeaders.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/HttpRequestHeaders.cs
@@ -16,14 +16,14 @@ namespace System.Net.Http.Headers
         private static readonly HashSet<string> s_invalidHeaders = CreateInvalidHeaders();
 
         private const int AcceptSlot = 0;
-        private const int ExpectSlot = 1;
-        private const int IfMatchSlot = 2;
-        private const int IfNoneMatchSlot = 3;
-        private const int TransferEncodingSlot = 4;
-        private const int UserAgentSlot = 5;
-        private const int AcceptCharsetSlot = 6;
-        private const int AcceptEncodingSlot = 7;
-        private const int AcceptLanguageSlot = 8;
+        private const int AcceptCharsetSlot = 1;
+        private const int AcceptEncodingSlot = 2;
+        private const int AcceptLanguageSlot = 3;
+        private const int ExpectSlot = 4;
+        private const int IfMatchSlot = 5;
+        private const int IfNoneMatchSlot = 6;
+        private const int TransferEncodingSlot = 7;
+        private const int UserAgentSlot = 8;
         private const int NumCollectionsSlots = 9;
 
         private object[] _specialCollectionsSlots;

--- a/src/System.Net.Http/src/System/Net/Http/Headers/HttpRequestHeaders.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/HttpRequestHeaders.cs
@@ -284,69 +284,67 @@ namespace System.Net.Http.Headers
 
         public CacheControlHeaderValue CacheControl
         {
-            get { return _generalHeaders.CacheControl; }
-            set { _generalHeaders.CacheControl = value; }
+            get { return GeneralHeaders.CacheControl; }
+            set { GeneralHeaders.CacheControl = value; }
         }
 
         public HttpHeaderValueCollection<string> Connection
         {
-            get { return _generalHeaders.Connection; }
+            get { return GeneralHeaders.Connection; }
         }
 
         public bool? ConnectionClose
         {
-            get { return _generalHeaders.ConnectionClose; }
-            set { _generalHeaders.ConnectionClose = value; }
+            get { return GeneralHeaders.ConnectionClose; }
+            set { GeneralHeaders.ConnectionClose = value; }
         }
 
         public DateTimeOffset? Date
         {
-            get { return _generalHeaders.Date; }
-            set { _generalHeaders.Date = value; }
+            get { return GeneralHeaders.Date; }
+            set { GeneralHeaders.Date = value; }
         }
 
         public HttpHeaderValueCollection<NameValueHeaderValue> Pragma
         {
-            get { return _generalHeaders.Pragma; }
+            get { return GeneralHeaders.Pragma; }
         }
 
         public HttpHeaderValueCollection<string> Trailer
         {
-            get { return _generalHeaders.Trailer; }
+            get { return GeneralHeaders.Trailer; }
         }
 
         public HttpHeaderValueCollection<TransferCodingHeaderValue> TransferEncoding
         {
-            get { return _generalHeaders.TransferEncoding; }
+            get { return GeneralHeaders.TransferEncoding; }
         }
 
         public bool? TransferEncodingChunked
         {
-            get { return _generalHeaders.TransferEncodingChunked; }
-            set { _generalHeaders.TransferEncodingChunked = value; }
+            get { return GeneralHeaders.TransferEncodingChunked; }
+            set { GeneralHeaders.TransferEncodingChunked = value; }
         }
 
         public HttpHeaderValueCollection<ProductHeaderValue> Upgrade
         {
-            get { return _generalHeaders.Upgrade; }
+            get { return GeneralHeaders.Upgrade; }
         }
 
         public HttpHeaderValueCollection<ViaHeaderValue> Via
         {
-            get { return _generalHeaders.Via; }
+            get { return GeneralHeaders.Via; }
         }
 
         public HttpHeaderValueCollection<WarningHeaderValue> Warning
         {
-            get { return _generalHeaders.Warning; }
+            get { return GeneralHeaders.Warning; }
         }
 
         #endregion
 
         internal HttpRequestHeaders()
         {
-            _generalHeaders = new HttpGeneralHeaders(this);
-
             base.SetConfiguration(s_parserStore, s_invalidHeaders);
         }
 
@@ -422,7 +420,10 @@ namespace System.Net.Http.Headers
             Debug.Assert(sourceRequestHeaders != null);
 
             // Copy special values but do not overwrite.
-            _generalHeaders.AddSpecialsFrom(sourceRequestHeaders._generalHeaders);
+            if (sourceRequestHeaders._generalHeaders != null)
+            {
+                GeneralHeaders.AddSpecialsFrom(sourceRequestHeaders._generalHeaders);
+            }
 
             bool? expectContinue = ExpectContinue;
             if (!expectContinue.HasValue)
@@ -430,5 +431,7 @@ namespace System.Net.Http.Headers
                 ExpectContinue = sourceRequestHeaders.ExpectContinue;
             }
         }
+
+        private HttpGeneralHeaders GeneralHeaders => _generalHeaders ?? (_generalHeaders = new HttpGeneralHeaders(this));
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/Headers/HttpRequestHeaders.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/HttpRequestHeaders.cs
@@ -322,7 +322,7 @@ namespace System.Net.Http.Headers
 
         public bool? TransferEncodingChunked
         {
-            get { return GeneralHeaders.TransferEncodingChunked; }
+            get { return HttpGeneralHeaders.GetTransferEncodingChunked(this, _generalHeaders); } // special-cased to avoid forcing _generalHeaders initialization
             set { GeneralHeaders.TransferEncodingChunked = value; }
         }
 

--- a/src/System.Net.Http/src/System/Net/Http/Headers/HttpResponseHeaders.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/HttpResponseHeaders.cs
@@ -16,10 +16,10 @@ namespace System.Net.Http.Headers
         private static readonly HashSet<string> s_invalidHeaders = CreateInvalidHeaders();
 
         private const int AcceptRangesSlot = 0;
-        private const int WwwAuthenticateSlot = 1;
-        private const int ProxyAuthenticateSlot = 2;
-        private const int ServerSlot = 3;
-        private const int VarySlot = 4;
+        private const int ProxyAuthenticateSlot = 1;
+        private const int ServerSlot = 2;
+        private const int VarySlot = 3;
+        private const int WwwAuthenticateSlot = 4;
         private const int NumCollectionsSlots = 5;
 
         private object[] _specialCollectionsSlots;

--- a/src/System.Net.Http/src/System/Net/Http/Headers/HttpResponseHeaders.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/HttpResponseHeaders.cs
@@ -118,69 +118,67 @@ namespace System.Net.Http.Headers
 
         public CacheControlHeaderValue CacheControl
         {
-            get { return _generalHeaders.CacheControl; }
-            set { _generalHeaders.CacheControl = value; }
+            get { return GeneralHeaders.CacheControl; }
+            set { GeneralHeaders.CacheControl = value; }
         }
 
         public HttpHeaderValueCollection<string> Connection
         {
-            get { return _generalHeaders.Connection; }
+            get { return GeneralHeaders.Connection; }
         }
 
         public bool? ConnectionClose
         {
-            get { return _generalHeaders.ConnectionClose; }
-            set { _generalHeaders.ConnectionClose = value; }
+            get { return GeneralHeaders.ConnectionClose; }
+            set { GeneralHeaders.ConnectionClose = value; }
         }
 
         public DateTimeOffset? Date
         {
-            get { return _generalHeaders.Date; }
-            set { _generalHeaders.Date = value; }
+            get { return GeneralHeaders.Date; }
+            set { GeneralHeaders.Date = value; }
         }
 
         public HttpHeaderValueCollection<NameValueHeaderValue> Pragma
         {
-            get { return _generalHeaders.Pragma; }
+            get { return GeneralHeaders.Pragma; }
         }
 
         public HttpHeaderValueCollection<string> Trailer
         {
-            get { return _generalHeaders.Trailer; }
+            get { return GeneralHeaders.Trailer; }
         }
 
         public HttpHeaderValueCollection<TransferCodingHeaderValue> TransferEncoding
         {
-            get { return _generalHeaders.TransferEncoding; }
+            get { return GeneralHeaders.TransferEncoding; }
         }
 
         public bool? TransferEncodingChunked
         {
-            get { return _generalHeaders.TransferEncodingChunked; }
-            set { _generalHeaders.TransferEncodingChunked = value; }
+            get { return HttpGeneralHeaders.GetTransferEncodingChunked(this, _generalHeaders); } // special-cased to avoid forcing _generalHeaders initialization
+            set { GeneralHeaders.TransferEncodingChunked = value; }
         }
 
         public HttpHeaderValueCollection<ProductHeaderValue> Upgrade
         {
-            get { return _generalHeaders.Upgrade; }
+            get { return GeneralHeaders.Upgrade; }
         }
 
         public HttpHeaderValueCollection<ViaHeaderValue> Via
         {
-            get { return _generalHeaders.Via; }
+            get { return GeneralHeaders.Via; }
         }
 
         public HttpHeaderValueCollection<WarningHeaderValue> Warning
         {
-            get { return _generalHeaders.Warning; }
+            get { return GeneralHeaders.Warning; }
         }
 
         #endregion
 
         internal HttpResponseHeaders()
         {
-            _generalHeaders = new HttpGeneralHeaders(this);
-
             base.SetConfiguration(s_parserStore, s_invalidHeaders);
         }
 
@@ -236,7 +234,12 @@ namespace System.Net.Http.Headers
             Debug.Assert(sourceResponseHeaders != null);
 
             // Copy special values, but do not overwrite
-            _generalHeaders.AddSpecialsFrom(sourceResponseHeaders._generalHeaders);
+            if (sourceResponseHeaders._generalHeaders != null)
+            {
+                GeneralHeaders.AddSpecialsFrom(sourceResponseHeaders._generalHeaders);
+            }
         }
+
+        private HttpGeneralHeaders GeneralHeaders => _generalHeaders ?? (_generalHeaders = new HttpGeneralHeaders(this));
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/Headers/HttpResponseHeaders.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/HttpResponseHeaders.cs
@@ -15,27 +15,34 @@ namespace System.Net.Http.Headers
         private static readonly Dictionary<string, HttpHeaderParser> s_parserStore = CreateParserStore();
         private static readonly HashSet<string> s_invalidHeaders = CreateInvalidHeaders();
 
+        private const int AcceptRangesSlot = 0;
+        private const int WwwAuthenticateSlot = 1;
+        private const int ProxyAuthenticateSlot = 2;
+        private const int ServerSlot = 3;
+        private const int VarySlot = 4;
+        private const int NumCollectionsSlots = 5;
+
+        private object[] _specialCollectionsSlots;
         private HttpGeneralHeaders _generalHeaders;
-        private HttpHeaderValueCollection<string> _acceptRanges;
-        private HttpHeaderValueCollection<AuthenticationHeaderValue> _wwwAuthenticate;
-        private HttpHeaderValueCollection<AuthenticationHeaderValue> _proxyAuthenticate;
-        private HttpHeaderValueCollection<ProductInfoHeaderValue> _server;
-        private HttpHeaderValueCollection<string> _vary;
 
         #region Response Headers
 
-        public HttpHeaderValueCollection<string> AcceptRanges
+        private T GetSpecializedCollection<T>(int slot, Func<HttpResponseHeaders, T> creationFunc)
         {
-            get
+            // 5 properties each lazily allocate a collection to store the value(s) for that property.
+            // Rather than having a field for each of these, store them untyped in an array that's lazily
+            // allocated.  Then we only pay for the 45 bytes for those fields when any is actually accessed.
+            object[] collections = _specialCollectionsSlots ?? (_specialCollectionsSlots = new object[NumCollectionsSlots]);
+            object result = collections[slot];
+            if (result == null)
             {
-                if (_acceptRanges == null)
-                {
-                    _acceptRanges = new HttpHeaderValueCollection<string>(HttpKnownHeaderNames.AcceptRanges,
-                        this, HeaderUtilities.TokenValidator);
-                }
-                return _acceptRanges;
+                collections[slot] = result = creationFunc(this);
             }
+            return (T)result;
         }
+
+        public HttpHeaderValueCollection<string> AcceptRanges =>
+            GetSpecializedCollection(AcceptRangesSlot, thisRef => new HttpHeaderValueCollection<string>(HttpKnownHeaderNames.AcceptRanges, thisRef, HeaderUtilities.TokenValidator));
 
         public TimeSpan? Age
         {
@@ -55,18 +62,8 @@ namespace System.Net.Http.Headers
             set { SetOrRemoveParsedValue(HttpKnownHeaderNames.Location, value); }
         }
 
-        public HttpHeaderValueCollection<AuthenticationHeaderValue> ProxyAuthenticate
-        {
-            get
-            {
-                if (_proxyAuthenticate == null)
-                {
-                    _proxyAuthenticate = new HttpHeaderValueCollection<AuthenticationHeaderValue>(
-                        HttpKnownHeaderNames.ProxyAuthenticate, this);
-                }
-                return _proxyAuthenticate;
-            }
-        }
+        public HttpHeaderValueCollection<AuthenticationHeaderValue> ProxyAuthenticate =>
+            GetSpecializedCollection(ProxyAuthenticateSlot, thisRef => new HttpHeaderValueCollection<AuthenticationHeaderValue>(HttpKnownHeaderNames.ProxyAuthenticate, thisRef));
 
         public RetryConditionHeaderValue RetryAfter
         {
@@ -74,43 +71,14 @@ namespace System.Net.Http.Headers
             set { SetOrRemoveParsedValue(HttpKnownHeaderNames.RetryAfter, value); }
         }
 
-        public HttpHeaderValueCollection<ProductInfoHeaderValue> Server
-        {
-            get
-            {
-                if (_server == null)
-                {
-                    _server = new HttpHeaderValueCollection<ProductInfoHeaderValue>(HttpKnownHeaderNames.Server, this);
-                }
-                return _server;
-            }
-        }
+        public HttpHeaderValueCollection<ProductInfoHeaderValue> Server =>
+            GetSpecializedCollection(ServerSlot, thisRef => new HttpHeaderValueCollection<ProductInfoHeaderValue>(HttpKnownHeaderNames.Server, thisRef));
 
-        public HttpHeaderValueCollection<string> Vary
-        {
-            get
-            {
-                if (_vary == null)
-                {
-                    _vary = new HttpHeaderValueCollection<string>(HttpKnownHeaderNames.Vary,
-                        this, HeaderUtilities.TokenValidator);
-                }
-                return _vary;
-            }
-        }
+        public HttpHeaderValueCollection<string> Vary =>
+            GetSpecializedCollection(VarySlot, thisRef => new HttpHeaderValueCollection<string>(HttpKnownHeaderNames.Vary, thisRef, HeaderUtilities.TokenValidator));
 
-        public HttpHeaderValueCollection<AuthenticationHeaderValue> WwwAuthenticate
-        {
-            get
-            {
-                if (_wwwAuthenticate == null)
-                {
-                    _wwwAuthenticate = new HttpHeaderValueCollection<AuthenticationHeaderValue>(
-                        HttpKnownHeaderNames.WWWAuthenticate, this);
-                }
-                return _wwwAuthenticate;
-            }
-        }
+        public HttpHeaderValueCollection<AuthenticationHeaderValue> WwwAuthenticate =>
+            GetSpecializedCollection(WwwAuthenticateSlot, thisRef => new HttpHeaderValueCollection<AuthenticationHeaderValue>(HttpKnownHeaderNames.WWWAuthenticate, thisRef));
 
         #endregion
 

--- a/src/System.Net.Http/src/System/Net/Http/HttpRequestMessage.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpRequestMessage.cs
@@ -110,6 +110,8 @@ namespace System.Net.Http
             }
         }
 
+        internal bool HasHeaders => _headers != null;
+
         public IDictionary<String, Object> Properties
         {
             get

--- a/src/System.Net.Http/src/System/Net/Http/Managed/DecompressionHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/DecompressionHandler.cs
@@ -127,7 +127,10 @@ namespace System.Net.Http
                 }
             }
 
-            protected override async Task<Stream> CreateContentReadStreamAsync()
+            protected override Task<Stream> CreateContentReadStreamAsync() =>
+                CreateContentReadStreamValueAsync().AsTask();
+
+            internal override async ValueTask<Stream> CreateContentReadStreamValueAsync()
             {
                 if (_contentConsumed)
                 {
@@ -136,7 +139,8 @@ namespace System.Net.Http
 
                 _contentConsumed = true;
 
-                Stream originalStream = await _originalContent.ReadAsStreamAsync().ConfigureAwait(false);
+                ValueTask<Stream> vt = _originalContent.ReadAsStreamValueAsync();
+                Stream originalStream = vt.IsCompletedSuccessfully ? vt.Result : await vt.AsTask().ConfigureAwait(false);
                 return GetDecompressedStream(originalStream);
             }
 

--- a/src/System.Net.Http/src/System/Net/Http/Managed/DecompressionHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/DecompressionHandler.cs
@@ -127,10 +127,7 @@ namespace System.Net.Http
                 }
             }
 
-            protected override Task<Stream> CreateContentReadStreamAsync() =>
-                CreateContentReadStreamValueAsync().AsTask();
-
-            internal override async ValueTask<Stream> CreateContentReadStreamValueAsync()
+            protected override async Task<Stream> CreateContentReadStreamAsync()
             {
                 if (_contentConsumed)
                 {
@@ -139,8 +136,7 @@ namespace System.Net.Http
 
                 _contentConsumed = true;
 
-                ValueTask<Stream> vt = _originalContent.ReadAsStreamValueAsync();
-                Stream originalStream = vt.IsCompletedSuccessfully ? vt.Result : await vt.AsTask().ConfigureAwait(false);
+                Stream originalStream = _originalContent.TryReadAsStream() ?? await _originalContent.ReadAsStreamAsync().ConfigureAwait(false);
                 return GetDecompressedStream(originalStream);
             }
 

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
@@ -93,6 +93,9 @@ namespace System.Net.Http
             protected override Task<Stream> CreateContentReadStreamAsync() =>
                 Task.FromResult<Stream>(ConsumeStream());
 
+            internal override ValueTask<Stream> CreateContentReadStreamValueAsync() =>
+                new ValueTask<Stream>(ConsumeStream());
+
             protected override void Dispose(bool disposing)
             {
                 if (disposing)

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
@@ -579,21 +579,17 @@ namespace System.Net.Http
                 await WriteAsciiStringAsync(header.Key, cancellationToken).ConfigureAwait(false);
                 await WriteTwoBytesAsync((byte)':', (byte)' ', cancellationToken).ConfigureAwait(false);
 
-                bool first = true;
-                foreach (string headerValue in header.Value)
+                var values = (string[])header.Value; // typed as IEnumerable<string>, but always a string[]
+                Debug.Assert(values.Length > 0, "No values for header??");
+                if (values.Length > 0)
                 {
-                    if (first)
-                    {
-                        first = false;
-                    }
-                    else
+                    await WriteStringAsync(values[0], cancellationToken).ConfigureAwait(false);
+                    for (int i = 1; i < values.Length; i++)
                     {
                         await WriteTwoBytesAsync((byte)',', (byte)' ', cancellationToken).ConfigureAwait(false);
+                        await WriteStringAsync(values[i], cancellationToken).ConfigureAwait(false);
                     }
-                    await WriteStringAsync(headerValue, cancellationToken).ConfigureAwait(false);
                 }
-
-                Debug.Assert(!first, "No values for header??");
 
                 await WriteTwoBytesAsync((byte)'\r', (byte)'\n', cancellationToken).ConfigureAwait(false);
             }

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
@@ -862,7 +862,10 @@ namespace System.Net.Http
             await WriteBytesAsync(s_spaceHttp11NewlineAsciiBytes, cancellationToken).ConfigureAwait(false);
 
             // Write request headers
-            await WriteHeadersAsync(request.Headers, cancellationToken).ConfigureAwait(false);
+            if (request.HasHeaders)
+            {
+                await WriteHeadersAsync(request.Headers, cancellationToken).ConfigureAwait(false);
+            }
 
             if (requestContent == null)
             {
@@ -882,7 +885,7 @@ namespace System.Net.Http
 
             // Write special additional headers.  If a host isn't in the headers list, then a Host header
             // wasn't sent, so as it's required by HTTP 1.1 spec, send one based on the Request Uri.
-            if (request.Headers.Host == null)
+            if (!request.HasHeaders || request.Headers.Host == null)
             {
                 await WriteHostHeaderAsync(request.RequestUri, cancellationToken).ConfigureAwait(false);
             }

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
@@ -651,7 +651,7 @@ namespace System.Net.Http
 
             // Add headers to define content transfer, if not present
             if (requestContent != null &&
-                request.Headers.TransferEncodingChunked != true &&
+                (!request.HasHeaders || request.Headers.TransferEncodingChunked != true) &&
                 requestContent.Headers.ContentLength == null)
             {
                 // We have content, but neither Transfer-Encoding or Content-Length is set.
@@ -716,7 +716,7 @@ namespace System.Net.Http
             // Write body, if any
             if (requestContent != null)
             {
-                HttpContentWriteStream stream = (request.Headers.TransferEncodingChunked == true ?
+                HttpContentWriteStream stream = (request.HasHeaders && request.Headers.TransferEncodingChunked == true ?
                     (HttpContentWriteStream)new ChunkedEncodingWriteStream(this) : 
                     (HttpContentWriteStream)new ContentLengthWriteStream(this));
 

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnection.cs
@@ -93,8 +93,8 @@ namespace System.Net.Http
             protected override Task<Stream> CreateContentReadStreamAsync() =>
                 Task.FromResult<Stream>(ConsumeStream());
 
-            internal override ValueTask<Stream> CreateContentReadStreamValueAsync() =>
-                new ValueTask<Stream>(ConsumeStream());
+            internal override Stream TryCreateContentReadStream() =>
+                ConsumeStream();
 
             protected override void Dispose(bool disposing)
             {

--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionPool.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpConnectionPool.cs
@@ -3,18 +3,19 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 
 namespace System.Net.Http
 {
     internal sealed class HttpConnectionPool : IDisposable
     {
-        private readonly ConcurrentDictionary<HttpConnection, HttpConnection> _activeConnections;
+        private readonly ConcurrentConnectionSet _activeConnections;
         private readonly ConcurrentBag<HttpConnection> _idleConnections;
         private bool _disposed;
 
         public HttpConnectionPool()
         {
-            _activeConnections = new ConcurrentDictionary<HttpConnection, HttpConnection>();
+            _activeConnections = new ConcurrentConnectionSet();
             _idleConnections = new ConcurrentBag<HttpConnection>();
         }
 
@@ -23,7 +24,7 @@ namespace System.Net.Http
             HttpConnection connection;
             if (_idleConnections.TryTake(out connection))
             {
-                if (!_activeConnections.TryAdd(connection, connection))
+                if (!_activeConnections.TryAdd(connection))
                 {
                     throw new InvalidOperationException();
                 }
@@ -36,7 +37,7 @@ namespace System.Net.Http
 
         public void AddConnection(HttpConnection connection)
         {
-            if (!_activeConnections.TryAdd(connection, connection))
+            if (!_activeConnections.TryAdd(connection))
             {
                 throw new InvalidOperationException();
             }
@@ -44,8 +45,7 @@ namespace System.Net.Http
 
         public void PutConnection(HttpConnection connection)
         {
-            HttpConnection unused;
-            if (!_activeConnections.TryRemove(connection, out unused))
+            if (!_activeConnections.TryRemove(connection))
             {
                 throw new InvalidOperationException();
             }
@@ -59,7 +59,7 @@ namespace System.Net.Http
             {
                 _disposed = true;
 
-                foreach (HttpConnection connection in _activeConnections.Keys)
+                foreach (HttpConnection connection in _activeConnections.ToArray())
                 {
                     connection.Dispose();
                 }
@@ -68,6 +68,56 @@ namespace System.Net.Http
                 {
                     connection.Dispose();
                 }
+            }
+        }
+
+        private sealed class ConcurrentConnectionSet
+        {
+            private static readonly int s_numSlots = Math.Max(4, RoundUpToPowerOf2(Environment.ProcessorCount));
+            private static readonly int s_slotsMask = s_numSlots - 1;
+            private readonly HashSet<HttpConnection>[] _sets;
+
+            public ConcurrentConnectionSet()
+            {
+                _sets = new HashSet<HttpConnection>[s_numSlots];
+                for (int i = 0; i < _sets.Length; i++)
+                {
+                    _sets[i] = new HashSet<HttpConnection>();
+                }
+            }
+
+            public bool TryAdd(HttpConnection connection)
+            {
+                HashSet<HttpConnection> set = _sets[connection.GetHashCode() & s_slotsMask];
+                lock (set) return set.Add(connection);
+            }
+
+            public bool TryRemove(HttpConnection connection)
+            {
+                HashSet<HttpConnection> set = _sets[connection.GetHashCode() & s_slotsMask];
+                lock (set) return set.Remove(connection);
+            }
+
+            public HttpConnection[] ToArray()
+            {
+                var results = new List<HttpConnection>();
+                foreach (HashSet<HttpConnection> set in _sets)
+                {
+                    lock (set) results.AddRange(set);
+                }
+                return results.ToArray();
+            }
+
+            /// <summary>Round the specified value up to the next power of 2, if it isn't one already.</summary>
+            private static int RoundUpToPowerOf2(int i)
+            {
+                --i;
+                i |= i >> 1;
+                i |= i >> 2;
+                i |= i >> 4;
+                i |= i >> 8;
+                i |= i >> 16;
+                return i + 1;
             }
         }
     }

--- a/src/System.Net.Http/src/System/Net/Http/StreamContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/StreamContent.cs
@@ -93,6 +93,10 @@ namespace System.Net.Http
             return Task.FromResult<Stream>(new ReadOnlyStream(_content));
         }
 
+        internal override ValueTask<Stream> CreateContentReadStreamValueAsync() =>
+            GetType() == typeof(StreamContent) ? new ValueTask<Stream>(new ReadOnlyStream(_content)) :
+            base.CreateContentReadStreamValueAsync();
+
         private void PrepareContent()
         {
             if (_contentConsumed)

--- a/src/System.Net.Http/src/System/Net/Http/StreamContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/StreamContent.cs
@@ -93,9 +93,9 @@ namespace System.Net.Http
             return Task.FromResult<Stream>(new ReadOnlyStream(_content));
         }
 
-        internal override ValueTask<Stream> CreateContentReadStreamValueAsync() =>
-            GetType() == typeof(StreamContent) ? new ValueTask<Stream>(new ReadOnlyStream(_content)) :
-            base.CreateContentReadStreamValueAsync();
+        internal override Stream TryCreateContentReadStream() =>
+            GetType() == typeof(StreamContent) ? new ReadOnlyStream(_content) : // type check ensures we use possible derived type's CreateContentReadStreamAsync override
+            null;
 
         private void PrepareContent()
         {

--- a/src/System.Net.Http/src/System/Net/Http/StringContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/StringContent.cs
@@ -11,7 +11,7 @@ namespace System.Net.Http
 {
     public class StringContent : ByteArrayContent
     {
-        private const string defaultMediaType = "text/plain";
+        private const string DefaultMediaType = "text/plain";
 
         public StringContent(string content)
             : this(content, null, null)
@@ -27,7 +27,7 @@ namespace System.Net.Http
             : base(GetContentByteArray(content, encoding))
         {
             // Initialize the 'Content-Type' header with information provided by parameters. 
-            MediaTypeHeaderValue headerValue = new MediaTypeHeaderValue((mediaType == null) ? defaultMediaType : mediaType);
+            MediaTypeHeaderValue headerValue = new MediaTypeHeaderValue((mediaType == null) ? DefaultMediaType : mediaType);
             headerValue.CharSet = (encoding == null) ? HttpContent.DefaultStringEncoding.WebName : encoding.WebName;
 
             Headers.ContentType = headerValue;
@@ -53,8 +53,8 @@ namespace System.Net.Http
             return encoding.GetBytes(content);
         }
 
-        internal override ValueTask<Stream> CreateContentReadStreamValueAsync() =>
-            GetType() == typeof(StringContent) ? new ValueTask<Stream>(CreateMemoryStreamForByteArray()) :
-            base.CreateContentReadStreamValueAsync();
+        internal override Stream TryCreateContentReadStream() =>
+            GetType() == typeof(StringContent) ? CreateMemoryStreamForByteArray() : // type check ensures we use possible derived type's CreateContentReadStreamAsync override
+            null;
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/StringContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/StringContent.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.IO;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace System.Net.Http
 {
@@ -50,5 +52,9 @@ namespace System.Net.Http
 
             return encoding.GetBytes(content);
         }
+
+        internal override ValueTask<Stream> CreateContentReadStreamValueAsync() =>
+            GetType() == typeof(StringContent) ? new ValueTask<Stream>(CreateMemoryStreamForByteArray()) :
+            base.CreateContentReadStreamValueAsync();
     }
 }


### PR DESCRIPTION
Some of these changes are specific to ManagedHandler, while others are applicable to HttpClient in general.

ManagedHandler-specific:
- We currently write out a host header with a port number by converting the port to a string.  This changes it to just write out the digits directly without the intermediate string.
- HttpRequestHeaders is currently always allocated, even if it's never accessed by the developer code.
- Parsing the response very likely yields at least once, and currently it's a helper that's called from the main SendAsync.  It's easy to combine them and avoid the extra allocations from the extra async layer.
- We're going to need to revisit the connection pooling anyway, but for now I was seeing allocations related to the ConcurrentDictionary show up.  ConcurrentyDictionary is optimized for many-reads-fewer-writes, but this usage is entirely writes.  CD just does striped locking for writes internally, so I replaced it with a simple striped-lock-HashSet structure that doesn't allocate on every add.
- We're currently incurring an array enumerator allocation on every header being written out.  We can avoid that with a cast.

HttpClient-general:
- Currently GetStream/String/ByteArrayAsync all incur a task allocation for getting the response stream.  But in most cases, the stream is available promptly (it's the reads on the stream that are likely to be async).  We can employ ValueTask to minimize the need for this allocation.
- HttpRequestHeaders has 9 reference fields dedicated to specific lazily-allocated collection properties, and HttpResponseHeaders has 5.  That's 112 bytes of fields allocated per request on 64-bit that are often unneeded.  This puts them into a lazily-allocated array to make them more pay for play: they're a bit more expensive when used (the space for the array's overhead plus a cast on each use), but we avoid having to pay for the allocations for the fields when they're not used.

Both:
- Both HttpRequestHeader and HttpResponseHeader currently promptly allocate another wrapped HttpGeneralHeaders object, but this is only really necessary in the implementation when various strongly-typed properties are accessed.  We can make it lazily-allocated and more pay-for-play.  This changes the headers to be lazily-allocated, and then modifies the ManagedHandler to avoid accessing them unless necessary.

cc: @davidsh, @geoffkizer 