### PR TITLE
Disable failing Microsoft.VisualBasic tests on uapaot

### DIFF
--- a/src/Microsoft.VisualBasic/tests/OperatorsTests.cs
+++ b/src/Microsoft.VisualBasic/tests/OperatorsTests.cs
@@ -168,6 +168,7 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
 
         [Theory]
         [MemberData(nameof(AddObject_Idempotent_TestData))]
+        [ActiveIssue(21682, TargetFrameworkMonikers.UapAot)]
         public void AddObject_Convertible_ReturnsExpected(object left, object right, object expected)
         {
             Assert.Equal(expected, Operators.AddObject(left, right));
@@ -238,6 +239,7 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
 
         [Theory]
         [MemberData(nameof(IncompatibleAddObject_TestData))]
+        [ActiveIssue(21682, TargetFrameworkMonikers.UapAot)]
         public void AddObject_Incompatible_ThrowsInvalidCastException(object left, object right)
         {
             Assert.Throws<InvalidCastException>(() => Operators.AddObject(left, right));

--- a/src/Microsoft.VisualBasic/tests/UtilsTests.cs
+++ b/src/Microsoft.VisualBasic/tests/UtilsTests.cs
@@ -72,6 +72,7 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
         }
 
         [Fact]
+        [ActiveIssue(21682, TargetFrameworkMonikers.UapAot)]
         public void CopyArray_RankGreaterThanTwoAndNonMatchingBounds_ThrowsArrayTypeMismatchException()
         {
             Array array1 = Array.CreateInstance(typeof(int), new int[] { 1, 2, 3 }, new int[] { 2, 3, 4 });
@@ -81,6 +82,7 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
         }
 
         [Fact]
+        [ActiveIssue(21682, TargetFrameworkMonikers.UapAot)]
         public void CopyArray_NonMatchingBounds_ThrowsArgumentOutOfRangeException()
         {
             Array array1 = Array.CreateInstance(typeof(int), new int[] { 1, 2 }, new int[] { 2, 3 });


### PR DESCRIPTION
cc: @danmosemsft @VSadov @OmarTawfik @hughbe 

Now that the VisualBasic tests are executing succesfully again in uapaot, disabling 4 tests that were recently added which are failing on that platform. A couple of them throw PNSE so perhaps they should just be skipped, but others are being reflection blocked.