### PR TITLE
ensure test helper do not treat non-serial ports as serial ports (fix #21699)

### DIFF
--- a/src/System.IO.Ports/tests/Support/PortHelper.cs
+++ b/src/System.IO.Ports/tests/Support/PortHelper.cs
@@ -5,8 +5,8 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 
 namespace Legacy.Support
 {
@@ -67,9 +67,10 @@ namespace Legacy.Support
 
             if (retval != null)
             {
+                var serialRegex = new Regex(@"^COM\d{1,3}$");
                 foreach (string str in retval)
                 {
-                    if (str.Length > 3 && str.Length < 7 && str.StartsWith("COM") && str.Substring(3).All(c => char.IsDigit(c)))
+                    if (serialRegex.IsMatch(str))
                     {
                         ports.Add(str);
                         Debug.WriteLine("Installed serial ports :" + str);

--- a/src/System.IO.Ports/tests/Support/PortHelper.cs
+++ b/src/System.IO.Ports/tests/Support/PortHelper.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Runtime.InteropServices;
 
 namespace Legacy.Support
@@ -68,7 +69,7 @@ namespace Legacy.Support
             {
                 foreach (string str in retval)
                 {
-                    if (str.StartsWith("COM"))
+                    if (str.Length > 3 && str.Length < 7 && str.StartsWith("COM") && str.Substring(3).All(c => char.IsDigit(c)))
                     {
                         ports.Add(str);
                         Debug.WriteLine("Installed serial ports :" + str);


### PR DESCRIPTION
Ensures that only serial ports are identified as such by the test helper fixing issue #21699 