### PR TITLE
Fix missing .NET Core argument validation for PrivateFontCollection.AddFontFile

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/Text/PrivateFontCollection.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Text/PrivateFontCollection.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Globalization;
+using System.IO;
 
 namespace System.Drawing.Text
 {
@@ -56,6 +57,8 @@ namespace System.Drawing.Text
         /// </summary>
         public void AddFontFile(string filename)
         {
+            filename = Path.GetFullPath(filename);
+
             int status = SafeNativeMethods.Gdip.GdipPrivateAddFontFile(new HandleRef(this, _nativeFontCollection), filename);
             SafeNativeMethods.Gdip.CheckStatus(status);
 

--- a/src/System.Drawing.Common/src/System/Drawing/Text/PrivateFontCollection.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Text/PrivateFontCollection.cs
@@ -57,7 +57,7 @@ namespace System.Drawing.Text
         /// </summary>
         public void AddFontFile(string filename)
         {
-            filename = Path.GetFullPath(filename);
+            Path.GetFullPath(filename);
 
             int status = SafeNativeMethods.Gdip.GdipPrivateAddFontFile(new HandleRef(this, _nativeFontCollection), filename);
             SafeNativeMethods.Gdip.CheckStatus(status);


### PR DESCRIPTION
This is a cleaned up copy of the netfx source code.

However, is the whole `IntSecurity.DemandReadFileIO(filename)` stuff necessary

Or maybe I could just replace that with `filename = Path.GetFullPath(filename)` and delete `IntSecurity.cs`

Fixes #21558