### PR TITLE
Fix memory leaks if native exception is thrown in GDI+

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/Bitmap.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Bitmap.cs
@@ -176,16 +176,21 @@ namespace System.Drawing
             return FromGDIplus(bitmap);
         }
 
-        public static Bitmap FromResource(IntPtr hinstance, String bitmapName)
+        public static Bitmap FromResource(IntPtr hinstance, string bitmapName)
         {
             IntPtr bitmap;
             IntPtr name = Marshal.StringToHGlobalUni(bitmapName);
-
-            int status = SafeNativeMethods.Gdip.GdipCreateBitmapFromResource(new HandleRef(null, hinstance),
-                                                              new HandleRef(null, name),
-                                                              out bitmap);
-            Marshal.FreeHGlobal(name);
-            SafeNativeMethods.Gdip.CheckStatus(status);
+            try
+            {
+                int status = SafeNativeMethods.Gdip.GdipCreateBitmapFromResource(new HandleRef(null, hinstance),
+                                                                  new HandleRef(null, name),
+                                                                  out bitmap);
+                SafeNativeMethods.Gdip.CheckStatus(status);
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(name);
+            }
 
             return FromGDIplus(bitmap);
         }

--- a/src/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPath.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPath.cs
@@ -201,7 +201,6 @@ namespace System.Drawing.Drawing2D
                 try
                 {
                     IntPtr typesPtr = typesHandle.AddrOfPinnedObject();
-                    //IntPtr typesPtr = Marshal.AddrOfArrayElement(pathData.Types, IntPtr.Zero);
 
                     Marshal.StructureToPtr(numPts, memoryPathData, false);
                     Marshal.StructureToPtr(memoryPoints, (IntPtr)((long)memoryPathData + IntPtr.Size), false);

--- a/src/System.Drawing.Common/src/System/Drawing/Image.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Image.cs
@@ -409,14 +409,13 @@ namespace System.Drawing
                 return null;
 
             IntPtr buffer = Marshal.AllocHGlobal(size);
-
-            status = SafeNativeMethods.Gdip.GdipGetEncoderParameterList(new HandleRef(this, nativeImage),
-                                                         ref encoder,
-                                                         size,
-                                                         buffer);
-
             try
             {
+                status = SafeNativeMethods.Gdip.GdipGetEncoderParameterList(new HandleRef(this, nativeImage),
+                                                             ref encoder,
+                                                             size,
+                                                             buffer);
+
                 if (status != SafeNativeMethods.Gdip.Ok)
                 {
                     throw SafeNativeMethods.Gdip.StatusException(status);
@@ -870,11 +869,9 @@ namespace System.Drawing
             //    ARGB Entries[size]
 
             IntPtr memory = Marshal.AllocHGlobal(size);
-
-            status = SafeNativeMethods.Gdip.GdipGetImagePalette(new HandleRef(this, nativeImage), memory, size);
-
             try
             {
+                status = SafeNativeMethods.Gdip.GdipGetImagePalette(new HandleRef(this, nativeImage), memory, size);
                 if (status != SafeNativeMethods.Gdip.Ok)
                 {
                     throw SafeNativeMethods.Gdip.StatusException(status);
@@ -1090,10 +1087,9 @@ namespace System.Drawing
             if (propdata == IntPtr.Zero)
                 throw SafeNativeMethods.Gdip.StatusException(SafeNativeMethods.Gdip.OutOfMemory);
 
-            status = SafeNativeMethods.Gdip.GdipGetPropertyItem(new HandleRef(this, nativeImage), propid, size, propdata);
-
             try
             {
+                status = SafeNativeMethods.Gdip.GdipGetPropertyItem(new HandleRef(this, nativeImage), propid, size, propdata);
                 if (status != SafeNativeMethods.Gdip.Ok)
                 {
                     throw SafeNativeMethods.Gdip.StatusException(status);
@@ -1159,26 +1155,20 @@ namespace System.Drawing
                     return new PropertyItem[0];
 
                 IntPtr propdata = Marshal.AllocHGlobal(size);
-
-                status = SafeNativeMethods.Gdip.GdipGetAllPropertyItems(new HandleRef(this, nativeImage), size, count, propdata);
-
-                PropertyItem[] props = null;
-
                 try
                 {
+                    status = SafeNativeMethods.Gdip.GdipGetAllPropertyItems(new HandleRef(this, nativeImage), size, count, propdata);
                     if (status != SafeNativeMethods.Gdip.Ok)
                     {
                         throw SafeNativeMethods.Gdip.StatusException(status);
                     }
 
-                    props = PropertyItemInternal.ConvertFromMemory(propdata, count);
+                    return PropertyItemInternal.ConvertFromMemory(propdata, count);
                 }
                 finally
                 {
                     Marshal.FreeHGlobal(propdata);
                 }
-
-                return props;
             }
         }
 

--- a/src/System.Drawing.Common/src/System/Drawing/Pen.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Pen.cs
@@ -916,10 +916,9 @@ namespace System.Drawing
                 // and pass it to GDI+ to retrieve dash array elements
 
                 IntPtr buf = Marshal.AllocHGlobal(checked(4 * count));
-                status = SafeNativeMethods.Gdip.GdipGetPenDashArray(new HandleRef(this, NativePen), buf, count);
-
                 try
                 {
+                    status = SafeNativeMethods.Gdip.GdipGetPenDashArray(new HandleRef(this, NativePen), buf, count);
                     if (status != SafeNativeMethods.Gdip.Ok)
                     {
                         throw SafeNativeMethods.Gdip.StatusException(status);


### PR DESCRIPTION
The main one is Bitmap.FromResource will always throw a DLLNotFoundException on Nano, for example.

The other cases are unlikely to throw unless a DLL was deleted or something went badly wrong causing exceptions. However, it's good to be safe.

In these situations, if a native exception is thrown, then the allocated memory will not be freed, which I believe is a memory leak.