### PR TITLE
Move ManagedWebSocket from System.Net.WebSockets.Client to System.Net.WebSockets

### DIFF
--- a/src/Common/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/Common/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -193,8 +193,9 @@ namespace System.Net.WebSockets
             // If we were provided with a buffer to use, use it, as long as it's big enough for our needs, and for simplicity
             // as long as we're not supposed to use only a portion of it.  If it doesn't meet our criteria, just create a new one.
             if (receiveBuffer.HasValue &&
-                receiveBuffer.Value.Offset == 0 && receiveBuffer.Value.Count == receiveBuffer.Value.Array.Length &&
-                receiveBuffer.Value.Count >= MaxMessageHeaderLength)
+                receiveBuffer.GetValueOrDefault().Array != null &&
+                receiveBuffer.GetValueOrDefault().Offset == 0 && receiveBuffer.GetValueOrDefault().Count == receiveBuffer.GetValueOrDefault().Array.Length &&
+                receiveBuffer.GetValueOrDefault().Count >= MaxMessageHeaderLength)
             {
                 _receiveBuffer = receiveBuffer.Value.Array;
             }
@@ -1148,7 +1149,7 @@ namespace System.Net.WebSockets
                         // being closed and that was expected, exit gracefully.
                         if (_disposed)
                         {
-                            throw new ObjectDisposedException(nameof(ClientWebSocket));
+                            throw new ObjectDisposedException(nameof(WebSocket));
                         }
                         else if (throwOnPrematureClosure)
                         {

--- a/src/Common/src/System/Net/WebSockets/WebSocketValidate.cs
+++ b/src/Common/src/System/Net/WebSockets/WebSocketValidate.cs
@@ -30,7 +30,7 @@ namespace System.Net.WebSockets
                         // Ordering is important to maintain .NET 4.5 WebSocket implementation exception behavior.
                         if (isDisposed)
                         {
-                            throw new ObjectDisposedException(nameof(ClientWebSocket));
+                            throw new ObjectDisposedException(nameof(WebSocket));
                         }
 
                         return;

--- a/src/System.Net.WebSockets.Client/src/System.Net.WebSockets.Client.csproj
+++ b/src/System.Net.WebSockets.Client/src/System.Net.WebSockets.Client.csproj
@@ -92,9 +92,6 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
     <Compile Include="System\Net\WebSockets\WebSocketHandle.Managed.cs" />
-    <Compile Include="$(CommonPath)\System\Net\WebSockets\ManagedWebSocket.cs">
-      <Link>Common\System\Net\WebSockets\ManagedWebSocket.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\System\StringExtensions.cs">
       <Link>Common\System\StringExtensions.cs</Link>
     </Compile>

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Managed.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Managed.cs
@@ -31,7 +31,7 @@ namespace System.Net.WebSockets
 
         private readonly CancellationTokenSource _abortSource = new CancellationTokenSource();
         private WebSocketState _state = WebSocketState.Connecting;
-        private ManagedWebSocket _webSocket;
+        private WebSocket _webSocket;
 
         public static WebSocketHandle Create() => new WebSocketHandle();
 
@@ -109,8 +109,8 @@ namespace System.Net.WebSockets
                 // Parse the response and store our state for the remainder of the connection
                 string subprotocol = await ParseAndValidateConnectResponseAsync(stream, options, secKeyAndSecWebSocketAccept.Value, cancellationToken).ConfigureAwait(false);
 
-                _webSocket = ManagedWebSocket.CreateFromConnectedStream(
-                    stream, false, subprotocol, options.KeepAliveInterval, options.ReceiveBufferSize, options.Buffer);
+                _webSocket = WebSocket.CreateClientWebSocket(
+                    stream, subprotocol, options.ReceiveBufferSize, options.SendBufferSize, options.KeepAliveInterval, false, options.Buffer.GetValueOrDefault());
 
                 // If a concurrent Abort or Dispose came in before we set _webSocket, make sure to update it appropriately
                 if (_state == WebSocketState.Aborted)

--- a/src/System.Net.WebSockets/src/Resources/Strings.resx
+++ b/src/System.Net.WebSockets/src/Resources/Strings.resx
@@ -91,4 +91,34 @@
   <data name="net_WebSockets_ArgumentOutOfRange_TooSmall" xml:space="preserve">
     <value>The argument must be a value greater than {0}.</value>
   </data>
+  <data name="net_WebSockets_InvalidEmptySubProtocol" xml:space="preserve">
+    <value>Empty string is not a valid subprotocol value. Please use \"null\" to specify no value.</value>
+  </data>
+  <data name="net_WebSockets_InvalidCharInProtocolString" xml:space="preserve">
+    <value>The WebSocket protocol '{0}' is invalid because it contains the invalid character '{1}'.</value>
+  </data>
+  <data name="net_WebSockets_ReasonNotNull" xml:space="preserve">
+    <value>The close status description '{0}' is invalid. When using close status code '{1}' the description must be null.</value>
+  </data>
+  <data name="net_WebSockets_InvalidCloseStatusCode" xml:space="preserve">
+    <value>The close status code '{0}' is reserved for system use only and cannot be specified when calling this method.</value>
+  </data>
+  <data name="net_WebSockets_InvalidCloseStatusDescription" xml:space="preserve">
+    <value>The close status description '{0}' is too long. The UTF8-representation of the status description must not be longer than {1} bytes.</value>
+  </data>
+  <data name="net_WebSockets_UnsupportedPlatform" xml:space="preserve">
+    <value>The WebSocket protocol is not supported on this platform.</value>
+  </data>
+  <data name="net_WebSockets_Argument_InvalidMessageType" xml:space="preserve">
+    <value>The message type '{0}' is not allowed for the '{1}' operation. Valid message types are: '{2}, {3}'. To close the WebSocket, use the '{4}' operation instead. </value>
+  </data>
+  <data name="net_Websockets_AlreadyOneOutstandingOperation" xml:space="preserve">
+    <value>There is already one outstanding '{0}' call for this WebSocket instance. ReceiveAsync and SendAsync can be called simultaneously, but at most one outstanding operation for each of them is allowed at the same time.</value>
+  </data>
+  <data name="NotReadableStream" xml:space="preserve">
+    <value>The base stream is not readable.</value>
+  </data>
+  <data name="NotWriteableStream" xml:space="preserve">
+    <value>The base stream is not writeable.</value>
+  </data>
 </root>

--- a/src/System.Net.WebSockets/src/System.Net.WebSockets.csproj
+++ b/src/System.Net.WebSockets/src/System.Net.WebSockets.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <ProjectGuid>{B0C83201-EC32-4E8D-9DE4-EEF41E052DA1}</ProjectGuid>
     <AssemblyName>System.Net.WebSockets</AssemblyName>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
@@ -18,18 +19,31 @@
     <Compile Include="System\Net\WebSockets\WebSocketMessageType.cs" />
     <Compile Include="System\Net\WebSockets\WebSocketReceiveResult.cs" />
     <Compile Include="System\Net\WebSockets\WebSocketState.cs" />
+    <Compile Include="$(CommonPath)\System\Net\WebSockets\ManagedWebSocket.cs">
+      <Link>Common\System\Net\WebSockets\ManagedWebSocket.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\WebSockets\WebSocketValidate.cs">
+      <Link>Common\System\Net\WebSockets\WebSocketValidate.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Win32.Primitives" />
+    <Reference Include="System.Buffers" />
     <Reference Include="System.Collections.Specialized" />
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.Diagnostics.Tools" />
     <Reference Include="System.Net.Primitives" />
+    <Reference Include="System.Numerics.Vectors" />
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Runtime.InteropServices" />
+    <Reference Include="System.Security.Cryptography.Algorithms" />
     <Reference Include="System.Security.Principal" />
+    <Reference Include="System.Text.Encoding.Extensions" />
+    <Reference Include="System.Threading" />
+    <Reference Include="System.Threading.Tasks" />
+    <Reference Include="System.Threading.Timer" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Net.WebSockets/tests/WebSocketTests.cs
+++ b/src/System.Net.WebSockets/tests/WebSocketTests.cs
@@ -69,12 +69,23 @@ namespace System.Net.WebSockets.Tests
             Assert.InRange(buffer.Count, size, int.MaxValue);
         }
 
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         [Fact]
-        public static void CreateClientWebSocket_Unsupported()
+        public static void CreateClientWebSocket_InvalidArguments_Throws()
         {
-            Assert.Throws<PlatformNotSupportedException>(() =>
-                WebSocket.CreateClientWebSocket(new MemoryStream(), "", 256, 16, TimeSpan.FromSeconds(30), false, new ArraySegment<byte>(new byte[64 * 1024])));
+            Assert.Throws<ArgumentNullException>(() => WebSocket.CreateClientWebSocket(
+                null, "subProtocol", 16480, 9856, TimeSpan.FromSeconds(30), false, WebSocket.CreateClientBuffer(16480, 9856)));
+
+            Assert.Throws<ArgumentException>(() => WebSocket.CreateClientWebSocket(
+                new MemoryStream(), "    ", 16480, 9856, TimeSpan.FromSeconds(30), false, WebSocket.CreateClientBuffer(16480, 9856)));
+            Assert.Throws<ArgumentException>(() => WebSocket.CreateClientWebSocket(
+                new MemoryStream(), "\xFF", 16480, 9856, TimeSpan.FromSeconds(30), false, WebSocket.CreateClientBuffer(16480, 9856)));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => WebSocket.CreateClientWebSocket(
+                new MemoryStream(), "subProtocol", 0, 9856, TimeSpan.FromSeconds(30), false, WebSocket.CreateClientBuffer(16480, 9856)));
+            Assert.Throws<ArgumentOutOfRangeException>(() => WebSocket.CreateClientWebSocket(
+                new MemoryStream(), "subProtocol", 16480, 0, TimeSpan.FromSeconds(30), false, WebSocket.CreateClientBuffer(16480, 9856)));
+            Assert.Throws<ArgumentOutOfRangeException>(() => WebSocket.CreateClientWebSocket(
+                new MemoryStream(), "subProtocol", 16480, 9856, TimeSpan.FromSeconds(-2), false, WebSocket.CreateClientBuffer(16480, 9856)));
         }
 
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]


### PR DESCRIPTION
Contributes to https://github.com/dotnet/corefx/issues/21537.  Regardless of which path we take for that issue, we'll want the managed implementation built into the System.Net.WebSockets.dll assembly.  This PR moves it down from System.Net.WebSockets.Client, and changes ClientWebSocket on Unix to use the ManagedWebSocket via the existing CreateClientWebSocket method (which we can leave implemented like this regardless of what path we take for adding an additional API).

cc: @davidsh, @cipop, @anurse, @geoffkizer, @Priya91 