### PR TITLE
Tracking ETW UAP test failures against a single issue. Global mutex is not supported in UAP.

### DIFF
--- a/src/Common/tests/System/Net/Configuration.Certificates.cs
+++ b/src/Common/tests/System/Net/Configuration.Certificates.cs
@@ -26,7 +26,7 @@ namespace System.Net.Test.Common
             {
                 if (PlatformDetection.IsUap)
                 {
-                    // TODO: dotnet/coreclr#11306
+                    // UWP doesn't support Global mutexes.
                     m = new Mutex(false, "Local\\CoreFXTest.Configuration.Certificates.LoadPfxCertificate");
                 }
                 else

--- a/src/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
@@ -19,7 +19,8 @@ namespace System.Net.Http.Functional.Tests
 {
     using Configuration = System.Net.Test.Common.Configuration;
 
-    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap | TargetFrameworkMonikers.NetFramework, "uap: dotnet/corefx #20010, netfx: .NET Core specific diagnostic test")]
+    [ActiveIssue(20470, TargetFrameworkMonikers.UapAot)]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core.")]
     public class DiagnosticsTest : RemoteExecutorTestBase
     {
         [Fact]

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientEKUTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientEKUTest.cs
@@ -15,6 +15,7 @@ namespace System.Net.Http.Functional.Tests
 {
     using Configuration = System.Net.Test.Common.Configuration;
 
+    [ActiveIssue(21738, TargetFrameworkMonikers.Uap)] // If Capability.IsTrustedRootCertificateInstalled()==true, the tests are hanging.
     public class HttpClientEKUTest
     {
         // Curl + OSX SecureTransport doesn't support the custom certificate callback.

--- a/src/System.Net.Mail/tests/Functional/LoggingTest.cs
+++ b/src/System.Net.Mail/tests/Functional/LoggingTest.cs
@@ -12,7 +12,8 @@ namespace System.Net.Mail.Tests
     public class LoggingTest : RemoteExecutorTestBase
     {
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework | TargetFrameworkMonikers.UapAot, "NetEventSource is only part of .NET Core. Cannot run on Aot: this test requires internal framework Reflection.")]
+        [ActiveIssue(20470, TargetFrameworkMonikers.UapAot)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core.")]
         public void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(SmtpClient).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);
@@ -24,9 +25,9 @@ namespace System.Net.Mail.Tests
             Assert.NotEmpty(EventSource.GenerateManifest(esType, esType.Assembly.Location));
         }
 
-        [ActiveIssue(20131, TargetFrameworkMonikers.Uap)]
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core")]
+        [ActiveIssue(20470, TargetFrameworkMonikers.UapAot)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core.")]
         public void EventSource_EventsRaisedAsExpected()
         {
             RemoteInvoke(() =>

--- a/src/System.Net.NameResolution/tests/FunctionalTests/LoggingTest.cs
+++ b/src/System.Net.NameResolution/tests/FunctionalTests/LoggingTest.cs
@@ -11,7 +11,8 @@ namespace System.Net.NameResolution.Tests
     public static class LoggingTest
     {
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework | TargetFrameworkMonikers.UapAot, "NetEventSource is only part of .NET Core and requires internal Reflection.")]
+        [ActiveIssue(20470, TargetFrameworkMonikers.UapAot)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core.")]
         public static void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(Dns).GetTypeInfo().Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/LoggingTest.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/LoggingTest.cs
@@ -10,8 +10,8 @@ namespace System.Net.NetworkInformation.Tests
     public class LoggingTest
     {
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core")]
         [ActiveIssue(20470, TargetFrameworkMonikers.UapAot)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core.")]
         public void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(NetworkChange).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);

--- a/src/System.Net.Ping/tests/FunctionalTests/LoggingTest.cs
+++ b/src/System.Net.Ping/tests/FunctionalTests/LoggingTest.cs
@@ -10,8 +10,8 @@ namespace System.Net.NetworkInformation.Tests
     public class LoggingTest
     {
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core")]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/20130", TargetFrameworkMonikers.Uap)]
+        [ActiveIssue(20470, TargetFrameworkMonikers.UapAot)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core.")]
         public void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(Ping).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);

--- a/src/System.Net.Primitives/tests/FunctionalTests/LoggingTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/LoggingTest.cs
@@ -12,7 +12,8 @@ namespace System.Net.Primitives.Functional.Tests
     public class LoggingTest : RemoteExecutorTestBase
     {
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework | TargetFrameworkMonikers.UapAot, "NetEventSource is only part of .NET Core and requires internal Reflection")]
+        [ActiveIssue(20470, TargetFrameworkMonikers.UapAot)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core.")]
         public void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(IPAddress).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);
@@ -26,7 +27,7 @@ namespace System.Net.Primitives.Functional.Tests
 
         [Fact]
         [ActiveIssue(20470, TargetFrameworkMonikers.UapAot)]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetFramework: NetEventSource is only part of .NET Core;")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core.")]
         public void EventSource_EventsRaisedAsExpected()
         {
             RemoteInvoke(() =>

--- a/src/System.Net.Requests/tests/LoggingTest.cs
+++ b/src/System.Net.Requests/tests/LoggingTest.cs
@@ -10,8 +10,8 @@ namespace System.Net.Tests
     public class LoggingTest
     {
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core")]
-        [ActiveIssue(20136, TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue(20470, TargetFrameworkMonikers.UapAot)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core.")]
         public void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(WebRequest).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);

--- a/src/System.Net.Security/tests/FunctionalTests/LoggingTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/LoggingTest.cs
@@ -12,7 +12,8 @@ namespace System.Net.Security.Tests
     public class LoggingTest : RemoteExecutorTestBase
     {
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework | TargetFrameworkMonikers.UapAot, "NetEventSource is only part of .NET Core")]
+        [ActiveIssue(20470, TargetFrameworkMonikers.UapAot)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core.")]
         public void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(SslStream).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);
@@ -26,7 +27,7 @@ namespace System.Net.Security.Tests
 
         [Fact]
         [ActiveIssue(20470, TargetFrameworkMonikers.UapAot)]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core.")]
         public void EventSource_EventsRaisedAsExpected()
         {
             RemoteInvoke(() =>

--- a/src/System.Net.Sockets/tests/FunctionalTests/LoggingTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/LoggingTest.cs
@@ -13,8 +13,8 @@ namespace System.Net.Sockets.Tests
     public class LoggingTest : RemoteExecutorTestBase
     {
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core")]
         [ActiveIssue(20470, TargetFrameworkMonikers.UapAot)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core.")]
         public static void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(Socket).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);
@@ -28,8 +28,8 @@ namespace System.Net.Sockets.Tests
 
         [OuterLoop]
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core")]
-        [ActiveIssue(21391, TargetFrameworkMonikers.UapAot)]
+        [ActiveIssue(20470, TargetFrameworkMonikers.UapAot)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core.")]
         public void EventSource_EventsRaisedAsExpected()
         {
             RemoteInvoke(() =>

--- a/src/System.Net.WebSockets.Client/tests/LoggingTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/LoggingTest.cs
@@ -10,9 +10,9 @@ namespace System.Net.WebSockets.Tests
 {
     public class LoggingTest
     {
-        [ActiveIssue(20132, TargetFrameworkMonikers.Uap)]
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core")]
+        [ActiveIssue(20470, TargetFrameworkMonikers.UapAot)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core.")]
         public void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(ClientWebSocket).GetTypeInfo().Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);


### PR DESCRIPTION
- Removing Global mutex bug# - it will not be supported in UAP.
- Tracking all ETW UAP tests failures against a single issue.
