### PR TITLE
[release/2.0] Port HighSierra crypto fixes

### DIFF
--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_symmetric.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_symmetric.cpp
@@ -131,6 +131,10 @@ extern "C" int32_t AppleCryptoNative_CryptorReset(CCCryptorRef cryptor, const ui
     if (cryptor == nullptr)
         return -1;
 
+    // 10.13 Beta reports an error when resetting ECB, which is the only mode which has a null IV.
+    if (pbIv == nullptr)
+        return 1;
+
     CCStatus status = CCCryptorReset(cryptor, pbIv);
     *pccStatus = status;
     return status == kCCSuccess;

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509chain.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509chain.cpp
@@ -174,7 +174,12 @@ static void MergeStatusCodes(CFTypeRef key, CFTypeRef value, void* context)
         // (On Windows CERT_CHAIN_PARA.pStrongSignPara is NULL, so "strongness" checks
         // are not performed).
     }
-
+    else if (CFEqual(keyString, CFSTR("StatusCodes")))
+    {
+        // 10.13 added a StatusCodes value which may be a numeric rehashing of the string data.
+        // It doesn't represent a new error code, and we're still getting the old ones, so
+        // just ignore it for now.
+    }
     else
     {
 #ifdef DEBUGGING_UNKNOWN_VALUE


### PR DESCRIPTION
Port the bugfixes for crypto on macOS High Sierra from https://github.com/dotnet/corefx/pull/21631.

Since the disabled test didn't eliminate the segfault in test execution it isn't being backported with this PR.