### PR TITLE
[release/1.1] Address kCCUnimplemented in CCCryptoReset for ECB

### DIFF
--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_symmetric.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_symmetric.cpp
@@ -128,6 +128,10 @@ extern "C" int AppleCryptoNative_CryptorReset(CCCryptorRef cryptor, const uint8_
     if (cryptor == nullptr)
         return -1;
 
+    // 10.13 Beta reports an error when resetting ECB, which is the only mode which has a null IV.
+    if (pbIv == nullptr)
+        return 1;
+
     CCStatus status = CCCryptorReset(cryptor, pbIv);
     *pccStatus = status;
     return status == kCCSuccess;


### PR DESCRIPTION
Backport from https://github.com/dotnet/corefx/pull/21631.  This commit is the only one relevant to the 1.1 release.