### PR TITLE
Enable a bunch of ManagedHandler tests

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Managed/ManagedHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/ManagedHandler.cs
@@ -287,9 +287,10 @@ namespace System.Net.Http
                 _checkCertificateRevocationList,
                 _sslProtocols);
 
-            if (_useProxy && _proxy != null)
+            if ((_useProxy && _proxy != null) ||
+                HttpProxyConnectionHandler.EnvironmentProxyConfigured)
             {
-                handler = new HttpProxyConnectionHandler(_proxy, handler);
+                handler = new HttpProxyConnectionHandler(_useProxy ? _proxy : null, handler);
             }
 
             if (_credentials != null)

--- a/src/System.Net.Http/src/System/Net/Http/Managed/ManagedHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/ManagedHandler.cs
@@ -290,7 +290,7 @@ namespace System.Net.Http
             if ((_useProxy && _proxy != null) ||
                 HttpProxyConnectionHandler.EnvironmentProxyConfigured)
             {
-                handler = new HttpProxyConnectionHandler(_useProxy ? _proxy : null, handler);
+                handler = new HttpProxyConnectionHandler(_useProxy ? _proxy : null, _defaultProxyCredentials, handler);
             }
 
             if (_credentials != null)

--- a/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
@@ -28,58 +28,58 @@ namespace System.Net.Http.Functional.Tests
         public static void SetEnvVar() => Environment.SetEnvironmentVariable(ManagedHandlerEnvVar, "true");
         public static void RemoveEnvVar() => Environment.SetEnvironmentVariable(ManagedHandlerEnvVar, null);
     }
+    
+    public sealed class ManagedHandler_HttpClientTest : HttpClientTest, IDisposable
+    {
+        public ManagedHandler_HttpClientTest() => ManagedHandlerTestHelpers.SetEnvVar();
+        public void Dispose() => ManagedHandlerTestHelpers.RemoveEnvVar();
+    }
+
+    public sealed class ManagedHandler_DiagnosticsTest : DiagnosticsTest, IDisposable
+    {
+        public ManagedHandler_DiagnosticsTest() => ManagedHandlerTestHelpers.SetEnvVar();
+        public new void Dispose()
+        {
+            ManagedHandlerTestHelpers.RemoveEnvVar();
+            base.Dispose();
+        }
+    }
+
+    public sealed class ManagedHandler_HttpClientEKUTest : HttpClientEKUTest, IDisposable
+    {
+        public ManagedHandler_HttpClientEKUTest() => ManagedHandlerTestHelpers.SetEnvVar();
+        public void Dispose() => ManagedHandlerTestHelpers.RemoveEnvVar();
+    }
+
+    public sealed class ManagedHandler_HttpClientHandler_DangerousAcceptAllCertificatesValidator_Test : HttpClientHandler_DangerousAcceptAllCertificatesValidator_Test, IDisposable
+    {
+        public ManagedHandler_HttpClientHandler_DangerousAcceptAllCertificatesValidator_Test() => ManagedHandlerTestHelpers.SetEnvVar();
+        public void Dispose() => ManagedHandlerTestHelpers.RemoveEnvVar();
+    }
+
+    public sealed class ManagedHandler_HttpClientHandler_ClientCertificates_Test : HttpClientHandler_ClientCertificates_Test, IDisposable
+    {
+        public ManagedHandler_HttpClientHandler_ClientCertificates_Test() => ManagedHandlerTestHelpers.SetEnvVar();
+        public void Dispose() => ManagedHandlerTestHelpers.RemoveEnvVar();
+    }
+
+    public sealed class ManagedHandler_HttpClientHandler_DefaultProxyCredentials_Test : HttpClientHandler_DefaultProxyCredentials_Test, IDisposable
+    {
+        public ManagedHandler_HttpClientHandler_DefaultProxyCredentials_Test() => ManagedHandlerTestHelpers.SetEnvVar();
+        public new void Dispose()
+        {
+            ManagedHandlerTestHelpers.RemoveEnvVar();
+            base.Dispose();
+        }
+    }
+
+    public sealed class ManagedHandler_HttpClientHandler_MaxConnectionsPerServer_Test : HttpClientHandler_MaxConnectionsPerServer_Test, IDisposable
+    {
+        public ManagedHandler_HttpClientHandler_MaxConnectionsPerServer_Test() => ManagedHandlerTestHelpers.SetEnvVar();
+        public void Dispose() => ManagedHandlerTestHelpers.RemoveEnvVar();
+    }
 
     // TODO: Uncomment once tests are fixed
-
-    //public sealed class ManagedHandler_HttpClientTest : HttpClientTest, IDisposable
-    //{
-    //    public ManagedHandler_HttpClientTest() => ManagedHandlerTestHelpers.SetEnvVar();
-    //    public void Dispose() => ManagedHandlerTestHelpers.RemoveEnvVar();
-    //}
-
-    //public sealed class ManagedHandler_DiagnosticsTest : DiagnosticsTest, IDisposable
-    //{
-    //    public ManagedHandler_DiagnosticsTest() => ManagedHandlerTestHelpers.SetEnvVar();
-    //    public new void Dispose()
-    //    {
-    //        ManagedHandlerTestHelpers.RemoveEnvVar();
-    //        base.Dispose();
-    //    }
-    //}
-
-    //public sealed class ManagedHandler_HttpClientEKUTest : HttpClientEKUTest, IDisposable
-    //{
-    //    public ManagedHandler_HttpClientEKUTest() => ManagedHandlerTestHelpers.SetEnvVar();
-    //    public void Dispose() => ManagedHandlerTestHelpers.RemoveEnvVar();
-    //}
-
-    //public sealed class ManagedHandler_HttpClientHandler_DangerousAcceptAllCertificatesValidator_Test : HttpClientHandler_DangerousAcceptAllCertificatesValidator_Test, IDisposable
-    //{
-    //    public ManagedHandler_HttpClientHandler_DangerousAcceptAllCertificatesValidator_Test() => ManagedHandlerTestHelpers.SetEnvVar();
-    //    public void Dispose() => ManagedHandlerTestHelpers.RemoveEnvVar();
-    //}
-
-    //public sealed class ManagedHandler_HttpClientHandler_ClientCertificates_Test : HttpClientHandler_ClientCertificates_Test, IDisposable
-    //{
-    //    public ManagedHandler_HttpClientHandler_ClientCertificates_Test() => ManagedHandlerTestHelpers.SetEnvVar();
-    //    public void Dispose() => ManagedHandlerTestHelpers.RemoveEnvVar();
-    //}
-
-    //public sealed class ManagedHandler_HttpClientHandler_DefaultProxyCredentials_Test : HttpClientHandler_DefaultProxyCredentials_Test, IDisposable
-    //{
-    //    public ManagedHandler_HttpClientHandler_DefaultProxyCredentials_Test() => ManagedHandlerTestHelpers.SetEnvVar();
-    //    public new void Dispose()
-    //    {
-    //        ManagedHandlerTestHelpers.RemoveEnvVar();
-    //        base.Dispose();
-    //    }
-    //}
-
-    //public sealed class ManagedHandler_HttpClientHandler_MaxConnectionsPerServer_Test : HttpClientHandler_MaxConnectionsPerServer_Test, IDisposable
-    //{
-    //    public ManagedHandler_HttpClientHandler_MaxConnectionsPerServer_Test() => ManagedHandlerTestHelpers.SetEnvVar();
-    //    public void Dispose() => ManagedHandlerTestHelpers.RemoveEnvVar();
-    //}
 
     //public sealed class ManagedHandler_HttpClientHandler_SslProtocols_Test : HttpClientHandler_SslProtocols_Test, IDisposable
     //{


### PR DESCRIPTION
Required a few fixes:
- libcurl respects the http_proxy environment variable, and we had a test verifying that. I added basic support for this, but we'll want to go back and add some additional support.
- DefaultProxyCredentials were being ignored.

cc: @geoffkizer 