### PR TITLE
UWP ClientWebSocket.ReceiveAsync returns partial message data as it arrives

### DIFF
--- a/src/Common/tests/System/PlatformDetection.cs
+++ b/src/Common/tests/System/PlatformDetection.cs
@@ -47,8 +47,6 @@ namespace System
 
         public static int WindowsVersion => GetWindowsVersion();
 
-        public static int WindowsBuildNumber => GetWindowsBuildNumber();
-
         public static bool IsNetfx462OrNewer()
         {
             if (!IsFullFramework)

--- a/src/Common/tests/System/PlatformDetection.cs
+++ b/src/Common/tests/System/PlatformDetection.cs
@@ -47,6 +47,8 @@ namespace System
 
         public static int WindowsVersion => GetWindowsVersion();
 
+        public static int WindowsBuildNumber => GetWindowsBuildNumber();
+
         public static bool IsNetfx462OrNewer()
         {
             if (!IsFullFramework)

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinRTWebSocket.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinRTWebSocket.cs
@@ -662,25 +662,7 @@ namespace System.Net.WebSockets
                 "ReceiveMode");
         }
 
-        // Regardless of whether we're running on a machine that supports this WinRT API, we still might not be able
-        // to call the API. This is due to the calling app being compiled against an older Windows 10 Tools SDK. Since
-        // this library was compiled against the newer SDK, having these new API calls in this class will cause JIT
-        // failures in CoreCLR which generate a MissingMethodException before the code actually runs. So, we need
-        // these helper methods and try/catch handling.
         private void InitMessageWebSocketReceiveMode(MessageWebSocket socket)
-        {
-            try
-            {
-                InitMessageWebSocketReceiveModeHelper(socket);
-            }
-            catch (MissingMethodException)
-            {
-                Debug.WriteLine("WinRTWebSocket.InitMessageWebSocketReceiveMode: MissingMethodException");
-            }
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private void InitMessageWebSocketReceiveModeHelper(MessageWebSocket socket)
         {
             // Always enable partial message receive mode if the WinRT API supports it.
             if (MessageWebSocketReceiveModeSupported)
@@ -689,29 +671,7 @@ namespace System.Net.WebSockets
             }
         }
 
-        // Regardless of whether we're running on a machine that supports this WinRT API, we still might not be able
-        // to call the API. This is due to the calling app being compiled against an older Windows 10 Tools SDK. Since
-        // this library was compiled against the newer SDK, having these new API calls in this class will cause JIT
-        // failures in CoreCLR which generate a MissingMethodException before the code actually runs. So, we need
-        // these helper methods and try/catch handling.
         private bool IsPartialMessageEvent(MessageWebSocketMessageReceivedEventArgs eventArgs)
-        {
-            try
-            {
-                return IsPartialMessageEventHelper(eventArgs);
-            }
-            catch (MissingMethodException)
-            {
-                Debug.WriteLine("WinRTWebSocket.IsPartialMessageEvent: MissingMethodException");
-
-                // When MessageWebSocketMessageReceivedEventArgs.IsMessageComplete is not available, WinRT's behavior
-                // is always to wait for the entire WebSocket message to arrive before raising a MessageReceived event.
-                return false;
-            }
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private bool IsPartialMessageEventHelper(MessageWebSocketMessageReceivedEventArgs eventArgs)
         {
             // The MessageWebSocketMessageReceivedEventArgs.IsMessageComplete property was introduced in the same
             // Windows SDK flight as MessageWebSocketControl.ReceiveMode.

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinRTWebSocket.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinRTWebSocket.cs
@@ -659,8 +659,6 @@ namespace System.Net.WebSockets
 
         private bool IsPartialMessageEvent(MessageWebSocketMessageReceivedEventArgs eventArgs)
         {
-            // The MessageWebSocketMessageReceivedEventArgs.IsMessageComplete property was introduced in the same
-            // Windows SDK flight as MessageWebSocketControl.ReceiveMode.
             if (MessageWebSocketReceiveModeSupported)
             {
                 return !eventArgs.IsMessageComplete;

--- a/src/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
@@ -58,13 +58,12 @@ namespace System.Net.WebSockets.Client.Tests
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task SendReceive_PartialMessageBeforeCompleteMessageArrives_Success(Uri server)
         {
-            if (PlatformDetection.IsUap && PlatformDetection.IsWindows &&
-                PlatformDetection.WindowsVersion == 10 && PlatformDetection.WindowsBuildNumber < 16215)
+            if (PlatformDetection.IsUap && !PlatformDetection.IsWindows10InsiderPreviewBuild16215OrGreater)
             {
                 // Windows 10 Insider Preview Build 16215 introduced the necessary APIs for the UAP version of
                 // ClientWebSocket.ReceiveAsync to consume partial message data as it arrives, without having to wait
                 // for "end of message" to be signaled.
-                _output.WriteLine("Skipping UAP test due to Windows 10 version prior to Insider Preview Build 16215.");
+                _output.WriteLine("Skipping UAP test due to OS version prior to Windows 10 Insider Preview Build 16215.");
                 return;
             }
 

--- a/src/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
@@ -54,11 +54,20 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
-        [ActiveIssue(21102, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task SendReceive_PartialMessageBeforeCompleteMessageArrives_Success(Uri server)
         {
+            if (PlatformDetection.IsUap && PlatformDetection.IsWindows &&
+                PlatformDetection.WindowsVersion == 10 && PlatformDetection.WindowsBuildNumber < 16215)
+            {
+                // Windows 10 Insider Preview Build 16215 introduced the necessary APIs for the UAP version of
+                // ClientWebSocket.ReceiveAsync to consume partial message data as it arrives, without having to wait
+                // for "end of message" to be signaled.
+                _output.WriteLine("Skipping UAP test due to Windows 10 version prior to Insider Preview Build 16215.");
+                return;
+            }
+
             var rand = new Random();
             var sendBuffer = new byte[ushort.MaxValue + 1];
             rand.NextBytes(sendBuffer);

--- a/src/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
@@ -16,6 +16,12 @@ namespace System.Net.WebSockets.Client.Tests
 {
     public class SendReceiveTest : ClientWebSocketTestBase
     {
+        // Windows 10 Insider Preview Build 16215 introduced the necessary APIs for the UAP version of
+        // ClientWebSocket.ReceiveAsync to consume partial message data as it arrives, without having to wait
+        // for "end of message" to be signaled.
+        public static bool PartialMessagesSupported =>
+            !PlatformDetection.IsUap || PlatformDetection.IsWindows10InsiderPreviewBuild16215OrGreater;
+
         public SendReceiveTest(ITestOutputHelper output) : base(output) { }
 
         [OuterLoop] // TODO: Issue #11345
@@ -55,18 +61,9 @@ namespace System.Net.WebSockets.Client.Tests
         }
 
         [OuterLoop] // TODO: Issue #11345
-        [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
+        [ConditionalTheory(nameof(WebSocketsSupported), nameof(PartialMessagesSupported)), MemberData(nameof(EchoServers))]
         public async Task SendReceive_PartialMessageBeforeCompleteMessageArrives_Success(Uri server)
         {
-            if (PlatformDetection.IsUap && !PlatformDetection.IsWindows10InsiderPreviewBuild16215OrGreater)
-            {
-                // Windows 10 Insider Preview Build 16215 introduced the necessary APIs for the UAP version of
-                // ClientWebSocket.ReceiveAsync to consume partial message data as it arrives, without having to wait
-                // for "end of message" to be signaled.
-                _output.WriteLine("Skipping UAP test due to OS version prior to Windows 10 Insider Preview Build 16215.");
-                return;
-            }
-
             var rand = new Random();
             var sendBuffer = new byte[ushort.MaxValue + 1];
             rand.NextBytes(sendBuffer);


### PR DESCRIPTION
With these changes, the UWP implementation of ClientWebSocket.ReceiveAsync hands partial WebSocket message data back to the app as soon as it arrives. This eliminates the behavioral difference between .NET Core and UWP tracked by issue #21102.

This fix leverages WinRT APIs that are only present since Windows 10 Insider Preview Build 16215, so API presence checks are in place. The pre-fix behavior takes effect when running on older Windows builds.

Fixes #21102 

CC: @mconnew 