### PR TITLE
Re-enable one System.Runtime.Extensions Evironment_Exit test and fix it for UAP

### DIFF
--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
@@ -47,6 +47,7 @@ namespace System.Diagnostics
         public RemoteInvokeOptions() { }
         public bool CheckExitCode { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public bool EnableProfiling { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public int ExpectedExitCode { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public bool Start { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public System.Diagnostics.ProcessStartInfo StartInfo { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public int TimeOut { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }

--- a/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.cs
@@ -168,7 +168,7 @@ namespace System.Diagnostics
 
                         if (Options.CheckExitCode)
                         {
-                            Assert.Equal(SuccessExitCode, Process.ExitCode);
+                            Assert.Equal(Options.ExpectedExitCode, Process.ExitCode);
                         }
                     }
                     finally
@@ -194,5 +194,6 @@ namespace System.Diagnostics
         public bool CheckExitCode { get; set; } = true;
 
         public int TimeOut {get; set; } = RemoteExecutorTestBase.FailWaitTimeoutMilliseconds;
+        public int ExpectedExitCode { get; set; } = RemoteExecutorTestBase.SuccessExitCode;
     }
 }

--- a/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.cs
@@ -4,6 +4,7 @@
 
 using System.IO;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -168,7 +169,10 @@ namespace System.Diagnostics
 
                         if (Options.CheckExitCode)
                         {
-                            Assert.Equal(Options.ExpectedExitCode, Process.ExitCode);
+                            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                                Assert.Equal(Options.ExpectedExitCode, Process.ExitCode);
+                            else
+                                Assert.Equal(unchecked((sbyte)Options.ExpectedExitCode), unchecked((sbyte)Process.ExitCode));
                         }
                     }
                     finally

--- a/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.uap.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.uap.cs
@@ -16,13 +16,12 @@ namespace System.Diagnostics
     public abstract partial class RemoteExecutorTestBase : FileCleanupTestBase
     {
         protected static readonly string HostRunnerName = "xunit.runner.uap.exe";
-        protected  static readonly string HostRunner = "xunit.runner.uap";
-        
+        protected static readonly string HostRunner = "xunit.runner.uap";
+
         /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
         /// <param name="method">The method to invoke.</param>
         /// <param name="args">The arguments to pass to the method.</param>
-        /// <param name="start">true if this function should Start the Process; false if that responsibility is left up to the caller.</param>
-        /// <param name="psi">The ProcessStartInfo to use, or null for a default.</param>
+        /// <param name="options"><see cref="System.Diagnostics.RemoteInvokeOptions"/> The options to execute the remote process.</param>
         /// <param name="pasteArguments">Unused in UAP.</param>
         private static RemoteInvokeHandle RemoteInvoke(MethodInfo method, string[] args, RemoteInvokeOptions options, bool pasteArguments = false)
         {
@@ -66,8 +65,8 @@ namespace System.Diagnostics
                 AppServiceResponse response = remoteExecutionService.SendMessageAsync(message).GetAwaiter().GetResult();
 
                 Assert.True(response.Status == AppServiceResponseStatus.Success, $"response.Status = {response.Status}");
-                int res = (int) response.Message["Results"];
-                Assert.True(res == SuccessExitCode, (string) response.Message["Log"] + Environment.NewLine + $"Returned Error code: {res}");
+                int res = (int)response.Message["Results"];
+                Assert.True(res == options.ExpectedExitCode, (string)response.Message["Log"] + Environment.NewLine + $"Returned Error code: {res}");
             }
 
             // RemoteInvokeHandle is not really needed in the UAP scenario but we use it just to have consistent interface as non UAP

--- a/src/System.Runtime.Extensions/tests/System/Environment.Exit.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.Exit.cs
@@ -4,7 +4,6 @@
 
 using System.Diagnostics;
 using System.IO;
-using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.Tests
@@ -25,8 +24,7 @@ namespace System.Tests
         [MemberData(nameof(ExitCodeValues))]
         public static void CheckExitCode(int expectedExitCode)
         {
-            var options = new RemoteInvokeOptions { ExpectedExitCode = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? expectedExitCode : (int)(sbyte)expectedExitCode };
-            RemoteInvoke(s => int.Parse(s), expectedExitCode.ToString(), options).Dispose();
+            RemoteInvoke(s => int.Parse(s), expectedExitCode.ToString(), new RemoteInvokeOptions { ExpectedExitCode = expectedExitCode }).Dispose();
         }
 
         [Theory]

--- a/src/System.Runtime.Extensions/tests/System/Environment.Exit.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.Exit.cs
@@ -23,30 +23,10 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(ExitCodeValues))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapNotUapAot, "RemoteExecutor behaves different in UAP.")]
         public static void CheckExitCode(int expectedExitCode)
         {
-            using (Process p = RemoteInvoke(s => int.Parse(s), expectedExitCode.ToString()).Process)
-            {
-                Assert.True(p.WaitForExit(30 * 1000));
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                {
-                    Assert.Equal(expectedExitCode, p.ExitCode);
-                }
-                else
-                {
-                    Assert.Equal(unchecked((sbyte)expectedExitCode), unchecked((sbyte)p.ExitCode));
-                }
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(ExitCodeValues))]
-        [SkipOnTargetFramework(~TargetFrameworkMonikers.UapNotUapAot, "RemoteExecutor behaves different in UAP.")]
-        public static void CheckExitCode_Uap(int expectedExitCode)
-        {
-            // Shouldn't fail as RemoteExecutor verifies that the exit code is the same as Options.ExpectedExitCode
-            RemoteInvoke(s => int.Parse(s), expectedExitCode.ToString(), new RemoteInvokeOptions { ExpectedExitCode = expectedExitCode });
+            var options = new RemoteInvokeOptions { ExpectedExitCode = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? expectedExitCode : (int)(sbyte)expectedExitCode };
+            RemoteInvoke(s => int.Parse(s), expectedExitCode.ToString(), options).Dispose();
         }
 
         [Theory]


### PR DESCRIPTION
Contributes: https://github.com/dotnet/corefx/issues/21415

The test CheckExitCode was failing because:

1. RemoteExecutor for UAP always checks that the invoke exit code is SuccessExitCode (42). Since the intention of this test was to check an specific exit code because we where manipulating the process through a parameter to tell it to set that exit code it was failing since it was different than 42. To solve this I added an ExpectedExitCode to the RemoteInvokeOptions class which defaults to SuccessExitCode but this allows testing to override that exit code if for some reason the test should expect for a different one. 

2. Even after I fixed that they where failing with NullReferenceException because we where trying to access the exit code from RemoteExecutor's result process, but for UAP this process is set to true. So I decided to split the tests.

cc: @tarekgh @joperezr @danmosemsft 