### PR TITLE
Clean up ValueTask code in preparation for copying it to coreclr

### DIFF
--- a/src/System.Threading.Tasks.Extensions/src/System/Runtime/CompilerServices/AsyncMethodBuilderAttribute.cs
+++ b/src/System.Threading.Tasks.Extensions/src/System/Runtime/CompilerServices/AsyncMethodBuilderAttribute.cs
@@ -13,10 +13,7 @@ namespace System.Runtime.CompilerServices
     {
         /// <summary>Initializes the <see cref="AsyncMethodBuilderAttribute"/>.</summary>
         /// <param name="builderType">The <see cref="Type"/> of the associated builder.</param>
-        public AsyncMethodBuilderAttribute(Type builderType)
-        {
-            BuilderType = builderType;
-        }
+        public AsyncMethodBuilderAttribute(Type builderType) => BuilderType = builderType;
 
         /// <summary>Gets the <see cref="Type"/> of the associated builder.</summary>
         public Type BuilderType { get; }

--- a/src/System.Threading.Tasks.Extensions/src/System/Runtime/CompilerServices/AsyncValueTaskMethodBuilder.cs
+++ b/src/System.Threading.Tasks.Extensions/src/System/Runtime/CompilerServices/AsyncValueTaskMethodBuilder.cs
@@ -30,10 +30,8 @@ namespace System.Runtime.CompilerServices
         /// <summary>Begins running the builder with the associated state machine.</summary>
         /// <typeparam name="TStateMachine">The type of the state machine.</typeparam>
         /// <param name="stateMachine">The state machine instance, passed by reference.</param>
-        public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine
-        {
+        public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine =>
             _methodBuilder.Start(ref stateMachine); // will provide the right ExecutionContext semantics
-        }
 
         /// <summary>Associates the builder with the specified state machine.</summary>
         /// <param name="stateMachine">The state machine instance to associate with the builder.</param>

--- a/src/System.Threading.Tasks.Extensions/src/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
+++ b/src/System.Threading.Tasks.Extensions/src/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
@@ -29,10 +29,8 @@ namespace System.Runtime.CompilerServices
         }
 
         /// <summary>Returns an awaiter for this <see cref="ConfiguredValueTaskAwaitable{TResult}"/> instance.</summary>
-        public ConfiguredValueTaskAwaiter GetAwaiter()
-        {
-            return new ConfiguredValueTaskAwaiter(_value, _continueOnCapturedContext);
-        }
+        public ConfiguredValueTaskAwaiter GetAwaiter() =>
+            new ConfiguredValueTaskAwaiter(_value, _continueOnCapturedContext);
 
         /// <summary>Provides an awaiter for a <see cref="ConfiguredValueTaskAwaitable{TResult}"/>.</summary>
         [StructLayout(LayoutKind.Auto)]
@@ -53,27 +51,21 @@ namespace System.Runtime.CompilerServices
             }
 
             /// <summary>Gets whether the <see cref="ConfiguredValueTaskAwaitable{TResult}"/> has completed.</summary>
-            public bool IsCompleted { get { return _value.IsCompleted; } }
+            public bool IsCompleted => _value.IsCompleted;
 
             /// <summary>Gets the result of the ValueTask.</summary>
-            public TResult GetResult()
-            {
-                return _value._task == null ? 
+            public TResult GetResult() =>
+                _value._task == null ? 
                     _value._result : 
                     _value._task.GetAwaiter().GetResult();
-            }
 
             /// <summary>Schedules the continuation action for the <see cref="ConfiguredValueTaskAwaitable{TResult}"/>.</summary>
-            public void OnCompleted(Action continuation)
-            {
+            public void OnCompleted(Action continuation) =>
                 _value.AsTask().ConfigureAwait(_continueOnCapturedContext).GetAwaiter().OnCompleted(continuation);
-            }
 
             /// <summary>Schedules the continuation action for the <see cref="ConfiguredValueTaskAwaitable{TResult}"/>.</summary>
-            public void UnsafeOnCompleted(Action continuation)
-            {
+            public void UnsafeOnCompleted(Action continuation) =>
                 _value.AsTask().ConfigureAwait(_continueOnCapturedContext).GetAwaiter().UnsafeOnCompleted(continuation);
-            }
         }
     }
 }

--- a/src/System.Threading.Tasks.Extensions/src/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
+++ b/src/System.Threading.Tasks.Extensions/src/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
@@ -15,29 +15,23 @@ namespace System.Runtime.CompilerServices
 
         /// <summary>Initializes the awaiter.</summary>
         /// <param name="value">The value to be awaited.</param>
-        internal ValueTaskAwaiter(ValueTask<TResult> value) { _value = value; }
+        internal ValueTaskAwaiter(ValueTask<TResult> value) => _value = value;
 
         /// <summary>Gets whether the <see cref="ValueTask{TResult}"/> has completed.</summary>
-        public bool IsCompleted { get { return _value.IsCompleted; } }
+        public bool IsCompleted => _value.IsCompleted;
 
         /// <summary>Gets the result of the ValueTask.</summary>
-        public TResult GetResult()
-        {
-            return _value._task == null ? 
+        public TResult GetResult() =>
+            _value._task == null ? 
                 _value._result : 
                 _value._task.GetAwaiter().GetResult();
-        }
 
         /// <summary>Schedules the continuation action for this ValueTask.</summary>
-        public void OnCompleted(Action continuation)
-        {
+        public void OnCompleted(Action continuation) =>
             _value.AsTask().ConfigureAwait(continueOnCapturedContext: true).GetAwaiter().OnCompleted(continuation);
-        }
 
         /// <summary>Schedules the continuation action for this ValueTask.</summary>
-        public void UnsafeOnCompleted(Action continuation)
-        {
+        public void UnsafeOnCompleted(Action continuation) =>
             _value.AsTask().ConfigureAwait(continueOnCapturedContext: true).GetAwaiter().UnsafeOnCompleted(continuation);
-        }
     }
 }

--- a/src/System.Threading.Tasks.Extensions/src/System/Threading/Tasks/ValueTask.cs
+++ b/src/System.Threading.Tasks.Extensions/src/System/Threading/Tasks/ValueTask.cs
@@ -71,94 +71,70 @@ namespace System.Threading.Tasks
         /// <param name="task">The task.</param>
         public ValueTask(Task<TResult> task)
         {
-            if (task == null)
-            {
-                throw new ArgumentNullException(nameof(task));
-            }
-
-            _task = task;
+            _task = task ?? throw new ArgumentNullException(nameof(task));
             _result = default(TResult);
         }
 
         /// <summary>Returns the hash code for this instance.</summary>
-        public override int GetHashCode()
-        {
-            return
-                _task != null ? _task.GetHashCode() :
-                _result != null ? _result.GetHashCode() :
-                0;
-        }
+        public override int GetHashCode() =>
+            _task != null ? _task.GetHashCode() :
+            _result != null ? _result.GetHashCode() :
+            0;
 
         /// <summary>Returns a value indicating whether this value is equal to a specified <see cref="object"/>.</summary>
-        public override bool Equals(object obj)
-        {
-            return 
-                obj is ValueTask<TResult> && 
-                Equals((ValueTask<TResult>)obj);
-        }
+        public override bool Equals(object obj) =>
+            obj is ValueTask<TResult> && 
+            Equals((ValueTask<TResult>)obj);
 
         /// <summary>Returns a value indicating whether this value is equal to a specified <see cref="ValueTask{TResult}"/> value.</summary>
-        public bool Equals(ValueTask<TResult> other)
-        {
-            return _task != null || other._task != null ? 
+        public bool Equals(ValueTask<TResult> other) =>
+            _task != null || other._task != null ? 
                 _task == other._task :
                 EqualityComparer<TResult>.Default.Equals(_result, other._result);
-        }
 
         /// <summary>Returns a value indicating whether two <see cref="ValueTask{TResult}"/> values are equal.</summary>
-        public static bool operator==(ValueTask<TResult> left, ValueTask<TResult> right)
-        {
-            return left.Equals(right);
-        }
+        public static bool operator==(ValueTask<TResult> left, ValueTask<TResult> right) =>
+            left.Equals(right);
 
         /// <summary>Returns a value indicating whether two <see cref="ValueTask{TResult}"/> values are not equal.</summary>
-        public static bool operator!=(ValueTask<TResult> left, ValueTask<TResult> right)
-        {
-            return !left.Equals(right);
-        }
+        public static bool operator!=(ValueTask<TResult> left, ValueTask<TResult> right) =>
+            !left.Equals(right);
 
         /// <summary>
         /// Gets a <see cref="Task{TResult}"/> object to represent this ValueTask.  It will
         /// either return the wrapped task object if one exists, or it'll manufacture a new
         /// task object to represent the result.
         /// </summary>
-        public Task<TResult> AsTask()
-        {
+        public Task<TResult> AsTask() =>
             // Return the task if we were constructed from one, otherwise manufacture one.  We don't
             // cache the generated task into _task as it would end up changing both equality comparison
             // and the hash code we generate in GetHashCode.
-            return _task ?? Task.FromResult(_result);
-        }
+            _task ?? Task.FromResult(_result);
 
         /// <summary>Gets whether the <see cref="ValueTask{TResult}"/> represents a completed operation.</summary>
-        public bool IsCompleted { get { return _task == null || _task.IsCompleted; } }
+        public bool IsCompleted => _task == null || _task.IsCompleted;
 
         /// <summary>Gets whether the <see cref="ValueTask{TResult}"/> represents a successfully completed operation.</summary>
-        public bool IsCompletedSuccessfully { get { return _task == null || _task.Status == TaskStatus.RanToCompletion; } }
+        public bool IsCompletedSuccessfully => _task == null || _task.Status == TaskStatus.RanToCompletion;
 
         /// <summary>Gets whether the <see cref="ValueTask{TResult}"/> represents a failed operation.</summary>
-        public bool IsFaulted { get { return _task != null && _task.IsFaulted; } }
+        public bool IsFaulted => _task != null && _task.IsFaulted;
 
         /// <summary>Gets whether the <see cref="ValueTask{TResult}"/> represents a canceled operation.</summary>
-        public bool IsCanceled { get { return _task != null && _task.IsCanceled; } }
+        public bool IsCanceled => _task != null && _task.IsCanceled;
 
         /// <summary>Gets the result.</summary>
-        public TResult Result { get { return _task == null ? _result : _task.GetAwaiter().GetResult(); } }
+        public TResult Result => _task == null ? _result : _task.GetAwaiter().GetResult();
 
         /// <summary>Gets an awaiter for this value.</summary>
-        public ValueTaskAwaiter<TResult> GetAwaiter()
-        {
-            return new ValueTaskAwaiter<TResult>(this);
-        }
+        public ValueTaskAwaiter<TResult> GetAwaiter() => new ValueTaskAwaiter<TResult>(this);
 
         /// <summary>Configures an awaiter for this value.</summary>
         /// <param name="continueOnCapturedContext">
         /// true to attempt to marshal the continuation back to the captured context; otherwise, false.
         /// </param>
-        public ConfiguredValueTaskAwaitable<TResult> ConfigureAwait(bool continueOnCapturedContext)
-        {
-            return new ConfiguredValueTaskAwaitable<TResult>(this, continueOnCapturedContext: continueOnCapturedContext);
-        }
+        public ConfiguredValueTaskAwaitable<TResult> ConfigureAwait(bool continueOnCapturedContext) =>
+            new ConfiguredValueTaskAwaitable<TResult>(this, continueOnCapturedContext: continueOnCapturedContext);
 
         /// <summary>Gets a string-representation of this <see cref="ValueTask{TResult}"/>.</summary>
         public override string ToString()


### PR DESCRIPTION
Contributes to #21753 

@weshaggard, we should have deleted the temporary, hidden member previously, but neglected to do so.  No one should be using it.  Concerns about removing it?