### PR TITLE
Disable System.Data.Common.Tests.SqlXmlTest for uapaot

### DIFF
--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlXmlTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlXmlTest.cs
@@ -49,6 +49,7 @@ namespace System.Data.Tests.SqlTypes
         // Test constructor
         [Fact] // .ctor (Stream)
                //[Category ("NotDotNet")] // Name cannot begin with the '.' character, hexadecimal value 0x00. Line 1, position 2
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19202", TargetFrameworkMonikers.UapAot)]
         public void Constructor2_Stream_Unicode()
         {
             string xmlStr = "<Employee><FirstName>Varadhan</FirstName><LastName>Veerapuram</LastName></Employee>";
@@ -59,6 +60,7 @@ namespace System.Data.Tests.SqlTypes
         }
 
         [Fact] // .ctor (Stream)
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19202", TargetFrameworkMonikers.UapAot)]
         public void Constructor2_Stream_Empty()
         {
             MemoryStream ms = new MemoryStream();
@@ -84,6 +86,7 @@ namespace System.Data.Tests.SqlTypes
         }
 
         [Fact] // .ctor (XmlReader)
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19202", TargetFrameworkMonikers.UapAot)]
         public void Constructor3()
         {
             string xmlStr = "<Employee><FirstName>Varadhan</FirstName><LastName>Veerapuram</LastName></Employee>";
@@ -94,6 +97,7 @@ namespace System.Data.Tests.SqlTypes
         }
 
         [Fact] // .ctor (XmlReader)
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19202", TargetFrameworkMonikers.UapAot)]
         public void Constructor3_XmlReader_Empty()
         {
             XmlReaderSettings xs = new XmlReaderSettings();
@@ -122,6 +126,7 @@ namespace System.Data.Tests.SqlTypes
 
         [Fact]
         //[Category ("NotDotNet")] // Name cannot begin with the '.' character, hexadecimal value 0x00. Line 1, position 2
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19202", TargetFrameworkMonikers.UapAot)]
         public void CreateReader_Stream_Unicode()
         {
             string xmlStr = "<Employee><FirstName>Varadhan</FirstName><LastName>Veerapuram</LastName></Employee>";
@@ -135,6 +140,7 @@ namespace System.Data.Tests.SqlTypes
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19202", TargetFrameworkMonikers.UapAot)]
         public void SqlXml_fromXmlReader_CreateReaderTest()
         {
             string xmlStr = "<Employee><FirstName>Varadhan</FirstName><LastName>Veerapuram</LastName></Employee>";
@@ -148,6 +154,7 @@ namespace System.Data.Tests.SqlTypes
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19202", TargetFrameworkMonikers.UapAot)]
         public void SqlXml_fromZeroLengthStream_CreateReaderTest()
         {
             MemoryStream stream = new MemoryStream();
@@ -159,6 +166,7 @@ namespace System.Data.Tests.SqlTypes
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19202", TargetFrameworkMonikers.UapAot)]
         public void SqlXml_fromZeroLengthXmlReader_CreateReaderTest_withFragment()
         {
             XmlReaderSettings xs = new XmlReaderSettings();


### PR DESCRIPTION
This tests are still crashing in uap. See: https://github.com/dotnet/corefx/issues/19202

cc: @saurabh500 @danmosemsft 