### PR TITLE
Remove checked floating negate instructions from S.L.Expressions

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NegateInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NegateInstruction.cs
@@ -79,7 +79,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(unchecked(-(float)obj));
+                    frame.Push(-(float)obj);
                 }
                 return 1;
             }
@@ -96,7 +96,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(unchecked(-(double)obj));
+                    frame.Push(-(double)obj);
                 }
                 return 1;
             }
@@ -120,7 +120,7 @@ namespace System.Linq.Expressions.Interpreter
 
     internal abstract class NegateCheckedInstruction : Instruction
     {
-        private static Instruction s_Int16, s_Int32, s_Int64, s_Single, s_Double;
+        private static Instruction s_Int16, s_Int32, s_Int64;
 
         public override int ConsumedStack => 1;
         public override int ProducedStack => 1;
@@ -179,40 +179,6 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-        private sealed class NegateCheckedSingle : NegateCheckedInstruction
-        {
-            public override int Run(InterpretedFrame frame)
-            {
-                object obj = frame.Pop();
-                if (obj == null)
-                {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push(checked(-(float)obj));
-                }
-                return 1;
-            }
-        }
-
-        private sealed class NegateCheckedDouble : NegateCheckedInstruction
-        {
-            public override int Run(InterpretedFrame frame)
-            {
-                object obj = frame.Pop();
-                if (obj == null)
-                {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push(checked(-(double)obj));
-                }
-                return 1;
-            }
-        }
-
         public static Instruction Create(Type type)
         {
             Debug.Assert(!type.IsEnum);
@@ -221,10 +187,8 @@ namespace System.Linq.Expressions.Interpreter
                 case TypeCode.Int16: return s_Int16 ?? (s_Int16 = new NegateCheckedInt16());
                 case TypeCode.Int32: return s_Int32 ?? (s_Int32 = new NegateCheckedInt32());
                 case TypeCode.Int64: return s_Int64 ?? (s_Int64 = new NegateCheckedInt64());
-                case TypeCode.Single: return s_Single ?? (s_Single = new NegateCheckedSingle());
-                case TypeCode.Double: return s_Double ?? (s_Double = new NegateCheckedDouble());
                 default:
-                    throw ContractUtils.Unreachable;
+                    return NegateInstruction.Create(type);
             }
         }
     }


### PR DESCRIPTION
Since checked/unchecked context has no effect on floating-point operations, `NegateCheckedSingle` is effectively a duplicate of `NegateSingle` and `NegateCheckedDouble` of `NegateDouble`.

Remove these duplicates, reducing code size and number of cached instruction instances.