### PR TITLE
Fix System.Linq.Parallel.Tests for UapAot by building them on chk mode only

### DIFF
--- a/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
+++ b/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <!-- [ActiveIssue(https://github.com/dotnet/corefx/issues/21804)] // when building this tests in ret mode they crash and not produce testResults.xml -->
-    <ILCBuildType>chk</ILCBuildType>
+    <ILCBuildType Condition="'$(ArchGroup)' == 'x86' OR ('$(ConfigurationGroup)' == 'Release' AND '$(ArchGroup)' == 'arm')">chk</ILCBuildType>
     <ProjectGuid>{A7074928-82C3-4739-88FE-9B528977950C}</ProjectGuid>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
+++ b/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
@@ -2,6 +2,8 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
+    <!-- [ActiveIssue(https://github.com/dotnet/corefx/issues/21804)] // when building this tests in ret mode they crash and not produce testResults.xml -->
+    <ILCBuildType>chk</ILCBuildType>
     <ProjectGuid>{A7074928-82C3-4739-88FE-9B528977950C}</ProjectGuid>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->


### PR DESCRIPTION
Since they where a lot of tests to disable and the debugger just crashes I think this is the best workaround to have the tests running and producing testResults.xml - please see: https://github.com/dotnet/corefx/issues/21804

cc: @kouvel @danmosemsft @joshfree 