### PR TITLE
Compile Boolean != as ^ in System.Linq.Expressions

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
@@ -170,28 +170,13 @@ namespace System.Linq.Expressions.Compiler
                     _ilg.Emit(OpCodes.Add);
                     break;
                 case ExpressionType.AddChecked:
-                    if (leftType.IsFloatingPoint())
-                    {
-                        _ilg.Emit(OpCodes.Add);
-                    }
-                    else if (leftType.IsUnsigned())
-                    {
-                        _ilg.Emit(OpCodes.Add_Ovf_Un);
-                    }
-                    else
-                    {
-                        _ilg.Emit(OpCodes.Add_Ovf);
-                    }
+                    _ilg.Emit(leftType.IsFloatingPoint() ? OpCodes.Add : (leftType.IsUnsigned() ? OpCodes.Add_Ovf_Un : OpCodes.Add_Ovf));
                     break;
                 case ExpressionType.Subtract:
                     _ilg.Emit(OpCodes.Sub);
                     break;
                 case ExpressionType.SubtractChecked:
-                    if (leftType.IsFloatingPoint())
-                    {
-                        _ilg.Emit(OpCodes.Sub);
-                    }
-                    else if (leftType.IsUnsigned())
+                    if (leftType.IsUnsigned())
                     {
                         _ilg.Emit(OpCodes.Sub_Ovf_Un);
                         // Guaranteed to fit within result type: no conversion
@@ -199,25 +184,14 @@ namespace System.Linq.Expressions.Compiler
                     }
                     else
                     {
-                        _ilg.Emit(OpCodes.Sub_Ovf);
+                        _ilg.Emit(leftType.IsFloatingPoint() ? OpCodes.Sub : OpCodes.Sub_Ovf);
                     }
                     break;
                 case ExpressionType.Multiply:
                     _ilg.Emit(OpCodes.Mul);
                     break;
                 case ExpressionType.MultiplyChecked:
-                    if (leftType.IsFloatingPoint())
-                    {
-                        _ilg.Emit(OpCodes.Mul);
-                    }
-                    else if (leftType.IsUnsigned())
-                    {
-                        _ilg.Emit(OpCodes.Mul_Ovf_Un);
-                    }
-                    else
-                    {
-                        _ilg.Emit(OpCodes.Mul_Ovf);
-                    }
+                    _ilg.Emit(leftType.IsFloatingPoint() ? OpCodes.Mul : (leftType.IsUnsigned() ? OpCodes.Mul_Ovf_Un : OpCodes.Mul_Ovf));
                     break;
                 case ExpressionType.Divide:
                     _ilg.Emit(leftType.IsUnsigned() ? OpCodes.Div_Un : OpCodes.Div);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotEqualInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotEqualInstruction.cs
@@ -11,7 +11,7 @@ namespace System.Linq.Expressions.Interpreter
     {
         // Perf: EqualityComparer<T> but is 3/2 to 2 times slower.
         private static Instruction s_reference, s_Boolean, s_SByte, s_Int16, s_Char, s_Int32, s_Int64, s_Byte, s_UInt16, s_UInt32, s_UInt64, s_Single, s_Double;
-        private static Instruction s_BooleanLiftedToNull, s_SByteLiftedToNull, s_Int16LiftedToNull, s_CharLiftedToNull, s_Int32LiftedToNull, s_Int64LiftedToNull, s_ByteLiftedToNull, s_UInt16LiftedToNull, s_UInt32LiftedToNull, s_UInt64LiftedToNull, s_SingleLiftedToNull, s_DoubleLiftedToNull;
+        private static Instruction s_SByteLiftedToNull, s_Int16LiftedToNull, s_CharLiftedToNull, s_Int32LiftedToNull, s_Int64LiftedToNull, s_ByteLiftedToNull, s_UInt16LiftedToNull, s_UInt32LiftedToNull, s_UInt64LiftedToNull, s_SingleLiftedToNull, s_DoubleLiftedToNull;
 
         public override int ConsumedStack => 2;
         public override int ProducedStack => 1;
@@ -292,24 +292,6 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-        private sealed class NotEqualBooleanLiftedToNull : NotEqualInstruction
-        {
-            public override int Run(InterpretedFrame frame)
-            {
-                object right = frame.Pop();
-                object left = frame.Pop();
-                if (left == null || right == null)
-                {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push((bool)left != (bool)right);
-                }
-                return 1;
-            }
-        }
-
         private sealed class NotEqualSByteLiftedToNull : NotEqualInstruction
         {
             public override int Run(InterpretedFrame frame)
@@ -515,7 +497,7 @@ namespace System.Linq.Expressions.Interpreter
             {
                 switch (type.GetNonNullableType().GetTypeCode())
                 {
-                    case TypeCode.Boolean: return s_BooleanLiftedToNull ?? (s_BooleanLiftedToNull = new NotEqualBooleanLiftedToNull());
+                    case TypeCode.Boolean: return ExclusiveOrInstruction.Create(type);
                     case TypeCode.SByte: return s_SByteLiftedToNull ?? (s_SByteLiftedToNull = new NotEqualSByteLiftedToNull());
                     case TypeCode.Int16: return s_Int16LiftedToNull ?? (s_Int16LiftedToNull = new NotEqualInt16LiftedToNull());
                     case TypeCode.Char: return s_CharLiftedToNull ?? (s_CharLiftedToNull = new NotEqualCharLiftedToNull());


### PR DESCRIPTION
Boolean and lifted Boolean `!=` is identical to `^` in results.

In the case of the interpreter this allows for one type, and its memoising field, to be removed, so do so.

In the case of the compiler this allows for a slightly shorter CIL output. Detecting this adds to the compilation complexity, but also inlining `EmitUnliftedEquality` into `EmitUnliftedBinaryOp` can remove a branch on two tests so the nett result is simpler.