### PR TITLE
remove Linux SSL assert that's no longer true

### DIFF
--- a/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
@@ -154,7 +154,6 @@ namespace System.Net.Security
                 }
                 else
                 {
-                    Debug.Assert(offset == 0, "Expected offset 0 when decrypting");
                     Debug.Assert(ReferenceEquals(input, output), "Expected input==output when decrypting");
                     resultSize = Interop.OpenSsl.Decrypt(scHandle, input, offset, size, out errorCode);
                 }


### PR DESCRIPTION
My previous change made this assert no longer valid.  Remove it.

@stephentoub 