### PR TITLE
XmlResolver: remove workaround, BaseUriTests: fix test

### DIFF
--- a/src/System.Private.Xml/src/System/Xml/XmlResolver.cs
+++ b/src/System.Private.Xml/src/System/Xml/XmlResolver.cs
@@ -40,7 +40,7 @@ namespace System.Xml
                 Uri uri = new Uri(relativeUri, UriKind.RelativeOrAbsolute);
                 if (!uri.IsAbsoluteUri && uri.OriginalString.Length > 0)
                 {
-                    uri = new Uri(Uri.UriSchemeFile + Uri.SchemeDelimiter + Path.GetFullPath(relativeUri));
+                    uri = new Uri(Path.GetFullPath(relativeUri));
                 }
                 return uri;
             }

--- a/src/System.Private.Xml/tests/XmlReader/Tests/BaseUriTests.cs
+++ b/src/System.Private.Xml/tests/XmlReader/Tests/BaseUriTests.cs
@@ -32,7 +32,7 @@ namespace System.Xml.Tests
             File.WriteAllText(tempPath, DummyXml);
             using (XmlReader reader = factory(tempPath))
             {
-                Assert.True(new Uri(reader.BaseURI).IsAbsoluteUri);
+                Assert.True(new Uri(reader.BaseURI, UriKind.RelativeOrAbsolute).IsAbsoluteUri);
             }
         }
     }


### PR DESCRIPTION
This includes the change that was in https://github.com/dotnet/corefx/pull/20564 but not included in https://github.com/dotnet/corefx/pull/20623.
It also fixes a test which was added in https://github.com/dotnet/corefx/pull/20561.

CC @sepidehMS 