### PR TITLE
Update CoreClr, CoreFx, CoreSetup, Standard to preview2-25503-01, preview2-25503-02, preview2-25502-02, preview1-25503-01, respectively (master)

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -13,8 +13,8 @@
     <CoreClrCurrentRef>9c2f0a658d96048b72f64cf7aaa8d8ae641281fe</CoreClrCurrentRef>
     <CoreSetupCurrentRef>9c2f0a658d96048b72f64cf7aaa8d8ae641281fe</CoreSetupCurrentRef>
     <ExternalCurrentRef>5a0606fccb09fce4b47545ae9896139acca547f5</ExternalCurrentRef>
-    <ProjectNTfsCurrentRef>9c2f0a658d96048b72f64cf7aaa8d8ae641281fe</ProjectNTfsCurrentRef>
-    <ProjectNTfsTestILCCurrentRef>9c2f0a658d96048b72f64cf7aaa8d8ae641281fe</ProjectNTfsTestILCCurrentRef>
+    <ProjectNTfsCurrentRef>5b11b9d95b0a9651fd4303af7285fcc22a5825d1</ProjectNTfsCurrentRef>
+    <ProjectNTfsTestILCCurrentRef>5b11b9d95b0a9651fd4303af7285fcc22a5825d1</ProjectNTfsTestILCCurrentRef>
     <SniCurrentRef>97059fa979a3c8fb8b9fba127c526f15e48c9dde</SniCurrentRef>
     <StandardCurrentRef>9c2f0a658d96048b72f64cf7aaa8d8ae641281fe</StandardCurrentRef>
   </PropertyGroup>
@@ -25,9 +25,9 @@
     <CoreFxExpectedPrerelease>preview2-25503-02</CoreFxExpectedPrerelease>
     <CoreClrPackageVersion>2.1.0-preview2-25503-01</CoreClrPackageVersion>
     <ExternalExpectedPrerelease>beta-25322-00</ExternalExpectedPrerelease>
-    <ProjectNTfsExpectedPrerelease>beta-25503-00</ProjectNTfsExpectedPrerelease>
-    <ProjectNTfsTestILCExpectedPrerelease>beta-25503-00</ProjectNTfsTestILCExpectedPrerelease>
-    <ProjectNTfsTestILCPackageVersion>1.0.0-beta-25503-00</ProjectNTfsTestILCPackageVersion>
+    <ProjectNTfsExpectedPrerelease>beta-25430-00</ProjectNTfsExpectedPrerelease>
+    <ProjectNTfsTestILCExpectedPrerelease>beta-25430-00</ProjectNTfsTestILCExpectedPrerelease>
+    <ProjectNTfsTestILCPackageVersion>1.0.0-beta-25430-00</ProjectNTfsTestILCPackageVersion>
     <NETStandardPackageVersion>2.1.0-preview1-25503-01</NETStandardPackageVersion>
     <NETStandardPackageId>NETStandard.Library</NETStandardPackageId>
     <MicrosoftNETCoreAppPackageVersion>2.1.0-preview2-25502-02</MicrosoftNETCoreAppPackageVersion>

--- a/dependencies.props
+++ b/dependencies.props
@@ -9,28 +9,28 @@
        These ref versions are pulled from https://github.com/dotnet/versions.
   -->
   <PropertyGroup>
-    <CoreFxCurrentRef>2342388ed30a2c364ae8e55d936a6a54d52b4efe</CoreFxCurrentRef>
-    <CoreClrCurrentRef>2342388ed30a2c364ae8e55d936a6a54d52b4efe</CoreClrCurrentRef>
-    <CoreSetupCurrentRef>2342388ed30a2c364ae8e55d936a6a54d52b4efe</CoreSetupCurrentRef>
+    <CoreFxCurrentRef>9c2f0a658d96048b72f64cf7aaa8d8ae641281fe</CoreFxCurrentRef>
+    <CoreClrCurrentRef>9c2f0a658d96048b72f64cf7aaa8d8ae641281fe</CoreClrCurrentRef>
+    <CoreSetupCurrentRef>9c2f0a658d96048b72f64cf7aaa8d8ae641281fe</CoreSetupCurrentRef>
     <ExternalCurrentRef>5a0606fccb09fce4b47545ae9896139acca547f5</ExternalCurrentRef>
-    <ProjectNTfsCurrentRef>5b11b9d95b0a9651fd4303af7285fcc22a5825d1</ProjectNTfsCurrentRef>
-    <ProjectNTfsTestILCCurrentRef>5b11b9d95b0a9651fd4303af7285fcc22a5825d1</ProjectNTfsTestILCCurrentRef>
+    <ProjectNTfsCurrentRef>9c2f0a658d96048b72f64cf7aaa8d8ae641281fe</ProjectNTfsCurrentRef>
+    <ProjectNTfsTestILCCurrentRef>9c2f0a658d96048b72f64cf7aaa8d8ae641281fe</ProjectNTfsTestILCCurrentRef>
     <SniCurrentRef>97059fa979a3c8fb8b9fba127c526f15e48c9dde</SniCurrentRef>
-    <StandardCurrentRef>217863ea1522764354c0cae722ffb90429e823c1</StandardCurrentRef>
+    <StandardCurrentRef>9c2f0a658d96048b72f64cf7aaa8d8ae641281fe</StandardCurrentRef>
   </PropertyGroup>
 
   <!-- Auto-upgraded properties for each build info dependency. -->
   <PropertyGroup>
     <PlatformPackageVersion>2.1.0-preview1-25324-02</PlatformPackageVersion>
-    <CoreFxExpectedPrerelease>preview2-25502-02</CoreFxExpectedPrerelease>
-    <CoreClrPackageVersion>2.1.0-preview2-25502-01</CoreClrPackageVersion>
+    <CoreFxExpectedPrerelease>preview2-25503-02</CoreFxExpectedPrerelease>
+    <CoreClrPackageVersion>2.1.0-preview2-25503-01</CoreClrPackageVersion>
     <ExternalExpectedPrerelease>beta-25322-00</ExternalExpectedPrerelease>
-    <ProjectNTfsExpectedPrerelease>beta-25430-00</ProjectNTfsExpectedPrerelease>
-    <ProjectNTfsTestILCExpectedPrerelease>beta-25430-00</ProjectNTfsTestILCExpectedPrerelease>
-    <ProjectNTfsTestILCPackageVersion>1.0.0-beta-25430-00</ProjectNTfsTestILCPackageVersion>
-    <NETStandardPackageVersion>2.1.0-preview1-25430-01</NETStandardPackageVersion>
+    <ProjectNTfsExpectedPrerelease>beta-25503-00</ProjectNTfsExpectedPrerelease>
+    <ProjectNTfsTestILCExpectedPrerelease>beta-25503-00</ProjectNTfsTestILCExpectedPrerelease>
+    <ProjectNTfsTestILCPackageVersion>1.0.0-beta-25503-00</ProjectNTfsTestILCPackageVersion>
+    <NETStandardPackageVersion>2.1.0-preview1-25503-01</NETStandardPackageVersion>
     <NETStandardPackageId>NETStandard.Library</NETStandardPackageId>
-    <MicrosoftNETCoreAppPackageVersion>2.1.0-preview2-25501-06</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>2.1.0-preview2-25502-02</MicrosoftNETCoreAppPackageVersion>
     <!-- Use the SNI runtime package -->
     <SniPackageVersion>4.4.0-preview2-25312-01</SniPackageVersion>
   </PropertyGroup>

--- a/external/test-runtime/optional.json
+++ b/external/test-runtime/optional.json
@@ -3,9 +3,9 @@
     "net45": {
       "dependencies": {
         "Microsoft.DotNet.IBCMerge": "4.6.0-alpha-00001",
-        "TestILC.amd64ret": "1.0.0-beta-25503-00",
-        "TestILC.armret": "1.0.0-beta-25503-00",
-        "TestILC.x86ret": "1.0.0-beta-25503-00"
+        "TestILC.amd64ret": "1.0.0-beta-25430-00",
+        "TestILC.armret": "1.0.0-beta-25430-00",
+        "TestILC.x86ret": "1.0.0-beta-25430-00"
       }
     }
   }

--- a/external/test-runtime/optional.json
+++ b/external/test-runtime/optional.json
@@ -3,9 +3,9 @@
     "net45": {
       "dependencies": {
         "Microsoft.DotNet.IBCMerge": "4.6.0-alpha-00001",
-        "TestILC.amd64ret": "1.0.0-beta-25430-00",
-        "TestILC.armret": "1.0.0-beta-25430-00",
-        "TestILC.x86ret": "1.0.0-beta-25430-00"
+        "TestILC.amd64ret": "1.0.0-beta-25503-00",
+        "TestILC.armret": "1.0.0-beta-25503-00",
+        "TestILC.x86ret": "1.0.0-beta-25503-00"
       }
     }
   }


### PR DESCRIPTION
Replacing #21812

Looks like ProjectN dependencies can't be ingested into corefx since PR https://github.com/dotnet/corert/pull/4031 broke the ingestion by removing some required members. This will update everything else.