### PR TITLE
Fix BinaryFormatter UAPAOT build

### DIFF
--- a/src/System.Runtime.Serialization.Formatters/tests/FormatterServicesTests.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/FormatterServicesTests.cs
@@ -127,6 +127,7 @@ namespace System.Runtime.Serialization.Formatters.Tests
         }
 
 #pragma warning disable 0169 // The private field 'class member' is never used
+        [System.Runtime.CompilerServices.IsByRefLike]
         private struct StructWithSpanField
         {
             Span<byte> _bytes;
@@ -318,6 +319,18 @@ namespace System.Runtime.Serialization.Formatters.Tests
         {
             AssertExtensions.Throws<ArgumentNullException>("assem", () => FormatterServices.GetTypeFromAssembly(null, "name"));
             Assert.Null(FormatterServices.GetTypeFromAssembly(GetType().Assembly, Guid.NewGuid().ToString("N"))); // non-existing type doesn't throw
+        }
+    }
+}
+
+namespace System.Runtime.CompilerServices
+{
+    // Local definition of IsByRefLikeAttribute while the real one becomes available in corefx
+    [AttributeUsage(AttributeTargets.Struct)]
+    public sealed class IsByRefLikeAttribute : Attribute
+    {
+        public IsByRefLikeAttribute()
+        {
         }
     }
 }


### PR DESCRIPTION
Fixes UAPAOT compilation for the System.Runtime.Serialization.Formatters test, which fails because a test struct has a field of type Span, but isn't marked IsByRefLike.