### PR TITLE
Disable hostname check on macOS with non-SecureTransport backend.

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/OSX/CurlHandler.SslProvider.cs
+++ b/src/System.Net.Http/src/System/Net/Http/OSX/CurlHandler.SslProvider.cs
@@ -78,7 +78,12 @@ namespace System.Net.Http
                     {
                         EventSourceTrace("Warning: Disabling peer verification per {0}", nameof(HttpClientHandler.DangerousAcceptAnyServerCertificateValidator), easy: easy);
                         easy.SetCurlOption(Interop.Http.CURLoption.CURLOPT_SSL_VERIFYPEER, 0); // don't verify the peer
-                        // Don't set CURLOPT_SSL_VERIFHOST to 0; doing so disables SNI.
+
+                        // Don't set CURLOPT_SSL_VERIFHOST to 0; doing so disables SNI with SecureTransport backend.
+                        if (!CurlSslVersionDescription.Equals(Interop.Http.SecureTransportDescription))
+                        {
+                            easy.SetCurlOption(Interop.Http.CURLoption.CURLOPT_SSL_VERIFYHOST, 0); // don't verify the hostname
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
fixes #21778

cc @bartonjs @stephentoub @danmosemsft 

OSX 10.13 has LibreSsl as crypto backend. Disable hostname checks on certificates when using ```HttpClientHandler.DangerousAcceptAnyServerCertificateValidator``` as ```ServerCertificateCustomValidationCallback```