### PR TITLE
Throw expected message for negative new array length in S.L.Expressions

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ArrayOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ArrayOperations.cs
@@ -47,12 +47,10 @@ namespace System.Linq.Expressions.Interpreter
         public override int Run(InterpretedFrame frame)
         {
             int length = ConvertHelper.ToInt32NoNull(frame.Pop());
-            if (length < 0)
-            {
-                // to make behavior aligned with array creation emitted by C# compiler
-                throw new OverflowException();
-            }
-            frame.Push(Array.CreateInstance(_elementType, length));
+            // To make behavior aligned with array creation emitted by C# compiler if length is less than
+            // zero we try to use it to create an array, which will throw an OverflowException with the
+            // correct localized error message.
+            frame.Push(length < 0 ? new int[length] : Array.CreateInstance(_elementType, length));
             return 1;
         }
     }

--- a/src/System.Linq.Expressions/tests/Array/NewArrayBoundsTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/NewArrayBoundsTests.cs
@@ -285,5 +285,46 @@ namespace System.Linq.Expressions.Tests
             NewArrayExpression newArrayExpression = Expression.NewArrayBounds(typeof(string), bound0, bound1);
             AssertExtensions.Throws<ArgumentNullException>("expressions", () => newArrayExpression.Update(null));
         }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void SingleNegativeBoundErrorMessage(bool useInterpreter)
+        {
+            string localizedMessage = null;
+            try
+            {
+                int[] dummy = new int["".Length - 2];
+            }
+            catch (OverflowException oe)
+            {
+                localizedMessage = oe.Message;
+            }
+
+            Expression<Func<int[]>> lambda =
+                Expression.Lambda<Func<int[]>>(Expression.NewArrayBounds(typeof(int), Expression.Constant(-2)));
+            var func = lambda.Compile(useInterpreter);
+            OverflowException ex = Assert.Throws<OverflowException>(() => func());
+            Assert.Equal(localizedMessage, ex.Message);
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void MultipleNegativeBoundErrorMessage(bool useInterpreter)
+        {
+            string localizedMessage = null;
+            try
+            {
+                int[,,] dummy = new int[1, 1, "".Length - 2];
+            }
+            catch (OverflowException oe)
+            {
+                localizedMessage = oe.Message;
+            }
+
+            Expression<Func<int[,,]>> lambda = Expression.Lambda<Func<int[,,]>>(
+                Expression.NewArrayBounds(
+                    typeof(int), Expression.Constant(0), Expression.Constant(0), Expression.Constant(-2)));
+            var func = lambda.Compile(useInterpreter);
+            OverflowException ex = Assert.Throws<OverflowException>(() => func());
+            Assert.Equal(localizedMessage, ex.Message);
+        }
     }
 }


### PR DESCRIPTION
Fixes #21842