### PR TITLE
Fix locking during drawing tests

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/ToolboxBitmapAttribute.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/ToolboxBitmapAttribute.cs
@@ -186,7 +186,7 @@ namespace System.Drawing
                     if (ext != null && string.Equals(ext, ".ico", StringComparison.OrdinalIgnoreCase))
                     {
                         //ico files support both large and small, so we respect the large flag here.
-                        using (FileStream reader = File.Open(imageFile, FileMode.Open, FileAccess.Read, FileShare.Read))
+                        using (FileStream reader = File.OpenRead(imageFile))
                         {
                             image = GetIconFromStream(reader, large, scaled);
                         }

--- a/src/System.Drawing.Common/src/System/Drawing/ToolboxBitmapAttribute.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/ToolboxBitmapAttribute.cs
@@ -186,8 +186,7 @@ namespace System.Drawing
                     if (ext != null && string.Equals(ext, ".ico", StringComparison.OrdinalIgnoreCase))
                     {
                         //ico files support both large and small, so we respect the large flag here.
-
-                        using (FileStream reader = File.Open(imageFile, FileMode.Open))
+                        using (FileStream reader = File.Open(imageFile, FileMode.Open, FileAccess.Read, FileShare.Read))
                         {
                             image = GetIconFromStream(reader, large, scaled);
                         }

--- a/src/System.Drawing.Common/tests/IconTests.cs
+++ b/src/System.Drawing.Common/tests/IconTests.cs
@@ -104,7 +104,7 @@ namespace System.Drawing.Tests
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void Ctor_Stream()
         {
-            using (var stream = new FileStream(Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico"), FileMode.Open, FileAccess.Read))
+            using (var stream = File.OpenRead(Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico")))
             {
                 var icon = new Icon(stream);
                 Assert.Equal(32, icon.Width);
@@ -117,7 +117,7 @@ namespace System.Drawing.Tests
         [MemberData(nameof(Size_TestData))]
         public void Ctor_Stream_Width_Height(string fileName, Size size, Size expectedSize)
         {
-            using (var stream = new FileStream(Helpers.GetTestBitmapPath(fileName), FileMode.Open, FileAccess.Read))
+            using (var stream = File.OpenRead(Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico")))
             using (var icon = new Icon(stream, size.Width, size.Height))
             {
                 Assert.Equal(expectedSize.Width, icon.Width);
@@ -130,7 +130,7 @@ namespace System.Drawing.Tests
         [MemberData(nameof(Size_TestData))]
         public void Ctor_Stream_Size(string fileName, Size size, Size expectedSize)
         {
-            using (var stream = new FileStream(Helpers.GetTestBitmapPath(fileName), FileMode.Open, FileAccess.Read))
+            using (var stream = File.OpenRead(Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico")))
             using (var icon = new Icon(stream, size))
             {
                 Assert.Equal(expectedSize.Width, icon.Width);

--- a/src/System.Drawing.Common/tests/IconTests.cs
+++ b/src/System.Drawing.Common/tests/IconTests.cs
@@ -117,7 +117,7 @@ namespace System.Drawing.Tests
         [MemberData(nameof(Size_TestData))]
         public void Ctor_Stream_Width_Height(string fileName, Size size, Size expectedSize)
         {
-            using (var stream = File.OpenRead(Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico")))
+            using (var stream = File.OpenRead(Helpers.GetTestBitmapPath(fileName)))
             using (var icon = new Icon(stream, size.Width, size.Height))
             {
                 Assert.Equal(expectedSize.Width, icon.Width);
@@ -130,7 +130,7 @@ namespace System.Drawing.Tests
         [MemberData(nameof(Size_TestData))]
         public void Ctor_Stream_Size(string fileName, Size size, Size expectedSize)
         {
-            using (var stream = File.OpenRead(Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico")))
+            using (var stream = File.OpenRead(Helpers.GetTestBitmapPath(fileName)))
             using (var icon = new Icon(stream, size))
             {
                 Assert.Equal(expectedSize.Width, icon.Width);

--- a/src/System.Drawing.Common/tests/IconTests.cs
+++ b/src/System.Drawing.Common/tests/IconTests.cs
@@ -104,7 +104,7 @@ namespace System.Drawing.Tests
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void Ctor_Stream()
         {
-            using (var stream = new FileStream(Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico"), FileMode.Open))
+            using (var stream = new FileStream(Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico"), FileMode.Open, FileAccess.Read))
             {
                 var icon = new Icon(stream);
                 Assert.Equal(32, icon.Width);
@@ -117,7 +117,7 @@ namespace System.Drawing.Tests
         [MemberData(nameof(Size_TestData))]
         public void Ctor_Stream_Width_Height(string fileName, Size size, Size expectedSize)
         {
-            using (var stream = new FileStream(Helpers.GetTestBitmapPath(fileName), FileMode.Open))
+            using (var stream = new FileStream(Helpers.GetTestBitmapPath(fileName), FileMode.Open, FileAccess.Read))
             using (var icon = new Icon(stream, size.Width, size.Height))
             {
                 Assert.Equal(expectedSize.Width, icon.Width);
@@ -130,7 +130,7 @@ namespace System.Drawing.Tests
         [MemberData(nameof(Size_TestData))]
         public void Ctor_Stream_Size(string fileName, Size size, Size expectedSize)
         {
-            using (var stream = new FileStream(Helpers.GetTestBitmapPath(fileName), FileMode.Open))
+            using (var stream = new FileStream(Helpers.GetTestBitmapPath(fileName), FileMode.Open, FileAccess.Read))
             using (var icon = new Icon(stream, size))
             {
                 Assert.Equal(expectedSize.Width, icon.Width);


### PR DESCRIPTION
Fix https://github.com/dotnet/corefx/issues/21845

FileStream.ctor and File.Open default for FileAccess is FileAccess.ReadWrite (unless FileMode.Append, then FileAccess.Write only). FileStream.ctor default for FileShare is FileShare.Read, but File.Open's default is FileShare.None.

In Windows, FileAccess maps to GENERIC_READ and/or GENERIC_WRITE, and FileShare to FILE_SHARE_READ, FILE_SHARE_WRITE, and/or "FILE_SHARE_NONE". The valid combinations for CreateFile calls are shown here: https://msdn.microsoft.com/en-us/library/windows/desktop/aa363874(v=vs.85).aspx. Essentially the file access required must be allowed by other handles' file share values. So if an existing handle has GENERIC_READ, other handles must all include FILE_SHARE_READ. I didn't look at Unix.

In this case the tests opened the icon file with a FileStream using FileMode.Open passed, and therefore the defaults of FileAccess.ReadWrite and FileShare.Read. Other tests called the Icon constructor which opened the icon file with `new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.Read)`. The FileAccess.ReadWrite is not compatible with the FileShare.Read, causing the error. The fix is to explicitly request FileAccess.Read in the tests.

Also noticed a use of File.Open with the default values of FileAccess.ReadWrite and FileShare.None. Since it's just reading from the file, it seems reasonable to pass FileAccess.Read, FileShare.Read explicitly, so another notional process could read concurrently.