### PR TITLE
Port Use monotonic clock for measuring time in sleep test (#20639) to 2.0

### DIFF
--- a/src/System.Threading.Thread/tests/ThreadTests.cs
+++ b/src/System.Threading.Thread/tests/ThreadTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -767,9 +768,11 @@ namespace System.Threading.Threads.Tests
             Assert.Throws<ArgumentOutOfRangeException>(() => Thread.Sleep(TimeSpan.FromMilliseconds((double)int.MaxValue + 1)));
 
             Thread.Sleep(0);
-            var startTime = DateTime.Now;
+
+            var stopwatch = Stopwatch.StartNew();
             Thread.Sleep(500);
-            Assert.True((DateTime.Now - startTime).TotalMilliseconds >= 100);
+            stopwatch.Stop();
+            Assert.InRange((int)stopwatch.ElapsedMilliseconds, 100, int.MaxValue);
         }
 
         [Fact]


### PR DESCRIPTION
https://github.com/dotnet/corefx/commit/fc7720842d8d1ae7c496b2d08e23f98f7de9c722

Fix flaky test