### PR TITLE
Port: fix IsUsingManagedSNI on desktop to 2.0

### DIFF
--- a/src/System.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -14,8 +14,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         public static readonly string NpConnStr = null;
         public static readonly string TcpConnStr = null;
         private static readonly Assembly s_systemDotData = typeof(System.Data.SqlClient.SqlConnection).GetTypeInfo().Assembly;
-        private static readonly Type s_tdsParserStateObjectFactory = s_systemDotData.GetType("System.Data.SqlClient.TdsParserStateObjectFactory");
-        private static readonly PropertyInfo s_useManagedSNI = s_tdsParserStateObjectFactory.GetProperty("UseManagedSNI", BindingFlags.Static | BindingFlags.Public);
+        private static readonly Type s_tdsParserStateObjectFactory = s_systemDotData?.GetType("System.Data.SqlClient.TdsParserStateObjectFactory");
+        private static readonly PropertyInfo s_useManagedSNI = s_tdsParserStateObjectFactory?.GetProperty("UseManagedSNI", BindingFlags.Static | BindingFlags.Public);
 
         static DataTestUtility()
         {
@@ -28,7 +28,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             return !string.IsNullOrEmpty(NpConnStr) && !string.IsNullOrEmpty(TcpConnStr);
         }
 
-        public static bool IsUsingManagedSNI() => (bool)s_useManagedSNI.GetValue(null);
+        public static bool IsUsingManagedSNI() => (bool)(s_useManagedSNI?.GetValue(null) ?? false);
 
         // the name length will be no more then (16 + prefix.Length + escapeLeft.Length + escapeRight.Length)
         // some providers does not support names (Oracle supports up to 30)


### PR DESCRIPTION
Port 8a93511ccd168ac46e907e80527635c7cf97f0fb 
Fix https://github.com/dotnet/corefx/issues/19918