### PR TITLE
[release/2.0] Fix segfault on chain build on macOS High Sierra

### DIFF
--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509chain.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509chain.cpp
@@ -65,7 +65,10 @@ extern "C" int32_t AppleCryptoNative_X509ChainEvaluate(SecTrustRef chain,
     SecTrustResultType trustResult;
     *pOSStatus = SecTrustEvaluate(chain, &trustResult);
 
-    if (*pOSStatus != noErr)
+    // If any error is reported from the function or the trust result value indicates that
+    // otherwise was a failed chain build (vs an untrusted chain, etc) return failure and
+    // we'll throw in the managed layer.  (but if we hit the "or" the message is "No error")
+    if (*pOSStatus != noErr || trustResult == kSecTrustResultInvalid)
     {
         return 0;
     }


### PR DESCRIPTION
When building a cert chain for self-issued certificates on High Sierra,
Security.framework gets into a bad state.  One minute after entering
SecTrustEvaluate the function exits with the trust result set to Invalid and
the return value (an OSStatus) set to success.

Continuing to interact with that chain results in more slowdowns and/or a
null-dereference triggering a segfault.

Hopefully the underlying issue is fixed before 10.13 RTM, but for now we can
be less destructive by throwing an exception instead of letting the native code
terminate the process.

Ports #21838 to release/2.0.