### PR TITLE
Add precision allowance and significantly better logging to Vector.SquareRoot tests.

### DIFF
--- a/src/Common/src/System/MathF.netstandard.cs
+++ b/src/Common/src/System/MathF.netstandard.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 
 namespace System
 {
+    // MathF emulation on platforms which don't support it natively.
     internal static class MathF
     {
         public const float PI = (float)Math.PI;

--- a/src/Common/src/System/MathF.netstandard.cs
+++ b/src/Common/src/System/MathF.netstandard.cs
@@ -36,6 +36,12 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Pow(float x, float y)
+        {
+            return (float)Math.Pow(x, y);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float Sin(float x)
         {
             return (float)Math.Sin(x);

--- a/src/System.Numerics.Vectors/src/System.Numerics.Vectors.csproj
+++ b/src/System.Numerics.Vectors/src/System.Numerics.Vectors.csproj
@@ -56,7 +56,9 @@
   </ItemGroup>
   <!-- Carry a copy of MathF where not available -->
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' == 'true' OR $(TargetGroup.StartsWith('netstandard'))">
-    <Compile Include="System\MathF.cs" />
+    <Compile Include="..\..\Common\src\System\MathF.netstandard.cs">
+      <Link>System\MathF.netstandard.cs</Link>
+    </Compile>
   </ItemGroup>
   <!-- Portable version only -->
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">

--- a/src/System.Numerics.Vectors/tests/GenericVectorTests.cs
+++ b/src/System.Numerics.Vectors/tests/GenericVectorTests.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using Xunit;
+using Xunit.Sdk;
 
 namespace System.Numerics.Tests
 {
@@ -1880,26 +1881,26 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
-        public void SquareRootByte() { TestSquareRoot<Byte>(); }
+        public void SquareRootByte() { TestSquareRoot<Byte>(-1); }
         [Fact]
-        public void SquareRootSByte() { TestSquareRoot<SByte>(); }
+        public void SquareRootSByte() { TestSquareRoot<SByte>(-1); }
         [Fact]
-        public void SquareRootUInt16() { TestSquareRoot<UInt16>(); }
+        public void SquareRootUInt16() { TestSquareRoot<UInt16>(-1); }
         [Fact]
-        public void SquareRootInt16() { TestSquareRoot<Int16>(); }
+        public void SquareRootInt16() { TestSquareRoot<Int16>(-1); }
         [Fact]
-        public void SquareRootUInt32() { TestSquareRoot<UInt32>(); }
+        public void SquareRootUInt32() { TestSquareRoot<UInt32>(-1); }
         [Fact]
-        public void SquareRootInt32() { TestSquareRoot<Int32>(); }
+        public void SquareRootInt32() { TestSquareRoot<Int32>(-1); }
         [Fact]
-        public void SquareRootUInt64() { TestSquareRoot<UInt64>(); }
+        public void SquareRootUInt64() { TestSquareRoot<UInt64>(-1); }
         [Fact]
-        public void SquareRootInt64() { TestSquareRoot<Int64>(); }
+        public void SquareRootInt64() { TestSquareRoot<Int64>(-1); }
         [Fact]
-        public void SquareRootSingle() { TestSquareRoot<Single>(); }
+        public void SquareRootSingle() { TestSquareRoot<Single>(6); }
         [Fact]
-        public void SquareRootDouble() { TestSquareRoot<Double>(); }
-        private void TestSquareRoot<T>() where T : struct
+        public void SquareRootDouble() { TestSquareRoot<Double>(15); }
+        private void TestSquareRoot<T>(int precision = -1) where T : struct, IEquatable<T>
         {
             T[] values = GenerateRandomValuesForVector<T>();
             Vector<T> vector = new Vector<T>(values);
@@ -1909,7 +1910,7 @@ namespace System.Numerics.Tests
                 (index, val) =>
                 {
                     T expected = Util.Sqrt(values[index]);
-                    Assert.Equal(expected, val);
+                    AssertEqual(expected, val, $"SquareRoot( {values[index]} )", precision);
                 });
         }
 
@@ -2610,6 +2611,76 @@ namespace System.Numerics.Tests
         #endregion Narrow / Widen
 
         #region Helper Methods
+        private static void AssertEqual<T>(T expected, T actual, string operation, int precision = -1) where T : IEquatable<T>
+        {
+            if (typeof(T) == typeof(float))
+            {
+                if (!IsDiffTolerable((float)(object)expected, (float)(object)actual, precision))
+                {
+                    throw new XunitException($"AssertEqual failed for operation {operation}. Expected: {expected}, Actual: {actual}.");
+                }
+            }
+            else if (typeof(T) == typeof(double))
+            {
+                if (!IsDiffTolerable((double)(object)expected, (double)(object)actual, precision))
+                {
+                    throw new XunitException($"AssertEqual failed for operation {operation}. Expected: {expected}, Actual: {actual}.");
+                }
+            }
+            else
+            {
+                if (!expected.Equals(actual))
+                {
+                    throw new XunitException($"AssertEqual failed for operation {operation}. Expected: {expected}, Actual: {actual}.");
+                }
+            }
+        }
+
+        private static bool IsDiffTolerable(double d1, double d2, int precision)
+        {
+            if (double.IsNaN(d1))
+            {
+                return double.IsNaN(d2);
+            }
+            if (double.IsInfinity(d1))
+            {
+                return AreSameInfinity(d1, d2 * 10);
+            }
+            if (double.IsInfinity(d2))
+            {
+                return AreSameInfinity(d1 * 10, d2);
+            }
+            double diffRatio = (d1 - d2) / d1;
+            diffRatio *= Math.Pow(10, precision);
+            return Math.Abs(diffRatio) < 1;
+        }
+
+        private static bool IsDiffTolerable(float f1, float f2, int precision)
+        {
+            if (float.IsNaN(f1))
+            {
+                return float.IsNaN(f2);
+            }
+            if (float.IsInfinity(f1))
+            {
+                return AreSameInfinity(f1, f2 * 10);
+            }
+            if (float.IsInfinity(f2))
+            {
+                return AreSameInfinity(f1 * 10, f2);
+            }
+            float diffRatio = (f1 - f2) / f1;
+            diffRatio *= MathF.Pow(10, precision);
+            return Math.Abs(diffRatio) < 1;
+        }
+
+        private static bool AreSameInfinity(double d1, double d2)
+        {
+            return
+                double.IsNegativeInfinity(d1) == double.IsNegativeInfinity(d2) &&
+                double.IsPositiveInfinity(d1) == double.IsPositiveInfinity(d2);
+        }
+
         private static void ValidateVector<T>(Vector<T> vector, Action<int, T> indexValidationFunc) where T : struct
         {
             for (int g = 0; g < Vector<T>.Count; g++)

--- a/src/System.Numerics.Vectors/tests/GenericVectorTests.cs
+++ b/src/System.Numerics.Vectors/tests/GenericVectorTests.cs
@@ -2670,7 +2670,7 @@ namespace System.Numerics.Tests
                 return AreSameInfinity(f1 * 10, f2);
             }
             float diffRatio = (f1 - f2) / f1;
-            diffRatio *= MathF.Pow(10, precision);
+            diffRatio *= (float)Math.Pow(10, precision);
             return Math.Abs(diffRatio) < 1;
         }
 

--- a/src/System.Numerics.Vectors/tests/GenericVectorTests.cs
+++ b/src/System.Numerics.Vectors/tests/GenericVectorTests.cs
@@ -2642,14 +2642,11 @@ namespace System.Numerics.Tests
             {
                 return double.IsNaN(d2);
             }
-            if (double.IsInfinity(d1))
+            if (double.IsInfinity(d1) || double.IsInfinity(d2))
             {
-                return AreSameInfinity(d1, d2 * 10);
+                return AreSameInfinity(d1, d2);
             }
-            if (double.IsInfinity(d2))
-            {
-                return AreSameInfinity(d1 * 10, d2);
-            }
+
             double diffRatio = (d1 - d2) / d1;
             diffRatio *= Math.Pow(10, precision);
             return Math.Abs(diffRatio) < 1;
@@ -2661,14 +2658,11 @@ namespace System.Numerics.Tests
             {
                 return float.IsNaN(f2);
             }
-            if (float.IsInfinity(f1))
+            if (float.IsInfinity(f1) || float.IsInfinity(f2))
             {
-                return AreSameInfinity(f1, f2 * 10);
+                return AreSameInfinity(f1, f2);
             }
-            if (float.IsInfinity(f2))
-            {
-                return AreSameInfinity(f1 * 10, f2);
-            }
+
             float diffRatio = (f1 - f2) / f1;
             diffRatio *= MathF.Pow(10, precision);
             return Math.Abs(diffRatio) < 1;

--- a/src/System.Numerics.Vectors/tests/GenericVectorTests.cs
+++ b/src/System.Numerics.Vectors/tests/GenericVectorTests.cs
@@ -1910,7 +1910,7 @@ namespace System.Numerics.Tests
                 (index, val) =>
                 {
                     T expected = Util.Sqrt(values[index]);
-                    AssertEqual(expected, val, $"SquareRoot( {values[index]} )", precision);
+                    AssertEqual(expected, val, $"SquareRoot( {FullString(values[index])} )", precision);
                 });
         }
 
@@ -2666,6 +2666,22 @@ namespace System.Numerics.Tests
             float diffRatio = (f1 - f2) / f1;
             diffRatio *= MathF.Pow(10, precision);
             return Math.Abs(diffRatio) < 1;
+        }
+
+        private static string FullString<T>(T value)
+        {
+            if (typeof(T) == typeof(float))
+            {
+                return ((float)(object)value).ToString("G9");
+            }
+            else if (typeof(T) == typeof(double))
+            {
+                return ((double)(object)value).ToString("G17");
+            }
+            else
+            {
+                return value.ToString();
+            }
         }
 
         private static bool AreSameInfinity(double d1, double d2)

--- a/src/System.Numerics.Vectors/tests/GenericVectorTests.cs
+++ b/src/System.Numerics.Vectors/tests/GenericVectorTests.cs
@@ -2617,14 +2617,14 @@ namespace System.Numerics.Tests
             {
                 if (!IsDiffTolerable((float)(object)expected, (float)(object)actual, precision))
                 {
-                    throw new XunitException($"AssertEqual failed for operation {operation}. Expected: {expected}, Actual: {actual}.");
+                    throw new XunitException($"AssertEqual failed for operation {operation}. Expected: {expected,10:G9}, Actual: {actual,10:G9}.");
                 }
             }
             else if (typeof(T) == typeof(double))
             {
                 if (!IsDiffTolerable((double)(object)expected, (double)(object)actual, precision))
                 {
-                    throw new XunitException($"AssertEqual failed for operation {operation}. Expected: {expected}, Actual: {actual}.");
+                    throw new XunitException($"AssertEqual failed for operation {operation}. Expected: {expected,20:G17}, Actual: {actual,20:G17}.");
                 }
             }
             else
@@ -2670,7 +2670,7 @@ namespace System.Numerics.Tests
                 return AreSameInfinity(f1 * 10, f2);
             }
             float diffRatio = (f1 - f2) / f1;
-            diffRatio *= (float)Math.Pow(10, precision);
+            diffRatio *= MathF.Pow(10, precision);
             return Math.Abs(diffRatio) < 1;
         }
 

--- a/src/System.Numerics.Vectors/tests/GenericVectorTests.tt
+++ b/src/System.Numerics.Vectors/tests/GenericVectorTests.tt
@@ -1710,14 +1710,14 @@ namespace System.Numerics.Tests
             {
                 if (!IsDiffTolerable((float)(object)expected, (float)(object)actual, precision))
                 {
-                    throw new XunitException($"AssertEqual failed for operation {operation}. Expected: {expected}, Actual: {actual}.");
+                    throw new XunitException($"AssertEqual failed for operation {operation}. Expected: {expected,10:G9}, Actual: {actual,10:G9}.");
                 }
             }
             else if (typeof(T) == typeof(double))
             {
                 if (!IsDiffTolerable((double)(object)expected, (double)(object)actual, precision))
                 {
-                    throw new XunitException($"AssertEqual failed for operation {operation}. Expected: {expected}, Actual: {actual}.");
+                    throw new XunitException($"AssertEqual failed for operation {operation}. Expected: {expected,20:G17}, Actual: {actual,20:G17}.");
                 }
             }
             else
@@ -1763,7 +1763,7 @@ namespace System.Numerics.Tests
                 return AreSameInfinity(f1 * 10, f2);
             }
             float diffRatio = (f1 - f2) / f1;
-            diffRatio *= (float)Math.Pow(10, precision);
+            diffRatio *= MathF.Pow(10, precision);
             return Math.Abs(diffRatio) < 1;
         }
 

--- a/src/System.Numerics.Vectors/tests/GenericVectorTests.tt
+++ b/src/System.Numerics.Vectors/tests/GenericVectorTests.tt
@@ -12,6 +12,7 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using Xunit;
+using Xunit.Sdk;
 
 namespace System.Numerics.Tests
 {
@@ -216,7 +217,7 @@ namespace System.Numerics.Tests
             Assert.Throws<NullReferenceException>(() => vector.CopyTo(null, 0));
             Assert.Throws<ArgumentOutOfRangeException>(() => vector.CopyTo(array, -1));
             Assert.Throws<ArgumentOutOfRangeException>(() => vector.CopyTo(array, array.Length));
-            Assert.Throws<ArgumentException>(() => vector.CopyTo(array, array.Length - 1));
+            AssertExtensions.Throws<ArgumentException>(null, () => vector.CopyTo(array, array.Length - 1));
 
             vector.CopyTo(array);
             for (int g = 0; g < array.Length; g++)
@@ -1383,13 +1384,14 @@ namespace System.Numerics.Tests
 <# 
     foreach (var type in supportedTypes)
     {
+        int precision = type == typeof(float) ? 6 : type == typeof(double) ? 15 : -1;
 #>
         [Fact]
-        public void SquareRoot<#=type.Name#>() { TestSquareRoot<<#=type.Name#>>(); }
+        public void SquareRoot<#=type.Name#>() { TestSquareRoot<<#=type.Name#>>(<#=precision#>); }
 <#
     }
 #>
-        private void TestSquareRoot<T>() where T : struct
+        private void TestSquareRoot<T>(int precision = -1) where T : struct, IEquatable<T>
         {
             T[] values = GenerateRandomValuesForVector<T>();
             Vector<T> vector = new Vector<T>(values);
@@ -1399,7 +1401,7 @@ namespace System.Numerics.Tests
                 (index, val) =>
                 {
                     T expected = Util.Sqrt(values[index]);
-                    Assert.Equal(expected, val);
+                    AssertEqual(expected, val, $"SquareRoot( {values[index]} )", precision);
                 });
         }
 
@@ -1702,6 +1704,76 @@ namespace System.Numerics.Tests
         #endregion Narrow / Widen
 
         #region Helper Methods
+        private static void AssertEqual<T>(T expected, T actual, string operation, int precision = -1) where T : IEquatable<T>
+        {
+            if (typeof(T) == typeof(float))
+            {
+                if (!IsDiffTolerable((float)(object)expected, (float)(object)actual, precision))
+                {
+                    throw new XunitException($"AssertEqual failed for operation {operation}. Expected: {expected}, Actual: {actual}.");
+                }
+            }
+            else if (typeof(T) == typeof(double))
+            {
+                if (!IsDiffTolerable((double)(object)expected, (double)(object)actual, precision))
+                {
+                    throw new XunitException($"AssertEqual failed for operation {operation}. Expected: {expected}, Actual: {actual}.");
+                }
+            }
+            else
+            {
+                if (!expected.Equals(actual))
+                {
+                    throw new XunitException($"AssertEqual failed for operation {operation}. Expected: {expected}, Actual: {actual}.");
+                }
+            }
+        }
+
+        private static bool IsDiffTolerable(double d1, double d2, int precision)
+        {
+            if (double.IsNaN(d1))
+            {
+                return double.IsNaN(d2);
+            }
+            if (double.IsInfinity(d1))
+            {
+                return AreSameInfinity(d1, d2 * 10);
+            }
+            if (double.IsInfinity(d2))
+            {
+                return AreSameInfinity(d1 * 10, d2);
+            }
+            double diffRatio = (d1 - d2) / d1;
+            diffRatio *= Math.Pow(10, precision);
+            return Math.Abs(diffRatio) < 1;
+        }
+
+        private static bool IsDiffTolerable(float f1, float f2, int precision)
+        {
+            if (float.IsNaN(f1))
+            {
+                return float.IsNaN(f2);
+            }
+            if (float.IsInfinity(f1))
+            {
+                return AreSameInfinity(f1, f2 * 10);
+            }
+            if (float.IsInfinity(f2))
+            {
+                return AreSameInfinity(f1 * 10, f2);
+            }
+            float diffRatio = (f1 - f2) / f1;
+            diffRatio *= MathF.Pow(10, precision);
+            return Math.Abs(diffRatio) < 1;
+        }
+
+        private static bool AreSameInfinity(double d1, double d2)
+        {
+            return
+                double.IsNegativeInfinity(d1) == double.IsNegativeInfinity(d2) &&
+                double.IsPositiveInfinity(d1) == double.IsPositiveInfinity(d2);
+        }
+
         private static void ValidateVector<T>(Vector<T> vector, Action<int, T> indexValidationFunc) where T : struct
         {
             for (int g = 0; g < Vector<T>.Count; g++)

--- a/src/System.Numerics.Vectors/tests/GenericVectorTests.tt
+++ b/src/System.Numerics.Vectors/tests/GenericVectorTests.tt
@@ -1735,14 +1735,11 @@ namespace System.Numerics.Tests
             {
                 return double.IsNaN(d2);
             }
-            if (double.IsInfinity(d1))
+            if (double.IsInfinity(d1) || double.IsInfinity(d2))
             {
-                return AreSameInfinity(d1, d2 * 10);
+                return AreSameInfinity(d1, d2);
             }
-            if (double.IsInfinity(d2))
-            {
-                return AreSameInfinity(d1 * 10, d2);
-            }
+
             double diffRatio = (d1 - d2) / d1;
             diffRatio *= Math.Pow(10, precision);
             return Math.Abs(diffRatio) < 1;
@@ -1754,14 +1751,11 @@ namespace System.Numerics.Tests
             {
                 return float.IsNaN(f2);
             }
-            if (float.IsInfinity(f1))
+            if (float.IsInfinity(f1) || float.IsInfinity(f2))
             {
-                return AreSameInfinity(f1, f2 * 10);
+                return AreSameInfinity(f1, f2);
             }
-            if (float.IsInfinity(f2))
-            {
-                return AreSameInfinity(f1 * 10, f2);
-            }
+
             float diffRatio = (f1 - f2) / f1;
             diffRatio *= MathF.Pow(10, precision);
             return Math.Abs(diffRatio) < 1;

--- a/src/System.Numerics.Vectors/tests/GenericVectorTests.tt
+++ b/src/System.Numerics.Vectors/tests/GenericVectorTests.tt
@@ -1401,7 +1401,7 @@ namespace System.Numerics.Tests
                 (index, val) =>
                 {
                     T expected = Util.Sqrt(values[index]);
-                    AssertEqual(expected, val, $"SquareRoot( {values[index]} )", precision);
+                    AssertEqual(expected, val, $"SquareRoot( {FullString(values[index])} )", precision);
                 });
         }
 
@@ -1759,6 +1759,22 @@ namespace System.Numerics.Tests
             float diffRatio = (f1 - f2) / f1;
             diffRatio *= MathF.Pow(10, precision);
             return Math.Abs(diffRatio) < 1;
+        }
+
+        private static string FullString<T>(T value)
+        {
+            if (typeof(T) == typeof(float))
+            {
+                return ((float)(object)value).ToString("G9");
+            }
+            else if (typeof(T) == typeof(double))
+            {
+                return ((double)(object)value).ToString("G17");
+            }
+            else
+            {
+                return value.ToString();
+            }
         }
 
         private static bool AreSameInfinity(double d1, double d2)

--- a/src/System.Numerics.Vectors/tests/GenericVectorTests.tt
+++ b/src/System.Numerics.Vectors/tests/GenericVectorTests.tt
@@ -1763,7 +1763,7 @@ namespace System.Numerics.Tests
                 return AreSameInfinity(f1 * 10, f2);
             }
             float diffRatio = (f1 - f2) / f1;
-            diffRatio *= MathF.Pow(10, precision);
+            diffRatio *= (float)Math.Pow(10, precision);
             return Math.Abs(diffRatio) < 1;
         }
 

--- a/src/System.Numerics.Vectors/tests/System.Numerics.Vectors.Tests.csproj
+++ b/src/System.Numerics.Vectors/tests/System.Numerics.Vectors.Tests.csproj
@@ -38,6 +38,9 @@
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
       <Link>Common\System\PlatformDetection.cs</Link>
     </Compile>
+    <Compile Condition="'$(TargetGroup)' == 'netfx'" Include="..\..\Common\src\System\MathF.netstandard.cs">
+      <Link>System\MathF.netstandard.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\src\System\Numerics\ConstantHelper.tt">


### PR DESCRIPTION
This change adds more lenient precision checking to the `Vector.SquareRoot` tests, and adds significantly better logging when an assertion fails. We will now get the input operation, including input values, as well as the expected and actual outcomes.

@danmosemsft @tannergooding 

Part of https://github.com/dotnet/corefx/issues/21261