### PR TITLE
Upgrade BuildTools to get support for filenames in symbol signing.

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-2.0.0-prerelease-01803-02
+2.0.0-prerelease-01805-01


### PR DESCRIPTION
This brings in https://github.com/dotnet/buildtools/pull/1594, which adds filenames to the symbol signing catalog - this was determined by the Crypto Board to be necessary for security.