### PR TITLE
Disable several ManagedHandler tests

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
@@ -38,11 +38,12 @@ namespace System.Net.Http.Functional.Tests
         }
     }
 
-    public sealed class ManagedHandler_HttpClientEKUTest : HttpClientEKUTest, IDisposable
-    {
-        public ManagedHandler_HttpClientEKUTest() => ManagedHandlerTestHelpers.SetEnvVar();
-        public void Dispose() => ManagedHandlerTestHelpers.RemoveEnvVar();
-    }
+    // TODO #21452: Tests on this class fail when the associated condition is enabled.
+    //public sealed class ManagedHandler_HttpClientEKUTest : HttpClientEKUTest, IDisposable
+    //{
+    //    public ManagedHandler_HttpClientEKUTest() => ManagedHandlerTestHelpers.SetEnvVar();
+    //    public void Dispose() => ManagedHandlerTestHelpers.RemoveEnvVar();
+    //}
 
     public sealed class ManagedHandler_HttpClientHandler_DangerousAcceptAllCertificatesValidator_Test : HttpClientHandler_DangerousAcceptAllCertificatesValidator_Test, IDisposable
     {


### PR DESCRIPTION
These were enabled as they weren't failing CI, but that's likely because they were being skipped rather than because they actually work.

cc: @davidsh