### PR TITLE
ClientWebSocket supports client certificates in UWP

### DIFF
--- a/src/Common/tests/System/PlatformDetection.cs
+++ b/src/Common/tests/System/PlatformDetection.cs
@@ -36,6 +36,8 @@ namespace System
             GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 14393;
         public static bool IsWindows10Version1703OrGreater => IsWindows &&
             GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 15063;
+        public static bool IsWindows10InsiderPreviewBuild16215OrGreater => IsWindows &&
+            GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 16215;
         public static bool IsArmProcess => RuntimeInformation.ProcessArchitecture == Architecture.Arm;
         public static bool IsNotArmProcess => !IsArmProcess;
 

--- a/src/System.Net.WebSockets.Client/src/Resources/Strings.resx
+++ b/src/System.Net.WebSockets.Client/src/Resources/Strings.resx
@@ -121,4 +121,10 @@
   <data name="net_securityprotocolnotsupported" xml:space="preserve">
     <value>The requested security protocol is not supported.</value>
   </data>
+  <data name="net_WebSockets_UWPClientCertSupportRequiresWindows10InsiderPreviewBuild16215OrGreater" xml:space="preserve">
+    <value>Support for client certificates in UWP requires Windows 10 Insider Preview Build 16215 or greater.</value>
+  </data>
+  <data name="net_WebSockets_UWPClientCertSupportRequiresCertInPersonalCertificateStore" xml:space="preserve">
+    <value>Client certificate was not found in the personal (\"MY\") certificate store. In UWP, client certificates are only supported if they have been added to that certificate store.</value>
+  </data>
 </root>

--- a/src/System.Net.WebSockets.Client/src/Resources/Strings.resx
+++ b/src/System.Net.WebSockets.Client/src/Resources/Strings.resx
@@ -121,8 +121,8 @@
   <data name="net_securityprotocolnotsupported" xml:space="preserve">
     <value>The requested security protocol is not supported.</value>
   </data>
-  <data name="net_WebSockets_UWPClientCertSupportRequiresWindows10InsiderPreviewBuild16215OrGreater" xml:space="preserve">
-    <value>Support for client certificates in UWP requires Windows 10 Insider Preview Build 16215 or greater.</value>
+  <data name="net_WebSockets_UWPClientCertSupportRequiresWindows10GreaterThan1703" xml:space="preserve">
+    <value>Client certificates in UWP are unsupported in Windows 10 version 1703 and earlier versions. Please upgrade Windows 10 to a later release.</value>
   </data>
   <data name="net_WebSockets_UWPClientCertSupportRequiresCertInPersonalCertificateStore" xml:space="preserve">
     <value>Client certificate was not found in the personal (\"MY\") certificate store. In UWP, client certificates are only supported if they have been added to that certificate store.</value>

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinRTWebSocket.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinRTWebSocket.cs
@@ -118,7 +118,7 @@ namespace System.Net.WebSockets
             {
                 if (!MessageWebSocketClientCertificateSupported)
                 {
-                    throw new NotSupportedException(string.Format(
+                    throw new PlatformNotSupportedException(string.Format(
                         CultureInfo.InvariantCulture,
                         SR.net_WebSockets_UWPClientCertSupportRequiresWindows10InsiderPreviewBuild16215OrGreater));
                 }

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinRTWebSocket.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinRTWebSocket.cs
@@ -129,10 +129,10 @@ namespace System.Net.WebSockets
                 var certsAsX509Certificate2Collection = new X509Certificate2Collection();
                 certsAsX509Certificate2Collection.AddRange(options.ClientCertificates);
 
-                X509Certificate2 dotNetCert = GetEligibleClientCertificate(certsAsX509Certificate2Collection);
-                if (dotNetCert != null)
+                X509Certificate2 dotNetClientCert = GetEligibleClientCertificate(certsAsX509Certificate2Collection);
+                if (dotNetClientCert != null)
                 {
-                    RTCertificate winRtClientCert = ConvertDotNetClientCertToWinRtClientCert(dotNetCert);
+                    RTCertificate winRtClientCert = ConvertDotNetClientCertToWinRtClientCert(dotNetClientCert);
                     Debug.Assert(winRtClientCert != null);
 
                     websocketControl.ClientCertificate = winRtClientCert;

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinRTWebSocket.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinRTWebSocket.cs
@@ -563,7 +563,6 @@ namespace System.Net.WebSockets
         // (i.e., "MY" store) due to other WinRT-specific private key limitations. With that in mind, approach (2) is the
         // most appropriate for our needs, as it guarantees that WinRT WebSockets will be able to handle the resulting
         // WinRT Certificate during ConnectAsync.
-
         private static RTCertificate ConvertDotNetClientCertToWinRtClientCert(X509Certificate dotNetCertificate)
         {
             var query = new RTCertificateQuery

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinRTWebSocket.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinRTWebSocket.cs
@@ -114,18 +114,19 @@ namespace System.Net.WebSockets
                 websocketControl.SupportedProtocols.Add(subProtocol);
             }
 
-            if (MessageWebSocketClientCertificateSupported)
+            if (options.ClientCertificates.Count > 0)
             {
-                // Use the first app-provided client cert that can be successfully converted into a WinRT client cert (if any).
-                foreach (X509Certificate dotNetClientCert in options.ClientCertificates)
+                if (!MessageWebSocketClientCertificateSupported)
                 {
-                    RTCertificate winRtClientCert = ConvertDotNetClientCertToWinRtClientCert(dotNetClientCert);
-                    if (winRtClientCert != null)
-                    {
-                        websocketControl.ClientCertificate = winRtClientCert;
-                        break;
-                    }
+                    throw new NotSupportedException(string.Format(
+                        CultureInfo.InvariantCulture,
+                        SR.net_WebSockets_UWPClientCertSupportRequiresWindows10InsiderPreviewBuild16215OrGreater));
                 }
+
+                RTCertificate winRtClientCert = ConvertDotNetClientCertToWinRtClientCert(options.ClientCertificates[0]);
+                Debug.Assert(winRtClientCert != null);
+
+                websocketControl.ClientCertificate = winRtClientCert;
             }
 
             try
@@ -578,7 +579,9 @@ namespace System.Net.WebSockets
                 return certificates[0];
             }
 
-            return null;
+            throw new NotSupportedException(string.Format(
+                        CultureInfo.InvariantCulture,
+                        SR.net_WebSockets_UWPClientCertSupportRequiresCertInPersonalCertificateStore));
         }
         #endregion Helpers
 

--- a/src/System.Net.WebSockets.Client/tests/ClientWebSocketOptionsTests.cs
+++ b/src/System.Net.WebSockets.Client/tests/ClientWebSocketOptionsTests.cs
@@ -25,6 +25,11 @@ namespace System.Net.WebSockets.Client.Tests
         public static bool CanTestClientCertificates =>
             CanTestCertificates && BackendSupportsCustomCertificateHandling;
 
+        // Windows 10 Insider Preview Build 16215 introduced the necessary APIs for the UAP version of
+        // ClientWebSocket.ConnectAsync to carry out mutual TLS authentication.
+        public static bool ClientCertificatesSupported =>
+            !PlatformDetection.IsUap || PlatformDetection.IsWindows10InsiderPreviewBuild16215OrGreater;
+
         public ClientWebSocketOptionsTests(ITestOutputHelper output) : base(output) { }
 
         [ConditionalFact(nameof(WebSocketsSupported))]
@@ -72,9 +77,8 @@ namespace System.Net.WebSockets.Client.Tests
         }
 
         [OuterLoop] // TODO: Issue #11345
-        [ActiveIssue(21393, TargetFrameworkMonikers.Uap)]
         [ActiveIssue(5120, TargetFrameworkMonikers.Netcoreapp)]
-        [ConditionalFact(nameof(WebSocketsSupported), nameof(CanTestClientCertificates))]
+        [ConditionalFact(nameof(WebSocketsSupported), nameof(CanTestClientCertificates), nameof(ClientCertificatesSupported))]
         public async Task ClientCertificates_ValidCertificate_ServerReceivesCertificateAndConnectAsyncSucceeds()
         {
             var options = new LoopbackServer.Options { UseSsl = true, WebSocketEndpoint = true };


### PR DESCRIPTION
With these changes, the UWP implementation of ClientWebSocket.ConnectAsync takes the _ClientCertificates_ member of the app-provided _ClientWebSocketOptions_ into account. The first client cert that can be successfully converted into a WinRT client cert (if any) is configured on the underlying WinRT MessageWebSocket instance, leading to the cert being used for mutual TLS authentication when establishing connections with WSS endpoints.

This fix leverages WinRT APIs that are only present since Windows 10 Insider Preview Build 16215, so API presence checks are in place.

Fixes #21393

CC: @mconnew 