### PR TITLE
Fix Activity test StopWithoutTimestamp on netfx

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
@@ -320,10 +320,11 @@ namespace System.Diagnostics.Tests
             // DateTime.UtcNow is not precise on some platforms, but Activity stop time is precise
             // in this test we set start time, but not stop time and check duration.
             //
-            // Let's check that duration is 1sec - maximum DateTime.UtcNow error or bigger.
+            // Let's check that duration is 1sec - 2 * maximum DateTime.UtcNow error or bigger.
+            // As both start and stop timestamps may have error.
             // There is another test (ActivityDateTimeTests.StartStopReturnsPreciseDuration) 
             // that checks duration precision on netfx.
-            Assert.InRange(activity.Duration.TotalMilliseconds, 1000 - MaxClockErrorMSec, double.MaxValue);
+            Assert.InRange(activity.Duration.TotalMilliseconds, 1000 - 2 * MaxClockErrorMSec, double.MaxValue);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #16856

This test checks that if `activity.Stop()` is called without timestamp, `Duration` is updated to some reasonable value.

Duration is calculated as a difference between start and stop timestamps.
Activity corrects `DateTime.UtcNow` and calculates precise timestamps, however for the first ~16ms after app domain was created, Activity may still use inaccurate UtcNow value.

This is the case for  the test:
1. Start time is set to UtcNow by test - so it's precision of 16ms error
2. Stop time is set in Activity.Stop, but may not be corrected yet, so it also has 16ms precision.

@vancem  @stephentoub please review