### PR TITLE
Re-enable Mutex test for uap

### DIFF
--- a/src/System.Threading/tests/MutexTests.cs
+++ b/src/System.Threading/tests/MutexTests.cs
@@ -222,7 +222,6 @@ namespace System.Threading.Tests
 
         [Theory]
         [MemberData(nameof(CrossProcess_NamedMutex_ProtectedFileAccessAtomic_MemberData))]
-        [ActiveIssue(21276, TargetFrameworkMonikers.Uap)]
         public void CrossProcess_NamedMutex_ProtectedFileAccessAtomic(string prefix)
         {
             ThreadTestHelpers.RunTestInBackgroundThread(() =>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/21276

The test passes locally in both Uap and UapAot.

cc: @danmosemsft @kouvel 