### PR TITLE
Fixed BufferedStream.ReadByteSlow() to correctly set _readPos

### DIFF
--- a/src/System.IO/tests/BufferedStream/BufferedStreamTests.cs
+++ b/src/System.IO/tests/BufferedStream/BufferedStreamTests.cs
@@ -113,6 +113,20 @@ namespace System.IO.Tests
         {
             return new BufferedStream(new MemoryStream(), bufferSize);
         }
+
+        [Fact]
+        public void ReadByte_ThenRead_EndOfStreamCorrectlyFound()
+        {
+            using (var s = new BufferedStream(new MemoryStream(new byte[] { 1, 2 }), 2))
+            {
+                Assert.Equal(1, s.ReadByte());
+                Assert.Equal(2, s.ReadByte());
+                Assert.Equal(-1, s.ReadByte());
+
+                Assert.Equal(0, s.Read(new byte[1], 0, 1));
+                Assert.Equal(0, s.Read(new byte[1], 0, 1));
+            }
+        }
     }
 
     public class BufferedStream_TestLeaveOpen : TestLeaveOpen

--- a/src/System.Runtime.Extensions/src/System/IO/BufferedStream.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/BufferedStream.cs
@@ -690,10 +690,11 @@ namespace System.IO
 
             EnsureBufferAllocated();
             _readLen = _stream.Read(_buffer, 0, _bufferSize);
+            _readPos = 0;
+
             if (_readLen == 0)
                 return -1;
 
-            _readPos = 0;
             return _buffer[_readPos++];
         }
 


### PR DESCRIPTION
Includes @channeladam's commit from https://github.com/dotnet/corefx/pull/21877 along with a test. (I accidentally closed his PR and for some reason GitHub wouldn't let me reopen it.)