### PR TITLE
Detect connection closed in ManagedHandler pooling

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
@@ -2,6 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.IO;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -44,7 +48,7 @@ namespace System.Net.Http.Functional.Tests
     //    public ManagedHandler_HttpClientEKUTest() => ManagedHandlerTestHelpers.SetEnvVar();
     //    public void Dispose() => ManagedHandlerTestHelpers.RemoveEnvVar();
     //}
-
+    
     public sealed class ManagedHandler_HttpClientHandler_DangerousAcceptAllCertificatesValidator_Test : HttpClientHandler_DangerousAcceptAllCertificatesValidator_Test, IDisposable
     {
         public ManagedHandler_HttpClientHandler_DangerousAcceptAllCertificatesValidator_Test() => ManagedHandlerTestHelpers.SetEnvVar();
@@ -110,7 +114,6 @@ namespace System.Net.Http.Functional.Tests
     }
 
     // TODO #21452:
-    //
     //public sealed class ManagedHandler_DefaultCredentialsTest : DefaultCredentialsTest, IDisposable
     //{
     //    public ManagedHandler_DefaultCredentialsTest(ITestOutputHelper output) : base(output) => ManagedHandlerTestHelpers.SetEnvVar();
@@ -128,7 +131,6 @@ namespace System.Net.Http.Functional.Tests
     // "cancelable", meaning that the underlying operation will still be running even though we've returned "canceled",
     // or we need to just recognize that cancellation in such situations can be left up to the caller to do the
     // same thing if it's really important.
-    //
     //public sealed class ManagedHandler_CancellationTest : CancellationTest, IDisposable
     //{
     //    public ManagedHandler_CancellationTest(ITestOutputHelper output) : base(output) => ManagedHandlerTestHelpers.SetEnvVar();
@@ -136,7 +138,6 @@ namespace System.Net.Http.Functional.Tests
     //}
 
     // TODO #21452: The managed handler doesn't currently track how much data was written for the response headers.
-    //
     //public sealed class ManagedHandler_HttpClientHandler_MaxResponseHeadersLength_Test : HttpClientHandler_MaxResponseHeadersLength_Test, IDisposable
     //{
     //    public ManagedHandler_HttpClientHandler_MaxResponseHeadersLength_Test() => ManagedHandlerTestHelpers.SetEnvVar();
@@ -146,4 +147,102 @@ namespace System.Net.Http.Functional.Tests
     //        base.Dispose();
     //    }
     //}
+
+    public sealed class ManagedHandler_HttpClientHandler_ConnectionPooling_Test
+    {
+        public ManagedHandler_HttpClientHandler_ConnectionPooling_Test() => ManagedHandlerTestHelpers.SetEnvVar();
+        public void Dispose() => ManagedHandlerTestHelpers.RemoveEnvVar();
+
+        // TODO: Currently the subsequent tests sometimes fail/hang with WinHttpHandler / CurlHandler.
+        // In theory they should pass with any handler that does appropriate connection pooling.
+        // We should understand why they sometimes fail there and ideally move them to be
+        // used by all handlers this test project tests.
+
+        [Fact]
+        public async Task MultipleIterativeRequests_SameConnectionReused()
+        {
+            using (var client = new HttpClient())
+            using (var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                listener.Listen(1);
+                var ep = (IPEndPoint)listener.LocalEndPoint;
+                var uri = new Uri($"http://{ep.Address}:{ep.Port}/");
+
+                string responseBody =
+                    "HTTP/1.1 200 OK\r\n" +
+                    $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
+                    "Content-Length: 0\r\n" +
+                    "\r\n";
+
+                Task<string> firstRequest = client.GetStringAsync(uri);
+                using (Socket server = await listener.AcceptAsync())
+                using (var serverStream = new NetworkStream(server, ownsSocket: false))
+                using (var serverReader = new StreamReader(serverStream))
+                using (var serverWriter = new StreamWriter(serverStream))
+                {
+                    await serverReader.ReadLineAsync(); // GET line
+                    await serverReader.ReadLineAsync(); // blank line
+                    await serverWriter.WriteAsync(responseBody);
+                    await serverWriter.FlushAsync();
+                    await firstRequest;
+
+                    Task<Socket> secondAccept = listener.AcceptAsync(); // shouldn't complete
+
+                    Task<string> additionalRequest = client.GetStringAsync(uri);
+                    await serverReader.ReadLineAsync(); // GET line
+                    await serverReader.ReadLineAsync(); // blank line
+                    await serverWriter.WriteAsync(responseBody);
+                    await serverWriter.FlushAsync();
+                    await additionalRequest;
+
+                    Assert.False(secondAccept.IsCompleted, $"Second accept should never complete");
+                }
+            }
+        }
+
+        [OuterLoop("Incurs a delay")]
+        [Fact]
+        public async Task ServerDisconnectsAfterInitialRequest_SubsequentRequestUsesDifferentConnection()
+        {
+            using (var client = new HttpClient())
+            using (var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                listener.Listen(100);
+                var ep = (IPEndPoint)listener.LocalEndPoint;
+                var uri = new Uri($"http://{ep.Address}:{ep.Port}/");
+
+                string responseBody =
+                    "HTTP/1.1 200 OK\r\n" +
+                    $"Date: {DateTimeOffset.UtcNow:R}\r\n" +
+                    "Content-Length: 0\r\n" +
+                    "\r\n";
+
+                // Make multiple requests iteratively.
+                for (int i = 0; i < 2; i++)
+                {
+                    Task<string> request = client.GetStringAsync(uri);
+                    using (Socket server = await listener.AcceptAsync())
+                    using (var serverStream = new NetworkStream(server, ownsSocket: false))
+                    using (var serverReader = new StreamReader(serverStream))
+                    using (var serverWriter = new StreamWriter(serverStream))
+                    {
+                        await serverReader.ReadLineAsync(); // GET line
+                        await serverReader.ReadLineAsync(); // blank line
+
+                        await server.SendAsync(new ArraySegment<byte>(Encoding.ASCII.GetBytes(responseBody)), SocketFlags.None);
+
+                        await request;
+
+                        server.Shutdown(SocketShutdown.Both);
+                        if (i == 0)
+                        {
+                            await Task.Delay(2000); // give client time to see the closing before next connect
+                        }
+                    }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
We still need a real connection pooling implementation, but this change at least helps mitigate the case where the server closes the connection.  When we take a connection from the pool, we now poll to see if it's readable, and if it is (meaning either it's been shutdown or there's data available to read), we discard it as it's unusable.

cc: @geoffkizer 