### PR TITLE
Wrap CurlHandler cert validation callback exceptions in HttpRequestException

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlException.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlException.cs
@@ -13,6 +13,11 @@ namespace System.Net.Http
             HResult = error;
         }
 
+        internal CurlException(int error, Exception innerException) : base(GetCurlErrorString(error, isMulti:false), innerException)
+        {
+            HResult = error;
+        }
+
         internal CurlException(int error, bool isMulti) : this(error, GetCurlErrorString(error, isMulti))
         {
         }

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.SslProvider.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.SslProvider.cs
@@ -266,7 +266,7 @@ namespace System.Net.Http
                 catch (Exception exc)
                 {
                     EventSourceTrace("Unexpected exception: {0}", exc, easy: easy);
-                    easy.FailRequest(CreateHttpRequestException(exc));
+                    easy.FailRequest(CreateHttpRequestException(new CurlException((int)CURLcode.CURLE_ABORTED_BY_CALLBACK, exc)));
                     return FailureResult;
                 }
                 finally

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.SslProvider.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.SslProvider.cs
@@ -266,7 +266,7 @@ namespace System.Net.Http
                 catch (Exception exc)
                 {
                     EventSourceTrace("Unexpected exception: {0}", exc, easy: easy);
-                    easy.FailRequest(exc);
+                    easy.FailRequest(CreateHttpRequestException(exc));
                     return FailureResult;
                 }
                 finally

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
@@ -162,6 +162,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(21904)]
         [OuterLoop] // TODO: Issue #11345
         [Fact]
         public async Task UseCallback_CallbackThrowsException_ExceptionPropagates()


### PR DESCRIPTION
Contributes to https://github.com/dotnet/corefx/issues/21904

(https://github.com/dotnet/corefx/issues/21905 is fixing the corresponding test, so for now in this PR I've just marked the associated test as ActiveIssue, and we'll just need to resolve the merge conflict accordingly based on whichever change is merged first.)

cc: @davidsh, @geoffkizer 