### PR TITLE
Change System.Data.Common to build with System.Xml.Private

### DIFF
--- a/src/System.Data.Common/src/Configurations.props
+++ b/src/System.Data.Common/src/Configurations.props
@@ -5,6 +5,7 @@
       uap-Windows_NT;
       netcoreapp;
       netfx;
+	  uapaot-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Data.Common/src/Configurations.props
+++ b/src/System.Data.Common/src/Configurations.props
@@ -5,7 +5,7 @@
       uap-Windows_NT;
       netcoreapp;
       netfx;
-	  uapaot-Windows_NT;
+      uapaot-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Data.Common/src/System.Data.Common.csproj
+++ b/src/System.Data.Common/src/System.Data.Common.csproj
@@ -7,6 +7,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netfx'">true</IsPartialFacadeAssembly>
+	<DefineConstants Condition="'$(TargetGroup)' == 'uapaot'">$(DefineConstants);uapaot</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
@@ -14,6 +15,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="System\Data\Common\DbColumn.cs" />
     <Compile Include="System\Data\Common\IDbColumnSchemaGenerator.cs" />
@@ -310,8 +313,13 @@
     <Reference Include="System.Threading" />
     <Reference Include="System.Threading.Thread" />
     <Reference Include="System.Transactions.Local" />
-    <Reference Include="System.Xml.ReaderWriter" />
-    <Reference Include="System.Xml.XmlSerializer" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' != 'uapaot' and '$(TargetGroup)' != 'netfx'">
+	<Reference Include="System.Xml.ReaderWriter" />
+	<Reference Include="System.Xml.XmlSerializer" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'uapaot' and '$(TargetGroup)' != 'netfx'">
+    <ProjectReference Include="..\..\System.Private.Xml\src\System.Private.Xml.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp' or '$(TargetGroup)' == 'uap'">
     <EmbeddedResource Include="Resources\$(AssemblyName).rd.xml" />

--- a/src/System.Data.Common/src/System.Data.Common.csproj
+++ b/src/System.Data.Common/src/System.Data.Common.csproj
@@ -321,7 +321,7 @@
   <ItemGroup Condition="'$(TargetGroup)' == 'uapaot'">
     <ProjectReference Include="..\..\System.Private.Xml\src\System.Private.Xml.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp' or '$(TargetGroup)' == 'uap'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp' or '$(TargetGroup)' == 'uap' or '$(TargetGroup)' == 'uapaot'">
     <EmbeddedResource Include="Resources\$(AssemblyName).rd.xml" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Data.Common/src/System.Data.Common.csproj
+++ b/src/System.Data.Common/src/System.Data.Common.csproj
@@ -315,8 +315,8 @@
     <Reference Include="System.Transactions.Local" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'uapaot' and '$(TargetGroup)' != 'netfx'">
-	<Reference Include="System.Xml.ReaderWriter" />
-	<Reference Include="System.Xml.XmlSerializer" />
+    <Reference Include="System.Xml.ReaderWriter" />
+    <Reference Include="System.Xml.XmlSerializer" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'uapaot'">
     <ProjectReference Include="..\..\System.Private.Xml\src\System.Private.Xml.csproj" />

--- a/src/System.Data.Common/src/System.Data.Common.csproj
+++ b/src/System.Data.Common/src/System.Data.Common.csproj
@@ -7,7 +7,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netfx'">true</IsPartialFacadeAssembly>
-	<DefineConstants Condition="'$(TargetGroup)' == 'uapaot'">$(DefineConstants);uapaot</DefineConstants>
+    <DefineConstants Condition="'$(TargetGroup)' == 'uapaot'">$(DefineConstants);uapaot</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
@@ -318,7 +318,7 @@
 	<Reference Include="System.Xml.ReaderWriter" />
 	<Reference Include="System.Xml.XmlSerializer" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'uapaot' and '$(TargetGroup)' != 'netfx'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'uapaot'">
     <ProjectReference Include="..\..\System.Private.Xml\src\System.Private.Xml.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp' or '$(TargetGroup)' == 'uap'">

--- a/src/System.Data.Common/src/System/Data/SQLTypes/SqlXml.cs
+++ b/src/System.Data.Common/src/System/Data/SQLTypes/SqlXml.cs
@@ -118,13 +118,19 @@ namespace System.Data.SqlTypes
             }
         }
 
+#if uapaot
+        private static Func<Stream, XmlReaderSettings, XmlParserContext, XmlReader> CreateSqlReaderDelegate()
+        {
+            return System.Xml.XmlReader.CreateSqlReader;
+        }
+#else
         private static Func<Stream, XmlReaderSettings, XmlParserContext, XmlReader> CreateSqlReaderDelegate()
         {
             Debug.Assert(CreateSqlReaderMethodInfo != null, "MethodInfo reference for XmlReader.CreateSqlReader should not be null.");
 
             return (Func<Stream, XmlReaderSettings, XmlParserContext, XmlReader>)CreateSqlReaderMethodInfo.CreateDelegate(typeof(Func<Stream, XmlReaderSettings, XmlParserContext, XmlReader>));
         }
-
+#endif
         private static MethodInfo CreateSqlReaderMethodInfo
         {
             get

--- a/src/System.Data.Common/src/System/Data/SQLTypes/SqlXml.cs
+++ b/src/System.Data.Common/src/System/Data/SQLTypes/SqlXml.cs
@@ -119,10 +119,7 @@ namespace System.Data.SqlTypes
         }
 
 #if uapaot
-        private static Func<Stream, XmlReaderSettings, XmlParserContext, XmlReader> CreateSqlReaderDelegate()
-        {
-            return System.Xml.XmlReader.CreateSqlReader;
-        }
+        private static Func<Stream, XmlReaderSettings, XmlParserContext, XmlReader> CreateSqlReaderDelegate() => System.Xml.XmlReader.CreateSqlReader;
 #else
         private static Func<Stream, XmlReaderSettings, XmlParserContext, XmlReader> CreateSqlReaderDelegate()
         {

--- a/src/System.Private.Xml/src/System.Private.Xml.csproj
+++ b/src/System.Private.Xml/src/System.Private.Xml.csproj
@@ -9,7 +9,7 @@
     <NoWarn>$(NoWarn),649</NoWarn>
     <FeatureCompiledXsl Condition="'$(TargetGroup)' != 'uap' AND '$(TargetGroup)' != 'uapaot'">true</FeatureCompiledXsl>
     <DefineConstants Condition="'$(FeatureCompiledXsl)' == 'true'">$(DefineConstants);FEATURE_COMPILED_XSL</DefineConstants>
-    <DefineConstants Condition="'$(TargetGroup)' == 'uapaot'">$(DefineConstants);FEATURE_SERIALIZATION_UAPAOT</DefineConstants>
+    <DefineConstants Condition="'$(TargetGroup)' == 'uapaot'">$(DefineConstants);FEATURE_SERIALIZATION_UAPAOT;UAPAOT</DefineConstants>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlReader.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlReader.cs
@@ -1849,7 +1849,11 @@ namespace System.Xml
         // NOTE: This method is called via reflection from System.Data.dll and from Analysis Services in Yukon. 
         // Do not change its signature without notifying the appropriate teams!
         // !!!!!!
+#if FEATURE_SERIALIZATION_UAPAOT
+        public static XmlReader CreateSqlReader(Stream input, XmlReaderSettings settings, XmlParserContext inputContext)
+#else
         internal static XmlReader CreateSqlReader(Stream input, XmlReaderSettings settings, XmlParserContext inputContext)
+#endif
         {
             if (input == null)
             {

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlReader.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlReader.cs
@@ -1849,7 +1849,7 @@ namespace System.Xml
         // NOTE: This method is called via reflection from System.Data.dll and from Analysis Services in Yukon. 
         // Do not change its signature without notifying the appropriate teams!
         // !!!!!!
-#if FEATURE_SERIALIZATION_UAPAOT
+#if UAPAOT
         public static XmlReader CreateSqlReader(Stream input, XmlReaderSettings settings, XmlParserContext inputContext)
 #else
         internal static XmlReader CreateSqlReader(Stream input, XmlReaderSettings settings, XmlParserContext inputContext)


### PR DESCRIPTION
For uapaot, SqlXml needs to have access to the XmlReader.CreateSqlReader via reflection. 
The options are to disable reflect block on System.Xml.* which may cause the application size to be larger. 

To get past this issue, the recommendation is to change the CreateSqlReader visibility to public in System.Private.Xml and take a dependency on the private assembly. 

Fixes #19202 
cc @tijoytom @stephentoub @joperezr @danmosemsft @jkotas 