### PR TITLE
Add license header to AdjustableArrowCapTests.cs

### DIFF
--- a/src/System.Drawing.Common/tests/Drawing2D/AdjustableArrowCapTests.cs
+++ b/src/System.Drawing.Common/tests/Drawing2D/AdjustableArrowCapTests.cs
@@ -1,4 +1,8 @@
-﻿using System.Collections.Generic;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
 using Xunit;
 
 namespace System.Drawing.Drawing2D.Tests


### PR DESCRIPTION
I forgot to add the license header to this file.