### PR TITLE
Fix uap package clrcompression import

### DIFF
--- a/pkg/frameworkPackage.targets
+++ b/pkg/frameworkPackage.targets
@@ -17,7 +17,7 @@
     <LibFileTargetPath Condition="'$(LibFileTargetPath)' == '' AND '$(PackageTargetRuntime)' != ''">runtimes/$(PackageTargetRuntime)/lib/$(TargetFramework)</LibFileTargetPath>
 
     <NativeFileTargetPath Condition="'$(NativeFileTargetPath)' == '' AND '$(PackageTargetRuntime)' != ''">runtimes/$(PackageTargetRuntime)/native</NativeFileTargetPath>
-    <NativeBinDir Condition="'$(PackageTargetRuntime)' != '' AND $(PackageTargetRuntime.EndsWith('aot'))">$(NativeBinDir)_aot</NativeBinDir>
+    <NativeBinDir Condition="'$(PackageTargetRuntimeSuffix)' == 'aot'">$(NativeBinDir)_aot</NativeBinDir>
   </PropertyGroup>
 
   <!-- Bring in ref content from binplaced ref props -->

--- a/pkg/frameworkPackage.targets
+++ b/pkg/frameworkPackage.targets
@@ -17,6 +17,7 @@
     <LibFileTargetPath Condition="'$(LibFileTargetPath)' == '' AND '$(PackageTargetRuntime)' != ''">runtimes/$(PackageTargetRuntime)/lib/$(TargetFramework)</LibFileTargetPath>
 
     <NativeFileTargetPath Condition="'$(NativeFileTargetPath)' == '' AND '$(PackageTargetRuntime)' != ''">runtimes/$(PackageTargetRuntime)/native</NativeFileTargetPath>
+    <NativeBinDir Condition="'$(PackageTargetRuntime)' != '' AND $(PackageTargetRuntime.EndsWith('aot'))">$(NativeBinDir)_aot</NativeBinDir>
   </PropertyGroup>
 
   <!-- Bring in ref content from binplaced ref props -->


### PR DESCRIPTION
The UAP AOT packages were taking a clrcompression that did not have the appx bit enabled.

@joperezr @ericstj 