### PR TITLE
Re-enable GCTests.GetAllocatedBytesForCurrentThread for UWPAOT

### DIFF
--- a/src/System.Runtime/tests/System/GCTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/GCTests.netcoreapp.cs
@@ -12,7 +12,6 @@ namespace System.Tests
         [Theory]
         [InlineData(1000)]
         [InlineData(100000)]
-        [ActiveIssue("https://github.com/dotnet/corert/issues/3648 - GC.GetAllocatedBytesForCurrentThread not yet ported to CoreRT", TargetFrameworkMonikers.UapAot)]
         public static void GetAllocatedBytesForCurrentThread(int size)
         {
             long start = GC.GetAllocatedBytesForCurrentThread();


### PR DESCRIPTION
Pending a check-in to CoreRT.