### PR TITLE
Convert Tests to Theory

### DIFF
--- a/src/CoreFx.Private.TestUtilities/src/System/IO/FileCleanupTestBase.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/IO/FileCleanupTestBase.cs
@@ -63,7 +63,10 @@ namespace System.IO
             catch { } // avoid exceptions escaping Dispose
         }
 
-        /// <summary>Gets the test directory into which all files and directories created by tests should be stored.</summary>
+        /// <summary>
+        /// Gets the test directory into which all files and directories created by tests should be stored.
+        /// This directory is isolated per test class.
+        /// </summary>
         protected string TestDirectory { get; }
 
         /// <summary>Gets a test file full path that is associated with the call site.</summary>

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
@@ -503,7 +503,7 @@ namespace System.IO
                 {
                     throw new ArgumentNullException("path");
                 }
-                if (string.IsNullOrWhiteSpace(userPath))
+                if (string.IsNullOrEmpty(userPath))
                 {
                     throw new ArgumentException(SR.Argument_EmptyPath, "path");
                 }

--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -9,6 +9,7 @@ namespace System.IO.Tests
 {
     public class Directory_CreateDirectory : FileSystemTest
     {
+        public static TheoryData ReservedDeviceNames = IOInputs.GetReservedDeviceNames().ToTheoryData(); 
         #region Utilities
 
         public virtual DirectoryInfo Create(string path)
@@ -122,38 +123,34 @@ namespace System.IO.Tests
             Assert.True(result.Exists);
         }
 
-        [ConditionalFact(nameof(UsingNewNormalization))]
+        [ConditionalTheory(nameof(UsingNewNormalization)),
+            MemberData(nameof(ValidPathComponentNames))]
         [ActiveIssue(20117, TargetFrameworkMonikers.Uap)]
         [PlatformSpecific(TestPlatforms.Windows)]  // trailing slash
-        public void ValidExtendedPathWithTrailingSlash()
+        public void ValidExtendedPathWithTrailingSlash(string component)
         {
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
 
-            var components = IOInputs.GetValidPathComponentNames();
-            Assert.All(components, (component) =>
-            {
-                string path = IOInputs.ExtendedPrefix + IOServices.AddTrailingSlashIfNeeded(Path.Combine(testDir.FullName, component));
-                DirectoryInfo result = Create(path);
+            string path = IOInputs.ExtendedPrefix + IOServices.AddTrailingSlashIfNeeded(Path.Combine(testDir.FullName, component));
+            DirectoryInfo result = Create(path);
 
-                Assert.Equal(path, result.FullName);
-                Assert.True(result.Exists);
-            });
+            Assert.Equal(path, result.FullName);
+            Assert.True(result.Exists);
+
         }
 
-        [Fact]
-        public void ValidPathWithoutTrailingSlash()
+        [Theory,
+            MemberData(nameof(ValidPathComponentNames))]
+        public void ValidPathWithoutTrailingSlash(string component)
         {
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
 
-            var components = IOInputs.GetValidPathComponentNames();
-            Assert.All(components, (component) =>
-            {
-                string path = testDir.FullName + Path.DirectorySeparatorChar + component;
-                DirectoryInfo result = Create(path);
+            string path = testDir.FullName + Path.DirectorySeparatorChar + component;
+            DirectoryInfo result = Create(path);
 
-                Assert.Equal(path, result.FullName);
-                Assert.True(Directory.Exists(result.FullName));
-            });
+            Assert.Equal(path, result.FullName);
+            Assert.True(Directory.Exists(result.FullName));
+
         }
 
         [Fact]
@@ -199,17 +196,13 @@ namespace System.IO.Tests
             Assert.True(Directory.Exists(result.FullName));
         }
 
-        [Fact]
-        public void DirectoryWithComponentLongerThanMaxComponentAsPath_ThrowsPathTooLongException()
+        [Theory,
+            MemberData(nameof(PathsWithComponentLongerThanMaxComponent))]
+        public void DirectoryWithComponentLongerThanMaxComponentAsPath_ThrowsPathTooLongException(string path)
         {
             // While paths themselves can be up to 260 characters including trailing null, file systems
             // limit each components of the path to a total of 255 characters.
-            var paths = IOInputs.GetPathsWithComponentLongerThanMaxComponent();
-
-            Assert.All(paths, (path) =>
-            {
-                Assert.Throws<PathTooLongException>(() => Create(path));
-            });
+             Assert.Throws<PathTooLongException>(() => Create(path));
         }
 
         #endregion
@@ -308,122 +301,97 @@ namespace System.IO.Tests
             }
         }
 
-        [Fact]
+        [Theory,
+            MemberData(nameof(WhiteSpace))]
         [PlatformSpecific(TestPlatforms.Windows)]  // whitespace as path throws ArgumentException on Windows
-        public void WindowsWhiteSpaceAsPath_ThrowsArgumentException()
+        public void WindowsWhiteSpaceAsPath_ThrowsArgumentException(string path)
         {
-            var paths = IOInputs.GetWhiteSpace();
-            Assert.All(paths, (path) =>
-            {
-                Assert.Throws<ArgumentException>(() => Create(path));
-            });
+            Assert.Throws<ArgumentException>(() => Create(path));
         }
 
-        [Fact]
+        [Theory,
+            MemberData(nameof(WhiteSpace))]
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // whitespace as path allowed
-        public void UnixWhiteSpaceAsPath_Allowed()
+        public void UnixWhiteSpaceAsPath_Allowed(string path)
         {
-            var paths = IOInputs.GetWhiteSpace();
-            Assert.All(paths, (path) =>
-            {
-                Create(Path.Combine(TestDirectory, path));
-                Assert.True(Directory.Exists(Path.Combine(TestDirectory, path)));
-            });
+            Create(Path.Combine(TestDirectory, path));
+            Assert.True(Directory.Exists(Path.Combine(TestDirectory, path)));
+
         }
 
-        [Fact]
+        [Theory,
+            MemberData(nameof(WhiteSpace))]
         [PlatformSpecific(TestPlatforms.Windows)]  // trailing whitespace in path is removed on Windows
-        public void WindowsTrailingWhiteSpace()
+        public void WindowsTrailingWhiteSpace(string component)
         {
             // Windows will remove all non-significant whitespace in a path
             DirectoryInfo testDir = Create(GetTestFilePath());
-            var components = IOInputs.GetWhiteSpace();
+            string path = IOServices.RemoveTrailingSlash(testDir.FullName) + component;
+            DirectoryInfo result = Create(path);
 
-            Assert.All(components, (component) =>
-            {
-                string path = IOServices.RemoveTrailingSlash(testDir.FullName) + component;
-                DirectoryInfo result = Create(path);
-
-                Assert.True(Directory.Exists(result.FullName));
-                Assert.Equal(testDir.FullName, IOServices.RemoveTrailingSlash(result.FullName));
-            });
+            Assert.True(Directory.Exists(result.FullName));
+            Assert.Equal(testDir.FullName, IOServices.RemoveTrailingSlash(result.FullName));
         }
 
-        [ConditionalFact(nameof(UsingNewNormalization))]
+        [ConditionalTheory(nameof(UsingNewNormalization)),
+            MemberData(nameof(SimpleWhiteSpace))]
         [ActiveIssue(20117, TargetFrameworkMonikers.Uap)]
         [PlatformSpecific(TestPlatforms.Windows)]  // extended syntax with whitespace
-        public void WindowsExtendedSyntaxWhiteSpace()
+        public void WindowsExtendedSyntaxWhiteSpace(string path)
         {
-            var paths = IOInputs.GetSimpleWhiteSpace();
-            foreach (var path in paths)
-            {
-                string extendedPath = Path.Combine(IOInputs.ExtendedPrefix + TestDirectory, path);
-                Directory.CreateDirectory(extendedPath);
-                Assert.True(Directory.Exists(extendedPath), extendedPath);
-            }
+            string extendedPath = Path.Combine(IOInputs.ExtendedPrefix + TestDirectory, path);
+            Directory.CreateDirectory(extendedPath);
+            Assert.True(Directory.Exists(extendedPath), extendedPath);
         }
 
-        [Fact]
+        [Theory,
+            MemberData(nameof(WhiteSpace))]
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // trailing whitespace in path treated as significant on Unix
-        public void UnixNonSignificantTrailingWhiteSpace()
+        public void UnixNonSignificantTrailingWhiteSpace(string component)
         {
             // Unix treats trailing/prename whitespace as significant and a part of the name.
             DirectoryInfo testDir = Create(GetTestFilePath());
-            var components = IOInputs.GetWhiteSpace();
 
-            Assert.All(components, (component) =>
-            {
-                string path = IOServices.RemoveTrailingSlash(testDir.FullName) + component;
-                DirectoryInfo result = Create(path);
+            string path = IOServices.RemoveTrailingSlash(testDir.FullName) + component;
+            DirectoryInfo result = Create(path);
 
-                Assert.True(Directory.Exists(result.FullName));
-                Assert.NotEqual(testDir.FullName, IOServices.RemoveTrailingSlash(result.FullName));
-            });
+            Assert.True(Directory.Exists(result.FullName));
+            Assert.NotEqual(testDir.FullName, IOServices.RemoveTrailingSlash(result.FullName));
+
         }
 
-        [Fact]
+        [Theory,
+            MemberData(nameof(PathsWithAlternativeDataStreams))]
         [PlatformSpecific(TestPlatforms.Windows)] // alternate data streams
-        public void PathWithAlternateDataStreams_ThrowsNotSupportedException()
+        public void PathWithAlternateDataStreams_ThrowsNotSupportedException(string path)
         {
-            var paths = IOInputs.GetPathsWithAlternativeDataStreams();
-            Assert.All(paths, (path) =>
-            {
-                Assert.Throws<NotSupportedException>(() => Create(path));
-            });
+            Assert.Throws<NotSupportedException>(() => Create(path));
         }
 
-        [Fact]
+        [Theory,
+            MemberData(nameof(PathsWithReservedDeviceNames))]
         [PlatformSpecific(TestPlatforms.Windows)] // device name prefixes
-        public void PathWithReservedDeviceNameAsPath_ThrowsDirectoryNotFoundException()
-        {   // Throws DirectoryNotFoundException, when the behavior really should be an invalid path
-            var paths = IOInputs.GetPathsWithReservedDeviceNames();
-            Assert.All(paths, (path) =>
-            {
-                Assert.Throws<DirectoryNotFoundException>(() => Create(path));
-            });
+        public void PathWithReservedDeviceNameAsPath_ThrowsDirectoryNotFoundException(string path)
+        {
+            // Throws DirectoryNotFoundException, when the behavior really should be an invalid path
+            Assert.Throws<DirectoryNotFoundException>(() => Create(path));
         }
 
-        [ConditionalFact(nameof(UsingNewNormalization))]
+        [ConditionalTheory(nameof(UsingNewNormalization)),
+            MemberData(nameof(ReservedDeviceNames))]
         [ActiveIssue(20117, TargetFrameworkMonikers.Uap)]
         [PlatformSpecific(TestPlatforms.Windows)] // device name prefixes
-        public void PathWithReservedDeviceNameAsExtendedPath()
+        public void PathWithReservedDeviceNameAsExtendedPath(string path)
         {
-            var paths = IOInputs.GetReservedDeviceNames();
-            Assert.All(paths, (path) =>
-            {
-                Assert.True(Create(IOInputs.ExtendedPrefix + Path.Combine(TestDirectory, path)).Exists, path);
-            });
+            Assert.True(Create(IOInputs.ExtendedPrefix + Path.Combine(TestDirectory, path)).Exists, path);
         }
 
-        [Fact]
+        [Theory,
+            MemberData(nameof(UncPathsWithoutShareName))]
         [PlatformSpecific(TestPlatforms.Windows)] // UNC shares
-        public void UncPathWithoutShareNameAsPath_ThrowsArgumentException()
+        public void UncPathWithoutShareNameAsPath_ThrowsArgumentException(string path)
         {
-            var paths = IOInputs.GetUncPathsWithoutShareName();
-            foreach (var path in paths)
-            {
-                Assert.Throws<ArgumentException>(() => Create(path));
-            }
+            Assert.Throws<ArgumentException>(() => Create(path));
         }
 
         [Fact]

--- a/src/System.IO.FileSystem/tests/Directory/Exists.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Exists.cs
@@ -254,7 +254,23 @@ namespace System.IO.Tests
             MemberData(nameof(SimpleWhiteSpace))]
         [ActiveIssue(20117, TargetFrameworkMonikers.Uap)]
         [PlatformSpecific(TestPlatforms.Windows)] // In Windows, trailing whitespace in a path is trimmed appropriately
-        public void TrailingWhitespaceExistence(string component)
+        public void TrailingWhitespaceExistence_SimpleWhiteSpace(string component)
+        {
+            // This test relies on \\?\ support
+
+            DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
+
+            string path = GetTestFilePath(memberName: "Extended") + component;
+            testDir = Directory.CreateDirectory(IOInputs.ExtendedPrefix + path);
+            Assert.False(Exists(path), path);
+            Assert.True(Exists(testDir.FullName));
+        }
+
+        [ConditionalTheory(nameof(UsingNewNormalization)),
+            MemberData(nameof(WhiteSpace))]
+        [ActiveIssue(20117, TargetFrameworkMonikers.Uap)]
+        [PlatformSpecific(TestPlatforms.Windows)] // In Windows, trailing whitespace in a path is trimmed appropriately
+        public void TrailingWhitespaceExistence_WhiteSpace(string component)
         {
             // This test relies on \\?\ support
 
@@ -264,10 +280,6 @@ namespace System.IO.Tests
             Assert.True(Exists(path), path); // string concat in case Path.Combine() trims whitespace before Exists gets to it
             Assert.False(Exists(IOInputs.ExtendedPrefix + path), path);
 
-            path = GetTestFilePath(memberName: "Extended") + component;
-            testDir = Directory.CreateDirectory(IOInputs.ExtendedPrefix + path);
-            Assert.False(Exists(path), path);
-            Assert.True(Exists(testDir.FullName));
         }
 
         [Theory,

--- a/src/System.IO.FileSystem/tests/Directory/Exists.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Exists.cs
@@ -33,24 +33,20 @@ namespace System.IO.Tests
             Assert.False(Exists(string.Empty));
         }
 
-        [Fact]
-        public void NonExistentValidPath_ReturnsFalse()
+        [Theory,
+            MemberData(nameof(ValidPathComponentNames))]
+        public void NonExistentValidPath_ReturnsFalse(string path)
         {
-            Assert.All((IOInputs.GetValidPathComponentNames()), (path) =>
-            {
-                Assert.False(Exists(path), path);
-            });
+            Assert.False(Exists(path), path);
         }
 
-        [Fact]
-        public void ValidPathExists_ReturnsTrue()
+        [Theory,
+            MemberData(nameof(ValidPathComponentNames))]
+        public void ValidPathExists_ReturnsTrue(string component)
         {
-            Assert.All((IOInputs.GetValidPathComponentNames()), (component) =>
-            {
-                string path = Path.Combine(TestDirectory, component);
-                DirectoryInfo testDir = Directory.CreateDirectory(path);
-                Assert.True(Exists(path));
-            });
+            string path = Path.Combine(TestDirectory, component);
+            DirectoryInfo testDir = Directory.CreateDirectory(path);
+            Assert.True(Exists(path));
         }
 
         [Theory, MemberData(nameof(PathsWithInvalidCharacters))]
@@ -176,17 +172,15 @@ namespace System.IO.Tests
 
         #region PlatformSpecific
 
-        [ConditionalFact(nameof(UsingNewNormalization))]
+        [ConditionalTheory(nameof(UsingNewNormalization)),
+            MemberData(nameof(ValidPathComponentNames))]
         [ActiveIssue(20117, TargetFrameworkMonikers.Uap)]
         [PlatformSpecific(TestPlatforms.Windows)]  // Extended path exists
-        public void ValidExtendedPathExists_ReturnsTrue()
+        public void ValidExtendedPathExists_ReturnsTrue(string component)
         {
-            Assert.All((IOInputs.GetValidPathComponentNames()), (component) =>
-            {
-                string path = IOInputs.ExtendedPrefix + Path.Combine(TestDirectory, "extended", component);
-                DirectoryInfo testDir = Directory.CreateDirectory(path);
-                Assert.True(Exists(path));
-            });
+            string path = IOInputs.ExtendedPrefix + Path.Combine(TestDirectory, "extended", component);
+            DirectoryInfo testDir = Directory.CreateDirectory(path);
+            Assert.True(Exists(path));
         }
 
         [ConditionalFact(nameof(UsingNewNormalization))]
@@ -226,15 +220,14 @@ namespace System.IO.Tests
             });
         }
 
-        [Fact]
+        [Theory,
+            MemberData(nameof(WhiteSpace))]
         [PlatformSpecific(TestPlatforms.Windows)] // Unix equivalent tested already in CreateDirectory
-        public void WindowsWhiteSpaceAsPath_ReturnsFalse()
+        public void WindowsWhiteSpaceAsPath_ReturnsFalse(string component)
         {
             // Checks that errors aren't thrown when calling Exists() on impossible paths
-            Assert.All(IOInputs.GetWhiteSpace(), (component) =>
-            {
-                Assert.False(Exists(component));
-            });
+            Assert.False(Exists(component));
+
         }
 
         [Fact]
@@ -257,58 +250,49 @@ namespace System.IO.Tests
             Assert.False(Exists(testDir.FullName.ToLowerInvariant()));
         }
 
-        [ConditionalFact(nameof(UsingNewNormalization))]
+        [ConditionalTheory(nameof(UsingNewNormalization)),
+            MemberData(nameof(SimpleWhiteSpace))]
         [ActiveIssue(20117, TargetFrameworkMonikers.Uap)]
         [PlatformSpecific(TestPlatforms.Windows)] // In Windows, trailing whitespace in a path is trimmed appropriately
-        public void TrailingWhitespaceExistence()
+        public void TrailingWhitespaceExistence(string component)
         {
             // This test relies on \\?\ support
 
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
-            Assert.All(IOInputs.GetWhiteSpace(), (component) =>
-            {
-                string path = testDir.FullName + component;
-                Assert.True(Exists(path), path); // string concat in case Path.Combine() trims whitespace before Exists gets to it
-                Assert.False(Exists(IOInputs.ExtendedPrefix + path), path);
-            });
 
-            Assert.All(IOInputs.GetSimpleWhiteSpace(), (component) =>
-            {
-                string path = GetTestFilePath(memberName: "Extended") + component;
-                testDir = Directory.CreateDirectory(IOInputs.ExtendedPrefix + path);
-                Assert.False(Exists(path), path);
-                Assert.True(Exists(testDir.FullName));
-            });
+            string path = testDir.FullName + component;
+            Assert.True(Exists(path), path); // string concat in case Path.Combine() trims whitespace before Exists gets to it
+            Assert.False(Exists(IOInputs.ExtendedPrefix + path), path);
+
+            path = GetTestFilePath(memberName: "Extended") + component;
+            testDir = Directory.CreateDirectory(IOInputs.ExtendedPrefix + path);
+            Assert.False(Exists(path), path);
+            Assert.True(Exists(testDir.FullName));
         }
 
-        [Fact]
+        [Theory,
+            MemberData(nameof(WhiteSpace))]
         [PlatformSpecific(TestPlatforms.Windows)] // alternate data stream
-        public void PathWithAlternateDataStreams_ReturnsFalse()
+        public void PathWithAlternateDataStreams_ReturnsFalse(string component)
         {
-            Assert.All(IOInputs.GetWhiteSpace(), (component) =>
-            {
-                Assert.False(Exists(component));
-            });
+            Assert.False(Exists(component));
+
         }
 
-        [Fact]
+        [Theory,
+            MemberData(nameof(PathsWithReservedDeviceNames))]
         [OuterLoop]
         [PlatformSpecific(TestPlatforms.Windows)] // device names
-        public void PathWithReservedDeviceNameAsPath_ReturnsFalse()
+        public void PathWithReservedDeviceNameAsPath_ReturnsFalse(string component)
         {
-            Assert.All((IOInputs.GetPathsWithReservedDeviceNames()), (component) =>
-            {
-                Assert.False(Exists(component));
-            });
+            Assert.False(Exists(component));
         }
 
-        [Fact]
-        public void UncPathWithoutShareNameAsPath_ReturnsFalse()
+        [Theory,
+            MemberData(nameof(UncPathsWithoutShareName))]
+        public void UncPathWithoutShareNameAsPath_ReturnsFalse(string component)
         {
-            Assert.All((IOInputs.GetUncPathsWithoutShareName()), (component) =>
-            {
-                Assert.False(Exists(component));
-            });
+            Assert.False(Exists(component));
         }
 
         [Fact]
@@ -322,14 +306,12 @@ namespace System.IO.Tests
             Assert.True(Exists(path.FullPath));
         }
 
-        [Fact]
+        [Theory,
+            MemberData(nameof(PathsWithComponentLongerThanMaxComponent))]
         [PlatformSpecific(TestPlatforms.Windows)] // max directory length not fixed on Unix
-        public void DirectoryWithComponentLongerThanMaxComponentAsPath_ReturnsFalse()
+        public void DirectoryWithComponentLongerThanMaxComponentAsPath_ReturnsFalse(string component)
         {
-            Assert.All((IOInputs.GetPathsWithComponentLongerThanMaxComponent()), (component) =>
-            {
-                Assert.False(Exists(component));
-            });
+            Assert.False(Exists(component));
         }
 
         [Fact]

--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str.cs
@@ -11,7 +11,7 @@ namespace System.IO.Tests
     {
         #region Utilities
 
-        public static string[] WindowsInvalidUnixValid = new string[] { "         ", " ", "\n", ">", "<", "\t" };
+        public static TheoryData WindowsInvalidUnixValid = new TheoryData<string> { "         ", " ", "\n", ">", "<", "\t" };
         protected virtual bool TestFiles { get { return true; } }       // True if the virtual GetEntries mmethod returns files
         protected virtual bool TestDirectories { get { return true; } } // True if the virtual GetEntries mmethod returns Directories
 
@@ -200,43 +200,45 @@ namespace System.IO.Tests
             }
         }
 
-        [Fact]
+        [Theory,
+            MemberData(nameof(WindowsInvalidUnixValid))]
         [PlatformSpecific(TestPlatforms.Windows)]  // Windows-only Invalid chars in path
-        public void WindowsInvalidCharsPath()
+        public void WindowsInvalidCharsPath(string invalid)
         {
-            Assert.All(WindowsInvalidUnixValid, invalid =>
-                Assert.Throws<ArgumentException>(() => GetEntries(invalid)));
+            
+            Assert.Throws<ArgumentException>(() => GetEntries(invalid));
         }
 
-        [Fact]
+        [Theory,
+            MemberData(nameof(WindowsInvalidUnixValid))]
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // Unix-only valid chars in file path
-        public void UnixValidCharsFilePath()
+        public void UnixValidCharsFilePath(string valid)
         {
             if (TestFiles)
             {
                 DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
-                foreach (string valid in WindowsInvalidUnixValid)
-                    File.Create(Path.Combine(testDir.FullName, valid)).Dispose();
+
+                File.Create(Path.Combine(testDir.FullName, valid)).Dispose();
 
                 string[] results = GetEntries(testDir.FullName);
-                Assert.All(WindowsInvalidUnixValid, valid =>
-                    Assert.Contains(Path.Combine(testDir.FullName, valid), results));
+                Assert.Contains(Path.Combine(testDir.FullName, valid), results);
             }
         }
 
-        [Fact]
+        [Theory,
+            MemberData(nameof(WindowsInvalidUnixValid))]
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // Windows-only invalid chars in directory path
-        public void UnixValidCharsDirectoryPath()
+        public void UnixValidCharsDirectoryPath(string valid)
         {
             if (TestDirectories)
             {
                 DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
-                foreach (string valid in WindowsInvalidUnixValid)
-                    testDir.CreateSubdirectory(valid);
+                
+                testDir.CreateSubdirectory(valid);
 
                 string[] results = GetEntries(testDir.FullName);
-                Assert.All(WindowsInvalidUnixValid, valid => 
-                    Assert.Contains(Path.Combine(testDir.FullName, valid), results));
+                 
+                Assert.Contains(Path.Combine(testDir.FullName, valid), results);
             }
         }
 

--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
@@ -801,33 +801,32 @@ namespace System.IO.Tests
             }
         }
 
-        [Fact]
+        [Theory,
+            MemberData(nameof(WindowsInvalidUnixValid))]
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // Unix-valid chars in file search patterns
-        public void UnixSearchPatternFileValidChar()
+        public void UnixSearchPatternFileValidChar(string valid)
         {
             if (TestFiles)
             {
                 DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
-                foreach (string valid in WindowsInvalidUnixValid)
-                    File.Create(Path.Combine(testDir.FullName, valid)).Dispose();
+                File.Create(Path.Combine(testDir.FullName, valid)).Dispose();
 
-                foreach (string valid in WindowsInvalidUnixValid)
-                    Assert.Contains(Path.Combine(testDir.FullName, valid), GetEntries(testDir.FullName, valid));
+                Assert.Contains(Path.Combine(testDir.FullName, valid), GetEntries(testDir.FullName, valid));
             }
         }
 
-        [Fact]
+        [Theory,
+            MemberData(nameof(WindowsInvalidUnixValid))]
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // Unix-valid chars in directory search patterns
-        public void UnixSearchPatternDirectoryValidChar()
+        public void UnixSearchPatternDirectoryValidChar(string valid)
         {
             if (TestDirectories)
             {
                 DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
-                foreach (string valid in WindowsInvalidUnixValid)
-                    testDir.CreateSubdirectory(valid);
 
-                foreach (string valid in WindowsInvalidUnixValid)
-                    Assert.Contains(Path.Combine(testDir.FullName, valid), GetEntries(testDir.FullName, valid));
+                testDir.CreateSubdirectory(valid);
+
+                Assert.Contains(Path.Combine(testDir.FullName, valid), GetEntries(testDir.FullName, valid));
             }
         }
 

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/CreateSubdirectory.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/CreateSubdirectory.cs
@@ -8,6 +8,7 @@ namespace System.IO.Tests
 {
     public class DirectoryInfo_CreateSubDirectory : FileSystemTest
     {
+        public static TheoryData ControlWhiteSpace = IOInputs.GetControlWhiteSpace().ToTheoryData(); 
         #region UniversalTests
 
         [Fact]
@@ -89,36 +90,31 @@ namespace System.IO.Tests
             Assert.Throws<ArgumentException>(() => new DirectoryInfo(TestDirectory + "/path").CreateSubdirectory("../../path2"));
         }
 
-        [Fact]
-        public void ValidPathWithTrailingSlash()
+        [Theory,
+            MemberData(nameof(ValidPathComponentNames))]
+        public void ValidPathWithTrailingSlash(string component)
         {
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
 
-            var components = IOInputs.GetValidPathComponentNames();
-            Assert.All(components, (component) =>
-            {
-                string path = IOServices.AddTrailingSlashIfNeeded(component);
-                DirectoryInfo result = new DirectoryInfo(testDir.FullName).CreateSubdirectory(path);
+            string path = IOServices.AddTrailingSlashIfNeeded(component);
+            DirectoryInfo result = new DirectoryInfo(testDir.FullName).CreateSubdirectory(path);
 
-                Assert.Equal(Path.Combine(testDir.FullName, path), result.FullName);
-                Assert.True(Directory.Exists(result.FullName));
-            });
+            Assert.Equal(Path.Combine(testDir.FullName, path), result.FullName);
+            Assert.True(Directory.Exists(result.FullName));
         }
 
-        [Fact]
-        public void ValidPathWithoutTrailingSlash()
+        [Theory,
+            MemberData(nameof(ValidPathComponentNames))]
+        public void ValidPathWithoutTrailingSlash(string component)
         {
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
 
-            var components = IOInputs.GetValidPathComponentNames();
-            Assert.All(components, (component) =>
-            {
-                string path = component;
-                DirectoryInfo result = new DirectoryInfo(testDir.FullName).CreateSubdirectory(path);
+            string path = component;
+            DirectoryInfo result = new DirectoryInfo(testDir.FullName).CreateSubdirectory(path);
 
-                Assert.Equal(Path.Combine(testDir.FullName, path), result.FullName);
-                Assert.True(Directory.Exists(result.FullName));
-            });
+            Assert.Equal(Path.Combine(testDir.FullName, path), result.FullName);
+            Assert.True(Directory.Exists(result.FullName));
+
         }
 
         [Fact]
@@ -143,65 +139,54 @@ namespace System.IO.Tests
 
         #region PlatformSpecific
 
-        [Fact]
+        [Theory,
+            MemberData(nameof(ControlWhiteSpace))]
         [PlatformSpecific(TestPlatforms.Windows)]  // Control whitespace in path throws ArgumentException
-        public void WindowsControlWhiteSpace()
+        public void WindowsControlWhiteSpace(string component)
         {
             // CreateSubdirectory will throw when passed a path with control whitespace e.g. "\t"
-            var components = IOInputs.GetControlWhiteSpace();
-            Assert.All(components, (component) =>
-            {
-                string path = IOServices.RemoveTrailingSlash(GetTestFileName());
-                Assert.Throws<ArgumentException>(() => new DirectoryInfo(TestDirectory).CreateSubdirectory(component));
-            });
+            string path = IOServices.RemoveTrailingSlash(GetTestFileName());
+            Assert.Throws<ArgumentException>(() => new DirectoryInfo(TestDirectory).CreateSubdirectory(component));
         }
 
-        [Fact]
+        [Theory,
+            MemberData(nameof(SimpleWhiteSpace))]
         [PlatformSpecific(TestPlatforms.Windows)]  // Simple whitespace is trimmed in path
-        public void WindowsSimpleWhiteSpace()
+        public void WindowsSimpleWhiteSpace(string component)
         {
             // CreateSubdirectory trims all simple whitespace, returning us the parent directory
             // that called CreateSubdirectory
-            var components = IOInputs.GetSimpleWhiteSpace();
+            string path = IOServices.RemoveTrailingSlash(GetTestFileName());
+            DirectoryInfo result = new DirectoryInfo(TestDirectory).CreateSubdirectory(component);
 
-            Assert.All(components, (component) =>
-            {
-                string path = IOServices.RemoveTrailingSlash(GetTestFileName());
-                DirectoryInfo result = new DirectoryInfo(TestDirectory).CreateSubdirectory(component);
+            Assert.True(Directory.Exists(result.FullName));
+            Assert.Equal(TestDirectory, IOServices.RemoveTrailingSlash(result.FullName));
 
-                Assert.True(Directory.Exists(result.FullName));
-                Assert.Equal(TestDirectory, IOServices.RemoveTrailingSlash(result.FullName));
-            });
         }
 
-        [Fact]
+        [Theory,
+            MemberData(nameof(WhiteSpace))]
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // Whitespace as path allowed
-        public void UnixWhiteSpaceAsPath_Allowed()
+        public void UnixWhiteSpaceAsPath_Allowed(string path)
         {
-            var paths = IOInputs.GetWhiteSpace();
-            Assert.All(paths, (path) =>
-            {
-                new DirectoryInfo(TestDirectory).CreateSubdirectory(path);
-                Assert.True(Directory.Exists(Path.Combine(TestDirectory, path)));
-            });
+            new DirectoryInfo(TestDirectory).CreateSubdirectory(path);
+            Assert.True(Directory.Exists(Path.Combine(TestDirectory, path)));
+
         }
 
-        [Fact]
+        [Theory,
+            MemberData(nameof(WhiteSpace))]
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // Trailing whitespace in path treated as significant
-        public void UnixNonSignificantTrailingWhiteSpace()
+        public void UnixNonSignificantTrailingWhiteSpace(string component)
         {
             // Unix treats trailing/prename whitespace as significant and a part of the name.
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
-            var components = IOInputs.GetWhiteSpace();
 
-            Assert.All(components, (component) =>
-            {
-                string path = IOServices.RemoveTrailingSlash(testDir.Name) + component;
-                DirectoryInfo result = new DirectoryInfo(TestDirectory).CreateSubdirectory(path);
+            string path = IOServices.RemoveTrailingSlash(testDir.Name) + component;
+            DirectoryInfo result = new DirectoryInfo(TestDirectory).CreateSubdirectory(path);
 
-                Assert.True(Directory.Exists(result.FullName));
-                Assert.NotEqual(testDir.FullName, IOServices.RemoveTrailingSlash(result.FullName));
-            });
+            Assert.True(Directory.Exists(result.FullName));
+            Assert.NotEqual(testDir.FullName, IOServices.RemoveTrailingSlash(result.FullName));
         }
 
         [ConditionalFact(nameof(UsingNewNormalization))]

--- a/src/System.IO.FileSystem/tests/File/Copy.cs
+++ b/src/System.IO.FileSystem/tests/File/Copy.cs
@@ -13,7 +13,7 @@ namespace System.IO.Tests
     {
         #region Utilities
 
-        public static string[] WindowsInvalidUnixValid = new string[] { "         ", " ", "\n", ">", "<", "\t" };
+        public static TheoryData WindowsInvalidUnixValid = new TheoryData<string> { "         ", " ", "\n", ">", "<", "\t" };
         public virtual void Copy(string source, string dest)
         {
             File.Copy(source, dest);
@@ -160,31 +160,29 @@ namespace System.IO.Tests
 
         #region PlatformSpecific
 
-        [Fact]
+        [Theory, 
+            MemberData(nameof(WindowsInvalidUnixValid))]
         [PlatformSpecific(TestPlatforms.Windows)]  // Whitespace path throws ArgumentException
-        public void WindowsWhitespacePath()
+        public void WindowsWhitespacePath(string invalid)
         {
             string testFile = GetTestFilePath();
             File.Create(testFile).Dispose();
-            foreach (string invalid in WindowsInvalidUnixValid)
-            {
-                Assert.Throws<ArgumentException>(() => Copy(testFile, invalid));
-                Assert.Throws<ArgumentException>(() => Copy(invalid, testFile));
-            }
+
+            Assert.Throws<ArgumentException>(() => Copy(testFile, invalid));
+            Assert.Throws<ArgumentException>(() => Copy(invalid, testFile));
         }
 
-        [Fact]
+        [Theory,
+            MemberData(nameof(WindowsInvalidUnixValid))]
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // Whitespace path allowed
-        public void UnixWhitespacePath()
+        public void UnixWhitespacePath(string valid)
         {
             string testFile = GetTestFilePath();
             File.Create(testFile).Dispose();
-            foreach (string valid in WindowsInvalidUnixValid)
-            {
-                Copy(testFile, Path.Combine(TestDirectory, valid));
-                Assert.True(File.Exists(testFile));
-                Assert.True(File.Exists(Path.Combine(TestDirectory, valid)));
-            }
+
+            Copy(testFile, Path.Combine(TestDirectory, valid));
+            Assert.True(File.Exists(testFile));
+            Assert.True(File.Exists(Path.Combine(TestDirectory, valid)));
         }
 
         #endregion

--- a/src/System.IO.FileSystem/tests/File/Create.cs
+++ b/src/System.IO.FileSystem/tests/File/Create.cs
@@ -207,38 +207,41 @@ namespace System.IO.Tests
             Assert.Throws<ArgumentException>(() => Create(Path.Combine(testDir.FullName, "*Tes*t")));
         }
 
-        [Fact]
+        [Theory,
+            InlineData("         "),
+            InlineData(" "),
+            InlineData("\n"),
+            InlineData(">"),
+            InlineData("<"),
+            InlineData("\0"),
+            InlineData("\t")]
         [PlatformSpecific(TestPlatforms.Windows)]  // Invalid file name with whitespace on Windows
-        public void WindowsWhitespacePath()
+        public void WindowsWhitespacePath(string path)
         {
-            Assert.Throws<ArgumentException>(() => Create("         "));
-            Assert.Throws<ArgumentException>(() => Create(" "));
-            Assert.Throws<ArgumentException>(() => Create("\n"));
-            Assert.Throws<ArgumentException>(() => Create(">"));
-            Assert.Throws<ArgumentException>(() => Create("<"));
-            Assert.Throws<ArgumentException>(() => Create("\0"));
-            Assert.Throws<ArgumentException>(() => Create("\t"));
+            Assert.Throws<ArgumentException>(() => Create(path));
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        public void CreateNullThrows_Unix()
+        {
+            Assert.Throws<ArgumentException>(() => Create("\0"));
+        }
+
+        [Theory,
+            InlineData("         "),
+            InlineData(" "),
+            InlineData("\n"),
+            InlineData(">"),
+            InlineData("<"),
+            InlineData("\t")]
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // Valid file name with Whitespace on Unix
-        public void UnixWhitespacePath()
+        public void UnixWhitespacePath(string path)
         {
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
-            Assert.Throws<ArgumentException>(() => Create("\0"));
-            using (Create(Path.Combine(testDir.FullName, "          ")))
-            using (Create(Path.Combine(testDir.FullName, " ")))
-            using (Create(Path.Combine(testDir.FullName, "\n")))
-            using (Create(Path.Combine(testDir.FullName, ">")))
-            using (Create(Path.Combine(testDir.FullName, "<")))
-            using (Create(Path.Combine(testDir.FullName, "\t")))
+            using (Create(Path.Combine(testDir.FullName, path)))
             {
-                Assert.True(File.Exists(Path.Combine(testDir.FullName, "          ")));
-                Assert.True(File.Exists(Path.Combine(testDir.FullName, " ")));
-                Assert.True(File.Exists(Path.Combine(testDir.FullName, "\n")));
-                Assert.True(File.Exists(Path.Combine(testDir.FullName, ">")));
-                Assert.True(File.Exists(Path.Combine(testDir.FullName, "<")));
-                Assert.True(File.Exists(Path.Combine(testDir.FullName, "\t")));
+                Assert.True(File.Exists(Path.Combine(testDir.FullName, path)));
             }
         }
 

--- a/src/System.IO.FileSystem/tests/File/Exists.cs
+++ b/src/System.IO.FileSystem/tests/File/Exists.cs
@@ -31,25 +31,21 @@ namespace System.IO.Tests
             Assert.False(Exists(string.Empty));
         }
 
-        [Fact]
-        public void NonExistentValidPath_ReturnsFalse()
+        [Theory,
+            MemberData(nameof(ValidPathComponentNames))]
+        public void NonExistentValidPath_ReturnsFalse(string path)
         {
-            Assert.All((IOInputs.GetValidPathComponentNames()), (path) =>
-            {
-                Assert.False(Exists(path), path);
-            });
+            Assert.False(Exists(path), path);
         }
 
-        [Fact]
-        public void ValidPathExists_ReturnsTrue()
+        [Theory,
+            MemberData(nameof(ValidPathComponentNames))]
+        public void ValidPathExists_ReturnsTrue(string component)
         {
-            Assert.All((IOInputs.GetValidPathComponentNames()), (component) =>
-            {
-                string path = Path.Combine(TestDirectory, component);
-                FileInfo testFile = new FileInfo(path);
-                testFile.Create().Dispose();
-                Assert.True(Exists(path));
-            });
+            string path = Path.Combine(TestDirectory, component);
+            FileInfo testFile = new FileInfo(path);
+            testFile.Create().Dispose();
+            Assert.True(Exists(path));
         }
 
         [Theory, MemberData(nameof(PathsWithInvalidCharacters))]
@@ -161,15 +157,14 @@ namespace System.IO.Tests
 
         #region PlatformSpecific
 
-        [Fact]
+        [Theory,
+            MemberData(nameof(WhiteSpace))]
         [PlatformSpecific(TestPlatforms.Windows)] // Unix equivalent tested already in CreateDirectory
-        public void WindowsNonSignificantWhiteSpaceAsPath_ReturnsFalse()
+        public void WindowsNonSignificantWhiteSpaceAsPath_ReturnsFalse(string component)
         {
             // Checks that errors aren't thrown when calling Exists() on impossible paths
-            Assert.All((IOInputs.GetWhiteSpace()), (component) =>
-            {
-                Assert.False(Exists(component));
-            });
+            Assert.False(Exists(component));
+
         }
 
         [Fact]
@@ -194,56 +189,48 @@ namespace System.IO.Tests
             Assert.False(Exists(testFile.FullName.ToLowerInvariant()));
         }
 
-        [Fact]
+        [Theory,
+            MemberData(nameof(WhiteSpace))]
         [PlatformSpecific(TestPlatforms.Windows)] // In Windows, trailing whitespace in a path is trimmed
-        public void TrimTrailingWhitespacePath()
+        public void TrimTrailingWhitespacePath(string component)
         {
             FileInfo testFile = new FileInfo(GetTestFilePath());
             testFile.Create().Dispose();
-            Assert.All((IOInputs.GetWhiteSpace()), (component) =>
-            {
-                Assert.True(Exists(testFile.FullName + component)); // string concat in case Path.Combine() trims whitespace before Exists gets to it
-            });
+
+            Assert.True(Exists(testFile.FullName + component)); // string concat in case Path.Combine() trims whitespace before Exists gets to it
+
         }
 
-        [Fact]
+        [Theory,
+            MemberData(nameof(PathsWithAlternativeDataStreams))]
         [PlatformSpecific(TestPlatforms.Windows)] // alternate data stream
-        public void PathWithAlternateDataStreams_ReturnsFalse()
+        public void PathWithAlternateDataStreams_ReturnsFalse(string component)
         {
-            Assert.All((IOInputs.GetPathsWithAlternativeDataStreams()), (component) =>
-            {
-                Assert.False(Exists(component));
-            });
+            Assert.False(Exists(component));
         }
 
-        [Fact]
+        [Theory,
+            MemberData(nameof(PathsWithReservedDeviceNames))]
         [OuterLoop]
         [PlatformSpecific(TestPlatforms.Windows)] // device names
-        public void PathWithReservedDeviceNameAsPath_ReturnsFalse()
+        public void PathWithReservedDeviceNameAsPath_ReturnsFalse(string component)
         {
-            Assert.All((IOInputs.GetPathsWithReservedDeviceNames()), (component) =>
-            {
-                Assert.False(Exists(component));
-            });
+            Assert.False(Exists(component));
         }
 
-        [Fact]
-        public void UncPathWithoutShareNameAsPath_ReturnsFalse()
+        [Theory,
+            MemberData(nameof(UncPathsWithoutShareName))]
+        public void UncPathWithoutShareNameAsPath_ReturnsFalse(string component)
         {
-            Assert.All((IOInputs.GetUncPathsWithoutShareName()), (component) =>
-            {
-                Assert.False(Exists(component));
-            });
+            Assert.False(Exists(component));
         }
 
-        [Fact]
+        [Theory,
+            MemberData(nameof(PathsWithComponentLongerThanMaxComponent))]
         [PlatformSpecific(TestPlatforms.Windows)] // max directory length not fixed on Unix
-        public void DirectoryWithComponentLongerThanMaxComponentAsPath_ReturnsFalse()
+        public void DirectoryWithComponentLongerThanMaxComponentAsPath_ReturnsFalse(string component)
         {
-            Assert.All((IOInputs.GetPathsWithComponentLongerThanMaxComponent()), (component) =>
-            {
-                Assert.False(Exists(component));
-            });
+            Assert.False(Exists(component));
         }
 
         [Fact]

--- a/src/System.IO.FileSystem/tests/File/Move.cs
+++ b/src/System.IO.FileSystem/tests/File/Move.cs
@@ -269,28 +269,26 @@ namespace System.IO.Tests
             Assert.True(File.Exists(testFileShouldntMove));
         }
 
-        [Fact]
+        [Theory,
+            MemberData(nameof(WhiteSpace))]
         [PlatformSpecific(TestPlatforms.Windows)]  // Whitespace in path throws ArgumentException
-        public void WindowsWhitespacePath()
+        public void WindowsWhitespacePath(string whitespace)
         {
             FileInfo testFile = new FileInfo(GetTestFilePath());
-            Assert.All(IOInputs.GetWhiteSpace(), (whitespace) =>
-            {
-                Assert.Throws<ArgumentException>(() => Move(testFile.FullName, whitespace));
-            });
+            Assert.Throws<ArgumentException>(() => Move(testFile.FullName, whitespace));
         }
 
-        [Fact]
+        [Theory,
+            MemberData(nameof(WhiteSpace))]
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // Whitespace in path allowed
-        public void UnixWhitespacePath()
+        public void UnixWhitespacePath(string whitespace)
         {
             FileInfo testFileSource = new FileInfo(GetTestFilePath());
             testFileSource.Create().Dispose();
-            Assert.All(IOInputs.GetWhiteSpace(), (whitespace) =>
-            {
-                Move(testFileSource.FullName, Path.Combine(TestDirectory, whitespace));
-                Move(Path.Combine(TestDirectory, whitespace), testFileSource.FullName);
-            });
+
+            Move(testFileSource.FullName, Path.Combine(TestDirectory, whitespace));
+            Move(Path.Combine(TestDirectory, whitespace), testFileSource.FullName);
+
         }
 
         #endregion

--- a/src/System.IO.FileSystem/tests/FileSystemTest.cs
+++ b/src/System.IO.FileSystem/tests/FileSystemTest.cs
@@ -24,6 +24,12 @@ namespace System.IO.Tests
         public static TheoryData<string> PathsWithInvalidCharacters = TestData.PathsWithInvalidCharacters;
         public static TheoryData<char> TrailingCharacters = TestData.TrailingCharacters;
         public static TheoryData ValidPathComponentNames = IOInputs.GetValidPathComponentNames().ToTheoryData();
+        public static TheoryData SimpleWhiteSpace = IOInputs.GetSimpleWhiteSpace().ToTheoryData();
+        public static TheoryData WhiteSpace = IOInputs.GetWhiteSpace().ToTheoryData();
+        public static TheoryData UncPathsWithoutShareName = IOInputs.GetUncPathsWithoutShareName().ToTheoryData();
+        public static TheoryData PathsWithReservedDeviceNames = IOInputs.GetPathsWithReservedDeviceNames().ToTheoryData();
+        public static TheoryData PathsWithAlternativeDataStreams = IOInputs.GetPathsWithAlternativeDataStreams().ToTheoryData();
+        public static TheoryData PathsWithComponentLongerThanMaxComponent = IOInputs.GetPathsWithComponentLongerThanMaxComponent().ToTheoryData();
 
         /// <summary>
         /// In some cases (such as when running without elevated privileges),

--- a/src/System.IO.FileSystem/tests/PortedCommon/IOInputs.cs
+++ b/src/System.IO.FileSystem/tests/PortedCommon/IOInputs.cs
@@ -27,7 +27,6 @@ internal static class IOInputs
     // Windows specific, this is the maximum length that can be passed using extended syntax. Does not include the trailing \0.
     public static readonly int MaxExtendedPath = short.MaxValue - 1;
 
-
     public const int MaxComponent = 255;
 
     public const string ExtendedPrefix = @"\\?\";
@@ -149,13 +148,13 @@ internal static class IOInputs
 
         string component = new string('s', MaxComponent + 1);
 
-        yield return String.Format(@"C:\{0}", component);
-        yield return String.Format(@"C:\{0}\Filename.txt", component);
-        yield return String.Format(@"C:\{0}\Filename.txt\", component);
-        yield return String.Format(@"\\{0}\Share", component);
-        yield return String.Format(@"\\LOCALHOST\{0}", component);
-        yield return String.Format(@"\\LOCALHOST\{0}\FileName.txt", component);
-        yield return String.Format(@"\\LOCALHOST\Share\{0}", component);
+        yield return string.Format(@"C:\{0}", component);
+        yield return string.Format(@"C:\{0}\Filename.txt", component);
+        yield return string.Format(@"C:\{0}\Filename.txt\", component);
+        yield return string.Format(@"\\{0}\Share", component);
+        yield return string.Format(@"\\LOCALHOST\{0}", component);
+        yield return string.Format(@"\\LOCALHOST\{0}\FileName.txt", component);
+        yield return string.Format(@"\\LOCALHOST\Share\{0}", component);
     }
 
     public static IEnumerable<string> GetPathsLongerThanMaxDirectory(string rootPath)


### PR DESCRIPTION
Converting tests from Fact to Theory to make it easier to recognize
which tests are failing instead of spending time sorting through
ambiguous test output.