### PR TITLE
Remove NtQuerySystemInformation from Uap

### DIFF
--- a/src/System.Diagnostics.Process/src/PinvokeAnalyzerExceptionList.analyzerdata.uap
+++ b/src/System.Diagnostics.Process/src/PinvokeAnalyzerExceptionList.analyzerdata.uap
@@ -2,4 +2,3 @@ advapi32.dll!OpenProcessToken
 kernel32.dll!GetProcessAffinityMask
 kernel32.dll!SetProcessAffinityMask
 kernel32.dll!SetThreadAffinityMask
-ntdll.dll!NtQuerySystemInformation

--- a/src/System.Diagnostics.Process/src/Resources/Strings.resx
+++ b/src/System.Diagnostics.Process/src/Resources/Strings.resx
@@ -303,4 +303,7 @@
   <data name="UseShellExecuteNotSupported" xml:space="preserve">
     <value>UseShellExecute is not supported on this platform.</value>
   </data>
+  <data name="GetProcessInfoNotSupported" xml:space="preserve">
+    <value>Retrieving information about local processes is not supported on this platform.</value>
+  </data>
 </root>

--- a/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
+++ b/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
@@ -50,6 +50,9 @@
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.EnumProcessModules.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.EnumProcessModules.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.NtQuerySystemInformation.cs">
+      <Link>Common\Interop\Windows\NtDll\Interop.NtQuerySystemInformation.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\user32\Interop.EnumWindows.cs">
       <Link>Common\Interop\Windows\user32\Interop.EnumWindows.cs</Link>
     </Compile>
@@ -177,9 +180,6 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.SetPriorityClass.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.SetPriorityClass.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.NtQuerySystemInformation.cs">
-      <Link>Common\Interop\Windows\NtDll\Interop.NtQuerySystemInformation.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.DuplicateHandle_SafeProcessHandle.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.DuplicateHandle.cs</Link>

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Uap.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Uap.cs
@@ -17,6 +17,14 @@ namespace System.Diagnostics
     internal static partial class ProcessManager
     {
         public static IntPtr GetMainWindowHandle(int processId) => IntPtr.Zero;
+
+        /// <summary>Gets process infos for each process on the specified machine.</summary>
+        /// <param name="machineName">The target machine.</param>
+        /// <returns>An array of process infos, one per found process.</returns>
+        public static ProcessInfo[] GetProcessInfos(string machineName)
+        {
+            return NtProcessManager.GetProcessInfos(machineName, IsRemoteMachine(machineName));
+        }
     }
 
     internal static partial class NtProcessManager

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Uap.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Uap.cs
@@ -23,7 +23,10 @@ namespace System.Diagnostics
         /// <returns>An array of process infos, one per found process.</returns>
         public static ProcessInfo[] GetProcessInfos(string machineName)
         {
-            return NtProcessManager.GetProcessInfos(machineName, IsRemoteMachine(machineName));
+            if (!IsRemoteMachine(machineName))
+                throw new PlatformNotSupportedException(SR.GetProcessInfoNotSupported); // NtDll.NtQuerySystemInformation is not available in Uap
+
+            return NtProcessManager.GetProcessInfos(machineName, isRemoteMachine: true);
         }
     }
 

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
@@ -18,6 +18,16 @@ namespace System.Diagnostics
             MainWindowFinder finder = new MainWindowFinder();
             return finder.FindMainWindow(processId);
         }
+
+        /// <summary>Gets process infos for each process on the specified machine.</summary>
+        /// <param name="machineName">The target machine.</param>
+        /// <returns>An array of process infos, one per found process.</returns>
+        public static ProcessInfo[] GetProcessInfos(string machineName)
+        {
+            return IsRemoteMachine(machineName) ?
+                NtProcessManager.GetProcessInfos(machineName, true) :
+                NtProcessInfoHelper.GetProcessInfos(); // Do not use performance counter for local machine
+        }
     }
 
     internal sealed class MainWindowFinder 
@@ -235,6 +245,76 @@ namespace System.Diagnostics
                     processHandle.Dispose();
                 }
             }
+        }
+    }
+
+    internal static partial class NtProcessInfoHelper
+    {
+        // Cache a single buffer for use in GetProcessInfos().
+        private static long[] CachedBuffer;
+
+        public static ProcessInfo[] GetProcessInfos()
+        {
+            int requiredSize = 0;
+            int status;
+
+            ProcessInfo[] processInfos;
+            GCHandle bufferHandle = new GCHandle();
+
+            // Start with the default buffer size.
+            int bufferSize = DefaultCachedBufferSize;
+
+            // Get the cached buffer.
+            long[] buffer = Interlocked.Exchange(ref CachedBuffer, null);
+
+            try
+            {
+                do
+                {
+                    if (buffer == null)
+                    {
+                        // Allocate buffer of longs since some platforms require the buffer to be 64-bit aligned.
+                        buffer = new long[(bufferSize + 7) / 8];
+                    }
+                    else
+                    {
+                        // If we have cached buffer, set the size properly.
+                        bufferSize = buffer.Length * sizeof(long);
+                    }
+
+                    bufferHandle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+
+                    status = Interop.NtDll.NtQuerySystemInformation(
+                        Interop.NtDll.NtQuerySystemProcessInformation,
+                        bufferHandle.AddrOfPinnedObject(),
+                        bufferSize,
+                        out requiredSize);
+
+                    if (unchecked((uint)status) == Interop.NtDll.STATUS_INFO_LENGTH_MISMATCH)
+                    {
+                        if (bufferHandle.IsAllocated) bufferHandle.Free();
+                        buffer = null;
+                        bufferSize = GetNewBufferSize(bufferSize, requiredSize);
+                    }
+                } while (unchecked((uint)status) == Interop.NtDll.STATUS_INFO_LENGTH_MISMATCH);
+
+                if (status < 0)
+                { // see definition of NT_SUCCESS(Status) in SDK
+                    throw new InvalidOperationException(SR.CouldntGetProcessInfos, new Win32Exception(status));
+                }
+
+                // Parse the data block to get process information
+                processInfos = GetProcessInfos(bufferHandle.AddrOfPinnedObject());
+            }
+            finally
+            {
+                // Cache the final buffer for use on the next call.
+                Interlocked.Exchange(ref CachedBuffer, buffer);
+
+                if (bufferHandle.IsAllocated) bufferHandle.Free();
+            }
+
+            return processInfos;
         }
     }
 }

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
@@ -25,7 +25,7 @@ namespace System.Diagnostics
         public static ProcessInfo[] GetProcessInfos(string machineName)
         {
             return IsRemoteMachine(machineName) ?
-                NtProcessManager.GetProcessInfos(machineName, true) :
+                NtProcessManager.GetProcessInfos(machineName, isRemoteMachine: true) :
                 NtProcessInfoHelper.GetProcessInfos(); // Do not use performance counter for local machine
         }
     }

--- a/src/System.Runtime.Extensions/src/System/Environment.cs
+++ b/src/System.Runtime.Extensions/src/System/Environment.cs
@@ -204,6 +204,13 @@ namespace System
                         object result = processType.GetTypeInfo().GetDeclaredProperty("WorkingSet64")?.GetMethod?.Invoke(currentProcess, null);
                         if (result is long) return (long)result;
                     }
+                    catch (TargetInvocationException tie)
+                    {
+                        if(tie.InnerException != null)
+                            throw tie.InnerException;
+
+                        throw tie;
+                    }
                     finally { currentProcess.Dispose(); }
                 }
 

--- a/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
@@ -175,6 +175,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)]
         public void WorkingSet_Valid()
         {
             Assert.True(Environment.WorkingSet > 0, "Expected positive WorkingSet value");

--- a/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
@@ -186,14 +186,7 @@ namespace System.Tests
         [SkipOnTargetFramework(~TargetFrameworkMonikers.Uap)] 
         public void WorkingSet_Valid_Uap()
         {
-            try
-            {
-                var workingSet = Environment.WorkingSet;
-            }
-            catch(TargetInvocationException ex)
-            {
-                Assert.True(ex.InnerException is PlatformNotSupportedException);
-            }
+            Assert.Throws<PlatformNotSupportedException>(() => Environment.WorkingSet);
         }
 
         [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // fail fast crashes the process

--- a/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
@@ -175,10 +175,17 @@ namespace System.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)] // Throws InvalidOperationException in Uap as NtQuerySystemInformation Pinvoke is not available
         public void WorkingSet_Valid()
         {
             Assert.True(Environment.WorkingSet > 0, "Expected positive WorkingSet value");
+        }
+        
+        [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.Uap)] 
+        public void WorkingSet_Valid_Uap()
+        {
+            Assert.Throws<InvalidOperationException>(() => Environment.WorkingSet);
         }
 
         [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // fail fast crashes the process

--- a/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Threading;
@@ -185,7 +186,14 @@ namespace System.Tests
         [SkipOnTargetFramework(~TargetFrameworkMonikers.Uap)] 
         public void WorkingSet_Valid_Uap()
         {
-            Assert.Throws<InvalidOperationException>(() => Environment.WorkingSet);
+            try
+            {
+                var workingSet = Environment.WorkingSet;
+            }
+            catch(TargetInvocationException ex)
+            {
+                Assert.True(ex.InnerException is PlatformNotSupportedException);
+            }
         }
 
         [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // fail fast crashes the process


### PR DESCRIPTION
Resolves https://github.com/dotnet/corefx/issues/21946

Since we can't use NtQuerySystemInformation in Uap, to enumerate/examine processes, I'm using `PerformanceCounterLib` as we do for remote machines.