### PR TITLE
Fix System.Xml.Linq.xNodeBuilder.Tests for UapAot

### DIFF
--- a/src/System.Private.Xml.Linq/tests/XDocument.Test.ModuleCore/testexception.cs
+++ b/src/System.Private.Xml.Linq/tests/XDocument.Test.ModuleCore/testexception.cs
@@ -93,8 +93,8 @@ namespace Microsoft.Test.ModuleCore
 
         public override string ToString()
         {
-            var expected = "Expected: " + Expected + " (" + Expected.GetType() + ")\n";
-            var actual = "Actual  : " + Actual + " (" + Actual.GetType() + ")\n";
+            var expected = "Expected: " + Expected + " (" + Expected?.GetType() + ")\n";
+            var actual = "Actual  : " + Actual + " (" + Actual?.GetType() + ")\n";
 
             return expected + actual + "\n" + base.ToString();
         }

--- a/src/System.Private.Xml.Linq/tests/xNodeBuilder/ErrorConditions.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeBuilder/ErrorConditions.cs
@@ -28,7 +28,7 @@ namespace CoreXml.Test.XLinq
                         }
                         catch (ArgumentNullException e)
                         {
-                            TestLog.Compare(e.ParamName, "ns", "prefix mismatch");
+                            TestLog.Compare(PlatformDetection.IsNetNative ? "ns" : e.ParamName, "ns", "prefix mismatch"); // ILC optimization sets ParamName always to null. 
                             try
                             {
                                 TestLog.Compare(w.WriteState, WriteState.Error, "Error");
@@ -37,7 +37,7 @@ namespace CoreXml.Test.XLinq
                             catch (ArgumentNullException ae)
                             {
                                 TestLog.Compare(w.WriteState, WriteState.Error, "Error");
-                                TestLog.Compare(ae.ParamName, "ns", "prefix mismatch");
+                                TestLog.Compare(PlatformDetection.IsNetNative ? "ns" : ae.ParamName, "ns", "prefix mismatch"); // ILC optimization sets ParamName always to null.
                                 return;
                             }
                         }
@@ -60,7 +60,7 @@ namespace CoreXml.Test.XLinq
                         }
                         catch (ArgumentNullException e)
                         {
-                            TestLog.Compare(e.ParamName, "reader", "mismatch");
+                            TestLog.Compare(PlatformDetection.IsNetNative ? "reader" : e.ParamName, "reader", "mismatch"); // ILC optimization sets ParamName always to null.
                             try
                             {
                                 TestLog.Compare(w.WriteState, WriteState.Start, "Error");
@@ -69,7 +69,7 @@ namespace CoreXml.Test.XLinq
                             catch (ArgumentNullException ae)
                             {
                                 TestLog.Compare(w.WriteState, WriteState.Start, "Error");
-                                TestLog.Compare(ae.ParamName, "reader", "mismatch");
+                                TestLog.Compare(PlatformDetection.IsNetNative ? "reader" : ae.ParamName, "reader", "mismatch"); // ILC optimization sets ParamName always to null.
                                 return;
                             }
                         }
@@ -122,7 +122,7 @@ namespace CoreXml.Test.XLinq
                         }
                         catch (ArgumentNullException e)
                         {
-                            TestLog.Compare(e.ParamName, "buffer", "mismatch");
+                            TestLog.Compare(PlatformDetection.IsNetNative ? "buffer" : e.ParamName, "buffer", "mismatch"); // ILC optimization sets ParamName always to null.
                             try
                             {
                                 TestLog.Compare(w.WriteState, WriteState.Error, "Error");
@@ -131,7 +131,7 @@ namespace CoreXml.Test.XLinq
                             catch (ArgumentNullException ae)
                             {
                                 TestLog.Compare(w.WriteState, WriteState.Error, "Error");
-                                TestLog.Compare(ae.ParamName, "buffer", "mismatch");
+                                TestLog.Compare(PlatformDetection.IsNetNative ? "buffer" : ae.ParamName, "buffer", "mismatch"); // ILC optimization sets ParamName always to null.
                                 return;
                             }
                         }
@@ -154,7 +154,7 @@ namespace CoreXml.Test.XLinq
                         }
                         catch (ArgumentNullException e)
                         {
-                            TestLog.Compare(e.ParamName, "buffer", "mismatch");
+                            TestLog.Compare(PlatformDetection.IsNetNative ? "buffer" : e.ParamName, "buffer", "mismatch"); // ILC optimization sets ParamName always to null.
                             try
                             {
                                 TestLog.Compare(w.WriteState, WriteState.Error, "Error");
@@ -449,7 +449,7 @@ namespace CoreXml.Test.XLinq
                         }
                         catch (ArgumentException e)
                         {
-                            TestLog.Compare(e.ParamName, "name", "mismatch");
+                            TestLog.Compare(PlatformDetection.IsNetNative ? "name" : e.ParamName, "name", "mismatch"); // ILC optimization sets ParamName always to null.
                             try
                             {
                                 TestLog.Compare(w.WriteState, WriteState.Start, "Error");
@@ -458,7 +458,7 @@ namespace CoreXml.Test.XLinq
                             catch (ArgumentException ae)
                             {
                                 TestLog.Compare(w.WriteState, WriteState.Start, "Error");
-                                TestLog.Compare(ae.ParamName, "name", "mismatch");
+                                TestLog.Compare(PlatformDetection.IsNetNative ? "name" : ae.ParamName, "name", "mismatch"); // ILC optimization sets ParamName always to null.
                                 return;
                             }
                         }
@@ -524,10 +524,10 @@ namespace CoreXml.Test.XLinq
                             switch (param1)
                             {
                                 case ("reader"):
-                                    TestLog.Compare(e.ParamName, "reader", "mismatch");
+                                    TestLog.Compare(PlatformDetection.IsNetNative ? "reader" : e.ParamName, "reader", "mismatch"); // ILC optimization sets ParamName always to null.
                                     break;
                                 case ("navigator"):
-                                    TestLog.Compare(e.ParamName, "navigator", "mismatch");
+                                    TestLog.Compare(PlatformDetection.IsNetNative ? "navigator" : e.ParamName, "navigator", "mismatch"); // ILC optimization sets ParamName always to null.
                                     break;
                             }
                             try
@@ -545,7 +545,7 @@ namespace CoreXml.Test.XLinq
                                 switch (param1)
                                 {
                                     case ("reader"):
-                                        TestLog.Compare(e.ParamName, "reader", "mismatch");
+                                        TestLog.Compare(PlatformDetection.IsNetNative ? "reader" : e.ParamName, "reader", "mismatch"); // ILC optimization sets ParamName always to null.
                                         break;
                                 }
                                 return;
@@ -632,7 +632,7 @@ namespace CoreXml.Test.XLinq
                         }
                         catch (ArgumentNullException e)
                         {
-                            TestLog.Compare(e.ParamName, "buffer", "mismatch");
+                            TestLog.Compare(PlatformDetection.IsNetNative ? "buffer" : e.ParamName, "buffer", "mismatch"); // ILC optimization sets ParamName always to null.
                             try
                             {
                                 TestLog.Compare(w.WriteState, WriteState.Error, "Error");
@@ -641,7 +641,7 @@ namespace CoreXml.Test.XLinq
                             catch (ArgumentNullException ae)
                             {
                                 TestLog.Compare(w.WriteState, WriteState.Error, "Error");
-                                TestLog.Compare(ae.ParamName, "buffer", "mismatch");
+                                TestLog.Compare(PlatformDetection.IsNetNative ? "buffer" : ae.ParamName, "buffer", "mismatch"); // ILC optimization sets ParamName always to null.
                                 return;
                             }
                         }

--- a/src/System.Private.Xml.Linq/tests/xNodeBuilder/ErrorConditions.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeBuilder/ErrorConditions.cs
@@ -28,7 +28,7 @@ namespace CoreXml.Test.XLinq
                         }
                         catch (ArgumentNullException e)
                         {
-                            TestLog.Compare(PlatformDetection.IsNetNative ? "ns" : e.ParamName, "ns", "prefix mismatch"); // ILC optimization sets ParamName always to null. 
+                            CompareParamName(e.ParamName, "ns", "prefix mismatch");
                             try
                             {
                                 TestLog.Compare(w.WriteState, WriteState.Error, "Error");
@@ -37,7 +37,7 @@ namespace CoreXml.Test.XLinq
                             catch (ArgumentNullException ae)
                             {
                                 TestLog.Compare(w.WriteState, WriteState.Error, "Error");
-                                TestLog.Compare(PlatformDetection.IsNetNative ? "ns" : ae.ParamName, "ns", "prefix mismatch"); // ILC optimization sets ParamName always to null.
+                                CompareParamName(ae.ParamName, "ns", "prefix mismatch");
                                 return;
                             }
                         }
@@ -60,7 +60,7 @@ namespace CoreXml.Test.XLinq
                         }
                         catch (ArgumentNullException e)
                         {
-                            TestLog.Compare(PlatformDetection.IsNetNative ? "reader" : e.ParamName, "reader", "mismatch"); // ILC optimization sets ParamName always to null.
+                            CompareParamName(e.ParamName, "reader", "mismatch");
                             try
                             {
                                 TestLog.Compare(w.WriteState, WriteState.Start, "Error");
@@ -69,7 +69,7 @@ namespace CoreXml.Test.XLinq
                             catch (ArgumentNullException ae)
                             {
                                 TestLog.Compare(w.WriteState, WriteState.Start, "Error");
-                                TestLog.Compare(PlatformDetection.IsNetNative ? "reader" : ae.ParamName, "reader", "mismatch"); // ILC optimization sets ParamName always to null.
+                                CompareParamName(ae.ParamName, "reader", "mismatch");
                                 return;
                             }
                         }
@@ -92,7 +92,7 @@ namespace CoreXml.Test.XLinq
                         }
                         catch (ArgumentException e)
                         {
-                            TestLog.Compare(e.ParamName, null, "mismatch");
+                            CompareParamName(e.ParamName, null, "mismatch");
                             try
                             {
                                 TestLog.Compare(w.WriteState, WriteState.Error, "Error");
@@ -101,7 +101,7 @@ namespace CoreXml.Test.XLinq
                             catch (ArgumentException)
                             {
                                 TestLog.Compare(w.WriteState, WriteState.Error, "Error");
-                                TestLog.Compare(e.ParamName, null, "mismatch");
+                                CompareParamName(e.ParamName, null, "mismatch");
                                 return;
                             }
                         }
@@ -122,7 +122,7 @@ namespace CoreXml.Test.XLinq
                         }
                         catch (ArgumentNullException e)
                         {
-                            TestLog.Compare(PlatformDetection.IsNetNative ? "buffer" : e.ParamName, "buffer", "mismatch"); // ILC optimization sets ParamName always to null.
+                            CompareParamName(e.ParamName, "buffer", "mismatch");
                             try
                             {
                                 TestLog.Compare(w.WriteState, WriteState.Error, "Error");
@@ -131,7 +131,7 @@ namespace CoreXml.Test.XLinq
                             catch (ArgumentNullException ae)
                             {
                                 TestLog.Compare(w.WriteState, WriteState.Error, "Error");
-                                TestLog.Compare(PlatformDetection.IsNetNative ? "buffer" : ae.ParamName, "buffer", "mismatch"); // ILC optimization sets ParamName always to null.
+                                CompareParamName(ae.ParamName, "buffer", "mismatch");
                                 return;
                             }
                         }
@@ -154,7 +154,7 @@ namespace CoreXml.Test.XLinq
                         }
                         catch (ArgumentNullException e)
                         {
-                            TestLog.Compare(PlatformDetection.IsNetNative ? "buffer" : e.ParamName, "buffer", "mismatch"); // ILC optimization sets ParamName always to null.
+                            CompareParamName(e.ParamName, "buffer", "mismatch");
                             try
                             {
                                 TestLog.Compare(w.WriteState, WriteState.Error, "Error");
@@ -278,7 +278,7 @@ namespace CoreXml.Test.XLinq
                         }
                         catch (ArgumentException e)
                         {
-                            TestLog.Compare(e.ParamName, null, "mismatch");
+                            CompareParamName(e.ParamName, null, "mismatch");
                             try
                             {
                                 TestLog.Compare(w.WriteState, WriteState.Error, "Error");
@@ -287,7 +287,7 @@ namespace CoreXml.Test.XLinq
                             catch (ArgumentException ae)
                             {
                                 TestLog.Compare(w.WriteState, WriteState.Error, "Error");
-                                TestLog.Compare(ae.ParamName, null, "mismatch");
+                                CompareParamName(ae.ParamName, null, "mismatch");
                                 return;
                             }
                         }
@@ -449,7 +449,7 @@ namespace CoreXml.Test.XLinq
                         }
                         catch (ArgumentException e)
                         {
-                            TestLog.Compare(PlatformDetection.IsNetNative ? "name" : e.ParamName, "name", "mismatch"); // ILC optimization sets ParamName always to null.
+                            CompareParamName(e.ParamName, "name", "mismatch");
                             try
                             {
                                 TestLog.Compare(w.WriteState, WriteState.Start, "Error");
@@ -458,7 +458,7 @@ namespace CoreXml.Test.XLinq
                             catch (ArgumentException ae)
                             {
                                 TestLog.Compare(w.WriteState, WriteState.Start, "Error");
-                                TestLog.Compare(PlatformDetection.IsNetNative ? "name" : ae.ParamName, "name", "mismatch"); // ILC optimization sets ParamName always to null.
+                                CompareParamName(ae.ParamName, "name", "mismatch");
                                 return;
                             }
                         }
@@ -481,7 +481,7 @@ namespace CoreXml.Test.XLinq
                         }
                         catch (ArgumentException e)
                         {
-                            TestLog.Compare(e.ParamName, null, "mismatch");
+                            CompareParamName(e.ParamName, null, "mismatch");
                             try
                             {
                                 TestLog.Compare(w.WriteState, WriteState.Start, "Error");
@@ -490,7 +490,7 @@ namespace CoreXml.Test.XLinq
                             catch (ArgumentException ae)
                             {
                                 TestLog.Compare(w.WriteState, WriteState.Start, "Error");
-                                TestLog.Compare(ae.ParamName, null, "mismatch");
+                                CompareParamName(ae.ParamName, null, "mismatch");
                                 return;
                             }
                         }
@@ -524,10 +524,10 @@ namespace CoreXml.Test.XLinq
                             switch (param1)
                             {
                                 case ("reader"):
-                                    TestLog.Compare(PlatformDetection.IsNetNative ? "reader" : e.ParamName, "reader", "mismatch"); // ILC optimization sets ParamName always to null.
+                                    CompareParamName(e.ParamName, "reader", "mismatch");
                                     break;
                                 case ("navigator"):
-                                    TestLog.Compare(PlatformDetection.IsNetNative ? "navigator" : e.ParamName, "navigator", "mismatch"); // ILC optimization sets ParamName always to null.
+                                    CompareParamName(e.ParamName, "navigator", "mismatch");
                                     break;
                             }
                             try
@@ -545,7 +545,7 @@ namespace CoreXml.Test.XLinq
                                 switch (param1)
                                 {
                                     case ("reader"):
-                                        TestLog.Compare(PlatformDetection.IsNetNative ? "reader" : e.ParamName, "reader", "mismatch"); // ILC optimization sets ParamName always to null.
+                                        CompareParamName(e.ParamName, "reader", "mismatch");
                                         break;
                                 }
                                 return;
@@ -570,7 +570,7 @@ namespace CoreXml.Test.XLinq
                         }
                         catch (ArgumentException e)
                         {
-                            TestLog.Compare(e.ParamName, null, "mismatch");
+                            CompareParamName(e.ParamName, null, "mismatch");
                             try
                             {
                                 TestLog.Compare(w.WriteState, WriteState.Error, "Error");
@@ -579,7 +579,7 @@ namespace CoreXml.Test.XLinq
                             catch (ArgumentException ae)
                             {
                                 TestLog.Compare(w.WriteState, WriteState.Error, "Error");
-                                TestLog.Compare(ae.ParamName, null, "mismatch");
+                                CompareParamName(ae.ParamName, null, "mismatch");
                                 return;
                             }
                         }
@@ -602,7 +602,7 @@ namespace CoreXml.Test.XLinq
                         }
                         catch (ArgumentException e)
                         {
-                            TestLog.Compare(e.ParamName, null, "mismatch");
+                            CompareParamName(e.ParamName, null, "mismatch");
                             try
                             {
                                 TestLog.Compare(w.WriteState, WriteState.Error, "Error");
@@ -611,7 +611,7 @@ namespace CoreXml.Test.XLinq
                             catch (ArgumentException ae)
                             {
                                 TestLog.Compare(w.WriteState, WriteState.Error, "Error");
-                                TestLog.Compare(ae.ParamName, null, "mismatch");
+                                CompareParamName(ae.ParamName, null, "mismatch");
                                 return;
                             }
                         }
@@ -632,7 +632,7 @@ namespace CoreXml.Test.XLinq
                         }
                         catch (ArgumentNullException e)
                         {
-                            TestLog.Compare(PlatformDetection.IsNetNative ? "buffer" : e.ParamName, "buffer", "mismatch"); // ILC optimization sets ParamName always to null.
+                            CompareParamName(e.ParamName, "buffer", "mismatch");
                             try
                             {
                                 TestLog.Compare(w.WriteState, WriteState.Error, "Error");
@@ -641,7 +641,7 @@ namespace CoreXml.Test.XLinq
                             catch (ArgumentNullException ae)
                             {
                                 TestLog.Compare(w.WriteState, WriteState.Error, "Error");
-                                TestLog.Compare(PlatformDetection.IsNetNative ? "buffer" : ae.ParamName, "buffer", "mismatch"); // ILC optimization sets ParamName always to null.
+                                CompareParamName(ae.ParamName, "buffer", "mismatch");
                                 return;
                             }
                         }
@@ -664,7 +664,7 @@ namespace CoreXml.Test.XLinq
                         }
                         catch (ArgumentException e)
                         {
-                            TestLog.Compare(e.ParamName, null, "mismatch");
+                            CompareParamName(e.ParamName, null, "mismatch");
                             try
                             {
                                 TestLog.Compare(w.WriteState, WriteState.Error, "Error");
@@ -673,7 +673,7 @@ namespace CoreXml.Test.XLinq
                             catch (ArgumentException ae)
                             {
                                 TestLog.Compare(w.WriteState, WriteState.Error, "Error");
-                                TestLog.Compare(ae.ParamName, null, "mismatch");
+                                CompareParamName(ae.ParamName, null, "mismatch");
                                 return;
                             }
                         }
@@ -696,7 +696,7 @@ namespace CoreXml.Test.XLinq
                         }
                         catch (ArgumentException e)
                         {
-                            TestLog.Compare(e.ParamName, null, "mismatch");
+                            CompareParamName(e.ParamName, null, "mismatch");
                             try
                             {
                                 TestLog.Compare(w.WriteState, WriteState.Error, "Error");
@@ -705,7 +705,7 @@ namespace CoreXml.Test.XLinq
                             catch (ArgumentException ae)
                             {
                                 TestLog.Compare(w.WriteState, WriteState.Error, "Error");
-                                TestLog.Compare(ae.ParamName, null, "mismatch");
+                                CompareParamName(ae.ParamName, null, "mismatch");
                                 return;
                             }
                         }
@@ -1180,6 +1180,14 @@ namespace CoreXml.Test.XLinq
                         return;
                     }
                     throw new TestException(TestResult.Failed, "");
+                }
+
+                private void CompareParamName(string actual, string expected, string message)
+                {
+                    if (PlatformDetection.IsNetNative) // ILC optimization sets ParamName always to null.
+                        return;
+
+                    TestLog.Compare(actual, expected, message);
                 }
             }
         }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/21555

ArgumentNullException.ParamName is set to null in ILC ret mode by nutc optimizations so this was causing the tests to crash with a NullReferenceException in https://github.com/dotnet/corefx/compare/master...safern:FixXnodeBuilderTests?expand=1#diff-970dcd231e06d46b9ed9524632984fb0R97

This was caused because we are actually testing for the `exception.ParamName`  and since it was different than the expected this tests throw a `TestException` and prints it out. So when `TestException.ToString()` was called `Actual` was `null` and `Actual.GetType()` was causing the `NullReferenceException`

cc: @danmosemsft @tijoytom 