### PR TITLE
[release/2.0] Unable to make https request when Oid lookup takes too long (#21320)

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpCertificateHelper.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpCertificateHelper.cs
@@ -11,7 +11,7 @@ namespace System.Net.Http
 {
     internal static class WinHttpCertificateHelper
     {
-		private const string ClientAuthenticationOID = "1.3.6.1.5.5.7.3.2";
+        private const string ClientAuthenticationOID = "1.3.6.1.5.5.7.3.2";
         private static readonly Oid s_serverAuthOid = new Oid("1.3.6.1.5.5.7.3.1", "1.3.6.1.5.5.7.3.1");
         
         // TODO: Issue #2165. Merge with similar code used in System.Net.Security move to Common/src//System/Net.

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpCertificateHelper.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpCertificateHelper.cs
@@ -11,8 +11,8 @@ namespace System.Net.Http
 {
     internal static class WinHttpCertificateHelper
     {
-        private const string ClientAuthenticationOID = "1.3.6.1.5.5.7.3.2";
-        private static readonly Oid s_serverAuthOid = new Oid("1.3.6.1.5.5.7.3.1");
+		private const string ClientAuthenticationOID = "1.3.6.1.5.5.7.3.2";
+        private static readonly Oid s_serverAuthOid = new Oid("1.3.6.1.5.5.7.3.1", "1.3.6.1.5.5.7.3.1");
         
         // TODO: Issue #2165. Merge with similar code used in System.Net.Security move to Common/src//System/Net.
         public static void BuildChain(

--- a/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -20,6 +20,7 @@ namespace System.Net.Security
     {
         // When reading a frame from the wire first read this many bytes for the header.
         internal const int ReadHeaderSize = 5;
+
         private SafeFreeCredentials _credentialsHandle;
         private SafeDeleteContext _securityContext;
         private readonly string _destination;
@@ -48,8 +49,8 @@ namespace System.Net.Security
 
         private bool _refreshCredentialNeeded;
 
-        private readonly Oid _serverAuthOid = new Oid("1.3.6.1.5.5.7.3.1");
-        private readonly Oid _clientAuthOid = new Oid("1.3.6.1.5.5.7.3.2");
+        private readonly Oid _serverAuthOid = new Oid("1.3.6.1.5.5.7.3.1", "1.3.6.1.5.5.7.3.1");
+        private readonly Oid _clientAuthOid = new Oid("1.3.6.1.5.5.7.3.2", "1.3.6.1.5.5.7.3.2");
 
         internal SecureChannel(string hostname, bool serverMode, SslProtocols sslProtocols, X509Certificate serverCertificate, X509CertificateCollection clientCertificates, bool remoteCertRequired, bool checkCertName,
                                                   bool checkCertRevocationStatus, EncryptionPolicy encryptionPolicy, LocalCertSelectionCallback certSelectionDelegate)


### PR DESCRIPTION
Port EKU Oid lookup fix which is causing hangs in TLS/SSL network connections.

Fix was verified by customers in (master) branch.  The same fix is being discussed for .NET Framework servicing.

Porting PR #21320