### PR TITLE
Delete unused static field

### DIFF
--- a/src/Common/src/Interop/Windows/kernel32/Interop.SafeCreateFile.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.SafeCreateFile.cs
@@ -10,8 +10,6 @@ internal partial class Interop
 {
     internal partial class Kernel32
     {
-        internal static readonly IntPtr INVALID_HANDLE_VALUE = new IntPtr(-1);  // WinBase.h
-
         /// <summary>
         /// Does not allow access to non-file devices. This disallows DOS devices like "con:", "com1:",
         /// "lpt1:", etc.  Use this to avoid security problems, like allowing a web client asking a server


### PR DESCRIPTION
This doesn't appear to be used anywhere, so the only purpose of it is to
give the `Kernel32` type a class constructor that needs to be checked on
each P/Invoke (that, and it found a bug in CoreRT (dotnet/corert#4096)).