### PR TITLE
include net/if.h to avoid build break on 10.13. It provides prototype…

### DIFF
--- a/src/Native/Unix/System.Native/pal_networkstatistics.cpp
+++ b/src/Native/Unix/System.Native/pal_networkstatistics.cpp
@@ -20,6 +20,7 @@
 #include <errno.h>
 #include <memory>
 #include <net/route.h>
+#include <net/if.h>
 
 #include <sys/types.h>
 #if HAVE_SYS_SYSCTL_H


### PR DESCRIPTION
the header exist on Linux, OSX and FreeBSD and man page states it has definition for if_nametoindex.
It is probably pulled in indirectly but build fails on 10.13 without this change.
