### PR TITLE
Added new params constructor to ForeignKeyAttribute

### DIFF
--- a/src/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.cs
+++ b/src/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.cs
@@ -360,6 +360,7 @@ namespace System.ComponentModel.DataAnnotations.Schema
     public partial class ForeignKeyAttribute : System.Attribute
     {
         public ForeignKeyAttribute(string name) { }
+        public ForeignKeyAttribute(params string[] names) { }
         public string Name { get { throw null; } }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(384), AllowMultiple = false)]

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Schema/ForeignKeyAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Schema/ForeignKeyAttribute.cs
@@ -36,6 +36,17 @@ namespace System.ComponentModel.DataAnnotations.Schema
         }
 
         /// <summary>
+        ///     Initializes a new instance of the <see cref="ForeignKeyAttribute" /> class.
+        /// </summary>
+        /// <param name="names">
+        ///     The list of names of the navigation property's foreign keys.
+        /// </param>
+        public ForeignKeyAttribute(params string[] names)
+            : this(string.Join(",", names))
+        {
+        }
+
+        /// <summary>
         ///     If placed on a foreign key property, the name of the associated navigation property.
         ///     If placed on a navigation property, the name of the associated foreign key(s).
         /// </summary>

--- a/src/System.ComponentModel.Annotations/tests/Schema/ForeignKeyAttributeTests.cs
+++ b/src/System.ComponentModel.Annotations/tests/Schema/ForeignKeyAttributeTests.cs
@@ -24,5 +24,13 @@ namespace System.ComponentModel.DataAnnotations.Schema.Tests
         {
             AssertExtensions.Throws<ArgumentException>(null, () => new ForeignKeyAttribute(name));
         }
+
+        [Theory]
+        [InlineData("Old", "Mother", "Dismass")]
+        public static void Ctor_Multiple_Strings(string name1, string name2, string name3)
+        {
+            ForeignKeyAttribute attribute = new ForeignKeyAttribute(name1, name2, name3);
+            Assert.Equal(string.Join(",", new[] {name1, name2, name3}), attribute.Name);
+        }
     }
 }


### PR DESCRIPTION
Added new params constructor to System.ComponentModel.DataAnnotations.Schema.ForeignKeyAttribute to enable support for passing in multiple names rather than requiring developers to concatenate them.