### PR TITLE
Speedup XmlSystemPathResolverTests.TestResolveInvalidPath test by using invalid hostname

### DIFF
--- a/src/System.Private.Xml/tests/XmlReader/XmlResolver/XmlSystemPathResolverTests.cs
+++ b/src/System.Private.Xml/tests/XmlReader/XmlResolver/XmlSystemPathResolverTests.cs
@@ -92,7 +92,7 @@ namespace System.Xml.Tests
         [Fact]
         public static void TestResolveInvalidPath()
         {
-            Assert.Throws<System.Net.WebException>(() => XmlReader.Create("ftp://www.bing.com"));
+            Assert.Throws<System.Net.WebException>(() => XmlReader.Create("ftp://host.invalid"));
         }
 
         [Fact]


### PR DESCRIPTION
Makes the test project run in less than a second instead of 2 minutes.

Pre:
```
System.Xml.RW.XmlSystemPathResolver.Tests  Total: 7, Errors: 0, Failed: 0, Skipped: 0, Time: 132.515s
```

Post:
```
System.Xml.RW.XmlSystemPathResolver.Tests  Total: 7, Errors: 0, Failed: 0, Skipped: 0, Time: 0.356s
```

CC @sepidehMS @krwq