### PR TITLE
HttpListenerFactory: improve port selection

### DIFF
--- a/src/System.Net.HttpListener/tests/HttpListenerFactory.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerFactory.cs
@@ -15,8 +15,8 @@ namespace System.Net.Tests
     // Utilities for generating URL prefixes for HttpListener
     public class HttpListenerFactory : IDisposable
     {
-        const int MaxStartAttempts = int.MaxValue;
-        private static int s_port = 1024;
+        const int MaxStartAttempts = 100;
+        private static int s_port = 10000;
 
         private readonly HttpListener _processPrefixListener;
         private readonly Exception _processPrefixException;
@@ -90,10 +90,6 @@ namespace System.Net.Tests
                 {
                     throw new Exception("Could not reserve a port for HttpListener", _processPrefixException);
                 }
-                if (_port != 0)
-                {
-                    throw new Exception($"Reserved port {_port}", _processPrefixException);
-                }
 
                 return _port;
             }
@@ -106,10 +102,6 @@ namespace System.Net.Tests
                 if (_processPrefix == null)
                 {
                     throw new Exception("Could not reserve a port for HttpListener", _processPrefixException);
-                }
-                if (_port != 0)
-                {
-                    throw new Exception($"Reserved port {_port}", _processPrefixException);
                 }
 
                 return _processPrefix;

--- a/src/System.Net.HttpListener/tests/HttpListenerFactory.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerFactory.cs
@@ -15,8 +15,8 @@ namespace System.Net.Tests
     // Utilities for generating URL prefixes for HttpListener
     public class HttpListenerFactory : IDisposable
     {
-        const int MaxStartAttempts = 50;
-        private static int s_port = 2048;
+        const int MaxStartAttempts = int.MaxValue;
+        private static int s_port = 1024;
 
         private readonly HttpListener _processPrefixListener;
         private readonly Exception _processPrefixException;
@@ -90,6 +90,10 @@ namespace System.Net.Tests
                 {
                     throw new Exception("Could not reserve a port for HttpListener", _processPrefixException);
                 }
+                if (_port != 0)
+                {
+                    throw new Exception($"Reserved port {_port}", _processPrefixException);
+                }
 
                 return _port;
             }
@@ -102,6 +106,10 @@ namespace System.Net.Tests
                 if (_processPrefix == null)
                 {
                     throw new Exception("Could not reserve a port for HttpListener", _processPrefixException);
+                }
+                if (_port != 0)
+                {
+                    throw new Exception($"Reserved port {_port}", _processPrefixException);
                 }
 
                 return _processPrefix;

--- a/src/System.Net.HttpListener/tests/HttpListenerFactory.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerFactory.cs
@@ -15,25 +15,15 @@ namespace System.Net.Tests
     public class HttpListenerFactory : IDisposable
     {
         const int MaxStartAttempts = 50;
-        const string ProcPortRangeFileName = "/proc/sys/net/ipv4/ip_local_port_range";
         private static int _minPort;
         private static int _maxPort;
         private static readonly Random _random = new Random();
 
         static HttpListenerFactory()
         {
-            // Chose a port from the dynamic port range. The IANA recommended range is 49152-65535.
-            _minPort = 49152;
-            _maxPort = 65535;
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && File.Exists(ProcPortRangeFileName))
-            {
-                string[] limits = File.ReadAllText(ProcPortRangeFileName).Split(new[] { '\t', '\n' }, 2, StringSplitOptions.RemoveEmptyEntries);
-                if (limits.Length == 2)
-                {
-                    int.TryParse(limits[0], out _minPort);
-                    int.TryParse(limits[1], out _maxPort);
-                }
-            }
+            // Chose ports from the user port range (Windows: 1024-49151; Linux 1024-32767)
+            _minPort = 1024;
+            _maxPort = 32767;
         }
 
         private readonly HttpListener _processPrefixListener;

--- a/src/System.Net.HttpListener/tests/HttpListenerFactory.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerFactory.cs
@@ -23,6 +23,7 @@ namespace System.Net.Tests
         private readonly string _processPrefix;
         private readonly string _hostname;
         private readonly string _path;
+        private readonly int _port;
 
         internal HttpListenerFactory(string hostname = "localhost", string path = null)
         {

--- a/src/System.Net.HttpListener/tests/HttpListenerFactory.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerFactory.cs
@@ -17,7 +17,7 @@ namespace System.Net.Tests
         private const int MaxStartAttempts = 500;
         private static int s_minPort;
         private static int s_maxPort;
-        private static readonly Random _random = new Random();
+        private static readonly Random s_random = new Random();
 
         static HttpListenerFactory()
         {
@@ -45,9 +45,9 @@ namespace System.Net.Tests
             for (int attempt = 0; attempt < MaxStartAttempts; attempt++)
             {
                 int port;
-                lock (_random)
+                lock (s_random)
                 {
-                    port = _random.Next(s_minPort, s_maxPort + 1);
+                    port = s_random.Next(s_minPort, s_maxPort + 1);
                 }
                 string prefix = $"http://{hostname}:{port}/{pathComponent}";
 

--- a/src/System.Net.HttpListener/tests/HttpListenerFactory.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerFactory.cs
@@ -16,7 +16,7 @@ namespace System.Net.Tests
     public class HttpListenerFactory : IDisposable
     {
         const int MaxStartAttempts = 50;
-        private static int s_port = 1024;
+        private static int s_port = 2048;
 
         private readonly HttpListener _processPrefixListener;
         private readonly Exception _processPrefixException;

--- a/src/System.Net.HttpListener/tests/HttpListenerFactory.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerFactory.cs
@@ -14,16 +14,16 @@ namespace System.Net.Tests
     // Utilities for generating URL prefixes for HttpListener
     public class HttpListenerFactory : IDisposable
     {
-        const int MaxStartAttempts = 50;
-        private static int _minPort;
-        private static int _maxPort;
+        private const int MaxStartAttempts = 500;
+        private static int s_minPort;
+        private static int s_maxPort;
         private static readonly Random _random = new Random();
 
         static HttpListenerFactory()
         {
             // Chose ports from the user port range (Windows: 1024-49151; Linux 1024-32767)
-            _minPort = 1024;
-            _maxPort = 32767;
+            s_minPort = 1024;
+            s_maxPort = 32767;
         }
 
         private readonly HttpListener _processPrefixListener;
@@ -47,7 +47,7 @@ namespace System.Net.Tests
                 int port;
                 lock (_random)
                 {
-                    port = _random.Next(_minPort, _maxPort + 1);
+                    port = _random.Next(s_minPort, s_maxPort + 1);
                 }
                 string prefix = $"http://{hostname}:{port}/{pathComponent}";
 

--- a/src/System.Net.HttpListener/tests/HttpListenerFactory.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerFactory.cs
@@ -7,17 +7,16 @@ using System.Linq;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.IO;
 
 namespace System.Net.Tests
 {
     // Utilities for generating URL prefixes for HttpListener
     public class HttpListenerFactory : IDisposable
     {
-        const int StartPort = 1024;
+        const int StartPort = 1025;
         const int MaxStartAttempts = IPEndPoint.MaxPort - StartPort + 1;
-        private static int s_port = StartPort;
-        private static readonly object s_portLock = new object();
+        private static readonly object s_nextPortLock = new object();
+        private static int s_nextPort = StartPort;
 
         private readonly HttpListener _processPrefixListener;
         private readonly Exception _processPrefixException;
@@ -199,12 +198,12 @@ namespace System.Net.Tests
 
         private static int GetNextPort()
         {
-            lock (s_portLock)
+            lock (s_nextPortLock)
             {
-                int port = s_port++;
-                if (s_port > IPEndPoint.MaxPort)
+                int port = s_nextPort++;
+                if (s_nextPort > IPEndPoint.MaxPort)
                 {
-                    s_port = StartPort;
+                    s_nextPort = StartPort;
                 }
                 return port;
             }


### PR DESCRIPTION
This speeds up test execution of System.Net.HttpListener.Tests by about 15 seconds.

Pre:
```
System.Net.HttpListener.Tests  Total: 638, Errors: 0, Failed: 0, Skipped: 16, Time: 141.388s
```
Post:
```
System.Net.HttpListener.Tests  Total: 638, Errors: 0, Failed: 0, Skipped: 16, Time: 127.527s
```