### PR TITLE
[release/1.0] Unable to make https request when Oid lookup takes too long (#21320)

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpCertificateHelper.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpCertificateHelper.cs
@@ -12,7 +12,7 @@ namespace System.Net.Http
     internal static class WinHttpCertificateHelper
     {
         private const string ClientAuthenticationOID = "1.3.6.1.5.5.7.3.2";
-        private static readonly Oid s_serverAuthOid = new Oid("1.3.6.1.5.5.7.3.1");
+        private static readonly Oid s_serverAuthOid = new Oid("1.3.6.1.5.5.7.3.1", "1.3.6.1.5.5.7.3.1");
         
         // TODO: Issue #2165. Merge with similar code used in System.Net.Security move to Common/src//System/Net.
         public static void BuildChain(

--- a/src/System.Net.Security/src/System/Net/SecureChannel.cs
+++ b/src/System.Net.Security/src/System/Net/SecureChannel.cs
@@ -47,8 +47,8 @@ namespace System.Net.Security
 
         private bool _refreshCredentialNeeded;
 
-        private readonly Oid _serverAuthOid = new Oid("1.3.6.1.5.5.7.3.1");
-        private readonly Oid _clientAuthOid = new Oid("1.3.6.1.5.5.7.3.2");
+        private readonly Oid _serverAuthOid = new Oid("1.3.6.1.5.5.7.3.1", "1.3.6.1.5.5.7.3.1");
+        private readonly Oid _clientAuthOid = new Oid("1.3.6.1.5.5.7.3.2", "1.3.6.1.5.5.7.3.2");
 
         internal SecureChannel(string hostname, bool serverMode, SslProtocols sslProtocols, X509Certificate serverCertificate, X509CertificateCollection clientCertificates, bool remoteCertRequired, bool checkCertName,
                                                   bool checkCertRevocationStatus, EncryptionPolicy encryptionPolicy, LocalCertSelectionCallback certSelectionDelegate)


### PR DESCRIPTION
Port EKU Oid lookup fix which is causing hangs in TLS/SSL network connections.

Porting PR #21320