### PR TITLE
Avoid HttpClient substring allocations for number parsing

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Headers/ContentRangeHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/ContentRangeHeaderValue.cs
@@ -363,13 +363,13 @@ namespace System.Net.Http.Headers
             parsedValue = null;
 
             long from = 0;
-            if ((fromLength > 0) && !HeaderUtilities.TryParseInt64(input.Substring(fromStartIndex, fromLength), out from))
+            if ((fromLength > 0) && !HeaderUtilities.TryParseInt64(input, fromStartIndex, fromLength, out from))
             {
                 return false;
             }
 
             long to = 0;
-            if ((toLength > 0) && !HeaderUtilities.TryParseInt64(input.Substring(toStartIndex, toLength), out to))
+            if ((toLength > 0) && !HeaderUtilities.TryParseInt64(input, toStartIndex, toLength, out to))
             {
                 return false;
             }
@@ -381,8 +381,7 @@ namespace System.Net.Http.Headers
             }
 
             long length = 0;
-            if ((lengthLength > 0) && !HeaderUtilities.TryParseInt64(input.Substring(lengthStartIndex, lengthLength),
-                out length))
+            if ((lengthLength > 0) && !HeaderUtilities.TryParseInt64(input, lengthStartIndex, lengthLength, out length))
             {
                 return false;
             }

--- a/src/System.Net.Http/src/System/Net/Http/Headers/Int32NumberHeaderParser.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/Int32NumberHeaderParser.cs
@@ -42,7 +42,7 @@ namespace System.Net.Http.Headers
             }
 
             int result = 0;
-            if (!HeaderUtilities.TryParseInt32(value.Substring(startIndex, numberLength), out result))
+            if (!HeaderUtilities.TryParseInt32(value, startIndex, numberLength, out result))
             {
                 return 0;
             }

--- a/src/System.Net.Http/src/System/Net/Http/Headers/Int64NumberHeaderParser.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/Int64NumberHeaderParser.cs
@@ -42,7 +42,7 @@ namespace System.Net.Http.Headers
             }
 
             long result = 0;
-            if (!HeaderUtilities.TryParseInt64(value.Substring(startIndex, numberLength), out result))
+            if (!HeaderUtilities.TryParseInt64(value, startIndex, numberLength, out result))
             {
                 return 0;
             }

--- a/src/System.Net.Http/src/System/Net/Http/Headers/RangeItemHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/RangeItemHeaderValue.cs
@@ -209,14 +209,14 @@ namespace System.Net.Http.Headers
 
             // Try convert first value to int64
             long from = 0;
-            if ((fromLength > 0) && !HeaderUtilities.TryParseInt64(input.Substring(fromStartIndex, fromLength), out from))
+            if ((fromLength > 0) && !HeaderUtilities.TryParseInt64(input, fromStartIndex, fromLength, out from))
             {
                 return 0;
             }
 
             // Try convert second value to int64
             long to = 0;
-            if ((toLength > 0) && !HeaderUtilities.TryParseInt64(input.Substring(toStartIndex, toLength), out to))
+            if ((toLength > 0) && !HeaderUtilities.TryParseInt64(input, toStartIndex, toLength, out to))
             {
                 return 0;
             }

--- a/src/System.Net.Http/src/System/Net/Http/Headers/RetryConditionHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/RetryConditionHeaderValue.cs
@@ -148,7 +148,7 @@ namespace System.Net.Http.Headers
                     return 0;
                 }
 
-                if (!HeaderUtilities.TryParseInt32(input.Substring(deltaStartIndex, deltaLength), out deltaSeconds))
+                if (!HeaderUtilities.TryParseInt32(input, deltaStartIndex, deltaLength, out deltaSeconds))
                 {
                     return 0; // int.TryParse() may return 'false' if the value has 10 digits and is > Int32.MaxValue.
                 }

--- a/src/System.Net.Http/src/System/Net/Http/Headers/TimeSpanHeaderParser.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/TimeSpanHeaderParser.cs
@@ -36,7 +36,7 @@ namespace System.Net.Http.Headers
             }
 
             int result = 0;
-            if (!HeaderUtilities.TryParseInt32(value.Substring(startIndex, numberLength), out result))
+            if (!HeaderUtilities.TryParseInt32(value, startIndex, numberLength, out result))
             {
                 return 0;
             }

--- a/src/System.Net.Http/src/System/Net/Http/Headers/WarningHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/WarningHeaderValue.cs
@@ -245,7 +245,7 @@ namespace System.Net.Http.Headers
                 return false;
             }
 
-            if (!HeaderUtilities.TryParseInt32(input.Substring(current, codeLength), out code))
+            if (!HeaderUtilities.TryParseInt32(input, current, codeLength, out code))
             {
                 Debug.Assert(false, "Unable to parse value even though it was parsed as <=3 digits string. Input: '" +
                     input + "', Current: " + current + ", CodeLength: " + codeLength);


### PR DESCRIPTION
This both avoids substring allocations and is faster than the current calls, at least in microbenchmarks.

cc: @geoffkizer, @davidsh