### PR TITLE
Fix handling of SslStream.None on Linux

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -50,9 +50,10 @@ internal static partial class Interop
         {
             SafeSslHandle context = null;
 
-            IntPtr method = GetSslMethod(protocols);
-
-            using (SafeSslContextHandle innerContext = Ssl.SslCtxCreate(method))
+            // Always use SSLv23_method, regardless of protocols.  It supports negotiating to the highest
+            // mutually supported version and can thus handle any of the set protocols, and we then use
+            // SetProtocolOptions to ensure we only allow the ones requested.
+            using (SafeSslContextHandle innerContext = Ssl.SslCtxCreate(Ssl.SslMethods.SSLv23_method))
             {
                 if (innerContext.IsInvalid)
                 {
@@ -307,54 +308,6 @@ internal static partial class Interop
             }
 
             bindingHandle.SetCertHashLength(certHashLength);
-        }
-
-        private static IntPtr GetSslMethod(SslProtocols protocols)
-        {
-#pragma warning disable 0618 // Ssl2, Ssl3 are deprecated.
-            bool ssl2 = (protocols & SslProtocols.Ssl2) == SslProtocols.Ssl2;
-            bool ssl3 = (protocols & SslProtocols.Ssl3) == SslProtocols.Ssl3;
-#pragma warning restore
-            bool tls10 = (protocols & SslProtocols.Tls) == SslProtocols.Tls;
-            bool tls11 = (protocols & SslProtocols.Tls11) == SslProtocols.Tls11;
-            bool tls12 = (protocols & SslProtocols.Tls12) == SslProtocols.Tls12;
-
-            IntPtr method = Ssl.SslMethods.SSLv23_method; // default
-            string methodName = "SSLv23_method";
-
-            if (!ssl2)
-            {
-                if (!ssl3)
-                {
-                    if (!tls11 && !tls12)
-                    {
-                        method = Ssl.SslMethods.TLSv1_method;
-                        methodName = "TLSv1_method";
-                    }
-                    else if (!tls10 && !tls12)
-                    {
-                        method = Ssl.SslMethods.TLSv1_1_method;
-                        methodName = "TLSv1_1_method";
-                    }
-                    else if (!tls10 && !tls11)
-                    {
-                        method = Ssl.SslMethods.TLSv1_2_method;
-                        methodName = "TLSv1_2_method";
-                    }
-                }
-                else if (!tls10 && !tls11 && !tls12)
-                {
-                    method = Ssl.SslMethods.SSLv3_method;
-                    methodName = "SSLv3_method";
-                }
-            }
-
-            if (IntPtr.Zero == method)
-            {
-                throw new SslException(SR.Format(SR.net_get_ssl_method_failed, methodName));
-            }
-
-            return method;
         }
 
         private static int VerifyClientCertificate(int preverify_ok, IntPtr x509_ctx_ptr)

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -20,18 +20,6 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslV2_3Method")]
         internal static extern IntPtr SslV2_3Method();
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslV3Method")]
-        internal static extern IntPtr SslV3Method();
-
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_TlsV1Method")]
-        internal static extern IntPtr TlsV1Method();
-
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_TlsV1_1Method")]
-        internal static extern IntPtr TlsV1_1Method();
-
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_TlsV1_2Method")]
-        internal static extern IntPtr TlsV1_2Method();
-
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCreate")]
         internal static extern SafeSslHandle SslCreate(SafeSslContextHandle ctx);
 
@@ -157,10 +145,6 @@ internal static partial class Interop
 
         internal static class SslMethods
         {
-            internal static readonly IntPtr TLSv1_method = TlsV1Method();
-            internal static readonly IntPtr TLSv1_1_method = TlsV1_1Method();
-            internal static readonly IntPtr TLSv1_2_method = TlsV1_2Method();
-            internal static readonly IntPtr SSLv3_method = SslV3Method();
             internal static readonly IntPtr SSLv23_method = SslV2_3Method();
         }
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -27,48 +27,6 @@ extern "C" const SSL_METHOD* CryptoNative_SslV2_3Method()
     return method;
 }
 
-extern "C" const SSL_METHOD* CryptoNative_SslV3Method()
-{
-    const SSL_METHOD* method = nullptr;
-#ifndef OPENSSL_NO_SSL3_METHOD
-    if (API_EXISTS(SSLv3_method))
-    {
-        method = SSLv3_method();
-        assert(method != nullptr);
-    }
-#endif
-    return method;
-}
-
-extern "C" const SSL_METHOD* CryptoNative_TlsV1Method()
-{
-    const SSL_METHOD* method = TLSv1_method();
-    assert(method != nullptr);
-    return method;
-}
-
-extern "C" const SSL_METHOD* CryptoNative_TlsV1_1Method()
-{
-#if HAVE_TLS_V1_1
-    const SSL_METHOD* method = TLSv1_1_method();
-    assert(method != nullptr);
-    return method;
-#else
-    return nullptr;
-#endif
-}
-
-extern "C" const SSL_METHOD* CryptoNative_TlsV1_2Method()
-{
-#if HAVE_TLS_V1_2
-    const SSL_METHOD* method = TLSv1_2_method();
-    assert(method != nullptr);
-    return method;
-#else
-    return nullptr;
-#endif
-}
-
 extern "C" SSL_CTX* CryptoNative_SslCtxCreate(SSL_METHOD* method)
 {
     SSL_CTX* ctx = SSL_CTX_new(method);
@@ -85,7 +43,12 @@ extern "C" SSL_CTX* CryptoNative_SslCtxCreate(SSL_METHOD* method)
 
 extern "C" void CryptoNative_SetProtocolOptions(SSL_CTX* ctx, SslProtocols protocols)
 {
-    // protocols may be 0 (default). Less secure protocols should be excluded in this case.    
+    // protocols may be 0, meaning system default, in which case let OpenSSL do what OpenSSL wants.
+    if (protocols == 0)
+    {
+        return;
+    }
+
     long protocolOptions = 0;
 
     if ((protocols & PAL_SSL_SSL2) != PAL_SSL_SSL2)
@@ -94,10 +57,13 @@ extern "C" void CryptoNative_SetProtocolOptions(SSL_CTX* ctx, SslProtocols proto
     }
 #ifndef OPENSSL_NO_SSL3
     if ((protocols & PAL_SSL_SSL3) != PAL_SSL_SSL3)
+#endif
     {
+        // If OPENSSL_NO_SSL3 is defined, then ensure we always include
+        // SSL_OP_NO_SSLv3 in case we end up running against a binary
+        // which had SSLv3 enabled (we don't want to use SSLv3 in that case).
         protocolOptions |= SSL_OP_NO_SSLv3;
     }
-#endif
     if ((protocols & PAL_SSL_TLS) != PAL_SSL_TLS)
     {
         protocolOptions |= SSL_OP_NO_TLSv1;

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.h
@@ -130,34 +130,6 @@ Returns the requested SSL_METHOD.
 extern "C" const SSL_METHOD* CryptoNative_SslV2_3Method();
 
 /*
-Shims the SSLv3_method method.
-
-Returns the requested SSL_METHOD.
-*/
-extern "C" const SSL_METHOD* CryptoNative_SslV3Method();
-
-/*
-Shims the TLSv1_method method.
-
-Returns the requested SSL_METHOD.
-*/
-extern "C" const SSL_METHOD* CryptoNative_TlsV1Method();
-
-/*
-Shims the TLSv1_1_method method.
-
-Returns the requested SSL_METHOD.
-*/
-extern "C" const SSL_METHOD* CryptoNative_TlsV1_1Method();
-
-/*
-Shims the TLSv1_2_method method.
-
-Returns the requested SSL_METHOD.
-*/
-extern "C" const SSL_METHOD* CryptoNative_TlsV1_2Method();
-
-/*
 Shims the SSL_CTX_new method.
 
 Returns the new SSL_CTX instance.


### PR DESCRIPTION
First commit refactors and augments SslStreamSystemDefaultTests to test not only default-to-default, but also default-to-other stuff and both explicitly and implicitly specifying the default.  The tests fail on Linux before the second commit.

Second commit makes two changes:
- Currently if None is specified, we end up disabling all protocols!  OpenSSL will then end up negotiating something very limited, and for example using None on the client won't be able to connect to a Tls12 server.
- If an explicit version is used, on the server we end up only allowing connections from clients sending that specific version's hello message, which means a client sending an earlier version but with support for upgrading to a newer is explicitly denied, which means on Unix a None can't connect to a Tls12, for example.

The fix for the first issue is to simply allow None to mean what was intended, the system default, and not override OpenSSL's default if None is specified.

The fix for the second issue is to simplify how protocol limitation is done.  Currently we both select the "proper" version method and then set context options.  Instead, we always use SSLv23_method, which the docs recommend, and then just use the context options to restrict the allowed protocol.

Contributes to #21991 (fix should be ported to 2.0)
cc: @bartonjs, @geoffkizer, @davidsh, @cipop, @Priya91 