### PR TITLE
Making UAP SqlClient sni.dll independent

### DIFF
--- a/src/System.Data.SqlClient/src/Interop/SNINativeMethodWrapper.Common.cs
+++ b/src/System.Data.SqlClient/src/Interop/SNINativeMethodWrapper.Common.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Data.SqlClient.SNI;
+
+namespace System.Data.SqlClient
+{
+    internal static partial class SNINativeMethodWrapper
+    {
+        internal enum SniSpecialErrors : uint
+        {
+            LocalDBErrorCode = SNICommon.LocalDBErrorCode,
+
+            // multi-subnet-failover specific error codes
+            MultiSubnetFailoverWithMoreThan64IPs = SNICommon.MultiSubnetFailoverWithMoreThan64IPs,
+            MultiSubnetFailoverWithInstanceSpecified = SNICommon.MultiSubnetFailoverWithInstanceSpecified,
+            MultiSubnetFailoverWithNonTcpProtocol = SNICommon.MultiSubnetFailoverWithNonTcpProtocol,
+
+            // max error code value
+            MaxErrorValue = SNICommon.MaxErrorValue
+        }
+    }
+}

--- a/src/System.Data.SqlClient/src/Interop/SNINativeMethodWrapper.Unix.cs
+++ b/src/System.Data.SqlClient/src/Interop/SNINativeMethodWrapper.Unix.cs
@@ -4,25 +4,6 @@
 
 using System.Data.SqlClient.SNI;
 
-namespace System.Data.SqlClient
-{
-    internal static class SNINativeMethodWrapper
-    {
-        internal enum SniSpecialErrors : uint
-        {
-            LocalDBErrorCode = SNICommon.LocalDBErrorCode,
-
-            // multi-subnet-failover specific error codes
-            MultiSubnetFailoverWithMoreThan64IPs = SNICommon.MultiSubnetFailoverWithMoreThan64IPs,
-            MultiSubnetFailoverWithInstanceSpecified = SNICommon.MultiSubnetFailoverWithInstanceSpecified,
-            MultiSubnetFailoverWithNonTcpProtocol = SNICommon.MultiSubnetFailoverWithNonTcpProtocol,
-
-            // max error code value
-            MaxErrorValue = SNICommon.MaxErrorValue
-        }
-    }
-}
-
 namespace System.Data
 {
     internal static partial class SafeNativeMethods

--- a/src/System.Data.SqlClient/src/Interop/SNINativeMethodWrapper.Windows.cs
+++ b/src/System.Data.SqlClient/src/Interop/SNINativeMethodWrapper.Windows.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 
 namespace System.Data.SqlClient
 {
-    internal static class SNINativeMethodWrapper
+    internal static partial class SNINativeMethodWrapper
     {
         private const string SNI = "sni.dll";
 
@@ -178,18 +178,6 @@ namespace System.Data.SqlClient
             internal uint lineNumber;
         }
 
-        internal enum SniSpecialErrors : uint
-        {
-            LocalDBErrorCode = 50,
-
-            // multi-subnet-failover specific error codes
-            MultiSubnetFailoverWithMoreThan64IPs = 47,
-            MultiSubnetFailoverWithInstanceSpecified = 48,
-            MultiSubnetFailoverWithNonTcpProtocol = 49,
-
-            // max error code value
-            MaxErrorValue = 50157
-        }
         #endregion
 
         #region DLL Imports

--- a/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
+++ b/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
@@ -189,6 +189,7 @@
     <Compile Include="System\Data\SqlClient\SNI\SspiClientContextStatus.cs" />
     <Compile Include="System\Data\SqlClient\SNI\SSRP.cs" />
     <Compile Include="System\Data\SqlClient\TdsParserStateObjectManaged.cs" />
+    <Compile Include="Interop\SNINativeMethodWrapper.Common.cs" />
   </ItemGroup>
   <!-- Manage the SNI toggle for Windows netstandard and UWP -->
   <ItemGroup Condition="'$(TargetGroup)' == 'netstandard' AND '$(TargetsWindows)' == 'true'">
@@ -196,15 +197,22 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'uap'">
     <Compile Include="System\Data\SqlClient\TdsParserStateObjectFactory.Managed.cs" />
+    <Compile Include="System\Data\SqlClient\LocalDBAPI.uap.cs" />
+    <Compile Include="System\Data\ProviderBase\DbConnectionPoolIdentity.Unix.cs" />
+    <Compile Include="System\Data\SqlClient\TdsParser.Unix.cs" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' And '$(IsPartialFacadeAssembly)' != 'true' ">
-    <Compile Include="System\Data\ProviderBase\DbConnectionPoolIdentity.Windows.cs" />
+  <!-- Assets needed on Windows but should be avoided on UAP to avoid sni.dll -->
+  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' And '$(IsPartialFacadeAssembly)' != 'true' and '$(TargetGroup)' != 'uap' ">
+    <Compile Include="System\Data\SqlClient\TdsParserStateObjectNative.cs" />
     <Compile Include="Interop\SNINativeMethodWrapper.Windows.cs" />
     <Compile Include="System\Data\SqlClient\TdsParserSafeHandles.cs" />
-    <Compile Include="System\Data\SqlClient\TdsParserStateObjectNative.cs" />
-    <Compile Include="System\Data\SqlClient\TdsParser.Windows.cs" />
     <Compile Include="System\Data\SqlClient\LocalDBAPI.Windows.cs" />
+    <Compile Include="System\Data\ProviderBase\DbConnectionPoolIdentity.Windows.cs" />
+    <Compile Include="System\Data\SqlClient\TdsParser.Windows.cs" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' And '$(IsPartialFacadeAssembly)' != 'true'">
     <Compile Include="System\Data\SqlClient\SNI\LocalDB.Windows.cs" />
+    <Compile Include="System\Data\SqlClient\LocalDBAPI.Common.cs" />
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.LoadLibraryEx.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.LoadLibraryEx.cs</Link>
     </Compile>
@@ -430,8 +438,8 @@
     <Reference Include="System.Diagnostics.Tracing" />
   </ItemGroup>
   <ItemGroup Condition="'$(OSGroup)' != 'AnyOS' AND '$(TargetGroup)' == 'uap'">
-    <Reference Include="System.Transactions.Local" /> 
-    <Reference Include="System.Collections.NonGeneric" /> 
+    <Reference Include="System.Transactions.Local" />
+    <Reference Include="System.Collections.NonGeneric" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netfx'">
     <Reference Include="mscorlib" />

--- a/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPoolIdentity.Unix.cs
+++ b/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPoolIdentity.Unix.cs
@@ -2,23 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
-//------------------------------------------------------------------------------
-
-using System.Security.Principal;
-
-
 namespace System.Data.ProviderBase
 {
     partial class DbConnectionPoolIdentity
     {
         internal static DbConnectionPoolIdentity GetCurrent()
         {
-            string sidString = (!string.IsNullOrWhiteSpace(System.Environment.UserDomainName) ? System.Environment.UserDomainName + "\\" : "")
-                                + System.Environment.UserName;
-            bool isNetwork = false;
-            bool isRestricted = false;
-            return new DbConnectionPoolIdentity(sidString, isRestricted, isNetwork);
+            return GetCurrentManaged();
         }
     }
 }

--- a/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPoolIdentity.Windows.cs
+++ b/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPoolIdentity.Windows.cs
@@ -2,11 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
-//------------------------------------------------------------------------------
-
+using System.Data.SqlClient;
 using System.Security.Principal;
-
 
 namespace System.Data.ProviderBase
 {
@@ -15,6 +12,11 @@ namespace System.Data.ProviderBase
         private static DbConnectionPoolIdentity s_lastIdentity = null;
 
         internal static DbConnectionPoolIdentity GetCurrent()
+        {
+            return TdsParserStateObjectFactory.UseManagedSNI ? GetCurrentManaged() : GetCurrentNative();
+        }
+
+        private static DbConnectionPoolIdentity GetCurrentNative()
         {
             DbConnectionPoolIdentity current;
             using (WindowsIdentity identity = WindowsIdentity.GetCurrent())

--- a/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPoolIdentity.cs
+++ b/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPoolIdentity.cs
@@ -2,12 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
-//------------------------------------------------------------------------------
-
-using System.Security.Principal;
-
-
 namespace System.Data.ProviderBase
 {
     sealed internal partial class DbConnectionPoolIdentity
@@ -47,6 +41,15 @@ namespace System.Data.ProviderBase
         override public int GetHashCode()
         {
             return _hashCode;
+        }
+
+        internal static DbConnectionPoolIdentity GetCurrentManaged()
+        {
+            string sidString = (!string.IsNullOrWhiteSpace(System.Environment.UserDomainName) ? System.Environment.UserDomainName + "\\" : "")
+                                + System.Environment.UserName;
+            bool isNetwork = false;
+            bool isRestricted = false;
+            return new DbConnectionPoolIdentity(sidString, isRestricted, isNetwork);
         }
     }
 }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/LocalDBAPI.Common.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/LocalDBAPI.Common.cs
@@ -1,0 +1,121 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+using System.Data.SqlClient;
+using System.Diagnostics;
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace System.Data
+{
+    internal static partial class LocalDBAPI
+    {
+        private static LocalDBFormatMessageDelegate s_localDBFormatMessage = null;
+
+        internal static void ReleaseDLLHandles()
+        {
+            s_userInstanceDLLHandle = IntPtr.Zero;
+            s_localDBFormatMessage = null;
+        }
+
+
+        private static LocalDBFormatMessageDelegate LocalDBFormatMessage
+        {
+            get
+            {
+                if (s_localDBFormatMessage == null)
+                {
+                    lock (s_dllLock)
+                    {
+                        if (s_localDBFormatMessage == null)
+                        {
+                            IntPtr functionAddr = LoadProcAddress();
+
+                            if (functionAddr == IntPtr.Zero)
+                            {
+                                int hResult = Marshal.GetLastWin32Error();
+                                throw CreateLocalDBException(errorMessage: SR.LocalDB_MethodNotFound);
+                            }
+                            s_localDBFormatMessage = Marshal.GetDelegateForFunctionPointer<LocalDBFormatMessageDelegate>(functionAddr);
+                        }
+                    }
+                }
+                return s_localDBFormatMessage;
+            }
+        }
+        
+        //This is copy of handle that SNI maintains, so we are responsible for freeing it - therefore there we are not using SafeHandle
+        private static IntPtr s_userInstanceDLLHandle = IntPtr.Zero;
+
+        private static readonly object s_dllLock = new object();
+
+
+        private const UInt32 const_LOCALDB_TRUNCATE_ERR_MESSAGE = 1;// flag for LocalDBFormatMessage that indicates that message can be truncated if it does not fit in the buffer
+        private const int const_ErrorMessageBufferSize = 1024;      // Buffer size for Local DB error message 1K will be enough for all messages
+
+
+        internal static string GetLocalDBMessage(int hrCode)
+        {
+            Debug.Assert(hrCode < 0, "HRCode does not indicate error");
+            try
+            {
+                StringBuilder buffer = new StringBuilder((int)const_ErrorMessageBufferSize);
+                UInt32 len = (UInt32)buffer.Capacity;
+
+
+                // First try for current culture                
+                int hResult = LocalDBFormatMessage(hrLocalDB: hrCode, dwFlags: const_LOCALDB_TRUNCATE_ERR_MESSAGE, dwLanguageId: (uint)CultureInfo.CurrentCulture.LCID,
+                                                 buffer: buffer, buflen: ref len);
+                if (hResult >= 0)
+                    return buffer.ToString();
+                else
+                {
+                    // Message is not available for current culture, try default 
+                    buffer = new StringBuilder((int)const_ErrorMessageBufferSize);
+                    len = (UInt32)buffer.Capacity;
+                    hResult = LocalDBFormatMessage(hrLocalDB: hrCode, dwFlags: const_LOCALDB_TRUNCATE_ERR_MESSAGE, dwLanguageId: 0 /* thread locale with fallback to English */,
+                                                 buffer: buffer, buflen: ref len);
+                    if (hResult >= 0)
+                        return buffer.ToString();
+                    else
+                        return string.Format(CultureInfo.CurrentCulture, "{0} (0x{1:X}).", SR.LocalDB_UnobtainableMessage, hResult);
+                }
+            }
+            catch (SqlException exc)
+            {
+                return string.Format(CultureInfo.CurrentCulture, "{0} ({1}).", SR.LocalDB_UnobtainableMessage, exc.Message);
+            }
+        }
+
+
+        private static SqlException CreateLocalDBException(string errorMessage, string instance = null, int localDbError = 0, int sniError = 0)
+        {
+            Debug.Assert((localDbError == 0) || (sniError == 0), "LocalDB error and SNI error cannot be specified simultaneously");
+            Debug.Assert(!string.IsNullOrEmpty(errorMessage), "Error message should not be null or empty");
+            SqlErrorCollection collection = new SqlErrorCollection();
+
+            int errorCode = (localDbError == 0) ? sniError : localDbError;
+
+            if (sniError != 0)
+            {
+                string sniErrorMessage = SQL.GetSNIErrorMessage(sniError);
+                errorMessage = String.Format((IFormatProvider)null, "{0} (error: {1} - {2})",
+                         errorMessage, sniError, sniErrorMessage);
+            }
+
+            collection.Add(new SqlError(errorCode, 0, TdsEnums.FATAL_ERROR_CLASS, instance, errorMessage, null, 0));
+
+            if (localDbError != 0)
+                collection.Add(new SqlError(errorCode, 0, TdsEnums.FATAL_ERROR_CLASS, instance, GetLocalDBMessage(localDbError), null, 0));
+
+            SqlException exc = SqlException.CreateException(collection, null);
+
+            exc._doNotReconnect = true;
+
+            return exc;
+        }
+    }
+}

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/LocalDBAPI.Unix.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/LocalDBAPI.Unix.cs
@@ -14,5 +14,8 @@ namespace System.Data
                 return IntPtr.Zero;
             }
         }
+
+        private static LocalDBFormatMessageDelegate LocalDBFormatMessage =>
+                throw new PlatformNotSupportedException(SR.LocalDBNotSupported); // LocalDB is not available for Unix and hence it cannot be supported.
     }
 }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/LocalDBAPI.Unix.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/LocalDBAPI.Unix.cs
@@ -7,15 +7,7 @@ namespace System.Data
 {
     internal static partial class LocalDBAPI
     {
-        private static IntPtr UserInstanceDLLHandle
-        {
-            get
-            {
-                return IntPtr.Zero;
-            }
-        }
-
-        private static LocalDBFormatMessageDelegate LocalDBFormatMessage =>
-                throw new PlatformNotSupportedException(SR.LocalDBNotSupported); // LocalDB is not available for Unix and hence it cannot be supported.
+        internal static string GetLocalDBMessage(int hrCode) => 
+            throw new PlatformNotSupportedException(SR.LocalDBNotSupported); // LocalDB is not available for Unix and hence it cannot be supported.
     }
 }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/LocalDBAPI.Windows.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/LocalDBAPI.Windows.cs
@@ -3,13 +3,17 @@
 // See the LICENSE file in the project root for more information.
 
 
-using System.Threading;
 using System.Data.SqlClient;
+using System.Diagnostics;
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Text;
 
 namespace System.Data
 {
     internal static partial class LocalDBAPI
     {
+        private static IntPtr LoadProcAddress() => SafeNativeMethods.GetProcAddress(UserInstanceDLLHandle, "LocalDBFormatMessage");
 
         private static IntPtr UserInstanceDLLHandle
         {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/LocalDBAPI.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/LocalDBAPI.cs
@@ -3,11 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.InteropServices;
-using System.Globalization;
-using System.Data.SqlClient;
 using System.Text;
-using System.Diagnostics;
-
 
 namespace System.Data
 {
@@ -15,6 +11,9 @@ namespace System.Data
     {
         private const string const_localDbPrefix = @"(localdb)\";
 
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+        private delegate int LocalDBFormatMessageDelegate(int hrLocalDB, UInt32 dwFlags, UInt32 dwLanguageId, StringBuilder buffer, ref UInt32 buflen);
 
         // check if name is in format (localdb)\<InstanceName - not empty> and return instance name if it is
         internal static string GetLocalDbInstanceNameFromServerName(string serverName)
@@ -29,115 +28,6 @@ namespace System.Data
                 return null;
             else
                 return instanceName;
-        }
-
-
-        internal static void ReleaseDLLHandles()
-        {
-            s_userInstanceDLLHandle = IntPtr.Zero;
-            s_localDBFormatMessage = null;
-        }
-
-
-
-        //This is copy of handle that SNI maintains, so we are responsible for freeing it - therefore there we are not using SafeHandle
-        private static IntPtr s_userInstanceDLLHandle = IntPtr.Zero;
-
-        private static readonly object s_dllLock = new object();
-
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-        private delegate int LocalDBFormatMessageDelegate(int hrLocalDB, UInt32 dwFlags, UInt32 dwLanguageId, StringBuilder buffer, ref UInt32 buflen);
-
-        private static LocalDBFormatMessageDelegate s_localDBFormatMessage = null;
-
-        private static LocalDBFormatMessageDelegate LocalDBFormatMessage
-        {
-            get
-            {
-                if (s_localDBFormatMessage == null)
-                {
-                    lock (s_dllLock)
-                    {
-                        if (s_localDBFormatMessage == null)
-                        {
-                            IntPtr functionAddr = SafeNativeMethods.GetProcAddress(UserInstanceDLLHandle, "LocalDBFormatMessage");
-
-                            if (functionAddr == IntPtr.Zero)
-                            {
-                                int hResult = Marshal.GetLastWin32Error();
-                                throw CreateLocalDBException(errorMessage: SR.LocalDB_MethodNotFound);
-                            }
-                            s_localDBFormatMessage = Marshal.GetDelegateForFunctionPointer<LocalDBFormatMessageDelegate>(functionAddr);
-                        }
-                    }
-                }
-                return s_localDBFormatMessage;
-            }
-        }
-
-        private const UInt32 const_LOCALDB_TRUNCATE_ERR_MESSAGE = 1;// flag for LocalDBFormatMessage that indicates that message can be truncated if it does not fit in the buffer
-        private const int const_ErrorMessageBufferSize = 1024;      // Buffer size for Local DB error message 1K will be enough for all messages
-
-
-        internal static string GetLocalDBMessage(int hrCode)
-        {
-            Debug.Assert(hrCode < 0, "HRCode does not indicate error");
-            try
-            {
-                StringBuilder buffer = new StringBuilder((int)const_ErrorMessageBufferSize);
-                UInt32 len = (UInt32)buffer.Capacity;
-
-
-                // First try for current culture                
-                int hResult = LocalDBFormatMessage(hrLocalDB: hrCode, dwFlags: const_LOCALDB_TRUNCATE_ERR_MESSAGE, dwLanguageId: (uint)CultureInfo.CurrentCulture.LCID,
-                                                 buffer: buffer, buflen: ref len);
-                if (hResult >= 0)
-                    return buffer.ToString();
-                else
-                {
-                    // Message is not available for current culture, try default 
-                    buffer = new StringBuilder((int)const_ErrorMessageBufferSize);
-                    len = (UInt32)buffer.Capacity;
-                    hResult = LocalDBFormatMessage(hrLocalDB: hrCode, dwFlags: const_LOCALDB_TRUNCATE_ERR_MESSAGE, dwLanguageId: 0 /* thread locale with fallback to English */,
-                                                 buffer: buffer, buflen: ref len);
-                    if (hResult >= 0)
-                        return buffer.ToString();
-                    else
-                        return string.Format(CultureInfo.CurrentCulture, "{0} (0x{1:X}).", SR.LocalDB_UnobtainableMessage, hResult);
-                }
-            }
-            catch (SqlException exc)
-            {
-                return string.Format(CultureInfo.CurrentCulture, "{0} ({1}).", SR.LocalDB_UnobtainableMessage, exc.Message);
-            }
-        }
-
-
-        private static SqlException CreateLocalDBException(string errorMessage, string instance = null, int localDbError = 0, int sniError = 0)
-        {
-            Debug.Assert((localDbError == 0) || (sniError == 0), "LocalDB error and SNI error cannot be specified simultaneously");
-            Debug.Assert(!string.IsNullOrEmpty(errorMessage), "Error message should not be null or empty");
-            SqlErrorCollection collection = new SqlErrorCollection();
-
-            int errorCode = (localDbError == 0) ? sniError : localDbError;
-
-            if (sniError != 0)
-            {
-                string sniErrorMessage = SQL.GetSNIErrorMessage(sniError);
-                errorMessage = String.Format((IFormatProvider)null, "{0} (error: {1} - {2})",
-                         errorMessage, sniError, sniErrorMessage);
-            }
-
-            collection.Add(new SqlError(errorCode, 0, TdsEnums.FATAL_ERROR_CLASS, instance, errorMessage, null, 0));
-
-            if (localDbError != 0)
-                collection.Add(new SqlError(errorCode, 0, TdsEnums.FATAL_ERROR_CLASS, instance, GetLocalDBMessage(localDbError), null, 0));
-
-            SqlException exc = SqlException.CreateException(collection, null);
-
-            exc._doNotReconnect = true;
-
-            return exc;
         }
     }
 }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/LocalDBAPI.uap.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/LocalDBAPI.uap.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+using System.Threading;
+using System.Data.SqlClient;
+using System.Data.SqlClient.SNI;
+using System.Runtime.InteropServices;
+
+namespace System.Data
+{
+    internal static partial class LocalDBAPI
+    {
+
+        private static IntPtr LoadProcAddress() => LocalDB.GetProcAddress("LocalDBFormatMessage");
+       
+    }
+}

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/LocalDB.Windows.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/LocalDB.Windows.cs
@@ -42,6 +42,9 @@ namespace System.Data.SqlClient.SNI
         internal static string GetLocalDBConnectionString(string localDbInstance) =>
             Instance.LoadUserInstanceDll() ? Instance.GetConnectionString(localDbInstance) : null;
 
+        internal static IntPtr GetProcAddress(string functionName) =>
+            Instance.LoadUserInstanceDll() ? Interop.Kernel32.GetProcAddress(LocalDB.Instance._sqlUserInstanceLibraryHandle, functionName) : IntPtr.Zero;
+
         private string GetConnectionString(string localDbInstance)
         {
             StringBuilder localDBConnectionString = new StringBuilder(MAX_LOCAL_DB_CONNECTION_STRING_SIZE + 1);


### PR DESCRIPTION
The changes include moving the code around, so that the SNI.dll is not a dependency for SqlClient. 

The new code that has been added is in LocalDB.Windows.cs and LocalDBAPI.uap.cs to get the message function pointer without using sni.dll. 

cc @corivera @joperezr 

Fixes https://github.com/dotnet/corefx/issues/21890 