### PR TITLE
Modify some HttpClient tests to use RemoteInvoke on UAP

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpCertificateHelper.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpCertificateHelper.cs
@@ -11,7 +11,7 @@ namespace System.Net.Http
 {
     internal static class WinHttpCertificateHelper
     {
-		private const string ClientAuthenticationOID = "1.3.6.1.5.5.7.3.2";
+        private const string ClientAuthenticationOID = "1.3.6.1.5.5.7.3.2";
         private static readonly Oid s_serverAuthOid = new Oid("1.3.6.1.5.5.7.3.1", "1.3.6.1.5.5.7.3.1");
         
         // TODO: Issue #2165. Merge with similar code used in System.Net.Security move to Common/src//System/Net.

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.Unix.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.Unix.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Net.Security;
 using System.Net.Test.Common;
 using System.Runtime.InteropServices;
@@ -13,7 +14,7 @@ using Xunit;
 
 namespace System.Net.Http.Functional.Tests
 {
-    public partial class HttpClientHandler_ServerCertificates_Test
+    public partial class HttpClientHandler_ServerCertificates_Test : RemoteExecutorTestBase
     {
         private static bool ShouldSuppressRevocationException
         {

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.Windows.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.Windows.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Net.Security;
 using System.Net.Test.Common;
 using System.Runtime.InteropServices;
@@ -13,7 +14,7 @@ using Xunit;
 
 namespace System.Net.Http.Functional.Tests
 {
-    public partial class HttpClientHandler_ServerCertificates_Test
+    public partial class HttpClientHandler_ServerCertificates_Test : RemoteExecutorTestBase
     {
         private static bool ShouldSuppressRevocationException => false;
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
@@ -327,7 +327,7 @@ namespace System.Net.Http.Functional.Tests
             if (PlatformDetection.IsUap)
             {
                 // UAP HTTP stack caches connections per-process. This causes interference when these tests run in
-                // the same process as the other tests. Each test needs to be isolated to  own process.
+                // the same process as the other tests. Each test needs to be isolated to its own process.
                 // See dicussion: https://github.com/dotnet/corefx/issues/21945
                 RemoteInvoke((remoteUrl, remoteExpectedErrors) =>
                 {

--- a/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
@@ -80,7 +80,11 @@ namespace System.Net.Http.Functional.Tests
     public sealed class ManagedHandler_HttpClientHandler_ServerCertificates_Test : HttpClientHandler_ServerCertificates_Test, IDisposable
     {
         public ManagedHandler_HttpClientHandler_ServerCertificates_Test() => ManagedHandlerTestHelpers.SetEnvVar();
-        public new void Dispose() => ManagedHandlerTestHelpers.RemoveEnvVar();
+        public new void Dispose()
+        {
+            ManagedHandlerTestHelpers.RemoveEnvVar();
+            base.Dispose();
+        }
     }
 
     public sealed class ManagedHandler_PostScenarioTest : PostScenarioTest, IDisposable

--- a/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
@@ -80,7 +80,7 @@ namespace System.Net.Http.Functional.Tests
     public sealed class ManagedHandler_HttpClientHandler_ServerCertificates_Test : HttpClientHandler_ServerCertificates_Test, IDisposable
     {
         public ManagedHandler_HttpClientHandler_ServerCertificates_Test() => ManagedHandlerTestHelpers.SetEnvVar();
-        public void Dispose() => ManagedHandlerTestHelpers.RemoveEnvVar();
+        public new void Dispose() => ManagedHandlerTestHelpers.RemoveEnvVar();
     }
 
     public sealed class ManagedHandler_PostScenarioTest : PostScenarioTest, IDisposable


### PR DESCRIPTION
A few of the HttpClient tests were failing and needed to be isolated into their
own process. This is due to the UAP stack using per-process connection pooling.

Fixes #21945