### PR TITLE
Disable ManagedHandler negative test failing on older Windows 10 builds

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
@@ -154,6 +154,14 @@ namespace System.Net.Http.Functional.Tests
         [MemberData(nameof(NotSupportedSSLVersionServers))]
         public async Task GetAsync_UnsupportedSSLVersion_Throws(string name, string url)
         {
+            if (ManagedHandlerTestHelpers.IsEnabled &&
+                PlatformDetection.IsWindows &&
+                !PlatformDetection.IsWindows10Version1607OrGreater)
+            {
+                // https://github.com/dotnet/corefx/issues/21925#issuecomment-313408314
+                return;
+            }
+
             using (var client = new HttpClient())
             {
                 await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(url));


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/21925