### PR TITLE
Correct usage of XmlSerializerNamespaces.Namespaces dictionary.

### DIFF
--- a/src/System.Private.Xml/src/System/Xml/Schema/XmlSchema.cs
+++ b/src/System.Private.Xml/src/System/Xml/Schema/XmlSchema.cs
@@ -181,7 +181,7 @@ namespace System.Xml.Schema
                 bool ignoreXS = false;
                 if (this.Namespaces != null)
                 { //User may have set both nsManager and Namespaces property on the XmlSchema object
-                    ignoreXS = this.Namespaces.Namespaces["xs"] != null || this.Namespaces.Namespaces.ContainsValue(XmlReservedNs.NsXs);
+                    ignoreXS = this.Namespaces.Namespaces.ContainsKey("xs") || this.Namespaces.Namespaces.ContainsValue(XmlReservedNs.NsXs);
                 }
                 if (!ignoreXS && namespaceManager.LookupPrefix(XmlReservedNs.NsXs) == null &&
                     namespaceManager.LookupNamespace("xs") == null)

--- a/src/System.Private.Xml/src/System/Xml/Serialization/Types.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/Types.cs
@@ -1399,8 +1399,8 @@ namespace System.Xml.Serialization
             {
                 if (parent.Namespaces != null)
                 {
-                    string wsdlNs = (string)parent.Namespaces.Namespaces[ns];
-                    if (wsdlNs != null)
+                    string wsdlNs;
+                    if (parent.Namespaces.Namespaces.TryGetValue(ns, out wsdlNs) && wsdlNs != null)
                     {
                         ns = wsdlNs;
                         break;

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationWriter.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationWriter.cs
@@ -1402,8 +1402,8 @@ namespace System.Xml.Serialization
                     string ns = (string)entry.Value;
                     if (_namespaces != null)
                     {
-                        string oldNs = _namespaces.Namespaces[prefix] as string;
-                        if (oldNs != null && oldNs != ns)
+                        string oldNs;
+                        if (_namespaces.Namespaces.TryGetValue(prefix, out oldNs) && oldNs != null && oldNs != ns)
                         {
                             throw new InvalidOperationException(SR.Format(SR.XmlDuplicateNs, prefix, ns));
                         }

--- a/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -13,6 +13,7 @@ using System.Text;
 using System.Threading;
 using System.Xml;
 using System.Xml.Linq;
+using System.Xml.Schema;
 using System.Xml.Serialization;
 using Xunit;
 
@@ -1235,6 +1236,16 @@ string.Format(@"<?xml version=""1.0"" encoding=""utf-8""?>
         Assert.StrictEqual(original.body, actual.body);
         Assert.NotNull(actual.xmlns);
         Assert.Contains(ns, actual.xmlns.ToArray());
+    }
+
+    [Fact]
+    public static void XML_XmlSchemaWithNamespacesWriteWithNamespaceManager()
+    {
+        var schema = new XmlSchema();
+        schema.Namespaces = new XmlSerializerNamespaces();
+
+        using (var memStream = new MemoryStream())
+            schema.Write(memStream, new XmlNamespaceManager(new NameTable()));
     }
 
     [Fact]

--- a/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -1219,6 +1219,25 @@ string.Format(@"<?xml version=""1.0"" encoding=""utf-8""?>
     }
 
     [Fact]
+    public static void XML_TypeWithMemberWithXmlNamespaceDeclarationsAttribute_WithInitialValue()
+    {
+        var ns = new XmlQualifiedName("ns", "http://tempuri.org");
+        var original = new TypeWithMemberWithXmlNamespaceDeclarationsAttribute() { header = "foo", body = "bar", xmlns = new XmlSerializerNamespaces(new[] { ns }) };
+
+        var actual = SerializeAndDeserialize<TypeWithMemberWithXmlNamespaceDeclarationsAttribute>(original,
+            @"<?xml version=""1.0""?>
+<Envelope xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns=""http://www.w3.org/2003/05/soap-envelope"" xmlns:ns=""http://tempuri.org"">
+  <header>foo</header>
+  <body>bar</body>
+</Envelope>");
+
+        Assert.StrictEqual(original.header, actual.header);
+        Assert.StrictEqual(original.body, actual.body);
+        Assert.NotNull(actual.xmlns);
+        Assert.Contains(ns, actual.xmlns.ToArray());
+    }
+
+    [Fact]
     public static void XML_TypeWithXmlTextAttributeOnArray()
     {
         var original = new TypeWithXmlTextAttributeOnArray() { Text = new string[] { "val1", "val2" } };


### PR DESCRIPTION
Namespaces changed from Hashtable to Dictionary in 517449e this fixes three occurrences where an unexpected KeyNotFoundException occurs instead of allowing no value.

fixes #21961

@sepidehMS 