### PR TITLE
Fix lifetime handling of ReceiveMessageFromAsync buffer on Windows

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
@@ -409,10 +409,17 @@ namespace System.Net.Sockets
             // WSAMsg also contains a single WSABuffer describing a control buffer.
             PinSocketAddressBuffer();
 
-            // Create and pin a WSAMessageBuffer if none already.
+            // Create a WSAMessageBuffer if none exists yet, and ensure the buffer is pinned.
+            Debug.Assert(
+                !_wsaMessageBufferGCHandle.IsAllocated ||
+                (_wsaMessageBufferGCHandle.Target == _wsaMessageBuffer && _wsaMessageBuffer != null));
+            Debug.Assert((_ptrWSAMessageBuffer != IntPtr.Zero) == _wsaMessageBufferGCHandle.IsAllocated);
             if (_wsaMessageBuffer == null)
             {
                 _wsaMessageBuffer = new byte[sizeof(Interop.Winsock.WSAMsg)];
+            }
+            if (_ptrWSAMessageBuffer == IntPtr.Zero)
+            {
                 _wsaMessageBufferGCHandle = GCHandle.Alloc(_wsaMessageBuffer, GCHandleType.Pinned);
                 _ptrWSAMessageBuffer = Marshal.UnsafeAddrOfPinnedArrayElement(_wsaMessageBuffer, 0);
             }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
@@ -409,19 +409,25 @@ namespace System.Net.Sockets
             // WSAMsg also contains a single WSABuffer describing a control buffer.
             PinSocketAddressBuffer();
 
-            // Create a WSAMessageBuffer if none exists yet, and ensure the buffer is pinned.
-            Debug.Assert(
-                !_wsaMessageBufferGCHandle.IsAllocated ||
-                (_wsaMessageBufferGCHandle.Target == _wsaMessageBuffer && _wsaMessageBuffer != null));
-            Debug.Assert((_ptrWSAMessageBuffer != IntPtr.Zero) == _wsaMessageBufferGCHandle.IsAllocated);
+            // Create a WSAMessageBuffer if none exists yet.
             if (_wsaMessageBuffer == null)
             {
+                Debug.Assert(!_wsaMessageBufferGCHandle.IsAllocated);
+                Debug.Assert(_ptrWSAMessageBuffer == IntPtr.Zero);
                 _wsaMessageBuffer = new byte[sizeof(Interop.Winsock.WSAMsg)];
             }
+
+            // And ensure the WSAMessageBuffer is appropriately pinned.
             if (_ptrWSAMessageBuffer == IntPtr.Zero)
             {
+                Debug.Assert(!_wsaMessageBufferGCHandle.IsAllocated);
                 _wsaMessageBufferGCHandle = GCHandle.Alloc(_wsaMessageBuffer, GCHandleType.Pinned);
                 _ptrWSAMessageBuffer = Marshal.UnsafeAddrOfPinnedArrayElement(_wsaMessageBuffer, 0);
+            }
+            else
+            {
+                Debug.Assert(_wsaMessageBufferGCHandle.IsAllocated);
+                Debug.Assert(_ptrWSAMessageBuffer == Marshal.UnsafeAddrOfPinnedArrayElement(_wsaMessageBuffer, 0));
             }
 
             // Create and pin an appropriately sized control buffer if none already


### PR DESCRIPTION
When a ReceiveMessageFromAsync is first used with a SocketAsyncEventArgs instance, it initializes the _wsaMessageBuffer.  Then in order to use the buffer, it pins it, storing both a GCHandle and a pointer to the target object.  But if the SAEA's buffer is ever changed with, for example, a SetBuffer call, a routine is invoked on the SocketAsyncEventArgs that frees all of its pinned data, including these for the _wsaMessageBuffer.  Then the next time ReceiveMessageFromAsync is used, this handle ends up not getting recreated, and we end up dereferencing a null pointer.

The essentially-one-line fix is to separate the creation of the buffer from the creation of the pinning handle, lazily initializing each independently.  If the pinning handle is freed due to SetBuffer, the next invocation will reinitialize it.

I also consolidated and augmented the existing ReceiveMessageFromAsync tests to test multiple receives with the same SocketAsyncEventArgs in order to catch this case.  The test now fails before the fix and passes after.

Contributes to https://github.com/dotnet/corefx/issues/21995 (hoping to port fix to 2.0 branch)
cc: @davidsh, @cipop, @geoffkizer 