### PR TITLE
Implement client certificates for HttpClient on UAP

### DIFF
--- a/src/Common/src/System/Net/Security/CertificateHelper.Uap.cs
+++ b/src/Common/src/System/Net/Security/CertificateHelper.Uap.cs
@@ -1,0 +1,60 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+
+using RTCertificate = Windows.Security.Cryptography.Certificates.Certificate;
+using RTCertificateQuery = Windows.Security.Cryptography.Certificates.CertificateQuery;
+using RTCertificateStores = Windows.Security.Cryptography.Certificates.CertificateStores;
+using RTIBuffer = Windows.Storage.Streams.IBuffer;
+
+namespace System.Net.Security
+{
+    internal static partial class CertificateHelper
+    {
+        // There are currently only two ways to convert a .NET X509Certificate2 object into a WinRT Certificate without
+        // losing its private keys, each with its own limitations:
+        //
+        // (1) Using the X509Certificate2.Export method with PKCS12/PFX to obtain a byte[] representation (including private
+        //     keys) that can then be passed into the IBuffer-based WinRT Certificate constructor. Unfortunately, the
+        //     X509Certificate2.Export operation will only succeed if the app-provided X509Certificate2 object was created
+        //     with the non-default X509KeyStorageFlags.Exportable flag.
+        //
+        // (2) Going through the certificate store. That is, retrieving the certificate represented by the X509Certificate2
+        //     object as a WinRT Certificate via WinRT CertificateStores APIs. Of course, this requires the certificate to
+        //     have been added to a certificate store in the first place.
+        //
+        // Furthermore, WinRT WebSockets only support certificates that have been added to the personal certificate store
+        // (i.e., "MY" store) due to other WinRT-specific private key limitations. With that in mind, approach (2) is the
+        // most appropriate for our needs, as it guarantees that WinRT WebSockets will be able to handle the resulting
+        // WinRT Certificate during ConnectAsync.
+        internal static async Task<RTCertificate> ConvertDotNetClientCertToWinRtClientCertAsync(X509Certificate2 dotNetCertificate)
+        {
+            var query = new RTCertificateQuery
+            {
+                Thumbprint = dotNetCertificate.GetCertHash(),
+                IncludeDuplicates = false,
+                StoreName = "MY"
+            };
+
+            IReadOnlyList<RTCertificate> certificates = await RTCertificateStores.FindAllAsync(query).AsTask().ConfigureAwait(false);
+            if (certificates.Count > 0)
+            {
+                return certificates[0];
+            }
+
+            return null;
+        }
+
+        internal static X509Certificate2 ConvertPublicKeyCertificate(RTCertificate cert)
+        {
+            // Convert Windows X509v2 cert to .NET X509v2 cert.
+            RTIBuffer blob = cert.GetCertificateBlob();
+            return new X509Certificate2(blob.ToArray());
+        }
+    }
+}

--- a/src/Common/src/System/Net/Security/CertificateHelper.Windows.cs
+++ b/src/Common/src/System/Net/Security/CertificateHelper.Windows.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System.Diagnostics;
+using System.Globalization;
+using System.Security.Cryptography.X509Certificates;
+
+namespace System.Net.Security
+{
+    internal static partial class CertificateHelper
+    {
+        internal static X509Certificate2 GetEligibleClientCertificate()
+        {
+            // Get initial list of client certificates from the MY store.
+            X509Certificate2Collection candidateCerts;
+            using (var myStore = new X509Store(StoreName.My, StoreLocation.CurrentUser))
+            {
+                myStore.Open(OpenFlags.OpenExistingOnly | OpenFlags.ReadOnly);
+                candidateCerts = myStore.Certificates;
+            }
+            
+            return GetEligibleClientCertificate(candidateCerts);
+        }
+    }
+}

--- a/src/Common/src/System/Net/Security/CertificateHelper.cs
+++ b/src/Common/src/System/Net/Security/CertificateHelper.cs
@@ -13,19 +13,6 @@ namespace System.Net.Security
     {
         private const string ClientAuthenticationOID = "1.3.6.1.5.5.7.3.2";
 
-        internal static X509Certificate2 GetEligibleClientCertificate()
-        {
-            // Get initial list of client certificates from the MY store.
-            X509Certificate2Collection candidateCerts;
-            using (var myStore = new X509Store(StoreName.My, StoreLocation.CurrentUser))
-            {
-                myStore.Open(OpenFlags.OpenExistingOnly | OpenFlags.ReadOnly);
-                candidateCerts = myStore.Certificates;
-            }
-            
-            return GetEligibleClientCertificate(candidateCerts);
-        }
-
         internal static X509Certificate2 GetEligibleClientCertificate(X509CertificateCollection candidateCerts)
         {
             if (candidateCerts.Count == 0)

--- a/src/Common/src/System/Net/Security/CertificateHelper.cs
+++ b/src/Common/src/System/Net/Security/CertificateHelper.cs
@@ -1,0 +1,84 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System.Diagnostics;
+using System.Globalization;
+using System.Security.Cryptography.X509Certificates;
+
+namespace System.Net.Security
+{
+    internal static partial class CertificateHelper
+    {
+        private const string ClientAuthenticationOID = "1.3.6.1.5.5.7.3.2";
+
+        internal static X509Certificate2 GetEligibleClientCertificate()
+        {
+            // Get initial list of client certificates from the MY store.
+            X509Certificate2Collection candidateCerts;
+            using (var myStore = new X509Store(StoreName.My, StoreLocation.CurrentUser))
+            {
+                myStore.Open(OpenFlags.OpenExistingOnly | OpenFlags.ReadOnly);
+                candidateCerts = myStore.Certificates;
+            }
+            
+            return GetEligibleClientCertificate(candidateCerts);
+        }
+
+        internal static X509Certificate2 GetEligibleClientCertificate(X509CertificateCollection candidateCerts)
+        {
+            if (candidateCerts.Count == 0)
+            {
+                return null;
+            }
+
+            var certs = new X509Certificate2Collection();
+            certs.AddRange(candidateCerts);
+
+            return GetEligibleClientCertificate(certs);
+        }
+
+        internal static X509Certificate2 GetEligibleClientCertificate(X509Certificate2Collection candidateCerts)
+        {
+            if (candidateCerts.Count == 0)
+            {
+                return null;
+            }
+
+            // Build a new collection with certs that have a private key. We need to do this manually because there is
+            // no X509FindType to match this criteria.
+            // Find(...) returns a collection of clones instead of a filtered collection, so do this before calling
+            // Find(...) to minimize the number of unnecessary allocations and finalizations.
+            var eligibleCerts = new X509Certificate2Collection();
+            foreach (X509Certificate2 cert in candidateCerts)
+            {
+                if (cert.HasPrivateKey)
+                {
+                    eligibleCerts.Add(cert);
+                }
+            }
+
+            // Don't call Find(...) if we don't need to.
+            if (eligibleCerts.Count == 0)
+            {
+                return null;
+            }
+
+            // Reduce the set of certificates to match the proper 'Client Authentication' criteria.
+            // Client EKU is probably more rare than the DigitalSignature KU. Filter by ClientAuthOid first to reduce
+            // the candidate space as quickly as possible.
+            eligibleCerts = eligibleCerts.Find(X509FindType.FindByApplicationPolicy, ClientAuthenticationOID, false);
+            eligibleCerts = eligibleCerts.Find(X509FindType.FindByKeyUsage, X509KeyUsageFlags.DigitalSignature, false);
+
+            if (eligibleCerts.Count > 0)
+            {
+                return eligibleCerts[0];
+            }
+            else
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/src/Common/tests/System/Net/Configuration.Http.cs
+++ b/src/Common/tests/System/Net/Configuration.Http.cs
@@ -39,6 +39,8 @@ namespace System.Net.Test.Common
             public static string SelfSignedCertRemoteServer => GetValue("COREFX_HTTPHOST_SELFSIGNEDCERT", "https://self-signed.badssl.com/");
             public static string RevokedCertRemoteServer => GetValue("COREFX_HTTPHOST_REVOKEDCERT", "https://revoked.grc.com/");
 
+            public static string EchoClientCertificateRemoteServer => GetValue("COREFX_HTTPHOST_ECHOCLIENTCERT", "https://corefx-net-tls.azurewebsites.net/EchoClientCertificate.ashx");
+
             private const string HttpScheme = "http";
             private const string HttpsScheme = "https";
 

--- a/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.msbuild
+++ b/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.msbuild
@@ -22,6 +22,7 @@
     <CompileItem Include="$(CommonPath)\System\Net\Http\HttpHandlerDefaults.cs" />
     <CompileItem Include="$(CommonPath)\System\Net\Http\NoWriteNoSeekStreamContent.cs" />
     <CompileItem Include="$(CommonPath)\System\Net\Http\WinHttpException.cs" />
+    <CompileItem Include="$(CommonPath)\System\Net\Security\CertificateHelper.cs" />
     <CompileItem Include="$(CommonPath)\System\Runtime\ExceptionServices\ExceptionStackTrace.cs" />
     <CompileItem Include="$(CommonPath)\System\Threading\Tasks\RendezvousAwaitable.cs" />
     <CompileItem Include="$(CommonPath)\System\Threading\Tasks\TaskToApm.cs" />

--- a/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.msbuild
+++ b/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.msbuild
@@ -23,6 +23,7 @@
     <CompileItem Include="$(CommonPath)\System\Net\Http\NoWriteNoSeekStreamContent.cs" />
     <CompileItem Include="$(CommonPath)\System\Net\Http\WinHttpException.cs" />
     <CompileItem Include="$(CommonPath)\System\Net\Security\CertificateHelper.cs" />
+    <CompileItem Include="$(CommonPath)\System\Net\Security\CertificateHelper.Windows.cs" />
     <CompileItem Include="$(CommonPath)\System\Runtime\ExceptionServices\ExceptionStackTrace.cs" />
     <CompileItem Include="$(CommonPath)\System\Threading\Tasks\RendezvousAwaitable.cs" />
     <CompileItem Include="$(CommonPath)\System\Threading\Tasks\TaskToApm.cs" />

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpCertificateHelper.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpCertificateHelper.cs
@@ -11,7 +11,6 @@ namespace System.Net.Http
 {
     internal static class WinHttpCertificateHelper
     {
-        private const string ClientAuthenticationOID = "1.3.6.1.5.5.7.3.2";
         private static readonly Oid s_serverAuthOid = new Oid("1.3.6.1.5.5.7.3.1", "1.3.6.1.5.5.7.3.1");
         
         // TODO: Issue #2165. Merge with similar code used in System.Net.Security move to Common/src//System/Net.
@@ -81,51 +80,7 @@ namespace System.Net.Http
             }
         }
 
-        public static X509Certificate2 GetEligibleClientCertificate()
-        {
-            // Get initial list of client certificates from the MY store.
-            X509Certificate2Collection candidateCerts;
-            using (var myStore = new X509Store(StoreName.My, StoreLocation.CurrentUser))
-            {
-                myStore.Open(OpenFlags.OpenExistingOnly | OpenFlags.ReadOnly);
-                candidateCerts = myStore.Certificates;
-            }
-            
-            return GetEligibleClientCertificate(candidateCerts);
-        }
-        
         // TODO: Issue #3891. Get the Trusted Issuers List from WinHTTP and use that to help narrow down
         // the list of eligible client certificates.
-        public static X509Certificate2 GetEligibleClientCertificate(X509Certificate2Collection candidateCerts)
-        {
-            if (candidateCerts.Count == 0)
-            {
-                return null;
-            }
-
-            // Reduce the set of certificates to match the proper 'Client Authentication' criteria.
-            candidateCerts = candidateCerts.Find(X509FindType.FindByKeyUsage, X509KeyUsageFlags.DigitalSignature, false);
-            candidateCerts = candidateCerts.Find(X509FindType.FindByApplicationPolicy, ClientAuthenticationOID, false);
-
-            // Build a new collection with certs that have a private key. Need to do this
-            // manually because there is no X509FindType to match this criteria.
-            var eligibleCerts = new X509Certificate2Collection();
-            foreach (X509Certificate2 cert in candidateCerts)
-            {
-                if (cert.HasPrivateKey)
-                {
-                    eligibleCerts.Add(cert);
-                }
-            }
-            
-            if (eligibleCerts.Count > 0)
-            {
-                return eligibleCerts[0];
-            }
-            else
-            {
-                return null;
-            }
-        }
     }
 }

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -1125,11 +1125,11 @@ namespace System.Net.Http
             X509Certificate2 clientCertificate = null;
             if (_clientCertificateOption == ClientCertificateOption.Manual)
             {
-                clientCertificate = WinHttpCertificateHelper.GetEligibleClientCertificate(ClientCertificates);
+                clientCertificate = CertificateHelper.GetEligibleClientCertificate(ClientCertificates);
             }
             else
             {
-                clientCertificate = WinHttpCertificateHelper.GetEligibleClientCertificate();
+                clientCertificate = CertificateHelper.GetEligibleClientCertificate();
             }
 
             if (clientCertificate != null)

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/FakeX509Certificates.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/FakeX509Certificates.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 using System.Net.Http.WinHttpHandlerUnitTests;
 using System.Security.Cryptography.X509Certificates;
 
-namespace System.Net.Http
+namespace System.Security.Cryptography.X509Certificates
 {
     public class X509Store : IDisposable
     {

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
@@ -70,6 +70,9 @@
     <Compile Include="$(CommonPath)\System\Net\Security\CertificateHelper.cs">
       <Link>Common\System\Net\Security\CertificateHelper.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Net\Security\CertificateHelper.Windows.cs">
+      <Link>Common\System\Net\Security\CertificateHelper.Windows.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Runtime\ExceptionServices\ExceptionStackTrace.cs">
       <Link>Common\System\Runtime\ExceptionServices\ExceptionStackTrace.cs</Link>
     </Compile>

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
@@ -3,6 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{A2ECDEDB-12B7-402C-9230-152B7601179F}</ProjectGuid>
+    <NoWarn>$(NoWarn);0436</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <StringResourcesPath>../../src/Resources/Strings.resx</StringResourcesPath>
   </PropertyGroup>
@@ -65,6 +66,9 @@
     </Compile>
     <Compile Include="$(CommonPath)\System\Net\Http\WinHttpException.cs">
       <Link>Common\System\Net\Http\WinHttpException.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\Security\CertificateHelper.cs">
+      <Link>Common\System\Net\Security\CertificateHelper.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\Runtime\ExceptionServices\ExceptionStackTrace.cs">
       <Link>Common\System\Runtime\ExceptionServices\ExceptionStackTrace.cs</Link>

--- a/src/System.Net.Http/src/Resources/Strings.resx
+++ b/src/System.Net.Http/src/Resources/Strings.resx
@@ -301,4 +301,7 @@
   <data name="net_http_feature_requires_Windows10Version1607" xml:space="preserve">
     <value>Using this feature requires Windows 10 Version 1607.</value>
   </data>
+  <data name="net_http_feature_UWPClientCertSupportRequiresCertInPersonalCertificateStore" xml:space="preserve">
+    <value>Client certificate was not found in the personal (\"MY\") certificate store. In UWP, client certificates are only supported if they have been added to that certificate store.</value>
+  </data>
 </root>

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -385,6 +385,12 @@
     <Compile Include="$(CommonPath)\System\Net\HttpStatusDescription.cs">
       <Link>Common\System\Net\HttpStatusDescription.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Net\Security\CertificateHelper.cs">
+      <Link>Common\System\Net\Security\CertificateHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\Security\CertificateHelper.Uap.cs">
+      <Link>Common\System\Net\Security\CertificateHelper.Uap.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\StringExtensions.cs">
       <Link>Common\System\StringExtensions.cs</Link>
     </Compile>

--- a/src/System.Net.Http/src/uap/System/Net/HttpClientHandler.cs
+++ b/src/System.Net.Http/src/uap/System/Net/HttpClientHandler.cs
@@ -489,9 +489,8 @@ namespace System.Net.Http
                     RTCertificate cert = await CertificateHelper.ConvertDotNetClientCertToWinRtClientCertAsync(_clientCertificates[0]);
                     if (cert == null)
                     {
-                        throw new PlatformNotSupportedException(string.Format(
-                                    CultureInfo.InvariantCulture,
-                                    SR.net_http_feature_UWPClientCertSupportRequiresCertInPersonalCertificateStore));
+                        throw new PlatformNotSupportedException(string.Format(CultureInfo.InvariantCulture,
+                            SR.net_http_feature_UWPClientCertSupportRequiresCertInPersonalCertificateStore));
                     }
 
                     _rtFilter.ClientCertificate = cert;

--- a/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
@@ -82,8 +82,8 @@ namespace System.Net.Http.Functional.Tests
         public ManagedHandler_HttpClientHandler_ServerCertificates_Test() => ManagedHandlerTestHelpers.SetEnvVar();
         public new void Dispose()
         {
-            ManagedHandlerTestHelpers.RemoveEnvVar();
-            base.Dispose();
+            ManagedHandlerTestHelpers.RemoveEnvVar();
+            base.Dispose();
         }
     }
 

--- a/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
@@ -57,7 +57,7 @@ namespace System.Net.Http.Functional.Tests
 
     public sealed class ManagedHandler_HttpClientHandler_ClientCertificates_Test : HttpClientHandler_ClientCertificates_Test, IDisposable
     {
-        public ManagedHandler_HttpClientHandler_ClientCertificates_Test() => ManagedHandlerTestHelpers.SetEnvVar();
+        public ManagedHandler_HttpClientHandler_ClientCertificates_Test(ITestOutputHelper output) : base(output) => ManagedHandlerTestHelpers.SetEnvVar();
         public void Dispose() => ManagedHandlerTestHelpers.RemoveEnvVar();
     }
 

--- a/src/System.Net.WebSockets.Client/src/System.Net.WebSockets.Client.csproj
+++ b/src/System.Net.WebSockets.Client/src/System.Net.WebSockets.Client.csproj
@@ -87,6 +87,12 @@
   </ItemGroup>
   <!-- Windows : Win32 + WinRT -->
   <ItemGroup Condition="'$(TargetsWindows)' == 'true' AND '$(TargetGroup)' == 'uap'">
+    <Compile Include="$(CommonPath)\System\Net\Security\CertificateHelper.cs">
+      <Link>Common\System\Net\Security\CertificateHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\Security\CertificateHelper.Uap.cs">
+      <Link>Common\System\Net\Security\CertificateHelper.Uap.cs</Link>
+    </Compile>  
     <Compile Include="System\Net\WebSockets\WebSocketHandle.WinRT.cs" />
     <Compile Include="System\Net\WebSockets\WinRTWebSocket.cs" />
   </ItemGroup>

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinRTWebSocket.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinRTWebSocket.cs
@@ -124,8 +124,7 @@ namespace System.Net.WebSockets
             {
                 if (!MessageWebSocketClientCertificateSupported)
                 {
-                    throw new PlatformNotSupportedException(string.Format(
-                        CultureInfo.InvariantCulture,
+                    throw new PlatformNotSupportedException(string.Format(CultureInfo.InvariantCulture,
                         SR.net_WebSockets_UWPClientCertSupportRequiresWindows10GreaterThan1703));
                 }
 

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinRTWebSocket.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinRTWebSocket.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using System.Net.Security;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Security.Cryptography.X509Certificates;
@@ -128,16 +129,16 @@ namespace System.Net.WebSockets
                         SR.net_WebSockets_UWPClientCertSupportRequiresWindows10GreaterThan1703));
                 }
 
-                // options.ClientCertificates is of type X509CertificateCollection. Upgrade it to a X509Certificate2Collection,
-                // which exposes the Find(...) functionality that is leveraged by GetEligibleClientCertificate(...).
-                var certsAsX509Certificate2Collection = new X509Certificate2Collection();
-                certsAsX509Certificate2Collection.AddRange(options.ClientCertificates);
-
-                X509Certificate2 dotNetClientCert = GetEligibleClientCertificate(certsAsX509Certificate2Collection);
+                X509Certificate2 dotNetClientCert = CertificateHelper.GetEligibleClientCertificate(options.ClientCertificates);
                 if (dotNetClientCert != null)
                 {
-                    RTCertificate winRtClientCert = ConvertDotNetClientCertToWinRtClientCert(dotNetClientCert);
-                    Debug.Assert(winRtClientCert != null);
+                    RTCertificate winRtClientCert = await CertificateHelper.ConvertDotNetClientCertToWinRtClientCertAsync(dotNetClientCert);
+                    if (winRtClientCert == null)
+                    {
+                        throw new PlatformNotSupportedException(string.Format(
+                                    CultureInfo.InvariantCulture,
+                                    SR.net_WebSockets_UWPClientCertSupportRequiresCertInPersonalCertificateStore));
+                    }
 
                     websocketControl.ClientCertificate = winRtClientCert;
                 }
@@ -570,84 +571,6 @@ namespace System.Net.WebSockets
             return ApiInformation.IsPropertyPresent(
                 "Windows.Networking.Sockets.MessageWebSocketControl",
                 "ClientCertificate");
-        }
-
-        // TODO: Issue #14542. Merge with similar WinHttpCertificateHelper.cs code and move to Common/src//System/Net.
-        private static X509Certificate2 GetEligibleClientCertificate(X509Certificate2Collection candidateCerts)
-        {
-            // Build a new collection with certs that have a private key. We need to do this manually because there is
-            // no X509FindType to match this criteria.
-            // Find(...) returns a collection of clones instead of a filtered collection, so do this before calling
-            // Find(...) to minimize the number of unnecessary allocations and finalizations.
-            var eligibleCerts = new X509Certificate2Collection();
-            foreach (X509Certificate2 cert in candidateCerts)
-            {
-                if (cert.HasPrivateKey)
-                {
-                    eligibleCerts.Add(cert);
-                }
-            }
-
-            // Don't call Find(...) if we don't need to.
-            if (eligibleCerts.Count == 0)
-            {
-                return null;
-            }
-            else if (eligibleCerts.Count == 1)
-            {
-                return eligibleCerts[0];
-            }
-
-            // Reduce the set of certificates to match the proper 'Client Authentication' criteria.
-            // Client EKU is probably more rare than the DigitalSignature KU. Filter by ClientAuthOid first to reduce
-            // the candidate space as quickly as possible.
-            eligibleCerts = eligibleCerts.Find(X509FindType.FindByApplicationPolicy, ClientAuthenticationOID, false);
-            eligibleCerts = eligibleCerts.Find(X509FindType.FindByKeyUsage, X509KeyUsageFlags.DigitalSignature, false);
-
-            if (eligibleCerts.Count > 0)
-            {
-                return eligibleCerts[0];
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        // There are currently only two ways to convert a .NET X509Certificate2 object into a WinRT Certificate without
-        // losing its private keys, each with its own limitations:
-        //
-        // (1) Using the X509Certificate2.Export method with PKCS12/PFX to obtain a byte[] representation (including private
-        //     keys) that can then be passed into the IBuffer-based WinRT Certificate constructor. Unfortunately, the
-        //     X509Certificate2.Export operation will only succeed if the app-provided X509Certificate2 object was created
-        //     with the non-default X509KeyStorageFlags.Exportable flag.
-        //
-        // (2) Going through the certificate store. That is, retrieving the certificate represented by the X509Certificate2
-        //     object as a WinRT Certificate via WinRT CertificateStores APIs. Of course, this requires the certificate to
-        //     have been added to a certificate store in the first place.
-        //
-        // Furthermore, WinRT WebSockets only support certificates that have been added to the personal certificate store
-        // (i.e., "MY" store) due to other WinRT-specific private key limitations. With that in mind, approach (2) is the
-        // most appropriate for our needs, as it guarantees that WinRT WebSockets will be able to handle the resulting
-        // WinRT Certificate during ConnectAsync.
-        private static RTCertificate ConvertDotNetClientCertToWinRtClientCert(X509Certificate2 dotNetCertificate)
-        {
-            var query = new RTCertificateQuery
-            {
-                Thumbprint = dotNetCertificate.GetCertHash(),
-                IncludeDuplicates = false,
-                StoreName = "MY"
-            };
-
-            IReadOnlyList<RTCertificate> certificates = RTCertificateStores.FindAllAsync(query).AsTask().GetAwaiter().GetResult();
-            if (certificates.Count > 0)
-            {
-                return certificates[0];
-            }
-
-            throw new PlatformNotSupportedException(string.Format(
-                        CultureInfo.InvariantCulture,
-                        SR.net_WebSockets_UWPClientCertSupportRequiresCertInPersonalCertificateStore));
         }
 
         private static bool InitMessageWebSocketReceiveModeSupported()


### PR DESCRIPTION
Added code for HttpClientHandler.ClientCertificates on UAP.

Moved code duplicated in several places into a common helper class, CertificateHelper.
Then I discovered a bug introduced into GetEligibleCertificates (from PR #21908) that
doesn't properly filter by EKU or KeyUsage if there is only one cert (this was failing
the WinHttpHandler Unit tests). So, I removed that optimization.

Used the new Azure test endpoint for client certificates. I did not use the loopback
server because there is a problem using it with HttpClient in UAP. There is a crash
in the SslStream.AuthenticateAsServer that I was not able to diagnose yet. It will
require a lot of time debugging and I wanted to get this HttpClientHandler feature
done now. Tracking that investigation with #22021.

Fixes #21628
Contributes to #14542