### PR TITLE
Re-enable x86 ret tests after fixing the unwinding issue.

### DIFF
--- a/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
+++ b/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
@@ -2,8 +2,8 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <!-- [ActiveIssue(https://github.com/dotnet/corefx/issues/21804)] // when building this tests in ret mode they crash and not produce testResults.xml -->
-    <ILCBuildType Condition="'$(ArchGroup)' == 'x86' OR '$(ArchGroup)' == 'arm'">chk</ILCBuildType>
+    <!-- [ActiveIssue(https://github.com/dotnet/corefx/issues/22040)] // when building this tests in ret mode they crash and not produce testResults.xml -->
+    <ILCBuildType Condition="'$(ArchGroup)' == 'arm'">chk</ILCBuildType>
     <ProjectGuid>{A7074928-82C3-4739-88FE-9B528977950C}</ProjectGuid>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/src/System.Private.Xml.Linq/tests/events/System.Xml.Linq.Events.Tests.csproj
+++ b/src/System.Private.Xml.Linq/tests/events/System.Xml.Linq.Events.Tests.csproj
@@ -2,8 +2,6 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <!-- [ActiveIssue(https://github.com/dotnet/corefx/issues/21986)] causes a read access violation when built in ret. -->
-    <ILCBuildType Condition="'$(ArchGroup)' == 'x86'">chk</ILCBuildType>
     <ProjectGuid>{C560E194-5B14-4112-ABC6-3208491E53E6}</ProjectGuid>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->


### PR DESCRIPTION
#21804, #21986.