### PR TITLE
Skipping test that is crashing UAP Outerloop runs

### DIFF
--- a/src/System.Private.Xml/tests/Writers/XmlWriterApi/TCXmlWriterTestModule.cs
+++ b/src/System.Private.Xml/tests/Writers/XmlWriterApi/TCXmlWriterTestModule.cs
@@ -97,6 +97,7 @@ namespace System.Xml.Tests
 
         [Fact]
         [OuterLoop]
+        [ActiveIssue(22042, TargetFrameworkMonikers.UapNotUapAot)]
         public static void TCFullEndElement()
         {
             RunTest(() => new TCFullEndElement() { Attribute = new TestCase() { Name = "WriteFullEndElement" } });


### PR DESCRIPTION
cc: @krwq @tarekgh @safern 

This test has been crashing our outerloop runs which is causing results to not be produced, so skipping for now with an activeissue