### PR TITLE
Remove calls to display init-tools.log in groovy scripts

### DIFF
--- a/buildpipeline/linux.groovy
+++ b/buildpipeline/linux.groovy
@@ -16,14 +16,8 @@ simpleDockerNode('microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2') {
     def logFolder = getLogFolder()
 
     stage ('Initialize tools') {
-        try {
-            // Init tools
-            sh './init-tools.sh'
-        }
-        catch (err) {
-            // Ensure the build result is still propagated.
-            throw err
-        }
+        // Init tools
+        sh './init-tools.sh'
     }
     stage ('Generate version assets') {
         // Generate the version assets.  Do we need to even do this for non-official builds?

--- a/buildpipeline/linux.groovy
+++ b/buildpipeline/linux.groovy
@@ -21,9 +21,6 @@ simpleDockerNode('microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2') {
             sh './init-tools.sh'
         }
         catch (err) {
-            // On errors for build tools initializations, it's useful to echo the contents of the file
-            // for easy diagnosis.  This could also be copied to the log directory
-            sh 'cat init-tools.log'
             // Ensure the build result is still propagated.
             throw err
         }

--- a/buildpipeline/osx.groovy
+++ b/buildpipeline/osx.groovy
@@ -22,9 +22,6 @@ simpleNode('OSX10.12','latest') {
             sh 'HOME=\$WORKSPACE/tempHome ./init-tools.sh'
         }
         catch (err) {
-            // On errors for build tools initializations, it's useful to echo the contents of the file
-            // for easy diagnosis.  This could also be copied to the log directory
-            sh 'cat init-tools.log'
             // Ensure the build result is still propagated.
             throw err
         }

--- a/buildpipeline/osx.groovy
+++ b/buildpipeline/osx.groovy
@@ -16,15 +16,9 @@ simpleNode('OSX10.12','latest') {
     def logFolder = getLogFolder()
 
     stage ('Initialize tools') {
-        try {
-            // Workaround nuget issue https://github.com/NuGet/Home/issues/5085 were we need to set HOME
-            // Init tools
-            sh 'HOME=\$WORKSPACE/tempHome ./init-tools.sh'
-        }
-        catch (err) {
-            // Ensure the build result is still propagated.
-            throw err
-        }
+        // Workaround nuget issue https://github.com/NuGet/Home/issues/5085 were we need to set HOME
+        // Init tools
+        sh 'HOME=\$WORKSPACE/tempHome ./init-tools.sh'
     }
     stage ('Generate version assets') {
         // Generate the version assets.  Do we need to even do this for non-official builds?

--- a/buildpipeline/windows.groovy
+++ b/buildpipeline/windows.groovy
@@ -28,16 +28,8 @@ simpleNode('Windows_NT','latest') {
     def buildTests = (params.TGroup != 'all')
 
     stage ('Initialize tools') {
-        try {
-            // Init tools
-            bat '.\\init-tools.cmd'
-            // Temporarily always dump the init-tools.log to try and identify why sometimes it takes really long
-            bat 'type init-tools.log'
-        }
-        catch (err) {
-            // Ensure the build result is still propagated.
-            throw err
-        }
+        // Init tools
+        bat '.\\init-tools.cmd'
     }
     stage ('Sync') {
         bat ".\\sync.cmd -p -- /p:ArchGroup=${params.AGroup} /p:RuntimeOS=win10"

--- a/buildpipeline/windows.groovy
+++ b/buildpipeline/windows.groovy
@@ -35,9 +35,6 @@ simpleNode('Windows_NT','latest') {
             bat 'type init-tools.log'
         }
         catch (err) {
-            // On errors for build tools initializations, it's useful to echo the contents of the file
-            // for easy diagnosis.  This could also be copied to the log directory
-            bat 'type init-tools.log'
             // Ensure the build result is still propagated.
             throw err
         }


### PR DESCRIPTION
https://github.com/dotnet/corefx/pull/21894 will display `init-tools.log` when `init-tools` command runs into an error. 

This PR removes the calls to display `init-tools.log` when an exception occurs while running `init-tools` in `.groovy` scripts.