### PR TITLE
Transaction code porting from Framwork for TransactionScope / TransactionBinding support

### DIFF
--- a/src/Common/src/System/Data/Common/AdapterUtil.cs
+++ b/src/Common/src/System/Data/Common/AdapterUtil.cs
@@ -11,6 +11,7 @@ using System.Security;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using SysTx = System.Transactions;
 
 namespace System.Data.Common
 {
@@ -414,6 +415,11 @@ namespace System.Data.Common
 
         internal static bool IsEmptyArray(string[] array) => (null == array) || (0 == array.Length);
 
+        internal static bool IsEmpty(string str)
+        {
+            return ((null == str) || (0 == str.Length));
+        }
+
         internal static bool IsNull(object value)
         {
             if ((null == value) || (DBNull.Value == value))
@@ -427,6 +433,14 @@ namespace System.Data.Common
         internal static Exception InvalidSeekOrigin(string parameterName)
         {
             return ArgumentOutOfRange(SR.ADP_InvalidSeekOrigin, parameterName);
+        }
+
+        internal static readonly bool IsWindowsNT = (PlatformID.Win32NT == Environment.OSVersion.Platform);
+        internal static readonly bool IsPlatformNT5 = (ADP.IsWindowsNT && (Environment.OSVersion.Version.Major >= 5));
+
+        static internal void SetCurrentTransaction(SysTx.Transaction transaction)
+        {
+            SysTx.Transaction.Current = transaction;
         }
     }
 }

--- a/src/Common/src/System/Data/Common/AdapterUtil.cs
+++ b/src/Common/src/System/Data/Common/AdapterUtil.cs
@@ -11,7 +11,7 @@ using System.Security;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using SysTx = System.Transactions;
+using System.Transactions;
 
 namespace System.Data.Common
 {
@@ -415,11 +415,6 @@ namespace System.Data.Common
 
         internal static bool IsEmptyArray(string[] array) => (null == array) || (0 == array.Length);
 
-        internal static bool IsEmpty(string str)
-        {
-            return ((null == str) || (0 == str.Length));
-        }
-
         internal static bool IsNull(object value)
         {
             if ((null == value) || (DBNull.Value == value))
@@ -438,9 +433,9 @@ namespace System.Data.Common
         internal static readonly bool IsWindowsNT = (PlatformID.Win32NT == Environment.OSVersion.Platform);
         internal static readonly bool IsPlatformNT5 = (ADP.IsWindowsNT && (Environment.OSVersion.Version.Major >= 5));
 
-        static internal void SetCurrentTransaction(SysTx.Transaction transaction)
+        internal static void SetCurrentTransaction(Transaction transaction)
         {
-            SysTx.Transaction.Current = transaction;
+            Transaction.Current = transaction;
         }
     }
 }

--- a/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
+++ b/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
@@ -433,6 +433,7 @@ namespace System.Data.SqlClient
         public bool PersistSecurityInfo { get { throw null; } set { } }
         public bool Pooling { get { throw null; } set { } }
         public bool Replication { get { throw null; } set { } }
+        public string TransactionBinding { get { throw null; } set { } }
         public bool TrustServerCertificate { get { throw null; } set { } }
         public string TypeSystemVersion { get { throw null; } set { } }
         public string UserID { get { throw null; } set { } }

--- a/src/System.Data.SqlClient/src/Resources/Strings.resx
+++ b/src/System.Data.SqlClient/src/Resources/Strings.resx
@@ -1,1159 +1,1177 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
-    <xsd:element name="root" msdata:IsDataSet="true">
-      <xsd:complexType>
-        <xsd:choice maxOccurs="unbounded">
-          <xsd:element name="metadata">
-            <xsd:complexType>
-              <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" />
-              </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string" />
-              <xsd:attribute name="type" type="xsd:string" />
-              <xsd:attribute name="mimetype" type="xsd:string" />
-              <xsd:attribute ref="xml:space" />
-            </xsd:complexType>
-          </xsd:element>
-          <xsd:element name="assembly">
-            <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string" />
-              <xsd:attribute name="name" type="xsd:string" />
-            </xsd:complexType>
-          </xsd:element>
-          <xsd:element name="data">
-            <xsd:complexType>
-              <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-              </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-              <xsd:attribute ref="xml:space" />
-            </xsd:complexType>
-          </xsd:element>
-          <xsd:element name="resheader">
-            <xsd:complexType>
-              <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-              </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" />
-            </xsd:complexType>
-          </xsd:element>
-        </xsd:choice>
-      </xsd:complexType>
-    </xsd:element>
-  </xsd:schema>
-  <resheader name="resmimetype">
-    <value>text/microsoft-resx</value>
-  </resheader>
-  <resheader name="version">
-    <value>2.0</value>
-  </resheader>
-  <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </resheader>
-  <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </resheader>
-  <data name="ADP_CollectionIndexInt32" xml:space="preserve">
-    <value>Invalid index {0} for this {1} with Count={2}.</value>
-  </data>
-  <data name="ADP_CollectionIndexString" xml:space="preserve">
-    <value>An {0} with {1} '{2}' is not contained by this {3}.</value>
-  </data>
-  <data name="ADP_CollectionInvalidType" xml:space="preserve">
-    <value>The {0} only accepts non-null {1} type objects, not {2} objects.</value>
-  </data>
-  <data name="ADP_CollectionIsNotParent" xml:space="preserve">
-    <value>The {0} is already contained by another {1}.</value>
-  </data>
-  <data name="ADP_CollectionNullValue" xml:space="preserve">
-    <value>The {0} only accepts non-null {1} type objects.</value>
-  </data>
-  <data name="ADP_CollectionRemoveInvalidObject" xml:space="preserve">
-    <value>Attempted to remove an {0} that is not contained by this {1}.</value>
-  </data>
-  <data name="ADP_ConnectionAlreadyOpen" xml:space="preserve">
-    <value>The connection was not closed. {0}</value>
-  </data>
-  <data name="ADP_ConnectionStateMsg_Closed" xml:space="preserve">
-    <value>The connection's current state is closed.</value>
-  </data>
-  <data name="ADP_ConnectionStateMsg_Connecting" xml:space="preserve">
-    <value>The connection's current state is connecting.</value>
-  </data>
-  <data name="ADP_ConnectionStateMsg_Open" xml:space="preserve">
-    <value>The connection's current state is open.</value>
-  </data>
-  <data name="ADP_ConnectionStateMsg_OpenExecuting" xml:space="preserve">
-    <value>The connection's current state is executing.</value>
-  </data>
-  <data name="ADP_ConnectionStateMsg_OpenFetching" xml:space="preserve">
-    <value>The connection's current state is fetching.</value>
-  </data>
-  <data name="ADP_ConnectionStateMsg" xml:space="preserve">
-    <value>The connection's current state: {0}.</value>
-  </data>
-  <data name="ADP_ConnectionStringSyntax" xml:space="preserve">
-    <value>Format of the initialization string does not conform to specification starting at index {0}.</value>
-  </data>
-  <data name="ADP_DataReaderClosed" xml:space="preserve">
-    <value>Invalid attempt to call {0} when reader is closed.</value>
-  </data>
-  <data name="ADP_InternalConnectionError" xml:space="preserve">
-    <value>Internal DbConnection Error: {0}</value>
-  </data>
-  <data name="ADP_InvalidEnumerationValue" xml:space="preserve">
-    <value>The {0} enumeration value, {1}, is invalid.</value>
-  </data>
-  <data name="ADP_NotSupportedEnumerationValue" xml:space="preserve">
-    <value>The {0} enumeration value, {1}, is not supported by the {2} method.</value>
-  </data>
-  <data name="ADP_InvalidOffsetValue" xml:space="preserve">
-    <value>Invalid parameter Offset value '{0}'. The value must be greater than or equal to 0.</value>
-  </data>
-  <data name="ADP_NoConnectionString" xml:space="preserve">
-    <value>The ConnectionString property has not been initialized.</value>
-  </data>
-  <data name="ADP_OpenConnectionPropertySet" xml:space="preserve">
-    <value>Not allowed to change the '{0}' property. {1}</value>
-  </data>
-  <data name="ADP_PendingAsyncOperation" xml:space="preserve">
-    <value>Can not start another operation while there is an asynchronous operation pending.</value>
-  </data>
-  <data name="ADP_PooledOpenTimeout" xml:space="preserve">
-    <value>Timeout expired.  The timeout period elapsed prior to obtaining a connection from the pool.  This may have occurred because all pooled connections were in use and max pool size was reached.</value>
-  </data>
-  <data name="ADP_NonPooledOpenTimeout" xml:space="preserve">
-    <value>Timeout attempting to open the connection.  The time period elapsed prior to attempting to open the connection has been exceeded.  This may have occurred because of too many simultaneous non-pooled connection attempts.</value>
-  </data>
-  <data name="ADP_SingleValuedProperty" xml:space="preserve">
-    <value>The only acceptable value for the property '{0}' is '{1}'.</value>
-  </data>
-  <data name="ADP_DoubleValuedProperty" xml:space="preserve">
-    <value>The acceptable values for the property '{0}' are '{1}' or '{2}'.</value>
-  </data>
-  <data name="ADP_InvalidPrefixSuffix" xml:space="preserve">
-    <value>Specified QuotePrefix and QuoteSuffix values do not match.</value>
-  </data>
-  <data name="Arg_ArrayPlusOffTooSmall" xml:space="preserve">
-    <value>Destination array is not long enough to copy all the items in the collection. Check array index and length.</value>
-  </data>
-  <data name="Arg_RankMultiDimNotSupported" xml:space="preserve">
-    <value>Only single dimensional arrays are supported for the requested action.</value>
-  </data>
-  <data name="Arg_RemoveArgNotFound" xml:space="preserve">
-    <value>Cannot remove the specified item because it was not found in the specified Collection.</value>
-  </data>
-  <data name="ArgumentOutOfRange_NeedNonNegNum" xml:space="preserve">
-    <value>Non-negative number required.</value>
-  </data>
-  <data name="Data_InvalidOffsetLength" xml:space="preserve">
-    <value>Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.</value>
-  </data>
-  <data name="SqlConvert_ConvertFailed" xml:space="preserve">
-    <value> Cannot convert object of type '{0}' to object of type '{1}'.</value>
-  </data>
-  <data name="SQL_WrongType" xml:space="preserve">
-    <value>Expecting argument of type {1}, but received type {0}.</value>
-  </data>
-  <data name="ADP_DeriveParametersNotSupported" xml:space="preserve">
-    <value>{0} DeriveParameters only supports CommandType.StoredProcedure, not CommandType.{1}.</value>
-  </data>
-  <data name="ADP_NoStoredProcedureExists" xml:space="preserve">
-    <value>The stored procedure '{0}' doesn't exist.</value>
-  </data>
-  <data name="ADP_InvalidConnectionOptionValue" xml:space="preserve">
-    <value>Invalid value for key '{0}'.</value>
-  </data>
-  <data name="ADP_MissingConnectionOptionValue" xml:space="preserve">
-    <value>Use of key '{0}' requires the key '{1}' to be present.</value>
-  </data>
-  <data name="ADP_InvalidConnectionOptionValueLength" xml:space="preserve">
-    <value>The value's length for key '{0}' exceeds it's limit of '{1}'.</value>
-  </data>
-  <data name="ADP_KeywordNotSupported" xml:space="preserve">
-    <value>Keyword not supported: '{0}'.</value>
-  </data>
-  <data name="ADP_InternalProviderError" xml:space="preserve">
-    <value>Internal .Net Framework Data Provider error {0}.</value>
-  </data>
-  <data name="ADP_InvalidMultipartName" xml:space="preserve">
-    <value>{0} '{1}'.</value>
-  </data>
-  <data name="ADP_InvalidMultipartNameQuoteUsage" xml:space="preserve">
-    <value>{0} '{1}', incorrect usage of quotes.</value>
-  </data>
-  <data name="ADP_InvalidMultipartNameToManyParts" xml:space="preserve">
-    <value>{0} '{1}', the current limit of '{2}' is insufficient.</value>
-  </data>
-  <data name="SQL_SqlCommandCommandText" xml:space="preserve">
-    <value>SqlCommand.DeriveParameters failed because the SqlCommand.CommandText property value is an invalid multipart name</value>
-  </data>
-  <data name="SQL_BatchedUpdatesNotAvailableOnContextConnection" xml:space="preserve">
-    <value>Batching updates is not supported on the context connection.</value>
-  </data>
-  <data name="SQL_BulkCopyDestinationTableName" xml:space="preserve">
-    <value>SqlBulkCopy.WriteToServer failed because the SqlBulkCopy.DestinationTableName is an invalid multipart name</value>
-  </data>
-  <data name="SQL_TDSParserTableName" xml:space="preserve">
-    <value>Processing of results from SQL Server failed because of an invalid multipart name</value>
-  </data>
-  <data name="SQL_TypeName" xml:space="preserve">
-    <value>SqlParameter.TypeName is an invalid multipart name</value>
-  </data>
-  <data name="SQLMSF_FailoverPartnerNotSupported" xml:space="preserve">
-    <value>Connecting to a mirrored SQL Server instance using the MultiSubnetFailover connection option is not supported.</value>
-  </data>
-  <data name="SQL_NotSupportedEnumerationValue" xml:space="preserve">
-    <value>The {0} enumeration value, {1}, is not supported by the .Net Framework SqlClient Data Provider.</value>
-  </data>
-  <data name="ADP_CommandTextRequired" xml:space="preserve">
-    <value>{0}: CommandText property has not been initialized</value>
-  </data>
-  <data name="ADP_ConnectionRequired" xml:space="preserve">
-    <value>{0}: Connection property has not been initialized.</value>
-  </data>
-  <data name="ADP_OpenConnectionRequired" xml:space="preserve">
-    <value>{0} requires an open and available Connection. {1}</value>
-  </data>
-  <data name="ADP_TransactionConnectionMismatch" xml:space="preserve">
-    <value>The transaction is either not associated with the current connection or has been completed.</value>
-  </data>
-  <data name="ADP_TransactionRequired" xml:space="preserve">
-    <value>{0} requires the command to have a transaction when the connection assigned to the command is in a pending local transaction.  The Transaction property of the command has not been initialized.</value>
-  </data>
-  <data name="ADP_OpenReaderExists" xml:space="preserve">
-    <value>There is already an open DataReader associated with this Command which must be closed first.</value>
-  </data>
-  <data name="ADP_CalledTwice" xml:space="preserve">
-    <value>The method '{0}' cannot be called more than once for the same execution.</value>
-  </data>
-  <data name="ADP_InvalidCommandTimeout" xml:space="preserve">
-    <value>Invalid CommandTimeout value {0}; the value must be &gt;= 0.</value>
-  </data>
-  <data name="ADP_UninitializedParameterSize" xml:space="preserve">
-    <value>{1}[{0}]: the Size property has an invalid size of 0.</value>
-  </data>
-  <data name="ADP_PrepareParameterType" xml:space="preserve">
-    <value>{0}.Prepare method requires all parameters to have an explicitly set type.</value>
-  </data>
-  <data name="ADP_PrepareParameterSize" xml:space="preserve">
-    <value>{0}.Prepare method requires all variable length parameters to have an explicitly set non-zero Size.</value>
-  </data>
-  <data name="ADP_PrepareParameterScale" xml:space="preserve">
-    <value>{0}.Prepare method requires parameters of type '{1}' have an explicitly set Precision and Scale.</value>
-  </data>
-  <data name="ADP_MismatchedAsyncResult" xml:space="preserve">
-    <value>Mismatched end method call for asyncResult.  Expected call to {0} but {1} was called instead.</value>
-  </data>
-  <data name="ADP_ClosedConnectionError" xml:space="preserve">
-    <value>Invalid operation. The connection is closed.</value>
-  </data>
-  <data name="ADP_ConnectionIsDisabled" xml:space="preserve">
-    <value>The connection has been disabled.</value>
-  </data>
-  <data name="ADP_EmptyDatabaseName" xml:space="preserve">
-    <value>Database cannot be null, the empty string, or string of only whitespace.</value>
-  </data>
-  <data name="ADP_InvalidSourceBufferIndex" xml:space="preserve">
-    <value>Invalid source buffer (size of {0}) offset: {1}</value>
-  </data>
-  <data name="ADP_InvalidDestinationBufferIndex" xml:space="preserve">
-    <value>Invalid destination buffer (size of {0}) offset: {1}</value>
-  </data>
-  <data name="ADP_StreamClosed" xml:space="preserve">
-    <value>Invalid attempt to {0} when stream is closed.</value>
-  </data>
-  <data name="ADP_InvalidSeekOrigin" xml:space="preserve">
-    <value>Specified SeekOrigin value is invalid.</value>
-  </data>
-  <data name="ADP_NonSequentialColumnAccess" xml:space="preserve">
-    <value>Invalid attempt to read from column ordinal '{0}'.  With CommandBehavior.SequentialAccess, you may only read from column ordinal '{1}' or greater.</value>
-  </data>
-  <data name="ADP_InvalidDataType" xml:space="preserve">
-    <value>The parameter data type of {0} is invalid.</value>
-  </data>
-  <data name="ADP_UnknownDataType" xml:space="preserve">
-    <value>No mapping exists from object type {0} to a known managed provider native type.</value>
-  </data>
-  <data name="ADP_DbTypeNotSupported" xml:space="preserve">
-    <value>No mapping exists from DbType {0} to a known {1}.</value>
-  </data>
-  <data name="ADP_VersionDoesNotSupportDataType" xml:space="preserve">
-    <value>The version of SQL Server in use does not support datatype '{0}'.</value>
-  </data>
-  <data name="ADP_ParameterValueOutOfRange" xml:space="preserve">
-    <value>Parameter value '{0}' is out of range.</value>
-  </data>
-  <data name="ADP_BadParameterName" xml:space="preserve">
-    <value>Specified parameter name '{0}' is not valid.</value>
-  </data>
-  <data name="ADP_InvalidSizeValue" xml:space="preserve">
-    <value>Invalid parameter Size value '{0}'. The value must be greater than or equal to 0.</value>
-  </data>
-  <data name="ADP_NegativeParameter" xml:space="preserve">
-    <value>Invalid value for argument '{0}'. The value must be greater than or equal to 0.</value>
-  </data>
-  <data name="ADP_InvalidMetaDataValue" xml:space="preserve">
-    <value>Invalid value for this metadata.</value>
-  </data>
-  <data name="ADP_ParameterConversionFailed" xml:space="preserve">
-    <value>Failed to convert parameter value from a {0} to a {1}.</value>
-  </data>
-  <data name="ADP_ParallelTransactionsNotSupported" xml:space="preserve">
-    <value>{0} does not support parallel transactions.</value>
-  </data>
-  <data name="ADP_TransactionZombied" xml:space="preserve">
-    <value>This {0} has completed; it is no longer usable.</value>
-  </data>
-  <data name="ADP_InvalidDataLength2" xml:space="preserve">
-    <value>Specified length '{0}' is out of range.</value>
-  </data>
-  <data name="ADP_NonSeqByteAccess" xml:space="preserve">
-    <value>Invalid {2} attempt at dataIndex '{0}'.  With CommandBehavior.SequentialAccess, you may only read from dataIndex '{1}' or greater.</value>
-  </data>
-  <data name="ADP_InvalidMinMaxPoolSizeValues" xml:space="preserve">
-    <value>Invalid min or max pool size values, min pool size cannot be greater than the max pool size.</value>
-  </data>
-  <data name="SQL_InvalidPacketSizeValue" xml:space="preserve">
-    <value>Invalid 'Packet Size'.  The value must be an integer &gt;= 512 and &lt;= 32768.</value>
-  </data>
-  <data name="SQL_NullEmptyTransactionName" xml:space="preserve">
-    <value>Invalid transaction or invalid name for a point at which to save within the transaction.</value>
-  </data>
-  <data name="SQL_UserInstanceFailoverNotCompatible" xml:space="preserve">
-    <value>User Instance and Failover are not compatible options.  Please choose only one of the two in the connection string.</value>
-  </data>
-  <data name="SQL_EncryptionNotSupportedByClient" xml:space="preserve">
-    <value>The instance of SQL Server you attempted to connect to requires encryption but this machine does not support it.</value>
-  </data>
-  <data name="SQL_EncryptionNotSupportedByServer" xml:space="preserve">
-    <value>The instance of SQL Server you attempted to connect to does not support encryption.</value>
-  </data>
-  <data name="SQL_InvalidSQLServerVersionUnknown" xml:space="preserve">
-    <value>Unsupported SQL Server version.  The .Net Framework SqlClient Data Provider can only be used with SQL Server versions 7.0 and later.</value>
-  </data>
-  <data name="SQL_CannotModifyPropertyAsyncOperationInProgress" xml:space="preserve">
-    <value>{0} cannot be changed while async operation is in progress.</value>
-  </data>
-  <data name="SQL_InstanceFailure" xml:space="preserve">
-    <value>Instance failure.</value>
-  </data>
-  <data name="SQL_InvalidPartnerConfiguration" xml:space="preserve">
-    <value>Server {0}, database {1} is not configured for database mirroring.</value>
-  </data>
-  <data name="SQL_MarsUnsupportedOnConnection" xml:space="preserve">
-    <value>The connection does not support MultipleActiveResultSets.</value>
-  </data>
-  <data name="SQL_NonLocalSSEInstance" xml:space="preserve">
-    <value>SSE Instance re-direction is not supported for non-local user instances.</value>
-  </data>
-  <data name="SQL_PendingBeginXXXExists" xml:space="preserve">
-    <value>The command execution cannot proceed due to a pending asynchronous operation already in progress.</value>
-  </data>
-  <data name="SQL_NonXmlResult" xml:space="preserve">
-    <value>Invalid command sent to ExecuteXmlReader.  The command must return an Xml result.</value>
-  </data>
-  <data name="SQL_InvalidParameterTypeNameFormat" xml:space="preserve">
-    <value>Invalid 3 part name format for TypeName.</value>
-  </data>
-  <data name="SQL_InvalidParameterNameLength" xml:space="preserve">
-    <value>The length of the parameter '{0}' exceeds the limit of 128 characters.</value>
-  </data>
-  <data name="SQL_PrecisionValueOutOfRange" xml:space="preserve">
-    <value>Precision value '{0}' is either less than 0 or greater than the maximum allowed precision of 38.</value>
-  </data>
-  <data name="SQL_ScaleValueOutOfRange" xml:space="preserve">
-    <value>Scale value '{0}' is either less than 0 or greater than the maximum allowed scale of 38.</value>
-  </data>
-  <data name="SQL_TimeScaleValueOutOfRange" xml:space="preserve">
-    <value>Scale value '{0}' is either less than 0 or greater than the maximum allowed scale of 7.</value>
-  </data>
-  <data name="SQL_ParameterInvalidVariant" xml:space="preserve">
-    <value>Parameter '{0}' exceeds the size limit for the sql_variant datatype.</value>
-  </data>
-  <data name="SQL_ParameterTypeNameRequired" xml:space="preserve">
-    <value>The {0} type parameter '{1}' must have a valid type name.</value>
-  </data>
-  <data name="SQL_InvalidInternalPacketSize" xml:space="preserve">
-    <value>Invalid internal packet size:</value>
-  </data>
-  <data name="SQL_InvalidTDSVersion" xml:space="preserve">
-    <value>The SQL Server instance returned an invalid or unsupported protocol version during login negotiation.</value>
-  </data>
-  <data name="SQL_InvalidTDSPacketSize" xml:space="preserve">
-    <value>Invalid Packet Size.</value>
-  </data>
-  <data name="SQL_ParsingError" xml:space="preserve">
-    <value>Internal connection fatal error.</value>
-  </data>
-  <data name="SQL_ConnectionLockedForBcpEvent" xml:space="preserve">
-    <value>The connection cannot be used because there is an ongoing operation that must be finished.</value>
-  </data>
-  <data name="SQL_SNIPacketAllocationFailure" xml:space="preserve">
-    <value>Memory allocation for internal connection failed.</value>
-  </data>
-  <data name="SQL_SmallDateTimeOverflow" xml:space="preserve">
-    <value>SqlDbType.SmallDateTime overflow.  Value '{0}' is out of range.  Must be between 1/1/1900 12:00:00 AM and 6/6/2079 11:59:59 PM.</value>
-  </data>
-  <data name="SQL_TimeOverflow" xml:space="preserve">
-    <value>SqlDbType.Time overflow.  Value '{0}' is out of range.  Must be between 00:00:00.0000000 and 23:59:59.9999999.</value>
-  </data>
-  <data name="SQL_MoneyOverflow" xml:space="preserve">
-    <value>SqlDbType.SmallMoney overflow.  Value '{0}' is out of range.  Must be between -214,748.3648 and 214,748.3647.</value>
-  </data>
-  <data name="SQL_CultureIdError" xml:space="preserve">
-    <value>The Collation specified by SQL Server is not supported.</value>
-  </data>
-  <data name="SQL_OperationCancelled" xml:space="preserve">
-    <value>Operation cancelled by user.</value>
-  </data>
-  <data name="SQL_SevereError" xml:space="preserve">
-    <value>A severe error occurred on the current command.  The results, if any, should be discarded.</value>
-  </data>
-  <data name="SQL_SSPIGenerateError" xml:space="preserve">
-    <value>Failed to generate SSPI context.</value>
-  </data>
-  <data name="SQL_KerberosTicketMissingError" xml:space="preserve">
-    <value>Cannot access Kerberos ticket. Ensure Kerberos has been initialized with 'kinit'.</value>
-  </data>
-  <data name="SQL_InvalidSSPIPacketSize" xml:space="preserve">
-    <value>Invalid SSPI packet size.</value>
-  </data>
-  <data name="SQL_SSPIInitializeError" xml:space="preserve">
-    <value>Cannot initialize SSPI package.</value>
-  </data>
-  <data name="SQL_Timeout" xml:space="preserve">
-    <value>Timeout expired.  The timeout period elapsed prior to completion of the operation or the server is not responding.</value>
-  </data>
-  <data name="SQL_Timeout_PreLogin_Begin" xml:space="preserve">
-    <value>Connection Timeout Expired.  The timeout period elapsed at the start of the pre-login phase.  This could be because of insufficient time provided for connection timeout.</value>
-  </data>
-  <data name="SQL_Timeout_PreLogin_InitializeConnection" xml:space="preserve">
-    <value>Connection Timeout Expired.  The timeout period elapsed while attempting to create and initialize a socket to the server.  This could be either because the server was unreachable or unable to respond back in time.</value>
-  </data>
-  <data name="SQL_Timeout_PreLogin_SendHandshake" xml:space="preserve">
-    <value>Connection Timeout Expired.  The timeout period elapsed while making a pre-login handshake request.  This could be because the server was unable to respond back in time.</value>
-  </data>
-  <data name="SQL_Timeout_PreLogin_ConsumeHandshake" xml:space="preserve">
-    <value>Connection Timeout Expired.  The timeout period elapsed while attempting to consume the pre-login handshake acknowledgement.  This could be because the pre-login handshake failed or the server was unable to respond back in time.</value>
-  </data>
-  <data name="SQL_Timeout_Login_Begin" xml:space="preserve">
-    <value>Connection Timeout Expired.  The timeout period elapsed at the start of the login phase.  This could be because of insufficient time provided for connection timeout.</value>
-  </data>
-  <data name="SQL_Timeout_Login_ProcessConnectionAuth" xml:space="preserve">
-    <value>Connection Timeout Expired.  The timeout period elapsed while attempting to authenticate the login.  This could be because the server failed to authenticate the user or the server was unable to respond back in time.</value>
-  </data>
-  <data name="SQL_Timeout_PostLogin" xml:space="preserve">
-    <value>Connection Timeout Expired.  The timeout period elapsed during the post-login phase.  The connection could have timed out while waiting for server to complete the login process and respond; Or it could have timed out while attempting to create multiple active connections.</value>
-  </data>
-  <data name="SQL_Timeout_FailoverInfo" xml:space="preserve">
-    <value>This failure occurred while attempting to connect to the {0} server.</value>
-  </data>
-  <data name="SQL_Timeout_RoutingDestinationInfo" xml:space="preserve">
-    <value>This failure occurred while attempting to connect to the routing destination. The duration spent while attempting to connect to the original server was - [Pre-Login] initialization={0}; handshake={1}; [Login] initialization={2}; authentication={3}; [Post-Login] complete={4};  </value>
-  </data>
-  <data name="SQL_Duration_PreLogin_Begin" xml:space="preserve">
-    <value>The duration spent while attempting to connect to this server was - [Pre-Login] initialization={0};</value>
-  </data>
-  <data name="SQL_Duration_PreLoginHandshake" xml:space="preserve">
-    <value>The duration spent while attempting to connect to this server was - [Pre-Login] initialization={0}; handshake={1}; </value>
-  </data>
-  <data name="SQL_Duration_Login_Begin" xml:space="preserve">
-    <value>The duration spent while attempting to connect to this server was - [Pre-Login] initialization={0}; handshake={1}; [Login] initialization={2}; </value>
-  </data>
-  <data name="SQL_Duration_Login_ProcessConnectionAuth" xml:space="preserve">
-    <value>The duration spent while attempting to connect to this server was - [Pre-Login] initialization={0}; handshake={1}; [Login] initialization={2}; authentication={3}; </value>
-  </data>
-  <data name="SQL_Duration_PostLogin" xml:space="preserve">
-    <value>The duration spent while attempting to connect to this server was - [Pre-Login] initialization={0}; handshake={1}; [Login] initialization={2}; authentication={3}; [Post-Login] complete={4}; </value>
-  </data>
-  <data name="SQL_UserInstanceFailure" xml:space="preserve">
-    <value>A user instance was requested in the connection string but the server specified does not support this option.</value>
-  </data>
-  <data name="SQL_InvalidRead" xml:space="preserve">
-    <value>Invalid attempt to read when no data is present.</value>
-  </data>
-  <data name="SQL_NonBlobColumn" xml:space="preserve">
-    <value>Invalid attempt to GetBytes on column '{0}'.  The GetBytes function can only be used on columns of type Text, NText, or Image.</value>
-  </data>
-  <data name="SQL_NonCharColumn" xml:space="preserve">
-    <value>Invalid attempt to GetChars on column '{0}'.  The GetChars function can only be used on columns of type Text, NText, Xml, VarChar or NVarChar.</value>
-  </data>
-  <data name="SQL_StreamNotSupportOnColumnType" xml:space="preserve">
-    <value>Invalid attempt to GetStream on column '{0}'. The GetStream function can only be used on columns of type Binary, Image, Udt or VarBinary.</value>
-  </data>
-  <data name="SQL_TextReaderNotSupportOnColumnType" xml:space="preserve">
-    <value>Invalid attempt to GetTextReader on column '{0}'. The GetTextReader function can only be used on columns of type Char, NChar, NText, NVarChar, Text or VarChar.</value>
-  </data>
-  <data name="SQL_XmlReaderNotSupportOnColumnType" xml:space="preserve">
-    <value>Invalid attempt to GetXmlReader on column '{0}'. The GetXmlReader function can only be used on columns of type Xml.</value>
-  </data>
-  <data name="SQL_InvalidBufferSizeOrIndex" xml:space="preserve">
-    <value>Buffer offset '{1}' plus the bytes available '{0}' is greater than the length of the passed in buffer.</value>
-  </data>
-  <data name="SQL_InvalidDataLength" xml:space="preserve">
-    <value>Data length '{0}' is less than 0.</value>
-  </data>
-  <data name="SQL_BulkLoadMappingInaccessible" xml:space="preserve">
-    <value>The mapped collection is in use and cannot be accessed at this time;</value>
-  </data>
-  <data name="SQL_BulkLoadMappingsNamesOrOrdinalsOnly" xml:space="preserve">
-    <value>Mappings must be either all name or all ordinal based.</value>
-  </data>
-  <data name="SQL_BulkLoadCannotConvertValue" xml:space="preserve">
-    <value>The given value of type {0} from the data source cannot be converted to type {1} of the specified target column.</value>
-  </data>
-  <data name="SQL_BulkLoadNonMatchingColumnMapping" xml:space="preserve">
-    <value>The given ColumnMapping does not match up with any column in the source or destination.</value>
-  </data>
-  <data name="SQL_BulkLoadNonMatchingColumnName" xml:space="preserve">
-    <value>The given ColumnName '{0}' does not match up with any column in data source.</value>
-  </data>
-  <data name="SQL_BulkLoadStringTooLong" xml:space="preserve">
-    <value>String or binary data would be truncated.</value>
-  </data>
-  <data name="SQL_BulkLoadInvalidTimeout" xml:space="preserve">
-    <value>Timeout Value '{0}' is less than 0.</value>
-  </data>
-  <data name="SQL_BulkLoadInvalidVariantValue" xml:space="preserve">
-    <value>Value cannot be converted to SqlVariant.</value>
-  </data>
-  <data name="SQL_BulkLoadExistingTransaction" xml:space="preserve">
-    <value>Unexpected existing transaction.</value>
-  </data>
-  <data name="SQL_BulkLoadNoCollation" xml:space="preserve">
-    <value>Failed to obtain column collation information for the destination table. If the table is not in the current database the name must be qualified using the database name (e.g. [mydb]..[mytable](e.g. [mydb]..[mytable]); this also applies to temporary-tables (e.g. #mytable would be specified as tempdb..#mytable).</value>
-  </data>
-  <data name="SQL_BulkLoadConflictingTransactionOption" xml:space="preserve">
-    <value>Must not specify SqlBulkCopyOption.UseInternalTransaction and pass an external Transaction at the same time.</value>
-  </data>
-  <data name="SQL_BulkLoadInvalidOperationInsideEvent" xml:space="preserve">
-    <value>Function must not be called during event.</value>
-  </data>
-  <data name="SQL_BulkLoadMissingDestinationTable" xml:space="preserve">
-    <value>The DestinationTableName property must be set before calling this method.</value>
-  </data>
-  <data name="SQL_BulkLoadInvalidDestinationTable" xml:space="preserve">
-    <value>Cannot access destination table '{0}'.</value>
-  </data>
-  <data name="SQL_BulkLoadNotAllowDBNull" xml:space="preserve">
-    <value>Column '{0}' does not allow DBNull.Value.</value>
-  </data>
-  <data name="Sql_BulkLoadLcidMismatch" xml:space="preserve">
-    <value>The locale id '{0}' of the source column '{1}' and the locale id '{2}' of the destination column '{3}' do not match.</value>
-  </data>
-  <data name="SQL_BulkLoadPendingOperation" xml:space="preserve">
-    <value>Attempt to invoke bulk copy on an object that has a pending operation.</value>
-  </data>
-  <data name="SQL_ConnectionDoomed" xml:space="preserve">
-    <value>The requested operation cannot be completed because the connection has been broken.</value>
-  </data>
-  <data name="SQL_OpenResultCountExceeded" xml:space="preserve">
-    <value>Open result count exceeded.</value>
-  </data>
-  <data name="SQL_StreamWriteNotSupported" xml:space="preserve">
-    <value>The Stream does not support writing.</value>
-  </data>
-  <data name="SQL_StreamReadNotSupported" xml:space="preserve">
-    <value>The Stream does not support reading.</value>
-  </data>
-  <data name="SQL_StreamSeekNotSupported" xml:space="preserve">
-    <value>The Stream does not support seeking.</value>
-  </data>
-  <data name="SQL_ExClientConnectionId" xml:space="preserve">
-    <value>ClientConnectionId:{0}</value>
-  </data>
-  <data name="SQL_ExErrorNumberStateClass" xml:space="preserve">
-    <value>Error Number:{0},State:{1},Class:{2}</value>
-  </data>
-  <data name="SQL_ExOriginalClientConnectionId" xml:space="preserve">
-    <value>ClientConnectionId before routing:{0}</value>
-  </data>
-  <data name="SQL_ExRoutingDestination" xml:space="preserve">
-    <value>Routing Destination:{0}</value>
-  </data>
-  <data name="SqlMisc_NullString" xml:space="preserve">
-    <value>Null</value>
-  </data>
-  <data name="SqlMisc_MessageString" xml:space="preserve">
-    <value>Message</value>
-  </data>
-  <data name="SqlMisc_ArithOverflowMessage" xml:space="preserve">
-    <value>Arithmetic Overflow.</value>
-  </data>
-  <data name="SqlMisc_DivideByZeroMessage" xml:space="preserve">
-    <value>Divide by zero error encountered.</value>
-  </data>
-  <data name="SqlMisc_NullValueMessage" xml:space="preserve">
-    <value>Data is Null. This method or property cannot be called on Null values.</value>
-  </data>
-  <data name="SqlMisc_TruncationMessage" xml:space="preserve">
-    <value>Numeric arithmetic causes truncation.</value>
-  </data>
-  <data name="SqlMisc_DateTimeOverflowMessage" xml:space="preserve">
-    <value>SqlDateTime overflow. Must be between 1/1/1753 12:00:00 AM and 12/31/9999 11:59:59 PM.</value>
-  </data>
-  <data name="SqlMisc_ConcatDiffCollationMessage" xml:space="preserve">
-    <value>Two strings to be concatenated have different collation.</value>
-  </data>
-  <data name="SqlMisc_CompareDiffCollationMessage" xml:space="preserve">
-    <value>Two strings to be compared have different collation.</value>
-  </data>
-  <data name="SqlMisc_InvalidFlagMessage" xml:space="preserve">
-    <value>Invalid flag value.</value>
-  </data>
-  <data name="SqlMisc_NumeToDecOverflowMessage" xml:space="preserve">
-    <value>Conversion from SqlDecimal to Decimal overflows.</value>
-  </data>
-  <data name="SqlMisc_ConversionOverflowMessage" xml:space="preserve">
-    <value>Conversion overflows.</value>
-  </data>
-  <data name="SqlMisc_InvalidDateTimeMessage" xml:space="preserve">
-    <value>Invalid SqlDateTime.</value>
-  </data>
-  <data name="SqlMisc_TimeZoneSpecifiedMessage" xml:space="preserve">
-    <value>A time zone was specified. SqlDateTime does not support time zones.</value>
-  </data>
-  <data name="SqlMisc_InvalidArraySizeMessage" xml:space="preserve">
-    <value>Invalid array size.</value>
-  </data>
-  <data name="SqlMisc_InvalidPrecScaleMessage" xml:space="preserve">
-    <value>Invalid numeric precision/scale.</value>
-  </data>
-  <data name="SqlMisc_FormatMessage" xml:space="preserve">
-    <value>The input wasn't in a correct format.</value>
-  </data>
-  <data name="SqlMisc_StreamErrorMessage" xml:space="preserve">
-    <value>An error occurred while reading.</value>
-  </data>
-  <data name="SqlMisc_TruncationMaxDataMessage" xml:space="preserve">
-    <value>Data returned is larger than 2Gb in size. Use SequentialAccess command behavior in order to get all of the data.</value>
-  </data>
-  <data name="SqlMisc_NotFilledMessage" xml:space="preserve">
-    <value>SQL Type has not been loaded with data.</value>
-  </data>
-  <data name="SqlMisc_AlreadyFilledMessage" xml:space="preserve">
-    <value>SQL Type has already been loaded with data.</value>
-  </data>
-  <data name="SqlMisc_ClosedXmlReaderMessage" xml:space="preserve">
-    <value>Invalid attempt to access a closed XmlReader.</value>
-  </data>
-  <data name="SqlMisc_InvalidOpStreamClosed" xml:space="preserve">
-    <value>Invalid attempt to call {0} when the stream is closed.</value>
-  </data>
-  <data name="SqlMisc_InvalidOpStreamNonWritable" xml:space="preserve">
-    <value>Invalid attempt to call {0} when the stream non-writable.</value>
-  </data>
-  <data name="SqlMisc_InvalidOpStreamNonReadable" xml:space="preserve">
-    <value>Invalid attempt to call {0} when the stream non-readable.</value>
-  </data>
-  <data name="SqlMisc_InvalidOpStreamNonSeekable" xml:space="preserve">
-    <value>Invalid attempt to call {0} when the stream is non-seekable.</value>
-  </data>
-  <data name="SqlMisc_SubclassMustOverride" xml:space="preserve">
-    <value>Subclass did not override a required method.</value>
-  </data>
-  <data name="Sql_InternalError" xml:space="preserve">
-    <value>Internal Error</value>
-  </data>
-  <data name="ADP_OperationAborted" xml:space="preserve">
-    <value>Operation aborted.</value>
-  </data>
-  <data name="ADP_OperationAbortedExceptionMessage" xml:space="preserve">
-    <value>Operation aborted due to an exception (see InnerException for details).</value>
-  </data>
-  <data name="SqlParameter_UnsupportedTVPOutputParameter" xml:space="preserve">
-    <value>ParameterDirection '{0}' specified for parameter '{1}' is not supported. Table-valued parameters only support ParameterDirection.Input.</value>
-  </data>
-  <data name="SqlParameter_DBNullNotSupportedForTVP" xml:space="preserve">
-    <value>DBNull value for parameter '{0}' is not supported. Table-valued parameters cannot be DBNull.</value>
-  </data>
-  <data name="SqlParameter_UnexpectedTypeNameForNonStruct" xml:space="preserve">
-    <value>TypeName specified for parameter '{0}'.  TypeName must only be set for Structured parameters.</value>
-  </data>
-  <data name="NullSchemaTableDataTypeNotSupported" xml:space="preserve">
-    <value>DateType column for field '{0}' in schema table is null.  DataType must be non-null.</value>
-  </data>
-  <data name="InvalidSchemaTableOrdinals" xml:space="preserve">
-    <value>Invalid column ordinals in schema table.  ColumnOrdinals, if present, must not have duplicates or gaps.</value>
-  </data>
-  <data name="SQL_EnumeratedRecordMetaDataChanged" xml:space="preserve">
-    <value>Metadata for field '{0}' of record '{1}' did not match the original record's metadata.</value>
-  </data>
-  <data name="SQL_EnumeratedRecordFieldCountChanged" xml:space="preserve">
-    <value>Number of fields in record '{0}' does not match the number in the original record.</value>
-  </data>
-  <data name="SQLNotify_AlreadyHasCommand" xml:space="preserve">
-    <value>This SqlCommand object is already associated with another SqlDependency object.</value>
-  </data>
-  <data name="SqlDependency_DatabaseBrokerDisabled" xml:space="preserve">
-    <value>The SQL Server Service Broker for the current database is not enabled, and as a result query notifications are not supported.  Please enable the Service Broker for this database if you wish to use notifications.</value>
-  </data>
-  <data name="SqlDependency_DefaultOptionsButNoStart" xml:space="preserve">
-    <value>When using SqlDependency without providing an options value, SqlDependency.Start() must be called prior to execution of a command added to the SqlDependency instance.</value>
-  </data>
-  <data name="SqlDependency_NoMatchingServerStart" xml:space="preserve">
-    <value>When using SqlDependency without providing an options value, SqlDependency.Start() must be called for each server that is being executed against.</value>
-  </data>
-  <data name="SqlDependency_NoMatchingServerDatabaseStart" xml:space="preserve">
-    <value>SqlDependency.Start has been called for the server the command is executing against more than once, but there is no matching server/user/database Start() call for current command.</value>
-  </data>
-  <data name="SqlDependency_EventNoDuplicate" xml:space="preserve">
-    <value>SqlDependency.OnChange does not support multiple event registrations for the same delegate.</value>
-  </data>
-  <data name="SqlDependency_IdMismatch" xml:space="preserve">
-    <value>No SqlDependency exists for the key.</value>
-  </data>
-  <data name="SqlDependency_InvalidTimeout" xml:space="preserve">
-    <value>Timeout specified is invalid. Timeout cannot be &lt; 0.</value>
-  </data>
-  <data name="SqlDependency_DuplicateStart" xml:space="preserve">
-    <value>SqlDependency does not support calling Start() with different connection strings having the same server, user, and database in the same app domain.</value>
-  </data>
-  <data name="SqlMetaData_InvalidSqlDbTypeForConstructorFormat" xml:space="preserve">
-    <value>The dbType {0} is invalid for this constructor.</value>
-  </data>
-  <data name="SqlMetaData_NameTooLong" xml:space="preserve">
-    <value>The name is too long.</value>
-  </data>
-  <data name="SqlMetaData_SpecifyBothSortOrderAndOrdinal" xml:space="preserve">
-    <value>The sort order and ordinal must either both be specified, or neither should be specified (SortOrder.Unspecified and -1).  The values given were: order = {0}, ordinal = {1}.</value>
-  </data>
-  <data name="SqlProvider_InvalidDataColumnType" xml:space="preserve">
-    <value>The type of column '{0}' is not supported.  The type is '{1}'</value>
-  </data>
-  <data name="SqlProvider_NotEnoughColumnsInStructuredType" xml:space="preserve">
-    <value>There are not enough fields in the Structured type.  Structured types must have at least one field.</value>
-  </data>
-  <data name="SqlProvider_DuplicateSortOrdinal" xml:space="preserve">
-    <value>The sort ordinal {0} was specified twice.</value>
-  </data>
-  <data name="SqlProvider_MissingSortOrdinal" xml:space="preserve">
-    <value>The sort ordinal {0} was not specified.</value>
-  </data>
-  <data name="SqlProvider_SortOrdinalGreaterThanFieldCount" xml:space="preserve">
-    <value>The sort ordinal {0} on field {1} exceeds the total number of fields.</value>
-  </data>
-  <data name="IEnumerableOfSqlDataRecordHasNoRows" xml:space="preserve">
-    <value>There are no records in the SqlDataRecord enumeration. To send a table-valued parameter with no rows, use a null reference for the value instead.</value>
-  </data>
-  <data name="SNI_ERROR_1" xml:space="preserve">
-    <value>I/O Error detected in read/write operation</value>
-  </data>
-  <data name="SNI_ERROR_2" xml:space="preserve">
-    <value>Connection was terminated</value>
-  </data>
-  <data name="SNI_ERROR_3" xml:space="preserve">
-    <value>Asynchronous operations not supported</value>
-  </data>
-  <data name="SNI_ERROR_5" xml:space="preserve">
-    <value>Invalid parameter(s) found</value>
-  </data>
-  <data name="SNI_ERROR_6" xml:space="preserve">
-    <value>Unsupported protocol specified</value>
-  </data>
-  <data name="SNI_ERROR_7" xml:space="preserve">
-    <value>Invalid connection found when setting up new session protocol</value>
-  </data>
-  <data name="SNI_ERROR_8" xml:space="preserve">
-    <value>Protocol not supported</value>
-  </data>
-  <data name="SNI_ERROR_9" xml:space="preserve">
-    <value>Associating port with I/O completion mechanism failed</value>
-  </data>
-  <data name="SNI_ERROR_11" xml:space="preserve">
-    <value>Timeout error</value>
-  </data>
-  <data name="SNI_ERROR_12" xml:space="preserve">
-    <value>No server name supplied</value>
-  </data>
-  <data name="SNI_ERROR_13" xml:space="preserve">
-    <value>TerminateListener() has been called</value>
-  </data>
-  <data name="SNI_ERROR_14" xml:space="preserve">
-    <value>Win9x not supported</value>
-  </data>
-  <data name="SNI_ERROR_15" xml:space="preserve">
-    <value>Function not supported</value>
-  </data>
-  <data name="SNI_ERROR_16" xml:space="preserve">
-    <value>Shared-Memory heap error</value>
-  </data>
-  <data name="SNI_ERROR_17" xml:space="preserve">
-    <value>Cannot find an ip/ipv6 type address to connect</value>
-  </data>
-  <data name="SNI_ERROR_18" xml:space="preserve">
-    <value>Connection has been closed by peer</value>
-  </data>
-  <data name="SNI_ERROR_19" xml:space="preserve">
-    <value>Physical connection is not usable</value>
-  </data>
-  <data name="SNI_ERROR_20" xml:space="preserve">
-    <value>Connection has been closed</value>
-  </data>
-  <data name="SNI_ERROR_21" xml:space="preserve">
-    <value>Encryption is enforced but there is no valid certificate</value>
-  </data>
-  <data name="SNI_ERROR_22" xml:space="preserve">
-    <value>Couldn't load library</value>
-  </data>
-  <data name="SNI_ERROR_23" xml:space="preserve">
-    <value>Cannot open a new thread in server process</value>
-  </data>
-  <data name="SNI_ERROR_24" xml:space="preserve">
-    <value>Cannot post event to completion port</value>
-  </data>
-  <data name="SNI_ERROR_25" xml:space="preserve">
-    <value>Connection string is not valid</value>
-  </data>
-  <data name="SNI_ERROR_26" xml:space="preserve">
-    <value>Error Locating Server/Instance Specified</value>
-  </data>
-  <data name="SNI_ERROR_27" xml:space="preserve">
-    <value>Error getting enabled protocols list from registry</value>
-  </data>
-  <data name="SNI_ERROR_28" xml:space="preserve">
-    <value>Server doesn't support requested protocol</value>
-  </data>
-  <data name="SNI_ERROR_29" xml:space="preserve">
-    <value>Shared Memory is not supported for clustered server connectivity</value>
-  </data>
-  <data name="SNI_ERROR_30" xml:space="preserve">
-    <value>Invalid attempt bind to shared memory segment</value>
-  </data>
-  <data name="SNI_ERROR_31" xml:space="preserve">
-    <value>Encryption(ssl/tls) handshake failed</value>
-  </data>
-  <data name="SNI_ERROR_32" xml:space="preserve">
-    <value>Packet size too large for SSL Encrypt/Decrypt operations</value>
-  </data>
-  <data name="SNI_ERROR_33" xml:space="preserve">
-    <value>SSRP error</value>
-  </data>
-  <data name="SNI_ERROR_34" xml:space="preserve">
-    <value>Could not connect to the Shared Memory pipe</value>
-  </data>
-  <data name="SNI_ERROR_35" xml:space="preserve">
-    <value>An internal exception was caught</value>
-  </data>
-  <data name="SNI_ERROR_36" xml:space="preserve">
-    <value>The Shared Memory dll used to connect to SQL Server 2000 was not found</value>
-  </data>
-  <data name="SNI_ERROR_37" xml:space="preserve">
-    <value>The SQL Server 2000 Shared Memory client dll appears to be invalid/corrupted</value>
-  </data>
-  <data name="SNI_ERROR_38" xml:space="preserve">
-    <value>Cannot open a Shared Memory connection to SQL Server 2000</value>
-  </data>
-  <data name="SNI_ERROR_39" xml:space="preserve">
-    <value>Shared memory connectivity to SQL Server 2000 is either disabled or not available on this machine</value>
-  </data>
-  <data name="SNI_ERROR_40" xml:space="preserve">
-    <value>Could not open a connection to SQL Server</value>
-  </data>
-  <data name="SNI_ERROR_41" xml:space="preserve">
-    <value>Cannot open a Shared Memory connection to a remote SQL server</value>
-  </data>
-  <data name="SNI_ERROR_42" xml:space="preserve">
-    <value>Could not establish dedicated administrator connection (DAC) on default port. Make sure that DAC is enabled</value>
-  </data>
-  <data name="SNI_ERROR_43" xml:space="preserve">
-    <value>An error occurred while obtaining the dedicated administrator connection (DAC) port. Make sure that SQL Browser is running, or check the error log for the port number</value>
-  </data>
-  <data name="SNI_ERROR_44" xml:space="preserve">
-    <value>Could not compose Service Principal Name (SPN) for Windows Integrated Authentication. Possible causes are server(s) incorrectly specified to connection API calls, Domain Name System (DNS) lookup failure or memory shortage</value>
-  </data>
-  <data name="SNI_ERROR_47" xml:space="preserve">
-    <value>Connecting with the MultiSubnetFailover connection option to a SQL Server instance configured with more than 64 IP addresses is not supported.</value>
-  </data>
-  <data name="SNI_ERROR_48" xml:space="preserve">
-    <value>Connecting to a named SQL Server instance using the MultiSubnetFailover connection option is not supported.</value>
-  </data>
-  <data name="SNI_ERROR_49" xml:space="preserve">
-    <value>Connecting to a SQL Server instance using the MultiSubnetFailover connection option is only supported when using the TCP protocol.</value>
-  </data>
-  <data name="SNI_ERROR_50" xml:space="preserve">
-    <value>Local Database Runtime error occurred. </value>
-  </data>
-  <data name="SNI_ERROR_51" xml:space="preserve">
-    <value>An instance name was not specified while connecting to a Local Database Runtime. Specify an instance name in the format (localdb)\instance_name.</value>
-  </data>
-  <data name="SNI_ERROR_52" xml:space="preserve">
-    <value>Unable to locate a Local Database Runtime installation. Verify that SQL Server Express is properly installed and that the Local Database Runtime feature is enabled.</value>
-  </data>
-  <data name="SNI_ERROR_53" xml:space="preserve">
-    <value>Invalid Local Database Runtime registry configuration found. Verify that SQL Server Express is properly installed.</value>
-  </data>
-  <data name="SNI_ERROR_54" xml:space="preserve">
-    <value>Unable to locate the registry entry for SQLUserInstance.dll file path. Verify that the Local Database Runtime feature of SQL Server Express is properly installed.</value>
-  </data>
-  <data name="SNI_ERROR_55" xml:space="preserve">
-    <value>Registry value contains an invalid SQLUserInstance.dll file path. Verify that the Local Database Runtime feature of SQL Server Express is properly installed.</value>
-  </data>
-  <data name="SNI_ERROR_56" xml:space="preserve">
-    <value>Unable to load the SQLUserInstance.dll from the location specified in the registry. Verify that the Local Database Runtime feature of SQL Server Express is properly installed.</value>
-  </data>
-  <data name="SNI_ERROR_57" xml:space="preserve">
-    <value>Invalid SQLUserInstance.dll found at the location specified in the registry. Verify that the Local Database Runtime feature of SQL Server Express is properly installed.</value>
-  </data>
-  <data name="Snix_Connect" xml:space="preserve">
-    <value>A network-related or instance-specific error occurred while establishing a connection to SQL Server. The server was not found or was not accessible. Verify that the instance name is correct and that SQL Server is configured to allow remote connections.</value>
-  </data>
-  <data name="Snix_PreLoginBeforeSuccessfullWrite" xml:space="preserve">
-    <value>The client was unable to establish a connection because of an error during connection initialization process before login. Possible causes include the following:  the client tried to connect to an unsupported version of SQL Server; the server was too busy to accept new connections; or there was a resource limitation (insufficient memory or maximum allowed connections) on the server.</value>
-  </data>
-  <data name="Snix_PreLogin" xml:space="preserve">
-    <value>A connection was successfully established with the server, but then an error occurred during the pre-login handshake.</value>
-  </data>
-  <data name="Snix_LoginSspi" xml:space="preserve">
-    <value>A connection was successfully established with the server, but then an error occurred when obtaining the security/SSPI context information for integrated security login.</value>
-  </data>
-  <data name="Snix_Login" xml:space="preserve">
-    <value>A connection was successfully established with the server, but then an error occurred during the login process.</value>
-  </data>
-  <data name="Snix_EnableMars" xml:space="preserve">
-    <value>Connection open and login was successful, but then an error occurred while enabling MARS for this connection.</value>
-  </data>
-  <data name="Snix_AutoEnlist" xml:space="preserve">
-    <value>Connection open and login was successful, but then an error occurred while enlisting the connection into the current distributed transaction.</value>
-  </data>
-  <data name="Snix_GetMarsSession" xml:space="preserve">
-    <value>Failed to establish a MARS session in preparation to send the request to the server.</value>
-  </data>
-  <data name="Snix_Execute" xml:space="preserve">
-    <value>A transport-level error has occurred when sending the request to the server.</value>
-  </data>
-  <data name="Snix_Read" xml:space="preserve">
-    <value>A transport-level error has occurred when receiving results from the server.</value>
-  </data>
-  <data name="Snix_Close" xml:space="preserve">
-    <value>A transport-level error has occurred during connection clean-up.</value>
-  </data>
-  <data name="Snix_SendRows" xml:space="preserve">
-    <value>A transport-level error has occurred while sending information to the server.</value>
-  </data>
-  <data name="Snix_ProcessSspi" xml:space="preserve">
-    <value>A transport-level error has occurred during SSPI handshake.</value>
-  </data>
-  <data name="LocalDB_FailedGetDLLHandle" xml:space="preserve">
-    <value>Local Database Runtime: Cannot load SQLUserInstance.dll.</value>
-  </data>
-  <data name="LocalDB_MethodNotFound" xml:space="preserve">
-    <value>Invalid SQLUserInstance.dll found at the location specified in the registry. Verify that the Local Database Runtime feature of SQL Server Express is properly installed.</value>
-  </data>
-  <data name="LocalDB_UnobtainableMessage" xml:space="preserve">
-    <value>Cannot obtain Local Database Runtime error message</value>
-  </data>
-  <data name="SQLROR_RecursiveRoutingNotSupported" xml:space="preserve">
-    <value>Two or more redirections have occurred. Only one redirection per login is allowed.</value>
-  </data>
-  <data name="SQLROR_FailoverNotSupported" xml:space="preserve">
-    <value>Connecting to a mirrored SQL Server instance using the ApplicationIntent ReadOnly connection option is not supported.</value>
-  </data>
-  <data name="SQLROR_UnexpectedRoutingInfo" xml:space="preserve">
-    <value>Unexpected routing information received.</value>
-  </data>
-  <data name="SQLROR_InvalidRoutingInfo" xml:space="preserve">
-    <value>Invalid routing information received.</value>
-  </data>
-  <data name="SQLROR_TimeoutAfterRoutingInfo" xml:space="preserve">
-    <value>Server provided routing information, but timeout already expired.</value>
-  </data>
-  <data name="SQLCR_InvalidConnectRetryCountValue" xml:space="preserve">
-    <value>Invalid ConnectRetryCount value (should be 0-255).</value>
-  </data>
-  <data name="SQLCR_InvalidConnectRetryIntervalValue" xml:space="preserve">
-    <value>Invalid ConnectRetryInterval value (should be 1-60).</value>
-  </data>
-  <data name="SQLCR_NextAttemptWillExceedQueryTimeout" xml:space="preserve">
-    <value>Next reconnection attempt will exceed query timeout. Reconnection was terminated.</value>
-  </data>
-  <data name="SQLCR_EncryptionChanged" xml:space="preserve">
-    <value>The server did not preserve SSL encryption during a recovery attempt, connection recovery is not possible.</value>
-  </data>
-  <data name="SQLCR_TDSVestionNotPreserved" xml:space="preserve">
-    <value>The server did not preserve the exact client TDS version requested during a recovery attempt, connection recovery is not possible.</value>
-  </data>
-  <data name="SQLCR_AllAttemptsFailed" xml:space="preserve">
-    <value>The connection is broken and recovery is not possible.  The client driver attempted to recover the connection one or more times and all attempts failed.  Increase the value of ConnectRetryCount to increase the number of recovery attempts.</value>
-  </data>
-  <data name="SQLCR_UnrecoverableServer" xml:space="preserve">
-    <value>The connection is broken and recovery is not possible.  The connection is marked by the server as unrecoverable.  No attempt was made to restore the connection.</value>
-  </data>
-  <data name="SQLCR_UnrecoverableClient" xml:space="preserve">
-    <value>The connection is broken and recovery is not possible.  The connection is marked by the client driver as unrecoverable.  No attempt was made to restore the connection.</value>
-  </data>
-  <data name="SQLCR_NoCRAckAtReconnection" xml:space="preserve">
-    <value>The server did not acknowledge a recovery attempt, connection recovery is not possible.</value>
-  </data>
-  <data name="SQL_UnsupportedKeyword" xml:space="preserve">
-    <value>The keyword '{0}' is not supported on this platform.</value>
-  </data>
-  <data name="SQL_UnsupportedFeature" xml:space="preserve">
-    <value>The server is attempting to use a feature that is not supported on this platform.</value>
-  </data>
-  <data name="SQL_UnsupportedToken" xml:space="preserve">
-    <value>Received an unsupported token '{0}' while reading data from the server.</value>
-  </data>
-  <data name="SQL_DbTypeNotSupportedOnThisPlatform" xml:space="preserve">
-    <value>Type {0} is not supported on this platform.</value>
-  </data>
-  <data name="SQL_NetworkLibraryNotSupported" xml:space="preserve">
-    <value>The keyword 'Network Library' is not supported on this platform, prefix the 'Data Source' with the protocol desired instead ('tcp:' for a TCP connection, or 'np:' for a Named Pipe connection).</value>
-  </data>
-  <data name="SNI_PN0" xml:space="preserve">
-    <value>HTTP Provider</value>
-  </data>
-  <data name="SNI_PN1" xml:space="preserve">
-    <value>Named Pipes Provider</value>
-  </data>
-  <data name="SNI_PN2" xml:space="preserve">
-    <value>Session Provider</value>
-  </data>
-  <data name="SNI_PN3" xml:space="preserve">
-    <value>Sign Provider</value>
-  </data>
-  <data name="SNI_PN4" xml:space="preserve">
-    <value>Shared Memory Provider</value>
-  </data>
-  <data name="SNI_PN5" xml:space="preserve">
-    <value>SMux Provider</value>
-  </data>
-  <data name="SNI_PN6" xml:space="preserve">
-    <value>SSL Provider</value>
-  </data>
-  <data name="SNI_PN7" xml:space="preserve">
-    <value>TCP Provider</value>
-  </data>
-  <data name="SNI_PN8" xml:space="preserve">
-    <value></value>
-  </data>
-  <data name="SNI_PN9" xml:space="preserve">
-    <value>SQL Network Interfaces</value>
-  </data>
-  <data name="AZURESQL_GenericEndpoint" xml:space="preserve">
-    <value>.database.windows.net</value>
-  </data>
-  <data name="AZURESQL_GermanEndpoint" xml:space="preserve">
-    <value>.database.cloudapi.de</value>
-  </data>
-  <data name="AZURESQL_UsGovEndpoint" xml:space="preserve">
-    <value>.database.usgovcloudapi.net</value>
-  </data>
-  <data name="AZURESQL_ChinaEndpoint" xml:space="preserve">
-    <value>.database.chinacloudapi.cn</value>
-  </data>
-  <data name="net_nego_channel_binding_not_supported" xml:space="preserve">
-    <value>No support for channel binding on operating systems other than Windows.</value>
-  </data>
-  <data name="net_gssapi_operation_failed_detailed" xml:space="preserve">
-    <value>GSSAPI operation failed with error - {0} ({1}).</value>
-  </data>
-  <data name="net_gssapi_operation_failed" xml:space="preserve">
-    <value>GSSAPI operation failed with status: {0} (Minor status: {1}).</value>
-  </data>
-  <data name="net_ntlm_not_possible_default_cred" xml:space="preserve">
-    <value>NTLM authentication is not possible with default credentials on this platform.</value>
-  </data>
-  <data name="net_nego_not_supported_empty_target_with_defaultcreds" xml:space="preserve">
-    <value>Target name should be non-empty if default credentials are passed.</value>
-  </data>
-  <data name="net_nego_server_not_supported" xml:space="preserve">
-    <value>Server implementation is not supported.</value>
-  </data>
-  <data name="net_nego_protection_level_not_supported" xml:space="preserve">
-    <value>Requested protection level is not supported with the GSSAPI implementation currently installed.</value>
-  </data>
-  <data name="net_context_buffer_too_small" xml:space="preserve">
-    <value>Insufficient buffer space. Required: {0} Actual: {1}.</value>
-  </data>
-  <data name="net_auth_message_not_encrypted" xml:space="preserve">
-    <value>Protocol error: A received message contains a valid signature but it was not encrypted as required by the effective Protection Level.</value>
-  </data>
-  <data name="net_securitypackagesupport" xml:space="preserve">
-    <value>The requested security package is not supported.</value>
-  </data>
-  <data name="net_log_operation_failed_with_error" xml:space="preserve">
-    <value>{0} failed with error {1}.</value>
-  </data>
-  <data name="net_MethodNotImplementedException" xml:space="preserve">
-    <value>This method is not implemented by this class.</value>
-  </data>
-  <data name="event_OperationReturnedSomething" xml:space="preserve">
-    <value>{0} returned {1}.</value>
-  </data>
-  <data name="net_invalid_enum" xml:space="preserve">
-    <value>The specified value is not valid in the '{0}' enumeration.</value>
-  </data>
-  <data name="SSPIInvalidHandleType" xml:space="preserve">
-    <value>'{0}' is not a supported handle type.</value>
-  </data>
-  <data name="LocalDBNotSupported" xml:space="preserve">
-    <value>LocalDB is not supported on this Platform.</value>
-  </data>
-  <data name="PlatformNotSupported_DataSqlClient" xml:space="preserve">
-    <value>System.Data.SqlClient is not supported on this platform.</value>
-  </data>
-  <data name="SqlParameter_InvalidTableDerivedPrecisionForTvp" xml:space="preserve">
-    <value>Precision '{0}' required to send all values in column '{1}' exceeds the maximum supported precision '{2}'. The values must all fit in a single precision.</value>
-  </data>
-  <data name="SqlProvider_InvalidDataColumnMaxLength" xml:space="preserve">
-    <value>The size of column '{0}' is not supported. The size is {1}.</value>
-  </data>
-  <data name="MDF_InvalidXmlInvalidValue" xml:space="preserve"> 
-	<value>The metadata XML is invalid. The {1} column of the {0} collection must contain a non-empty string.</value>
-  </data>
-  <data name="MDF_CollectionNameISNotUnique" xml:space="preserve"> 
-	<value>There are multiple collections named '{0}'.</value>
-  </data>
-  <data name="MDF_InvalidXmlMissingColumn" xml:space="preserve"> 
-	<value>The metadata XML is invalid. The {0} collection must contain a {1} column and it must be a string column.</value>
-  </data>
-  <data name="MDF_InvalidXml" xml:space="preserve"> 
-	<value>The metadata XML is invalid.</value>
-  </data>
-  <data name="MDF_NoColumns" xml:space="preserve"> 
-	<value>The schema table contains no columns.</value>
-  </data>
-  <data name="MDF_QueryFailed" xml:space="preserve"> 
-	<value>Unable to build the '{0}' collection because execution of the SQL query failed. See the inner exception for details.</value>
-  </data>
-  <data name="MDF_TooManyRestrictions" xml:space="preserve"> 
-	<value>More restrictions were provided than the requested schema ('{0}') supports.</value>
-  </data>
-  <data name="MDF_DataTableDoesNotExist" xml:space="preserve"> 
-	<value>The collection '{0}' is missing from the metadata XML.</value>
-  </data>
-  <data name="MDF_UndefinedCollection" xml:space="preserve"> 
-    <value>The requested collection ({0}) is not defined.</value> 
-  </data>
-  <data name="MDF_UnsupportedVersion" xml:space="preserve">
-    <value> requested collection ({0}) is not supported by this version of the provider.</value>
-  </data>
-  <data name="MDF_MissingRestrictionColumn" xml:space="preserve">
-    <value>One or more of the required columns of the restrictions collection is missing.</value>
-  </data>
-  <data name="MDF_MissingRestrictionRow" xml:space="preserve">
-    <value>A restriction exists for which there is no matching row in the restrictions collection.</value>
-  </data>
-  <data name="MDF_IncorrectNumberOfDataSourceInformationRows" xml:space="preserve">
-    <value>The DataSourceInformation table must contain exactly one row.</value>
-  </data>
-  <data name="MDF_MissingDataSourceInformationColumn" xml:space="preserve">
-    <value>One of the required DataSourceInformation tables columns is missing.</value>
-  </data>
-  <data name="MDF_AmbigousCollectionName" xml:space="preserve">
-    <value>The collection name '{0}' matches at least two collections with the same name but with different case, but does not match any of them exactly.</value>
-  </data>
-  <data name="MDF_UnableToBuildCollection" xml:space="preserve">
-    <value>Unable to build schema collection '{0}';</value>
-  </data>
-  <data name="AmbientTransactionsNotSupported" xml:space="preserve">
-    <value>Enlisting in Ambient transactions is not supported.</value>
-  </data>
+	<xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+		<xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+		<xsd:element name="root" msdata:IsDataSet="true">
+			<xsd:complexType>
+				<xsd:choice maxOccurs="unbounded">
+					<xsd:element name="metadata">
+						<xsd:complexType>
+							<xsd:sequence>
+								<xsd:element name="value" type="xsd:string" minOccurs="0" />
+							</xsd:sequence>
+							<xsd:attribute name="name" use="required" type="xsd:string" />
+							<xsd:attribute name="type" type="xsd:string" />
+							<xsd:attribute name="mimetype" type="xsd:string" />
+							<xsd:attribute ref="xml:space" />
+						</xsd:complexType>
+					</xsd:element>
+					<xsd:element name="assembly">
+						<xsd:complexType>
+							<xsd:attribute name="alias" type="xsd:string" />
+							<xsd:attribute name="name" type="xsd:string" />
+						</xsd:complexType>
+					</xsd:element>
+					<xsd:element name="data">
+						<xsd:complexType>
+							<xsd:sequence>
+								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+								<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+							</xsd:sequence>
+							<xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+							<xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+							<xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+							<xsd:attribute ref="xml:space" />
+						</xsd:complexType>
+					</xsd:element>
+					<xsd:element name="resheader">
+						<xsd:complexType>
+							<xsd:sequence>
+								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+							</xsd:sequence>
+							<xsd:attribute name="name" type="xsd:string" use="required" />
+						</xsd:complexType>
+					</xsd:element>
+				</xsd:choice>
+			</xsd:complexType>
+		</xsd:element>
+	</xsd:schema>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>2.0</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<data name="ADP_CollectionIndexInt32" xml:space="preserve">
+		<value>Invalid index {0} for this {1} with Count={2}.</value>
+	</data>
+	<data name="ADP_CollectionIndexString" xml:space="preserve">
+		<value>An {0} with {1} '{2}' is not contained by this {3}.</value>
+	</data>
+	<data name="ADP_CollectionInvalidType" xml:space="preserve">
+		<value>The {0} only accepts non-null {1} type objects, not {2} objects.</value>
+	</data>
+	<data name="ADP_CollectionIsNotParent" xml:space="preserve">
+		<value>The {0} is already contained by another {1}.</value>
+	</data>
+	<data name="ADP_CollectionNullValue" xml:space="preserve">
+		<value>The {0} only accepts non-null {1} type objects.</value>
+	</data>
+	<data name="ADP_CollectionRemoveInvalidObject" xml:space="preserve">
+		<value>Attempted to remove an {0} that is not contained by this {1}.</value>
+	</data>
+	<data name="ADP_ConnectionAlreadyOpen" xml:space="preserve">
+		<value>The connection was not closed. {0}</value>
+	</data>
+	<data name="ADP_ConnectionStateMsg_Closed" xml:space="preserve">
+		<value>The connection's current state is closed.</value>
+	</data>
+	<data name="ADP_ConnectionStateMsg_Connecting" xml:space="preserve">
+		<value>The connection's current state is connecting.</value>
+	</data>
+	<data name="ADP_ConnectionStateMsg_Open" xml:space="preserve">
+		<value>The connection's current state is open.</value>
+	</data>
+	<data name="ADP_ConnectionStateMsg_OpenExecuting" xml:space="preserve">
+		<value>The connection's current state is executing.</value>
+	</data>
+	<data name="ADP_ConnectionStateMsg_OpenFetching" xml:space="preserve">
+		<value>The connection's current state is fetching.</value>
+	</data>
+	<data name="ADP_ConnectionStateMsg" xml:space="preserve">
+		<value>The connection's current state: {0}.</value>
+	</data>
+	<data name="ADP_ConnectionStringSyntax" xml:space="preserve">
+		<value>Format of the initialization string does not conform to specification starting at index {0}.</value>
+	</data>
+	<data name="ADP_DataReaderClosed" xml:space="preserve">
+		<value>Invalid attempt to call {0} when reader is closed.</value>
+	</data>
+	<data name="ADP_InternalConnectionError" xml:space="preserve">
+		<value>Internal DbConnection Error: {0}</value>
+	</data>
+	<data name="ADP_InvalidEnumerationValue" xml:space="preserve">
+		<value>The {0} enumeration value, {1}, is invalid.</value>
+	</data>
+	<data name="ADP_NotSupportedEnumerationValue" xml:space="preserve">
+		<value>The {0} enumeration value, {1}, is not supported by the {2} method.</value>
+	</data>
+	<data name="ADP_InvalidOffsetValue" xml:space="preserve">
+		<value>Invalid parameter Offset value '{0}'. The value must be greater than or equal to 0.</value>
+	</data>
+	<data name="ADP_NoConnectionString" xml:space="preserve">
+		<value>The ConnectionString property has not been initialized.</value>
+	</data>
+	<data name="ADP_OpenConnectionPropertySet" xml:space="preserve">
+		<value>Not allowed to change the '{0}' property. {1}</value>
+	</data>
+	<data name="ADP_PendingAsyncOperation" xml:space="preserve">
+		<value>Can not start another operation while there is an asynchronous operation pending.</value>
+	</data>
+	<data name="ADP_PooledOpenTimeout" xml:space="preserve">
+		<value>Timeout expired.  The timeout period elapsed prior to obtaining a connection from the pool.  This may have occurred because all pooled connections were in use and max pool size was reached.</value>
+	</data>
+	<data name="ADP_NonPooledOpenTimeout" xml:space="preserve">
+		<value>Timeout attempting to open the connection.  The time period elapsed prior to attempting to open the connection has been exceeded.  This may have occurred because of too many simultaneous non-pooled connection attempts.</value>
+	</data>
+	<data name="ADP_SingleValuedProperty" xml:space="preserve">
+		<value>The only acceptable value for the property '{0}' is '{1}'.</value>
+	</data>
+	<data name="ADP_DoubleValuedProperty" xml:space="preserve">
+		<value>The acceptable values for the property '{0}' are '{1}' or '{2}'.</value>
+	</data>
+	<data name="ADP_InvalidPrefixSuffix" xml:space="preserve">
+		<value>Specified QuotePrefix and QuoteSuffix values do not match.</value>
+	</data>
+	<data name="Arg_ArrayPlusOffTooSmall" xml:space="preserve">
+		<value>Destination array is not long enough to copy all the items in the collection. Check array index and length.</value>
+	</data>
+	<data name="Arg_RankMultiDimNotSupported" xml:space="preserve">
+		<value>Only single dimensional arrays are supported for the requested action.</value>
+	</data>
+	<data name="Arg_RemoveArgNotFound" xml:space="preserve">
+		<value>Cannot remove the specified item because it was not found in the specified Collection.</value>
+	</data>
+	<data name="ArgumentOutOfRange_NeedNonNegNum" xml:space="preserve">
+		<value>Non-negative number required.</value>
+	</data>
+	<data name="Data_InvalidOffsetLength" xml:space="preserve">
+		<value>Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.</value>
+	</data>
+	<data name="SqlConvert_ConvertFailed" xml:space="preserve">
+		<value> Cannot convert object of type '{0}' to object of type '{1}'.</value>
+	</data>
+	<data name="SQL_WrongType" xml:space="preserve">
+		<value>Expecting argument of type {1}, but received type {0}.</value>
+	</data>
+	<data name="ADP_DeriveParametersNotSupported" xml:space="preserve">
+		<value>{0} DeriveParameters only supports CommandType.StoredProcedure, not CommandType.{1}.</value>
+	</data>
+	<data name="ADP_NoStoredProcedureExists" xml:space="preserve">
+		<value>The stored procedure '{0}' doesn't exist.</value>
+	</data>
+	<data name="ADP_InvalidConnectionOptionValue" xml:space="preserve">
+		<value>Invalid value for key '{0}'.</value>
+	</data>
+	<data name="ADP_MissingConnectionOptionValue" xml:space="preserve">
+		<value>Use of key '{0}' requires the key '{1}' to be present.</value>
+	</data>
+	<data name="ADP_InvalidConnectionOptionValueLength" xml:space="preserve">
+		<value>The value's length for key '{0}' exceeds it's limit of '{1}'.</value>
+	</data>
+	<data name="ADP_KeywordNotSupported" xml:space="preserve">
+		<value>Keyword not supported: '{0}'.</value>
+	</data>
+	<data name="ADP_InternalProviderError" xml:space="preserve">
+		<value>Internal .Net Framework Data Provider error {0}.</value>
+	</data>
+	<data name="ADP_InvalidMultipartName" xml:space="preserve">
+		<value>{0} '{1}'.</value>
+	</data>
+	<data name="ADP_InvalidMultipartNameQuoteUsage" xml:space="preserve">
+		<value>{0} '{1}', incorrect usage of quotes.</value>
+	</data>
+	<data name="ADP_InvalidMultipartNameToManyParts" xml:space="preserve">
+		<value>{0} '{1}', the current limit of '{2}' is insufficient.</value>
+	</data>
+	<data name="SQL_SqlCommandCommandText" xml:space="preserve">
+		<value>SqlCommand.DeriveParameters failed because the SqlCommand.CommandText property value is an invalid multipart name</value>
+	</data>
+	<data name="SQL_BatchedUpdatesNotAvailableOnContextConnection" xml:space="preserve">
+		<value>Batching updates is not supported on the context connection.</value>
+	</data>
+	<data name="SQL_BulkCopyDestinationTableName" xml:space="preserve">
+		<value>SqlBulkCopy.WriteToServer failed because the SqlBulkCopy.DestinationTableName is an invalid multipart name</value>
+	</data>
+	<data name="SQL_TDSParserTableName" xml:space="preserve">
+		<value>Processing of results from SQL Server failed because of an invalid multipart name</value>
+	</data>
+	<data name="SQL_TypeName" xml:space="preserve">
+		<value>SqlParameter.TypeName is an invalid multipart name</value>
+	</data>
+	<data name="SQLMSF_FailoverPartnerNotSupported" xml:space="preserve">
+		<value>Connecting to a mirrored SQL Server instance using the MultiSubnetFailover connection option is not supported.</value>
+	</data>
+	<data name="SQL_NotSupportedEnumerationValue" xml:space="preserve">
+		<value>The {0} enumeration value, {1}, is not supported by the .Net Framework SqlClient Data Provider.</value>
+	</data>
+	<data name="ADP_CommandTextRequired" xml:space="preserve">
+		<value>{0}: CommandText property has not been initialized</value>
+	</data>
+	<data name="ADP_ConnectionRequired" xml:space="preserve">
+		<value>{0}: Connection property has not been initialized.</value>
+	</data>
+	<data name="ADP_OpenConnectionRequired" xml:space="preserve">
+		<value>{0} requires an open and available Connection. {1}</value>
+	</data>
+	<data name="ADP_TransactionConnectionMismatch" xml:space="preserve">
+		<value>The transaction is either not associated with the current connection or has been completed.</value>
+	</data>
+	<data name="ADP_TransactionRequired" xml:space="preserve">
+		<value>{0} requires the command to have a transaction when the connection assigned to the command is in a pending local transaction.  The Transaction property of the command has not been initialized.</value>
+	</data>
+	<data name="ADP_OpenReaderExists" xml:space="preserve">
+		<value>There is already an open DataReader associated with this Command which must be closed first.</value>
+	</data>
+	<data name="ADP_CalledTwice" xml:space="preserve">
+		<value>The method '{0}' cannot be called more than once for the same execution.</value>
+	</data>
+	<data name="ADP_InvalidCommandTimeout" xml:space="preserve">
+		<value>Invalid CommandTimeout value {0}; the value must be &gt;= 0.</value>
+	</data>
+	<data name="ADP_UninitializedParameterSize" xml:space="preserve">
+		<value>{1}[{0}]: the Size property has an invalid size of 0.</value>
+	</data>
+	<data name="ADP_PrepareParameterType" xml:space="preserve">
+		<value>{0}.Prepare method requires all parameters to have an explicitly set type.</value>
+	</data>
+	<data name="ADP_PrepareParameterSize" xml:space="preserve">
+		<value>{0}.Prepare method requires all variable length parameters to have an explicitly set non-zero Size.</value>
+	</data>
+	<data name="ADP_PrepareParameterScale" xml:space="preserve">
+		<value>{0}.Prepare method requires parameters of type '{1}' have an explicitly set Precision and Scale.</value>
+	</data>
+	<data name="ADP_MismatchedAsyncResult" xml:space="preserve">
+		<value>Mismatched end method call for asyncResult.  Expected call to {0} but {1} was called instead.</value>
+	</data>
+	<data name="ADP_ClosedConnectionError" xml:space="preserve">
+		<value>Invalid operation. The connection is closed.</value>
+	</data>
+	<data name="ADP_ConnectionIsDisabled" xml:space="preserve">
+		<value>The connection has been disabled.</value>
+	</data>
+	<data name="ADP_EmptyDatabaseName" xml:space="preserve">
+		<value>Database cannot be null, the empty string, or string of only whitespace.</value>
+	</data>
+	<data name="ADP_InvalidSourceBufferIndex" xml:space="preserve">
+		<value>Invalid source buffer (size of {0}) offset: {1}</value>
+	</data>
+	<data name="ADP_InvalidDestinationBufferIndex" xml:space="preserve">
+		<value>Invalid destination buffer (size of {0}) offset: {1}</value>
+	</data>
+	<data name="ADP_StreamClosed" xml:space="preserve">
+		<value>Invalid attempt to {0} when stream is closed.</value>
+	</data>
+	<data name="ADP_InvalidSeekOrigin" xml:space="preserve">
+		<value>Specified SeekOrigin value is invalid.</value>
+	</data>
+	<data name="ADP_NonSequentialColumnAccess" xml:space="preserve">
+		<value>Invalid attempt to read from column ordinal '{0}'.  With CommandBehavior.SequentialAccess, you may only read from column ordinal '{1}' or greater.</value>
+	</data>
+	<data name="ADP_InvalidDataType" xml:space="preserve">
+		<value>The parameter data type of {0} is invalid.</value>
+	</data>
+	<data name="ADP_UnknownDataType" xml:space="preserve">
+		<value>No mapping exists from object type {0} to a known managed provider native type.</value>
+	</data>
+	<data name="ADP_DbTypeNotSupported" xml:space="preserve">
+		<value>No mapping exists from DbType {0} to a known {1}.</value>
+	</data>
+	<data name="ADP_VersionDoesNotSupportDataType" xml:space="preserve">
+		<value>The version of SQL Server in use does not support datatype '{0}'.</value>
+	</data>
+	<data name="ADP_ParameterValueOutOfRange" xml:space="preserve">
+		<value>Parameter value '{0}' is out of range.</value>
+	</data>
+	<data name="ADP_BadParameterName" xml:space="preserve">
+		<value>Specified parameter name '{0}' is not valid.</value>
+	</data>
+	<data name="ADP_InvalidSizeValue" xml:space="preserve">
+		<value>Invalid parameter Size value '{0}'. The value must be greater than or equal to 0.</value>
+	</data>
+	<data name="ADP_NegativeParameter" xml:space="preserve">
+		<value>Invalid value for argument '{0}'. The value must be greater than or equal to 0.</value>
+	</data>
+	<data name="ADP_InvalidMetaDataValue" xml:space="preserve">
+		<value>Invalid value for this metadata.</value>
+	</data>
+	<data name="ADP_ParameterConversionFailed" xml:space="preserve">
+		<value>Failed to convert parameter value from a {0} to a {1}.</value>
+	</data>
+	<data name="ADP_ParallelTransactionsNotSupported" xml:space="preserve">
+		<value>{0} does not support parallel transactions.</value>
+	</data>
+	<data name="ADP_TransactionZombied" xml:space="preserve">
+		<value>This {0} has completed; it is no longer usable.</value>
+	</data>
+	<data name="ADP_InvalidDataLength2" xml:space="preserve">
+		<value>Specified length '{0}' is out of range.</value>
+	</data>
+	<data name="ADP_NonSeqByteAccess" xml:space="preserve">
+		<value>Invalid {2} attempt at dataIndex '{0}'.  With CommandBehavior.SequentialAccess, you may only read from dataIndex '{1}' or greater.</value>
+	</data>
+	<data name="ADP_InvalidMinMaxPoolSizeValues" xml:space="preserve">
+		<value>Invalid min or max pool size values, min pool size cannot be greater than the max pool size.</value>
+	</data>
+	<data name="SQL_InvalidPacketSizeValue" xml:space="preserve">
+		<value>Invalid 'Packet Size'.  The value must be an integer &gt;= 512 and &lt;= 32768.</value>
+	</data>
+	<data name="SQL_NullEmptyTransactionName" xml:space="preserve">
+		<value>Invalid transaction or invalid name for a point at which to save within the transaction.</value>
+	</data>
+	<data name="SQL_UserInstanceFailoverNotCompatible" xml:space="preserve">
+		<value>User Instance and Failover are not compatible options.  Please choose only one of the two in the connection string.</value>
+	</data>
+	<data name="SQL_EncryptionNotSupportedByClient" xml:space="preserve">
+		<value>The instance of SQL Server you attempted to connect to requires encryption but this machine does not support it.</value>
+	</data>
+	<data name="SQL_EncryptionNotSupportedByServer" xml:space="preserve">
+		<value>The instance of SQL Server you attempted to connect to does not support encryption.</value>
+	</data>
+	<data name="SQL_InvalidSQLServerVersionUnknown" xml:space="preserve">
+		<value>Unsupported SQL Server version.  The .Net Framework SqlClient Data Provider can only be used with SQL Server versions 7.0 and later.</value>
+	</data>
+	<data name="SQL_CannotModifyPropertyAsyncOperationInProgress" xml:space="preserve">
+		<value>{0} cannot be changed while async operation is in progress.</value>
+	</data>
+	<data name="SQL_InstanceFailure" xml:space="preserve">
+		<value>Instance failure.</value>
+	</data>
+	<data name="SQL_InvalidPartnerConfiguration" xml:space="preserve">
+		<value>Server {0}, database {1} is not configured for database mirroring.</value>
+	</data>
+	<data name="SQL_MarsUnsupportedOnConnection" xml:space="preserve">
+		<value>The connection does not support MultipleActiveResultSets.</value>
+	</data>
+	<data name="SQL_NonLocalSSEInstance" xml:space="preserve">
+		<value>SSE Instance re-direction is not supported for non-local user instances.</value>
+	</data>
+	<data name="SQL_PendingBeginXXXExists" xml:space="preserve">
+		<value>The command execution cannot proceed due to a pending asynchronous operation already in progress.</value>
+	</data>
+	<data name="SQL_NonXmlResult" xml:space="preserve">
+		<value>Invalid command sent to ExecuteXmlReader.  The command must return an Xml result.</value>
+	</data>
+	<data name="SQL_InvalidParameterTypeNameFormat" xml:space="preserve">
+		<value>Invalid 3 part name format for TypeName.</value>
+	</data>
+	<data name="SQL_InvalidParameterNameLength" xml:space="preserve">
+		<value>The length of the parameter '{0}' exceeds the limit of 128 characters.</value>
+	</data>
+	<data name="SQL_PrecisionValueOutOfRange" xml:space="preserve">
+		<value>Precision value '{0}' is either less than 0 or greater than the maximum allowed precision of 38.</value>
+	</data>
+	<data name="SQL_ScaleValueOutOfRange" xml:space="preserve">
+		<value>Scale value '{0}' is either less than 0 or greater than the maximum allowed scale of 38.</value>
+	</data>
+	<data name="SQL_TimeScaleValueOutOfRange" xml:space="preserve">
+		<value>Scale value '{0}' is either less than 0 or greater than the maximum allowed scale of 7.</value>
+	</data>
+	<data name="SQL_ParameterInvalidVariant" xml:space="preserve">
+		<value>Parameter '{0}' exceeds the size limit for the sql_variant datatype.</value>
+	</data>
+	<data name="SQL_ParameterTypeNameRequired" xml:space="preserve">
+		<value>The {0} type parameter '{1}' must have a valid type name.</value>
+	</data>
+	<data name="SQL_InvalidInternalPacketSize" xml:space="preserve">
+		<value>Invalid internal packet size:</value>
+	</data>
+	<data name="SQL_InvalidTDSVersion" xml:space="preserve">
+		<value>The SQL Server instance returned an invalid or unsupported protocol version during login negotiation.</value>
+	</data>
+	<data name="SQL_InvalidTDSPacketSize" xml:space="preserve">
+		<value>Invalid Packet Size.</value>
+	</data>
+	<data name="SQL_ParsingError" xml:space="preserve">
+		<value>Internal connection fatal error.</value>
+	</data>
+	<data name="SQL_ConnectionLockedForBcpEvent" xml:space="preserve">
+		<value>The connection cannot be used because there is an ongoing operation that must be finished.</value>
+	</data>
+	<data name="SQL_SNIPacketAllocationFailure" xml:space="preserve">
+		<value>Memory allocation for internal connection failed.</value>
+	</data>
+	<data name="SQL_SmallDateTimeOverflow" xml:space="preserve">
+		<value>SqlDbType.SmallDateTime overflow.  Value '{0}' is out of range.  Must be between 1/1/1900 12:00:00 AM and 6/6/2079 11:59:59 PM.</value>
+	</data>
+	<data name="SQL_TimeOverflow" xml:space="preserve">
+		<value>SqlDbType.Time overflow.  Value '{0}' is out of range.  Must be between 00:00:00.0000000 and 23:59:59.9999999.</value>
+	</data>
+	<data name="SQL_MoneyOverflow" xml:space="preserve">
+		<value>SqlDbType.SmallMoney overflow.  Value '{0}' is out of range.  Must be between -214,748.3648 and 214,748.3647.</value>
+	</data>
+	<data name="SQL_CultureIdError" xml:space="preserve">
+		<value>The Collation specified by SQL Server is not supported.</value>
+	</data>
+	<data name="SQL_OperationCancelled" xml:space="preserve">
+		<value>Operation cancelled by user.</value>
+	</data>
+	<data name="SQL_SevereError" xml:space="preserve">
+		<value>A severe error occurred on the current command.  The results, if any, should be discarded.</value>
+	</data>
+	<data name="SQL_SSPIGenerateError" xml:space="preserve">
+		<value>Failed to generate SSPI context.</value>
+	</data>
+	<data name="SQL_KerberosTicketMissingError" xml:space="preserve">
+		<value>Cannot access Kerberos ticket. Ensure Kerberos has been initialized with 'kinit'.</value>
+	</data>
+	<data name="SQL_InvalidSSPIPacketSize" xml:space="preserve">
+		<value>Invalid SSPI packet size.</value>
+	</data>
+	<data name="SQL_SSPIInitializeError" xml:space="preserve">
+		<value>Cannot initialize SSPI package.</value>
+	</data>
+	<data name="SQL_Timeout" xml:space="preserve">
+		<value>Timeout expired.  The timeout period elapsed prior to completion of the operation or the server is not responding.</value>
+	</data>
+	<data name="SQL_Timeout_PreLogin_Begin" xml:space="preserve">
+		<value>Connection Timeout Expired.  The timeout period elapsed at the start of the pre-login phase.  This could be because of insufficient time provided for connection timeout.</value>
+	</data>
+	<data name="SQL_Timeout_PreLogin_InitializeConnection" xml:space="preserve">
+		<value>Connection Timeout Expired.  The timeout period elapsed while attempting to create and initialize a socket to the server.  This could be either because the server was unreachable or unable to respond back in time.</value>
+	</data>
+	<data name="SQL_Timeout_PreLogin_SendHandshake" xml:space="preserve">
+		<value>Connection Timeout Expired.  The timeout period elapsed while making a pre-login handshake request.  This could be because the server was unable to respond back in time.</value>
+	</data>
+	<data name="SQL_Timeout_PreLogin_ConsumeHandshake" xml:space="preserve">
+		<value>Connection Timeout Expired.  The timeout period elapsed while attempting to consume the pre-login handshake acknowledgement.  This could be because the pre-login handshake failed or the server was unable to respond back in time.</value>
+	</data>
+	<data name="SQL_Timeout_Login_Begin" xml:space="preserve">
+		<value>Connection Timeout Expired.  The timeout period elapsed at the start of the login phase.  This could be because of insufficient time provided for connection timeout.</value>
+	</data>
+	<data name="SQL_Timeout_Login_ProcessConnectionAuth" xml:space="preserve">
+		<value>Connection Timeout Expired.  The timeout period elapsed while attempting to authenticate the login.  This could be because the server failed to authenticate the user or the server was unable to respond back in time.</value>
+	</data>
+	<data name="SQL_Timeout_PostLogin" xml:space="preserve">
+		<value>Connection Timeout Expired.  The timeout period elapsed during the post-login phase.  The connection could have timed out while waiting for server to complete the login process and respond; Or it could have timed out while attempting to create multiple active connections.</value>
+	</data>
+	<data name="SQL_Timeout_FailoverInfo" xml:space="preserve">
+		<value>This failure occurred while attempting to connect to the {0} server.</value>
+	</data>
+	<data name="SQL_Timeout_RoutingDestinationInfo" xml:space="preserve">
+		<value>This failure occurred while attempting to connect to the routing destination. The duration spent while attempting to connect to the original server was - [Pre-Login] initialization={0}; handshake={1}; [Login] initialization={2}; authentication={3}; [Post-Login] complete={4};  </value>
+	</data>
+	<data name="SQL_Duration_PreLogin_Begin" xml:space="preserve">
+		<value>The duration spent while attempting to connect to this server was - [Pre-Login] initialization={0};</value>
+	</data>
+	<data name="SQL_Duration_PreLoginHandshake" xml:space="preserve">
+		<value>The duration spent while attempting to connect to this server was - [Pre-Login] initialization={0}; handshake={1}; </value>
+	</data>
+	<data name="SQL_Duration_Login_Begin" xml:space="preserve">
+		<value>The duration spent while attempting to connect to this server was - [Pre-Login] initialization={0}; handshake={1}; [Login] initialization={2}; </value>
+	</data>
+	<data name="SQL_Duration_Login_ProcessConnectionAuth" xml:space="preserve">
+		<value>The duration spent while attempting to connect to this server was - [Pre-Login] initialization={0}; handshake={1}; [Login] initialization={2}; authentication={3}; </value>
+	</data>
+	<data name="SQL_Duration_PostLogin" xml:space="preserve">
+		<value>The duration spent while attempting to connect to this server was - [Pre-Login] initialization={0}; handshake={1}; [Login] initialization={2}; authentication={3}; [Post-Login] complete={4}; </value>
+	</data>
+	<data name="SQL_UserInstanceFailure" xml:space="preserve">
+		<value>A user instance was requested in the connection string but the server specified does not support this option.</value>
+	</data>
+	<data name="SQL_InvalidRead" xml:space="preserve">
+		<value>Invalid attempt to read when no data is present.</value>
+	</data>
+	<data name="SQL_NonBlobColumn" xml:space="preserve">
+		<value>Invalid attempt to GetBytes on column '{0}'.  The GetBytes function can only be used on columns of type Text, NText, or Image.</value>
+	</data>
+	<data name="SQL_NonCharColumn" xml:space="preserve">
+		<value>Invalid attempt to GetChars on column '{0}'.  The GetChars function can only be used on columns of type Text, NText, Xml, VarChar or NVarChar.</value>
+	</data>
+	<data name="SQL_StreamNotSupportOnColumnType" xml:space="preserve">
+		<value>Invalid attempt to GetStream on column '{0}'. The GetStream function can only be used on columns of type Binary, Image, Udt or VarBinary.</value>
+	</data>
+	<data name="SQL_TextReaderNotSupportOnColumnType" xml:space="preserve">
+		<value>Invalid attempt to GetTextReader on column '{0}'. The GetTextReader function can only be used on columns of type Char, NChar, NText, NVarChar, Text or VarChar.</value>
+	</data>
+	<data name="SQL_XmlReaderNotSupportOnColumnType" xml:space="preserve">
+		<value>Invalid attempt to GetXmlReader on column '{0}'. The GetXmlReader function can only be used on columns of type Xml.</value>
+	</data>
+	<data name="SqlDelegatedTransaction_PromotionFailed" xml:space="preserve">
+		<value>Failure while attempting to promote transaction.</value>
+	</data>
+	<data name="SQL_InvalidBufferSizeOrIndex" xml:space="preserve">
+		<value>Buffer offset '{1}' plus the bytes available '{0}' is greater than the length of the passed in buffer.</value>
+	</data>
+	<data name="SQL_InvalidDataLength" xml:space="preserve">
+		<value>Data length '{0}' is less than 0.</value>
+	</data>
+	<data name="SQL_BulkLoadMappingInaccessible" xml:space="preserve">
+		<value>The mapped collection is in use and cannot be accessed at this time;</value>
+	</data>
+	<data name="SQL_BulkLoadMappingsNamesOrOrdinalsOnly" xml:space="preserve">
+		<value>Mappings must be either all name or all ordinal based.</value>
+	</data>
+	<data name="SQL_BulkLoadCannotConvertValue" xml:space="preserve">
+		<value>The given value of type {0} from the data source cannot be converted to type {1} of the specified target column.</value>
+	</data>
+	<data name="SQL_BulkLoadNonMatchingColumnMapping" xml:space="preserve">
+		<value>The given ColumnMapping does not match up with any column in the source or destination.</value>
+	</data>
+	<data name="SQL_BulkLoadNonMatchingColumnName" xml:space="preserve">
+		<value>The given ColumnName '{0}' does not match up with any column in data source.</value>
+	</data>
+	<data name="SQL_BulkLoadStringTooLong" xml:space="preserve">
+		<value>String or binary data would be truncated.</value>
+	</data>
+	<data name="SQL_BulkLoadInvalidTimeout" xml:space="preserve">
+		<value>Timeout Value '{0}' is less than 0.</value>
+	</data>
+	<data name="SQL_BulkLoadInvalidVariantValue" xml:space="preserve">
+		<value>Value cannot be converted to SqlVariant.</value>
+	</data>
+	<data name="SQL_BulkLoadExistingTransaction" xml:space="preserve">
+		<value>Unexpected existing transaction.</value>
+	</data>
+	<data name="SQL_BulkLoadNoCollation" xml:space="preserve">
+		<value>Failed to obtain column collation information for the destination table. If the table is not in the current database the name must be qualified using the database name (e.g. [mydb]..[mytable](e.g. [mydb]..[mytable]); this also applies to temporary-tables (e.g. #mytable would be specified as tempdb..#mytable).</value>
+	</data>
+	<data name="SQL_BulkLoadConflictingTransactionOption" xml:space="preserve">
+		<value>Must not specify SqlBulkCopyOption.UseInternalTransaction and pass an external Transaction at the same time.</value>
+	</data>
+	<data name="SQL_BulkLoadInvalidOperationInsideEvent" xml:space="preserve">
+		<value>Function must not be called during event.</value>
+	</data>
+	<data name="SQL_BulkLoadMissingDestinationTable" xml:space="preserve">
+		<value>The DestinationTableName property must be set before calling this method.</value>
+	</data>
+	<data name="SQL_BulkLoadInvalidDestinationTable" xml:space="preserve">
+		<value>Cannot access destination table '{0}'.</value>
+	</data>
+	<data name="SQL_BulkLoadNotAllowDBNull" xml:space="preserve">
+		<value>Column '{0}' does not allow DBNull.Value.</value>
+	</data>
+	<data name="Sql_BulkLoadLcidMismatch" xml:space="preserve">
+		<value>The locale id '{0}' of the source column '{1}' and the locale id '{2}' of the destination column '{3}' do not match.</value>
+	</data>
+	<data name="SQL_BulkLoadPendingOperation" xml:space="preserve">
+		<value>Attempt to invoke bulk copy on an object that has a pending operation.</value>
+	</data>
+	<data name="SQL_CannotGetDTCAddress" xml:space="preserve">
+		<value>Unable to get the address of the distributed transaction coordinator for the server, from the server.  Is DTC enabled on the server?</value>
+	</data>
+	<data name="SQL_ConnectionDoomed" xml:space="preserve">
+		<value>The requested operation cannot be completed because the connection has been broken.</value>
+	</data>
+	<data name="SQL_OpenResultCountExceeded" xml:space="preserve">
+		<value>Open result count exceeded.</value>
+	</data>
+	<data name="SQL_StreamWriteNotSupported" xml:space="preserve">
+		<value>The Stream does not support writing.</value>
+	</data>
+	<data name="SQL_StreamReadNotSupported" xml:space="preserve">
+		<value>The Stream does not support reading.</value>
+	</data>
+	<data name="SQL_StreamSeekNotSupported" xml:space="preserve">
+		<value>The Stream does not support seeking.</value>
+	</data>
+	<data name="SQL_ExClientConnectionId" xml:space="preserve">
+		<value>ClientConnectionId:{0}</value>
+	</data>
+	<data name="SQL_ExErrorNumberStateClass" xml:space="preserve">
+		<value>Error Number:{0},State:{1},Class:{2}</value>
+	</data>
+	<data name="SQL_ExOriginalClientConnectionId" xml:space="preserve">
+		<value>ClientConnectionId before routing:{0}</value>
+	</data>
+	<data name="SQL_ExRoutingDestination" xml:space="preserve">
+		<value>Routing Destination:{0}</value>
+	</data>
+	<data name="SQL_UnsupportedSysTxVersion" xml:space="preserve">
+		<value>The currently loaded System.Transactions.dll does not support Global Transactions.</value>
+	</data>
+	<data name="SqlMisc_NullString" xml:space="preserve">
+		<value>Null</value>
+	</data>
+	<data name="SqlMisc_MessageString" xml:space="preserve">
+		<value>Message</value>
+	</data>
+	<data name="SqlMisc_ArithOverflowMessage" xml:space="preserve">
+		<value>Arithmetic Overflow.</value>
+	</data>
+	<data name="SqlMisc_DivideByZeroMessage" xml:space="preserve">
+		<value>Divide by zero error encountered.</value>
+	</data>
+	<data name="SqlMisc_NullValueMessage" xml:space="preserve">
+		<value>Data is Null. This method or property cannot be called on Null values.</value>
+	</data>
+	<data name="SqlMisc_TruncationMessage" xml:space="preserve">
+		<value>Numeric arithmetic causes truncation.</value>
+	</data>
+	<data name="SqlMisc_DateTimeOverflowMessage" xml:space="preserve">
+		<value>SqlDateTime overflow. Must be between 1/1/1753 12:00:00 AM and 12/31/9999 11:59:59 PM.</value>
+	</data>
+	<data name="SqlMisc_ConcatDiffCollationMessage" xml:space="preserve">
+		<value>Two strings to be concatenated have different collation.</value>
+	</data>
+	<data name="SqlMisc_CompareDiffCollationMessage" xml:space="preserve">
+		<value>Two strings to be compared have different collation.</value>
+	</data>
+	<data name="SqlMisc_InvalidFlagMessage" xml:space="preserve">
+		<value>Invalid flag value.</value>
+	</data>
+	<data name="SqlMisc_NumeToDecOverflowMessage" xml:space="preserve">
+		<value>Conversion from SqlDecimal to Decimal overflows.</value>
+	</data>
+	<data name="SqlMisc_ConversionOverflowMessage" xml:space="preserve">
+		<value>Conversion overflows.</value>
+	</data>
+	<data name="SqlMisc_InvalidDateTimeMessage" xml:space="preserve">
+		<value>Invalid SqlDateTime.</value>
+	</data>
+	<data name="SqlMisc_TimeZoneSpecifiedMessage" xml:space="preserve">
+		<value>A time zone was specified. SqlDateTime does not support time zones.</value>
+	</data>
+	<data name="SqlMisc_InvalidArraySizeMessage" xml:space="preserve">
+		<value>Invalid array size.</value>
+	</data>
+	<data name="SqlMisc_InvalidPrecScaleMessage" xml:space="preserve">
+		<value>Invalid numeric precision/scale.</value>
+	</data>
+	<data name="SqlMisc_FormatMessage" xml:space="preserve">
+		<value>The input wasn't in a correct format.</value>
+	</data>
+	<data name="SqlMisc_StreamErrorMessage" xml:space="preserve">
+		<value>An error occurred while reading.</value>
+	</data>
+	<data name="SqlMisc_TruncationMaxDataMessage" xml:space="preserve">
+		<value>Data returned is larger than 2Gb in size. Use SequentialAccess command behavior in order to get all of the data.</value>
+	</data>
+	<data name="SqlMisc_NotFilledMessage" xml:space="preserve">
+		<value>SQL Type has not been loaded with data.</value>
+	</data>
+	<data name="SqlMisc_AlreadyFilledMessage" xml:space="preserve">
+		<value>SQL Type has already been loaded with data.</value>
+	</data>
+	<data name="SqlMisc_ClosedXmlReaderMessage" xml:space="preserve">
+		<value>Invalid attempt to access a closed XmlReader.</value>
+	</data>
+	<data name="SqlMisc_InvalidOpStreamClosed" xml:space="preserve">
+		<value>Invalid attempt to call {0} when the stream is closed.</value>
+	</data>
+	<data name="SqlMisc_InvalidOpStreamNonWritable" xml:space="preserve">
+		<value>Invalid attempt to call {0} when the stream non-writable.</value>
+	</data>
+	<data name="SqlMisc_InvalidOpStreamNonReadable" xml:space="preserve">
+		<value>Invalid attempt to call {0} when the stream non-readable.</value>
+	</data>
+	<data name="SqlMisc_InvalidOpStreamNonSeekable" xml:space="preserve">
+		<value>Invalid attempt to call {0} when the stream is non-seekable.</value>
+	</data>
+	<data name="SqlMisc_SubclassMustOverride" xml:space="preserve">
+		<value>Subclass did not override a required method.</value>
+	</data>
+	<data name="Sql_InternalError" xml:space="preserve">
+		<value>Internal Error</value>
+	</data>
+	<data name="ADP_OperationAborted" xml:space="preserve">
+		<value>Operation aborted.</value>
+	</data>
+	<data name="ADP_OperationAbortedExceptionMessage" xml:space="preserve">
+		<value>Operation aborted due to an exception (see InnerException for details).</value>
+	</data>
+	<data name="ADP_TransactionCompletedButNotDisposed" xml:space="preserve">
+		<value>The transaction associated with the current connection has completed but has not been disposed.  The transaction must be disposed before the connection can be used to execute SQL statements.</value>
+	</data>
+	<data name="SqlParameter_UnsupportedTVPOutputParameter" xml:space="preserve">
+		<value>ParameterDirection '{0}' specified for parameter '{1}' is not supported. Table-valued parameters only support ParameterDirection.Input.</value>
+	</data>
+	<data name="SqlParameter_DBNullNotSupportedForTVP" xml:space="preserve">
+		<value>DBNull value for parameter '{0}' is not supported. Table-valued parameters cannot be DBNull.</value>
+	</data>
+	<data name="SqlParameter_UnexpectedTypeNameForNonStruct" xml:space="preserve">
+		<value>TypeName specified for parameter '{0}'.  TypeName must only be set for Structured parameters.</value>
+	</data>
+	<data name="NullSchemaTableDataTypeNotSupported" xml:space="preserve">
+		<value>DateType column for field '{0}' in schema table is null.  DataType must be non-null.</value>
+	</data>
+	<data name="InvalidSchemaTableOrdinals" xml:space="preserve">
+		<value>Invalid column ordinals in schema table.  ColumnOrdinals, if present, must not have duplicates or gaps.</value>
+	</data>
+	<data name="SQL_EnumeratedRecordMetaDataChanged" xml:space="preserve">
+		<value>Metadata for field '{0}' of record '{1}' did not match the original record's metadata.</value>
+	</data>
+	<data name="SQL_EnumeratedRecordFieldCountChanged" xml:space="preserve">
+		<value>Number of fields in record '{0}' does not match the number in the original record.</value>
+	</data>
+	<data name="GT_Disabled" xml:space="preserve">
+		<value>Global Transactions are not enabled for this Azure SQL Database. Please contact Azure SQL Database support for assistance.</value>
+	</data>
+	<data name="SQL_UnknownSysTxIsolationLevel" xml:space="preserve">
+		<value>Unrecognized System.Transactions.IsolationLevel enumeration value: {0}.</value>
+	</data>
+	<data name="SQLNotify_AlreadyHasCommand" xml:space="preserve">
+		<value>This SqlCommand object is already associated with another SqlDependency object.</value>
+	</data>
+	<data name="SqlDependency_DatabaseBrokerDisabled" xml:space="preserve">
+		<value>The SQL Server Service Broker for the current database is not enabled, and as a result query notifications are not supported.  Please enable the Service Broker for this database if you wish to use notifications.</value>
+	</data>
+	<data name="SqlDependency_DefaultOptionsButNoStart" xml:space="preserve">
+		<value>When using SqlDependency without providing an options value, SqlDependency.Start() must be called prior to execution of a command added to the SqlDependency instance.</value>
+	</data>
+	<data name="SqlDependency_NoMatchingServerStart" xml:space="preserve">
+		<value>When using SqlDependency without providing an options value, SqlDependency.Start() must be called for each server that is being executed against.</value>
+	</data>
+	<data name="SqlDependency_NoMatchingServerDatabaseStart" xml:space="preserve">
+		<value>SqlDependency.Start has been called for the server the command is executing against more than once, but there is no matching server/user/database Start() call for current command.</value>
+	</data>
+	<data name="SqlDependency_EventNoDuplicate" xml:space="preserve">
+		<value>SqlDependency.OnChange does not support multiple event registrations for the same delegate.</value>
+	</data>
+	<data name="SqlDependency_IdMismatch" xml:space="preserve">
+		<value>No SqlDependency exists for the key.</value>
+	</data>
+	<data name="SqlDependency_InvalidTimeout" xml:space="preserve">
+		<value>Timeout specified is invalid. Timeout cannot be &lt; 0.</value>
+	</data>
+	<data name="SqlDependency_DuplicateStart" xml:space="preserve">
+		<value>SqlDependency does not support calling Start() with different connection strings having the same server, user, and database in the same app domain.</value>
+	</data>
+	<data name="SqlMetaData_InvalidSqlDbTypeForConstructorFormat" xml:space="preserve">
+		<value>The dbType {0} is invalid for this constructor.</value>
+	</data>
+	<data name="SqlMetaData_NameTooLong" xml:space="preserve">
+		<value>The name is too long.</value>
+	</data>
+	<data name="SqlMetaData_SpecifyBothSortOrderAndOrdinal" xml:space="preserve">
+		<value>The sort order and ordinal must either both be specified, or neither should be specified (SortOrder.Unspecified and -1).  The values given were: order = {0}, ordinal = {1}.</value>
+	</data>
+	<data name="SqlProvider_InvalidDataColumnType" xml:space="preserve">
+		<value>The type of column '{0}' is not supported.  The type is '{1}'</value>
+	</data>
+	<data name="SqlProvider_NotEnoughColumnsInStructuredType" xml:space="preserve">
+		<value>There are not enough fields in the Structured type.  Structured types must have at least one field.</value>
+	</data>
+	<data name="SqlProvider_DuplicateSortOrdinal" xml:space="preserve">
+		<value>The sort ordinal {0} was specified twice.</value>
+	</data>
+	<data name="SqlProvider_MissingSortOrdinal" xml:space="preserve">
+		<value>The sort ordinal {0} was not specified.</value>
+	</data>
+	<data name="SqlProvider_SortOrdinalGreaterThanFieldCount" xml:space="preserve">
+		<value>The sort ordinal {0} on field {1} exceeds the total number of fields.</value>
+	</data>
+	<data name="IEnumerableOfSqlDataRecordHasNoRows" xml:space="preserve">
+		<value>There are no records in the SqlDataRecord enumeration. To send a table-valued parameter with no rows, use a null reference for the value instead.</value>
+	</data>
+	<data name="SNI_ERROR_1" xml:space="preserve">
+		<value>I/O Error detected in read/write operation</value>
+	</data>
+	<data name="SNI_ERROR_2" xml:space="preserve">
+		<value>Connection was terminated</value>
+	</data>
+	<data name="SNI_ERROR_3" xml:space="preserve">
+		<value>Asynchronous operations not supported</value>
+	</data>
+	<data name="SNI_ERROR_5" xml:space="preserve">
+		<value>Invalid parameter(s) found</value>
+	</data>
+	<data name="SNI_ERROR_6" xml:space="preserve">
+		<value>Unsupported protocol specified</value>
+	</data>
+	<data name="SNI_ERROR_7" xml:space="preserve">
+		<value>Invalid connection found when setting up new session protocol</value>
+	</data>
+	<data name="SNI_ERROR_8" xml:space="preserve">
+		<value>Protocol not supported</value>
+	</data>
+	<data name="SNI_ERROR_9" xml:space="preserve">
+		<value>Associating port with I/O completion mechanism failed</value>
+	</data>
+	<data name="SNI_ERROR_11" xml:space="preserve">
+		<value>Timeout error</value>
+	</data>
+	<data name="SNI_ERROR_12" xml:space="preserve">
+		<value>No server name supplied</value>
+	</data>
+	<data name="SNI_ERROR_13" xml:space="preserve">
+		<value>TerminateListener() has been called</value>
+	</data>
+	<data name="SNI_ERROR_14" xml:space="preserve">
+		<value>Win9x not supported</value>
+	</data>
+	<data name="SNI_ERROR_15" xml:space="preserve">
+		<value>Function not supported</value>
+	</data>
+	<data name="SNI_ERROR_16" xml:space="preserve">
+		<value>Shared-Memory heap error</value>
+	</data>
+	<data name="SNI_ERROR_17" xml:space="preserve">
+		<value>Cannot find an ip/ipv6 type address to connect</value>
+	</data>
+	<data name="SNI_ERROR_18" xml:space="preserve">
+		<value>Connection has been closed by peer</value>
+	</data>
+	<data name="SNI_ERROR_19" xml:space="preserve">
+		<value>Physical connection is not usable</value>
+	</data>
+	<data name="SNI_ERROR_20" xml:space="preserve">
+		<value>Connection has been closed</value>
+	</data>
+	<data name="SNI_ERROR_21" xml:space="preserve">
+		<value>Encryption is enforced but there is no valid certificate</value>
+	</data>
+	<data name="SNI_ERROR_22" xml:space="preserve">
+		<value>Couldn't load library</value>
+	</data>
+	<data name="SNI_ERROR_23" xml:space="preserve">
+		<value>Cannot open a new thread in server process</value>
+	</data>
+	<data name="SNI_ERROR_24" xml:space="preserve">
+		<value>Cannot post event to completion port</value>
+	</data>
+	<data name="SNI_ERROR_25" xml:space="preserve">
+		<value>Connection string is not valid</value>
+	</data>
+	<data name="SNI_ERROR_26" xml:space="preserve">
+		<value>Error Locating Server/Instance Specified</value>
+	</data>
+	<data name="SNI_ERROR_27" xml:space="preserve">
+		<value>Error getting enabled protocols list from registry</value>
+	</data>
+	<data name="SNI_ERROR_28" xml:space="preserve">
+		<value>Server doesn't support requested protocol</value>
+	</data>
+	<data name="SNI_ERROR_29" xml:space="preserve">
+		<value>Shared Memory is not supported for clustered server connectivity</value>
+	</data>
+	<data name="SNI_ERROR_30" xml:space="preserve">
+		<value>Invalid attempt bind to shared memory segment</value>
+	</data>
+	<data name="SNI_ERROR_31" xml:space="preserve">
+		<value>Encryption(ssl/tls) handshake failed</value>
+	</data>
+	<data name="SNI_ERROR_32" xml:space="preserve">
+		<value>Packet size too large for SSL Encrypt/Decrypt operations</value>
+	</data>
+	<data name="SNI_ERROR_33" xml:space="preserve">
+		<value>SSRP error</value>
+	</data>
+	<data name="SNI_ERROR_34" xml:space="preserve">
+		<value>Could not connect to the Shared Memory pipe</value>
+	</data>
+	<data name="SNI_ERROR_35" xml:space="preserve">
+		<value>An internal exception was caught</value>
+	</data>
+	<data name="SNI_ERROR_36" xml:space="preserve">
+		<value>The Shared Memory dll used to connect to SQL Server 2000 was not found</value>
+	</data>
+	<data name="SNI_ERROR_37" xml:space="preserve">
+		<value>The SQL Server 2000 Shared Memory client dll appears to be invalid/corrupted</value>
+	</data>
+	<data name="SNI_ERROR_38" xml:space="preserve">
+		<value>Cannot open a Shared Memory connection to SQL Server 2000</value>
+	</data>
+	<data name="SNI_ERROR_39" xml:space="preserve">
+		<value>Shared memory connectivity to SQL Server 2000 is either disabled or not available on this machine</value>
+	</data>
+	<data name="SNI_ERROR_40" xml:space="preserve">
+		<value>Could not open a connection to SQL Server</value>
+	</data>
+	<data name="SNI_ERROR_41" xml:space="preserve">
+		<value>Cannot open a Shared Memory connection to a remote SQL server</value>
+	</data>
+	<data name="SNI_ERROR_42" xml:space="preserve">
+		<value>Could not establish dedicated administrator connection (DAC) on default port. Make sure that DAC is enabled</value>
+	</data>
+	<data name="SNI_ERROR_43" xml:space="preserve">
+		<value>An error occurred while obtaining the dedicated administrator connection (DAC) port. Make sure that SQL Browser is running, or check the error log for the port number</value>
+	</data>
+	<data name="SNI_ERROR_44" xml:space="preserve">
+		<value>Could not compose Service Principal Name (SPN) for Windows Integrated Authentication. Possible causes are server(s) incorrectly specified to connection API calls, Domain Name System (DNS) lookup failure or memory shortage</value>
+	</data>
+	<data name="SNI_ERROR_47" xml:space="preserve">
+		<value>Connecting with the MultiSubnetFailover connection option to a SQL Server instance configured with more than 64 IP addresses is not supported.</value>
+	</data>
+	<data name="SNI_ERROR_48" xml:space="preserve">
+		<value>Connecting to a named SQL Server instance using the MultiSubnetFailover connection option is not supported.</value>
+	</data>
+	<data name="SNI_ERROR_49" xml:space="preserve">
+		<value>Connecting to a SQL Server instance using the MultiSubnetFailover connection option is only supported when using the TCP protocol.</value>
+	</data>
+	<data name="SNI_ERROR_50" xml:space="preserve">
+		<value>Local Database Runtime error occurred. </value>
+	</data>
+	<data name="SNI_ERROR_51" xml:space="preserve">
+		<value>An instance name was not specified while connecting to a Local Database Runtime. Specify an instance name in the format (localdb)\instance_name.</value>
+	</data>
+	<data name="SNI_ERROR_52" xml:space="preserve">
+		<value>Unable to locate a Local Database Runtime installation. Verify that SQL Server Express is properly installed and that the Local Database Runtime feature is enabled.</value>
+	</data>
+	<data name="SNI_ERROR_53" xml:space="preserve">
+		<value>Invalid Local Database Runtime registry configuration found. Verify that SQL Server Express is properly installed.</value>
+	</data>
+	<data name="SNI_ERROR_54" xml:space="preserve">
+		<value>Unable to locate the registry entry for SQLUserInstance.dll file path. Verify that the Local Database Runtime feature of SQL Server Express is properly installed.</value>
+	</data>
+	<data name="SNI_ERROR_55" xml:space="preserve">
+		<value>Registry value contains an invalid SQLUserInstance.dll file path. Verify that the Local Database Runtime feature of SQL Server Express is properly installed.</value>
+	</data>
+	<data name="SNI_ERROR_56" xml:space="preserve">
+		<value>Unable to load the SQLUserInstance.dll from the location specified in the registry. Verify that the Local Database Runtime feature of SQL Server Express is properly installed.</value>
+	</data>
+	<data name="SNI_ERROR_57" xml:space="preserve">
+		<value>Invalid SQLUserInstance.dll found at the location specified in the registry. Verify that the Local Database Runtime feature of SQL Server Express is properly installed.</value>
+	</data>
+	<data name="Snix_Connect" xml:space="preserve">
+		<value>A network-related or instance-specific error occurred while establishing a connection to SQL Server. The server was not found or was not accessible. Verify that the instance name is correct and that SQL Server is configured to allow remote connections.</value>
+	</data>
+	<data name="Snix_PreLoginBeforeSuccessfullWrite" xml:space="preserve">
+		<value>The client was unable to establish a connection because of an error during connection initialization process before login. Possible causes include the following:  the client tried to connect to an unsupported version of SQL Server; the server was too busy to accept new connections; or there was a resource limitation (insufficient memory or maximum allowed connections) on the server.</value>
+	</data>
+	<data name="Snix_PreLogin" xml:space="preserve">
+		<value>A connection was successfully established with the server, but then an error occurred during the pre-login handshake.</value>
+	</data>
+	<data name="Snix_LoginSspi" xml:space="preserve">
+		<value>A connection was successfully established with the server, but then an error occurred when obtaining the security/SSPI context information for integrated security login.</value>
+	</data>
+	<data name="Snix_Login" xml:space="preserve">
+		<value>A connection was successfully established with the server, but then an error occurred during the login process.</value>
+	</data>
+	<data name="Snix_EnableMars" xml:space="preserve">
+		<value>Connection open and login was successful, but then an error occurred while enabling MARS for this connection.</value>
+	</data>
+	<data name="Snix_AutoEnlist" xml:space="preserve">
+		<value>Connection open and login was successful, but then an error occurred while enlisting the connection into the current distributed transaction.</value>
+	</data>
+	<data name="Snix_GetMarsSession" xml:space="preserve">
+		<value>Failed to establish a MARS session in preparation to send the request to the server.</value>
+	</data>
+	<data name="Snix_Execute" xml:space="preserve">
+		<value>A transport-level error has occurred when sending the request to the server.</value>
+	</data>
+	<data name="Snix_Read" xml:space="preserve">
+		<value>A transport-level error has occurred when receiving results from the server.</value>
+	</data>
+	<data name="Snix_Close" xml:space="preserve">
+		<value>A transport-level error has occurred during connection clean-up.</value>
+	</data>
+	<data name="Snix_SendRows" xml:space="preserve">
+		<value>A transport-level error has occurred while sending information to the server.</value>
+	</data>
+	<data name="Snix_ProcessSspi" xml:space="preserve">
+		<value>A transport-level error has occurred during SSPI handshake.</value>
+	</data>
+	<data name="LocalDB_FailedGetDLLHandle" xml:space="preserve">
+		<value>Local Database Runtime: Cannot load SQLUserInstance.dll.</value>
+	</data>
+	<data name="LocalDB_MethodNotFound" xml:space="preserve">
+		<value>Invalid SQLUserInstance.dll found at the location specified in the registry. Verify that the Local Database Runtime feature of SQL Server Express is properly installed.</value>
+	</data>
+	<data name="LocalDB_UnobtainableMessage" xml:space="preserve">
+		<value>Cannot obtain Local Database Runtime error message</value>
+	</data>
+	<data name="SQLROR_RecursiveRoutingNotSupported" xml:space="preserve">
+		<value>Two or more redirections have occurred. Only one redirection per login is allowed.</value>
+	</data>
+	<data name="SQLROR_FailoverNotSupported" xml:space="preserve">
+		<value>Connecting to a mirrored SQL Server instance using the ApplicationIntent ReadOnly connection option is not supported.</value>
+	</data>
+	<data name="SQLROR_UnexpectedRoutingInfo" xml:space="preserve">
+		<value>Unexpected routing information received.</value>
+	</data>
+	<data name="SQLROR_InvalidRoutingInfo" xml:space="preserve">
+		<value>Invalid routing information received.</value>
+	</data>
+	<data name="SQLROR_TimeoutAfterRoutingInfo" xml:space="preserve">
+		<value>Server provided routing information, but timeout already expired.</value>
+	</data>
+	<data name="SQLCR_InvalidConnectRetryCountValue" xml:space="preserve">
+		<value>Invalid ConnectRetryCount value (should be 0-255).</value>
+	</data>
+	<data name="SQLCR_InvalidConnectRetryIntervalValue" xml:space="preserve">
+		<value>Invalid ConnectRetryInterval value (should be 1-60).</value>
+	</data>
+	<data name="SQLCR_NextAttemptWillExceedQueryTimeout" xml:space="preserve">
+		<value>Next reconnection attempt will exceed query timeout. Reconnection was terminated.</value>
+	</data>
+	<data name="SQLCR_EncryptionChanged" xml:space="preserve">
+		<value>The server did not preserve SSL encryption during a recovery attempt, connection recovery is not possible.</value>
+	</data>
+	<data name="SQLCR_TDSVestionNotPreserved" xml:space="preserve">
+		<value>The server did not preserve the exact client TDS version requested during a recovery attempt, connection recovery is not possible.</value>
+	</data>
+	<data name="SQLCR_AllAttemptsFailed" xml:space="preserve">
+		<value>The connection is broken and recovery is not possible.  The client driver attempted to recover the connection one or more times and all attempts failed.  Increase the value of ConnectRetryCount to increase the number of recovery attempts.</value>
+	</data>
+	<data name="SQLCR_UnrecoverableServer" xml:space="preserve">
+		<value>The connection is broken and recovery is not possible.  The connection is marked by the server as unrecoverable.  No attempt was made to restore the connection.</value>
+	</data>
+	<data name="SQLCR_UnrecoverableClient" xml:space="preserve">
+		<value>The connection is broken and recovery is not possible.  The connection is marked by the client driver as unrecoverable.  No attempt was made to restore the connection.</value>
+	</data>
+	<data name="SQLCR_NoCRAckAtReconnection" xml:space="preserve">
+		<value>The server did not acknowledge a recovery attempt, connection recovery is not possible.</value>
+	</data>
+	<data name="SQL_UnsupportedKeyword" xml:space="preserve">
+		<value>The keyword '{0}' is not supported on this platform.</value>
+	</data>
+	<data name="SQL_UnsupportedFeature" xml:space="preserve">
+		<value>The server is attempting to use a feature that is not supported on this platform.</value>
+	</data>
+	<data name="SQL_UnsupportedToken" xml:space="preserve">
+		<value>Received an unsupported token '{0}' while reading data from the server.</value>
+	</data>
+	<data name="SQL_DbTypeNotSupportedOnThisPlatform" xml:space="preserve">
+		<value>Type {0} is not supported on this platform.</value>
+	</data>
+	<data name="SQL_NetworkLibraryNotSupported" xml:space="preserve">
+		<value>The keyword 'Network Library' is not supported on this platform, prefix the 'Data Source' with the protocol desired instead ('tcp:' for a TCP connection, or 'np:' for a Named Pipe connection).</value>
+	</data>
+	<data name="SNI_PN0" xml:space="preserve">
+		<value>HTTP Provider</value>
+	</data>
+	<data name="SNI_PN1" xml:space="preserve">
+		<value>Named Pipes Provider</value>
+	</data>
+	<data name="SNI_PN2" xml:space="preserve">
+		<value>Session Provider</value>
+	</data>
+	<data name="SNI_PN3" xml:space="preserve">
+		<value>Sign Provider</value>
+	</data>
+	<data name="SNI_PN4" xml:space="preserve">
+		<value>Shared Memory Provider</value>
+	</data>
+	<data name="SNI_PN5" xml:space="preserve">
+		<value>SMux Provider</value>
+	</data>
+	<data name="SNI_PN6" xml:space="preserve">
+		<value>SSL Provider</value>
+	</data>
+	<data name="SNI_PN7" xml:space="preserve">
+		<value>TCP Provider</value>
+	</data>
+	<data name="SNI_PN8" xml:space="preserve">
+		<value></value>
+	</data>
+	<data name="SNI_PN9" xml:space="preserve">
+		<value>SQL Network Interfaces</value>
+	</data>
+	<data name="AZURESQL_GenericEndpoint" xml:space="preserve">
+		<value>.database.windows.net</value>
+	</data>
+	<data name="AZURESQL_GermanEndpoint" xml:space="preserve">
+		<value>.database.cloudapi.de</value>
+	</data>
+	<data name="AZURESQL_UsGovEndpoint" xml:space="preserve">
+		<value>.database.usgovcloudapi.net</value>
+	</data>
+	<data name="AZURESQL_ChinaEndpoint" xml:space="preserve">
+		<value>.database.chinacloudapi.cn</value>
+	</data>
+	<data name="net_nego_channel_binding_not_supported" xml:space="preserve">
+		<value>No support for channel binding on operating systems other than Windows.</value>
+	</data>
+	<data name="net_gssapi_operation_failed_detailed" xml:space="preserve">
+		<value>GSSAPI operation failed with error - {0} ({1}).</value>
+	</data>
+	<data name="net_gssapi_operation_failed" xml:space="preserve">
+		<value>GSSAPI operation failed with status: {0} (Minor status: {1}).</value>
+	</data>
+	<data name="net_ntlm_not_possible_default_cred" xml:space="preserve">
+		<value>NTLM authentication is not possible with default credentials on this platform.</value>
+	</data>
+	<data name="net_nego_not_supported_empty_target_with_defaultcreds" xml:space="preserve">
+		<value>Target name should be non-empty if default credentials are passed.</value>
+	</data>
+	<data name="net_nego_server_not_supported" xml:space="preserve">
+		<value>Server implementation is not supported.</value>
+	</data>
+	<data name="net_nego_protection_level_not_supported" xml:space="preserve">
+		<value>Requested protection level is not supported with the GSSAPI implementation currently installed.</value>
+	</data>
+	<data name="net_context_buffer_too_small" xml:space="preserve">
+		<value>Insufficient buffer space. Required: {0} Actual: {1}.</value>
+	</data>
+	<data name="net_auth_message_not_encrypted" xml:space="preserve">
+		<value>Protocol error: A received message contains a valid signature but it was not encrypted as required by the effective Protection Level.</value>
+	</data>
+	<data name="net_securitypackagesupport" xml:space="preserve">
+		<value>The requested security package is not supported.</value>
+	</data>
+	<data name="net_log_operation_failed_with_error" xml:space="preserve">
+		<value>{0} failed with error {1}.</value>
+	</data>
+	<data name="net_MethodNotImplementedException" xml:space="preserve">
+		<value>This method is not implemented by this class.</value>
+	</data>
+	<data name="event_OperationReturnedSomething" xml:space="preserve">
+		<value>{0} returned {1}.</value>
+	</data>
+	<data name="net_invalid_enum" xml:space="preserve">
+		<value>The specified value is not valid in the '{0}' enumeration.</value>
+	</data>
+	<data name="SSPIInvalidHandleType" xml:space="preserve">
+		<value>'{0}' is not a supported handle type.</value>
+	</data>
+	<data name="LocalDBNotSupported" xml:space="preserve">
+		<value>LocalDB is not supported on this Platform.</value>
+	</data>
+	<data name="PlatformNotSupported_DataSqlClient" xml:space="preserve">
+		<value>System.Data.SqlClient is not supported on this platform.</value>
+	</data>
+	<data name="SqlParameter_InvalidTableDerivedPrecisionForTvp" xml:space="preserve">
+		<value>Precision '{0}' required to send all values in column '{1}' exceeds the maximum supported precision '{2}'. The values must all fit in a single precision.</value>
+	</data>
+	<data name="SqlProvider_InvalidDataColumnMaxLength" xml:space="preserve">
+		<value>The size of column '{0}' is not supported. The size is {1}.</value>
+	</data>
+	<data name="MDF_InvalidXmlInvalidValue" xml:space="preserve"> 
+		<value>The metadata XML is invalid. The {1} column of the {0} collection must contain a non-empty string.</value>
+	</data>
+	<data name="MDF_CollectionNameISNotUnique" xml:space="preserve"> 
+		<value>There are multiple collections named '{0}'.</value>
+	</data>
+	<data name="MDF_InvalidXmlMissingColumn" xml:space="preserve"> 
+		<value>The metadata XML is invalid. The {0} collection must contain a {1} column and it must be a string column.</value>
+	</data>
+	<data name="MDF_InvalidXml" xml:space="preserve"> 
+		<value>The metadata XML is invalid.</value>
+	</data>
+	<data name="MDF_NoColumns" xml:space="preserve"> 
+		<value>The schema table contains no columns.</value>
+	</data>
+	<data name="MDF_QueryFailed" xml:space="preserve"> 
+		<value>Unable to build the '{0}' collection because execution of the SQL query failed. See the inner exception for details.</value>
+	</data>
+	<data name="MDF_TooManyRestrictions" xml:space="preserve"> 
+		<value>More restrictions were provided than the requested schema ('{0}') supports.</value>
+	</data>
+	<data name="MDF_DataTableDoesNotExist" xml:space="preserve"> 
+		<value>The collection '{0}' is missing from the metadata XML.</value>
+	</data>
+	<data name="MDF_UndefinedCollection" xml:space="preserve"> 
+		<value>The requested collection ({0}) is not defined.</value> 
+	</data>
+	<data name="MDF_UnsupportedVersion" xml:space="preserve">
+		<value> requested collection ({0}) is not supported by this version of the provider.</value>
+	</data>
+	<data name="MDF_MissingRestrictionColumn" xml:space="preserve">
+		<value>One or more of the required columns of the restrictions collection is missing.</value>
+	</data>
+	<data name="MDF_MissingRestrictionRow" xml:space="preserve">
+		<value>A restriction exists for which there is no matching row in the restrictions collection.</value>
+	</data>
+	<data name="MDF_IncorrectNumberOfDataSourceInformationRows" xml:space="preserve">
+		<value>The DataSourceInformation table must contain exactly one row.</value>
+	</data>
+	<data name="MDF_MissingDataSourceInformationColumn" xml:space="preserve">
+		<value>One of the required DataSourceInformation tables columns is missing.</value>
+	</data>
+	<data name="MDF_AmbigousCollectionName" xml:space="preserve">
+		<value>The collection name '{0}' matches at least two collections with the same name but with different case, but does not match any of them exactly.</value>
+	</data>
+	<data name="MDF_UnableToBuildCollection" xml:space="preserve">
+		<value>Unable to build schema collection '{0}';</value>
+	</data>
+	<data name="AmbientTransactionsNotSupported" xml:space="preserve">
+		<value>Enlisting in Ambient transactions is not supported.</value>
+	</data>
 </root>

--- a/src/System.Data.SqlClient/src/Resources/Strings.resx
+++ b/src/System.Data.SqlClient/src/Resources/Strings.resx
@@ -115,6 +115,12 @@
 	<data name="ADP_InvalidOffsetValue" xml:space="preserve">
 		<value>Invalid parameter Offset value '{0}'. The value must be greater than or equal to 0.</value>
 	</data>
+	<data name="ADP_TransactionPresent" xml:space="preserve">
+		<value>Connection currently has transaction enlisted.  Finish current transaction and retry.</value>
+	</data>
+	<data name="ADP_LocalTransactionPresent" xml:space="preserve">
+		<value>Cannot enlist in the transaction because a local transaction is in progress on the connection.  Finish local transaction and retry.</value>
+	</data>
 	<data name="ADP_NoConnectionString" xml:space="preserve">
 		<value>The ConnectionString property has not been initialized.</value>
 	</data>

--- a/src/System.Data.SqlClient/src/Resources/Strings.resx
+++ b/src/System.Data.SqlClient/src/Resources/Strings.resx
@@ -1,1183 +1,1183 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-	<xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-		<xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
-		<xsd:element name="root" msdata:IsDataSet="true">
-			<xsd:complexType>
-				<xsd:choice maxOccurs="unbounded">
-					<xsd:element name="metadata">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" />
-							</xsd:sequence>
-							<xsd:attribute name="name" use="required" type="xsd:string" />
-							<xsd:attribute name="type" type="xsd:string" />
-							<xsd:attribute name="mimetype" type="xsd:string" />
-							<xsd:attribute ref="xml:space" />
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="assembly">
-						<xsd:complexType>
-							<xsd:attribute name="alias" type="xsd:string" />
-							<xsd:attribute name="name" type="xsd:string" />
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="data">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-								<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
-							<xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-							<xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-							<xsd:attribute ref="xml:space" />
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="resheader">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" use="required" />
-						</xsd:complexType>
-					</xsd:element>
-				</xsd:choice>
-			</xsd:complexType>
-		</xsd:element>
-	</xsd:schema>
-	<resheader name="resmimetype">
-		<value>text/microsoft-resx</value>
-	</resheader>
-	<resheader name="version">
-		<value>2.0</value>
-	</resheader>
-	<resheader name="reader">
-		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
-	<resheader name="writer">
-		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
-	<data name="ADP_CollectionIndexInt32" xml:space="preserve">
-		<value>Invalid index {0} for this {1} with Count={2}.</value>
-	</data>
-	<data name="ADP_CollectionIndexString" xml:space="preserve">
-		<value>An {0} with {1} '{2}' is not contained by this {3}.</value>
-	</data>
-	<data name="ADP_CollectionInvalidType" xml:space="preserve">
-		<value>The {0} only accepts non-null {1} type objects, not {2} objects.</value>
-	</data>
-	<data name="ADP_CollectionIsNotParent" xml:space="preserve">
-		<value>The {0} is already contained by another {1}.</value>
-	</data>
-	<data name="ADP_CollectionNullValue" xml:space="preserve">
-		<value>The {0} only accepts non-null {1} type objects.</value>
-	</data>
-	<data name="ADP_CollectionRemoveInvalidObject" xml:space="preserve">
-		<value>Attempted to remove an {0} that is not contained by this {1}.</value>
-	</data>
-	<data name="ADP_ConnectionAlreadyOpen" xml:space="preserve">
-		<value>The connection was not closed. {0}</value>
-	</data>
-	<data name="ADP_ConnectionStateMsg_Closed" xml:space="preserve">
-		<value>The connection's current state is closed.</value>
-	</data>
-	<data name="ADP_ConnectionStateMsg_Connecting" xml:space="preserve">
-		<value>The connection's current state is connecting.</value>
-	</data>
-	<data name="ADP_ConnectionStateMsg_Open" xml:space="preserve">
-		<value>The connection's current state is open.</value>
-	</data>
-	<data name="ADP_ConnectionStateMsg_OpenExecuting" xml:space="preserve">
-		<value>The connection's current state is executing.</value>
-	</data>
-	<data name="ADP_ConnectionStateMsg_OpenFetching" xml:space="preserve">
-		<value>The connection's current state is fetching.</value>
-	</data>
-	<data name="ADP_ConnectionStateMsg" xml:space="preserve">
-		<value>The connection's current state: {0}.</value>
-	</data>
-	<data name="ADP_ConnectionStringSyntax" xml:space="preserve">
-		<value>Format of the initialization string does not conform to specification starting at index {0}.</value>
-	</data>
-	<data name="ADP_DataReaderClosed" xml:space="preserve">
-		<value>Invalid attempt to call {0} when reader is closed.</value>
-	</data>
-	<data name="ADP_InternalConnectionError" xml:space="preserve">
-		<value>Internal DbConnection Error: {0}</value>
-	</data>
-	<data name="ADP_InvalidEnumerationValue" xml:space="preserve">
-		<value>The {0} enumeration value, {1}, is invalid.</value>
-	</data>
-	<data name="ADP_NotSupportedEnumerationValue" xml:space="preserve">
-		<value>The {0} enumeration value, {1}, is not supported by the {2} method.</value>
-	</data>
-	<data name="ADP_InvalidOffsetValue" xml:space="preserve">
-		<value>Invalid parameter Offset value '{0}'. The value must be greater than or equal to 0.</value>
-	</data>
-	<data name="ADP_TransactionPresent" xml:space="preserve">
-		<value>Connection currently has transaction enlisted.  Finish current transaction and retry.</value>
-	</data>
-	<data name="ADP_LocalTransactionPresent" xml:space="preserve">
-		<value>Cannot enlist in the transaction because a local transaction is in progress on the connection.  Finish local transaction and retry.</value>
-	</data>
-	<data name="ADP_NoConnectionString" xml:space="preserve">
-		<value>The ConnectionString property has not been initialized.</value>
-	</data>
-	<data name="ADP_OpenConnectionPropertySet" xml:space="preserve">
-		<value>Not allowed to change the '{0}' property. {1}</value>
-	</data>
-	<data name="ADP_PendingAsyncOperation" xml:space="preserve">
-		<value>Can not start another operation while there is an asynchronous operation pending.</value>
-	</data>
-	<data name="ADP_PooledOpenTimeout" xml:space="preserve">
-		<value>Timeout expired.  The timeout period elapsed prior to obtaining a connection from the pool.  This may have occurred because all pooled connections were in use and max pool size was reached.</value>
-	</data>
-	<data name="ADP_NonPooledOpenTimeout" xml:space="preserve">
-		<value>Timeout attempting to open the connection.  The time period elapsed prior to attempting to open the connection has been exceeded.  This may have occurred because of too many simultaneous non-pooled connection attempts.</value>
-	</data>
-	<data name="ADP_SingleValuedProperty" xml:space="preserve">
-		<value>The only acceptable value for the property '{0}' is '{1}'.</value>
-	</data>
-	<data name="ADP_DoubleValuedProperty" xml:space="preserve">
-		<value>The acceptable values for the property '{0}' are '{1}' or '{2}'.</value>
-	</data>
-	<data name="ADP_InvalidPrefixSuffix" xml:space="preserve">
-		<value>Specified QuotePrefix and QuoteSuffix values do not match.</value>
-	</data>
-	<data name="Arg_ArrayPlusOffTooSmall" xml:space="preserve">
-		<value>Destination array is not long enough to copy all the items in the collection. Check array index and length.</value>
-	</data>
-	<data name="Arg_RankMultiDimNotSupported" xml:space="preserve">
-		<value>Only single dimensional arrays are supported for the requested action.</value>
-	</data>
-	<data name="Arg_RemoveArgNotFound" xml:space="preserve">
-		<value>Cannot remove the specified item because it was not found in the specified Collection.</value>
-	</data>
-	<data name="ArgumentOutOfRange_NeedNonNegNum" xml:space="preserve">
-		<value>Non-negative number required.</value>
-	</data>
-	<data name="Data_InvalidOffsetLength" xml:space="preserve">
-		<value>Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.</value>
-	</data>
-	<data name="SqlConvert_ConvertFailed" xml:space="preserve">
-		<value> Cannot convert object of type '{0}' to object of type '{1}'.</value>
-	</data>
-	<data name="SQL_WrongType" xml:space="preserve">
-		<value>Expecting argument of type {1}, but received type {0}.</value>
-	</data>
-	<data name="ADP_DeriveParametersNotSupported" xml:space="preserve">
-		<value>{0} DeriveParameters only supports CommandType.StoredProcedure, not CommandType.{1}.</value>
-	</data>
-	<data name="ADP_NoStoredProcedureExists" xml:space="preserve">
-		<value>The stored procedure '{0}' doesn't exist.</value>
-	</data>
-	<data name="ADP_InvalidConnectionOptionValue" xml:space="preserve">
-		<value>Invalid value for key '{0}'.</value>
-	</data>
-	<data name="ADP_MissingConnectionOptionValue" xml:space="preserve">
-		<value>Use of key '{0}' requires the key '{1}' to be present.</value>
-	</data>
-	<data name="ADP_InvalidConnectionOptionValueLength" xml:space="preserve">
-		<value>The value's length for key '{0}' exceeds it's limit of '{1}'.</value>
-	</data>
-	<data name="ADP_KeywordNotSupported" xml:space="preserve">
-		<value>Keyword not supported: '{0}'.</value>
-	</data>
-	<data name="ADP_InternalProviderError" xml:space="preserve">
-		<value>Internal .Net Framework Data Provider error {0}.</value>
-	</data>
-	<data name="ADP_InvalidMultipartName" xml:space="preserve">
-		<value>{0} '{1}'.</value>
-	</data>
-	<data name="ADP_InvalidMultipartNameQuoteUsage" xml:space="preserve">
-		<value>{0} '{1}', incorrect usage of quotes.</value>
-	</data>
-	<data name="ADP_InvalidMultipartNameToManyParts" xml:space="preserve">
-		<value>{0} '{1}', the current limit of '{2}' is insufficient.</value>
-	</data>
-	<data name="SQL_SqlCommandCommandText" xml:space="preserve">
-		<value>SqlCommand.DeriveParameters failed because the SqlCommand.CommandText property value is an invalid multipart name</value>
-	</data>
-	<data name="SQL_BatchedUpdatesNotAvailableOnContextConnection" xml:space="preserve">
-		<value>Batching updates is not supported on the context connection.</value>
-	</data>
-	<data name="SQL_BulkCopyDestinationTableName" xml:space="preserve">
-		<value>SqlBulkCopy.WriteToServer failed because the SqlBulkCopy.DestinationTableName is an invalid multipart name</value>
-	</data>
-	<data name="SQL_TDSParserTableName" xml:space="preserve">
-		<value>Processing of results from SQL Server failed because of an invalid multipart name</value>
-	</data>
-	<data name="SQL_TypeName" xml:space="preserve">
-		<value>SqlParameter.TypeName is an invalid multipart name</value>
-	</data>
-	<data name="SQLMSF_FailoverPartnerNotSupported" xml:space="preserve">
-		<value>Connecting to a mirrored SQL Server instance using the MultiSubnetFailover connection option is not supported.</value>
-	</data>
-	<data name="SQL_NotSupportedEnumerationValue" xml:space="preserve">
-		<value>The {0} enumeration value, {1}, is not supported by the .Net Framework SqlClient Data Provider.</value>
-	</data>
-	<data name="ADP_CommandTextRequired" xml:space="preserve">
-		<value>{0}: CommandText property has not been initialized</value>
-	</data>
-	<data name="ADP_ConnectionRequired" xml:space="preserve">
-		<value>{0}: Connection property has not been initialized.</value>
-	</data>
-	<data name="ADP_OpenConnectionRequired" xml:space="preserve">
-		<value>{0} requires an open and available Connection. {1}</value>
-	</data>
-	<data name="ADP_TransactionConnectionMismatch" xml:space="preserve">
-		<value>The transaction is either not associated with the current connection or has been completed.</value>
-	</data>
-	<data name="ADP_TransactionRequired" xml:space="preserve">
-		<value>{0} requires the command to have a transaction when the connection assigned to the command is in a pending local transaction.  The Transaction property of the command has not been initialized.</value>
-	</data>
-	<data name="ADP_OpenReaderExists" xml:space="preserve">
-		<value>There is already an open DataReader associated with this Command which must be closed first.</value>
-	</data>
-	<data name="ADP_CalledTwice" xml:space="preserve">
-		<value>The method '{0}' cannot be called more than once for the same execution.</value>
-	</data>
-	<data name="ADP_InvalidCommandTimeout" xml:space="preserve">
-		<value>Invalid CommandTimeout value {0}; the value must be &gt;= 0.</value>
-	</data>
-	<data name="ADP_UninitializedParameterSize" xml:space="preserve">
-		<value>{1}[{0}]: the Size property has an invalid size of 0.</value>
-	</data>
-	<data name="ADP_PrepareParameterType" xml:space="preserve">
-		<value>{0}.Prepare method requires all parameters to have an explicitly set type.</value>
-	</data>
-	<data name="ADP_PrepareParameterSize" xml:space="preserve">
-		<value>{0}.Prepare method requires all variable length parameters to have an explicitly set non-zero Size.</value>
-	</data>
-	<data name="ADP_PrepareParameterScale" xml:space="preserve">
-		<value>{0}.Prepare method requires parameters of type '{1}' have an explicitly set Precision and Scale.</value>
-	</data>
-	<data name="ADP_MismatchedAsyncResult" xml:space="preserve">
-		<value>Mismatched end method call for asyncResult.  Expected call to {0} but {1} was called instead.</value>
-	</data>
-	<data name="ADP_ClosedConnectionError" xml:space="preserve">
-		<value>Invalid operation. The connection is closed.</value>
-	</data>
-	<data name="ADP_ConnectionIsDisabled" xml:space="preserve">
-		<value>The connection has been disabled.</value>
-	</data>
-	<data name="ADP_EmptyDatabaseName" xml:space="preserve">
-		<value>Database cannot be null, the empty string, or string of only whitespace.</value>
-	</data>
-	<data name="ADP_InvalidSourceBufferIndex" xml:space="preserve">
-		<value>Invalid source buffer (size of {0}) offset: {1}</value>
-	</data>
-	<data name="ADP_InvalidDestinationBufferIndex" xml:space="preserve">
-		<value>Invalid destination buffer (size of {0}) offset: {1}</value>
-	</data>
-	<data name="ADP_StreamClosed" xml:space="preserve">
-		<value>Invalid attempt to {0} when stream is closed.</value>
-	</data>
-	<data name="ADP_InvalidSeekOrigin" xml:space="preserve">
-		<value>Specified SeekOrigin value is invalid.</value>
-	</data>
-	<data name="ADP_NonSequentialColumnAccess" xml:space="preserve">
-		<value>Invalid attempt to read from column ordinal '{0}'.  With CommandBehavior.SequentialAccess, you may only read from column ordinal '{1}' or greater.</value>
-	</data>
-	<data name="ADP_InvalidDataType" xml:space="preserve">
-		<value>The parameter data type of {0} is invalid.</value>
-	</data>
-	<data name="ADP_UnknownDataType" xml:space="preserve">
-		<value>No mapping exists from object type {0} to a known managed provider native type.</value>
-	</data>
-	<data name="ADP_DbTypeNotSupported" xml:space="preserve">
-		<value>No mapping exists from DbType {0} to a known {1}.</value>
-	</data>
-	<data name="ADP_VersionDoesNotSupportDataType" xml:space="preserve">
-		<value>The version of SQL Server in use does not support datatype '{0}'.</value>
-	</data>
-	<data name="ADP_ParameterValueOutOfRange" xml:space="preserve">
-		<value>Parameter value '{0}' is out of range.</value>
-	</data>
-	<data name="ADP_BadParameterName" xml:space="preserve">
-		<value>Specified parameter name '{0}' is not valid.</value>
-	</data>
-	<data name="ADP_InvalidSizeValue" xml:space="preserve">
-		<value>Invalid parameter Size value '{0}'. The value must be greater than or equal to 0.</value>
-	</data>
-	<data name="ADP_NegativeParameter" xml:space="preserve">
-		<value>Invalid value for argument '{0}'. The value must be greater than or equal to 0.</value>
-	</data>
-	<data name="ADP_InvalidMetaDataValue" xml:space="preserve">
-		<value>Invalid value for this metadata.</value>
-	</data>
-	<data name="ADP_ParameterConversionFailed" xml:space="preserve">
-		<value>Failed to convert parameter value from a {0} to a {1}.</value>
-	</data>
-	<data name="ADP_ParallelTransactionsNotSupported" xml:space="preserve">
-		<value>{0} does not support parallel transactions.</value>
-	</data>
-	<data name="ADP_TransactionZombied" xml:space="preserve">
-		<value>This {0} has completed; it is no longer usable.</value>
-	</data>
-	<data name="ADP_InvalidDataLength2" xml:space="preserve">
-		<value>Specified length '{0}' is out of range.</value>
-	</data>
-	<data name="ADP_NonSeqByteAccess" xml:space="preserve">
-		<value>Invalid {2} attempt at dataIndex '{0}'.  With CommandBehavior.SequentialAccess, you may only read from dataIndex '{1}' or greater.</value>
-	</data>
-	<data name="ADP_InvalidMinMaxPoolSizeValues" xml:space="preserve">
-		<value>Invalid min or max pool size values, min pool size cannot be greater than the max pool size.</value>
-	</data>
-	<data name="SQL_InvalidPacketSizeValue" xml:space="preserve">
-		<value>Invalid 'Packet Size'.  The value must be an integer &gt;= 512 and &lt;= 32768.</value>
-	</data>
-	<data name="SQL_NullEmptyTransactionName" xml:space="preserve">
-		<value>Invalid transaction or invalid name for a point at which to save within the transaction.</value>
-	</data>
-	<data name="SQL_UserInstanceFailoverNotCompatible" xml:space="preserve">
-		<value>User Instance and Failover are not compatible options.  Please choose only one of the two in the connection string.</value>
-	</data>
-	<data name="SQL_EncryptionNotSupportedByClient" xml:space="preserve">
-		<value>The instance of SQL Server you attempted to connect to requires encryption but this machine does not support it.</value>
-	</data>
-	<data name="SQL_EncryptionNotSupportedByServer" xml:space="preserve">
-		<value>The instance of SQL Server you attempted to connect to does not support encryption.</value>
-	</data>
-	<data name="SQL_InvalidSQLServerVersionUnknown" xml:space="preserve">
-		<value>Unsupported SQL Server version.  The .Net Framework SqlClient Data Provider can only be used with SQL Server versions 7.0 and later.</value>
-	</data>
-	<data name="SQL_CannotModifyPropertyAsyncOperationInProgress" xml:space="preserve">
-		<value>{0} cannot be changed while async operation is in progress.</value>
-	</data>
-	<data name="SQL_InstanceFailure" xml:space="preserve">
-		<value>Instance failure.</value>
-	</data>
-	<data name="SQL_InvalidPartnerConfiguration" xml:space="preserve">
-		<value>Server {0}, database {1} is not configured for database mirroring.</value>
-	</data>
-	<data name="SQL_MarsUnsupportedOnConnection" xml:space="preserve">
-		<value>The connection does not support MultipleActiveResultSets.</value>
-	</data>
-	<data name="SQL_NonLocalSSEInstance" xml:space="preserve">
-		<value>SSE Instance re-direction is not supported for non-local user instances.</value>
-	</data>
-	<data name="SQL_PendingBeginXXXExists" xml:space="preserve">
-		<value>The command execution cannot proceed due to a pending asynchronous operation already in progress.</value>
-	</data>
-	<data name="SQL_NonXmlResult" xml:space="preserve">
-		<value>Invalid command sent to ExecuteXmlReader.  The command must return an Xml result.</value>
-	</data>
-	<data name="SQL_InvalidParameterTypeNameFormat" xml:space="preserve">
-		<value>Invalid 3 part name format for TypeName.</value>
-	</data>
-	<data name="SQL_InvalidParameterNameLength" xml:space="preserve">
-		<value>The length of the parameter '{0}' exceeds the limit of 128 characters.</value>
-	</data>
-	<data name="SQL_PrecisionValueOutOfRange" xml:space="preserve">
-		<value>Precision value '{0}' is either less than 0 or greater than the maximum allowed precision of 38.</value>
-	</data>
-	<data name="SQL_ScaleValueOutOfRange" xml:space="preserve">
-		<value>Scale value '{0}' is either less than 0 or greater than the maximum allowed scale of 38.</value>
-	</data>
-	<data name="SQL_TimeScaleValueOutOfRange" xml:space="preserve">
-		<value>Scale value '{0}' is either less than 0 or greater than the maximum allowed scale of 7.</value>
-	</data>
-	<data name="SQL_ParameterInvalidVariant" xml:space="preserve">
-		<value>Parameter '{0}' exceeds the size limit for the sql_variant datatype.</value>
-	</data>
-	<data name="SQL_ParameterTypeNameRequired" xml:space="preserve">
-		<value>The {0} type parameter '{1}' must have a valid type name.</value>
-	</data>
-	<data name="SQL_InvalidInternalPacketSize" xml:space="preserve">
-		<value>Invalid internal packet size:</value>
-	</data>
-	<data name="SQL_InvalidTDSVersion" xml:space="preserve">
-		<value>The SQL Server instance returned an invalid or unsupported protocol version during login negotiation.</value>
-	</data>
-	<data name="SQL_InvalidTDSPacketSize" xml:space="preserve">
-		<value>Invalid Packet Size.</value>
-	</data>
-	<data name="SQL_ParsingError" xml:space="preserve">
-		<value>Internal connection fatal error.</value>
-	</data>
-	<data name="SQL_ConnectionLockedForBcpEvent" xml:space="preserve">
-		<value>The connection cannot be used because there is an ongoing operation that must be finished.</value>
-	</data>
-	<data name="SQL_SNIPacketAllocationFailure" xml:space="preserve">
-		<value>Memory allocation for internal connection failed.</value>
-	</data>
-	<data name="SQL_SmallDateTimeOverflow" xml:space="preserve">
-		<value>SqlDbType.SmallDateTime overflow.  Value '{0}' is out of range.  Must be between 1/1/1900 12:00:00 AM and 6/6/2079 11:59:59 PM.</value>
-	</data>
-	<data name="SQL_TimeOverflow" xml:space="preserve">
-		<value>SqlDbType.Time overflow.  Value '{0}' is out of range.  Must be between 00:00:00.0000000 and 23:59:59.9999999.</value>
-	</data>
-	<data name="SQL_MoneyOverflow" xml:space="preserve">
-		<value>SqlDbType.SmallMoney overflow.  Value '{0}' is out of range.  Must be between -214,748.3648 and 214,748.3647.</value>
-	</data>
-	<data name="SQL_CultureIdError" xml:space="preserve">
-		<value>The Collation specified by SQL Server is not supported.</value>
-	</data>
-	<data name="SQL_OperationCancelled" xml:space="preserve">
-		<value>Operation cancelled by user.</value>
-	</data>
-	<data name="SQL_SevereError" xml:space="preserve">
-		<value>A severe error occurred on the current command.  The results, if any, should be discarded.</value>
-	</data>
-	<data name="SQL_SSPIGenerateError" xml:space="preserve">
-		<value>Failed to generate SSPI context.</value>
-	</data>
-	<data name="SQL_KerberosTicketMissingError" xml:space="preserve">
-		<value>Cannot access Kerberos ticket. Ensure Kerberos has been initialized with 'kinit'.</value>
-	</data>
-	<data name="SQL_InvalidSSPIPacketSize" xml:space="preserve">
-		<value>Invalid SSPI packet size.</value>
-	</data>
-	<data name="SQL_SSPIInitializeError" xml:space="preserve">
-		<value>Cannot initialize SSPI package.</value>
-	</data>
-	<data name="SQL_Timeout" xml:space="preserve">
-		<value>Timeout expired.  The timeout period elapsed prior to completion of the operation or the server is not responding.</value>
-	</data>
-	<data name="SQL_Timeout_PreLogin_Begin" xml:space="preserve">
-		<value>Connection Timeout Expired.  The timeout period elapsed at the start of the pre-login phase.  This could be because of insufficient time provided for connection timeout.</value>
-	</data>
-	<data name="SQL_Timeout_PreLogin_InitializeConnection" xml:space="preserve">
-		<value>Connection Timeout Expired.  The timeout period elapsed while attempting to create and initialize a socket to the server.  This could be either because the server was unreachable or unable to respond back in time.</value>
-	</data>
-	<data name="SQL_Timeout_PreLogin_SendHandshake" xml:space="preserve">
-		<value>Connection Timeout Expired.  The timeout period elapsed while making a pre-login handshake request.  This could be because the server was unable to respond back in time.</value>
-	</data>
-	<data name="SQL_Timeout_PreLogin_ConsumeHandshake" xml:space="preserve">
-		<value>Connection Timeout Expired.  The timeout period elapsed while attempting to consume the pre-login handshake acknowledgement.  This could be because the pre-login handshake failed or the server was unable to respond back in time.</value>
-	</data>
-	<data name="SQL_Timeout_Login_Begin" xml:space="preserve">
-		<value>Connection Timeout Expired.  The timeout period elapsed at the start of the login phase.  This could be because of insufficient time provided for connection timeout.</value>
-	</data>
-	<data name="SQL_Timeout_Login_ProcessConnectionAuth" xml:space="preserve">
-		<value>Connection Timeout Expired.  The timeout period elapsed while attempting to authenticate the login.  This could be because the server failed to authenticate the user or the server was unable to respond back in time.</value>
-	</data>
-	<data name="SQL_Timeout_PostLogin" xml:space="preserve">
-		<value>Connection Timeout Expired.  The timeout period elapsed during the post-login phase.  The connection could have timed out while waiting for server to complete the login process and respond; Or it could have timed out while attempting to create multiple active connections.</value>
-	</data>
-	<data name="SQL_Timeout_FailoverInfo" xml:space="preserve">
-		<value>This failure occurred while attempting to connect to the {0} server.</value>
-	</data>
-	<data name="SQL_Timeout_RoutingDestinationInfo" xml:space="preserve">
-		<value>This failure occurred while attempting to connect to the routing destination. The duration spent while attempting to connect to the original server was - [Pre-Login] initialization={0}; handshake={1}; [Login] initialization={2}; authentication={3}; [Post-Login] complete={4};  </value>
-	</data>
-	<data name="SQL_Duration_PreLogin_Begin" xml:space="preserve">
-		<value>The duration spent while attempting to connect to this server was - [Pre-Login] initialization={0};</value>
-	</data>
-	<data name="SQL_Duration_PreLoginHandshake" xml:space="preserve">
-		<value>The duration spent while attempting to connect to this server was - [Pre-Login] initialization={0}; handshake={1}; </value>
-	</data>
-	<data name="SQL_Duration_Login_Begin" xml:space="preserve">
-		<value>The duration spent while attempting to connect to this server was - [Pre-Login] initialization={0}; handshake={1}; [Login] initialization={2}; </value>
-	</data>
-	<data name="SQL_Duration_Login_ProcessConnectionAuth" xml:space="preserve">
-		<value>The duration spent while attempting to connect to this server was - [Pre-Login] initialization={0}; handshake={1}; [Login] initialization={2}; authentication={3}; </value>
-	</data>
-	<data name="SQL_Duration_PostLogin" xml:space="preserve">
-		<value>The duration spent while attempting to connect to this server was - [Pre-Login] initialization={0}; handshake={1}; [Login] initialization={2}; authentication={3}; [Post-Login] complete={4}; </value>
-	</data>
-	<data name="SQL_UserInstanceFailure" xml:space="preserve">
-		<value>A user instance was requested in the connection string but the server specified does not support this option.</value>
-	</data>
-	<data name="SQL_InvalidRead" xml:space="preserve">
-		<value>Invalid attempt to read when no data is present.</value>
-	</data>
-	<data name="SQL_NonBlobColumn" xml:space="preserve">
-		<value>Invalid attempt to GetBytes on column '{0}'.  The GetBytes function can only be used on columns of type Text, NText, or Image.</value>
-	</data>
-	<data name="SQL_NonCharColumn" xml:space="preserve">
-		<value>Invalid attempt to GetChars on column '{0}'.  The GetChars function can only be used on columns of type Text, NText, Xml, VarChar or NVarChar.</value>
-	</data>
-	<data name="SQL_StreamNotSupportOnColumnType" xml:space="preserve">
-		<value>Invalid attempt to GetStream on column '{0}'. The GetStream function can only be used on columns of type Binary, Image, Udt or VarBinary.</value>
-	</data>
-	<data name="SQL_TextReaderNotSupportOnColumnType" xml:space="preserve">
-		<value>Invalid attempt to GetTextReader on column '{0}'. The GetTextReader function can only be used on columns of type Char, NChar, NText, NVarChar, Text or VarChar.</value>
-	</data>
-	<data name="SQL_XmlReaderNotSupportOnColumnType" xml:space="preserve">
-		<value>Invalid attempt to GetXmlReader on column '{0}'. The GetXmlReader function can only be used on columns of type Xml.</value>
-	</data>
-	<data name="SqlDelegatedTransaction_PromotionFailed" xml:space="preserve">
-		<value>Failure while attempting to promote transaction.</value>
-	</data>
-	<data name="SQL_InvalidBufferSizeOrIndex" xml:space="preserve">
-		<value>Buffer offset '{1}' plus the bytes available '{0}' is greater than the length of the passed in buffer.</value>
-	</data>
-	<data name="SQL_InvalidDataLength" xml:space="preserve">
-		<value>Data length '{0}' is less than 0.</value>
-	</data>
-	<data name="SQL_BulkLoadMappingInaccessible" xml:space="preserve">
-		<value>The mapped collection is in use and cannot be accessed at this time;</value>
-	</data>
-	<data name="SQL_BulkLoadMappingsNamesOrOrdinalsOnly" xml:space="preserve">
-		<value>Mappings must be either all name or all ordinal based.</value>
-	</data>
-	<data name="SQL_BulkLoadCannotConvertValue" xml:space="preserve">
-		<value>The given value of type {0} from the data source cannot be converted to type {1} of the specified target column.</value>
-	</data>
-	<data name="SQL_BulkLoadNonMatchingColumnMapping" xml:space="preserve">
-		<value>The given ColumnMapping does not match up with any column in the source or destination.</value>
-	</data>
-	<data name="SQL_BulkLoadNonMatchingColumnName" xml:space="preserve">
-		<value>The given ColumnName '{0}' does not match up with any column in data source.</value>
-	</data>
-	<data name="SQL_BulkLoadStringTooLong" xml:space="preserve">
-		<value>String or binary data would be truncated.</value>
-	</data>
-	<data name="SQL_BulkLoadInvalidTimeout" xml:space="preserve">
-		<value>Timeout Value '{0}' is less than 0.</value>
-	</data>
-	<data name="SQL_BulkLoadInvalidVariantValue" xml:space="preserve">
-		<value>Value cannot be converted to SqlVariant.</value>
-	</data>
-	<data name="SQL_BulkLoadExistingTransaction" xml:space="preserve">
-		<value>Unexpected existing transaction.</value>
-	</data>
-	<data name="SQL_BulkLoadNoCollation" xml:space="preserve">
-		<value>Failed to obtain column collation information for the destination table. If the table is not in the current database the name must be qualified using the database name (e.g. [mydb]..[mytable](e.g. [mydb]..[mytable]); this also applies to temporary-tables (e.g. #mytable would be specified as tempdb..#mytable).</value>
-	</data>
-	<data name="SQL_BulkLoadConflictingTransactionOption" xml:space="preserve">
-		<value>Must not specify SqlBulkCopyOption.UseInternalTransaction and pass an external Transaction at the same time.</value>
-	</data>
-	<data name="SQL_BulkLoadInvalidOperationInsideEvent" xml:space="preserve">
-		<value>Function must not be called during event.</value>
-	</data>
-	<data name="SQL_BulkLoadMissingDestinationTable" xml:space="preserve">
-		<value>The DestinationTableName property must be set before calling this method.</value>
-	</data>
-	<data name="SQL_BulkLoadInvalidDestinationTable" xml:space="preserve">
-		<value>Cannot access destination table '{0}'.</value>
-	</data>
-	<data name="SQL_BulkLoadNotAllowDBNull" xml:space="preserve">
-		<value>Column '{0}' does not allow DBNull.Value.</value>
-	</data>
-	<data name="Sql_BulkLoadLcidMismatch" xml:space="preserve">
-		<value>The locale id '{0}' of the source column '{1}' and the locale id '{2}' of the destination column '{3}' do not match.</value>
-	</data>
-	<data name="SQL_BulkLoadPendingOperation" xml:space="preserve">
-		<value>Attempt to invoke bulk copy on an object that has a pending operation.</value>
-	</data>
-	<data name="SQL_CannotGetDTCAddress" xml:space="preserve">
-		<value>Unable to get the address of the distributed transaction coordinator for the server, from the server.  Is DTC enabled on the server?</value>
-	</data>
-	<data name="SQL_ConnectionDoomed" xml:space="preserve">
-		<value>The requested operation cannot be completed because the connection has been broken.</value>
-	</data>
-	<data name="SQL_OpenResultCountExceeded" xml:space="preserve">
-		<value>Open result count exceeded.</value>
-	</data>
-	<data name="SQL_StreamWriteNotSupported" xml:space="preserve">
-		<value>The Stream does not support writing.</value>
-	</data>
-	<data name="SQL_StreamReadNotSupported" xml:space="preserve">
-		<value>The Stream does not support reading.</value>
-	</data>
-	<data name="SQL_StreamSeekNotSupported" xml:space="preserve">
-		<value>The Stream does not support seeking.</value>
-	</data>
-	<data name="SQL_ExClientConnectionId" xml:space="preserve">
-		<value>ClientConnectionId:{0}</value>
-	</data>
-	<data name="SQL_ExErrorNumberStateClass" xml:space="preserve">
-		<value>Error Number:{0},State:{1},Class:{2}</value>
-	</data>
-	<data name="SQL_ExOriginalClientConnectionId" xml:space="preserve">
-		<value>ClientConnectionId before routing:{0}</value>
-	</data>
-	<data name="SQL_ExRoutingDestination" xml:space="preserve">
-		<value>Routing Destination:{0}</value>
-	</data>
-	<data name="SQL_UnsupportedSysTxVersion" xml:space="preserve">
-		<value>The currently loaded System.Transactions.dll does not support Global Transactions.</value>
-	</data>
-	<data name="SqlMisc_NullString" xml:space="preserve">
-		<value>Null</value>
-	</data>
-	<data name="SqlMisc_MessageString" xml:space="preserve">
-		<value>Message</value>
-	</data>
-	<data name="SqlMisc_ArithOverflowMessage" xml:space="preserve">
-		<value>Arithmetic Overflow.</value>
-	</data>
-	<data name="SqlMisc_DivideByZeroMessage" xml:space="preserve">
-		<value>Divide by zero error encountered.</value>
-	</data>
-	<data name="SqlMisc_NullValueMessage" xml:space="preserve">
-		<value>Data is Null. This method or property cannot be called on Null values.</value>
-	</data>
-	<data name="SqlMisc_TruncationMessage" xml:space="preserve">
-		<value>Numeric arithmetic causes truncation.</value>
-	</data>
-	<data name="SqlMisc_DateTimeOverflowMessage" xml:space="preserve">
-		<value>SqlDateTime overflow. Must be between 1/1/1753 12:00:00 AM and 12/31/9999 11:59:59 PM.</value>
-	</data>
-	<data name="SqlMisc_ConcatDiffCollationMessage" xml:space="preserve">
-		<value>Two strings to be concatenated have different collation.</value>
-	</data>
-	<data name="SqlMisc_CompareDiffCollationMessage" xml:space="preserve">
-		<value>Two strings to be compared have different collation.</value>
-	</data>
-	<data name="SqlMisc_InvalidFlagMessage" xml:space="preserve">
-		<value>Invalid flag value.</value>
-	</data>
-	<data name="SqlMisc_NumeToDecOverflowMessage" xml:space="preserve">
-		<value>Conversion from SqlDecimal to Decimal overflows.</value>
-	</data>
-	<data name="SqlMisc_ConversionOverflowMessage" xml:space="preserve">
-		<value>Conversion overflows.</value>
-	</data>
-	<data name="SqlMisc_InvalidDateTimeMessage" xml:space="preserve">
-		<value>Invalid SqlDateTime.</value>
-	</data>
-	<data name="SqlMisc_TimeZoneSpecifiedMessage" xml:space="preserve">
-		<value>A time zone was specified. SqlDateTime does not support time zones.</value>
-	</data>
-	<data name="SqlMisc_InvalidArraySizeMessage" xml:space="preserve">
-		<value>Invalid array size.</value>
-	</data>
-	<data name="SqlMisc_InvalidPrecScaleMessage" xml:space="preserve">
-		<value>Invalid numeric precision/scale.</value>
-	</data>
-	<data name="SqlMisc_FormatMessage" xml:space="preserve">
-		<value>The input wasn't in a correct format.</value>
-	</data>
-	<data name="SqlMisc_StreamErrorMessage" xml:space="preserve">
-		<value>An error occurred while reading.</value>
-	</data>
-	<data name="SqlMisc_TruncationMaxDataMessage" xml:space="preserve">
-		<value>Data returned is larger than 2Gb in size. Use SequentialAccess command behavior in order to get all of the data.</value>
-	</data>
-	<data name="SqlMisc_NotFilledMessage" xml:space="preserve">
-		<value>SQL Type has not been loaded with data.</value>
-	</data>
-	<data name="SqlMisc_AlreadyFilledMessage" xml:space="preserve">
-		<value>SQL Type has already been loaded with data.</value>
-	</data>
-	<data name="SqlMisc_ClosedXmlReaderMessage" xml:space="preserve">
-		<value>Invalid attempt to access a closed XmlReader.</value>
-	</data>
-	<data name="SqlMisc_InvalidOpStreamClosed" xml:space="preserve">
-		<value>Invalid attempt to call {0} when the stream is closed.</value>
-	</data>
-	<data name="SqlMisc_InvalidOpStreamNonWritable" xml:space="preserve">
-		<value>Invalid attempt to call {0} when the stream non-writable.</value>
-	</data>
-	<data name="SqlMisc_InvalidOpStreamNonReadable" xml:space="preserve">
-		<value>Invalid attempt to call {0} when the stream non-readable.</value>
-	</data>
-	<data name="SqlMisc_InvalidOpStreamNonSeekable" xml:space="preserve">
-		<value>Invalid attempt to call {0} when the stream is non-seekable.</value>
-	</data>
-	<data name="SqlMisc_SubclassMustOverride" xml:space="preserve">
-		<value>Subclass did not override a required method.</value>
-	</data>
-	<data name="Sql_InternalError" xml:space="preserve">
-		<value>Internal Error</value>
-	</data>
-	<data name="ADP_OperationAborted" xml:space="preserve">
-		<value>Operation aborted.</value>
-	</data>
-	<data name="ADP_OperationAbortedExceptionMessage" xml:space="preserve">
-		<value>Operation aborted due to an exception (see InnerException for details).</value>
-	</data>
-	<data name="ADP_TransactionCompletedButNotDisposed" xml:space="preserve">
-		<value>The transaction associated with the current connection has completed but has not been disposed.  The transaction must be disposed before the connection can be used to execute SQL statements.</value>
-	</data>
-	<data name="SqlParameter_UnsupportedTVPOutputParameter" xml:space="preserve">
-		<value>ParameterDirection '{0}' specified for parameter '{1}' is not supported. Table-valued parameters only support ParameterDirection.Input.</value>
-	</data>
-	<data name="SqlParameter_DBNullNotSupportedForTVP" xml:space="preserve">
-		<value>DBNull value for parameter '{0}' is not supported. Table-valued parameters cannot be DBNull.</value>
-	</data>
-	<data name="SqlParameter_UnexpectedTypeNameForNonStruct" xml:space="preserve">
-		<value>TypeName specified for parameter '{0}'.  TypeName must only be set for Structured parameters.</value>
-	</data>
-	<data name="NullSchemaTableDataTypeNotSupported" xml:space="preserve">
-		<value>DateType column for field '{0}' in schema table is null.  DataType must be non-null.</value>
-	</data>
-	<data name="InvalidSchemaTableOrdinals" xml:space="preserve">
-		<value>Invalid column ordinals in schema table.  ColumnOrdinals, if present, must not have duplicates or gaps.</value>
-	</data>
-	<data name="SQL_EnumeratedRecordMetaDataChanged" xml:space="preserve">
-		<value>Metadata for field '{0}' of record '{1}' did not match the original record's metadata.</value>
-	</data>
-	<data name="SQL_EnumeratedRecordFieldCountChanged" xml:space="preserve">
-		<value>Number of fields in record '{0}' does not match the number in the original record.</value>
-	</data>
-	<data name="GT_Disabled" xml:space="preserve">
-		<value>Global Transactions are not enabled for this Azure SQL Database. Please contact Azure SQL Database support for assistance.</value>
-	</data>
-	<data name="SQL_UnknownSysTxIsolationLevel" xml:space="preserve">
-		<value>Unrecognized System.Transactions.IsolationLevel enumeration value: {0}.</value>
-	</data>
-	<data name="SQLNotify_AlreadyHasCommand" xml:space="preserve">
-		<value>This SqlCommand object is already associated with another SqlDependency object.</value>
-	</data>
-	<data name="SqlDependency_DatabaseBrokerDisabled" xml:space="preserve">
-		<value>The SQL Server Service Broker for the current database is not enabled, and as a result query notifications are not supported.  Please enable the Service Broker for this database if you wish to use notifications.</value>
-	</data>
-	<data name="SqlDependency_DefaultOptionsButNoStart" xml:space="preserve">
-		<value>When using SqlDependency without providing an options value, SqlDependency.Start() must be called prior to execution of a command added to the SqlDependency instance.</value>
-	</data>
-	<data name="SqlDependency_NoMatchingServerStart" xml:space="preserve">
-		<value>When using SqlDependency without providing an options value, SqlDependency.Start() must be called for each server that is being executed against.</value>
-	</data>
-	<data name="SqlDependency_NoMatchingServerDatabaseStart" xml:space="preserve">
-		<value>SqlDependency.Start has been called for the server the command is executing against more than once, but there is no matching server/user/database Start() call for current command.</value>
-	</data>
-	<data name="SqlDependency_EventNoDuplicate" xml:space="preserve">
-		<value>SqlDependency.OnChange does not support multiple event registrations for the same delegate.</value>
-	</data>
-	<data name="SqlDependency_IdMismatch" xml:space="preserve">
-		<value>No SqlDependency exists for the key.</value>
-	</data>
-	<data name="SqlDependency_InvalidTimeout" xml:space="preserve">
-		<value>Timeout specified is invalid. Timeout cannot be &lt; 0.</value>
-	</data>
-	<data name="SqlDependency_DuplicateStart" xml:space="preserve">
-		<value>SqlDependency does not support calling Start() with different connection strings having the same server, user, and database in the same app domain.</value>
-	</data>
-	<data name="SqlMetaData_InvalidSqlDbTypeForConstructorFormat" xml:space="preserve">
-		<value>The dbType {0} is invalid for this constructor.</value>
-	</data>
-	<data name="SqlMetaData_NameTooLong" xml:space="preserve">
-		<value>The name is too long.</value>
-	</data>
-	<data name="SqlMetaData_SpecifyBothSortOrderAndOrdinal" xml:space="preserve">
-		<value>The sort order and ordinal must either both be specified, or neither should be specified (SortOrder.Unspecified and -1).  The values given were: order = {0}, ordinal = {1}.</value>
-	</data>
-	<data name="SqlProvider_InvalidDataColumnType" xml:space="preserve">
-		<value>The type of column '{0}' is not supported.  The type is '{1}'</value>
-	</data>
-	<data name="SqlProvider_NotEnoughColumnsInStructuredType" xml:space="preserve">
-		<value>There are not enough fields in the Structured type.  Structured types must have at least one field.</value>
-	</data>
-	<data name="SqlProvider_DuplicateSortOrdinal" xml:space="preserve">
-		<value>The sort ordinal {0} was specified twice.</value>
-	</data>
-	<data name="SqlProvider_MissingSortOrdinal" xml:space="preserve">
-		<value>The sort ordinal {0} was not specified.</value>
-	</data>
-	<data name="SqlProvider_SortOrdinalGreaterThanFieldCount" xml:space="preserve">
-		<value>The sort ordinal {0} on field {1} exceeds the total number of fields.</value>
-	</data>
-	<data name="IEnumerableOfSqlDataRecordHasNoRows" xml:space="preserve">
-		<value>There are no records in the SqlDataRecord enumeration. To send a table-valued parameter with no rows, use a null reference for the value instead.</value>
-	</data>
-	<data name="SNI_ERROR_1" xml:space="preserve">
-		<value>I/O Error detected in read/write operation</value>
-	</data>
-	<data name="SNI_ERROR_2" xml:space="preserve">
-		<value>Connection was terminated</value>
-	</data>
-	<data name="SNI_ERROR_3" xml:space="preserve">
-		<value>Asynchronous operations not supported</value>
-	</data>
-	<data name="SNI_ERROR_5" xml:space="preserve">
-		<value>Invalid parameter(s) found</value>
-	</data>
-	<data name="SNI_ERROR_6" xml:space="preserve">
-		<value>Unsupported protocol specified</value>
-	</data>
-	<data name="SNI_ERROR_7" xml:space="preserve">
-		<value>Invalid connection found when setting up new session protocol</value>
-	</data>
-	<data name="SNI_ERROR_8" xml:space="preserve">
-		<value>Protocol not supported</value>
-	</data>
-	<data name="SNI_ERROR_9" xml:space="preserve">
-		<value>Associating port with I/O completion mechanism failed</value>
-	</data>
-	<data name="SNI_ERROR_11" xml:space="preserve">
-		<value>Timeout error</value>
-	</data>
-	<data name="SNI_ERROR_12" xml:space="preserve">
-		<value>No server name supplied</value>
-	</data>
-	<data name="SNI_ERROR_13" xml:space="preserve">
-		<value>TerminateListener() has been called</value>
-	</data>
-	<data name="SNI_ERROR_14" xml:space="preserve">
-		<value>Win9x not supported</value>
-	</data>
-	<data name="SNI_ERROR_15" xml:space="preserve">
-		<value>Function not supported</value>
-	</data>
-	<data name="SNI_ERROR_16" xml:space="preserve">
-		<value>Shared-Memory heap error</value>
-	</data>
-	<data name="SNI_ERROR_17" xml:space="preserve">
-		<value>Cannot find an ip/ipv6 type address to connect</value>
-	</data>
-	<data name="SNI_ERROR_18" xml:space="preserve">
-		<value>Connection has been closed by peer</value>
-	</data>
-	<data name="SNI_ERROR_19" xml:space="preserve">
-		<value>Physical connection is not usable</value>
-	</data>
-	<data name="SNI_ERROR_20" xml:space="preserve">
-		<value>Connection has been closed</value>
-	</data>
-	<data name="SNI_ERROR_21" xml:space="preserve">
-		<value>Encryption is enforced but there is no valid certificate</value>
-	</data>
-	<data name="SNI_ERROR_22" xml:space="preserve">
-		<value>Couldn't load library</value>
-	</data>
-	<data name="SNI_ERROR_23" xml:space="preserve">
-		<value>Cannot open a new thread in server process</value>
-	</data>
-	<data name="SNI_ERROR_24" xml:space="preserve">
-		<value>Cannot post event to completion port</value>
-	</data>
-	<data name="SNI_ERROR_25" xml:space="preserve">
-		<value>Connection string is not valid</value>
-	</data>
-	<data name="SNI_ERROR_26" xml:space="preserve">
-		<value>Error Locating Server/Instance Specified</value>
-	</data>
-	<data name="SNI_ERROR_27" xml:space="preserve">
-		<value>Error getting enabled protocols list from registry</value>
-	</data>
-	<data name="SNI_ERROR_28" xml:space="preserve">
-		<value>Server doesn't support requested protocol</value>
-	</data>
-	<data name="SNI_ERROR_29" xml:space="preserve">
-		<value>Shared Memory is not supported for clustered server connectivity</value>
-	</data>
-	<data name="SNI_ERROR_30" xml:space="preserve">
-		<value>Invalid attempt bind to shared memory segment</value>
-	</data>
-	<data name="SNI_ERROR_31" xml:space="preserve">
-		<value>Encryption(ssl/tls) handshake failed</value>
-	</data>
-	<data name="SNI_ERROR_32" xml:space="preserve">
-		<value>Packet size too large for SSL Encrypt/Decrypt operations</value>
-	</data>
-	<data name="SNI_ERROR_33" xml:space="preserve">
-		<value>SSRP error</value>
-	</data>
-	<data name="SNI_ERROR_34" xml:space="preserve">
-		<value>Could not connect to the Shared Memory pipe</value>
-	</data>
-	<data name="SNI_ERROR_35" xml:space="preserve">
-		<value>An internal exception was caught</value>
-	</data>
-	<data name="SNI_ERROR_36" xml:space="preserve">
-		<value>The Shared Memory dll used to connect to SQL Server 2000 was not found</value>
-	</data>
-	<data name="SNI_ERROR_37" xml:space="preserve">
-		<value>The SQL Server 2000 Shared Memory client dll appears to be invalid/corrupted</value>
-	</data>
-	<data name="SNI_ERROR_38" xml:space="preserve">
-		<value>Cannot open a Shared Memory connection to SQL Server 2000</value>
-	</data>
-	<data name="SNI_ERROR_39" xml:space="preserve">
-		<value>Shared memory connectivity to SQL Server 2000 is either disabled or not available on this machine</value>
-	</data>
-	<data name="SNI_ERROR_40" xml:space="preserve">
-		<value>Could not open a connection to SQL Server</value>
-	</data>
-	<data name="SNI_ERROR_41" xml:space="preserve">
-		<value>Cannot open a Shared Memory connection to a remote SQL server</value>
-	</data>
-	<data name="SNI_ERROR_42" xml:space="preserve">
-		<value>Could not establish dedicated administrator connection (DAC) on default port. Make sure that DAC is enabled</value>
-	</data>
-	<data name="SNI_ERROR_43" xml:space="preserve">
-		<value>An error occurred while obtaining the dedicated administrator connection (DAC) port. Make sure that SQL Browser is running, or check the error log for the port number</value>
-	</data>
-	<data name="SNI_ERROR_44" xml:space="preserve">
-		<value>Could not compose Service Principal Name (SPN) for Windows Integrated Authentication. Possible causes are server(s) incorrectly specified to connection API calls, Domain Name System (DNS) lookup failure or memory shortage</value>
-	</data>
-	<data name="SNI_ERROR_47" xml:space="preserve">
-		<value>Connecting with the MultiSubnetFailover connection option to a SQL Server instance configured with more than 64 IP addresses is not supported.</value>
-	</data>
-	<data name="SNI_ERROR_48" xml:space="preserve">
-		<value>Connecting to a named SQL Server instance using the MultiSubnetFailover connection option is not supported.</value>
-	</data>
-	<data name="SNI_ERROR_49" xml:space="preserve">
-		<value>Connecting to a SQL Server instance using the MultiSubnetFailover connection option is only supported when using the TCP protocol.</value>
-	</data>
-	<data name="SNI_ERROR_50" xml:space="preserve">
-		<value>Local Database Runtime error occurred. </value>
-	</data>
-	<data name="SNI_ERROR_51" xml:space="preserve">
-		<value>An instance name was not specified while connecting to a Local Database Runtime. Specify an instance name in the format (localdb)\instance_name.</value>
-	</data>
-	<data name="SNI_ERROR_52" xml:space="preserve">
-		<value>Unable to locate a Local Database Runtime installation. Verify that SQL Server Express is properly installed and that the Local Database Runtime feature is enabled.</value>
-	</data>
-	<data name="SNI_ERROR_53" xml:space="preserve">
-		<value>Invalid Local Database Runtime registry configuration found. Verify that SQL Server Express is properly installed.</value>
-	</data>
-	<data name="SNI_ERROR_54" xml:space="preserve">
-		<value>Unable to locate the registry entry for SQLUserInstance.dll file path. Verify that the Local Database Runtime feature of SQL Server Express is properly installed.</value>
-	</data>
-	<data name="SNI_ERROR_55" xml:space="preserve">
-		<value>Registry value contains an invalid SQLUserInstance.dll file path. Verify that the Local Database Runtime feature of SQL Server Express is properly installed.</value>
-	</data>
-	<data name="SNI_ERROR_56" xml:space="preserve">
-		<value>Unable to load the SQLUserInstance.dll from the location specified in the registry. Verify that the Local Database Runtime feature of SQL Server Express is properly installed.</value>
-	</data>
-	<data name="SNI_ERROR_57" xml:space="preserve">
-		<value>Invalid SQLUserInstance.dll found at the location specified in the registry. Verify that the Local Database Runtime feature of SQL Server Express is properly installed.</value>
-	</data>
-	<data name="Snix_Connect" xml:space="preserve">
-		<value>A network-related or instance-specific error occurred while establishing a connection to SQL Server. The server was not found or was not accessible. Verify that the instance name is correct and that SQL Server is configured to allow remote connections.</value>
-	</data>
-	<data name="Snix_PreLoginBeforeSuccessfullWrite" xml:space="preserve">
-		<value>The client was unable to establish a connection because of an error during connection initialization process before login. Possible causes include the following:  the client tried to connect to an unsupported version of SQL Server; the server was too busy to accept new connections; or there was a resource limitation (insufficient memory or maximum allowed connections) on the server.</value>
-	</data>
-	<data name="Snix_PreLogin" xml:space="preserve">
-		<value>A connection was successfully established with the server, but then an error occurred during the pre-login handshake.</value>
-	</data>
-	<data name="Snix_LoginSspi" xml:space="preserve">
-		<value>A connection was successfully established with the server, but then an error occurred when obtaining the security/SSPI context information for integrated security login.</value>
-	</data>
-	<data name="Snix_Login" xml:space="preserve">
-		<value>A connection was successfully established with the server, but then an error occurred during the login process.</value>
-	</data>
-	<data name="Snix_EnableMars" xml:space="preserve">
-		<value>Connection open and login was successful, but then an error occurred while enabling MARS for this connection.</value>
-	</data>
-	<data name="Snix_AutoEnlist" xml:space="preserve">
-		<value>Connection open and login was successful, but then an error occurred while enlisting the connection into the current distributed transaction.</value>
-	</data>
-	<data name="Snix_GetMarsSession" xml:space="preserve">
-		<value>Failed to establish a MARS session in preparation to send the request to the server.</value>
-	</data>
-	<data name="Snix_Execute" xml:space="preserve">
-		<value>A transport-level error has occurred when sending the request to the server.</value>
-	</data>
-	<data name="Snix_Read" xml:space="preserve">
-		<value>A transport-level error has occurred when receiving results from the server.</value>
-	</data>
-	<data name="Snix_Close" xml:space="preserve">
-		<value>A transport-level error has occurred during connection clean-up.</value>
-	</data>
-	<data name="Snix_SendRows" xml:space="preserve">
-		<value>A transport-level error has occurred while sending information to the server.</value>
-	</data>
-	<data name="Snix_ProcessSspi" xml:space="preserve">
-		<value>A transport-level error has occurred during SSPI handshake.</value>
-	</data>
-	<data name="LocalDB_FailedGetDLLHandle" xml:space="preserve">
-		<value>Local Database Runtime: Cannot load SQLUserInstance.dll.</value>
-	</data>
-	<data name="LocalDB_MethodNotFound" xml:space="preserve">
-		<value>Invalid SQLUserInstance.dll found at the location specified in the registry. Verify that the Local Database Runtime feature of SQL Server Express is properly installed.</value>
-	</data>
-	<data name="LocalDB_UnobtainableMessage" xml:space="preserve">
-		<value>Cannot obtain Local Database Runtime error message</value>
-	</data>
-	<data name="SQLROR_RecursiveRoutingNotSupported" xml:space="preserve">
-		<value>Two or more redirections have occurred. Only one redirection per login is allowed.</value>
-	</data>
-	<data name="SQLROR_FailoverNotSupported" xml:space="preserve">
-		<value>Connecting to a mirrored SQL Server instance using the ApplicationIntent ReadOnly connection option is not supported.</value>
-	</data>
-	<data name="SQLROR_UnexpectedRoutingInfo" xml:space="preserve">
-		<value>Unexpected routing information received.</value>
-	</data>
-	<data name="SQLROR_InvalidRoutingInfo" xml:space="preserve">
-		<value>Invalid routing information received.</value>
-	</data>
-	<data name="SQLROR_TimeoutAfterRoutingInfo" xml:space="preserve">
-		<value>Server provided routing information, but timeout already expired.</value>
-	</data>
-	<data name="SQLCR_InvalidConnectRetryCountValue" xml:space="preserve">
-		<value>Invalid ConnectRetryCount value (should be 0-255).</value>
-	</data>
-	<data name="SQLCR_InvalidConnectRetryIntervalValue" xml:space="preserve">
-		<value>Invalid ConnectRetryInterval value (should be 1-60).</value>
-	</data>
-	<data name="SQLCR_NextAttemptWillExceedQueryTimeout" xml:space="preserve">
-		<value>Next reconnection attempt will exceed query timeout. Reconnection was terminated.</value>
-	</data>
-	<data name="SQLCR_EncryptionChanged" xml:space="preserve">
-		<value>The server did not preserve SSL encryption during a recovery attempt, connection recovery is not possible.</value>
-	</data>
-	<data name="SQLCR_TDSVestionNotPreserved" xml:space="preserve">
-		<value>The server did not preserve the exact client TDS version requested during a recovery attempt, connection recovery is not possible.</value>
-	</data>
-	<data name="SQLCR_AllAttemptsFailed" xml:space="preserve">
-		<value>The connection is broken and recovery is not possible.  The client driver attempted to recover the connection one or more times and all attempts failed.  Increase the value of ConnectRetryCount to increase the number of recovery attempts.</value>
-	</data>
-	<data name="SQLCR_UnrecoverableServer" xml:space="preserve">
-		<value>The connection is broken and recovery is not possible.  The connection is marked by the server as unrecoverable.  No attempt was made to restore the connection.</value>
-	</data>
-	<data name="SQLCR_UnrecoverableClient" xml:space="preserve">
-		<value>The connection is broken and recovery is not possible.  The connection is marked by the client driver as unrecoverable.  No attempt was made to restore the connection.</value>
-	</data>
-	<data name="SQLCR_NoCRAckAtReconnection" xml:space="preserve">
-		<value>The server did not acknowledge a recovery attempt, connection recovery is not possible.</value>
-	</data>
-	<data name="SQL_UnsupportedKeyword" xml:space="preserve">
-		<value>The keyword '{0}' is not supported on this platform.</value>
-	</data>
-	<data name="SQL_UnsupportedFeature" xml:space="preserve">
-		<value>The server is attempting to use a feature that is not supported on this platform.</value>
-	</data>
-	<data name="SQL_UnsupportedToken" xml:space="preserve">
-		<value>Received an unsupported token '{0}' while reading data from the server.</value>
-	</data>
-	<data name="SQL_DbTypeNotSupportedOnThisPlatform" xml:space="preserve">
-		<value>Type {0} is not supported on this platform.</value>
-	</data>
-	<data name="SQL_NetworkLibraryNotSupported" xml:space="preserve">
-		<value>The keyword 'Network Library' is not supported on this platform, prefix the 'Data Source' with the protocol desired instead ('tcp:' for a TCP connection, or 'np:' for a Named Pipe connection).</value>
-	</data>
-	<data name="SNI_PN0" xml:space="preserve">
-		<value>HTTP Provider</value>
-	</data>
-	<data name="SNI_PN1" xml:space="preserve">
-		<value>Named Pipes Provider</value>
-	</data>
-	<data name="SNI_PN2" xml:space="preserve">
-		<value>Session Provider</value>
-	</data>
-	<data name="SNI_PN3" xml:space="preserve">
-		<value>Sign Provider</value>
-	</data>
-	<data name="SNI_PN4" xml:space="preserve">
-		<value>Shared Memory Provider</value>
-	</data>
-	<data name="SNI_PN5" xml:space="preserve">
-		<value>SMux Provider</value>
-	</data>
-	<data name="SNI_PN6" xml:space="preserve">
-		<value>SSL Provider</value>
-	</data>
-	<data name="SNI_PN7" xml:space="preserve">
-		<value>TCP Provider</value>
-	</data>
-	<data name="SNI_PN8" xml:space="preserve">
-		<value></value>
-	</data>
-	<data name="SNI_PN9" xml:space="preserve">
-		<value>SQL Network Interfaces</value>
-	</data>
-	<data name="AZURESQL_GenericEndpoint" xml:space="preserve">
-		<value>.database.windows.net</value>
-	</data>
-	<data name="AZURESQL_GermanEndpoint" xml:space="preserve">
-		<value>.database.cloudapi.de</value>
-	</data>
-	<data name="AZURESQL_UsGovEndpoint" xml:space="preserve">
-		<value>.database.usgovcloudapi.net</value>
-	</data>
-	<data name="AZURESQL_ChinaEndpoint" xml:space="preserve">
-		<value>.database.chinacloudapi.cn</value>
-	</data>
-	<data name="net_nego_channel_binding_not_supported" xml:space="preserve">
-		<value>No support for channel binding on operating systems other than Windows.</value>
-	</data>
-	<data name="net_gssapi_operation_failed_detailed" xml:space="preserve">
-		<value>GSSAPI operation failed with error - {0} ({1}).</value>
-	</data>
-	<data name="net_gssapi_operation_failed" xml:space="preserve">
-		<value>GSSAPI operation failed with status: {0} (Minor status: {1}).</value>
-	</data>
-	<data name="net_ntlm_not_possible_default_cred" xml:space="preserve">
-		<value>NTLM authentication is not possible with default credentials on this platform.</value>
-	</data>
-	<data name="net_nego_not_supported_empty_target_with_defaultcreds" xml:space="preserve">
-		<value>Target name should be non-empty if default credentials are passed.</value>
-	</data>
-	<data name="net_nego_server_not_supported" xml:space="preserve">
-		<value>Server implementation is not supported.</value>
-	</data>
-	<data name="net_nego_protection_level_not_supported" xml:space="preserve">
-		<value>Requested protection level is not supported with the GSSAPI implementation currently installed.</value>
-	</data>
-	<data name="net_context_buffer_too_small" xml:space="preserve">
-		<value>Insufficient buffer space. Required: {0} Actual: {1}.</value>
-	</data>
-	<data name="net_auth_message_not_encrypted" xml:space="preserve">
-		<value>Protocol error: A received message contains a valid signature but it was not encrypted as required by the effective Protection Level.</value>
-	</data>
-	<data name="net_securitypackagesupport" xml:space="preserve">
-		<value>The requested security package is not supported.</value>
-	</data>
-	<data name="net_log_operation_failed_with_error" xml:space="preserve">
-		<value>{0} failed with error {1}.</value>
-	</data>
-	<data name="net_MethodNotImplementedException" xml:space="preserve">
-		<value>This method is not implemented by this class.</value>
-	</data>
-	<data name="event_OperationReturnedSomething" xml:space="preserve">
-		<value>{0} returned {1}.</value>
-	</data>
-	<data name="net_invalid_enum" xml:space="preserve">
-		<value>The specified value is not valid in the '{0}' enumeration.</value>
-	</data>
-	<data name="SSPIInvalidHandleType" xml:space="preserve">
-		<value>'{0}' is not a supported handle type.</value>
-	</data>
-	<data name="LocalDBNotSupported" xml:space="preserve">
-		<value>LocalDB is not supported on this Platform.</value>
-	</data>
-	<data name="PlatformNotSupported_DataSqlClient" xml:space="preserve">
-		<value>System.Data.SqlClient is not supported on this platform.</value>
-	</data>
-	<data name="SqlParameter_InvalidTableDerivedPrecisionForTvp" xml:space="preserve">
-		<value>Precision '{0}' required to send all values in column '{1}' exceeds the maximum supported precision '{2}'. The values must all fit in a single precision.</value>
-	</data>
-	<data name="SqlProvider_InvalidDataColumnMaxLength" xml:space="preserve">
-		<value>The size of column '{0}' is not supported. The size is {1}.</value>
-	</data>
-	<data name="MDF_InvalidXmlInvalidValue" xml:space="preserve"> 
-		<value>The metadata XML is invalid. The {1} column of the {0} collection must contain a non-empty string.</value>
-	</data>
-	<data name="MDF_CollectionNameISNotUnique" xml:space="preserve"> 
-		<value>There are multiple collections named '{0}'.</value>
-	</data>
-	<data name="MDF_InvalidXmlMissingColumn" xml:space="preserve"> 
-		<value>The metadata XML is invalid. The {0} collection must contain a {1} column and it must be a string column.</value>
-	</data>
-	<data name="MDF_InvalidXml" xml:space="preserve"> 
-		<value>The metadata XML is invalid.</value>
-	</data>
-	<data name="MDF_NoColumns" xml:space="preserve"> 
-		<value>The schema table contains no columns.</value>
-	</data>
-	<data name="MDF_QueryFailed" xml:space="preserve"> 
-		<value>Unable to build the '{0}' collection because execution of the SQL query failed. See the inner exception for details.</value>
-	</data>
-	<data name="MDF_TooManyRestrictions" xml:space="preserve"> 
-		<value>More restrictions were provided than the requested schema ('{0}') supports.</value>
-	</data>
-	<data name="MDF_DataTableDoesNotExist" xml:space="preserve"> 
-		<value>The collection '{0}' is missing from the metadata XML.</value>
-	</data>
-	<data name="MDF_UndefinedCollection" xml:space="preserve"> 
-		<value>The requested collection ({0}) is not defined.</value> 
-	</data>
-	<data name="MDF_UnsupportedVersion" xml:space="preserve">
-		<value> requested collection ({0}) is not supported by this version of the provider.</value>
-	</data>
-	<data name="MDF_MissingRestrictionColumn" xml:space="preserve">
-		<value>One or more of the required columns of the restrictions collection is missing.</value>
-	</data>
-	<data name="MDF_MissingRestrictionRow" xml:space="preserve">
-		<value>A restriction exists for which there is no matching row in the restrictions collection.</value>
-	</data>
-	<data name="MDF_IncorrectNumberOfDataSourceInformationRows" xml:space="preserve">
-		<value>The DataSourceInformation table must contain exactly one row.</value>
-	</data>
-	<data name="MDF_MissingDataSourceInformationColumn" xml:space="preserve">
-		<value>One of the required DataSourceInformation tables columns is missing.</value>
-	</data>
-	<data name="MDF_AmbigousCollectionName" xml:space="preserve">
-		<value>The collection name '{0}' matches at least two collections with the same name but with different case, but does not match any of them exactly.</value>
-	</data>
-	<data name="MDF_UnableToBuildCollection" xml:space="preserve">
-		<value>Unable to build schema collection '{0}';</value>
-	</data>
-	<data name="AmbientTransactionsNotSupported" xml:space="preserve">
-		<value>Enlisting in Ambient transactions is not supported.</value>
-	</data>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ADP_CollectionIndexInt32" xml:space="preserve">
+    <value>Invalid index {0} for this {1} with Count={2}.</value>
+  </data>
+  <data name="ADP_CollectionIndexString" xml:space="preserve">
+    <value>An {0} with {1} '{2}' is not contained by this {3}.</value>
+  </data>
+  <data name="ADP_CollectionInvalidType" xml:space="preserve">
+    <value>The {0} only accepts non-null {1} type objects, not {2} objects.</value>
+  </data>
+  <data name="ADP_CollectionIsNotParent" xml:space="preserve">
+    <value>The {0} is already contained by another {1}.</value>
+  </data>
+  <data name="ADP_CollectionNullValue" xml:space="preserve">
+    <value>The {0} only accepts non-null {1} type objects.</value>
+  </data>
+  <data name="ADP_CollectionRemoveInvalidObject" xml:space="preserve">
+    <value>Attempted to remove an {0} that is not contained by this {1}.</value>
+  </data>
+  <data name="ADP_ConnectionAlreadyOpen" xml:space="preserve">
+    <value>The connection was not closed. {0}</value>
+  </data>
+  <data name="ADP_ConnectionStateMsg_Closed" xml:space="preserve">
+    <value>The connection's current state is closed.</value>
+  </data>
+  <data name="ADP_ConnectionStateMsg_Connecting" xml:space="preserve">
+    <value>The connection's current state is connecting.</value>
+  </data>
+  <data name="ADP_ConnectionStateMsg_Open" xml:space="preserve">
+    <value>The connection's current state is open.</value>
+  </data>
+  <data name="ADP_ConnectionStateMsg_OpenExecuting" xml:space="preserve">
+    <value>The connection's current state is executing.</value>
+  </data>
+  <data name="ADP_ConnectionStateMsg_OpenFetching" xml:space="preserve">
+    <value>The connection's current state is fetching.</value>
+  </data>
+  <data name="ADP_ConnectionStateMsg" xml:space="preserve">
+    <value>The connection's current state: {0}.</value>
+  </data>
+  <data name="ADP_ConnectionStringSyntax" xml:space="preserve">
+    <value>Format of the initialization string does not conform to specification starting at index {0}.</value>
+  </data>
+  <data name="ADP_DataReaderClosed" xml:space="preserve">
+    <value>Invalid attempt to call {0} when reader is closed.</value>
+  </data>
+  <data name="ADP_InternalConnectionError" xml:space="preserve">
+    <value>Internal DbConnection Error: {0}</value>
+  </data>
+  <data name="ADP_InvalidEnumerationValue" xml:space="preserve">
+    <value>The {0} enumeration value, {1}, is invalid.</value>
+  </data>
+  <data name="ADP_NotSupportedEnumerationValue" xml:space="preserve">
+    <value>The {0} enumeration value, {1}, is not supported by the {2} method.</value>
+  </data>
+  <data name="ADP_InvalidOffsetValue" xml:space="preserve">
+    <value>Invalid parameter Offset value '{0}'. The value must be greater than or equal to 0.</value>
+  </data>
+  <data name="ADP_TransactionPresent" xml:space="preserve">
+    <value>Connection currently has transaction enlisted.  Finish current transaction and retry.</value>
+  </data>
+  <data name="ADP_LocalTransactionPresent" xml:space="preserve">
+    <value>Cannot enlist in the transaction because a local transaction is in progress on the connection.  Finish local transaction and retry.</value>
+  </data>
+  <data name="ADP_NoConnectionString" xml:space="preserve">
+    <value>The ConnectionString property has not been initialized.</value>
+  </data>
+  <data name="ADP_OpenConnectionPropertySet" xml:space="preserve">
+    <value>Not allowed to change the '{0}' property. {1}</value>
+  </data>
+  <data name="ADP_PendingAsyncOperation" xml:space="preserve">
+    <value>Can not start another operation while there is an asynchronous operation pending.</value>
+  </data>
+  <data name="ADP_PooledOpenTimeout" xml:space="preserve">
+    <value>Timeout expired.  The timeout period elapsed prior to obtaining a connection from the pool.  This may have occurred because all pooled connections were in use and max pool size was reached.</value>
+  </data>
+  <data name="ADP_NonPooledOpenTimeout" xml:space="preserve">
+    <value>Timeout attempting to open the connection.  The time period elapsed prior to attempting to open the connection has been exceeded.  This may have occurred because of too many simultaneous non-pooled connection attempts.</value>
+  </data>
+  <data name="ADP_SingleValuedProperty" xml:space="preserve">
+    <value>The only acceptable value for the property '{0}' is '{1}'.</value>
+  </data>
+  <data name="ADP_DoubleValuedProperty" xml:space="preserve">
+    <value>The acceptable values for the property '{0}' are '{1}' or '{2}'.</value>
+  </data>
+  <data name="ADP_InvalidPrefixSuffix" xml:space="preserve">
+    <value>Specified QuotePrefix and QuoteSuffix values do not match.</value>
+  </data>
+  <data name="Arg_ArrayPlusOffTooSmall" xml:space="preserve">
+    <value>Destination array is not long enough to copy all the items in the collection. Check array index and length.</value>
+  </data>
+  <data name="Arg_RankMultiDimNotSupported" xml:space="preserve">
+    <value>Only single dimensional arrays are supported for the requested action.</value>
+  </data>
+  <data name="Arg_RemoveArgNotFound" xml:space="preserve">
+    <value>Cannot remove the specified item because it was not found in the specified Collection.</value>
+  </data>
+  <data name="ArgumentOutOfRange_NeedNonNegNum" xml:space="preserve">
+    <value>Non-negative number required.</value>
+  </data>
+  <data name="Data_InvalidOffsetLength" xml:space="preserve">
+    <value>Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.</value>
+  </data>
+  <data name="SqlConvert_ConvertFailed" xml:space="preserve">
+    <value> Cannot convert object of type '{0}' to object of type '{1}'.</value>
+  </data>
+  <data name="SQL_WrongType" xml:space="preserve">
+    <value>Expecting argument of type {1}, but received type {0}.</value>
+  </data>
+  <data name="ADP_DeriveParametersNotSupported" xml:space="preserve">
+    <value>{0} DeriveParameters only supports CommandType.StoredProcedure, not CommandType.{1}.</value>
+  </data>
+  <data name="ADP_NoStoredProcedureExists" xml:space="preserve">
+    <value>The stored procedure '{0}' doesn't exist.</value>
+  </data>
+  <data name="ADP_InvalidConnectionOptionValue" xml:space="preserve">
+    <value>Invalid value for key '{0}'.</value>
+  </data>
+  <data name="ADP_MissingConnectionOptionValue" xml:space="preserve">
+    <value>Use of key '{0}' requires the key '{1}' to be present.</value>
+  </data>
+  <data name="ADP_InvalidConnectionOptionValueLength" xml:space="preserve">
+    <value>The value's length for key '{0}' exceeds it's limit of '{1}'.</value>
+  </data>
+  <data name="ADP_KeywordNotSupported" xml:space="preserve">
+    <value>Keyword not supported: '{0}'.</value>
+  </data>
+  <data name="ADP_InternalProviderError" xml:space="preserve">
+    <value>Internal .Net Framework Data Provider error {0}.</value>
+  </data>
+  <data name="ADP_InvalidMultipartName" xml:space="preserve">
+    <value>{0} '{1}'.</value>
+  </data>
+  <data name="ADP_InvalidMultipartNameQuoteUsage" xml:space="preserve">
+    <value>{0} '{1}', incorrect usage of quotes.</value>
+  </data>
+  <data name="ADP_InvalidMultipartNameToManyParts" xml:space="preserve">
+    <value>{0} '{1}', the current limit of '{2}' is insufficient.</value>
+  </data>
+  <data name="SQL_SqlCommandCommandText" xml:space="preserve">
+    <value>SqlCommand.DeriveParameters failed because the SqlCommand.CommandText property value is an invalid multipart name</value>
+  </data>
+  <data name="SQL_BatchedUpdatesNotAvailableOnContextConnection" xml:space="preserve">
+    <value>Batching updates is not supported on the context connection.</value>
+  </data>
+  <data name="SQL_BulkCopyDestinationTableName" xml:space="preserve">
+    <value>SqlBulkCopy.WriteToServer failed because the SqlBulkCopy.DestinationTableName is an invalid multipart name</value>
+  </data>
+  <data name="SQL_TDSParserTableName" xml:space="preserve">
+    <value>Processing of results from SQL Server failed because of an invalid multipart name</value>
+  </data>
+  <data name="SQL_TypeName" xml:space="preserve">
+    <value>SqlParameter.TypeName is an invalid multipart name</value>
+  </data>
+  <data name="SQLMSF_FailoverPartnerNotSupported" xml:space="preserve">
+    <value>Connecting to a mirrored SQL Server instance using the MultiSubnetFailover connection option is not supported.</value>
+  </data>
+  <data name="SQL_NotSupportedEnumerationValue" xml:space="preserve">
+    <value>The {0} enumeration value, {1}, is not supported by the .Net Framework SqlClient Data Provider.</value>
+  </data>
+  <data name="ADP_CommandTextRequired" xml:space="preserve">
+    <value>{0}: CommandText property has not been initialized</value>
+  </data>
+  <data name="ADP_ConnectionRequired" xml:space="preserve">
+    <value>{0}: Connection property has not been initialized.</value>
+  </data>
+  <data name="ADP_OpenConnectionRequired" xml:space="preserve">
+    <value>{0} requires an open and available Connection. {1}</value>
+  </data>
+  <data name="ADP_TransactionConnectionMismatch" xml:space="preserve">
+    <value>The transaction is either not associated with the current connection or has been completed.</value>
+  </data>
+  <data name="ADP_TransactionRequired" xml:space="preserve">
+    <value>{0} requires the command to have a transaction when the connection assigned to the command is in a pending local transaction.  The Transaction property of the command has not been initialized.</value>
+  </data>
+  <data name="ADP_OpenReaderExists" xml:space="preserve">
+    <value>There is already an open DataReader associated with this Command which must be closed first.</value>
+  </data>
+  <data name="ADP_CalledTwice" xml:space="preserve">
+    <value>The method '{0}' cannot be called more than once for the same execution.</value>
+  </data>
+  <data name="ADP_InvalidCommandTimeout" xml:space="preserve">
+    <value>Invalid CommandTimeout value {0}; the value must be &gt;= 0.</value>
+  </data>
+  <data name="ADP_UninitializedParameterSize" xml:space="preserve">
+    <value>{1}[{0}]: the Size property has an invalid size of 0.</value>
+  </data>
+  <data name="ADP_PrepareParameterType" xml:space="preserve">
+    <value>{0}.Prepare method requires all parameters to have an explicitly set type.</value>
+  </data>
+  <data name="ADP_PrepareParameterSize" xml:space="preserve">
+    <value>{0}.Prepare method requires all variable length parameters to have an explicitly set non-zero Size.</value>
+  </data>
+  <data name="ADP_PrepareParameterScale" xml:space="preserve">
+    <value>{0}.Prepare method requires parameters of type '{1}' have an explicitly set Precision and Scale.</value>
+  </data>
+  <data name="ADP_MismatchedAsyncResult" xml:space="preserve">
+    <value>Mismatched end method call for asyncResult.  Expected call to {0} but {1} was called instead.</value>
+  </data>
+  <data name="ADP_ClosedConnectionError" xml:space="preserve">
+    <value>Invalid operation. The connection is closed.</value>
+  </data>
+  <data name="ADP_ConnectionIsDisabled" xml:space="preserve">
+    <value>The connection has been disabled.</value>
+  </data>
+  <data name="ADP_EmptyDatabaseName" xml:space="preserve">
+    <value>Database cannot be null, the empty string, or string of only whitespace.</value>
+  </data>
+  <data name="ADP_InvalidSourceBufferIndex" xml:space="preserve">
+    <value>Invalid source buffer (size of {0}) offset: {1}</value>
+  </data>
+  <data name="ADP_InvalidDestinationBufferIndex" xml:space="preserve">
+    <value>Invalid destination buffer (size of {0}) offset: {1}</value>
+  </data>
+  <data name="ADP_StreamClosed" xml:space="preserve">
+    <value>Invalid attempt to {0} when stream is closed.</value>
+  </data>
+  <data name="ADP_InvalidSeekOrigin" xml:space="preserve">
+    <value>Specified SeekOrigin value is invalid.</value>
+  </data>
+  <data name="ADP_NonSequentialColumnAccess" xml:space="preserve">
+    <value>Invalid attempt to read from column ordinal '{0}'.  With CommandBehavior.SequentialAccess, you may only read from column ordinal '{1}' or greater.</value>
+  </data>
+  <data name="ADP_InvalidDataType" xml:space="preserve">
+    <value>The parameter data type of {0} is invalid.</value>
+  </data>
+  <data name="ADP_UnknownDataType" xml:space="preserve">
+    <value>No mapping exists from object type {0} to a known managed provider native type.</value>
+  </data>
+  <data name="ADP_DbTypeNotSupported" xml:space="preserve">
+    <value>No mapping exists from DbType {0} to a known {1}.</value>
+  </data>
+  <data name="ADP_VersionDoesNotSupportDataType" xml:space="preserve">
+    <value>The version of SQL Server in use does not support datatype '{0}'.</value>
+  </data>
+  <data name="ADP_ParameterValueOutOfRange" xml:space="preserve">
+    <value>Parameter value '{0}' is out of range.</value>
+  </data>
+  <data name="ADP_BadParameterName" xml:space="preserve">
+    <value>Specified parameter name '{0}' is not valid.</value>
+  </data>
+  <data name="ADP_InvalidSizeValue" xml:space="preserve">
+    <value>Invalid parameter Size value '{0}'. The value must be greater than or equal to 0.</value>
+  </data>
+  <data name="ADP_NegativeParameter" xml:space="preserve">
+    <value>Invalid value for argument '{0}'. The value must be greater than or equal to 0.</value>
+  </data>
+  <data name="ADP_InvalidMetaDataValue" xml:space="preserve">
+    <value>Invalid value for this metadata.</value>
+  </data>
+  <data name="ADP_ParameterConversionFailed" xml:space="preserve">
+    <value>Failed to convert parameter value from a {0} to a {1}.</value>
+  </data>
+  <data name="ADP_ParallelTransactionsNotSupported" xml:space="preserve">
+    <value>{0} does not support parallel transactions.</value>
+  </data>
+  <data name="ADP_TransactionZombied" xml:space="preserve">
+    <value>This {0} has completed; it is no longer usable.</value>
+  </data>
+  <data name="ADP_InvalidDataLength2" xml:space="preserve">
+    <value>Specified length '{0}' is out of range.</value>
+  </data>
+  <data name="ADP_NonSeqByteAccess" xml:space="preserve">
+    <value>Invalid {2} attempt at dataIndex '{0}'.  With CommandBehavior.SequentialAccess, you may only read from dataIndex '{1}' or greater.</value>
+  </data>
+  <data name="ADP_InvalidMinMaxPoolSizeValues" xml:space="preserve">
+    <value>Invalid min or max pool size values, min pool size cannot be greater than the max pool size.</value>
+  </data>
+  <data name="SQL_InvalidPacketSizeValue" xml:space="preserve">
+    <value>Invalid 'Packet Size'.  The value must be an integer &gt;= 512 and &lt;= 32768.</value>
+  </data>
+  <data name="SQL_NullEmptyTransactionName" xml:space="preserve">
+    <value>Invalid transaction or invalid name for a point at which to save within the transaction.</value>
+  </data>
+  <data name="SQL_UserInstanceFailoverNotCompatible" xml:space="preserve">
+    <value>User Instance and Failover are not compatible options.  Please choose only one of the two in the connection string.</value>
+  </data>
+  <data name="SQL_EncryptionNotSupportedByClient" xml:space="preserve">
+    <value>The instance of SQL Server you attempted to connect to requires encryption but this machine does not support it.</value>
+  </data>
+  <data name="SQL_EncryptionNotSupportedByServer" xml:space="preserve">
+    <value>The instance of SQL Server you attempted to connect to does not support encryption.</value>
+  </data>
+  <data name="SQL_InvalidSQLServerVersionUnknown" xml:space="preserve">
+    <value>Unsupported SQL Server version.  The .Net Framework SqlClient Data Provider can only be used with SQL Server versions 7.0 and later.</value>
+  </data>
+  <data name="SQL_CannotModifyPropertyAsyncOperationInProgress" xml:space="preserve">
+    <value>{0} cannot be changed while async operation is in progress.</value>
+  </data>
+  <data name="SQL_InstanceFailure" xml:space="preserve">
+    <value>Instance failure.</value>
+  </data>
+  <data name="SQL_InvalidPartnerConfiguration" xml:space="preserve">
+    <value>Server {0}, database {1} is not configured for database mirroring.</value>
+  </data>
+  <data name="SQL_MarsUnsupportedOnConnection" xml:space="preserve">
+    <value>The connection does not support MultipleActiveResultSets.</value>
+  </data>
+  <data name="SQL_NonLocalSSEInstance" xml:space="preserve">
+    <value>SSE Instance re-direction is not supported for non-local user instances.</value>
+  </data>
+  <data name="SQL_PendingBeginXXXExists" xml:space="preserve">
+    <value>The command execution cannot proceed due to a pending asynchronous operation already in progress.</value>
+  </data>
+  <data name="SQL_NonXmlResult" xml:space="preserve">
+    <value>Invalid command sent to ExecuteXmlReader.  The command must return an Xml result.</value>
+  </data>
+  <data name="SQL_InvalidParameterTypeNameFormat" xml:space="preserve">
+    <value>Invalid 3 part name format for TypeName.</value>
+  </data>
+  <data name="SQL_InvalidParameterNameLength" xml:space="preserve">
+    <value>The length of the parameter '{0}' exceeds the limit of 128 characters.</value>
+  </data>
+  <data name="SQL_PrecisionValueOutOfRange" xml:space="preserve">
+    <value>Precision value '{0}' is either less than 0 or greater than the maximum allowed precision of 38.</value>
+  </data>
+  <data name="SQL_ScaleValueOutOfRange" xml:space="preserve">
+    <value>Scale value '{0}' is either less than 0 or greater than the maximum allowed scale of 38.</value>
+  </data>
+  <data name="SQL_TimeScaleValueOutOfRange" xml:space="preserve">
+    <value>Scale value '{0}' is either less than 0 or greater than the maximum allowed scale of 7.</value>
+  </data>
+  <data name="SQL_ParameterInvalidVariant" xml:space="preserve">
+    <value>Parameter '{0}' exceeds the size limit for the sql_variant datatype.</value>
+  </data>
+  <data name="SQL_ParameterTypeNameRequired" xml:space="preserve">
+    <value>The {0} type parameter '{1}' must have a valid type name.</value>
+  </data>
+  <data name="SQL_InvalidInternalPacketSize" xml:space="preserve">
+    <value>Invalid internal packet size:</value>
+  </data>
+  <data name="SQL_InvalidTDSVersion" xml:space="preserve">
+    <value>The SQL Server instance returned an invalid or unsupported protocol version during login negotiation.</value>
+  </data>
+  <data name="SQL_InvalidTDSPacketSize" xml:space="preserve">
+    <value>Invalid Packet Size.</value>
+  </data>
+  <data name="SQL_ParsingError" xml:space="preserve">
+    <value>Internal connection fatal error.</value>
+  </data>
+  <data name="SQL_ConnectionLockedForBcpEvent" xml:space="preserve">
+    <value>The connection cannot be used because there is an ongoing operation that must be finished.</value>
+  </data>
+  <data name="SQL_SNIPacketAllocationFailure" xml:space="preserve">
+    <value>Memory allocation for internal connection failed.</value>
+  </data>
+  <data name="SQL_SmallDateTimeOverflow" xml:space="preserve">
+    <value>SqlDbType.SmallDateTime overflow.  Value '{0}' is out of range.  Must be between 1/1/1900 12:00:00 AM and 6/6/2079 11:59:59 PM.</value>
+  </data>
+  <data name="SQL_TimeOverflow" xml:space="preserve">
+    <value>SqlDbType.Time overflow.  Value '{0}' is out of range.  Must be between 00:00:00.0000000 and 23:59:59.9999999.</value>
+  </data>
+  <data name="SQL_MoneyOverflow" xml:space="preserve">
+    <value>SqlDbType.SmallMoney overflow.  Value '{0}' is out of range.  Must be between -214,748.3648 and 214,748.3647.</value>
+  </data>
+  <data name="SQL_CultureIdError" xml:space="preserve">
+    <value>The Collation specified by SQL Server is not supported.</value>
+  </data>
+  <data name="SQL_OperationCancelled" xml:space="preserve">
+    <value>Operation cancelled by user.</value>
+  </data>
+  <data name="SQL_SevereError" xml:space="preserve">
+    <value>A severe error occurred on the current command.  The results, if any, should be discarded.</value>
+  </data>
+  <data name="SQL_SSPIGenerateError" xml:space="preserve">
+    <value>Failed to generate SSPI context.</value>
+  </data>
+  <data name="SQL_KerberosTicketMissingError" xml:space="preserve">
+    <value>Cannot access Kerberos ticket. Ensure Kerberos has been initialized with 'kinit'.</value>
+  </data>
+  <data name="SQL_InvalidSSPIPacketSize" xml:space="preserve">
+    <value>Invalid SSPI packet size.</value>
+  </data>
+  <data name="SQL_SSPIInitializeError" xml:space="preserve">
+    <value>Cannot initialize SSPI package.</value>
+  </data>
+  <data name="SQL_Timeout" xml:space="preserve">
+    <value>Timeout expired.  The timeout period elapsed prior to completion of the operation or the server is not responding.</value>
+  </data>
+  <data name="SQL_Timeout_PreLogin_Begin" xml:space="preserve">
+    <value>Connection Timeout Expired.  The timeout period elapsed at the start of the pre-login phase.  This could be because of insufficient time provided for connection timeout.</value>
+  </data>
+  <data name="SQL_Timeout_PreLogin_InitializeConnection" xml:space="preserve">
+    <value>Connection Timeout Expired.  The timeout period elapsed while attempting to create and initialize a socket to the server.  This could be either because the server was unreachable or unable to respond back in time.</value>
+  </data>
+  <data name="SQL_Timeout_PreLogin_SendHandshake" xml:space="preserve">
+    <value>Connection Timeout Expired.  The timeout period elapsed while making a pre-login handshake request.  This could be because the server was unable to respond back in time.</value>
+  </data>
+  <data name="SQL_Timeout_PreLogin_ConsumeHandshake" xml:space="preserve">
+    <value>Connection Timeout Expired.  The timeout period elapsed while attempting to consume the pre-login handshake acknowledgement.  This could be because the pre-login handshake failed or the server was unable to respond back in time.</value>
+  </data>
+  <data name="SQL_Timeout_Login_Begin" xml:space="preserve">
+    <value>Connection Timeout Expired.  The timeout period elapsed at the start of the login phase.  This could be because of insufficient time provided for connection timeout.</value>
+  </data>
+  <data name="SQL_Timeout_Login_ProcessConnectionAuth" xml:space="preserve">
+    <value>Connection Timeout Expired.  The timeout period elapsed while attempting to authenticate the login.  This could be because the server failed to authenticate the user or the server was unable to respond back in time.</value>
+  </data>
+  <data name="SQL_Timeout_PostLogin" xml:space="preserve">
+    <value>Connection Timeout Expired.  The timeout period elapsed during the post-login phase.  The connection could have timed out while waiting for server to complete the login process and respond; Or it could have timed out while attempting to create multiple active connections.</value>
+  </data>
+  <data name="SQL_Timeout_FailoverInfo" xml:space="preserve">
+    <value>This failure occurred while attempting to connect to the {0} server.</value>
+  </data>
+  <data name="SQL_Timeout_RoutingDestinationInfo" xml:space="preserve">
+    <value>This failure occurred while attempting to connect to the routing destination. The duration spent while attempting to connect to the original server was - [Pre-Login] initialization={0}; handshake={1}; [Login] initialization={2}; authentication={3}; [Post-Login] complete={4};  </value>
+  </data>
+  <data name="SQL_Duration_PreLogin_Begin" xml:space="preserve">
+    <value>The duration spent while attempting to connect to this server was - [Pre-Login] initialization={0};</value>
+  </data>
+  <data name="SQL_Duration_PreLoginHandshake" xml:space="preserve">
+    <value>The duration spent while attempting to connect to this server was - [Pre-Login] initialization={0}; handshake={1}; </value>
+  </data>
+  <data name="SQL_Duration_Login_Begin" xml:space="preserve">
+    <value>The duration spent while attempting to connect to this server was - [Pre-Login] initialization={0}; handshake={1}; [Login] initialization={2}; </value>
+  </data>
+  <data name="SQL_Duration_Login_ProcessConnectionAuth" xml:space="preserve">
+    <value>The duration spent while attempting to connect to this server was - [Pre-Login] initialization={0}; handshake={1}; [Login] initialization={2}; authentication={3}; </value>
+  </data>
+  <data name="SQL_Duration_PostLogin" xml:space="preserve">
+    <value>The duration spent while attempting to connect to this server was - [Pre-Login] initialization={0}; handshake={1}; [Login] initialization={2}; authentication={3}; [Post-Login] complete={4}; </value>
+  </data>
+  <data name="SQL_UserInstanceFailure" xml:space="preserve">
+    <value>A user instance was requested in the connection string but the server specified does not support this option.</value>
+  </data>
+  <data name="SQL_InvalidRead" xml:space="preserve">
+    <value>Invalid attempt to read when no data is present.</value>
+  </data>
+  <data name="SQL_NonBlobColumn" xml:space="preserve">
+    <value>Invalid attempt to GetBytes on column '{0}'.  The GetBytes function can only be used on columns of type Text, NText, or Image.</value>
+  </data>
+  <data name="SQL_NonCharColumn" xml:space="preserve">
+    <value>Invalid attempt to GetChars on column '{0}'.  The GetChars function can only be used on columns of type Text, NText, Xml, VarChar or NVarChar.</value>
+  </data>
+  <data name="SQL_StreamNotSupportOnColumnType" xml:space="preserve">
+    <value>Invalid attempt to GetStream on column '{0}'. The GetStream function can only be used on columns of type Binary, Image, Udt or VarBinary.</value>
+  </data>
+  <data name="SQL_TextReaderNotSupportOnColumnType" xml:space="preserve">
+    <value>Invalid attempt to GetTextReader on column '{0}'. The GetTextReader function can only be used on columns of type Char, NChar, NText, NVarChar, Text or VarChar.</value>
+  </data>
+  <data name="SQL_XmlReaderNotSupportOnColumnType" xml:space="preserve">
+    <value>Invalid attempt to GetXmlReader on column '{0}'. The GetXmlReader function can only be used on columns of type Xml.</value>
+  </data>
+  <data name="SqlDelegatedTransaction_PromotionFailed" xml:space="preserve">
+    <value>Failure while attempting to promote transaction.</value>
+  </data>
+  <data name="SQL_InvalidBufferSizeOrIndex" xml:space="preserve">
+    <value>Buffer offset '{1}' plus the bytes available '{0}' is greater than the length of the passed in buffer.</value>
+  </data>
+  <data name="SQL_InvalidDataLength" xml:space="preserve">
+    <value>Data length '{0}' is less than 0.</value>
+  </data>
+  <data name="SQL_BulkLoadMappingInaccessible" xml:space="preserve">
+    <value>The mapped collection is in use and cannot be accessed at this time;</value>
+  </data>
+  <data name="SQL_BulkLoadMappingsNamesOrOrdinalsOnly" xml:space="preserve">
+    <value>Mappings must be either all name or all ordinal based.</value>
+  </data>
+  <data name="SQL_BulkLoadCannotConvertValue" xml:space="preserve">
+    <value>The given value of type {0} from the data source cannot be converted to type {1} of the specified target column.</value>
+  </data>
+  <data name="SQL_BulkLoadNonMatchingColumnMapping" xml:space="preserve">
+    <value>The given ColumnMapping does not match up with any column in the source or destination.</value>
+  </data>
+  <data name="SQL_BulkLoadNonMatchingColumnName" xml:space="preserve">
+    <value>The given ColumnName '{0}' does not match up with any column in data source.</value>
+  </data>
+  <data name="SQL_BulkLoadStringTooLong" xml:space="preserve">
+    <value>String or binary data would be truncated.</value>
+  </data>
+  <data name="SQL_BulkLoadInvalidTimeout" xml:space="preserve">
+    <value>Timeout Value '{0}' is less than 0.</value>
+  </data>
+  <data name="SQL_BulkLoadInvalidVariantValue" xml:space="preserve">
+    <value>Value cannot be converted to SqlVariant.</value>
+  </data>
+  <data name="SQL_BulkLoadExistingTransaction" xml:space="preserve">
+    <value>Unexpected existing transaction.</value>
+  </data>
+  <data name="SQL_BulkLoadNoCollation" xml:space="preserve">
+    <value>Failed to obtain column collation information for the destination table. If the table is not in the current database the name must be qualified using the database name (e.g. [mydb]..[mytable](e.g. [mydb]..[mytable]); this also applies to temporary-tables (e.g. #mytable would be specified as tempdb..#mytable).</value>
+  </data>
+  <data name="SQL_BulkLoadConflictingTransactionOption" xml:space="preserve">
+    <value>Must not specify SqlBulkCopyOption.UseInternalTransaction and pass an external Transaction at the same time.</value>
+  </data>
+  <data name="SQL_BulkLoadInvalidOperationInsideEvent" xml:space="preserve">
+    <value>Function must not be called during event.</value>
+  </data>
+  <data name="SQL_BulkLoadMissingDestinationTable" xml:space="preserve">
+    <value>The DestinationTableName property must be set before calling this method.</value>
+  </data>
+  <data name="SQL_BulkLoadInvalidDestinationTable" xml:space="preserve">
+    <value>Cannot access destination table '{0}'.</value>
+  </data>
+  <data name="SQL_BulkLoadNotAllowDBNull" xml:space="preserve">
+    <value>Column '{0}' does not allow DBNull.Value.</value>
+  </data>
+  <data name="Sql_BulkLoadLcidMismatch" xml:space="preserve">
+    <value>The locale id '{0}' of the source column '{1}' and the locale id '{2}' of the destination column '{3}' do not match.</value>
+  </data>
+  <data name="SQL_BulkLoadPendingOperation" xml:space="preserve">
+    <value>Attempt to invoke bulk copy on an object that has a pending operation.</value>
+  </data>
+  <data name="SQL_CannotGetDTCAddress" xml:space="preserve">
+    <value>Unable to get the address of the distributed transaction coordinator for the server, from the server.  Is DTC enabled on the server?</value>
+  </data>
+  <data name="SQL_ConnectionDoomed" xml:space="preserve">
+    <value>The requested operation cannot be completed because the connection has been broken.</value>
+  </data>
+  <data name="SQL_OpenResultCountExceeded" xml:space="preserve">
+    <value>Open result count exceeded.</value>
+  </data>
+  <data name="SQL_StreamWriteNotSupported" xml:space="preserve">
+    <value>The Stream does not support writing.</value>
+  </data>
+  <data name="SQL_StreamReadNotSupported" xml:space="preserve">
+    <value>The Stream does not support reading.</value>
+  </data>
+  <data name="SQL_StreamSeekNotSupported" xml:space="preserve">
+    <value>The Stream does not support seeking.</value>
+  </data>
+  <data name="SQL_ExClientConnectionId" xml:space="preserve">
+    <value>ClientConnectionId:{0}</value>
+  </data>
+  <data name="SQL_ExErrorNumberStateClass" xml:space="preserve">
+    <value>Error Number:{0},State:{1},Class:{2}</value>
+  </data>
+  <data name="SQL_ExOriginalClientConnectionId" xml:space="preserve">
+    <value>ClientConnectionId before routing:{0}</value>
+  </data>
+  <data name="SQL_ExRoutingDestination" xml:space="preserve">
+    <value>Routing Destination:{0}</value>
+  </data>
+  <data name="SQL_UnsupportedSysTxVersion" xml:space="preserve">
+    <value>The currently loaded System.Transactions.dll does not support Global Transactions.</value>
+  </data>
+  <data name="SqlMisc_NullString" xml:space="preserve">
+    <value>Null</value>
+  </data>
+  <data name="SqlMisc_MessageString" xml:space="preserve">
+    <value>Message</value>
+  </data>
+  <data name="SqlMisc_ArithOverflowMessage" xml:space="preserve">
+    <value>Arithmetic Overflow.</value>
+  </data>
+  <data name="SqlMisc_DivideByZeroMessage" xml:space="preserve">
+    <value>Divide by zero error encountered.</value>
+  </data>
+  <data name="SqlMisc_NullValueMessage" xml:space="preserve">
+    <value>Data is Null. This method or property cannot be called on Null values.</value>
+  </data>
+  <data name="SqlMisc_TruncationMessage" xml:space="preserve">
+    <value>Numeric arithmetic causes truncation.</value>
+  </data>
+  <data name="SqlMisc_DateTimeOverflowMessage" xml:space="preserve">
+    <value>SqlDateTime overflow. Must be between 1/1/1753 12:00:00 AM and 12/31/9999 11:59:59 PM.</value>
+  </data>
+  <data name="SqlMisc_ConcatDiffCollationMessage" xml:space="preserve">
+    <value>Two strings to be concatenated have different collation.</value>
+  </data>
+  <data name="SqlMisc_CompareDiffCollationMessage" xml:space="preserve">
+    <value>Two strings to be compared have different collation.</value>
+  </data>
+  <data name="SqlMisc_InvalidFlagMessage" xml:space="preserve">
+    <value>Invalid flag value.</value>
+  </data>
+  <data name="SqlMisc_NumeToDecOverflowMessage" xml:space="preserve">
+    <value>Conversion from SqlDecimal to Decimal overflows.</value>
+  </data>
+  <data name="SqlMisc_ConversionOverflowMessage" xml:space="preserve">
+    <value>Conversion overflows.</value>
+  </data>
+  <data name="SqlMisc_InvalidDateTimeMessage" xml:space="preserve">
+    <value>Invalid SqlDateTime.</value>
+  </data>
+  <data name="SqlMisc_TimeZoneSpecifiedMessage" xml:space="preserve">
+    <value>A time zone was specified. SqlDateTime does not support time zones.</value>
+  </data>
+  <data name="SqlMisc_InvalidArraySizeMessage" xml:space="preserve">
+    <value>Invalid array size.</value>
+  </data>
+  <data name="SqlMisc_InvalidPrecScaleMessage" xml:space="preserve">
+    <value>Invalid numeric precision/scale.</value>
+  </data>
+  <data name="SqlMisc_FormatMessage" xml:space="preserve">
+    <value>The input wasn't in a correct format.</value>
+  </data>
+  <data name="SqlMisc_StreamErrorMessage" xml:space="preserve">
+    <value>An error occurred while reading.</value>
+  </data>
+  <data name="SqlMisc_TruncationMaxDataMessage" xml:space="preserve">
+    <value>Data returned is larger than 2Gb in size. Use SequentialAccess command behavior in order to get all of the data.</value>
+  </data>
+  <data name="SqlMisc_NotFilledMessage" xml:space="preserve">
+    <value>SQL Type has not been loaded with data.</value>
+  </data>
+  <data name="SqlMisc_AlreadyFilledMessage" xml:space="preserve">
+    <value>SQL Type has already been loaded with data.</value>
+  </data>
+  <data name="SqlMisc_ClosedXmlReaderMessage" xml:space="preserve">
+    <value>Invalid attempt to access a closed XmlReader.</value>
+  </data>
+  <data name="SqlMisc_InvalidOpStreamClosed" xml:space="preserve">
+    <value>Invalid attempt to call {0} when the stream is closed.</value>
+  </data>
+  <data name="SqlMisc_InvalidOpStreamNonWritable" xml:space="preserve">
+    <value>Invalid attempt to call {0} when the stream non-writable.</value>
+  </data>
+  <data name="SqlMisc_InvalidOpStreamNonReadable" xml:space="preserve">
+    <value>Invalid attempt to call {0} when the stream non-readable.</value>
+  </data>
+  <data name="SqlMisc_InvalidOpStreamNonSeekable" xml:space="preserve">
+    <value>Invalid attempt to call {0} when the stream is non-seekable.</value>
+  </data>
+  <data name="SqlMisc_SubclassMustOverride" xml:space="preserve">
+    <value>Subclass did not override a required method.</value>
+  </data>
+  <data name="Sql_InternalError" xml:space="preserve">
+    <value>Internal Error</value>
+  </data>
+  <data name="ADP_OperationAborted" xml:space="preserve">
+    <value>Operation aborted.</value>
+  </data>
+  <data name="ADP_OperationAbortedExceptionMessage" xml:space="preserve">
+    <value>Operation aborted due to an exception (see InnerException for details).</value>
+  </data>
+  <data name="ADP_TransactionCompletedButNotDisposed" xml:space="preserve">
+    <value>The transaction associated with the current connection has completed but has not been disposed.  The transaction must be disposed before the connection can be used to execute SQL statements.</value>
+  </data>
+  <data name="SqlParameter_UnsupportedTVPOutputParameter" xml:space="preserve">
+    <value>ParameterDirection '{0}' specified for parameter '{1}' is not supported. Table-valued parameters only support ParameterDirection.Input.</value>
+  </data>
+  <data name="SqlParameter_DBNullNotSupportedForTVP" xml:space="preserve">
+    <value>DBNull value for parameter '{0}' is not supported. Table-valued parameters cannot be DBNull.</value>
+  </data>
+  <data name="SqlParameter_UnexpectedTypeNameForNonStruct" xml:space="preserve">
+    <value>TypeName specified for parameter '{0}'.  TypeName must only be set for Structured parameters.</value>
+  </data>
+  <data name="NullSchemaTableDataTypeNotSupported" xml:space="preserve">
+    <value>DateType column for field '{0}' in schema table is null.  DataType must be non-null.</value>
+  </data>
+  <data name="InvalidSchemaTableOrdinals" xml:space="preserve">
+    <value>Invalid column ordinals in schema table.  ColumnOrdinals, if present, must not have duplicates or gaps.</value>
+  </data>
+  <data name="SQL_EnumeratedRecordMetaDataChanged" xml:space="preserve">
+    <value>Metadata for field '{0}' of record '{1}' did not match the original record's metadata.</value>
+  </data>
+  <data name="SQL_EnumeratedRecordFieldCountChanged" xml:space="preserve">
+    <value>Number of fields in record '{0}' does not match the number in the original record.</value>
+  </data>
+  <data name="GT_Disabled" xml:space="preserve">
+    <value>Global Transactions are not enabled for this Azure SQL Database. Please contact Azure SQL Database support for assistance.</value>
+  </data>
+  <data name="SQL_UnknownSysTxIsolationLevel" xml:space="preserve">
+    <value>Unrecognized System.Transactions.IsolationLevel enumeration value: {0}.</value>
+  </data>
+  <data name="SQLNotify_AlreadyHasCommand" xml:space="preserve">
+    <value>This SqlCommand object is already associated with another SqlDependency object.</value>
+  </data>
+  <data name="SqlDependency_DatabaseBrokerDisabled" xml:space="preserve">
+    <value>The SQL Server Service Broker for the current database is not enabled, and as a result query notifications are not supported.  Please enable the Service Broker for this database if you wish to use notifications.</value>
+  </data>
+  <data name="SqlDependency_DefaultOptionsButNoStart" xml:space="preserve">
+    <value>When using SqlDependency without providing an options value, SqlDependency.Start() must be called prior to execution of a command added to the SqlDependency instance.</value>
+  </data>
+  <data name="SqlDependency_NoMatchingServerStart" xml:space="preserve">
+    <value>When using SqlDependency without providing an options value, SqlDependency.Start() must be called for each server that is being executed against.</value>
+  </data>
+  <data name="SqlDependency_NoMatchingServerDatabaseStart" xml:space="preserve">
+    <value>SqlDependency.Start has been called for the server the command is executing against more than once, but there is no matching server/user/database Start() call for current command.</value>
+  </data>
+  <data name="SqlDependency_EventNoDuplicate" xml:space="preserve">
+    <value>SqlDependency.OnChange does not support multiple event registrations for the same delegate.</value>
+  </data>
+  <data name="SqlDependency_IdMismatch" xml:space="preserve">
+    <value>No SqlDependency exists for the key.</value>
+  </data>
+  <data name="SqlDependency_InvalidTimeout" xml:space="preserve">
+    <value>Timeout specified is invalid. Timeout cannot be &lt; 0.</value>
+  </data>
+  <data name="SqlDependency_DuplicateStart" xml:space="preserve">
+    <value>SqlDependency does not support calling Start() with different connection strings having the same server, user, and database in the same app domain.</value>
+  </data>
+  <data name="SqlMetaData_InvalidSqlDbTypeForConstructorFormat" xml:space="preserve">
+    <value>The dbType {0} is invalid for this constructor.</value>
+  </data>
+  <data name="SqlMetaData_NameTooLong" xml:space="preserve">
+    <value>The name is too long.</value>
+  </data>
+  <data name="SqlMetaData_SpecifyBothSortOrderAndOrdinal" xml:space="preserve">
+    <value>The sort order and ordinal must either both be specified, or neither should be specified (SortOrder.Unspecified and -1).  The values given were: order = {0}, ordinal = {1}.</value>
+  </data>
+  <data name="SqlProvider_InvalidDataColumnType" xml:space="preserve">
+    <value>The type of column '{0}' is not supported.  The type is '{1}'</value>
+  </data>
+  <data name="SqlProvider_NotEnoughColumnsInStructuredType" xml:space="preserve">
+    <value>There are not enough fields in the Structured type.  Structured types must have at least one field.</value>
+  </data>
+  <data name="SqlProvider_DuplicateSortOrdinal" xml:space="preserve">
+    <value>The sort ordinal {0} was specified twice.</value>
+  </data>
+  <data name="SqlProvider_MissingSortOrdinal" xml:space="preserve">
+    <value>The sort ordinal {0} was not specified.</value>
+  </data>
+  <data name="SqlProvider_SortOrdinalGreaterThanFieldCount" xml:space="preserve">
+    <value>The sort ordinal {0} on field {1} exceeds the total number of fields.</value>
+  </data>
+  <data name="IEnumerableOfSqlDataRecordHasNoRows" xml:space="preserve">
+    <value>There are no records in the SqlDataRecord enumeration. To send a table-valued parameter with no rows, use a null reference for the value instead.</value>
+  </data>
+  <data name="SNI_ERROR_1" xml:space="preserve">
+    <value>I/O Error detected in read/write operation</value>
+  </data>
+  <data name="SNI_ERROR_2" xml:space="preserve">
+    <value>Connection was terminated</value>
+  </data>
+  <data name="SNI_ERROR_3" xml:space="preserve">
+    <value>Asynchronous operations not supported</value>
+  </data>
+  <data name="SNI_ERROR_5" xml:space="preserve">
+    <value>Invalid parameter(s) found</value>
+  </data>
+  <data name="SNI_ERROR_6" xml:space="preserve">
+    <value>Unsupported protocol specified</value>
+  </data>
+  <data name="SNI_ERROR_7" xml:space="preserve">
+    <value>Invalid connection found when setting up new session protocol</value>
+  </data>
+  <data name="SNI_ERROR_8" xml:space="preserve">
+    <value>Protocol not supported</value>
+  </data>
+  <data name="SNI_ERROR_9" xml:space="preserve">
+    <value>Associating port with I/O completion mechanism failed</value>
+  </data>
+  <data name="SNI_ERROR_11" xml:space="preserve">
+    <value>Timeout error</value>
+  </data>
+  <data name="SNI_ERROR_12" xml:space="preserve">
+    <value>No server name supplied</value>
+  </data>
+  <data name="SNI_ERROR_13" xml:space="preserve">
+    <value>TerminateListener() has been called</value>
+  </data>
+  <data name="SNI_ERROR_14" xml:space="preserve">
+    <value>Win9x not supported</value>
+  </data>
+  <data name="SNI_ERROR_15" xml:space="preserve">
+    <value>Function not supported</value>
+  </data>
+  <data name="SNI_ERROR_16" xml:space="preserve">
+    <value>Shared-Memory heap error</value>
+  </data>
+  <data name="SNI_ERROR_17" xml:space="preserve">
+    <value>Cannot find an ip/ipv6 type address to connect</value>
+  </data>
+  <data name="SNI_ERROR_18" xml:space="preserve">
+    <value>Connection has been closed by peer</value>
+  </data>
+  <data name="SNI_ERROR_19" xml:space="preserve">
+    <value>Physical connection is not usable</value>
+  </data>
+  <data name="SNI_ERROR_20" xml:space="preserve">
+    <value>Connection has been closed</value>
+  </data>
+  <data name="SNI_ERROR_21" xml:space="preserve">
+    <value>Encryption is enforced but there is no valid certificate</value>
+  </data>
+  <data name="SNI_ERROR_22" xml:space="preserve">
+    <value>Couldn't load library</value>
+  </data>
+  <data name="SNI_ERROR_23" xml:space="preserve">
+    <value>Cannot open a new thread in server process</value>
+  </data>
+  <data name="SNI_ERROR_24" xml:space="preserve">
+    <value>Cannot post event to completion port</value>
+  </data>
+  <data name="SNI_ERROR_25" xml:space="preserve">
+    <value>Connection string is not valid</value>
+  </data>
+  <data name="SNI_ERROR_26" xml:space="preserve">
+    <value>Error Locating Server/Instance Specified</value>
+  </data>
+  <data name="SNI_ERROR_27" xml:space="preserve">
+    <value>Error getting enabled protocols list from registry</value>
+  </data>
+  <data name="SNI_ERROR_28" xml:space="preserve">
+    <value>Server doesn't support requested protocol</value>
+  </data>
+  <data name="SNI_ERROR_29" xml:space="preserve">
+    <value>Shared Memory is not supported for clustered server connectivity</value>
+  </data>
+  <data name="SNI_ERROR_30" xml:space="preserve">
+    <value>Invalid attempt bind to shared memory segment</value>
+  </data>
+  <data name="SNI_ERROR_31" xml:space="preserve">
+    <value>Encryption(ssl/tls) handshake failed</value>
+  </data>
+  <data name="SNI_ERROR_32" xml:space="preserve">
+    <value>Packet size too large for SSL Encrypt/Decrypt operations</value>
+  </data>
+  <data name="SNI_ERROR_33" xml:space="preserve">
+    <value>SSRP error</value>
+  </data>
+  <data name="SNI_ERROR_34" xml:space="preserve">
+    <value>Could not connect to the Shared Memory pipe</value>
+  </data>
+  <data name="SNI_ERROR_35" xml:space="preserve">
+    <value>An internal exception was caught</value>
+  </data>
+  <data name="SNI_ERROR_36" xml:space="preserve">
+    <value>The Shared Memory dll used to connect to SQL Server 2000 was not found</value>
+  </data>
+  <data name="SNI_ERROR_37" xml:space="preserve">
+    <value>The SQL Server 2000 Shared Memory client dll appears to be invalid/corrupted</value>
+  </data>
+  <data name="SNI_ERROR_38" xml:space="preserve">
+    <value>Cannot open a Shared Memory connection to SQL Server 2000</value>
+  </data>
+  <data name="SNI_ERROR_39" xml:space="preserve">
+    <value>Shared memory connectivity to SQL Server 2000 is either disabled or not available on this machine</value>
+  </data>
+  <data name="SNI_ERROR_40" xml:space="preserve">
+    <value>Could not open a connection to SQL Server</value>
+  </data>
+  <data name="SNI_ERROR_41" xml:space="preserve">
+    <value>Cannot open a Shared Memory connection to a remote SQL server</value>
+  </data>
+  <data name="SNI_ERROR_42" xml:space="preserve">
+    <value>Could not establish dedicated administrator connection (DAC) on default port. Make sure that DAC is enabled</value>
+  </data>
+  <data name="SNI_ERROR_43" xml:space="preserve">
+    <value>An error occurred while obtaining the dedicated administrator connection (DAC) port. Make sure that SQL Browser is running, or check the error log for the port number</value>
+  </data>
+  <data name="SNI_ERROR_44" xml:space="preserve">
+    <value>Could not compose Service Principal Name (SPN) for Windows Integrated Authentication. Possible causes are server(s) incorrectly specified to connection API calls, Domain Name System (DNS) lookup failure or memory shortage</value>
+  </data>
+  <data name="SNI_ERROR_47" xml:space="preserve">
+    <value>Connecting with the MultiSubnetFailover connection option to a SQL Server instance configured with more than 64 IP addresses is not supported.</value>
+  </data>
+  <data name="SNI_ERROR_48" xml:space="preserve">
+    <value>Connecting to a named SQL Server instance using the MultiSubnetFailover connection option is not supported.</value>
+  </data>
+  <data name="SNI_ERROR_49" xml:space="preserve">
+    <value>Connecting to a SQL Server instance using the MultiSubnetFailover connection option is only supported when using the TCP protocol.</value>
+  </data>
+  <data name="SNI_ERROR_50" xml:space="preserve">
+    <value>Local Database Runtime error occurred. </value>
+  </data>
+  <data name="SNI_ERROR_51" xml:space="preserve">
+    <value>An instance name was not specified while connecting to a Local Database Runtime. Specify an instance name in the format (localdb)\instance_name.</value>
+  </data>
+  <data name="SNI_ERROR_52" xml:space="preserve">
+    <value>Unable to locate a Local Database Runtime installation. Verify that SQL Server Express is properly installed and that the Local Database Runtime feature is enabled.</value>
+  </data>
+  <data name="SNI_ERROR_53" xml:space="preserve">
+    <value>Invalid Local Database Runtime registry configuration found. Verify that SQL Server Express is properly installed.</value>
+  </data>
+  <data name="SNI_ERROR_54" xml:space="preserve">
+    <value>Unable to locate the registry entry for SQLUserInstance.dll file path. Verify that the Local Database Runtime feature of SQL Server Express is properly installed.</value>
+  </data>
+  <data name="SNI_ERROR_55" xml:space="preserve">
+    <value>Registry value contains an invalid SQLUserInstance.dll file path. Verify that the Local Database Runtime feature of SQL Server Express is properly installed.</value>
+  </data>
+  <data name="SNI_ERROR_56" xml:space="preserve">
+    <value>Unable to load the SQLUserInstance.dll from the location specified in the registry. Verify that the Local Database Runtime feature of SQL Server Express is properly installed.</value>
+  </data>
+  <data name="SNI_ERROR_57" xml:space="preserve">
+    <value>Invalid SQLUserInstance.dll found at the location specified in the registry. Verify that the Local Database Runtime feature of SQL Server Express is properly installed.</value>
+  </data>
+  <data name="Snix_Connect" xml:space="preserve">
+    <value>A network-related or instance-specific error occurred while establishing a connection to SQL Server. The server was not found or was not accessible. Verify that the instance name is correct and that SQL Server is configured to allow remote connections.</value>
+  </data>
+  <data name="Snix_PreLoginBeforeSuccessfullWrite" xml:space="preserve">
+    <value>The client was unable to establish a connection because of an error during connection initialization process before login. Possible causes include the following:  the client tried to connect to an unsupported version of SQL Server; the server was too busy to accept new connections; or there was a resource limitation (insufficient memory or maximum allowed connections) on the server.</value>
+  </data>
+  <data name="Snix_PreLogin" xml:space="preserve">
+    <value>A connection was successfully established with the server, but then an error occurred during the pre-login handshake.</value>
+  </data>
+  <data name="Snix_LoginSspi" xml:space="preserve">
+    <value>A connection was successfully established with the server, but then an error occurred when obtaining the security/SSPI context information for integrated security login.</value>
+  </data>
+  <data name="Snix_Login" xml:space="preserve">
+    <value>A connection was successfully established with the server, but then an error occurred during the login process.</value>
+  </data>
+  <data name="Snix_EnableMars" xml:space="preserve">
+    <value>Connection open and login was successful, but then an error occurred while enabling MARS for this connection.</value>
+  </data>
+  <data name="Snix_AutoEnlist" xml:space="preserve">
+    <value>Connection open and login was successful, but then an error occurred while enlisting the connection into the current distributed transaction.</value>
+  </data>
+  <data name="Snix_GetMarsSession" xml:space="preserve">
+    <value>Failed to establish a MARS session in preparation to send the request to the server.</value>
+  </data>
+  <data name="Snix_Execute" xml:space="preserve">
+    <value>A transport-level error has occurred when sending the request to the server.</value>
+  </data>
+  <data name="Snix_Read" xml:space="preserve">
+    <value>A transport-level error has occurred when receiving results from the server.</value>
+  </data>
+  <data name="Snix_Close" xml:space="preserve">
+    <value>A transport-level error has occurred during connection clean-up.</value>
+  </data>
+  <data name="Snix_SendRows" xml:space="preserve">
+    <value>A transport-level error has occurred while sending information to the server.</value>
+  </data>
+  <data name="Snix_ProcessSspi" xml:space="preserve">
+    <value>A transport-level error has occurred during SSPI handshake.</value>
+  </data>
+  <data name="LocalDB_FailedGetDLLHandle" xml:space="preserve">
+    <value>Local Database Runtime: Cannot load SQLUserInstance.dll.</value>
+  </data>
+  <data name="LocalDB_MethodNotFound" xml:space="preserve">
+    <value>Invalid SQLUserInstance.dll found at the location specified in the registry. Verify that the Local Database Runtime feature of SQL Server Express is properly installed.</value>
+  </data>
+  <data name="LocalDB_UnobtainableMessage" xml:space="preserve">
+    <value>Cannot obtain Local Database Runtime error message</value>
+  </data>
+  <data name="SQLROR_RecursiveRoutingNotSupported" xml:space="preserve">
+    <value>Two or more redirections have occurred. Only one redirection per login is allowed.</value>
+  </data>
+  <data name="SQLROR_FailoverNotSupported" xml:space="preserve">
+    <value>Connecting to a mirrored SQL Server instance using the ApplicationIntent ReadOnly connection option is not supported.</value>
+  </data>
+  <data name="SQLROR_UnexpectedRoutingInfo" xml:space="preserve">
+    <value>Unexpected routing information received.</value>
+  </data>
+  <data name="SQLROR_InvalidRoutingInfo" xml:space="preserve">
+    <value>Invalid routing information received.</value>
+  </data>
+  <data name="SQLROR_TimeoutAfterRoutingInfo" xml:space="preserve">
+    <value>Server provided routing information, but timeout already expired.</value>
+  </data>
+  <data name="SQLCR_InvalidConnectRetryCountValue" xml:space="preserve">
+    <value>Invalid ConnectRetryCount value (should be 0-255).</value>
+  </data>
+  <data name="SQLCR_InvalidConnectRetryIntervalValue" xml:space="preserve">
+    <value>Invalid ConnectRetryInterval value (should be 1-60).</value>
+  </data>
+  <data name="SQLCR_NextAttemptWillExceedQueryTimeout" xml:space="preserve">
+    <value>Next reconnection attempt will exceed query timeout. Reconnection was terminated.</value>
+  </data>
+  <data name="SQLCR_EncryptionChanged" xml:space="preserve">
+    <value>The server did not preserve SSL encryption during a recovery attempt, connection recovery is not possible.</value>
+  </data>
+  <data name="SQLCR_TDSVestionNotPreserved" xml:space="preserve">
+    <value>The server did not preserve the exact client TDS version requested during a recovery attempt, connection recovery is not possible.</value>
+  </data>
+  <data name="SQLCR_AllAttemptsFailed" xml:space="preserve">
+    <value>The connection is broken and recovery is not possible.  The client driver attempted to recover the connection one or more times and all attempts failed.  Increase the value of ConnectRetryCount to increase the number of recovery attempts.</value>
+  </data>
+  <data name="SQLCR_UnrecoverableServer" xml:space="preserve">
+    <value>The connection is broken and recovery is not possible.  The connection is marked by the server as unrecoverable.  No attempt was made to restore the connection.</value>
+  </data>
+  <data name="SQLCR_UnrecoverableClient" xml:space="preserve">
+    <value>The connection is broken and recovery is not possible.  The connection is marked by the client driver as unrecoverable.  No attempt was made to restore the connection.</value>
+  </data>
+  <data name="SQLCR_NoCRAckAtReconnection" xml:space="preserve">
+    <value>The server did not acknowledge a recovery attempt, connection recovery is not possible.</value>
+  </data>
+  <data name="SQL_UnsupportedKeyword" xml:space="preserve">
+    <value>The keyword '{0}' is not supported on this platform.</value>
+  </data>
+  <data name="SQL_UnsupportedFeature" xml:space="preserve">
+    <value>The server is attempting to use a feature that is not supported on this platform.</value>
+  </data>
+  <data name="SQL_UnsupportedToken" xml:space="preserve">
+    <value>Received an unsupported token '{0}' while reading data from the server.</value>
+  </data>
+  <data name="SQL_DbTypeNotSupportedOnThisPlatform" xml:space="preserve">
+    <value>Type {0} is not supported on this platform.</value>
+  </data>
+  <data name="SQL_NetworkLibraryNotSupported" xml:space="preserve">
+    <value>The keyword 'Network Library' is not supported on this platform, prefix the 'Data Source' with the protocol desired instead ('tcp:' for a TCP connection, or 'np:' for a Named Pipe connection).</value>
+  </data>
+  <data name="SNI_PN0" xml:space="preserve">
+    <value>HTTP Provider</value>
+  </data>
+  <data name="SNI_PN1" xml:space="preserve">
+    <value>Named Pipes Provider</value>
+  </data>
+  <data name="SNI_PN2" xml:space="preserve">
+    <value>Session Provider</value>
+  </data>
+  <data name="SNI_PN3" xml:space="preserve">
+    <value>Sign Provider</value>
+  </data>
+  <data name="SNI_PN4" xml:space="preserve">
+    <value>Shared Memory Provider</value>
+  </data>
+  <data name="SNI_PN5" xml:space="preserve">
+    <value>SMux Provider</value>
+  </data>
+  <data name="SNI_PN6" xml:space="preserve">
+    <value>SSL Provider</value>
+  </data>
+  <data name="SNI_PN7" xml:space="preserve">
+    <value>TCP Provider</value>
+  </data>
+  <data name="SNI_PN8" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="SNI_PN9" xml:space="preserve">
+    <value>SQL Network Interfaces</value>
+  </data>
+  <data name="AZURESQL_GenericEndpoint" xml:space="preserve">
+    <value>.database.windows.net</value>
+  </data>
+  <data name="AZURESQL_GermanEndpoint" xml:space="preserve">
+    <value>.database.cloudapi.de</value>
+  </data>
+  <data name="AZURESQL_UsGovEndpoint" xml:space="preserve">
+    <value>.database.usgovcloudapi.net</value>
+  </data>
+  <data name="AZURESQL_ChinaEndpoint" xml:space="preserve">
+    <value>.database.chinacloudapi.cn</value>
+  </data>
+  <data name="net_nego_channel_binding_not_supported" xml:space="preserve">
+    <value>No support for channel binding on operating systems other than Windows.</value>
+  </data>
+  <data name="net_gssapi_operation_failed_detailed" xml:space="preserve">
+    <value>GSSAPI operation failed with error - {0} ({1}).</value>
+  </data>
+  <data name="net_gssapi_operation_failed" xml:space="preserve">
+    <value>GSSAPI operation failed with status: {0} (Minor status: {1}).</value>
+  </data>
+  <data name="net_ntlm_not_possible_default_cred" xml:space="preserve">
+    <value>NTLM authentication is not possible with default credentials on this platform.</value>
+  </data>
+  <data name="net_nego_not_supported_empty_target_with_defaultcreds" xml:space="preserve">
+    <value>Target name should be non-empty if default credentials are passed.</value>
+  </data>
+  <data name="net_nego_server_not_supported" xml:space="preserve">
+    <value>Server implementation is not supported.</value>
+  </data>
+  <data name="net_nego_protection_level_not_supported" xml:space="preserve">
+    <value>Requested protection level is not supported with the GSSAPI implementation currently installed.</value>
+  </data>
+  <data name="net_context_buffer_too_small" xml:space="preserve">
+    <value>Insufficient buffer space. Required: {0} Actual: {1}.</value>
+  </data>
+  <data name="net_auth_message_not_encrypted" xml:space="preserve">
+    <value>Protocol error: A received message contains a valid signature but it was not encrypted as required by the effective Protection Level.</value>
+  </data>
+  <data name="net_securitypackagesupport" xml:space="preserve">
+    <value>The requested security package is not supported.</value>
+  </data>
+  <data name="net_log_operation_failed_with_error" xml:space="preserve">
+    <value>{0} failed with error {1}.</value>
+  </data>
+  <data name="net_MethodNotImplementedException" xml:space="preserve">
+    <value>This method is not implemented by this class.</value>
+  </data>
+  <data name="event_OperationReturnedSomething" xml:space="preserve">
+    <value>{0} returned {1}.</value>
+  </data>
+  <data name="net_invalid_enum" xml:space="preserve">
+    <value>The specified value is not valid in the '{0}' enumeration.</value>
+  </data>
+  <data name="SSPIInvalidHandleType" xml:space="preserve">
+    <value>'{0}' is not a supported handle type.</value>
+  </data>
+  <data name="LocalDBNotSupported" xml:space="preserve">
+    <value>LocalDB is not supported on this Platform.</value>
+  </data>
+  <data name="PlatformNotSupported_DataSqlClient" xml:space="preserve">
+    <value>System.Data.SqlClient is not supported on this platform.</value>
+  </data>
+  <data name="SqlParameter_InvalidTableDerivedPrecisionForTvp" xml:space="preserve">
+    <value>Precision '{0}' required to send all values in column '{1}' exceeds the maximum supported precision '{2}'. The values must all fit in a single precision.</value>
+  </data>
+  <data name="SqlProvider_InvalidDataColumnMaxLength" xml:space="preserve">
+    <value>The size of column '{0}' is not supported. The size is {1}.</value>
+  </data>
+  <data name="MDF_InvalidXmlInvalidValue" xml:space="preserve"> 
+    <value>The metadata XML is invalid. The {1} column of the {0} collection must contain a non-empty string.</value>
+  </data>
+  <data name="MDF_CollectionNameISNotUnique" xml:space="preserve"> 
+    <value>There are multiple collections named '{0}'.</value>
+  </data>
+  <data name="MDF_InvalidXmlMissingColumn" xml:space="preserve"> 
+    <value>The metadata XML is invalid. The {0} collection must contain a {1} column and it must be a string column.</value>
+  </data>
+  <data name="MDF_InvalidXml" xml:space="preserve"> 
+    <value>The metadata XML is invalid.</value>
+  </data>
+  <data name="MDF_NoColumns" xml:space="preserve"> 
+    <value>The schema table contains no columns.</value>
+  </data>
+  <data name="MDF_QueryFailed" xml:space="preserve"> 
+    <value>Unable to build the '{0}' collection because execution of the SQL query failed. See the inner exception for details.</value>
+  </data>
+  <data name="MDF_TooManyRestrictions" xml:space="preserve"> 
+    <value>More restrictions were provided than the requested schema ('{0}') supports.</value>
+  </data>
+  <data name="MDF_DataTableDoesNotExist" xml:space="preserve"> 
+    <value>The collection '{0}' is missing from the metadata XML.</value>
+  </data>
+  <data name="MDF_UndefinedCollection" xml:space="preserve"> 
+    <value>The requested collection ({0}) is not defined.</value> 
+  </data>
+  <data name="MDF_UnsupportedVersion" xml:space="preserve">
+    <value> requested collection ({0}) is not supported by this version of the provider.</value>
+  </data>
+  <data name="MDF_MissingRestrictionColumn" xml:space="preserve">
+    <value>One or more of the required columns of the restrictions collection is missing.</value>
+  </data>
+  <data name="MDF_MissingRestrictionRow" xml:space="preserve">
+    <value>A restriction exists for which there is no matching row in the restrictions collection.</value>
+  </data>
+  <data name="MDF_IncorrectNumberOfDataSourceInformationRows" xml:space="preserve">
+    <value>The DataSourceInformation table must contain exactly one row.</value>
+  </data>
+  <data name="MDF_MissingDataSourceInformationColumn" xml:space="preserve">
+    <value>One of the required DataSourceInformation tables columns is missing.</value>
+  </data>
+  <data name="MDF_AmbigousCollectionName" xml:space="preserve">
+    <value>The collection name '{0}' matches at least two collections with the same name but with different case, but does not match any of them exactly.</value>
+  </data>
+  <data name="MDF_UnableToBuildCollection" xml:space="preserve">
+    <value>Unable to build schema collection '{0}';</value>
+  </data>
+  <data name="AmbientTransactionsNotSupported" xml:space="preserve">
+    <value>Enlisting in Ambient transactions is not supported.</value>
+  </data>
 </root>

--- a/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
+++ b/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
@@ -113,18 +113,23 @@
     <Compile Include="System\Data\SqlClient\SqlCommandSet.cs" />
     <Compile Include="System\Data\SqlClient\SqlConnection.cs" />
     <Compile Include="System\Data\SqlClient\SqlConnectionFactory.cs" />
-    <Compile Include="System\Data\SqlClient\SqlConnectionHelper.cs" />
+    <Compile Include="System\Data\SqlClient\SqlConnectionHelper.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="System\Data\SqlClient\SqlConnectionPoolGroupProviderInfo.cs" />
     <Compile Include="System\Data\SqlClient\SqlConnectionPoolKey.cs" />
     <Compile Include="System\Data\SqlClient\SqlConnectionPoolProviderInfo.cs" />
     <Compile Include="System\Data\SqlClient\SqlConnectionString.cs" />
     <Compile Include="System\Data\SqlClient\SqlConnectionStringBuilder.cs" />
     <Compile Include="System\Data\SqlClient\SqlConnectionTimeoutErrorInternal.cs" />
-    <Compile Include="System\Data\SqlClient\SqlDataAdapter.cs" />
+    <Compile Include="System\Data\SqlClient\SqlDataAdapter.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="System\Data\SqlClient\SqlDataReader.cs" />
     <Compile Include="System\Data\SqlClient\SqlDependency.cs" />
     <Compile Include="System\Data\SqlClient\SqlDependencyListener.cs" />
     <Compile Include="System\Data\SqlClient\SqlDependencyUtils.cs" />
+    <Compile Include="System\Data\SqlClient\SqlDelegatedTransaction.cs" />
     <Compile Include="System\Data\SqlClient\SqlEnums.cs" />
     <Compile Include="System\Data\SqlClient\SqlError.cs" />
     <Compile Include="System\Data\SqlClient\SqlErrorCollection.cs" />

--- a/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
+++ b/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
@@ -113,18 +113,14 @@
     <Compile Include="System\Data\SqlClient\SqlCommandSet.cs" />
     <Compile Include="System\Data\SqlClient\SqlConnection.cs" />
     <Compile Include="System\Data\SqlClient\SqlConnectionFactory.cs" />
-    <Compile Include="System\Data\SqlClient\SqlConnectionHelper.cs">
-      <SubType>Component</SubType>
-    </Compile>
+    <Compile Include="System\Data\SqlClient\SqlConnectionHelper.cs" />
     <Compile Include="System\Data\SqlClient\SqlConnectionPoolGroupProviderInfo.cs" />
     <Compile Include="System\Data\SqlClient\SqlConnectionPoolKey.cs" />
     <Compile Include="System\Data\SqlClient\SqlConnectionPoolProviderInfo.cs" />
     <Compile Include="System\Data\SqlClient\SqlConnectionString.cs" />
     <Compile Include="System\Data\SqlClient\SqlConnectionStringBuilder.cs" />
     <Compile Include="System\Data\SqlClient\SqlConnectionTimeoutErrorInternal.cs" />
-    <Compile Include="System\Data\SqlClient\SqlDataAdapter.cs">
-      <SubType>Component</SubType>
-    </Compile>
+    <Compile Include="System\Data\SqlClient\SqlDataAdapter.cs" />
     <Compile Include="System\Data\SqlClient\SqlDataReader.cs" />
     <Compile Include="System\Data\SqlClient\SqlDependency.cs" />
     <Compile Include="System\Data\SqlClient\SqlDependencyListener.cs" />

--- a/src/System.Data.SqlClient/src/System/Data/Common/AdapterUtil.SqlClient.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Common/AdapterUtil.SqlClient.cs
@@ -897,5 +897,13 @@ namespace System.Data.Common
         {
             return InvalidOperation(SR.GetString(SR.ADP_NoStoredProcedureExists, sproc));
         }
+
+        //
+        // DbProviderException
+        //
+        static internal InvalidOperationException TransactionCompletedButNotDisposed()
+        {
+            return Provider(SR.GetString(SR.ADP_TransactionCompletedButNotDisposed));
+        }
     }
 }

--- a/src/System.Data.SqlClient/src/System/Data/Common/AdapterUtil.SqlClient.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Common/AdapterUtil.SqlClient.cs
@@ -312,7 +312,7 @@ namespace System.Data.Common
             return InvalidOperation(SR.GetString(SR.ADP_NonSequentialColumnAccess, badCol.ToString(CultureInfo.InvariantCulture), currCol.ToString(CultureInfo.InvariantCulture)));
         }
 
-        static internal Exception InvalidXmlInvalidValue(string collectionName, string columnName)
+        internal static Exception InvalidXmlInvalidValue(string collectionName, string columnName)
         {
             return Argument(SR.GetString(SR.MDF_InvalidXmlInvalidValue, collectionName, columnName));
         }
@@ -777,7 +777,7 @@ namespace System.Data.Common
             return false;
         }
 
-        static internal ArgumentOutOfRangeException InvalidDataRowVersion(DataRowVersion value)
+        internal static ArgumentOutOfRangeException InvalidDataRowVersion(DataRowVersion value)
         {
 #if DEBUG
             switch (value)
@@ -909,7 +909,7 @@ namespace System.Data.Common
         //
         // DbProviderException
         //
-        static internal InvalidOperationException TransactionCompletedButNotDisposed()
+        internal static InvalidOperationException TransactionCompletedButNotDisposed()
         {
             return Provider(SR.GetString(SR.ADP_TransactionCompletedButNotDisposed));
         }

--- a/src/System.Data.SqlClient/src/System/Data/Common/AdapterUtil.SqlClient.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Common/AdapterUtil.SqlClient.cs
@@ -395,6 +395,14 @@ namespace System.Data.Common
         {
             return InvalidOperation(SR.GetString(SR.ADP_ConnectionAlreadyOpen, ADP.ConnectionStateMsg(state)));
         }
+        internal static Exception TransactionPresent()
+        {
+            return InvalidOperation(SR.GetString(SR.ADP_TransactionPresent));
+        }
+        internal static Exception LocalTransactionPresent()
+        {
+            return InvalidOperation(SR.GetString(SR.ADP_LocalTransactionPresent));
+        }
         internal static Exception OpenConnectionPropertySet(string property, ConnectionState state)
         {
             return InvalidOperation(SR.GetString(SR.ADP_OpenConnectionPropertySet, property, ADP.ConnectionStateMsg(state)));

--- a/src/System.Data.SqlClient/src/System/Data/Common/DbConnectionStringCommon.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Common/DbConnectionStringCommon.cs
@@ -227,8 +227,7 @@ namespace System.Data.Common
     internal static partial class DbConnectionStringDefaults
     {
         // all
-        //        internal const string NamedConnection           = "";
-
+        // internal const string NamedConnection = "";
 
         // SqlClient
         internal const ApplicationIntent ApplicationIntent = System.Data.SqlClient.ApplicationIntent.ReadWrite;
@@ -266,8 +265,7 @@ namespace System.Data.Common
     internal static partial class DbConnectionStringKeywords
     {
         // all
-        //        internal const string NamedConnection           = "Named Connection";
-
+        // internal const string NamedConnection = "Named Connection";
 
         // SqlClient
         internal const string ApplicationIntent = "ApplicationIntent";

--- a/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionClosed.cs
+++ b/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionClosed.cs
@@ -9,6 +9,7 @@
 using System.Data.Common;
 using System.Diagnostics;
 using System.Threading.Tasks;
+using SysTx = System.Transactions;
 
 
 namespace System.Data.ProviderBase
@@ -28,7 +29,7 @@ namespace System.Data.ProviderBase
             }
         }
 
-        override protected void Activate()
+        override protected void Activate(SysTx.Transaction transaction)
         {
             throw ADP.ClosedConnectionError();
         }

--- a/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionClosed.cs
+++ b/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionClosed.cs
@@ -21,7 +21,7 @@ namespace System.Data.ProviderBase
         {
         }
 
-        override public string ServerVersion
+        public override string ServerVersion
         {
             get
             {
@@ -29,17 +29,17 @@ namespace System.Data.ProviderBase
             }
         }
 
-        override protected void Activate(SysTx.Transaction transaction)
+        protected override void Activate(SysTx.Transaction transaction)
         {
             throw ADP.ClosedConnectionError();
         }
 
-        override public DbTransaction BeginTransaction(IsolationLevel il)
+        public override DbTransaction BeginTransaction(IsolationLevel il)
         {
             throw ADP.ClosedConnectionError();
         }
 
-        override public void ChangeDatabase(string database)
+        public override void ChangeDatabase(string database)
         {
             throw ADP.ClosedConnectionError();
         }
@@ -49,12 +49,12 @@ namespace System.Data.ProviderBase
             // not much to do here...
         }
 
-        override protected void Deactivate()
+        protected override void Deactivate()
         {
             throw ADP.ClosedConnectionError();
         }
 
-        override public void EnlistTransaction(SysTx.Transaction transaction)
+        public override void EnlistTransaction(SysTx.Transaction transaction)
         {
             throw ADP.ClosedConnectionError();
         }

--- a/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionClosed.cs
+++ b/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionClosed.cs
@@ -54,6 +54,10 @@ namespace System.Data.ProviderBase
             throw ADP.ClosedConnectionError();
         }
 
+        override public void EnlistTransaction(SysTx.Transaction transaction)
+        {
+            throw ADP.ClosedConnectionError();
+        }
 
         protected override DbReferenceCollection CreateReferenceCollection()
         {

--- a/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionClosed.cs
+++ b/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionClosed.cs
@@ -9,7 +9,7 @@
 using System.Data.Common;
 using System.Diagnostics;
 using System.Threading.Tasks;
-using SysTx = System.Transactions;
+using System.Transactions;
 
 
 namespace System.Data.ProviderBase
@@ -29,7 +29,7 @@ namespace System.Data.ProviderBase
             }
         }
 
-        protected override void Activate(SysTx.Transaction transaction)
+        protected override void Activate(Transaction transaction)
         {
             throw ADP.ClosedConnectionError();
         }
@@ -54,7 +54,7 @@ namespace System.Data.ProviderBase
             throw ADP.ClosedConnectionError();
         }
 
-        public override void EnlistTransaction(SysTx.Transaction transaction)
+        public override void EnlistTransaction(Transaction transaction)
         {
             throw ADP.ClosedConnectionError();
         }

--- a/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionFactory.cs
+++ b/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionFactory.cs
@@ -20,7 +20,6 @@ namespace System.Data.ProviderBase
         private readonly List<DbConnectionPool> _poolsToRelease;
         private readonly List<DbConnectionPoolGroup> _poolGroupsToRelease;
         private readonly Timer _pruningTimer;
-
         private const int PruningDueTime = 4 * 60 * 1000;           // 4 minutes
         private const int PruningPeriod = 30 * 1000;           // thirty seconds
 
@@ -219,13 +218,22 @@ namespace System.Data.ProviderBase
                             // If it is a new slot or a completed task, this continuation will start right away.
                             newTask = s_pendingOpenNonPooled[idx].ContinueWith((_) =>
                             {
-                                var newConnection = CreateNonPooledConnection(owningConnection, poolGroup, userOptions);
-                                if ((oldConnection != null) && (oldConnection.State == ConnectionState.Open))
+                                Transactions.Transaction originalTransaction = ADP.GetCurrentTransaction();
+                                try
                                 {
-                                    oldConnection.PrepareForReplaceConnection();
-                                    oldConnection.Dispose();
+                                    ADP.SetCurrentTransaction(retry.Task.AsyncState as Transactions.Transaction);
+                                    var newConnection = CreateNonPooledConnection(owningConnection, poolGroup, userOptions);
+                                    if ((oldConnection != null) && (oldConnection.State == ConnectionState.Open))
+                                    {
+                                        oldConnection.PrepareForReplaceConnection();
+                                        oldConnection.Dispose();
+                                    }
+                                    return newConnection;
                                 }
-                                return newConnection;
+                                finally
+                                {
+                                    ADP.SetCurrentTransaction(originalTransaction);
+                                }
                             }, cancellationTokenSource.Token, TaskContinuationOptions.LongRunning, TaskScheduler.Default);
 
                             // Place this new task in the slot so any future work will be queued behind it

--- a/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionInternal.cs
@@ -11,6 +11,7 @@ using System.Data.SqlClient;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using SysTx = System.Transactions;
 
 
 namespace System.Data.ProviderBase
@@ -32,9 +33,17 @@ namespace System.Data.ProviderBase
 
         private bool _connectionIsDoomed;       // true when the connection should no longer be used.
         private bool _cannotBePooled;           // true when the connection should no longer be pooled.
+        private bool _isInStasis;
 
         private DateTime _createTime;               // when the connection was created.
 
+        private SysTx.Transaction _enlistedTransaction;      // [usage must be thread-safe] the transaction that we're enlisted in, either manually or automatically
+
+        // _enlistedTransaction is a clone, so that transaction information can be queried even if the original transaction object is disposed.
+        // However, there are times when we need to know if the original transaction object was disposed, so we keep a reference to it here.
+        // This field should only be assigned a value at the same time _enlistedTransaction is updated.
+        // Also, this reference should not be disposed, since we aren't taking ownership of it.
+        private SysTx.Transaction _enlistedTransactionOriginal;
 
 #if DEBUG
         private int _activateCount;            // debug only counter to verify activate/deactivates are in sync.
@@ -69,6 +78,164 @@ namespace System.Data.ProviderBase
             }
         }
 
+        protected internal SysTx.Transaction EnlistedTransaction
+        {
+            get
+            {
+                return _enlistedTransaction;
+            }
+            set
+            {
+                SysTx.Transaction currentEnlistedTransaction = _enlistedTransaction;
+                if (((null == currentEnlistedTransaction) && (null != value))
+                    || ((null != currentEnlistedTransaction) && !currentEnlistedTransaction.Equals(value)))
+                {  // WebData 20000024
+
+                    // Pay attention to the order here:
+                    // 1) defect from any notifications
+                    // 2) replace the transaction
+                    // 3) re-enlist in notifications for the new transaction
+
+                    // SQLBUDT #230558 we need to use a clone of the transaction
+                    // when we store it, or we'll end up keeping it past the
+                    // duration of the using block of the TransactionScope
+                    SysTx.Transaction valueClone = null;
+                    SysTx.Transaction previousTransactionClone = null;
+                    try
+                    {
+                        if (null != value)
+                        {
+                            valueClone = value.Clone();
+                        }
+
+                        // NOTE: rather than take locks around several potential round-
+                        // trips to the server, and/or virtual function calls, we simply
+                        // presume that you aren't doing something illegal from multiple
+                        // threads, and check once we get around to finalizing things
+                        // inside a lock.
+
+                        lock (this)
+                        {
+                            // NOTE: There is still a race condition here, when we are
+                            // called from EnlistTransaction (which cannot re-enlist)
+                            // instead of EnlistDistributedTransaction (which can),
+                            // however this should have been handled by the outer
+                            // connection which checks to ensure that it's OK.  The
+                            // only case where we have the race condition is multiple
+                            // concurrent enlist requests to the same connection, which
+                            // is a bit out of line with something we should have to
+                            // support.
+
+                            // enlisted transaction can be nullified in Dispose call without lock
+                            previousTransactionClone = Interlocked.Exchange(ref _enlistedTransaction, valueClone);
+                            _enlistedTransactionOriginal = value;
+                            value = valueClone;
+                            valueClone = null; // we've stored it, don't dispose it.
+                        }
+                    }
+                    finally
+                    {
+                        // we really need to dispose our clones; they may have
+                        // native resources and GC may not happen soon enough.
+                        // VSDevDiv 479564: don't dispose if still holding reference in _enlistedTransaction
+                        if (null != previousTransactionClone &&
+                                !Object.ReferenceEquals(previousTransactionClone, _enlistedTransaction))
+                        {
+                            previousTransactionClone.Dispose();
+                        }
+                        if (null != valueClone && !Object.ReferenceEquals(valueClone, _enlistedTransaction))
+                        {
+                            valueClone.Dispose();
+                        }
+                    }
+
+                    // I don't believe that we need to lock to protect the actual
+                    // enlistment in the transaction; it would only protect us
+                    // against multiple concurrent calls to enlist, which really
+                    // isn't supported anyway.
+
+                    if (null != value)
+                    {
+                        TransactionOutcomeEnlist(value);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Get boolean value that indicates whether the enlisted transaction has been disposed.
+        /// </summary>
+        /// <value>
+        /// True if there is an enlisted transaction, and it has been diposed.
+        /// False if there is an enlisted transaction that has not been disposed, or if the transaction reference is null.
+        /// </value>
+        /// <remarks>
+        /// This method must be called while holding a lock on the DbConnectionInternal instance.
+        /// </remarks>
+        protected bool EnlistedTransactionDisposed
+        {
+            get
+            {
+                // Until the Transaction.Disposed property is public it is necessary to access a member
+                // that throws if the object is disposed to determine if in fact the transaction is disposed.
+                try
+                {
+                    bool disposed;
+
+                    SysTx.Transaction currentEnlistedTransactionOriginal = _enlistedTransactionOriginal;
+                    if (currentEnlistedTransactionOriginal != null)
+                    {
+                        disposed = currentEnlistedTransactionOriginal.TransactionInformation == null;
+                    }
+                    else
+                    {
+                        // Don't expect to get here in the general case,
+                        // Since this getter is called by CheckEnlistedTransactionBinding
+                        // after checking for a non-null enlisted transaction (and it does so under lock).
+                        disposed = false;
+                    }
+
+                    return disposed;
+                }
+                catch (ObjectDisposedException)
+                {
+                    return true;
+                }
+            }
+        }
+
+        internal bool IsTxRootWaitingForTxEnd
+        {
+            get
+            {
+                return _isInStasis;
+            }
+        }
+
+        virtual protected bool UnbindOnTransactionCompletion
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        // Is this a connection that must be put in stasis (or is already in stasis) pending the end of it's transaction?
+        virtual protected internal bool IsNonPoolableTransactionRoot
+        {
+            get
+            {
+                return false; // if you want to have delegated transactions that are non-poolable, you better override this...
+            }
+        }
+
+        virtual internal bool IsTransactionRoot
+        {
+            get
+            {
+                return false; // if you want to have delegated transactions, you better override this...
+            }
+        }
 
         protected internal bool IsConnectionDoomed
         {
@@ -177,20 +344,14 @@ namespace System.Data.ProviderBase
             }
         }
 
-        abstract protected void Activate();
+        abstract protected void Activate(SysTx.Transaction transaction);
 
-        internal void ActivateConnection()
+        internal void ActivateConnection(SysTx.Transaction transaction)
         {
             // Internal method called from the connection pooler so we don't expose
             // the Activate method publicly.
 
-#if DEBUG
-
-            int activateCount = Interlocked.Increment(ref _activateCount);
-            Debug.Assert(1 == activateCount, "activated multiple times?");
-#endif // DEBUG
-
-            Activate();
+            Activate(transaction);
         }
 
         internal void AddWeakReference(object value, int tag)
@@ -344,7 +505,7 @@ namespace System.Data.ProviderBase
 
 #if DEBUG
             int activateCount = Interlocked.Decrement(ref _activateCount);
-            Debug.Assert(0 == activateCount, "activated multiple times?");
+            //Debug.Assert(0 == activateCount, "activated multiple times?");
 #endif // DEBUG
 
 
@@ -362,6 +523,56 @@ namespace System.Data.ProviderBase
             Deactivate();
         }
 
+        virtual internal void DelegatedTransactionEnded()
+        {
+            // Called by System.Transactions when the delegated transaction has
+            // completed.  We need to make closed connections that are in stasis
+            // available again, or disposed closed/leaked non-pooled connections.
+
+            // IMPORTANT NOTE: You must have taken a lock on the object before
+            // you call this method to prevent race conditions with Clear and
+            // ReclaimEmancipatedObjects.
+
+
+            if (1 == _pooledCount)
+            {
+                // When _pooledCount is 1, it indicates a closed, pooled,
+                // connection so it is ready to put back into the pool for
+                // general use.
+
+                TerminateStasis(true);
+
+                Deactivate(); // call it one more time just in case
+
+                DbConnectionPool pool = Pool;
+
+                if (null == pool)
+                {
+                    throw ADP.InternalError(ADP.InternalErrorCode.PooledObjectWithoutPool);      // pooled connection does not have a pool
+                }
+                pool.PutObjectFromTransactedPool(this);
+            }
+            else if (-1 == _pooledCount && !_owningObject.IsAlive)
+            {
+                // When _pooledCount is -1 and the owning object no longer exists,
+                // it indicates a closed (or leaked), non-pooled connection so 
+                // it is safe to dispose.
+
+                TerminateStasis(false);
+
+                Deactivate(); // call it one more time just in case
+
+                // it's a non-pooled connection, we need to dispose of it
+                // once and for all, or the server will have fits about us
+                // leaving connections open until the client-side GC kicks 
+                // in.
+                Dispose();
+            }
+            // When _pooledCount is 0, the connection is a pooled connection
+            // that is either open (if the owning object is alive) or leaked (if
+            // the owning object is not alive)  In either case, we can't muck 
+            // with the connection here.
+        }
 
         public virtual void Dispose()
         {
@@ -380,6 +591,15 @@ namespace System.Data.ProviderBase
             _connectionIsDoomed = true;
         }
 
+        protected internal virtual DataTable GetSchema(DbConnectionFactory factory, DbConnectionPoolGroup poolGroup, DbConnection outerConnection, string collectionName, string[] restrictions)
+        {
+            Debug.Assert(outerConnection != null, "outerConnection may not be null.");
+
+            DbMetaDataFactory metaDataFactory = factory.GetMetaDataFactory(poolGroup, this);
+            Debug.Assert(metaDataFactory != null, "metaDataFactory may not be null.");
+
+            return metaDataFactory.GetSchema(outerConnection, collectionName, restrictions);
+        }
 
         internal void MakeNonPooledObject(object owningObject)
         {
@@ -539,6 +759,76 @@ namespace System.Data.ProviderBase
             }
         }
 
+        // Cleanup connection's transaction-specific structures (currently used by Delegated transaction).
+        //  This is a separate method because cleanup can be triggered in multiple ways for a delegated
+        //  transaction.
+        virtual protected void CleanupTransactionOnCompletion(SysTx.Transaction transaction)
+        {
+        }
+
+        // Detach transaction from connection.
+        internal void DetachTransaction(SysTx.Transaction transaction, bool isExplicitlyReleasing)
+        {
+            // potentially a multi-threaded event, so lock the connection to make sure we don't enlist in a new
+            // transaction between compare and assignment. No need to short circuit outside of lock, since failed comparisons should
+            // be the exception, not the rule.
+            lock (this)
+            {
+                // Detach if detach-on-end behavior, or if outer connection was closed
+                DbConnection owner = (DbConnection)Owner;
+                if (isExplicitlyReleasing || UnbindOnTransactionCompletion || null == owner)
+                {
+                    SysTx.Transaction currentEnlistedTransaction = _enlistedTransaction;
+                    if (currentEnlistedTransaction != null && transaction.Equals(currentEnlistedTransaction))
+                    {
+                        EnlistedTransaction = null;
+
+                        if (IsTxRootWaitingForTxEnd)
+                        {
+                            DelegatedTransactionEnded();
+                        }
+                    }
+                }
+            }
+        }
+
+        // Handle transaction detach, pool cleanup and other post-transaction cleanup tasks associated with
+        internal void CleanupConnectionOnTransactionCompletion(SysTx.Transaction transaction)
+        {
+            DetachTransaction(transaction, false);
+
+            DbConnectionPool pool = Pool;
+            if (null != pool)
+            {
+                pool.TransactionEnded(transaction, this);
+            }
+        }
+
+        void TransactionCompletedEvent(object sender, SysTx.TransactionEventArgs e)
+        {
+            SysTx.Transaction transaction = e.Transaction;
+
+            CleanupTransactionOnCompletion(transaction);
+
+            CleanupConnectionOnTransactionCompletion(transaction);
+        }
+
+        // TODO: Review whether we need the unmanaged code permission when we have the new object model available.
+        // [SecurityPermission(SecurityAction.Assert, Flags = SecurityPermissionFlag.UnmanagedCode)]
+        private void TransactionOutcomeEnlist(SysTx.Transaction transaction)
+        {
+            transaction.TransactionCompleted += new SysTx.TransactionCompletedEventHandler(TransactionCompletedEvent);
+        }
+
+        internal void SetInStasis()
+        {
+            _isInStasis = true;
+        }
+
+        private void TerminateStasis(bool returningToPool)
+        {
+            _isInStasis = false;
+        }
 
         /// <summary>
         /// When overridden in a derived class, will check if the underlying connection is still actually alive
@@ -549,16 +839,6 @@ namespace System.Data.ProviderBase
         internal virtual bool IsConnectionAlive(bool throwOnException = false)
         {
             return true;
-        }
-
-        protected internal virtual DataTable GetSchema(DbConnectionFactory factory, DbConnectionPoolGroup poolGroup, DbConnection outerConnection, string collectionName, string[] restrictions)
-        {
-            Debug.Assert(outerConnection != null, "outerConnection may not be null.");
-
-            DbMetaDataFactory metaDataFactory = factory.GetMetaDataFactory(poolGroup, this);
-            Debug.Assert(metaDataFactory != null, "metaDataFactory may not be null.");
-
-            return metaDataFactory.GetSchema(outerConnection, collectionName, restrictions);
         }
     }
 }

--- a/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionInternal.cs
@@ -521,7 +521,6 @@ namespace System.Data.ProviderBase
 
 #if DEBUG
             int activateCount = Interlocked.Decrement(ref _activateCount);
-            //Debug.Assert(0 == activateCount, "activated multiple times?");
 #endif // DEBUG
 
 

--- a/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPool.cs
+++ b/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPool.cs
@@ -12,6 +12,7 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Concurrent;
+using SysTx = System.Transactions;
 
 namespace System.Data.ProviderBase
 {
@@ -24,6 +25,25 @@ namespace System.Data.ProviderBase
             ShuttingDown,
         }
 
+        // This class is a way to stash our cloned Tx key for later disposal when it's no longer needed.
+        // We can't get at the key in the dictionary without enumerating entries, so we stash an extra
+        // copy as part of the value.
+        sealed private class TransactedConnectionList : List<DbConnectionInternal>
+        {
+            private SysTx.Transaction _transaction;
+            internal TransactedConnectionList(int initialAllocation, SysTx.Transaction tx) : base(initialAllocation)
+            {
+                _transaction = tx;
+            }
+
+            internal void Dispose()
+            {
+                if (null != _transaction)
+                {
+                    _transaction.Dispose();
+                }
+            }
+        }
 
         private sealed class PendingGetConnection
         {
@@ -39,6 +59,230 @@ namespace System.Data.ProviderBase
             public DbConnectionOptions UserOptions { get; private set; }
         }
 
+        sealed private class TransactedConnectionPool
+        {
+
+            Dictionary<SysTx.Transaction, TransactedConnectionList> _transactedCxns;
+
+            DbConnectionPool _pool;
+
+            private static int _objectTypeCount; // Bid counter
+            internal readonly int _objectID = System.Threading.Interlocked.Increment(ref _objectTypeCount);
+
+            internal TransactedConnectionPool(DbConnectionPool pool)
+            {
+                Debug.Assert(null != pool, "null pool?");
+
+                _pool = pool;
+                _transactedCxns = new Dictionary<SysTx.Transaction, TransactedConnectionList>();
+            }
+
+            internal int ObjectID
+            {
+                get
+                {
+                    return _objectID;
+                }
+            }
+
+            internal DbConnectionPool Pool
+            {
+                get
+                {
+                    return _pool;
+                }
+            }
+
+            internal DbConnectionInternal GetTransactedObject(SysTx.Transaction transaction)
+            {
+                Debug.Assert(null != transaction, "null transaction?");
+
+                DbConnectionInternal transactedObject = null;
+
+                TransactedConnectionList connections;
+                bool txnFound = false;
+
+                lock (_transactedCxns)
+                {
+                    txnFound = _transactedCxns.TryGetValue(transaction, out connections);
+                }
+
+                // NOTE: GetTransactedObject is only used when AutoEnlist = True and the ambient transaction 
+                //   (Sys.Txns.Txn.Current) is still valid/non-null. This, in turn, means that we don't need 
+                //   to worry about a pending asynchronous TransactionCompletedEvent to trigger processing in
+                //   TransactionEnded below and potentially wipe out the connections list underneath us. It
+                //   is similarly alright if a pending addition to the connections list in PutTransactedObject
+                //   below is not completed prior to the lock on the connections object here...getting a new
+                //   connection is probably better than unnecessarily locking
+                if (txnFound)
+                {
+                    Debug.Assert(connections != null);
+
+                    // synchronize multi-threaded access with PutTransactedObject (TransactionEnded should
+                    //   not be a concern, see comments above)
+                    lock (connections)
+                    {
+                        int i = connections.Count - 1;
+                        if (0 <= i)
+                        {
+                            transactedObject = connections[i];
+                            connections.RemoveAt(i);
+                        }
+                    }
+                }
+                
+                return transactedObject;
+            }
+
+            internal void PutTransactedObject(SysTx.Transaction transaction, DbConnectionInternal transactedObject)
+            {
+                Debug.Assert(null != transaction, "null transaction?");
+                Debug.Assert(null != transactedObject, "null transactedObject?");
+
+                TransactedConnectionList connections;
+                bool txnFound = false;
+
+                // NOTE: because TransactionEnded is an asynchronous notification, there's no guarantee
+                //   around the order in which PutTransactionObject and TransactionEnded are called. 
+
+                lock (_transactedCxns)
+                {
+                    // Check if a transacted pool has been created for this transaction
+                    if (txnFound = _transactedCxns.TryGetValue(transaction, out connections))
+                    {
+                        Debug.Assert(connections != null);
+
+                        // synchronize multi-threaded access with GetTransactedObject
+                        lock (connections)
+                        {
+                            Debug.Assert(0 > connections.IndexOf(transactedObject), "adding to pool a second time?");
+                            connections.Add(transactedObject);
+                        }
+                    }
+                }
+
+                // CONSIDER: the following code is more complicated than it needs to be to avoid cloning the 
+                //   transaction and allocating memory within a lock. Is that complexity really necessary?
+                if (!txnFound)
+                {
+                    // create the transacted pool, making sure to clone the associated transaction
+                    //   for use as a key in our internal dictionary of transactions and connections
+                    SysTx.Transaction transactionClone = null;
+                    TransactedConnectionList newConnections = null;
+
+                    try
+                    {
+                        transactionClone = transaction.Clone();
+                        newConnections = new TransactedConnectionList(2, transactionClone); // start with only two connections in the list; most times we won't need that many.
+
+                        lock (_transactedCxns)
+                        {
+                            // NOTE: in the interim between the locks on the transacted pool (this) during 
+                            //   execution of this method, another thread (threadB) may have attempted to 
+                            //   add a different connection to the transacted pool under the same 
+                            //   transaction. As a result, threadB may have completed creating the
+                            //   transacted pool while threadA was processing the above instructions.
+                            if (txnFound = _transactedCxns.TryGetValue(transaction, out connections))
+                            {
+                                Debug.Assert(connections != null);
+
+                                // synchronize multi-threaded access with GetTransactedObject
+                                lock (connections)
+                                {
+                                    Debug.Assert(0 > connections.IndexOf(transactedObject), "adding to pool a second time?");
+                                    connections.Add(transactedObject);
+                                }
+                            }
+                            else
+                            {
+                                // add the connection/transacted object to the list
+                                newConnections.Add(transactedObject);
+
+                                _transactedCxns.Add(transactionClone, newConnections);
+                                transactionClone = null; // we've used it -- don't throw it or the TransactedConnectionList that references it away.                                
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        if (null != transactionClone)
+                        {
+                            if (newConnections != null)
+                            {
+                                // another thread created the transaction pool and thus the new 
+                                //   TransactedConnectionList was not used, so dispose of it and
+                                //   the transaction clone that it incorporates.
+                                newConnections.Dispose();
+                            }
+                            else
+                            {
+                                // memory allocation for newConnections failed...clean up unused transactionClone
+                                transactionClone.Dispose();
+                            }
+                        }
+                    }
+                }
+            }
+
+            internal void TransactionEnded(SysTx.Transaction transaction, DbConnectionInternal transactedObject)
+            {
+                TransactedConnectionList connections;
+                int entry = -1;
+
+                // NOTE: because TransactionEnded is an asynchronous notification, there's no guarantee
+                //   around the order in which PutTransactionObject and TransactionEnded are called. As
+                //   such, it is possible that the transaction does not yet have a pool created.
+
+                // TODO: is this a plausible and/or likely scenario? Do we need to have a mechanism to ensure
+                // TODO:   that the pending creation of a transacted pool for this transaction is aborted when
+                // TODO:   PutTransactedObject finally gets some CPU time?
+
+                lock (_transactedCxns)
+                {
+                    if (_transactedCxns.TryGetValue(transaction, out connections))
+                    {
+                        Debug.Assert(connections != null);
+
+                        bool shouldDisposeConnections = false;
+
+                        // Lock connections to avoid conflict with GetTransactionObject
+                        lock (connections)
+                        {
+                            entry = connections.IndexOf(transactedObject);
+
+                            if (entry >= 0)
+                            {
+                                connections.RemoveAt(entry);
+                            }
+
+                            // Once we've completed all the ended notifications, we can
+                            // safely remove the list from the transacted pool.
+                            if (0 >= connections.Count)
+                            {
+                                _transactedCxns.Remove(transaction);
+
+                                // we really need to dispose our connection list; it may have 
+                                // native resources via the tx and GC may not happen soon enough.
+                                shouldDisposeConnections = true;
+                            }
+                        }
+
+                        if (shouldDisposeConnections)
+                        {
+                            connections.Dispose();
+                        }
+                    }
+                }
+
+                // If (and only if) we found the connection in the list of
+                // connections, we'll put it back...
+                if (0 <= entry)
+                {
+                    Pool.PutObjectFromTransactedPool(transactedObject);
+                }
+            }
+
+        }
 
         private sealed class PoolWaitHandles
         {
@@ -130,6 +374,7 @@ namespace System.Data.ProviderBase
 
         private Timer _cleanupTimer;
 
+        private readonly TransactedConnectionPool _transactedConnectionPool;
 
         private readonly List<DbConnectionInternal> _objectList;
         private int _totalObjects;
@@ -169,6 +414,11 @@ namespace System.Data.ProviderBase
 
             _objectList = new List<DbConnectionInternal>(MaxPoolSize);
 
+            if (ADP.IsPlatformNT5)
+            {
+                _transactedConnectionPool = new TransactedConnectionPool(this);
+            }
+
             _poolCreateRequest = new WaitCallback(PoolCreateRequest); // used by CleanupCallback
             _state = State.Running;
 
@@ -196,6 +446,10 @@ namespace System.Data.ProviderBase
             get { return _errorOccurred; }
         }
 
+        private bool HasTransactionAffinity
+        {
+            get { return PoolGroupOptions.HasTransactionAffinity; }
+        }
 
         internal TimeSpan LoadBalanceTimeout
         {
@@ -244,7 +498,6 @@ namespace System.Data.ProviderBase
         {
             get { return PoolGroupOptions.MinPoolSize; }
         }
-
 
         internal DbConnectionPoolGroup PoolGroup
         {
@@ -484,6 +737,7 @@ namespace System.Data.ProviderBase
 
             bool returnToGeneralPool = false;
             bool destroyObject = false;
+            bool rootTxn = false;
 
             if (obj.IsConnectionDoomed)
             {
@@ -506,26 +760,78 @@ namespace System.Data.ProviderBase
 
                     if (_state == State.ShuttingDown)
                     {
-                        // connection is being closed and the pool has been marked as shutting
-                        //   down, so destroy this object.
-                        destroyObject = true;
+                        if (obj.IsTransactionRoot)
+                        {
+                            // SQLHotfix# 50003503 - connections that are affiliated with a 
+                            //   root transaction and that also happen to be in a connection 
+                            //   pool that is being shutdown need to be put in stasis so that 
+                            //   the root transaction isn't effectively orphaned with no 
+                            //   means to promote itself to a full delegated transaction or
+                            //   Commit or Rollback
+                            obj.SetInStasis();
+                            rootTxn = true;
+                        }
+                        else
+                        {
+                            // connection is being closed and the pool has been marked as shutting
+                            //   down, so destroy this object.
+                            destroyObject = true;
+                        }
                     }
                     else
                     {
-                        if (obj.CanBePooled)
+                        if (obj.IsNonPoolableTransactionRoot)
+                        {
+                            obj.SetInStasis();
+                            rootTxn = true;
+                        }
+                        else if (obj.CanBePooled)
                         {
                             // We must put this connection into the transacted pool
                             // while inside a lock to prevent a race condition with
                             // the transaction asynchronously completing on a second
                             // thread.
 
-                            // return to general pool
-                            returnToGeneralPool = true;
+                            SysTx.Transaction transaction = obj.EnlistedTransaction;
+                            if (null != transaction)
+                            {
+                                // NOTE: we're not locking on _state, so it's possible that its
+                                //   value could change between the conditional check and here.
+                                //   Although perhaps not ideal, this is OK because the 
+                                //   DelegatedTransactionEnded event will clean up the
+                                //   connection appropriately regardless of the pool state.
+                                Debug.Assert(_transactedConnectionPool != null, "Transacted connection pool was not expected to be null.");
+                                _transactedConnectionPool.PutTransactedObject(transaction, obj);
+                                rootTxn = true;
+                            }
+                            else
+                            {
+                                // return to general pool
+                                returnToGeneralPool = true;
+                            }
                         }
                         else
                         {
-                            // object is not fit for reuse -- just dispose of it
-                            destroyObject = true;
+                            if (obj.IsTransactionRoot && !obj.IsConnectionDoomed)
+                            {
+                                // SQLHotfix# 50003503 - if the object cannot be pooled but is a transaction
+                                //   root, then we must have hit one of two race conditions:
+                                //       1) PruneConnectionPoolGroups shutdown the pool and marked this connection 
+                                //          as non-poolable while we were processing within this lock
+                                //       2) The LoadBalancingTimeout expired on this connection and marked this
+                                //          connection as DoNotPool.
+                                //
+                                //   This connection needs to be put in stasis so that the root transaction isn't
+                                //   effectively orphaned with no means to promote itself to a full delegated 
+                                //   transaction or Commit or Rollback
+                                obj.SetInStasis();
+                                rootTxn = true;
+                            }
+                            else
+                            {
+                                // object is not fit for reuse -- just dispose of it
+                                destroyObject = true;
+                            }
                         }
                     }
                 }
@@ -549,8 +855,7 @@ namespace System.Data.ProviderBase
             // postcondition
 
             // ensure that the connection was processed
-            Debug.Assert(
-                returnToGeneralPool == true || destroyObject == true);
+            Debug.Assert(rootTxn == true || returnToGeneralPool == true || destroyObject == true);
         }
 
         internal void DestroyObject(DbConnectionInternal obj)
@@ -742,6 +1047,15 @@ namespace System.Data.ProviderBase
         private bool TryGetConnection(DbConnection owningObject, uint waitForMultipleObjectsTimeout, bool allowCreate, bool onlyOneCheckConnection, DbConnectionOptions userOptions, out DbConnectionInternal connection)
         {
             DbConnectionInternal obj = null;
+            SysTx.Transaction transaction = null;
+
+            // If automatic transaction enlistment is required, then we try to
+            // get the connection from the transacted connection pool first.
+            if (HasTransactionAffinity)
+            {
+                obj = GetFromTransactedPool(out transaction);
+            }
+
             if (null == obj)
             {
                 Interlocked.Increment(ref _waitCount);
@@ -870,14 +1184,14 @@ namespace System.Data.ProviderBase
 
             if (null != obj)
             {
-                PrepareConnection(owningObject, obj);
+                PrepareConnection(owningObject, obj, transaction);
             }
 
             connection = obj;
             return true;
         }
 
-        private void PrepareConnection(DbConnection owningObject, DbConnectionInternal obj)
+        private void PrepareConnection(DbConnection owningObject, DbConnectionInternal obj, SysTx.Transaction transaction)
         {
             lock (obj)
             {   // Protect against Clear and ReclaimEmancipatedObjects, which call IsEmancipated, which is affected by PrePush and PostPop
@@ -885,7 +1199,7 @@ namespace System.Data.ProviderBase
             }
             try
             {
-                obj.ActivateConnection();
+                obj.ActivateConnection(transaction);
             }
             catch
             {
@@ -909,7 +1223,7 @@ namespace System.Data.ProviderBase
 
             if (newConnection != null)
             {
-                PrepareConnection(owningObject, newConnection);
+                PrepareConnection(owningObject, newConnection, oldConnection.EnlistedTransaction);
                 oldConnection.PrepareForReplaceConnection();
                 oldConnection.DeactivateConnection();
                 oldConnection.Dispose();
@@ -947,6 +1261,39 @@ namespace System.Data.ProviderBase
             {
             }
             return (obj);
+        }
+
+        private DbConnectionInternal GetFromTransactedPool(out SysTx.Transaction transaction)
+        {
+            transaction = ADP.GetCurrentTransaction();
+            DbConnectionInternal obj = null;
+
+            if (null != transaction && null != _transactedConnectionPool)
+            {
+                obj = _transactedConnectionPool.GetTransactedObject(transaction);
+
+                if (null != obj)
+                {
+                    if (obj.IsTransactionRoot)
+                    {
+                        try
+                        {
+                            obj.IsConnectionAlive(true);
+                        }
+                        catch
+                        {
+                            DestroyObject(obj);
+                            throw;
+                        }
+                    }
+                    else if (!obj.IsConnectionAlive())
+                    {
+                        DestroyObject(obj);
+                        obj = null;
+                    }
+                }
+            }
+            return obj;
         }
 
         private void PoolCreateRequest(object state)
@@ -1071,6 +1418,30 @@ namespace System.Data.ProviderBase
             DeactivateObject(obj);
         }
 
+        internal void PutObjectFromTransactedPool(DbConnectionInternal obj)
+        {
+            Debug.Assert(null != obj, "null pooledObject?");
+            Debug.Assert(obj.EnlistedTransaction == null, "pooledObject is still enlisted?");
+
+            // called by the transacted connection pool , once it's removed the
+            // connection from it's list.  We put the connection back in general
+            // circulation.
+
+            // NOTE: there is no locking required here because if we're in this
+            // method, we can safely presume that the caller is the only person
+            // that is using the connection, and that all pre-push logic has been
+            // done and all transactions are ended.
+
+            if (_state == State.Running && obj.CanBePooled)
+            {
+                PutNewObject(obj);
+            }
+            else
+            {
+                DestroyObject(obj);
+                QueuePoolCreateRequest();
+            }
+        }
 
         private void QueuePoolCreateRequest()
         {
@@ -1166,6 +1537,27 @@ namespace System.Data.ProviderBase
             }
         }
 
+        // TransactionEnded merely provides the plumbing for DbConnectionInternal to access the transacted pool
+        //   that is implemented inside DbConnectionPool. This method's counterpart (PutTransactedObject) should
+        //   only be called from DbConnectionPool.DeactivateObject and thus the plumbing to provide access to 
+        //   other objects is unnecessary (hence the asymmetry of Ended but no Begin)
+        internal void TransactionEnded(SysTx.Transaction transaction, DbConnectionInternal transactedObject)
+        {
+            Debug.Assert(null != transaction, "null transaction?");
+            Debug.Assert(null != transactedObject, "null transactedObject?");
+            // Note: connection may still be associated with transaction due to Explicit Unbinding requirement.
+
+            // called by the internal connection when it get's told that the
+            // transaction is completed.  We tell the transacted pool to remove
+            // the connection from it's list, then we put the connection back in
+            // general circulation.
+
+            TransactedConnectionPool transactedConnectionPool = _transactedConnectionPool;
+            if (null != transactedConnectionPool)
+            {
+                transactedConnectionPool.TransactionEnded(transaction, transactedObject);
+            }
+        }
 
         private DbConnectionInternal UserCreateRequest(DbConnection owningObject, DbConnectionOptions userOptions, DbConnectionInternal oldConnection = null)
         {

--- a/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPool.cs
+++ b/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPool.cs
@@ -12,7 +12,7 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Concurrent;
-using SysTx = System.Transactions;
+using System.Transactions;
 
 namespace System.Data.ProviderBase
 {
@@ -30,8 +30,8 @@ namespace System.Data.ProviderBase
         // copy as part of the value.
         sealed private class TransactedConnectionList : List<DbConnectionInternal>
         {
-            private SysTx.Transaction _transaction;
-            internal TransactedConnectionList(int initialAllocation, SysTx.Transaction tx) : base(initialAllocation)
+            private Transaction _transaction;
+            internal TransactedConnectionList(int initialAllocation, Transaction tx) : base(initialAllocation)
             {
                 _transaction = tx;
             }
@@ -61,7 +61,7 @@ namespace System.Data.ProviderBase
 
         sealed private class TransactedConnectionPool
         {
-            Dictionary<SysTx.Transaction, TransactedConnectionList> _transactedCxns;
+            Dictionary<Transaction, TransactedConnectionList> _transactedCxns;
 
             DbConnectionPool _pool;
 
@@ -73,7 +73,7 @@ namespace System.Data.ProviderBase
                 Debug.Assert(null != pool, "null pool?");
 
                 _pool = pool;
-                _transactedCxns = new Dictionary<SysTx.Transaction, TransactedConnectionList>();
+                _transactedCxns = new Dictionary<Transaction, TransactedConnectionList>();
             }
 
             internal int ObjectID
@@ -92,7 +92,7 @@ namespace System.Data.ProviderBase
                 }
             }
 
-            internal DbConnectionInternal GetTransactedObject(SysTx.Transaction transaction)
+            internal DbConnectionInternal GetTransactedObject(Transaction transaction)
             {
                 Debug.Assert(null != transaction, "null transaction?");
 
@@ -133,7 +133,7 @@ namespace System.Data.ProviderBase
                 return transactedObject;
             }
 
-            internal void PutTransactedObject(SysTx.Transaction transaction, DbConnectionInternal transactedObject)
+            internal void PutTransactedObject(Transaction transaction, DbConnectionInternal transactedObject)
             {
                 Debug.Assert(null != transaction, "null transaction?");
                 Debug.Assert(null != transactedObject, "null transactedObject?");
@@ -166,7 +166,7 @@ namespace System.Data.ProviderBase
                 {
                     // create the transacted pool, making sure to clone the associated transaction
                     //   for use as a key in our internal dictionary of transactions and connections
-                    SysTx.Transaction transactionClone = null;
+                    Transaction transactionClone = null;
                     TransactedConnectionList newConnections = null;
 
                     try
@@ -223,7 +223,7 @@ namespace System.Data.ProviderBase
                 }
             }
 
-            internal void TransactionEnded(SysTx.Transaction transaction, DbConnectionInternal transactedObject)
+            internal void TransactionEnded(Transaction transaction, DbConnectionInternal transactedObject)
             {
                 TransactedConnectionList connections;
                 int entry = -1;
@@ -818,7 +818,7 @@ namespace System.Data.ProviderBase
                             // the transaction asynchronously completing on a second
                             // thread.
 
-                            SysTx.Transaction transaction = obj.EnlistedTransaction;
+                            Transaction transaction = obj.EnlistedTransaction;
                             if (null != transaction)
                             {
                                 // NOTE: we're not locking on _state, so it's possible that its
@@ -1074,7 +1074,7 @@ namespace System.Data.ProviderBase
         private bool TryGetConnection(DbConnection owningObject, uint waitForMultipleObjectsTimeout, bool allowCreate, bool onlyOneCheckConnection, DbConnectionOptions userOptions, out DbConnectionInternal connection)
         {
             DbConnectionInternal obj = null;
-            SysTx.Transaction transaction = null;
+            Transaction transaction = null;
 
             // If automatic transaction enlistment is required, then we try to
             // get the connection from the transacted connection pool first.
@@ -1217,7 +1217,7 @@ namespace System.Data.ProviderBase
             return true;
         }
 
-        private void PrepareConnection(DbConnection owningObject, DbConnectionInternal obj, SysTx.Transaction transaction)
+        private void PrepareConnection(DbConnection owningObject, DbConnectionInternal obj, Transaction transaction)
         {
             lock (obj)
             {   // Protect against Clear and ReclaimEmancipatedObjects, which call IsEmancipated, which is affected by PrePush and PostPop
@@ -1289,7 +1289,7 @@ namespace System.Data.ProviderBase
             return (obj);
         }
 
-        private DbConnectionInternal GetFromTransactedPool(out SysTx.Transaction transaction)
+        private DbConnectionInternal GetFromTransactedPool(out Transaction transaction)
         {
             transaction = ADP.GetCurrentTransaction();
             DbConnectionInternal obj = null;
@@ -1568,7 +1568,7 @@ namespace System.Data.ProviderBase
         //   that is implemented inside DbConnectionPool. This method's counterpart (PutTransactedObject) should
         //   only be called from DbConnectionPool.DeactivateObject and thus the plumbing to provide access to 
         //   other objects is unnecessary (hence the asymmetry of Ended but no Begin)
-        internal void TransactionEnded(SysTx.Transaction transaction, DbConnectionInternal transactedObject)
+        internal void TransactionEnded(Transaction transaction, DbConnectionInternal transactedObject)
         {
             Debug.Assert(null != transaction, "null transaction?");
             Debug.Assert(null != transactedObject, "null transactedObject?");

--- a/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPoolOptions.cs
+++ b/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPoolOptions.cs
@@ -15,6 +15,7 @@ namespace System.Data.ProviderBase
         private readonly int _maxPoolSize;
         private readonly int _creationTimeout;
         private readonly TimeSpan _loadBalanceTimeout;
+        private readonly bool _hasTransactionAffinity;
         private readonly bool _useLoadBalancing;
 
         public DbConnectionPoolGroupOptions(
@@ -22,7 +23,8 @@ namespace System.Data.ProviderBase
                                         int minPoolSize,
                                         int maxPoolSize,
                                         int creationTimeout,
-                                        int loadBalanceTimeout
+                                        int loadBalanceTimeout,
+                                        bool hasTransactionAffinity
         )
         {
             _poolByIdentity = poolByIdentity;
@@ -35,11 +37,17 @@ namespace System.Data.ProviderBase
                 _loadBalanceTimeout = new TimeSpan(0, 0, loadBalanceTimeout);
                 _useLoadBalancing = true;
             }
+
+            _hasTransactionAffinity = hasTransactionAffinity;
         }
 
         public int CreationTimeout
         {
             get { return _creationTimeout; }
+        }
+        public bool HasTransactionAffinity
+        {
+            get { return _hasTransactionAffinity; }
         }
         public TimeSpan LoadBalanceTimeout
         {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
@@ -187,6 +187,8 @@ namespace System.Data.SqlClient
         internal int _rowsAffected = -1; // rows affected by the command
 
         private SqlNotificationRequest _notification;
+		
+		private bool _notificationAutoEnlist = true;            // Notifications auto enlistment is turned on by default
 
         // transaction support
         private SqlTransaction _transaction;
@@ -331,6 +333,18 @@ namespace System.Data.SqlClient
             {
                 _sqlDep = null;
                 _notification = value;
+            }
+        }
+
+        public bool NotificationAutoEnlist
+        {
+            get
+            {
+                return _notificationAutoEnlist;
+            }
+            set
+            {
+                _notificationAutoEnlist = value;
             }
         }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
@@ -17,3858 +17,3865 @@ using Microsoft.SqlServer.Server;
 
 namespace System.Data.SqlClient
 {
-	public sealed class SqlCommand : DbCommand, ICloneable
-	{
-		private string _commandText;
-		private CommandType _commandType;
-		private int _commandTimeout = ADP.DefaultCommandTimeout;
-		private UpdateRowSource _updatedRowSource = UpdateRowSource.Both;
-		private bool _designTimeInvisible;
+    public sealed class SqlCommand : DbCommand, ICloneable
+    {
+        private string _commandText;
+        private CommandType _commandType;
+        private int _commandTimeout = ADP.DefaultCommandTimeout;
+        private UpdateRowSource _updatedRowSource = UpdateRowSource.Both;
+        private bool _designTimeInvisible;
 
-		internal SqlDependency _sqlDep;
+        internal SqlDependency _sqlDep;
 
-		private static readonly DiagnosticListener _diagnosticListener = new DiagnosticListener(SqlClientDiagnosticListenerExtensions.DiagnosticListenerName);
-		private bool _parentOperationStarted = false;
+        private static readonly DiagnosticListener _diagnosticListener = new DiagnosticListener(SqlClientDiagnosticListenerExtensions.DiagnosticListenerName);
+        private bool _parentOperationStarted = false;
 
-		// Prepare
-		// Against 7.0 Serve a prepare/unprepare requires an extra roundtrip to the server.
-		//
-		// From 8.0 and above  the preparation can be done as part of the command execution.
+        // Prepare
+        // Against 7.0 Serve a prepare/unprepare requires an extra roundtrip to the server.
+        //
+        // From 8.0 and above  the preparation can be done as part of the command execution.
 
-		private enum EXECTYPE
-		{
-			UNPREPARED,         // execute unprepared commands, all server versions (results in sp_execsql call)
-			PREPAREPENDING,     // prepare and execute command, 8.0 and above only  (results in sp_prepexec call)
-			PREPARED,           // execute prepared commands, all server versions   (results in sp_exec call)
-		}
+        private enum EXECTYPE
+        {
+            UNPREPARED,         // execute unprepared commands, all server versions (results in sp_execsql call)
+            PREPAREPENDING,     // prepare and execute command, 8.0 and above only  (results in sp_prepexec call)
+            PREPARED,           // execute prepared commands, all server versions   (results in sp_exec call)
+        }
 
-		// _hiddenPrepare
-		// On 8.0 and above the Prepared state cannot be left. Once a command is prepared it will always be prepared.
-		// A change in parameters, commandtext etc (IsDirty) automatically causes a hidden prepare
-		//
-		// _inPrepare will be set immediately before the actual prepare is done.
-		// The OnReturnValue function will test this flag to determine whether the returned value is a _prepareHandle or something else.
-		//
-		// _prepareHandle - the handle of a prepared command. Apparently there can be multiple prepared commands at a time - a feature that we do not support yet.
+        // _hiddenPrepare
+        // On 8.0 and above the Prepared state cannot be left. Once a command is prepared it will always be prepared.
+        // A change in parameters, commandtext etc (IsDirty) automatically causes a hidden prepare
+        //
+        // _inPrepare will be set immediately before the actual prepare is done.
+        // The OnReturnValue function will test this flag to determine whether the returned value is a _prepareHandle or something else.
+        //
+        // _prepareHandle - the handle of a prepared command. Apparently there can be multiple prepared commands at a time - a feature that we do not support yet.
 
-		private bool _inPrepare = false;
-		private int _prepareHandle = -1;
-		private bool _hiddenPrepare = false;
-		private int _preparedConnectionCloseCount = -1;
-		private int _preparedConnectionReconnectCount = -1;
+        private bool _inPrepare = false;
+        private int _prepareHandle = -1;
+        private bool _hiddenPrepare = false;
+        private int _preparedConnectionCloseCount = -1;
+        private int _preparedConnectionReconnectCount = -1;
 
-		private SqlParameterCollection _parameters;
-		private SqlConnection _activeConnection;
-		private bool _dirty = false;               // true if the user changes the commandtext or number of parameters after the command is already prepared
-		private EXECTYPE _execType = EXECTYPE.UNPREPARED; // by default, assume the user is not sharing a connection so the command has not been prepared
-		private _SqlRPC[] _rpcArrayOf1 = null;                // Used for RPC executes
+        private SqlParameterCollection _parameters;
+        private SqlConnection _activeConnection;
+        private bool _dirty = false;               // true if the user changes the commandtext or number of parameters after the command is already prepared
+        private EXECTYPE _execType = EXECTYPE.UNPREPARED; // by default, assume the user is not sharing a connection so the command has not been prepared
+        private _SqlRPC[] _rpcArrayOf1 = null;                // Used for RPC executes
 
-		// cut down on object creation and cache all these
-		// cached metadata
-		private _SqlMetaDataSet _cachedMetaData;
+        // cut down on object creation and cache all these
+        // cached metadata
+        private _SqlMetaDataSet _cachedMetaData;
 
-		// Last TaskCompletionSource for reconnect task - use for cancellation only
-		private TaskCompletionSource<object> _reconnectionCompletionSource = null;
+        // Last TaskCompletionSource for reconnect task - use for cancellation only
+        private TaskCompletionSource<object> _reconnectionCompletionSource = null;
 
 #if DEBUG
-		internal static int DebugForceAsyncWriteDelay { get; set; }
+        internal static int DebugForceAsyncWriteDelay { get; set; }
 #endif
-		internal bool InPrepare
-		{
-			get
-			{
-				return _inPrepare;
-			}
-		}
-
-		// Cached info for async executions
-		private class CachedAsyncState
-		{
-			private int _cachedAsyncCloseCount = -1;    // value of the connection's CloseCount property when the asyncResult was set; tracks when connections are closed after an async operation
-			private TaskCompletionSource<object> _cachedAsyncResult = null;
-			private SqlConnection _cachedAsyncConnection = null;  // Used to validate that the connection hasn't changed when end the connection;
-			private SqlDataReader _cachedAsyncReader = null;
-			private RunBehavior _cachedRunBehavior = RunBehavior.ReturnImmediately;
-			private string _cachedSetOptions = null;
-			private string _cachedEndMethod = null;
-
-			internal CachedAsyncState()
-			{
-			}
-
-			internal SqlDataReader CachedAsyncReader
-			{
-				get { return _cachedAsyncReader; }
-			}
-			internal RunBehavior CachedRunBehavior
-			{
-				get { return _cachedRunBehavior; }
-			}
-			internal string CachedSetOptions
-			{
-				get { return _cachedSetOptions; }
-			}
-			internal bool PendingAsyncOperation
-			{
-				get { return (null != _cachedAsyncResult); }
-			}
-			internal string EndMethodName
-			{
-				get { return _cachedEndMethod; }
-			}
-
-			internal bool IsActiveConnectionValid(SqlConnection activeConnection)
-			{
-				return (_cachedAsyncConnection == activeConnection && _cachedAsyncCloseCount == activeConnection.CloseCount);
-			}
-
-			internal void ResetAsyncState()
-			{
-				_cachedAsyncCloseCount = -1;
-				_cachedAsyncResult = null;
-				if (_cachedAsyncConnection != null)
-				{
-					_cachedAsyncConnection.AsyncCommandInProgress = false;
-					_cachedAsyncConnection = null;
-				}
-				_cachedAsyncReader = null;
-				_cachedRunBehavior = RunBehavior.ReturnImmediately;
-				_cachedSetOptions = null;
-				_cachedEndMethod = null;
-			}
-
-			internal void SetActiveConnectionAndResult(TaskCompletionSource<object> completion, string endMethod, SqlConnection activeConnection)
-			{
-				Debug.Assert(activeConnection != null, "Unexpected null connection argument on SetActiveConnectionAndResult!");
-				TdsParser parser = activeConnection?.Parser;
-				if ((parser == null) || (parser.State == TdsParserState.Closed) || (parser.State == TdsParserState.Broken))
-				{
-					throw ADP.ClosedConnectionError();
-				}
-
-				_cachedAsyncCloseCount = activeConnection.CloseCount;
-				_cachedAsyncResult = completion;
-				if (!parser.MARSOn)
-				{
-					if (activeConnection.AsyncCommandInProgress)
-						throw SQL.MARSUnspportedOnConnection();
-				}
-				_cachedAsyncConnection = activeConnection;
-
-				// Should only be needed for non-MARS, but set anyways.
-				_cachedAsyncConnection.AsyncCommandInProgress = true;
-				_cachedEndMethod = endMethod;
-			}
-
-			internal void SetAsyncReaderState(SqlDataReader ds, RunBehavior runBehavior, string optionSettings)
-			{
-				_cachedAsyncReader = ds;
-				_cachedRunBehavior = runBehavior;
-				_cachedSetOptions = optionSettings;
-			}
-		}
-
-		private CachedAsyncState _cachedAsyncState = null;
-
-		private CachedAsyncState cachedAsyncState
-		{
-			get
-			{
-				if (_cachedAsyncState == null)
-				{
-					_cachedAsyncState = new CachedAsyncState();
-				}
-				return _cachedAsyncState;
-			}
-		}
-
-		// sql reader will pull this value out for each NextResult call.  It is not cumulative
-		// _rowsAffected is cumulative for ExecuteNonQuery across all rpc batches
-		internal int _rowsAffected = -1; // rows affected by the command
-
-		private SqlNotificationRequest _notification;
-		
-		private bool _notificationAutoEnlist = true;            // Notifications auto enlistment is turned on by default
-
-		// transaction support
-		private SqlTransaction _transaction;
-
-		private StatementCompletedEventHandler _statementCompletedEventHandler;
-
-		private TdsParserStateObject _stateObj; // this is the TDS session we're using.
-
-		// Volatile bool used to synchronize with cancel thread the state change of an executing
-		// command going from pre-processing to obtaining a stateObject.  The cancel synchronization
-		// we require in the command is only from entering an Execute* API to obtaining a 
-		// stateObj.  Once a stateObj is successfully obtained, cancel synchronization is handled
-		// by the stateObject.
-		private volatile bool _pendingCancel;
-
-		private bool _batchRPCMode;
-		private List<_SqlRPC> _RPCList;
-		private _SqlRPC[] _SqlRPCBatchArray;
-		private List<SqlParameterCollection> _parameterCollectionList;
-		private int _currentlyExecutingBatch;
-
-
-		public SqlCommand() : base()
-		{
-			GC.SuppressFinalize(this);
-		}
-
-		public SqlCommand(string cmdText) : this()
-		{
-			CommandText = cmdText;
-		}
-
-		public SqlCommand(string cmdText, SqlConnection connection) : this()
-		{
-			CommandText = cmdText;
-			Connection = connection;
-		}
-
-		public SqlCommand(string cmdText, SqlConnection connection, SqlTransaction transaction) : this()
-		{
-			CommandText = cmdText;
-			Connection = connection;
-			Transaction = transaction;
-		}
-
-		private SqlCommand(SqlCommand from) : this()
-		{
-			CommandText = from.CommandText;
-			CommandTimeout = from.CommandTimeout;
-			CommandType = from.CommandType;
-			Connection = from.Connection;
-			DesignTimeVisible = from.DesignTimeVisible;
-			Transaction = from.Transaction;
-			UpdatedRowSource = from.UpdatedRowSource;
-
-			SqlParameterCollection parameters = Parameters;
-			foreach (object parameter in from.Parameters)
-			{
-				parameters.Add((parameter is ICloneable) ? (parameter as ICloneable).Clone() : parameter);
-			}
-		}
-
-		new public SqlConnection Connection
-		{
-			get
-			{
-				return _activeConnection;
-			}
-			set
-			{
-				// Don't allow the connection to be changed while in a async operation.
-				if (_activeConnection != value && _activeConnection != null)
-				{ // If new value...
-					if (cachedAsyncState.PendingAsyncOperation)
-					{ // If in pending async state, throw.
-						throw SQL.CannotModifyPropertyAsyncOperationInProgress();
-					}
-				}
-
-				// Check to see if the currently set transaction has completed.  If so,
-				// null out our local reference.
-				if (null != _transaction && _transaction.Connection == null)
-				{
-					_transaction = null;
-				}
-
-
-				// Command is no longer prepared on new connection, cleanup prepare status
-				if (IsPrepared)
-				{
-					if (_activeConnection != value && _activeConnection != null)
-					{
-						try
-						{
-							// cleanup
-							Unprepare();
-						}
-						catch (Exception)
-						{
-							// we do not really care about errors in unprepare (may be the old connection went bad)                                        
-						}
-						finally
-						{
-							// clean prepare status (even successful Unprepare does not do that)
-							_prepareHandle = -1;
-							_execType = EXECTYPE.UNPREPARED;
-						}
-					}
-				}
-
-				_activeConnection = value;
-			}
-		}
-
-		override protected DbConnection DbConnection
-		{
-			get
-			{
-				return Connection;
-			}
-			set
-			{
-				Connection = (SqlConnection)value;
-			}
-		}
-
-		private SqlInternalConnectionTds InternalTdsConnection
-		{
-			get
-			{
-				return (SqlInternalConnectionTds)_activeConnection.InnerConnection;
-			}
-		}
-
-		public SqlNotificationRequest Notification
-		{
-			get
-			{
-				return _notification;
-			}
-			set
-			{
-				_sqlDep = null;
-				_notification = value;
-			}
-		}
-
-		public bool NotificationAutoEnlist
-		{
-			get
-			{
-				return _notificationAutoEnlist;
-			}
-			set
-			{
-				_notificationAutoEnlist = value;
-			}
-		}
-
-		internal SqlStatistics Statistics
-		{
-			get
-			{
-				if (null != _activeConnection)
-				{
-					if (_activeConnection.StatisticsEnabled || 
-						_diagnosticListener.IsEnabled(SqlClientDiagnosticListenerExtensions.SqlAfterExecuteCommand))
-					{
-						return _activeConnection.Statistics;
-					}
-				}
-				return null;
-			}
-		}
-
-		new public SqlTransaction Transaction
-		{
-			get
-			{
-				// if the transaction object has been zombied, just return null
-				if ((null != _transaction) && (null == _transaction.Connection))
-				{
-					_transaction = null;
-				}
-				return _transaction;
-			}
-			set
-			{
-				// Don't allow the transaction to be changed while in a async operation.
-				if (_transaction != value && _activeConnection != null)
-				{ // If new value...
-					if (cachedAsyncState.PendingAsyncOperation)
-					{ // If in pending async state, throw
-						throw SQL.CannotModifyPropertyAsyncOperationInProgress();
-					}
-				}
-
-				_transaction = value;
-			}
-		}
-
-		override protected DbTransaction DbTransaction
-		{
-			get
-			{
-				return Transaction;
-			}
-			set
-			{
-				Transaction = (SqlTransaction)value;
-			}
-		}
-
-		override public string CommandText
-		{
-			get
-			{
-				string value = _commandText;
-				return ((null != value) ? value : ADP.StrEmpty);
-			}
-			set
-			{
-				if (_commandText != value)
-				{
-					PropertyChanging();
-					_commandText = value;
-				}
-			}
-		}
-
-		override public int CommandTimeout
-		{
-			get
-			{
-				return _commandTimeout;
-			}
-			set
-			{
-				if (value < 0)
-				{
-					throw ADP.InvalidCommandTimeout(value);
-				}
-				if (value != _commandTimeout)
-				{
-					PropertyChanging();
-					_commandTimeout = value;
-				}
-			}
-		}
-
-		public void ResetCommandTimeout()
-		{
-			if (ADP.DefaultCommandTimeout != _commandTimeout)
-			{
-				PropertyChanging();
-				_commandTimeout = ADP.DefaultCommandTimeout;
-			}
-		}
-
-		override public CommandType CommandType
-		{
-			get
-			{
-				CommandType cmdType = _commandType;
-				return ((0 != cmdType) ? cmdType : CommandType.Text);
-			}
-			set
-			{
-				if (_commandType != value)
-				{
-					switch (value)
-					{
-						case CommandType.Text:
-						case CommandType.StoredProcedure:
-							PropertyChanging();
-							_commandType = value;
-							break;
-						case System.Data.CommandType.TableDirect:
-							throw SQL.NotSupportedCommandType(value);
-						default:
-							throw ADP.InvalidCommandType(value);
-					}
-				}
-			}
-		}
-
-		// @devnote: By default, the cmd object is visible on the design surface (i.e. VS7 Server Tray)
-		// to limit the number of components that clutter the design surface,
-		// when the DataAdapter design wizard generates the insert/update/delete commands it will
-		// set the DesignTimeVisible property to false so that cmds won't appear as individual objects
-		public override bool DesignTimeVisible
-		{
-			get
-			{
-				return !_designTimeInvisible;
-			}
-			set
-			{
-				_designTimeInvisible = !value;
-			}
-		}
-
-		new public SqlParameterCollection Parameters
-		{
-			get
-			{
-				if (null == _parameters)
-				{
-					// delay the creation of the SqlParameterCollection
-					// until user actually uses the Parameters property
-					_parameters = new SqlParameterCollection();
-				}
-				return _parameters;
-			}
-		}
-
-		override protected DbParameterCollection DbParameterCollection
-		{
-			get
-			{
-				return Parameters;
-			}
-		}
-
-		override public UpdateRowSource UpdatedRowSource
-		{
-			get
-			{
-				return _updatedRowSource;
-			}
-			set
-			{
-				switch (value)
-				{
-					case UpdateRowSource.None:
-					case UpdateRowSource.OutputParameters:
-					case UpdateRowSource.FirstReturnedRecord:
-					case UpdateRowSource.Both:
-						_updatedRowSource = value;
-						break;
-					default:
-						throw ADP.InvalidUpdateRowSource(value);
-				}
-			}
-		}
-
-		public event StatementCompletedEventHandler StatementCompleted
-		{
-			add
-			{
-				_statementCompletedEventHandler += value;
-			}
-			remove
-			{
-				_statementCompletedEventHandler -= value;
-			}
-		}
-
-		internal void OnStatementCompleted(int recordCount)
-		{
-			if (0 <= recordCount)
-			{
-				StatementCompletedEventHandler handler = _statementCompletedEventHandler;
-				if (null != handler)
-				{
-					try
-					{
-						handler(this, new StatementCompletedEventArgs(recordCount));
-					}
-					catch (Exception e)
-					{
-						if (!ADP.IsCatchableOrSecurityExceptionType(e))
-						{
-							throw;
-						}
-					}
-				}
-			}
-		}
-
-		private void PropertyChanging()
-		{ // also called from SqlParameterCollection
-			this.IsDirty = true;
-		}
-
-		override public void Prepare()
-		{
-			// Reset _pendingCancel upon entry into any Execute - used to synchronize state
-			// between entry into Execute* API and the thread obtaining the stateObject.
-			_pendingCancel = false;
-
-
-			SqlStatistics statistics = null;
-			statistics = SqlStatistics.StartTimer(Statistics);
-
-			// only prepare if batch with parameters
-			if (
-				this.IsPrepared && !this.IsDirty
-				|| (this.CommandType == CommandType.StoredProcedure)
-				|| (
-						(System.Data.CommandType.Text == this.CommandType)
-						&& (0 == GetParameterCount(_parameters))
-					)
-
-			)
-			{
-				if (null != Statistics)
-				{
-					Statistics.SafeIncrement(ref Statistics._prepares);
-				}
-				_hiddenPrepare = false;
-			}
-			else
-			{
-				// Validate the command outside of the try\catch to avoid putting the _stateObj on error
-				ValidateCommand(async: false);
-
-				bool processFinallyBlock = true;
-				try
-				{
-					// NOTE: The state object isn't actually needed for this, but it is still here for back-compat (since it does a bunch of checks)
-					GetStateObject();
-
-					// Loop through parameters ensuring that we do not have unspecified types, sizes, scales, or precisions
-					if (null != _parameters)
-					{
-						int count = _parameters.Count;
-						for (int i = 0; i < count; ++i)
-						{
-							_parameters[i].Prepare(this);
-						}
-					}
-
-					InternalPrepare();
-				}
-				catch (Exception e)
-				{
-					processFinallyBlock = ADP.IsCatchableExceptionType(e);
-					throw;
-				}
-				finally
-				{
-					if (processFinallyBlock)
-					{
-						_hiddenPrepare = false; // The command is now officially prepared
-
-						ReliablePutStateObject();
-					}
-				}
-			}
-
-			SqlStatistics.StopTimer(statistics);
-		}
-
-		private void InternalPrepare()
-		{
-			if (this.IsDirty)
-			{
-				Debug.Assert(_cachedMetaData == null || !_dirty, "dirty query should not have cached metadata!"); // can have cached metadata if dirty because of parameters
-				//
-				// someone changed the command text or the parameter schema so we must unprepare the command
-				//
-				this.Unprepare();
-				this.IsDirty = false;
-			}
-			Debug.Assert(_execType != EXECTYPE.PREPARED, "Invalid attempt to Prepare already Prepared command!");
-			Debug.Assert(_activeConnection != null, "must have an open connection to Prepare");
-			Debug.Assert(null != _stateObj, "TdsParserStateObject should not be null");
-			Debug.Assert(null != _stateObj.Parser, "TdsParser class should not be null in Command.Execute!");
-			Debug.Assert(_stateObj.Parser == _activeConnection.Parser, "stateobject parser not same as connection parser");
-			Debug.Assert(false == _inPrepare, "Already in Prepare cycle, this.inPrepare should be false!");
-
-			// remember that the user wants to do a prepare but don't actually do an rpc
-			_execType = EXECTYPE.PREPAREPENDING;
-			// Note the current close count of the connection - this will tell us if the connection has been closed between calls to Prepare() and Execute
-			_preparedConnectionCloseCount = _activeConnection.CloseCount;
-			_preparedConnectionReconnectCount = _activeConnection.ReconnectCount;
-
-			if (null != Statistics)
-			{
-				Statistics.SafeIncrement(ref Statistics._prepares);
-			}
-		}
-
-		// SqlInternalConnectionTds needs to be able to unprepare a statement
-		internal void Unprepare()
-		{
-			Debug.Assert(true == IsPrepared, "Invalid attempt to Unprepare a non-prepared command!");
-			Debug.Assert(_activeConnection != null, "must have an open connection to UnPrepare");
-			Debug.Assert(false == _inPrepare, "_inPrepare should be false!");
-			_execType = EXECTYPE.PREPAREPENDING;
-			// Don't zero out the handle because we'll pass it in to sp_prepexec on the next prepare
-			// Unless the close count isn't the same as when we last prepared
-			if ((_activeConnection.CloseCount != _preparedConnectionCloseCount) || (_activeConnection.ReconnectCount != _preparedConnectionReconnectCount))
-			{
-				// reset our handle
-				_prepareHandle = -1;
-			}
-
-			_cachedMetaData = null;
-		}
-
-
-		// Cancel is supposed to be multi-thread safe.
-		// It doesn't make sense to verify the connection exists or that it is open during cancel
-		// because immediately after checkin the connection can be closed or removed via another thread.
-		//
-		override public void Cancel()
-		{
-			SqlStatistics statistics = null;
-			try
-			{
-				statistics = SqlStatistics.StartTimer(Statistics);
-
-				// If we are in reconnect phase simply cancel the waiting task
-				var reconnectCompletionSource = _reconnectionCompletionSource;
-				if (reconnectCompletionSource != null)
-				{
-					if (reconnectCompletionSource.TrySetCanceled())
-					{
-						return;
-					}
-				}
-
-				// the pending data flag means that we are awaiting a response or are in the middle of processing a response
-				// if we have no pending data, then there is nothing to cancel
-				// if we have pending data, but it is not a result of this command, then we don't cancel either.  Note that
-				// this model is implementable because we only allow one active command at any one time.  This code
-				// will have to change we allow multiple outstanding batches
-				if (null == _activeConnection)
-				{
-					return;
-				}
-				SqlInternalConnectionTds connection = (_activeConnection.InnerConnection as SqlInternalConnectionTds);
-				if (null == connection)
-				{  // Fail with out locking
-					return;
-				}
-
-				// The lock here is to protect against the command.cancel / connection.close race condition
-				// The SqlInternalConnectionTds is set to OpenBusy during close, once this happens the cast below will fail and 
-				// the command will no longer be cancelable.  It might be desirable to be able to cancel the close operation, but this is
-				// outside of the scope of Whidbey RTM.  See (SqlConnection::Close) for other lock.
-				lock (connection)
-				{
-					if (connection != (_activeConnection.InnerConnection as SqlInternalConnectionTds))
-					{ // make sure the connection held on the active connection is what we have stored in our temp connection variable, if not between getting "connection" and taking the lock, the connection has been closed
-						return;
-					}
-
-					TdsParser parser = connection.Parser;
-					if (null == parser)
-					{
-						return;
-					}
-
-
-					if (!_pendingCancel)
-					{ // Do nothing if already pending.
-					  // Before attempting actual cancel, set the _pendingCancel flag to false.
-					  // This denotes to other thread before obtaining stateObject from the
-					  // session pool that there is another thread wishing to cancel.
-					  // The period in question is between entering the ExecuteAPI and obtaining 
-					  // a stateObject.
-						_pendingCancel = true;
-
-						TdsParserStateObject stateObj = _stateObj;
-						if (null != stateObj)
-						{
-							stateObj.Cancel(this);
-						}
-						else
-						{
-							SqlDataReader reader = connection.FindLiveReader(this);
-							if (reader != null)
-							{
-								reader.Cancel(this);
-							}
-						}
-					}
-				}
-			}
-			finally
-			{
-				SqlStatistics.StopTimer(statistics);
-			}
-		}
-
-		new public SqlParameter CreateParameter()
-		{
-			return new SqlParameter();
-		}
-
-		override protected DbParameter CreateDbParameter()
-		{
-			return CreateParameter();
-		}
-
-		override protected void Dispose(bool disposing)
-		{
-			if (disposing)
-			{ // release managed objects
-				_cachedMetaData = null;
-			}
-			// release unmanaged objects
-			base.Dispose(disposing);
-		}
-
-		override public object ExecuteScalar()
-		{
-			// Reset _pendingCancel upon entry into any Execute - used to synchronize state
-			// between entry into Execute* API and the thread obtaining the stateObject.
-			_pendingCancel = false;
-
-			Guid operationId = _diagnosticListener.WriteCommandBefore(this);
-
-			SqlStatistics statistics = null;
-			
-			Exception e = null;
-			try
-			{
-				statistics = SqlStatistics.StartTimer(Statistics);
-				SqlDataReader ds;
-				ds = RunExecuteReader(0, RunBehavior.ReturnImmediately, returnStream: true);
-				return CompleteExecuteScalar(ds, false);
-			}
-			catch (Exception ex)
-			{
-				e = ex;
-				throw;
-			}
-			finally
-			{
-				SqlStatistics.StopTimer(statistics);
-
-				if (e != null)
-				{
-					_diagnosticListener.WriteCommandError(operationId, this, e);
-				}
-				else
-				{
-					_diagnosticListener.WriteCommandAfter(operationId, this);
-				}
-			}
-		}
-
-		private object CompleteExecuteScalar(SqlDataReader ds, bool returnSqlValue)
-		{
-			object retResult = null;
-
-			try
-			{
-				if (ds.Read())
-				{
-					if (ds.FieldCount > 0)
-					{
-						if (returnSqlValue)
-						{
-							retResult = ds.GetSqlValue(0);
-						}
-						else
-						{
-							retResult = ds.GetValue(0);
-						}
-					}
-				}
-			}
-			finally
-			{
-				// clean off the wire
-				ds.Close();
-			}
-
-			return retResult;
-		}
-
-		override public int ExecuteNonQuery()
-		{
-			// Reset _pendingCancel upon entry into any Execute - used to synchronize state
-			// between entry into Execute* API and the thread obtaining the stateObject.
-			_pendingCancel = false;
-
-			Guid operationId = _diagnosticListener.WriteCommandBefore(this);
-
-			SqlStatistics statistics = null;
-			
-			Exception e = null;
-			try
-			{
-				statistics = SqlStatistics.StartTimer(Statistics);
-				InternalExecuteNonQuery(completion: null, sendToPipe: false, timeout: CommandTimeout);
-				return _rowsAffected;
-			}
-			catch (Exception ex)
-			{
-				e = ex;
-				throw;
-			}
-			finally
-			{
-				SqlStatistics.StopTimer(statistics);
-				
-				if (e != null)
-				{
-					_diagnosticListener.WriteCommandError(operationId, this, e);
-				}
-				else
-				{
-					_diagnosticListener.WriteCommandAfter(operationId, this);
-				}
-			}
-		}
-
-
-		private IAsyncResult BeginExecuteNonQuery(AsyncCallback callback, object stateObject)
-		{
-			// Reset _pendingCancel upon entry into any Execute - used to synchronize state
-			// between entry into Execute* API and the thread obtaining the stateObject.
-			_pendingCancel = false;
-
-			ValidateAsyncCommand(); // Special case - done outside of try/catches to prevent putting a stateObj
-									// back into pool when we should not.
-
-			SqlStatistics statistics = null;
-			try
-			{
-				statistics = SqlStatistics.StartTimer(Statistics);
-				TaskCompletionSource<object> completion = new TaskCompletionSource<object>(stateObject);
-
-				try
-				{ // InternalExecuteNonQuery already has reliability block, but if failure will not put stateObj back into pool.
-					Task execNQ = InternalExecuteNonQuery(completion, false, CommandTimeout, asyncWrite: true);
-
-					// must finish caching information before ReadSni which can activate the callback before returning
-					cachedAsyncState.SetActiveConnectionAndResult(completion, nameof(EndExecuteNonQuery), _activeConnection);
-					if (execNQ != null)
-					{
-						AsyncHelper.ContinueTask(execNQ, completion, () => BeginExecuteNonQueryInternalReadStage(completion));
-					}
-					else
-					{
-						BeginExecuteNonQueryInternalReadStage(completion);
-					}
-				}
-				catch (Exception e)
-				{
-					if (!ADP.IsCatchableOrSecurityExceptionType(e))
-					{
-						// If not catchable - the connection has already been caught and doomed in RunExecuteReader.
-						throw;
-					}
-
-					// For async, RunExecuteReader will never put the stateObj back into the pool, so do so now.
-					ReliablePutStateObject();
-					throw;
-				}
-
-				// Add callback after work is done to avoid overlapping Begin\End methods
-				if (callback != null)
-				{
-					completion.Task.ContinueWith((t) => callback(t), TaskScheduler.Default);
-				}
-
-				return completion.Task;
-			}
-			finally
-			{
-				SqlStatistics.StopTimer(statistics);
-			}
-		}
-
-		private void BeginExecuteNonQueryInternalReadStage(TaskCompletionSource<object> completion)
-		{
-			// Read SNI does not have catches for async exceptions, handle here.
-			try
-			{
-				_stateObj.ReadSni(completion);
-			}
-			catch (Exception)
-			{
-				// Similarly, if an exception occurs put the stateObj back into the pool.
-				// and reset async cache information to allow a second async execute
-				if (null != _cachedAsyncState)
-				{
-					_cachedAsyncState.ResetAsyncState();
-				}
-				ReliablePutStateObject();
-				throw;
-			}
-		}
-
-		private void VerifyEndExecuteState(Task completionTask, String endMethod)
-		{
-			Debug.Assert(completionTask != null);
-
-			if (completionTask.IsCanceled)
-			{
-				if (_stateObj != null)
-				{
-					_stateObj.Parser.State = TdsParserState.Broken; // We failed to respond to attention, we have to quit!
-					_stateObj.Parser.Connection.BreakConnection();
-					_stateObj.Parser.ThrowExceptionAndWarning(_stateObj);
-				}
-				else
-				{
-					Debug.Assert(_reconnectionCompletionSource == null || _reconnectionCompletionSource.Task.IsCanceled, "ReconnectCompletionSource should be null or cancelled");
-					throw SQL.CR_ReconnectionCancelled();
-				}
-			}
-			else if (completionTask.IsFaulted)
-			{
-				throw completionTask.Exception.InnerException;
-			}
-			if (cachedAsyncState.EndMethodName == null)
-			{
-				throw ADP.MethodCalledTwice(endMethod);
-			}
-			if (endMethod != cachedAsyncState.EndMethodName)
-			{
-				throw ADP.MismatchedAsyncResult(cachedAsyncState.EndMethodName, endMethod);
-			}
-			if ((_activeConnection.State != ConnectionState.Open) || (!cachedAsyncState.IsActiveConnectionValid(_activeConnection)))
-			{
-				// If the connection is not 'valid' then it was closed while we were executing
-				throw ADP.ClosedConnectionError();
-			}
-		}
-
-		private void WaitForAsyncResults(IAsyncResult asyncResult)
-		{
-			Task completionTask = (Task)asyncResult;
-			if (!asyncResult.IsCompleted)
-			{
-				asyncResult.AsyncWaitHandle.WaitOne();
-			}
-			_stateObj._networkPacketTaskSource = null;
-			_activeConnection.GetOpenTdsConnection().DecrementAsyncCount();
-		}
-
-		private void ThrowIfReconnectionHasBeenCanceled()
-		{
-			if (_stateObj == null)
-			{
-				var reconnectionCompletionSource = _reconnectionCompletionSource;
-				if (reconnectionCompletionSource != null && reconnectionCompletionSource.Task.IsCanceled)
-				{
-					throw SQL.CR_ReconnectionCancelled();
-				}
-			}
-		}
-
-		private int EndExecuteNonQuery(IAsyncResult asyncResult)
-		{
-			Exception asyncException = ((Task)asyncResult).Exception;
-			if (asyncException != null)
-			{
-				// Leftover exception from the Begin...InternalReadStage
-				if (cachedAsyncState != null)
-				{
-					cachedAsyncState.ResetAsyncState();
-				}
-				ReliablePutStateObject();
-				throw asyncException.InnerException;
-			}
-			else
-			{
-				ThrowIfReconnectionHasBeenCanceled();
-				// lock on _stateObj prevents races with close/cancel.
-				lock (_stateObj)
-				{
-					return EndExecuteNonQueryInternal(asyncResult);
-				}
-			}
-		}
-
-		private int EndExecuteNonQueryInternal(IAsyncResult asyncResult)
-		{
-			SqlStatistics statistics = null;
-
-			try
-			{
-				statistics = SqlStatistics.StartTimer(Statistics);
-				VerifyEndExecuteState((Task)asyncResult, nameof(EndExecuteNonQuery));
-				WaitForAsyncResults(asyncResult);
-
-				bool processFinallyBlock = true;
-				try
-				{
-					CheckThrowSNIException();
-
-					// only send over SQL Batch command if we are not a stored proc and have no parameters
-					if ((System.Data.CommandType.Text == this.CommandType) && (0 == GetParameterCount(_parameters)))
-					{
-						try
-						{
-							bool dataReady;
-							Debug.Assert(_stateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
-							bool result = _stateObj.Parser.TryRun(RunBehavior.UntilDone, this, null, null, _stateObj, out dataReady);
-							if (!result) { throw SQL.SynchronousCallMayNotPend(); }
-						}
-						finally
-						{
-							cachedAsyncState.ResetAsyncState();
-						}
-					}
-					else
-					{ // otherwise, use a full-fledged execute that can handle params and stored procs
-						SqlDataReader reader = CompleteAsyncExecuteReader();
-						if (null != reader)
-						{
-							reader.Close();
-						}
-					}
-				}
-				catch (Exception e)
-				{
-					processFinallyBlock = ADP.IsCatchableExceptionType(e);
-					throw;
-				}
-				finally
-				{
-					if (processFinallyBlock)
-					{
-						PutStateObject();
-					}
-				}
-
-				Debug.Assert(null == _stateObj, "non-null state object in EndExecuteNonQuery");
-				return _rowsAffected;
-			}
-			catch (Exception e)
-			{
-				if (cachedAsyncState != null)
-				{
-					cachedAsyncState.ResetAsyncState();
-				};
-				if (ADP.IsCatchableExceptionType(e))
-				{
-					ReliablePutStateObject();
-				};
-				throw;
-			}
-			finally
-			{
-				SqlStatistics.StopTimer(statistics);
-			}
-		}
-
-		private Task InternalExecuteNonQuery(TaskCompletionSource<object> completion, bool sendToPipe, int timeout, bool asyncWrite = false, [CallerMemberName] string methodName = "")
-		{
-			bool async = (null != completion);
-
-			SqlStatistics statistics = Statistics;
-			_rowsAffected = -1;
-
-			// this function may throw for an invalid connection
-			// returns false for empty command text
-			ValidateCommand(async, methodName);
-
-			CheckNotificationStateAndAutoEnlist(); // Only call after validate - requires non null connection!
-
-			Task task = null;
-
-			// only send over SQL Batch command if we are not a stored proc and have no parameters and not in batch RPC mode
-			if ((System.Data.CommandType.Text == this.CommandType) && (0 == GetParameterCount(_parameters)))
-			{
-				Debug.Assert(!sendToPipe, "trying to send non-context command to pipe");
-				if (null != statistics)
-				{
-					if (!this.IsDirty && this.IsPrepared)
-					{
-						statistics.SafeIncrement(ref statistics._preparedExecs);
-					}
-					else
-					{
-						statistics.SafeIncrement(ref statistics._unpreparedExecs);
-					}
-				}
-
-				task = RunExecuteNonQueryTds(methodName, async, timeout, asyncWrite);
-			}
-			else
-			{ // otherwise, use a full-fledged execute that can handle params and stored procs
-				Debug.Assert(!sendToPipe, "trying to send non-context command to pipe");
-				SqlDataReader reader = RunExecuteReader(0, RunBehavior.UntilDone, false, completion, timeout, out task, asyncWrite, methodName);
-				if (null != reader)
-				{
-					if (task != null)
-					{
-						task = AsyncHelper.CreateContinuationTask(task, () => reader.Close());
-					}
-					else
-					{
-						reader.Close();
-					}
-				}
-			}
-			Debug.Assert(async || null == _stateObj, "non-null state object in InternalExecuteNonQuery");
-			return task;
-		}
-
-		public XmlReader ExecuteXmlReader()
-		{
-			// Reset _pendingCancel upon entry into any Execute - used to synchronize state
-			// between entry into Execute* API and the thread obtaining the stateObject.
-			_pendingCancel = false;
-
-			Guid operationId = _diagnosticListener.WriteCommandBefore(this);
-
-			SqlStatistics statistics = null;
-			
-			Exception e = null;
-			try
-			{
-				statistics = SqlStatistics.StartTimer(Statistics);
-
-				// use the reader to consume metadata
-				SqlDataReader ds;
-				ds = RunExecuteReader(CommandBehavior.SequentialAccess, RunBehavior.ReturnImmediately, returnStream: true);
-				return CompleteXmlReader(ds);
-			}
-			catch (Exception ex)
-			{
-				e = ex;
-				throw;
-			}
-			finally
-			{
-				SqlStatistics.StopTimer(statistics);
-				
-				if (e != null)
-				{
-					_diagnosticListener.WriteCommandError(operationId, this, e);
-				}
-				else
-				{
-					_diagnosticListener.WriteCommandAfter(operationId, this);
-				}
-			}
-		}
-
-
-		private IAsyncResult BeginExecuteXmlReader(AsyncCallback callback, object stateObject)
-		{
-			// Reset _pendingCancel upon entry into any Execute - used to synchronize state
-			// between entry into Execute* API and the thread obtaining the stateObject.
-			_pendingCancel = false;
-
-			ValidateAsyncCommand(); // Special case - done outside of try/catches to prevent putting a stateObj
-									// back into pool when we should not.
-
-			SqlStatistics statistics = null;
-			try
-			{
-				statistics = SqlStatistics.StartTimer(Statistics);
-				TaskCompletionSource<object> completion = new TaskCompletionSource<object>(stateObject);
-
-				Task writeTask;
-				try
-				{ // InternalExecuteNonQuery already has reliability block, but if failure will not put stateObj back into pool.
-					RunExecuteReader(CommandBehavior.SequentialAccess, RunBehavior.ReturnImmediately, true, completion, CommandTimeout, out writeTask, asyncWrite: true);
-				}
-				catch (Exception e)
-				{
-					if (!ADP.IsCatchableOrSecurityExceptionType(e))
-					{
-						// If not catchable - the connection has already been caught and doomed in RunExecuteReader.
-						throw;
-					}
-
-					// For async, RunExecuteReader will never put the stateObj back into the pool, so do so now.
-					ReliablePutStateObject();
-					throw;
-				}
-
-				// must finish caching information before ReadSni which can activate the callback before returning
-				cachedAsyncState.SetActiveConnectionAndResult(completion, nameof(EndExecuteXmlReader), _activeConnection);
-				if (writeTask != null)
-				{
-					AsyncHelper.ContinueTask(writeTask, completion, () => BeginExecuteXmlReaderInternalReadStage(completion));
-				}
-				else
-				{
-					BeginExecuteXmlReaderInternalReadStage(completion);
-				}
-
-				// Add callback after work is done to avoid overlapping Begin\End methods
-				if (callback != null)
-				{
-					completion.Task.ContinueWith((t) => callback(t), TaskScheduler.Default);
-				}
-				return completion.Task;
-			}
-			finally
-			{
-				SqlStatistics.StopTimer(statistics);
-			}
-		}
-
-		private void BeginExecuteXmlReaderInternalReadStage(TaskCompletionSource<object> completion)
-		{
-			Debug.Assert(completion != null, "Completion source should not be null");
-			// Read SNI does not have catches for async exceptions, handle here.
-			try
-			{
-				_stateObj.ReadSni(completion);
-			}
-			catch (Exception e)
-			{
-				// Similarly, if an exception occurs put the stateObj back into the pool.
-				// and reset async cache information to allow a second async execute
-				if (null != _cachedAsyncState)
-				{
-					_cachedAsyncState.ResetAsyncState();
-				}
-				ReliablePutStateObject();
-				completion.TrySetException(e);
-			}
-		}
-
-
-		private XmlReader EndExecuteXmlReader(IAsyncResult asyncResult)
-		{
-			Exception asyncException = ((Task)asyncResult).Exception;
-			if (asyncException != null)
-			{
-				// Leftover exception from the Begin...InternalReadStage
-				if (cachedAsyncState != null)
-				{
-					cachedAsyncState.ResetAsyncState();
-				}
-				ReliablePutStateObject();
-				throw asyncException.InnerException;
-			}
-			else
-			{
-				ThrowIfReconnectionHasBeenCanceled();
-				// lock on _stateObj prevents races with close/cancel.
-				lock (_stateObj)
-				{
-					return EndExecuteXmlReaderInternal(asyncResult);
-				}
-			}
-		}
-
-		private XmlReader EndExecuteXmlReaderInternal(IAsyncResult asyncResult)
-		{
-			try
-			{
-				return CompleteXmlReader(InternalEndExecuteReader(asyncResult, nameof(EndExecuteXmlReader)), async: true);
-			}
-			catch (Exception e)
-			{
-				if (cachedAsyncState != null)
-				{
-					cachedAsyncState.ResetAsyncState();
-				};
-				if (ADP.IsCatchableExceptionType(e))
-				{
-					ReliablePutStateObject();
-				};
-				throw;
-			}
-		}
-
-		private XmlReader CompleteXmlReader(SqlDataReader ds, bool async = false)
-		{
-			XmlReader xr = null;
-
-			SmiExtendedMetaData[] md = ds.GetInternalSmiMetaData();
-			bool isXmlCapable = (null != md && md.Length == 1 && (md[0].SqlDbType == SqlDbType.NText
-														 || md[0].SqlDbType == SqlDbType.NVarChar
-														 || md[0].SqlDbType == SqlDbType.Xml));
-
-			if (isXmlCapable)
-			{
-				try
-				{
-					SqlStream sqlBuf = new SqlStream(ds, true /*addByteOrderMark*/, (md[0].SqlDbType == SqlDbType.Xml) ? false : true /*process all rows*/);
-					xr = sqlBuf.ToXmlReader(async);
-				}
-				catch (Exception e)
-				{
-					if (ADP.IsCatchableExceptionType(e))
-					{
-						ds.Close();
-					}
-					throw;
-				}
-			}
-			if (xr == null)
-			{
-				ds.Close();
-				throw SQL.NonXmlResult();
-			}
-			return xr;
-		}
-
-
-		override protected DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
-		{
-			return ExecuteReader(behavior);
-		}
-
-		new public SqlDataReader ExecuteReader()
-		{
-			SqlStatistics statistics = null;
-			try
-			{
-				statistics = SqlStatistics.StartTimer(Statistics);
-				return ExecuteReader(CommandBehavior.Default);
-			}
-			finally
-			{
-				SqlStatistics.StopTimer(statistics);
-			}
-		}
-
-		new public SqlDataReader ExecuteReader(CommandBehavior behavior)
-		{
-			// Reset _pendingCancel upon entry into any Execute - used to synchronize state
-			// between entry into Execute* API and the thread obtaining the stateObject.
-			_pendingCancel = false;
-
-			Guid operationId = _diagnosticListener.WriteCommandBefore(this);
-
-			SqlStatistics statistics = null;
-			
-			Exception e = null;
-			try
-			{
-				statistics = SqlStatistics.StartTimer(Statistics);
-				return RunExecuteReader(behavior, RunBehavior.ReturnImmediately, returnStream: true);
-			}
-			catch (Exception ex)
-			{
-				e = ex;
-				throw;
-			}
-			finally
-			{
-				SqlStatistics.StopTimer(statistics);
-				
-				if (e != null)
-				{
-					_diagnosticListener.WriteCommandError(operationId, this, e);
-				}
-				else
-				{
-					_diagnosticListener.WriteCommandAfter(operationId, this);
-				}
-			}
-		}
-
-
-		internal SqlDataReader EndExecuteReader(IAsyncResult asyncResult)
-		{
-			Exception asyncException = ((Task)asyncResult).Exception;
-			if (asyncException != null)
-			{
-				// Leftover exception from the Begin...InternalReadStage
-				if (cachedAsyncState != null)
-				{
-					cachedAsyncState.ResetAsyncState();
-				}
-				ReliablePutStateObject();
-				throw asyncException.InnerException;
-			}
-			else
-			{
-				ThrowIfReconnectionHasBeenCanceled();
-				// lock on _stateObj prevents races with close/cancel.
-				lock (_stateObj)
-				{
-					return EndExecuteReaderInternal(asyncResult);
-				}
-			}
-		}
-
-		private SqlDataReader EndExecuteReaderInternal(IAsyncResult asyncResult)
-		{
-			SqlStatistics statistics = null;
-			try
-			{
-				statistics = SqlStatistics.StartTimer(Statistics);
-				return InternalEndExecuteReader(asyncResult, nameof(EndExecuteReader));
-			}
-			catch (Exception e)
-			{
-				if (cachedAsyncState != null)
-				{
-					cachedAsyncState.ResetAsyncState();
-				};
-				if (ADP.IsCatchableExceptionType(e))
-				{
-					ReliablePutStateObject();
-				};
-				throw;
-			}
-			finally
-			{
-				SqlStatistics.StopTimer(statistics);
-			}
-		}
-
-		internal IAsyncResult BeginExecuteReader(CommandBehavior behavior, AsyncCallback callback, object stateObject)
-		{
-			// Reset _pendingCancel upon entry into any Execute - used to synchronize state
-			// between entry into Execute* API and the thread obtaining the stateObject.
-			_pendingCancel = false;
-
-			SqlStatistics statistics = null;
-			try
-			{
-				statistics = SqlStatistics.StartTimer(Statistics);
-				TaskCompletionSource<object> completion = new TaskCompletionSource<object>(stateObject);
-
-				ValidateAsyncCommand(); // Special case - done outside of try/catches to prevent putting a stateObj
-										// back into pool when we should not.
-
-				Task writeTask = null;
-				try
-				{ // InternalExecuteNonQuery already has reliability block, but if failure will not put stateObj back into pool.
-					RunExecuteReader(behavior, RunBehavior.ReturnImmediately, true, completion, CommandTimeout, out writeTask, asyncWrite: true);
-				}
-				catch (Exception e)
-				{
-					if (!ADP.IsCatchableOrSecurityExceptionType(e))
-					{
-						// If not catchable - the connection has already been caught and doomed in RunExecuteReader.
-						throw;
-					}
-
-					// For async, RunExecuteReader will never put the stateObj back into the pool, so do so now.
-					ReliablePutStateObject();
-					throw;
-				}
-
-				// must finish caching information before ReadSni which can activate the callback before returning
-				cachedAsyncState.SetActiveConnectionAndResult(completion, nameof(EndExecuteReader), _activeConnection);
-				if (writeTask != null)
-				{
-					AsyncHelper.ContinueTask(writeTask, completion, () => BeginExecuteReaderInternalReadStage(completion));
-				}
-				else
-				{
-					BeginExecuteReaderInternalReadStage(completion);
-				}
-
-				// Add callback after work is done to avoid overlapping Begin\End methods
-				if (callback != null)
-				{
-					completion.Task.ContinueWith((t) => callback(t), TaskScheduler.Default);
-				}
-				return completion.Task;
-			}
-			finally
-			{
-				SqlStatistics.StopTimer(statistics);
-			}
-		}
-
-		private void BeginExecuteReaderInternalReadStage(TaskCompletionSource<object> completion)
-		{
-			Debug.Assert(completion != null, "CompletionSource should not be null");
-			// Read SNI does not have catches for async exceptions, handle here.
-			try
-			{
-				_stateObj.ReadSni(completion);
-			}
-			catch (Exception e)
-			{
-				// Similarly, if an exception occurs put the stateObj back into the pool.
-				// and reset async cache information to allow a second async execute
-				if (null != _cachedAsyncState)
-				{
-					_cachedAsyncState.ResetAsyncState();
-				}
-				ReliablePutStateObject();
-				completion.TrySetException(e);
-			}
-		}
-
-		private SqlDataReader InternalEndExecuteReader(IAsyncResult asyncResult, string endMethod)
-		{
-			VerifyEndExecuteState((Task)asyncResult, endMethod);
-			WaitForAsyncResults(asyncResult);
-
-			CheckThrowSNIException();
-
-			SqlDataReader reader = CompleteAsyncExecuteReader();
-			Debug.Assert(null == _stateObj, "non-null state object in InternalEndExecuteReader");
-			return reader;
-		}
-
-		public override Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
-		{
-			Guid operationId = _diagnosticListener.WriteCommandBefore(this);
-
-			TaskCompletionSource<int> source = new TaskCompletionSource<int>();
-
-			CancellationTokenRegistration registration = new CancellationTokenRegistration();
-			if (cancellationToken.CanBeCanceled)
-			{
-				if (cancellationToken.IsCancellationRequested)
-				{
-					source.SetCanceled();
-					return source.Task;
-				}
-				registration = cancellationToken.Register(s => ((SqlCommand)s).CancelIgnoreFailure(), this);
-			}
-
-			Task<int> returnedTask = source.Task;
-			try
-			{
-				RegisterForConnectionCloseNotification(ref returnedTask);
-
-				Task<int>.Factory.FromAsync(BeginExecuteNonQuery, EndExecuteNonQuery, null).ContinueWith((t) =>
-				{
-					registration.Dispose();
-					if (t.IsFaulted)
-					{
-						Exception e = t.Exception.InnerException;
-						_diagnosticListener.WriteCommandError(operationId, this, e);
-						source.SetException(e);
-					}
-					else
-					{
-						if (t.IsCanceled)
-						{
-							source.SetCanceled();
-						}
-						else
-						{
-							source.SetResult(t.Result);
-						}
-						_diagnosticListener.WriteCommandAfter(operationId, this);
-					}
-				}, TaskScheduler.Default);
-			}
-			catch (Exception e)
-			{
-				_diagnosticListener.WriteCommandError(operationId, this, e);
-				source.SetException(e);
-			}
-
-			return returnedTask;
-		}
-
-		protected override Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
-		{
-			return ExecuteReaderAsync(behavior, cancellationToken).ContinueWith<DbDataReader>((result) =>
-			{
-				if (result.IsFaulted)
-				{
-					throw result.Exception.InnerException;
-				}
-				return result.Result;
-			}, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.NotOnCanceled, TaskScheduler.Default);
-		}
-
-		new public Task<SqlDataReader> ExecuteReaderAsync()
-		{
-			return ExecuteReaderAsync(CommandBehavior.Default, CancellationToken.None);
-		}
-
-		new public Task<SqlDataReader> ExecuteReaderAsync(CommandBehavior behavior)
-		{
-			return ExecuteReaderAsync(behavior, CancellationToken.None);
-		}
-
-		new public Task<SqlDataReader> ExecuteReaderAsync(CancellationToken cancellationToken)
-		{
-			return ExecuteReaderAsync(CommandBehavior.Default, cancellationToken);
-		}
-
-		new public Task<SqlDataReader> ExecuteReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
-		{
-			Guid operationId = default(Guid);
-			if (!_parentOperationStarted)
-				operationId = _diagnosticListener.WriteCommandBefore(this);
-
-			TaskCompletionSource<SqlDataReader> source = new TaskCompletionSource<SqlDataReader>();
-
-			CancellationTokenRegistration registration = new CancellationTokenRegistration();
-			if (cancellationToken.CanBeCanceled)
-			{
-				if (cancellationToken.IsCancellationRequested)
-				{
-					source.SetCanceled();
-					return source.Task;
-				}
-				registration = cancellationToken.Register(s => ((SqlCommand)s).CancelIgnoreFailure(), this);
-			}
-
-			Task<SqlDataReader> returnedTask = source.Task;
-			try
-			{
-				RegisterForConnectionCloseNotification(ref returnedTask);
-
-				Task<SqlDataReader>.Factory.FromAsync(BeginExecuteReader, EndExecuteReader, behavior, null).ContinueWith((t) =>
-				{
-					registration.Dispose();
-					if (t.IsFaulted)
-					{
-						Exception e = t.Exception.InnerException;
-						if (!_parentOperationStarted)
-							_diagnosticListener.WriteCommandError(operationId, this, e);
-						source.SetException(e);
-					}
-					else
-					{
-						if (t.IsCanceled)
-						{
-							source.SetCanceled();
-						}
-						else
-						{
-							source.SetResult(t.Result);
-						}
-						if (!_parentOperationStarted)
-							_diagnosticListener.WriteCommandAfter(operationId, this);
-					}
-				}, TaskScheduler.Default);
-			}
-			catch (Exception e)
-			{
-				if (!_parentOperationStarted)
-					_diagnosticListener.WriteCommandError(operationId, this, e);
-
-				source.SetException(e);
-			}
-
-			return returnedTask;
-		}
-
-		public override Task<object> ExecuteScalarAsync(CancellationToken cancellationToken)
-		{
-			_parentOperationStarted = true;
-			Guid operationId = _diagnosticListener.WriteCommandBefore(this);
-
-			return ExecuteReaderAsync(cancellationToken).ContinueWith((executeTask) =>
-			{
-				TaskCompletionSource<object> source = new TaskCompletionSource<object>();
-				if (executeTask.IsCanceled)
-				{
-					source.SetCanceled();
-				}
-				else if (executeTask.IsFaulted)
-				{
-					_diagnosticListener.WriteCommandError(operationId, this, executeTask.Exception.InnerException);
-					source.SetException(executeTask.Exception.InnerException);
-				}
-				else
-				{
-					SqlDataReader reader = executeTask.Result;
-					reader.ReadAsync(cancellationToken).ContinueWith((readTask) =>
-					{
-						try
-						{
-							if (readTask.IsCanceled)
-							{
-								reader.Dispose();
-								source.SetCanceled();
-							}
-							else if (readTask.IsFaulted)
-							{
-								reader.Dispose();
-								_diagnosticListener.WriteCommandError(operationId, this, readTask.Exception.InnerException);
-								source.SetException(readTask.Exception.InnerException);
-							}
-							else
-							{
-								Exception exception = null;
-								object result = null;
-								try
-								{
-									bool more = readTask.Result;
-									if (more && reader.FieldCount > 0)
-									{
-										try
-										{
-											result = reader.GetValue(0);
-										}
-										catch (Exception e)
-										{
-											exception = e;
-										}
-									}
-								}
-								finally
-								{
-									reader.Dispose();
-								}
-								if (exception != null)
-								{
-									_diagnosticListener.WriteCommandError(operationId, this, exception);
-									source.SetException(exception);
-								}
-								else
-								{
-									_diagnosticListener.WriteCommandAfter(operationId, this);
-									source.SetResult(result);
-								}
-							}
-						}
-						catch (Exception e)
-						{
-							// exception thrown by Dispose...
-							source.SetException(e);
-						}
-					}, TaskScheduler.Default);
-				}
-				_parentOperationStarted = false;
-				return source.Task;
-			}, TaskScheduler.Default).Unwrap();
-		}
-
-		public Task<XmlReader> ExecuteXmlReaderAsync()
-		{
-			return ExecuteXmlReaderAsync(CancellationToken.None);
-		}
-
-		public Task<XmlReader> ExecuteXmlReaderAsync(CancellationToken cancellationToken)
-		{
-			Guid operationId = _diagnosticListener.WriteCommandBefore(this);
-
-			TaskCompletionSource<XmlReader> source = new TaskCompletionSource<XmlReader>();
-
-			CancellationTokenRegistration registration = new CancellationTokenRegistration();
-			if (cancellationToken.CanBeCanceled)
-			{
-				if (cancellationToken.IsCancellationRequested)
-				{
-					source.SetCanceled();
-					return source.Task;
-				}
-				registration = cancellationToken.Register(s => ((SqlCommand)s).CancelIgnoreFailure(), this);
-			}
-
-			Task<XmlReader> returnedTask = source.Task;
-			try
-			{
-				RegisterForConnectionCloseNotification(ref returnedTask);
-
-				Task<XmlReader>.Factory.FromAsync(BeginExecuteXmlReader, EndExecuteXmlReader, null).ContinueWith((t) =>
-				{
-					registration.Dispose();
-					if (t.IsFaulted)
-					{
-						Exception e = t.Exception.InnerException;
-						_diagnosticListener.WriteCommandError(operationId, this, e);
-						source.SetException(e);
-					}
-					else
-					{
-						if (t.IsCanceled)
-						{
-							source.SetCanceled();
-						}
-						else
-						{
-							source.SetResult(t.Result);
-						}
-						_diagnosticListener.WriteCommandAfter(operationId, this);
-					}
-				}, TaskScheduler.Default);
-			}
-			catch (Exception e)
-			{
-				_diagnosticListener.WriteCommandError(operationId, this, e);
-				source.SetException(e);
-			}
-
-			return returnedTask;
-		}
-
-		// If the user part is quoted, remove first and last brackets and then unquote any right square
-		// brackets in the procedure.  This is a very simple parser that performs no validation.  As
-		// with the function below, ideally we should have support from the server for this.
-		private static string UnquoteProcedurePart(string part)
-		{
-			if ((null != part) && (2 <= part.Length))
-			{
-				if ('[' == part[0] && ']' == part[part.Length - 1])
-				{
-					part = part.Substring(1, part.Length - 2); // strip outer '[' & ']'
-					part = part.Replace("]]", "]"); // undo quoted "]" from "]]" to "]"
-				}
-			}
-			return part;
-		}
-
-		// User value in this format: [server].[database].[schema].[sp_foo];1
-		// This function should only be passed "[sp_foo];1".
-		// This function uses a pretty simple parser that doesn't do any validation.
-		// Ideally, we would have support from the server rather than us having to do this.
-		private static string UnquoteProcedureName(string name, out object groupNumber)
-		{
-			groupNumber = null; // Out param - initialize value to no value.
-			string sproc = name;
-
-			if (null != sproc)
-			{
-				if (char.IsDigit(sproc[sproc.Length - 1]))
-				{ // If last char is a digit, parse.
-					int semicolon = sproc.LastIndexOf(';');
-					if (semicolon != -1)
-					{ // If we found a semicolon, obtain the integer.
-						string part = sproc.Substring(semicolon + 1);
-						int number = 0;
-						if (int.TryParse(part, out number))
-						{ // No checking, just fail if this doesn't work.
-							groupNumber = number;
-							sproc = sproc.Substring(0, semicolon);
-						}
-					}
-				}
-				sproc = UnquoteProcedurePart(sproc);
-			}
-			return sproc;
-		}
-
-		// Index into indirection arrays for columns of interest to DeriveParameters
-		private enum ProcParamsColIndex
-		{
-			ParameterName = 0,
-			ParameterType,
-			DataType, // obsolete in katmai, use ManagedDataType instead
-			ManagedDataType, // new in katmai
-			CharacterMaximumLength,
-			NumericPrecision,
-			NumericScale,
-			TypeCatalogName,
-			TypeSchemaName,
-			TypeName,
-			XmlSchemaCollectionCatalogName,
-			XmlSchemaCollectionSchemaName,
-			XmlSchemaCollectionName,
-			UdtTypeName, // obsolete in Katmai.  Holds the actual typename if UDT, since TypeName didn't back then.
-			DateTimeScale // new in Katmai
-		};
-
-		// Yukon- column ordinals (this array indexed by ProcParamsColIndex
-		internal static readonly string[] PreKatmaiProcParamsNames = new string[] {
-			"PARAMETER_NAME",           // ParameterName,
-			"PARAMETER_TYPE",           // ParameterType,
-			"DATA_TYPE",                // DataType
-			null,                       // ManagedDataType,     introduced in Katmai
-			"CHARACTER_MAXIMUM_LENGTH", // CharacterMaximumLength,
-			"NUMERIC_PRECISION",        // NumericPrecision,
-			"NUMERIC_SCALE",            // NumericScale,
-			"UDT_CATALOG",              // TypeCatalogName,
-			"UDT_SCHEMA",               // TypeSchemaName,
-			"TYPE_NAME",                // TypeName,
-			"XML_CATALOGNAME",          // XmlSchemaCollectionCatalogName,
-			"XML_SCHEMANAME",           // XmlSchemaCollectionSchemaName,
-			"XML_SCHEMACOLLECTIONNAME", // XmlSchemaCollectionName
-			"UDT_NAME",                 // UdtTypeName
-			null,                       // Scale for datetime types with scale, introduced in Katmai
-		};
-
-		// Katmai+ column ordinals (this array indexed by ProcParamsColIndex
-		internal static readonly string[] KatmaiProcParamsNames = new string[] {
-			"PARAMETER_NAME",           // ParameterName,
-			"PARAMETER_TYPE",           // ParameterType,
-			null,                       // DataType, removed from Katmai+
-			"MANAGED_DATA_TYPE",        // ManagedDataType,
-			"CHARACTER_MAXIMUM_LENGTH", // CharacterMaximumLength,
-			"NUMERIC_PRECISION",        // NumericPrecision,
-			"NUMERIC_SCALE",            // NumericScale,
-			"TYPE_CATALOG_NAME",        // TypeCatalogName,
-			"TYPE_SCHEMA_NAME",         // TypeSchemaName,
-			"TYPE_NAME",                // TypeName,
-			"XML_CATALOGNAME",          // XmlSchemaCollectionCatalogName,
-			"XML_SCHEMANAME",           // XmlSchemaCollectionSchemaName,
-			"XML_SCHEMACOLLECTIONNAME", // XmlSchemaCollectionName
-			null,                       // UdtTypeName, removed from Katmai+
-			"SS_DATETIME_PRECISION",    // Scale for datetime types with scale
-		};
-
-		internal void DeriveParameters()
-		{
-			switch (CommandType)
-			{
-				case CommandType.Text:
-					throw ADP.DeriveParametersNotSupported(this);
-				case CommandType.StoredProcedure:
-					break;
-				case CommandType.TableDirect:
-					// CommandType.TableDirect - do nothing, parameters are not supported
-					throw ADP.DeriveParametersNotSupported(this);
-				default:
-					throw ADP.InvalidCommandType(CommandType);
-			}
-
-			// validate that we have a valid connection
-			ValidateCommand(false /*not async*/, nameof(DeriveParameters));
-
-			// Use common parser for SqlClient and OleDb - parse into 4 parts - Server, Catalog, Schema, ProcedureName
-			string[] parsedSProc = MultipartIdentifier.ParseMultipartIdentifier(CommandText, "[\"", "]\"", SR.SQL_SqlCommandCommandText, false);
-			if (null == parsedSProc[3] || string.IsNullOrEmpty(parsedSProc[3]))
-			{
-				throw ADP.NoStoredProcedureExists(CommandText);
-			}
-
-			Debug.Assert(parsedSProc.Length == 4, "Invalid array length result from SqlCommandBuilder.ParseProcedureName");
-
-			SqlCommand paramsCmd = null;
-			StringBuilder cmdText = new StringBuilder();
-
-			// Build call for sp_procedure_params_rowset built of unquoted values from user:
-			// [user server, if provided].[user catalog, else current database].[sys if Yukon, else blank].[sp_procedure_params_rowset]
-
-			// Server - pass only if user provided.
-			if (!string.IsNullOrEmpty(parsedSProc[0]))
-			{
-				SqlCommandSet.BuildStoredProcedureName(cmdText, parsedSProc[0]);
-				cmdText.Append(".");
-			}
-
-			// Catalog - pass user provided, otherwise use current database.
-			if (string.IsNullOrEmpty(parsedSProc[1]))
-			{
-				parsedSProc[1] = Connection.Database;
-			}
-			SqlCommandSet.BuildStoredProcedureName(cmdText, parsedSProc[1]);
-			cmdText.Append(".");
-
-			// Schema - only if Yukon, and then only pass sys.  Also - pass managed version of sproc
-			// for Yukon, else older sproc.
-			string[] colNames;
-			bool useManagedDataType;
-			if (Connection.IsKatmaiOrNewer)
-			{
-				// Procedure - [sp_procedure_params_managed]
-				cmdText.Append("[sys].[").Append(TdsEnums.SP_PARAMS_MGD10).Append("]");
-
-				colNames = KatmaiProcParamsNames;
-				useManagedDataType = true;
-			}
-			else
-			{
-				// Procedure - [sp_procedure_params_managed]
-				cmdText.Append("[sys].[").Append(TdsEnums.SP_PARAMS_MANAGED).Append("]");
-
-				colNames = PreKatmaiProcParamsNames;
-				useManagedDataType = false;
-			}
-
-			paramsCmd = new SqlCommand(cmdText.ToString(), Connection, Transaction)
-			{
-				CommandType = CommandType.StoredProcedure
-			};
-
-			object groupNumber;
-
-			// Prepare parameters for sp_procedure_params_rowset:
-			// 1) procedure name - unquote user value
-			// 2) group number - parsed at the time we unquoted procedure name
-			// 3) procedure schema - unquote user value
-
-			paramsCmd.Parameters.Add(new SqlParameter("@procedure_name", SqlDbType.NVarChar, 255));
-			paramsCmd.Parameters[0].Value = UnquoteProcedureName(parsedSProc[3], out groupNumber); // ProcedureName is 4rd element in parsed array
-
-			if (null != groupNumber)
-			{
-				SqlParameter param = paramsCmd.Parameters.Add(new SqlParameter("@group_number", SqlDbType.Int));
-				param.Value = groupNumber;
-			}
-
-			if (!string.IsNullOrEmpty(parsedSProc[2]))
-			{ // SchemaName is 3rd element in parsed array
-				SqlParameter param = paramsCmd.Parameters.Add(new SqlParameter("@procedure_schema", SqlDbType.NVarChar, 255));
-				param.Value = UnquoteProcedurePart(parsedSProc[2]);
-			}
-
-			SqlDataReader r = null;
-
-			List<SqlParameter> parameters = new List<SqlParameter>();
-			bool processFinallyBlock = true;
-
-			try
-			{
-				r = paramsCmd.ExecuteReader();
-
-				SqlParameter p = null;
-
-				while (r.Read())
-				{
-					// each row corresponds to a parameter of the stored proc.  Fill in all the info
-					p = new SqlParameter()
-					{
-						ParameterName = (string)r[colNames[(int)ProcParamsColIndex.ParameterName]]
-					};
-
-					// type
-					if (useManagedDataType)
-					{
-						p.SqlDbType = (SqlDbType)(short)r[colNames[(int)ProcParamsColIndex.ManagedDataType]];
-
-						// Yukon didn't have as accurate of information as we're getting for Katmai, so re-map a couple of
-						//  types for backward compatability.
-						switch (p.SqlDbType)
-						{
-							case SqlDbType.Image:
-							case SqlDbType.Timestamp:
-								p.SqlDbType = SqlDbType.VarBinary;
-								break;
-
-							case SqlDbType.NText:
-								p.SqlDbType = SqlDbType.NVarChar;
-								break;
-
-							case SqlDbType.Text:
-								p.SqlDbType = SqlDbType.VarChar;
-								break;
-
-							default:
-								break;
-						}
-					}
-					else
-					{
-						p.SqlDbType = MetaType.GetSqlDbTypeFromOleDbType((short)r[colNames[(int)ProcParamsColIndex.DataType]],
-							ADP.IsNull(r[colNames[(int)ProcParamsColIndex.TypeName]]) ?
-								ADP.StrEmpty :
-								(string)r[colNames[(int)ProcParamsColIndex.TypeName]]);
-					}
-
-					// size
-					object a = r[colNames[(int)ProcParamsColIndex.CharacterMaximumLength]];
-					if (a is int)
-					{
-						int size = (int)a;
-
-						// Map MAX sizes correctly.  The Katmai server-side proc sends 0 for these instead of -1.
-						//  Should be fixed on the Katmai side, but would likely hold up the RI, and is safer to fix here.
-						//  If we can get the server-side fixed before shipping Katmai, we can remove this mapping.
-						if (0 == size &&
-								(p.SqlDbType == SqlDbType.NVarChar ||
-								 p.SqlDbType == SqlDbType.VarBinary ||
-								 p.SqlDbType == SqlDbType.VarChar))
-						{
-							size = -1;
-						}
-						p.Size = size;
-					}
-
-					// direction
-					p.Direction = ParameterDirectionFromOleDbDirection((short)r[colNames[(int)ProcParamsColIndex.ParameterType]]);
-
-					if (p.SqlDbType == SqlDbType.Decimal)
-					{
-						p.ScaleInternal = (byte)((short)r[colNames[(int)ProcParamsColIndex.NumericScale]] & 0xff);
-						p.PrecisionInternal = (byte)((short)r[colNames[(int)ProcParamsColIndex.NumericPrecision]] & 0xff);
-					}
-
-					// type name for Structured types (same as for Udt's except assign p.TypeName instead of p.UdtTypeName
-					if (SqlDbType.Structured == p.SqlDbType)
-					{
-
-						Debug.Assert(_activeConnection.IsKatmaiOrNewer, "Invalid datatype token received from pre-katmai server");
-
-						//read the type name
-						p.TypeName = r[colNames[(int)ProcParamsColIndex.TypeCatalogName]] + "." +
-							r[colNames[(int)ProcParamsColIndex.TypeSchemaName]] + "." +
-							r[colNames[(int)ProcParamsColIndex.TypeName]];
-					}
-
-					// XmlSchema name for Xml types
-					if (SqlDbType.Xml == p.SqlDbType)
-					{
-						object value;
-
-						value = r[colNames[(int)ProcParamsColIndex.XmlSchemaCollectionCatalogName]];
-						p.XmlSchemaCollectionDatabase = ADP.IsNull(value) ? String.Empty : (string)value;
-
-						value = r[colNames[(int)ProcParamsColIndex.XmlSchemaCollectionSchemaName]];
-						p.XmlSchemaCollectionOwningSchema = ADP.IsNull(value) ? String.Empty : (string)value;
-
-						value = r[colNames[(int)ProcParamsColIndex.XmlSchemaCollectionName]];
-						p.XmlSchemaCollectionName = ADP.IsNull(value) ? String.Empty : (string)value;
-					}
-
-					if (MetaType._IsVarTime(p.SqlDbType))
-					{
-						object value = r[colNames[(int)ProcParamsColIndex.DateTimeScale]];
-						if (value is int)
-						{
-							p.ScaleInternal = (byte)(((int)value) & 0xff);
-						}
-					}
-
-					parameters.Add(p);
-				}
-			}
-			catch (Exception e)
-			{
-				processFinallyBlock = ADP.IsCatchableExceptionType(e);
-				throw;
-			}
-			finally
-			{
-				if (processFinallyBlock)
-				{
-					r?.Close();
-
-					// always unhook the user's connection
-					paramsCmd.Connection = null;
-				}
-			}
-
-			if (parameters.Count == 0)
-			{
-				throw ADP.NoStoredProcedureExists(this.CommandText);
-			}
-
-			Parameters.Clear();
-
-			foreach (SqlParameter temp in parameters)
-			{
-				_parameters.Add(temp);
-			}
-		}
-
-		private ParameterDirection ParameterDirectionFromOleDbDirection(short oledbDirection)
-		{
-			Debug.Assert(oledbDirection >= 1 && oledbDirection <= 4, "invalid parameter direction from params_rowset!");
-
-			switch (oledbDirection)
-			{
-				case 2:
-					return ParameterDirection.InputOutput;
-				case 3:
-					return ParameterDirection.Output;
-				case 4:
-					return ParameterDirection.ReturnValue;
-				default:
-					return ParameterDirection.Input;
-			}
-
-		}
-
-		// get cached metadata
-		internal _SqlMetaDataSet MetaData
-		{
-			get
-			{
-				return _cachedMetaData;
-			}
-		}
-
-		// Check to see if notificactions auto enlistment is turned on. Enlist if so.
-		private void CheckNotificationStateAndAutoEnlist()
-		{
-			// Auto-enlist not supported in Core
-
-			// If we have a notification with a dependency, setup the notification options at this time.
-
-			// If user passes options, then we will always have option data at the time the SqlDependency
-			// ctor is called.  But, if we are using default queue, then we do not have this data until
-			// Start().  Due to this, we always delay setting options until execute.
-
-			// There is a variance in order between Start(), SqlDependency(), and Execute.  This is the 
-			// best way to solve that problem.
-			if (null != Notification)
-			{
-				if (_sqlDep != null)
-				{
-					if (null == _sqlDep.Options)
-					{
-						// If null, SqlDependency was not created with options, so we need to obtain default options now.
-						// GetDefaultOptions can and will throw under certain conditions.
-
-						// In order to match to the appropriate start - we need 3 pieces of info:
-						// 1) server 2) user identity (SQL Auth or Int Sec) 3) database
-
-						SqlDependency.IdentityUserNamePair identityUserName = null;
-
-						// Obtain identity from connection.
-						SqlInternalConnectionTds internalConnection = _activeConnection.InnerConnection as SqlInternalConnectionTds;
-						if (internalConnection.Identity != null)
-						{
-							identityUserName = new SqlDependency.IdentityUserNamePair(internalConnection.Identity, null);
-						}
-						else
-						{
-							identityUserName = new SqlDependency.IdentityUserNamePair(null, internalConnection.ConnectionOptions.UserID);
-						}
-
-						Notification.Options = SqlDependency.GetDefaultComposedOptions(_activeConnection.DataSource,
-															 InternalTdsConnection.ServerProvidedFailOverPartner,
-															 identityUserName, _activeConnection.Database);
-					}
-
-					// Set UserData on notifications, as well as adding to the appdomain dispatcher.  The value is
-					// computed by an algorithm on the dependency - fixed and will always produce the same value
-					// given identical commandtext + parameter values.
-					Notification.UserData = _sqlDep.ComputeHashAndAddToDispatcher(this);
-					// Maintain server list for SqlDependency.
-					_sqlDep.AddToServerList(_activeConnection.DataSource);
-				}
-			}
-		}
-
-		// Tds-specific logic for ExecuteNonQuery run handling
-		private Task RunExecuteNonQueryTds(string methodName, bool async, int timeout, bool asyncWrite)
-		{
-			Debug.Assert(!asyncWrite || async, "AsyncWrite should be always accompanied by Async");
-			bool processFinallyBlock = true;
-			try
-			{
-				Task reconnectTask = _activeConnection.ValidateAndReconnect(null, timeout);
-
-				if (reconnectTask != null)
-				{
-					long reconnectionStart = ADP.TimerCurrent();
-					if (async)
-					{
-						TaskCompletionSource<object> completion = new TaskCompletionSource<object>();
-						_activeConnection.RegisterWaitingForReconnect(completion.Task);
-						_reconnectionCompletionSource = completion;
-						CancellationTokenSource timeoutCTS = new CancellationTokenSource();
-						AsyncHelper.SetTimeoutException(completion, timeout, SQL.CR_ReconnectTimeout, timeoutCTS.Token);
-						AsyncHelper.ContinueTask(reconnectTask, completion,
-							() =>
-							{
-								if (completion.Task.IsCompleted)
-								{
-									return;
-								}
-								Interlocked.CompareExchange(ref _reconnectionCompletionSource, null, completion);
-								timeoutCTS.Cancel();
-								Task subTask = RunExecuteNonQueryTds(methodName, async, TdsParserStaticMethods.GetRemainingTimeout(timeout, reconnectionStart), asyncWrite);
-								if (subTask == null)
-								{
-									completion.SetResult(null);
-								}
-								else
-								{
-									AsyncHelper.ContinueTask(subTask, completion, () => completion.SetResult(null));
-								}
-							}, connectionToAbort: _activeConnection);
-						return completion.Task;
-					}
-					else
-					{
-						AsyncHelper.WaitForCompletion(reconnectTask, timeout, () => { throw SQL.CR_ReconnectTimeout(); });
-						timeout = TdsParserStaticMethods.GetRemainingTimeout(timeout, reconnectionStart);
-					}
-				}
-
-				if (asyncWrite)
-				{
-					_activeConnection.AddWeakReference(this, SqlReferenceCollection.CommandTag);
-				}
-
-				GetStateObject();
-
-				// we just send over the raw text with no annotation
-				// no parameters are sent over
-				// no data reader is returned
-				// use this overload for "batch SQL" tds token type
-				Task executeTask = _stateObj.Parser.TdsExecuteSQLBatch(this.CommandText, timeout, this.Notification, _stateObj, sync: true);
-				Debug.Assert(executeTask == null, "Shouldn't get a task when doing sync writes");
-
-				NotifyDependency();
-				if (async)
-				{
-					_activeConnection.GetOpenTdsConnection(methodName).IncrementAsyncCount();
-				}
-				else
-				{
-					bool dataReady;
-					Debug.Assert(_stateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
-					bool result = _stateObj.Parser.TryRun(RunBehavior.UntilDone, this, null, null, _stateObj, out dataReady);
-					if (!result) { throw SQL.SynchronousCallMayNotPend(); }
-				}
-			}
-			catch (Exception e)
-			{
-				processFinallyBlock = ADP.IsCatchableExceptionType(e);
-				throw;
-			}
-			finally
-			{
-				if (processFinallyBlock && !async)
-				{
-					// When executing Async, we need to keep the _stateObj alive...
-					PutStateObject();
-				}
-			}
-			return null;
-		}
-
-
-		internal SqlDataReader RunExecuteReader(CommandBehavior cmdBehavior, RunBehavior runBehavior, bool returnStream, [CallerMemberName] string method = "")
-		{
-			Task unused; // sync execution 
-			SqlDataReader reader = RunExecuteReader(cmdBehavior, runBehavior, returnStream, completion: null, timeout: CommandTimeout, task: out unused, method: method);
-			Debug.Assert(unused == null, "returned task during synchronous execution");
-			return reader;
-		}
-
-		// task is created in case of pending asynchronous write, returned SqlDataReader should not be utilized until that task is complete 
-		internal SqlDataReader RunExecuteReader(CommandBehavior cmdBehavior, RunBehavior runBehavior, bool returnStream, TaskCompletionSource<object> completion, int timeout, out Task task, bool asyncWrite = false, [CallerMemberName] string method = "")
-		{
-			bool async = (null != completion);
-
-			task = null;
-
-			_rowsAffected = -1;
-
-			if (0 != (CommandBehavior.SingleRow & cmdBehavior))
-			{
-				// CommandBehavior.SingleRow implies CommandBehavior.SingleResult
-				cmdBehavior |= CommandBehavior.SingleResult;
-			}
-
-			// this function may throw for an invalid connection
-			// returns false for empty command text
-			ValidateCommand(async, method);
-
-			CheckNotificationStateAndAutoEnlist(); // Only call after validate - requires non null connection!
-
-			SqlStatistics statistics = Statistics;
-			if (null != statistics)
-			{
-				if ((!this.IsDirty && this.IsPrepared && !_hiddenPrepare)
-					|| (this.IsPrepared && _execType == EXECTYPE.PREPAREPENDING))
-				{
-					statistics.SafeIncrement(ref statistics._preparedExecs);
-				}
-				else
-				{
-					statistics.SafeIncrement(ref statistics._unpreparedExecs);
-				}
-			}
-
-			return RunExecuteReaderTds(cmdBehavior, runBehavior, returnStream, async, timeout, out task, asyncWrite && async);
-		}
-
-		private SqlDataReader RunExecuteReaderTds(CommandBehavior cmdBehavior, RunBehavior runBehavior, bool returnStream, bool async, int timeout, out Task task, bool asyncWrite, SqlDataReader ds = null)
-		{
-			Debug.Assert(!asyncWrite || async, "AsyncWrite should be always accompanied by Async");
-
-			if (ds == null && returnStream)
-			{
-				ds = new SqlDataReader(this, cmdBehavior);
-			}
-
-			Task reconnectTask = _activeConnection.ValidateAndReconnect(null, timeout);
-
-			if (reconnectTask != null)
-			{
-				long reconnectionStart = ADP.TimerCurrent();
-				if (async)
-				{
-					TaskCompletionSource<object> completion = new TaskCompletionSource<object>();
-					_activeConnection.RegisterWaitingForReconnect(completion.Task);
-					_reconnectionCompletionSource = completion;
-					CancellationTokenSource timeoutCTS = new CancellationTokenSource();
-					AsyncHelper.SetTimeoutException(completion, timeout, SQL.CR_ReconnectTimeout, timeoutCTS.Token);
-					AsyncHelper.ContinueTask(reconnectTask, completion,
-						() =>
-						{
-							if (completion.Task.IsCompleted)
-							{
-								return;
-							}
-							Interlocked.CompareExchange(ref _reconnectionCompletionSource, null, completion);
-							timeoutCTS.Cancel();
-							Task subTask;
-							RunExecuteReaderTds(cmdBehavior, runBehavior, returnStream, async, TdsParserStaticMethods.GetRemainingTimeout(timeout, reconnectionStart), out subTask, asyncWrite, ds);
-							if (subTask == null)
-							{
-								completion.SetResult(null);
-							}
-							else
-							{
-								AsyncHelper.ContinueTask(subTask, completion, () => completion.SetResult(null));
-							}
-						}, connectionToAbort: _activeConnection);
-					task = completion.Task;
-					return ds;
-				}
-				else
-				{
-					AsyncHelper.WaitForCompletion(reconnectTask, timeout, () => { throw SQL.CR_ReconnectTimeout(); });
-					timeout = TdsParserStaticMethods.GetRemainingTimeout(timeout, reconnectionStart);
-				}
-			}
-
-			// make sure we have good parameter information
-			// prepare the command
-			// execute
-			Debug.Assert(null != _activeConnection.Parser, "TdsParser class should not be null in Command.Execute!");
-
-			bool inSchema = (0 != (cmdBehavior & CommandBehavior.SchemaOnly));
-
-			// create a new RPC
-			_SqlRPC rpc = null;
-
-			task = null;
-
-			string optionSettings = null;
-			bool processFinallyBlock = true;
-			bool decrementAsyncCountOnFailure = false;
-
-			if (async)
-			{
-				_activeConnection.GetOpenTdsConnection().IncrementAsyncCount();
-				decrementAsyncCountOnFailure = true;
-			}
-
-			try
-			{
-				if (asyncWrite)
-				{
-					_activeConnection.AddWeakReference(this, SqlReferenceCollection.CommandTag);
-				}
-
-				GetStateObject();
-				Task writeTask = null;
-
-				if ((System.Data.CommandType.Text == this.CommandType) && (0 == GetParameterCount(_parameters)))
-				{
-					// Send over SQL Batch command if we are not a stored proc and have no parameters
-					Debug.Assert(!IsUserPrepared, "CommandType.Text with no params should not be prepared!");
-					string text = GetCommandText(cmdBehavior) + GetResetOptionsString(cmdBehavior);
-					writeTask = _stateObj.Parser.TdsExecuteSQLBatch(text, timeout, this.Notification, _stateObj, sync: !asyncWrite);
-				}
-				else if (System.Data.CommandType.Text == this.CommandType)
-				{
-					if (this.IsDirty)
-					{
-						Debug.Assert(_cachedMetaData == null || !_dirty, "dirty query should not have cached metadata!"); // can have cached metadata if dirty because of parameters
-						//
-						// someone changed the command text or the parameter schema so we must unprepare the command
-						//
-						// remember that IsDirty includes test for IsPrepared!
-						if (_execType == EXECTYPE.PREPARED)
-						{
-							_hiddenPrepare = true;
-						}
-						Unprepare();
-						IsDirty = false;
-					}
-
-					if (_execType == EXECTYPE.PREPARED)
-					{
-						Debug.Assert(this.IsPrepared && (_prepareHandle != -1), "invalid attempt to call sp_execute without a handle!");
-						rpc = BuildExecute(inSchema);
-					}
-					else if (_execType == EXECTYPE.PREPAREPENDING)
-					{
-						rpc = BuildPrepExec(cmdBehavior);
-						// next time through, only do an exec
-						_execType = EXECTYPE.PREPARED;
-						_preparedConnectionCloseCount = _activeConnection.CloseCount;
-						_preparedConnectionReconnectCount = _activeConnection.ReconnectCount;
-						// mark ourselves as preparing the command
-						_inPrepare = true;
-					}
-					else
-					{
-						Debug.Assert(_execType == EXECTYPE.UNPREPARED, "Invalid execType!");
-						BuildExecuteSql(cmdBehavior, null, _parameters, ref rpc);
-					}
-
-					// if shiloh, then set NOMETADATA_UNLESSCHANGED flag
-					rpc.options = TdsEnums.RPC_NOMETADATA;
-
-					Debug.Assert(_rpcArrayOf1[0] == rpc);
-					writeTask = _stateObj.Parser.TdsExecuteRPC(_rpcArrayOf1, timeout, inSchema, this.Notification, _stateObj, CommandType.StoredProcedure == CommandType, sync: !asyncWrite);
-				}
-				else
-				{
-					Debug.Assert(this.CommandType == System.Data.CommandType.StoredProcedure, "unknown command type!");
-
-					BuildRPC(inSchema, _parameters, ref rpc);
-
-					// if we need to augment the command because a user has changed the command behavior (e.g. FillSchema)
-					// then batch sql them over.  This is inefficient (3 round trips) but the only way we can get metadata only from
-					// a stored proc
-					optionSettings = GetSetOptionsString(cmdBehavior);
-					// turn set options ON
-					if (null != optionSettings)
-					{
-						Task executeTask = _stateObj.Parser.TdsExecuteSQLBatch(optionSettings, timeout, this.Notification, _stateObj, sync: true);
-						Debug.Assert(executeTask == null, "Shouldn't get a task when doing sync writes");
-						bool dataReady;
-						Debug.Assert(_stateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
-						bool result = _stateObj.Parser.TryRun(RunBehavior.UntilDone, this, null, null, _stateObj, out dataReady);
-						if (!result) { throw SQL.SynchronousCallMayNotPend(); }
-						// and turn OFF when the ds exhausts the stream on Close()
-						optionSettings = GetResetOptionsString(cmdBehavior);
-					}
-
-
-					// execute sp
-					Debug.Assert(_rpcArrayOf1[0] == rpc);
-					writeTask = _stateObj.Parser.TdsExecuteRPC(_rpcArrayOf1, timeout, inSchema, this.Notification, _stateObj, CommandType.StoredProcedure == CommandType, sync: !asyncWrite);
-				}
-
-				Debug.Assert(writeTask == null || async, "Returned task in sync mode");
-
-				if (async)
-				{
-					decrementAsyncCountOnFailure = false;
-					if (writeTask != null)
-					{
-						task = AsyncHelper.CreateContinuationTask(writeTask, () =>
-						{
-							_activeConnection.GetOpenTdsConnection(); // it will throw if connection is closed
-							cachedAsyncState.SetAsyncReaderState(ds, runBehavior, optionSettings);
-						},
-								 onFailure: (exc) =>
-								 {
-									 _activeConnection.GetOpenTdsConnection().DecrementAsyncCount();
-								 });
-					}
-					else
-					{
-						cachedAsyncState.SetAsyncReaderState(ds, runBehavior, optionSettings);
-					}
-				}
-				else
-				{
-					// Always execute - even if no reader!
-					FinishExecuteReader(ds, runBehavior, optionSettings);
-				}
-			}
-			catch (Exception e)
-			{
-				processFinallyBlock = ADP.IsCatchableExceptionType(e);
-				if (decrementAsyncCountOnFailure)
-				{
-					SqlInternalConnectionTds innerConnectionTds = (_activeConnection.InnerConnection as SqlInternalConnectionTds);
-					if (null != innerConnectionTds)
-					{ // it may be closed 
-						innerConnectionTds.DecrementAsyncCount();
-					}
-				}
-				throw;
-			}
-			finally
-			{
-				if (processFinallyBlock && !async)
-				{
-					// When executing async, we need to keep the _stateObj alive...
-					PutStateObject();
-				}
-			}
-
-			Debug.Assert(async || null == _stateObj, "non-null state object in RunExecuteReader");
-			return ds;
-		}
-
-
-		private SqlDataReader CompleteAsyncExecuteReader()
-		{
-			SqlDataReader ds = cachedAsyncState.CachedAsyncReader; // should not be null
-			bool processFinallyBlock = true;
-			try
-			{
-				FinishExecuteReader(ds, cachedAsyncState.CachedRunBehavior, cachedAsyncState.CachedSetOptions);
-			}
-			catch (Exception e)
-			{
-				processFinallyBlock = ADP.IsCatchableExceptionType(e);
-				throw;
-			}
-			finally
-			{
-				if (processFinallyBlock)
-				{
-					cachedAsyncState.ResetAsyncState();
-					PutStateObject();
-				}
-			}
-
-			return ds;
-		}
-
-		private void FinishExecuteReader(SqlDataReader ds, RunBehavior runBehavior, string resetOptionsString)
-		{
-			// always wrap with a try { FinishExecuteReader(...) } finally { PutStateObject(); }
-
-			NotifyDependency();
-
-			if (runBehavior == RunBehavior.UntilDone)
-			{
-				try
-				{
-					bool dataReady;
-					Debug.Assert(_stateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
-					bool result = _stateObj.Parser.TryRun(RunBehavior.UntilDone, this, ds, null, _stateObj, out dataReady);
-					if (!result) { throw SQL.SynchronousCallMayNotPend(); }
-				}
-				catch (Exception e)
-				{
-					if (ADP.IsCatchableExceptionType(e))
-					{
-						if (_inPrepare)
-						{
-							// The flag is expected to be reset by OnReturnValue.  We should receive
-							// the handle unless command execution failed.  If fail, move back to pending
-							// state.
-							_inPrepare = false;                  // reset the flag
-							IsDirty = true;                      // mark command as dirty so it will be prepared next time we're coming through
-							_execType = EXECTYPE.PREPAREPENDING; // reset execution type to pending
-						}
-
-						if (null != ds)
-						{
-							try
-							{
-								ds.Close();
-							}
-							catch(Exception exClose)
-							{
-								Debug.WriteLine("Received this exception from SqlDataReader.Close() while in another catch block: " + exClose.ToString());
-							}
-						}
-					}
-					throw;
-				}
-			}
-
-			// bind the parser to the reader if we get this far
-			if (ds != null)
-			{
-				ds.Bind(_stateObj);
-				_stateObj = null;   // the reader now owns this...
-				ds.ResetOptionsString = resetOptionsString;
-				// bind this reader to this connection now
-				_activeConnection.AddWeakReference(ds, SqlReferenceCollection.DataReaderTag);
-
-				// force this command to start reading data off the wire.
-				// this will cause an error to be reported at Execute() time instead of Read() time
-				// if the command is not set.
-				try
-				{
-					_cachedMetaData = ds.MetaData;
-					ds.IsInitialized = true;
-				}
-				catch (Exception e)
-				{
-					if (ADP.IsCatchableExceptionType(e))
-					{
-						if (_inPrepare)
-						{
-							// The flag is expected to be reset by OnReturnValue.  We should receive
-							// the handle unless command execution failed.  If fail, move back to pending
-							// state.
-							_inPrepare = false;                  // reset the flag
-							IsDirty = true;                      // mark command as dirty so it will be prepared next time we're coming through
-							_execType = EXECTYPE.PREPAREPENDING; // reset execution type to pending
-						}
-
-						try
-						{
-							ds.Close();
-						}
-						catch (Exception exClose)
-						{
-							Debug.WriteLine("Received this exception from SqlDataReader.Close() while in another catch block: " + exClose.ToString());
-						}
-					}
-
-					throw;
-				}
-			}
-		}
-
-
-		private void RegisterForConnectionCloseNotification<T>(ref Task<T> outerTask)
-		{
-			SqlConnection connection = _activeConnection;
-			if (connection == null)
-			{
-				// No connection
-				throw ADP.ClosedConnectionError();
-			}
-
-			connection.RegisterForConnectionCloseNotification<T>(ref outerTask, this, SqlReferenceCollection.CommandTag);
-		}
-
-		// validates that a command has commandText and a non-busy open connection
-		// throws exception for error case, returns false if the commandText is empty
-		private void ValidateCommand(bool async, [CallerMemberName] string method = "")
-		{
-			if (null == _activeConnection)
-			{
-				throw ADP.ConnectionRequired(method);
-			}
-
-			// Ensure that the connection is open and that the Parser is in the correct state
-			SqlInternalConnectionTds tdsConnection = _activeConnection.InnerConnection as SqlInternalConnectionTds;
-			if (tdsConnection != null)
-			{
-				var parser = tdsConnection.Parser;
-				if ((parser == null) || (parser.State == TdsParserState.Closed))
-				{
-					throw ADP.OpenConnectionRequired(method, ConnectionState.Closed);
-				}
-				else if (parser.State != TdsParserState.OpenLoggedIn)
-				{
-					throw ADP.OpenConnectionRequired(method, ConnectionState.Broken);
-				}
-			}
-			else if (_activeConnection.State == ConnectionState.Closed)
-			{
-				throw ADP.OpenConnectionRequired(method, ConnectionState.Closed);
-			}
-			else if (_activeConnection.State == ConnectionState.Broken)
-			{
-				throw ADP.OpenConnectionRequired(method, ConnectionState.Broken);
-			}
-
-			ValidateAsyncCommand();
-
-			// close any non MARS dead readers, if applicable, and then throw if still busy.
-			// Throw if we have a live reader on this command
-			_activeConnection.ValidateConnectionForExecute(method, this);
-			// Check to see if the currently set transaction has completed.  If so,
-			// null out our local reference.
-			if (null != _transaction && _transaction.Connection == null)
-				_transaction = null;
-
-			// throw if the connection is in a transaction but there is no
-			// locally assigned transaction object
-			if (_activeConnection.HasLocalTransactionFromAPI && (null == _transaction))
-				throw ADP.TransactionRequired(method);
-
-			// if we have a transaction, check to ensure that the active
-			// connection property matches the connection associated with
-			// the transaction
-			if (null != _transaction && _activeConnection != _transaction.Connection)
-				throw ADP.TransactionConnectionMismatch();
-
-			if (string.IsNullOrEmpty(this.CommandText))
-				throw ADP.CommandTextRequired(method);
-		}
-
-		private void ValidateAsyncCommand()
-		{
-			if (cachedAsyncState.PendingAsyncOperation)
-			{ // Enforce only one pending async execute at a time.
-				if (cachedAsyncState.IsActiveConnectionValid(_activeConnection))
-				{
-					throw SQL.PendingBeginXXXExists();
-				}
-				else
-				{
-					_stateObj = null; // Session was re-claimed by session pool upon connection close.
-					cachedAsyncState.ResetAsyncState();
-				}
-			}
-		}
-
-		private void GetStateObject(TdsParser parser = null)
-		{
-			Debug.Assert(null == _stateObj, "StateObject not null on GetStateObject");
-			Debug.Assert(null != _activeConnection, "no active connection?");
-
-			if (_pendingCancel)
-			{
-				_pendingCancel = false; // Not really needed, but we'll reset anyways.
-
-				// If a pendingCancel exists on the object, we must have had a Cancel() call
-				// between the point that we entered an Execute* API and the point in Execute* that
-				// we proceeded to call this function and obtain a stateObject.  In that case,
-				// we now throw a cancelled error.
-				throw SQL.OperationCancelled();
-			}
-
-			if (parser == null)
-			{
-				parser = _activeConnection.Parser;
-				if ((parser == null) || (parser.State == TdsParserState.Broken) || (parser.State == TdsParserState.Closed))
-				{
-					// Connection's parser is null as well, therefore we must be closed
-					throw ADP.ClosedConnectionError();
-				}
-			}
-
-			TdsParserStateObject stateObj = parser.GetSession(this);
-			stateObj.StartSession(this);
-
-			_stateObj = stateObj;
-
-			if (_pendingCancel)
-			{
-				_pendingCancel = false; // Not really needed, but we'll reset anyways.
-
-				// If a pendingCancel exists on the object, we must have had a Cancel() call
-				// between the point that we entered this function and the point where we obtained
-				// and actually assigned the stateObject to the local member.  It is possible
-				// that the flag is set as well as a call to stateObj.Cancel - though that would
-				// be a no-op.  So - throw.
-				throw SQL.OperationCancelled();
-			}
-		}
-
-		private void ReliablePutStateObject()
-		{
-			PutStateObject();
-		}
-
-		private void PutStateObject()
-		{
-			TdsParserStateObject stateObj = _stateObj;
-			_stateObj = null;
-
-			if (null != stateObj)
-			{
-				stateObj.CloseSession();
-			}
-		}
-		internal void OnDoneProc()
-		{ // called per rpc batch complete
-			if (BatchRPCMode)
-			{
-				// track the records affected for the just completed rpc batch
-				// _rowsAffected is cumulative for ExecuteNonQuery across all rpc batches
-				_SqlRPCBatchArray[_currentlyExecutingBatch].cumulativeRecordsAffected = _rowsAffected;
-
-				_SqlRPCBatchArray[_currentlyExecutingBatch].recordsAffected =
-					(((0 < _currentlyExecutingBatch) && (0 <= _rowsAffected))
-						? (_rowsAffected - Math.Max(_SqlRPCBatchArray[_currentlyExecutingBatch - 1].cumulativeRecordsAffected, 0))
-						: _rowsAffected);
-
-				// track the error collection (not available from TdsParser after ExecuteNonQuery)
-				// and the which errors are associated with the just completed rpc batch
-				_SqlRPCBatchArray[_currentlyExecutingBatch].errorsIndexStart =
-					((0 < _currentlyExecutingBatch)
-						? _SqlRPCBatchArray[_currentlyExecutingBatch - 1].errorsIndexEnd
-						: 0);
-				_SqlRPCBatchArray[_currentlyExecutingBatch].errorsIndexEnd = _stateObj.ErrorCount;
-				_SqlRPCBatchArray[_currentlyExecutingBatch].errors = _stateObj._errors;
-
-				// track the warning collection (not available from TdsParser after ExecuteNonQuery)
-				// and the which warnings are associated with the just completed rpc batch
-				_SqlRPCBatchArray[_currentlyExecutingBatch].warningsIndexStart =
-					((0 < _currentlyExecutingBatch)
-						? _SqlRPCBatchArray[_currentlyExecutingBatch - 1].warningsIndexEnd
-						: 0);
-				_SqlRPCBatchArray[_currentlyExecutingBatch].warningsIndexEnd = _stateObj.WarningCount;
-				_SqlRPCBatchArray[_currentlyExecutingBatch].warnings = _stateObj._warnings;
-
-				_currentlyExecutingBatch++;
-				Debug.Assert(_parameterCollectionList.Count >= _currentlyExecutingBatch, "OnDoneProc: Too many DONEPROC events");
-			}
-		}
-		internal void OnReturnStatus(int status)
-		{
-			if (_inPrepare)
-				return;
-
-			SqlParameterCollection parameters = _parameters;
-			if (BatchRPCMode)
-			{
-				if (_parameterCollectionList.Count > _currentlyExecutingBatch)
-				{
-					parameters = _parameterCollectionList[_currentlyExecutingBatch];
-				}
-				else
-				{
-					Debug.Assert(false, "OnReturnStatus: SqlCommand got too many DONEPROC events");
-					parameters = null;
-				}
-			}
-			// see if a return value is bound
-			int count = GetParameterCount(parameters);
-			for (int i = 0; i < count; i++)
-			{
-				SqlParameter parameter = parameters[i];
-				if (parameter.Direction == ParameterDirection.ReturnValue)
-				{
-					object v = parameter.Value;
-
-					// if the user bound a sqlint32 (the only valid one for status, use it)
-					if ((null != v) && (v.GetType() == typeof(SqlInt32)))
-					{
-						parameter.Value = new SqlInt32(status); // value type
-					}
-					else
-					{
-						parameter.Value = status;
-
-					}
-
-					break;
-				}
-			}
-		}
-
-		//
-		// Move the return value to the corresponding output parameter.
-		// Return parameters are sent in the order in which they were defined in the procedure.
-		// If named, match the parameter name, otherwise fill in based on ordinal position.
-		// If the parameter is not bound, then ignore the return value.
-		//
-		internal void OnReturnValue(SqlReturnValue rec)
-		{
-
-			if (_inPrepare)
-			{
-				if (!rec.value.IsNull)
-				{
-					_prepareHandle = rec.value.Int32;
-				}
-				_inPrepare = false;
-				return;
-			}
-
-			SqlParameterCollection parameters = GetCurrentParameterCollection();
-			int count = GetParameterCount(parameters);
-
-
-			SqlParameter thisParam = GetParameterForOutputValueExtraction(parameters, rec.parameter, count);
-
-			if (null != thisParam)
-			{
-				// copy over data
-
-				// if the value user has supplied a SqlType class, then just copy over the SqlType, otherwise convert
-				// to the com type
-				object val = thisParam.Value;
-
-				thisParam.SetSqlBuffer(rec.value);
-
-				MetaType mt = MetaType.GetMetaTypeFromSqlDbType(rec.type, false);
-
-				if (rec.type == SqlDbType.Decimal)
-				{
-					thisParam.ScaleInternal = rec.scale;
-					thisParam.PrecisionInternal = rec.precision;
-				}
-				else if (mt.IsVarTime)
-				{
-					thisParam.ScaleInternal = rec.scale;
-				}
-				else if (rec.type == SqlDbType.Xml)
-				{
-					SqlCachedBuffer cachedBuffer = (thisParam.Value as SqlCachedBuffer);
-					if (null != cachedBuffer)
-					{
-						thisParam.Value = cachedBuffer.ToString();
-					}
-				}
-
-				if (rec.collation != null)
-				{
-					Debug.Assert(mt.IsCharType, "Invalid collation structure for non-char type");
-					thisParam.Collation = rec.collation;
-				}
-			}
-
-			return;
-		}
-
-		private SqlParameterCollection GetCurrentParameterCollection()
-		{
-			if (BatchRPCMode)
-			{
-				if (_parameterCollectionList.Count > _currentlyExecutingBatch)
-				{
-					return _parameterCollectionList[_currentlyExecutingBatch];
-				}
-				else
-				{
-					Debug.Assert(false, "OnReturnValue: SqlCommand got too many DONEPROC events");
-					return null;
-				}
-			}
-			else
-			{
-				return _parameters;
-			}
-		}
-
-		private SqlParameter GetParameterForOutputValueExtraction(SqlParameterCollection parameters,
-						string paramName, int paramCount)
-		{
-			SqlParameter thisParam = null;
-			bool foundParam = false;
-
-			if (null == paramName)
-			{
-				// rec.parameter should only be null for a return value from a function
-				for (int i = 0; i < paramCount; i++)
-				{
-					thisParam = parameters[i];
-					// searching for ReturnValue
-					if (thisParam.Direction == ParameterDirection.ReturnValue)
-					{
-						foundParam = true;
-						break; // found it
-					}
-				}
-			}
-			else
-			{
-				for (int i = 0; i < paramCount; i++)
-				{
-					thisParam = parameters[i];
-					// searching for Output or InputOutput or ReturnValue with matching name
-					if (thisParam.Direction != ParameterDirection.Input && thisParam.Direction != ParameterDirection.ReturnValue && paramName == thisParam.ParameterNameFixed)
-					{
-						foundParam = true;
-						break; // found it
-					}
-				}
-			}
-			if (foundParam)
-				return thisParam;
-			else
-				return null;
-		}
-
-		private void GetRPCObject(int paramCount, ref _SqlRPC rpc)
-		{
-			// Designed to minimize necessary allocations
-			int ii;
-			if (rpc == null)
-			{
-				if (_rpcArrayOf1 == null)
-				{
-					_rpcArrayOf1 = new _SqlRPC[1];
-					_rpcArrayOf1[0] = new _SqlRPC();
-				}
-				rpc = _rpcArrayOf1[0];
-			}
-
-			rpc.ProcID = 0;
-			rpc.rpcName = null;
-			rpc.options = 0;
-
-
-			// Make sure there is enough space in the parameters and paramoptions arrays
-			if (rpc.parameters == null || rpc.parameters.Length < paramCount)
-			{
-				rpc.parameters = new SqlParameter[paramCount];
-			}
-			else if (rpc.parameters.Length > paramCount)
-			{
-				rpc.parameters[paramCount] = null;    // Terminator
-			}
-			if (rpc.paramoptions == null || (rpc.paramoptions.Length < paramCount))
-			{
-				rpc.paramoptions = new byte[paramCount];
-			}
-			else
-			{
-				for (ii = 0; ii < paramCount; ii++)
-					rpc.paramoptions[ii] = 0;
-			}
-		}
-
-		private void SetUpRPCParameters(_SqlRPC rpc, int startCount, bool inSchema, SqlParameterCollection parameters)
-		{
-			int ii;
-			int paramCount = GetParameterCount(parameters);
-			int j = startCount;
-			TdsParser parser = _activeConnection.Parser;
-
-			for (ii = 0; ii < paramCount; ii++)
-			{
-				SqlParameter parameter = parameters[ii];
-				parameter.Validate(ii, CommandType.StoredProcedure == CommandType);
-
-				// func will change type to that with a 4 byte length if the type has a two
-				// byte length and a parameter length > than that expressible in 2 bytes
-				if ((!parameter.ValidateTypeLengths().IsPlp) && (parameter.Direction != ParameterDirection.Output))
-				{
-					parameter.FixStreamDataForNonPLP();
-				}
-
-				if (ShouldSendParameter(parameter))
-				{
-					rpc.parameters[j] = parameter;
-
-					// set output bit
-					if (parameter.Direction == ParameterDirection.InputOutput ||
-						parameter.Direction == ParameterDirection.Output)
-						rpc.paramoptions[j] = TdsEnums.RPC_PARAM_BYREF;
-
-					// set default value bit
-					if (parameter.Direction != ParameterDirection.Output)
-					{
-						// remember that null == Convert.IsEmpty, DBNull.Value is a database null!
-
-						// Don't assume a default value exists for parameters in the case when
-						// the user is simply requesting schema.
-						// TVPs use DEFAULT and do not allow NULL, even for schema only.
-						if (null == parameter.Value && (!inSchema || SqlDbType.Structured == parameter.SqlDbType))
-						{
-							rpc.paramoptions[j] |= TdsEnums.RPC_PARAM_DEFAULT;
-						}
-					}
-
-					// Must set parameter option bit for LOB_COOKIE if unfilled LazyMat blob
-					j++;
-				}
-			}
-		}
-
-		private _SqlRPC BuildPrepExec(CommandBehavior behavior)
-		{
-			Debug.Assert(System.Data.CommandType.Text == this.CommandType, "invalid use of sp_prepexec for stored proc invocation!");
-			SqlParameter sqlParam;
-			int j = 3;
-
-			int count = CountSendableParameters(_parameters);
-
-			_SqlRPC rpc = null;
-			GetRPCObject(count + j, ref rpc);
-
-			rpc.ProcID = TdsEnums.RPC_PROCID_PREPEXEC;
-			rpc.rpcName = TdsEnums.SP_PREPEXEC;
-
-			//@handle
-			sqlParam = new SqlParameter(null, SqlDbType.Int);
-			sqlParam.Direction = ParameterDirection.InputOutput;
-			sqlParam.Value = _prepareHandle;
-			rpc.parameters[0] = sqlParam;
-			rpc.paramoptions[0] = TdsEnums.RPC_PARAM_BYREF;
-
-			//@batch_params
-			string paramList = BuildParamList(_stateObj.Parser, _parameters);
-			sqlParam = new SqlParameter(null, ((paramList.Length << 1) <= TdsEnums.TYPE_SIZE_LIMIT) ? SqlDbType.NVarChar : SqlDbType.NText, paramList.Length);
-			sqlParam.Value = paramList;
-			rpc.parameters[1] = sqlParam;
-
-			//@batch_text
-			string text = GetCommandText(behavior);
-			sqlParam = new SqlParameter(null, ((text.Length << 1) <= TdsEnums.TYPE_SIZE_LIMIT) ? SqlDbType.NVarChar : SqlDbType.NText, text.Length);
-			sqlParam.Value = text;
-			rpc.parameters[2] = sqlParam;
-
-			SetUpRPCParameters(rpc, j, false, _parameters);
-			return rpc;
-		}
-
-
-		//
-		// returns true if the parameter is not a return value
-		// and it's value is not DBNull (for a nullable parameter)
-		//
-		private static bool ShouldSendParameter(SqlParameter p)
-		{
-			switch (p.Direction)
-			{
-				case ParameterDirection.ReturnValue:
-					// return value parameters are never sent
-					return false;
-				case ParameterDirection.Output:
-				case ParameterDirection.InputOutput:
-				case ParameterDirection.Input:
-					// InputOutput/Output parameters are aways sent
-					return true;
-				default:
-					Debug.Assert(false, "Invalid ParameterDirection!");
-					return false;
-			}
-		}
-
-		private int CountSendableParameters(SqlParameterCollection parameters)
-		{
-			int cParams = 0;
-
-			if (parameters != null)
-			{
-				int count = parameters.Count;
-				for (int i = 0; i < count; i++)
-				{
-					if (ShouldSendParameter(parameters[i]))
-						cParams++;
-				}
-			}
-			return cParams;
-		}
-
-		// Returns total number of parameters
-		private int GetParameterCount(SqlParameterCollection parameters)
-		{
-			return ((null != parameters) ? parameters.Count : 0);
-		}
-
-		//
-		// build the RPC record header for this stored proc and add parameters
-		//
-		private void BuildRPC(bool inSchema, SqlParameterCollection parameters, ref _SqlRPC rpc)
-		{
-			Debug.Assert(this.CommandType == System.Data.CommandType.StoredProcedure, "Command must be a stored proc to execute an RPC");
-			int count = CountSendableParameters(parameters);
-			GetRPCObject(count, ref rpc);
-
-			rpc.rpcName = this.CommandText; // just get the raw command text
-
-			SetUpRPCParameters(rpc, 0, inSchema, parameters);
-		}
-
-		//
-		// build the RPC record header for sp_unprepare
-		//
-		// prototype for sp_unprepare is:
-		// sp_unprepare(@handle)
-
-		// build the RPC record header for sp_execute
-		//
-		// prototype for sp_execute is:
-		// sp_execute(@handle int,param1value,param2value...)
-
-		private _SqlRPC BuildExecute(bool inSchema)
-		{
-			Debug.Assert(_prepareHandle != -1, "Invalid call to sp_execute without a valid handle!");
-			int j = 1;
-
-			int count = CountSendableParameters(_parameters);
-
-			_SqlRPC rpc = null;
-			GetRPCObject(count + j, ref rpc);
-
-			SqlParameter sqlParam;
-
-			rpc.ProcID = TdsEnums.RPC_PROCID_EXECUTE;
-			rpc.rpcName = TdsEnums.SP_EXECUTE;
-
-			//@handle
-			sqlParam = new SqlParameter(null, SqlDbType.Int);
-			sqlParam.Value = _prepareHandle;
-			rpc.parameters[0] = sqlParam;
-
-			SetUpRPCParameters(rpc, j, inSchema, _parameters);
-			return rpc;
-		}
-
-		//
-		// build the RPC record header for sp_executesql and add the parameters
-		//
-		// prototype for sp_executesql is:
-		// sp_executesql(@batch_text nvarchar(4000),@batch_params nvarchar(4000), param1,.. paramN)
-		private void BuildExecuteSql(CommandBehavior behavior, string commandText, SqlParameterCollection parameters, ref _SqlRPC rpc)
-		{
-
-			Debug.Assert(_prepareHandle == -1, "This command has an existing handle, use sp_execute!");
-			Debug.Assert(CommandType.Text == this.CommandType, "invalid use of sp_executesql for stored proc invocation!");
-			int j;
-			SqlParameter sqlParam;
-
-			int cParams = CountSendableParameters(parameters);
-			if (cParams > 0)
-			{
-				j = 2;
-			}
-			else
-			{
-				j = 1;
-			}
-
-			GetRPCObject(cParams + j, ref rpc);
-			rpc.ProcID = TdsEnums.RPC_PROCID_EXECUTESQL;
-			rpc.rpcName = TdsEnums.SP_EXECUTESQL;
-
-			// @sql
-			if (commandText == null)
-			{
-				commandText = GetCommandText(behavior);
-			}
-			sqlParam = new SqlParameter(null, ((commandText.Length << 1) <= TdsEnums.TYPE_SIZE_LIMIT) ? SqlDbType.NVarChar : SqlDbType.NText, commandText.Length);
-			sqlParam.Value = commandText;
-			rpc.parameters[0] = sqlParam;
-
-			if (cParams > 0)
-			{
-				string paramList = BuildParamList(_stateObj.Parser, BatchRPCMode ? parameters : _parameters);
-				sqlParam = new SqlParameter(null, ((paramList.Length << 1) <= TdsEnums.TYPE_SIZE_LIMIT) ? SqlDbType.NVarChar : SqlDbType.NText, paramList.Length);
-				sqlParam.Value = paramList;
-				rpc.parameters[1] = sqlParam;
-
-				bool inSchema = (0 != (behavior & CommandBehavior.SchemaOnly));
-				SetUpRPCParameters(rpc, j, inSchema, parameters);
-			}
-		}
-
-		// paramList parameter for sp_executesql, sp_prepare, and sp_prepexec
-		internal string BuildParamList(TdsParser parser, SqlParameterCollection parameters)
-		{
-			StringBuilder paramList = new StringBuilder();
-			bool fAddSeperator = false;
-
-			int count = 0;
-
-			count = parameters.Count;
-			for (int i = 0; i < count; i++)
-			{
-				SqlParameter sqlParam = parameters[i];
-				sqlParam.Validate(i, CommandType.StoredProcedure == CommandType);
-				// skip ReturnValue parameters; we never send them to the server
-				if (!ShouldSendParameter(sqlParam))
-					continue;
-
-				// add our separator for the ith parameter
-				if (fAddSeperator)
-					paramList.Append(',');
-
-				paramList.Append(sqlParam.ParameterNameFixed);
-
-				MetaType mt = sqlParam.InternalMetaType;
-
-				//for UDTs, get the actual type name. Get only the typename, omit catalog and schema names.
-				//in TSQL you should only specify the unqualified type name
-
-				// paragraph above doesn't seem to be correct. Server won't find the type
-				// if we don't provide a fully qualified name
-				paramList.Append(" ");
-				if (mt.SqlDbType == SqlDbType.Udt)
-				{
-					throw ADP.DbTypeNotSupported(SqlDbType.Udt.ToString());
-				}
-				else if (mt.SqlDbType == SqlDbType.Structured)
-				{
-					string typeName = sqlParam.TypeName;
-					if (string.IsNullOrEmpty(typeName))
-					{
-						throw SQL.MustSetTypeNameForParam(mt.TypeName, sqlParam.ParameterNameFixed);
-					}
-					paramList.Append(ParseAndQuoteIdentifier(typeName));
-
-					// TVPs currently are the only Structured type and must be read only, so add that keyword
-					paramList.Append(" READONLY");
-				}
-				else
-				{
-					// func will change type to that with a 4 byte length if the type has a two
-					// byte length and a parameter length > than that expressible in 2 bytes
-					mt = sqlParam.ValidateTypeLengths();
-					if ((!mt.IsPlp) && (sqlParam.Direction != ParameterDirection.Output))
-					{
-						sqlParam.FixStreamDataForNonPLP();
-					}
-					paramList.Append(mt.TypeName);
-				}
-
-				fAddSeperator = true;
-
-				if (mt.SqlDbType == SqlDbType.Decimal)
-				{
-					byte precision = sqlParam.GetActualPrecision();
-					byte scale = sqlParam.GetActualScale();
-
-					paramList.Append('(');
-
-					if (0 == precision)
-					{
-						precision = TdsEnums.DEFAULT_NUMERIC_PRECISION;
-					}
-
-					paramList.Append(precision);
-					paramList.Append(',');
-					paramList.Append(scale);
-					paramList.Append(')');
-				}
-				else if (mt.IsVarTime)
-				{
-					byte scale = sqlParam.GetActualScale();
-
-					paramList.Append('(');
-					paramList.Append(scale);
-					paramList.Append(')');
-				}
-				else if (false == mt.IsFixed && false == mt.IsLong && mt.SqlDbType != SqlDbType.Timestamp && mt.SqlDbType != SqlDbType.Udt && SqlDbType.Structured != mt.SqlDbType)
-				{
-					int size = sqlParam.Size;
-
-					paramList.Append('(');
-
-					// if using non unicode types, obtain the actual byte length from the parser, with it's associated code page
-					if (mt.IsAnsiType)
-					{
-						object val = sqlParam.GetCoercedValue();
-						string s = null;
-
-						// deal with the sql types
-						if ((null != val) && (DBNull.Value != val))
-						{
-							s = (val as string);
-							if (null == s)
-							{
-								SqlString sval = val is SqlString ? (SqlString)val : SqlString.Null;
-								if (!sval.IsNull)
-								{
-									s = sval.Value;
-								}
-							}
-						}
-
-						if (null != s)
-						{
-							int actualBytes = parser.GetEncodingCharLength(s, sqlParam.GetActualSize(), sqlParam.Offset, null);
-							// if actual number of bytes is greater than the user given number of chars, use actual bytes
-							if (actualBytes > size)
-								size = actualBytes;
-						}
-					}
-
-					// If the user specifies a 0-sized parameter for a variable len field
-					// pass over max size (8000 bytes or 4000 characters for wide types)
-					if (0 == size)
-						size = mt.IsSizeInCharacters ? (TdsEnums.MAXSIZE >> 1) : TdsEnums.MAXSIZE;
-
-					paramList.Append(size);
-					paramList.Append(')');
-				}
-				else if (mt.IsPlp && (mt.SqlDbType != SqlDbType.Xml) && (mt.SqlDbType != SqlDbType.Udt))
-				{
-					paramList.Append("(max) ");
-				}
-
-				// set the output bit for Output or InputOutput parameters
-				if (sqlParam.Direction != ParameterDirection.Input)
-					paramList.Append(" " + TdsEnums.PARAM_OUTPUT);
-			}
-
-			return paramList.ToString();
-		}
-
-		// Adds quotes to each part of a SQL identifier that may be multi-part, while leaving
-		//  the result as a single composite name.
-		private string ParseAndQuoteIdentifier(string identifier)
-		{
-			string[] strings = SqlParameter.ParseTypeName(identifier);
-			StringBuilder bld = new StringBuilder();
-
-			// Stitching back together is a little tricky. Assume we want to build a full multi-part name
-			//  with all parts except trimming separators for leading empty names (null or empty strings,
-			//  but not whitespace). Separators in the middle should be added, even if the name part is 
-			//  null/empty, to maintain proper location of the parts.
-			for (int i = 0; i < strings.Length; i++)
-			{
-				if (0 < bld.Length)
-				{
-					bld.Append('.');
-				}
-				if (null != strings[i] && 0 != strings[i].Length)
-				{
-					bld.Append(ADP.BuildQuotedString("[", "]", strings[i]));
-				}
-			}
-
-			return bld.ToString();
-		}
-
-		// returns set option text to turn on format only and key info on and off
-		//  When we are executing as a text command, then we never need
-		// to turn off the options since they command text is executed in the scope of sp_executesql.
-		// For a stored proc command, however, we must send over batch sql and then turn off
-		// the set options after we read the data.  See the code in Command.Execute()
-		private string GetSetOptionsString(CommandBehavior behavior)
-		{
-			string s = null;
-
-			if ((System.Data.CommandBehavior.SchemaOnly == (behavior & CommandBehavior.SchemaOnly)) ||
-			   (System.Data.CommandBehavior.KeyInfo == (behavior & CommandBehavior.KeyInfo)))
-			{
-				// SET FMTONLY ON will cause the server to ignore other SET OPTIONS, so turn
-				// it off before we ask for browse mode metadata
-				s = TdsEnums.FMTONLY_OFF;
-
-				if (System.Data.CommandBehavior.KeyInfo == (behavior & CommandBehavior.KeyInfo))
-				{
-					s = s + TdsEnums.BROWSE_ON;
-				}
-
-				if (System.Data.CommandBehavior.SchemaOnly == (behavior & CommandBehavior.SchemaOnly))
-				{
-					s = s + TdsEnums.FMTONLY_ON;
-				}
-			}
-
-			return s;
-		}
-
-		private string GetResetOptionsString(CommandBehavior behavior)
-		{
-			string s = null;
-
-			// SET FMTONLY ON OFF
-			if (System.Data.CommandBehavior.SchemaOnly == (behavior & CommandBehavior.SchemaOnly))
-			{
-				s = s + TdsEnums.FMTONLY_OFF;
-			}
-
-			// SET NO_BROWSETABLE OFF
-			if (System.Data.CommandBehavior.KeyInfo == (behavior & CommandBehavior.KeyInfo))
-			{
-				s = s + TdsEnums.BROWSE_OFF;
-			}
-
-			return s;
-		}
-
-		private String GetCommandText(CommandBehavior behavior)
-		{
-			// build the batch string we send over, since we execute within a stored proc (sp_executesql), the SET options never need to be
-			// turned off since they are scoped to the sproc
-			Debug.Assert(System.Data.CommandType.Text == this.CommandType, "invalid call to GetCommandText for stored proc!");
-			return GetSetOptionsString(behavior) + this.CommandText;
-		}
-
-		internal void CheckThrowSNIException()
-		{
-			var stateObj = _stateObj;
-			if (stateObj != null)
-			{
-				stateObj.CheckThrowSNIException();
-			}
-		}
-
-		// We're being notified that the underlying connection has closed
-		internal void OnConnectionClosed()
-		{
-			var stateObj = _stateObj;
-			if (stateObj != null)
-			{
-				stateObj.OnConnectionClosed();
-			}
-		}
-
-		internal TdsParserStateObject StateObject
-		{
-			get
-			{
-				return _stateObj;
-			}
-		}
-
-		private bool IsPrepared
-		{
-			get { return (_execType != EXECTYPE.UNPREPARED); }
-		}
-
-		private bool IsUserPrepared
-		{
-			get { return IsPrepared && !_hiddenPrepare && !IsDirty; }
-		}
-
-		internal bool IsDirty
-		{
-			get
-			{
-				// only dirty if prepared
-				var activeConnection = _activeConnection;
-				return (IsPrepared &&
-					(_dirty ||
-					((_parameters != null) && (_parameters.IsDirty)) ||
-					((activeConnection != null) && ((activeConnection.CloseCount != _preparedConnectionCloseCount) || (activeConnection.ReconnectCount != _preparedConnectionReconnectCount)))));
-			}
-			set
-			{
-				// only mark the command as dirty if it is already prepared
-				// but always clear the value if it we are clearing the dirty flag
-				_dirty = value ? IsPrepared : false;
-				if (null != _parameters)
-				{
-					_parameters.IsDirty = _dirty;
-				}
-				_cachedMetaData = null;
-			}
-		}
-
-		internal int InternalRecordsAffected
-		{
-			get
-			{
-				return _rowsAffected;
-			}
-			set
-			{
-				if (-1 == _rowsAffected)
-				{
-					_rowsAffected = value;
-				}
-				else if (0 < value)
-				{
-					_rowsAffected += value;
-				}
-			}
-		}
-
-		internal void ClearBatchCommand()
-		{
-			List<_SqlRPC> rpcList = _RPCList;
-			if (null != rpcList)
-			{
-				rpcList.Clear();
-			}
-			if (null != _parameterCollectionList)
-			{
-				_parameterCollectionList.Clear();
-			}
-
-			_SqlRPCBatchArray = null;
-			_currentlyExecutingBatch = 0;
-		}
-
-		internal bool BatchRPCMode
-		{
-			get
-			{
-				return _batchRPCMode;
-			}
-			set
-			{
-				_batchRPCMode = value;
-
-				if (_batchRPCMode == false)
-				{
-					ClearBatchCommand();
-				}
-				else
-				{
-					if (_RPCList == null)
-					{
-						_RPCList = new List<_SqlRPC>();
-					}
-					if (_parameterCollectionList == null)
-					{
-						_parameterCollectionList = new List<SqlParameterCollection>();
-					}
-				}
-			}
-		}
-
-		internal void AddBatchCommand(string commandText, SqlParameterCollection parameters, CommandType cmdType)
-		{
-			Debug.Assert(BatchRPCMode, "Command is not in batch RPC Mode");
-			Debug.Assert(_RPCList != null);
-			Debug.Assert(_parameterCollectionList != null);
-
-			_SqlRPC rpc = new _SqlRPC();
-
-			CommandText = commandText;
-			CommandType = cmdType;
-
-			GetStateObject();
-			if (cmdType == CommandType.StoredProcedure)
-			{
-				BuildRPC(false, parameters, ref rpc);
-			}
-			else
-			{
-				// All batch sql statements must be executed inside sp_executesql, including those without parameters
-				BuildExecuteSql(CommandBehavior.Default, commandText, parameters, ref rpc);
-			}
-
-			_RPCList.Add(rpc);
-			// Always add a parameters collection per RPC, even if there are no parameters.
-			_parameterCollectionList.Add(parameters);
-
-			ReliablePutStateObject();
-		}
-
-		internal int ExecuteBatchRPCCommand()
-		{
-
-			Debug.Assert(BatchRPCMode, "Command is not in batch RPC Mode");
-			Debug.Assert(_RPCList != null, "No batch commands specified");
-
-			_SqlRPCBatchArray = _RPCList.ToArray();
-			_currentlyExecutingBatch = 0;
-			return ExecuteNonQuery();       // Check permissions, execute, return output params
-		}
-
-		internal int? GetRecordsAffected(int commandIndex)
-		{
-			Debug.Assert(BatchRPCMode, "Command is not in batch RPC Mode");
-			Debug.Assert(_SqlRPCBatchArray != null, "batch command have been cleared");
-			return _SqlRPCBatchArray[commandIndex].recordsAffected;
-		}
-
-		internal SqlException GetErrors(int commandIndex)
-		{
-			SqlException result = null;
-			int length = (_SqlRPCBatchArray[commandIndex].errorsIndexEnd - _SqlRPCBatchArray[commandIndex].errorsIndexStart);
-			if (0 < length)
-			{
-				SqlErrorCollection errors = new SqlErrorCollection();
-				for (int i = _SqlRPCBatchArray[commandIndex].errorsIndexStart; i < _SqlRPCBatchArray[commandIndex].errorsIndexEnd; ++i)
-				{
-					errors.Add(_SqlRPCBatchArray[commandIndex].errors[i]);
-				}
-				for (int i = _SqlRPCBatchArray[commandIndex].warningsIndexStart; i < _SqlRPCBatchArray[commandIndex].warningsIndexEnd; ++i)
-				{
-					errors.Add(_SqlRPCBatchArray[commandIndex].warnings[i]);
-				}
-				result = SqlException.CreateException(errors, Connection.ServerVersion, Connection.ClientConnectionId);
-			}
-			return result;
-		}
+        internal bool InPrepare
+        {
+            get
+            {
+                return _inPrepare;
+            }
+        }
+
+        // Cached info for async executions
+        private class CachedAsyncState
+        {
+            private int _cachedAsyncCloseCount = -1;    // value of the connection's CloseCount property when the asyncResult was set; tracks when connections are closed after an async operation
+            private TaskCompletionSource<object> _cachedAsyncResult = null;
+            private SqlConnection _cachedAsyncConnection = null;  // Used to validate that the connection hasn't changed when end the connection;
+            private SqlDataReader _cachedAsyncReader = null;
+            private RunBehavior _cachedRunBehavior = RunBehavior.ReturnImmediately;
+            private string _cachedSetOptions = null;
+            private string _cachedEndMethod = null;
+
+            internal CachedAsyncState()
+            {
+            }
+
+            internal SqlDataReader CachedAsyncReader
+            {
+                get { return _cachedAsyncReader; }
+            }
+            internal RunBehavior CachedRunBehavior
+            {
+                get { return _cachedRunBehavior; }
+            }
+            internal string CachedSetOptions
+            {
+                get { return _cachedSetOptions; }
+            }
+            internal bool PendingAsyncOperation
+            {
+                get { return (null != _cachedAsyncResult); }
+            }
+            internal string EndMethodName
+            {
+                get { return _cachedEndMethod; }
+            }
+
+            internal bool IsActiveConnectionValid(SqlConnection activeConnection)
+            {
+                return (_cachedAsyncConnection == activeConnection && _cachedAsyncCloseCount == activeConnection.CloseCount);
+            }
+
+            internal void ResetAsyncState()
+            {
+                _cachedAsyncCloseCount = -1;
+                _cachedAsyncResult = null;
+                if (_cachedAsyncConnection != null)
+                {
+                    _cachedAsyncConnection.AsyncCommandInProgress = false;
+                    _cachedAsyncConnection = null;
+                }
+                _cachedAsyncReader = null;
+                _cachedRunBehavior = RunBehavior.ReturnImmediately;
+                _cachedSetOptions = null;
+                _cachedEndMethod = null;
+            }
+
+            internal void SetActiveConnectionAndResult(TaskCompletionSource<object> completion, string endMethod, SqlConnection activeConnection)
+            {
+                Debug.Assert(activeConnection != null, "Unexpected null connection argument on SetActiveConnectionAndResult!");
+                TdsParser parser = activeConnection?.Parser;
+                if ((parser == null) || (parser.State == TdsParserState.Closed) || (parser.State == TdsParserState.Broken))
+                {
+                    throw ADP.ClosedConnectionError();
+                }
+
+                _cachedAsyncCloseCount = activeConnection.CloseCount;
+                _cachedAsyncResult = completion;
+                if (!parser.MARSOn)
+                {
+                    if (activeConnection.AsyncCommandInProgress)
+                        throw SQL.MARSUnspportedOnConnection();
+                }
+                _cachedAsyncConnection = activeConnection;
+
+                // Should only be needed for non-MARS, but set anyways.
+                _cachedAsyncConnection.AsyncCommandInProgress = true;
+                _cachedEndMethod = endMethod;
+            }
+
+            internal void SetAsyncReaderState(SqlDataReader ds, RunBehavior runBehavior, string optionSettings)
+            {
+                _cachedAsyncReader = ds;
+                _cachedRunBehavior = runBehavior;
+                _cachedSetOptions = optionSettings;
+            }
+        }
+
+        private CachedAsyncState _cachedAsyncState = null;
+
+        private CachedAsyncState cachedAsyncState
+        {
+            get
+            {
+                if (_cachedAsyncState == null)
+                {
+                    _cachedAsyncState = new CachedAsyncState();
+                }
+                return _cachedAsyncState;
+            }
+        }
+
+        // sql reader will pull this value out for each NextResult call.  It is not cumulative
+        // _rowsAffected is cumulative for ExecuteNonQuery across all rpc batches
+        internal int _rowsAffected = -1; // rows affected by the command
+
+        private SqlNotificationRequest _notification;
+
+        private bool _notificationAutoEnlist = true;            // Notifications auto enlistment is turned on by default
+
+        // transaction support
+        private SqlTransaction _transaction;
+
+        private StatementCompletedEventHandler _statementCompletedEventHandler;
+
+        private TdsParserStateObject _stateObj; // this is the TDS session we're using.
+
+        // Volatile bool used to synchronize with cancel thread the state change of an executing
+        // command going from pre-processing to obtaining a stateObject.  The cancel synchronization
+        // we require in the command is only from entering an Execute* API to obtaining a 
+        // stateObj.  Once a stateObj is successfully obtained, cancel synchronization is handled
+        // by the stateObject.
+        private volatile bool _pendingCancel;
+
+        private bool _batchRPCMode;
+        private List<_SqlRPC> _RPCList;
+        private _SqlRPC[] _SqlRPCBatchArray;
+        private List<SqlParameterCollection> _parameterCollectionList;
+        private int _currentlyExecutingBatch;
+
+
+        public SqlCommand() : base()
+        {
+            GC.SuppressFinalize(this);
+        }
+
+        public SqlCommand(string cmdText) : this()
+        {
+            CommandText = cmdText;
+        }
+
+        public SqlCommand(string cmdText, SqlConnection connection) : this()
+        {
+            CommandText = cmdText;
+            Connection = connection;
+        }
+
+        public SqlCommand(string cmdText, SqlConnection connection, SqlTransaction transaction) : this()
+        {
+            CommandText = cmdText;
+            Connection = connection;
+            Transaction = transaction;
+        }
+
+        private SqlCommand(SqlCommand from) : this()
+        {
+            CommandText = from.CommandText;
+            CommandTimeout = from.CommandTimeout;
+            CommandType = from.CommandType;
+            Connection = from.Connection;
+            DesignTimeVisible = from.DesignTimeVisible;
+            Transaction = from.Transaction;
+            UpdatedRowSource = from.UpdatedRowSource;
+
+            SqlParameterCollection parameters = Parameters;
+            foreach (object parameter in from.Parameters)
+            {
+                parameters.Add((parameter is ICloneable) ? (parameter as ICloneable).Clone() : parameter);
+            }
+        }
+
+        new public SqlConnection Connection
+        {
+            get
+            {
+                return _activeConnection;
+            }
+            set
+            {
+                // Don't allow the connection to be changed while in a async operation.
+                if (_activeConnection != value && _activeConnection != null)
+                { // If new value...
+                    if (cachedAsyncState.PendingAsyncOperation)
+                    { // If in pending async state, throw.
+                        throw SQL.CannotModifyPropertyAsyncOperationInProgress();
+                    }
+                }
+
+                // Check to see if the currently set transaction has completed.  If so,
+                // null out our local reference.
+                if (null != _transaction && _transaction.Connection == null)
+                {
+                    _transaction = null;
+                }
+
+
+                // Command is no longer prepared on new connection, cleanup prepare status
+                if (IsPrepared)
+                {
+                    if (_activeConnection != value && _activeConnection != null)
+                    {
+                        try
+                        {
+                            // cleanup
+                            Unprepare();
+                        }
+                        catch (Exception)
+                        {
+                            // we do not really care about errors in unprepare (may be the old connection went bad)                                        
+                        }
+                        finally
+                        {
+                            // clean prepare status (even successful Unprepare does not do that)
+                            _prepareHandle = -1;
+                            _execType = EXECTYPE.UNPREPARED;
+                        }
+                    }
+                }
+
+                _activeConnection = value;
+            }
+        }
+
+        override protected DbConnection DbConnection
+        {
+            get
+            {
+                return Connection;
+            }
+            set
+            {
+                Connection = (SqlConnection)value;
+            }
+        }
+
+        private SqlInternalConnectionTds InternalTdsConnection
+        {
+            get
+            {
+                return (SqlInternalConnectionTds)_activeConnection.InnerConnection;
+            }
+        }
+
+        public SqlNotificationRequest Notification
+        {
+            get
+            {
+                return _notification;
+            }
+            set
+            {
+                _sqlDep = null;
+                _notification = value;
+            }
+        }
+
+        public bool NotificationAutoEnlist
+        {
+            get
+            {
+                return _notificationAutoEnlist;
+            }
+            set
+            {
+                _notificationAutoEnlist = value;
+            }
+        }
+
+        internal SqlStatistics Statistics
+        {
+            get
+            {
+                if (null != _activeConnection)
+                {
+                    if (_activeConnection.StatisticsEnabled ||
+                        _diagnosticListener.IsEnabled(SqlClientDiagnosticListenerExtensions.SqlAfterExecuteCommand))
+                    {
+                        return _activeConnection.Statistics;
+                    }
+                }
+                return null;
+            }
+        }
+
+        new public SqlTransaction Transaction
+        {
+            get
+            {
+                // if the transaction object has been zombied, just return null
+                if ((null != _transaction) && (null == _transaction.Connection))
+                {
+                    _transaction = null;
+                }
+                return _transaction;
+            }
+            set
+            {
+                // Don't allow the transaction to be changed while in a async operation.
+                if (_transaction != value && _activeConnection != null)
+                { // If new value...
+                    if (cachedAsyncState.PendingAsyncOperation)
+                    { // If in pending async state, throw
+                        throw SQL.CannotModifyPropertyAsyncOperationInProgress();
+                    }
+                }
+
+                _transaction = value;
+            }
+        }
+
+        override protected DbTransaction DbTransaction
+        {
+            get
+            {
+                return Transaction;
+            }
+            set
+            {
+                Transaction = (SqlTransaction)value;
+            }
+        }
+
+        override public string CommandText
+        {
+            get
+            {
+                string value = _commandText;
+                return ((null != value) ? value : ADP.StrEmpty);
+            }
+            set
+            {
+                if (_commandText != value)
+                {
+                    PropertyChanging();
+                    _commandText = value;
+                }
+            }
+        }
+
+        override public int CommandTimeout
+        {
+            get
+            {
+                return _commandTimeout;
+            }
+            set
+            {
+                if (value < 0)
+                {
+                    throw ADP.InvalidCommandTimeout(value);
+                }
+                if (value != _commandTimeout)
+                {
+                    PropertyChanging();
+                    _commandTimeout = value;
+                }
+            }
+        }
+
+        public void ResetCommandTimeout()
+        {
+            if (ADP.DefaultCommandTimeout != _commandTimeout)
+            {
+                PropertyChanging();
+                _commandTimeout = ADP.DefaultCommandTimeout;
+            }
+        }
+
+        override public CommandType CommandType
+        {
+            get
+            {
+                CommandType cmdType = _commandType;
+                return ((0 != cmdType) ? cmdType : CommandType.Text);
+            }
+            set
+            {
+                if (_commandType != value)
+                {
+                    switch (value)
+                    {
+                        case CommandType.Text:
+                        case CommandType.StoredProcedure:
+                            PropertyChanging();
+                            _commandType = value;
+                            break;
+                        case System.Data.CommandType.TableDirect:
+                            throw SQL.NotSupportedCommandType(value);
+                        default:
+                            throw ADP.InvalidCommandType(value);
+                    }
+                }
+            }
+        }
+
+        // @devnote: By default, the cmd object is visible on the design surface (i.e. VS7 Server Tray)
+        // to limit the number of components that clutter the design surface,
+        // when the DataAdapter design wizard generates the insert/update/delete commands it will
+        // set the DesignTimeVisible property to false so that cmds won't appear as individual objects
+        public override bool DesignTimeVisible
+        {
+            get
+            {
+                return !_designTimeInvisible;
+            }
+            set
+            {
+                _designTimeInvisible = !value;
+            }
+        }
+
+        new public SqlParameterCollection Parameters
+        {
+            get
+            {
+                if (null == _parameters)
+                {
+                    // delay the creation of the SqlParameterCollection
+                    // until user actually uses the Parameters property
+                    _parameters = new SqlParameterCollection();
+                }
+                return _parameters;
+            }
+        }
+
+        override protected DbParameterCollection DbParameterCollection
+        {
+            get
+            {
+                return Parameters;
+            }
+        }
+
+        override public UpdateRowSource UpdatedRowSource
+        {
+            get
+            {
+                return _updatedRowSource;
+            }
+            set
+            {
+                switch (value)
+                {
+                    case UpdateRowSource.None:
+                    case UpdateRowSource.OutputParameters:
+                    case UpdateRowSource.FirstReturnedRecord:
+                    case UpdateRowSource.Both:
+                        _updatedRowSource = value;
+                        break;
+                    default:
+                        throw ADP.InvalidUpdateRowSource(value);
+                }
+            }
+        }
+
+        public event StatementCompletedEventHandler StatementCompleted
+        {
+            add
+            {
+                _statementCompletedEventHandler += value;
+            }
+            remove
+            {
+                _statementCompletedEventHandler -= value;
+            }
+        }
+
+        internal void OnStatementCompleted(int recordCount)
+        {
+            if (0 <= recordCount)
+            {
+                StatementCompletedEventHandler handler = _statementCompletedEventHandler;
+                if (null != handler)
+                {
+                    try
+                    {
+                        handler(this, new StatementCompletedEventArgs(recordCount));
+                    }
+                    catch (Exception e)
+                    {
+                        if (!ADP.IsCatchableOrSecurityExceptionType(e))
+                        {
+                            throw;
+                        }
+                    }
+                }
+            }
+        }
+
+        private void PropertyChanging()
+        { // also called from SqlParameterCollection
+            this.IsDirty = true;
+        }
+
+        override public void Prepare()
+        {
+            // Reset _pendingCancel upon entry into any Execute - used to synchronize state
+            // between entry into Execute* API and the thread obtaining the stateObject.
+            _pendingCancel = false;
+
+
+            SqlStatistics statistics = null;
+            statistics = SqlStatistics.StartTimer(Statistics);
+
+            // only prepare if batch with parameters
+            if (
+                this.IsPrepared && !this.IsDirty
+                || (this.CommandType == CommandType.StoredProcedure)
+                || (
+                        (System.Data.CommandType.Text == this.CommandType)
+                        && (0 == GetParameterCount(_parameters))
+                    )
+
+            )
+            {
+                if (null != Statistics)
+                {
+                    Statistics.SafeIncrement(ref Statistics._prepares);
+                }
+                _hiddenPrepare = false;
+            }
+            else
+            {
+                // Validate the command outside of the try\catch to avoid putting the _stateObj on error
+                ValidateCommand(async: false);
+
+                bool processFinallyBlock = true;
+                try
+                {
+                    // NOTE: The state object isn't actually needed for this, but it is still here for back-compat (since it does a bunch of checks)
+                    GetStateObject();
+
+                    // Loop through parameters ensuring that we do not have unspecified types, sizes, scales, or precisions
+                    if (null != _parameters)
+                    {
+                        int count = _parameters.Count;
+                        for (int i = 0; i < count; ++i)
+                        {
+                            _parameters[i].Prepare(this);
+                        }
+                    }
+
+                    InternalPrepare();
+                }
+                catch (Exception e)
+                {
+                    processFinallyBlock = ADP.IsCatchableExceptionType(e);
+                    throw;
+                }
+                finally
+                {
+                    if (processFinallyBlock)
+                    {
+                        _hiddenPrepare = false; // The command is now officially prepared
+
+                        ReliablePutStateObject();
+                    }
+                }
+            }
+
+            SqlStatistics.StopTimer(statistics);
+        }
+
+        private void InternalPrepare()
+        {
+            if (this.IsDirty)
+            {
+                Debug.Assert(_cachedMetaData == null || !_dirty, "dirty query should not have cached metadata!"); // can have cached metadata if dirty because of parameters
+                //
+                // someone changed the command text or the parameter schema so we must unprepare the command
+                //
+                this.Unprepare();
+                this.IsDirty = false;
+            }
+            Debug.Assert(_execType != EXECTYPE.PREPARED, "Invalid attempt to Prepare already Prepared command!");
+            Debug.Assert(_activeConnection != null, "must have an open connection to Prepare");
+            Debug.Assert(null != _stateObj, "TdsParserStateObject should not be null");
+            Debug.Assert(null != _stateObj.Parser, "TdsParser class should not be null in Command.Execute!");
+            Debug.Assert(_stateObj.Parser == _activeConnection.Parser, "stateobject parser not same as connection parser");
+            Debug.Assert(false == _inPrepare, "Already in Prepare cycle, this.inPrepare should be false!");
+
+            // remember that the user wants to do a prepare but don't actually do an rpc
+            _execType = EXECTYPE.PREPAREPENDING;
+            // Note the current close count of the connection - this will tell us if the connection has been closed between calls to Prepare() and Execute
+            _preparedConnectionCloseCount = _activeConnection.CloseCount;
+            _preparedConnectionReconnectCount = _activeConnection.ReconnectCount;
+
+            if (null != Statistics)
+            {
+                Statistics.SafeIncrement(ref Statistics._prepares);
+            }
+        }
+
+        // SqlInternalConnectionTds needs to be able to unprepare a statement
+        internal void Unprepare()
+        {
+            Debug.Assert(true == IsPrepared, "Invalid attempt to Unprepare a non-prepared command!");
+            Debug.Assert(_activeConnection != null, "must have an open connection to UnPrepare");
+            Debug.Assert(false == _inPrepare, "_inPrepare should be false!");
+            _execType = EXECTYPE.PREPAREPENDING;
+            // Don't zero out the handle because we'll pass it in to sp_prepexec on the next prepare
+            // Unless the close count isn't the same as when we last prepared
+            if ((_activeConnection.CloseCount != _preparedConnectionCloseCount) || (_activeConnection.ReconnectCount != _preparedConnectionReconnectCount))
+            {
+                // reset our handle
+                _prepareHandle = -1;
+            }
+
+            _cachedMetaData = null;
+        }
+
+
+        // Cancel is supposed to be multi-thread safe.
+        // It doesn't make sense to verify the connection exists or that it is open during cancel
+        // because immediately after checkin the connection can be closed or removed via another thread.
+        //
+        override public void Cancel()
+        {
+            SqlStatistics statistics = null;
+            try
+            {
+                statistics = SqlStatistics.StartTimer(Statistics);
+
+                // If we are in reconnect phase simply cancel the waiting task
+                var reconnectCompletionSource = _reconnectionCompletionSource;
+                if (reconnectCompletionSource != null)
+                {
+                    if (reconnectCompletionSource.TrySetCanceled())
+                    {
+                        return;
+                    }
+                }
+
+                // the pending data flag means that we are awaiting a response or are in the middle of processing a response
+                // if we have no pending data, then there is nothing to cancel
+                // if we have pending data, but it is not a result of this command, then we don't cancel either.  Note that
+                // this model is implementable because we only allow one active command at any one time.  This code
+                // will have to change we allow multiple outstanding batches
+                if (null == _activeConnection)
+                {
+                    return;
+                }
+                SqlInternalConnectionTds connection = (_activeConnection.InnerConnection as SqlInternalConnectionTds);
+                if (null == connection)
+                {  // Fail with out locking
+                    return;
+                }
+
+                // The lock here is to protect against the command.cancel / connection.close race condition
+                // The SqlInternalConnectionTds is set to OpenBusy during close, once this happens the cast below will fail and 
+                // the command will no longer be cancelable.  It might be desirable to be able to cancel the close operation, but this is
+                // outside of the scope of Whidbey RTM.  See (SqlConnection::Close) for other lock.
+                lock (connection)
+                {
+                    if (connection != (_activeConnection.InnerConnection as SqlInternalConnectionTds))
+                    { // make sure the connection held on the active connection is what we have stored in our temp connection variable, if not between getting "connection" and taking the lock, the connection has been closed
+                        return;
+                    }
+
+                    TdsParser parser = connection.Parser;
+                    if (null == parser)
+                    {
+                        return;
+                    }
+
+
+                    if (!_pendingCancel)
+                    { // Do nothing if already pending.
+                      // Before attempting actual cancel, set the _pendingCancel flag to false.
+                      // This denotes to other thread before obtaining stateObject from the
+                      // session pool that there is another thread wishing to cancel.
+                      // The period in question is between entering the ExecuteAPI and obtaining 
+                      // a stateObject.
+                        _pendingCancel = true;
+
+                        TdsParserStateObject stateObj = _stateObj;
+                        if (null != stateObj)
+                        {
+                            stateObj.Cancel(this);
+                        }
+                        else
+                        {
+                            SqlDataReader reader = connection.FindLiveReader(this);
+                            if (reader != null)
+                            {
+                                reader.Cancel(this);
+                            }
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                SqlStatistics.StopTimer(statistics);
+            }
+        }
+
+        new public SqlParameter CreateParameter()
+        {
+            return new SqlParameter();
+        }
+
+        override protected DbParameter CreateDbParameter()
+        {
+            return CreateParameter();
+        }
+
+        override protected void Dispose(bool disposing)
+        {
+            if (disposing)
+            { // release managed objects
+                _cachedMetaData = null;
+            }
+            // release unmanaged objects
+            base.Dispose(disposing);
+        }
+
+        override public object ExecuteScalar()
+        {
+            // Reset _pendingCancel upon entry into any Execute - used to synchronize state
+            // between entry into Execute* API and the thread obtaining the stateObject.
+            _pendingCancel = false;
+
+            Guid operationId = _diagnosticListener.WriteCommandBefore(this);
+
+            SqlStatistics statistics = null;
+
+            Exception e = null;
+            try
+            {
+                statistics = SqlStatistics.StartTimer(Statistics);
+                SqlDataReader ds;
+                ds = RunExecuteReader(0, RunBehavior.ReturnImmediately, returnStream: true);
+                return CompleteExecuteScalar(ds, false);
+            }
+            catch (Exception ex)
+            {
+                e = ex;
+                throw;
+            }
+            finally
+            {
+                SqlStatistics.StopTimer(statistics);
+
+                if (e != null)
+                {
+                    _diagnosticListener.WriteCommandError(operationId, this, e);
+                }
+                else
+                {
+                    _diagnosticListener.WriteCommandAfter(operationId, this);
+                }
+            }
+        }
+
+        private object CompleteExecuteScalar(SqlDataReader ds, bool returnSqlValue)
+        {
+            object retResult = null;
+
+            try
+            {
+                if (ds.Read())
+                {
+                    if (ds.FieldCount > 0)
+                    {
+                        if (returnSqlValue)
+                        {
+                            retResult = ds.GetSqlValue(0);
+                        }
+                        else
+                        {
+                            retResult = ds.GetValue(0);
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                // clean off the wire
+                ds.Close();
+            }
+
+            return retResult;
+        }
+
+        override public int ExecuteNonQuery()
+        {
+            // Reset _pendingCancel upon entry into any Execute - used to synchronize state
+            // between entry into Execute* API and the thread obtaining the stateObject.
+            _pendingCancel = false;
+
+            Guid operationId = _diagnosticListener.WriteCommandBefore(this);
+
+            SqlStatistics statistics = null;
+
+            Exception e = null;
+            try
+            {
+                statistics = SqlStatistics.StartTimer(Statistics);
+                InternalExecuteNonQuery(completion: null, sendToPipe: false, timeout: CommandTimeout);
+                return _rowsAffected;
+            }
+            catch (Exception ex)
+            {
+                e = ex;
+                throw;
+            }
+            finally
+            {
+                SqlStatistics.StopTimer(statistics);
+
+                if (e != null)
+                {
+                    _diagnosticListener.WriteCommandError(operationId, this, e);
+                }
+                else
+                {
+                    _diagnosticListener.WriteCommandAfter(operationId, this);
+                }
+            }
+        }
+
+
+        private IAsyncResult BeginExecuteNonQuery(AsyncCallback callback, object stateObject)
+        {
+            // Reset _pendingCancel upon entry into any Execute - used to synchronize state
+            // between entry into Execute* API and the thread obtaining the stateObject.
+            _pendingCancel = false;
+
+            ValidateAsyncCommand(); // Special case - done outside of try/catches to prevent putting a stateObj
+                                    // back into pool when we should not.
+
+            SqlStatistics statistics = null;
+            try
+            {
+                statistics = SqlStatistics.StartTimer(Statistics);
+                TaskCompletionSource<object> completion = new TaskCompletionSource<object>(stateObject);
+
+                try
+                { // InternalExecuteNonQuery already has reliability block, but if failure will not put stateObj back into pool.
+                    Task execNQ = InternalExecuteNonQuery(completion, false, CommandTimeout, asyncWrite: true);
+
+                    // must finish caching information before ReadSni which can activate the callback before returning
+                    cachedAsyncState.SetActiveConnectionAndResult(completion, nameof(EndExecuteNonQuery), _activeConnection);
+                    if (execNQ != null)
+                    {
+                        AsyncHelper.ContinueTask(execNQ, completion, () => BeginExecuteNonQueryInternalReadStage(completion));
+                    }
+                    else
+                    {
+                        BeginExecuteNonQueryInternalReadStage(completion);
+                    }
+                }
+                catch (Exception e)
+                {
+                    if (!ADP.IsCatchableOrSecurityExceptionType(e))
+                    {
+                        // If not catchable - the connection has already been caught and doomed in RunExecuteReader.
+                        throw;
+                    }
+
+                    // For async, RunExecuteReader will never put the stateObj back into the pool, so do so now.
+                    ReliablePutStateObject();
+                    throw;
+                }
+
+                // Add callback after work is done to avoid overlapping Begin\End methods
+                if (callback != null)
+                {
+                    completion.Task.ContinueWith((t) => callback(t), TaskScheduler.Default);
+                }
+
+                return completion.Task;
+            }
+            finally
+            {
+                SqlStatistics.StopTimer(statistics);
+            }
+        }
+
+        private void BeginExecuteNonQueryInternalReadStage(TaskCompletionSource<object> completion)
+        {
+            // Read SNI does not have catches for async exceptions, handle here.
+            try
+            {
+                _stateObj.ReadSni(completion);
+            }
+            catch (Exception)
+            {
+                // Similarly, if an exception occurs put the stateObj back into the pool.
+                // and reset async cache information to allow a second async execute
+                if (null != _cachedAsyncState)
+                {
+                    _cachedAsyncState.ResetAsyncState();
+                }
+                ReliablePutStateObject();
+                throw;
+            }
+        }
+
+        private void VerifyEndExecuteState(Task completionTask, String endMethod)
+        {
+            Debug.Assert(completionTask != null);
+
+            if (completionTask.IsCanceled)
+            {
+                if (_stateObj != null)
+                {
+                    _stateObj.Parser.State = TdsParserState.Broken; // We failed to respond to attention, we have to quit!
+                    _stateObj.Parser.Connection.BreakConnection();
+                    _stateObj.Parser.ThrowExceptionAndWarning(_stateObj);
+                }
+                else
+                {
+                    Debug.Assert(_reconnectionCompletionSource == null || _reconnectionCompletionSource.Task.IsCanceled, "ReconnectCompletionSource should be null or cancelled");
+                    throw SQL.CR_ReconnectionCancelled();
+                }
+            }
+            else if (completionTask.IsFaulted)
+            {
+                throw completionTask.Exception.InnerException;
+            }
+            if (cachedAsyncState.EndMethodName == null)
+            {
+                throw ADP.MethodCalledTwice(endMethod);
+            }
+            if (endMethod != cachedAsyncState.EndMethodName)
+            {
+                throw ADP.MismatchedAsyncResult(cachedAsyncState.EndMethodName, endMethod);
+            }
+            if ((_activeConnection.State != ConnectionState.Open) || (!cachedAsyncState.IsActiveConnectionValid(_activeConnection)))
+            {
+                // If the connection is not 'valid' then it was closed while we were executing
+                throw ADP.ClosedConnectionError();
+            }
+        }
+
+        private void WaitForAsyncResults(IAsyncResult asyncResult)
+        {
+            Task completionTask = (Task)asyncResult;
+            if (!asyncResult.IsCompleted)
+            {
+                asyncResult.AsyncWaitHandle.WaitOne();
+            }
+            _stateObj._networkPacketTaskSource = null;
+            _activeConnection.GetOpenTdsConnection().DecrementAsyncCount();
+        }
+
+        private void ThrowIfReconnectionHasBeenCanceled()
+        {
+            if (_stateObj == null)
+            {
+                var reconnectionCompletionSource = _reconnectionCompletionSource;
+                if (reconnectionCompletionSource != null && reconnectionCompletionSource.Task.IsCanceled)
+                {
+                    throw SQL.CR_ReconnectionCancelled();
+                }
+            }
+        }
+
+        private int EndExecuteNonQuery(IAsyncResult asyncResult)
+        {
+            Exception asyncException = ((Task)asyncResult).Exception;
+            if (asyncException != null)
+            {
+                // Leftover exception from the Begin...InternalReadStage
+                if (cachedAsyncState != null)
+                {
+                    cachedAsyncState.ResetAsyncState();
+                }
+                ReliablePutStateObject();
+                throw asyncException.InnerException;
+            }
+            else
+            {
+                ThrowIfReconnectionHasBeenCanceled();
+                // lock on _stateObj prevents races with close/cancel.
+                lock (_stateObj)
+                {
+                    return EndExecuteNonQueryInternal(asyncResult);
+                }
+            }
+        }
+
+        private int EndExecuteNonQueryInternal(IAsyncResult asyncResult)
+        {
+            SqlStatistics statistics = null;
+
+            try
+            {
+                statistics = SqlStatistics.StartTimer(Statistics);
+                VerifyEndExecuteState((Task)asyncResult, nameof(EndExecuteNonQuery));
+                WaitForAsyncResults(asyncResult);
+
+                bool processFinallyBlock = true;
+                try
+                {
+                    CheckThrowSNIException();
+
+                    // only send over SQL Batch command if we are not a stored proc and have no parameters
+                    if ((System.Data.CommandType.Text == this.CommandType) && (0 == GetParameterCount(_parameters)))
+                    {
+                        try
+                        {
+                            bool dataReady;
+                            Debug.Assert(_stateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
+                            bool result = _stateObj.Parser.TryRun(RunBehavior.UntilDone, this, null, null, _stateObj, out dataReady);
+                            if (!result)
+                            { throw SQL.SynchronousCallMayNotPend(); }
+                        }
+                        finally
+                        {
+                            cachedAsyncState.ResetAsyncState();
+                        }
+                    }
+                    else
+                    { // otherwise, use a full-fledged execute that can handle params and stored procs
+                        SqlDataReader reader = CompleteAsyncExecuteReader();
+                        if (null != reader)
+                        {
+                            reader.Close();
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    processFinallyBlock = ADP.IsCatchableExceptionType(e);
+                    throw;
+                }
+                finally
+                {
+                    if (processFinallyBlock)
+                    {
+                        PutStateObject();
+                    }
+                }
+
+                Debug.Assert(null == _stateObj, "non-null state object in EndExecuteNonQuery");
+                return _rowsAffected;
+            }
+            catch (Exception e)
+            {
+                if (cachedAsyncState != null)
+                {
+                    cachedAsyncState.ResetAsyncState();
+                };
+                if (ADP.IsCatchableExceptionType(e))
+                {
+                    ReliablePutStateObject();
+                };
+                throw;
+            }
+            finally
+            {
+                SqlStatistics.StopTimer(statistics);
+            }
+        }
+
+        private Task InternalExecuteNonQuery(TaskCompletionSource<object> completion, bool sendToPipe, int timeout, bool asyncWrite = false, [CallerMemberName] string methodName = "")
+        {
+            bool async = (null != completion);
+
+            SqlStatistics statistics = Statistics;
+            _rowsAffected = -1;
+
+            // this function may throw for an invalid connection
+            // returns false for empty command text
+            ValidateCommand(async, methodName);
+
+            CheckNotificationStateAndAutoEnlist(); // Only call after validate - requires non null connection!
+
+            Task task = null;
+
+            // only send over SQL Batch command if we are not a stored proc and have no parameters and not in batch RPC mode
+            if ((System.Data.CommandType.Text == this.CommandType) && (0 == GetParameterCount(_parameters)))
+            {
+                Debug.Assert(!sendToPipe, "trying to send non-context command to pipe");
+                if (null != statistics)
+                {
+                    if (!this.IsDirty && this.IsPrepared)
+                    {
+                        statistics.SafeIncrement(ref statistics._preparedExecs);
+                    }
+                    else
+                    {
+                        statistics.SafeIncrement(ref statistics._unpreparedExecs);
+                    }
+                }
+
+                task = RunExecuteNonQueryTds(methodName, async, timeout, asyncWrite);
+            }
+            else
+            { // otherwise, use a full-fledged execute that can handle params and stored procs
+                Debug.Assert(!sendToPipe, "trying to send non-context command to pipe");
+                SqlDataReader reader = RunExecuteReader(0, RunBehavior.UntilDone, false, completion, timeout, out task, asyncWrite, methodName);
+                if (null != reader)
+                {
+                    if (task != null)
+                    {
+                        task = AsyncHelper.CreateContinuationTask(task, () => reader.Close());
+                    }
+                    else
+                    {
+                        reader.Close();
+                    }
+                }
+            }
+            Debug.Assert(async || null == _stateObj, "non-null state object in InternalExecuteNonQuery");
+            return task;
+        }
+
+        public XmlReader ExecuteXmlReader()
+        {
+            // Reset _pendingCancel upon entry into any Execute - used to synchronize state
+            // between entry into Execute* API and the thread obtaining the stateObject.
+            _pendingCancel = false;
+
+            Guid operationId = _diagnosticListener.WriteCommandBefore(this);
+
+            SqlStatistics statistics = null;
+
+            Exception e = null;
+            try
+            {
+                statistics = SqlStatistics.StartTimer(Statistics);
+
+                // use the reader to consume metadata
+                SqlDataReader ds;
+                ds = RunExecuteReader(CommandBehavior.SequentialAccess, RunBehavior.ReturnImmediately, returnStream: true);
+                return CompleteXmlReader(ds);
+            }
+            catch (Exception ex)
+            {
+                e = ex;
+                throw;
+            }
+            finally
+            {
+                SqlStatistics.StopTimer(statistics);
+
+                if (e != null)
+                {
+                    _diagnosticListener.WriteCommandError(operationId, this, e);
+                }
+                else
+                {
+                    _diagnosticListener.WriteCommandAfter(operationId, this);
+                }
+            }
+        }
+
+
+        private IAsyncResult BeginExecuteXmlReader(AsyncCallback callback, object stateObject)
+        {
+            // Reset _pendingCancel upon entry into any Execute - used to synchronize state
+            // between entry into Execute* API and the thread obtaining the stateObject.
+            _pendingCancel = false;
+
+            ValidateAsyncCommand(); // Special case - done outside of try/catches to prevent putting a stateObj
+                                    // back into pool when we should not.
+
+            SqlStatistics statistics = null;
+            try
+            {
+                statistics = SqlStatistics.StartTimer(Statistics);
+                TaskCompletionSource<object> completion = new TaskCompletionSource<object>(stateObject);
+
+                Task writeTask;
+                try
+                { // InternalExecuteNonQuery already has reliability block, but if failure will not put stateObj back into pool.
+                    RunExecuteReader(CommandBehavior.SequentialAccess, RunBehavior.ReturnImmediately, true, completion, CommandTimeout, out writeTask, asyncWrite: true);
+                }
+                catch (Exception e)
+                {
+                    if (!ADP.IsCatchableOrSecurityExceptionType(e))
+                    {
+                        // If not catchable - the connection has already been caught and doomed in RunExecuteReader.
+                        throw;
+                    }
+
+                    // For async, RunExecuteReader will never put the stateObj back into the pool, so do so now.
+                    ReliablePutStateObject();
+                    throw;
+                }
+
+                // must finish caching information before ReadSni which can activate the callback before returning
+                cachedAsyncState.SetActiveConnectionAndResult(completion, nameof(EndExecuteXmlReader), _activeConnection);
+                if (writeTask != null)
+                {
+                    AsyncHelper.ContinueTask(writeTask, completion, () => BeginExecuteXmlReaderInternalReadStage(completion));
+                }
+                else
+                {
+                    BeginExecuteXmlReaderInternalReadStage(completion);
+                }
+
+                // Add callback after work is done to avoid overlapping Begin\End methods
+                if (callback != null)
+                {
+                    completion.Task.ContinueWith((t) => callback(t), TaskScheduler.Default);
+                }
+                return completion.Task;
+            }
+            finally
+            {
+                SqlStatistics.StopTimer(statistics);
+            }
+        }
+
+        private void BeginExecuteXmlReaderInternalReadStage(TaskCompletionSource<object> completion)
+        {
+            Debug.Assert(completion != null, "Completion source should not be null");
+            // Read SNI does not have catches for async exceptions, handle here.
+            try
+            {
+                _stateObj.ReadSni(completion);
+            }
+            catch (Exception e)
+            {
+                // Similarly, if an exception occurs put the stateObj back into the pool.
+                // and reset async cache information to allow a second async execute
+                if (null != _cachedAsyncState)
+                {
+                    _cachedAsyncState.ResetAsyncState();
+                }
+                ReliablePutStateObject();
+                completion.TrySetException(e);
+            }
+        }
+
+
+        private XmlReader EndExecuteXmlReader(IAsyncResult asyncResult)
+        {
+            Exception asyncException = ((Task)asyncResult).Exception;
+            if (asyncException != null)
+            {
+                // Leftover exception from the Begin...InternalReadStage
+                if (cachedAsyncState != null)
+                {
+                    cachedAsyncState.ResetAsyncState();
+                }
+                ReliablePutStateObject();
+                throw asyncException.InnerException;
+            }
+            else
+            {
+                ThrowIfReconnectionHasBeenCanceled();
+                // lock on _stateObj prevents races with close/cancel.
+                lock (_stateObj)
+                {
+                    return EndExecuteXmlReaderInternal(asyncResult);
+                }
+            }
+        }
+
+        private XmlReader EndExecuteXmlReaderInternal(IAsyncResult asyncResult)
+        {
+            try
+            {
+                return CompleteXmlReader(InternalEndExecuteReader(asyncResult, nameof(EndExecuteXmlReader)), async: true);
+            }
+            catch (Exception e)
+            {
+                if (cachedAsyncState != null)
+                {
+                    cachedAsyncState.ResetAsyncState();
+                };
+                if (ADP.IsCatchableExceptionType(e))
+                {
+                    ReliablePutStateObject();
+                };
+                throw;
+            }
+        }
+
+        private XmlReader CompleteXmlReader(SqlDataReader ds, bool async = false)
+        {
+            XmlReader xr = null;
+
+            SmiExtendedMetaData[] md = ds.GetInternalSmiMetaData();
+            bool isXmlCapable = (null != md && md.Length == 1 && (md[0].SqlDbType == SqlDbType.NText
+                                                         || md[0].SqlDbType == SqlDbType.NVarChar
+                                                         || md[0].SqlDbType == SqlDbType.Xml));
+
+            if (isXmlCapable)
+            {
+                try
+                {
+                    SqlStream sqlBuf = new SqlStream(ds, true /*addByteOrderMark*/, (md[0].SqlDbType == SqlDbType.Xml) ? false : true /*process all rows*/);
+                    xr = sqlBuf.ToXmlReader(async);
+                }
+                catch (Exception e)
+                {
+                    if (ADP.IsCatchableExceptionType(e))
+                    {
+                        ds.Close();
+                    }
+                    throw;
+                }
+            }
+            if (xr == null)
+            {
+                ds.Close();
+                throw SQL.NonXmlResult();
+            }
+            return xr;
+        }
+
+
+        override protected DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
+        {
+            return ExecuteReader(behavior);
+        }
+
+        new public SqlDataReader ExecuteReader()
+        {
+            SqlStatistics statistics = null;
+            try
+            {
+                statistics = SqlStatistics.StartTimer(Statistics);
+                return ExecuteReader(CommandBehavior.Default);
+            }
+            finally
+            {
+                SqlStatistics.StopTimer(statistics);
+            }
+        }
+
+        new public SqlDataReader ExecuteReader(CommandBehavior behavior)
+        {
+            // Reset _pendingCancel upon entry into any Execute - used to synchronize state
+            // between entry into Execute* API and the thread obtaining the stateObject.
+            _pendingCancel = false;
+
+            Guid operationId = _diagnosticListener.WriteCommandBefore(this);
+
+            SqlStatistics statistics = null;
+
+            Exception e = null;
+            try
+            {
+                statistics = SqlStatistics.StartTimer(Statistics);
+                return RunExecuteReader(behavior, RunBehavior.ReturnImmediately, returnStream: true);
+            }
+            catch (Exception ex)
+            {
+                e = ex;
+                throw;
+            }
+            finally
+            {
+                SqlStatistics.StopTimer(statistics);
+
+                if (e != null)
+                {
+                    _diagnosticListener.WriteCommandError(operationId, this, e);
+                }
+                else
+                {
+                    _diagnosticListener.WriteCommandAfter(operationId, this);
+                }
+            }
+        }
+
+
+        internal SqlDataReader EndExecuteReader(IAsyncResult asyncResult)
+        {
+            Exception asyncException = ((Task)asyncResult).Exception;
+            if (asyncException != null)
+            {
+                // Leftover exception from the Begin...InternalReadStage
+                if (cachedAsyncState != null)
+                {
+                    cachedAsyncState.ResetAsyncState();
+                }
+                ReliablePutStateObject();
+                throw asyncException.InnerException;
+            }
+            else
+            {
+                ThrowIfReconnectionHasBeenCanceled();
+                // lock on _stateObj prevents races with close/cancel.
+                lock (_stateObj)
+                {
+                    return EndExecuteReaderInternal(asyncResult);
+                }
+            }
+        }
+
+        private SqlDataReader EndExecuteReaderInternal(IAsyncResult asyncResult)
+        {
+            SqlStatistics statistics = null;
+            try
+            {
+                statistics = SqlStatistics.StartTimer(Statistics);
+                return InternalEndExecuteReader(asyncResult, nameof(EndExecuteReader));
+            }
+            catch (Exception e)
+            {
+                if (cachedAsyncState != null)
+                {
+                    cachedAsyncState.ResetAsyncState();
+                };
+                if (ADP.IsCatchableExceptionType(e))
+                {
+                    ReliablePutStateObject();
+                };
+                throw;
+            }
+            finally
+            {
+                SqlStatistics.StopTimer(statistics);
+            }
+        }
+
+        internal IAsyncResult BeginExecuteReader(CommandBehavior behavior, AsyncCallback callback, object stateObject)
+        {
+            // Reset _pendingCancel upon entry into any Execute - used to synchronize state
+            // between entry into Execute* API and the thread obtaining the stateObject.
+            _pendingCancel = false;
+
+            SqlStatistics statistics = null;
+            try
+            {
+                statistics = SqlStatistics.StartTimer(Statistics);
+                TaskCompletionSource<object> completion = new TaskCompletionSource<object>(stateObject);
+
+                ValidateAsyncCommand(); // Special case - done outside of try/catches to prevent putting a stateObj
+                                        // back into pool when we should not.
+
+                Task writeTask = null;
+                try
+                { // InternalExecuteNonQuery already has reliability block, but if failure will not put stateObj back into pool.
+                    RunExecuteReader(behavior, RunBehavior.ReturnImmediately, true, completion, CommandTimeout, out writeTask, asyncWrite: true);
+                }
+                catch (Exception e)
+                {
+                    if (!ADP.IsCatchableOrSecurityExceptionType(e))
+                    {
+                        // If not catchable - the connection has already been caught and doomed in RunExecuteReader.
+                        throw;
+                    }
+
+                    // For async, RunExecuteReader will never put the stateObj back into the pool, so do so now.
+                    ReliablePutStateObject();
+                    throw;
+                }
+
+                // must finish caching information before ReadSni which can activate the callback before returning
+                cachedAsyncState.SetActiveConnectionAndResult(completion, nameof(EndExecuteReader), _activeConnection);
+                if (writeTask != null)
+                {
+                    AsyncHelper.ContinueTask(writeTask, completion, () => BeginExecuteReaderInternalReadStage(completion));
+                }
+                else
+                {
+                    BeginExecuteReaderInternalReadStage(completion);
+                }
+
+                // Add callback after work is done to avoid overlapping Begin\End methods
+                if (callback != null)
+                {
+                    completion.Task.ContinueWith((t) => callback(t), TaskScheduler.Default);
+                }
+                return completion.Task;
+            }
+            finally
+            {
+                SqlStatistics.StopTimer(statistics);
+            }
+        }
+
+        private void BeginExecuteReaderInternalReadStage(TaskCompletionSource<object> completion)
+        {
+            Debug.Assert(completion != null, "CompletionSource should not be null");
+            // Read SNI does not have catches for async exceptions, handle here.
+            try
+            {
+                _stateObj.ReadSni(completion);
+            }
+            catch (Exception e)
+            {
+                // Similarly, if an exception occurs put the stateObj back into the pool.
+                // and reset async cache information to allow a second async execute
+                if (null != _cachedAsyncState)
+                {
+                    _cachedAsyncState.ResetAsyncState();
+                }
+                ReliablePutStateObject();
+                completion.TrySetException(e);
+            }
+        }
+
+        private SqlDataReader InternalEndExecuteReader(IAsyncResult asyncResult, string endMethod)
+        {
+            VerifyEndExecuteState((Task)asyncResult, endMethod);
+            WaitForAsyncResults(asyncResult);
+
+            CheckThrowSNIException();
+
+            SqlDataReader reader = CompleteAsyncExecuteReader();
+            Debug.Assert(null == _stateObj, "non-null state object in InternalEndExecuteReader");
+            return reader;
+        }
+
+        public override Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
+        {
+            Guid operationId = _diagnosticListener.WriteCommandBefore(this);
+
+            TaskCompletionSource<int> source = new TaskCompletionSource<int>();
+
+            CancellationTokenRegistration registration = new CancellationTokenRegistration();
+            if (cancellationToken.CanBeCanceled)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    source.SetCanceled();
+                    return source.Task;
+                }
+                registration = cancellationToken.Register(s => ((SqlCommand)s).CancelIgnoreFailure(), this);
+            }
+
+            Task<int> returnedTask = source.Task;
+            try
+            {
+                RegisterForConnectionCloseNotification(ref returnedTask);
+
+                Task<int>.Factory.FromAsync(BeginExecuteNonQuery, EndExecuteNonQuery, null).ContinueWith((t) =>
+                {
+                    registration.Dispose();
+                    if (t.IsFaulted)
+                    {
+                        Exception e = t.Exception.InnerException;
+                        _diagnosticListener.WriteCommandError(operationId, this, e);
+                        source.SetException(e);
+                    }
+                    else
+                    {
+                        if (t.IsCanceled)
+                        {
+                            source.SetCanceled();
+                        }
+                        else
+                        {
+                            source.SetResult(t.Result);
+                        }
+                        _diagnosticListener.WriteCommandAfter(operationId, this);
+                    }
+                }, TaskScheduler.Default);
+            }
+            catch (Exception e)
+            {
+                _diagnosticListener.WriteCommandError(operationId, this, e);
+                source.SetException(e);
+            }
+
+            return returnedTask;
+        }
+
+        protected override Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
+        {
+            return ExecuteReaderAsync(behavior, cancellationToken).ContinueWith<DbDataReader>((result) =>
+            {
+                if (result.IsFaulted)
+                {
+                    throw result.Exception.InnerException;
+                }
+                return result.Result;
+            }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.NotOnCanceled, TaskScheduler.Default);
+        }
+
+        new public Task<SqlDataReader> ExecuteReaderAsync()
+        {
+            return ExecuteReaderAsync(CommandBehavior.Default, CancellationToken.None);
+        }
+
+        new public Task<SqlDataReader> ExecuteReaderAsync(CommandBehavior behavior)
+        {
+            return ExecuteReaderAsync(behavior, CancellationToken.None);
+        }
+
+        new public Task<SqlDataReader> ExecuteReaderAsync(CancellationToken cancellationToken)
+        {
+            return ExecuteReaderAsync(CommandBehavior.Default, cancellationToken);
+        }
+
+        new public Task<SqlDataReader> ExecuteReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
+        {
+            Guid operationId = default(Guid);
+            if (!_parentOperationStarted)
+                operationId = _diagnosticListener.WriteCommandBefore(this);
+
+            TaskCompletionSource<SqlDataReader> source = new TaskCompletionSource<SqlDataReader>();
+
+            CancellationTokenRegistration registration = new CancellationTokenRegistration();
+            if (cancellationToken.CanBeCanceled)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    source.SetCanceled();
+                    return source.Task;
+                }
+                registration = cancellationToken.Register(s => ((SqlCommand)s).CancelIgnoreFailure(), this);
+            }
+
+            Task<SqlDataReader> returnedTask = source.Task;
+            try
+            {
+                RegisterForConnectionCloseNotification(ref returnedTask);
+
+                Task<SqlDataReader>.Factory.FromAsync(BeginExecuteReader, EndExecuteReader, behavior, null).ContinueWith((t) =>
+                {
+                    registration.Dispose();
+                    if (t.IsFaulted)
+                    {
+                        Exception e = t.Exception.InnerException;
+                        if (!_parentOperationStarted)
+                            _diagnosticListener.WriteCommandError(operationId, this, e);
+                        source.SetException(e);
+                    }
+                    else
+                    {
+                        if (t.IsCanceled)
+                        {
+                            source.SetCanceled();
+                        }
+                        else
+                        {
+                            source.SetResult(t.Result);
+                        }
+                        if (!_parentOperationStarted)
+                            _diagnosticListener.WriteCommandAfter(operationId, this);
+                    }
+                }, TaskScheduler.Default);
+            }
+            catch (Exception e)
+            {
+                if (!_parentOperationStarted)
+                    _diagnosticListener.WriteCommandError(operationId, this, e);
+
+                source.SetException(e);
+            }
+
+            return returnedTask;
+        }
+
+        public override Task<object> ExecuteScalarAsync(CancellationToken cancellationToken)
+        {
+            _parentOperationStarted = true;
+            Guid operationId = _diagnosticListener.WriteCommandBefore(this);
+
+            return ExecuteReaderAsync(cancellationToken).ContinueWith((executeTask) =>
+            {
+                TaskCompletionSource<object> source = new TaskCompletionSource<object>();
+                if (executeTask.IsCanceled)
+                {
+                    source.SetCanceled();
+                }
+                else if (executeTask.IsFaulted)
+                {
+                    _diagnosticListener.WriteCommandError(operationId, this, executeTask.Exception.InnerException);
+                    source.SetException(executeTask.Exception.InnerException);
+                }
+                else
+                {
+                    SqlDataReader reader = executeTask.Result;
+                    reader.ReadAsync(cancellationToken).ContinueWith((readTask) =>
+                    {
+                        try
+                        {
+                            if (readTask.IsCanceled)
+                            {
+                                reader.Dispose();
+                                source.SetCanceled();
+                            }
+                            else if (readTask.IsFaulted)
+                            {
+                                reader.Dispose();
+                                _diagnosticListener.WriteCommandError(operationId, this, readTask.Exception.InnerException);
+                                source.SetException(readTask.Exception.InnerException);
+                            }
+                            else
+                            {
+                                Exception exception = null;
+                                object result = null;
+                                try
+                                {
+                                    bool more = readTask.Result;
+                                    if (more && reader.FieldCount > 0)
+                                    {
+                                        try
+                                        {
+                                            result = reader.GetValue(0);
+                                        }
+                                        catch (Exception e)
+                                        {
+                                            exception = e;
+                                        }
+                                    }
+                                }
+                                finally
+                                {
+                                    reader.Dispose();
+                                }
+                                if (exception != null)
+                                {
+                                    _diagnosticListener.WriteCommandError(operationId, this, exception);
+                                    source.SetException(exception);
+                                }
+                                else
+                                {
+                                    _diagnosticListener.WriteCommandAfter(operationId, this);
+                                    source.SetResult(result);
+                                }
+                            }
+                        }
+                        catch (Exception e)
+                        {
+                            // exception thrown by Dispose...
+                            source.SetException(e);
+                        }
+                    }, TaskScheduler.Default);
+                }
+                _parentOperationStarted = false;
+                return source.Task;
+            }, TaskScheduler.Default).Unwrap();
+        }
+
+        public Task<XmlReader> ExecuteXmlReaderAsync()
+        {
+            return ExecuteXmlReaderAsync(CancellationToken.None);
+        }
+
+        public Task<XmlReader> ExecuteXmlReaderAsync(CancellationToken cancellationToken)
+        {
+            Guid operationId = _diagnosticListener.WriteCommandBefore(this);
+
+            TaskCompletionSource<XmlReader> source = new TaskCompletionSource<XmlReader>();
+
+            CancellationTokenRegistration registration = new CancellationTokenRegistration();
+            if (cancellationToken.CanBeCanceled)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    source.SetCanceled();
+                    return source.Task;
+                }
+                registration = cancellationToken.Register(s => ((SqlCommand)s).CancelIgnoreFailure(), this);
+            }
+
+            Task<XmlReader> returnedTask = source.Task;
+            try
+            {
+                RegisterForConnectionCloseNotification(ref returnedTask);
+
+                Task<XmlReader>.Factory.FromAsync(BeginExecuteXmlReader, EndExecuteXmlReader, null).ContinueWith((t) =>
+                {
+                    registration.Dispose();
+                    if (t.IsFaulted)
+                    {
+                        Exception e = t.Exception.InnerException;
+                        _diagnosticListener.WriteCommandError(operationId, this, e);
+                        source.SetException(e);
+                    }
+                    else
+                    {
+                        if (t.IsCanceled)
+                        {
+                            source.SetCanceled();
+                        }
+                        else
+                        {
+                            source.SetResult(t.Result);
+                        }
+                        _diagnosticListener.WriteCommandAfter(operationId, this);
+                    }
+                }, TaskScheduler.Default);
+            }
+            catch (Exception e)
+            {
+                _diagnosticListener.WriteCommandError(operationId, this, e);
+                source.SetException(e);
+            }
+
+            return returnedTask;
+        }
+
+        // If the user part is quoted, remove first and last brackets and then unquote any right square
+        // brackets in the procedure.  This is a very simple parser that performs no validation.  As
+        // with the function below, ideally we should have support from the server for this.
+        private static string UnquoteProcedurePart(string part)
+        {
+            if ((null != part) && (2 <= part.Length))
+            {
+                if ('[' == part[0] && ']' == part[part.Length - 1])
+                {
+                    part = part.Substring(1, part.Length - 2); // strip outer '[' & ']'
+                    part = part.Replace("]]", "]"); // undo quoted "]" from "]]" to "]"
+                }
+            }
+            return part;
+        }
+
+        // User value in this format: [server].[database].[schema].[sp_foo];1
+        // This function should only be passed "[sp_foo];1".
+        // This function uses a pretty simple parser that doesn't do any validation.
+        // Ideally, we would have support from the server rather than us having to do this.
+        private static string UnquoteProcedureName(string name, out object groupNumber)
+        {
+            groupNumber = null; // Out param - initialize value to no value.
+            string sproc = name;
+
+            if (null != sproc)
+            {
+                if (char.IsDigit(sproc[sproc.Length - 1]))
+                { // If last char is a digit, parse.
+                    int semicolon = sproc.LastIndexOf(';');
+                    if (semicolon != -1)
+                    { // If we found a semicolon, obtain the integer.
+                        string part = sproc.Substring(semicolon + 1);
+                        int number = 0;
+                        if (int.TryParse(part, out number))
+                        { // No checking, just fail if this doesn't work.
+                            groupNumber = number;
+                            sproc = sproc.Substring(0, semicolon);
+                        }
+                    }
+                }
+                sproc = UnquoteProcedurePart(sproc);
+            }
+            return sproc;
+        }
+
+        // Index into indirection arrays for columns of interest to DeriveParameters
+        private enum ProcParamsColIndex
+        {
+            ParameterName = 0,
+            ParameterType,
+            DataType, // obsolete in katmai, use ManagedDataType instead
+            ManagedDataType, // new in katmai
+            CharacterMaximumLength,
+            NumericPrecision,
+            NumericScale,
+            TypeCatalogName,
+            TypeSchemaName,
+            TypeName,
+            XmlSchemaCollectionCatalogName,
+            XmlSchemaCollectionSchemaName,
+            XmlSchemaCollectionName,
+            UdtTypeName, // obsolete in Katmai.  Holds the actual typename if UDT, since TypeName didn't back then.
+            DateTimeScale // new in Katmai
+        };
+
+        // Yukon- column ordinals (this array indexed by ProcParamsColIndex
+        internal static readonly string[] PreKatmaiProcParamsNames = new string[] {
+            "PARAMETER_NAME",           // ParameterName,
+            "PARAMETER_TYPE",           // ParameterType,
+            "DATA_TYPE",                // DataType
+            null,                       // ManagedDataType,     introduced in Katmai
+            "CHARACTER_MAXIMUM_LENGTH", // CharacterMaximumLength,
+            "NUMERIC_PRECISION",        // NumericPrecision,
+            "NUMERIC_SCALE",            // NumericScale,
+            "UDT_CATALOG",              // TypeCatalogName,
+            "UDT_SCHEMA",               // TypeSchemaName,
+            "TYPE_NAME",                // TypeName,
+            "XML_CATALOGNAME",          // XmlSchemaCollectionCatalogName,
+            "XML_SCHEMANAME",           // XmlSchemaCollectionSchemaName,
+            "XML_SCHEMACOLLECTIONNAME", // XmlSchemaCollectionName
+            "UDT_NAME",                 // UdtTypeName
+            null,                       // Scale for datetime types with scale, introduced in Katmai
+        };
+
+        // Katmai+ column ordinals (this array indexed by ProcParamsColIndex
+        internal static readonly string[] KatmaiProcParamsNames = new string[] {
+            "PARAMETER_NAME",           // ParameterName,
+            "PARAMETER_TYPE",           // ParameterType,
+            null,                       // DataType, removed from Katmai+
+            "MANAGED_DATA_TYPE",        // ManagedDataType,
+            "CHARACTER_MAXIMUM_LENGTH", // CharacterMaximumLength,
+            "NUMERIC_PRECISION",        // NumericPrecision,
+            "NUMERIC_SCALE",            // NumericScale,
+            "TYPE_CATALOG_NAME",        // TypeCatalogName,
+            "TYPE_SCHEMA_NAME",         // TypeSchemaName,
+            "TYPE_NAME",                // TypeName,
+            "XML_CATALOGNAME",          // XmlSchemaCollectionCatalogName,
+            "XML_SCHEMANAME",           // XmlSchemaCollectionSchemaName,
+            "XML_SCHEMACOLLECTIONNAME", // XmlSchemaCollectionName
+            null,                       // UdtTypeName, removed from Katmai+
+            "SS_DATETIME_PRECISION",    // Scale for datetime types with scale
+        };
+
+        internal void DeriveParameters()
+        {
+            switch (CommandType)
+            {
+                case CommandType.Text:
+                    throw ADP.DeriveParametersNotSupported(this);
+                case CommandType.StoredProcedure:
+                    break;
+                case CommandType.TableDirect:
+                    // CommandType.TableDirect - do nothing, parameters are not supported
+                    throw ADP.DeriveParametersNotSupported(this);
+                default:
+                    throw ADP.InvalidCommandType(CommandType);
+            }
+
+            // validate that we have a valid connection
+            ValidateCommand(false /*not async*/, nameof(DeriveParameters));
+
+            // Use common parser for SqlClient and OleDb - parse into 4 parts - Server, Catalog, Schema, ProcedureName
+            string[] parsedSProc = MultipartIdentifier.ParseMultipartIdentifier(CommandText, "[\"", "]\"", SR.SQL_SqlCommandCommandText, false);
+            if (null == parsedSProc[3] || string.IsNullOrEmpty(parsedSProc[3]))
+            {
+                throw ADP.NoStoredProcedureExists(CommandText);
+            }
+
+            Debug.Assert(parsedSProc.Length == 4, "Invalid array length result from SqlCommandBuilder.ParseProcedureName");
+
+            SqlCommand paramsCmd = null;
+            StringBuilder cmdText = new StringBuilder();
+
+            // Build call for sp_procedure_params_rowset built of unquoted values from user:
+            // [user server, if provided].[user catalog, else current database].[sys if Yukon, else blank].[sp_procedure_params_rowset]
+
+            // Server - pass only if user provided.
+            if (!string.IsNullOrEmpty(parsedSProc[0]))
+            {
+                SqlCommandSet.BuildStoredProcedureName(cmdText, parsedSProc[0]);
+                cmdText.Append(".");
+            }
+
+            // Catalog - pass user provided, otherwise use current database.
+            if (string.IsNullOrEmpty(parsedSProc[1]))
+            {
+                parsedSProc[1] = Connection.Database;
+            }
+            SqlCommandSet.BuildStoredProcedureName(cmdText, parsedSProc[1]);
+            cmdText.Append(".");
+
+            // Schema - only if Yukon, and then only pass sys.  Also - pass managed version of sproc
+            // for Yukon, else older sproc.
+            string[] colNames;
+            bool useManagedDataType;
+            if (Connection.IsKatmaiOrNewer)
+            {
+                // Procedure - [sp_procedure_params_managed]
+                cmdText.Append("[sys].[").Append(TdsEnums.SP_PARAMS_MGD10).Append("]");
+
+                colNames = KatmaiProcParamsNames;
+                useManagedDataType = true;
+            }
+            else
+            {
+                // Procedure - [sp_procedure_params_managed]
+                cmdText.Append("[sys].[").Append(TdsEnums.SP_PARAMS_MANAGED).Append("]");
+
+                colNames = PreKatmaiProcParamsNames;
+                useManagedDataType = false;
+            }
+
+            paramsCmd = new SqlCommand(cmdText.ToString(), Connection, Transaction)
+            {
+                CommandType = CommandType.StoredProcedure
+            };
+
+            object groupNumber;
+
+            // Prepare parameters for sp_procedure_params_rowset:
+            // 1) procedure name - unquote user value
+            // 2) group number - parsed at the time we unquoted procedure name
+            // 3) procedure schema - unquote user value
+
+            paramsCmd.Parameters.Add(new SqlParameter("@procedure_name", SqlDbType.NVarChar, 255));
+            paramsCmd.Parameters[0].Value = UnquoteProcedureName(parsedSProc[3], out groupNumber); // ProcedureName is 4rd element in parsed array
+
+            if (null != groupNumber)
+            {
+                SqlParameter param = paramsCmd.Parameters.Add(new SqlParameter("@group_number", SqlDbType.Int));
+                param.Value = groupNumber;
+            }
+
+            if (!string.IsNullOrEmpty(parsedSProc[2]))
+            { // SchemaName is 3rd element in parsed array
+                SqlParameter param = paramsCmd.Parameters.Add(new SqlParameter("@procedure_schema", SqlDbType.NVarChar, 255));
+                param.Value = UnquoteProcedurePart(parsedSProc[2]);
+            }
+
+            SqlDataReader r = null;
+
+            List<SqlParameter> parameters = new List<SqlParameter>();
+            bool processFinallyBlock = true;
+
+            try
+            {
+                r = paramsCmd.ExecuteReader();
+
+                SqlParameter p = null;
+
+                while (r.Read())
+                {
+                    // each row corresponds to a parameter of the stored proc.  Fill in all the info
+                    p = new SqlParameter()
+                    {
+                        ParameterName = (string)r[colNames[(int)ProcParamsColIndex.ParameterName]]
+                    };
+
+                    // type
+                    if (useManagedDataType)
+                    {
+                        p.SqlDbType = (SqlDbType)(short)r[colNames[(int)ProcParamsColIndex.ManagedDataType]];
+
+                        // Yukon didn't have as accurate of information as we're getting for Katmai, so re-map a couple of
+                        //  types for backward compatability.
+                        switch (p.SqlDbType)
+                        {
+                            case SqlDbType.Image:
+                            case SqlDbType.Timestamp:
+                                p.SqlDbType = SqlDbType.VarBinary;
+                                break;
+
+                            case SqlDbType.NText:
+                                p.SqlDbType = SqlDbType.NVarChar;
+                                break;
+
+                            case SqlDbType.Text:
+                                p.SqlDbType = SqlDbType.VarChar;
+                                break;
+
+                            default:
+                                break;
+                        }
+                    }
+                    else
+                    {
+                        p.SqlDbType = MetaType.GetSqlDbTypeFromOleDbType((short)r[colNames[(int)ProcParamsColIndex.DataType]],
+                            ADP.IsNull(r[colNames[(int)ProcParamsColIndex.TypeName]]) ?
+                                ADP.StrEmpty :
+                                (string)r[colNames[(int)ProcParamsColIndex.TypeName]]);
+                    }
+
+                    // size
+                    object a = r[colNames[(int)ProcParamsColIndex.CharacterMaximumLength]];
+                    if (a is int)
+                    {
+                        int size = (int)a;
+
+                        // Map MAX sizes correctly.  The Katmai server-side proc sends 0 for these instead of -1.
+                        //  Should be fixed on the Katmai side, but would likely hold up the RI, and is safer to fix here.
+                        //  If we can get the server-side fixed before shipping Katmai, we can remove this mapping.
+                        if (0 == size &&
+                                (p.SqlDbType == SqlDbType.NVarChar ||
+                                 p.SqlDbType == SqlDbType.VarBinary ||
+                                 p.SqlDbType == SqlDbType.VarChar))
+                        {
+                            size = -1;
+                        }
+                        p.Size = size;
+                    }
+
+                    // direction
+                    p.Direction = ParameterDirectionFromOleDbDirection((short)r[colNames[(int)ProcParamsColIndex.ParameterType]]);
+
+                    if (p.SqlDbType == SqlDbType.Decimal)
+                    {
+                        p.ScaleInternal = (byte)((short)r[colNames[(int)ProcParamsColIndex.NumericScale]] & 0xff);
+                        p.PrecisionInternal = (byte)((short)r[colNames[(int)ProcParamsColIndex.NumericPrecision]] & 0xff);
+                    }
+
+                    // type name for Structured types (same as for Udt's except assign p.TypeName instead of p.UdtTypeName
+                    if (SqlDbType.Structured == p.SqlDbType)
+                    {
+
+                        Debug.Assert(_activeConnection.IsKatmaiOrNewer, "Invalid datatype token received from pre-katmai server");
+
+                        //read the type name
+                        p.TypeName = r[colNames[(int)ProcParamsColIndex.TypeCatalogName]] + "." +
+                            r[colNames[(int)ProcParamsColIndex.TypeSchemaName]] + "." +
+                            r[colNames[(int)ProcParamsColIndex.TypeName]];
+                    }
+
+                    // XmlSchema name for Xml types
+                    if (SqlDbType.Xml == p.SqlDbType)
+                    {
+                        object value;
+
+                        value = r[colNames[(int)ProcParamsColIndex.XmlSchemaCollectionCatalogName]];
+                        p.XmlSchemaCollectionDatabase = ADP.IsNull(value) ? String.Empty : (string)value;
+
+                        value = r[colNames[(int)ProcParamsColIndex.XmlSchemaCollectionSchemaName]];
+                        p.XmlSchemaCollectionOwningSchema = ADP.IsNull(value) ? String.Empty : (string)value;
+
+                        value = r[colNames[(int)ProcParamsColIndex.XmlSchemaCollectionName]];
+                        p.XmlSchemaCollectionName = ADP.IsNull(value) ? String.Empty : (string)value;
+                    }
+
+                    if (MetaType._IsVarTime(p.SqlDbType))
+                    {
+                        object value = r[colNames[(int)ProcParamsColIndex.DateTimeScale]];
+                        if (value is int)
+                        {
+                            p.ScaleInternal = (byte)(((int)value) & 0xff);
+                        }
+                    }
+
+                    parameters.Add(p);
+                }
+            }
+            catch (Exception e)
+            {
+                processFinallyBlock = ADP.IsCatchableExceptionType(e);
+                throw;
+            }
+            finally
+            {
+                if (processFinallyBlock)
+                {
+                    r?.Close();
+
+                    // always unhook the user's connection
+                    paramsCmd.Connection = null;
+                }
+            }
+
+            if (parameters.Count == 0)
+            {
+                throw ADP.NoStoredProcedureExists(this.CommandText);
+            }
+
+            Parameters.Clear();
+
+            foreach (SqlParameter temp in parameters)
+            {
+                _parameters.Add(temp);
+            }
+        }
+
+        private ParameterDirection ParameterDirectionFromOleDbDirection(short oledbDirection)
+        {
+            Debug.Assert(oledbDirection >= 1 && oledbDirection <= 4, "invalid parameter direction from params_rowset!");
+
+            switch (oledbDirection)
+            {
+                case 2:
+                    return ParameterDirection.InputOutput;
+                case 3:
+                    return ParameterDirection.Output;
+                case 4:
+                    return ParameterDirection.ReturnValue;
+                default:
+                    return ParameterDirection.Input;
+            }
+
+        }
+
+        // get cached metadata
+        internal _SqlMetaDataSet MetaData
+        {
+            get
+            {
+                return _cachedMetaData;
+            }
+        }
+
+        // Check to see if notificactions auto enlistment is turned on. Enlist if so.
+        private void CheckNotificationStateAndAutoEnlist()
+        {
+            // Auto-enlist not supported in Core
+
+            // If we have a notification with a dependency, setup the notification options at this time.
+
+            // If user passes options, then we will always have option data at the time the SqlDependency
+            // ctor is called.  But, if we are using default queue, then we do not have this data until
+            // Start().  Due to this, we always delay setting options until execute.
+
+            // There is a variance in order between Start(), SqlDependency(), and Execute.  This is the 
+            // best way to solve that problem.
+            if (null != Notification)
+            {
+                if (_sqlDep != null)
+                {
+                    if (null == _sqlDep.Options)
+                    {
+                        // If null, SqlDependency was not created with options, so we need to obtain default options now.
+                        // GetDefaultOptions can and will throw under certain conditions.
+
+                        // In order to match to the appropriate start - we need 3 pieces of info:
+                        // 1) server 2) user identity (SQL Auth or Int Sec) 3) database
+
+                        SqlDependency.IdentityUserNamePair identityUserName = null;
+
+                        // Obtain identity from connection.
+                        SqlInternalConnectionTds internalConnection = _activeConnection.InnerConnection as SqlInternalConnectionTds;
+                        if (internalConnection.Identity != null)
+                        {
+                            identityUserName = new SqlDependency.IdentityUserNamePair(internalConnection.Identity, null);
+                        }
+                        else
+                        {
+                            identityUserName = new SqlDependency.IdentityUserNamePair(null, internalConnection.ConnectionOptions.UserID);
+                        }
+
+                        Notification.Options = SqlDependency.GetDefaultComposedOptions(_activeConnection.DataSource,
+                                                             InternalTdsConnection.ServerProvidedFailOverPartner,
+                                                             identityUserName, _activeConnection.Database);
+                    }
+
+                    // Set UserData on notifications, as well as adding to the appdomain dispatcher.  The value is
+                    // computed by an algorithm on the dependency - fixed and will always produce the same value
+                    // given identical commandtext + parameter values.
+                    Notification.UserData = _sqlDep.ComputeHashAndAddToDispatcher(this);
+                    // Maintain server list for SqlDependency.
+                    _sqlDep.AddToServerList(_activeConnection.DataSource);
+                }
+            }
+        }
+
+        // Tds-specific logic for ExecuteNonQuery run handling
+        private Task RunExecuteNonQueryTds(string methodName, bool async, int timeout, bool asyncWrite)
+        {
+            Debug.Assert(!asyncWrite || async, "AsyncWrite should be always accompanied by Async");
+            bool processFinallyBlock = true;
+            try
+            {
+                Task reconnectTask = _activeConnection.ValidateAndReconnect(null, timeout);
+
+                if (reconnectTask != null)
+                {
+                    long reconnectionStart = ADP.TimerCurrent();
+                    if (async)
+                    {
+                        TaskCompletionSource<object> completion = new TaskCompletionSource<object>();
+                        _activeConnection.RegisterWaitingForReconnect(completion.Task);
+                        _reconnectionCompletionSource = completion;
+                        CancellationTokenSource timeoutCTS = new CancellationTokenSource();
+                        AsyncHelper.SetTimeoutException(completion, timeout, SQL.CR_ReconnectTimeout, timeoutCTS.Token);
+                        AsyncHelper.ContinueTask(reconnectTask, completion,
+                            () =>
+                            {
+                                if (completion.Task.IsCompleted)
+                                {
+                                    return;
+                                }
+                                Interlocked.CompareExchange(ref _reconnectionCompletionSource, null, completion);
+                                timeoutCTS.Cancel();
+                                Task subTask = RunExecuteNonQueryTds(methodName, async, TdsParserStaticMethods.GetRemainingTimeout(timeout, reconnectionStart), asyncWrite);
+                                if (subTask == null)
+                                {
+                                    completion.SetResult(null);
+                                }
+                                else
+                                {
+                                    AsyncHelper.ContinueTask(subTask, completion, () => completion.SetResult(null));
+                                }
+                            }, connectionToAbort: _activeConnection);
+                        return completion.Task;
+                    }
+                    else
+                    {
+                        AsyncHelper.WaitForCompletion(reconnectTask, timeout, () => { throw SQL.CR_ReconnectTimeout(); });
+                        timeout = TdsParserStaticMethods.GetRemainingTimeout(timeout, reconnectionStart);
+                    }
+                }
+
+                if (asyncWrite)
+                {
+                    _activeConnection.AddWeakReference(this, SqlReferenceCollection.CommandTag);
+                }
+
+                GetStateObject();
+
+                // we just send over the raw text with no annotation
+                // no parameters are sent over
+                // no data reader is returned
+                // use this overload for "batch SQL" tds token type
+                Task executeTask = _stateObj.Parser.TdsExecuteSQLBatch(this.CommandText, timeout, this.Notification, _stateObj, sync: true);
+                Debug.Assert(executeTask == null, "Shouldn't get a task when doing sync writes");
+
+                NotifyDependency();
+                if (async)
+                {
+                    _activeConnection.GetOpenTdsConnection(methodName).IncrementAsyncCount();
+                }
+                else
+                {
+                    bool dataReady;
+                    Debug.Assert(_stateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
+                    bool result = _stateObj.Parser.TryRun(RunBehavior.UntilDone, this, null, null, _stateObj, out dataReady);
+                    if (!result)
+                    { throw SQL.SynchronousCallMayNotPend(); }
+                }
+            }
+            catch (Exception e)
+            {
+                processFinallyBlock = ADP.IsCatchableExceptionType(e);
+                throw;
+            }
+            finally
+            {
+                if (processFinallyBlock && !async)
+                {
+                    // When executing Async, we need to keep the _stateObj alive...
+                    PutStateObject();
+                }
+            }
+            return null;
+        }
+
+
+        internal SqlDataReader RunExecuteReader(CommandBehavior cmdBehavior, RunBehavior runBehavior, bool returnStream, [CallerMemberName] string method = "")
+        {
+            Task unused; // sync execution 
+            SqlDataReader reader = RunExecuteReader(cmdBehavior, runBehavior, returnStream, completion: null, timeout: CommandTimeout, task: out unused, method: method);
+            Debug.Assert(unused == null, "returned task during synchronous execution");
+            return reader;
+        }
+
+        // task is created in case of pending asynchronous write, returned SqlDataReader should not be utilized until that task is complete 
+        internal SqlDataReader RunExecuteReader(CommandBehavior cmdBehavior, RunBehavior runBehavior, bool returnStream, TaskCompletionSource<object> completion, int timeout, out Task task, bool asyncWrite = false, [CallerMemberName] string method = "")
+        {
+            bool async = (null != completion);
+
+            task = null;
+
+            _rowsAffected = -1;
+
+            if (0 != (CommandBehavior.SingleRow & cmdBehavior))
+            {
+                // CommandBehavior.SingleRow implies CommandBehavior.SingleResult
+                cmdBehavior |= CommandBehavior.SingleResult;
+            }
+
+            // this function may throw for an invalid connection
+            // returns false for empty command text
+            ValidateCommand(async, method);
+
+            CheckNotificationStateAndAutoEnlist(); // Only call after validate - requires non null connection!
+
+            SqlStatistics statistics = Statistics;
+            if (null != statistics)
+            {
+                if ((!this.IsDirty && this.IsPrepared && !_hiddenPrepare)
+                    || (this.IsPrepared && _execType == EXECTYPE.PREPAREPENDING))
+                {
+                    statistics.SafeIncrement(ref statistics._preparedExecs);
+                }
+                else
+                {
+                    statistics.SafeIncrement(ref statistics._unpreparedExecs);
+                }
+            }
+
+
+            {
+                return RunExecuteReaderTds(cmdBehavior, runBehavior, returnStream, async, timeout, out task, asyncWrite && async);
+            }
+        }
+
+        private SqlDataReader RunExecuteReaderTds(CommandBehavior cmdBehavior, RunBehavior runBehavior, bool returnStream, bool async, int timeout, out Task task, bool asyncWrite, SqlDataReader ds = null)
+        {
+            Debug.Assert(!asyncWrite || async, "AsyncWrite should be always accompanied by Async");
+
+            if (ds == null && returnStream)
+            {
+                ds = new SqlDataReader(this, cmdBehavior);
+            }
+
+            Task reconnectTask = _activeConnection.ValidateAndReconnect(null, timeout);
+
+            if (reconnectTask != null)
+            {
+                long reconnectionStart = ADP.TimerCurrent();
+                if (async)
+                {
+                    TaskCompletionSource<object> completion = new TaskCompletionSource<object>();
+                    _activeConnection.RegisterWaitingForReconnect(completion.Task);
+                    _reconnectionCompletionSource = completion;
+                    CancellationTokenSource timeoutCTS = new CancellationTokenSource();
+                    AsyncHelper.SetTimeoutException(completion, timeout, SQL.CR_ReconnectTimeout, timeoutCTS.Token);
+                    AsyncHelper.ContinueTask(reconnectTask, completion,
+                        () =>
+                        {
+                            if (completion.Task.IsCompleted)
+                            {
+                                return;
+                            }
+                            Interlocked.CompareExchange(ref _reconnectionCompletionSource, null, completion);
+                            timeoutCTS.Cancel();
+                            Task subTask;
+                            RunExecuteReaderTds(cmdBehavior, runBehavior, returnStream, async, TdsParserStaticMethods.GetRemainingTimeout(timeout, reconnectionStart), out subTask, asyncWrite, ds);
+                            if (subTask == null)
+                            {
+                                completion.SetResult(null);
+                            }
+                            else
+                            {
+                                AsyncHelper.ContinueTask(subTask, completion, () => completion.SetResult(null));
+                            }
+                        }, connectionToAbort: _activeConnection);
+                    task = completion.Task;
+                    return ds;
+                }
+                else
+                {
+                    AsyncHelper.WaitForCompletion(reconnectTask, timeout, () => { throw SQL.CR_ReconnectTimeout(); });
+                    timeout = TdsParserStaticMethods.GetRemainingTimeout(timeout, reconnectionStart);
+                }
+            }
+
+            // make sure we have good parameter information
+            // prepare the command
+            // execute
+            Debug.Assert(null != _activeConnection.Parser, "TdsParser class should not be null in Command.Execute!");
+
+            bool inSchema = (0 != (cmdBehavior & CommandBehavior.SchemaOnly));
+
+            // create a new RPC
+            _SqlRPC rpc = null;
+
+            task = null;
+
+            string optionSettings = null;
+            bool processFinallyBlock = true;
+            bool decrementAsyncCountOnFailure = false;
+
+            if (async)
+            {
+                _activeConnection.GetOpenTdsConnection().IncrementAsyncCount();
+                decrementAsyncCountOnFailure = true;
+            }
+
+            try
+            {
+                if (asyncWrite)
+                {
+                    _activeConnection.AddWeakReference(this, SqlReferenceCollection.CommandTag);
+                }
+
+                GetStateObject();
+                Task writeTask = null;
+
+                if ((System.Data.CommandType.Text == this.CommandType) && (0 == GetParameterCount(_parameters)))
+                {
+                    // Send over SQL Batch command if we are not a stored proc and have no parameters
+                    Debug.Assert(!IsUserPrepared, "CommandType.Text with no params should not be prepared!");
+                    string text = GetCommandText(cmdBehavior) + GetResetOptionsString(cmdBehavior);
+                    writeTask = _stateObj.Parser.TdsExecuteSQLBatch(text, timeout, this.Notification, _stateObj, sync: !asyncWrite);
+                }
+                else if (System.Data.CommandType.Text == this.CommandType)
+                {
+                    if (this.IsDirty)
+                    {
+                        Debug.Assert(_cachedMetaData == null || !_dirty, "dirty query should not have cached metadata!"); // can have cached metadata if dirty because of parameters
+                        //
+                        // someone changed the command text or the parameter schema so we must unprepare the command
+                        //
+                        // remember that IsDirty includes test for IsPrepared!
+                        if (_execType == EXECTYPE.PREPARED)
+                        {
+                            _hiddenPrepare = true;
+                        }
+                        Unprepare();
+                        IsDirty = false;
+                    }
+
+                    if (_execType == EXECTYPE.PREPARED)
+                    {
+                        Debug.Assert(this.IsPrepared && (_prepareHandle != -1), "invalid attempt to call sp_execute without a handle!");
+                        rpc = BuildExecute(inSchema);
+                    }
+                    else if (_execType == EXECTYPE.PREPAREPENDING)
+                    {
+                        rpc = BuildPrepExec(cmdBehavior);
+                        // next time through, only do an exec
+                        _execType = EXECTYPE.PREPARED;
+                        _preparedConnectionCloseCount = _activeConnection.CloseCount;
+                        _preparedConnectionReconnectCount = _activeConnection.ReconnectCount;
+                        // mark ourselves as preparing the command
+                        _inPrepare = true;
+                    }
+                    else
+                    {
+                        Debug.Assert(_execType == EXECTYPE.UNPREPARED, "Invalid execType!");
+                        BuildExecuteSql(cmdBehavior, null, _parameters, ref rpc);
+                    }
+
+                    // if shiloh, then set NOMETADATA_UNLESSCHANGED flag
+                    rpc.options = TdsEnums.RPC_NOMETADATA;
+
+                    Debug.Assert(_rpcArrayOf1[0] == rpc);
+                    writeTask = _stateObj.Parser.TdsExecuteRPC(_rpcArrayOf1, timeout, inSchema, this.Notification, _stateObj, CommandType.StoredProcedure == CommandType, sync: !asyncWrite);
+                }
+                else
+                {
+                    Debug.Assert(this.CommandType == System.Data.CommandType.StoredProcedure, "unknown command type!");
+
+                    BuildRPC(inSchema, _parameters, ref rpc);
+
+                    // if we need to augment the command because a user has changed the command behavior (e.g. FillSchema)
+                    // then batch sql them over.  This is inefficient (3 round trips) but the only way we can get metadata only from
+                    // a stored proc
+                    optionSettings = GetSetOptionsString(cmdBehavior);
+                    // turn set options ON
+                    if (null != optionSettings)
+                    {
+                        Task executeTask = _stateObj.Parser.TdsExecuteSQLBatch(optionSettings, timeout, this.Notification, _stateObj, sync: true);
+                        Debug.Assert(executeTask == null, "Shouldn't get a task when doing sync writes");
+                        bool dataReady;
+                        Debug.Assert(_stateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
+                        bool result = _stateObj.Parser.TryRun(RunBehavior.UntilDone, this, null, null, _stateObj, out dataReady);
+                        if (!result)
+                        { throw SQL.SynchronousCallMayNotPend(); }
+                        // and turn OFF when the ds exhausts the stream on Close()
+                        optionSettings = GetResetOptionsString(cmdBehavior);
+                    }
+
+
+                    // execute sp
+                    Debug.Assert(_rpcArrayOf1[0] == rpc);
+                    writeTask = _stateObj.Parser.TdsExecuteRPC(_rpcArrayOf1, timeout, inSchema, this.Notification, _stateObj, CommandType.StoredProcedure == CommandType, sync: !asyncWrite);
+                }
+
+                Debug.Assert(writeTask == null || async, "Returned task in sync mode");
+
+                if (async)
+                {
+                    decrementAsyncCountOnFailure = false;
+                    if (writeTask != null)
+                    {
+                        task = AsyncHelper.CreateContinuationTask(writeTask, () =>
+                        {
+                            _activeConnection.GetOpenTdsConnection(); // it will throw if connection is closed
+                            cachedAsyncState.SetAsyncReaderState(ds, runBehavior, optionSettings);
+                        },
+                                 onFailure: (exc) =>
+                                 {
+                                     _activeConnection.GetOpenTdsConnection().DecrementAsyncCount();
+                                 });
+                    }
+                    else
+                    {
+                        cachedAsyncState.SetAsyncReaderState(ds, runBehavior, optionSettings);
+                    }
+                }
+                else
+                {
+                    // Always execute - even if no reader!
+                    FinishExecuteReader(ds, runBehavior, optionSettings);
+                }
+            }
+            catch (Exception e)
+            {
+                processFinallyBlock = ADP.IsCatchableExceptionType(e);
+                if (decrementAsyncCountOnFailure)
+                {
+                    SqlInternalConnectionTds innerConnectionTds = (_activeConnection.InnerConnection as SqlInternalConnectionTds);
+                    if (null != innerConnectionTds)
+                    { // it may be closed 
+                        innerConnectionTds.DecrementAsyncCount();
+                    }
+                }
+                throw;
+            }
+            finally
+            {
+                if (processFinallyBlock && !async)
+                {
+                    // When executing async, we need to keep the _stateObj alive...
+                    PutStateObject();
+                }
+            }
+
+            Debug.Assert(async || null == _stateObj, "non-null state object in RunExecuteReader");
+            return ds;
+        }
+
+
+        private SqlDataReader CompleteAsyncExecuteReader()
+        {
+            SqlDataReader ds = cachedAsyncState.CachedAsyncReader; // should not be null
+            bool processFinallyBlock = true;
+            try
+            {
+                FinishExecuteReader(ds, cachedAsyncState.CachedRunBehavior, cachedAsyncState.CachedSetOptions);
+            }
+            catch (Exception e)
+            {
+                processFinallyBlock = ADP.IsCatchableExceptionType(e);
+                throw;
+            }
+            finally
+            {
+                if (processFinallyBlock)
+                {
+                    cachedAsyncState.ResetAsyncState();
+                    PutStateObject();
+                }
+            }
+
+            return ds;
+        }
+
+        private void FinishExecuteReader(SqlDataReader ds, RunBehavior runBehavior, string resetOptionsString)
+        {
+            // always wrap with a try { FinishExecuteReader(...) } finally { PutStateObject(); }
+
+            NotifyDependency();
+
+            if (runBehavior == RunBehavior.UntilDone)
+            {
+                try
+                {
+                    bool dataReady;
+                    Debug.Assert(_stateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
+                    bool result = _stateObj.Parser.TryRun(RunBehavior.UntilDone, this, ds, null, _stateObj, out dataReady);
+                    if (!result)
+                    { throw SQL.SynchronousCallMayNotPend(); }
+                }
+                catch (Exception e)
+                {
+                    if (ADP.IsCatchableExceptionType(e))
+                    {
+                        if (_inPrepare)
+                        {
+                            // The flag is expected to be reset by OnReturnValue.  We should receive
+                            // the handle unless command execution failed.  If fail, move back to pending
+                            // state.
+                            _inPrepare = false;                  // reset the flag
+                            IsDirty = true;                      // mark command as dirty so it will be prepared next time we're coming through
+                            _execType = EXECTYPE.PREPAREPENDING; // reset execution type to pending
+                        }
+
+                        if (null != ds)
+                        {
+                            try
+                            {
+                                ds.Close();
+                            }
+                            catch (Exception exClose)
+                            {
+                                Debug.WriteLine("Received this exception from SqlDataReader.Close() while in another catch block: " + exClose.ToString());
+                            }
+                        }
+                    }
+                    throw;
+                }
+            }
+
+            // bind the parser to the reader if we get this far
+            if (ds != null)
+            {
+                ds.Bind(_stateObj);
+                _stateObj = null;   // the reader now owns this...
+                ds.ResetOptionsString = resetOptionsString;
+                // bind this reader to this connection now
+                _activeConnection.AddWeakReference(ds, SqlReferenceCollection.DataReaderTag);
+
+                // force this command to start reading data off the wire.
+                // this will cause an error to be reported at Execute() time instead of Read() time
+                // if the command is not set.
+                try
+                {
+                    _cachedMetaData = ds.MetaData;
+                    ds.IsInitialized = true;
+                }
+                catch (Exception e)
+                {
+                    if (ADP.IsCatchableExceptionType(e))
+                    {
+                        if (_inPrepare)
+                        {
+                            // The flag is expected to be reset by OnReturnValue.  We should receive
+                            // the handle unless command execution failed.  If fail, move back to pending
+                            // state.
+                            _inPrepare = false;                  // reset the flag
+                            IsDirty = true;                      // mark command as dirty so it will be prepared next time we're coming through
+                            _execType = EXECTYPE.PREPAREPENDING; // reset execution type to pending
+                        }
+
+                        try
+                        {
+                            ds.Close();
+                        }
+                        catch (Exception exClose)
+                        {
+                            Debug.WriteLine("Received this exception from SqlDataReader.Close() while in another catch block: " + exClose.ToString());
+                        }
+                    }
+
+                    throw;
+                }
+            }
+        }
+
+
+        private void RegisterForConnectionCloseNotification<T>(ref Task<T> outerTask)
+        {
+            SqlConnection connection = _activeConnection;
+            if (connection == null)
+            {
+                // No connection
+                throw ADP.ClosedConnectionError();
+            }
+
+            connection.RegisterForConnectionCloseNotification<T>(ref outerTask, this, SqlReferenceCollection.CommandTag);
+        }
+
+        // validates that a command has commandText and a non-busy open connection
+        // throws exception for error case, returns false if the commandText is empty
+        private void ValidateCommand(bool async, [CallerMemberName] string method = "")
+        {
+            if (null == _activeConnection)
+            {
+                throw ADP.ConnectionRequired(method);
+            }
+
+            // Ensure that the connection is open and that the Parser is in the correct state
+            SqlInternalConnectionTds tdsConnection = _activeConnection.InnerConnection as SqlInternalConnectionTds;
+            if (tdsConnection != null)
+            {
+                var parser = tdsConnection.Parser;
+                if ((parser == null) || (parser.State == TdsParserState.Closed))
+                {
+                    throw ADP.OpenConnectionRequired(method, ConnectionState.Closed);
+                }
+                else if (parser.State != TdsParserState.OpenLoggedIn)
+                {
+                    throw ADP.OpenConnectionRequired(method, ConnectionState.Broken);
+                }
+            }
+            else if (_activeConnection.State == ConnectionState.Closed)
+            {
+                throw ADP.OpenConnectionRequired(method, ConnectionState.Closed);
+            }
+            else if (_activeConnection.State == ConnectionState.Broken)
+            {
+                throw ADP.OpenConnectionRequired(method, ConnectionState.Broken);
+            }
+
+            ValidateAsyncCommand();
+
+            // close any non MARS dead readers, if applicable, and then throw if still busy.
+            // Throw if we have a live reader on this command
+            _activeConnection.ValidateConnectionForExecute(method, this);
+            // Check to see if the currently set transaction has completed.  If so,
+            // null out our local reference.
+            if (null != _transaction && _transaction.Connection == null)
+                _transaction = null;
+
+            // throw if the connection is in a transaction but there is no
+            // locally assigned transaction object
+            if (_activeConnection.HasLocalTransactionFromAPI && (null == _transaction))
+                throw ADP.TransactionRequired(method);
+
+            // if we have a transaction, check to ensure that the active
+            // connection property matches the connection associated with
+            // the transaction
+            if (null != _transaction && _activeConnection != _transaction.Connection)
+                throw ADP.TransactionConnectionMismatch();
+
+            if (string.IsNullOrEmpty(this.CommandText))
+                throw ADP.CommandTextRequired(method);
+        }
+
+        private void ValidateAsyncCommand()
+        {
+            if (cachedAsyncState.PendingAsyncOperation)
+            { // Enforce only one pending async execute at a time.
+                if (cachedAsyncState.IsActiveConnectionValid(_activeConnection))
+                {
+                    throw SQL.PendingBeginXXXExists();
+                }
+                else
+                {
+                    _stateObj = null; // Session was re-claimed by session pool upon connection close.
+                    cachedAsyncState.ResetAsyncState();
+                }
+            }
+        }
+
+        private void GetStateObject(TdsParser parser = null)
+        {
+            Debug.Assert(null == _stateObj, "StateObject not null on GetStateObject");
+            Debug.Assert(null != _activeConnection, "no active connection?");
+
+            if (_pendingCancel)
+            {
+                _pendingCancel = false; // Not really needed, but we'll reset anyways.
+
+                // If a pendingCancel exists on the object, we must have had a Cancel() call
+                // between the point that we entered an Execute* API and the point in Execute* that
+                // we proceeded to call this function and obtain a stateObject.  In that case,
+                // we now throw a cancelled error.
+                throw SQL.OperationCancelled();
+            }
+
+            if (parser == null)
+            {
+                parser = _activeConnection.Parser;
+                if ((parser == null) || (parser.State == TdsParserState.Broken) || (parser.State == TdsParserState.Closed))
+                {
+                    // Connection's parser is null as well, therefore we must be closed
+                    throw ADP.ClosedConnectionError();
+                }
+            }
+
+            TdsParserStateObject stateObj = parser.GetSession(this);
+            stateObj.StartSession(this);
+
+            _stateObj = stateObj;
+
+            if (_pendingCancel)
+            {
+                _pendingCancel = false; // Not really needed, but we'll reset anyways.
+
+                // If a pendingCancel exists on the object, we must have had a Cancel() call
+                // between the point that we entered this function and the point where we obtained
+                // and actually assigned the stateObject to the local member.  It is possible
+                // that the flag is set as well as a call to stateObj.Cancel - though that would
+                // be a no-op.  So - throw.
+                throw SQL.OperationCancelled();
+            }
+        }
+
+        private void ReliablePutStateObject()
+        {
+            PutStateObject();
+        }
+
+        private void PutStateObject()
+        {
+            TdsParserStateObject stateObj = _stateObj;
+            _stateObj = null;
+
+            if (null != stateObj)
+            {
+                stateObj.CloseSession();
+            }
+        }
+        internal void OnDoneProc()
+        { // called per rpc batch complete
+            if (BatchRPCMode)
+            {
+                // track the records affected for the just completed rpc batch
+                // _rowsAffected is cumulative for ExecuteNonQuery across all rpc batches
+                _SqlRPCBatchArray[_currentlyExecutingBatch].cumulativeRecordsAffected = _rowsAffected;
+
+                _SqlRPCBatchArray[_currentlyExecutingBatch].recordsAffected =
+                    (((0 < _currentlyExecutingBatch) && (0 <= _rowsAffected))
+                        ? (_rowsAffected - Math.Max(_SqlRPCBatchArray[_currentlyExecutingBatch - 1].cumulativeRecordsAffected, 0))
+                        : _rowsAffected);
+
+                // track the error collection (not available from TdsParser after ExecuteNonQuery)
+                // and the which errors are associated with the just completed rpc batch
+                _SqlRPCBatchArray[_currentlyExecutingBatch].errorsIndexStart =
+                    ((0 < _currentlyExecutingBatch)
+                        ? _SqlRPCBatchArray[_currentlyExecutingBatch - 1].errorsIndexEnd
+                        : 0);
+                _SqlRPCBatchArray[_currentlyExecutingBatch].errorsIndexEnd = _stateObj.ErrorCount;
+                _SqlRPCBatchArray[_currentlyExecutingBatch].errors = _stateObj._errors;
+
+                // track the warning collection (not available from TdsParser after ExecuteNonQuery)
+                // and the which warnings are associated with the just completed rpc batch
+                _SqlRPCBatchArray[_currentlyExecutingBatch].warningsIndexStart =
+                    ((0 < _currentlyExecutingBatch)
+                        ? _SqlRPCBatchArray[_currentlyExecutingBatch - 1].warningsIndexEnd
+                        : 0);
+                _SqlRPCBatchArray[_currentlyExecutingBatch].warningsIndexEnd = _stateObj.WarningCount;
+                _SqlRPCBatchArray[_currentlyExecutingBatch].warnings = _stateObj._warnings;
+
+                _currentlyExecutingBatch++;
+                Debug.Assert(_parameterCollectionList.Count >= _currentlyExecutingBatch, "OnDoneProc: Too many DONEPROC events");
+            }
+        }
+        internal void OnReturnStatus(int status)
+        {
+            if (_inPrepare)
+                return;
+
+            SqlParameterCollection parameters = _parameters;
+            if (BatchRPCMode)
+            {
+                if (_parameterCollectionList.Count > _currentlyExecutingBatch)
+                {
+                    parameters = _parameterCollectionList[_currentlyExecutingBatch];
+                }
+                else
+                {
+                    Debug.Assert(false, "OnReturnStatus: SqlCommand got too many DONEPROC events");
+                    parameters = null;
+                }
+            }
+            // see if a return value is bound
+            int count = GetParameterCount(parameters);
+            for (int i = 0; i < count; i++)
+            {
+                SqlParameter parameter = parameters[i];
+                if (parameter.Direction == ParameterDirection.ReturnValue)
+                {
+                    object v = parameter.Value;
+
+                    // if the user bound a sqlint32 (the only valid one for status, use it)
+                    if ((null != v) && (v.GetType() == typeof(SqlInt32)))
+                    {
+                        parameter.Value = new SqlInt32(status); // value type
+                    }
+                    else
+                    {
+                        parameter.Value = status;
+
+                    }
+
+                    break;
+                }
+            }
+        }
+
+        //
+        // Move the return value to the corresponding output parameter.
+        // Return parameters are sent in the order in which they were defined in the procedure.
+        // If named, match the parameter name, otherwise fill in based on ordinal position.
+        // If the parameter is not bound, then ignore the return value.
+        //
+        internal void OnReturnValue(SqlReturnValue rec)
+        {
+
+            if (_inPrepare)
+            {
+                if (!rec.value.IsNull)
+                {
+                    _prepareHandle = rec.value.Int32;
+                }
+                _inPrepare = false;
+                return;
+            }
+
+            SqlParameterCollection parameters = GetCurrentParameterCollection();
+            int count = GetParameterCount(parameters);
+
+
+            SqlParameter thisParam = GetParameterForOutputValueExtraction(parameters, rec.parameter, count);
+
+            if (null != thisParam)
+            {
+                // copy over data
+
+                // if the value user has supplied a SqlType class, then just copy over the SqlType, otherwise convert
+                // to the com type
+                object val = thisParam.Value;
+
+                thisParam.SetSqlBuffer(rec.value);
+
+                MetaType mt = MetaType.GetMetaTypeFromSqlDbType(rec.type, false);
+
+                if (rec.type == SqlDbType.Decimal)
+                {
+                    thisParam.ScaleInternal = rec.scale;
+                    thisParam.PrecisionInternal = rec.precision;
+                }
+                else if (mt.IsVarTime)
+                {
+                    thisParam.ScaleInternal = rec.scale;
+                }
+                else if (rec.type == SqlDbType.Xml)
+                {
+                    SqlCachedBuffer cachedBuffer = (thisParam.Value as SqlCachedBuffer);
+                    if (null != cachedBuffer)
+                    {
+                        thisParam.Value = cachedBuffer.ToString();
+                    }
+                }
+
+                if (rec.collation != null)
+                {
+                    Debug.Assert(mt.IsCharType, "Invalid collation structure for non-char type");
+                    thisParam.Collation = rec.collation;
+                }
+            }
+
+            return;
+        }
+
+        private SqlParameterCollection GetCurrentParameterCollection()
+        {
+            if (BatchRPCMode)
+            {
+                if (_parameterCollectionList.Count > _currentlyExecutingBatch)
+                {
+                    return _parameterCollectionList[_currentlyExecutingBatch];
+                }
+                else
+                {
+                    Debug.Assert(false, "OnReturnValue: SqlCommand got too many DONEPROC events");
+                    return null;
+                }
+            }
+            else
+            {
+                return _parameters;
+            }
+        }
+
+        private SqlParameter GetParameterForOutputValueExtraction(SqlParameterCollection parameters,
+                        string paramName, int paramCount)
+        {
+            SqlParameter thisParam = null;
+            bool foundParam = false;
+
+            if (null == paramName)
+            {
+                // rec.parameter should only be null for a return value from a function
+                for (int i = 0; i < paramCount; i++)
+                {
+                    thisParam = parameters[i];
+                    // searching for ReturnValue
+                    if (thisParam.Direction == ParameterDirection.ReturnValue)
+                    {
+                        foundParam = true;
+                        break; // found it
+                    }
+                }
+            }
+            else
+            {
+                for (int i = 0; i < paramCount; i++)
+                {
+                    thisParam = parameters[i];
+                    // searching for Output or InputOutput or ReturnValue with matching name
+                    if (thisParam.Direction != ParameterDirection.Input && thisParam.Direction != ParameterDirection.ReturnValue && paramName == thisParam.ParameterNameFixed)
+                    {
+                        foundParam = true;
+                        break; // found it
+                    }
+                }
+            }
+            if (foundParam)
+                return thisParam;
+            else
+                return null;
+        }
+
+        private void GetRPCObject(int paramCount, ref _SqlRPC rpc)
+        {
+            // Designed to minimize necessary allocations
+            int ii;
+            if (rpc == null)
+            {
+                if (_rpcArrayOf1 == null)
+                {
+                    _rpcArrayOf1 = new _SqlRPC[1];
+                    _rpcArrayOf1[0] = new _SqlRPC();
+                }
+                rpc = _rpcArrayOf1[0];
+            }
+
+            rpc.ProcID = 0;
+            rpc.rpcName = null;
+            rpc.options = 0;
+
+
+            // Make sure there is enough space in the parameters and paramoptions arrays
+            if (rpc.parameters == null || rpc.parameters.Length < paramCount)
+            {
+                rpc.parameters = new SqlParameter[paramCount];
+            }
+            else if (rpc.parameters.Length > paramCount)
+            {
+                rpc.parameters[paramCount] = null;    // Terminator
+            }
+            if (rpc.paramoptions == null || (rpc.paramoptions.Length < paramCount))
+            {
+                rpc.paramoptions = new byte[paramCount];
+            }
+            else
+            {
+                for (ii = 0; ii < paramCount; ii++)
+                    rpc.paramoptions[ii] = 0;
+            }
+        }
+
+        private void SetUpRPCParameters(_SqlRPC rpc, int startCount, bool inSchema, SqlParameterCollection parameters)
+        {
+            int ii;
+            int paramCount = GetParameterCount(parameters);
+            int j = startCount;
+            TdsParser parser = _activeConnection.Parser;
+
+            for (ii = 0; ii < paramCount; ii++)
+            {
+                SqlParameter parameter = parameters[ii];
+                parameter.Validate(ii, CommandType.StoredProcedure == CommandType);
+
+                // func will change type to that with a 4 byte length if the type has a two
+                // byte length and a parameter length > than that expressible in 2 bytes
+                if ((!parameter.ValidateTypeLengths().IsPlp) && (parameter.Direction != ParameterDirection.Output))
+                {
+                    parameter.FixStreamDataForNonPLP();
+                }
+
+                if (ShouldSendParameter(parameter))
+                {
+                    rpc.parameters[j] = parameter;
+
+                    // set output bit
+                    if (parameter.Direction == ParameterDirection.InputOutput ||
+                        parameter.Direction == ParameterDirection.Output)
+                        rpc.paramoptions[j] = TdsEnums.RPC_PARAM_BYREF;
+
+                    // set default value bit
+                    if (parameter.Direction != ParameterDirection.Output)
+                    {
+                        // remember that null == Convert.IsEmpty, DBNull.Value is a database null!
+
+                        // Don't assume a default value exists for parameters in the case when
+                        // the user is simply requesting schema.
+                        // TVPs use DEFAULT and do not allow NULL, even for schema only.
+                        if (null == parameter.Value && (!inSchema || SqlDbType.Structured == parameter.SqlDbType))
+                        {
+                            rpc.paramoptions[j] |= TdsEnums.RPC_PARAM_DEFAULT;
+                        }
+                    }
+
+                    // Must set parameter option bit for LOB_COOKIE if unfilled LazyMat blob
+                    j++;
+                }
+            }
+        }
+
+        private _SqlRPC BuildPrepExec(CommandBehavior behavior)
+        {
+            Debug.Assert(System.Data.CommandType.Text == this.CommandType, "invalid use of sp_prepexec for stored proc invocation!");
+            SqlParameter sqlParam;
+            int j = 3;
+
+            int count = CountSendableParameters(_parameters);
+
+            _SqlRPC rpc = null;
+            GetRPCObject(count + j, ref rpc);
+
+            rpc.ProcID = TdsEnums.RPC_PROCID_PREPEXEC;
+            rpc.rpcName = TdsEnums.SP_PREPEXEC;
+
+            //@handle
+            sqlParam = new SqlParameter(null, SqlDbType.Int);
+            sqlParam.Direction = ParameterDirection.InputOutput;
+            sqlParam.Value = _prepareHandle;
+            rpc.parameters[0] = sqlParam;
+            rpc.paramoptions[0] = TdsEnums.RPC_PARAM_BYREF;
+
+            //@batch_params
+            string paramList = BuildParamList(_stateObj.Parser, _parameters);
+            sqlParam = new SqlParameter(null, ((paramList.Length << 1) <= TdsEnums.TYPE_SIZE_LIMIT) ? SqlDbType.NVarChar : SqlDbType.NText, paramList.Length);
+            sqlParam.Value = paramList;
+            rpc.parameters[1] = sqlParam;
+
+            //@batch_text
+            string text = GetCommandText(behavior);
+            sqlParam = new SqlParameter(null, ((text.Length << 1) <= TdsEnums.TYPE_SIZE_LIMIT) ? SqlDbType.NVarChar : SqlDbType.NText, text.Length);
+            sqlParam.Value = text;
+            rpc.parameters[2] = sqlParam;
+
+            SetUpRPCParameters(rpc, j, false, _parameters);
+            return rpc;
+        }
+
+
+        //
+        // returns true if the parameter is not a return value
+        // and it's value is not DBNull (for a nullable parameter)
+        //
+        private static bool ShouldSendParameter(SqlParameter p)
+        {
+            switch (p.Direction)
+            {
+                case ParameterDirection.ReturnValue:
+                    // return value parameters are never sent
+                    return false;
+                case ParameterDirection.Output:
+                case ParameterDirection.InputOutput:
+                case ParameterDirection.Input:
+                    // InputOutput/Output parameters are aways sent
+                    return true;
+                default:
+                    Debug.Assert(false, "Invalid ParameterDirection!");
+                    return false;
+            }
+        }
+
+        private int CountSendableParameters(SqlParameterCollection parameters)
+        {
+            int cParams = 0;
+
+            if (parameters != null)
+            {
+                int count = parameters.Count;
+                for (int i = 0; i < count; i++)
+                {
+                    if (ShouldSendParameter(parameters[i]))
+                        cParams++;
+                }
+            }
+            return cParams;
+        }
+
+        // Returns total number of parameters
+        private int GetParameterCount(SqlParameterCollection parameters)
+        {
+            return ((null != parameters) ? parameters.Count : 0);
+        }
+
+        //
+        // build the RPC record header for this stored proc and add parameters
+        //
+        private void BuildRPC(bool inSchema, SqlParameterCollection parameters, ref _SqlRPC rpc)
+        {
+            Debug.Assert(this.CommandType == System.Data.CommandType.StoredProcedure, "Command must be a stored proc to execute an RPC");
+            int count = CountSendableParameters(parameters);
+            GetRPCObject(count, ref rpc);
+
+            rpc.rpcName = this.CommandText; // just get the raw command text
+
+            SetUpRPCParameters(rpc, 0, inSchema, parameters);
+        }
+
+        //
+        // build the RPC record header for sp_unprepare
+        //
+        // prototype for sp_unprepare is:
+        // sp_unprepare(@handle)
+
+        // build the RPC record header for sp_execute
+        //
+        // prototype for sp_execute is:
+        // sp_execute(@handle int,param1value,param2value...)
+
+        private _SqlRPC BuildExecute(bool inSchema)
+        {
+            Debug.Assert(_prepareHandle != -1, "Invalid call to sp_execute without a valid handle!");
+            int j = 1;
+
+            int count = CountSendableParameters(_parameters);
+
+            _SqlRPC rpc = null;
+            GetRPCObject(count + j, ref rpc);
+
+            SqlParameter sqlParam;
+
+            rpc.ProcID = TdsEnums.RPC_PROCID_EXECUTE;
+            rpc.rpcName = TdsEnums.SP_EXECUTE;
+
+            //@handle
+            sqlParam = new SqlParameter(null, SqlDbType.Int);
+            sqlParam.Value = _prepareHandle;
+            rpc.parameters[0] = sqlParam;
+
+            SetUpRPCParameters(rpc, j, inSchema, _parameters);
+            return rpc;
+        }
+
+        //
+        // build the RPC record header for sp_executesql and add the parameters
+        //
+        // prototype for sp_executesql is:
+        // sp_executesql(@batch_text nvarchar(4000),@batch_params nvarchar(4000), param1,.. paramN)
+        private void BuildExecuteSql(CommandBehavior behavior, string commandText, SqlParameterCollection parameters, ref _SqlRPC rpc)
+        {
+
+            Debug.Assert(_prepareHandle == -1, "This command has an existing handle, use sp_execute!");
+            Debug.Assert(CommandType.Text == this.CommandType, "invalid use of sp_executesql for stored proc invocation!");
+            int j;
+            SqlParameter sqlParam;
+
+            int cParams = CountSendableParameters(parameters);
+            if (cParams > 0)
+            {
+                j = 2;
+            }
+            else
+            {
+                j = 1;
+            }
+
+            GetRPCObject(cParams + j, ref rpc);
+            rpc.ProcID = TdsEnums.RPC_PROCID_EXECUTESQL;
+            rpc.rpcName = TdsEnums.SP_EXECUTESQL;
+
+            // @sql
+            if (commandText == null)
+            {
+                commandText = GetCommandText(behavior);
+            }
+            sqlParam = new SqlParameter(null, ((commandText.Length << 1) <= TdsEnums.TYPE_SIZE_LIMIT) ? SqlDbType.NVarChar : SqlDbType.NText, commandText.Length);
+            sqlParam.Value = commandText;
+            rpc.parameters[0] = sqlParam;
+
+            if (cParams > 0)
+            {
+                string paramList = BuildParamList(_stateObj.Parser, BatchRPCMode ? parameters : _parameters);
+                sqlParam = new SqlParameter(null, ((paramList.Length << 1) <= TdsEnums.TYPE_SIZE_LIMIT) ? SqlDbType.NVarChar : SqlDbType.NText, paramList.Length);
+                sqlParam.Value = paramList;
+                rpc.parameters[1] = sqlParam;
+
+                bool inSchema = (0 != (behavior & CommandBehavior.SchemaOnly));
+                SetUpRPCParameters(rpc, j, inSchema, parameters);
+            }
+        }
+
+        // paramList parameter for sp_executesql, sp_prepare, and sp_prepexec
+        internal string BuildParamList(TdsParser parser, SqlParameterCollection parameters)
+        {
+            StringBuilder paramList = new StringBuilder();
+            bool fAddSeperator = false;
+
+            int count = 0;
+
+            count = parameters.Count;
+            for (int i = 0; i < count; i++)
+            {
+                SqlParameter sqlParam = parameters[i];
+                sqlParam.Validate(i, CommandType.StoredProcedure == CommandType);
+                // skip ReturnValue parameters; we never send them to the server
+                if (!ShouldSendParameter(sqlParam))
+                    continue;
+
+                // add our separator for the ith parameter
+                if (fAddSeperator)
+                    paramList.Append(',');
+
+                paramList.Append(sqlParam.ParameterNameFixed);
+
+                MetaType mt = sqlParam.InternalMetaType;
+
+                //for UDTs, get the actual type name. Get only the typename, omit catalog and schema names.
+                //in TSQL you should only specify the unqualified type name
+
+                // paragraph above doesn't seem to be correct. Server won't find the type
+                // if we don't provide a fully qualified name
+                paramList.Append(" ");
+                if (mt.SqlDbType == SqlDbType.Udt)
+                {
+                    throw ADP.DbTypeNotSupported(SqlDbType.Udt.ToString());
+                }
+                else if (mt.SqlDbType == SqlDbType.Structured)
+                {
+                    string typeName = sqlParam.TypeName;
+                    if (string.IsNullOrEmpty(typeName))
+                    {
+                        throw SQL.MustSetTypeNameForParam(mt.TypeName, sqlParam.ParameterNameFixed);
+                    }
+                    paramList.Append(ParseAndQuoteIdentifier(typeName));
+
+                    // TVPs currently are the only Structured type and must be read only, so add that keyword
+                    paramList.Append(" READONLY");
+                }
+                else
+                {
+                    // func will change type to that with a 4 byte length if the type has a two
+                    // byte length and a parameter length > than that expressible in 2 bytes
+                    mt = sqlParam.ValidateTypeLengths();
+                    if ((!mt.IsPlp) && (sqlParam.Direction != ParameterDirection.Output))
+                    {
+                        sqlParam.FixStreamDataForNonPLP();
+                    }
+                    paramList.Append(mt.TypeName);
+                }
+
+                fAddSeperator = true;
+
+                if (mt.SqlDbType == SqlDbType.Decimal)
+                {
+                    byte precision = sqlParam.GetActualPrecision();
+                    byte scale = sqlParam.GetActualScale();
+
+                    paramList.Append('(');
+
+                    if (0 == precision)
+                    {
+                        precision = TdsEnums.DEFAULT_NUMERIC_PRECISION;
+                    }
+
+                    paramList.Append(precision);
+                    paramList.Append(',');
+                    paramList.Append(scale);
+                    paramList.Append(')');
+                }
+                else if (mt.IsVarTime)
+                {
+                    byte scale = sqlParam.GetActualScale();
+
+                    paramList.Append('(');
+                    paramList.Append(scale);
+                    paramList.Append(')');
+                }
+                else if (false == mt.IsFixed && false == mt.IsLong && mt.SqlDbType != SqlDbType.Timestamp && mt.SqlDbType != SqlDbType.Udt && SqlDbType.Structured != mt.SqlDbType)
+                {
+                    int size = sqlParam.Size;
+
+                    paramList.Append('(');
+
+                    // if using non unicode types, obtain the actual byte length from the parser, with it's associated code page
+                    if (mt.IsAnsiType)
+                    {
+                        object val = sqlParam.GetCoercedValue();
+                        string s = null;
+
+                        // deal with the sql types
+                        if ((null != val) && (DBNull.Value != val))
+                        {
+                            s = (val as string);
+                            if (null == s)
+                            {
+                                SqlString sval = val is SqlString ? (SqlString)val : SqlString.Null;
+                                if (!sval.IsNull)
+                                {
+                                    s = sval.Value;
+                                }
+                            }
+                        }
+
+                        if (null != s)
+                        {
+                            int actualBytes = parser.GetEncodingCharLength(s, sqlParam.GetActualSize(), sqlParam.Offset, null);
+                            // if actual number of bytes is greater than the user given number of chars, use actual bytes
+                            if (actualBytes > size)
+                                size = actualBytes;
+                        }
+                    }
+
+                    // If the user specifies a 0-sized parameter for a variable len field
+                    // pass over max size (8000 bytes or 4000 characters for wide types)
+                    if (0 == size)
+                        size = mt.IsSizeInCharacters ? (TdsEnums.MAXSIZE >> 1) : TdsEnums.MAXSIZE;
+
+                    paramList.Append(size);
+                    paramList.Append(')');
+                }
+                else if (mt.IsPlp && (mt.SqlDbType != SqlDbType.Xml) && (mt.SqlDbType != SqlDbType.Udt))
+                {
+                    paramList.Append("(max) ");
+                }
+
+                // set the output bit for Output or InputOutput parameters
+                if (sqlParam.Direction != ParameterDirection.Input)
+                    paramList.Append(" " + TdsEnums.PARAM_OUTPUT);
+            }
+
+            return paramList.ToString();
+        }
+
+        // Adds quotes to each part of a SQL identifier that may be multi-part, while leaving
+        //  the result as a single composite name.
+        private string ParseAndQuoteIdentifier(string identifier)
+        {
+            string[] strings = SqlParameter.ParseTypeName(identifier);
+            StringBuilder bld = new StringBuilder();
+
+            // Stitching back together is a little tricky. Assume we want to build a full multi-part name
+            //  with all parts except trimming separators for leading empty names (null or empty strings,
+            //  but not whitespace). Separators in the middle should be added, even if the name part is 
+            //  null/empty, to maintain proper location of the parts.
+            for (int i = 0; i < strings.Length; i++)
+            {
+                if (0 < bld.Length)
+                {
+                    bld.Append('.');
+                }
+                if (null != strings[i] && 0 != strings[i].Length)
+                {
+                    bld.Append(ADP.BuildQuotedString("[", "]", strings[i]));
+                }
+            }
+
+            return bld.ToString();
+        }
+
+        // returns set option text to turn on format only and key info on and off
+        //  When we are executing as a text command, then we never need
+        // to turn off the options since they command text is executed in the scope of sp_executesql.
+        // For a stored proc command, however, we must send over batch sql and then turn off
+        // the set options after we read the data.  See the code in Command.Execute()
+        private string GetSetOptionsString(CommandBehavior behavior)
+        {
+            string s = null;
+
+            if ((System.Data.CommandBehavior.SchemaOnly == (behavior & CommandBehavior.SchemaOnly)) ||
+               (System.Data.CommandBehavior.KeyInfo == (behavior & CommandBehavior.KeyInfo)))
+            {
+                // SET FMTONLY ON will cause the server to ignore other SET OPTIONS, so turn
+                // it off before we ask for browse mode metadata
+                s = TdsEnums.FMTONLY_OFF;
+
+                if (System.Data.CommandBehavior.KeyInfo == (behavior & CommandBehavior.KeyInfo))
+                {
+                    s = s + TdsEnums.BROWSE_ON;
+                }
+
+                if (System.Data.CommandBehavior.SchemaOnly == (behavior & CommandBehavior.SchemaOnly))
+                {
+                    s = s + TdsEnums.FMTONLY_ON;
+                }
+            }
+
+            return s;
+        }
+
+        private string GetResetOptionsString(CommandBehavior behavior)
+        {
+            string s = null;
+
+            // SET FMTONLY ON OFF
+            if (System.Data.CommandBehavior.SchemaOnly == (behavior & CommandBehavior.SchemaOnly))
+            {
+                s = s + TdsEnums.FMTONLY_OFF;
+            }
+
+            // SET NO_BROWSETABLE OFF
+            if (System.Data.CommandBehavior.KeyInfo == (behavior & CommandBehavior.KeyInfo))
+            {
+                s = s + TdsEnums.BROWSE_OFF;
+            }
+
+            return s;
+        }
+
+        private String GetCommandText(CommandBehavior behavior)
+        {
+            // build the batch string we send over, since we execute within a stored proc (sp_executesql), the SET options never need to be
+            // turned off since they are scoped to the sproc
+            Debug.Assert(System.Data.CommandType.Text == this.CommandType, "invalid call to GetCommandText for stored proc!");
+            return GetSetOptionsString(behavior) + this.CommandText;
+        }
+
+        internal void CheckThrowSNIException()
+        {
+            var stateObj = _stateObj;
+            if (stateObj != null)
+            {
+                stateObj.CheckThrowSNIException();
+            }
+        }
+
+        // We're being notified that the underlying connection has closed
+        internal void OnConnectionClosed()
+        {
+            var stateObj = _stateObj;
+            if (stateObj != null)
+            {
+                stateObj.OnConnectionClosed();
+            }
+        }
+
+        internal TdsParserStateObject StateObject
+        {
+            get
+            {
+                return _stateObj;
+            }
+        }
+
+        private bool IsPrepared
+        {
+            get { return (_execType != EXECTYPE.UNPREPARED); }
+        }
+
+        private bool IsUserPrepared
+        {
+            get { return IsPrepared && !_hiddenPrepare && !IsDirty; }
+        }
+
+        internal bool IsDirty
+        {
+            get
+            {
+                // only dirty if prepared
+                var activeConnection = _activeConnection;
+                return (IsPrepared &&
+                    (_dirty ||
+                    ((_parameters != null) && (_parameters.IsDirty)) ||
+                    ((activeConnection != null) && ((activeConnection.CloseCount != _preparedConnectionCloseCount) || (activeConnection.ReconnectCount != _preparedConnectionReconnectCount)))));
+            }
+            set
+            {
+                // only mark the command as dirty if it is already prepared
+                // but always clear the value if it we are clearing the dirty flag
+                _dirty = value ? IsPrepared : false;
+                if (null != _parameters)
+                {
+                    _parameters.IsDirty = _dirty;
+                }
+                _cachedMetaData = null;
+            }
+        }
+
+        internal int InternalRecordsAffected
+        {
+            get
+            {
+                return _rowsAffected;
+            }
+            set
+            {
+                if (-1 == _rowsAffected)
+                {
+                    _rowsAffected = value;
+                }
+                else if (0 < value)
+                {
+                    _rowsAffected += value;
+                }
+            }
+        }
+
+        internal void ClearBatchCommand()
+        {
+            List<_SqlRPC> rpcList = _RPCList;
+            if (null != rpcList)
+            {
+                rpcList.Clear();
+            }
+            if (null != _parameterCollectionList)
+            {
+                _parameterCollectionList.Clear();
+            }
+
+            _SqlRPCBatchArray = null;
+            _currentlyExecutingBatch = 0;
+        }
+
+        internal bool BatchRPCMode
+        {
+            get
+            {
+                return _batchRPCMode;
+            }
+            set
+            {
+                _batchRPCMode = value;
+
+                if (_batchRPCMode == false)
+                {
+                    ClearBatchCommand();
+                }
+                else
+                {
+                    if (_RPCList == null)
+                    {
+                        _RPCList = new List<_SqlRPC>();
+                    }
+                    if (_parameterCollectionList == null)
+                    {
+                        _parameterCollectionList = new List<SqlParameterCollection>();
+                    }
+                }
+            }
+        }
+
+        internal void AddBatchCommand(string commandText, SqlParameterCollection parameters, CommandType cmdType)
+        {
+            Debug.Assert(BatchRPCMode, "Command is not in batch RPC Mode");
+            Debug.Assert(_RPCList != null);
+            Debug.Assert(_parameterCollectionList != null);
+
+            _SqlRPC rpc = new _SqlRPC();
+
+            CommandText = commandText;
+            CommandType = cmdType;
+
+            GetStateObject();
+            if (cmdType == CommandType.StoredProcedure)
+            {
+                BuildRPC(false, parameters, ref rpc);
+            }
+            else
+            {
+                // All batch sql statements must be executed inside sp_executesql, including those without parameters
+                BuildExecuteSql(CommandBehavior.Default, commandText, parameters, ref rpc);
+            }
+
+            _RPCList.Add(rpc);
+            // Always add a parameters collection per RPC, even if there are no parameters.
+            _parameterCollectionList.Add(parameters);
+
+            ReliablePutStateObject();
+        }
+
+        internal int ExecuteBatchRPCCommand()
+        {
+
+            Debug.Assert(BatchRPCMode, "Command is not in batch RPC Mode");
+            Debug.Assert(_RPCList != null, "No batch commands specified");
+
+            _SqlRPCBatchArray = _RPCList.ToArray();
+            _currentlyExecutingBatch = 0;
+            return ExecuteNonQuery();       // Check permissions, execute, return output params
+        }
+
+        internal int? GetRecordsAffected(int commandIndex)
+        {
+            Debug.Assert(BatchRPCMode, "Command is not in batch RPC Mode");
+            Debug.Assert(_SqlRPCBatchArray != null, "batch command have been cleared");
+            return _SqlRPCBatchArray[commandIndex].recordsAffected;
+        }
+
+        internal SqlException GetErrors(int commandIndex)
+        {
+            SqlException result = null;
+            int length = (_SqlRPCBatchArray[commandIndex].errorsIndexEnd - _SqlRPCBatchArray[commandIndex].errorsIndexStart);
+            if (0 < length)
+            {
+                SqlErrorCollection errors = new SqlErrorCollection();
+                for (int i = _SqlRPCBatchArray[commandIndex].errorsIndexStart; i < _SqlRPCBatchArray[commandIndex].errorsIndexEnd; ++i)
+                {
+                    errors.Add(_SqlRPCBatchArray[commandIndex].errors[i]);
+                }
+                for (int i = _SqlRPCBatchArray[commandIndex].warningsIndexStart; i < _SqlRPCBatchArray[commandIndex].warningsIndexEnd; ++i)
+                {
+                    errors.Add(_SqlRPCBatchArray[commandIndex].warnings[i]);
+                }
+                result = SqlException.CreateException(errors, Connection.ServerVersion, Connection.ClientConnectionId);
+            }
+            return result;
+        }
 
 
 #if DEBUG
-		internal void CompletePendingReadWithSuccess(bool resetForcePendingReadsToWait)
-		{
-			var stateObj = _stateObj;
-			if (stateObj != null)
-			{
-				stateObj.CompletePendingReadWithSuccess(resetForcePendingReadsToWait);
-			}
-			else
-			{
-				var tempCachedAsyncState = cachedAsyncState;
-				if (tempCachedAsyncState != null)
-				{
-					var reader = tempCachedAsyncState.CachedAsyncReader;
-					if (reader != null)
-					{
-						reader.CompletePendingReadWithSuccess(resetForcePendingReadsToWait);
-					}
-				}
-			}
-		}
+        internal void CompletePendingReadWithSuccess(bool resetForcePendingReadsToWait)
+        {
+            var stateObj = _stateObj;
+            if (stateObj != null)
+            {
+                stateObj.CompletePendingReadWithSuccess(resetForcePendingReadsToWait);
+            }
+            else
+            {
+                var tempCachedAsyncState = cachedAsyncState;
+                if (tempCachedAsyncState != null)
+                {
+                    var reader = tempCachedAsyncState.CachedAsyncReader;
+                    if (reader != null)
+                    {
+                        reader.CompletePendingReadWithSuccess(resetForcePendingReadsToWait);
+                    }
+                }
+            }
+        }
 
-		internal void CompletePendingReadWithFailure(int errorCode, bool resetForcePendingReadsToWait)
-		{
-			var stateObj = _stateObj;
-			if (stateObj != null)
-			{
-				stateObj.CompletePendingReadWithFailure(errorCode, resetForcePendingReadsToWait);
-			}
-			else
-			{
-				var tempCachedAsyncState = _cachedAsyncState;
-				if (tempCachedAsyncState != null)
-				{
-					var reader = tempCachedAsyncState.CachedAsyncReader;
-					if (reader != null)
-					{
-						reader.CompletePendingReadWithFailure(errorCode, resetForcePendingReadsToWait);
-					}
-				}
-			}
-		}
+        internal void CompletePendingReadWithFailure(int errorCode, bool resetForcePendingReadsToWait)
+        {
+            var stateObj = _stateObj;
+            if (stateObj != null)
+            {
+                stateObj.CompletePendingReadWithFailure(errorCode, resetForcePendingReadsToWait);
+            }
+            else
+            {
+                var tempCachedAsyncState = _cachedAsyncState;
+                if (tempCachedAsyncState != null)
+                {
+                    var reader = tempCachedAsyncState.CachedAsyncReader;
+                    if (reader != null)
+                    {
+                        reader.CompletePendingReadWithFailure(errorCode, resetForcePendingReadsToWait);
+                    }
+                }
+            }
+        }
 #endif
 
-		internal void CancelIgnoreFailure()
-		{
-			// This method is used to route CancellationTokens to the Cancel method.
-			// Cancellation is a suggestion, and exceptions should be ignored
-			// rather than allowed to be unhandled, as there is no way to route
-			// them to the caller.  It would be expected that the error will be
-			// observed anyway from the regular method.  An example is canceling
-			// an operation on a closed connection.
-			try
-			{
-				Cancel();
-			}
-			catch (Exception)
-			{
-			}
-		}
+        internal void CancelIgnoreFailure()
+        {
+            // This method is used to route CancellationTokens to the Cancel method.
+            // Cancellation is a suggestion, and exceptions should be ignored
+            // rather than allowed to be unhandled, as there is no way to route
+            // them to the caller.  It would be expected that the error will be
+            // observed anyway from the regular method.  An example is canceling
+            // an operation on a closed connection.
+            try
+            {
+                Cancel();
+            }
+            catch (Exception)
+            {
+            }
+        }
 
-		private void NotifyDependency()
-		{
-			if (_sqlDep != null)
-			{
-				_sqlDep.StartTimer(Notification);
-			}
-		}
+        private void NotifyDependency()
+        {
+            if (_sqlDep != null)
+            {
+                _sqlDep.StartTimer(Notification);
+            }
+        }
 
-		object ICloneable.Clone() => Clone();
+        object ICloneable.Clone() => Clone();
 
-		public SqlCommand Clone() => new SqlCommand(this);
-	}
+        public SqlCommand Clone() => new SqlCommand(this);
+    }
 }
 
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
@@ -17,3861 +17,3858 @@ using Microsoft.SqlServer.Server;
 
 namespace System.Data.SqlClient
 {
-    public sealed class SqlCommand : DbCommand, ICloneable
-    {
-        private string _commandText;
-        private CommandType _commandType;
-        private int _commandTimeout = ADP.DefaultCommandTimeout;
-        private UpdateRowSource _updatedRowSource = UpdateRowSource.Both;
-        private bool _designTimeInvisible;
+	public sealed class SqlCommand : DbCommand, ICloneable
+	{
+		private string _commandText;
+		private CommandType _commandType;
+		private int _commandTimeout = ADP.DefaultCommandTimeout;
+		private UpdateRowSource _updatedRowSource = UpdateRowSource.Both;
+		private bool _designTimeInvisible;
 
-        internal SqlDependency _sqlDep;
+		internal SqlDependency _sqlDep;
 
-        private static readonly DiagnosticListener _diagnosticListener = new DiagnosticListener(SqlClientDiagnosticListenerExtensions.DiagnosticListenerName);
-        private bool _parentOperationStarted = false;
+		private static readonly DiagnosticListener _diagnosticListener = new DiagnosticListener(SqlClientDiagnosticListenerExtensions.DiagnosticListenerName);
+		private bool _parentOperationStarted = false;
 
-        // Prepare
-        // Against 7.0 Serve a prepare/unprepare requires an extra roundtrip to the server.
-        //
-        // From 8.0 and above  the preparation can be done as part of the command execution.
+		// Prepare
+		// Against 7.0 Serve a prepare/unprepare requires an extra roundtrip to the server.
+		//
+		// From 8.0 and above  the preparation can be done as part of the command execution.
 
-        private enum EXECTYPE
-        {
-            UNPREPARED,         // execute unprepared commands, all server versions (results in sp_execsql call)
-            PREPAREPENDING,     // prepare and execute command, 8.0 and above only  (results in sp_prepexec call)
-            PREPARED,           // execute prepared commands, all server versions   (results in sp_exec call)
-        }
+		private enum EXECTYPE
+		{
+			UNPREPARED,         // execute unprepared commands, all server versions (results in sp_execsql call)
+			PREPAREPENDING,     // prepare and execute command, 8.0 and above only  (results in sp_prepexec call)
+			PREPARED,           // execute prepared commands, all server versions   (results in sp_exec call)
+		}
 
-        // _hiddenPrepare
-        // On 8.0 and above the Prepared state cannot be left. Once a command is prepared it will always be prepared.
-        // A change in parameters, commandtext etc (IsDirty) automatically causes a hidden prepare
-        //
-        // _inPrepare will be set immediately before the actual prepare is done.
-        // The OnReturnValue function will test this flag to determine whether the returned value is a _prepareHandle or something else.
-        //
-        // _prepareHandle - the handle of a prepared command. Apparently there can be multiple prepared commands at a time - a feature that we do not support yet.
+		// _hiddenPrepare
+		// On 8.0 and above the Prepared state cannot be left. Once a command is prepared it will always be prepared.
+		// A change in parameters, commandtext etc (IsDirty) automatically causes a hidden prepare
+		//
+		// _inPrepare will be set immediately before the actual prepare is done.
+		// The OnReturnValue function will test this flag to determine whether the returned value is a _prepareHandle or something else.
+		//
+		// _prepareHandle - the handle of a prepared command. Apparently there can be multiple prepared commands at a time - a feature that we do not support yet.
 
-        private bool _inPrepare = false;
-        private int _prepareHandle = -1;
-        private bool _hiddenPrepare = false;
-        private int _preparedConnectionCloseCount = -1;
-        private int _preparedConnectionReconnectCount = -1;
+		private bool _inPrepare = false;
+		private int _prepareHandle = -1;
+		private bool _hiddenPrepare = false;
+		private int _preparedConnectionCloseCount = -1;
+		private int _preparedConnectionReconnectCount = -1;
 
-        private SqlParameterCollection _parameters;
-        private SqlConnection _activeConnection;
-        private bool _dirty = false;               // true if the user changes the commandtext or number of parameters after the command is already prepared
-        private EXECTYPE _execType = EXECTYPE.UNPREPARED; // by default, assume the user is not sharing a connection so the command has not been prepared
-        private _SqlRPC[] _rpcArrayOf1 = null;                // Used for RPC executes
+		private SqlParameterCollection _parameters;
+		private SqlConnection _activeConnection;
+		private bool _dirty = false;               // true if the user changes the commandtext or number of parameters after the command is already prepared
+		private EXECTYPE _execType = EXECTYPE.UNPREPARED; // by default, assume the user is not sharing a connection so the command has not been prepared
+		private _SqlRPC[] _rpcArrayOf1 = null;                // Used for RPC executes
 
-        // cut down on object creation and cache all these
-        // cached metadata
-        private _SqlMetaDataSet _cachedMetaData;
+		// cut down on object creation and cache all these
+		// cached metadata
+		private _SqlMetaDataSet _cachedMetaData;
 
-        // Last TaskCompletionSource for reconnect task - use for cancellation only
-        private TaskCompletionSource<object> _reconnectionCompletionSource = null;
+		// Last TaskCompletionSource for reconnect task - use for cancellation only
+		private TaskCompletionSource<object> _reconnectionCompletionSource = null;
 
 #if DEBUG
-        internal static int DebugForceAsyncWriteDelay { get; set; }
+		internal static int DebugForceAsyncWriteDelay { get; set; }
 #endif
-        internal bool InPrepare
-        {
-            get
-            {
-                return _inPrepare;
-            }
-        }
+		internal bool InPrepare
+		{
+			get
+			{
+				return _inPrepare;
+			}
+		}
 
-        // Cached info for async executions
-        private class CachedAsyncState
-        {
-            private int _cachedAsyncCloseCount = -1;    // value of the connection's CloseCount property when the asyncResult was set; tracks when connections are closed after an async operation
-            private TaskCompletionSource<object> _cachedAsyncResult = null;
-            private SqlConnection _cachedAsyncConnection = null;  // Used to validate that the connection hasn't changed when end the connection;
-            private SqlDataReader _cachedAsyncReader = null;
-            private RunBehavior _cachedRunBehavior = RunBehavior.ReturnImmediately;
-            private string _cachedSetOptions = null;
-            private string _cachedEndMethod = null;
+		// Cached info for async executions
+		private class CachedAsyncState
+		{
+			private int _cachedAsyncCloseCount = -1;    // value of the connection's CloseCount property when the asyncResult was set; tracks when connections are closed after an async operation
+			private TaskCompletionSource<object> _cachedAsyncResult = null;
+			private SqlConnection _cachedAsyncConnection = null;  // Used to validate that the connection hasn't changed when end the connection;
+			private SqlDataReader _cachedAsyncReader = null;
+			private RunBehavior _cachedRunBehavior = RunBehavior.ReturnImmediately;
+			private string _cachedSetOptions = null;
+			private string _cachedEndMethod = null;
 
-            internal CachedAsyncState()
-            {
-            }
+			internal CachedAsyncState()
+			{
+			}
 
-            internal SqlDataReader CachedAsyncReader
-            {
-                get { return _cachedAsyncReader; }
-            }
-            internal RunBehavior CachedRunBehavior
-            {
-                get { return _cachedRunBehavior; }
-            }
-            internal string CachedSetOptions
-            {
-                get { return _cachedSetOptions; }
-            }
-            internal bool PendingAsyncOperation
-            {
-                get { return (null != _cachedAsyncResult); }
-            }
-            internal string EndMethodName
-            {
-                get { return _cachedEndMethod; }
-            }
+			internal SqlDataReader CachedAsyncReader
+			{
+				get { return _cachedAsyncReader; }
+			}
+			internal RunBehavior CachedRunBehavior
+			{
+				get { return _cachedRunBehavior; }
+			}
+			internal string CachedSetOptions
+			{
+				get { return _cachedSetOptions; }
+			}
+			internal bool PendingAsyncOperation
+			{
+				get { return (null != _cachedAsyncResult); }
+			}
+			internal string EndMethodName
+			{
+				get { return _cachedEndMethod; }
+			}
 
-            internal bool IsActiveConnectionValid(SqlConnection activeConnection)
-            {
-                return (_cachedAsyncConnection == activeConnection && _cachedAsyncCloseCount == activeConnection.CloseCount);
-            }
+			internal bool IsActiveConnectionValid(SqlConnection activeConnection)
+			{
+				return (_cachedAsyncConnection == activeConnection && _cachedAsyncCloseCount == activeConnection.CloseCount);
+			}
 
-            internal void ResetAsyncState()
-            {
-                _cachedAsyncCloseCount = -1;
-                _cachedAsyncResult = null;
-                if (_cachedAsyncConnection != null)
-                {
-                    _cachedAsyncConnection.AsyncCommandInProgress = false;
-                    _cachedAsyncConnection = null;
-                }
-                _cachedAsyncReader = null;
-                _cachedRunBehavior = RunBehavior.ReturnImmediately;
-                _cachedSetOptions = null;
-                _cachedEndMethod = null;
-            }
+			internal void ResetAsyncState()
+			{
+				_cachedAsyncCloseCount = -1;
+				_cachedAsyncResult = null;
+				if (_cachedAsyncConnection != null)
+				{
+					_cachedAsyncConnection.AsyncCommandInProgress = false;
+					_cachedAsyncConnection = null;
+				}
+				_cachedAsyncReader = null;
+				_cachedRunBehavior = RunBehavior.ReturnImmediately;
+				_cachedSetOptions = null;
+				_cachedEndMethod = null;
+			}
 
-            internal void SetActiveConnectionAndResult(TaskCompletionSource<object> completion, string endMethod, SqlConnection activeConnection)
-            {
-                Debug.Assert(activeConnection != null, "Unexpected null connection argument on SetActiveConnectionAndResult!");
-                TdsParser parser = activeConnection?.Parser;
-                if ((parser == null) || (parser.State == TdsParserState.Closed) || (parser.State == TdsParserState.Broken))
-                {
-                    throw ADP.ClosedConnectionError();
-                }
+			internal void SetActiveConnectionAndResult(TaskCompletionSource<object> completion, string endMethod, SqlConnection activeConnection)
+			{
+				Debug.Assert(activeConnection != null, "Unexpected null connection argument on SetActiveConnectionAndResult!");
+				TdsParser parser = activeConnection?.Parser;
+				if ((parser == null) || (parser.State == TdsParserState.Closed) || (parser.State == TdsParserState.Broken))
+				{
+					throw ADP.ClosedConnectionError();
+				}
 
-                _cachedAsyncCloseCount = activeConnection.CloseCount;
-                _cachedAsyncResult = completion;
-                if (!parser.MARSOn)
-                {
-                    if (activeConnection.AsyncCommandInProgress)
-                        throw SQL.MARSUnspportedOnConnection();
-                }
-                _cachedAsyncConnection = activeConnection;
+				_cachedAsyncCloseCount = activeConnection.CloseCount;
+				_cachedAsyncResult = completion;
+				if (!parser.MARSOn)
+				{
+					if (activeConnection.AsyncCommandInProgress)
+						throw SQL.MARSUnspportedOnConnection();
+				}
+				_cachedAsyncConnection = activeConnection;
 
-                // Should only be needed for non-MARS, but set anyways.
-                _cachedAsyncConnection.AsyncCommandInProgress = true;
-                _cachedEndMethod = endMethod;
-            }
+				// Should only be needed for non-MARS, but set anyways.
+				_cachedAsyncConnection.AsyncCommandInProgress = true;
+				_cachedEndMethod = endMethod;
+			}
 
-            internal void SetAsyncReaderState(SqlDataReader ds, RunBehavior runBehavior, string optionSettings)
-            {
-                _cachedAsyncReader = ds;
-                _cachedRunBehavior = runBehavior;
-                _cachedSetOptions = optionSettings;
-            }
-        }
+			internal void SetAsyncReaderState(SqlDataReader ds, RunBehavior runBehavior, string optionSettings)
+			{
+				_cachedAsyncReader = ds;
+				_cachedRunBehavior = runBehavior;
+				_cachedSetOptions = optionSettings;
+			}
+		}
 
-        private CachedAsyncState _cachedAsyncState = null;
+		private CachedAsyncState _cachedAsyncState = null;
 
-        private CachedAsyncState cachedAsyncState
-        {
-            get
-            {
-                if (_cachedAsyncState == null)
-                {
-                    _cachedAsyncState = new CachedAsyncState();
-                }
-                return _cachedAsyncState;
-            }
-        }
+		private CachedAsyncState cachedAsyncState
+		{
+			get
+			{
+				if (_cachedAsyncState == null)
+				{
+					_cachedAsyncState = new CachedAsyncState();
+				}
+				return _cachedAsyncState;
+			}
+		}
 
-        // sql reader will pull this value out for each NextResult call.  It is not cumulative
-        // _rowsAffected is cumulative for ExecuteNonQuery across all rpc batches
-        internal int _rowsAffected = -1; // rows affected by the command
+		// sql reader will pull this value out for each NextResult call.  It is not cumulative
+		// _rowsAffected is cumulative for ExecuteNonQuery across all rpc batches
+		internal int _rowsAffected = -1; // rows affected by the command
 
-        private SqlNotificationRequest _notification;
+		private SqlNotificationRequest _notification;
 		
 		private bool _notificationAutoEnlist = true;            // Notifications auto enlistment is turned on by default
 
-        // transaction support
-        private SqlTransaction _transaction;
-
-        private StatementCompletedEventHandler _statementCompletedEventHandler;
-
-        private TdsParserStateObject _stateObj; // this is the TDS session we're using.
-
-        // Volatile bool used to synchronize with cancel thread the state change of an executing
-        // command going from pre-processing to obtaining a stateObject.  The cancel synchronization
-        // we require in the command is only from entering an Execute* API to obtaining a 
-        // stateObj.  Once a stateObj is successfully obtained, cancel synchronization is handled
-        // by the stateObject.
-        private volatile bool _pendingCancel;
-
-        private bool _batchRPCMode;
-        private List<_SqlRPC> _RPCList;
-        private _SqlRPC[] _SqlRPCBatchArray;
-        private List<SqlParameterCollection> _parameterCollectionList;
-        private int _currentlyExecutingBatch;
-
-
-        public SqlCommand() : base()
-        {
-            GC.SuppressFinalize(this);
-        }
-
-        public SqlCommand(string cmdText) : this()
-        {
-            CommandText = cmdText;
-        }
-
-        public SqlCommand(string cmdText, SqlConnection connection) : this()
-        {
-            CommandText = cmdText;
-            Connection = connection;
-        }
-
-        public SqlCommand(string cmdText, SqlConnection connection, SqlTransaction transaction) : this()
-        {
-            CommandText = cmdText;
-            Connection = connection;
-            Transaction = transaction;
-        }
-
-        private SqlCommand(SqlCommand from) : this()
-        {
-            CommandText = from.CommandText;
-            CommandTimeout = from.CommandTimeout;
-            CommandType = from.CommandType;
-            Connection = from.Connection;
-            DesignTimeVisible = from.DesignTimeVisible;
-            Transaction = from.Transaction;
-            UpdatedRowSource = from.UpdatedRowSource;
-
-            SqlParameterCollection parameters = Parameters;
-            foreach (object parameter in from.Parameters)
-            {
-                parameters.Add((parameter is ICloneable) ? (parameter as ICloneable).Clone() : parameter);
-            }
-        }
-
-        new public SqlConnection Connection
-        {
-            get
-            {
-                return _activeConnection;
-            }
-            set
-            {
-                // Don't allow the connection to be changed while in a async operation.
-                if (_activeConnection != value && _activeConnection != null)
-                { // If new value...
-                    if (cachedAsyncState.PendingAsyncOperation)
-                    { // If in pending async state, throw.
-                        throw SQL.CannotModifyPropertyAsyncOperationInProgress();
-                    }
-                }
-
-                // Check to see if the currently set transaction has completed.  If so,
-                // null out our local reference.
-                if (null != _transaction && _transaction.Connection == null)
-                {
-                    _transaction = null;
-                }
-
-
-                // Command is no longer prepared on new connection, cleanup prepare status
-                if (IsPrepared)
-                {
-                    if (_activeConnection != value && _activeConnection != null)
-                    {
-                        try
-                        {
-                            // cleanup
-                            Unprepare();
-                        }
-                        catch (Exception)
-                        {
-                            // we do not really care about errors in unprepare (may be the old connection went bad)                                        
-                        }
-                        finally
-                        {
-                            // clean prepare status (even successful Unprepare does not do that)
-                            _prepareHandle = -1;
-                            _execType = EXECTYPE.UNPREPARED;
-                        }
-                    }
-                }
-
-                _activeConnection = value;
-            }
-        }
-
-        override protected DbConnection DbConnection
-        {
-            get
-            {
-                return Connection;
-            }
-            set
-            {
-                Connection = (SqlConnection)value;
-            }
-        }
-
-        private SqlInternalConnectionTds InternalTdsConnection
-        {
-            get
-            {
-                return (SqlInternalConnectionTds)_activeConnection.InnerConnection;
-            }
-        }
-
-        public SqlNotificationRequest Notification
-        {
-            get
-            {
-                return _notification;
-            }
-            set
-            {
-                _sqlDep = null;
-                _notification = value;
-            }
-        }
-
-        public bool NotificationAutoEnlist
-        {
-            get
-            {
-                return _notificationAutoEnlist;
-            }
-            set
-            {
-                _notificationAutoEnlist = value;
-            }
-        }
-
-        internal SqlStatistics Statistics
-        {
-            get
-            {
-                if (null != _activeConnection)
-                {
-                    if (_activeConnection.StatisticsEnabled || 
-                        _diagnosticListener.IsEnabled(SqlClientDiagnosticListenerExtensions.SqlAfterExecuteCommand))
-                    {
-                        return _activeConnection.Statistics;
-                    }
-                }
-                return null;
-            }
-        }
-
-        new public SqlTransaction Transaction
-        {
-            get
-            {
-                // if the transaction object has been zombied, just return null
-                if ((null != _transaction) && (null == _transaction.Connection))
-                {
-                    _transaction = null;
-                }
-                return _transaction;
-            }
-            set
-            {
-                // Don't allow the transaction to be changed while in a async operation.
-                if (_transaction != value && _activeConnection != null)
-                { // If new value...
-                    if (cachedAsyncState.PendingAsyncOperation)
-                    { // If in pending async state, throw
-                        throw SQL.CannotModifyPropertyAsyncOperationInProgress();
-                    }
-                }
-
-                _transaction = value;
-            }
-        }
-
-        override protected DbTransaction DbTransaction
-        {
-            get
-            {
-                return Transaction;
-            }
-            set
-            {
-                Transaction = (SqlTransaction)value;
-            }
-        }
-
-        override public string CommandText
-        {
-            get
-            {
-                string value = _commandText;
-                return ((null != value) ? value : ADP.StrEmpty);
-            }
-            set
-            {
-                if (_commandText != value)
-                {
-                    PropertyChanging();
-                    _commandText = value;
-                }
-            }
-        }
-
-        override public int CommandTimeout
-        {
-            get
-            {
-                return _commandTimeout;
-            }
-            set
-            {
-                if (value < 0)
-                {
-                    throw ADP.InvalidCommandTimeout(value);
-                }
-                if (value != _commandTimeout)
-                {
-                    PropertyChanging();
-                    _commandTimeout = value;
-                }
-            }
-        }
-
-        public void ResetCommandTimeout()
-        {
-            if (ADP.DefaultCommandTimeout != _commandTimeout)
-            {
-                PropertyChanging();
-                _commandTimeout = ADP.DefaultCommandTimeout;
-            }
-        }
-
-        override public CommandType CommandType
-        {
-            get
-            {
-                CommandType cmdType = _commandType;
-                return ((0 != cmdType) ? cmdType : CommandType.Text);
-            }
-            set
-            {
-                if (_commandType != value)
-                {
-                    switch (value)
-                    {
-                        case CommandType.Text:
-                        case CommandType.StoredProcedure:
-                            PropertyChanging();
-                            _commandType = value;
-                            break;
-                        case System.Data.CommandType.TableDirect:
-                            throw SQL.NotSupportedCommandType(value);
-                        default:
-                            throw ADP.InvalidCommandType(value);
-                    }
-                }
-            }
-        }
-
-        // @devnote: By default, the cmd object is visible on the design surface (i.e. VS7 Server Tray)
-        // to limit the number of components that clutter the design surface,
-        // when the DataAdapter design wizard generates the insert/update/delete commands it will
-        // set the DesignTimeVisible property to false so that cmds won't appear as individual objects
-        public override bool DesignTimeVisible
-        {
-            get
-            {
-                return !_designTimeInvisible;
-            }
-            set
-            {
-                _designTimeInvisible = !value;
-            }
-        }
-
-        new public SqlParameterCollection Parameters
-        {
-            get
-            {
-                if (null == _parameters)
-                {
-                    // delay the creation of the SqlParameterCollection
-                    // until user actually uses the Parameters property
-                    _parameters = new SqlParameterCollection();
-                }
-                return _parameters;
-            }
-        }
-
-        override protected DbParameterCollection DbParameterCollection
-        {
-            get
-            {
-                return Parameters;
-            }
-        }
-
-        override public UpdateRowSource UpdatedRowSource
-        {
-            get
-            {
-                return _updatedRowSource;
-            }
-            set
-            {
-                switch (value)
-                {
-                    case UpdateRowSource.None:
-                    case UpdateRowSource.OutputParameters:
-                    case UpdateRowSource.FirstReturnedRecord:
-                    case UpdateRowSource.Both:
-                        _updatedRowSource = value;
-                        break;
-                    default:
-                        throw ADP.InvalidUpdateRowSource(value);
-                }
-            }
-        }
-
-        public event StatementCompletedEventHandler StatementCompleted
-        {
-            add
-            {
-                _statementCompletedEventHandler += value;
-            }
-            remove
-            {
-                _statementCompletedEventHandler -= value;
-            }
-        }
-
-        internal void OnStatementCompleted(int recordCount)
-        {
-            if (0 <= recordCount)
-            {
-                StatementCompletedEventHandler handler = _statementCompletedEventHandler;
-                if (null != handler)
-                {
-                    try
-                    {
-                        handler(this, new StatementCompletedEventArgs(recordCount));
-                    }
-                    catch (Exception e)
-                    {
-                        if (!ADP.IsCatchableOrSecurityExceptionType(e))
-                        {
-                            throw;
-                        }
-                    }
-                }
-            }
-        }
-
-        private void PropertyChanging()
-        { // also called from SqlParameterCollection
-            this.IsDirty = true;
-        }
-
-        override public void Prepare()
-        {
-            // Reset _pendingCancel upon entry into any Execute - used to synchronize state
-            // between entry into Execute* API and the thread obtaining the stateObject.
-            _pendingCancel = false;
-
-
-            SqlStatistics statistics = null;
-            statistics = SqlStatistics.StartTimer(Statistics);
-
-            // only prepare if batch with parameters
-            if (
-                this.IsPrepared && !this.IsDirty
-                || (this.CommandType == CommandType.StoredProcedure)
-                || (
-                        (System.Data.CommandType.Text == this.CommandType)
-                        && (0 == GetParameterCount(_parameters))
-                    )
-
-            )
-            {
-                if (null != Statistics)
-                {
-                    Statistics.SafeIncrement(ref Statistics._prepares);
-                }
-                _hiddenPrepare = false;
-            }
-            else
-            {
-                // Validate the command outside of the try\catch to avoid putting the _stateObj on error
-                ValidateCommand(async: false);
-
-                bool processFinallyBlock = true;
-                try
-                {
-                    // NOTE: The state object isn't actually needed for this, but it is still here for back-compat (since it does a bunch of checks)
-                    GetStateObject();
-
-                    // Loop through parameters ensuring that we do not have unspecified types, sizes, scales, or precisions
-                    if (null != _parameters)
-                    {
-                        int count = _parameters.Count;
-                        for (int i = 0; i < count; ++i)
-                        {
-                            _parameters[i].Prepare(this);
-                        }
-                    }
-
-                    InternalPrepare();
-                }
-                catch (Exception e)
-                {
-                    processFinallyBlock = ADP.IsCatchableExceptionType(e);
-                    throw;
-                }
-                finally
-                {
-                    if (processFinallyBlock)
-                    {
-                        _hiddenPrepare = false; // The command is now officially prepared
-
-                        ReliablePutStateObject();
-                    }
-                }
-            }
-
-            SqlStatistics.StopTimer(statistics);
-        }
-
-        private void InternalPrepare()
-        {
-            if (this.IsDirty)
-            {
-                Debug.Assert(_cachedMetaData == null || !_dirty, "dirty query should not have cached metadata!"); // can have cached metadata if dirty because of parameters
-                //
-                // someone changed the command text or the parameter schema so we must unprepare the command
-                //
-                this.Unprepare();
-                this.IsDirty = false;
-            }
-            Debug.Assert(_execType != EXECTYPE.PREPARED, "Invalid attempt to Prepare already Prepared command!");
-            Debug.Assert(_activeConnection != null, "must have an open connection to Prepare");
-            Debug.Assert(null != _stateObj, "TdsParserStateObject should not be null");
-            Debug.Assert(null != _stateObj.Parser, "TdsParser class should not be null in Command.Execute!");
-            Debug.Assert(_stateObj.Parser == _activeConnection.Parser, "stateobject parser not same as connection parser");
-            Debug.Assert(false == _inPrepare, "Already in Prepare cycle, this.inPrepare should be false!");
-
-            // remember that the user wants to do a prepare but don't actually do an rpc
-            _execType = EXECTYPE.PREPAREPENDING;
-            // Note the current close count of the connection - this will tell us if the connection has been closed between calls to Prepare() and Execute
-            _preparedConnectionCloseCount = _activeConnection.CloseCount;
-            _preparedConnectionReconnectCount = _activeConnection.ReconnectCount;
-
-            if (null != Statistics)
-            {
-                Statistics.SafeIncrement(ref Statistics._prepares);
-            }
-        }
-
-        // SqlInternalConnectionTds needs to be able to unprepare a statement
-        internal void Unprepare()
-        {
-            Debug.Assert(true == IsPrepared, "Invalid attempt to Unprepare a non-prepared command!");
-            Debug.Assert(_activeConnection != null, "must have an open connection to UnPrepare");
-            Debug.Assert(false == _inPrepare, "_inPrepare should be false!");
-            _execType = EXECTYPE.PREPAREPENDING;
-            // Don't zero out the handle because we'll pass it in to sp_prepexec on the next prepare
-            // Unless the close count isn't the same as when we last prepared
-            if ((_activeConnection.CloseCount != _preparedConnectionCloseCount) || (_activeConnection.ReconnectCount != _preparedConnectionReconnectCount))
-            {
-                // reset our handle
-                _prepareHandle = -1;
-            }
-
-            _cachedMetaData = null;
-        }
-
-
-        // Cancel is supposed to be multi-thread safe.
-        // It doesn't make sense to verify the connection exists or that it is open during cancel
-        // because immediately after checkin the connection can be closed or removed via another thread.
-        //
-        override public void Cancel()
-        {
-            SqlStatistics statistics = null;
-            try
-            {
-                statistics = SqlStatistics.StartTimer(Statistics);
-
-                // If we are in reconnect phase simply cancel the waiting task
-                var reconnectCompletionSource = _reconnectionCompletionSource;
-                if (reconnectCompletionSource != null)
-                {
-                    if (reconnectCompletionSource.TrySetCanceled())
-                    {
-                        return;
-                    }
-                }
-
-                // the pending data flag means that we are awaiting a response or are in the middle of processing a response
-                // if we have no pending data, then there is nothing to cancel
-                // if we have pending data, but it is not a result of this command, then we don't cancel either.  Note that
-                // this model is implementable because we only allow one active command at any one time.  This code
-                // will have to change we allow multiple outstanding batches
-                if (null == _activeConnection)
-                {
-                    return;
-                }
-                SqlInternalConnectionTds connection = (_activeConnection.InnerConnection as SqlInternalConnectionTds);
-                if (null == connection)
-                {  // Fail with out locking
-                    return;
-                }
-
-                // The lock here is to protect against the command.cancel / connection.close race condition
-                // The SqlInternalConnectionTds is set to OpenBusy during close, once this happens the cast below will fail and 
-                // the command will no longer be cancelable.  It might be desirable to be able to cancel the close operation, but this is
-                // outside of the scope of Whidbey RTM.  See (SqlConnection::Close) for other lock.
-                lock (connection)
-                {
-                    if (connection != (_activeConnection.InnerConnection as SqlInternalConnectionTds))
-                    { // make sure the connection held on the active connection is what we have stored in our temp connection variable, if not between getting "connection" and taking the lock, the connection has been closed
-                        return;
-                    }
-
-                    TdsParser parser = connection.Parser;
-                    if (null == parser)
-                    {
-                        return;
-                    }
-
-
-                    if (!_pendingCancel)
-                    { // Do nothing if already pending.
-                      // Before attempting actual cancel, set the _pendingCancel flag to false.
-                      // This denotes to other thread before obtaining stateObject from the
-                      // session pool that there is another thread wishing to cancel.
-                      // The period in question is between entering the ExecuteAPI and obtaining 
-                      // a stateObject.
-                        _pendingCancel = true;
-
-                        TdsParserStateObject stateObj = _stateObj;
-                        if (null != stateObj)
-                        {
-                            stateObj.Cancel(this);
-                        }
-                        else
-                        {
-                            SqlDataReader reader = connection.FindLiveReader(this);
-                            if (reader != null)
-                            {
-                                reader.Cancel(this);
-                            }
-                        }
-                    }
-                }
-            }
-            finally
-            {
-                SqlStatistics.StopTimer(statistics);
-            }
-        }
-
-        new public SqlParameter CreateParameter()
-        {
-            return new SqlParameter();
-        }
-
-        override protected DbParameter CreateDbParameter()
-        {
-            return CreateParameter();
-        }
-
-        override protected void Dispose(bool disposing)
-        {
-            if (disposing)
-            { // release managed objects
-                _cachedMetaData = null;
-            }
-            // release unmanaged objects
-            base.Dispose(disposing);
-        }
-
-        override public object ExecuteScalar()
-        {
-            // Reset _pendingCancel upon entry into any Execute - used to synchronize state
-            // between entry into Execute* API and the thread obtaining the stateObject.
-            _pendingCancel = false;
-
-            Guid operationId = _diagnosticListener.WriteCommandBefore(this);
-
-            SqlStatistics statistics = null;
-            
-            Exception e = null;
-            try
-            {
-                statistics = SqlStatistics.StartTimer(Statistics);
-                SqlDataReader ds;
-                ds = RunExecuteReader(0, RunBehavior.ReturnImmediately, returnStream: true);
-                return CompleteExecuteScalar(ds, false);
-            }
-            catch (Exception ex)
-            {
-                e = ex;
-                throw;
-            }
-            finally
-            {
-                SqlStatistics.StopTimer(statistics);
-
-                if (e != null)
-                {
-                    _diagnosticListener.WriteCommandError(operationId, this, e);
-                }
-                else
-                {
-                    _diagnosticListener.WriteCommandAfter(operationId, this);
-                }
-            }
-        }
-
-        private object CompleteExecuteScalar(SqlDataReader ds, bool returnSqlValue)
-        {
-            object retResult = null;
-
-            try
-            {
-                if (ds.Read())
-                {
-                    if (ds.FieldCount > 0)
-                    {
-                        if (returnSqlValue)
-                        {
-                            retResult = ds.GetSqlValue(0);
-                        }
-                        else
-                        {
-                            retResult = ds.GetValue(0);
-                        }
-                    }
-                }
-            }
-            finally
-            {
-                // clean off the wire
-                ds.Close();
-            }
-
-            return retResult;
-        }
-
-        override public int ExecuteNonQuery()
-        {
-            // Reset _pendingCancel upon entry into any Execute - used to synchronize state
-            // between entry into Execute* API and the thread obtaining the stateObject.
-            _pendingCancel = false;
-
-            Guid operationId = _diagnosticListener.WriteCommandBefore(this);
-
-            SqlStatistics statistics = null;
-            
-            Exception e = null;
-            try
-            {
-                statistics = SqlStatistics.StartTimer(Statistics);
-                InternalExecuteNonQuery(completion: null, sendToPipe: false, timeout: CommandTimeout);
-                return _rowsAffected;
-            }
-            catch (Exception ex)
-            {
-                e = ex;
-                throw;
-            }
-            finally
-            {
-                SqlStatistics.StopTimer(statistics);
-                
-                if (e != null)
-                {
-                    _diagnosticListener.WriteCommandError(operationId, this, e);
-                }
-                else
-                {
-                    _diagnosticListener.WriteCommandAfter(operationId, this);
-                }
-            }
-        }
-
-
-        private IAsyncResult BeginExecuteNonQuery(AsyncCallback callback, object stateObject)
-        {
-            // Reset _pendingCancel upon entry into any Execute - used to synchronize state
-            // between entry into Execute* API and the thread obtaining the stateObject.
-            _pendingCancel = false;
-
-            ValidateAsyncCommand(); // Special case - done outside of try/catches to prevent putting a stateObj
-                                    // back into pool when we should not.
-
-            SqlStatistics statistics = null;
-            try
-            {
-                statistics = SqlStatistics.StartTimer(Statistics);
-                TaskCompletionSource<object> completion = new TaskCompletionSource<object>(stateObject);
-
-                try
-                { // InternalExecuteNonQuery already has reliability block, but if failure will not put stateObj back into pool.
-                    Task execNQ = InternalExecuteNonQuery(completion, false, CommandTimeout, asyncWrite: true);
-
-                    // must finish caching information before ReadSni which can activate the callback before returning
-                    cachedAsyncState.SetActiveConnectionAndResult(completion, nameof(EndExecuteNonQuery), _activeConnection);
-                    if (execNQ != null)
-                    {
-                        AsyncHelper.ContinueTask(execNQ, completion, () => BeginExecuteNonQueryInternalReadStage(completion));
-                    }
-                    else
-                    {
-                        BeginExecuteNonQueryInternalReadStage(completion);
-                    }
-                }
-                catch (Exception e)
-                {
-                    if (!ADP.IsCatchableOrSecurityExceptionType(e))
-                    {
-                        // If not catchable - the connection has already been caught and doomed in RunExecuteReader.
-                        throw;
-                    }
-
-                    // For async, RunExecuteReader will never put the stateObj back into the pool, so do so now.
-                    ReliablePutStateObject();
-                    throw;
-                }
-
-                // Add callback after work is done to avoid overlapping Begin\End methods
-                if (callback != null)
-                {
-                    completion.Task.ContinueWith((t) => callback(t), TaskScheduler.Default);
-                }
-
-                return completion.Task;
-            }
-            finally
-            {
-                SqlStatistics.StopTimer(statistics);
-            }
-        }
-
-        private void BeginExecuteNonQueryInternalReadStage(TaskCompletionSource<object> completion)
-        {
-            // Read SNI does not have catches for async exceptions, handle here.
-            try
-            {
-                _stateObj.ReadSni(completion);
-            }
-            catch (Exception)
-            {
-                // Similarly, if an exception occurs put the stateObj back into the pool.
-                // and reset async cache information to allow a second async execute
-                if (null != _cachedAsyncState)
-                {
-                    _cachedAsyncState.ResetAsyncState();
-                }
-                ReliablePutStateObject();
-                throw;
-            }
-        }
-
-        private void VerifyEndExecuteState(Task completionTask, String endMethod)
-        {
-            Debug.Assert(completionTask != null);
-
-            if (completionTask.IsCanceled)
-            {
-                if (_stateObj != null)
-                {
-                    _stateObj.Parser.State = TdsParserState.Broken; // We failed to respond to attention, we have to quit!
-                    _stateObj.Parser.Connection.BreakConnection();
-                    _stateObj.Parser.ThrowExceptionAndWarning(_stateObj);
-                }
-                else
-                {
-                    Debug.Assert(_reconnectionCompletionSource == null || _reconnectionCompletionSource.Task.IsCanceled, "ReconnectCompletionSource should be null or cancelled");
-                    throw SQL.CR_ReconnectionCancelled();
-                }
-            }
-            else if (completionTask.IsFaulted)
-            {
-                throw completionTask.Exception.InnerException;
-            }
-            if (cachedAsyncState.EndMethodName == null)
-            {
-                throw ADP.MethodCalledTwice(endMethod);
-            }
-            if (endMethod != cachedAsyncState.EndMethodName)
-            {
-                throw ADP.MismatchedAsyncResult(cachedAsyncState.EndMethodName, endMethod);
-            }
-            if ((_activeConnection.State != ConnectionState.Open) || (!cachedAsyncState.IsActiveConnectionValid(_activeConnection)))
-            {
-                // If the connection is not 'valid' then it was closed while we were executing
-                throw ADP.ClosedConnectionError();
-            }
-        }
-
-        private void WaitForAsyncResults(IAsyncResult asyncResult)
-        {
-            Task completionTask = (Task)asyncResult;
-            if (!asyncResult.IsCompleted)
-            {
-                asyncResult.AsyncWaitHandle.WaitOne();
-            }
-            _stateObj._networkPacketTaskSource = null;
-            _activeConnection.GetOpenTdsConnection().DecrementAsyncCount();
-        }
-
-        private void ThrowIfReconnectionHasBeenCanceled()
-        {
-            if (_stateObj == null)
-            {
-                var reconnectionCompletionSource = _reconnectionCompletionSource;
-                if (reconnectionCompletionSource != null && reconnectionCompletionSource.Task.IsCanceled)
-                {
-                    throw SQL.CR_ReconnectionCancelled();
-                }
-            }
-        }
-
-        private int EndExecuteNonQuery(IAsyncResult asyncResult)
-        {
-            Exception asyncException = ((Task)asyncResult).Exception;
-            if (asyncException != null)
-            {
-                // Leftover exception from the Begin...InternalReadStage
-                if (cachedAsyncState != null)
-                {
-                    cachedAsyncState.ResetAsyncState();
-                }
-                ReliablePutStateObject();
-                throw asyncException.InnerException;
-            }
-            else
-            {
-                ThrowIfReconnectionHasBeenCanceled();
-                // lock on _stateObj prevents races with close/cancel.
-                lock (_stateObj)
-                {
-                    return EndExecuteNonQueryInternal(asyncResult);
-                }
-            }
-        }
-
-        private int EndExecuteNonQueryInternal(IAsyncResult asyncResult)
-        {
-            SqlStatistics statistics = null;
-
-            try
-            {
-                statistics = SqlStatistics.StartTimer(Statistics);
-                VerifyEndExecuteState((Task)asyncResult, nameof(EndExecuteNonQuery));
-                WaitForAsyncResults(asyncResult);
-
-                bool processFinallyBlock = true;
-                try
-                {
-                    CheckThrowSNIException();
-
-                    // only send over SQL Batch command if we are not a stored proc and have no parameters
-                    if ((System.Data.CommandType.Text == this.CommandType) && (0 == GetParameterCount(_parameters)))
-                    {
-                        try
-                        {
-                            bool dataReady;
-                            Debug.Assert(_stateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
-                            bool result = _stateObj.Parser.TryRun(RunBehavior.UntilDone, this, null, null, _stateObj, out dataReady);
-                            if (!result) { throw SQL.SynchronousCallMayNotPend(); }
-                        }
-                        finally
-                        {
-                            cachedAsyncState.ResetAsyncState();
-                        }
-                    }
-                    else
-                    { // otherwise, use a full-fledged execute that can handle params and stored procs
-                        SqlDataReader reader = CompleteAsyncExecuteReader();
-                        if (null != reader)
-                        {
-                            reader.Close();
-                        }
-                    }
-                }
-                catch (Exception e)
-                {
-                    processFinallyBlock = ADP.IsCatchableExceptionType(e);
-                    throw;
-                }
-                finally
-                {
-                    if (processFinallyBlock)
-                    {
-                        PutStateObject();
-                    }
-                }
-
-                Debug.Assert(null == _stateObj, "non-null state object in EndExecuteNonQuery");
-                return _rowsAffected;
-            }
-            catch (Exception e)
-            {
-                if (cachedAsyncState != null)
-                {
-                    cachedAsyncState.ResetAsyncState();
-                };
-                if (ADP.IsCatchableExceptionType(e))
-                {
-                    ReliablePutStateObject();
-                };
-                throw;
-            }
-            finally
-            {
-                SqlStatistics.StopTimer(statistics);
-            }
-        }
-
-        private Task InternalExecuteNonQuery(TaskCompletionSource<object> completion, bool sendToPipe, int timeout, bool asyncWrite = false, [CallerMemberName] string methodName = "")
-        {
-            bool async = (null != completion);
-
-            SqlStatistics statistics = Statistics;
-            _rowsAffected = -1;
-
-            // this function may throw for an invalid connection
-            // returns false for empty command text
-            ValidateCommand(async, methodName);
-
-            CheckNotificationStateAndAutoEnlist(); // Only call after validate - requires non null connection!
-
-            Task task = null;
-
-            // only send over SQL Batch command if we are not a stored proc and have no parameters and not in batch RPC mode
-            if ((System.Data.CommandType.Text == this.CommandType) && (0 == GetParameterCount(_parameters)))
-            {
-                Debug.Assert(!sendToPipe, "trying to send non-context command to pipe");
-                if (null != statistics)
-                {
-                    if (!this.IsDirty && this.IsPrepared)
-                    {
-                        statistics.SafeIncrement(ref statistics._preparedExecs);
-                    }
-                    else
-                    {
-                        statistics.SafeIncrement(ref statistics._unpreparedExecs);
-                    }
-                }
-
-                task = RunExecuteNonQueryTds(methodName, async, timeout, asyncWrite);
-            }
-            else
-            { // otherwise, use a full-fledged execute that can handle params and stored procs
-                Debug.Assert(!sendToPipe, "trying to send non-context command to pipe");
-                SqlDataReader reader = RunExecuteReader(0, RunBehavior.UntilDone, false, completion, timeout, out task, asyncWrite, methodName);
-                if (null != reader)
-                {
-                    if (task != null)
-                    {
-                        task = AsyncHelper.CreateContinuationTask(task, () => reader.Close());
-                    }
-                    else
-                    {
-                        reader.Close();
-                    }
-                }
-            }
-            Debug.Assert(async || null == _stateObj, "non-null state object in InternalExecuteNonQuery");
-            return task;
-        }
-
-        public XmlReader ExecuteXmlReader()
-        {
-            // Reset _pendingCancel upon entry into any Execute - used to synchronize state
-            // between entry into Execute* API and the thread obtaining the stateObject.
-            _pendingCancel = false;
-
-            Guid operationId = _diagnosticListener.WriteCommandBefore(this);
-
-            SqlStatistics statistics = null;
-            
-            Exception e = null;
-            try
-            {
-                statistics = SqlStatistics.StartTimer(Statistics);
-
-                // use the reader to consume metadata
-                SqlDataReader ds;
-                ds = RunExecuteReader(CommandBehavior.SequentialAccess, RunBehavior.ReturnImmediately, returnStream: true);
-                return CompleteXmlReader(ds);
-            }
-            catch (Exception ex)
-            {
-                e = ex;
-                throw;
-            }
-            finally
-            {
-                SqlStatistics.StopTimer(statistics);
-                
-                if (e != null)
-                {
-                    _diagnosticListener.WriteCommandError(operationId, this, e);
-                }
-                else
-                {
-                    _diagnosticListener.WriteCommandAfter(operationId, this);
-                }
-            }
-        }
-
-
-        private IAsyncResult BeginExecuteXmlReader(AsyncCallback callback, object stateObject)
-        {
-            // Reset _pendingCancel upon entry into any Execute - used to synchronize state
-            // between entry into Execute* API and the thread obtaining the stateObject.
-            _pendingCancel = false;
-
-            ValidateAsyncCommand(); // Special case - done outside of try/catches to prevent putting a stateObj
-                                    // back into pool when we should not.
-
-            SqlStatistics statistics = null;
-            try
-            {
-                statistics = SqlStatistics.StartTimer(Statistics);
-                TaskCompletionSource<object> completion = new TaskCompletionSource<object>(stateObject);
-
-                Task writeTask;
-                try
-                { // InternalExecuteNonQuery already has reliability block, but if failure will not put stateObj back into pool.
-                    RunExecuteReader(CommandBehavior.SequentialAccess, RunBehavior.ReturnImmediately, true, completion, CommandTimeout, out writeTask, asyncWrite: true);
-                }
-                catch (Exception e)
-                {
-                    if (!ADP.IsCatchableOrSecurityExceptionType(e))
-                    {
-                        // If not catchable - the connection has already been caught and doomed in RunExecuteReader.
-                        throw;
-                    }
-
-                    // For async, RunExecuteReader will never put the stateObj back into the pool, so do so now.
-                    ReliablePutStateObject();
-                    throw;
-                }
-
-                // must finish caching information before ReadSni which can activate the callback before returning
-                cachedAsyncState.SetActiveConnectionAndResult(completion, nameof(EndExecuteXmlReader), _activeConnection);
-                if (writeTask != null)
-                {
-                    AsyncHelper.ContinueTask(writeTask, completion, () => BeginExecuteXmlReaderInternalReadStage(completion));
-                }
-                else
-                {
-                    BeginExecuteXmlReaderInternalReadStage(completion);
-                }
-
-                // Add callback after work is done to avoid overlapping Begin\End methods
-                if (callback != null)
-                {
-                    completion.Task.ContinueWith((t) => callback(t), TaskScheduler.Default);
-                }
-                return completion.Task;
-            }
-            finally
-            {
-                SqlStatistics.StopTimer(statistics);
-            }
-        }
-
-        private void BeginExecuteXmlReaderInternalReadStage(TaskCompletionSource<object> completion)
-        {
-            Debug.Assert(completion != null, "Completion source should not be null");
-            // Read SNI does not have catches for async exceptions, handle here.
-            try
-            {
-                _stateObj.ReadSni(completion);
-            }
-            catch (Exception e)
-            {
-                // Similarly, if an exception occurs put the stateObj back into the pool.
-                // and reset async cache information to allow a second async execute
-                if (null != _cachedAsyncState)
-                {
-                    _cachedAsyncState.ResetAsyncState();
-                }
-                ReliablePutStateObject();
-                completion.TrySetException(e);
-            }
-        }
-
-
-        private XmlReader EndExecuteXmlReader(IAsyncResult asyncResult)
-        {
-            Exception asyncException = ((Task)asyncResult).Exception;
-            if (asyncException != null)
-            {
-                // Leftover exception from the Begin...InternalReadStage
-                if (cachedAsyncState != null)
-                {
-                    cachedAsyncState.ResetAsyncState();
-                }
-                ReliablePutStateObject();
-                throw asyncException.InnerException;
-            }
-            else
-            {
-                ThrowIfReconnectionHasBeenCanceled();
-                // lock on _stateObj prevents races with close/cancel.
-                lock (_stateObj)
-                {
-                    return EndExecuteXmlReaderInternal(asyncResult);
-                }
-            }
-        }
-
-        private XmlReader EndExecuteXmlReaderInternal(IAsyncResult asyncResult)
-        {
-            try
-            {
-                return CompleteXmlReader(InternalEndExecuteReader(asyncResult, nameof(EndExecuteXmlReader)), async: true);
-            }
-            catch (Exception e)
-            {
-                if (cachedAsyncState != null)
-                {
-                    cachedAsyncState.ResetAsyncState();
-                };
-                if (ADP.IsCatchableExceptionType(e))
-                {
-                    ReliablePutStateObject();
-                };
-                throw;
-            }
-        }
-
-        private XmlReader CompleteXmlReader(SqlDataReader ds, bool async = false)
-        {
-            XmlReader xr = null;
-
-            SmiExtendedMetaData[] md = ds.GetInternalSmiMetaData();
-            bool isXmlCapable = (null != md && md.Length == 1 && (md[0].SqlDbType == SqlDbType.NText
-                                                         || md[0].SqlDbType == SqlDbType.NVarChar
-                                                         || md[0].SqlDbType == SqlDbType.Xml));
-
-            if (isXmlCapable)
-            {
-                try
-                {
-                    SqlStream sqlBuf = new SqlStream(ds, true /*addByteOrderMark*/, (md[0].SqlDbType == SqlDbType.Xml) ? false : true /*process all rows*/);
-                    xr = sqlBuf.ToXmlReader(async);
-                }
-                catch (Exception e)
-                {
-                    if (ADP.IsCatchableExceptionType(e))
-                    {
-                        ds.Close();
-                    }
-                    throw;
-                }
-            }
-            if (xr == null)
-            {
-                ds.Close();
-                throw SQL.NonXmlResult();
-            }
-            return xr;
-        }
-
-
-        override protected DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
-        {
-            return ExecuteReader(behavior);
-        }
-
-        new public SqlDataReader ExecuteReader()
-        {
-            SqlStatistics statistics = null;
-            try
-            {
-                statistics = SqlStatistics.StartTimer(Statistics);
-                return ExecuteReader(CommandBehavior.Default);
-            }
-            finally
-            {
-                SqlStatistics.StopTimer(statistics);
-            }
-        }
-
-        new public SqlDataReader ExecuteReader(CommandBehavior behavior)
-        {
-            // Reset _pendingCancel upon entry into any Execute - used to synchronize state
-            // between entry into Execute* API and the thread obtaining the stateObject.
-            _pendingCancel = false;
-
-            Guid operationId = _diagnosticListener.WriteCommandBefore(this);
-
-            SqlStatistics statistics = null;
-            
-            Exception e = null;
-            try
-            {
-                statistics = SqlStatistics.StartTimer(Statistics);
-                return RunExecuteReader(behavior, RunBehavior.ReturnImmediately, returnStream: true);
-            }
-            catch (Exception ex)
-            {
-                e = ex;
-                throw;
-            }
-            finally
-            {
-                SqlStatistics.StopTimer(statistics);
-                
-                if (e != null)
-                {
-                    _diagnosticListener.WriteCommandError(operationId, this, e);
-                }
-                else
-                {
-                    _diagnosticListener.WriteCommandAfter(operationId, this);
-                }
-            }
-        }
-
-
-        internal SqlDataReader EndExecuteReader(IAsyncResult asyncResult)
-        {
-            Exception asyncException = ((Task)asyncResult).Exception;
-            if (asyncException != null)
-            {
-                // Leftover exception from the Begin...InternalReadStage
-                if (cachedAsyncState != null)
-                {
-                    cachedAsyncState.ResetAsyncState();
-                }
-                ReliablePutStateObject();
-                throw asyncException.InnerException;
-            }
-            else
-            {
-                ThrowIfReconnectionHasBeenCanceled();
-                // lock on _stateObj prevents races with close/cancel.
-                lock (_stateObj)
-                {
-                    return EndExecuteReaderInternal(asyncResult);
-                }
-            }
-        }
-
-        private SqlDataReader EndExecuteReaderInternal(IAsyncResult asyncResult)
-        {
-            SqlStatistics statistics = null;
-            try
-            {
-                statistics = SqlStatistics.StartTimer(Statistics);
-                return InternalEndExecuteReader(asyncResult, nameof(EndExecuteReader));
-            }
-            catch (Exception e)
-            {
-                if (cachedAsyncState != null)
-                {
-                    cachedAsyncState.ResetAsyncState();
-                };
-                if (ADP.IsCatchableExceptionType(e))
-                {
-                    ReliablePutStateObject();
-                };
-                throw;
-            }
-            finally
-            {
-                SqlStatistics.StopTimer(statistics);
-            }
-        }
-
-        internal IAsyncResult BeginExecuteReader(CommandBehavior behavior, AsyncCallback callback, object stateObject)
-        {
-            // Reset _pendingCancel upon entry into any Execute - used to synchronize state
-            // between entry into Execute* API and the thread obtaining the stateObject.
-            _pendingCancel = false;
-
-            SqlStatistics statistics = null;
-            try
-            {
-                statistics = SqlStatistics.StartTimer(Statistics);
-                TaskCompletionSource<object> completion = new TaskCompletionSource<object>(stateObject);
-
-                ValidateAsyncCommand(); // Special case - done outside of try/catches to prevent putting a stateObj
-                                        // back into pool when we should not.
-
-                Task writeTask = null;
-                try
-                { // InternalExecuteNonQuery already has reliability block, but if failure will not put stateObj back into pool.
-                    RunExecuteReader(behavior, RunBehavior.ReturnImmediately, true, completion, CommandTimeout, out writeTask, asyncWrite: true);
-                }
-                catch (Exception e)
-                {
-                    if (!ADP.IsCatchableOrSecurityExceptionType(e))
-                    {
-                        // If not catchable - the connection has already been caught and doomed in RunExecuteReader.
-                        throw;
-                    }
-
-                    // For async, RunExecuteReader will never put the stateObj back into the pool, so do so now.
-                    ReliablePutStateObject();
-                    throw;
-                }
-
-                // must finish caching information before ReadSni which can activate the callback before returning
-                cachedAsyncState.SetActiveConnectionAndResult(completion, nameof(EndExecuteReader), _activeConnection);
-                if (writeTask != null)
-                {
-                    AsyncHelper.ContinueTask(writeTask, completion, () => BeginExecuteReaderInternalReadStage(completion));
-                }
-                else
-                {
-                    BeginExecuteReaderInternalReadStage(completion);
-                }
-
-                // Add callback after work is done to avoid overlapping Begin\End methods
-                if (callback != null)
-                {
-                    completion.Task.ContinueWith((t) => callback(t), TaskScheduler.Default);
-                }
-                return completion.Task;
-            }
-            finally
-            {
-                SqlStatistics.StopTimer(statistics);
-            }
-        }
-
-        private void BeginExecuteReaderInternalReadStage(TaskCompletionSource<object> completion)
-        {
-            Debug.Assert(completion != null, "CompletionSource should not be null");
-            // Read SNI does not have catches for async exceptions, handle here.
-            try
-            {
-                _stateObj.ReadSni(completion);
-            }
-            catch (Exception e)
-            {
-                // Similarly, if an exception occurs put the stateObj back into the pool.
-                // and reset async cache information to allow a second async execute
-                if (null != _cachedAsyncState)
-                {
-                    _cachedAsyncState.ResetAsyncState();
-                }
-                ReliablePutStateObject();
-                completion.TrySetException(e);
-            }
-        }
-
-        private SqlDataReader InternalEndExecuteReader(IAsyncResult asyncResult, string endMethod)
-        {
-            VerifyEndExecuteState((Task)asyncResult, endMethod);
-            WaitForAsyncResults(asyncResult);
-
-            CheckThrowSNIException();
-
-            SqlDataReader reader = CompleteAsyncExecuteReader();
-            Debug.Assert(null == _stateObj, "non-null state object in InternalEndExecuteReader");
-            return reader;
-        }
-
-        public override Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
-        {
-            Guid operationId = _diagnosticListener.WriteCommandBefore(this);
-
-            TaskCompletionSource<int> source = new TaskCompletionSource<int>();
-
-            CancellationTokenRegistration registration = new CancellationTokenRegistration();
-            if (cancellationToken.CanBeCanceled)
-            {
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    source.SetCanceled();
-                    return source.Task;
-                }
-                registration = cancellationToken.Register(s => ((SqlCommand)s).CancelIgnoreFailure(), this);
-            }
-
-            Task<int> returnedTask = source.Task;
-            try
-            {
-                RegisterForConnectionCloseNotification(ref returnedTask);
-
-                Task<int>.Factory.FromAsync(BeginExecuteNonQuery, EndExecuteNonQuery, null).ContinueWith((t) =>
-                {
-                    registration.Dispose();
-                    if (t.IsFaulted)
-                    {
-                        Exception e = t.Exception.InnerException;
-                        _diagnosticListener.WriteCommandError(operationId, this, e);
-                        source.SetException(e);
-                    }
-                    else
-                    {
-                        if (t.IsCanceled)
-                        {
-                            source.SetCanceled();
-                        }
-                        else
-                        {
-                            source.SetResult(t.Result);
-                        }
-                        _diagnosticListener.WriteCommandAfter(operationId, this);
-                    }
-                }, TaskScheduler.Default);
-            }
-            catch (Exception e)
-            {
-                _diagnosticListener.WriteCommandError(operationId, this, e);
-                source.SetException(e);
-            }
-
-            return returnedTask;
-        }
-
-        protected override Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
-        {
-            return ExecuteReaderAsync(behavior, cancellationToken).ContinueWith<DbDataReader>((result) =>
-            {
-                if (result.IsFaulted)
-                {
-                    throw result.Exception.InnerException;
-                }
-                return result.Result;
-            }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.NotOnCanceled, TaskScheduler.Default);
-        }
-
-        new public Task<SqlDataReader> ExecuteReaderAsync()
-        {
-            return ExecuteReaderAsync(CommandBehavior.Default, CancellationToken.None);
-        }
-
-        new public Task<SqlDataReader> ExecuteReaderAsync(CommandBehavior behavior)
-        {
-            return ExecuteReaderAsync(behavior, CancellationToken.None);
-        }
-
-        new public Task<SqlDataReader> ExecuteReaderAsync(CancellationToken cancellationToken)
-        {
-            return ExecuteReaderAsync(CommandBehavior.Default, cancellationToken);
-        }
-
-        new public Task<SqlDataReader> ExecuteReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
-        {
-            Guid operationId = default(Guid);
-            if (!_parentOperationStarted)
-                operationId = _diagnosticListener.WriteCommandBefore(this);
-
-            TaskCompletionSource<SqlDataReader> source = new TaskCompletionSource<SqlDataReader>();
-
-            CancellationTokenRegistration registration = new CancellationTokenRegistration();
-            if (cancellationToken.CanBeCanceled)
-            {
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    source.SetCanceled();
-                    return source.Task;
-                }
-                registration = cancellationToken.Register(s => ((SqlCommand)s).CancelIgnoreFailure(), this);
-            }
-
-            Task<SqlDataReader> returnedTask = source.Task;
-            try
-            {
-                RegisterForConnectionCloseNotification(ref returnedTask);
-
-                Task<SqlDataReader>.Factory.FromAsync(BeginExecuteReader, EndExecuteReader, behavior, null).ContinueWith((t) =>
-                {
-                    registration.Dispose();
-                    if (t.IsFaulted)
-                    {
-                        Exception e = t.Exception.InnerException;
-                        if (!_parentOperationStarted)
-                            _diagnosticListener.WriteCommandError(operationId, this, e);
-                        source.SetException(e);
-                    }
-                    else
-                    {
-                        if (t.IsCanceled)
-                        {
-                            source.SetCanceled();
-                        }
-                        else
-                        {
-                            source.SetResult(t.Result);
-                        }
-                        if (!_parentOperationStarted)
-                            _diagnosticListener.WriteCommandAfter(operationId, this);
-                    }
-                }, TaskScheduler.Default);
-            }
-            catch (Exception e)
-            {
-                if (!_parentOperationStarted)
-                    _diagnosticListener.WriteCommandError(operationId, this, e);
-
-                source.SetException(e);
-            }
-
-            return returnedTask;
-        }
-
-        public override Task<object> ExecuteScalarAsync(CancellationToken cancellationToken)
-        {
-            _parentOperationStarted = true;
-            Guid operationId = _diagnosticListener.WriteCommandBefore(this);
-
-            return ExecuteReaderAsync(cancellationToken).ContinueWith((executeTask) =>
-            {
-                TaskCompletionSource<object> source = new TaskCompletionSource<object>();
-                if (executeTask.IsCanceled)
-                {
-                    source.SetCanceled();
-                }
-                else if (executeTask.IsFaulted)
-                {
-                    _diagnosticListener.WriteCommandError(operationId, this, executeTask.Exception.InnerException);
-                    source.SetException(executeTask.Exception.InnerException);
-                }
-                else
-                {
-                    SqlDataReader reader = executeTask.Result;
-                    reader.ReadAsync(cancellationToken).ContinueWith((readTask) =>
-                    {
-                        try
-                        {
-                            if (readTask.IsCanceled)
-                            {
-                                reader.Dispose();
-                                source.SetCanceled();
-                            }
-                            else if (readTask.IsFaulted)
-                            {
-                                reader.Dispose();
-                                _diagnosticListener.WriteCommandError(operationId, this, readTask.Exception.InnerException);
-                                source.SetException(readTask.Exception.InnerException);
-                            }
-                            else
-                            {
-                                Exception exception = null;
-                                object result = null;
-                                try
-                                {
-                                    bool more = readTask.Result;
-                                    if (more && reader.FieldCount > 0)
-                                    {
-                                        try
-                                        {
-                                            result = reader.GetValue(0);
-                                        }
-                                        catch (Exception e)
-                                        {
-                                            exception = e;
-                                        }
-                                    }
-                                }
-                                finally
-                                {
-                                    reader.Dispose();
-                                }
-                                if (exception != null)
-                                {
-                                    _diagnosticListener.WriteCommandError(operationId, this, exception);
-                                    source.SetException(exception);
-                                }
-                                else
-                                {
-                                    _diagnosticListener.WriteCommandAfter(operationId, this);
-                                    source.SetResult(result);
-                                }
-                            }
-                        }
-                        catch (Exception e)
-                        {
-                            // exception thrown by Dispose...
-                            source.SetException(e);
-                        }
-                    }, TaskScheduler.Default);
-                }
-                _parentOperationStarted = false;
-                return source.Task;
-            }, TaskScheduler.Default).Unwrap();
-        }
-
-        public Task<XmlReader> ExecuteXmlReaderAsync()
-        {
-            return ExecuteXmlReaderAsync(CancellationToken.None);
-        }
-
-        public Task<XmlReader> ExecuteXmlReaderAsync(CancellationToken cancellationToken)
-        {
-            Guid operationId = _diagnosticListener.WriteCommandBefore(this);
-
-            TaskCompletionSource<XmlReader> source = new TaskCompletionSource<XmlReader>();
-
-            CancellationTokenRegistration registration = new CancellationTokenRegistration();
-            if (cancellationToken.CanBeCanceled)
-            {
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    source.SetCanceled();
-                    return source.Task;
-                }
-                registration = cancellationToken.Register(s => ((SqlCommand)s).CancelIgnoreFailure(), this);
-            }
-
-            Task<XmlReader> returnedTask = source.Task;
-            try
-            {
-                RegisterForConnectionCloseNotification(ref returnedTask);
-
-                Task<XmlReader>.Factory.FromAsync(BeginExecuteXmlReader, EndExecuteXmlReader, null).ContinueWith((t) =>
-                {
-                    registration.Dispose();
-                    if (t.IsFaulted)
-                    {
-                        Exception e = t.Exception.InnerException;
-                        _diagnosticListener.WriteCommandError(operationId, this, e);
-                        source.SetException(e);
-                    }
-                    else
-                    {
-                        if (t.IsCanceled)
-                        {
-                            source.SetCanceled();
-                        }
-                        else
-                        {
-                            source.SetResult(t.Result);
-                        }
-                        _diagnosticListener.WriteCommandAfter(operationId, this);
-                    }
-                }, TaskScheduler.Default);
-            }
-            catch (Exception e)
-            {
-                _diagnosticListener.WriteCommandError(operationId, this, e);
-                source.SetException(e);
-            }
-
-            return returnedTask;
-        }
-
-        // If the user part is quoted, remove first and last brackets and then unquote any right square
-        // brackets in the procedure.  This is a very simple parser that performs no validation.  As
-        // with the function below, ideally we should have support from the server for this.
-        private static string UnquoteProcedurePart(string part)
-        {
-            if ((null != part) && (2 <= part.Length))
-            {
-                if ('[' == part[0] && ']' == part[part.Length - 1])
-                {
-                    part = part.Substring(1, part.Length - 2); // strip outer '[' & ']'
-                    part = part.Replace("]]", "]"); // undo quoted "]" from "]]" to "]"
-                }
-            }
-            return part;
-        }
-
-        // User value in this format: [server].[database].[schema].[sp_foo];1
-        // This function should only be passed "[sp_foo];1".
-        // This function uses a pretty simple parser that doesn't do any validation.
-        // Ideally, we would have support from the server rather than us having to do this.
-        private static string UnquoteProcedureName(string name, out object groupNumber)
-        {
-            groupNumber = null; // Out param - initialize value to no value.
-            string sproc = name;
-
-            if (null != sproc)
-            {
-                if (char.IsDigit(sproc[sproc.Length - 1]))
-                { // If last char is a digit, parse.
-                    int semicolon = sproc.LastIndexOf(';');
-                    if (semicolon != -1)
-                    { // If we found a semicolon, obtain the integer.
-                        string part = sproc.Substring(semicolon + 1);
-                        int number = 0;
-                        if (int.TryParse(part, out number))
-                        { // No checking, just fail if this doesn't work.
-                            groupNumber = number;
-                            sproc = sproc.Substring(0, semicolon);
-                        }
-                    }
-                }
-                sproc = UnquoteProcedurePart(sproc);
-            }
-            return sproc;
-        }
-
-        // Index into indirection arrays for columns of interest to DeriveParameters
-        private enum ProcParamsColIndex
-        {
-            ParameterName = 0,
-            ParameterType,
-            DataType, // obsolete in katmai, use ManagedDataType instead
-            ManagedDataType, // new in katmai
-            CharacterMaximumLength,
-            NumericPrecision,
-            NumericScale,
-            TypeCatalogName,
-            TypeSchemaName,
-            TypeName,
-            XmlSchemaCollectionCatalogName,
-            XmlSchemaCollectionSchemaName,
-            XmlSchemaCollectionName,
-            UdtTypeName, // obsolete in Katmai.  Holds the actual typename if UDT, since TypeName didn't back then.
-            DateTimeScale // new in Katmai
-        };
-
-        // Yukon- column ordinals (this array indexed by ProcParamsColIndex
-        internal static readonly string[] PreKatmaiProcParamsNames = new string[] {
-            "PARAMETER_NAME",           // ParameterName,
-            "PARAMETER_TYPE",           // ParameterType,
-            "DATA_TYPE",                // DataType
-            null,                       // ManagedDataType,     introduced in Katmai
-            "CHARACTER_MAXIMUM_LENGTH", // CharacterMaximumLength,
-            "NUMERIC_PRECISION",        // NumericPrecision,
-            "NUMERIC_SCALE",            // NumericScale,
-            "UDT_CATALOG",              // TypeCatalogName,
-            "UDT_SCHEMA",               // TypeSchemaName,
-            "TYPE_NAME",                // TypeName,
-            "XML_CATALOGNAME",          // XmlSchemaCollectionCatalogName,
-            "XML_SCHEMANAME",           // XmlSchemaCollectionSchemaName,
-            "XML_SCHEMACOLLECTIONNAME", // XmlSchemaCollectionName
-            "UDT_NAME",                 // UdtTypeName
-            null,                       // Scale for datetime types with scale, introduced in Katmai
-        };
-
-        // Katmai+ column ordinals (this array indexed by ProcParamsColIndex
-        internal static readonly string[] KatmaiProcParamsNames = new string[] {
-            "PARAMETER_NAME",           // ParameterName,
-            "PARAMETER_TYPE",           // ParameterType,
-            null,                       // DataType, removed from Katmai+
-            "MANAGED_DATA_TYPE",        // ManagedDataType,
-            "CHARACTER_MAXIMUM_LENGTH", // CharacterMaximumLength,
-            "NUMERIC_PRECISION",        // NumericPrecision,
-            "NUMERIC_SCALE",            // NumericScale,
-            "TYPE_CATALOG_NAME",        // TypeCatalogName,
-            "TYPE_SCHEMA_NAME",         // TypeSchemaName,
-            "TYPE_NAME",                // TypeName,
-            "XML_CATALOGNAME",          // XmlSchemaCollectionCatalogName,
-            "XML_SCHEMANAME",           // XmlSchemaCollectionSchemaName,
-            "XML_SCHEMACOLLECTIONNAME", // XmlSchemaCollectionName
-            null,                       // UdtTypeName, removed from Katmai+
-            "SS_DATETIME_PRECISION",    // Scale for datetime types with scale
-        };
-
-        internal void DeriveParameters()
-        {
-            switch (CommandType)
-            {
-                case CommandType.Text:
-                    throw ADP.DeriveParametersNotSupported(this);
-                case CommandType.StoredProcedure:
-                    break;
-                case CommandType.TableDirect:
-                    // CommandType.TableDirect - do nothing, parameters are not supported
-                    throw ADP.DeriveParametersNotSupported(this);
-                default:
-                    throw ADP.InvalidCommandType(CommandType);
-            }
-
-            // validate that we have a valid connection
-            ValidateCommand(false /*not async*/, nameof(DeriveParameters));
-
-            // Use common parser for SqlClient and OleDb - parse into 4 parts - Server, Catalog, Schema, ProcedureName
-            string[] parsedSProc = MultipartIdentifier.ParseMultipartIdentifier(CommandText, "[\"", "]\"", SR.SQL_SqlCommandCommandText, false);
-            if (null == parsedSProc[3] || string.IsNullOrEmpty(parsedSProc[3]))
-            {
-                throw ADP.NoStoredProcedureExists(CommandText);
-            }
-
-            Debug.Assert(parsedSProc.Length == 4, "Invalid array length result from SqlCommandBuilder.ParseProcedureName");
-
-            SqlCommand paramsCmd = null;
-            StringBuilder cmdText = new StringBuilder();
-
-            // Build call for sp_procedure_params_rowset built of unquoted values from user:
-            // [user server, if provided].[user catalog, else current database].[sys if Yukon, else blank].[sp_procedure_params_rowset]
-
-            // Server - pass only if user provided.
-            if (!string.IsNullOrEmpty(parsedSProc[0]))
-            {
-                SqlCommandSet.BuildStoredProcedureName(cmdText, parsedSProc[0]);
-                cmdText.Append(".");
-            }
-
-            // Catalog - pass user provided, otherwise use current database.
-            if (string.IsNullOrEmpty(parsedSProc[1]))
-            {
-                parsedSProc[1] = Connection.Database;
-            }
-            SqlCommandSet.BuildStoredProcedureName(cmdText, parsedSProc[1]);
-            cmdText.Append(".");
-
-            // Schema - only if Yukon, and then only pass sys.  Also - pass managed version of sproc
-            // for Yukon, else older sproc.
-            string[] colNames;
-            bool useManagedDataType;
-            if (Connection.IsKatmaiOrNewer)
-            {
-                // Procedure - [sp_procedure_params_managed]
-                cmdText.Append("[sys].[").Append(TdsEnums.SP_PARAMS_MGD10).Append("]");
-
-                colNames = KatmaiProcParamsNames;
-                useManagedDataType = true;
-            }
-            else
-            {
-                // Procedure - [sp_procedure_params_managed]
-                cmdText.Append("[sys].[").Append(TdsEnums.SP_PARAMS_MANAGED).Append("]");
-
-                colNames = PreKatmaiProcParamsNames;
-                useManagedDataType = false;
-            }
-
-            paramsCmd = new SqlCommand(cmdText.ToString(), Connection, Transaction)
-            {
-                CommandType = CommandType.StoredProcedure
-            };
-
-            object groupNumber;
-
-            // Prepare parameters for sp_procedure_params_rowset:
-            // 1) procedure name - unquote user value
-            // 2) group number - parsed at the time we unquoted procedure name
-            // 3) procedure schema - unquote user value
-
-            paramsCmd.Parameters.Add(new SqlParameter("@procedure_name", SqlDbType.NVarChar, 255));
-            paramsCmd.Parameters[0].Value = UnquoteProcedureName(parsedSProc[3], out groupNumber); // ProcedureName is 4rd element in parsed array
-
-            if (null != groupNumber)
-            {
-                SqlParameter param = paramsCmd.Parameters.Add(new SqlParameter("@group_number", SqlDbType.Int));
-                param.Value = groupNumber;
-            }
-
-            if (!string.IsNullOrEmpty(parsedSProc[2]))
-            { // SchemaName is 3rd element in parsed array
-                SqlParameter param = paramsCmd.Parameters.Add(new SqlParameter("@procedure_schema", SqlDbType.NVarChar, 255));
-                param.Value = UnquoteProcedurePart(parsedSProc[2]);
-            }
-
-            SqlDataReader r = null;
-
-            List<SqlParameter> parameters = new List<SqlParameter>();
-            bool processFinallyBlock = true;
-
-            try
-            {
-                r = paramsCmd.ExecuteReader();
-
-                SqlParameter p = null;
-
-                while (r.Read())
-                {
-                    // each row corresponds to a parameter of the stored proc.  Fill in all the info
-                    p = new SqlParameter()
-                    {
-                        ParameterName = (string)r[colNames[(int)ProcParamsColIndex.ParameterName]]
-                    };
-
-                    // type
-                    if (useManagedDataType)
-                    {
-                        p.SqlDbType = (SqlDbType)(short)r[colNames[(int)ProcParamsColIndex.ManagedDataType]];
-
-                        // Yukon didn't have as accurate of information as we're getting for Katmai, so re-map a couple of
-                        //  types for backward compatability.
-                        switch (p.SqlDbType)
-                        {
-                            case SqlDbType.Image:
-                            case SqlDbType.Timestamp:
-                                p.SqlDbType = SqlDbType.VarBinary;
-                                break;
-
-                            case SqlDbType.NText:
-                                p.SqlDbType = SqlDbType.NVarChar;
-                                break;
-
-                            case SqlDbType.Text:
-                                p.SqlDbType = SqlDbType.VarChar;
-                                break;
-
-                            default:
-                                break;
-                        }
-                    }
-                    else
-                    {
-                        p.SqlDbType = MetaType.GetSqlDbTypeFromOleDbType((short)r[colNames[(int)ProcParamsColIndex.DataType]],
-                            ADP.IsNull(r[colNames[(int)ProcParamsColIndex.TypeName]]) ?
-                                ADP.StrEmpty :
-                                (string)r[colNames[(int)ProcParamsColIndex.TypeName]]);
-                    }
-
-                    // size
-                    object a = r[colNames[(int)ProcParamsColIndex.CharacterMaximumLength]];
-                    if (a is int)
-                    {
-                        int size = (int)a;
-
-                        // Map MAX sizes correctly.  The Katmai server-side proc sends 0 for these instead of -1.
-                        //  Should be fixed on the Katmai side, but would likely hold up the RI, and is safer to fix here.
-                        //  If we can get the server-side fixed before shipping Katmai, we can remove this mapping.
-                        if (0 == size &&
-                                (p.SqlDbType == SqlDbType.NVarChar ||
-                                 p.SqlDbType == SqlDbType.VarBinary ||
-                                 p.SqlDbType == SqlDbType.VarChar))
-                        {
-                            size = -1;
-                        }
-                        p.Size = size;
-                    }
-
-                    // direction
-                    p.Direction = ParameterDirectionFromOleDbDirection((short)r[colNames[(int)ProcParamsColIndex.ParameterType]]);
-
-                    if (p.SqlDbType == SqlDbType.Decimal)
-                    {
-                        p.ScaleInternal = (byte)((short)r[colNames[(int)ProcParamsColIndex.NumericScale]] & 0xff);
-                        p.PrecisionInternal = (byte)((short)r[colNames[(int)ProcParamsColIndex.NumericPrecision]] & 0xff);
-                    }
-
-                    // type name for Structured types (same as for Udt's except assign p.TypeName instead of p.UdtTypeName
-                    if (SqlDbType.Structured == p.SqlDbType)
-                    {
-
-                        Debug.Assert(_activeConnection.IsKatmaiOrNewer, "Invalid datatype token received from pre-katmai server");
-
-                        //read the type name
-                        p.TypeName = r[colNames[(int)ProcParamsColIndex.TypeCatalogName]] + "." +
-                            r[colNames[(int)ProcParamsColIndex.TypeSchemaName]] + "." +
-                            r[colNames[(int)ProcParamsColIndex.TypeName]];
-                    }
-
-                    // XmlSchema name for Xml types
-                    if (SqlDbType.Xml == p.SqlDbType)
-                    {
-                        object value;
-
-                        value = r[colNames[(int)ProcParamsColIndex.XmlSchemaCollectionCatalogName]];
-                        p.XmlSchemaCollectionDatabase = ADP.IsNull(value) ? String.Empty : (string)value;
-
-                        value = r[colNames[(int)ProcParamsColIndex.XmlSchemaCollectionSchemaName]];
-                        p.XmlSchemaCollectionOwningSchema = ADP.IsNull(value) ? String.Empty : (string)value;
-
-                        value = r[colNames[(int)ProcParamsColIndex.XmlSchemaCollectionName]];
-                        p.XmlSchemaCollectionName = ADP.IsNull(value) ? String.Empty : (string)value;
-                    }
-
-                    if (MetaType._IsVarTime(p.SqlDbType))
-                    {
-                        object value = r[colNames[(int)ProcParamsColIndex.DateTimeScale]];
-                        if (value is int)
-                        {
-                            p.ScaleInternal = (byte)(((int)value) & 0xff);
-                        }
-                    }
-
-                    parameters.Add(p);
-                }
-            }
-            catch (Exception e)
-            {
-                processFinallyBlock = ADP.IsCatchableExceptionType(e);
-                throw;
-            }
-            finally
-            {
-                if (processFinallyBlock)
-                {
-                    r?.Close();
-
-                    // always unhook the user's connection
-                    paramsCmd.Connection = null;
-                }
-            }
-
-            if (parameters.Count == 0)
-            {
-                throw ADP.NoStoredProcedureExists(this.CommandText);
-            }
-
-            Parameters.Clear();
-
-            foreach (SqlParameter temp in parameters)
-            {
-                _parameters.Add(temp);
-            }
-        }
-
-        private ParameterDirection ParameterDirectionFromOleDbDirection(short oledbDirection)
-        {
-            Debug.Assert(oledbDirection >= 1 && oledbDirection <= 4, "invalid parameter direction from params_rowset!");
-
-            switch (oledbDirection)
-            {
-                case 2:
-                    return ParameterDirection.InputOutput;
-                case 3:
-                    return ParameterDirection.Output;
-                case 4:
-                    return ParameterDirection.ReturnValue;
-                default:
-                    return ParameterDirection.Input;
-            }
-
-        }
-
-        // get cached metadata
-        internal _SqlMetaDataSet MetaData
-        {
-            get
-            {
-                return _cachedMetaData;
-            }
-        }
-
-        // Check to see if notificactions auto enlistment is turned on. Enlist if so.
-        private void CheckNotificationStateAndAutoEnlist()
-        {
-            // Auto-enlist not supported in Core
-
-            // If we have a notification with a dependency, setup the notification options at this time.
-
-            // If user passes options, then we will always have option data at the time the SqlDependency
-            // ctor is called.  But, if we are using default queue, then we do not have this data until
-            // Start().  Due to this, we always delay setting options until execute.
-
-            // There is a variance in order between Start(), SqlDependency(), and Execute.  This is the 
-            // best way to solve that problem.
-            if (null != Notification)
-            {
-                if (_sqlDep != null)
-                {
-                    if (null == _sqlDep.Options)
-                    {
-                        // If null, SqlDependency was not created with options, so we need to obtain default options now.
-                        // GetDefaultOptions can and will throw under certain conditions.
-
-                        // In order to match to the appropriate start - we need 3 pieces of info:
-                        // 1) server 2) user identity (SQL Auth or Int Sec) 3) database
-
-                        SqlDependency.IdentityUserNamePair identityUserName = null;
-
-                        // Obtain identity from connection.
-                        SqlInternalConnectionTds internalConnection = _activeConnection.InnerConnection as SqlInternalConnectionTds;
-                        if (internalConnection.Identity != null)
-                        {
-                            identityUserName = new SqlDependency.IdentityUserNamePair(internalConnection.Identity, null);
-                        }
-                        else
-                        {
-                            identityUserName = new SqlDependency.IdentityUserNamePair(null, internalConnection.ConnectionOptions.UserID);
-                        }
-
-                        Notification.Options = SqlDependency.GetDefaultComposedOptions(_activeConnection.DataSource,
-                                                             InternalTdsConnection.ServerProvidedFailOverPartner,
-                                                             identityUserName, _activeConnection.Database);
-                    }
-
-                    // Set UserData on notifications, as well as adding to the appdomain dispatcher.  The value is
-                    // computed by an algorithm on the dependency - fixed and will always produce the same value
-                    // given identical commandtext + parameter values.
-                    Notification.UserData = _sqlDep.ComputeHashAndAddToDispatcher(this);
-                    // Maintain server list for SqlDependency.
-                    _sqlDep.AddToServerList(_activeConnection.DataSource);
-                }
-            }
-        }
-
-        // Tds-specific logic for ExecuteNonQuery run handling
-        private Task RunExecuteNonQueryTds(string methodName, bool async, int timeout, bool asyncWrite)
-        {
-            Debug.Assert(!asyncWrite || async, "AsyncWrite should be always accompanied by Async");
-            bool processFinallyBlock = true;
-            try
-            {
-                Task reconnectTask = _activeConnection.ValidateAndReconnect(null, timeout);
-
-                if (reconnectTask != null)
-                {
-                    long reconnectionStart = ADP.TimerCurrent();
-                    if (async)
-                    {
-                        TaskCompletionSource<object> completion = new TaskCompletionSource<object>();
-                        _activeConnection.RegisterWaitingForReconnect(completion.Task);
-                        _reconnectionCompletionSource = completion;
-                        CancellationTokenSource timeoutCTS = new CancellationTokenSource();
-                        AsyncHelper.SetTimeoutException(completion, timeout, SQL.CR_ReconnectTimeout, timeoutCTS.Token);
-                        AsyncHelper.ContinueTask(reconnectTask, completion,
-                            () =>
-                            {
-                                if (completion.Task.IsCompleted)
-                                {
-                                    return;
-                                }
-                                Interlocked.CompareExchange(ref _reconnectionCompletionSource, null, completion);
-                                timeoutCTS.Cancel();
-                                Task subTask = RunExecuteNonQueryTds(methodName, async, TdsParserStaticMethods.GetRemainingTimeout(timeout, reconnectionStart), asyncWrite);
-                                if (subTask == null)
-                                {
-                                    completion.SetResult(null);
-                                }
-                                else
-                                {
-                                    AsyncHelper.ContinueTask(subTask, completion, () => completion.SetResult(null));
-                                }
-                            }, connectionToAbort: _activeConnection);
-                        return completion.Task;
-                    }
-                    else
-                    {
-                        AsyncHelper.WaitForCompletion(reconnectTask, timeout, () => { throw SQL.CR_ReconnectTimeout(); });
-                        timeout = TdsParserStaticMethods.GetRemainingTimeout(timeout, reconnectionStart);
-                    }
-                }
-
-                if (asyncWrite)
-                {
-                    _activeConnection.AddWeakReference(this, SqlReferenceCollection.CommandTag);
-                }
-
-                GetStateObject();
-
-                // we just send over the raw text with no annotation
-                // no parameters are sent over
-                // no data reader is returned
-                // use this overload for "batch SQL" tds token type
-                Task executeTask = _stateObj.Parser.TdsExecuteSQLBatch(this.CommandText, timeout, this.Notification, _stateObj, sync: true);
-                Debug.Assert(executeTask == null, "Shouldn't get a task when doing sync writes");
-
-                NotifyDependency();
-                if (async)
-                {
-                    _activeConnection.GetOpenTdsConnection(methodName).IncrementAsyncCount();
-                }
-                else
-                {
-                    bool dataReady;
-                    Debug.Assert(_stateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
-                    bool result = _stateObj.Parser.TryRun(RunBehavior.UntilDone, this, null, null, _stateObj, out dataReady);
-                    if (!result) { throw SQL.SynchronousCallMayNotPend(); }
-                }
-            }
-            catch (Exception e)
-            {
-                processFinallyBlock = ADP.IsCatchableExceptionType(e);
-                throw;
-            }
-            finally
-            {
-                if (processFinallyBlock && !async)
-                {
-                    // When executing Async, we need to keep the _stateObj alive...
-                    PutStateObject();
-                }
-            }
-            return null;
-        }
-
-
-        internal SqlDataReader RunExecuteReader(CommandBehavior cmdBehavior, RunBehavior runBehavior, bool returnStream, [CallerMemberName] string method = "")
-        {
-            Task unused; // sync execution 
-            SqlDataReader reader = RunExecuteReader(cmdBehavior, runBehavior, returnStream, completion: null, timeout: CommandTimeout, task: out unused, method: method);
-            Debug.Assert(unused == null, "returned task during synchronous execution");
-            return reader;
-        }
-
-        // task is created in case of pending asynchronous write, returned SqlDataReader should not be utilized until that task is complete 
-        internal SqlDataReader RunExecuteReader(CommandBehavior cmdBehavior, RunBehavior runBehavior, bool returnStream, TaskCompletionSource<object> completion, int timeout, out Task task, bool asyncWrite = false, [CallerMemberName] string method = "")
-        {
-            bool async = (null != completion);
-
-            task = null;
-
-            _rowsAffected = -1;
-
-            if (0 != (CommandBehavior.SingleRow & cmdBehavior))
-            {
-                // CommandBehavior.SingleRow implies CommandBehavior.SingleResult
-                cmdBehavior |= CommandBehavior.SingleResult;
-            }
-
-            // this function may throw for an invalid connection
-            // returns false for empty command text
-            ValidateCommand(async, method);
-
-            CheckNotificationStateAndAutoEnlist(); // Only call after validate - requires non null connection!
-
-            SqlStatistics statistics = Statistics;
-            if (null != statistics)
-            {
-                if ((!this.IsDirty && this.IsPrepared && !_hiddenPrepare)
-                    || (this.IsPrepared && _execType == EXECTYPE.PREPAREPENDING))
-                {
-                    statistics.SafeIncrement(ref statistics._preparedExecs);
-                }
-                else
-                {
-                    statistics.SafeIncrement(ref statistics._unpreparedExecs);
-                }
-            }
-
-
-            {
-                return RunExecuteReaderTds(cmdBehavior, runBehavior, returnStream, async, timeout, out task, asyncWrite && async);
-            }
-        }
-
-        private SqlDataReader RunExecuteReaderTds(CommandBehavior cmdBehavior, RunBehavior runBehavior, bool returnStream, bool async, int timeout, out Task task, bool asyncWrite, SqlDataReader ds = null)
-        {
-            Debug.Assert(!asyncWrite || async, "AsyncWrite should be always accompanied by Async");
-
-            if (ds == null && returnStream)
-            {
-                ds = new SqlDataReader(this, cmdBehavior);
-            }
-
-            Task reconnectTask = _activeConnection.ValidateAndReconnect(null, timeout);
-
-            if (reconnectTask != null)
-            {
-                long reconnectionStart = ADP.TimerCurrent();
-                if (async)
-                {
-                    TaskCompletionSource<object> completion = new TaskCompletionSource<object>();
-                    _activeConnection.RegisterWaitingForReconnect(completion.Task);
-                    _reconnectionCompletionSource = completion;
-                    CancellationTokenSource timeoutCTS = new CancellationTokenSource();
-                    AsyncHelper.SetTimeoutException(completion, timeout, SQL.CR_ReconnectTimeout, timeoutCTS.Token);
-                    AsyncHelper.ContinueTask(reconnectTask, completion,
-                        () =>
-                        {
-                            if (completion.Task.IsCompleted)
-                            {
-                                return;
-                            }
-                            Interlocked.CompareExchange(ref _reconnectionCompletionSource, null, completion);
-                            timeoutCTS.Cancel();
-                            Task subTask;
-                            RunExecuteReaderTds(cmdBehavior, runBehavior, returnStream, async, TdsParserStaticMethods.GetRemainingTimeout(timeout, reconnectionStart), out subTask, asyncWrite, ds);
-                            if (subTask == null)
-                            {
-                                completion.SetResult(null);
-                            }
-                            else
-                            {
-                                AsyncHelper.ContinueTask(subTask, completion, () => completion.SetResult(null));
-                            }
-                        }, connectionToAbort: _activeConnection);
-                    task = completion.Task;
-                    return ds;
-                }
-                else
-                {
-                    AsyncHelper.WaitForCompletion(reconnectTask, timeout, () => { throw SQL.CR_ReconnectTimeout(); });
-                    timeout = TdsParserStaticMethods.GetRemainingTimeout(timeout, reconnectionStart);
-                }
-            }
-
-            // make sure we have good parameter information
-            // prepare the command
-            // execute
-            Debug.Assert(null != _activeConnection.Parser, "TdsParser class should not be null in Command.Execute!");
-
-            bool inSchema = (0 != (cmdBehavior & CommandBehavior.SchemaOnly));
-
-            // create a new RPC
-            _SqlRPC rpc = null;
-
-            task = null;
-
-            string optionSettings = null;
-            bool processFinallyBlock = true;
-            bool decrementAsyncCountOnFailure = false;
-
-            if (async)
-            {
-                _activeConnection.GetOpenTdsConnection().IncrementAsyncCount();
-                decrementAsyncCountOnFailure = true;
-            }
-
-            try
-            {
-                if (asyncWrite)
-                {
-                    _activeConnection.AddWeakReference(this, SqlReferenceCollection.CommandTag);
-                }
-
-                GetStateObject();
-                Task writeTask = null;
-
-                if ((System.Data.CommandType.Text == this.CommandType) && (0 == GetParameterCount(_parameters)))
-                {
-                    // Send over SQL Batch command if we are not a stored proc and have no parameters
-                    Debug.Assert(!IsUserPrepared, "CommandType.Text with no params should not be prepared!");
-                    string text = GetCommandText(cmdBehavior) + GetResetOptionsString(cmdBehavior);
-                    writeTask = _stateObj.Parser.TdsExecuteSQLBatch(text, timeout, this.Notification, _stateObj, sync: !asyncWrite);
-                }
-                else if (System.Data.CommandType.Text == this.CommandType)
-                {
-                    if (this.IsDirty)
-                    {
-                        Debug.Assert(_cachedMetaData == null || !_dirty, "dirty query should not have cached metadata!"); // can have cached metadata if dirty because of parameters
-                        //
-                        // someone changed the command text or the parameter schema so we must unprepare the command
-                        //
-                        // remember that IsDirty includes test for IsPrepared!
-                        if (_execType == EXECTYPE.PREPARED)
-                        {
-                            _hiddenPrepare = true;
-                        }
-                        Unprepare();
-                        IsDirty = false;
-                    }
-
-                    if (_execType == EXECTYPE.PREPARED)
-                    {
-                        Debug.Assert(this.IsPrepared && (_prepareHandle != -1), "invalid attempt to call sp_execute without a handle!");
-                        rpc = BuildExecute(inSchema);
-                    }
-                    else if (_execType == EXECTYPE.PREPAREPENDING)
-                    {
-                        rpc = BuildPrepExec(cmdBehavior);
-                        // next time through, only do an exec
-                        _execType = EXECTYPE.PREPARED;
-                        _preparedConnectionCloseCount = _activeConnection.CloseCount;
-                        _preparedConnectionReconnectCount = _activeConnection.ReconnectCount;
-                        // mark ourselves as preparing the command
-                        _inPrepare = true;
-                    }
-                    else
-                    {
-                        Debug.Assert(_execType == EXECTYPE.UNPREPARED, "Invalid execType!");
-                        BuildExecuteSql(cmdBehavior, null, _parameters, ref rpc);
-                    }
-
-                    // if shiloh, then set NOMETADATA_UNLESSCHANGED flag
-                    rpc.options = TdsEnums.RPC_NOMETADATA;
-
-                    Debug.Assert(_rpcArrayOf1[0] == rpc);
-                    writeTask = _stateObj.Parser.TdsExecuteRPC(_rpcArrayOf1, timeout, inSchema, this.Notification, _stateObj, CommandType.StoredProcedure == CommandType, sync: !asyncWrite);
-                }
-                else
-                {
-                    Debug.Assert(this.CommandType == System.Data.CommandType.StoredProcedure, "unknown command type!");
-
-                    BuildRPC(inSchema, _parameters, ref rpc);
-
-                    // if we need to augment the command because a user has changed the command behavior (e.g. FillSchema)
-                    // then batch sql them over.  This is inefficient (3 round trips) but the only way we can get metadata only from
-                    // a stored proc
-                    optionSettings = GetSetOptionsString(cmdBehavior);
-                    // turn set options ON
-                    if (null != optionSettings)
-                    {
-                        Task executeTask = _stateObj.Parser.TdsExecuteSQLBatch(optionSettings, timeout, this.Notification, _stateObj, sync: true);
-                        Debug.Assert(executeTask == null, "Shouldn't get a task when doing sync writes");
-                        bool dataReady;
-                        Debug.Assert(_stateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
-                        bool result = _stateObj.Parser.TryRun(RunBehavior.UntilDone, this, null, null, _stateObj, out dataReady);
-                        if (!result) { throw SQL.SynchronousCallMayNotPend(); }
-                        // and turn OFF when the ds exhausts the stream on Close()
-                        optionSettings = GetResetOptionsString(cmdBehavior);
-                    }
-
-
-                    // execute sp
-                    Debug.Assert(_rpcArrayOf1[0] == rpc);
-                    writeTask = _stateObj.Parser.TdsExecuteRPC(_rpcArrayOf1, timeout, inSchema, this.Notification, _stateObj, CommandType.StoredProcedure == CommandType, sync: !asyncWrite);
-                }
-
-                Debug.Assert(writeTask == null || async, "Returned task in sync mode");
-
-                if (async)
-                {
-                    decrementAsyncCountOnFailure = false;
-                    if (writeTask != null)
-                    {
-                        task = AsyncHelper.CreateContinuationTask(writeTask, () =>
-                        {
-                            _activeConnection.GetOpenTdsConnection(); // it will throw if connection is closed
-                            cachedAsyncState.SetAsyncReaderState(ds, runBehavior, optionSettings);
-                        },
-                                 onFailure: (exc) =>
-                                 {
-                                     _activeConnection.GetOpenTdsConnection().DecrementAsyncCount();
-                                 });
-                    }
-                    else
-                    {
-                        cachedAsyncState.SetAsyncReaderState(ds, runBehavior, optionSettings);
-                    }
-                }
-                else
-                {
-                    // Always execute - even if no reader!
-                    FinishExecuteReader(ds, runBehavior, optionSettings);
-                }
-            }
-            catch (Exception e)
-            {
-                processFinallyBlock = ADP.IsCatchableExceptionType(e);
-                if (decrementAsyncCountOnFailure)
-                {
-                    SqlInternalConnectionTds innerConnectionTds = (_activeConnection.InnerConnection as SqlInternalConnectionTds);
-                    if (null != innerConnectionTds)
-                    { // it may be closed 
-                        innerConnectionTds.DecrementAsyncCount();
-                    }
-                }
-                throw;
-            }
-            finally
-            {
-                if (processFinallyBlock && !async)
-                {
-                    // When executing async, we need to keep the _stateObj alive...
-                    PutStateObject();
-                }
-            }
-
-            Debug.Assert(async || null == _stateObj, "non-null state object in RunExecuteReader");
-            return ds;
-        }
-
-
-        private SqlDataReader CompleteAsyncExecuteReader()
-        {
-            SqlDataReader ds = cachedAsyncState.CachedAsyncReader; // should not be null
-            bool processFinallyBlock = true;
-            try
-            {
-                FinishExecuteReader(ds, cachedAsyncState.CachedRunBehavior, cachedAsyncState.CachedSetOptions);
-            }
-            catch (Exception e)
-            {
-                processFinallyBlock = ADP.IsCatchableExceptionType(e);
-                throw;
-            }
-            finally
-            {
-                if (processFinallyBlock)
-                {
-                    cachedAsyncState.ResetAsyncState();
-                    PutStateObject();
-                }
-            }
-
-            return ds;
-        }
-
-        private void FinishExecuteReader(SqlDataReader ds, RunBehavior runBehavior, string resetOptionsString)
-        {
-            // always wrap with a try { FinishExecuteReader(...) } finally { PutStateObject(); }
-
-            NotifyDependency();
-
-            if (runBehavior == RunBehavior.UntilDone)
-            {
-                try
-                {
-                    bool dataReady;
-                    Debug.Assert(_stateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
-                    bool result = _stateObj.Parser.TryRun(RunBehavior.UntilDone, this, ds, null, _stateObj, out dataReady);
-                    if (!result) { throw SQL.SynchronousCallMayNotPend(); }
-                }
-                catch (Exception e)
-                {
-                    if (ADP.IsCatchableExceptionType(e))
-                    {
-                        if (_inPrepare)
-                        {
-                            // The flag is expected to be reset by OnReturnValue.  We should receive
-                            // the handle unless command execution failed.  If fail, move back to pending
-                            // state.
-                            _inPrepare = false;                  // reset the flag
-                            IsDirty = true;                      // mark command as dirty so it will be prepared next time we're coming through
-                            _execType = EXECTYPE.PREPAREPENDING; // reset execution type to pending
-                        }
-
-                        if (null != ds)
-                        {
-                            try
-                            {
-                                ds.Close();
-                            }
-                            catch(Exception exClose)
-                            {
-                                Debug.WriteLine("Received this exception from SqlDataReader.Close() while in another catch block: " + exClose.ToString());
-                            }
-                        }
-                    }
-                    throw;
-                }
-            }
-
-            // bind the parser to the reader if we get this far
-            if (ds != null)
-            {
-                ds.Bind(_stateObj);
-                _stateObj = null;   // the reader now owns this...
-                ds.ResetOptionsString = resetOptionsString;
-                // bind this reader to this connection now
-                _activeConnection.AddWeakReference(ds, SqlReferenceCollection.DataReaderTag);
-
-                // force this command to start reading data off the wire.
-                // this will cause an error to be reported at Execute() time instead of Read() time
-                // if the command is not set.
-                try
-                {
-                    _cachedMetaData = ds.MetaData;
-                    ds.IsInitialized = true;
-                }
-                catch (Exception e)
-                {
-                    if (ADP.IsCatchableExceptionType(e))
-                    {
-                        if (_inPrepare)
-                        {
-                            // The flag is expected to be reset by OnReturnValue.  We should receive
-                            // the handle unless command execution failed.  If fail, move back to pending
-                            // state.
-                            _inPrepare = false;                  // reset the flag
-                            IsDirty = true;                      // mark command as dirty so it will be prepared next time we're coming through
-                            _execType = EXECTYPE.PREPAREPENDING; // reset execution type to pending
-                        }
-
-                        try
-                        {
-                            ds.Close();
-                        }
-                        catch (Exception exClose)
-                        {
-                            Debug.WriteLine("Received this exception from SqlDataReader.Close() while in another catch block: " + exClose.ToString());
-                        }
-                    }
-
-                    throw;
-                }
-            }
-        }
-
-
-        private void RegisterForConnectionCloseNotification<T>(ref Task<T> outerTask)
-        {
-            SqlConnection connection = _activeConnection;
-            if (connection == null)
-            {
-                // No connection
-                throw ADP.ClosedConnectionError();
-            }
-
-            connection.RegisterForConnectionCloseNotification<T>(ref outerTask, this, SqlReferenceCollection.CommandTag);
-        }
-
-        // validates that a command has commandText and a non-busy open connection
-        // throws exception for error case, returns false if the commandText is empty
-        private void ValidateCommand(bool async, [CallerMemberName] string method = "")
-        {
-            if (null == _activeConnection)
-            {
-                throw ADP.ConnectionRequired(method);
-            }
-
-            // Ensure that the connection is open and that the Parser is in the correct state
-            SqlInternalConnectionTds tdsConnection = _activeConnection.InnerConnection as SqlInternalConnectionTds;
-            if (tdsConnection != null)
-            {
-                var parser = tdsConnection.Parser;
-                if ((parser == null) || (parser.State == TdsParserState.Closed))
-                {
-                    throw ADP.OpenConnectionRequired(method, ConnectionState.Closed);
-                }
-                else if (parser.State != TdsParserState.OpenLoggedIn)
-                {
-                    throw ADP.OpenConnectionRequired(method, ConnectionState.Broken);
-                }
-            }
-            else if (_activeConnection.State == ConnectionState.Closed)
-            {
-                throw ADP.OpenConnectionRequired(method, ConnectionState.Closed);
-            }
-            else if (_activeConnection.State == ConnectionState.Broken)
-            {
-                throw ADP.OpenConnectionRequired(method, ConnectionState.Broken);
-            }
-
-            ValidateAsyncCommand();
-
-            // close any non MARS dead readers, if applicable, and then throw if still busy.
-            // Throw if we have a live reader on this command
-            _activeConnection.ValidateConnectionForExecute(method, this);
-            // Check to see if the currently set transaction has completed.  If so,
-            // null out our local reference.
-            if (null != _transaction && _transaction.Connection == null)
-                _transaction = null;
-
-            // throw if the connection is in a transaction but there is no
-            // locally assigned transaction object
-            if (_activeConnection.HasLocalTransactionFromAPI && (null == _transaction))
-                throw ADP.TransactionRequired(method);
-
-            // if we have a transaction, check to ensure that the active
-            // connection property matches the connection associated with
-            // the transaction
-            if (null != _transaction && _activeConnection != _transaction.Connection)
-                throw ADP.TransactionConnectionMismatch();
-
-            if (string.IsNullOrEmpty(this.CommandText))
-                throw ADP.CommandTextRequired(method);
-        }
-
-        private void ValidateAsyncCommand()
-        {
-            if (cachedAsyncState.PendingAsyncOperation)
-            { // Enforce only one pending async execute at a time.
-                if (cachedAsyncState.IsActiveConnectionValid(_activeConnection))
-                {
-                    throw SQL.PendingBeginXXXExists();
-                }
-                else
-                {
-                    _stateObj = null; // Session was re-claimed by session pool upon connection close.
-                    cachedAsyncState.ResetAsyncState();
-                }
-            }
-        }
-
-        private void GetStateObject(TdsParser parser = null)
-        {
-            Debug.Assert(null == _stateObj, "StateObject not null on GetStateObject");
-            Debug.Assert(null != _activeConnection, "no active connection?");
-
-            if (_pendingCancel)
-            {
-                _pendingCancel = false; // Not really needed, but we'll reset anyways.
-
-                // If a pendingCancel exists on the object, we must have had a Cancel() call
-                // between the point that we entered an Execute* API and the point in Execute* that
-                // we proceeded to call this function and obtain a stateObject.  In that case,
-                // we now throw a cancelled error.
-                throw SQL.OperationCancelled();
-            }
-
-            if (parser == null)
-            {
-                parser = _activeConnection.Parser;
-                if ((parser == null) || (parser.State == TdsParserState.Broken) || (parser.State == TdsParserState.Closed))
-                {
-                    // Connection's parser is null as well, therefore we must be closed
-                    throw ADP.ClosedConnectionError();
-                }
-            }
-
-            TdsParserStateObject stateObj = parser.GetSession(this);
-            stateObj.StartSession(this);
-
-            _stateObj = stateObj;
-
-            if (_pendingCancel)
-            {
-                _pendingCancel = false; // Not really needed, but we'll reset anyways.
-
-                // If a pendingCancel exists on the object, we must have had a Cancel() call
-                // between the point that we entered this function and the point where we obtained
-                // and actually assigned the stateObject to the local member.  It is possible
-                // that the flag is set as well as a call to stateObj.Cancel - though that would
-                // be a no-op.  So - throw.
-                throw SQL.OperationCancelled();
-            }
-        }
-
-        private void ReliablePutStateObject()
-        {
-            PutStateObject();
-        }
-
-        private void PutStateObject()
-        {
-            TdsParserStateObject stateObj = _stateObj;
-            _stateObj = null;
-
-            if (null != stateObj)
-            {
-                stateObj.CloseSession();
-            }
-        }
-        internal void OnDoneProc()
-        { // called per rpc batch complete
-            if (BatchRPCMode)
-            {
-                // track the records affected for the just completed rpc batch
-                // _rowsAffected is cumulative for ExecuteNonQuery across all rpc batches
-                _SqlRPCBatchArray[_currentlyExecutingBatch].cumulativeRecordsAffected = _rowsAffected;
-
-                _SqlRPCBatchArray[_currentlyExecutingBatch].recordsAffected =
-                    (((0 < _currentlyExecutingBatch) && (0 <= _rowsAffected))
-                        ? (_rowsAffected - Math.Max(_SqlRPCBatchArray[_currentlyExecutingBatch - 1].cumulativeRecordsAffected, 0))
-                        : _rowsAffected);
-
-                // track the error collection (not available from TdsParser after ExecuteNonQuery)
-                // and the which errors are associated with the just completed rpc batch
-                _SqlRPCBatchArray[_currentlyExecutingBatch].errorsIndexStart =
-                    ((0 < _currentlyExecutingBatch)
-                        ? _SqlRPCBatchArray[_currentlyExecutingBatch - 1].errorsIndexEnd
-                        : 0);
-                _SqlRPCBatchArray[_currentlyExecutingBatch].errorsIndexEnd = _stateObj.ErrorCount;
-                _SqlRPCBatchArray[_currentlyExecutingBatch].errors = _stateObj._errors;
-
-                // track the warning collection (not available from TdsParser after ExecuteNonQuery)
-                // and the which warnings are associated with the just completed rpc batch
-                _SqlRPCBatchArray[_currentlyExecutingBatch].warningsIndexStart =
-                    ((0 < _currentlyExecutingBatch)
-                        ? _SqlRPCBatchArray[_currentlyExecutingBatch - 1].warningsIndexEnd
-                        : 0);
-                _SqlRPCBatchArray[_currentlyExecutingBatch].warningsIndexEnd = _stateObj.WarningCount;
-                _SqlRPCBatchArray[_currentlyExecutingBatch].warnings = _stateObj._warnings;
-
-                _currentlyExecutingBatch++;
-                Debug.Assert(_parameterCollectionList.Count >= _currentlyExecutingBatch, "OnDoneProc: Too many DONEPROC events");
-            }
-        }
-        internal void OnReturnStatus(int status)
-        {
-            if (_inPrepare)
-                return;
-
-            SqlParameterCollection parameters = _parameters;
-            if (BatchRPCMode)
-            {
-                if (_parameterCollectionList.Count > _currentlyExecutingBatch)
-                {
-                    parameters = _parameterCollectionList[_currentlyExecutingBatch];
-                }
-                else
-                {
-                    Debug.Assert(false, "OnReturnStatus: SqlCommand got too many DONEPROC events");
-                    parameters = null;
-                }
-            }
-            // see if a return value is bound
-            int count = GetParameterCount(parameters);
-            for (int i = 0; i < count; i++)
-            {
-                SqlParameter parameter = parameters[i];
-                if (parameter.Direction == ParameterDirection.ReturnValue)
-                {
-                    object v = parameter.Value;
-
-                    // if the user bound a sqlint32 (the only valid one for status, use it)
-                    if ((null != v) && (v.GetType() == typeof(SqlInt32)))
-                    {
-                        parameter.Value = new SqlInt32(status); // value type
-                    }
-                    else
-                    {
-                        parameter.Value = status;
-
-                    }
-
-                    break;
-                }
-            }
-        }
-
-        //
-        // Move the return value to the corresponding output parameter.
-        // Return parameters are sent in the order in which they were defined in the procedure.
-        // If named, match the parameter name, otherwise fill in based on ordinal position.
-        // If the parameter is not bound, then ignore the return value.
-        //
-        internal void OnReturnValue(SqlReturnValue rec)
-        {
-
-            if (_inPrepare)
-            {
-                if (!rec.value.IsNull)
-                {
-                    _prepareHandle = rec.value.Int32;
-                }
-                _inPrepare = false;
-                return;
-            }
-
-            SqlParameterCollection parameters = GetCurrentParameterCollection();
-            int count = GetParameterCount(parameters);
-
-
-            SqlParameter thisParam = GetParameterForOutputValueExtraction(parameters, rec.parameter, count);
-
-            if (null != thisParam)
-            {
-                // copy over data
-
-                // if the value user has supplied a SqlType class, then just copy over the SqlType, otherwise convert
-                // to the com type
-                object val = thisParam.Value;
-
-                thisParam.SetSqlBuffer(rec.value);
-
-                MetaType mt = MetaType.GetMetaTypeFromSqlDbType(rec.type, false);
-
-                if (rec.type == SqlDbType.Decimal)
-                {
-                    thisParam.ScaleInternal = rec.scale;
-                    thisParam.PrecisionInternal = rec.precision;
-                }
-                else if (mt.IsVarTime)
-                {
-                    thisParam.ScaleInternal = rec.scale;
-                }
-                else if (rec.type == SqlDbType.Xml)
-                {
-                    SqlCachedBuffer cachedBuffer = (thisParam.Value as SqlCachedBuffer);
-                    if (null != cachedBuffer)
-                    {
-                        thisParam.Value = cachedBuffer.ToString();
-                    }
-                }
-
-                if (rec.collation != null)
-                {
-                    Debug.Assert(mt.IsCharType, "Invalid collation structure for non-char type");
-                    thisParam.Collation = rec.collation;
-                }
-            }
-
-            return;
-        }
-
-        private SqlParameterCollection GetCurrentParameterCollection()
-        {
-            if (BatchRPCMode)
-            {
-                if (_parameterCollectionList.Count > _currentlyExecutingBatch)
-                {
-                    return _parameterCollectionList[_currentlyExecutingBatch];
-                }
-                else
-                {
-                    Debug.Assert(false, "OnReturnValue: SqlCommand got too many DONEPROC events");
-                    return null;
-                }
-            }
-            else
-            {
-                return _parameters;
-            }
-        }
-
-        private SqlParameter GetParameterForOutputValueExtraction(SqlParameterCollection parameters,
-                        string paramName, int paramCount)
-        {
-            SqlParameter thisParam = null;
-            bool foundParam = false;
-
-            if (null == paramName)
-            {
-                // rec.parameter should only be null for a return value from a function
-                for (int i = 0; i < paramCount; i++)
-                {
-                    thisParam = parameters[i];
-                    // searching for ReturnValue
-                    if (thisParam.Direction == ParameterDirection.ReturnValue)
-                    {
-                        foundParam = true;
-                        break; // found it
-                    }
-                }
-            }
-            else
-            {
-                for (int i = 0; i < paramCount; i++)
-                {
-                    thisParam = parameters[i];
-                    // searching for Output or InputOutput or ReturnValue with matching name
-                    if (thisParam.Direction != ParameterDirection.Input && thisParam.Direction != ParameterDirection.ReturnValue && paramName == thisParam.ParameterNameFixed)
-                    {
-                        foundParam = true;
-                        break; // found it
-                    }
-                }
-            }
-            if (foundParam)
-                return thisParam;
-            else
-                return null;
-        }
-
-        private void GetRPCObject(int paramCount, ref _SqlRPC rpc)
-        {
-            // Designed to minimize necessary allocations
-            int ii;
-            if (rpc == null)
-            {
-                if (_rpcArrayOf1 == null)
-                {
-                    _rpcArrayOf1 = new _SqlRPC[1];
-                    _rpcArrayOf1[0] = new _SqlRPC();
-                }
-                rpc = _rpcArrayOf1[0];
-            }
-
-            rpc.ProcID = 0;
-            rpc.rpcName = null;
-            rpc.options = 0;
-
-
-            // Make sure there is enough space in the parameters and paramoptions arrays
-            if (rpc.parameters == null || rpc.parameters.Length < paramCount)
-            {
-                rpc.parameters = new SqlParameter[paramCount];
-            }
-            else if (rpc.parameters.Length > paramCount)
-            {
-                rpc.parameters[paramCount] = null;    // Terminator
-            }
-            if (rpc.paramoptions == null || (rpc.paramoptions.Length < paramCount))
-            {
-                rpc.paramoptions = new byte[paramCount];
-            }
-            else
-            {
-                for (ii = 0; ii < paramCount; ii++)
-                    rpc.paramoptions[ii] = 0;
-            }
-        }
-
-        private void SetUpRPCParameters(_SqlRPC rpc, int startCount, bool inSchema, SqlParameterCollection parameters)
-        {
-            int ii;
-            int paramCount = GetParameterCount(parameters);
-            int j = startCount;
-            TdsParser parser = _activeConnection.Parser;
-
-            for (ii = 0; ii < paramCount; ii++)
-            {
-                SqlParameter parameter = parameters[ii];
-                parameter.Validate(ii, CommandType.StoredProcedure == CommandType);
-
-                // func will change type to that with a 4 byte length if the type has a two
-                // byte length and a parameter length > than that expressible in 2 bytes
-                if ((!parameter.ValidateTypeLengths().IsPlp) && (parameter.Direction != ParameterDirection.Output))
-                {
-                    parameter.FixStreamDataForNonPLP();
-                }
-
-                if (ShouldSendParameter(parameter))
-                {
-                    rpc.parameters[j] = parameter;
-
-                    // set output bit
-                    if (parameter.Direction == ParameterDirection.InputOutput ||
-                        parameter.Direction == ParameterDirection.Output)
-                        rpc.paramoptions[j] = TdsEnums.RPC_PARAM_BYREF;
-
-                    // set default value bit
-                    if (parameter.Direction != ParameterDirection.Output)
-                    {
-                        // remember that null == Convert.IsEmpty, DBNull.Value is a database null!
-
-                        // Don't assume a default value exists for parameters in the case when
-                        // the user is simply requesting schema.
-                        // TVPs use DEFAULT and do not allow NULL, even for schema only.
-                        if (null == parameter.Value && (!inSchema || SqlDbType.Structured == parameter.SqlDbType))
-                        {
-                            rpc.paramoptions[j] |= TdsEnums.RPC_PARAM_DEFAULT;
-                        }
-                    }
-
-                    // Must set parameter option bit for LOB_COOKIE if unfilled LazyMat blob
-                    j++;
-                }
-            }
-        }
-
-        private _SqlRPC BuildPrepExec(CommandBehavior behavior)
-        {
-            Debug.Assert(System.Data.CommandType.Text == this.CommandType, "invalid use of sp_prepexec for stored proc invocation!");
-            SqlParameter sqlParam;
-            int j = 3;
-
-            int count = CountSendableParameters(_parameters);
-
-            _SqlRPC rpc = null;
-            GetRPCObject(count + j, ref rpc);
-
-            rpc.ProcID = TdsEnums.RPC_PROCID_PREPEXEC;
-            rpc.rpcName = TdsEnums.SP_PREPEXEC;
-
-            //@handle
-            sqlParam = new SqlParameter(null, SqlDbType.Int);
-            sqlParam.Direction = ParameterDirection.InputOutput;
-            sqlParam.Value = _prepareHandle;
-            rpc.parameters[0] = sqlParam;
-            rpc.paramoptions[0] = TdsEnums.RPC_PARAM_BYREF;
-
-            //@batch_params
-            string paramList = BuildParamList(_stateObj.Parser, _parameters);
-            sqlParam = new SqlParameter(null, ((paramList.Length << 1) <= TdsEnums.TYPE_SIZE_LIMIT) ? SqlDbType.NVarChar : SqlDbType.NText, paramList.Length);
-            sqlParam.Value = paramList;
-            rpc.parameters[1] = sqlParam;
-
-            //@batch_text
-            string text = GetCommandText(behavior);
-            sqlParam = new SqlParameter(null, ((text.Length << 1) <= TdsEnums.TYPE_SIZE_LIMIT) ? SqlDbType.NVarChar : SqlDbType.NText, text.Length);
-            sqlParam.Value = text;
-            rpc.parameters[2] = sqlParam;
-
-            SetUpRPCParameters(rpc, j, false, _parameters);
-            return rpc;
-        }
-
-
-        //
-        // returns true if the parameter is not a return value
-        // and it's value is not DBNull (for a nullable parameter)
-        //
-        private static bool ShouldSendParameter(SqlParameter p)
-        {
-            switch (p.Direction)
-            {
-                case ParameterDirection.ReturnValue:
-                    // return value parameters are never sent
-                    return false;
-                case ParameterDirection.Output:
-                case ParameterDirection.InputOutput:
-                case ParameterDirection.Input:
-                    // InputOutput/Output parameters are aways sent
-                    return true;
-                default:
-                    Debug.Assert(false, "Invalid ParameterDirection!");
-                    return false;
-            }
-        }
-
-        private int CountSendableParameters(SqlParameterCollection parameters)
-        {
-            int cParams = 0;
-
-            if (parameters != null)
-            {
-                int count = parameters.Count;
-                for (int i = 0; i < count; i++)
-                {
-                    if (ShouldSendParameter(parameters[i]))
-                        cParams++;
-                }
-            }
-            return cParams;
-        }
-
-        // Returns total number of parameters
-        private int GetParameterCount(SqlParameterCollection parameters)
-        {
-            return ((null != parameters) ? parameters.Count : 0);
-        }
-
-        //
-        // build the RPC record header for this stored proc and add parameters
-        //
-        private void BuildRPC(bool inSchema, SqlParameterCollection parameters, ref _SqlRPC rpc)
-        {
-            Debug.Assert(this.CommandType == System.Data.CommandType.StoredProcedure, "Command must be a stored proc to execute an RPC");
-            int count = CountSendableParameters(parameters);
-            GetRPCObject(count, ref rpc);
-
-            rpc.rpcName = this.CommandText; // just get the raw command text
-
-            SetUpRPCParameters(rpc, 0, inSchema, parameters);
-        }
-
-        //
-        // build the RPC record header for sp_unprepare
-        //
-        // prototype for sp_unprepare is:
-        // sp_unprepare(@handle)
-
-        // build the RPC record header for sp_execute
-        //
-        // prototype for sp_execute is:
-        // sp_execute(@handle int,param1value,param2value...)
-
-        private _SqlRPC BuildExecute(bool inSchema)
-        {
-            Debug.Assert(_prepareHandle != -1, "Invalid call to sp_execute without a valid handle!");
-            int j = 1;
-
-            int count = CountSendableParameters(_parameters);
-
-            _SqlRPC rpc = null;
-            GetRPCObject(count + j, ref rpc);
-
-            SqlParameter sqlParam;
-
-            rpc.ProcID = TdsEnums.RPC_PROCID_EXECUTE;
-            rpc.rpcName = TdsEnums.SP_EXECUTE;
-
-            //@handle
-            sqlParam = new SqlParameter(null, SqlDbType.Int);
-            sqlParam.Value = _prepareHandle;
-            rpc.parameters[0] = sqlParam;
-
-            SetUpRPCParameters(rpc, j, inSchema, _parameters);
-            return rpc;
-        }
-
-        //
-        // build the RPC record header for sp_executesql and add the parameters
-        //
-        // prototype for sp_executesql is:
-        // sp_executesql(@batch_text nvarchar(4000),@batch_params nvarchar(4000), param1,.. paramN)
-        private void BuildExecuteSql(CommandBehavior behavior, string commandText, SqlParameterCollection parameters, ref _SqlRPC rpc)
-        {
-
-            Debug.Assert(_prepareHandle == -1, "This command has an existing handle, use sp_execute!");
-            Debug.Assert(CommandType.Text == this.CommandType, "invalid use of sp_executesql for stored proc invocation!");
-            int j;
-            SqlParameter sqlParam;
-
-            int cParams = CountSendableParameters(parameters);
-            if (cParams > 0)
-            {
-                j = 2;
-            }
-            else
-            {
-                j = 1;
-            }
-
-            GetRPCObject(cParams + j, ref rpc);
-            rpc.ProcID = TdsEnums.RPC_PROCID_EXECUTESQL;
-            rpc.rpcName = TdsEnums.SP_EXECUTESQL;
-
-            // @sql
-            if (commandText == null)
-            {
-                commandText = GetCommandText(behavior);
-            }
-            sqlParam = new SqlParameter(null, ((commandText.Length << 1) <= TdsEnums.TYPE_SIZE_LIMIT) ? SqlDbType.NVarChar : SqlDbType.NText, commandText.Length);
-            sqlParam.Value = commandText;
-            rpc.parameters[0] = sqlParam;
-
-            if (cParams > 0)
-            {
-                string paramList = BuildParamList(_stateObj.Parser, BatchRPCMode ? parameters : _parameters);
-                sqlParam = new SqlParameter(null, ((paramList.Length << 1) <= TdsEnums.TYPE_SIZE_LIMIT) ? SqlDbType.NVarChar : SqlDbType.NText, paramList.Length);
-                sqlParam.Value = paramList;
-                rpc.parameters[1] = sqlParam;
-
-                bool inSchema = (0 != (behavior & CommandBehavior.SchemaOnly));
-                SetUpRPCParameters(rpc, j, inSchema, parameters);
-            }
-        }
-
-        // paramList parameter for sp_executesql, sp_prepare, and sp_prepexec
-        internal string BuildParamList(TdsParser parser, SqlParameterCollection parameters)
-        {
-            StringBuilder paramList = new StringBuilder();
-            bool fAddSeperator = false;
-
-            int count = 0;
-
-            count = parameters.Count;
-            for (int i = 0; i < count; i++)
-            {
-                SqlParameter sqlParam = parameters[i];
-                sqlParam.Validate(i, CommandType.StoredProcedure == CommandType);
-                // skip ReturnValue parameters; we never send them to the server
-                if (!ShouldSendParameter(sqlParam))
-                    continue;
-
-                // add our separator for the ith parameter
-                if (fAddSeperator)
-                    paramList.Append(',');
-
-                paramList.Append(sqlParam.ParameterNameFixed);
-
-                MetaType mt = sqlParam.InternalMetaType;
-
-                //for UDTs, get the actual type name. Get only the typename, omit catalog and schema names.
-                //in TSQL you should only specify the unqualified type name
-
-                // paragraph above doesn't seem to be correct. Server won't find the type
-                // if we don't provide a fully qualified name
-                paramList.Append(" ");
-                if (mt.SqlDbType == SqlDbType.Udt)
-                {
-                    throw ADP.DbTypeNotSupported(SqlDbType.Udt.ToString());
-                }
-                else if (mt.SqlDbType == SqlDbType.Structured)
-                {
-                    string typeName = sqlParam.TypeName;
-                    if (string.IsNullOrEmpty(typeName))
-                    {
-                        throw SQL.MustSetTypeNameForParam(mt.TypeName, sqlParam.ParameterNameFixed);
-                    }
-                    paramList.Append(ParseAndQuoteIdentifier(typeName));
-
-                    // TVPs currently are the only Structured type and must be read only, so add that keyword
-                    paramList.Append(" READONLY");
-                }
-                else
-                {
-                    // func will change type to that with a 4 byte length if the type has a two
-                    // byte length and a parameter length > than that expressible in 2 bytes
-                    mt = sqlParam.ValidateTypeLengths();
-                    if ((!mt.IsPlp) && (sqlParam.Direction != ParameterDirection.Output))
-                    {
-                        sqlParam.FixStreamDataForNonPLP();
-                    }
-                    paramList.Append(mt.TypeName);
-                }
-
-                fAddSeperator = true;
-
-                if (mt.SqlDbType == SqlDbType.Decimal)
-                {
-                    byte precision = sqlParam.GetActualPrecision();
-                    byte scale = sqlParam.GetActualScale();
-
-                    paramList.Append('(');
-
-                    if (0 == precision)
-                    {
-                        precision = TdsEnums.DEFAULT_NUMERIC_PRECISION;
-                    }
-
-                    paramList.Append(precision);
-                    paramList.Append(',');
-                    paramList.Append(scale);
-                    paramList.Append(')');
-                }
-                else if (mt.IsVarTime)
-                {
-                    byte scale = sqlParam.GetActualScale();
-
-                    paramList.Append('(');
-                    paramList.Append(scale);
-                    paramList.Append(')');
-                }
-                else if (false == mt.IsFixed && false == mt.IsLong && mt.SqlDbType != SqlDbType.Timestamp && mt.SqlDbType != SqlDbType.Udt && SqlDbType.Structured != mt.SqlDbType)
-                {
-                    int size = sqlParam.Size;
-
-                    paramList.Append('(');
-
-                    // if using non unicode types, obtain the actual byte length from the parser, with it's associated code page
-                    if (mt.IsAnsiType)
-                    {
-                        object val = sqlParam.GetCoercedValue();
-                        string s = null;
-
-                        // deal with the sql types
-                        if ((null != val) && (DBNull.Value != val))
-                        {
-                            s = (val as string);
-                            if (null == s)
-                            {
-                                SqlString sval = val is SqlString ? (SqlString)val : SqlString.Null;
-                                if (!sval.IsNull)
-                                {
-                                    s = sval.Value;
-                                }
-                            }
-                        }
-
-                        if (null != s)
-                        {
-                            int actualBytes = parser.GetEncodingCharLength(s, sqlParam.GetActualSize(), sqlParam.Offset, null);
-                            // if actual number of bytes is greater than the user given number of chars, use actual bytes
-                            if (actualBytes > size)
-                                size = actualBytes;
-                        }
-                    }
-
-                    // If the user specifies a 0-sized parameter for a variable len field
-                    // pass over max size (8000 bytes or 4000 characters for wide types)
-                    if (0 == size)
-                        size = mt.IsSizeInCharacters ? (TdsEnums.MAXSIZE >> 1) : TdsEnums.MAXSIZE;
-
-                    paramList.Append(size);
-                    paramList.Append(')');
-                }
-                else if (mt.IsPlp && (mt.SqlDbType != SqlDbType.Xml) && (mt.SqlDbType != SqlDbType.Udt))
-                {
-                    paramList.Append("(max) ");
-                }
-
-                // set the output bit for Output or InputOutput parameters
-                if (sqlParam.Direction != ParameterDirection.Input)
-                    paramList.Append(" " + TdsEnums.PARAM_OUTPUT);
-            }
-
-            return paramList.ToString();
-        }
-
-        // Adds quotes to each part of a SQL identifier that may be multi-part, while leaving
-        //  the result as a single composite name.
-        private string ParseAndQuoteIdentifier(string identifier)
-        {
-            string[] strings = SqlParameter.ParseTypeName(identifier);
-            StringBuilder bld = new StringBuilder();
-
-            // Stitching back together is a little tricky. Assume we want to build a full multi-part name
-            //  with all parts except trimming separators for leading empty names (null or empty strings,
-            //  but not whitespace). Separators in the middle should be added, even if the name part is 
-            //  null/empty, to maintain proper location of the parts.
-            for (int i = 0; i < strings.Length; i++)
-            {
-                if (0 < bld.Length)
-                {
-                    bld.Append('.');
-                }
-                if (null != strings[i] && 0 != strings[i].Length)
-                {
-                    bld.Append(ADP.BuildQuotedString("[", "]", strings[i]));
-                }
-            }
-
-            return bld.ToString();
-        }
-
-        // returns set option text to turn on format only and key info on and off
-        //  When we are executing as a text command, then we never need
-        // to turn off the options since they command text is executed in the scope of sp_executesql.
-        // For a stored proc command, however, we must send over batch sql and then turn off
-        // the set options after we read the data.  See the code in Command.Execute()
-        private string GetSetOptionsString(CommandBehavior behavior)
-        {
-            string s = null;
-
-            if ((System.Data.CommandBehavior.SchemaOnly == (behavior & CommandBehavior.SchemaOnly)) ||
-               (System.Data.CommandBehavior.KeyInfo == (behavior & CommandBehavior.KeyInfo)))
-            {
-                // SET FMTONLY ON will cause the server to ignore other SET OPTIONS, so turn
-                // it off before we ask for browse mode metadata
-                s = TdsEnums.FMTONLY_OFF;
-
-                if (System.Data.CommandBehavior.KeyInfo == (behavior & CommandBehavior.KeyInfo))
-                {
-                    s = s + TdsEnums.BROWSE_ON;
-                }
-
-                if (System.Data.CommandBehavior.SchemaOnly == (behavior & CommandBehavior.SchemaOnly))
-                {
-                    s = s + TdsEnums.FMTONLY_ON;
-                }
-            }
-
-            return s;
-        }
-
-        private string GetResetOptionsString(CommandBehavior behavior)
-        {
-            string s = null;
-
-            // SET FMTONLY ON OFF
-            if (System.Data.CommandBehavior.SchemaOnly == (behavior & CommandBehavior.SchemaOnly))
-            {
-                s = s + TdsEnums.FMTONLY_OFF;
-            }
-
-            // SET NO_BROWSETABLE OFF
-            if (System.Data.CommandBehavior.KeyInfo == (behavior & CommandBehavior.KeyInfo))
-            {
-                s = s + TdsEnums.BROWSE_OFF;
-            }
-
-            return s;
-        }
-
-        private String GetCommandText(CommandBehavior behavior)
-        {
-            // build the batch string we send over, since we execute within a stored proc (sp_executesql), the SET options never need to be
-            // turned off since they are scoped to the sproc
-            Debug.Assert(System.Data.CommandType.Text == this.CommandType, "invalid call to GetCommandText for stored proc!");
-            return GetSetOptionsString(behavior) + this.CommandText;
-        }
-
-        internal void CheckThrowSNIException()
-        {
-            var stateObj = _stateObj;
-            if (stateObj != null)
-            {
-                stateObj.CheckThrowSNIException();
-            }
-        }
-
-        // We're being notified that the underlying connection has closed
-        internal void OnConnectionClosed()
-        {
-            var stateObj = _stateObj;
-            if (stateObj != null)
-            {
-                stateObj.OnConnectionClosed();
-            }
-        }
-
-        internal TdsParserStateObject StateObject
-        {
-            get
-            {
-                return _stateObj;
-            }
-        }
-
-        private bool IsPrepared
-        {
-            get { return (_execType != EXECTYPE.UNPREPARED); }
-        }
-
-        private bool IsUserPrepared
-        {
-            get { return IsPrepared && !_hiddenPrepare && !IsDirty; }
-        }
-
-        internal bool IsDirty
-        {
-            get
-            {
-                // only dirty if prepared
-                var activeConnection = _activeConnection;
-                return (IsPrepared &&
-                    (_dirty ||
-                    ((_parameters != null) && (_parameters.IsDirty)) ||
-                    ((activeConnection != null) && ((activeConnection.CloseCount != _preparedConnectionCloseCount) || (activeConnection.ReconnectCount != _preparedConnectionReconnectCount)))));
-            }
-            set
-            {
-                // only mark the command as dirty if it is already prepared
-                // but always clear the value if it we are clearing the dirty flag
-                _dirty = value ? IsPrepared : false;
-                if (null != _parameters)
-                {
-                    _parameters.IsDirty = _dirty;
-                }
-                _cachedMetaData = null;
-            }
-        }
-
-        internal int InternalRecordsAffected
-        {
-            get
-            {
-                return _rowsAffected;
-            }
-            set
-            {
-                if (-1 == _rowsAffected)
-                {
-                    _rowsAffected = value;
-                }
-                else if (0 < value)
-                {
-                    _rowsAffected += value;
-                }
-            }
-        }
-
-        internal void ClearBatchCommand()
-        {
-            List<_SqlRPC> rpcList = _RPCList;
-            if (null != rpcList)
-            {
-                rpcList.Clear();
-            }
-            if (null != _parameterCollectionList)
-            {
-                _parameterCollectionList.Clear();
-            }
-
-            _SqlRPCBatchArray = null;
-            _currentlyExecutingBatch = 0;
-        }
-
-        internal bool BatchRPCMode
-        {
-            get
-            {
-                return _batchRPCMode;
-            }
-            set
-            {
-                _batchRPCMode = value;
-
-                if (_batchRPCMode == false)
-                {
-                    ClearBatchCommand();
-                }
-                else
-                {
-                    if (_RPCList == null)
-                    {
-                        _RPCList = new List<_SqlRPC>();
-                    }
-                    if (_parameterCollectionList == null)
-                    {
-                        _parameterCollectionList = new List<SqlParameterCollection>();
-                    }
-                }
-            }
-        }
-
-        internal void AddBatchCommand(string commandText, SqlParameterCollection parameters, CommandType cmdType)
-        {
-            Debug.Assert(BatchRPCMode, "Command is not in batch RPC Mode");
-            Debug.Assert(_RPCList != null);
-            Debug.Assert(_parameterCollectionList != null);
-
-            _SqlRPC rpc = new _SqlRPC();
-
-            CommandText = commandText;
-            CommandType = cmdType;
-
-            GetStateObject();
-            if (cmdType == CommandType.StoredProcedure)
-            {
-                BuildRPC(false, parameters, ref rpc);
-            }
-            else
-            {
-                // All batch sql statements must be executed inside sp_executesql, including those without parameters
-                BuildExecuteSql(CommandBehavior.Default, commandText, parameters, ref rpc);
-            }
-
-            _RPCList.Add(rpc);
-            // Always add a parameters collection per RPC, even if there are no parameters.
-            _parameterCollectionList.Add(parameters);
-
-            ReliablePutStateObject();
-        }
-
-        internal int ExecuteBatchRPCCommand()
-        {
-
-            Debug.Assert(BatchRPCMode, "Command is not in batch RPC Mode");
-            Debug.Assert(_RPCList != null, "No batch commands specified");
-
-            _SqlRPCBatchArray = _RPCList.ToArray();
-            _currentlyExecutingBatch = 0;
-            return ExecuteNonQuery();       // Check permissions, execute, return output params
-        }
-
-        internal int? GetRecordsAffected(int commandIndex)
-        {
-            Debug.Assert(BatchRPCMode, "Command is not in batch RPC Mode");
-            Debug.Assert(_SqlRPCBatchArray != null, "batch command have been cleared");
-            return _SqlRPCBatchArray[commandIndex].recordsAffected;
-        }
-
-        internal SqlException GetErrors(int commandIndex)
-        {
-            SqlException result = null;
-            int length = (_SqlRPCBatchArray[commandIndex].errorsIndexEnd - _SqlRPCBatchArray[commandIndex].errorsIndexStart);
-            if (0 < length)
-            {
-                SqlErrorCollection errors = new SqlErrorCollection();
-                for (int i = _SqlRPCBatchArray[commandIndex].errorsIndexStart; i < _SqlRPCBatchArray[commandIndex].errorsIndexEnd; ++i)
-                {
-                    errors.Add(_SqlRPCBatchArray[commandIndex].errors[i]);
-                }
-                for (int i = _SqlRPCBatchArray[commandIndex].warningsIndexStart; i < _SqlRPCBatchArray[commandIndex].warningsIndexEnd; ++i)
-                {
-                    errors.Add(_SqlRPCBatchArray[commandIndex].warnings[i]);
-                }
-                result = SqlException.CreateException(errors, Connection.ServerVersion, Connection.ClientConnectionId);
-            }
-            return result;
-        }
+		// transaction support
+		private SqlTransaction _transaction;
+
+		private StatementCompletedEventHandler _statementCompletedEventHandler;
+
+		private TdsParserStateObject _stateObj; // this is the TDS session we're using.
+
+		// Volatile bool used to synchronize with cancel thread the state change of an executing
+		// command going from pre-processing to obtaining a stateObject.  The cancel synchronization
+		// we require in the command is only from entering an Execute* API to obtaining a 
+		// stateObj.  Once a stateObj is successfully obtained, cancel synchronization is handled
+		// by the stateObject.
+		private volatile bool _pendingCancel;
+
+		private bool _batchRPCMode;
+		private List<_SqlRPC> _RPCList;
+		private _SqlRPC[] _SqlRPCBatchArray;
+		private List<SqlParameterCollection> _parameterCollectionList;
+		private int _currentlyExecutingBatch;
+
+
+		public SqlCommand() : base()
+		{
+			GC.SuppressFinalize(this);
+		}
+
+		public SqlCommand(string cmdText) : this()
+		{
+			CommandText = cmdText;
+		}
+
+		public SqlCommand(string cmdText, SqlConnection connection) : this()
+		{
+			CommandText = cmdText;
+			Connection = connection;
+		}
+
+		public SqlCommand(string cmdText, SqlConnection connection, SqlTransaction transaction) : this()
+		{
+			CommandText = cmdText;
+			Connection = connection;
+			Transaction = transaction;
+		}
+
+		private SqlCommand(SqlCommand from) : this()
+		{
+			CommandText = from.CommandText;
+			CommandTimeout = from.CommandTimeout;
+			CommandType = from.CommandType;
+			Connection = from.Connection;
+			DesignTimeVisible = from.DesignTimeVisible;
+			Transaction = from.Transaction;
+			UpdatedRowSource = from.UpdatedRowSource;
+
+			SqlParameterCollection parameters = Parameters;
+			foreach (object parameter in from.Parameters)
+			{
+				parameters.Add((parameter is ICloneable) ? (parameter as ICloneable).Clone() : parameter);
+			}
+		}
+
+		new public SqlConnection Connection
+		{
+			get
+			{
+				return _activeConnection;
+			}
+			set
+			{
+				// Don't allow the connection to be changed while in a async operation.
+				if (_activeConnection != value && _activeConnection != null)
+				{ // If new value...
+					if (cachedAsyncState.PendingAsyncOperation)
+					{ // If in pending async state, throw.
+						throw SQL.CannotModifyPropertyAsyncOperationInProgress();
+					}
+				}
+
+				// Check to see if the currently set transaction has completed.  If so,
+				// null out our local reference.
+				if (null != _transaction && _transaction.Connection == null)
+				{
+					_transaction = null;
+				}
+
+
+				// Command is no longer prepared on new connection, cleanup prepare status
+				if (IsPrepared)
+				{
+					if (_activeConnection != value && _activeConnection != null)
+					{
+						try
+						{
+							// cleanup
+							Unprepare();
+						}
+						catch (Exception)
+						{
+							// we do not really care about errors in unprepare (may be the old connection went bad)                                        
+						}
+						finally
+						{
+							// clean prepare status (even successful Unprepare does not do that)
+							_prepareHandle = -1;
+							_execType = EXECTYPE.UNPREPARED;
+						}
+					}
+				}
+
+				_activeConnection = value;
+			}
+		}
+
+		override protected DbConnection DbConnection
+		{
+			get
+			{
+				return Connection;
+			}
+			set
+			{
+				Connection = (SqlConnection)value;
+			}
+		}
+
+		private SqlInternalConnectionTds InternalTdsConnection
+		{
+			get
+			{
+				return (SqlInternalConnectionTds)_activeConnection.InnerConnection;
+			}
+		}
+
+		public SqlNotificationRequest Notification
+		{
+			get
+			{
+				return _notification;
+			}
+			set
+			{
+				_sqlDep = null;
+				_notification = value;
+			}
+		}
+
+		public bool NotificationAutoEnlist
+		{
+			get
+			{
+				return _notificationAutoEnlist;
+			}
+			set
+			{
+				_notificationAutoEnlist = value;
+			}
+		}
+
+		internal SqlStatistics Statistics
+		{
+			get
+			{
+				if (null != _activeConnection)
+				{
+					if (_activeConnection.StatisticsEnabled || 
+						_diagnosticListener.IsEnabled(SqlClientDiagnosticListenerExtensions.SqlAfterExecuteCommand))
+					{
+						return _activeConnection.Statistics;
+					}
+				}
+				return null;
+			}
+		}
+
+		new public SqlTransaction Transaction
+		{
+			get
+			{
+				// if the transaction object has been zombied, just return null
+				if ((null != _transaction) && (null == _transaction.Connection))
+				{
+					_transaction = null;
+				}
+				return _transaction;
+			}
+			set
+			{
+				// Don't allow the transaction to be changed while in a async operation.
+				if (_transaction != value && _activeConnection != null)
+				{ // If new value...
+					if (cachedAsyncState.PendingAsyncOperation)
+					{ // If in pending async state, throw
+						throw SQL.CannotModifyPropertyAsyncOperationInProgress();
+					}
+				}
+
+				_transaction = value;
+			}
+		}
+
+		override protected DbTransaction DbTransaction
+		{
+			get
+			{
+				return Transaction;
+			}
+			set
+			{
+				Transaction = (SqlTransaction)value;
+			}
+		}
+
+		override public string CommandText
+		{
+			get
+			{
+				string value = _commandText;
+				return ((null != value) ? value : ADP.StrEmpty);
+			}
+			set
+			{
+				if (_commandText != value)
+				{
+					PropertyChanging();
+					_commandText = value;
+				}
+			}
+		}
+
+		override public int CommandTimeout
+		{
+			get
+			{
+				return _commandTimeout;
+			}
+			set
+			{
+				if (value < 0)
+				{
+					throw ADP.InvalidCommandTimeout(value);
+				}
+				if (value != _commandTimeout)
+				{
+					PropertyChanging();
+					_commandTimeout = value;
+				}
+			}
+		}
+
+		public void ResetCommandTimeout()
+		{
+			if (ADP.DefaultCommandTimeout != _commandTimeout)
+			{
+				PropertyChanging();
+				_commandTimeout = ADP.DefaultCommandTimeout;
+			}
+		}
+
+		override public CommandType CommandType
+		{
+			get
+			{
+				CommandType cmdType = _commandType;
+				return ((0 != cmdType) ? cmdType : CommandType.Text);
+			}
+			set
+			{
+				if (_commandType != value)
+				{
+					switch (value)
+					{
+						case CommandType.Text:
+						case CommandType.StoredProcedure:
+							PropertyChanging();
+							_commandType = value;
+							break;
+						case System.Data.CommandType.TableDirect:
+							throw SQL.NotSupportedCommandType(value);
+						default:
+							throw ADP.InvalidCommandType(value);
+					}
+				}
+			}
+		}
+
+		// @devnote: By default, the cmd object is visible on the design surface (i.e. VS7 Server Tray)
+		// to limit the number of components that clutter the design surface,
+		// when the DataAdapter design wizard generates the insert/update/delete commands it will
+		// set the DesignTimeVisible property to false so that cmds won't appear as individual objects
+		public override bool DesignTimeVisible
+		{
+			get
+			{
+				return !_designTimeInvisible;
+			}
+			set
+			{
+				_designTimeInvisible = !value;
+			}
+		}
+
+		new public SqlParameterCollection Parameters
+		{
+			get
+			{
+				if (null == _parameters)
+				{
+					// delay the creation of the SqlParameterCollection
+					// until user actually uses the Parameters property
+					_parameters = new SqlParameterCollection();
+				}
+				return _parameters;
+			}
+		}
+
+		override protected DbParameterCollection DbParameterCollection
+		{
+			get
+			{
+				return Parameters;
+			}
+		}
+
+		override public UpdateRowSource UpdatedRowSource
+		{
+			get
+			{
+				return _updatedRowSource;
+			}
+			set
+			{
+				switch (value)
+				{
+					case UpdateRowSource.None:
+					case UpdateRowSource.OutputParameters:
+					case UpdateRowSource.FirstReturnedRecord:
+					case UpdateRowSource.Both:
+						_updatedRowSource = value;
+						break;
+					default:
+						throw ADP.InvalidUpdateRowSource(value);
+				}
+			}
+		}
+
+		public event StatementCompletedEventHandler StatementCompleted
+		{
+			add
+			{
+				_statementCompletedEventHandler += value;
+			}
+			remove
+			{
+				_statementCompletedEventHandler -= value;
+			}
+		}
+
+		internal void OnStatementCompleted(int recordCount)
+		{
+			if (0 <= recordCount)
+			{
+				StatementCompletedEventHandler handler = _statementCompletedEventHandler;
+				if (null != handler)
+				{
+					try
+					{
+						handler(this, new StatementCompletedEventArgs(recordCount));
+					}
+					catch (Exception e)
+					{
+						if (!ADP.IsCatchableOrSecurityExceptionType(e))
+						{
+							throw;
+						}
+					}
+				}
+			}
+		}
+
+		private void PropertyChanging()
+		{ // also called from SqlParameterCollection
+			this.IsDirty = true;
+		}
+
+		override public void Prepare()
+		{
+			// Reset _pendingCancel upon entry into any Execute - used to synchronize state
+			// between entry into Execute* API and the thread obtaining the stateObject.
+			_pendingCancel = false;
+
+
+			SqlStatistics statistics = null;
+			statistics = SqlStatistics.StartTimer(Statistics);
+
+			// only prepare if batch with parameters
+			if (
+				this.IsPrepared && !this.IsDirty
+				|| (this.CommandType == CommandType.StoredProcedure)
+				|| (
+						(System.Data.CommandType.Text == this.CommandType)
+						&& (0 == GetParameterCount(_parameters))
+					)
+
+			)
+			{
+				if (null != Statistics)
+				{
+					Statistics.SafeIncrement(ref Statistics._prepares);
+				}
+				_hiddenPrepare = false;
+			}
+			else
+			{
+				// Validate the command outside of the try\catch to avoid putting the _stateObj on error
+				ValidateCommand(async: false);
+
+				bool processFinallyBlock = true;
+				try
+				{
+					// NOTE: The state object isn't actually needed for this, but it is still here for back-compat (since it does a bunch of checks)
+					GetStateObject();
+
+					// Loop through parameters ensuring that we do not have unspecified types, sizes, scales, or precisions
+					if (null != _parameters)
+					{
+						int count = _parameters.Count;
+						for (int i = 0; i < count; ++i)
+						{
+							_parameters[i].Prepare(this);
+						}
+					}
+
+					InternalPrepare();
+				}
+				catch (Exception e)
+				{
+					processFinallyBlock = ADP.IsCatchableExceptionType(e);
+					throw;
+				}
+				finally
+				{
+					if (processFinallyBlock)
+					{
+						_hiddenPrepare = false; // The command is now officially prepared
+
+						ReliablePutStateObject();
+					}
+				}
+			}
+
+			SqlStatistics.StopTimer(statistics);
+		}
+
+		private void InternalPrepare()
+		{
+			if (this.IsDirty)
+			{
+				Debug.Assert(_cachedMetaData == null || !_dirty, "dirty query should not have cached metadata!"); // can have cached metadata if dirty because of parameters
+				//
+				// someone changed the command text or the parameter schema so we must unprepare the command
+				//
+				this.Unprepare();
+				this.IsDirty = false;
+			}
+			Debug.Assert(_execType != EXECTYPE.PREPARED, "Invalid attempt to Prepare already Prepared command!");
+			Debug.Assert(_activeConnection != null, "must have an open connection to Prepare");
+			Debug.Assert(null != _stateObj, "TdsParserStateObject should not be null");
+			Debug.Assert(null != _stateObj.Parser, "TdsParser class should not be null in Command.Execute!");
+			Debug.Assert(_stateObj.Parser == _activeConnection.Parser, "stateobject parser not same as connection parser");
+			Debug.Assert(false == _inPrepare, "Already in Prepare cycle, this.inPrepare should be false!");
+
+			// remember that the user wants to do a prepare but don't actually do an rpc
+			_execType = EXECTYPE.PREPAREPENDING;
+			// Note the current close count of the connection - this will tell us if the connection has been closed between calls to Prepare() and Execute
+			_preparedConnectionCloseCount = _activeConnection.CloseCount;
+			_preparedConnectionReconnectCount = _activeConnection.ReconnectCount;
+
+			if (null != Statistics)
+			{
+				Statistics.SafeIncrement(ref Statistics._prepares);
+			}
+		}
+
+		// SqlInternalConnectionTds needs to be able to unprepare a statement
+		internal void Unprepare()
+		{
+			Debug.Assert(true == IsPrepared, "Invalid attempt to Unprepare a non-prepared command!");
+			Debug.Assert(_activeConnection != null, "must have an open connection to UnPrepare");
+			Debug.Assert(false == _inPrepare, "_inPrepare should be false!");
+			_execType = EXECTYPE.PREPAREPENDING;
+			// Don't zero out the handle because we'll pass it in to sp_prepexec on the next prepare
+			// Unless the close count isn't the same as when we last prepared
+			if ((_activeConnection.CloseCount != _preparedConnectionCloseCount) || (_activeConnection.ReconnectCount != _preparedConnectionReconnectCount))
+			{
+				// reset our handle
+				_prepareHandle = -1;
+			}
+
+			_cachedMetaData = null;
+		}
+
+
+		// Cancel is supposed to be multi-thread safe.
+		// It doesn't make sense to verify the connection exists or that it is open during cancel
+		// because immediately after checkin the connection can be closed or removed via another thread.
+		//
+		override public void Cancel()
+		{
+			SqlStatistics statistics = null;
+			try
+			{
+				statistics = SqlStatistics.StartTimer(Statistics);
+
+				// If we are in reconnect phase simply cancel the waiting task
+				var reconnectCompletionSource = _reconnectionCompletionSource;
+				if (reconnectCompletionSource != null)
+				{
+					if (reconnectCompletionSource.TrySetCanceled())
+					{
+						return;
+					}
+				}
+
+				// the pending data flag means that we are awaiting a response or are in the middle of processing a response
+				// if we have no pending data, then there is nothing to cancel
+				// if we have pending data, but it is not a result of this command, then we don't cancel either.  Note that
+				// this model is implementable because we only allow one active command at any one time.  This code
+				// will have to change we allow multiple outstanding batches
+				if (null == _activeConnection)
+				{
+					return;
+				}
+				SqlInternalConnectionTds connection = (_activeConnection.InnerConnection as SqlInternalConnectionTds);
+				if (null == connection)
+				{  // Fail with out locking
+					return;
+				}
+
+				// The lock here is to protect against the command.cancel / connection.close race condition
+				// The SqlInternalConnectionTds is set to OpenBusy during close, once this happens the cast below will fail and 
+				// the command will no longer be cancelable.  It might be desirable to be able to cancel the close operation, but this is
+				// outside of the scope of Whidbey RTM.  See (SqlConnection::Close) for other lock.
+				lock (connection)
+				{
+					if (connection != (_activeConnection.InnerConnection as SqlInternalConnectionTds))
+					{ // make sure the connection held on the active connection is what we have stored in our temp connection variable, if not between getting "connection" and taking the lock, the connection has been closed
+						return;
+					}
+
+					TdsParser parser = connection.Parser;
+					if (null == parser)
+					{
+						return;
+					}
+
+
+					if (!_pendingCancel)
+					{ // Do nothing if already pending.
+					  // Before attempting actual cancel, set the _pendingCancel flag to false.
+					  // This denotes to other thread before obtaining stateObject from the
+					  // session pool that there is another thread wishing to cancel.
+					  // The period in question is between entering the ExecuteAPI and obtaining 
+					  // a stateObject.
+						_pendingCancel = true;
+
+						TdsParserStateObject stateObj = _stateObj;
+						if (null != stateObj)
+						{
+							stateObj.Cancel(this);
+						}
+						else
+						{
+							SqlDataReader reader = connection.FindLiveReader(this);
+							if (reader != null)
+							{
+								reader.Cancel(this);
+							}
+						}
+					}
+				}
+			}
+			finally
+			{
+				SqlStatistics.StopTimer(statistics);
+			}
+		}
+
+		new public SqlParameter CreateParameter()
+		{
+			return new SqlParameter();
+		}
+
+		override protected DbParameter CreateDbParameter()
+		{
+			return CreateParameter();
+		}
+
+		override protected void Dispose(bool disposing)
+		{
+			if (disposing)
+			{ // release managed objects
+				_cachedMetaData = null;
+			}
+			// release unmanaged objects
+			base.Dispose(disposing);
+		}
+
+		override public object ExecuteScalar()
+		{
+			// Reset _pendingCancel upon entry into any Execute - used to synchronize state
+			// between entry into Execute* API and the thread obtaining the stateObject.
+			_pendingCancel = false;
+
+			Guid operationId = _diagnosticListener.WriteCommandBefore(this);
+
+			SqlStatistics statistics = null;
+			
+			Exception e = null;
+			try
+			{
+				statistics = SqlStatistics.StartTimer(Statistics);
+				SqlDataReader ds;
+				ds = RunExecuteReader(0, RunBehavior.ReturnImmediately, returnStream: true);
+				return CompleteExecuteScalar(ds, false);
+			}
+			catch (Exception ex)
+			{
+				e = ex;
+				throw;
+			}
+			finally
+			{
+				SqlStatistics.StopTimer(statistics);
+
+				if (e != null)
+				{
+					_diagnosticListener.WriteCommandError(operationId, this, e);
+				}
+				else
+				{
+					_diagnosticListener.WriteCommandAfter(operationId, this);
+				}
+			}
+		}
+
+		private object CompleteExecuteScalar(SqlDataReader ds, bool returnSqlValue)
+		{
+			object retResult = null;
+
+			try
+			{
+				if (ds.Read())
+				{
+					if (ds.FieldCount > 0)
+					{
+						if (returnSqlValue)
+						{
+							retResult = ds.GetSqlValue(0);
+						}
+						else
+						{
+							retResult = ds.GetValue(0);
+						}
+					}
+				}
+			}
+			finally
+			{
+				// clean off the wire
+				ds.Close();
+			}
+
+			return retResult;
+		}
+
+		override public int ExecuteNonQuery()
+		{
+			// Reset _pendingCancel upon entry into any Execute - used to synchronize state
+			// between entry into Execute* API and the thread obtaining the stateObject.
+			_pendingCancel = false;
+
+			Guid operationId = _diagnosticListener.WriteCommandBefore(this);
+
+			SqlStatistics statistics = null;
+			
+			Exception e = null;
+			try
+			{
+				statistics = SqlStatistics.StartTimer(Statistics);
+				InternalExecuteNonQuery(completion: null, sendToPipe: false, timeout: CommandTimeout);
+				return _rowsAffected;
+			}
+			catch (Exception ex)
+			{
+				e = ex;
+				throw;
+			}
+			finally
+			{
+				SqlStatistics.StopTimer(statistics);
+				
+				if (e != null)
+				{
+					_diagnosticListener.WriteCommandError(operationId, this, e);
+				}
+				else
+				{
+					_diagnosticListener.WriteCommandAfter(operationId, this);
+				}
+			}
+		}
+
+
+		private IAsyncResult BeginExecuteNonQuery(AsyncCallback callback, object stateObject)
+		{
+			// Reset _pendingCancel upon entry into any Execute - used to synchronize state
+			// between entry into Execute* API and the thread obtaining the stateObject.
+			_pendingCancel = false;
+
+			ValidateAsyncCommand(); // Special case - done outside of try/catches to prevent putting a stateObj
+									// back into pool when we should not.
+
+			SqlStatistics statistics = null;
+			try
+			{
+				statistics = SqlStatistics.StartTimer(Statistics);
+				TaskCompletionSource<object> completion = new TaskCompletionSource<object>(stateObject);
+
+				try
+				{ // InternalExecuteNonQuery already has reliability block, but if failure will not put stateObj back into pool.
+					Task execNQ = InternalExecuteNonQuery(completion, false, CommandTimeout, asyncWrite: true);
+
+					// must finish caching information before ReadSni which can activate the callback before returning
+					cachedAsyncState.SetActiveConnectionAndResult(completion, nameof(EndExecuteNonQuery), _activeConnection);
+					if (execNQ != null)
+					{
+						AsyncHelper.ContinueTask(execNQ, completion, () => BeginExecuteNonQueryInternalReadStage(completion));
+					}
+					else
+					{
+						BeginExecuteNonQueryInternalReadStage(completion);
+					}
+				}
+				catch (Exception e)
+				{
+					if (!ADP.IsCatchableOrSecurityExceptionType(e))
+					{
+						// If not catchable - the connection has already been caught and doomed in RunExecuteReader.
+						throw;
+					}
+
+					// For async, RunExecuteReader will never put the stateObj back into the pool, so do so now.
+					ReliablePutStateObject();
+					throw;
+				}
+
+				// Add callback after work is done to avoid overlapping Begin\End methods
+				if (callback != null)
+				{
+					completion.Task.ContinueWith((t) => callback(t), TaskScheduler.Default);
+				}
+
+				return completion.Task;
+			}
+			finally
+			{
+				SqlStatistics.StopTimer(statistics);
+			}
+		}
+
+		private void BeginExecuteNonQueryInternalReadStage(TaskCompletionSource<object> completion)
+		{
+			// Read SNI does not have catches for async exceptions, handle here.
+			try
+			{
+				_stateObj.ReadSni(completion);
+			}
+			catch (Exception)
+			{
+				// Similarly, if an exception occurs put the stateObj back into the pool.
+				// and reset async cache information to allow a second async execute
+				if (null != _cachedAsyncState)
+				{
+					_cachedAsyncState.ResetAsyncState();
+				}
+				ReliablePutStateObject();
+				throw;
+			}
+		}
+
+		private void VerifyEndExecuteState(Task completionTask, String endMethod)
+		{
+			Debug.Assert(completionTask != null);
+
+			if (completionTask.IsCanceled)
+			{
+				if (_stateObj != null)
+				{
+					_stateObj.Parser.State = TdsParserState.Broken; // We failed to respond to attention, we have to quit!
+					_stateObj.Parser.Connection.BreakConnection();
+					_stateObj.Parser.ThrowExceptionAndWarning(_stateObj);
+				}
+				else
+				{
+					Debug.Assert(_reconnectionCompletionSource == null || _reconnectionCompletionSource.Task.IsCanceled, "ReconnectCompletionSource should be null or cancelled");
+					throw SQL.CR_ReconnectionCancelled();
+				}
+			}
+			else if (completionTask.IsFaulted)
+			{
+				throw completionTask.Exception.InnerException;
+			}
+			if (cachedAsyncState.EndMethodName == null)
+			{
+				throw ADP.MethodCalledTwice(endMethod);
+			}
+			if (endMethod != cachedAsyncState.EndMethodName)
+			{
+				throw ADP.MismatchedAsyncResult(cachedAsyncState.EndMethodName, endMethod);
+			}
+			if ((_activeConnection.State != ConnectionState.Open) || (!cachedAsyncState.IsActiveConnectionValid(_activeConnection)))
+			{
+				// If the connection is not 'valid' then it was closed while we were executing
+				throw ADP.ClosedConnectionError();
+			}
+		}
+
+		private void WaitForAsyncResults(IAsyncResult asyncResult)
+		{
+			Task completionTask = (Task)asyncResult;
+			if (!asyncResult.IsCompleted)
+			{
+				asyncResult.AsyncWaitHandle.WaitOne();
+			}
+			_stateObj._networkPacketTaskSource = null;
+			_activeConnection.GetOpenTdsConnection().DecrementAsyncCount();
+		}
+
+		private void ThrowIfReconnectionHasBeenCanceled()
+		{
+			if (_stateObj == null)
+			{
+				var reconnectionCompletionSource = _reconnectionCompletionSource;
+				if (reconnectionCompletionSource != null && reconnectionCompletionSource.Task.IsCanceled)
+				{
+					throw SQL.CR_ReconnectionCancelled();
+				}
+			}
+		}
+
+		private int EndExecuteNonQuery(IAsyncResult asyncResult)
+		{
+			Exception asyncException = ((Task)asyncResult).Exception;
+			if (asyncException != null)
+			{
+				// Leftover exception from the Begin...InternalReadStage
+				if (cachedAsyncState != null)
+				{
+					cachedAsyncState.ResetAsyncState();
+				}
+				ReliablePutStateObject();
+				throw asyncException.InnerException;
+			}
+			else
+			{
+				ThrowIfReconnectionHasBeenCanceled();
+				// lock on _stateObj prevents races with close/cancel.
+				lock (_stateObj)
+				{
+					return EndExecuteNonQueryInternal(asyncResult);
+				}
+			}
+		}
+
+		private int EndExecuteNonQueryInternal(IAsyncResult asyncResult)
+		{
+			SqlStatistics statistics = null;
+
+			try
+			{
+				statistics = SqlStatistics.StartTimer(Statistics);
+				VerifyEndExecuteState((Task)asyncResult, nameof(EndExecuteNonQuery));
+				WaitForAsyncResults(asyncResult);
+
+				bool processFinallyBlock = true;
+				try
+				{
+					CheckThrowSNIException();
+
+					// only send over SQL Batch command if we are not a stored proc and have no parameters
+					if ((System.Data.CommandType.Text == this.CommandType) && (0 == GetParameterCount(_parameters)))
+					{
+						try
+						{
+							bool dataReady;
+							Debug.Assert(_stateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
+							bool result = _stateObj.Parser.TryRun(RunBehavior.UntilDone, this, null, null, _stateObj, out dataReady);
+							if (!result) { throw SQL.SynchronousCallMayNotPend(); }
+						}
+						finally
+						{
+							cachedAsyncState.ResetAsyncState();
+						}
+					}
+					else
+					{ // otherwise, use a full-fledged execute that can handle params and stored procs
+						SqlDataReader reader = CompleteAsyncExecuteReader();
+						if (null != reader)
+						{
+							reader.Close();
+						}
+					}
+				}
+				catch (Exception e)
+				{
+					processFinallyBlock = ADP.IsCatchableExceptionType(e);
+					throw;
+				}
+				finally
+				{
+					if (processFinallyBlock)
+					{
+						PutStateObject();
+					}
+				}
+
+				Debug.Assert(null == _stateObj, "non-null state object in EndExecuteNonQuery");
+				return _rowsAffected;
+			}
+			catch (Exception e)
+			{
+				if (cachedAsyncState != null)
+				{
+					cachedAsyncState.ResetAsyncState();
+				};
+				if (ADP.IsCatchableExceptionType(e))
+				{
+					ReliablePutStateObject();
+				};
+				throw;
+			}
+			finally
+			{
+				SqlStatistics.StopTimer(statistics);
+			}
+		}
+
+		private Task InternalExecuteNonQuery(TaskCompletionSource<object> completion, bool sendToPipe, int timeout, bool asyncWrite = false, [CallerMemberName] string methodName = "")
+		{
+			bool async = (null != completion);
+
+			SqlStatistics statistics = Statistics;
+			_rowsAffected = -1;
+
+			// this function may throw for an invalid connection
+			// returns false for empty command text
+			ValidateCommand(async, methodName);
+
+			CheckNotificationStateAndAutoEnlist(); // Only call after validate - requires non null connection!
+
+			Task task = null;
+
+			// only send over SQL Batch command if we are not a stored proc and have no parameters and not in batch RPC mode
+			if ((System.Data.CommandType.Text == this.CommandType) && (0 == GetParameterCount(_parameters)))
+			{
+				Debug.Assert(!sendToPipe, "trying to send non-context command to pipe");
+				if (null != statistics)
+				{
+					if (!this.IsDirty && this.IsPrepared)
+					{
+						statistics.SafeIncrement(ref statistics._preparedExecs);
+					}
+					else
+					{
+						statistics.SafeIncrement(ref statistics._unpreparedExecs);
+					}
+				}
+
+				task = RunExecuteNonQueryTds(methodName, async, timeout, asyncWrite);
+			}
+			else
+			{ // otherwise, use a full-fledged execute that can handle params and stored procs
+				Debug.Assert(!sendToPipe, "trying to send non-context command to pipe");
+				SqlDataReader reader = RunExecuteReader(0, RunBehavior.UntilDone, false, completion, timeout, out task, asyncWrite, methodName);
+				if (null != reader)
+				{
+					if (task != null)
+					{
+						task = AsyncHelper.CreateContinuationTask(task, () => reader.Close());
+					}
+					else
+					{
+						reader.Close();
+					}
+				}
+			}
+			Debug.Assert(async || null == _stateObj, "non-null state object in InternalExecuteNonQuery");
+			return task;
+		}
+
+		public XmlReader ExecuteXmlReader()
+		{
+			// Reset _pendingCancel upon entry into any Execute - used to synchronize state
+			// between entry into Execute* API and the thread obtaining the stateObject.
+			_pendingCancel = false;
+
+			Guid operationId = _diagnosticListener.WriteCommandBefore(this);
+
+			SqlStatistics statistics = null;
+			
+			Exception e = null;
+			try
+			{
+				statistics = SqlStatistics.StartTimer(Statistics);
+
+				// use the reader to consume metadata
+				SqlDataReader ds;
+				ds = RunExecuteReader(CommandBehavior.SequentialAccess, RunBehavior.ReturnImmediately, returnStream: true);
+				return CompleteXmlReader(ds);
+			}
+			catch (Exception ex)
+			{
+				e = ex;
+				throw;
+			}
+			finally
+			{
+				SqlStatistics.StopTimer(statistics);
+				
+				if (e != null)
+				{
+					_diagnosticListener.WriteCommandError(operationId, this, e);
+				}
+				else
+				{
+					_diagnosticListener.WriteCommandAfter(operationId, this);
+				}
+			}
+		}
+
+
+		private IAsyncResult BeginExecuteXmlReader(AsyncCallback callback, object stateObject)
+		{
+			// Reset _pendingCancel upon entry into any Execute - used to synchronize state
+			// between entry into Execute* API and the thread obtaining the stateObject.
+			_pendingCancel = false;
+
+			ValidateAsyncCommand(); // Special case - done outside of try/catches to prevent putting a stateObj
+									// back into pool when we should not.
+
+			SqlStatistics statistics = null;
+			try
+			{
+				statistics = SqlStatistics.StartTimer(Statistics);
+				TaskCompletionSource<object> completion = new TaskCompletionSource<object>(stateObject);
+
+				Task writeTask;
+				try
+				{ // InternalExecuteNonQuery already has reliability block, but if failure will not put stateObj back into pool.
+					RunExecuteReader(CommandBehavior.SequentialAccess, RunBehavior.ReturnImmediately, true, completion, CommandTimeout, out writeTask, asyncWrite: true);
+				}
+				catch (Exception e)
+				{
+					if (!ADP.IsCatchableOrSecurityExceptionType(e))
+					{
+						// If not catchable - the connection has already been caught and doomed in RunExecuteReader.
+						throw;
+					}
+
+					// For async, RunExecuteReader will never put the stateObj back into the pool, so do so now.
+					ReliablePutStateObject();
+					throw;
+				}
+
+				// must finish caching information before ReadSni which can activate the callback before returning
+				cachedAsyncState.SetActiveConnectionAndResult(completion, nameof(EndExecuteXmlReader), _activeConnection);
+				if (writeTask != null)
+				{
+					AsyncHelper.ContinueTask(writeTask, completion, () => BeginExecuteXmlReaderInternalReadStage(completion));
+				}
+				else
+				{
+					BeginExecuteXmlReaderInternalReadStage(completion);
+				}
+
+				// Add callback after work is done to avoid overlapping Begin\End methods
+				if (callback != null)
+				{
+					completion.Task.ContinueWith((t) => callback(t), TaskScheduler.Default);
+				}
+				return completion.Task;
+			}
+			finally
+			{
+				SqlStatistics.StopTimer(statistics);
+			}
+		}
+
+		private void BeginExecuteXmlReaderInternalReadStage(TaskCompletionSource<object> completion)
+		{
+			Debug.Assert(completion != null, "Completion source should not be null");
+			// Read SNI does not have catches for async exceptions, handle here.
+			try
+			{
+				_stateObj.ReadSni(completion);
+			}
+			catch (Exception e)
+			{
+				// Similarly, if an exception occurs put the stateObj back into the pool.
+				// and reset async cache information to allow a second async execute
+				if (null != _cachedAsyncState)
+				{
+					_cachedAsyncState.ResetAsyncState();
+				}
+				ReliablePutStateObject();
+				completion.TrySetException(e);
+			}
+		}
+
+
+		private XmlReader EndExecuteXmlReader(IAsyncResult asyncResult)
+		{
+			Exception asyncException = ((Task)asyncResult).Exception;
+			if (asyncException != null)
+			{
+				// Leftover exception from the Begin...InternalReadStage
+				if (cachedAsyncState != null)
+				{
+					cachedAsyncState.ResetAsyncState();
+				}
+				ReliablePutStateObject();
+				throw asyncException.InnerException;
+			}
+			else
+			{
+				ThrowIfReconnectionHasBeenCanceled();
+				// lock on _stateObj prevents races with close/cancel.
+				lock (_stateObj)
+				{
+					return EndExecuteXmlReaderInternal(asyncResult);
+				}
+			}
+		}
+
+		private XmlReader EndExecuteXmlReaderInternal(IAsyncResult asyncResult)
+		{
+			try
+			{
+				return CompleteXmlReader(InternalEndExecuteReader(asyncResult, nameof(EndExecuteXmlReader)), async: true);
+			}
+			catch (Exception e)
+			{
+				if (cachedAsyncState != null)
+				{
+					cachedAsyncState.ResetAsyncState();
+				};
+				if (ADP.IsCatchableExceptionType(e))
+				{
+					ReliablePutStateObject();
+				};
+				throw;
+			}
+		}
+
+		private XmlReader CompleteXmlReader(SqlDataReader ds, bool async = false)
+		{
+			XmlReader xr = null;
+
+			SmiExtendedMetaData[] md = ds.GetInternalSmiMetaData();
+			bool isXmlCapable = (null != md && md.Length == 1 && (md[0].SqlDbType == SqlDbType.NText
+														 || md[0].SqlDbType == SqlDbType.NVarChar
+														 || md[0].SqlDbType == SqlDbType.Xml));
+
+			if (isXmlCapable)
+			{
+				try
+				{
+					SqlStream sqlBuf = new SqlStream(ds, true /*addByteOrderMark*/, (md[0].SqlDbType == SqlDbType.Xml) ? false : true /*process all rows*/);
+					xr = sqlBuf.ToXmlReader(async);
+				}
+				catch (Exception e)
+				{
+					if (ADP.IsCatchableExceptionType(e))
+					{
+						ds.Close();
+					}
+					throw;
+				}
+			}
+			if (xr == null)
+			{
+				ds.Close();
+				throw SQL.NonXmlResult();
+			}
+			return xr;
+		}
+
+
+		override protected DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
+		{
+			return ExecuteReader(behavior);
+		}
+
+		new public SqlDataReader ExecuteReader()
+		{
+			SqlStatistics statistics = null;
+			try
+			{
+				statistics = SqlStatistics.StartTimer(Statistics);
+				return ExecuteReader(CommandBehavior.Default);
+			}
+			finally
+			{
+				SqlStatistics.StopTimer(statistics);
+			}
+		}
+
+		new public SqlDataReader ExecuteReader(CommandBehavior behavior)
+		{
+			// Reset _pendingCancel upon entry into any Execute - used to synchronize state
+			// between entry into Execute* API and the thread obtaining the stateObject.
+			_pendingCancel = false;
+
+			Guid operationId = _diagnosticListener.WriteCommandBefore(this);
+
+			SqlStatistics statistics = null;
+			
+			Exception e = null;
+			try
+			{
+				statistics = SqlStatistics.StartTimer(Statistics);
+				return RunExecuteReader(behavior, RunBehavior.ReturnImmediately, returnStream: true);
+			}
+			catch (Exception ex)
+			{
+				e = ex;
+				throw;
+			}
+			finally
+			{
+				SqlStatistics.StopTimer(statistics);
+				
+				if (e != null)
+				{
+					_diagnosticListener.WriteCommandError(operationId, this, e);
+				}
+				else
+				{
+					_diagnosticListener.WriteCommandAfter(operationId, this);
+				}
+			}
+		}
+
+
+		internal SqlDataReader EndExecuteReader(IAsyncResult asyncResult)
+		{
+			Exception asyncException = ((Task)asyncResult).Exception;
+			if (asyncException != null)
+			{
+				// Leftover exception from the Begin...InternalReadStage
+				if (cachedAsyncState != null)
+				{
+					cachedAsyncState.ResetAsyncState();
+				}
+				ReliablePutStateObject();
+				throw asyncException.InnerException;
+			}
+			else
+			{
+				ThrowIfReconnectionHasBeenCanceled();
+				// lock on _stateObj prevents races with close/cancel.
+				lock (_stateObj)
+				{
+					return EndExecuteReaderInternal(asyncResult);
+				}
+			}
+		}
+
+		private SqlDataReader EndExecuteReaderInternal(IAsyncResult asyncResult)
+		{
+			SqlStatistics statistics = null;
+			try
+			{
+				statistics = SqlStatistics.StartTimer(Statistics);
+				return InternalEndExecuteReader(asyncResult, nameof(EndExecuteReader));
+			}
+			catch (Exception e)
+			{
+				if (cachedAsyncState != null)
+				{
+					cachedAsyncState.ResetAsyncState();
+				};
+				if (ADP.IsCatchableExceptionType(e))
+				{
+					ReliablePutStateObject();
+				};
+				throw;
+			}
+			finally
+			{
+				SqlStatistics.StopTimer(statistics);
+			}
+		}
+
+		internal IAsyncResult BeginExecuteReader(CommandBehavior behavior, AsyncCallback callback, object stateObject)
+		{
+			// Reset _pendingCancel upon entry into any Execute - used to synchronize state
+			// between entry into Execute* API and the thread obtaining the stateObject.
+			_pendingCancel = false;
+
+			SqlStatistics statistics = null;
+			try
+			{
+				statistics = SqlStatistics.StartTimer(Statistics);
+				TaskCompletionSource<object> completion = new TaskCompletionSource<object>(stateObject);
+
+				ValidateAsyncCommand(); // Special case - done outside of try/catches to prevent putting a stateObj
+										// back into pool when we should not.
+
+				Task writeTask = null;
+				try
+				{ // InternalExecuteNonQuery already has reliability block, but if failure will not put stateObj back into pool.
+					RunExecuteReader(behavior, RunBehavior.ReturnImmediately, true, completion, CommandTimeout, out writeTask, asyncWrite: true);
+				}
+				catch (Exception e)
+				{
+					if (!ADP.IsCatchableOrSecurityExceptionType(e))
+					{
+						// If not catchable - the connection has already been caught and doomed in RunExecuteReader.
+						throw;
+					}
+
+					// For async, RunExecuteReader will never put the stateObj back into the pool, so do so now.
+					ReliablePutStateObject();
+					throw;
+				}
+
+				// must finish caching information before ReadSni which can activate the callback before returning
+				cachedAsyncState.SetActiveConnectionAndResult(completion, nameof(EndExecuteReader), _activeConnection);
+				if (writeTask != null)
+				{
+					AsyncHelper.ContinueTask(writeTask, completion, () => BeginExecuteReaderInternalReadStage(completion));
+				}
+				else
+				{
+					BeginExecuteReaderInternalReadStage(completion);
+				}
+
+				// Add callback after work is done to avoid overlapping Begin\End methods
+				if (callback != null)
+				{
+					completion.Task.ContinueWith((t) => callback(t), TaskScheduler.Default);
+				}
+				return completion.Task;
+			}
+			finally
+			{
+				SqlStatistics.StopTimer(statistics);
+			}
+		}
+
+		private void BeginExecuteReaderInternalReadStage(TaskCompletionSource<object> completion)
+		{
+			Debug.Assert(completion != null, "CompletionSource should not be null");
+			// Read SNI does not have catches for async exceptions, handle here.
+			try
+			{
+				_stateObj.ReadSni(completion);
+			}
+			catch (Exception e)
+			{
+				// Similarly, if an exception occurs put the stateObj back into the pool.
+				// and reset async cache information to allow a second async execute
+				if (null != _cachedAsyncState)
+				{
+					_cachedAsyncState.ResetAsyncState();
+				}
+				ReliablePutStateObject();
+				completion.TrySetException(e);
+			}
+		}
+
+		private SqlDataReader InternalEndExecuteReader(IAsyncResult asyncResult, string endMethod)
+		{
+			VerifyEndExecuteState((Task)asyncResult, endMethod);
+			WaitForAsyncResults(asyncResult);
+
+			CheckThrowSNIException();
+
+			SqlDataReader reader = CompleteAsyncExecuteReader();
+			Debug.Assert(null == _stateObj, "non-null state object in InternalEndExecuteReader");
+			return reader;
+		}
+
+		public override Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
+		{
+			Guid operationId = _diagnosticListener.WriteCommandBefore(this);
+
+			TaskCompletionSource<int> source = new TaskCompletionSource<int>();
+
+			CancellationTokenRegistration registration = new CancellationTokenRegistration();
+			if (cancellationToken.CanBeCanceled)
+			{
+				if (cancellationToken.IsCancellationRequested)
+				{
+					source.SetCanceled();
+					return source.Task;
+				}
+				registration = cancellationToken.Register(s => ((SqlCommand)s).CancelIgnoreFailure(), this);
+			}
+
+			Task<int> returnedTask = source.Task;
+			try
+			{
+				RegisterForConnectionCloseNotification(ref returnedTask);
+
+				Task<int>.Factory.FromAsync(BeginExecuteNonQuery, EndExecuteNonQuery, null).ContinueWith((t) =>
+				{
+					registration.Dispose();
+					if (t.IsFaulted)
+					{
+						Exception e = t.Exception.InnerException;
+						_diagnosticListener.WriteCommandError(operationId, this, e);
+						source.SetException(e);
+					}
+					else
+					{
+						if (t.IsCanceled)
+						{
+							source.SetCanceled();
+						}
+						else
+						{
+							source.SetResult(t.Result);
+						}
+						_diagnosticListener.WriteCommandAfter(operationId, this);
+					}
+				}, TaskScheduler.Default);
+			}
+			catch (Exception e)
+			{
+				_diagnosticListener.WriteCommandError(operationId, this, e);
+				source.SetException(e);
+			}
+
+			return returnedTask;
+		}
+
+		protected override Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
+		{
+			return ExecuteReaderAsync(behavior, cancellationToken).ContinueWith<DbDataReader>((result) =>
+			{
+				if (result.IsFaulted)
+				{
+					throw result.Exception.InnerException;
+				}
+				return result.Result;
+			}, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.NotOnCanceled, TaskScheduler.Default);
+		}
+
+		new public Task<SqlDataReader> ExecuteReaderAsync()
+		{
+			return ExecuteReaderAsync(CommandBehavior.Default, CancellationToken.None);
+		}
+
+		new public Task<SqlDataReader> ExecuteReaderAsync(CommandBehavior behavior)
+		{
+			return ExecuteReaderAsync(behavior, CancellationToken.None);
+		}
+
+		new public Task<SqlDataReader> ExecuteReaderAsync(CancellationToken cancellationToken)
+		{
+			return ExecuteReaderAsync(CommandBehavior.Default, cancellationToken);
+		}
+
+		new public Task<SqlDataReader> ExecuteReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
+		{
+			Guid operationId = default(Guid);
+			if (!_parentOperationStarted)
+				operationId = _diagnosticListener.WriteCommandBefore(this);
+
+			TaskCompletionSource<SqlDataReader> source = new TaskCompletionSource<SqlDataReader>();
+
+			CancellationTokenRegistration registration = new CancellationTokenRegistration();
+			if (cancellationToken.CanBeCanceled)
+			{
+				if (cancellationToken.IsCancellationRequested)
+				{
+					source.SetCanceled();
+					return source.Task;
+				}
+				registration = cancellationToken.Register(s => ((SqlCommand)s).CancelIgnoreFailure(), this);
+			}
+
+			Task<SqlDataReader> returnedTask = source.Task;
+			try
+			{
+				RegisterForConnectionCloseNotification(ref returnedTask);
+
+				Task<SqlDataReader>.Factory.FromAsync(BeginExecuteReader, EndExecuteReader, behavior, null).ContinueWith((t) =>
+				{
+					registration.Dispose();
+					if (t.IsFaulted)
+					{
+						Exception e = t.Exception.InnerException;
+						if (!_parentOperationStarted)
+							_diagnosticListener.WriteCommandError(operationId, this, e);
+						source.SetException(e);
+					}
+					else
+					{
+						if (t.IsCanceled)
+						{
+							source.SetCanceled();
+						}
+						else
+						{
+							source.SetResult(t.Result);
+						}
+						if (!_parentOperationStarted)
+							_diagnosticListener.WriteCommandAfter(operationId, this);
+					}
+				}, TaskScheduler.Default);
+			}
+			catch (Exception e)
+			{
+				if (!_parentOperationStarted)
+					_diagnosticListener.WriteCommandError(operationId, this, e);
+
+				source.SetException(e);
+			}
+
+			return returnedTask;
+		}
+
+		public override Task<object> ExecuteScalarAsync(CancellationToken cancellationToken)
+		{
+			_parentOperationStarted = true;
+			Guid operationId = _diagnosticListener.WriteCommandBefore(this);
+
+			return ExecuteReaderAsync(cancellationToken).ContinueWith((executeTask) =>
+			{
+				TaskCompletionSource<object> source = new TaskCompletionSource<object>();
+				if (executeTask.IsCanceled)
+				{
+					source.SetCanceled();
+				}
+				else if (executeTask.IsFaulted)
+				{
+					_diagnosticListener.WriteCommandError(operationId, this, executeTask.Exception.InnerException);
+					source.SetException(executeTask.Exception.InnerException);
+				}
+				else
+				{
+					SqlDataReader reader = executeTask.Result;
+					reader.ReadAsync(cancellationToken).ContinueWith((readTask) =>
+					{
+						try
+						{
+							if (readTask.IsCanceled)
+							{
+								reader.Dispose();
+								source.SetCanceled();
+							}
+							else if (readTask.IsFaulted)
+							{
+								reader.Dispose();
+								_diagnosticListener.WriteCommandError(operationId, this, readTask.Exception.InnerException);
+								source.SetException(readTask.Exception.InnerException);
+							}
+							else
+							{
+								Exception exception = null;
+								object result = null;
+								try
+								{
+									bool more = readTask.Result;
+									if (more && reader.FieldCount > 0)
+									{
+										try
+										{
+											result = reader.GetValue(0);
+										}
+										catch (Exception e)
+										{
+											exception = e;
+										}
+									}
+								}
+								finally
+								{
+									reader.Dispose();
+								}
+								if (exception != null)
+								{
+									_diagnosticListener.WriteCommandError(operationId, this, exception);
+									source.SetException(exception);
+								}
+								else
+								{
+									_diagnosticListener.WriteCommandAfter(operationId, this);
+									source.SetResult(result);
+								}
+							}
+						}
+						catch (Exception e)
+						{
+							// exception thrown by Dispose...
+							source.SetException(e);
+						}
+					}, TaskScheduler.Default);
+				}
+				_parentOperationStarted = false;
+				return source.Task;
+			}, TaskScheduler.Default).Unwrap();
+		}
+
+		public Task<XmlReader> ExecuteXmlReaderAsync()
+		{
+			return ExecuteXmlReaderAsync(CancellationToken.None);
+		}
+
+		public Task<XmlReader> ExecuteXmlReaderAsync(CancellationToken cancellationToken)
+		{
+			Guid operationId = _diagnosticListener.WriteCommandBefore(this);
+
+			TaskCompletionSource<XmlReader> source = new TaskCompletionSource<XmlReader>();
+
+			CancellationTokenRegistration registration = new CancellationTokenRegistration();
+			if (cancellationToken.CanBeCanceled)
+			{
+				if (cancellationToken.IsCancellationRequested)
+				{
+					source.SetCanceled();
+					return source.Task;
+				}
+				registration = cancellationToken.Register(s => ((SqlCommand)s).CancelIgnoreFailure(), this);
+			}
+
+			Task<XmlReader> returnedTask = source.Task;
+			try
+			{
+				RegisterForConnectionCloseNotification(ref returnedTask);
+
+				Task<XmlReader>.Factory.FromAsync(BeginExecuteXmlReader, EndExecuteXmlReader, null).ContinueWith((t) =>
+				{
+					registration.Dispose();
+					if (t.IsFaulted)
+					{
+						Exception e = t.Exception.InnerException;
+						_diagnosticListener.WriteCommandError(operationId, this, e);
+						source.SetException(e);
+					}
+					else
+					{
+						if (t.IsCanceled)
+						{
+							source.SetCanceled();
+						}
+						else
+						{
+							source.SetResult(t.Result);
+						}
+						_diagnosticListener.WriteCommandAfter(operationId, this);
+					}
+				}, TaskScheduler.Default);
+			}
+			catch (Exception e)
+			{
+				_diagnosticListener.WriteCommandError(operationId, this, e);
+				source.SetException(e);
+			}
+
+			return returnedTask;
+		}
+
+		// If the user part is quoted, remove first and last brackets and then unquote any right square
+		// brackets in the procedure.  This is a very simple parser that performs no validation.  As
+		// with the function below, ideally we should have support from the server for this.
+		private static string UnquoteProcedurePart(string part)
+		{
+			if ((null != part) && (2 <= part.Length))
+			{
+				if ('[' == part[0] && ']' == part[part.Length - 1])
+				{
+					part = part.Substring(1, part.Length - 2); // strip outer '[' & ']'
+					part = part.Replace("]]", "]"); // undo quoted "]" from "]]" to "]"
+				}
+			}
+			return part;
+		}
+
+		// User value in this format: [server].[database].[schema].[sp_foo];1
+		// This function should only be passed "[sp_foo];1".
+		// This function uses a pretty simple parser that doesn't do any validation.
+		// Ideally, we would have support from the server rather than us having to do this.
+		private static string UnquoteProcedureName(string name, out object groupNumber)
+		{
+			groupNumber = null; // Out param - initialize value to no value.
+			string sproc = name;
+
+			if (null != sproc)
+			{
+				if (char.IsDigit(sproc[sproc.Length - 1]))
+				{ // If last char is a digit, parse.
+					int semicolon = sproc.LastIndexOf(';');
+					if (semicolon != -1)
+					{ // If we found a semicolon, obtain the integer.
+						string part = sproc.Substring(semicolon + 1);
+						int number = 0;
+						if (int.TryParse(part, out number))
+						{ // No checking, just fail if this doesn't work.
+							groupNumber = number;
+							sproc = sproc.Substring(0, semicolon);
+						}
+					}
+				}
+				sproc = UnquoteProcedurePart(sproc);
+			}
+			return sproc;
+		}
+
+		// Index into indirection arrays for columns of interest to DeriveParameters
+		private enum ProcParamsColIndex
+		{
+			ParameterName = 0,
+			ParameterType,
+			DataType, // obsolete in katmai, use ManagedDataType instead
+			ManagedDataType, // new in katmai
+			CharacterMaximumLength,
+			NumericPrecision,
+			NumericScale,
+			TypeCatalogName,
+			TypeSchemaName,
+			TypeName,
+			XmlSchemaCollectionCatalogName,
+			XmlSchemaCollectionSchemaName,
+			XmlSchemaCollectionName,
+			UdtTypeName, // obsolete in Katmai.  Holds the actual typename if UDT, since TypeName didn't back then.
+			DateTimeScale // new in Katmai
+		};
+
+		// Yukon- column ordinals (this array indexed by ProcParamsColIndex
+		internal static readonly string[] PreKatmaiProcParamsNames = new string[] {
+			"PARAMETER_NAME",           // ParameterName,
+			"PARAMETER_TYPE",           // ParameterType,
+			"DATA_TYPE",                // DataType
+			null,                       // ManagedDataType,     introduced in Katmai
+			"CHARACTER_MAXIMUM_LENGTH", // CharacterMaximumLength,
+			"NUMERIC_PRECISION",        // NumericPrecision,
+			"NUMERIC_SCALE",            // NumericScale,
+			"UDT_CATALOG",              // TypeCatalogName,
+			"UDT_SCHEMA",               // TypeSchemaName,
+			"TYPE_NAME",                // TypeName,
+			"XML_CATALOGNAME",          // XmlSchemaCollectionCatalogName,
+			"XML_SCHEMANAME",           // XmlSchemaCollectionSchemaName,
+			"XML_SCHEMACOLLECTIONNAME", // XmlSchemaCollectionName
+			"UDT_NAME",                 // UdtTypeName
+			null,                       // Scale for datetime types with scale, introduced in Katmai
+		};
+
+		// Katmai+ column ordinals (this array indexed by ProcParamsColIndex
+		internal static readonly string[] KatmaiProcParamsNames = new string[] {
+			"PARAMETER_NAME",           // ParameterName,
+			"PARAMETER_TYPE",           // ParameterType,
+			null,                       // DataType, removed from Katmai+
+			"MANAGED_DATA_TYPE",        // ManagedDataType,
+			"CHARACTER_MAXIMUM_LENGTH", // CharacterMaximumLength,
+			"NUMERIC_PRECISION",        // NumericPrecision,
+			"NUMERIC_SCALE",            // NumericScale,
+			"TYPE_CATALOG_NAME",        // TypeCatalogName,
+			"TYPE_SCHEMA_NAME",         // TypeSchemaName,
+			"TYPE_NAME",                // TypeName,
+			"XML_CATALOGNAME",          // XmlSchemaCollectionCatalogName,
+			"XML_SCHEMANAME",           // XmlSchemaCollectionSchemaName,
+			"XML_SCHEMACOLLECTIONNAME", // XmlSchemaCollectionName
+			null,                       // UdtTypeName, removed from Katmai+
+			"SS_DATETIME_PRECISION",    // Scale for datetime types with scale
+		};
+
+		internal void DeriveParameters()
+		{
+			switch (CommandType)
+			{
+				case CommandType.Text:
+					throw ADP.DeriveParametersNotSupported(this);
+				case CommandType.StoredProcedure:
+					break;
+				case CommandType.TableDirect:
+					// CommandType.TableDirect - do nothing, parameters are not supported
+					throw ADP.DeriveParametersNotSupported(this);
+				default:
+					throw ADP.InvalidCommandType(CommandType);
+			}
+
+			// validate that we have a valid connection
+			ValidateCommand(false /*not async*/, nameof(DeriveParameters));
+
+			// Use common parser for SqlClient and OleDb - parse into 4 parts - Server, Catalog, Schema, ProcedureName
+			string[] parsedSProc = MultipartIdentifier.ParseMultipartIdentifier(CommandText, "[\"", "]\"", SR.SQL_SqlCommandCommandText, false);
+			if (null == parsedSProc[3] || string.IsNullOrEmpty(parsedSProc[3]))
+			{
+				throw ADP.NoStoredProcedureExists(CommandText);
+			}
+
+			Debug.Assert(parsedSProc.Length == 4, "Invalid array length result from SqlCommandBuilder.ParseProcedureName");
+
+			SqlCommand paramsCmd = null;
+			StringBuilder cmdText = new StringBuilder();
+
+			// Build call for sp_procedure_params_rowset built of unquoted values from user:
+			// [user server, if provided].[user catalog, else current database].[sys if Yukon, else blank].[sp_procedure_params_rowset]
+
+			// Server - pass only if user provided.
+			if (!string.IsNullOrEmpty(parsedSProc[0]))
+			{
+				SqlCommandSet.BuildStoredProcedureName(cmdText, parsedSProc[0]);
+				cmdText.Append(".");
+			}
+
+			// Catalog - pass user provided, otherwise use current database.
+			if (string.IsNullOrEmpty(parsedSProc[1]))
+			{
+				parsedSProc[1] = Connection.Database;
+			}
+			SqlCommandSet.BuildStoredProcedureName(cmdText, parsedSProc[1]);
+			cmdText.Append(".");
+
+			// Schema - only if Yukon, and then only pass sys.  Also - pass managed version of sproc
+			// for Yukon, else older sproc.
+			string[] colNames;
+			bool useManagedDataType;
+			if (Connection.IsKatmaiOrNewer)
+			{
+				// Procedure - [sp_procedure_params_managed]
+				cmdText.Append("[sys].[").Append(TdsEnums.SP_PARAMS_MGD10).Append("]");
+
+				colNames = KatmaiProcParamsNames;
+				useManagedDataType = true;
+			}
+			else
+			{
+				// Procedure - [sp_procedure_params_managed]
+				cmdText.Append("[sys].[").Append(TdsEnums.SP_PARAMS_MANAGED).Append("]");
+
+				colNames = PreKatmaiProcParamsNames;
+				useManagedDataType = false;
+			}
+
+			paramsCmd = new SqlCommand(cmdText.ToString(), Connection, Transaction)
+			{
+				CommandType = CommandType.StoredProcedure
+			};
+
+			object groupNumber;
+
+			// Prepare parameters for sp_procedure_params_rowset:
+			// 1) procedure name - unquote user value
+			// 2) group number - parsed at the time we unquoted procedure name
+			// 3) procedure schema - unquote user value
+
+			paramsCmd.Parameters.Add(new SqlParameter("@procedure_name", SqlDbType.NVarChar, 255));
+			paramsCmd.Parameters[0].Value = UnquoteProcedureName(parsedSProc[3], out groupNumber); // ProcedureName is 4rd element in parsed array
+
+			if (null != groupNumber)
+			{
+				SqlParameter param = paramsCmd.Parameters.Add(new SqlParameter("@group_number", SqlDbType.Int));
+				param.Value = groupNumber;
+			}
+
+			if (!string.IsNullOrEmpty(parsedSProc[2]))
+			{ // SchemaName is 3rd element in parsed array
+				SqlParameter param = paramsCmd.Parameters.Add(new SqlParameter("@procedure_schema", SqlDbType.NVarChar, 255));
+				param.Value = UnquoteProcedurePart(parsedSProc[2]);
+			}
+
+			SqlDataReader r = null;
+
+			List<SqlParameter> parameters = new List<SqlParameter>();
+			bool processFinallyBlock = true;
+
+			try
+			{
+				r = paramsCmd.ExecuteReader();
+
+				SqlParameter p = null;
+
+				while (r.Read())
+				{
+					// each row corresponds to a parameter of the stored proc.  Fill in all the info
+					p = new SqlParameter()
+					{
+						ParameterName = (string)r[colNames[(int)ProcParamsColIndex.ParameterName]]
+					};
+
+					// type
+					if (useManagedDataType)
+					{
+						p.SqlDbType = (SqlDbType)(short)r[colNames[(int)ProcParamsColIndex.ManagedDataType]];
+
+						// Yukon didn't have as accurate of information as we're getting for Katmai, so re-map a couple of
+						//  types for backward compatability.
+						switch (p.SqlDbType)
+						{
+							case SqlDbType.Image:
+							case SqlDbType.Timestamp:
+								p.SqlDbType = SqlDbType.VarBinary;
+								break;
+
+							case SqlDbType.NText:
+								p.SqlDbType = SqlDbType.NVarChar;
+								break;
+
+							case SqlDbType.Text:
+								p.SqlDbType = SqlDbType.VarChar;
+								break;
+
+							default:
+								break;
+						}
+					}
+					else
+					{
+						p.SqlDbType = MetaType.GetSqlDbTypeFromOleDbType((short)r[colNames[(int)ProcParamsColIndex.DataType]],
+							ADP.IsNull(r[colNames[(int)ProcParamsColIndex.TypeName]]) ?
+								ADP.StrEmpty :
+								(string)r[colNames[(int)ProcParamsColIndex.TypeName]]);
+					}
+
+					// size
+					object a = r[colNames[(int)ProcParamsColIndex.CharacterMaximumLength]];
+					if (a is int)
+					{
+						int size = (int)a;
+
+						// Map MAX sizes correctly.  The Katmai server-side proc sends 0 for these instead of -1.
+						//  Should be fixed on the Katmai side, but would likely hold up the RI, and is safer to fix here.
+						//  If we can get the server-side fixed before shipping Katmai, we can remove this mapping.
+						if (0 == size &&
+								(p.SqlDbType == SqlDbType.NVarChar ||
+								 p.SqlDbType == SqlDbType.VarBinary ||
+								 p.SqlDbType == SqlDbType.VarChar))
+						{
+							size = -1;
+						}
+						p.Size = size;
+					}
+
+					// direction
+					p.Direction = ParameterDirectionFromOleDbDirection((short)r[colNames[(int)ProcParamsColIndex.ParameterType]]);
+
+					if (p.SqlDbType == SqlDbType.Decimal)
+					{
+						p.ScaleInternal = (byte)((short)r[colNames[(int)ProcParamsColIndex.NumericScale]] & 0xff);
+						p.PrecisionInternal = (byte)((short)r[colNames[(int)ProcParamsColIndex.NumericPrecision]] & 0xff);
+					}
+
+					// type name for Structured types (same as for Udt's except assign p.TypeName instead of p.UdtTypeName
+					if (SqlDbType.Structured == p.SqlDbType)
+					{
+
+						Debug.Assert(_activeConnection.IsKatmaiOrNewer, "Invalid datatype token received from pre-katmai server");
+
+						//read the type name
+						p.TypeName = r[colNames[(int)ProcParamsColIndex.TypeCatalogName]] + "." +
+							r[colNames[(int)ProcParamsColIndex.TypeSchemaName]] + "." +
+							r[colNames[(int)ProcParamsColIndex.TypeName]];
+					}
+
+					// XmlSchema name for Xml types
+					if (SqlDbType.Xml == p.SqlDbType)
+					{
+						object value;
+
+						value = r[colNames[(int)ProcParamsColIndex.XmlSchemaCollectionCatalogName]];
+						p.XmlSchemaCollectionDatabase = ADP.IsNull(value) ? String.Empty : (string)value;
+
+						value = r[colNames[(int)ProcParamsColIndex.XmlSchemaCollectionSchemaName]];
+						p.XmlSchemaCollectionOwningSchema = ADP.IsNull(value) ? String.Empty : (string)value;
+
+						value = r[colNames[(int)ProcParamsColIndex.XmlSchemaCollectionName]];
+						p.XmlSchemaCollectionName = ADP.IsNull(value) ? String.Empty : (string)value;
+					}
+
+					if (MetaType._IsVarTime(p.SqlDbType))
+					{
+						object value = r[colNames[(int)ProcParamsColIndex.DateTimeScale]];
+						if (value is int)
+						{
+							p.ScaleInternal = (byte)(((int)value) & 0xff);
+						}
+					}
+
+					parameters.Add(p);
+				}
+			}
+			catch (Exception e)
+			{
+				processFinallyBlock = ADP.IsCatchableExceptionType(e);
+				throw;
+			}
+			finally
+			{
+				if (processFinallyBlock)
+				{
+					r?.Close();
+
+					// always unhook the user's connection
+					paramsCmd.Connection = null;
+				}
+			}
+
+			if (parameters.Count == 0)
+			{
+				throw ADP.NoStoredProcedureExists(this.CommandText);
+			}
+
+			Parameters.Clear();
+
+			foreach (SqlParameter temp in parameters)
+			{
+				_parameters.Add(temp);
+			}
+		}
+
+		private ParameterDirection ParameterDirectionFromOleDbDirection(short oledbDirection)
+		{
+			Debug.Assert(oledbDirection >= 1 && oledbDirection <= 4, "invalid parameter direction from params_rowset!");
+
+			switch (oledbDirection)
+			{
+				case 2:
+					return ParameterDirection.InputOutput;
+				case 3:
+					return ParameterDirection.Output;
+				case 4:
+					return ParameterDirection.ReturnValue;
+				default:
+					return ParameterDirection.Input;
+			}
+
+		}
+
+		// get cached metadata
+		internal _SqlMetaDataSet MetaData
+		{
+			get
+			{
+				return _cachedMetaData;
+			}
+		}
+
+		// Check to see if notificactions auto enlistment is turned on. Enlist if so.
+		private void CheckNotificationStateAndAutoEnlist()
+		{
+			// Auto-enlist not supported in Core
+
+			// If we have a notification with a dependency, setup the notification options at this time.
+
+			// If user passes options, then we will always have option data at the time the SqlDependency
+			// ctor is called.  But, if we are using default queue, then we do not have this data until
+			// Start().  Due to this, we always delay setting options until execute.
+
+			// There is a variance in order between Start(), SqlDependency(), and Execute.  This is the 
+			// best way to solve that problem.
+			if (null != Notification)
+			{
+				if (_sqlDep != null)
+				{
+					if (null == _sqlDep.Options)
+					{
+						// If null, SqlDependency was not created with options, so we need to obtain default options now.
+						// GetDefaultOptions can and will throw under certain conditions.
+
+						// In order to match to the appropriate start - we need 3 pieces of info:
+						// 1) server 2) user identity (SQL Auth or Int Sec) 3) database
+
+						SqlDependency.IdentityUserNamePair identityUserName = null;
+
+						// Obtain identity from connection.
+						SqlInternalConnectionTds internalConnection = _activeConnection.InnerConnection as SqlInternalConnectionTds;
+						if (internalConnection.Identity != null)
+						{
+							identityUserName = new SqlDependency.IdentityUserNamePair(internalConnection.Identity, null);
+						}
+						else
+						{
+							identityUserName = new SqlDependency.IdentityUserNamePair(null, internalConnection.ConnectionOptions.UserID);
+						}
+
+						Notification.Options = SqlDependency.GetDefaultComposedOptions(_activeConnection.DataSource,
+															 InternalTdsConnection.ServerProvidedFailOverPartner,
+															 identityUserName, _activeConnection.Database);
+					}
+
+					// Set UserData on notifications, as well as adding to the appdomain dispatcher.  The value is
+					// computed by an algorithm on the dependency - fixed and will always produce the same value
+					// given identical commandtext + parameter values.
+					Notification.UserData = _sqlDep.ComputeHashAndAddToDispatcher(this);
+					// Maintain server list for SqlDependency.
+					_sqlDep.AddToServerList(_activeConnection.DataSource);
+				}
+			}
+		}
+
+		// Tds-specific logic for ExecuteNonQuery run handling
+		private Task RunExecuteNonQueryTds(string methodName, bool async, int timeout, bool asyncWrite)
+		{
+			Debug.Assert(!asyncWrite || async, "AsyncWrite should be always accompanied by Async");
+			bool processFinallyBlock = true;
+			try
+			{
+				Task reconnectTask = _activeConnection.ValidateAndReconnect(null, timeout);
+
+				if (reconnectTask != null)
+				{
+					long reconnectionStart = ADP.TimerCurrent();
+					if (async)
+					{
+						TaskCompletionSource<object> completion = new TaskCompletionSource<object>();
+						_activeConnection.RegisterWaitingForReconnect(completion.Task);
+						_reconnectionCompletionSource = completion;
+						CancellationTokenSource timeoutCTS = new CancellationTokenSource();
+						AsyncHelper.SetTimeoutException(completion, timeout, SQL.CR_ReconnectTimeout, timeoutCTS.Token);
+						AsyncHelper.ContinueTask(reconnectTask, completion,
+							() =>
+							{
+								if (completion.Task.IsCompleted)
+								{
+									return;
+								}
+								Interlocked.CompareExchange(ref _reconnectionCompletionSource, null, completion);
+								timeoutCTS.Cancel();
+								Task subTask = RunExecuteNonQueryTds(methodName, async, TdsParserStaticMethods.GetRemainingTimeout(timeout, reconnectionStart), asyncWrite);
+								if (subTask == null)
+								{
+									completion.SetResult(null);
+								}
+								else
+								{
+									AsyncHelper.ContinueTask(subTask, completion, () => completion.SetResult(null));
+								}
+							}, connectionToAbort: _activeConnection);
+						return completion.Task;
+					}
+					else
+					{
+						AsyncHelper.WaitForCompletion(reconnectTask, timeout, () => { throw SQL.CR_ReconnectTimeout(); });
+						timeout = TdsParserStaticMethods.GetRemainingTimeout(timeout, reconnectionStart);
+					}
+				}
+
+				if (asyncWrite)
+				{
+					_activeConnection.AddWeakReference(this, SqlReferenceCollection.CommandTag);
+				}
+
+				GetStateObject();
+
+				// we just send over the raw text with no annotation
+				// no parameters are sent over
+				// no data reader is returned
+				// use this overload for "batch SQL" tds token type
+				Task executeTask = _stateObj.Parser.TdsExecuteSQLBatch(this.CommandText, timeout, this.Notification, _stateObj, sync: true);
+				Debug.Assert(executeTask == null, "Shouldn't get a task when doing sync writes");
+
+				NotifyDependency();
+				if (async)
+				{
+					_activeConnection.GetOpenTdsConnection(methodName).IncrementAsyncCount();
+				}
+				else
+				{
+					bool dataReady;
+					Debug.Assert(_stateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
+					bool result = _stateObj.Parser.TryRun(RunBehavior.UntilDone, this, null, null, _stateObj, out dataReady);
+					if (!result) { throw SQL.SynchronousCallMayNotPend(); }
+				}
+			}
+			catch (Exception e)
+			{
+				processFinallyBlock = ADP.IsCatchableExceptionType(e);
+				throw;
+			}
+			finally
+			{
+				if (processFinallyBlock && !async)
+				{
+					// When executing Async, we need to keep the _stateObj alive...
+					PutStateObject();
+				}
+			}
+			return null;
+		}
+
+
+		internal SqlDataReader RunExecuteReader(CommandBehavior cmdBehavior, RunBehavior runBehavior, bool returnStream, [CallerMemberName] string method = "")
+		{
+			Task unused; // sync execution 
+			SqlDataReader reader = RunExecuteReader(cmdBehavior, runBehavior, returnStream, completion: null, timeout: CommandTimeout, task: out unused, method: method);
+			Debug.Assert(unused == null, "returned task during synchronous execution");
+			return reader;
+		}
+
+		// task is created in case of pending asynchronous write, returned SqlDataReader should not be utilized until that task is complete 
+		internal SqlDataReader RunExecuteReader(CommandBehavior cmdBehavior, RunBehavior runBehavior, bool returnStream, TaskCompletionSource<object> completion, int timeout, out Task task, bool asyncWrite = false, [CallerMemberName] string method = "")
+		{
+			bool async = (null != completion);
+
+			task = null;
+
+			_rowsAffected = -1;
+
+			if (0 != (CommandBehavior.SingleRow & cmdBehavior))
+			{
+				// CommandBehavior.SingleRow implies CommandBehavior.SingleResult
+				cmdBehavior |= CommandBehavior.SingleResult;
+			}
+
+			// this function may throw for an invalid connection
+			// returns false for empty command text
+			ValidateCommand(async, method);
+
+			CheckNotificationStateAndAutoEnlist(); // Only call after validate - requires non null connection!
+
+			SqlStatistics statistics = Statistics;
+			if (null != statistics)
+			{
+				if ((!this.IsDirty && this.IsPrepared && !_hiddenPrepare)
+					|| (this.IsPrepared && _execType == EXECTYPE.PREPAREPENDING))
+				{
+					statistics.SafeIncrement(ref statistics._preparedExecs);
+				}
+				else
+				{
+					statistics.SafeIncrement(ref statistics._unpreparedExecs);
+				}
+			}
+
+			return RunExecuteReaderTds(cmdBehavior, runBehavior, returnStream, async, timeout, out task, asyncWrite && async);
+		}
+
+		private SqlDataReader RunExecuteReaderTds(CommandBehavior cmdBehavior, RunBehavior runBehavior, bool returnStream, bool async, int timeout, out Task task, bool asyncWrite, SqlDataReader ds = null)
+		{
+			Debug.Assert(!asyncWrite || async, "AsyncWrite should be always accompanied by Async");
+
+			if (ds == null && returnStream)
+			{
+				ds = new SqlDataReader(this, cmdBehavior);
+			}
+
+			Task reconnectTask = _activeConnection.ValidateAndReconnect(null, timeout);
+
+			if (reconnectTask != null)
+			{
+				long reconnectionStart = ADP.TimerCurrent();
+				if (async)
+				{
+					TaskCompletionSource<object> completion = new TaskCompletionSource<object>();
+					_activeConnection.RegisterWaitingForReconnect(completion.Task);
+					_reconnectionCompletionSource = completion;
+					CancellationTokenSource timeoutCTS = new CancellationTokenSource();
+					AsyncHelper.SetTimeoutException(completion, timeout, SQL.CR_ReconnectTimeout, timeoutCTS.Token);
+					AsyncHelper.ContinueTask(reconnectTask, completion,
+						() =>
+						{
+							if (completion.Task.IsCompleted)
+							{
+								return;
+							}
+							Interlocked.CompareExchange(ref _reconnectionCompletionSource, null, completion);
+							timeoutCTS.Cancel();
+							Task subTask;
+							RunExecuteReaderTds(cmdBehavior, runBehavior, returnStream, async, TdsParserStaticMethods.GetRemainingTimeout(timeout, reconnectionStart), out subTask, asyncWrite, ds);
+							if (subTask == null)
+							{
+								completion.SetResult(null);
+							}
+							else
+							{
+								AsyncHelper.ContinueTask(subTask, completion, () => completion.SetResult(null));
+							}
+						}, connectionToAbort: _activeConnection);
+					task = completion.Task;
+					return ds;
+				}
+				else
+				{
+					AsyncHelper.WaitForCompletion(reconnectTask, timeout, () => { throw SQL.CR_ReconnectTimeout(); });
+					timeout = TdsParserStaticMethods.GetRemainingTimeout(timeout, reconnectionStart);
+				}
+			}
+
+			// make sure we have good parameter information
+			// prepare the command
+			// execute
+			Debug.Assert(null != _activeConnection.Parser, "TdsParser class should not be null in Command.Execute!");
+
+			bool inSchema = (0 != (cmdBehavior & CommandBehavior.SchemaOnly));
+
+			// create a new RPC
+			_SqlRPC rpc = null;
+
+			task = null;
+
+			string optionSettings = null;
+			bool processFinallyBlock = true;
+			bool decrementAsyncCountOnFailure = false;
+
+			if (async)
+			{
+				_activeConnection.GetOpenTdsConnection().IncrementAsyncCount();
+				decrementAsyncCountOnFailure = true;
+			}
+
+			try
+			{
+				if (asyncWrite)
+				{
+					_activeConnection.AddWeakReference(this, SqlReferenceCollection.CommandTag);
+				}
+
+				GetStateObject();
+				Task writeTask = null;
+
+				if ((System.Data.CommandType.Text == this.CommandType) && (0 == GetParameterCount(_parameters)))
+				{
+					// Send over SQL Batch command if we are not a stored proc and have no parameters
+					Debug.Assert(!IsUserPrepared, "CommandType.Text with no params should not be prepared!");
+					string text = GetCommandText(cmdBehavior) + GetResetOptionsString(cmdBehavior);
+					writeTask = _stateObj.Parser.TdsExecuteSQLBatch(text, timeout, this.Notification, _stateObj, sync: !asyncWrite);
+				}
+				else if (System.Data.CommandType.Text == this.CommandType)
+				{
+					if (this.IsDirty)
+					{
+						Debug.Assert(_cachedMetaData == null || !_dirty, "dirty query should not have cached metadata!"); // can have cached metadata if dirty because of parameters
+						//
+						// someone changed the command text or the parameter schema so we must unprepare the command
+						//
+						// remember that IsDirty includes test for IsPrepared!
+						if (_execType == EXECTYPE.PREPARED)
+						{
+							_hiddenPrepare = true;
+						}
+						Unprepare();
+						IsDirty = false;
+					}
+
+					if (_execType == EXECTYPE.PREPARED)
+					{
+						Debug.Assert(this.IsPrepared && (_prepareHandle != -1), "invalid attempt to call sp_execute without a handle!");
+						rpc = BuildExecute(inSchema);
+					}
+					else if (_execType == EXECTYPE.PREPAREPENDING)
+					{
+						rpc = BuildPrepExec(cmdBehavior);
+						// next time through, only do an exec
+						_execType = EXECTYPE.PREPARED;
+						_preparedConnectionCloseCount = _activeConnection.CloseCount;
+						_preparedConnectionReconnectCount = _activeConnection.ReconnectCount;
+						// mark ourselves as preparing the command
+						_inPrepare = true;
+					}
+					else
+					{
+						Debug.Assert(_execType == EXECTYPE.UNPREPARED, "Invalid execType!");
+						BuildExecuteSql(cmdBehavior, null, _parameters, ref rpc);
+					}
+
+					// if shiloh, then set NOMETADATA_UNLESSCHANGED flag
+					rpc.options = TdsEnums.RPC_NOMETADATA;
+
+					Debug.Assert(_rpcArrayOf1[0] == rpc);
+					writeTask = _stateObj.Parser.TdsExecuteRPC(_rpcArrayOf1, timeout, inSchema, this.Notification, _stateObj, CommandType.StoredProcedure == CommandType, sync: !asyncWrite);
+				}
+				else
+				{
+					Debug.Assert(this.CommandType == System.Data.CommandType.StoredProcedure, "unknown command type!");
+
+					BuildRPC(inSchema, _parameters, ref rpc);
+
+					// if we need to augment the command because a user has changed the command behavior (e.g. FillSchema)
+					// then batch sql them over.  This is inefficient (3 round trips) but the only way we can get metadata only from
+					// a stored proc
+					optionSettings = GetSetOptionsString(cmdBehavior);
+					// turn set options ON
+					if (null != optionSettings)
+					{
+						Task executeTask = _stateObj.Parser.TdsExecuteSQLBatch(optionSettings, timeout, this.Notification, _stateObj, sync: true);
+						Debug.Assert(executeTask == null, "Shouldn't get a task when doing sync writes");
+						bool dataReady;
+						Debug.Assert(_stateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
+						bool result = _stateObj.Parser.TryRun(RunBehavior.UntilDone, this, null, null, _stateObj, out dataReady);
+						if (!result) { throw SQL.SynchronousCallMayNotPend(); }
+						// and turn OFF when the ds exhausts the stream on Close()
+						optionSettings = GetResetOptionsString(cmdBehavior);
+					}
+
+
+					// execute sp
+					Debug.Assert(_rpcArrayOf1[0] == rpc);
+					writeTask = _stateObj.Parser.TdsExecuteRPC(_rpcArrayOf1, timeout, inSchema, this.Notification, _stateObj, CommandType.StoredProcedure == CommandType, sync: !asyncWrite);
+				}
+
+				Debug.Assert(writeTask == null || async, "Returned task in sync mode");
+
+				if (async)
+				{
+					decrementAsyncCountOnFailure = false;
+					if (writeTask != null)
+					{
+						task = AsyncHelper.CreateContinuationTask(writeTask, () =>
+						{
+							_activeConnection.GetOpenTdsConnection(); // it will throw if connection is closed
+							cachedAsyncState.SetAsyncReaderState(ds, runBehavior, optionSettings);
+						},
+								 onFailure: (exc) =>
+								 {
+									 _activeConnection.GetOpenTdsConnection().DecrementAsyncCount();
+								 });
+					}
+					else
+					{
+						cachedAsyncState.SetAsyncReaderState(ds, runBehavior, optionSettings);
+					}
+				}
+				else
+				{
+					// Always execute - even if no reader!
+					FinishExecuteReader(ds, runBehavior, optionSettings);
+				}
+			}
+			catch (Exception e)
+			{
+				processFinallyBlock = ADP.IsCatchableExceptionType(e);
+				if (decrementAsyncCountOnFailure)
+				{
+					SqlInternalConnectionTds innerConnectionTds = (_activeConnection.InnerConnection as SqlInternalConnectionTds);
+					if (null != innerConnectionTds)
+					{ // it may be closed 
+						innerConnectionTds.DecrementAsyncCount();
+					}
+				}
+				throw;
+			}
+			finally
+			{
+				if (processFinallyBlock && !async)
+				{
+					// When executing async, we need to keep the _stateObj alive...
+					PutStateObject();
+				}
+			}
+
+			Debug.Assert(async || null == _stateObj, "non-null state object in RunExecuteReader");
+			return ds;
+		}
+
+
+		private SqlDataReader CompleteAsyncExecuteReader()
+		{
+			SqlDataReader ds = cachedAsyncState.CachedAsyncReader; // should not be null
+			bool processFinallyBlock = true;
+			try
+			{
+				FinishExecuteReader(ds, cachedAsyncState.CachedRunBehavior, cachedAsyncState.CachedSetOptions);
+			}
+			catch (Exception e)
+			{
+				processFinallyBlock = ADP.IsCatchableExceptionType(e);
+				throw;
+			}
+			finally
+			{
+				if (processFinallyBlock)
+				{
+					cachedAsyncState.ResetAsyncState();
+					PutStateObject();
+				}
+			}
+
+			return ds;
+		}
+
+		private void FinishExecuteReader(SqlDataReader ds, RunBehavior runBehavior, string resetOptionsString)
+		{
+			// always wrap with a try { FinishExecuteReader(...) } finally { PutStateObject(); }
+
+			NotifyDependency();
+
+			if (runBehavior == RunBehavior.UntilDone)
+			{
+				try
+				{
+					bool dataReady;
+					Debug.Assert(_stateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
+					bool result = _stateObj.Parser.TryRun(RunBehavior.UntilDone, this, ds, null, _stateObj, out dataReady);
+					if (!result) { throw SQL.SynchronousCallMayNotPend(); }
+				}
+				catch (Exception e)
+				{
+					if (ADP.IsCatchableExceptionType(e))
+					{
+						if (_inPrepare)
+						{
+							// The flag is expected to be reset by OnReturnValue.  We should receive
+							// the handle unless command execution failed.  If fail, move back to pending
+							// state.
+							_inPrepare = false;                  // reset the flag
+							IsDirty = true;                      // mark command as dirty so it will be prepared next time we're coming through
+							_execType = EXECTYPE.PREPAREPENDING; // reset execution type to pending
+						}
+
+						if (null != ds)
+						{
+							try
+							{
+								ds.Close();
+							}
+							catch(Exception exClose)
+							{
+								Debug.WriteLine("Received this exception from SqlDataReader.Close() while in another catch block: " + exClose.ToString());
+							}
+						}
+					}
+					throw;
+				}
+			}
+
+			// bind the parser to the reader if we get this far
+			if (ds != null)
+			{
+				ds.Bind(_stateObj);
+				_stateObj = null;   // the reader now owns this...
+				ds.ResetOptionsString = resetOptionsString;
+				// bind this reader to this connection now
+				_activeConnection.AddWeakReference(ds, SqlReferenceCollection.DataReaderTag);
+
+				// force this command to start reading data off the wire.
+				// this will cause an error to be reported at Execute() time instead of Read() time
+				// if the command is not set.
+				try
+				{
+					_cachedMetaData = ds.MetaData;
+					ds.IsInitialized = true;
+				}
+				catch (Exception e)
+				{
+					if (ADP.IsCatchableExceptionType(e))
+					{
+						if (_inPrepare)
+						{
+							// The flag is expected to be reset by OnReturnValue.  We should receive
+							// the handle unless command execution failed.  If fail, move back to pending
+							// state.
+							_inPrepare = false;                  // reset the flag
+							IsDirty = true;                      // mark command as dirty so it will be prepared next time we're coming through
+							_execType = EXECTYPE.PREPAREPENDING; // reset execution type to pending
+						}
+
+						try
+						{
+							ds.Close();
+						}
+						catch (Exception exClose)
+						{
+							Debug.WriteLine("Received this exception from SqlDataReader.Close() while in another catch block: " + exClose.ToString());
+						}
+					}
+
+					throw;
+				}
+			}
+		}
+
+
+		private void RegisterForConnectionCloseNotification<T>(ref Task<T> outerTask)
+		{
+			SqlConnection connection = _activeConnection;
+			if (connection == null)
+			{
+				// No connection
+				throw ADP.ClosedConnectionError();
+			}
+
+			connection.RegisterForConnectionCloseNotification<T>(ref outerTask, this, SqlReferenceCollection.CommandTag);
+		}
+
+		// validates that a command has commandText and a non-busy open connection
+		// throws exception for error case, returns false if the commandText is empty
+		private void ValidateCommand(bool async, [CallerMemberName] string method = "")
+		{
+			if (null == _activeConnection)
+			{
+				throw ADP.ConnectionRequired(method);
+			}
+
+			// Ensure that the connection is open and that the Parser is in the correct state
+			SqlInternalConnectionTds tdsConnection = _activeConnection.InnerConnection as SqlInternalConnectionTds;
+			if (tdsConnection != null)
+			{
+				var parser = tdsConnection.Parser;
+				if ((parser == null) || (parser.State == TdsParserState.Closed))
+				{
+					throw ADP.OpenConnectionRequired(method, ConnectionState.Closed);
+				}
+				else if (parser.State != TdsParserState.OpenLoggedIn)
+				{
+					throw ADP.OpenConnectionRequired(method, ConnectionState.Broken);
+				}
+			}
+			else if (_activeConnection.State == ConnectionState.Closed)
+			{
+				throw ADP.OpenConnectionRequired(method, ConnectionState.Closed);
+			}
+			else if (_activeConnection.State == ConnectionState.Broken)
+			{
+				throw ADP.OpenConnectionRequired(method, ConnectionState.Broken);
+			}
+
+			ValidateAsyncCommand();
+
+			// close any non MARS dead readers, if applicable, and then throw if still busy.
+			// Throw if we have a live reader on this command
+			_activeConnection.ValidateConnectionForExecute(method, this);
+			// Check to see if the currently set transaction has completed.  If so,
+			// null out our local reference.
+			if (null != _transaction && _transaction.Connection == null)
+				_transaction = null;
+
+			// throw if the connection is in a transaction but there is no
+			// locally assigned transaction object
+			if (_activeConnection.HasLocalTransactionFromAPI && (null == _transaction))
+				throw ADP.TransactionRequired(method);
+
+			// if we have a transaction, check to ensure that the active
+			// connection property matches the connection associated with
+			// the transaction
+			if (null != _transaction && _activeConnection != _transaction.Connection)
+				throw ADP.TransactionConnectionMismatch();
+
+			if (string.IsNullOrEmpty(this.CommandText))
+				throw ADP.CommandTextRequired(method);
+		}
+
+		private void ValidateAsyncCommand()
+		{
+			if (cachedAsyncState.PendingAsyncOperation)
+			{ // Enforce only one pending async execute at a time.
+				if (cachedAsyncState.IsActiveConnectionValid(_activeConnection))
+				{
+					throw SQL.PendingBeginXXXExists();
+				}
+				else
+				{
+					_stateObj = null; // Session was re-claimed by session pool upon connection close.
+					cachedAsyncState.ResetAsyncState();
+				}
+			}
+		}
+
+		private void GetStateObject(TdsParser parser = null)
+		{
+			Debug.Assert(null == _stateObj, "StateObject not null on GetStateObject");
+			Debug.Assert(null != _activeConnection, "no active connection?");
+
+			if (_pendingCancel)
+			{
+				_pendingCancel = false; // Not really needed, but we'll reset anyways.
+
+				// If a pendingCancel exists on the object, we must have had a Cancel() call
+				// between the point that we entered an Execute* API and the point in Execute* that
+				// we proceeded to call this function and obtain a stateObject.  In that case,
+				// we now throw a cancelled error.
+				throw SQL.OperationCancelled();
+			}
+
+			if (parser == null)
+			{
+				parser = _activeConnection.Parser;
+				if ((parser == null) || (parser.State == TdsParserState.Broken) || (parser.State == TdsParserState.Closed))
+				{
+					// Connection's parser is null as well, therefore we must be closed
+					throw ADP.ClosedConnectionError();
+				}
+			}
+
+			TdsParserStateObject stateObj = parser.GetSession(this);
+			stateObj.StartSession(this);
+
+			_stateObj = stateObj;
+
+			if (_pendingCancel)
+			{
+				_pendingCancel = false; // Not really needed, but we'll reset anyways.
+
+				// If a pendingCancel exists on the object, we must have had a Cancel() call
+				// between the point that we entered this function and the point where we obtained
+				// and actually assigned the stateObject to the local member.  It is possible
+				// that the flag is set as well as a call to stateObj.Cancel - though that would
+				// be a no-op.  So - throw.
+				throw SQL.OperationCancelled();
+			}
+		}
+
+		private void ReliablePutStateObject()
+		{
+			PutStateObject();
+		}
+
+		private void PutStateObject()
+		{
+			TdsParserStateObject stateObj = _stateObj;
+			_stateObj = null;
+
+			if (null != stateObj)
+			{
+				stateObj.CloseSession();
+			}
+		}
+		internal void OnDoneProc()
+		{ // called per rpc batch complete
+			if (BatchRPCMode)
+			{
+				// track the records affected for the just completed rpc batch
+				// _rowsAffected is cumulative for ExecuteNonQuery across all rpc batches
+				_SqlRPCBatchArray[_currentlyExecutingBatch].cumulativeRecordsAffected = _rowsAffected;
+
+				_SqlRPCBatchArray[_currentlyExecutingBatch].recordsAffected =
+					(((0 < _currentlyExecutingBatch) && (0 <= _rowsAffected))
+						? (_rowsAffected - Math.Max(_SqlRPCBatchArray[_currentlyExecutingBatch - 1].cumulativeRecordsAffected, 0))
+						: _rowsAffected);
+
+				// track the error collection (not available from TdsParser after ExecuteNonQuery)
+				// and the which errors are associated with the just completed rpc batch
+				_SqlRPCBatchArray[_currentlyExecutingBatch].errorsIndexStart =
+					((0 < _currentlyExecutingBatch)
+						? _SqlRPCBatchArray[_currentlyExecutingBatch - 1].errorsIndexEnd
+						: 0);
+				_SqlRPCBatchArray[_currentlyExecutingBatch].errorsIndexEnd = _stateObj.ErrorCount;
+				_SqlRPCBatchArray[_currentlyExecutingBatch].errors = _stateObj._errors;
+
+				// track the warning collection (not available from TdsParser after ExecuteNonQuery)
+				// and the which warnings are associated with the just completed rpc batch
+				_SqlRPCBatchArray[_currentlyExecutingBatch].warningsIndexStart =
+					((0 < _currentlyExecutingBatch)
+						? _SqlRPCBatchArray[_currentlyExecutingBatch - 1].warningsIndexEnd
+						: 0);
+				_SqlRPCBatchArray[_currentlyExecutingBatch].warningsIndexEnd = _stateObj.WarningCount;
+				_SqlRPCBatchArray[_currentlyExecutingBatch].warnings = _stateObj._warnings;
+
+				_currentlyExecutingBatch++;
+				Debug.Assert(_parameterCollectionList.Count >= _currentlyExecutingBatch, "OnDoneProc: Too many DONEPROC events");
+			}
+		}
+		internal void OnReturnStatus(int status)
+		{
+			if (_inPrepare)
+				return;
+
+			SqlParameterCollection parameters = _parameters;
+			if (BatchRPCMode)
+			{
+				if (_parameterCollectionList.Count > _currentlyExecutingBatch)
+				{
+					parameters = _parameterCollectionList[_currentlyExecutingBatch];
+				}
+				else
+				{
+					Debug.Assert(false, "OnReturnStatus: SqlCommand got too many DONEPROC events");
+					parameters = null;
+				}
+			}
+			// see if a return value is bound
+			int count = GetParameterCount(parameters);
+			for (int i = 0; i < count; i++)
+			{
+				SqlParameter parameter = parameters[i];
+				if (parameter.Direction == ParameterDirection.ReturnValue)
+				{
+					object v = parameter.Value;
+
+					// if the user bound a sqlint32 (the only valid one for status, use it)
+					if ((null != v) && (v.GetType() == typeof(SqlInt32)))
+					{
+						parameter.Value = new SqlInt32(status); // value type
+					}
+					else
+					{
+						parameter.Value = status;
+
+					}
+
+					break;
+				}
+			}
+		}
+
+		//
+		// Move the return value to the corresponding output parameter.
+		// Return parameters are sent in the order in which they were defined in the procedure.
+		// If named, match the parameter name, otherwise fill in based on ordinal position.
+		// If the parameter is not bound, then ignore the return value.
+		//
+		internal void OnReturnValue(SqlReturnValue rec)
+		{
+
+			if (_inPrepare)
+			{
+				if (!rec.value.IsNull)
+				{
+					_prepareHandle = rec.value.Int32;
+				}
+				_inPrepare = false;
+				return;
+			}
+
+			SqlParameterCollection parameters = GetCurrentParameterCollection();
+			int count = GetParameterCount(parameters);
+
+
+			SqlParameter thisParam = GetParameterForOutputValueExtraction(parameters, rec.parameter, count);
+
+			if (null != thisParam)
+			{
+				// copy over data
+
+				// if the value user has supplied a SqlType class, then just copy over the SqlType, otherwise convert
+				// to the com type
+				object val = thisParam.Value;
+
+				thisParam.SetSqlBuffer(rec.value);
+
+				MetaType mt = MetaType.GetMetaTypeFromSqlDbType(rec.type, false);
+
+				if (rec.type == SqlDbType.Decimal)
+				{
+					thisParam.ScaleInternal = rec.scale;
+					thisParam.PrecisionInternal = rec.precision;
+				}
+				else if (mt.IsVarTime)
+				{
+					thisParam.ScaleInternal = rec.scale;
+				}
+				else if (rec.type == SqlDbType.Xml)
+				{
+					SqlCachedBuffer cachedBuffer = (thisParam.Value as SqlCachedBuffer);
+					if (null != cachedBuffer)
+					{
+						thisParam.Value = cachedBuffer.ToString();
+					}
+				}
+
+				if (rec.collation != null)
+				{
+					Debug.Assert(mt.IsCharType, "Invalid collation structure for non-char type");
+					thisParam.Collation = rec.collation;
+				}
+			}
+
+			return;
+		}
+
+		private SqlParameterCollection GetCurrentParameterCollection()
+		{
+			if (BatchRPCMode)
+			{
+				if (_parameterCollectionList.Count > _currentlyExecutingBatch)
+				{
+					return _parameterCollectionList[_currentlyExecutingBatch];
+				}
+				else
+				{
+					Debug.Assert(false, "OnReturnValue: SqlCommand got too many DONEPROC events");
+					return null;
+				}
+			}
+			else
+			{
+				return _parameters;
+			}
+		}
+
+		private SqlParameter GetParameterForOutputValueExtraction(SqlParameterCollection parameters,
+						string paramName, int paramCount)
+		{
+			SqlParameter thisParam = null;
+			bool foundParam = false;
+
+			if (null == paramName)
+			{
+				// rec.parameter should only be null for a return value from a function
+				for (int i = 0; i < paramCount; i++)
+				{
+					thisParam = parameters[i];
+					// searching for ReturnValue
+					if (thisParam.Direction == ParameterDirection.ReturnValue)
+					{
+						foundParam = true;
+						break; // found it
+					}
+				}
+			}
+			else
+			{
+				for (int i = 0; i < paramCount; i++)
+				{
+					thisParam = parameters[i];
+					// searching for Output or InputOutput or ReturnValue with matching name
+					if (thisParam.Direction != ParameterDirection.Input && thisParam.Direction != ParameterDirection.ReturnValue && paramName == thisParam.ParameterNameFixed)
+					{
+						foundParam = true;
+						break; // found it
+					}
+				}
+			}
+			if (foundParam)
+				return thisParam;
+			else
+				return null;
+		}
+
+		private void GetRPCObject(int paramCount, ref _SqlRPC rpc)
+		{
+			// Designed to minimize necessary allocations
+			int ii;
+			if (rpc == null)
+			{
+				if (_rpcArrayOf1 == null)
+				{
+					_rpcArrayOf1 = new _SqlRPC[1];
+					_rpcArrayOf1[0] = new _SqlRPC();
+				}
+				rpc = _rpcArrayOf1[0];
+			}
+
+			rpc.ProcID = 0;
+			rpc.rpcName = null;
+			rpc.options = 0;
+
+
+			// Make sure there is enough space in the parameters and paramoptions arrays
+			if (rpc.parameters == null || rpc.parameters.Length < paramCount)
+			{
+				rpc.parameters = new SqlParameter[paramCount];
+			}
+			else if (rpc.parameters.Length > paramCount)
+			{
+				rpc.parameters[paramCount] = null;    // Terminator
+			}
+			if (rpc.paramoptions == null || (rpc.paramoptions.Length < paramCount))
+			{
+				rpc.paramoptions = new byte[paramCount];
+			}
+			else
+			{
+				for (ii = 0; ii < paramCount; ii++)
+					rpc.paramoptions[ii] = 0;
+			}
+		}
+
+		private void SetUpRPCParameters(_SqlRPC rpc, int startCount, bool inSchema, SqlParameterCollection parameters)
+		{
+			int ii;
+			int paramCount = GetParameterCount(parameters);
+			int j = startCount;
+			TdsParser parser = _activeConnection.Parser;
+
+			for (ii = 0; ii < paramCount; ii++)
+			{
+				SqlParameter parameter = parameters[ii];
+				parameter.Validate(ii, CommandType.StoredProcedure == CommandType);
+
+				// func will change type to that with a 4 byte length if the type has a two
+				// byte length and a parameter length > than that expressible in 2 bytes
+				if ((!parameter.ValidateTypeLengths().IsPlp) && (parameter.Direction != ParameterDirection.Output))
+				{
+					parameter.FixStreamDataForNonPLP();
+				}
+
+				if (ShouldSendParameter(parameter))
+				{
+					rpc.parameters[j] = parameter;
+
+					// set output bit
+					if (parameter.Direction == ParameterDirection.InputOutput ||
+						parameter.Direction == ParameterDirection.Output)
+						rpc.paramoptions[j] = TdsEnums.RPC_PARAM_BYREF;
+
+					// set default value bit
+					if (parameter.Direction != ParameterDirection.Output)
+					{
+						// remember that null == Convert.IsEmpty, DBNull.Value is a database null!
+
+						// Don't assume a default value exists for parameters in the case when
+						// the user is simply requesting schema.
+						// TVPs use DEFAULT and do not allow NULL, even for schema only.
+						if (null == parameter.Value && (!inSchema || SqlDbType.Structured == parameter.SqlDbType))
+						{
+							rpc.paramoptions[j] |= TdsEnums.RPC_PARAM_DEFAULT;
+						}
+					}
+
+					// Must set parameter option bit for LOB_COOKIE if unfilled LazyMat blob
+					j++;
+				}
+			}
+		}
+
+		private _SqlRPC BuildPrepExec(CommandBehavior behavior)
+		{
+			Debug.Assert(System.Data.CommandType.Text == this.CommandType, "invalid use of sp_prepexec for stored proc invocation!");
+			SqlParameter sqlParam;
+			int j = 3;
+
+			int count = CountSendableParameters(_parameters);
+
+			_SqlRPC rpc = null;
+			GetRPCObject(count + j, ref rpc);
+
+			rpc.ProcID = TdsEnums.RPC_PROCID_PREPEXEC;
+			rpc.rpcName = TdsEnums.SP_PREPEXEC;
+
+			//@handle
+			sqlParam = new SqlParameter(null, SqlDbType.Int);
+			sqlParam.Direction = ParameterDirection.InputOutput;
+			sqlParam.Value = _prepareHandle;
+			rpc.parameters[0] = sqlParam;
+			rpc.paramoptions[0] = TdsEnums.RPC_PARAM_BYREF;
+
+			//@batch_params
+			string paramList = BuildParamList(_stateObj.Parser, _parameters);
+			sqlParam = new SqlParameter(null, ((paramList.Length << 1) <= TdsEnums.TYPE_SIZE_LIMIT) ? SqlDbType.NVarChar : SqlDbType.NText, paramList.Length);
+			sqlParam.Value = paramList;
+			rpc.parameters[1] = sqlParam;
+
+			//@batch_text
+			string text = GetCommandText(behavior);
+			sqlParam = new SqlParameter(null, ((text.Length << 1) <= TdsEnums.TYPE_SIZE_LIMIT) ? SqlDbType.NVarChar : SqlDbType.NText, text.Length);
+			sqlParam.Value = text;
+			rpc.parameters[2] = sqlParam;
+
+			SetUpRPCParameters(rpc, j, false, _parameters);
+			return rpc;
+		}
+
+
+		//
+		// returns true if the parameter is not a return value
+		// and it's value is not DBNull (for a nullable parameter)
+		//
+		private static bool ShouldSendParameter(SqlParameter p)
+		{
+			switch (p.Direction)
+			{
+				case ParameterDirection.ReturnValue:
+					// return value parameters are never sent
+					return false;
+				case ParameterDirection.Output:
+				case ParameterDirection.InputOutput:
+				case ParameterDirection.Input:
+					// InputOutput/Output parameters are aways sent
+					return true;
+				default:
+					Debug.Assert(false, "Invalid ParameterDirection!");
+					return false;
+			}
+		}
+
+		private int CountSendableParameters(SqlParameterCollection parameters)
+		{
+			int cParams = 0;
+
+			if (parameters != null)
+			{
+				int count = parameters.Count;
+				for (int i = 0; i < count; i++)
+				{
+					if (ShouldSendParameter(parameters[i]))
+						cParams++;
+				}
+			}
+			return cParams;
+		}
+
+		// Returns total number of parameters
+		private int GetParameterCount(SqlParameterCollection parameters)
+		{
+			return ((null != parameters) ? parameters.Count : 0);
+		}
+
+		//
+		// build the RPC record header for this stored proc and add parameters
+		//
+		private void BuildRPC(bool inSchema, SqlParameterCollection parameters, ref _SqlRPC rpc)
+		{
+			Debug.Assert(this.CommandType == System.Data.CommandType.StoredProcedure, "Command must be a stored proc to execute an RPC");
+			int count = CountSendableParameters(parameters);
+			GetRPCObject(count, ref rpc);
+
+			rpc.rpcName = this.CommandText; // just get the raw command text
+
+			SetUpRPCParameters(rpc, 0, inSchema, parameters);
+		}
+
+		//
+		// build the RPC record header for sp_unprepare
+		//
+		// prototype for sp_unprepare is:
+		// sp_unprepare(@handle)
+
+		// build the RPC record header for sp_execute
+		//
+		// prototype for sp_execute is:
+		// sp_execute(@handle int,param1value,param2value...)
+
+		private _SqlRPC BuildExecute(bool inSchema)
+		{
+			Debug.Assert(_prepareHandle != -1, "Invalid call to sp_execute without a valid handle!");
+			int j = 1;
+
+			int count = CountSendableParameters(_parameters);
+
+			_SqlRPC rpc = null;
+			GetRPCObject(count + j, ref rpc);
+
+			SqlParameter sqlParam;
+
+			rpc.ProcID = TdsEnums.RPC_PROCID_EXECUTE;
+			rpc.rpcName = TdsEnums.SP_EXECUTE;
+
+			//@handle
+			sqlParam = new SqlParameter(null, SqlDbType.Int);
+			sqlParam.Value = _prepareHandle;
+			rpc.parameters[0] = sqlParam;
+
+			SetUpRPCParameters(rpc, j, inSchema, _parameters);
+			return rpc;
+		}
+
+		//
+		// build the RPC record header for sp_executesql and add the parameters
+		//
+		// prototype for sp_executesql is:
+		// sp_executesql(@batch_text nvarchar(4000),@batch_params nvarchar(4000), param1,.. paramN)
+		private void BuildExecuteSql(CommandBehavior behavior, string commandText, SqlParameterCollection parameters, ref _SqlRPC rpc)
+		{
+
+			Debug.Assert(_prepareHandle == -1, "This command has an existing handle, use sp_execute!");
+			Debug.Assert(CommandType.Text == this.CommandType, "invalid use of sp_executesql for stored proc invocation!");
+			int j;
+			SqlParameter sqlParam;
+
+			int cParams = CountSendableParameters(parameters);
+			if (cParams > 0)
+			{
+				j = 2;
+			}
+			else
+			{
+				j = 1;
+			}
+
+			GetRPCObject(cParams + j, ref rpc);
+			rpc.ProcID = TdsEnums.RPC_PROCID_EXECUTESQL;
+			rpc.rpcName = TdsEnums.SP_EXECUTESQL;
+
+			// @sql
+			if (commandText == null)
+			{
+				commandText = GetCommandText(behavior);
+			}
+			sqlParam = new SqlParameter(null, ((commandText.Length << 1) <= TdsEnums.TYPE_SIZE_LIMIT) ? SqlDbType.NVarChar : SqlDbType.NText, commandText.Length);
+			sqlParam.Value = commandText;
+			rpc.parameters[0] = sqlParam;
+
+			if (cParams > 0)
+			{
+				string paramList = BuildParamList(_stateObj.Parser, BatchRPCMode ? parameters : _parameters);
+				sqlParam = new SqlParameter(null, ((paramList.Length << 1) <= TdsEnums.TYPE_SIZE_LIMIT) ? SqlDbType.NVarChar : SqlDbType.NText, paramList.Length);
+				sqlParam.Value = paramList;
+				rpc.parameters[1] = sqlParam;
+
+				bool inSchema = (0 != (behavior & CommandBehavior.SchemaOnly));
+				SetUpRPCParameters(rpc, j, inSchema, parameters);
+			}
+		}
+
+		// paramList parameter for sp_executesql, sp_prepare, and sp_prepexec
+		internal string BuildParamList(TdsParser parser, SqlParameterCollection parameters)
+		{
+			StringBuilder paramList = new StringBuilder();
+			bool fAddSeperator = false;
+
+			int count = 0;
+
+			count = parameters.Count;
+			for (int i = 0; i < count; i++)
+			{
+				SqlParameter sqlParam = parameters[i];
+				sqlParam.Validate(i, CommandType.StoredProcedure == CommandType);
+				// skip ReturnValue parameters; we never send them to the server
+				if (!ShouldSendParameter(sqlParam))
+					continue;
+
+				// add our separator for the ith parameter
+				if (fAddSeperator)
+					paramList.Append(',');
+
+				paramList.Append(sqlParam.ParameterNameFixed);
+
+				MetaType mt = sqlParam.InternalMetaType;
+
+				//for UDTs, get the actual type name. Get only the typename, omit catalog and schema names.
+				//in TSQL you should only specify the unqualified type name
+
+				// paragraph above doesn't seem to be correct. Server won't find the type
+				// if we don't provide a fully qualified name
+				paramList.Append(" ");
+				if (mt.SqlDbType == SqlDbType.Udt)
+				{
+					throw ADP.DbTypeNotSupported(SqlDbType.Udt.ToString());
+				}
+				else if (mt.SqlDbType == SqlDbType.Structured)
+				{
+					string typeName = sqlParam.TypeName;
+					if (string.IsNullOrEmpty(typeName))
+					{
+						throw SQL.MustSetTypeNameForParam(mt.TypeName, sqlParam.ParameterNameFixed);
+					}
+					paramList.Append(ParseAndQuoteIdentifier(typeName));
+
+					// TVPs currently are the only Structured type and must be read only, so add that keyword
+					paramList.Append(" READONLY");
+				}
+				else
+				{
+					// func will change type to that with a 4 byte length if the type has a two
+					// byte length and a parameter length > than that expressible in 2 bytes
+					mt = sqlParam.ValidateTypeLengths();
+					if ((!mt.IsPlp) && (sqlParam.Direction != ParameterDirection.Output))
+					{
+						sqlParam.FixStreamDataForNonPLP();
+					}
+					paramList.Append(mt.TypeName);
+				}
+
+				fAddSeperator = true;
+
+				if (mt.SqlDbType == SqlDbType.Decimal)
+				{
+					byte precision = sqlParam.GetActualPrecision();
+					byte scale = sqlParam.GetActualScale();
+
+					paramList.Append('(');
+
+					if (0 == precision)
+					{
+						precision = TdsEnums.DEFAULT_NUMERIC_PRECISION;
+					}
+
+					paramList.Append(precision);
+					paramList.Append(',');
+					paramList.Append(scale);
+					paramList.Append(')');
+				}
+				else if (mt.IsVarTime)
+				{
+					byte scale = sqlParam.GetActualScale();
+
+					paramList.Append('(');
+					paramList.Append(scale);
+					paramList.Append(')');
+				}
+				else if (false == mt.IsFixed && false == mt.IsLong && mt.SqlDbType != SqlDbType.Timestamp && mt.SqlDbType != SqlDbType.Udt && SqlDbType.Structured != mt.SqlDbType)
+				{
+					int size = sqlParam.Size;
+
+					paramList.Append('(');
+
+					// if using non unicode types, obtain the actual byte length from the parser, with it's associated code page
+					if (mt.IsAnsiType)
+					{
+						object val = sqlParam.GetCoercedValue();
+						string s = null;
+
+						// deal with the sql types
+						if ((null != val) && (DBNull.Value != val))
+						{
+							s = (val as string);
+							if (null == s)
+							{
+								SqlString sval = val is SqlString ? (SqlString)val : SqlString.Null;
+								if (!sval.IsNull)
+								{
+									s = sval.Value;
+								}
+							}
+						}
+
+						if (null != s)
+						{
+							int actualBytes = parser.GetEncodingCharLength(s, sqlParam.GetActualSize(), sqlParam.Offset, null);
+							// if actual number of bytes is greater than the user given number of chars, use actual bytes
+							if (actualBytes > size)
+								size = actualBytes;
+						}
+					}
+
+					// If the user specifies a 0-sized parameter for a variable len field
+					// pass over max size (8000 bytes or 4000 characters for wide types)
+					if (0 == size)
+						size = mt.IsSizeInCharacters ? (TdsEnums.MAXSIZE >> 1) : TdsEnums.MAXSIZE;
+
+					paramList.Append(size);
+					paramList.Append(')');
+				}
+				else if (mt.IsPlp && (mt.SqlDbType != SqlDbType.Xml) && (mt.SqlDbType != SqlDbType.Udt))
+				{
+					paramList.Append("(max) ");
+				}
+
+				// set the output bit for Output or InputOutput parameters
+				if (sqlParam.Direction != ParameterDirection.Input)
+					paramList.Append(" " + TdsEnums.PARAM_OUTPUT);
+			}
+
+			return paramList.ToString();
+		}
+
+		// Adds quotes to each part of a SQL identifier that may be multi-part, while leaving
+		//  the result as a single composite name.
+		private string ParseAndQuoteIdentifier(string identifier)
+		{
+			string[] strings = SqlParameter.ParseTypeName(identifier);
+			StringBuilder bld = new StringBuilder();
+
+			// Stitching back together is a little tricky. Assume we want to build a full multi-part name
+			//  with all parts except trimming separators for leading empty names (null or empty strings,
+			//  but not whitespace). Separators in the middle should be added, even if the name part is 
+			//  null/empty, to maintain proper location of the parts.
+			for (int i = 0; i < strings.Length; i++)
+			{
+				if (0 < bld.Length)
+				{
+					bld.Append('.');
+				}
+				if (null != strings[i] && 0 != strings[i].Length)
+				{
+					bld.Append(ADP.BuildQuotedString("[", "]", strings[i]));
+				}
+			}
+
+			return bld.ToString();
+		}
+
+		// returns set option text to turn on format only and key info on and off
+		//  When we are executing as a text command, then we never need
+		// to turn off the options since they command text is executed in the scope of sp_executesql.
+		// For a stored proc command, however, we must send over batch sql and then turn off
+		// the set options after we read the data.  See the code in Command.Execute()
+		private string GetSetOptionsString(CommandBehavior behavior)
+		{
+			string s = null;
+
+			if ((System.Data.CommandBehavior.SchemaOnly == (behavior & CommandBehavior.SchemaOnly)) ||
+			   (System.Data.CommandBehavior.KeyInfo == (behavior & CommandBehavior.KeyInfo)))
+			{
+				// SET FMTONLY ON will cause the server to ignore other SET OPTIONS, so turn
+				// it off before we ask for browse mode metadata
+				s = TdsEnums.FMTONLY_OFF;
+
+				if (System.Data.CommandBehavior.KeyInfo == (behavior & CommandBehavior.KeyInfo))
+				{
+					s = s + TdsEnums.BROWSE_ON;
+				}
+
+				if (System.Data.CommandBehavior.SchemaOnly == (behavior & CommandBehavior.SchemaOnly))
+				{
+					s = s + TdsEnums.FMTONLY_ON;
+				}
+			}
+
+			return s;
+		}
+
+		private string GetResetOptionsString(CommandBehavior behavior)
+		{
+			string s = null;
+
+			// SET FMTONLY ON OFF
+			if (System.Data.CommandBehavior.SchemaOnly == (behavior & CommandBehavior.SchemaOnly))
+			{
+				s = s + TdsEnums.FMTONLY_OFF;
+			}
+
+			// SET NO_BROWSETABLE OFF
+			if (System.Data.CommandBehavior.KeyInfo == (behavior & CommandBehavior.KeyInfo))
+			{
+				s = s + TdsEnums.BROWSE_OFF;
+			}
+
+			return s;
+		}
+
+		private String GetCommandText(CommandBehavior behavior)
+		{
+			// build the batch string we send over, since we execute within a stored proc (sp_executesql), the SET options never need to be
+			// turned off since they are scoped to the sproc
+			Debug.Assert(System.Data.CommandType.Text == this.CommandType, "invalid call to GetCommandText for stored proc!");
+			return GetSetOptionsString(behavior) + this.CommandText;
+		}
+
+		internal void CheckThrowSNIException()
+		{
+			var stateObj = _stateObj;
+			if (stateObj != null)
+			{
+				stateObj.CheckThrowSNIException();
+			}
+		}
+
+		// We're being notified that the underlying connection has closed
+		internal void OnConnectionClosed()
+		{
+			var stateObj = _stateObj;
+			if (stateObj != null)
+			{
+				stateObj.OnConnectionClosed();
+			}
+		}
+
+		internal TdsParserStateObject StateObject
+		{
+			get
+			{
+				return _stateObj;
+			}
+		}
+
+		private bool IsPrepared
+		{
+			get { return (_execType != EXECTYPE.UNPREPARED); }
+		}
+
+		private bool IsUserPrepared
+		{
+			get { return IsPrepared && !_hiddenPrepare && !IsDirty; }
+		}
+
+		internal bool IsDirty
+		{
+			get
+			{
+				// only dirty if prepared
+				var activeConnection = _activeConnection;
+				return (IsPrepared &&
+					(_dirty ||
+					((_parameters != null) && (_parameters.IsDirty)) ||
+					((activeConnection != null) && ((activeConnection.CloseCount != _preparedConnectionCloseCount) || (activeConnection.ReconnectCount != _preparedConnectionReconnectCount)))));
+			}
+			set
+			{
+				// only mark the command as dirty if it is already prepared
+				// but always clear the value if it we are clearing the dirty flag
+				_dirty = value ? IsPrepared : false;
+				if (null != _parameters)
+				{
+					_parameters.IsDirty = _dirty;
+				}
+				_cachedMetaData = null;
+			}
+		}
+
+		internal int InternalRecordsAffected
+		{
+			get
+			{
+				return _rowsAffected;
+			}
+			set
+			{
+				if (-1 == _rowsAffected)
+				{
+					_rowsAffected = value;
+				}
+				else if (0 < value)
+				{
+					_rowsAffected += value;
+				}
+			}
+		}
+
+		internal void ClearBatchCommand()
+		{
+			List<_SqlRPC> rpcList = _RPCList;
+			if (null != rpcList)
+			{
+				rpcList.Clear();
+			}
+			if (null != _parameterCollectionList)
+			{
+				_parameterCollectionList.Clear();
+			}
+
+			_SqlRPCBatchArray = null;
+			_currentlyExecutingBatch = 0;
+		}
+
+		internal bool BatchRPCMode
+		{
+			get
+			{
+				return _batchRPCMode;
+			}
+			set
+			{
+				_batchRPCMode = value;
+
+				if (_batchRPCMode == false)
+				{
+					ClearBatchCommand();
+				}
+				else
+				{
+					if (_RPCList == null)
+					{
+						_RPCList = new List<_SqlRPC>();
+					}
+					if (_parameterCollectionList == null)
+					{
+						_parameterCollectionList = new List<SqlParameterCollection>();
+					}
+				}
+			}
+		}
+
+		internal void AddBatchCommand(string commandText, SqlParameterCollection parameters, CommandType cmdType)
+		{
+			Debug.Assert(BatchRPCMode, "Command is not in batch RPC Mode");
+			Debug.Assert(_RPCList != null);
+			Debug.Assert(_parameterCollectionList != null);
+
+			_SqlRPC rpc = new _SqlRPC();
+
+			CommandText = commandText;
+			CommandType = cmdType;
+
+			GetStateObject();
+			if (cmdType == CommandType.StoredProcedure)
+			{
+				BuildRPC(false, parameters, ref rpc);
+			}
+			else
+			{
+				// All batch sql statements must be executed inside sp_executesql, including those without parameters
+				BuildExecuteSql(CommandBehavior.Default, commandText, parameters, ref rpc);
+			}
+
+			_RPCList.Add(rpc);
+			// Always add a parameters collection per RPC, even if there are no parameters.
+			_parameterCollectionList.Add(parameters);
+
+			ReliablePutStateObject();
+		}
+
+		internal int ExecuteBatchRPCCommand()
+		{
+
+			Debug.Assert(BatchRPCMode, "Command is not in batch RPC Mode");
+			Debug.Assert(_RPCList != null, "No batch commands specified");
+
+			_SqlRPCBatchArray = _RPCList.ToArray();
+			_currentlyExecutingBatch = 0;
+			return ExecuteNonQuery();       // Check permissions, execute, return output params
+		}
+
+		internal int? GetRecordsAffected(int commandIndex)
+		{
+			Debug.Assert(BatchRPCMode, "Command is not in batch RPC Mode");
+			Debug.Assert(_SqlRPCBatchArray != null, "batch command have been cleared");
+			return _SqlRPCBatchArray[commandIndex].recordsAffected;
+		}
+
+		internal SqlException GetErrors(int commandIndex)
+		{
+			SqlException result = null;
+			int length = (_SqlRPCBatchArray[commandIndex].errorsIndexEnd - _SqlRPCBatchArray[commandIndex].errorsIndexStart);
+			if (0 < length)
+			{
+				SqlErrorCollection errors = new SqlErrorCollection();
+				for (int i = _SqlRPCBatchArray[commandIndex].errorsIndexStart; i < _SqlRPCBatchArray[commandIndex].errorsIndexEnd; ++i)
+				{
+					errors.Add(_SqlRPCBatchArray[commandIndex].errors[i]);
+				}
+				for (int i = _SqlRPCBatchArray[commandIndex].warningsIndexStart; i < _SqlRPCBatchArray[commandIndex].warningsIndexEnd; ++i)
+				{
+					errors.Add(_SqlRPCBatchArray[commandIndex].warnings[i]);
+				}
+				result = SqlException.CreateException(errors, Connection.ServerVersion, Connection.ClientConnectionId);
+			}
+			return result;
+		}
 
 
 #if DEBUG
-        internal void CompletePendingReadWithSuccess(bool resetForcePendingReadsToWait)
-        {
-            var stateObj = _stateObj;
-            if (stateObj != null)
-            {
-                stateObj.CompletePendingReadWithSuccess(resetForcePendingReadsToWait);
-            }
-            else
-            {
-                var tempCachedAsyncState = cachedAsyncState;
-                if (tempCachedAsyncState != null)
-                {
-                    var reader = tempCachedAsyncState.CachedAsyncReader;
-                    if (reader != null)
-                    {
-                        reader.CompletePendingReadWithSuccess(resetForcePendingReadsToWait);
-                    }
-                }
-            }
-        }
+		internal void CompletePendingReadWithSuccess(bool resetForcePendingReadsToWait)
+		{
+			var stateObj = _stateObj;
+			if (stateObj != null)
+			{
+				stateObj.CompletePendingReadWithSuccess(resetForcePendingReadsToWait);
+			}
+			else
+			{
+				var tempCachedAsyncState = cachedAsyncState;
+				if (tempCachedAsyncState != null)
+				{
+					var reader = tempCachedAsyncState.CachedAsyncReader;
+					if (reader != null)
+					{
+						reader.CompletePendingReadWithSuccess(resetForcePendingReadsToWait);
+					}
+				}
+			}
+		}
 
-        internal void CompletePendingReadWithFailure(int errorCode, bool resetForcePendingReadsToWait)
-        {
-            var stateObj = _stateObj;
-            if (stateObj != null)
-            {
-                stateObj.CompletePendingReadWithFailure(errorCode, resetForcePendingReadsToWait);
-            }
-            else
-            {
-                var tempCachedAsyncState = _cachedAsyncState;
-                if (tempCachedAsyncState != null)
-                {
-                    var reader = tempCachedAsyncState.CachedAsyncReader;
-                    if (reader != null)
-                    {
-                        reader.CompletePendingReadWithFailure(errorCode, resetForcePendingReadsToWait);
-                    }
-                }
-            }
-        }
+		internal void CompletePendingReadWithFailure(int errorCode, bool resetForcePendingReadsToWait)
+		{
+			var stateObj = _stateObj;
+			if (stateObj != null)
+			{
+				stateObj.CompletePendingReadWithFailure(errorCode, resetForcePendingReadsToWait);
+			}
+			else
+			{
+				var tempCachedAsyncState = _cachedAsyncState;
+				if (tempCachedAsyncState != null)
+				{
+					var reader = tempCachedAsyncState.CachedAsyncReader;
+					if (reader != null)
+					{
+						reader.CompletePendingReadWithFailure(errorCode, resetForcePendingReadsToWait);
+					}
+				}
+			}
+		}
 #endif
 
-        internal void CancelIgnoreFailure()
-        {
-            // This method is used to route CancellationTokens to the Cancel method.
-            // Cancellation is a suggestion, and exceptions should be ignored
-            // rather than allowed to be unhandled, as there is no way to route
-            // them to the caller.  It would be expected that the error will be
-            // observed anyway from the regular method.  An example is canceling
-            // an operation on a closed connection.
-            try
-            {
-                Cancel();
-            }
-            catch (Exception)
-            {
-            }
-        }
+		internal void CancelIgnoreFailure()
+		{
+			// This method is used to route CancellationTokens to the Cancel method.
+			// Cancellation is a suggestion, and exceptions should be ignored
+			// rather than allowed to be unhandled, as there is no way to route
+			// them to the caller.  It would be expected that the error will be
+			// observed anyway from the regular method.  An example is canceling
+			// an operation on a closed connection.
+			try
+			{
+				Cancel();
+			}
+			catch (Exception)
+			{
+			}
+		}
 
-        private void NotifyDependency()
-        {
-            if (_sqlDep != null)
-            {
-                _sqlDep.StartTimer(Notification);
-            }
-        }
+		private void NotifyDependency()
+		{
+			if (_sqlDep != null)
+			{
+				_sqlDep.StartTimer(Notification);
+			}
+		}
 
-        object ICloneable.Clone() => Clone();
+		object ICloneable.Clone() => Clone();
 
-        public SqlCommand Clone() => new SqlCommand(this);
-    }
+		public SqlCommand Clone() => new SqlCommand(this);
+	}
 }
 
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
@@ -188,8 +188,6 @@ namespace System.Data.SqlClient
 
         private SqlNotificationRequest _notification;
 
-        private bool _notificationAutoEnlist = true;            // Notifications auto enlistment is turned on by default
-
         // transaction support
         private SqlTransaction _transaction;
 
@@ -333,18 +331,6 @@ namespace System.Data.SqlClient
             {
                 _sqlDep = null;
                 _notification = value;
-            }
-        }
-
-        public bool NotificationAutoEnlist
-        {
-            get
-            {
-                return _notificationAutoEnlist;
-            }
-            set
-            {
-                _notificationAutoEnlist = value;
             }
         }
 
@@ -1087,8 +1073,7 @@ namespace System.Data.SqlClient
                             bool dataReady;
                             Debug.Assert(_stateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
                             bool result = _stateObj.Parser.TryRun(RunBehavior.UntilDone, this, null, null, _stateObj, out dataReady);
-                            if (!result)
-                            { throw SQL.SynchronousCallMayNotPend(); }
+                            if (!result) { throw SQL.SynchronousCallMayNotPend(); }
                         }
                         finally
                         {
@@ -2367,8 +2352,7 @@ namespace System.Data.SqlClient
                     bool dataReady;
                     Debug.Assert(_stateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
                     bool result = _stateObj.Parser.TryRun(RunBehavior.UntilDone, this, null, null, _stateObj, out dataReady);
-                    if (!result)
-                    { throw SQL.SynchronousCallMayNotPend(); }
+                    if (!result) { throw SQL.SynchronousCallMayNotPend(); }
                 }
             }
             catch (Exception e)
@@ -2589,8 +2573,7 @@ namespace System.Data.SqlClient
                         bool dataReady;
                         Debug.Assert(_stateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
                         bool result = _stateObj.Parser.TryRun(RunBehavior.UntilDone, this, null, null, _stateObj, out dataReady);
-                        if (!result)
-                        { throw SQL.SynchronousCallMayNotPend(); }
+                        if (!result) { throw SQL.SynchronousCallMayNotPend(); }
                         // and turn OFF when the ds exhausts the stream on Close()
                         optionSettings = GetResetOptionsString(cmdBehavior);
                     }
@@ -2694,8 +2677,7 @@ namespace System.Data.SqlClient
                     bool dataReady;
                     Debug.Assert(_stateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
                     bool result = _stateObj.Parser.TryRun(RunBehavior.UntilDone, this, ds, null, _stateObj, out dataReady);
-                    if (!result)
-                    { throw SQL.SynchronousCallMayNotPend(); }
+                    if (!result) { throw SQL.SynchronousCallMayNotPend(); }
                 }
                 catch (Exception e)
                 {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
@@ -1017,12 +1017,6 @@ namespace System.Data.SqlClient
         {
             SqlConnectionString connectionOptions = (SqlConnectionString)ConnectionOptions;
 
-            // Fail Fast in case an application is trying to enlist the SqlConnection in a Transaction Scope.
-            if (connectionOptions.Enlist && ADP.GetCurrentTransaction() != null)
-            {
-                //throw ADP.AmbientTransactionIsNotSupported();
-            }
-
             _applyTransientFaultHandling = (retry == null && connectionOptions != null && connectionOptions.ConnectRetryCount > 0);
 
             if (ForceNewConnection)

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionFactory.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionFactory.cs
@@ -175,8 +175,8 @@ namespace System.Data.SqlClient
                                                     opt.MinPoolSize,
                                                     opt.MaxPoolSize,
                                                     connectionTimeout,
-                                                    opt.LoadBalanceTimeout
-                                                    );
+                                                    opt.LoadBalanceTimeout,
+                                                    opt.Enlist);
             }
             return poolingOptions;
         }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionHelper.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionHelper.cs
@@ -10,7 +10,7 @@ using System.Data.Common;
 using System.Data.ProviderBase;
 using System.Diagnostics;
 using System.Threading;
-using SysTx = System.Transactions;
+using System.Transactions;
 
 
 namespace System.Data.SqlClient
@@ -155,7 +155,7 @@ namespace System.Data.SqlClient
 
         partial void RepairInnerConnection();
 
-        public override void EnlistTransaction(SysTx.Transaction transaction)
+        public override void EnlistTransaction(Transaction transaction)
         {
             // If we're currently enlisted in a transaction and we were called
             // on the EnlistTransaction method (Whidbey) we're not allowed to
@@ -166,7 +166,7 @@ namespace System.Data.SqlClient
             // NOTE: since transaction enlistment involves round trips to the
             // server, we don't want to lock here, we'll handle the race conditions
             // elsewhere.
-            SysTx.Transaction enlistedTransaction = innerConnection.EnlistedTransaction;
+            Transaction enlistedTransaction = innerConnection.EnlistedTransaction;
             if (enlistedTransaction != null)
             {
                 // Allow calling enlist if already enlisted (no-op)
@@ -176,7 +176,7 @@ namespace System.Data.SqlClient
                 }
 
                 // Allow enlisting in a different transaction if the enlisted transaction has completed.
-                if (enlistedTransaction.TransactionInformation.Status == SysTx.TransactionStatus.Active)
+                if (enlistedTransaction.TransactionInformation.Status == TransactionStatus.Active)
                 {
                     throw ADP.TransactionPresent();
                 }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionHelper.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionHelper.cs
@@ -10,6 +10,7 @@ using System.Data.Common;
 using System.Data.ProviderBase;
 using System.Diagnostics;
 using System.Threading;
+using SysTx = System.Transactions;
 
 
 namespace System.Data.SqlClient
@@ -154,6 +155,41 @@ namespace System.Data.SqlClient
 
         partial void RepairInnerConnection();
 
+        override public void EnlistTransaction(SysTx.Transaction transaction)
+        {
+            // If we're currently enlisted in a transaction and we were called
+            // on the EnlistTransaction method (Whidbey) we're not allowed to
+            // enlist in a different transaction.
+
+            DbConnectionInternal innerConnection = InnerConnection;
+
+            // NOTE: since transaction enlistment involves round trips to the
+            // server, we don't want to lock here, we'll handle the race conditions
+            // elsewhere.
+            SysTx.Transaction enlistedTransaction = innerConnection.EnlistedTransaction;
+            if (enlistedTransaction != null)
+            {
+                // Allow calling enlist if already enlisted (no-op)
+                if (enlistedTransaction.Equals(transaction))
+                {
+                    return;
+                }
+
+                // Allow enlisting in a different transaction if the enlisted transaction has completed.
+                if (enlistedTransaction.TransactionInformation.Status == SysTx.TransactionStatus.Active)
+                {
+                    throw ADP.TransactionPresent();
+                }
+            }
+            RepairInnerConnection();
+            InnerConnection.EnlistTransaction(transaction);
+
+            // NOTE: If this outer connection were to be GC'd while we're
+            // enlisting, the pooler would attempt to reclaim the inner connection
+            // while we're attempting to enlist; not sure how likely that is but
+            // we should consider a GC.KeepAlive(this) here.
+            GC.KeepAlive(this);
+        }
 
         internal void NotifyWeakReference(int message)
         {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionHelper.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionHelper.cs
@@ -155,7 +155,7 @@ namespace System.Data.SqlClient
 
         partial void RepairInnerConnection();
 
-        override public void EnlistTransaction(SysTx.Transaction transaction)
+        public override void EnlistTransaction(SysTx.Transaction transaction)
         {
             // If we're currently enlisted in a transaction and we were called
             // on the EnlistTransaction method (Whidbey) we're not allowed to

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionString.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionString.cs
@@ -4,9 +4,6 @@
 
 
 
-//------------------------------------------------------------------------------
-
-using System.Collections;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Diagnostics;
@@ -159,7 +156,7 @@ namespace System.Data.SqlClient
             ExplicitUnbind
         }
 
-        internal static class TRANSACIONBINDING
+        internal static class TRANSACTIONBINDING
         {
             internal const string ImplicitUnbind = "Implicit Unbind";
             internal const string ExplicitUnbind = "Explicit Unbind";
@@ -356,16 +353,16 @@ namespace System.Data.SqlClient
                 throw ADP.InvalidConnectionOptionValue(KEY.Type_System_Version);
             }
 
-            if (ADP.IsEmpty(transactionBindingString))
+            if (string.IsNullOrEmpty(transactionBindingString))
             {
                 transactionBindingString = DbConnectionStringDefaults.TransactionBinding;
             }
 
-            if (transactionBindingString.Equals(TRANSACIONBINDING.ImplicitUnbind, StringComparison.OrdinalIgnoreCase))
+            if (transactionBindingString.Equals(TRANSACTIONBINDING.ImplicitUnbind, StringComparison.OrdinalIgnoreCase))
             {
                 _transactionBinding = TransactionBindingEnum.ImplicitUnbind;
             }
-            else if (transactionBindingString.Equals(TRANSACIONBINDING.ExplicitUnbind, StringComparison.OrdinalIgnoreCase))
+            else if (transactionBindingString.Equals(TRANSACTIONBINDING.ExplicitUnbind, StringComparison.OrdinalIgnoreCase))
             {
                 _transactionBinding = TransactionBindingEnum.ExplicitUnbind;
             }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionString.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionString.cs
@@ -544,7 +544,7 @@ namespace System.Data.SqlClient
                     { SYNONYM.User, KEY.User_ID },
                     { SYNONYM.WSID, KEY.Workstation_Id }
                 };
-                //Debug.Assert(synonyms.Count == count, "incorrect initial ParseSynonyms size");
+                Debug.Assert(synonyms.Count == count, "incorrect initial ParseSynonyms size");
                 s_sqlClientSynonyms = synonyms;
             }
             return synonyms;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionString.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionString.cs
@@ -246,9 +246,8 @@ namespace System.Data.SqlClient
             _trustServerCertificate = ConvertValueToBoolean(KEY.TrustServerCertificate, DEFAULT.TrustServerCertificate);
 
             // Temporary string - this value is stored internally as an enum.
-            string transactionBindingString = ConvertValueToString(KEY.TransactionBinding, null);
-
             string typeSystemVersionString = ConvertValueToString(KEY.Type_System_Version, null);
+            string transactionBindingString = ConvertValueToString(KEY.TransactionBinding, null);
 
             _userID = ConvertValueToString(KEY.User_ID, DEFAULT.User_ID);
             _workstationId = ConvertValueToString(KEY.Workstation_Id, null);
@@ -545,7 +544,7 @@ namespace System.Data.SqlClient
                     { SYNONYM.User, KEY.User_ID },
                     { SYNONYM.WSID, KEY.Workstation_Id }
                 };
-                Debug.Assert(synonyms.Count == count, "incorrect initial ParseSynonyms size");
+                //Debug.Assert(synonyms.Count == count, "incorrect initial ParseSynonyms size");
                 s_sqlClientSynonyms = synonyms;
             }
             return synonyms;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionStringBuilder.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionStringBuilder.cs
@@ -47,6 +47,7 @@ namespace System.Data.SqlClient
 
             UserInstance,
 
+            TransactionBinding,
 
             ApplicationIntent,
 
@@ -75,6 +76,7 @@ namespace System.Data.SqlClient
         private string _initialCatalog = DbConnectionStringDefaults.InitialCatalog;
         //      private string _namedConnection   = DbConnectionStringDefaults.NamedConnection;
         private string _password = DbConnectionStringDefaults.Password;
+        private string _transactionBinding = DbConnectionStringDefaults.TransactionBinding;
         private string _typeSystemVersion = DbConnectionStringDefaults.TypeSystemVersion;
         private string _userID = DbConnectionStringDefaults.UserID;
         private string _workstationID = DbConnectionStringDefaults.WorkstationID;
@@ -123,6 +125,7 @@ namespace System.Data.SqlClient
             validKeywords[(int)Keywords.PersistSecurityInfo] = DbConnectionStringKeywords.PersistSecurityInfo;
             validKeywords[(int)Keywords.Pooling] = DbConnectionStringKeywords.Pooling;
             validKeywords[(int)Keywords.Replication] = DbConnectionStringKeywords.Replication;
+            validKeywords[(int)Keywords.TransactionBinding] = DbConnectionStringKeywords.TransactionBinding;
             validKeywords[(int)Keywords.TrustServerCertificate] = DbConnectionStringKeywords.TrustServerCertificate;
             validKeywords[(int)Keywords.TypeSystemVersion] = DbConnectionStringKeywords.TypeSystemVersion;
             validKeywords[(int)Keywords.UserID] = DbConnectionStringKeywords.UserID;
@@ -158,6 +161,7 @@ namespace System.Data.SqlClient
             hash.Add(DbConnectionStringKeywords.PersistSecurityInfo, Keywords.PersistSecurityInfo);
             hash.Add(DbConnectionStringKeywords.Pooling, Keywords.Pooling);
             hash.Add(DbConnectionStringKeywords.Replication, Keywords.Replication);
+            hash.Add(DbConnectionStringKeywords.TransactionBinding, Keywords.TransactionBinding);
             hash.Add(DbConnectionStringKeywords.TrustServerCertificate, Keywords.TrustServerCertificate);
             hash.Add(DbConnectionStringKeywords.TypeSystemVersion, Keywords.TypeSystemVersion);
             hash.Add(DbConnectionStringKeywords.UserID, Keywords.UserID);
@@ -224,6 +228,7 @@ namespace System.Data.SqlClient
                         //                  case Keywords.NamedConnection:          NamedConnection = ConvertToString(value); break;
                         case Keywords.Password: Password = ConvertToString(value); break;
                         case Keywords.UserID: UserID = ConvertToString(value); break;
+                        case Keywords.TransactionBinding: TransactionBinding = ConvertToString(value); break;
                         case Keywords.TypeSystemVersion: TypeSystemVersion = ConvertToString(value); break;
                         case Keywords.WorkstationID: WorkstationID = ConvertToString(value); break;
 
@@ -549,6 +554,16 @@ namespace System.Data.SqlClient
             }
         }
 
+        public string TransactionBinding
+        {
+            get { return _transactionBinding; }
+            set
+            {
+                SetValue(DbConnectionStringKeywords.TransactionBinding, value);
+                _transactionBinding = value;
+            }
+        }
+
         public string TypeSystemVersion
         {
             get { return _typeSystemVersion; }
@@ -675,6 +690,7 @@ namespace System.Data.SqlClient
                 case Keywords.PersistSecurityInfo: return PersistSecurityInfo;
                 case Keywords.Pooling: return Pooling;
                 case Keywords.Replication: return Replication;
+                case Keywords.TransactionBinding: return TransactionBinding;
                 case Keywords.TrustServerCertificate: return TrustServerCertificate;
                 case Keywords.TypeSystemVersion: return TypeSystemVersion;
                 case Keywords.UserID: return UserID;
@@ -791,6 +807,9 @@ namespace System.Data.SqlClient
                     break;
                 case Keywords.Replication:
                     _replication = DbConnectionStringDefaults.Replication;
+                    break;
+                case Keywords.TransactionBinding:
+                    _transactionBinding = DbConnectionStringDefaults.TransactionBinding;
                     break;
                 case Keywords.TrustServerCertificate:
                     _trustServerCertificate = DbConnectionStringDefaults.TrustServerCertificate;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionStringBuilder.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionStringBuilder.cs
@@ -62,7 +62,7 @@ namespace System.Data.SqlClient
         }
 
         internal const int KeywordsCount = (int)Keywords.KeywordsCount;
-        internal const int DeprecatedKeywordsCount = 5;
+        internal const int DeprecatedKeywordsCount = 4;
 
         private static readonly string[] s_validKeywords = CreateValidKeywords();
         private static readonly Dictionary<string, Keywords> s_keywords = CreateKeywordsDictionary();

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDelegatedTransaction.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDelegatedTransaction.cs
@@ -1,0 +1,467 @@
+﻿using System.Data.Common;
+using System.Data.SqlClient;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.ConstrainedExecution;
+using System.Threading;
+using SysTx = System.Transactions;
+
+namespace System.Data.SqlClient
+{
+    sealed internal class SqlDelegatedTransaction : SysTx.IPromotableSinglePhaseNotification
+    {
+        private static int _objectTypeCount;
+        private readonly int _objectID = Interlocked.Increment(ref _objectTypeCount);
+        private const int _globalTransactionsTokenVersionSizeInBytes = 4; // the size of the version in the PromotedDTCToken for Global Transactions
+        internal int ObjectID
+        {
+            get
+            {
+                return _objectID;
+            }
+        }
+
+        // WARNING!!! Multithreaded object!
+        // Locking strategy: Any potentailly-multithreaded operation must first lock the associated connection, then
+        //  validate this object's active state.  Locked activities should ONLY include Sql-transaction state altering activities
+        //  or notifications of same. Updates to the connection's association with the transaction or to the connection pool
+        //  may be initiated here AFTER the connection lock is released, but should NOT fall under this class's locking strategy.
+
+        private SqlInternalConnection _connection;            // the internal connection that is the root of the transaction
+        private IsolationLevel _isolationLevel;        // the IsolationLevel of the transaction we delegated to the server
+        private SqlInternalTransaction _internalTransaction;   // the SQL Server transaction we're delegating to
+
+        private SysTx.Transaction _atomicTransaction;
+
+        private bool _active;                // Is the transaction active?
+
+        internal SqlDelegatedTransaction(SqlInternalConnection connection, SysTx.Transaction tx)
+        {
+            Debug.Assert(null != connection, "null connection?");
+            _connection = connection;
+            _atomicTransaction = tx;
+            _active = false;
+            SysTx.IsolationLevel systxIsolationLevel = (SysTx.IsolationLevel)tx.IsolationLevel;
+
+            // We need to map the System.Transactions IsolationLevel to the one
+            // that System.Data uses and communicates to SqlServer.  We could
+            // arguably do that in Initialize when the transaction is delegated,
+            // however it is better to do this before we actually begin the process
+            // of delegation, in case System.Transactions adds another isolation
+            // level we don't know about -- we can throw the exception at a better
+            // place.
+            switch (systxIsolationLevel)
+            {
+                case SysTx.IsolationLevel.ReadCommitted:
+                    _isolationLevel = IsolationLevel.ReadCommitted;
+                    break;
+                case SysTx.IsolationLevel.ReadUncommitted:
+                    _isolationLevel = IsolationLevel.ReadUncommitted;
+                    break;
+                case SysTx.IsolationLevel.RepeatableRead:
+                    _isolationLevel = IsolationLevel.RepeatableRead;
+                    break;
+                case SysTx.IsolationLevel.Serializable:
+                    _isolationLevel = IsolationLevel.Serializable;
+                    break;
+                case SysTx.IsolationLevel.Snapshot:
+                    _isolationLevel = IsolationLevel.Snapshot;
+                    break;
+                default:
+                    throw SQL.UnknownSysTxIsolationLevel(systxIsolationLevel);
+            }
+        }
+
+        internal SysTx.Transaction Transaction
+        {
+            get { return _atomicTransaction; }
+        }
+
+        public void Initialize()
+        {
+            // if we get here, then we know for certain that we're the delegated
+            // transaction.
+            SqlInternalConnection connection = _connection;
+            SqlConnection usersConnection = connection.Connection;
+
+            RuntimeHelpers.PrepareConstrainedRegions();
+            try
+            {
+                if (connection.IsEnlistedInTransaction)
+                { // defect first
+                    connection.EnlistNull();
+                }
+
+                _internalTransaction = new SqlInternalTransaction(connection, TransactionType.Delegated, null);
+
+                connection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.Begin, null, _isolationLevel, _internalTransaction, true);
+
+                // Handle case where ExecuteTran didn't produce a new transaction, but also didn't throw.
+                if (null == connection.CurrentTransaction)
+                {
+                    connection.DoomThisConnection();
+                    throw ADP.InternalError(ADP.InternalErrorCode.UnknownTransactionFailure);
+                }
+
+                _active = true;
+            }
+            catch (System.OutOfMemoryException e)
+            {
+                usersConnection.Abort(e);
+                throw;
+            }
+            catch (System.StackOverflowException e)
+            {
+                usersConnection.Abort(e);
+                throw;
+            }
+            catch (System.Threading.ThreadAbortException e)
+            {
+                usersConnection.Abort(e);
+                throw;
+            }
+        }
+
+        internal bool IsActive
+        {
+            get
+            {
+                return _active;
+            }
+        }
+
+        public Byte[] Promote()
+        {
+            // Operations that might be affected by multi-threaded use MUST be done inside the lock.
+            //  Don't read values off of the connection outside the lock unless it doesn't really matter
+            //  from an operational standpoint (i.e. logging connection's ObjectID should be fine,
+            //  but the PromotedDTCToken can change over calls. so that must be protected).
+            SqlInternalConnection connection = GetValidConnection();
+
+            Exception promoteException;
+            byte[] returnValue = null;
+            SqlConnection usersConnection = connection.Connection;
+
+            RuntimeHelpers.PrepareConstrainedRegions();
+            try
+            {
+                lock (connection)
+                {
+                    try
+                    {
+                        // Now that we've acquired the lock, make sure we still have valid state for this operation.
+                        ValidateActiveOnConnection(connection);
+
+                        connection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.Promote, null, IsolationLevel.Unspecified, _internalTransaction, true);
+                        returnValue = _connection.PromotedDTCToken;
+
+                        // For Global Transactions, we need to set the Transaction Id since we use a Non-MSDTC Promoter type.
+                        if (_connection.IsGlobalTransaction)
+                        {
+                            if (SysTxForGlobalTransactions.SetDistributedTransactionIdentifier == null)
+                            {
+                                throw SQL.UnsupportedSysTxForGlobalTransactions();
+                            }
+
+                            if (!_connection.IsGlobalTransactionsEnabledForServer)
+                            {
+                                throw SQL.GlobalTransactionsNotEnabled();
+                            }
+
+                            SysTxForGlobalTransactions.SetDistributedTransactionIdentifier.Invoke(_atomicTransaction, new object[] { this, GetGlobalTxnIdentifierFromToken() });
+                        }
+
+                        promoteException = null;
+                    }
+                    catch (SqlException e)
+                    {
+                        promoteException = e;
+
+                        // Doom the connection, to make sure that the transaction is
+                        // eventually rolled back.
+                        // VSTS 144562: doom the connection while having the lock on it to prevent race condition with "Transaction Ended" Event
+                        connection.DoomThisConnection();
+                    }
+                    catch (InvalidOperationException e)
+                    {
+                        promoteException = e;
+                        connection.DoomThisConnection();
+                    }
+                }
+            }
+            catch (System.OutOfMemoryException e)
+            {
+                usersConnection.Abort(e);
+                throw;
+            }
+            catch (System.StackOverflowException e)
+            {
+                usersConnection.Abort(e);
+                throw;
+            }
+            catch (System.Threading.ThreadAbortException e)
+            {
+                usersConnection.Abort(e);
+                throw;
+            }
+
+            if (promoteException != null)
+            {
+                throw SQL.PromotionFailed(promoteException);
+            }
+
+            return returnValue;
+        }
+
+        // Called by transaction to initiate abort sequence
+        public void Rollback(SysTx.SinglePhaseEnlistment enlistment)
+        {
+            Debug.Assert(null != enlistment, "null enlistment?");
+
+            SqlInternalConnection connection = GetValidConnection();
+            SqlConnection usersConnection = connection.Connection;
+
+            RuntimeHelpers.PrepareConstrainedRegions();
+            try
+            {
+                lock (connection)
+                {
+                    try
+                    {
+                        // Now that we've acquired the lock, make sure we still have valid state for this operation.
+                        ValidateActiveOnConnection(connection);
+                        _active = false; // set to inactive first, doesn't matter how the execute completes, this transaction is done.
+                        _connection = null;  // Set prior to ExecuteTransaction call in case this initiates a TransactionEnd event
+
+                        // If we haven't already rolled back (or aborted) then tell the SQL Server to roll back
+                        if (!_internalTransaction.IsAborted)
+                        {
+                            connection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.Rollback, null, IsolationLevel.Unspecified, _internalTransaction, true);
+                        }
+                    }
+                    catch (SqlException)
+                    {
+                        // Doom the connection, to make sure that the transaction is
+                        // eventually rolled back.
+                        // VSTS 144562: doom the connection while having the lock on it to prevent race condition with "Transaction Ended" Event
+                        connection.DoomThisConnection();
+
+                        // Unlike SinglePhaseCommit, a rollback is a rollback, regardless 
+                        // of how it happens, so SysTx won't throw an exception, and we
+                        // don't want to throw an exception either, because SysTx isn't 
+                        // handling it and it may create a fail fast scenario. In the end,
+                        // there is no way for us to communicate to the consumer that this
+                        // failed for more serious reasons than usual.
+                        // 
+                        // This is a bit like "should you throw if Close fails", however,
+                        // it only matters when you really need to know.  In that case, 
+                        // we have the tracing that we're doing to fallback on for the
+                        // investigation.
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        connection.DoomThisConnection();
+                    }
+                }
+
+                // it doesn't matter whether the rollback succeeded or not, we presume
+                // that the transaction is aborted, because it will be eventually.
+                connection.CleanupConnectionOnTransactionCompletion(_atomicTransaction);
+                enlistment.Aborted();
+            }
+            catch (System.OutOfMemoryException e)
+            {
+                usersConnection.Abort(e);
+                throw;
+            }
+            catch (System.StackOverflowException e)
+            {
+                usersConnection.Abort(e);
+                throw;
+            }
+            catch (System.Threading.ThreadAbortException e)
+            {
+                usersConnection.Abort(e);
+                throw;
+            }
+        }
+
+        // Called by the transaction to initiate commit sequence
+        public void SinglePhaseCommit(SysTx.SinglePhaseEnlistment enlistment)
+        {
+            Debug.Assert(null != enlistment, "null enlistment?");
+
+            SqlInternalConnection connection = GetValidConnection();
+            SqlConnection usersConnection = connection.Connection;
+
+            RuntimeHelpers.PrepareConstrainedRegions();
+            try
+            {
+                // If the connection is dooomed, we can be certain that the
+                // transaction will eventually be rolled back, and we shouldn't
+                // attempt to commit it.
+                if (connection.IsConnectionDoomed)
+                {
+                    lock (connection)
+                    {
+                        _active = false; // set to inactive first, doesn't matter how the rest completes, this transaction is done.
+                        _connection = null;
+                    }
+
+                    enlistment.Aborted(SQL.ConnectionDoomed());
+                }
+                else
+                {
+                    Exception commitException;
+                    lock (connection)
+                    {
+                        try
+                        {
+                            // Now that we've acquired the lock, make sure we still have valid state for this operation.
+                            ValidateActiveOnConnection(connection);
+
+                            _active = false; // set to inactive first, doesn't matter how the rest completes, this transaction is done.
+                            _connection = null;   // Set prior to ExecuteTransaction call in case this initiates a TransactionEnd event
+
+                            connection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.Commit, null, IsolationLevel.Unspecified, _internalTransaction, true);
+                            commitException = null;
+                        }
+                        catch (SqlException e)
+                        {
+                            commitException = e;
+
+                            // Doom the connection, to make sure that the transaction is
+                            // eventually rolled back.
+                            // VSTS 144562: doom the connection while having the lock on it to prevent race condition with "Transaction Ended" Event
+                            connection.DoomThisConnection();
+                        }
+                        catch (InvalidOperationException e)
+                        {
+                            commitException = e;
+                            connection.DoomThisConnection();
+                        }
+                    }
+                    if (commitException != null)
+                    {
+                        // connection.ExecuteTransaction failed with exception
+                        if (_internalTransaction.IsCommitted)
+                        {
+                            // Even though we got an exception, the transaction
+                            // was committed by the server.
+                            enlistment.Committed();
+                        }
+                        else if (_internalTransaction.IsAborted)
+                        {
+                            // The transaction was aborted, report that to
+                            // SysTx.
+                            enlistment.Aborted(commitException);
+                        }
+                        else
+                        {
+                            // The transaction is still active, we cannot
+                            // know the state of the transaction.
+                            enlistment.InDoubt(commitException);
+                        }
+
+                        // We eat the exception.  This is called on the SysTx
+                        // thread, not the applications thread.  If we don't 
+                        // eat the exception an UnhandledException will occur,
+                        // causing the process to FailFast.
+                    }
+
+                    connection.CleanupConnectionOnTransactionCompletion(_atomicTransaction);
+                    if (commitException == null)
+                    {
+                        // connection.ExecuteTransaction succeeded
+                        enlistment.Committed();
+                    }
+                }
+                
+            }
+            catch (System.OutOfMemoryException e)
+            {
+                usersConnection.Abort(e);
+                throw;
+            }
+            catch (System.StackOverflowException e)
+            {
+                usersConnection.Abort(e);
+                throw;
+            }
+            catch (System.Threading.ThreadAbortException e)
+            {
+                usersConnection.Abort(e);
+                throw;
+            }
+        }
+
+        // Event notification that transaction ended. This comes from the subscription to the Transaction's
+        //  ended event via the internal connection. If it occurs without a prior Rollback or SinglePhaseCommit call,
+        //  it indicates the transaction was ended externally (generally that one the the DTC participants aborted
+        //  the transaction).
+        internal void TransactionEnded(SysTx.Transaction transaction)
+        {
+            SqlInternalConnection connection = _connection;
+
+            if (connection != null)
+            {
+                lock (connection)
+                {
+                    if (_atomicTransaction.Equals(transaction))
+                    {
+                        // No need to validate active on connection, this operation can be called on completed transactions
+                        _active = false;
+                        _connection = null;
+                    }
+                }
+            }
+        }
+
+        // Check for connection validity
+        private SqlInternalConnection GetValidConnection()
+        {
+            SqlInternalConnection connection = _connection;
+            if (null == connection)
+            {
+                throw ADP.ObjectDisposed(this);
+            }
+
+            return connection;
+        }
+
+        // Dooms connection and throws and error if not a valid, active, delegated transaction for the given
+        //  connection. Designed to be called AFTER a lock is placed on the connection, otherwise a normal return
+        //  may not be trusted.
+        private void ValidateActiveOnConnection(SqlInternalConnection connection)
+        {
+            bool valid = _active && (connection == _connection) && (connection.DelegatedTransaction == this);
+
+            if (!valid)
+            {
+                // Invalid indicates something BAAAD happened (Commit after TransactionEnded, for instance)
+                //  Doom anything remotely involved.
+                if (null != connection)
+                {
+                    connection.DoomThisConnection();
+                }
+                if (connection != _connection && null != _connection)
+                {
+                    _connection.DoomThisConnection();
+                }
+
+                throw ADP.InternalError(ADP.InternalErrorCode.UnpooledObjectHasWrongOwner);  //TODO: Create a new code
+            }
+        }
+
+        // Get the server-side Global Transaction Id from the PromotedDTCToken
+        // Skip first 4 bytes since they contain the version
+        private Guid GetGlobalTxnIdentifierFromToken()
+        {
+            byte[] txnGuid = new byte[16];
+            Array.Copy(_connection.PromotedDTCToken, _globalTransactionsTokenVersionSizeInBytes, // Skip the version
+                txnGuid, 0, txnGuid.Length);
+            return new Guid(txnGuid);
+        }
+    }
+}

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDelegatedTransaction.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDelegatedTransaction.cs
@@ -377,7 +377,6 @@ namespace System.Data.SqlClient
                         enlistment.Committed();
                     }
                 }
-                
             }
             catch (System.OutOfMemoryException e)
             {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDelegatedTransaction.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDelegatedTransaction.cs
@@ -5,11 +5,11 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.ConstrainedExecution;
 using System.Threading;
-using SysTx = System.Transactions;
+using System.Transactions;
 
 namespace System.Data.SqlClient
 {
-    sealed internal class SqlDelegatedTransaction : SysTx.IPromotableSinglePhaseNotification
+    sealed internal class SqlDelegatedTransaction : IPromotableSinglePhaseNotification
     {
         private static int _objectTypeCount;
         private readonly int _objectID = Interlocked.Increment(ref _objectTypeCount);
@@ -32,17 +32,17 @@ namespace System.Data.SqlClient
         private IsolationLevel _isolationLevel;        // the IsolationLevel of the transaction we delegated to the server
         private SqlInternalTransaction _internalTransaction;   // the SQL Server transaction we're delegating to
 
-        private SysTx.Transaction _atomicTransaction;
+        private Transaction _atomicTransaction;
 
         private bool _active;                // Is the transaction active?
 
-        internal SqlDelegatedTransaction(SqlInternalConnection connection, SysTx.Transaction tx)
+        internal SqlDelegatedTransaction(SqlInternalConnection connection, Transaction tx)
         {
             Debug.Assert(null != connection, "null connection?");
             _connection = connection;
             _atomicTransaction = tx;
             _active = false;
-            SysTx.IsolationLevel systxIsolationLevel = (SysTx.IsolationLevel)tx.IsolationLevel;
+            Transactions.IsolationLevel systxIsolationLevel = (Transactions.IsolationLevel)tx.IsolationLevel;
 
             // We need to map the System.Transactions IsolationLevel to the one
             // that System.Data uses and communicates to SqlServer.  We could
@@ -53,19 +53,19 @@ namespace System.Data.SqlClient
             // place.
             switch (systxIsolationLevel)
             {
-                case SysTx.IsolationLevel.ReadCommitted:
+                case Transactions.IsolationLevel.ReadCommitted:
                     _isolationLevel = IsolationLevel.ReadCommitted;
                     break;
-                case SysTx.IsolationLevel.ReadUncommitted:
+                case Transactions.IsolationLevel.ReadUncommitted:
                     _isolationLevel = IsolationLevel.ReadUncommitted;
                     break;
-                case SysTx.IsolationLevel.RepeatableRead:
+                case Transactions.IsolationLevel.RepeatableRead:
                     _isolationLevel = IsolationLevel.RepeatableRead;
                     break;
-                case SysTx.IsolationLevel.Serializable:
+                case Transactions.IsolationLevel.Serializable:
                     _isolationLevel = IsolationLevel.Serializable;
                     break;
-                case SysTx.IsolationLevel.Snapshot:
+                case Transactions.IsolationLevel.Snapshot:
                     _isolationLevel = IsolationLevel.Snapshot;
                     break;
                 default:
@@ -73,7 +73,7 @@ namespace System.Data.SqlClient
             }
         }
 
-        internal SysTx.Transaction Transaction
+        internal Transaction Transaction
         {
             get { return _atomicTransaction; }
         }
@@ -215,7 +215,7 @@ namespace System.Data.SqlClient
         }
 
         // Called by transaction to initiate abort sequence
-        public void Rollback(SysTx.SinglePhaseEnlistment enlistment)
+        public void Rollback(SinglePhaseEnlistment enlistment)
         {
             Debug.Assert(null != enlistment, "null enlistment?");
 
@@ -288,7 +288,7 @@ namespace System.Data.SqlClient
         }
 
         // Called by the transaction to initiate commit sequence
-        public void SinglePhaseCommit(SysTx.SinglePhaseEnlistment enlistment)
+        public void SinglePhaseCommit(SinglePhaseEnlistment enlistment)
         {
             Debug.Assert(null != enlistment, "null enlistment?");
 
@@ -399,7 +399,7 @@ namespace System.Data.SqlClient
         //  ended event via the internal connection. If it occurs without a prior Rollback or SinglePhaseCommit call,
         //  it indicates the transaction was ended externally (generally that one the the DTC participants aborted
         //  the transaction).
-        internal void TransactionEnded(SysTx.Transaction transaction)
+        internal void TransactionEnded(Transaction transaction)
         {
             SqlInternalConnection connection = _connection;
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlInternalConnection.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlInternalConnection.cs
@@ -9,6 +9,7 @@
 using System.Data.Common;
 using System.Data.ProviderBase;
 using System.Diagnostics;
+using SysTx = System.Transactions;
 
 
 namespace System.Data.SqlClient
@@ -16,6 +17,13 @@ namespace System.Data.SqlClient
     abstract internal class SqlInternalConnection : DbConnectionInternal
     {
         private readonly SqlConnectionString _connectionOptions;
+        private bool _isEnlistedInTransaction; // is the server-side connection enlisted? true while we're enlisted, reset only after we send a null...
+        private byte[] _promotedDTCToken;        // token returned by the server when we promote transaction
+        private byte[] _whereAbouts;             // cache the whereabouts (DTC Address) for exporting
+
+        private bool _isGlobalTransaction = false; // Whether this is a Global Transaction (Non-MSDTC, Azure SQL DB Transaction)
+        private bool _isGlobalTransactionEnabledForServer = false; // Whether Global Transactions are enabled for this Azure SQL DB Server
+        private static readonly Guid _globalTransactionTMID = new Guid("1c742caf-6680-40ea-9c26-6b6846079764"); // ID of the Non-MSDTC, Azure SQL DB Transaction Manager
 
         // if connection is not open: null
         // if connection is open: currently active database
@@ -27,10 +35,13 @@ namespace System.Data.SqlClient
         // * for connections with FailoverPartner, it is set to the FailoverPartner value from connection string if the connection was opened to it.
         internal string CurrentDataSource { get; set; }
 
+        // the delegated (or promoted) transaction we're responsible for.
+        internal SqlDelegatedTransaction DelegatedTransaction { get; set; }
 
         internal enum TransactionRequest
         {
             Begin,
+            Promote,
             Commit,
             Rollback,
             IfRollback,
@@ -75,6 +86,23 @@ namespace System.Data.SqlClient
             }
         }
 
+        override protected internal bool IsNonPoolableTransactionRoot
+        {
+            get
+            {
+                return IsTransactionRoot;  // default behavior is that root transactions are NOT poolable.  Subclasses may override.
+            }
+        }
+
+        override internal bool IsTransactionRoot
+        {
+            get
+            {
+                var delegatedTransaction = DelegatedTransaction;
+                return ((null != delegatedTransaction) && (delegatedTransaction.IsActive));
+            }
+        }
+
 
         internal bool HasLocalTransaction
         {
@@ -96,6 +124,13 @@ namespace System.Data.SqlClient
             }
         }
 
+        internal bool IsEnlistedInTransaction
+        {
+            get
+            {
+                return _isEnlistedInTransaction;
+            }
+        }
 
         abstract internal bool IsLockedForBulkCopy
         {
@@ -108,6 +143,41 @@ namespace System.Data.SqlClient
             get;
         }
 
+        internal byte[] PromotedDTCToken
+        {
+            get
+            {
+                return _promotedDTCToken;
+            }
+            set
+            {
+                _promotedDTCToken = value;
+            }
+        }
+
+        internal bool IsGlobalTransaction
+        {
+            get
+            {
+                return _isGlobalTransaction;
+            }
+            set
+            {
+                _isGlobalTransaction = value;
+            }
+        }
+
+        internal bool IsGlobalTransactionsEnabledForServer
+        {
+            get
+            {
+                return _isGlobalTransactionEnabledForServer;
+            }
+            set
+            {
+                _isGlobalTransactionEnabledForServer = value;
+            }
+        }
 
         override public DbTransaction BeginTransaction(IsolationLevel iso)
         {
@@ -134,7 +204,7 @@ namespace System.Data.SqlClient
 
                 SqlTransaction transaction = new SqlTransaction(this, Connection, iso, AvailableInternalTransaction);
                 transaction.InternalTransaction.RestoreBrokenConnection = shouldReconnect;
-                ExecuteTransaction(TransactionRequest.Begin, transactionName, iso, transaction.InternalTransaction);
+                ExecuteTransaction(TransactionRequest.Begin, transactionName, iso, transaction.InternalTransaction, false);
                 transaction.InternalTransaction.RestoreBrokenConnection = false;
                 return transaction;
             }
@@ -198,7 +268,289 @@ namespace System.Data.SqlClient
             base.Dispose();
         }
 
-        abstract internal void ExecuteTransaction(TransactionRequest transactionRequest, string name, IsolationLevel iso, SqlInternalTransaction internalTransaction);
+        protected void Enlist(SysTx.Transaction tx)
+        {
+            // This method should not be called while the connection has a 
+            // reference to an active delegated transaction.
+            // Manual enlistment via SqlConnection.EnlistTransaction
+            // should catch this case and throw an exception.
+            //
+            // Automatic enlistment isn't possible because 
+            // Sys.Tx keeps the connection alive until the transaction is completed.
+            Debug.Assert(!IsNonPoolableTransactionRoot, "cannot defect an active delegated transaction!");  // potential race condition, but it's an assert
+
+            if (null == tx)
+            {
+                if (IsEnlistedInTransaction)
+                {
+                    EnlistNull();
+                }
+                else
+                {
+                    // When IsEnlistedInTransaction is false, it means we are in one of two states:
+                    // 1. EnlistTransaction is null, so the connection is truly not enlisted in a transaction, or
+                    // 2. Connection is enlisted in a SqlDelegatedTransaction.
+                    //
+                    // For #2, we have to consider whether or not the delegated transaction is active.
+                    // If it is not active, we allow the enlistment in the NULL transaction.
+                    //
+                    // If it is active, technically this is an error.
+                    // However, no exception is thrown as this was the precedent (and this case is silently ignored, no error, but no enlistment either).
+                    // There are two mitigations for this:
+                    // 1. SqlConnection.EnlistTransaction checks that the enlisted transaction has completed before allowing a different enlistment.
+                    // 2. For debug builds, the assert at the beginning of this method checks for an enlistment in an active delegated transaction.
+                    SysTx.Transaction enlistedTransaction = EnlistedTransaction;
+                    if (enlistedTransaction != null && enlistedTransaction.TransactionInformation.Status != SysTx.TransactionStatus.Active)
+                    {
+                        EnlistNull();
+                    }
+                }
+            }
+            // Only enlist if it's different...
+            else if (!tx.Equals(EnlistedTransaction))
+            { // WebData 20000024 - Must use Equals, not !=
+                EnlistNonNull(tx);
+            }
+        }
+
+        private void EnlistNonNull(SysTx.Transaction tx)
+        {
+            Debug.Assert(null != tx, "null transaction?");
+
+            bool hasDelegatedTransaction = false;
+
+            // Promotable transactions are only supported on Yukon
+            // servers or newer.
+            SqlDelegatedTransaction delegatedTransaction = new SqlDelegatedTransaction(this, tx);
+
+            try
+            {
+                // NOTE: System.Transactions claims to resolve all
+                // potential race conditions between multiple delegate
+                // requests of the same transaction to different
+                // connections in their code, such that only one
+                // attempt to delegate will succeed.
+
+                // NOTE: PromotableSinglePhaseEnlist will eventually
+                // make a round trip to the server; doing this inside
+                // a lock is not the best choice.  We presume that you
+                // aren't trying to enlist concurrently on two threads
+                // and leave it at that -- We don't claim any thread
+                // safety with regard to multiple concurrent requests
+                // to enlist the same connection in different
+                // transactions, which is good, because we don't have
+                // it anyway.
+
+                // PromotableSinglePhaseEnlist may not actually promote
+                // the transaction when it is already delegated (this is
+                // the way they resolve the race condition when two
+                // threads attempt to delegate the same Lightweight
+                // Transaction)  In that case, we can safely ignore
+                // our delegated transaction, and proceed to enlist
+                // in the promoted one.
+
+                // NOTE: Global Transactions is an Azure SQL DB only 
+                // feature where the Transaction Manager (TM) is not
+                // MS-DTC. Sys.Tx added APIs to support Non MS-DTC
+                // promoter types/TM in .NET 4.6.1. Following directions
+                // from .NETFX shiproom, to avoid a "hard-dependency"
+                // (compile time) on Sys.Tx, we use reflection to invoke
+                // the new APIs. Further, the _isGlobalTransaction flag
+                // indicates that this is an Azure SQL DB Transaction
+                // that could be promoted to a Global Transaction (it's
+                // always false for on-prem Sql Server). The Promote()
+                // call in SqlDelegatedTransaction makes sure that the
+                // right Sys.Tx.dll is loaded and that Global Transactions
+                // are actually allowed for this Azure SQL DB.
+
+                if (_isGlobalTransaction)
+                {
+                    if (SysTxForGlobalTransactions.EnlistPromotableSinglePhase == null)
+                    {
+                        // This could be a local Azure SQL DB transaction. 
+                        hasDelegatedTransaction = tx.EnlistPromotableSinglePhase(delegatedTransaction);
+                    }
+                    else
+                    {
+                        hasDelegatedTransaction = (bool)SysTxForGlobalTransactions.EnlistPromotableSinglePhase.Invoke(tx, new object[] { delegatedTransaction, _globalTransactionTMID });
+                    }
+                }
+                else
+                {
+                    // This is an MS-DTC distributed transaction
+                    hasDelegatedTransaction = tx.EnlistPromotableSinglePhase(delegatedTransaction);
+                }
+
+                if (hasDelegatedTransaction)
+                {
+                    this.DelegatedTransaction = delegatedTransaction;
+                }
+            }
+            catch (SqlException e)
+            {
+                // we do not want to eat the error if it is a fatal one
+                if (e.Class >= TdsEnums.FATAL_ERROR_CLASS)
+                {
+                    throw;
+                }
+
+                // if the parser is null or its state is not openloggedin, the connection is no longer good.
+                SqlInternalConnectionTds tdsConnection = this as SqlInternalConnectionTds;
+                if (tdsConnection != null)
+                {
+                    TdsParser parser = tdsConnection.Parser;
+                    if (parser == null || parser.State != TdsParserState.OpenLoggedIn)
+                    {
+                        throw;
+                    }
+                }
+
+                // In this case, SqlDelegatedTransaction.Initialize
+                // failed and we don't necessarily want to reject
+                // things -- there may have been a legitimate reason
+                // for the failure.
+            }
+
+            if (!hasDelegatedTransaction)
+            {
+                byte[] cookie = null;
+
+                if (_isGlobalTransaction)
+                {
+                    if (SysTxForGlobalTransactions.GetPromotedToken == null)
+                    {
+                        throw SQL.UnsupportedSysTxForGlobalTransactions();
+                    }
+
+                    cookie = (byte[])SysTxForGlobalTransactions.GetPromotedToken.Invoke(tx, null);
+                }
+                else
+                {
+                    if (null == _whereAbouts)
+                    {
+                        byte[] dtcAddress = GetDTCAddress();
+
+                        if (null == dtcAddress)
+                        {
+                            throw SQL.CannotGetDTCAddress();
+                        }
+                        _whereAbouts = dtcAddress;
+                    }
+                    cookie = GetTransactionCookie(tx, _whereAbouts);
+                }
+
+                // send cookie to server to finish enlistment
+                PropagateTransactionCookie(cookie);
+
+                _isEnlistedInTransaction = true;
+            }
+
+            EnlistedTransaction = tx; // Tell the base class about our enlistment
+
+
+            // If we're on a Yukon or newer server, and we we delegate the 
+            // transaction successfully, we will have done a begin transaction, 
+            // which produces a transaction id that we should execute all requests
+            // on.  The TdsParser or SmiEventSink will store this information as
+            // the current transaction.
+            // 
+            // Likewise, propagating a transaction to a Yukon or newer server will
+            // produce a transaction id that The TdsParser or SmiEventSink will 
+            // store as the current transaction.
+            //
+            // In either case, when we're working with a Yukon or newer server 
+            // we better have a current transaction by now.
+
+            Debug.Assert(null != CurrentTransaction, "delegated/enlisted transaction with null current transaction?");
+        }
+
+        internal void EnlistNull()
+        {
+            // We were in a transaction, but now we are not - so send
+            // message to server with empty transaction - confirmed proper
+            // behavior from Sameet Agarwal
+            //
+            // The connection pooler maintains separate pools for enlisted
+            // transactions, and only when that transaction is committed or
+            // rolled back will those connections be taken from that
+            // separate pool and returned to the general pool of connections
+            // that are not affiliated with any transactions.  When this
+            // occurs, we will have a new transaction of null and we are
+            // required to send an empty transaction payload to the server.
+
+            PropagateTransactionCookie(null);
+
+            _isEnlistedInTransaction = false;
+            EnlistedTransaction = null; // Tell the base class about our enlistment
+
+            // The EnlistTransaction above will return an TransactionEnded event, 
+            // which causes the TdsParser or SmiEventSink should to clear the
+            // current transaction.
+            //
+            // In either case, when we're working with a Yukon or newer server 
+            // we better not have a current transaction at this point.
+
+            Debug.Assert(null == CurrentTransaction, "unenlisted transaction with non-null current transaction?");   // verify it!
+        }
+
+        /*
+        override public void EnlistTransaction(SysTx.Transaction transaction)
+        {
+            SqlConnection.VerifyExecutePermission();
+
+            ValidateConnectionForExecute(null);
+
+            // If a connection has a local transaction outstanding and you try
+            // to enlist in a DTC transaction, SQL Server will rollback the
+            // local transaction and then do the enlist (7.0 and 2000).  So, if
+            // the user tries to do this, throw.
+            if (HasLocalTransaction)
+            {
+                throw ADP.LocalTransactionPresent();
+            }
+
+            if (null != transaction && transaction.Equals(EnlistedTransaction))
+            {
+                // No-op if this is the current transaction
+                return;
+            }
+
+            // If a connection is already enlisted in a DTC transaction and you
+            // try to enlist in another one, in 7.0 the existing DTC transaction
+            // would roll back and then the connection would enlist in the new
+            // one. In SQL 2000 & Yukon, when you enlist in a DTC transaction
+            // while the connection is already enlisted in a DTC transaction,
+            // the connection simply switches enlistments.  Regardless, simply
+            // enlist in the user specified distributed transaction.  This
+            // behavior matches OLEDB and ODBC.
+
+            TdsParser bestEffortCleanupTarget = null;
+            RuntimeHelpers.PrepareConstrainedRegions();
+            try
+            {
+                bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(Connection);
+                Enlist(transaction);
+            }
+            catch (System.OutOfMemoryException e)
+            {
+                Connection.Abort(e);
+                throw;
+            }
+            catch (System.StackOverflowException e)
+            {
+                Connection.Abort(e);
+                throw;
+            }
+            catch (System.Threading.ThreadAbortException e)
+            {
+                Connection.Abort(e);
+                SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
+                throw;
+            }
+        }
+        */
+
+        abstract internal void ExecuteTransaction(TransactionRequest transactionRequest, string name, IsolationLevel iso, SqlInternalTransaction internalTransaction, bool isDelegateControlRequest);
 
         internal SqlDataReader FindLiveReader(SqlCommand command)
         {
@@ -222,6 +574,17 @@ namespace System.Data.SqlClient
             return command;
         }
 
+        abstract protected byte[] GetDTCAddress();
+
+        static private byte[] GetTransactionCookie(SysTx.Transaction transaction, byte[] whereAbouts)
+        {
+            byte[] transactionCookie = null;
+            if (null != transaction)
+            {
+                transactionCookie = SysTx.TransactionInterop.GetExportCookie(transaction, whereAbouts);
+            }
+            return transactionCookie;
+        }
 
         virtual protected void InternalDeactivate()
         {
@@ -249,6 +612,7 @@ namespace System.Data.SqlClient
             }
         }
 
+        abstract protected void PropagateTransactionCookie(byte[] transactionCookie);
 
         abstract internal void ValidateConnectionForExecute(SqlCommand command);
     }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlInternalConnection.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlInternalConnection.cs
@@ -9,7 +9,7 @@
 using System.Data.Common;
 using System.Data.ProviderBase;
 using System.Diagnostics;
-using SysTx = System.Transactions;
+using System.Transactions;
 
 
 namespace System.Data.SqlClient
@@ -232,7 +232,7 @@ namespace System.Data.SqlClient
 
         abstract protected void ChangeDatabaseInternal(string database);
 
-        override protected void CleanupTransactionOnCompletion(SysTx.Transaction transaction)
+        override protected void CleanupTransactionOnCompletion(Transaction transaction)
         {
             // Note: unlocked, potentially multi-threaded code, so pull delegate to local to 
             //  ensure it doesn't change between test and call.
@@ -283,7 +283,7 @@ namespace System.Data.SqlClient
             base.Dispose();
         }
 
-        protected void Enlist(SysTx.Transaction tx)
+        protected void Enlist(Transaction tx)
         {
             // This method should not be called while the connection has a 
             // reference to an active delegated transaction.
@@ -314,8 +314,8 @@ namespace System.Data.SqlClient
                     // There are two mitigations for this:
                     // 1. SqlConnection.EnlistTransaction checks that the enlisted transaction has completed before allowing a different enlistment.
                     // 2. For debug builds, the assert at the beginning of this method checks for an enlistment in an active delegated transaction.
-                    SysTx.Transaction enlistedTransaction = EnlistedTransaction;
-                    if (enlistedTransaction != null && enlistedTransaction.TransactionInformation.Status != SysTx.TransactionStatus.Active)
+                    Transaction enlistedTransaction = EnlistedTransaction;
+                    if (enlistedTransaction != null && enlistedTransaction.TransactionInformation.Status != TransactionStatus.Active)
                     {
                         EnlistNull();
                     }
@@ -328,7 +328,7 @@ namespace System.Data.SqlClient
             }
         }
 
-        private void EnlistNonNull(SysTx.Transaction tx)
+        private void EnlistNonNull(Transaction tx)
         {
             Debug.Assert(null != tx, "null transaction?");
 
@@ -508,7 +508,7 @@ namespace System.Data.SqlClient
             Debug.Assert(null == CurrentTransaction, "unenlisted transaction with non-null current transaction?");   // verify it!
         }
 
-        override public void EnlistTransaction(SysTx.Transaction transaction)
+        override public void EnlistTransaction(Transaction transaction)
         {
             ValidateConnectionForExecute(null);
 
@@ -583,12 +583,12 @@ namespace System.Data.SqlClient
 
         abstract protected byte[] GetDTCAddress();
 
-        static private byte[] GetTransactionCookie(SysTx.Transaction transaction, byte[] whereAbouts)
+        static private byte[] GetTransactionCookie(Transaction transaction, byte[] whereAbouts)
         {
             byte[] transactionCookie = null;
             if (null != transaction)
             {
-                transactionCookie = SysTx.TransactionInterop.GetExportCookie(transaction, whereAbouts);
+                transactionCookie = TransactionInterop.GetExportCookie(transaction, whereAbouts);
             }
             return transactionCookie;
         }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -425,7 +425,7 @@ namespace System.Data.SqlClient
             }
         }
 
-        override internal SqlInternalTransaction CurrentTransaction
+        internal override SqlInternalTransaction CurrentTransaction
         {
             get
             {
@@ -433,7 +433,7 @@ namespace System.Data.SqlClient
             }
         }
 
-        override internal SqlInternalTransaction AvailableInternalTransaction
+        internal override SqlInternalTransaction AvailableInternalTransaction
         {
             get
             {
@@ -441,7 +441,7 @@ namespace System.Data.SqlClient
             }
         }
 
-        override internal SqlInternalTransaction PendingTransaction
+        internal override SqlInternalTransaction PendingTransaction
         {
             get
             {
@@ -465,7 +465,7 @@ namespace System.Data.SqlClient
             }
         }
 
-        override internal bool IsLockedForBulkCopy
+        internal override bool IsLockedForBulkCopy
         {
             get
             {
@@ -473,7 +473,7 @@ namespace System.Data.SqlClient
             }
         }
 
-        override protected internal bool IsNonPoolableTransactionRoot
+        internal protected override bool IsNonPoolableTransactionRoot
         {
             get
             {
@@ -481,7 +481,7 @@ namespace System.Data.SqlClient
             }
         }
 
-        override internal bool IsKatmaiOrNewer
+        internal override bool IsKatmaiOrNewer
         {
             get
             {
@@ -521,7 +521,7 @@ namespace System.Data.SqlClient
             }
         }
 
-        override protected bool ReadyToPrepareTransaction
+        protected override bool ReadyToPrepareTransaction
         {
             get
             {
@@ -530,7 +530,7 @@ namespace System.Data.SqlClient
             }
         }
 
-        override public string ServerVersion
+        public override string ServerVersion
         {
             get
             {
@@ -552,7 +552,7 @@ namespace System.Data.SqlClient
         // GENERAL METHODS
         ////////////////////////////////////////////////////////////////////////////////////////
         [SuppressMessage("Microsoft.Globalization", "CA1303:DoNotPassLiteralsAsLocalizedParameters")] // copied from Triaged.cs
-        override protected void ChangeDatabaseInternal(string database)
+        protected override void ChangeDatabaseInternal(string database)
         {
             // Add brackets around database
             database = SqlConnection.FixupDatabaseTransactionName(database);
@@ -561,7 +561,7 @@ namespace System.Data.SqlClient
             _parser.Run(RunBehavior.UntilDone, null, null, null, _parser._physicalStateObj);
         }
 
-        override public void Dispose()
+        public override void Dispose()
         {
             try
             {
@@ -583,7 +583,7 @@ namespace System.Data.SqlClient
             base.Dispose();
         }
 
-        override internal void ValidateConnectionForExecute(SqlCommand command)
+        internal override void ValidateConnectionForExecute(SqlCommand command)
         {
             TdsParser parser = _parser;
             if ((parser == null) || (parser.State == TdsParserState.Broken) || (parser.State == TdsParserState.Closed))
@@ -695,7 +695,7 @@ namespace System.Data.SqlClient
         // POOLING METHODS
         ////////////////////////////////////////////////////////////////////////////////////////
 
-        override protected void Activate(SysTx.Transaction transaction)
+        protected override void Activate(SysTx.Transaction transaction)
         {
             // When we're required to automatically enlist in transactions and
             // there is one we enlist in it. On the other hand, if there isn't a
@@ -718,7 +718,7 @@ namespace System.Data.SqlClient
             }
         }
 
-        override protected void InternalDeactivate()
+        protected override void InternalDeactivate()
         {
             // When we're deactivated, the user must have called End on all
             // the async commands, or we don't know that we're in a state that
@@ -789,7 +789,7 @@ namespace System.Data.SqlClient
         // LOCAL TRANSACTION METHODS
         ////////////////////////////////////////////////////////////////////////////////////////
 
-        override internal void DisconnectTransaction(SqlInternalTransaction internalTransaction)
+        internal override void DisconnectTransaction(SqlInternalTransaction internalTransaction)
         {
             TdsParser parser = Parser;
 
@@ -804,7 +804,7 @@ namespace System.Data.SqlClient
             ExecuteTransaction(transactionRequest, name, iso, null, false);
         }
 
-        override internal void ExecuteTransaction(TransactionRequest transactionRequest, string name, IsolationLevel iso, SqlInternalTransaction internalTransaction, bool isDelegateControlRequest)
+        internal override void ExecuteTransaction(TransactionRequest transactionRequest, string name, IsolationLevel iso, SqlInternalTransaction internalTransaction, bool isDelegateControlRequest)
         {
             if (IsConnectionDoomed)
             {  // doomed means we can't do anything else...
@@ -979,19 +979,19 @@ namespace System.Data.SqlClient
         // DISTRIBUTED TRANSACTION METHODS
         ////////////////////////////////////////////////////////////////////////////////////////
 
-        override internal void DelegatedTransactionEnded()
+        internal override void DelegatedTransactionEnded()
         {
             base.DelegatedTransactionEnded();
         }
 
-        override protected byte[] GetDTCAddress()
+        protected override byte[] GetDTCAddress()
         {
             byte[] dtcAddress = _parser.GetDTCAddress(ConnectionOptions.ConnectTimeout, _parser.GetSession(this));
             Debug.Assert(null != dtcAddress, "null dtcAddress?");
             return dtcAddress;
         }
 
-        override protected void PropagateTransactionCookie(byte[] cookie)
+        protected override void PropagateTransactionCookie(byte[] cookie)
         {
             _parser.PropagateDistributedTransaction(cookie, ConnectionOptions.ConnectTimeout, _parser._physicalStateObj);
         }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -14,7 +14,7 @@ using System.Globalization;
 using System.Threading;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
-using SysTx = System.Transactions;
+using System.Transactions;
 
 namespace System.Data.SqlClient
 {
@@ -652,7 +652,7 @@ namespace System.Data.SqlClient
         {
             // If we are enlisted in a transaction, check that transaction is active.
             // When using explicit transaction unbinding, also verify that the enlisted transaction is the current transaction.
-            SysTx.Transaction enlistedTransaction = EnlistedTransaction;
+            Transaction enlistedTransaction = EnlistedTransaction;
 
             if (enlistedTransaction != null)
             {
@@ -660,16 +660,16 @@ namespace System.Data.SqlClient
 
                 if (requireExplicitTransactionUnbind)
                 {
-                    SysTx.Transaction currentTransaction = SysTx.Transaction.Current;
+                    Transaction currentTransaction = Transaction.Current;
 
-                    if (SysTx.TransactionStatus.Active != enlistedTransaction.TransactionInformation.Status || !enlistedTransaction.Equals(currentTransaction))
+                    if (TransactionStatus.Active != enlistedTransaction.TransactionInformation.Status || !enlistedTransaction.Equals(currentTransaction))
                     {
                         throw ADP.TransactionConnectionMismatch();
                     }
                 }
                 else // implicit transaction unbind
                 {
-                    if (SysTx.TransactionStatus.Active != enlistedTransaction.TransactionInformation.Status)
+                    if (TransactionStatus.Active != enlistedTransaction.TransactionInformation.Status)
                     {
                         if (EnlistedTransactionDisposed)
                         {
@@ -695,7 +695,7 @@ namespace System.Data.SqlClient
         // POOLING METHODS
         ////////////////////////////////////////////////////////////////////////////////////////
 
-        protected override void Activate(SysTx.Transaction transaction)
+        protected override void Activate(Transaction transaction)
         {
             // When we're required to automatically enlist in transactions and
             // there is one we enlist in it. On the other hand, if there isn't a
@@ -1046,7 +1046,7 @@ namespace System.Data.SqlClient
             if (enlistOK && ConnectionOptions.Enlist)
             {
                 _parser._physicalStateObj.SniContext = SniContext.Snix_AutoEnlist;
-                SysTx.Transaction tx = ADP.GetCurrentTransaction();
+                Transaction tx = ADP.GetCurrentTransaction();
                 Enlist(tx);
             }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlUtil.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlUtil.cs
@@ -10,6 +10,8 @@ using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Reflection;
+using SysTx = System.Transactions;
 
 namespace System.Data.SqlClient
 {
@@ -157,6 +159,10 @@ namespace System.Data.SqlClient
         //
         // SQL.Connection
         //
+        static internal Exception CannotGetDTCAddress()
+        {
+            return ADP.InvalidOperation(SR.GetString(SR.SQL_CannotGetDTCAddress));
+        }
 
         internal static Exception InvalidInternalPacketSize(string str)
         {
@@ -198,6 +204,20 @@ namespace System.Data.SqlClient
         {
             return ADP.InvalidOperation(SR.GetString(SR.SQL_InstanceFailure));
         }
+
+        //
+        // Global Transactions.
+        //
+        static internal Exception GlobalTransactionsNotEnabled()
+        {
+            return ADP.InvalidOperation(SR.GetString(SR.GT_Disabled));
+        }
+        static internal Exception UnknownSysTxIsolationLevel(SysTx.IsolationLevel isolationLevel)
+        {
+            return ADP.InvalidOperation(SR.GetString(SR.SQL_UnknownSysTxIsolationLevel, isolationLevel.ToString()));
+        }
+
+
         internal static Exception InvalidPartnerConfiguration(string server, string database)
         {
             return ADP.InvalidOperation(SR.GetString(SR.SQL_InvalidPartnerConfiguration, server, database));
@@ -461,6 +481,17 @@ namespace System.Data.SqlClient
             return ADP.InvalidOperation(SR.GetString(SR.SqlDependency_NoMatchingServerDatabaseStart));
         }
 
+		//
+        // SQL.SqlDelegatedTransaction
+        //
+        static internal SysTx.TransactionPromotionException PromotionFailed(Exception inner)
+        {
+            SysTx.TransactionPromotionException e = new SysTx.TransactionPromotionException(SR.GetString(SR.SqlDelegatedTransaction_PromotionFailed), inner);
+            ADP.TraceExceptionAsReturnValue(e);
+            return e;
+        }
+        //Failure while attempting to promote transaction.
+
         //
         // SQL.SqlMetaData
         //
@@ -611,6 +642,11 @@ namespace System.Data.SqlClient
         internal static Exception OpenResultCountExceeded()
         {
             return ADP.InvalidOperation(SR.GetString(SR.SQL_OpenResultCountExceeded));
+        }
+
+        static internal Exception UnsupportedSysTxForGlobalTransactions()
+        {
+            return ADP.InvalidOperation(SR.GetString(SR.SQL_UnsupportedSysTxVersion));
         }
 
         internal static readonly byte[] AttentionHeader = new byte[] {
@@ -1047,6 +1083,58 @@ namespace System.Data.SqlClient
             else
             {
                 return "'" + EscapeStringAsLiteral(input) + "'";
+            }
+        }
+    }
+
+    /// <summary>
+    /// This class holds methods invoked on System.Transactions through reflection for Global Transactions
+    /// </summary>
+    static internal class SysTxForGlobalTransactions
+    {
+        private static readonly Lazy<MethodInfo> _enlistPromotableSinglePhase = new Lazy<MethodInfo>(() =>
+            typeof(SysTx.Transaction).GetMethod("EnlistPromotableSinglePhase", new Type[] { typeof(SysTx.IPromotableSinglePhaseNotification), typeof(Guid) }));
+
+        private static readonly Lazy<MethodInfo> _setDistributedTransactionIdentifier = new Lazy<MethodInfo>(() =>
+            typeof(SysTx.Transaction).GetMethod("SetDistributedTransactionIdentifier", new Type[] { typeof(SysTx.IPromotableSinglePhaseNotification), typeof(Guid) }));
+
+        private static readonly Lazy<MethodInfo> _getPromotedToken = new Lazy<MethodInfo>(() =>
+            typeof(SysTx.Transaction).GetMethod("GetPromotedToken"));
+
+        /// <summary>
+        /// Enlists the given IPromotableSinglePhaseNotification and Non-MSDTC Promoter type into a transaction
+        /// </summary>
+        /// <returns>The MethodInfo instance to be invoked. Null if the method doesn't exist</returns>
+        public static MethodInfo EnlistPromotableSinglePhase
+        {
+            get
+            {
+                return _enlistPromotableSinglePhase.Value;
+            }
+        }
+
+        /// <summary>
+        /// Sets the given DistributedTransactionIdentifier for a Transaction instance.
+        /// Needs to be invoked when using a Non-MSDTC Promoter type
+        /// </summary>
+        /// <returns>The MethodInfo instance to be invoked. Null if the method doesn't exist</returns>
+        public static MethodInfo SetDistributedTransactionIdentifier
+        {
+            get
+            {
+                return _setDistributedTransactionIdentifier.Value;
+            }
+        }
+
+        /// <summary>
+        /// Gets the Promoted Token for a Transaction
+        /// </summary>
+        /// <returns>The MethodInfo instance to be invoked. Null if the method doesn't exist</returns>
+        public static MethodInfo GetPromotedToken
+        {
+            get
+            {
+                return _getPromotedToken.Value;
             }
         }
     }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlUtil.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlUtil.cs
@@ -11,7 +11,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Reflection;
-using SysTx = System.Transactions;
+using System.Transactions;
 
 namespace System.Data.SqlClient
 {
@@ -212,7 +212,7 @@ namespace System.Data.SqlClient
         {
             return ADP.InvalidOperation(SR.GetString(SR.GT_Disabled));
         }
-        internal static Exception UnknownSysTxIsolationLevel(SysTx.IsolationLevel isolationLevel)
+        internal static Exception UnknownSysTxIsolationLevel(Transactions.IsolationLevel isolationLevel)
         {
             return ADP.InvalidOperation(SR.GetString(SR.SQL_UnknownSysTxIsolationLevel, isolationLevel.ToString()));
         }
@@ -484,9 +484,9 @@ namespace System.Data.SqlClient
         //
         // SQL.SqlDelegatedTransaction
         //
-        internal static SysTx.TransactionPromotionException PromotionFailed(Exception inner)
+        internal static TransactionPromotionException PromotionFailed(Exception inner)
         {
-            SysTx.TransactionPromotionException e = new SysTx.TransactionPromotionException(SR.GetString(SR.SqlDelegatedTransaction_PromotionFailed), inner);
+            TransactionPromotionException e = new TransactionPromotionException(SR.GetString(SR.SqlDelegatedTransaction_PromotionFailed), inner);
             ADP.TraceExceptionAsReturnValue(e);
             return e;
         }
@@ -1093,13 +1093,13 @@ namespace System.Data.SqlClient
     static internal class SysTxForGlobalTransactions
     {
         private static readonly Lazy<MethodInfo> _enlistPromotableSinglePhase = new Lazy<MethodInfo>(() =>
-            typeof(SysTx.Transaction).GetMethod("EnlistPromotableSinglePhase", new Type[] { typeof(SysTx.IPromotableSinglePhaseNotification), typeof(Guid) }));
+            typeof(Transaction).GetMethod("EnlistPromotableSinglePhase", new Type[] { typeof(IPromotableSinglePhaseNotification), typeof(Guid) }));
 
         private static readonly Lazy<MethodInfo> _setDistributedTransactionIdentifier = new Lazy<MethodInfo>(() =>
-            typeof(SysTx.Transaction).GetMethod("SetDistributedTransactionIdentifier", new Type[] { typeof(SysTx.IPromotableSinglePhaseNotification), typeof(Guid) }));
+            typeof(Transaction).GetMethod("SetDistributedTransactionIdentifier", new Type[] { typeof(IPromotableSinglePhaseNotification), typeof(Guid) }));
 
         private static readonly Lazy<MethodInfo> _getPromotedToken = new Lazy<MethodInfo>(() =>
-            typeof(SysTx.Transaction).GetMethod("GetPromotedToken"));
+            typeof(Transaction).GetMethod("GetPromotedToken"));
 
         /// <summary>
         /// Enlists the given IPromotableSinglePhaseNotification and Non-MSDTC Promoter type into a transaction

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlUtil.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlUtil.cs
@@ -159,7 +159,7 @@ namespace System.Data.SqlClient
         //
         // SQL.Connection
         //
-        static internal Exception CannotGetDTCAddress()
+        internal static Exception CannotGetDTCAddress()
         {
             return ADP.InvalidOperation(SR.GetString(SR.SQL_CannotGetDTCAddress));
         }
@@ -208,11 +208,11 @@ namespace System.Data.SqlClient
         //
         // Global Transactions.
         //
-        static internal Exception GlobalTransactionsNotEnabled()
+        internal static Exception GlobalTransactionsNotEnabled()
         {
             return ADP.InvalidOperation(SR.GetString(SR.GT_Disabled));
         }
-        static internal Exception UnknownSysTxIsolationLevel(SysTx.IsolationLevel isolationLevel)
+        internal static Exception UnknownSysTxIsolationLevel(SysTx.IsolationLevel isolationLevel)
         {
             return ADP.InvalidOperation(SR.GetString(SR.SQL_UnknownSysTxIsolationLevel, isolationLevel.ToString()));
         }
@@ -481,10 +481,10 @@ namespace System.Data.SqlClient
             return ADP.InvalidOperation(SR.GetString(SR.SqlDependency_NoMatchingServerDatabaseStart));
         }
 
-		//
+        //
         // SQL.SqlDelegatedTransaction
         //
-        static internal SysTx.TransactionPromotionException PromotionFailed(Exception inner)
+        internal static SysTx.TransactionPromotionException PromotionFailed(Exception inner)
         {
             SysTx.TransactionPromotionException e = new SysTx.TransactionPromotionException(SR.GetString(SR.SqlDelegatedTransaction_PromotionFailed), inner);
             ADP.TraceExceptionAsReturnValue(e);
@@ -644,7 +644,7 @@ namespace System.Data.SqlClient
             return ADP.InvalidOperation(SR.GetString(SR.SQL_OpenResultCountExceeded));
         }
 
-        static internal Exception UnsupportedSysTxForGlobalTransactions()
+        internal static Exception UnsupportedSysTxForGlobalTransactions()
         {
             return ADP.InvalidOperation(SR.GetString(SR.SQL_UnsupportedSysTxVersion));
         }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsEnums.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsEnums.cs
@@ -828,7 +828,10 @@ namespace System.Data.SqlClient
 
         internal enum TransactionManagerRequestType
         {
+            GetDTCAddress = 0,
+            Propagate = 1,
             Begin = 5,
+            Promote = 6,
             Commit = 7,
             Rollback = 8,
             Save = 9

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsEnums.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsEnums.cs
@@ -204,12 +204,14 @@ namespace System.Data.SqlClient
         // Feature Extension
         public const byte FEATUREEXT_TERMINATOR = 0xFF;
         public const byte FEATUREEXT_SRECOVERY = 0x01;
+        public const byte FEATUREEXT_GLOBALTRANSACTIONS = 0x05;
 
         [Flags]
         public enum FeatureExtension : uint
         {
             None = 0,
             SessionRecovery = 1,
+            GlobalTransactions = 8,
         }
 
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
@@ -1853,7 +1853,6 @@ namespace System.Data.SqlClient
                                         case TdsEnums.ENV_DEFECTDTC:
                                         case TdsEnums.ENV_TRANSACTIONENDED:
                                         case TdsEnums.ENV_COMMITTRAN:
-                                            // SQLHOT 483
                                             //  Must clear the retain id if the server-side transaction ends by anything other
                                             //  than rollback.
                                             _retainedTransactionId = SqlInternalTransaction.NullTransactionId;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/sqlinternaltransaction.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/sqlinternaltransaction.cs
@@ -25,6 +25,7 @@ namespace System.Data.SqlClient
     {
         LocalFromTSQL = 1,
         LocalFromAPI = 2,
+        Delegated = 3,
     };
 
     sealed internal class SqlInternalTransaction
@@ -109,6 +110,14 @@ namespace System.Data.SqlClient
             }
         }
 
+        internal bool IsDelegated
+        {
+            get
+            {
+                bool result = (TransactionType.Delegated == _transactionType);
+                return result;
+            }
+        }
 
         internal bool IsLocal
         {
@@ -230,7 +239,7 @@ namespace System.Data.SqlClient
             bool processFinallyBlock = true;
             try
             {
-                innerConnection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.IfRollback, null, IsolationLevel.Unspecified, null);
+                innerConnection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.IfRollback, null, IsolationLevel.Unspecified, null, false);
             }
             catch (Exception e)
             {
@@ -264,7 +273,7 @@ namespace System.Data.SqlClient
             {
                 // COMMIT ignores transaction names, and so there is no reason to pass it anything.  COMMIT
                 // simply commits the transaction from the most recent BEGIN, nested or otherwise.
-                _innerConnection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.Commit, null, IsolationLevel.Unspecified, null);
+                _innerConnection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.Commit, null, IsolationLevel.Unspecified, null, false);
                 {
                     ZombieParent();
                 }
@@ -366,7 +375,7 @@ namespace System.Data.SqlClient
             {
                 // If no arg is given to ROLLBACK it will rollback to the outermost begin - rolling back
                 // all nested transactions as well as the outermost transaction.
-                _innerConnection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.IfRollback, null, IsolationLevel.Unspecified, null);
+                _innerConnection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.IfRollback, null, IsolationLevel.Unspecified, null, false);
 
                 // Since Rollback will rollback to outermost begin, no need to check
                 // server transaction level.  This transaction has been completed.
@@ -409,7 +418,7 @@ namespace System.Data.SqlClient
 
             try
             {
-                _innerConnection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.Rollback, transactionName, IsolationLevel.Unspecified, null);
+                _innerConnection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.Rollback, transactionName, IsolationLevel.Unspecified, null, false);
             }
             catch (Exception e)
             {
@@ -436,7 +445,7 @@ namespace System.Data.SqlClient
 
             try
             {
-                _innerConnection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.Save, savePointName, IsolationLevel.Unspecified, null);
+                _innerConnection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.Save, savePointName, IsolationLevel.Unspecified, null, false);
             }
             catch (Exception e)
             {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/sqlinternaltransaction.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/sqlinternaltransaction.cs
@@ -26,6 +26,8 @@ namespace System.Data.SqlClient
         LocalFromTSQL = 1,
         LocalFromAPI = 2,
         Delegated = 3,
+        Distributed = 4,
+        Context = 5,     // only valid in proc.
     };
 
     sealed internal class SqlInternalTransaction
@@ -115,6 +117,15 @@ namespace System.Data.SqlClient
             get
             {
                 bool result = (TransactionType.Delegated == _transactionType);
+                return result;
+            }
+        }
+
+        internal bool IsDistributed
+        {
+            get
+            {
+                bool result = (TransactionType.Distributed == _transactionType);
                 return result;
             }
         }

--- a/src/System.Data.SqlClient/tests/FunctionalTests/AmbientTransactionFailureTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/AmbientTransactionFailureTest.cs
@@ -82,17 +82,6 @@ namespace System.Data.SqlClient.Tests
             });
         }
 
-        [Theory]
-        [MemberData(nameof(ExceptionTestDataForNotSupportedException))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Framework doesn't throw the Not Supported Exception")]
-        public void TestNotSupportedException(Action<string> connectAction, string connectionString)
-        {
-            Assert.Throws<NotSupportedException>(() =>
-            {
-                connectAction(connectionString);
-            });
-        }
-
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Framework doesn't throw the Not Supported Exception")]
         public void TestNotSupportedExceptionForTransactionScopeAsync()

--- a/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionTest.cs
@@ -2,28 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+
 using System.Data.Common;
 using System.Reflection;
 using Xunit;
-using System.Net;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Net.Security;
-using System.Net.Sockets;
-using System.Text;
-using System.Threading.Tasks;
-using System;
-using System.Threading;
-using System.Collections;
-using System.Transactions;
-using System.Data.SqlClient;
 
 namespace System.Data.SqlClient.Tests
 {
     public class SqlConnectionBasicTests
     {
-        //[Fact]
+
+        [Fact]
         public void ConnectionTest()
         {
             using (TestTdsServer server = TestTdsServer.StartTestServer())
@@ -34,6 +23,7 @@ namespace System.Data.SqlClient.Tests
                 }
             }
         }
+
 
         [PlatformSpecific(TestPlatforms.Windows)]  // Integ auth on Test server is supported on Windows right now
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer), nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotArmProcess))] // https://github.com/dotnet/corefx/issues/19218 And https://github.com/dotnet/corefx/issues/21598
@@ -51,7 +41,7 @@ namespace System.Data.SqlClient.Tests
             }
         }
 
-        //[Fact]
+        [Fact]
         public void SqlConnectionDbProviderFactoryTest()
         {
             SqlConnection con = new SqlConnection();
@@ -61,58 +51,6 @@ namespace System.Data.SqlClient.Tests
             Assert.NotNull(factory);
             Assert.Same(typeof(SqlClientFactory), factory.GetType());
             Assert.Same(SqlClientFactory.Instance, factory);
-        }
-
-        [Fact]
-        public static void Test8()
-        {
-            Console.WriteLine("Test8");
-            string connString = "Server=tcp:GELEE-VM-WIN10B,1433;User ID=testuser;Password=test1234;pooling=false;Enlist=true";
-            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(connString);
-            string connectionString = builder.ConnectionString;
-
-            using (TransactionScope txScope = new TransactionScope(TransactionScopeOption.Required, TimeSpan.MaxValue))
-            {
-                using (SqlConnection connection = new SqlConnection(connectionString))
-                {
-                    connection.Open();
-                    /*
-                    try
-                    {
-                        using (SqlCommand command = connection.CreateCommand())
-                        {
-                            command.CommandText = "drop table mytable";
-                            command.ExecuteNonQuery();
-                        }
-                    }
-                    catch { }
-                    using (SqlCommand command = connection.CreateCommand())
-                    {
-                        command.CommandText = "create table mytable (col1 text, col2 text)";
-                        command.ExecuteNonQuery();
-                    }
-                    
-                    using (SqlCommand command = connection.CreateCommand())
-                    {
-                        command.CommandText = "INSERT INTO mytable VALUES ('11', '22')";
-                        command.ExecuteNonQuery();
-                    }
-                    */
-                    using (SqlCommand command = connection.CreateCommand())
-                    {
-                        command.CommandText = "INSERT INTO mytable VALUES ('31', '44')";
-                        command.ExecuteNonQuery();
-                    }
-                    /*
-                    using (SqlCommand command = connection.CreateCommand())
-                    {
-                        command.CommandText = "SELECT @@SPID";
-                        Console.WriteLine(command.ExecuteScalar());
-                    }
-                    */
-                }
-                txScope.Complete();
-            }
         }
     }
 }

--- a/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionTest.cs
@@ -67,11 +67,11 @@ namespace System.Data.SqlClient.Tests
         public static void Test8()
         {
             Console.WriteLine("Test8");
-            string connString = "Server=tcp:GELEE-VM-WIN10B,1433;User ID=testuser;Password=test1234;Connect Timeout=600;pooling=true;Enlist=true";
+            string connString = "Server=tcp:GELEE-VM-WIN10B,1433;User ID=testuser;Password=test1234;pooling=false;Enlist=true";
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(connString);
             string connectionString = builder.ConnectionString;
 
-            using (TransactionScope txScope = new TransactionScope())
+            using (TransactionScope txScope = new TransactionScope(TransactionScopeOption.Required, TimeSpan.MaxValue))
             {
                 using (SqlConnection connection = new SqlConnection(connectionString))
                 {
@@ -91,6 +91,7 @@ namespace System.Data.SqlClient.Tests
                         command.CommandText = "create table mytable (col1 text, col2 text)";
                         command.ExecuteNonQuery();
                     }
+                    
                     using (SqlCommand command = connection.CreateCommand())
                     {
                         command.CommandText = "INSERT INTO mytable VALUES ('11', '22')";
@@ -99,9 +100,16 @@ namespace System.Data.SqlClient.Tests
                     */
                     using (SqlCommand command = connection.CreateCommand())
                     {
-                        command.CommandText = "INSERT INTO mytable VALUES ('33', '44')";
+                        command.CommandText = "INSERT INTO mytable VALUES ('31', '44')";
                         command.ExecuteNonQuery();
                     }
+                    /*
+                    using (SqlCommand command = connection.CreateCommand())
+                    {
+                        command.CommandText = "SELECT @@SPID";
+                        Console.WriteLine(command.ExecuteScalar());
+                    }
+                    */
                 }
                 txScope.Complete();
             }

--- a/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionTest.cs
@@ -2,17 +2,28 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using System.Data.Common;
 using System.Reflection;
 using Xunit;
+using System.Net;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+using System;
+using System.Threading;
+using System.Collections;
+using System.Transactions;
+using System.Data.SqlClient;
 
 namespace System.Data.SqlClient.Tests
 {
     public class SqlConnectionBasicTests
     {
-
-        [Fact]
+        //[Fact]
         public void ConnectionTest()
         {
             using (TestTdsServer server = TestTdsServer.StartTestServer())
@@ -23,7 +34,6 @@ namespace System.Data.SqlClient.Tests
                 }
             }
         }
-
 
         [PlatformSpecific(TestPlatforms.Windows)]  // Integ auth on Test server is supported on Windows right now
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer), nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotArmProcess))] // https://github.com/dotnet/corefx/issues/19218 And https://github.com/dotnet/corefx/issues/21598
@@ -41,7 +51,7 @@ namespace System.Data.SqlClient.Tests
             }
         }
 
-        [Fact]
+        //[Fact]
         public void SqlConnectionDbProviderFactoryTest()
         {
             SqlConnection con = new SqlConnection();
@@ -51,6 +61,50 @@ namespace System.Data.SqlClient.Tests
             Assert.NotNull(factory);
             Assert.Same(typeof(SqlClientFactory), factory.GetType());
             Assert.Same(SqlClientFactory.Instance, factory);
+        }
+
+        [Fact]
+        public static void Test8()
+        {
+            Console.WriteLine("Test8");
+            string connString = "Server=tcp:GELEE-VM-WIN10B,1433;User ID=testuser;Password=test1234;Connect Timeout=600;pooling=true;Enlist=true";
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(connString);
+            string connectionString = builder.ConnectionString;
+
+            using (TransactionScope txScope = new TransactionScope())
+            {
+                using (SqlConnection connection = new SqlConnection(connectionString))
+                {
+                    connection.Open();
+                    /*
+                    try
+                    {
+                        using (SqlCommand command = connection.CreateCommand())
+                        {
+                            command.CommandText = "drop table mytable";
+                            command.ExecuteNonQuery();
+                        }
+                    }
+                    catch { }
+                    using (SqlCommand command = connection.CreateCommand())
+                    {
+                        command.CommandText = "create table mytable (col1 text, col2 text)";
+                        command.ExecuteNonQuery();
+                    }
+                    using (SqlCommand command = connection.CreateCommand())
+                    {
+                        command.CommandText = "INSERT INTO mytable VALUES ('11', '22')";
+                        command.ExecuteNonQuery();
+                    }
+                    */
+                    using (SqlCommand command = connection.CreateCommand())
+                    {
+                        command.CommandText = "INSERT INTO mytable VALUES ('33', '44')";
+                        command.ExecuteNonQuery();
+                    }
+                }
+                txScope.Complete();
+            }
         }
     }
 }

--- a/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
@@ -11,8 +11,12 @@
   <ItemGroup>
     <Compile Include="CloneTests.cs" />
     <Compile Include="BaseProviderAsyncTest\BaseProviderAsyncTest.cs" />
-    <Compile Include="BaseProviderAsyncTest\MockCommand.cs" />
-    <Compile Include="BaseProviderAsyncTest\MockConnection.cs" />
+    <Compile Include="BaseProviderAsyncTest\MockCommand.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Include="BaseProviderAsyncTest\MockConnection.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="BaseProviderAsyncTest\MockDataReader.cs" />
     <Compile Include="DiagnosticTest.cs" />
     <Compile Include="AmbientTransactionFailureTest.cs" />

--- a/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
@@ -11,12 +11,8 @@
   <ItemGroup>
     <Compile Include="CloneTests.cs" />
     <Compile Include="BaseProviderAsyncTest\BaseProviderAsyncTest.cs" />
-    <Compile Include="BaseProviderAsyncTest\MockCommand.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Include="BaseProviderAsyncTest\MockConnection.cs">
-      <SubType>Component</SubType>
-    </Compile>
+    <Compile Include="BaseProviderAsyncTest\MockCommand.cs" />
+    <Compile Include="BaseProviderAsyncTest\MockConnection.cs" />
     <Compile Include="BaseProviderAsyncTest\MockDataReader.cs" />
     <Compile Include="DiagnosticTest.cs" />
     <Compile Include="AmbientTransactionFailureTest.cs" />

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/TransactionTest/TransactionEnlistmentTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/TransactionTest/TransactionEnlistmentTest.cs
@@ -11,7 +11,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
     public class TransactionEnlistmentTest
     {
         [CheckConnStrSetupFact]
-        public static void Test8__()
+        public static void TestAmbientTransaction_TxScopeComplete()
         {
             const int inputCol1 = 1;
             const string inputCol2 = "one";
@@ -20,7 +20,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             string connectionString = builder.ConnectionString;
             string testTableName = GenerateTableName();
 
-            RunNonQuery(connectionString, string.Format("create table {0} (col1 int, col2 text)", testTableName));
+            RunNonQuery(connectionString, $"create table {testTableName} (col1 int, col2 text)");
 
             try
             {
@@ -31,20 +31,20 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                         connection.Open();
                         using (SqlCommand command = connection.CreateCommand())
                         {
-                            command.CommandText = string.Format("INSERT INTO {0} VALUES ({1}, '{2}')", testTableName, inputCol1, inputCol2);
+                            command.CommandText = $"INSERT INTO {testTableName} VALUES ({inputCol1}, '{inputCol2}')";
                             command.ExecuteNonQuery();
                         }
                     }
                     txScope.Complete();
                 }
 
-                DataTable result = RunQuery(connectionString, string.Format("select col2 from {0} where col1 = {1}", testTableName, inputCol1));
+                DataTable result = RunQuery(connectionString, $"select col2 from {testTableName} where col1 = {inputCol1}");
                 Assert.True(result.Rows.Count > 0);
                 Assert.True(string.Equals(result.Rows[0][0], inputCol2));
             }
             finally
             {
-                RunNonQuery(connectionString, string.Format("drop table {0}", testTableName));
+                RunNonQuery(connectionString, $"drop table {testTableName}");
             }
         }
 

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/TransactionTest/TransactionEnlistmentTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/TransactionTest/TransactionEnlistmentTest.cs
@@ -13,8 +13,6 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [CheckConnStrSetupFact]
         public static void Test8__()
         {
-            Console.WriteLine("Test8__");
-
             const int inputCol1 = 1;
             const string inputCol2 = "one";
 
@@ -74,18 +72,6 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                     command.CommandText = sql;
                     using (SqlDataReader reader = command.ExecuteReader())
                     {
-                        /*
-                        result = new List<Object[]>();
-                        while(reader.Read())
-                        {
-                            Object[] row = new Object[reader.FieldCount];
-                            for (int j = 0; j < reader.FieldCount; ++j)
-                            {
-                                row[j] = reader.GetValue(j);
-                            }
-                            result.Add(row);
-                        }
-                        */
                         result = new DataTable();
                         result.Load(reader);
                     }

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/TransactionTest/TransactionEnlistmentTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/TransactionTest/TransactionEnlistmentTest.cs
@@ -1,0 +1,102 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Transactions;
+using Xunit;
+
+namespace System.Data.SqlClient.ManualTesting.Tests
+{
+    public class TransactionEnlistmentTest
+    {
+        [CheckConnStrSetupFact]
+        public static void Test8__()
+        {
+            Console.WriteLine("Test8__");
+
+            const int inputCol1 = 1;
+            const string inputCol2 = "one";
+
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr);
+            string connectionString = builder.ConnectionString;
+            string testTableName = GenerateTableName();
+
+            RunNonQuery(connectionString, string.Format("create table {0} (col1 int, col2 text)", testTableName));
+
+            try
+            {
+                using (TransactionScope txScope = new TransactionScope(TransactionScopeOption.Required, TimeSpan.MaxValue))
+                {
+                    using (SqlConnection connection = new SqlConnection(connectionString))
+                    {
+                        connection.Open();
+                        using (SqlCommand command = connection.CreateCommand())
+                        {
+                            command.CommandText = string.Format("INSERT INTO {0} VALUES ({1}, '{2}')", testTableName, inputCol1, inputCol2);
+                            command.ExecuteNonQuery();
+                        }
+                    }
+                    txScope.Complete();
+                }
+
+                DataTable result = RunQuery(connectionString, string.Format("select col2 from {0} where col1 = {1}", testTableName, inputCol1));
+                Assert.True(result.Rows.Count > 0);
+                Assert.True(string.Equals(result.Rows[0][0], inputCol2));
+            }
+            finally
+            {
+                RunNonQuery(connectionString, string.Format("drop table {0}", testTableName));
+            }
+        }
+
+        private static void RunNonQuery(string connectionString, string sql)
+        {
+            using (SqlConnection connection = new SqlConnection(connectionString))
+            {
+                connection.Open();
+                using (SqlCommand command = connection.CreateCommand())
+                {
+                    command.CommandText = sql;
+                    command.ExecuteNonQuery();
+                }
+            }
+        }
+
+        private static DataTable RunQuery(string connectionString, string sql)
+        {
+            DataTable result = null;
+            using (SqlConnection connection = new SqlConnection(connectionString))
+            {
+                connection.Open();
+                using (SqlCommand command = connection.CreateCommand())
+                {
+                    command.CommandText = sql;
+                    using (SqlDataReader reader = command.ExecuteReader())
+                    {
+                        /*
+                        result = new List<Object[]>();
+                        while(reader.Read())
+                        {
+                            Object[] row = new Object[reader.FieldCount];
+                            for (int j = 0; j < reader.FieldCount; ++j)
+                            {
+                                row[j] = reader.GetValue(j);
+                            }
+                            result.Add(row);
+                        }
+                        */
+                        result = new DataTable();
+                        result.Load(reader);
+                    }
+                }
+            }
+            return result;
+        }
+
+        private static string GenerateTableName()
+        {
+            return string.Format("TEST_{0}{1}{2}", Environment.GetEnvironmentVariable("ComputerName"), Environment.TickCount, Guid.NewGuid()).Replace('-', '_');
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
@@ -108,7 +108,7 @@
     <Compile Include="SQL\SplitPacketTest\SplitPacketTest.cs" />
     <Compile Include="SQL\SqlNotificationTest\SqlNotificationTest.cs" />
     <Compile Include="SQL\TransactionTest\TransactionTest.cs" />
-	<Compile Include="SQL\TransactionTest\TransactionEnlistmentTest.cs" />
+    <Compile Include="SQL\TransactionTest\TransactionEnlistmentTest.cs" />
     <Compile Include="SQL\WeakRefTest\WeakRefTest.cs" />
     <Compile Include="SQL\WeakRefTestYukonSpecific\WeakRefTestYukonSpecific.cs" />
     <Compile Include="XUnitAssemblyAttributes.cs" />

--- a/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
@@ -108,6 +108,7 @@
     <Compile Include="SQL\SplitPacketTest\SplitPacketTest.cs" />
     <Compile Include="SQL\SqlNotificationTest\SqlNotificationTest.cs" />
     <Compile Include="SQL\TransactionTest\TransactionTest.cs" />
+	<Compile Include="SQL\TransactionTest\TransactionEnlistmentTest.cs" />
     <Compile Include="SQL\WeakRefTest\WeakRefTest.cs" />
     <Compile Include="SQL\WeakRefTestYukonSpecific\WeakRefTestYukonSpecific.cs" />
     <Compile Include="XUnitAssemblyAttributes.cs" />


### PR DESCRIPTION
Code related to SQL transaction was ported from NET Framework for supporting TransactionScope and TransactionBinding.