### PR TITLE
Replace RETAILVERIFY in MS.CSharp with Debug.Assert

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
@@ -57,15 +57,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         private static long I64(long x) { return x; }
         private static long I64(ulong x) { return (long)x; }
 
-        private static void RETAILVERIFY(bool b)
-        {
-            if (!b)
-            {
-                Debug.Assert(false, "panic!");
-                throw Error.InternalCompilerError();
-            }
-        }
-
         // 13.1.2 Implicit numeric conversions
         //
         // The implicit numeric conversions are:
@@ -250,8 +241,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 #if DEBUG
             CheckBetterTable();
 #endif // DEBUG
-            RETAILVERIFY((int)pt1 < NUM_EXT_TYPES);
-            RETAILVERIFY((int)pt2 < NUM_EXT_TYPES);
+            Debug.Assert((int)pt1 < NUM_EXT_TYPES);
+            Debug.Assert((int)pt2 < NUM_EXT_TYPES);
             return (BetterType)s_simpleTypeBetter[(int)pt1][(int)pt2];
         }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
@@ -1243,7 +1243,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public Expr BindStandardUnaryOperator(OperatorKind op, Expr pArgument)
         {
-            RETAILVERIFY(pArgument != null);
+            Debug.Assert(pArgument != null);
 
             ExpressionKind ek;
             UnaOpKind unaryOpKind;
@@ -1340,7 +1340,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
             }
 
-            RETAILVERIFY(nBestSignature < pSignatures.Count);
+            Debug.Assert(nBestSignature < pSignatures.Count);
 
             UnaOpFullSig uofs = pSignatures[nBestSignature];
 
@@ -2471,7 +2471,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
          */
         private ExprOperator ambiguousOperatorError(ExpressionKind ek, Expr op1, Expr op2)
         {
-            RETAILVERIFY(op1 != null);
+            Debug.Assert(op1 != null);
 
             // This is exactly the same "hack" that BadOperatorError uses. The first operand contains the
             // name of the operator in its errorString.
@@ -2494,9 +2494,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         private Expr BindUserBoolOp(ExpressionKind kind, ExprCall pCall)
         {
-            RETAILVERIFY(pCall != null);
-            RETAILVERIFY(pCall.MethWithInst.Meth() != null);
-            RETAILVERIFY(pCall.OptionalArguments != null);
+            Debug.Assert(pCall != null);
+            Debug.Assert(pCall.MethWithInst.Meth() != null);
+            Debug.Assert(pCall.OptionalArguments != null);
             Debug.Assert(kind == ExpressionKind.LogicalAnd || kind == ExpressionKind.LogicalOr);
 
             CType typeRet = pCall.Type;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/PredefinedMembers.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/PredefinedMembers.cs
@@ -237,12 +237,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     // Also finds constructors on delegate types.
     internal sealed class PredefinedMembers
     {
-        private static void RETAILVERIFY(bool f)
-        {
-            if (!f)
-                Debug.Assert(false, "panic!");
-        }
-
         private readonly SymbolLoader _loader;
         internal SymbolTable RuntimeBinderSymbolTable;
         private readonly MethodSymbol[] _methods = new MethodSymbol[(int)PREDEFMETH.PM_COUNT];
@@ -301,7 +295,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         // property specific helpers
         private PropertySymbol EnsureProperty(PREDEFPROP property)
         {
-            RETAILVERIFY((int)property > (int)PREDEFMETH.PM_FIRST && (int)property < (int)PREDEFMETH.PM_COUNT);
+            Debug.Assert((int)property > (int)PREDEFMETH.PM_FIRST && (int)property < (int)PREDEFMETH.PM_COUNT);
 
             if (_properties[(int)property] == null)
             {
@@ -557,7 +551,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         private MethodSymbol EnsureMethod(PREDEFMETH method)
         {
-            RETAILVERIFY(method > PREDEFMETH.PM_FIRST && method < PREDEFMETH.PM_COUNT);
+            Debug.Assert(method > PREDEFMETH.PM_FIRST && method < PREDEFMETH.PM_COUNT);
             if (_methods[(int)method] == null)
             {
                 _methods[(int)method] = LoadMethod(method);
@@ -702,16 +696,16 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         private static PredefinedPropertyInfo GetPropInfo(PREDEFPROP property)
         {
-            RETAILVERIFY(property > PREDEFPROP.PP_FIRST && property < PREDEFPROP.PP_COUNT);
-            RETAILVERIFY(s_predefinedProperties[(int)property].property == property);
+            Debug.Assert(property > PREDEFPROP.PP_FIRST && property < PREDEFPROP.PP_COUNT);
+            Debug.Assert(s_predefinedProperties[(int)property].property == property);
 
             return s_predefinedProperties[(int)property];
         }
 
         private static PredefinedMethodInfo GetMethInfo(PREDEFMETH method)
         {
-            RETAILVERIFY(method > PREDEFMETH.PM_FIRST && method < PREDEFMETH.PM_COUNT);
-            RETAILVERIFY(s_predefinedMethods[(int)method].method == method);
+            Debug.Assert(method > PREDEFMETH.PM_FIRST && method < PREDEFMETH.PM_COUNT);
+            Debug.Assert(s_predefinedMethods[(int)method].method == method);
 
             return s_predefinedMethods[(int)method];
         }


### PR DESCRIPTION
There are two such methods. One simplifies to a call to `Debug.Assert` and so can obviously be replace with it, reducing retail builds.

The other would throw `RuntimeBinderInternalCompilerException` but all calls do seem more reasonable as asserts than runtime checks.