### PR TITLE
Re-enabling ClientWebSocket close and cancel tests in UWP

### DIFF
--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinRTWebSocket.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinRTWebSocket.cs
@@ -177,7 +177,7 @@ namespace System.Net.WebSockets
             AbortInternal();
         }
 
-        private void AbortInternal(WebSocketException customException = null)
+        private void AbortInternal(Exception customException = null)
         {
             lock (_stateLock)
             {
@@ -196,7 +196,7 @@ namespace System.Net.WebSockets
             Dispose();
         }
 
-        private void CancelAllOperations(WebSocketException customException)
+        private void CancelAllOperations(Exception customException)
         {
             if (_receiveAsyncBufferTcs != null)
             {
@@ -412,7 +412,7 @@ namespace System.Net.WebSockets
                         break;
                 }
 
-                // Propagate a custom exception to any pending SendAsync/ReceiveAsync operations and close the socket.
+                // Propagate a custom exception to any pending SendAsync/CloseAsync operations and close the socket.
                 WebSocketException customException = new WebSocketException(actualError, exc);
                 AbortInternal(customException);
             }
@@ -469,7 +469,14 @@ namespace System.Net.WebSockets
             }
 
             CancellationTokenRegistration cancellationRegistration =
-                cancellationToken.Register(s => ((WinRTWebSocket)s).Abort(), this);
+                cancellationToken.Register(s =>
+                {
+                    var thisRef = (WinRTWebSocket)s;
+
+                    // Propagate a custom exception to any pending SendAsync/CloseAsync operations and close the socket.
+                    var customException = new OperationCanceledException(nameof(WebSocketState.Aborted));
+                    thisRef.AbortInternal(customException);
+                }, this);
 
             return cancellationRegistration;
         }
@@ -545,21 +552,6 @@ namespace System.Net.WebSockets
             if ((_state != WebSocketState.Closed) && (_state != WebSocketState.Aborted))
             {
                 _state = value;
-            }
-        }
-
-        private void UpdateStateCloseReceived()
-        {
-            lock (_stateLock)
-            {
-                if (_state == WebSocketState.CloseSent)
-                {
-                    UpdateState(WebSocketState.Closed);
-                }
-                else if (_state == WebSocketState.Open)
-                {
-                    UpdateState(WebSocketState.CloseReceived);
-                }
             }
         }
         #endregion

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinRTWebSocket.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinRTWebSocket.cs
@@ -412,7 +412,7 @@ namespace System.Net.WebSockets
                         break;
                 }
 
-                // Propagate a custom exception to any pending SendAsync/CloseAsync operations and close the socket.
+                // Propagate a custom exception to any pending ReceiveAsync/CloseAsync operations and close the socket.
                 WebSocketException customException = new WebSocketException(actualError, exc);
                 AbortInternal(customException);
             }
@@ -473,7 +473,7 @@ namespace System.Net.WebSockets
                 {
                     var thisRef = (WinRTWebSocket)s;
 
-                    // Propagate a custom exception to any pending SendAsync/CloseAsync operations and close the socket.
+                    // Propagate a custom exception to any pending ReceiveAsync/CloseAsync operations and close the socket.
                     var customException = new OperationCanceledException(nameof(WebSocketState.Aborted));
                     thisRef.AbortInternal(customException);
                 }, this);

--- a/src/System.Net.WebSockets.Client/tests/CancelTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/CancelTest.cs
@@ -10,7 +10,6 @@ using Xunit.Abstractions;
 
 namespace System.Net.WebSockets.Client.Tests
 {
-    [ActiveIssue(20132, TargetFrameworkMonikers.Uap)]
     public class CancelTest : ClientWebSocketTestBase
     {
         public CancelTest(ITestOutputHelper output) : base(output) { }

--- a/src/System.Net.WebSockets.Client/tests/CloseTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/CloseTest.cs
@@ -13,7 +13,6 @@ using Xunit.Abstractions;
 
 namespace System.Net.WebSockets.Client.Tests
 {
-    [ActiveIssue(20132, TargetFrameworkMonikers.Uap)]
     public class CloseTest : ClientWebSocketTestBase
     {
         public CloseTest(ITestOutputHelper output) : base(output) { }
@@ -257,6 +256,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
+        [ActiveIssue(20362, TargetFrameworkMonikers.Uap)]
         [ActiveIssue(20362, TargetFrameworkMonikers.NetFramework)]
         [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]


### PR DESCRIPTION
Re-enabling ClientWebSocket's CloseTest and CancelTest runs for UWP.

All of these tests pass after a minor behavioral fix, where the "cancel pending ReceiveAsync" scenario was resulting in a different exception type compared to .NET Framework and non-UWP .NET Core. The following CancelTest test cases caught the bad behavior that I'm fixing as part of this PR:

- ReceiveAsync_CancelThenReceive_ThrowsOperationCanceledException
- ReceiveAsync_ReceiveThenCancel_ThrowsOperationCanceledException
- ReceiveAsync_AfterCancellationDoReceiveAsync_ThrowsWebSocketException

Contributes to #20132