### PR TITLE
Optimise Microsoft.CSharp's AllPossibleInterfaces method.

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/UtilityTypeExtensions.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/UtilityTypeExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -44,20 +45,32 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     yield return t;
         }
 
-        public static IEnumerable<CType> AllPossibleInterfaces(this CType type)
+        public static IEnumerable<AggregateType> AllPossibleInterfaces(this CType type)
         {
             Debug.Assert(type != null);
-            if (type.IsAggregateType())
+            if (type is AggregateType ats)
             {
-                foreach (CType t in type.AsAggregateType().TypeAndBaseClassInterfaces())
-                    yield return t;
+                return ats.TypeAndBaseClassInterfaces();
             }
-            else if (type.IsTypeParameterType())
+
+            if (type is TypeParameterType typeParameter)
             {
-                foreach (CType t in type.AsTypeParameterType().GetEffectiveBaseClass().TypeAndBaseClassInterfaces())
-                    yield return t;
-                foreach (CType t in type.AsTypeParameterType().GetInterfaceBounds().AllConstraintInterfaces())
-                    yield return t;
+                return AllPossibleInterfaces(typeParameter);
+            }
+
+            return Array.Empty<AggregateType>();
+        }
+
+        private static IEnumerable<AggregateType> AllPossibleInterfaces(TypeParameterType type)
+        {
+            foreach (AggregateType t in type.GetEffectiveBaseClass().TypeAndBaseClassInterfaces())
+            {
+                yield return t;
+            }
+
+            foreach (AggregateType t in type.GetInterfaceBounds().AllConstraintInterfaces())
+            {
+                yield return t;
             }
         }
     }


### PR DESCRIPTION
Loops are casting up unnecessarily, forcing downcast by consumer.

Change to return `IEnumerable<AggregateType>` instead.

Split possible paths into separate functions, for simpler iterators.