### PR TITLE
Iterate TypeArray's inner array instead of TypeArray when safe.

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -705,11 +705,8 @@ namespace Microsoft.CSharp.RuntimeBinder
             // as well so that overload resolution can find them.
             if (callingType.IsWindowsRuntimeType())
             {
-                TypeArray collectioniFaces = callingType.GetWinRTCollectionIfacesAll(SymbolLoader);
-
-                for (int i = 0; i < collectioniFaces.Count; i++)
+                foreach (CType t in callingType.GetWinRTCollectionIfacesAll(SymbolLoader).Items)
                 {
-                    CType t = collectioniFaces[i];
                     // Collection interfaces will be aggregates.
                     Debug.Assert(t.IsAggregateType());
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -1439,13 +1439,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
 
                 // We need to check unsafe on the parameters as well, since we cannot check in conversion.
-                TypeArray pParams = pMWI.Meth().Params;
-
-                for (int i = 0; i < pParams.Count; i++)
+                foreach (CType type in pMWI.Meth().Params.Items)
                 {
                     // This is an optimization: don't call this in the vast majority of cases
-                    CType type = pParams[i];
-
                     if (type.isUnsafe())
                     {
                         checkUnsafe(type);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
@@ -322,11 +322,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                         if (_pCurrentType.isInterfaceType())
                         {
-                            TypeArray ifaces = _pCurrentType.GetIfacesAll();
-                            for (int i = 0; i < ifaces.Count; i++)
+                            foreach (AggregateType type in _pCurrentType.GetIfacesAll().Items)
                             {
-                                AggregateType type = ifaces[i].AsAggregateType();
-
                                 Debug.Assert(type.isInterfaceType());
                                 _HiddenTypes.Add(type);
                             }
@@ -1242,10 +1239,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     return false;
                 }
 
-                TypeArray typeVars = var.AsAggregateType().GetTypeArgsAll();
-                for (int i = 0; i < typeVars.Count; i++)
+                foreach (CType type in var.AsAggregateType().GetTypeArgsAll().Items)
                 {
-                    CType type = typeVars[i];
                     if (type.IsErrorType())
                     {
                         return true;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinderResult.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinderResult.cs
@@ -56,9 +56,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             private static int NumberOfErrorTypes(TypeArray pTypeArgs)
             {
                 int nCount = 0;
-                for (int i = 0; i < pTypeArgs.Count; i++)
+                foreach (CType typeArg in pTypeArgs.Items)
                 {
-                    if (pTypeArgs[i].IsErrorType())
+                    if (typeArg.IsErrorType())
                     {
                         nCount++;
                     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookup.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookup.cs
@@ -475,9 +475,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 typeStart.fDiffHidden = (_swtFirst != null);
             }
 
-            for (int i = 0; i < types.Count; i++)
+            foreach (AggregateType type in types.Items)
             {
-                AggregateType type = types[i].AsAggregateType();
                 Debug.Assert(type.isInterfaceType());
                 type.fAllHidden = false;
                 type.fDiffHidden = !!_swtFirst;
@@ -505,10 +504,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     fHideByName |= !_fMulti;
 
                     // Mark base interfaces appropriately.
-                    TypeArray ifaces = typeCur.GetIfacesAll();
-                    for (int i = 0; i < ifaces.Count; i++)
+                    foreach (AggregateType type in typeCur.GetIfacesAll().Items)
                     {
-                        AggregateType type = ifaces[i].AsAggregateType();
                         Debug.Assert(type.isInterfaceType());
                         if (fHideByName)
                             type.fAllHidden = true;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SemanticChecker.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SemanticChecker.cs
@@ -102,10 +102,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
             }
 
-            TypeArray typeArgs = type.AsAggregateType().GetTypeArgsAll();
-            for (int i = 0; i < typeArgs.Count; i++)
+            foreach (CType typeArg in type.AsAggregateType().GetTypeArgsAll().Items)
             {
-                if (!CheckTypeAccess(typeArgs[i], symWhere))
+                if (!CheckTypeAccess(typeArg, symWhere))
                     return false;
             }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/MethodSymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/MethodSymbol.cs
@@ -44,9 +44,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
             Debug.Assert(!_inferenceMustFail);
             _checkedInfMustFail = true;
-            for (int ivar = 0; ivar < typeVars.Count; ivar++)
+
+            foreach (CType type in typeVars.Items)
             {
-                TypeParameterType var = typeVars.ItemAsTypeParameterType(ivar);
+                TypeParameterType var = type as TypeParameterType;
                 // See if type var is used in a parameter.
                 for (int ipar = 0; ; ipar++)
                 {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
@@ -160,11 +160,15 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         {
                             fBogus = meth.RetType.computeCurrentBogusState();
                         }
-                        if (meth.Params != null)
+                        if (!fBogus && meth.Params != null)
                         {
-                            for (int i = 0; !fBogus && i < meth.Params.Count; i++)
+                            foreach (CType methParam in meth.Params.Items)
                             {
-                                fBogus |= meth.Params[i].computeCurrentBogusState();
+                                if (methParam.computeCurrentBogusState())
+                                {
+                                    fBogus = true;
+                                    break;
+                                }
                             }
                         }
                     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolLoader.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolLoader.cs
@@ -199,10 +199,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             AggregateType atsDer = pDerived.AsAggregateType();
             while (atsDer != null)
             {
-                TypeArray ifacesAll = atsDer.GetIfacesAll();
-                for (int i = 0; i < ifacesAll.Count; i++)
+                foreach (CType iface in atsDer.GetIfacesAll().Items)
                 {
-                    if (AreTypesEqualForConversion(ifacesAll[i], pBase))
+                    if (AreTypesEqualForConversion(iface, pBase))
                     {
                         return true;
                     }
@@ -499,10 +498,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
             // * From T to any interface type I in T's effective interface set, and
             //   from T to any base interface of I.
-            TypeArray pInterfaces = pSource.GetInterfaceBounds();
-            for (int i = 0; i < pInterfaces.Count; ++i)
+            foreach (CType iface in pSource.GetInterfaceBounds().Items)
             {
-                if (pInterfaces[i] == pDest)
+                if (iface == pDest)
                 {
                     return true;
                 }
@@ -528,10 +526,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             AggregateType atsDer = pDerived.AsAggregateType();
             while (atsDer != null)
             {
-                TypeArray ifacesAll = atsDer.GetIfacesAll();
-                for (int i = 0; i < ifacesAll.Count; i++)
+                foreach (CType iface in atsDer.GetIfacesAll().Items)
                 {
-                    if (HasInterfaceConversion(ifacesAll[i].AsAggregateType(), pBase.AsAggregateType()))
+                    if (HasInterfaceConversion(iface.AsAggregateType(), pBase.AsAggregateType()))
                     {
                         return true;
                     }
@@ -658,10 +655,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
             // * From T to any interface type I in T's effective interface set, and
             //   from T to any base interface of I.
-            TypeArray pInterfaces = pSource.GetInterfaceBounds();
-            for (int i = 0; i < pInterfaces.Count; ++i)
+            foreach (CType iface in pSource.GetInterfaceBounds().Items)
             {
-                if (pInterfaces[i] == pDest)
+                if (iface == pDest)
                 {
                     return true;
                 }
@@ -819,9 +815,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                 while (derived != null)
                 {
-                    for (int i = 0; i < derived.GetIfacesAll().Count; i++)
+                    foreach (AggregateType iface in derived.GetIfacesAll().Items)
                     {
-                        AggregateType iface = derived.GetIfacesAll()[i].AsAggregateType();
                         if (iface.getAggregate() == @base)
                             return true;
                     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/TypeBind.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/TypeBind.cs
@@ -92,9 +92,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 ats.fConstraintError |= !CheckConstraintsCore(checker, errHandling, ats.getAggregate(), typeVars, typeArgsThis, typeArgsAll, null, (flags & CheckConstraintsFlags.NoErrors));
 
             // Now check type args themselves.
-            for (int i = 0; i < typeArgsThis.Count; i++)
+            foreach (CType typeArg in typeArgsThis.Items)
             {
-                CType arg = typeArgsThis[i].GetNakedType(true);
+                CType arg = typeArg.GetNakedType(true);
                 if (arg.IsAggregateType() && !arg.AsAggregateType().fConstraintsChecked)
                 {
                     CheckConstraints(checker, errHandling, arg.AsAggregateType(), flags | CheckConstraintsFlags.Outer);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/AggregateType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/AggregateType.cs
@@ -116,19 +116,15 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         private bool AreAllTypeArgumentsUnitTypes(TypeArray typeArray)
         {
-            if (typeArray.Count == 0)
+            foreach (CType type in typeArray.Items)
             {
-                return true;
-            }
-
-            for (int i = 0; i < typeArray.Count; i++)
-            {
-                Debug.Assert(typeArray[i] != null);
-                if (!typeArray[i].IsOpenTypePlaceholderType())
+                Debug.Assert(type != null);
+                if (!type.IsOpenTypePlaceholderType())
                 {
                     return false;
                 }
             }
+
             return true;
         }
 
@@ -155,12 +151,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             if (_winrtifacesAll == null)
             {
-                TypeArray ifaces = GetIfacesAll();
                 System.Collections.Generic.List<CType> typeList = new System.Collections.Generic.List<CType>();
 
-                for (int i = 0; i < ifaces.Count; i++)
+                foreach (AggregateType type in GetIfacesAll().Items)
                 {
-                    AggregateType type = ifaces[i].AsAggregateType();
                     Debug.Assert(type.isInterfaceType());
 
                     if (type.IsCollectionType())

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
@@ -157,19 +157,18 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         private static Type CalculateAssociatedSystemTypeForAggregate(AggregateType aggtype)
         {
             AggregateSymbol agg = aggtype.GetOwningAggregate();
-            TypeArray typeArgs = aggtype.GetTypeArgsAll();
 
             List<Type> list = new List<Type>();
 
             // Get each type arg.
-            for (int i = 0; i < typeArgs.Count; i++)
+            foreach (CType typeArg in aggtype.GetTypeArgsAll().Items)
             {
                 // Unnamed type parameter types are just placeholders.
-                if (typeArgs[i].IsTypeParameterType() && typeArgs[i].AsTypeParameterType().GetTypeParameterSymbol().name == null)
+                if (typeArg.IsTypeParameterType() && typeArg.AsTypeParameterType().GetTypeParameterSymbol().name == null)
                 {
                     return null;
                 }
-                list.Add(typeArgs[i].AssociatedSystemType);
+                list.Add(typeArg.AssociatedSystemType);
             }
 
             Type[] systemTypeArgs = list.ToArray();
@@ -231,10 +230,18 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                 case TypeKind.TK_AggregateType:
                     fBogus = AsAggregateType().getAggregate().computeCurrentBogusState();
-                    for (int i = 0; !fBogus && i < AsAggregateType().GetTypeArgsAll().Count; i++)
+                    if (!fBogus)
                     {
-                        fBogus |= AsAggregateType().GetTypeArgsAll()[i].computeCurrentBogusState();
+                        foreach (CType typeArg in AsAggregateType().GetTypeArgsAll().Items)
+                        {
+                            if (typeArg.computeCurrentBogusState())
+                            {
+                                fBogus = true;
+                                break;
+                            }
+                        }
                     }
+
                     break;
 
                 case TypeKind.TK_TypeParameterType:

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -805,9 +805,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     { // BLOCK
                         AggregateType ats = type.AsAggregateType();
 
-                        for (int i = 0; i < ats.GetTypeArgsAll().Count; i++)
+                        foreach (CType typeArg in ats.GetTypeArgsAll().Items)
                         {
-                            if (TypeContainsType(ats.GetTypeArgsAll()[i], typeFind))
+                            if (TypeContainsType(typeArg, typeFind))
                                 return true;
                         }
                     }
@@ -819,9 +819,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         ErrorType err = type.AsErrorType();
                         Debug.Assert(err.nameText != null && err.typeArgs != null);
 
-                        for (int i = 0; i < err.typeArgs.Count; i++)
+                        foreach (CType errTypeArg in err.typeArgs.Items)
                         {
-                            if (TypeContainsType(err.typeArgs[i], typeFind))
+                            if (TypeContainsType(errTypeArg, typeFind))
                                 return true;
                         }
                         if (err.HasTypeParent())
@@ -865,9 +865,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     { // BLOCK
                         AggregateType ats = type.AsAggregateType();
 
-                        for (int i = 0; i < ats.GetTypeArgsAll().Count; i++)
+                        foreach (CType typeArg in ats.GetTypeArgsAll().Items)
                         {
-                            if (TypeContainsTyVars(ats.GetTypeArgsAll()[i], typeVars))
+                            if (TypeContainsTyVars(typeArg, typeVars))
                             {
                                 return true;
                             }
@@ -881,9 +881,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         ErrorType err = type.AsErrorType();
                         Debug.Assert(err.nameText != null && err.typeArgs != null);
 
-                        for (int i = 0; i < err.typeArgs.Count; i++)
+                        foreach (CType errTypeArg in err.typeArgs.Items)
                         {
-                            if (TypeContainsTyVars(err.typeArgs[i], typeVars))
+                            if (TypeContainsTyVars(errTypeArg, typeVars))
                             {
                                 return true;
                             }
@@ -910,9 +910,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             Debug.Assert(@params != null);
             Debug.Assert(typeFind != null);
-            for (int p = 0; p < @params.Count; p++)
+            foreach (CType sym in @params.Items)
             {
-                CType sym = @params[p];
                 if (TypeContainsType(sym, typeFind))
                 {
                     return true;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeParameterType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeParameterType.cs
@@ -25,10 +25,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // * If a type parameter S depends on a type parameter T and T depends on
             //   U then S depends on U.
 
-            TypeArray pConstraints = GetBounds();
-            for (int iConstraint = 0; iConstraint < pConstraints.Count; ++iConstraint)
+            foreach (CType pConstraint in GetBounds().Items)
             {
-                CType pConstraint = pConstraints[iConstraint];
                 if (pConstraint == pType)
                 {
                     return true;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
@@ -326,11 +326,8 @@ namespace Microsoft.CSharp.RuntimeBinder
             CType ctype = GetCTypeFromType(type);
             if (ctype.IsWindowsRuntimeType())
             {
-                TypeArray collectioniFaces = ctype.AsAggregateType().GetWinRTCollectionIfacesAll(_semanticChecker.GetSymbolLoader());
-
-                for (int i = 0; i < collectioniFaces.Count; i++)
+                foreach (CType collectionType in ctype.AsAggregateType().GetWinRTCollectionIfacesAll(_semanticChecker.GetSymbolLoader()).Items)
                 {
-                    CType collectionType = collectioniFaces[i];
                     Debug.Assert(collectionType.isInterfaceType());
 
                     // Insert into our list of Types.


### PR DESCRIPTION
Rewrite enumerations of `TypeArray`s in Microsoft.CSharp to instead enumerate on the inner array, allowing bounds check eliminations and removing some indirection.

This could be done in more places, but for now conservatively only done where the "translation" is direct, so more easily confirmed as safely equivalent to the existing code, and no local holds the array and no slip-up could overwrite an element.