### PR TITLE
Add RIDs for Amazon Linux.

### DIFF
--- a/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -930,6 +930,41 @@
         "opensuse.42.1-x64-corert": {
             "#import": [ "opensuse.42.1-corert", "opensuse.13.2-x64-corert", "opensuse.42.1-x64" ]
         },
-
+        "amzn": {
+            "#import": [ "linux" ]
+        },
+        "amzn-x64": {
+            "#import": [ "amzn", "linux-x64" ]
+        },
+        "amzn.2015.03": {
+            "#import": [ "amzn" ]
+        },
+        "amzn.2015.03-x64": {
+            "#import": [ "amzn.2015.03", "amzn-x64" ]
+        },
+        "amzn.2015.09": {
+            "#import": [ "amzn.2015.03" ]
+        },
+        "amzn.2015.09-x64": {
+            "#import": [ "amzn.2015.09", "amzn.2015.03-x64" ]
+        },
+        "amzn.2016.03": {
+            "#import": [ "amzn.2015.09" ]
+        },
+        "amzn.2016.03-x64": {
+            "#import": [ "amzn.2016.03", "amzn.2015.09-x64" ]
+        },
+        "amzn.2016.09": {
+            "#import": [ "amzn.2016.03" ]
+        },
+        "amzn.2016.09-x64": {
+            "#import": [ "amzn.2016.09", "amzn.2016.03-x64" ]
+        },
+        "amzn.2017.03": {
+            "#import": [ "amzn.2016.09" ]
+        },
+        "amzn.2017.03-x64": {
+            "#import": [ "amzn.2017.03", "amzn.2016.09-x64" ]
+        },
     }
 }


### PR DESCRIPTION
PR to add Amazon Linux RIDs to runtime.json. Related to #21591. 

- /etc/os-release is available on Amazon Linux. Here is an example.
```
NAME="Amazon Linux AMI"
VERSION="2017.03"
ID="amzn"
ID_LIKE="rhel fedora"
VERSION_ID="2017.03"
PRETTY_NAME="Amazon Linux AMI 2017.03"
ANSI_COLOR="0;33"
CPE_NAME="cpe:/o:amazon:linux:2017.03:ga"
HOME_URL="http://aws.amazon.com/amazon-linux-ami/"
```
- VERSION_ID is always in the form _year.month_ .
