### PR TITLE
Remove dead error case from MS.CSharp and test some other error cases.

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Error.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Error.cs
@@ -58,11 +58,6 @@ namespace Microsoft.CSharp.RuntimeBinder
             return new ArgumentException(SR.BindImplicitConversionRequireOneArgument);
         }
 
-        internal static Exception BindExplicitConversionRequireOneArgument()
-        {
-            return new ArgumentException(SR.BindExplicitConversionRequireOneArgument);
-        }
-
         internal static Exception BindBinaryAssignmentFailedNullReference()
         {
             return new RuntimeBinderException(SR.BindBinaryAssignmentFailedNullReference);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Error.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Error.cs
@@ -53,11 +53,6 @@ namespace Microsoft.CSharp.RuntimeBinder
             return new RuntimeBinderException(SR.BindInvokeFailedNonDelegate);
         }
 
-        internal static Exception BindImplicitConversionRequireOneArgument()
-        {
-            return new ArgumentException(SR.BindImplicitConversionRequireOneArgument);
-        }
-
         internal static Exception BindBinaryAssignmentFailedNullReference()
         {
             return new RuntimeBinderException(SR.BindBinaryAssignmentFailedNullReference);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -1505,10 +1505,7 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         internal Expr BindExplicitConversion(ArgumentObject[] arguments, Type returnType, LocalVariableSymbol[] locals)
         {
-            if (arguments.Length != 1)
-            {
-                throw Error.BindExplicitConversionRequireOneArgument();
-            }
+            Debug.Assert(arguments.Length == 1);
 
             // Load the conversions on the target.
             _symbolTable.AddConversionsForType(returnType);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -1463,10 +1463,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             LocalVariableSymbol[] locals,
             bool bIsArrayCreationConversion)
         {
-            if (arguments.Length != 1)
-            {
-                throw Error.BindImplicitConversionRequireOneArgument();
-            }
+            Debug.Assert(arguments.Length == 1);
 
             // Load the conversions on the target.
             _symbolTable.AddConversionsForType(returnType);

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.de.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.de.xlf
@@ -42,10 +42,6 @@
           <source>Implicit conversion takes exactly one argument</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Eine implizite Konvertierung akzeptiert genau ein Argument.</target>
         </trans-unit>
-        <trans-unit id="BindExplicitConversionRequireOneArgument" translate="yes" xml:space="preserve">
-          <source>Explicit conversion takes exactly one argument</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Eine explizite Konvertierung akzeptiert genau ein Argument.</target>
-        </trans-unit>
         <trans-unit id="BindBinaryAssignmentRequireTwoArguments" translate="yes" xml:space="preserve">
           <source>Binary operators cannot be invoked with one argument</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Binäre Operatoren können nicht mit einem Argument aufgerufen werden.</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.de.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.de.xlf
@@ -38,10 +38,6 @@
           <source>Cannot invoke a non-delegate type</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Ein Nichtdelegattyp kann nicht aufgerufen werden.</target>
         </trans-unit>
-        <trans-unit id="BindImplicitConversionRequireOneArgument" translate="yes" xml:space="preserve">
-          <source>Implicit conversion takes exactly one argument</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Eine implizite Konvertierung akzeptiert genau ein Argument.</target>
-        </trans-unit>
         <trans-unit id="BindBinaryAssignmentRequireTwoArguments" translate="yes" xml:space="preserve">
           <source>Binary operators cannot be invoked with one argument</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Binäre Operatoren können nicht mit einem Argument aufgerufen werden.</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.es.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.es.xlf
@@ -38,10 +38,6 @@
           <source>Cannot invoke a non-delegate type</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">No se puede invocar un tipo no delegado.</target>
         </trans-unit>
-        <trans-unit id="BindImplicitConversionRequireOneArgument" translate="yes" xml:space="preserve">
-          <source>Implicit conversion takes exactly one argument</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">La conversión implícita toma exactamente un argumento.</target>
-        </trans-unit>
         <trans-unit id="BindBinaryAssignmentRequireTwoArguments" translate="yes" xml:space="preserve">
           <source>Binary operators cannot be invoked with one argument</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">No se pueden invocar operadores binarios con un argumento.</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.es.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.es.xlf
@@ -42,10 +42,6 @@
           <source>Implicit conversion takes exactly one argument</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">La conversión implícita toma exactamente un argumento.</target>
         </trans-unit>
-        <trans-unit id="BindExplicitConversionRequireOneArgument" translate="yes" xml:space="preserve">
-          <source>Explicit conversion takes exactly one argument</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">La conversión explícita toma exactamente un argumento.</target>
-        </trans-unit>
         <trans-unit id="BindBinaryAssignmentRequireTwoArguments" translate="yes" xml:space="preserve">
           <source>Binary operators cannot be invoked with one argument</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">No se pueden invocar operadores binarios con un argumento.</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.fr.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.fr.xlf
@@ -38,10 +38,6 @@
           <source>Cannot invoke a non-delegate type</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible d'appeler un type non-délégué</target>
         </trans-unit>
-        <trans-unit id="BindImplicitConversionRequireOneArgument" translate="yes" xml:space="preserve">
-          <source>Implicit conversion takes exactly one argument</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">La conversion implicite n'accepte qu'un seul argument</target>
-        </trans-unit>
         <trans-unit id="BindBinaryAssignmentRequireTwoArguments" translate="yes" xml:space="preserve">
           <source>Binary operators cannot be invoked with one argument</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible d'appeler les opérateurs binaires avec un argument</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.fr.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.fr.xlf
@@ -42,10 +42,6 @@
           <source>Implicit conversion takes exactly one argument</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">La conversion implicite n'accepte qu'un seul argument</target>
         </trans-unit>
-        <trans-unit id="BindExplicitConversionRequireOneArgument" translate="yes" xml:space="preserve">
-          <source>Explicit conversion takes exactly one argument</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">La conversion explicite n'accepte qu'un seul argument</target>
-        </trans-unit>
         <trans-unit id="BindBinaryAssignmentRequireTwoArguments" translate="yes" xml:space="preserve">
           <source>Binary operators cannot be invoked with one argument</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible d'appeler les opérateurs binaires avec un argument</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.it.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.it.xlf
@@ -42,10 +42,6 @@
           <source>Implicit conversion takes exactly one argument</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Per la conversione implicita viene accettato un solo argomento</target>
         </trans-unit>
-        <trans-unit id="BindExplicitConversionRequireOneArgument" translate="yes" xml:space="preserve">
-          <source>Explicit conversion takes exactly one argument</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Per la conversione esplicita viene accettato un solo argomento</target>
-        </trans-unit>
         <trans-unit id="BindBinaryAssignmentRequireTwoArguments" translate="yes" xml:space="preserve">
           <source>Binary operators cannot be invoked with one argument</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile richiamare operatori binari con un solo argomento</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.it.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.it.xlf
@@ -38,10 +38,6 @@
           <source>Cannot invoke a non-delegate type</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile richiamare un tipo non delegato</target>
         </trans-unit>
-        <trans-unit id="BindImplicitConversionRequireOneArgument" translate="yes" xml:space="preserve">
-          <source>Implicit conversion takes exactly one argument</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Per la conversione implicita viene accettato un solo argomento</target>
-        </trans-unit>
         <trans-unit id="BindBinaryAssignmentRequireTwoArguments" translate="yes" xml:space="preserve">
           <source>Binary operators cannot be invoked with one argument</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile richiamare operatori binari con un solo argomento</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ja.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ja.xlf
@@ -38,10 +38,6 @@
           <source>Cannot invoke a non-delegate type</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">非デリゲート型を呼び出すことはできません</target>
         </trans-unit>
-        <trans-unit id="BindImplicitConversionRequireOneArgument" translate="yes" xml:space="preserve">
-          <source>Implicit conversion takes exactly one argument</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">暗黙の型変換では 1 つの引数のみ受け取ります</target>
-        </trans-unit>
         <trans-unit id="BindBinaryAssignmentRequireTwoArguments" translate="yes" xml:space="preserve">
           <source>Binary operators cannot be invoked with one argument</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">1 つの引数を指定して二項演算子を呼び出すことはできません</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ja.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ja.xlf
@@ -42,10 +42,6 @@
           <source>Implicit conversion takes exactly one argument</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">暗黙の型変換では 1 つの引数のみ受け取ります</target>
         </trans-unit>
-        <trans-unit id="BindExplicitConversionRequireOneArgument" translate="yes" xml:space="preserve">
-          <source>Explicit conversion takes exactly one argument</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">明示的な変換では 1 つの引数のみ受け取ります</target>
-        </trans-unit>
         <trans-unit id="BindBinaryAssignmentRequireTwoArguments" translate="yes" xml:space="preserve">
           <source>Binary operators cannot be invoked with one argument</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">1 つの引数を指定して二項演算子を呼び出すことはできません</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ko.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ko.xlf
@@ -42,10 +42,6 @@
           <source>Implicit conversion takes exactly one argument</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">암시적 변환에서는 정확히 하나의 인수를 사용합니다.</target>
         </trans-unit>
-        <trans-unit id="BindExplicitConversionRequireOneArgument" translate="yes" xml:space="preserve">
-          <source>Explicit conversion takes exactly one argument</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">명시적 변환에서는 정확히 하나의 인수를 사용합니다.</target>
-        </trans-unit>
         <trans-unit id="BindBinaryAssignmentRequireTwoArguments" translate="yes" xml:space="preserve">
           <source>Binary operators cannot be invoked with one argument</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">하나의 인수를 사용하여 이항 연산자를 호출할 수 없습니다.</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ko.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ko.xlf
@@ -38,10 +38,6 @@
           <source>Cannot invoke a non-delegate type</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">비대리자 형식을 호출할 수 없습니다.</target>
         </trans-unit>
-        <trans-unit id="BindImplicitConversionRequireOneArgument" translate="yes" xml:space="preserve">
-          <source>Implicit conversion takes exactly one argument</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">암시적 변환에서는 정확히 하나의 인수를 사용합니다.</target>
-        </trans-unit>
         <trans-unit id="BindBinaryAssignmentRequireTwoArguments" translate="yes" xml:space="preserve">
           <source>Binary operators cannot be invoked with one argument</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">하나의 인수를 사용하여 이항 연산자를 호출할 수 없습니다.</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ru.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ru.xlf
@@ -42,10 +42,6 @@
           <source>Implicit conversion takes exactly one argument</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Для неявного преобразования нужен строго один аргумент</target>
         </trans-unit>
-        <trans-unit id="BindExplicitConversionRequireOneArgument" translate="yes" xml:space="preserve">
-          <source>Explicit conversion takes exactly one argument</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Для явного преобразования нужен строго один аргумент</target>
-        </trans-unit>
         <trans-unit id="BindBinaryAssignmentRequireTwoArguments" translate="yes" xml:space="preserve">
           <source>Binary operators cannot be invoked with one argument</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Невозможно вызвать бинарные операторы с использованием одного аргумента</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ru.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ru.xlf
@@ -38,10 +38,6 @@
           <source>Cannot invoke a non-delegate type</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Не удалось вызвать тип, не являющийся делегатом</target>
         </trans-unit>
-        <trans-unit id="BindImplicitConversionRequireOneArgument" translate="yes" xml:space="preserve">
-          <source>Implicit conversion takes exactly one argument</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Для неявного преобразования нужен строго один аргумент</target>
-        </trans-unit>
         <trans-unit id="BindBinaryAssignmentRequireTwoArguments" translate="yes" xml:space="preserve">
           <source>Binary operators cannot be invoked with one argument</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Невозможно вызвать бинарные операторы с использованием одного аргумента</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.zh-Hans.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.zh-Hans.xlf
@@ -42,10 +42,6 @@
           <source>Implicit conversion takes exactly one argument</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">隐式转换采用一个且仅一个参数</target>
         </trans-unit>
-        <trans-unit id="BindExplicitConversionRequireOneArgument" translate="yes" xml:space="preserve">
-          <source>Explicit conversion takes exactly one argument</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">显式转换采用一个且仅一个参数</target>
-        </trans-unit>
         <trans-unit id="BindBinaryAssignmentRequireTwoArguments" translate="yes" xml:space="preserve">
           <source>Binary operators cannot be invoked with one argument</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">无法使用一个参数调用二元运算符</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.zh-Hans.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.zh-Hans.xlf
@@ -38,10 +38,6 @@
           <source>Cannot invoke a non-delegate type</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">无法调用非委托类型</target>
         </trans-unit>
-        <trans-unit id="BindImplicitConversionRequireOneArgument" translate="yes" xml:space="preserve">
-          <source>Implicit conversion takes exactly one argument</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">隐式转换采用一个且仅一个参数</target>
-        </trans-unit>
         <trans-unit id="BindBinaryAssignmentRequireTwoArguments" translate="yes" xml:space="preserve">
           <source>Binary operators cannot be invoked with one argument</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">无法使用一个参数调用二元运算符</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.zh-Hant.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.zh-Hant.xlf
@@ -38,10 +38,6 @@
           <source>Cannot invoke a non-delegate type</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">無法叫用非委派型別</target>
         </trans-unit>
-        <trans-unit id="BindImplicitConversionRequireOneArgument" translate="yes" xml:space="preserve">
-          <source>Implicit conversion takes exactly one argument</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">隱含轉換只接受一個引數</target>
-        </trans-unit>
         <trans-unit id="BindBinaryAssignmentRequireTwoArguments" translate="yes" xml:space="preserve">
           <source>Binary operators cannot be invoked with one argument</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">無法以一個引數叫用二元運算子</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.zh-Hant.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.zh-Hant.xlf
@@ -42,10 +42,6 @@
           <source>Implicit conversion takes exactly one argument</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">隱含轉換只接受一個引數</target>
         </trans-unit>
-        <trans-unit id="BindExplicitConversionRequireOneArgument" translate="yes" xml:space="preserve">
-          <source>Explicit conversion takes exactly one argument</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">明確轉換只接受一個引數</target>
-        </trans-unit>
         <trans-unit id="BindBinaryAssignmentRequireTwoArguments" translate="yes" xml:space="preserve">
           <source>Binary operators cannot be invoked with one argument</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">無法以一個引數叫用二元運算子</target>

--- a/src/Microsoft.CSharp/src/Resources/Strings.de.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.de.resx
@@ -36,9 +36,6 @@
   <data name="BindInvokeFailedNonDelegate" xml:space="preserve">
     <value>Ein Nichtdelegattyp kann nicht aufgerufen werden.</value>
   </data>
-  <data name="BindImplicitConversionRequireOneArgument" xml:space="preserve">
-    <value>Eine implizite Konvertierung akzeptiert genau ein Argument.</value>
-  </data>
   <data name="BindBinaryAssignmentRequireTwoArguments" xml:space="preserve">
     <value>Binäre Operatoren können nicht mit einem Argument aufgerufen werden.</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.de.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.de.resx
@@ -39,9 +39,6 @@
   <data name="BindImplicitConversionRequireOneArgument" xml:space="preserve">
     <value>Eine implizite Konvertierung akzeptiert genau ein Argument.</value>
   </data>
-  <data name="BindExplicitConversionRequireOneArgument" xml:space="preserve">
-    <value>Eine explizite Konvertierung akzeptiert genau ein Argument.</value>
-  </data>
   <data name="BindBinaryAssignmentRequireTwoArguments" xml:space="preserve">
     <value>Binäre Operatoren können nicht mit einem Argument aufgerufen werden.</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.es.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.es.resx
@@ -39,9 +39,6 @@
   <data name="BindImplicitConversionRequireOneArgument" xml:space="preserve">
     <value>La conversión implícita toma exactamente un argumento.</value>
   </data>
-  <data name="BindExplicitConversionRequireOneArgument" xml:space="preserve">
-    <value>La conversión explícita toma exactamente un argumento.</value>
-  </data>
   <data name="BindBinaryAssignmentRequireTwoArguments" xml:space="preserve">
     <value>No se pueden invocar operadores binarios con un argumento.</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.es.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.es.resx
@@ -36,9 +36,6 @@
   <data name="BindInvokeFailedNonDelegate" xml:space="preserve">
     <value>No se puede invocar un tipo no delegado.</value>
   </data>
-  <data name="BindImplicitConversionRequireOneArgument" xml:space="preserve">
-    <value>La conversión implícita toma exactamente un argumento.</value>
-  </data>
   <data name="BindBinaryAssignmentRequireTwoArguments" xml:space="preserve">
     <value>No se pueden invocar operadores binarios con un argumento.</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.fr.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.fr.resx
@@ -36,9 +36,6 @@
   <data name="BindInvokeFailedNonDelegate" xml:space="preserve">
     <value>Impossible d'appeler un type non-délégué</value>
   </data>
-  <data name="BindImplicitConversionRequireOneArgument" xml:space="preserve">
-    <value>La conversion implicite n'accepte qu'un seul argument</value>
-  </data>
   <data name="BindBinaryAssignmentRequireTwoArguments" xml:space="preserve">
     <value>Impossible d'appeler les opérateurs binaires avec un argument</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.fr.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.fr.resx
@@ -39,9 +39,6 @@
   <data name="BindImplicitConversionRequireOneArgument" xml:space="preserve">
     <value>La conversion implicite n'accepte qu'un seul argument</value>
   </data>
-  <data name="BindExplicitConversionRequireOneArgument" xml:space="preserve">
-    <value>La conversion explicite n'accepte qu'un seul argument</value>
-  </data>
   <data name="BindBinaryAssignmentRequireTwoArguments" xml:space="preserve">
     <value>Impossible d'appeler les opérateurs binaires avec un argument</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.it.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.it.resx
@@ -39,9 +39,6 @@
   <data name="BindImplicitConversionRequireOneArgument" xml:space="preserve">
     <value>Per la conversione implicita viene accettato un solo argomento</value>
   </data>
-  <data name="BindExplicitConversionRequireOneArgument" xml:space="preserve">
-    <value>Per la conversione esplicita viene accettato un solo argomento</value>
-  </data>
   <data name="BindBinaryAssignmentRequireTwoArguments" xml:space="preserve">
     <value>Impossibile richiamare operatori binari con un solo argomento</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.it.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.it.resx
@@ -36,9 +36,6 @@
   <data name="BindInvokeFailedNonDelegate" xml:space="preserve">
     <value>Impossibile richiamare un tipo non delegato</value>
   </data>
-  <data name="BindImplicitConversionRequireOneArgument" xml:space="preserve">
-    <value>Per la conversione implicita viene accettato un solo argomento</value>
-  </data>
   <data name="BindBinaryAssignmentRequireTwoArguments" xml:space="preserve">
     <value>Impossibile richiamare operatori binari con un solo argomento</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.ja.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.ja.resx
@@ -39,9 +39,6 @@
   <data name="BindImplicitConversionRequireOneArgument" xml:space="preserve">
     <value>暗黙の型変換では 1 つの引数のみ受け取ります</value>
   </data>
-  <data name="BindExplicitConversionRequireOneArgument" xml:space="preserve">
-    <value>明示的な変換では 1 つの引数のみ受け取ります</value>
-  </data>
   <data name="BindBinaryAssignmentRequireTwoArguments" xml:space="preserve">
     <value>1 つの引数を指定して二項演算子を呼び出すことはできません</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.ja.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.ja.resx
@@ -36,9 +36,6 @@
   <data name="BindInvokeFailedNonDelegate" xml:space="preserve">
     <value>非デリゲート型を呼び出すことはできません</value>
   </data>
-  <data name="BindImplicitConversionRequireOneArgument" xml:space="preserve">
-    <value>暗黙の型変換では 1 つの引数のみ受け取ります</value>
-  </data>
   <data name="BindBinaryAssignmentRequireTwoArguments" xml:space="preserve">
     <value>1 つの引数を指定して二項演算子を呼び出すことはできません</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.ko.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.ko.resx
@@ -39,9 +39,6 @@
   <data name="BindImplicitConversionRequireOneArgument" xml:space="preserve">
     <value>암시적 변환에서는 정확히 하나의 인수를 사용합니다.</value>
   </data>
-  <data name="BindExplicitConversionRequireOneArgument" xml:space="preserve">
-    <value>명시적 변환에서는 정확히 하나의 인수를 사용합니다.</value>
-  </data>
   <data name="BindBinaryAssignmentRequireTwoArguments" xml:space="preserve">
     <value>하나의 인수를 사용하여 이항 연산자를 호출할 수 없습니다.</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.ko.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.ko.resx
@@ -36,9 +36,6 @@
   <data name="BindInvokeFailedNonDelegate" xml:space="preserve">
     <value>비대리자 형식을 호출할 수 없습니다.</value>
   </data>
-  <data name="BindImplicitConversionRequireOneArgument" xml:space="preserve">
-    <value>암시적 변환에서는 정확히 하나의 인수를 사용합니다.</value>
-  </data>
   <data name="BindBinaryAssignmentRequireTwoArguments" xml:space="preserve">
     <value>하나의 인수를 사용하여 이항 연산자를 호출할 수 없습니다.</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.resx
@@ -85,9 +85,6 @@
   <data name="BindImplicitConversionRequireOneArgument" xml:space="preserve">
     <value>Implicit conversion takes exactly one argument</value>
   </data>
-  <data name="BindExplicitConversionRequireOneArgument" xml:space="preserve">
-    <value>Explicit conversion takes exactly one argument</value>
-  </data>
   <data name="BindBinaryAssignmentRequireTwoArguments" xml:space="preserve">
     <value>Binary operators cannot be invoked with one argument</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.resx
@@ -82,9 +82,6 @@
   <data name="BindInvokeFailedNonDelegate" xml:space="preserve">
     <value>Cannot invoke a non-delegate type</value>
   </data>
-  <data name="BindImplicitConversionRequireOneArgument" xml:space="preserve">
-    <value>Implicit conversion takes exactly one argument</value>
-  </data>
   <data name="BindBinaryAssignmentRequireTwoArguments" xml:space="preserve">
     <value>Binary operators cannot be invoked with one argument</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.ru.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.ru.resx
@@ -36,9 +36,6 @@
   <data name="BindInvokeFailedNonDelegate" xml:space="preserve">
     <value>Не удалось вызвать тип, не являющийся делегатом</value>
   </data>
-  <data name="BindImplicitConversionRequireOneArgument" xml:space="preserve">
-    <value>Для неявного преобразования нужен строго один аргумент</value>
-  </data>
   <data name="BindBinaryAssignmentRequireTwoArguments" xml:space="preserve">
     <value>Невозможно вызвать бинарные операторы с использованием одного аргумента</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.ru.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.ru.resx
@@ -39,9 +39,6 @@
   <data name="BindImplicitConversionRequireOneArgument" xml:space="preserve">
     <value>Для неявного преобразования нужен строго один аргумент</value>
   </data>
-  <data name="BindExplicitConversionRequireOneArgument" xml:space="preserve">
-    <value>Для явного преобразования нужен строго один аргумент</value>
-  </data>
   <data name="BindBinaryAssignmentRequireTwoArguments" xml:space="preserve">
     <value>Невозможно вызвать бинарные операторы с использованием одного аргумента</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.zh-Hans.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.zh-Hans.resx
@@ -36,9 +36,6 @@
   <data name="BindInvokeFailedNonDelegate" xml:space="preserve">
     <value>无法调用非委托类型</value>
   </data>
-  <data name="BindImplicitConversionRequireOneArgument" xml:space="preserve">
-    <value>隐式转换采用一个且仅一个参数</value>
-  </data>
   <data name="BindBinaryAssignmentRequireTwoArguments" xml:space="preserve">
     <value>无法使用一个参数调用二元运算符</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.zh-Hans.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.zh-Hans.resx
@@ -39,9 +39,6 @@
   <data name="BindImplicitConversionRequireOneArgument" xml:space="preserve">
     <value>隐式转换采用一个且仅一个参数</value>
   </data>
-  <data name="BindExplicitConversionRequireOneArgument" xml:space="preserve">
-    <value>显式转换采用一个且仅一个参数</value>
-  </data>
   <data name="BindBinaryAssignmentRequireTwoArguments" xml:space="preserve">
     <value>无法使用一个参数调用二元运算符</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.zh-Hant.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.zh-Hant.resx
@@ -39,9 +39,6 @@
   <data name="BindImplicitConversionRequireOneArgument" xml:space="preserve">
     <value>隱含轉換只接受一個引數</value>
   </data>
-  <data name="BindExplicitConversionRequireOneArgument" xml:space="preserve">
-    <value>明確轉換只接受一個引數</value>
-  </data>
   <data name="BindBinaryAssignmentRequireTwoArguments" xml:space="preserve">
     <value>無法以一個引數叫用二元運算子</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.zh-Hant.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.zh-Hant.resx
@@ -36,9 +36,6 @@
   <data name="BindInvokeFailedNonDelegate" xml:space="preserve">
     <value>無法叫用非委派型別</value>
   </data>
-  <data name="BindImplicitConversionRequireOneArgument" xml:space="preserve">
-    <value>隱含轉換只接受一個引數</value>
-  </data>
   <data name="BindBinaryAssignmentRequireTwoArguments" xml:space="preserve">
     <value>無法以一個引數叫用二元運算子</value>
   </data>

--- a/src/Microsoft.CSharp/tests/BindingErrors.cs
+++ b/src/Microsoft.CSharp/tests/BindingErrors.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#define TEST_DEFINITION
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.CSharp.RuntimeBinder.Tests
+{
+    public class BindingErrors
+    {
+
+
+        private class TypeWithConditional
+        {
+            [Conditional("TEST_DEFINITION")]
+            public virtual void DoNothing()
+            {
+            }
+        }
+
+        private class DerivedTypeWithConditional : TypeWithConditional
+        {
+            public override void DoNothing()
+            {
+            }
+        }
+
+        [Fact]
+        public void CannotBindToConditional()
+        {
+            var obj = new TypeWithConditional();
+            obj.DoNothing();
+            dynamic d = obj;
+            Assert.Throws<RuntimeBinderException>(() => d.DoNothing());
+        }
+
+        [Fact]
+        public void CannotBindToOverriddenConditional()
+        {
+            var obj = new DerivedTypeWithConditional();
+            obj.DoNothing();
+            dynamic d = obj;
+            Assert.Throws<RuntimeBinderException>(() => d.DoNothing());
+        }
+    }
+}

--- a/src/Microsoft.CSharp/tests/BindingErrors.cs
+++ b/src/Microsoft.CSharp/tests/BindingErrors.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Dynamic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -16,8 +17,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
 {
     public class BindingErrors
     {
-
-
         private class TypeWithConditional
         {
             [Conditional("TEST_DEFINITION")]
@@ -33,11 +32,32 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
             }
         }
 
+        private class TypeWithEvent
+        {
+            public event Action<object, EventArgs> Event;
+
+            protected virtual void OnTrigger(EventArgs e)
+            {
+                Event?.Invoke(this, e);
+            }
+        }
+
+        private class TypeWithOverloads
+        {
+            public void DoNothing(int x, long y)
+            {
+            }
+
+            public void DoNothing(long x, int y)
+            {
+            }
+        }
+
         [Fact]
         public void CannotBindToConditional()
         {
             var obj = new TypeWithConditional();
-            obj.DoNothing();
+            obj.DoNothing(); // Confirm can bind statically.
             dynamic d = obj;
             Assert.Throws<RuntimeBinderException>(() => d.DoNothing());
         }
@@ -46,9 +66,93 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         public void CannotBindToOverriddenConditional()
         {
             var obj = new DerivedTypeWithConditional();
-            obj.DoNothing();
+            obj.DoNothing(); // Confirm can bind statically.
             dynamic d = obj;
             Assert.Throws<RuntimeBinderException>(() => d.DoNothing());
+        }
+
+        [Fact]
+        public void CannotBindToEventAsProperty()
+        {
+            dynamic d = new TypeWithEvent();
+            Assert.Throws<RuntimeBinderException>(() => d.Event = 3);
+            Assert.Throws<RuntimeBinderException>(() =>
+            {
+                int x = d.Event;
+            });
+        }
+
+        [Fact]
+        public void CannotBindToEventAsInvokable()
+        {
+            dynamic d = new TypeWithEvent();
+            Assert.Throws<RuntimeBinderException>(() => d.Event(new EventArgs()));
+        }
+
+        [Fact]
+        public void MethodOnNullReference()
+        {
+            dynamic d = null;
+            Assert.Throws<RuntimeBinderException>(() => d.DoStuff());
+        }
+
+        [Fact]
+        public void PropertyOrFieldOnNullReference()
+        {
+            dynamic d = null;
+            Assert.Throws<RuntimeBinderException>(() => d.Value = 3);
+            Assert.Throws<RuntimeBinderException>(() =>
+            {
+                int x = d.Value;
+            });
+        }
+
+        [Fact]
+        public void CannotConvertVoid()
+        {
+            dynamic d = new List<int>();
+            Assert.Throws<RuntimeBinderException>(() => d.Add(1).ToString());
+            Assert.Throws<RuntimeBinderException>(() =>
+            {
+                int i = d.Add(1);
+            });
+        }
+
+        [Fact]
+        public void MethodGroupLikeProperty()
+        {
+            dynamic d = new List<int>();
+            Assert.Throws<RuntimeBinderException>(() => d.Add = 42);
+            Assert.Throws<RuntimeBinderException>(() =>
+            {
+                int i = d.Add;
+            });
+        }
+
+        [Fact]
+        public void PropertyLikeMethod()
+        {
+            dynamic d = new List<int>();
+            Assert.Throws<RuntimeBinderException>(() => d.Add = 42);
+            Assert.Throws<RuntimeBinderException>(() =>
+            {
+                int i = d.Add;
+            });
+        }
+
+        [Fact]
+        public void AmbiguousOverloadAsTarget()
+        {
+            dynamic d = new TypeWithOverloads();
+            Assert.Throws<RuntimeBinderException>(() => d.DoNothing(1, 2));
+        }
+
+        [Fact]
+        public void AmbiguousOverloadAsArgument()
+        {
+            TypeWithOverloads target = new TypeWithOverloads();
+            dynamic d = 2;
+            Assert.Throws<RuntimeBinderException>(() => target.DoNothing(1, d));
         }
     }
 }

--- a/src/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj
+++ b/src/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj
@@ -14,6 +14,7 @@
       <Link>Common\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
     </Compile>
     <Compile Include="ArrayHandling.cs" />
+    <Compile Include="BindingErrors.cs" />
     <Compile Include="CSharpArgumentInfoTests.cs" />
     <Compile Include="EnumArithmeticTests.cs" />
     <Compile Include="IntegerBinaryOperationTests.cs" />


### PR DESCRIPTION
`Error.BindExplicitConversionRequireOneArgument` is triggered if `RuntimeBinder.BindExplicitConversion` is called with any number of arguments other than 1, but this is only called by
`CSharpConvertBinder.DispatchPayload` which takes its arguments from the
`args` and `parameters` passed to `RuntimeBinder.BindCore` which is called by
`RuntimeBinder.Bind` which is called by `BinderHelper.Bind` which is called
by `CSharpConvertBinder.FallbackConvert` with a single argument.

So tracing that lot through shows that this is dead code.

`BindImplicitConversionRequireOneArgument` has a path that is much as the above and another from `RuntimeBinder.BindCall` which also always sets a single argument, so again this is dead code.

Remove these dead methods, and add tests covering some of the other error methods.