### PR TITLE
Re-enabling ClientWebSocketUnitTest runs in UWP

### DIFF
--- a/src/System.Net.WebSockets.Client/tests/ClientWebSocketUnitTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/ClientWebSocketUnitTest.cs
@@ -57,7 +57,6 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
-        [ActiveIssue(20132, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(WebSocketsSupported))]
         public void CloseAsync_CreateAndCloseOutput_ThrowsInvalidOperationExceptionWithMessage()
@@ -90,7 +89,6 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
-        [ActiveIssue(20132, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(WebSocketsSupported))]
         public void CloseAsync_CreateAndReceive_ThrowsInvalidOperationExceptionWithMessage()
@@ -126,7 +124,6 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
-        [ActiveIssue(20132, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(WebSocketsSupported))]
         public void CloseAsync_CreateAndSend_ThrowsInvalidOperationExceptionWithMessage()
@@ -184,7 +181,6 @@ namespace System.Net.WebSockets.Client.Tests
             Assert.Equal(WebSocketState.Closed, cws.State);
         }
 
-        [ActiveIssue(20132, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(WebSocketsSupported))]
         public void CloseAsync_DisposeAndCloseOutput_ThrowsObjectDisposedExceptionWithMessage()
@@ -202,7 +198,6 @@ namespace System.Net.WebSockets.Client.Tests
             Assert.Equal(WebSocketState.Closed, cws.State);
         }
 
-        [ActiveIssue(20132, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(WebSocketsSupported))]
         public void ReceiveAsync_CreateAndDisposeAndReceive_ThrowsObjectDisposedExceptionWithMessage()
@@ -223,7 +218,6 @@ namespace System.Net.WebSockets.Client.Tests
             Assert.Equal(WebSocketState.Closed, cws.State);
         }
 
-        [ActiveIssue(20132, TargetFrameworkMonikers.Uap)]
         [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(WebSocketsSupported))]
         public void SendAsync_CreateAndDisposeAndSend_ThrowsObjectDisposedExceptionWithMessage()

--- a/src/System.Net.WebSockets.Client/tests/ResourceHelper.cs
+++ b/src/System.Net.WebSockets.Client/tests/ResourceHelper.cs
@@ -16,6 +16,8 @@ namespace System.Net.WebSockets.Client.Tests
         {
             if (PlatformDetection.IsNetNative)
             {
+                // .NET Native does not include the full exception message. Instead, the exception text
+                // consists of the 'resourceName' along with a link to follow for more information.
                 return string.Concat(resourceName, ". For more information, visit http://go.microsoft.com/fwlink/?LinkId=623485");
             }
 

--- a/src/System.Net.WebSockets.Client/tests/ResourceHelper.cs
+++ b/src/System.Net.WebSockets.Client/tests/ResourceHelper.cs
@@ -14,6 +14,11 @@ namespace System.Net.WebSockets.Client.Tests
     {
         public static string GetExceptionMessage(string resourceName, params object[] parameters)
         {
+            if (PlatformDetection.IsNetNative)
+            {
+                return string.Concat(resourceName, ". For more information, visit http://go.microsoft.com/fwlink/?LinkId=623485");
+            }
+
             Type srType = typeof(SR);
             PropertyInfo property = srType.GetRuntimeProperties().Single(p => p.Name == resourceName);
 


### PR DESCRIPTION
Re-enabling ClientWebSocket's unit tests for UWP.

Note that the following code fails in UAPAOT without the ResourceHelper change proposed in this PR, even though it's already using AssertExtensions:

```
AssertExtensions.Throws<InvalidOperationException>(
                    () =>
                    cws.CloseOutputAsync(WebSocketCloseStatus.Empty, "", new CancellationToken()).GetAwaiter().GetResult(),
                    ResourceHelper.GetExceptionMessage("net_WebSockets_NotConnected"));
```

**Exception message from ResourceHelper (pre-changes):** _The WebSocket is not connected._
**Actual exception message:** _net_WebSockets_NotConnected. For more information, visit http://go.microsoft.com/fwlink/?LinkId=623485_

Contributes to #20132