### PR TITLE
Fix SNI version issues in Named Pipes tests in SqlClient functional tests

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNINpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNINpHandle.cs
@@ -6,7 +6,6 @@ using System.ComponentModel;
 using System.IO;
 using System.IO.Pipes;
 using System.Net.Security;
-using System.Net.Sockets;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
@@ -68,8 +67,8 @@ namespace System.Data.SqlClient.SNI
             }
             catch(TimeoutException te)
             {
-                SNICommon.ReportSNIError(SNIProviders.NP_PROV, SNICommon.ConnTimeoutError, te);
-                _status = TdsEnums.SNI_WAIT_TIMEOUT;
+                SNICommon.ReportSNIError(SNIProviders.NP_PROV, SNICommon.ConnOpenFailedError, te);
+                _status = TdsEnums.SNI_ERROR;
                 return;
             }
             catch(IOException ioe)

--- a/src/System.Data.SqlClient/tests/FunctionalTests/ExceptionTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/ExceptionTest.cs
@@ -76,8 +76,6 @@ namespace System.Data.SqlClient.Tests
             }
         }
 
-        public static bool IsUsingManagedSNI() => ManualTesting.Tests.DataTestUtility.IsUsingManagedSNI();
-
         [Theory]
         [InlineData(@"np:\\.\pipe\sqlbad\query")]
         [InlineData(@"np:\\.\pipe\MSSQL$NonExistentInstance\sql\query")]
@@ -93,17 +91,15 @@ namespace System.Data.SqlClient.Tests
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder();
             builder.DataSource = dataSource;
             builder.ConnectTimeout = 1;
+
             using (SqlConnection connection = new SqlConnection(builder.ConnectionString))
             {
-                string expectedErrorMsg;
-                if (IsUsingManagedSNI())
-                    expectedErrorMsg = "(provider: Named Pipes Provider, error: 11 - Timeout error)";
-                else
-                    expectedErrorMsg = "(provider: Named Pipes Provider, error: 40 - Could not open a connection to SQL Server)";
-
+                string expectedErrorMsg = "(provider: Named Pipes Provider, error: 40 - Could not open a connection to SQL Server)";
                 VerifyConnectionFailure<SqlException>(() => connection.Open(), expectedErrorMsg);
             }
         }
+
+        public static bool IsUsingManagedSNI() => ManualTesting.Tests.DataTestUtility.IsUsingManagedSNI();
 
         [ConditionalFact(nameof(IsUsingManagedSNI))]
         public void NamedPipeInvalidConnStringTest_ManagedSNI()


### PR DESCRIPTION
Error messages sometimes differ when using Native & Managed SNI, so these changes check the SNI version before running these tests.