### PR TITLE
Enabling some HttpListener tests. Disabling UAP and UAPAOT tests against individual classes of bugs. Fixing test string AOT lookups.

### DIFF
--- a/src/System.Net.HttpListener/tests/HttpListenerAuthenticationTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerAuthenticationTests.cs
@@ -32,7 +32,6 @@ namespace System.Net.Tests
 
         // [ActiveIssue(20840, TestPlatforms.Unix)] // Managed implementation connects successfully.
         [ConditionalTheory(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData("Basic")]
         [InlineData("NTLM")]
         [InlineData("Negotiate")]
@@ -50,7 +49,6 @@ namespace System.Net.Tests
 
         // [ActiveIssue(20840, TestPlatforms.Unix)] Managed implementation connects successfully.
         [ConditionalTheory(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData("Basic")]
         [InlineData("NTLM")]
         [InlineData("Negotiate")]
@@ -67,7 +65,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(AuthenticationSchemes.Basic)]
         [InlineData(AuthenticationSchemes.Basic | AuthenticationSchemes.None)]
         [InlineData(AuthenticationSchemes.Basic | AuthenticationSchemes.Anonymous)]
@@ -79,7 +76,6 @@ namespace System.Net.Tests
 
         [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [MemberData(nameof(BasicAuthenticationHeader_TestData))]
         public async Task BasicAuthentication_InvalidRequest_SendsStatusCodeClient(string header, HttpStatusCode statusCode)
         {
@@ -112,7 +108,6 @@ namespace System.Net.Tests
 
         [ActiveIssue(19967, TargetFrameworkMonikers.NetFramework)]
         [ConditionalTheory(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [ActiveIssue(20098, TestPlatforms.Unix)]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData("ExampleRealm")]
         [InlineData("  ExampleRealm  ")]
         [InlineData("")]
@@ -131,7 +126,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task TestAnonymousAuthentication()
         {
             _listener.AuthenticationSchemes = AuthenticationSchemes.Anonymous;
@@ -139,7 +133,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task TestBasicAuthenticationWithDelegate()
         {
             _listener.AuthenticationSchemes = AuthenticationSchemes.None;
@@ -150,7 +143,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData("somename:somepassword", "somename", "somepassword")]
         [InlineData("somename:", "somename", "")]
         [InlineData(":somepassword", "", "somepassword")]
@@ -163,7 +155,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task TestAnonymousAuthenticationWithDelegate()
         {
             _listener.AuthenticationSchemes = AuthenticationSchemes.None;
@@ -174,7 +165,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [PlatformSpecific(TestPlatforms.Windows, "Managed impl doesn't support NTLM")]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [ActiveIssue(20604)]
         public async Task NtlmAuthentication_Conversation_ReturnsExpectedType2Message()
         {
@@ -198,7 +188,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [PlatformSpecific(TestPlatforms.Windows, "Managed impl doesn't support NTLM")]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [ActiveIssue(20604)]
         [MemberData(nameof(InvalidNtlmNegotiateAuthentication_TestData))]
         public async Task NtlmAuthentication_InvalidRequestHeaders_ReturnsExpectedStatusCode(string header, HttpStatusCode statusCode)
@@ -222,7 +211,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [PlatformSpecific(TestPlatforms.Windows, "Managed impl doesn't support Negotiate")]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [ActiveIssue(20604)]
         public async Task NegotiateAuthentication_Conversation_ReturnsExpectedType2Message()
         {
@@ -238,7 +226,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [PlatformSpecific(TestPlatforms.Windows, "Managed impl doesn't support Negotiate")]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [ActiveIssue(20604)]
         [MemberData(nameof(InvalidNtlmNegotiateAuthentication_TestData))]
         public async Task NegotiateAuthentication_InvalidRequestHeaders_ReturnsExpectedStatusCode(string header, HttpStatusCode statusCode)
@@ -255,7 +242,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task AuthenticationSchemeSelectorDelegate_ReturnsInvalidAuthenticationScheme_PerformsNoAuthentication()
         {
             _listener.AuthenticationSchemes = AuthenticationSchemes.Basic;
@@ -274,7 +260,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task AuthenticationSchemeSelectorDelegate_ThrowsException_SendsInternalServerErrorToClient()
         {
             _listener.AuthenticationSchemes = AuthenticationSchemes.Basic;
@@ -287,7 +272,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void AuthenticationSchemeSelectorDelegate_ThrowsOutOfMemoryException_RethrowsException()
         {
             _listener.AuthenticationSchemes = AuthenticationSchemes.Basic;
@@ -301,7 +285,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void AuthenticationSchemeSelectorDelegate_SetDisposed_ThrowsObjectDisposedException()
         {
             var listener = new HttpListener();
@@ -311,7 +294,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void AuthenticationSchemes_SetDisposed_ThrowsObjectDisposedException()
         {
             var listener = new HttpListener();
@@ -321,7 +303,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void ExtendedProtectionPolicy_SetNull_ThrowsArgumentNullException()
         {
             using (var listener = new HttpListener())
@@ -331,7 +312,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void ExtendedProtectionPolicy_SetDisposed_ThrowsObjectDisposedException()
         {
             var listener = new HttpListener();
@@ -341,7 +321,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void ExtendedProtectionPolicy_SetCustomChannelBinding_ThrowsObjectDisposedException()
         {
             using (var listener = new HttpListener())
@@ -352,7 +331,6 @@ namespace System.Net.Tests
         }
         
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void UnsafeConnectionNtlmAuthentication_SetGet_ReturnsExpected()
         {
             using (var listener = new HttpListener())
@@ -371,7 +349,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void UnsafeConnectionNtlmAuthentication_SetDisposed_ThrowsObjectDisposedException()
         {
             var listener = new HttpListener();
@@ -381,7 +358,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void ExtendedProtectionSelectorDelegate_SetNull_ThrowsArgumentNullException()
         {
             using (var listener = new HttpListener())
@@ -391,7 +367,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void ExtendedProtectionSelectorDelegate_SetDisposed_ThrowsObjectDisposedException()
         {
             var listener = new HttpListener();
@@ -401,7 +376,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task Realm_SetWithoutBasicAuthenticationScheme_SendsNoChallengeToClient()
         {
             _listener.Realm = "ExampleRealm";
@@ -418,7 +392,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void Realm_SetDisposed_ThrowsObjectDisposedException()
         {
             var listener = new HttpListener();

--- a/src/System.Net.HttpListener/tests/HttpListenerContextTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerContextTests.cs
@@ -46,7 +46,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalTheory(nameof(IsNotWindows7))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [MemberData(nameof(SubProtocol_TestData))]
         public async Task AcceptWebSocketAsync_ValidSubProtocol_Success(string[] clientProtocols, string serverProtocol)
         {
@@ -56,7 +55,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalTheory(nameof(IsNotWindows7))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task AcceptWebSocketAsync_ValidWebSocket_SetsUpHeadersInResponse()
         {
             HttpListenerContext context = await GetWebSocketContext(new string[] { "SubProtocol", "SubProtocol2" });
@@ -81,7 +79,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(IsNotWindows7))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task AcceptWebSocketAsync_ValidWebSocket_SetsUpContextProperties()
         {
             Socket.Options.SetRequestHeader("origin", "Browser");
@@ -100,7 +97,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(IsNotWindows7))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task AcceptWebSocketAsync_AuthorizationInHeaders_ThrowsNotImplementedException()
         {
             Socket.Options.SetRequestHeader("Authorization", "Basic " + Convert.ToBase64String(Encoding.ASCII.GetBytes("user:password")));
@@ -120,7 +116,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(IsNotWindows7))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task AcceptWebSocketAsync_UnsupportedProtocol_ThrowsWebSocketException()
         {
             HttpListenerContext context = await GetWebSocketContext(new string[] { "MyProtocol" });
@@ -128,7 +123,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(IsNotWindows7))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task AcceptWebSocketAsync_NoClientSubProtocol_ThrowsWebSocketException()
         {
             HttpListenerContext context = await GetWebSocketContext();
@@ -136,7 +130,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalTheory(nameof(IsNotWindows7))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData("Connection: ")]
         [InlineData("Connection: Connection\r\nUpgrade: ")]
         [InlineData("Connection: Test1\r\nUpgrade: Test2")]
@@ -157,7 +150,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalTheory(nameof(IsNotWindows7))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData("")]
         [InlineData(" ")]
         [InlineData("random(text")]
@@ -186,7 +178,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalTheory(nameof(IsNotWindows7))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData("!")]
         [InlineData("#")]
         [InlineData("YouDontKnowMe")]
@@ -197,7 +188,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(IsNotWindows7))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task AcceptWebSocketAsync_InvalidKeepAlive_ThrowsWebSocketException()
         {
             HttpListenerContext context = await GetWebSocketContext();
@@ -207,7 +197,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalTheory(nameof(IsNotWindows7))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(-1)]
         [InlineData(0)]
         [InlineData(255)]
@@ -219,7 +208,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(IsNotWindows7))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]   
         public async Task AcceptWebSocketAsync_NullArrayInArraySegment_ThrowsArgumentNullException()
         {
             HttpListenerContext context = await GetWebSocketContext();
@@ -229,7 +217,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalTheory(nameof(IsNotWindows7))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(-1)]
         [InlineData(11)]
         public async Task AcceptWebSocketAsync_InvalidOffsetInArraySegment_ThrowsArgumentNullException(int offset)
@@ -241,7 +228,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalTheory(nameof(IsNotWindows7))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(0, -1)]
         [InlineData(0, 11)]
         [InlineData(10, 1)]

--- a/src/System.Net.HttpListener/tests/HttpListenerPrefixCollectionTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerPrefixCollectionTests.cs
@@ -12,7 +12,6 @@ namespace System.Net.Tests
     public class HttpListenerPrefixCollectionTests
     {
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void Prefixes_Get_ReturnsEmpty()
         {
             var listener = new HttpListener();
@@ -24,7 +23,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(0)]
         [InlineData(1)]
         public void CopyTo_StringArray_ReturnsExpected(int offset)
@@ -46,7 +44,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(0)]
         [InlineData(1)]
         public void CopyTo_Array_ReturnsExpected(int offset)
@@ -68,7 +65,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void CopyTo_DisposedListener_ThrowsObjectDisposedException()
         {
             var listener = new HttpListener();
@@ -80,7 +76,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Core fixes a bug where HttpListenerPrefixCollection.CopyTo(null) throws an NRE.")]
         public void CopyTo_NullArray_ThrowsArgumentNullExceptionOnNetCore()
         {
@@ -90,7 +85,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, ".NET Core fixes a bug where HttpListenerPrefixCollection.CopyTo(null) throws an NRE.")]
         public void CopyTo_NullArray_ThrowsNullReferenceExceptionOnNetFx()
         {
@@ -100,7 +94,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void CopyTo_MultidimensionalArray_ThrowsIndexOutOfRangeException()
         {
             var listener = new HttpListener();
@@ -113,8 +106,8 @@ namespace System.Net.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => listener.Prefixes.CopyTo(new object[1, 1], 0));
         }
 
+        [ActiveIssue(22055, TargetFrameworkMonikers.UapAot)]
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.UapAot)]
         public void CopyTo_NonZeroLowerBoundArray_ThrowsIndexOutOfRangeException()
         {
             var listener = new HttpListener();
@@ -129,7 +122,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void CopyTo_InvalidArrayType_ThrowsInvalidCastException()
         {
             var listener = new HttpListener();
@@ -143,7 +135,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void CopyTo_ArrayTooSmall_ThrowsArgumentOutOfRangeException()
         {
             var listener = new HttpListener();
@@ -153,7 +144,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(1)]
         [InlineData(2)]
         public void CopyTo_InvalidOffset_ThrowsArgumentOutOfRangeException(int offset)
@@ -165,7 +155,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void IsSynchronized_Get_ReturnsFalse()
         {
             var listener = new HttpListener();
@@ -173,7 +162,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void IsReadOnly_Get_ReturnsFalse()
         {
             var listener = new HttpListener();
@@ -181,7 +169,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData("http://*/")]
         [InlineData("http://+/")]
         [InlineData("http://localhost/")]
@@ -202,7 +189,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void Add_AlreadyStarted_ReturnsExpected()
         {
             using (var factory = new HttpListenerFactory())
@@ -231,7 +217,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [MemberData(nameof(Hosts_TestData))]
         public void Add_PrefixAlreadyRegisteredAndNotStarted_ThrowsHttpListenerException(string hostname)
         {
@@ -247,7 +232,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [MemberData(nameof(Hosts_TestData))]
         public void Add_PrefixAlreadyRegisteredWithDifferentPathAndNotStarted_Works(string hostname)
         {
@@ -265,7 +249,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [MemberData(nameof(Hosts_TestData))]
         public void Add_PrefixAlreadyRegisteredAndStarted_ThrowsHttpListenerException(string hostname)
         {
@@ -292,7 +275,6 @@ namespace System.Net.Tests
         }
         
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [MemberData(nameof(Hosts_TestData))]
         public void Add_SamePortDifferentPathDifferentListenerNotStarted_Works(string host)
         {
@@ -312,7 +294,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [MemberData(nameof(Hosts_TestData))]
         public void Add_SamePortDifferentPathDifferentListenerStarted_Works(string host)
         {
@@ -341,7 +322,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [MemberData(nameof(Hosts_TestData))]
         public void Add_SamePortDifferentPathMultipleStarted_Success(string host)
         {
@@ -388,7 +368,6 @@ namespace System.Net.Tests
 
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)] // Issue #19619
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [MemberData(nameof(InvalidPrefix_TestData))]
         public void Add_InvalidPrefixNotStarted_ThrowsHttpListenerExceptionOnStart(string uriPrefix)
         {
@@ -402,7 +381,6 @@ namespace System.Net.Tests
 
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)] // Issue #19619
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [MemberData(nameof(InvalidPrefix_TestData))]
         public void Add_InvalidPrefixAlreadyStarted_ThrowsHttpListenerExceptionOnAdd(string uriPrefix)
         {
@@ -416,7 +394,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData("")]
         [InlineData("http")]
         [InlineData("https")]
@@ -440,7 +417,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void Add_NullPrefix_ThrowsArgumentNullException()
         {
             var listener = new HttpListener();
@@ -448,7 +424,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void Add_LongHost_ThrowsArgumentOutOfRangeException()
         {
             var listener = new HttpListener();
@@ -464,7 +439,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void Add_DisposedListener_ThrowsObjectDisposedException()
         {
             var listener = new HttpListener();
@@ -476,7 +450,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData("")]
         [InlineData("http://localhost:80/")]
         [InlineData("http://localhost:9200")]
@@ -490,7 +463,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void Contains_NullPrefix_ThrowsArgumentNullException()
         {
             var listener = new HttpListener();
@@ -498,7 +470,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void Remove_PrefixExistsNotStarted_ReturnsTrue()
         {
             var listener = new HttpListener();
@@ -510,7 +481,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void Remove_PrefixExistsStarted_ReturnsTrue()
         {
             using (var factory = new HttpListenerFactory())
@@ -528,7 +498,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData("")]
         [InlineData("http://localhost:80/")]
         [InlineData("http://localhost:9200")]
@@ -542,7 +511,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void Remove_DisposedListener_ThrowsObjectDisposedException()
         {
             var listener = new HttpListener();
@@ -553,7 +521,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void Remove_NullPrefix_ThrowsArgumentNullException()
         {
             var listener = new HttpListener();
@@ -561,7 +528,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void Clear_NonEmpty_Success()
         {
             var listener = new HttpListener();
@@ -573,7 +539,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void Clear_DisposedListener_ThrowsObjectDisposedException()
         {
             var listener = new HttpListener();
@@ -584,7 +549,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void GetEnumeratorGeneric_ResetMultipleTimes_ReturnsExpected()
         {
             var listener = new HttpListener();
@@ -610,7 +574,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void GetEnumeratorNonGeneric_ResetMultipleTimes_ReturnsExpected()
         {
             var listener = new HttpListener();

--- a/src/System.Net.HttpListener/tests/HttpListenerRequestTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerRequestTests.cs
@@ -241,7 +241,6 @@ namespace System.Net.Tests
         [InlineData("Unknown-Header: Test", false)]
         public async Task IsWebSocketRequest_GetProperty_ReturnsExpected(string webSocketString, bool expected)
         {
-            // Skip on Windows 7 or UAP platforms. WebSocket support is not present.
             if (PlatformDetection.IsWindows7)
             {
                 return;

--- a/src/System.Net.HttpListener/tests/HttpListenerRequestTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerRequestTests.cs
@@ -30,7 +30,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData("Accept: Test", new string[] { "Test" })]
         [InlineData("Accept: Test, Test2,Test3 ,  Test4", new string[] { "Test", "Test2", "Test3 ", " Test4" })]
         [InlineData("Accept: Test", new string[] { "Test" })]
@@ -88,8 +87,8 @@ namespace System.Net.Tests
             yield return new object[] { "Unknown-Header: Test", Encoding.Default };
         }
 
+        [ActiveIssue(22063, TargetFrameworkMonikers.UapAot)]
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [MemberData(nameof(ContentEncoding_TestData))]
         public async Task ContentEncoding_GetProperty_ReturnsExpected(string header, Encoding expected)
         {
@@ -98,7 +97,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task ContentEncoding_NoBody_ReturnsDefault()
         {
             HttpListenerRequest request = await GetRequest("POST", "", new string[] { "Content-Length: 0", "Content-Type:application/json;charset=unicode" }, content: null);
@@ -106,7 +104,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData("POST", "Content-Length: 9223372036854775807", 9223372036854775807, true)] // long.MaxValue
         [InlineData("POST", "Content-Length: 9223372036854775808", 0, false)] // long.MaxValue + 1
         [InlineData("POST", "Content-Length: 18446744073709551615 ", 0, false)] // ulong.MaxValue
@@ -127,7 +124,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(100)]
         [InlineData("-100")]
         [InlineData("")]
@@ -147,7 +143,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [ActiveIssue(20294, TargetFrameworkMonikers.Netcoreapp)]
         public async Task ContentLength_ManuallyRemovedFromHeaders_DoesNotAffect()
         {
@@ -161,7 +156,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task ContentLength_SetInHeadersAfterAccessingProperty_DoesNothing()
         {
             HttpListenerRequest request = await GetRequest("POST", null, new string[] { "Content-Length: 1" }, content: "\r\n");
@@ -176,7 +170,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData("Referer: http://microsoft.com", "http://microsoft.com/")]
         [InlineData("referer: /relativePath", "/relativePath")]
         [InlineData("Referer: NoSuchSite", "NoSuchSite")]
@@ -190,7 +183,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData("User-Agent: Test", "Test")]
         [InlineData("user-agent: Test", "Test")]
         [InlineData("User-Agent: ", "")]
@@ -202,7 +194,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task UserHostName_GetProperty_ReturnsExpected()
         {
             HttpListenerRequest request = await GetRequest("POST", null, null);
@@ -210,7 +201,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task EndPointProperties_GetProperty_ReturnsExpected()
         {
             HttpListenerRequest request = await GetRequest("POST", "", null);
@@ -229,7 +219,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task ServiceName_GetNoSpn_ReturnsExpected()
         {
             HttpListenerRequest request = await GetRequest("POST", null, null);
@@ -237,14 +226,12 @@ namespace System.Net.Tests
         }
         
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task RequestTraceIdentifier_GetWindows_ReturnsExpected()
         {
             HttpListenerRequest request = await GetRequest("POST", null, null);
             Assert.NotEqual(Guid.Empty, request.RequestTraceIdentifier);
         }
 
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [Theory]
         [InlineData("Connection: ", false)]
         [InlineData("Connection: Connection\r\nUpgrade: ", false)]
@@ -255,7 +242,7 @@ namespace System.Net.Tests
         public async Task IsWebSocketRequest_GetProperty_ReturnsExpected(string webSocketString, bool expected)
         {
             // Skip on Windows 7 or UAP platforms. WebSocket support is not present.
-            if (PlatformDetection.IsWindows7 || !PlatformDetection.IsNotOneCoreUAP)
+            if (PlatformDetection.IsWindows7)
             {
                 return;
             }
@@ -265,7 +252,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData("Accept-Language: Lang1,Lang2,Lang3", new string[] { "Lang1", "Lang2", "Lang3" })]
         [InlineData("Accept-Language: Lang1, Lang2, Lang3", new string[] { "Lang1", "Lang2", "Lang3" })]
         [InlineData("Accept-Language: Lang1,,Lang3", new string[] { "Lang1", "", "Lang3" })]
@@ -285,7 +271,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task ClientCertificateError_GetNotInitialized_ThrowsInvalidOperationException()
         {
             HttpListenerRequest request = await GetRequest("POST", null, null);
@@ -293,7 +278,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task GetClientCertificate_NoCertificate_ReturnsNull()
         {
             HttpListenerRequest request = await GetRequest("POST", null, null);
@@ -302,7 +286,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task GetClientCertificateAsync_NoCertificate_ReturnsNull()
         {
             HttpListenerRequest request = await GetRequest("POST", null, null);
@@ -310,7 +293,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task EndGetClientCertificate_NullAsyncResult_ThrowsArgumentException()
         {
             HttpListenerRequest request = await GetRequest("POST", null, null);
@@ -318,7 +300,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task EndGetClientCertificate_InvalidAsyncResult_ThrowsArgumentException()
         {
             HttpListenerRequest request1 = await GetRequest("POST", null, null);
@@ -333,7 +314,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task EndGetClientCertificate_AlreadyCalled_ThrowsInvalidOperationException()
         {
             HttpListenerRequest request = await GetRequest("POST", null, null);
@@ -344,7 +324,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task TransportContext_GetChannelBinding_ReturnsExpected()
         {
             // This might not work on other devices:
@@ -355,7 +334,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(ChannelBindingKind.Unique)]
         public async Task TransportContext_GetChannelBindingInvalid_ThrowsNotSupportedException(ChannelBindingKind kind)
         {
@@ -450,7 +428,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [MemberData(nameof(QueryString_TestData))]
         public async Task QueryString_GetProperty_ReturnsExpected(string query, NameValueCollection expected)
         {
@@ -466,7 +443,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData("POST")]
         [InlineData("PATCH")]
         [InlineData("get")]
@@ -479,7 +455,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData("1.1", new string[] { "Proxy-Connection: random" }, true)]
         [InlineData("1.1", new string[] { "Proxy-Connection: close" }, false)]
         [InlineData("1.1", new string[] { "proxy-connection: CLOSE" }, false)]
@@ -505,7 +480,6 @@ namespace System.Net.Tests
             Assert.Equal(expected, request.KeepAlive);
         }
 
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [Theory]
         [InlineData("1.0")]
         [InlineData("1.1")]
@@ -615,8 +589,8 @@ namespace System.Net.Tests
             yield return new object[] { "Unknown-Header: Test", new CookieCollection() };
         }
 
+        [ActiveIssue(20482, TargetFrameworkMonikers.UapAot)]
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [MemberData(nameof(Cookies_TestData))]
         public async Task Cookies_GetProperty_ReturnsExpected(string cookieString, CookieCollection expected)
         {
@@ -640,7 +614,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [MemberData(nameof(Headers_TestData))]
         public async Task Headers_Get_ReturnsExpected(string[] headers, WebHeaderCollection expected)
         {

--- a/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Cookies.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Cookies.cs
@@ -12,7 +12,6 @@ namespace System.Net.Tests
     public class HttpListenerResponseCookiesTests : HttpListenerResponseTestBase
     {
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task Cookies_GetSet_ReturnsExpected()
         {
             HttpListenerResponse response = await GetResponse();
@@ -88,8 +87,8 @@ namespace System.Net.Tests
             };
         }
 
+        [ActiveIssue(22056, TargetFrameworkMonikers.UapAot)]
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [MemberData(nameof(Cookies_TestData))]
         public async Task Cookies_SetAndSend_ClientReceivesExpectedHeaders(CookieCollection cookies, int expectedBytes, string expectedSetCookie, string expectedSetCookie2)
         {
@@ -122,7 +121,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task Cookies_SetInHeader_ClientReceivesExpectedHeaders()
         {
             HttpListenerResponse response = await GetResponse();
@@ -136,8 +134,8 @@ namespace System.Net.Tests
             Assert.Contains($"\r\nSet-Cookie2: name2=value2\r\n", clientResponse);
         }
 
+        [ActiveIssue(22056, TargetFrameworkMonikers.UapAot)]
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task Cookies_SetCookie2InHeadersButNotInCookies_RemovesFromHeaders()
         {
             HttpListenerResponse response = await GetResponse();
@@ -156,8 +154,8 @@ namespace System.Net.Tests
             Assert.Contains($"\r\nSet-Cookie2: name3=value3; Port=\"200\"; Version=1\r\n", clientResponse);
         }
 
+        [ActiveIssue(22056, TargetFrameworkMonikers.UapAot)]
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task Cookies_SetCookieInHeadersButNotInCookies_RemovesFromHeaders()
         {
             HttpListenerResponse response = await GetResponse();
@@ -176,8 +174,8 @@ namespace System.Net.Tests
             Assert.DoesNotContain("Set-Cookie2", clientResponse);
         }
 
+        [ActiveIssue(22056, TargetFrameworkMonikers.UapAot)]
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task AppendCookie_ValidCookie_AddsCookieToCollection()
         {
             HttpListenerResponse response = await GetResponse();
@@ -199,15 +197,14 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task AppendCookie_NullCookie_ThrowsArgumentNullException()
         {
             HttpListenerResponse response = await GetResponse();
             AssertExtensions.Throws<ArgumentNullException>("cookie", () => response.AppendCookie(null));
         }
 
+        [ActiveIssue(22056, TargetFrameworkMonikers.UapAot)]
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task SetCookie_ValidCookie_AddsCookieToCollection()
         {
             HttpListenerResponse response = await GetResponse();
@@ -220,8 +217,8 @@ namespace System.Net.Tests
             Assert.Equal(new Cookie[] { cookie1, cookie2 }, response.Cookies.Cast<Cookie>());
         }
 
+        [ActiveIssue(22056, TargetFrameworkMonikers.UapAot)]
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task SetCookie_ValidCookie_ClonesCookie()
         {
             HttpListenerResponse response = await GetResponse();
@@ -234,15 +231,14 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task SetCookie_NullCookie_ThrowsArgumentNullException()
         {
             HttpListenerResponse response = await GetResponse();
             AssertExtensions.Throws<ArgumentNullException>("cookie", () => response.SetCookie(null));
         }
 
+        [ActiveIssue(22056, TargetFrameworkMonikers.UapAot)]
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task SetCookie_CookieDoesntExist_ThrowsArgumentException()
         {
             HttpListenerResponse response = await GetResponse();

--- a/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Headers.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Headers.cs
@@ -9,12 +9,12 @@ using Xunit;
 
 namespace System.Net.Tests
 {
+    [ActiveIssue(18784, TargetFrameworkMonikers.Uap)]
     public class HttpListenerResponseHeadersTests : HttpListenerResponseTestBase
     {
         private static string s_longString = new string('a', ushort.MaxValue + 1);
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task AddHeader_ValidValue_ReplacesHeaderInCollection()
         {
             HttpListenerResponse response = await GetResponse();
@@ -27,7 +27,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task AddHeader_NullOrEmptyName_ThrowsArgumentNullException()
         {
             HttpListenerResponse response = await GetResponse();
@@ -36,8 +35,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Netcoreapp)]
+        [ActiveIssue(22057, TargetFrameworkMonikers.Netcoreapp)]
         public async Task AddHeader_LongName_ThrowsArgumentOutOfRangeException()
         {
             HttpListenerResponse response = await GetResponse();
@@ -45,7 +43,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task AddHeader_InvalidNameOrValue_ThrowsArgumentException()
         {
             HttpListenerResponse response = await GetResponse();
@@ -55,7 +52,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task AppendHeader_ValidValue_AddsHeaderToCollection()
         {
             HttpListenerResponse response = await GetResponse();
@@ -68,7 +64,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(null)]
         [InlineData("")]
         public async Task AppendHeader_NullOrEmptyName_ThrowsArgumentNullException(string name)
@@ -78,8 +73,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Netcoreapp)]
+        [ActiveIssue(22057, TargetFrameworkMonikers.Netcoreapp)]
         public async Task AppendHeader_LongName_ThrowsArgumentOutOfRangeException()
         {
             HttpListenerResponse response = await GetResponse();
@@ -87,7 +81,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task AppendHeader_InvalidNameOrValue_ThrowsArgumentException()
         {
             HttpListenerResponse response = await GetResponse();
@@ -97,7 +90,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task ContentEncoding_SetCustom_DoesNothing()
         {
             // Setting HttpListenerResponse.ContentEncoding does nothing - it is never used.
@@ -113,7 +105,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task ContentEncoding_SetDisposed_DoesNothing()
         {
             HttpListenerResponse response = await GetResponse();
@@ -127,7 +118,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task ContentEncoding_SetAfterHeadersSent_DoesNothing()
         {
             using (HttpListenerResponse response = await GetResponse())
@@ -144,7 +134,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData("application/json", 152)]
         [InlineData("  applICATion/jSOn   ", 152)]
         [InlineData("garbage", 143)]
@@ -162,7 +151,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(null, null)]
         [InlineData("", null)]
         [InlineData("\r \t \n", "")]
@@ -183,7 +171,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task ContentType_SetDisposed_ThrowsObjectDisposedException()
         {
             HttpListenerResponse response = await GetResponse();
@@ -194,7 +181,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task ContentType_SetAfterHeadersSent_DoesNothing()
         {
             using (HttpListenerResponse response = await GetResponse())
@@ -211,7 +197,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task OutputStream_GetDisposed_ThrowsObjectDisposedException()
         {
             HttpListenerResponse response = await GetResponse();
@@ -221,7 +206,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData("http://microsoft.com", 152)]
         [InlineData("  http://MICROSOFT.com   ", 152)]
         [InlineData("garbage", 139)]
@@ -240,7 +224,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(null, null)]
         [InlineData("", null)]
         [InlineData("\r \t \n", "")]
@@ -264,7 +247,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task RedirectLocation_SetDisposed_ThrowsObjectDisposedException()
         {
             HttpListenerResponse response = await GetResponse();
@@ -275,7 +257,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task RedirectLocation_SetAfterHeadersSent_DoesNothing()
         {
             using (HttpListenerResponse response = await GetResponse())
@@ -292,7 +273,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(100, "HTTP/1.1 100 Continue", 112)]
         [InlineData(404, "HTTP/1.1 404 Not Found", 127)]
         [InlineData(401, "HTTP/1.1 401 Unauthorized", 130)]
@@ -312,7 +292,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task StatusCode_SetDisposed_ThrowsObjectDisposedException()
         {
             HttpListenerResponse response = await GetResponse();
@@ -323,7 +302,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task StatusCode_SetAfterHeadersSent_DoesNothing()
         {
             using (HttpListenerResponse response = await GetResponse())
@@ -340,7 +318,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(99)]
         [InlineData(1000)]
         public async Task StatusCode_SetInvalid_ThrowsProtocolViolationException(int statusCode)
@@ -353,7 +330,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(100, "Continue")]
         [InlineData(101, "Switching Protocols")]
         [InlineData(102, "Processing")]
@@ -419,7 +395,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData("", "", 118)]
         [InlineData("A !#\t1\u1234", "A !#\t14", 125)] // 
         [InlineData("StatusDescription", "StatusDescription", 135)]
@@ -437,7 +412,6 @@ namespace System.Net.Tests
         }
         
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task StatusDescription_SetNull_ThrowsArgumentNullException()
         {
             using (HttpListenerResponse response = await GetResponse())
@@ -448,7 +422,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData("\0abc")]
         [InlineData("\u007F")]
         [InlineData("\r")]
@@ -463,7 +436,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task StatusDescription_SetDisposed_ThrowsObjectDisposedException()
         {
             HttpListenerResponse response = await GetResponse();
@@ -474,7 +446,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task StatusDescription_SetAfterHeadersSent_DoesNothing()
         {
             using (HttpListenerResponse response = await GetResponse())
@@ -491,7 +462,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(true, 120)]
         [InlineData(false, 106)]
         public async Task SendChunked_GetSet_ReturnsExpected(bool sendChunked, int expectedNumberOfBytes)
@@ -527,7 +497,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task SendChunked_SetDisposed_ThrowsObjectDisposedException()
         {
             HttpListenerResponse response = await GetResponse();
@@ -541,7 +510,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task SendChunked_SetAfterHeadersSent_ThrowsInvalidOperationException()
         {
             using (HttpListenerResponse response = await GetResponse())
@@ -558,7 +526,6 @@ namespace System.Net.Tests
         }
         
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task SendChunked_SetTrueAndRequestHttpVersionMinorIsZero_ThrowsInvalidOperationException()
         {
             using (HttpListenerResponse response = await GetResponse("1.0"))
@@ -575,7 +542,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(true, 120)]
         [InlineData(false, 139)]
         public async Task KeepAlive_GetSet_ReturnsExpected(bool keepAlive, int expectedNumberOfBytes)
@@ -613,7 +579,6 @@ namespace System.Net.Tests
         }
         
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task KeepAlive_SetDisposed_ThrowsObjectDisposedException()
         {
             HttpListenerResponse response = await GetResponse();
@@ -630,7 +595,6 @@ namespace System.Net.Tests
         }
         
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task KeepAlive_SetAfterHeadersSent_DoesNothing()
         {
             using (HttpListenerResponse response = await GetResponse())
@@ -647,7 +611,6 @@ namespace System.Net.Tests
         }
         
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task KeepAlive_NoBoundaryAndRequestHttpRequestVersionMinorIsZero_SetsToFalseWhenSendingHeaders()
         {
             using (HttpListenerResponse response = await GetResponse("1.0"))
@@ -663,7 +626,6 @@ namespace System.Net.Tests
         }
         
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task KeepAlive_ContentLengthBoundaryAndRequestHttpVersionMinorIsZero_DoesNotChangeWhenSendingHeaders()
         {
             using (HttpListenerResponse response = await GetResponse("1.0"))
@@ -682,7 +644,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(0, 106)]
         [InlineData(10, 117)]
         public async Task ContentLength64_GetSet_ReturnsExpected(int contentLength64, int expectedNumberOfBytes)
@@ -713,7 +674,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(100, 0, 112)]
         [InlineData(101, 0, 123)]
         [InlineData(204, 0, 114)]
@@ -742,7 +702,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task ContentLength64_SetDisposed_ThrowsObjectDisposedException()
         {
             HttpListenerResponse response = await GetResponse();
@@ -757,7 +716,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task ContentLength64_SetAfterHeadersSent_ThrowsInvalidOperationException()
         {
             using (HttpListenerResponse response = await GetResponse())
@@ -774,7 +732,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task ContentLength64_SetNegative_ThrowsArgumentOutOfRangeException()
         {
             using (HttpListenerResponse response = await GetResponse())
@@ -799,7 +756,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [MemberData(nameof(ProtocolVersion_Set_TestData))]
         public async Task ProtocolVersion_SetValid_ReturnsExpected(Version version)
         {
@@ -816,7 +772,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task ProtocolVersion_SetNull_ThrowsArgumentNullException()
         {
             using (HttpListenerResponse response = await GetResponse())
@@ -827,7 +782,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(0, 0)]
         [InlineData(1, 2)]
         [InlineData(2, 0)]
@@ -841,7 +795,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task Headers_GetSet_ReturnsExpected()
         {
             using (HttpListenerResponse response = await GetResponse())
@@ -865,7 +818,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task Headers_SetCollectionWithRequestHeaders_Works()
         {
             HttpListenerResponse response = await GetResponse();
@@ -880,9 +832,8 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData("Transfer-Encoding")]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Netcoreapp)]
+        [ActiveIssue(22057, TargetFrameworkMonikers.Netcoreapp)]
         public async Task Headers_SetRestricted_ThrowsArgumentException(string name)
         {
             HttpListenerResponse response = await GetResponse();
@@ -891,7 +842,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task Headers_SetNull_ThrowsNullReferenceException()
         {
             using (HttpListenerResponse response = await GetResponse())
@@ -904,8 +854,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Netcoreapp)]
+        [ActiveIssue(22057, TargetFrameworkMonikers.Netcoreapp)]
         public async Task Headers_SetLongName_ThrowsArgumentOutOfRangeException()
         {
             HttpListenerResponse response = await GetResponse();
@@ -917,8 +866,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Netcoreapp)]
+        [ActiveIssue(22057, TargetFrameworkMonikers.Netcoreapp)]
         public async Task Headers_SetRequestHeader_ThrowsInvalidOperationException()
         {
             HttpListenerResponse response = await GetResponse();

--- a/src/System.Net.HttpListener/tests/HttpListenerResponseTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerResponseTests.cs
@@ -60,7 +60,6 @@ namespace System.Net.Tests
     public class HttpListenerResponseTests : HttpListenerResponseTestBase
     {
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task CopyFrom_AllValues_ReturnsClone()
         {
             using (HttpListenerResponse response1 = await GetResponse())
@@ -98,7 +97,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task CopyFrom_NullTemplateResponse_ThrowsNullReferenceException()
         {
             using (HttpListenerResponse response = await GetResponse())
@@ -108,7 +106,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(null, 123)]
         [InlineData("", 123)]
         [InlineData(" \r \t \n", 123)]
@@ -141,7 +138,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task Redirect_Disposed_ThrowsObjectDisposedException()
         {
             HttpListenerResponse response = await GetResponse();
@@ -157,7 +153,6 @@ namespace System.Net.Tests
         
         // The managed implementation should also dispose the OutputStream after calling Abort.
         [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [ActiveIssue(19975, TestPlatforms.AnyUnix)]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task Abort_Invoke_ForciblyTerminatesConnection()
         {
             Client.Send(Factory.GetContent("1.1", "POST", null, "Give me a context, please", null, headerOnly: false));
@@ -193,7 +188,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task Close_Invoke_ClosesConnection()
         {
             using (HttpListenerResponse response = await GetResponse())
@@ -219,7 +213,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task Dispose_Invoke_ClosesConnection()
         {
             using (HttpListenerResponse response = await GetResponse())
@@ -245,7 +238,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task CloseResponseEntity_EmptyResponseEntity_Success(bool willBlock)
@@ -272,7 +264,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalTheory(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [ActiveIssue(20201, TestPlatforms.AnyUnix)]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task CloseResponseEntity_AllContentLengthAlreadySent_DoesNotSendEntity(bool willBlock)
@@ -292,7 +283,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(true)]
         [InlineData(false)]
         [OuterLoop("Investigating reliability in CI.")]
@@ -313,7 +303,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(true)]
         [InlineData(false)]
         [OuterLoop("Investigating reliability in CI.")]
@@ -332,7 +321,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(true)]
         [InlineData(false)]
         [OuterLoop("Investigating reliability in CI.")]
@@ -352,7 +340,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task CloseResponseEntity_AlreadyDisposed_ThrowsObjectDisposedException()
         {
             HttpListenerResponse response = await GetResponse();
@@ -362,7 +349,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task CloseResponseEntity_NullResponseEntity_ThrowsArgumentNullException()
         {
             using (HttpListenerResponse response = await GetResponse())
@@ -372,7 +358,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalTheory(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [ActiveIssue(20201, TestPlatforms.AnyUnix)]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task CloseResponseEntity_SendMoreThanContentLength_ThrowsInvalidOperationException(bool willBlock)
@@ -418,7 +403,6 @@ namespace System.Net.Tests
         }
         
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task CloseResponseEntity_SendToClosedConnection_DoesNotThrow(bool willBlock)

--- a/src/System.Net.HttpListener/tests/HttpListenerTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerTests.cs
@@ -14,7 +14,6 @@ namespace System.Net.Tests
     public class HttpListenerTests
     {
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void IgnoreWriteExceptions_SetDisposed_ThrowsObjectDisposedException()
         {
             var listener = new HttpListener();
@@ -24,7 +23,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void Stop_Disposed_ThrowsObjectDisposedException()
         {
             var listener = new HttpListener();
@@ -34,7 +32,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void IsListening_NotStarted_ReturnsFalse()
         {
             using (var listener = new HttpListener())
@@ -44,7 +41,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void IsListening_Disposed_ReturnsFalse()
         {
             var listener = new HttpListener();
@@ -56,7 +52,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void IsListening_Aborted_ReturnsFalse()
         {
             var listener = new HttpListener();
@@ -68,7 +63,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void IsListening_Stopped_ReturnsFalse()
         {
             var listener = new HttpListener();
@@ -80,7 +74,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void Start_Disposed_ThrowsObjectDisposedException()
         {
             var listener = new HttpListener();
@@ -90,7 +83,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void GetContext_Disposed_ThrowsObjectDisposedException()
         {
             var listener = new HttpListener();
@@ -101,7 +93,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void GetContext_NotStarted_ThrowsInvalidOperationException()
         {
             using (var listener = new HttpListener())
@@ -112,7 +103,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void GetContext_NoPrefixes_ThrowsInvalidOperationException()
         {
             using (var listener = new HttpListener())
@@ -124,7 +114,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void EndGetContext_NullAsyncResult_ThrowsArgumentNullException()
         {
             using (var listener = new HttpListener())
@@ -134,7 +123,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void EndGetContext_InvalidAsyncResult_ThrowsArgumentException()
         {
             using (var listener1 = new HttpListener())
@@ -150,7 +138,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void EndGetContext_AlreadyCalled_ThrowsInvalidOperationException()
         {
             using (var listenerFactory = new HttpListenerFactory())

--- a/src/System.Net.HttpListener/tests/HttpListenerTimeoutManagerTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerTimeoutManagerTests.cs
@@ -11,7 +11,6 @@ namespace System.Net.Tests
     public class HttpListenerTimeoutManagerTests
     {
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(-1)]
         [InlineData((long)uint.MaxValue + 1)]
         public void MinSendBytesPerSecond_NotUInt_ThrowsArgumentOutOfRangeException(long value)
@@ -23,7 +22,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(-1)]
         [InlineData((uint)ushort.MaxValue + 1)]
         public void TimeoutValue_NotUShort_ThrowsArgumentOutOfRangeException(long totalSeconds)
@@ -40,7 +38,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void Get_Disposed_ThrowsObjectDisposedException()
         {
             var listener = new HttpListener();
@@ -127,7 +124,6 @@ namespace System.Net.Tests
         public void Dispose() => _listener.Close();
 
         [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void TimeoutManager_AccessNoStart_Success()
         {
             // Access the TimeoutManager without calling Start and make sure it is initialized.
@@ -139,7 +135,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void TimeoutManager_AccessAfterStart_Success()
         {
             // Access the TimeoutManager after calling Start and make sure it is initialized.
@@ -152,7 +147,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void TimeoutManager_AccessAfterClose_GetObjectDisposedException()
         {
             // Access the TimeoutManager after calling Close and make sure it is not accessible.
@@ -162,7 +156,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void TimeoutManager_AccessBeforeAndAfterClose_GetObjectDisposedException()
         {
             // Access the TimeoutManager after calling Close and make sure it is not accessible.
@@ -174,7 +167,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void TimeoutManager_AccessAfterStop_Success()
         {
             // Access the TimeoutManager after calling Stop and make sure it is accessible.
@@ -189,7 +181,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void DrainEntityBody_SetTimeoutNoStart_GetReturnsNewValue()
         {
             // Set the DrainEntityBody timeout without calling Start and make sure that native layer return new value.
@@ -200,7 +191,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void DrainEntityBody_SetTimeoutAfterStart_GetReturnsNewValue()
         {
             // Set the DrainEntityBody timeout after calling Start and make sure that native layer return new value.
@@ -212,7 +202,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void EntityBody_SetTimeoutNoStart_GetReturnsNewValue()
         {
             // Set the DrainEntityBody timeout without calling Start and make sure that native layer return new value.
@@ -223,7 +212,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void EntityBody_SetTimeoutAfterStart_GetReturnsNewValue()
         {
             // Set the EntityBody timeout after calling Start and make sure that native layer return new value.
@@ -235,7 +223,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void HeaderWait_SetTimeoutNoStart_GetReturnsNewValue()
         {
             // Set the HeaderWait timeout without calling Start and make sure that native layer return new value.
@@ -246,7 +233,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void HeaderWait_SetTimeoutAfterStart_GetReturnsNewValue()
         {
             // Set the HeaderWait timeout after calling Start and make sure that native layer return new value.
@@ -258,7 +244,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void RequestQueue_SetTimeoutNoStart_GetReturnsNewValue()
         {
             // Set the DrainEntityBody timeout without calling Start and make sure that native layer return new value.
@@ -269,7 +254,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void RequestQueue_SetTimeoutAfterStart_GetReturnsNewValue()
         {
             // Set the RequestQueue timeout after calling Start and make sure that native layer return new value.
@@ -281,7 +265,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void IdleConnection_SetTimeoutNoStart_GetReturnsNewValue()
         {
             // Set the IdleConnection timeout without calling Start and make sure that native layer return new value.
@@ -292,7 +275,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void IdleConnection_SetTimeoutAfterStart_GetReturnsNewValue()
         {
             // Set the IdleConnection timeout after calling Start and make sure that native layer return new value.
@@ -304,7 +286,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void MinSendBytesPerSecond_SetNoStart_GetReturnsNewValue()
         {
             // Set the MinSendBytesPerSecond timeout without calling Start and make sure that native layer 
@@ -316,7 +297,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void MinSendBytesPerSecond_SetAfterStart_GetReturnsNewValue()
         {
             // Set the MinSendBytesPerSecond timeout after calling Start and make sure that native 
@@ -329,7 +309,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void MinSendBytesPerSecond_SetAfterClose_GetObjectDisposedException()
         {
             // Set the MinSendBytesPerSecond timeout after calling Close and make sure that we get the exception.
@@ -339,7 +318,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void MinSendBytesPerSecond_SetAfterStop_GetReturnsNewValue()
         {
             // Set the MinSendBytesPerSecond timeout after calling Stop and make sure that native 
@@ -401,7 +379,6 @@ namespace System.Net.Tests
 
 
         [ConditionalTheory(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(1.3, 1)]
         [InlineData(1.6, 2)]
         public void TimeoutValue_Double_Truncates(double seconds, int expected)
@@ -418,7 +395,6 @@ namespace System.Net.Tests
     public class HttpListenerTimeoutManagerUnixTests
     {
         [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsManagedImplementation))] // [PlatformSpecific(TestPlatforms.AnyUnix)] // managed implementation doesn't support all members
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void Properties_DefaultValues()
         {
             using (var listener = new HttpListener())
@@ -435,7 +411,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsManagedImplementation))] // [PlatformSpecific(TestPlatforms.AnyUnix)] // managed implementation doesn't support all members
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void UnsupportedProperties_Throw()
         {
             using (var listener = new HttpListener())
@@ -449,7 +424,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsManagedImplementation))] // [PlatformSpecific(TestPlatforms.AnyUnix)] // managed implementation doesn't support all members
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void DrainEntityBody_Roundtrips()
         {
             using (var listener = new HttpListener())
@@ -464,7 +438,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsManagedImplementation))] // [PlatformSpecific(TestPlatforms.AnyUnix)] // managed implementation doesn't support all members
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void IdleConnection_Roundtrips()
         {
             using (var listener = new HttpListener())

--- a/src/System.Net.HttpListener/tests/HttpListenerWebSocketTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerWebSocketTests.cs
@@ -34,6 +34,7 @@ namespace System.Net.Tests
             Client.Dispose();
         }
 
+        [ActiveIssue(22164, TargetFrameworkMonikers.Uap)] // Fails in RS2 only (works in RS3).
         [ConditionalTheory(nameof(IsNotWindows7))]
         [InlineData(WebSocketMessageType.Text, false)]
         [InlineData(WebSocketMessageType.Binary, false)]

--- a/src/System.Net.HttpListener/tests/HttpListenerWebSocketTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerWebSocketTests.cs
@@ -35,7 +35,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalTheory(nameof(IsNotWindows7))]
-        [ActiveIssue(22053, TargetFrameworkMonikers.Uap)]
         [InlineData(WebSocketMessageType.Text, false)]
         [InlineData(WebSocketMessageType.Binary, false)]
         [InlineData(WebSocketMessageType.Text, true)]
@@ -61,26 +60,23 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(IsNotWindows7))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task SendAsync_NoInnerBuffer_ThrowsArgumentNullException()
         {
             HttpListenerWebSocketContext context = await GetWebSocketContext();
-            await Assert.ThrowsAsync<ArgumentNullException>("buffer.Array", () => context.WebSocket.SendAsync(new ArraySegment<byte>(), WebSocketMessageType.Text, false, new CancellationToken()));
+            await AssertExtensions.ThrowsAsync<ArgumentNullException>("buffer.Array", () => context.WebSocket.SendAsync(new ArraySegment<byte>(), WebSocketMessageType.Text, false, new CancellationToken()));
         }
 
         [ConditionalTheory(nameof(IsNotWindows7))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(WebSocketMessageType.Close)]
         [InlineData(WebSocketMessageType.Text - 1)]
         [InlineData(WebSocketMessageType.Binary + 1)]
         public async Task SendAsync_InvalidMessageType_ThrowsArgumentNullException(WebSocketMessageType messageType)
         {
             HttpListenerWebSocketContext context = await GetWebSocketContext();
-            await Assert.ThrowsAsync<ArgumentException>("messageType", () => context.WebSocket.SendAsync(new ArraySegment<byte>(), messageType, false, new CancellationToken()));
+            await AssertExtensions.ThrowsAsync<ArgumentException>("messageType", () => context.WebSocket.SendAsync(new ArraySegment<byte>(), messageType, false, new CancellationToken()));
         }
 
         [ConditionalFact(nameof(IsNotWindows7AndIsWindowsImplementation))] // [ActiveIssue(20395, TestPlatforms.AnyUnix)]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task SendAsync_Disposed_ThrowsObjectDisposedException()
         {
             HttpListenerWebSocketContext context = await GetWebSocketContext();
@@ -89,8 +85,8 @@ namespace System.Net.Tests
             await Assert.ThrowsAsync<ObjectDisposedException>(() => context.WebSocket.SendAsync(new ArraySegment<byte>(new byte[10]), WebSocketMessageType.Text, false, new CancellationToken()));
         }
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "WebSocket partial send is not supported on UAP. (#22053)")]
         [ConditionalTheory(nameof(IsNotWindows7))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(WebSocketMessageType.Text, false)]
         [InlineData(WebSocketMessageType.Binary, false)]
         [InlineData(WebSocketMessageType.Text, true)]
@@ -116,17 +112,15 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(IsNotWindows7))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task ReceiveAsync_NoInnerBuffer_ThrowsArgumentNullException()
         {
             HttpListenerWebSocketContext context = await GetWebSocketContext();
             await ClientConnectTask;
 
-            await Assert.ThrowsAsync<ArgumentNullException>("buffer.Array", () => context.WebSocket.ReceiveAsync(new ArraySegment<byte>(), new CancellationToken()));
+            await AssertExtensions.ThrowsAsync<ArgumentNullException>("buffer.Array", () => context.WebSocket.ReceiveAsync(new ArraySegment<byte>(), new CancellationToken()));
         }
 
         [ConditionalFact(nameof(IsNotWindows7AndIsWindowsImplementation))] // [ActiveIssue(20395, TestPlatforms.AnyUnix)]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task ReceiveAsync_Disposed_ThrowsObjectDisposedException()
         {
             HttpListenerWebSocketContext context = await GetWebSocketContext();
@@ -145,7 +139,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalTheory(nameof(IsNotWindows7AndIsWindowsImplementation))] // [ActiveIssue(20396, TestPlatforms.AnyUnix)]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [MemberData(nameof(CloseStatus_Valid_TestData))]
         public async Task CloseOutputAsync_HandshakeStartedFromClient_Success(WebSocketCloseStatus status, string statusDescription, WebSocketCloseStatus expectedCloseStatus)
         {
@@ -209,7 +202,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalTheory(nameof(IsNotWindows7AndIsWindowsImplementation))] // [ActiveIssue(20396, TestPlatforms.AnyUnix)]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [MemberData(nameof(CloseStatus_Valid_TestData))]
         public async Task CloseAsync_HandshakeStartedFromClient_Success(WebSocketCloseStatus status, string statusDescription, WebSocketCloseStatus expectedCloseStatus)
         {
@@ -283,7 +275,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalTheory(nameof(IsNotWindows7))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [MemberData(nameof(CloseStatus_Invalid_TestData))]
         public async Task CloseAsync_InvalidCloseStatus_ThrowsArgumentException(WebSocketCloseStatus status, string statusDescription, string paramName)
         {
@@ -294,7 +285,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(IsNotWindows7AndIsWindowsImplementation))] // [ActiveIssue(20394, TestPlatforms.AnyUnix)]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task CloseAsync_AfterDisposed_Nop()
         {
             HttpListenerWebSocketContext context = await GetWebSocketContext();
@@ -305,7 +295,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(IsNotWindows7AndIsWindowsImplementation))] // [ActiveIssue(20394, TestPlatforms.AnyUnix)]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task CloseAsync_AfterAborted_Nop()
         {
             HttpListenerWebSocketContext context = await GetWebSocketContext();
@@ -316,7 +305,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(IsNotWindows7AndIsWindowsImplementation))] // [ActiveIssue(20397, TestPlatforms.AnyUnix)]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task Dispose_CallAfterDisposed_Nop()
         {
             HttpListenerWebSocketContext context = await GetWebSocketContext();
@@ -331,7 +319,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(IsNotWindows7))]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task Abort_CallAfterAborted_Nop()
         {
             HttpListenerWebSocketContext context = await GetWebSocketContext();

--- a/src/System.Net.HttpListener/tests/HttpRequestStreamTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpRequestStreamTests.cs
@@ -33,7 +33,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(true, "")]
         [InlineData(false, "")]
         [InlineData(true, "Non-Empty")]
@@ -77,8 +76,8 @@ namespace System.Net.Tests
             }
         }
 
+        [ActiveIssue(22110, TargetFrameworkMonikers.UapAot)]
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(true, "")]
         [InlineData(false, "")]
         [InlineData(true, "Non-Empty")]
@@ -125,7 +124,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(true, "")]
         [InlineData(false, "")]
         [InlineData(true, "Non-Empty")]
@@ -170,7 +168,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task Read_LargeLengthAsynchronous_Success(bool transferEncodingChunked)
@@ -210,7 +207,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task Read_LargeLengthSynchronous_Success(bool transferEncodingChunked)
@@ -248,9 +244,9 @@ namespace System.Net.Tests
                 context.Response.Close();
             }
         }
-        
+
+        [ActiveIssue(22110, TargetFrameworkMonikers.UapAot)]
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task Read_TooMuchAsynchronous_Success(bool transferEncodingChunked)
@@ -275,8 +271,8 @@ namespace System.Net.Tests
             }
         }
 
+        [ActiveIssue(22110, TargetFrameworkMonikers.UapAot)]
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task Read_TooMuchSynchronous_Success(bool transferEncodingChunked)
@@ -302,7 +298,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task Read_NotEnoughThenCloseAsynchronous_Success(bool transferEncodingChunked)
@@ -326,8 +321,8 @@ namespace System.Net.Tests
             }
         }
 
+        [ActiveIssue(22110, TargetFrameworkMonikers.UapAot)]
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task Read_Disposed_ReturnsZero(bool transferEncodingChunked)
@@ -356,7 +351,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task CanSeek_Get_ReturnsFalse()
         {
             HttpListenerRequest response = await _helper.GetRequest(chunked: true);
@@ -374,8 +368,8 @@ namespace System.Net.Tests
             }
         }
 
+        [ActiveIssue(22110, TargetFrameworkMonikers.UapAot)]
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task CanRead_Get_ReturnsTrue()
         {
             HttpListenerRequest request = await _helper.GetRequest(chunked: true);
@@ -385,8 +379,8 @@ namespace System.Net.Tests
             }
         }
 
+        [ActiveIssue(22066, TargetFrameworkMonikers.UapAot)]
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task CanWrite_Get_ReturnsFalse()
         {
             HttpListenerRequest request = await _helper.GetRequest(chunked: true);
@@ -405,7 +399,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task Read_NullBuffer_ThrowsArgumentNullException(bool chunked)
@@ -414,12 +407,12 @@ namespace System.Net.Tests
             using (Stream inputStream = request.InputStream)
             {
                 AssertExtensions.Throws<ArgumentNullException>("buffer", () => inputStream.Read(null, 0, 0));
-                await Assert.ThrowsAsync<ArgumentNullException>("buffer", () => inputStream.ReadAsync(null, 0, 0));
+                await AssertExtensions.ThrowsAsync<ArgumentNullException>("buffer", () => inputStream.ReadAsync(null, 0, 0));
             }
         }
 
+        [ActiveIssue(22110, TargetFrameworkMonikers.UapAot)]
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(-1, true)]
         [InlineData(3, true)]
         [InlineData(-1, false)]
@@ -430,12 +423,12 @@ namespace System.Net.Tests
             using (Stream inputStream = request.InputStream)
             {
                 AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => inputStream.Read(new byte[2], offset, 0));
-                await Assert.ThrowsAsync<ArgumentOutOfRangeException>("offset", () => inputStream.ReadAsync(new byte[2], offset, 0));
+                await AssertExtensions.ThrowsAsync<ArgumentOutOfRangeException>("offset", () => inputStream.ReadAsync(new byte[2], offset, 0));
             }
         }
 
+        [ActiveIssue(22110, TargetFrameworkMonikers.UapAot)]
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(0, 3, true)]
         [InlineData(1, 2, true)]
         [InlineData(2, 1, true)]
@@ -448,12 +441,11 @@ namespace System.Net.Tests
             using (Stream inputStream = request.InputStream)
             {
                 AssertExtensions.Throws<ArgumentOutOfRangeException>("size", () => inputStream.Read(new byte[2], offset, size));
-                await Assert.ThrowsAsync<ArgumentOutOfRangeException>("size", () => inputStream.ReadAsync(new byte[2], offset, size));
+                await AssertExtensions.ThrowsAsync<ArgumentOutOfRangeException>("size", () => inputStream.ReadAsync(new byte[2], offset, size));
             }
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task EndRead_NullAsyncResult_ThrowsArgumentNullException(bool chunked)
@@ -466,7 +458,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task EndRead_InvalidAsyncResult_ThrowsArgumentException(bool chunked)
@@ -485,7 +476,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task EndRead_CalledTwice_ThrowsInvalidOperationException(bool chunked)
@@ -501,7 +491,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task Read_FromClosedConnectionAsynchronously_ThrowsHttpListenerException()
         {
             const string Text = "Some-String";
@@ -528,7 +517,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task Read_FromClosedConnectionSynchronously_ThrowsHttpListenerException()
         {
             const string Text = "Some-String";

--- a/src/System.Net.HttpListener/tests/HttpResponseStreamTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpResponseStreamTests.cs
@@ -552,6 +552,7 @@ namespace System.Net.Tests
             }
         }
 
+        [ActiveIssue(22110, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public async Task EndWrite_InvalidAsyncResult_ThrowsArgumentException()
         {

--- a/src/System.Net.HttpListener/tests/HttpResponseStreamTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpResponseStreamTests.cs
@@ -33,7 +33,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task SimpleRequest_WriteAsynchronously_Succeeds(bool sendChunked)
@@ -72,7 +71,6 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task SimpleRequest_WriteSynchronouslyNonEmpty_Succeeds(bool sendChunked)
@@ -111,7 +109,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task SimpleRequest_WriteAsynchronouslyInParts_Succeeds()
         {
             const string expectedResponse = "hello from HttpListener";
@@ -140,8 +137,8 @@ namespace System.Net.Tests
             }
         }
 
+        [ActiveIssue(22110, TargetFrameworkMonikers.UapAot)]
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task SimpleRequest_WriteSynchronouslyInParts_Succeeds()
         {
             const string expectedResponse = "hello from HttpListener";
@@ -170,8 +167,8 @@ namespace System.Net.Tests
             }
         }
 
+        [ActiveIssue(22110, TargetFrameworkMonikers.UapAot)]
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task SimpleRequest_WriteAynchronouslyEmpty_Succeeds()
         {
             Task<HttpListenerContext> serverContextTask = _listener.GetContextAsync();
@@ -195,7 +192,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task SimpleRequest_WriteSynchronouslyEmpty_Succeeds()
         {
             Task<HttpListenerContext> serverContextTask = _listener.GetContextAsync();
@@ -219,7 +215,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task CanSeek_Get_ReturnsFalse()
         {
             using (HttpListenerResponse response = await _helper.GetResponse())
@@ -237,8 +232,8 @@ namespace System.Net.Tests
             }
         }
 
+        [ActiveIssue(22066, TargetFrameworkMonikers.UapAot)]
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task CanRead_Get_ReturnsFalse()
         {
             using (HttpListenerResponse response = await _helper.GetResponse())
@@ -253,7 +248,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task CanWrite_Get_ReturnsTrue()
         {
             using (HttpListenerResponse response = await _helper.GetResponse())
@@ -268,18 +262,16 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task Write_NullBuffer_ThrowsArgumentNullException()
         {
             using (HttpListenerResponse response = await _helper.GetResponse())
             using (Stream outputStream = response.OutputStream)
             {
                 AssertExtensions.Throws<ArgumentNullException>("buffer", () => outputStream.Write(null, 0, 0));
-                await Assert.ThrowsAsync<ArgumentNullException>("buffer", () => outputStream.WriteAsync(null, 0, 0));
+                await AssertExtensions.ThrowsAsync<ArgumentNullException>("buffer", () => outputStream.WriteAsync(null, 0, 0));
             }
         }
 
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [Theory]
         [InlineData(-1)]
         [InlineData(3)]
@@ -289,11 +281,11 @@ namespace System.Net.Tests
             using (Stream outputStream = response.OutputStream)
             {
                 AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => outputStream.Write(new byte[2], offset, 0));
-                await Assert.ThrowsAsync<ArgumentOutOfRangeException>("offset", () => outputStream.WriteAsync(new byte[2], offset, 0));
+                await AssertExtensions.ThrowsAsync<ArgumentOutOfRangeException>("offset", () => outputStream.WriteAsync(new byte[2], offset, 0));
             }
         }
 
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
+        [ActiveIssue(22110, TargetFrameworkMonikers.UapAot)]
         [Theory]
         [InlineData(0, 3)]
         [InlineData(1, 2)]
@@ -304,12 +296,11 @@ namespace System.Net.Tests
             using (Stream outputStream = response.OutputStream)
             {
                 AssertExtensions.Throws<ArgumentOutOfRangeException>("size", () => outputStream.Write(new byte[2], offset, size));
-                await Assert.ThrowsAsync<ArgumentOutOfRangeException>("size", () => outputStream.WriteAsync(new byte[2], offset, size));
+                await AssertExtensions.ThrowsAsync<ArgumentOutOfRangeException>("size", () => outputStream.WriteAsync(new byte[2], offset, size));
             }
         }
 
         [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [ActiveIssue(20201, TestPlatforms.AnyUnix)]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task Write_TooMuch_ThrowsProtocolViolationException()
         {
             using (HttpClient client = new HttpClient())
@@ -338,7 +329,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [ActiveIssue(20201, TestPlatforms.AnyUnix)]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task Write_TooLittleAsynchronouslyAndClose_ThrowsInvalidOperationException()
         {
             using (HttpClient client = new HttpClient())
@@ -365,7 +355,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [ActiveIssue(20201, TestPlatforms.AnyUnix)]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task Write_TooLittleSynchronouslyAndClose_ThrowsInvalidOperationException()
         {
             using (HttpClient client = new HttpClient())
@@ -394,7 +383,6 @@ namespace System.Net.Tests
         [ActiveIssue(20246)] // CI hanging frequently
         [ActiveIssue(19534, TestPlatforms.OSX)]
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task Write_HeadersToClosedConnectionAsynchronously_ThrowsHttpListenerException(bool ignoreWriteExceptions)
@@ -434,7 +422,6 @@ namespace System.Net.Tests
         [ActiveIssue(20246)] // CI hanging frequently
         [ActiveIssue(19534, TestPlatforms.OSX)]
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task Write_HeadersToClosedConnectionSynchronously_ThrowsHttpListenerException(bool ignoreWriteExceptions)
@@ -474,7 +461,6 @@ namespace System.Net.Tests
 
         [ActiveIssue(19534, TestPlatforms.OSX)]
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(true)]
         [InlineData(false)]
         [ActiveIssue(18188, platforms: TestPlatforms.Windows)] // Indeterminate failure - socket not always fully disconnected.
@@ -515,7 +501,6 @@ namespace System.Net.Tests
 
         [ActiveIssue(19534, TestPlatforms.OSX)]
         [Theory]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [InlineData(true)]
         [InlineData(false)]
         [ActiveIssue(18188, platforms: TestPlatforms.Windows)] // Indeterminate failure - socket not always fully disconnected.
@@ -554,7 +539,6 @@ namespace System.Net.Tests
             }
         }
 
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
@@ -568,7 +552,6 @@ namespace System.Net.Tests
             }
         }
 
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [Fact]
         public async Task EndWrite_InvalidAsyncResult_ThrowsArgumentException()
         {
@@ -584,7 +567,6 @@ namespace System.Net.Tests
             }
         }
 
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         [Fact]
         public async Task EndWrite_CalledTwice_ThrowsInvalidOperationException()
         {

--- a/src/System.Net.HttpListener/tests/HttpResponseStreamTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpResponseStreamTests.cs
@@ -539,6 +539,7 @@ namespace System.Net.Tests
             }
         }
 
+        [ActiveIssue(22110, TargetFrameworkMonikers.UapAot)]
         [Theory]
         [InlineData(true)]
         [InlineData(false)]

--- a/src/System.Net.HttpListener/tests/InvalidClientRequestTests.cs
+++ b/src/System.Net.HttpListener/tests/InvalidClientRequestTests.cs
@@ -92,7 +92,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task GetContext_InvalidRequest_DoesNotGetContext()
         {
             // These tests take upwards of 20s if this uses [Theory].

--- a/src/System.Net.HttpListener/tests/SimpleHttpTests.cs
+++ b/src/System.Net.HttpListener/tests/SimpleHttpTests.cs
@@ -22,14 +22,12 @@ namespace System.Net.Tests
         public void Dispose() => _factory.Dispose();
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public static void Supported_True()
         {
             Assert.True(HttpListener.IsSupported);
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void BasicTest_StartStop_NoException()
         {
             HttpListener listener = new HttpListener();
@@ -46,7 +44,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void BasicTest_StartCloseAbort_NoException()
         {
             HttpListener listener = new HttpListener();
@@ -63,7 +60,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void BasicTest_StartAbortClose_NoException()
         {
             HttpListener listener = new HttpListener();
@@ -80,7 +76,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void BasicTest_StopNoStart_NoException()
         {
             HttpListener listener = new HttpListener();
@@ -89,7 +84,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void BasicTest_CloseNoStart_NoException()
         {
             HttpListener listener = new HttpListener();
@@ -97,7 +91,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void BasicTest_AbortNoStart_NoException()
         {
             HttpListener listener = new HttpListener();
@@ -105,7 +98,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public void BasicTest_StartThrowsAbortCalledInFinally_AbortDoesntThrow()
         {
             HttpListener listener = new HttpListener();

--- a/src/System.Net.HttpListener/tests/System.Net.HttpListener.Tests.csproj
+++ b/src/System.Net.HttpListener/tests/System.Net.HttpListener.Tests.csproj
@@ -10,26 +10,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="GetContextHelper.cs" />
+    <Compile Include="HttpListenerFactory.cs" />
     <Compile Include="HttpListenerAuthenticationTests.cs" />
     <Compile Include="HttpListenerContextTests.cs" />
     <Compile Include="HttpListenerPrefixCollectionTests.cs" />
+    <Compile Include="HttpListenerResponseTests.cs" />
     <Compile Include="HttpListenerResponseTests.Cookies.cs" />
     <Compile Include="HttpListenerResponseTests.Headers.cs" />
-    <Compile Include="HttpListenerResponseTests.cs" />
     <Compile Include="HttpListenerRequestTests.cs" />
     <Compile Include="HttpListenerTests.cs" />
+    <Compile Include="HttpListenerTimeoutManagerTests.cs" />
+    <Compile Include="HttpListenerWebSocketTests.cs" />
     <Compile Include="HttpRequestStreamTests.cs" />
     <Compile Include="HttpResponseStreamTests.cs" />
     <Compile Include="InvalidClientRequestTests.cs" />
     <Compile Include="SimpleHttpTests.cs" />
-    <Compile Include="HttpListenerFactory.cs" />
-    <Compile Include="HttpListenerWebSocketTests.cs" />
     <Compile Include="WebSocketTests.cs" />
     <Compile Include="XUnitAssemblyAttributes.cs" />
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
       <Link>Common\tests\System\PlatformDetection.cs</Link>
     </Compile>
-    <Compile Include="HttpListenerTimeoutManagerTests.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Net.HttpListener/tests/WebSocketTests.cs
+++ b/src/System.Net.HttpListener/tests/WebSocketTests.cs
@@ -24,7 +24,6 @@ namespace System.Net.Tests
         public void Dispose() => _factory.Dispose();
 
         [Fact]
-        [ActiveIssue(17462, TargetFrameworkMonikers.Uap)]
         public async Task AcceptWebSocketAsync_NullSubProtocol_Succeeds()
         {
             if (PlatformDetection.IsWindows7)


### PR DESCRIPTION
Contributes to #17462.