### PR TITLE
Fix bug in MS.CSharp handling non-generic classes nested in generic

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
@@ -354,7 +354,16 @@ namespace Microsoft.CSharp.RuntimeBinder
         private Name GetName(Type type)
         {
             string name = type.Name;
-            return type.IsGenericType ? _nameManager.Add(name, name.IndexOf('`')) : _nameManager.Add(name);
+            if (type.IsGenericType)
+            {
+                int idx = name.IndexOf('`');
+                if (idx >= 0)
+                {
+                    return _nameManager.Add(name, idx);
+                }
+            }
+
+            return _nameManager.Add(name);
         }
 
         #endregion

--- a/src/Microsoft.CSharp/tests/RuntimeBinderTests.cs
+++ b/src/Microsoft.CSharp/tests/RuntimeBinderTests.cs
@@ -110,5 +110,23 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
                                                          );
         }
 
+        public class OuterType<T>
+        {
+            public class MyEntity
+            {
+                public int Id { get; set; }
+
+                public string Name { get; set; }
+            }
+        }
+
+        [Fact]
+        public void AccessMemberOfNonGenericNestedInGeneric()
+        {
+            Func<dynamic, int> dynamicDelegate = e => e.Id;
+            var dto = new OuterType<int>.MyEntity { Id = 1, Name = "Foo" };
+            Assert.Equal(1, dynamicDelegate(dto));
+        }
+
     }
 }


### PR DESCRIPTION
Such types are still generic but don't have a tick in their name, which the name lookup expects all generic types' names to have.

Handle this case correctly.

Fixes #21689