### PR TITLE
Increase ulimit value on OSX to allow opening multiple sockets for testing.

### DIFF
--- a/src/System.Net.HttpListener/tests/System.Net.HttpListener.Tests.csproj
+++ b/src/System.Net.HttpListener/tests/System.Net.HttpListener.Tests.csproj
@@ -31,5 +31,8 @@
     </Compile>
     <Compile Include="HttpListenerTimeoutManagerTests.cs" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetsOSX)'=='true'">
+    <TestCommandLines Include="ulimit -n 70000" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
cc @MattGal @Petermarcu @bartonjs 

@MattGal I made this change and tested on a OSX machine. I didn't notice this line getting added in the ```RunTests.sh``` file. Is this something that only gets parsed for helix builds?