### PR TITLE
Fixing WindowsIdentity.IsAuthenticated for UWP and removing test workarounds.

### DIFF
--- a/src/Common/src/Interop/Windows/kernel32/Interop.CheckTokenMembershipEx.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.CheckTokenMembershipEx.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Kernel32
+    {
+		internal const uint CTMF_INCLUDE_APPCONTAINER = 0x00000001;
+
+        [DllImport(Interop.Libraries.Kernel32, SetLastError = true)]
+        internal static extern bool CheckTokenMembershipEx(SafeAccessTokenHandle TokenHandle, byte[] SidToCheck, uint Flags, ref bool IsMember);
+    }
+}

--- a/src/Common/src/Interop/Windows/kernel32/Interop.CheckTokenMembershipEx.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.CheckTokenMembershipEx.cs
@@ -10,7 +10,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-		internal const uint CTMF_INCLUDE_APPCONTAINER = 0x00000001;
+        internal const uint CTMF_INCLUDE_APPCONTAINER = 0x00000001;
 
         [DllImport(Interop.Libraries.Kernel32, SetLastError = true)]
         internal static extern bool CheckTokenMembershipEx(SafeAccessTokenHandle TokenHandle, byte[] SidToCheck, uint Flags, ref bool IsMember);

--- a/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamStreamToStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamStreamToStreamTest.cs
@@ -21,7 +21,6 @@ namespace System.Net.Security.Tests
         protected abstract Task AuthenticateAsClientAsync(NegotiateStream client, NetworkCredential credential, string targetName);
         protected abstract Task AuthenticateAsServerAsync(NegotiateStream server);
 
-        [ActiveIssue(18760, TargetFrameworkMonikers.UapAot)] // In order to properly test this, we need UWP-AOT to run within an App Container.
         [Fact]
         public void NegotiateStream_StreamToStream_Authentication_Success()
         {
@@ -68,21 +67,12 @@ namespace System.Net.Security.Tests
                 IIdentity clientIdentity = server.RemoteIdentity;
                 Assert.Equal("NTLM", clientIdentity.AuthenticationType);
 
-                if (PlatformDetection.IsUap)
-                {
-                    // TODO #21282: UWP AppContainer issue - clientIdentity.IsAuthenticated == false.
-                    Assert.Equal(false, clientIdentity.IsAuthenticated);
-                }
-                else
-                {
-                    Assert.Equal(true, clientIdentity.IsAuthenticated);
-                }
+                Assert.Equal(true, clientIdentity.IsAuthenticated);
 
                 IdentityValidator.AssertIsCurrentIdentity(clientIdentity);
             }
         }
 
-        [ActiveIssue(18760, TargetFrameworkMonikers.UapAot)] // In order to properly test this, we need UWP-AOT to run within an App Container.
         [Fact]
         public void NegotiateStream_StreamToStream_Authentication_TargetName_Success()
         {
@@ -132,15 +122,7 @@ namespace System.Net.Security.Tests
                 IIdentity clientIdentity = server.RemoteIdentity;
                 Assert.Equal("NTLM", clientIdentity.AuthenticationType);
 
-                if (PlatformDetection.IsUap)
-                {
-                    // TODO #21282: UWP issue - clientIdentity.IsAuthenticated == false.
-                    Assert.Equal(false, clientIdentity.IsAuthenticated);
-                }
-                else
-                {
-                    Assert.Equal(true, clientIdentity.IsAuthenticated);
-                }
+                Assert.Equal(true, clientIdentity.IsAuthenticated);
 
                 IdentityValidator.AssertIsCurrentIdentity(clientIdentity);
             }

--- a/src/System.Security.Principal.Windows/src/PinvokeAnalyzerExceptionList.analyzerdata.uap
+++ b/src/System.Security.Principal.Windows/src/PinvokeAnalyzerExceptionList.analyzerdata.uap
@@ -6,6 +6,7 @@ advapi32.dll!LsaLookupSids
 advapi32.dll!LsaNtStatusToWinError
 advapi32.dll!LsaOpenPolicy
 advapi32.dll!OpenProcessToken
+kernel32.dll!CheckTokenMembershipEx
 ntdll.dll!RtlNtStatusToDosError
 sspicli.dll!LsaConnectUntrusted
 sspicli.dll!LsaDeregisterLogonProcess

--- a/src/System.Security.Principal.Windows/src/System.Security.Principal.Windows.csproj
+++ b/src/System.Security.Principal.Windows/src/System.Security.Principal.Windows.csproj
@@ -8,12 +8,6 @@
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netfx'">true</IsPartialFacadeAssembly>
     <ResourcesSourceOutputDirectory Condition="'$(TargetGroup)' == 'netfx'">None</ResourcesSourceOutputDirectory>
     <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsWindows)' != 'true'">SR.PlatformNotSupported_Principal</GeneratePlatformNotSupportedAssemblyMessage>
-    <!-- 
-      TODO: #22128
-      Getting error BCL0015: kernel32.dll!CheckTokenMembershipEx is not supported on one\more targeted platforms.Consider using advapi32.dll!CheckTokenMembershipEx instead which doesn't exist.
-      Using advapi32.dll!CheckTokenMembershipEx will give out a runtime error: System.EntryPointNotFoundException : Unable to find an entry point named 'CheckTokenMembershipEx' in DLL 'advapi32.dll'.
-    -->
-    <UWPCompatible>false</UWPCompatible>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetGroup)' == 'uap'">
     <DefineConstants>$(DefineConstants);uap</DefineConstants>

--- a/src/System.Security.Principal.Windows/src/System.Security.Principal.Windows.csproj
+++ b/src/System.Security.Principal.Windows/src/System.Security.Principal.Windows.csproj
@@ -8,6 +8,15 @@
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netfx'">true</IsPartialFacadeAssembly>
     <ResourcesSourceOutputDirectory Condition="'$(TargetGroup)' == 'netfx'">None</ResourcesSourceOutputDirectory>
     <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsWindows)' != 'true'">SR.PlatformNotSupported_Principal</GeneratePlatformNotSupportedAssemblyMessage>
+    <!-- 
+      TODO: #22128
+      Getting error BCL0015: kernel32.dll!CheckTokenMembershipEx is not supported on one\more targeted platforms.Consider using advapi32.dll!CheckTokenMembershipEx instead which doesn't exist.
+      Using advapi32.dll!CheckTokenMembershipEx will give out a runtime error: System.EntryPointNotFoundException : Unable to find an entry point named 'CheckTokenMembershipEx' in DLL 'advapi32.dll'.
+    -->
+    <UWPCompatible>false</UWPCompatible>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetGroup)' == 'uap'">
+    <DefineConstants>$(DefineConstants);uap</DefineConstants>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />
@@ -64,9 +73,6 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.OpenProcessToken_SafeAccessTokenHandle.cs">
       <Link>Common\Interop\Interop.OpenProcessToken.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.CheckTokenMembership.cs">
-      <Link>Common\Interop\Interop.CheckTokenMembership.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.GetTokenInformation.cs">
       <Link>Common\Interop\Interop.GetTokenInformation.cs</Link>
@@ -181,6 +187,16 @@
     </Compile>
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeLsaHandle.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeLsaHandle.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp' AND '$(TargetsWindows)' == 'true'">
+    <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.CheckTokenMembership.cs">
+      <Link>Common\Interop\Interop.CheckTokenMembership.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'uap' AND '$(TargetsWindows)' == 'true'">
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.CheckTokenMembershipEx.cs">
+      <Link>Common\Interop\Interop.CheckTokenMembershipEx.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netfx'">

--- a/src/System.Security.Principal.Windows/src/System/Security/Principal/WindowsIdentity.cs
+++ b/src/System.Security.Principal.Windows/src/System/Security/Principal/WindowsIdentity.cs
@@ -403,10 +403,20 @@ namespace System.Security.Principal
 
 
                 // CheckTokenMembership will check if the SID is both present and enabled in the access token.
+#if uap
+                if (!Interop.Kernel32.CheckTokenMembershipEx((til != TokenImpersonationLevel.None ? _safeTokenHandle : token),
+                                                      sid.BinaryForm,
+                                                      Interop.Kernel32.CTMF_INCLUDE_APPCONTAINER,
+                                                      ref isMember))
+                    throw new SecurityException(new Win32Exception().Message);
+#else
                 if (!Interop.Advapi32.CheckTokenMembership((til != TokenImpersonationLevel.None ? _safeTokenHandle : token),
                                                       sid.BinaryForm,
                                                       ref isMember))
                     throw new SecurityException(new Win32Exception().Message);
+#endif
+
+
             }
             finally
             {

--- a/src/System.Security.Principal.Windows/src/System/Security/Principal/WindowsPrincipal.cs
+++ b/src/System.Security.Principal.Windows/src/System/Security/Principal/WindowsPrincipal.cs
@@ -194,11 +194,20 @@ namespace System.Security.Principal
             }
 
             bool isMember = false;
+
             // CheckTokenMembership will check if the SID is both present and enabled in the access token.
+#if uap
+            if (!Interop.Kernel32.CheckTokenMembershipEx((_identity.ImpersonationLevel != TokenImpersonationLevel.None ? _identity.AccessToken : token),
+                                                  sid.BinaryForm,
+                                                  Interop.Kernel32.CTMF_INCLUDE_APPCONTAINER,
+                                                  ref isMember))
+                throw new SecurityException(new Win32Exception().Message);
+#else
             if (!Interop.Advapi32.CheckTokenMembership((_identity.ImpersonationLevel != TokenImpersonationLevel.None ? _identity.AccessToken : token),
                                                   sid.BinaryForm,
                                                   ref isMember))
                 throw new SecurityException(new Win32Exception().Message);
+#endif
 
             token.Dispose();
             return isMember;

--- a/src/System.Security.Principal.Windows/tests/WindowsIdentityTests.cs
+++ b/src/System.Security.Principal.Windows/tests/WindowsIdentityTests.cs
@@ -39,15 +39,7 @@ public class WindowsIdentityTests
             string authenticationType = "WindowsAuthentication";
             WindowsIdentity windowsIdentity2 = new WindowsIdentity(logonToken, authenticationType);
             Assert.NotNull(windowsIdentity2);
-
-            if (PlatformDetection.IsWinRT)
-            {
-                Assert.False(windowsIdentity2.IsAuthenticated);
-            }
-            else
-            {
-                Assert.True(windowsIdentity2.IsAuthenticated);
-            }
+            Assert.True(windowsIdentity2.IsAuthenticated);
 
             Assert.Equal(authenticationType, windowsIdentity2.AuthenticationType);
             CheckDispose(windowsIdentity2);


### PR DESCRIPTION
Apps running in a container need to call [CheckTokenMembershipEx ](https://msdn.microsoft.com/en-us/library/windows/desktop/hh448479(v=vs.85).aspx) instead of CheckTokenMembership passing the `CTMF_INCLUDE_APPCONTAINER` flag for authentication validation to work.

A potential Windows SDK issue is misplacing the new API. I'm tracking the temporary workaround with #22128. (/cc @danmosemsft @AlexGhiondea )

Fixes #21282.
