### PR TITLE
Remove preemptive checks for path being too long in CoreFX

### DIFF
--- a/src/Common/src/System/IO/PathInternal.Unix.cs
+++ b/src/Common/src/System/IO/PathInternal.Unix.cs
@@ -39,22 +39,6 @@ namespace System.IO
         }
 
         /// <summary>
-        /// Returns true if the path is too long
-        /// </summary>
-        internal static bool IsPathTooLong(string fullPath)
-        {
-            return fullPath.Length >= Interop.Sys.MaxPath;
-        }
-
-        /// <summary>
-        /// Returns true if the directory is too long
-        /// </summary>
-        internal static bool IsDirectoryTooLong(string fullPath)
-        {
-            return fullPath.Length >= Interop.Sys.MaxPath;
-        }
-
-        /// <summary>
         /// Normalize separators in the given path. Compresses forward slash runs.
         /// </summary>
         internal static string NormalizeDirectorySeparators(string path)

--- a/src/Common/src/System/IO/PathInternal.Windows.cs
+++ b/src/Common/src/System/IO/PathInternal.Windows.cs
@@ -83,24 +83,6 @@ namespace System.IO
         }
 
         /// <summary>
-        /// Returns true if the path is too long
-        /// </summary>
-        internal static bool IsPathTooLong(string fullPath)
-        {
-            // We'll never know precisely what will fail as paths get changed internally in Windows and
-            // may grow to exceed MaxLongPath.
-            return fullPath.Length >= MaxLongPath;
-        }
-
-        /// <summary>
-        /// Returns true if the directory is too long
-        /// </summary>
-        internal static bool IsDirectoryTooLong(string fullPath)
-        {
-            return IsPathTooLong(fullPath);
-        }
-
-        /// <summary>
         /// Adds the extended path prefix (\\?\) if not already a device path, IF the path is not relative,
         /// AND the path is more than 259 characters. (> MAX_PATH + null)
         /// </summary>

--- a/src/System.IO.FileSystem/src/System/IO/Directory.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Directory.cs
@@ -512,8 +512,6 @@ namespace System.IO
             if (path.Length == 0)
                 throw new ArgumentException(SR.Argument_PathEmpty, nameof(path));
             Contract.EndContractBlock();
-            if (PathInternal.IsPathTooLong(path))
-                throw new PathTooLongException(SR.IO_PathTooLong);
 
             string fulldestDirName = Path.GetFullPath(path);
 
@@ -537,13 +535,8 @@ namespace System.IO
             string fullsourceDirName = Path.GetFullPath(sourceDirName);
             string sourcePath = EnsureTrailingDirectorySeparator(fullsourceDirName);
 
-            if (PathInternal.IsDirectoryTooLong(sourcePath))
-                throw new PathTooLongException(SR.IO_PathTooLong);
-
             string fulldestDirName = Path.GetFullPath(destDirName);
             string destPath = EnsureTrailingDirectorySeparator(fulldestDirName);
-            if (PathInternal.IsDirectoryTooLong(destPath))
-                throw new PathTooLongException(SR.IO_PathTooLong);
 
             StringComparison pathComparison = PathInternal.StringComparison;
 

--- a/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
+++ b/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
@@ -391,12 +391,6 @@ namespace System.IO
             else
                 fullSourcePath = FullPath + PathHelpers.DirectorySeparatorCharAsString;
 
-            if (PathInternal.IsDirectoryTooLong(fullSourcePath))
-                throw new PathTooLongException(SR.IO_PathTooLong);
-
-            if (PathInternal.IsDirectoryTooLong(destinationWithSeparator))
-                throw new PathTooLongException(SR.IO_PathTooLong);
-
             StringComparison pathComparison = PathInternal.StringComparison;
             if (string.Equals(fullSourcePath, destinationWithSeparator, pathComparison))
                 throw new IOException(SR.IO_SourceDestMustBeDifferent);

--- a/src/System.IO.FileSystem/src/System/IO/PathHelpers.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/PathHelpers.Windows.cs
@@ -36,11 +36,6 @@ namespace System.IO
                     throw new ArgumentException(SR.Arg_InvalidSearchPattern, nameof(searchPattern));
                 }
             }
-
-            if (searchPattern.Length >= PathInternal.MaxComponentLength)
-            {
-                throw new PathTooLongException(SR.IO_PathTooLong);
-            }
         }
 
         // this is a lightweight version of GetDirectoryName that doesn't renormalize

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
@@ -248,10 +248,6 @@ namespace System.IO
             while (stackDir.Count > 0)
             {
                 string name = stackDir.Pop();
-                if (name.Length >= Interop.Sys.MaxPath)
-                {
-                    throw new PathTooLongException(SR.IO_PathTooLong);
-                }
 
                 // The mkdir command uses 0777 by default (it'll be AND'd with the process umask internally).
                 // We do the same.

--- a/src/System.IO.FileSystem/src/System/IO/Win32FileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Win32FileSystem.cs
@@ -61,9 +61,6 @@ namespace System.IO
         [System.Security.SecuritySafeCritical]
         public override void CreateDirectory(string fullPath)
         {
-            if (PathInternal.IsDirectoryTooLong(fullPath))
-                throw new PathTooLongException(SR.IO_PathTooLong);
-
             // We can save a bunch of work if the directory we want to create already exists.  This also
             // saves us in the case where sub paths are inaccessible (due to ERROR_ACCESS_DENIED) but the
             // final path is accessible and the directory already exists.  For example, consider trying

--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -243,13 +243,13 @@ namespace System.IO.Tests
 
         [ConditionalFact(nameof(LongPathsAreNotBlocked), nameof(UsingNewNormalization))]
         [ActiveIssue(20117, TargetFrameworkMonikers.Uap)]
-        [PlatformSpecific(TestPlatforms.Windows)]  // long directory path with extended syntax throws PathTooLongException
-        public void DirectoryLongerThanMaxLongPathWithExtendedSyntax_ThrowsPathTooLongException()
+        [PlatformSpecific(TestPlatforms.Windows)]  // long directory path with extended syntax throws DirectoryNotFoundException
+        public void DirectoryLongerThanMaxLongPathWithExtendedSyntax_ThrowsDirectoryNotFoundException()
         {
             var paths = IOInputs.GetPathsLongerThanMaxLongPath(GetTestFilePath(), useExtendedSyntax: true);
             Assert.All(paths, (path) =>
             {
-                Assert.Throws<PathTooLongException>(() => Create(path));
+                Assert.Throws<DirectoryNotFoundException>(() => Create(path));
             });
         }
 

--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -243,14 +243,23 @@ namespace System.IO.Tests
 
         [ConditionalFact(nameof(LongPathsAreNotBlocked), nameof(UsingNewNormalization))]
         [ActiveIssue(20117, TargetFrameworkMonikers.Uap)]
-        [PlatformSpecific(TestPlatforms.Windows)]  // long directory path with extended syntax throws DirectoryNotFoundException
-        public void DirectoryLongerThanMaxLongPathWithExtendedSyntax_ThrowsDirectoryNotFoundException()
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void DirectoryLongerThanMaxLongPathWithExtendedSyntax_ThrowsException()
         {
             var paths = IOInputs.GetPathsLongerThanMaxLongPath(GetTestFilePath(), useExtendedSyntax: true);
-            Assert.All(paths, (path) =>
+
+            // Long directory path with extended syntax throws PathTooLongException on Nano,
+            // otherwise DirectoryNotFoundException.
+            if (PlatformDetection.IsWindowsNanoServer)
             {
-                Assert.Throws<DirectoryNotFoundException>(() => Create(path));
-            });
+                Assert.All(paths,
+                    path => { Assert.Throws<PathTooLongException>(() => Create(path)); });
+            }
+            else
+            {
+                Assert.All(paths,
+                    path => { Assert.Throws<DirectoryNotFoundException>(() => Create(path)); });
+            }
         }
 
         [ConditionalFact(nameof(LongPathsAreNotBlocked), nameof(UsingNewNormalization))]

--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -248,18 +248,8 @@ namespace System.IO.Tests
         {
             var paths = IOInputs.GetPathsLongerThanMaxLongPath(GetTestFilePath(), useExtendedSyntax: true);
 
-            // Long directory path with extended syntax throws PathTooLongException on Nano,
-            // otherwise DirectoryNotFoundException.
-            if (PlatformDetection.IsWindowsNanoServer)
-            {
-                Assert.All(paths,
-                    path => { Assert.Throws<PathTooLongException>(() => Create(path)); });
-            }
-            else
-            {
-                Assert.All(paths,
-                    path => { Assert.Throws<DirectoryNotFoundException>(() => Create(path)); });
-            }
+            // Long directory path with extended syntax throws PathTooLongException.
+            Assert.All(paths, path => { Assert.Throws<PathTooLongException>(() => Create(path)); });
         }
 
         [ConditionalFact(nameof(LongPathsAreNotBlocked), nameof(UsingNewNormalization))]

--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -248,8 +248,22 @@ namespace System.IO.Tests
         {
             var paths = IOInputs.GetPathsLongerThanMaxLongPath(GetTestFilePath(), useExtendedSyntax: true);
 
-            // Long directory path with extended syntax throws PathTooLongException.
-            Assert.All(paths, path => { Assert.Throws<PathTooLongException>(() => Create(path)); });
+            // Long directory path with extended syntax throws PathTooLongException on Desktop.
+            // Everywhere else, it may be either PathTooLongException or DirectoryNotFoundException
+            if (PlatformDetection.IsFullFramework)
+            {
+                Assert.All(paths, path => { Assert.Throws<PathTooLongException>(() => Create(path)); });
+            }
+            else
+            {
+                Assert.All(paths,
+                    path =>
+                    {
+                        AssertExtensions
+                            .ThrowsAny<PathTooLongException, DirectoryNotFoundException>(
+                                () => Create(path));
+                    });
+            }
         }
 
         [ConditionalFact(nameof(LongPathsAreNotBlocked), nameof(UsingNewNormalization))]

--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
@@ -607,14 +607,14 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)]  // Long path segment in search pattern throws PathTooLongException
+        [PlatformSpecific(TestPlatforms.Windows)]  // Long path segment in search pattern throws DirectoryNotFoundException
         public void WindowsSearchPatternLongSegment()
         {
-            // Create a path segment longer than the normal max of 255
+            // Create a path segment longer than the extended max
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
-            string longName = new string('k', 257);
+            string longName = new string('k', IOInputs.MaxLongPath);
 
-            Assert.Throws<PathTooLongException>(() => GetEntries(testDir.FullName, longName));
+            Assert.Throws<DirectoryNotFoundException>(() => GetEntries(testDir.FullName, longName));
         }
 
         [ConditionalFact(nameof(AreAllLongPathsAvailable))]

--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
@@ -607,14 +607,25 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)]  // Long path segment in search pattern throws IOException
+        [PlatformSpecific(TestPlatforms.Windows)]  
         public void WindowsSearchPatternLongSegment()
         {
             // Create a path segment longer than the normal max of 255
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
             string longName = new string('k', 257);
-
-            Assert.Throws<IOException>(() => GetEntries(testDir.FullName, longName));
+            
+            // Long path segment in search pattern throws PathTooLongException on Desktop,
+            // otherwise it is an IOException.
+            if (PlatformDetection.IsFullFramework)
+            {
+                Assert.Throws<PathTooLongException>(() => GetEntries(testDir.FullName, longName));
+            }
+            else
+            {
+                var exception = Assert.Throws<IOException>(() => GetEntries(testDir.FullName, longName));
+                // Should be Interop.Errors.ERROR_INVALID_PARAMETER converted to a HResult
+                Assert.Equal(unchecked((int)0x80070057), exception.HResult);
+            }
         }
 
         [ConditionalFact(nameof(AreAllLongPathsAvailable))]

--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
@@ -607,14 +607,14 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)]  // Long path segment in search pattern throws DirectoryNotFoundException
+        [PlatformSpecific(TestPlatforms.Windows)]  // Long path segment in search pattern throws IOException
         public void WindowsSearchPatternLongSegment()
         {
-            // Create a path segment longer than the extended max
+            // Create a path segment longer than the normal max of 255
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
-            string longName = new string('k', IOInputs.MaxLongPath);
+            string longName = new string('k', 257);
 
-            Assert.Throws<DirectoryNotFoundException>(() => GetEntries(testDir.FullName, longName));
+            Assert.Throws<IOException>(() => GetEntries(testDir.FullName, longName));
         }
 
         [ConditionalFact(nameof(AreAllLongPathsAvailable))]

--- a/src/System.IO.FileSystem/tests/PortedCommon/IOInputs.cs
+++ b/src/System.IO.FileSystem/tests/PortedCommon/IOInputs.cs
@@ -16,6 +16,9 @@ internal static class IOInputs
     // Max path length (minus trailing \0). Unix values vary system to system; just using really long values here likely to be more than on the average system.
     public static readonly int MaxPath = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 259 : 10000;
 
+    // Windows specific, this is the maximum length that can be passed using extended syntax. Does not include the trailing \0.
+    public static readonly int MaxExtendedPath = short.MaxValue - 1;
+
     // Same as MaxPath on Unix
     public static readonly int MaxLongPath = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? MaxExtendedPath : MaxPath;
 
@@ -23,10 +26,7 @@ internal static class IOInputs
     // Does not include the trailing \0.
     // We now do the appropriate wrapping to allow creating longer directories. Like MaxPath, this is a legacy restriction.
     public static readonly int MaxDirectory = 247;
-
-    // Windows specific, this is the maximum length that can be passed using extended syntax. Does not include the trailing \0.
-    public static readonly int MaxExtendedPath = short.MaxValue - 1;
-
+    
     public const int MaxComponent = 255;
 
     public const string ExtendedPrefix = @"\\?\";


### PR DESCRIPTION
This is a work in progress on the CoreFX side to remove preemptive checks that result in throwing of PathTooLongException when it otherwise might have succeeded. See #8655 

I have fixed failing IO unit tests for now. I expect once I work on the CoreCLR side, more will start failing.

cc @JeremyKuhne 