### PR TITLE
Replace CSharpArgumentInfo.IsByRef with CSharpArgumentInfo.IsByRefOrOut

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpArgumentInfo.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpArgumentInfo.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CSharp.RuntimeBinder
         /// <summary>
         /// The flags for the argument.
         /// </summary>
-        internal CSharpArgumentInfoFlags Flags { get; }
+        private CSharpArgumentInfoFlags Flags { get; }
 
         /// <summary>
         /// The name of the argument, if named; otherwise null.
@@ -49,7 +49,7 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         internal bool NamedArgument => (Flags & CSharpArgumentInfoFlags.NamedArgument) != 0;
 
-        internal bool IsByRef => (Flags & CSharpArgumentInfoFlags.IsRef) != 0;
+        internal bool IsByRefOrOut => (Flags & (CSharpArgumentInfoFlags.IsRef | CSharpArgumentInfoFlags.IsOut)) != 0;
 
         internal bool IsOut => (Flags & CSharpArgumentInfoFlags.IsOut) != 0;
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -313,7 +313,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             Type t = argInfo.UseCompileTimeType ? param.Type : arg.LimitType;
             Debug.Assert(t != null);
 
-            if ((argInfo.Flags & (CSharpArgumentInfoFlags.IsRef | CSharpArgumentInfoFlags.IsOut)) != 0)
+            if (argInfo.IsByRefOrOut)
             {
                 // If we have a ref our an out parameter, make the byref type.
                 // If we have the receiver of a call or invoke that is ref, it must be because of 
@@ -459,7 +459,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                     if (paramExp != null && paramExp.IsByRef)
                     {
                         CSharpArgumentInfo info = arguments[i].Info;
-                        if (info.IsByRef || info.IsOut)
+                        if (info.IsByRefOrOut)
                         {
                             type = _semanticChecker.GetTypeManager().GetParameterModifier(type, info.IsOut);
                         }


### PR DESCRIPTION
`Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo` has an internal `IsByRef` method that is only used in conjunction with `IsOut`. Since these are both flag tests, it can be replaced with a single `IsByRefOrOut` test.

The same flag test is done inside `RuntimeBinder`, so replace that with a call to this new method.

The `Flags` property is now no longer used from outside the class, so make it private.