### PR TITLE
Remove unnecessary char[] allocation from StreamReader

### DIFF
--- a/src/System.IO/tests/StreamReader/StreamReader.cs
+++ b/src/System.IO/tests/StreamReader/StreamReader.cs
@@ -2,11 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using System.Text;
 using Xunit;
 
 namespace System.IO.Tests
 {
-    public partial class StreamReaderTests
+    public partial class StreamReaderTests : FileCleanupTestBase
     {
         [Fact]
         public void ObjectClosedReadLine()
@@ -39,6 +41,36 @@ namespace System.IO.Tests
                 int res1 = reader.Read();
                 int res2 = synced.Read();
                 Assert.NotEqual(res1, res2);
+            }
+        }
+
+        public static IEnumerable<object[]> DetectEncoding_EncodingRoundtrips_MemberData()
+        {
+            yield return new object[] { new UTF8Encoding(encoderShouldEmitUTF8Identifier:true) };
+            yield return new object[] { new UTF32Encoding(bigEndian:false, byteOrderMark:true) };
+            yield return new object[] { new UTF32Encoding(bigEndian:true, byteOrderMark:true) };
+            yield return new object[] { new UnicodeEncoding(bigEndian:false, byteOrderMark:true) };
+            yield return new object[] { new UnicodeEncoding(bigEndian:true, byteOrderMark:true) };
+        }
+
+        [Theory]
+        [MemberData(nameof(DetectEncoding_EncodingRoundtrips_MemberData))]
+        public void DetectEncoding_EncodingRoundtrips(Encoding encoding)
+        {
+            const string Text = "This is some text for testing.";
+            string path = GetTestFilePath();
+
+            using (var stream = File.OpenWrite(path))
+            using (var writer = new StreamWriter(stream, encoding))
+            {
+                writer.Write(Text);
+            }
+
+            using (var stream = File.OpenRead(path))
+            using (var reader = new StreamReader(stream, detectEncodingFromByteOrderMarks:true))
+            {
+                Assert.Equal(Text, reader.ReadToEnd());
+                Assert.Equal(encoding.EncodingName, reader.CurrentEncoding.EncodingName);
             }
         }
     }

--- a/src/System.Runtime.Extensions/src/System/IO/StreamReader.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/StreamReader.cs
@@ -540,8 +540,12 @@ namespace System.IO
             if (changedEncoding)
             {
                 _decoder = _encoding.GetDecoder();
-                _maxCharsPerBuffer = _encoding.GetMaxCharCount(_byteBuffer.Length);
-                _charBuffer = new char[_maxCharsPerBuffer];
+                int newMaxCharsPerBuffer = _encoding.GetMaxCharCount(_byteBuffer.Length);
+                if (newMaxCharsPerBuffer > _maxCharsPerBuffer)
+                {
+                    _charBuffer = new char[newMaxCharsPerBuffer];
+                }
+                _maxCharsPerBuffer = newMaxCharsPerBuffer;
             }
         }
 


### PR DESCRIPTION
When StreamReader detects a different encoding than what it was initially told or defaulted to, it allocates a new char[] to hold the read chars.  But it really only needs to do this if the previously allocated char[] was too small, and since the default encoding is UTF8 and very few encodings have a larger byte:maxchar ratio than UTF8, we can avoid the allocation most of the time simply by checking to see if the existing array is large enough.

Fixes https://github.com/dotnet/corefx/issues/22137
cc: @davkean, @JeremyKuhne, @ianhays 