### PR TITLE
Add missing return statement in test VerifyWithRevocation skip path.

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
@@ -581,6 +581,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 else if (!valid)
                 {
                     Console.WriteLine($"SKIP [{nameof(VerifyWithRevocation)}]: Chain failed to build within {RetryLimit} tries.");
+                    return;
                 }
 
                 // Since the network was enabled, we should get the whole chain.


### PR DESCRIPTION
When revocation couldn't be checked (due to network or other issues) the
VerifyWithRevocation test is supposed to print "SKIP" and exit successfully.

Due to a missing return statement it prints SKIP, then fails.

Addresses https://github.com/dotnet/corefx/issues/21926 in master.