### PR TITLE
Disable tests on High Sierra which trigger corrupt chains

### DIFF
--- a/src/Common/tests/System/PlatformDetection.cs
+++ b/src/Common/tests/System/PlatformDetection.cs
@@ -197,6 +197,10 @@ namespace System
         public static bool IsCentos7 => IsDistroAndVersion("centos", "7");
         public static bool IsTizen => IsDistroAndVersion("tizen");
 
+        // If we need this long-term hopefully we can come up with a better detection than the kernel verison.
+        public static bool IsMacOsHighSierra { get; } =
+            IsOSX && RuntimeInformation.OSDescription.StartsWith("Darwin 17.0.0");
+
         /// <summary>
         /// Get whether the OS platform matches the given Linux distro and optional version.
         /// </summary>

--- a/src/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
@@ -114,15 +114,20 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.True(success, "MicrosoftDotComIssuerBytes");
             }
 
-            using (var microsoftDotComRoot = new X509Certificate2(TestData.MicrosoftDotComRootBytes))
+            // High Sierra fails to build a chain for a self-signed certificate with revocation enabled.
+            // https://github.com/dotnet/corefx/issues/21875
+            if (!PlatformDetection.IsMacOsHighSierra)
             {
-                // NotAfter=7/17/2036
-                success = microsoftDotComRoot.Verify();
-                if (!success)
+                using (var microsoftDotComRoot = new X509Certificate2(TestData.MicrosoftDotComRootBytes))
                 {
-                    LogVerifyErrors(microsoftDotComRoot, "MicrosoftDotComRootBytes");
+                    // NotAfter=7/17/2036
+                    success = microsoftDotComRoot.Verify();
+                    if (!success)
+                    {
+                        LogVerifyErrors(microsoftDotComRoot, "MicrosoftDotComRootBytes");
+                    }
+                    Assert.True(success, "MicrosoftDotComRootBytes");
                 }
-                Assert.True(success, "MicrosoftDotComRootBytes");
             }
         }
 

--- a/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
@@ -14,6 +14,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
     public static class ChainTests
     {
         internal static bool CanModifyStores { get; } = TestEnvironmentConfiguration.CanModifyStores;
+        internal static bool CanBuildSelfSignedChainReliably { get; } = !PlatformDetection.IsMacOsHighSierra;
 
         private static bool TrustsMicrosoftDotComRoot
         {
@@ -164,7 +165,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             Assert.Equal(IntPtr.Zero, chain.ChainContext);
         }
 
-        [Fact]
+        [ConditionalFact(nameof(CanBuildSelfSignedChainReliably))]
         public static void TestResetMethod()
         {
             using (var sampleCert = new X509Certificate2(TestData.DssCer))


### PR DESCRIPTION
Whatever bad loop is currently present on High Sierra with building self-signed
chains with revocation enabled seems to be inside a critical section, so any other
tests running concurrently have a chance of hitting the "took too long" internal
timeout and reporting an invalid chain, too.

Avoiding calling Verify on a self-signed cert in TestVerify and avoiding
TestResetMethod (whose first chain has revocation enabled) results in all tests
passing with parallelism enabled across ~60 sequential runs on High Sierra Beta2.

Addresses https://github.com/dotnet/corefx/issues/21875 in master.