### PR TITLE
Always run cleanup agent task on windows build

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
@@ -285,7 +285,7 @@
     {
       "enabled": true,
       "continueOnError": true,
-      "alwaysRun": false,
+      "alwaysRun": true,
       "displayName": "Build solution corefx\\Tools\\scripts\\vstsagent\\cleanupagent.proj",
       "timeoutInMinutes": 0,
       "task": {


### PR DESCRIPTION
I recently changed the Linux builds to always run cleanup agent, and it looks like the Windows-NoTest build does this as well.  Enabling this for the Windows build.  Turning this on will reduce the amount of out of disk space issues we hit, particularly because repeated failures would continue to build up disk space usage.  