### PR TITLE
Updating PN versions due to incomplete build failing uapaot tests

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -13,8 +13,8 @@
     <CoreClrCurrentRef>25eb8c91d68da0a0484dd2532c4cf23248516bf5</CoreClrCurrentRef>
     <CoreSetupCurrentRef>25eb8c91d68da0a0484dd2532c4cf23248516bf5</CoreSetupCurrentRef>
     <ExternalCurrentRef>5a0606fccb09fce4b47545ae9896139acca547f5</ExternalCurrentRef>
-    <ProjectNTfsCurrentRef>25eb8c91d68da0a0484dd2532c4cf23248516bf5</ProjectNTfsCurrentRef>
-    <ProjectNTfsTestILCCurrentRef>25eb8c91d68da0a0484dd2532c4cf23248516bf5</ProjectNTfsTestILCCurrentRef>
+    <ProjectNTfsCurrentRef>537765d2d0246d19a6aebbe6da497751447c9721</ProjectNTfsCurrentRef>
+    <ProjectNTfsTestILCCurrentRef>537765d2d0246d19a6aebbe6da497751447c9721</ProjectNTfsTestILCCurrentRef>
     <SniCurrentRef>97059fa979a3c8fb8b9fba127c526f15e48c9dde</SniCurrentRef>
     <StandardCurrentRef>e7e2bd1f8c78028e2a188dc15d758d4c4624989e</StandardCurrentRef>
   </PropertyGroup>
@@ -25,9 +25,9 @@
     <CoreFxExpectedPrerelease>preview2-25512-01</CoreFxExpectedPrerelease>
     <CoreClrPackageVersion>2.1.0-preview2-25511-05</CoreClrPackageVersion>
     <ExternalExpectedPrerelease>beta-25322-00</ExternalExpectedPrerelease>
-    <ProjectNTfsExpectedPrerelease>beta-25512-00</ProjectNTfsExpectedPrerelease>
-    <ProjectNTfsTestILCExpectedPrerelease>beta-25512-00</ProjectNTfsTestILCExpectedPrerelease>
-    <ProjectNTfsTestILCPackageVersion>1.0.0-beta-25512-00</ProjectNTfsTestILCPackageVersion>
+    <ProjectNTfsExpectedPrerelease>beta-25512-01</ProjectNTfsExpectedPrerelease>
+    <ProjectNTfsTestILCExpectedPrerelease>beta-25512-01</ProjectNTfsTestILCExpectedPrerelease>
+    <ProjectNTfsTestILCPackageVersion>1.0.0-beta-25512-01</ProjectNTfsTestILCPackageVersion>
     <NETStandardPackageVersion>2.1.0-preview1-25511-01</NETStandardPackageVersion>
     <NETStandardPackageId>NETStandard.Library</NETStandardPackageId>
     <MicrosoftNETCoreAppPackageVersion>2.1.0-preview2-25511-04</MicrosoftNETCoreAppPackageVersion>

--- a/external/test-runtime/optional.json
+++ b/external/test-runtime/optional.json
@@ -3,9 +3,9 @@
     "net45": {
       "dependencies": {
         "Microsoft.DotNet.IBCMerge": "4.6.0-alpha-00001",
-        "TestILC.amd64ret": "1.0.0-beta-25512-00",
-        "TestILC.armret": "1.0.0-beta-25512-00",
-        "TestILC.x86ret": "1.0.0-beta-25512-00"
+        "TestILC.amd64ret": "1.0.0-beta-25512-01",
+        "TestILC.armret": "1.0.0-beta-25512-01",
+        "TestILC.x86ret": "1.0.0-beta-25512-01"
       }
     }
   }


### PR DESCRIPTION
cc: @weshaggard @MattGal @tijoytom 

PN produced an incomplete build yesterday and we updated our versions to target that, which caused our uapaot build to use an incomplete ILC toolchain for running tests which failed all tests. This versions are the complete nightly build, so it should fix the issue.