### PR TITLE
Remove unused usings.

### DIFF
--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CryptoHelpers.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CryptoHelpers.cs
@@ -2,18 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Security.Cryptography.Xml
 {
     internal static class CryptoHelpers
     {
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA5350", Justification = "SHA1 needed for compat.")]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA5351", Justification = "HMACMD5 needed for compat.")]
+        [SuppressMessage("Microsoft.Security", "CA5350", Justification = "SHA1 needed for compat.")]
+        [SuppressMessage("Microsoft.Security", "CA5351", Justification = "HMACMD5 needed for compat.")]
         public static object CreateFromName(string name)
         {
             switch (name)

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/DSASignatureDescription.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/DSASignatureDescription.cs
@@ -2,11 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Security.Cryptography.Xml
 {
@@ -16,9 +12,9 @@ namespace System.Security.Cryptography.Xml
 
         public DSASignatureDescription()
         {
-            KeyAlgorithm = typeof(System.Security.Cryptography.DSA).AssemblyQualifiedName;
-            FormatterAlgorithm = typeof(System.Security.Cryptography.DSASignatureFormatter).AssemblyQualifiedName;
-            DeformatterAlgorithm = typeof(System.Security.Cryptography.DSASignatureDeformatter).AssemblyQualifiedName;
+            KeyAlgorithm = typeof(DSA).AssemblyQualifiedName;
+            FormatterAlgorithm = typeof(DSASignatureFormatter).AssemblyQualifiedName;
+            DeformatterAlgorithm = typeof(DSASignatureDeformatter).AssemblyQualifiedName;
             DigestAlgorithm = "SHA1";
         }
 
@@ -38,7 +34,7 @@ namespace System.Security.Cryptography.Xml
             return item;
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA5350", Justification = "SHA1 needed for compat.")]
+        [SuppressMessage("Microsoft.Security", "CA5350", Justification = "SHA1 needed for compat.")]
         public sealed override HashAlgorithm CreateDigest()
         {
             return SHA1.Create();

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/RSAPKCS1SHA1SignatureDescription.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/RSAPKCS1SHA1SignatureDescription.cs
@@ -2,11 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Security.Cryptography.Xml
 {
@@ -16,7 +12,7 @@ namespace System.Security.Cryptography.Xml
         {
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA5350", Justification = "SHA1 needed for compat.")]
+        [SuppressMessage("Microsoft.Security", "CA5350", Justification = "SHA1 needed for compat.")]
         public sealed override HashAlgorithm CreateDigest()
         {
             return SHA1.Create();

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/RSAPKCS1SHA256SignatureDescription.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/RSAPKCS1SHA256SignatureDescription.cs
@@ -2,12 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace System.Security.Cryptography.Xml
 {
     internal class RSAPKCS1SHA256SignatureDescription : RSAPKCS1SignatureDescription

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/RSAPKCS1SHA384SignatureDescription.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/RSAPKCS1SHA384SignatureDescription.cs
@@ -2,12 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace System.Security.Cryptography.Xml
 {
     internal class RSAPKCS1SHA384SignatureDescription : RSAPKCS1SignatureDescription

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/RSAPKCS1SHA512SignatureDescription.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/RSAPKCS1SHA512SignatureDescription.cs
@@ -2,12 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace System.Security.Cryptography.Xml
 {
     internal class RSAPKCS1SHA512SignatureDescription : RSAPKCS1SignatureDescription

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/RSAPKCS1SignatureDescription.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/RSAPKCS1SignatureDescription.cs
@@ -2,21 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace System.Security.Cryptography.Xml
 {
     internal abstract class RSAPKCS1SignatureDescription : SignatureDescription
     {
         public RSAPKCS1SignatureDescription(string hashAlgorithmName)
         {
-            KeyAlgorithm = typeof(System.Security.Cryptography.RSA).AssemblyQualifiedName;
-            FormatterAlgorithm = typeof(System.Security.Cryptography.RSAPKCS1SignatureFormatter).AssemblyQualifiedName;
-            DeformatterAlgorithm = typeof(System.Security.Cryptography.RSAPKCS1SignatureDeformatter).AssemblyQualifiedName;
+            KeyAlgorithm = typeof(RSA).AssemblyQualifiedName;
+            FormatterAlgorithm = typeof(RSAPKCS1SignatureFormatter).AssemblyQualifiedName;
+            DeformatterAlgorithm = typeof(RSAPKCS1SignatureDeformatter).AssemblyQualifiedName;
             DigestAlgorithm = hashAlgorithmName;
         }
 


### PR DESCRIPTION
I'm trying to replace Mono's implementation of `System.Security.Cryptography.Xml` with the .NET Core's implementation. While doing it, I faced with a problem that files, affected by this pull request, are using the `System.Linq` namespace, which is the part of the `System.Core` assembly. Mono's `System.Security.Cryptography.Xml` is located in the `System.Security` assembly, which cannot reference the `System.Core` assembly, because circular dependencies are not allowed. More details can be found here: https://github.com/mono/mono/pull/5164.

Since `System.Linq` usings are not used, I removed them (and other unused ones), which makes it possible to use affected files in Mono.