### PR TITLE
Simplify some S.L.Expressions branch compilation methods

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Logical.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Logical.cs
@@ -319,17 +319,20 @@ namespace System.Linq.Expressions.Compiler
         {
             BinaryExpression b = (BinaryExpression)expr;
 
-            if (b.Method != null && !b.IsLiftedLogical)
+            if (b.Method != null)
             {
-                EmitMethodAndAlso(b, flags);
+                if (b.IsLiftedLogical)
+                {
+                    EmitExpression(b.ReduceUserdefinedLifted());
+                }
+                else
+                {
+                    EmitMethodAndAlso(b, flags);
+                }
             }
             else if (b.Left.Type == typeof(bool?))
             {
                 EmitLiftedAndAlso(b);
-            }
-            else if (b.IsLiftedLogical)
-            {
-                EmitExpression(b.ReduceUserdefinedLifted());
             }
             else
             {
@@ -420,17 +423,20 @@ namespace System.Linq.Expressions.Compiler
         {
             BinaryExpression b = (BinaryExpression)expr;
 
-            if (b.Method != null && !b.IsLiftedLogical)
+            if (b.Method != null)
             {
-                EmitMethodOrElse(b, flags);
+                if (b.IsLiftedLogical)
+                {
+                    EmitExpression(b.ReduceUserdefinedLifted());
+                }
+                else
+                {
+                    EmitMethodOrElse(b, flags);
+                }
             }
             else if (b.Left.Type == typeof(bool?))
             {
                 EmitLiftedOrElse(b);
-            }
-            else if (b.IsLiftedLogical)
-            {
-                EmitExpression(b.ReduceUserdefinedLifted());
             }
             else
             {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Logical.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Logical.cs
@@ -468,36 +468,36 @@ namespace System.Linq.Expressions.Compiler
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1800:DoNotCastUnnecessarily")]
         private void EmitExpressionAndBranch(bool branchValue, Expression node, Label label)
         {
+            Debug.Assert(node.Type == typeof(bool));
             CompilationFlags startEmitted = EmitExpressionStart(node);
-            try
+            switch (node.NodeType)
             {
-                if (node.Type == typeof(bool))
-                {
-                    switch (node.NodeType)
-                    {
-                        case ExpressionType.Not:
-                            EmitBranchNot(branchValue, (UnaryExpression)node, label);
-                            return;
-                        case ExpressionType.AndAlso:
-                        case ExpressionType.OrElse:
-                            EmitBranchLogical(branchValue, (BinaryExpression)node, label);
-                            return;
-                        case ExpressionType.Block:
-                            EmitBranchBlock(branchValue, (BlockExpression)node, label);
-                            return;
-                        case ExpressionType.Equal:
-                        case ExpressionType.NotEqual:
-                            EmitBranchComparison(branchValue, (BinaryExpression)node, label);
-                            return;
-                    }
-                }
-                EmitExpression(node, CompilationFlags.EmitAsNoTail | CompilationFlags.EmitNoExpressionStart);
-                EmitBranchOp(branchValue, label);
+                case ExpressionType.Not:
+                    EmitBranchNot(branchValue, (UnaryExpression)node, label);
+                    break;
+
+                case ExpressionType.AndAlso:
+                case ExpressionType.OrElse:
+                    EmitBranchLogical(branchValue, (BinaryExpression)node, label);
+                    break;
+
+                case ExpressionType.Block:
+                    EmitBranchBlock(branchValue, (BlockExpression)node, label);
+                    break;
+
+                case ExpressionType.Equal:
+                case ExpressionType.NotEqual:
+                    EmitBranchComparison(branchValue, (BinaryExpression)node, label);
+                    break;
+
+                default:
+                    EmitExpression(node, CompilationFlags.EmitAsNoTail | CompilationFlags.EmitNoExpressionStart);
+                    EmitBranchOp(branchValue, label);
+                    break;
+
             }
-            finally
-            {
-                EmitExpressionEnd(startEmitted);
-            }
+
+            EmitExpressionEnd(startEmitted);
         }
 
         private void EmitBranchOp(bool branch, Label label)

--- a/src/System.Linq.Expressions/tests/Conditional/ConditionalTests.cs
+++ b/src/System.Linq.Expressions/tests/Conditional/ConditionalTests.cs
@@ -169,6 +169,41 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(expected, func());
         }
 
+        [Theory, PerCompilationType(nameof(ConditionalValues))]
+        public void InvertedConditionalSelectsCorrectExpression(bool test, object ifTrue, object ifFalse, object expected, bool useInterpreter)
+        {
+            Func<object> func = Expression.Lambda<Func<object>>(
+                Expression.Convert(
+                    Expression.Condition(
+                        Expression.Not(Expression.Constant(test)),
+                        Expression.Constant(ifFalse),
+                        Expression.Constant(ifTrue)
+                    ),
+                    typeof(object)
+                )
+            ).Compile(useInterpreter);
+
+            Assert.Equal(expected, func());
+        }
+
+
+        [Theory, PerCompilationType(nameof(ConditionalValues))]
+        public void ConditionalWithMethodSelectsCorrectExpression(bool test, object ifTrue, object ifFalse, object expected, bool useInterpreter)
+        {
+            Func<object> func = Expression.Lambda<Func<object>>(
+                Expression.Convert(
+                    Expression.Condition(
+                        Expression.Not(Expression.Constant(test), GetType().GetMethod(nameof(NotNot))),
+                        Expression.Constant(ifTrue),
+                        Expression.Constant(ifFalse)
+                    ),
+                    typeof(object)
+                )
+            ).Compile(useInterpreter);
+
+            Assert.Equal(expected, func());
+        }
+
         [Theory, PerCompilationType(nameof(ConditionalValuesWithTypes))]
         public void ConditionalSelectsCorrectExpressionWithType(bool test, object ifTrue, object ifFalse, object expected, Type type, bool useInterpreter)
         {
@@ -270,5 +305,7 @@ namespace System.Linq.Expressions.Tests
         private class Visitor : ExpressionVisitor
         {
         }
+
+        public static bool NotNot(bool value) => value;
     }
 }


### PR DESCRIPTION
#### Simplify `EmitExpressionAndBranch` method

`EmitExpressionAndBranch` is called from non-lifted non-method `AndAlso` and `OrElse` expressions, from `Conditional` and from `Switch` expressions' use of `Equal`, and from calls which originate with itself, all of which mean the node's type is boolean. Removing the test for `node.Type == typeof(bool)` allows for the rest of the method to be simplified and no longer need a `try`…`finally`.

Also include tests covering the `EmitBranchNot` case. Contributes to #11409

#### Reduce if-else ladders in `EmitAndAlsoBinaryExpression` and `EmitOrElseBinaryExpression`

Handle all cases in 2 tests, instead of between 2 and 4.

#### Simplify IL produced for `EmitMethodAndAlso` and `EmitMethodOrElse`

These methods `dup` the lhs operand, then if not short-circuiting store it, then obtain the rhs and store than, the retrieve lhs and rhs and call the method.

Instead just `dup` the lhs and if not short-circuiting leave it on the stack, obtain the rhs and call the method.