### PR TITLE
Create Windows PDBs from Portable PDBs during symbol archive

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-2.0.0-prerelease-01811-01
+2.0.0-prerelease-01812-02

--- a/buildpipeline/DotNet-Trusted-Publish-Symbols.json
+++ b/buildpipeline/DotNet-Trusted-Publish-Symbols.json
@@ -56,7 +56,7 @@
         "scriptName": "",
         "arguments": "-ConfigGroup $(PB_ConfigurationGroup) -SymPkgGlob $(PB_AzureContainerSymbolPackageGlob) -Branch $(SourceBranch)",
         "workingFolder": "$(Pipeline.SourcesDirectory)",
-        "inlineScript": "param($ConfigGroup, $SymPkgGlob, $Branch)\nif ($ConfigGroup -ne \"Release\") { exit }\n$archive = $Branch.StartsWith(\"release/\")\n\n$target = \"UnzipSymbolPackagesForPublish\"\nif ($archive) { $target = \"SubmitSymbolsRequest\" }\n\n.\\build-managed.cmd -- `\n/t:$target `\n/p:SymbolPackagesToPublishGlob=$SymPkgGlob `\n/p:ArchiveSymbols=$archive `\n/v:D",
+        "inlineScript": "param($ConfigGroup, $SymPkgGlob, $Branch)\nif ($ConfigGroup -ne \"Release\") { exit }\n$archive = $Branch.StartsWith(\"release/\")\n\n$target = \"GetAllSymbolFilesToPublish\"\nif ($archive) { $target = \"SubmitSymbolsRequest\" }\n\n.\\build-managed.cmd -- `\n/t:$target `\n/p:SymbolPackagesToPublishGlob=$SymPkgGlob `\n/p:ArchiveSymbols=$archive `\n/v:D",
         "failOnStandardError": "true"
       }
     },


### PR DESCRIPTION
Update buildtools to get https://github.com/dotnet/buildtools/pull/1605, which automatically creates converted Windows PDBs for any Portable PDBs in the symbol archive build leg.

I changed the target used for master branch builds to `GetAllSymbolFilesToPublish` rather than `UnzipSymbolPackagesForPublish` so that we create converted symbols even if we aren't going to archive them. (We index them on symweb using VSTS Symbol.)

On a current CoreFX master build, this new extra target takes ~14 seconds. Windows builds produce Windows PDBs right now, so it only converted PDBs for the Linux and OSX symbol packages.

This is part of https://github.com/dotnet/core-eng/issues/698.
Note: the converted symbols won't be put on MyGet yet. https://github.com/dotnet/core-eng/issues/1132 tracks that.