### PR TITLE
Remove 6 IntPtr fields from SocketAsyncEventArgs on Windows

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
@@ -36,7 +36,6 @@ namespace System.Net.Sockets
         // Internal SocketAddress buffer
         private GCHandle _socketAddressGCHandle;
         private Internals.SocketAddress _pinnedSocketAddress;
-        private IntPtr _ptrSocketAddressBufferSize;
 
         // SendPacketsElements property variables.
         private SendPacketsElement[] _sendPacketsElementsInternal;
@@ -366,7 +365,7 @@ namespace System.Net.Sockets
                         out bytesTransferred,
                         ref flags,
                         PtrSocketAddressBuffer,
-                        _ptrSocketAddressBufferSize,
+                        PtrSocketAddressBufferSize,
                         overlapped,
                         IntPtr.Zero);
                 }
@@ -379,7 +378,7 @@ namespace System.Net.Sockets
                         out bytesTransferred,
                         ref flags,
                         PtrSocketAddressBuffer,
-                        _ptrSocketAddressBufferSize,
+                        PtrSocketAddressBufferSize,
                         overlapped,
                         IntPtr.Zero);
                 }
@@ -902,7 +901,6 @@ namespace System.Net.Sockets
             // Pin down the new one.
             _socketAddressGCHandle = GCHandle.Alloc(_socketAddress.Buffer, GCHandleType.Pinned);
             _socketAddress.CopyAddressSizeIntoBuffer();
-            _ptrSocketAddressBufferSize = Marshal.UnsafeAddrOfPinnedArrayElement(_socketAddress.Buffer, _socketAddress.GetAddressSizeOffset());
             _pinnedSocketAddress = _socketAddress;
         }
 
@@ -921,6 +919,8 @@ namespace System.Net.Sockets
                 }
             }
         }
+
+        private IntPtr PtrSocketAddressBufferSize => PtrSocketAddressBuffer + _socketAddress.GetAddressSizeOffset();
 
         // Cleans up any existing Overlapped object and related state variables.
         private void FreeOverlapped()
@@ -1269,7 +1269,7 @@ namespace System.Net.Sockets
 
         private unsafe int GetSocketAddressSize()
         {
-            return *(int*)_ptrSocketAddressBufferSize;
+            return *(int*)PtrSocketAddressBufferSize;
         }
 
         private unsafe void FinishOperationReceiveMessageFrom()


### PR DESCRIPTION
In the Windows implementation of SocketAsyncEventArgs, we're currently storing in six IntPtr fields values that we can efficiently recreate at run time, and by removing the fields, we save 48 bytes per SocketAsyncEventArgs instance (on 64-bit).  Unfortunately SocketAsyncEventArgs is currently quite large, so that's "only" 7%, but it's a good start.

cc: @geoffkizer, @davidsh, @cipop