### PR TITLE
Enable X509Certificates tests to run on uap and uapaot

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.Import.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.Import.cs
@@ -234,9 +234,6 @@ namespace Internal.Cryptography.Pal
             // For .NET Native (UWP) the API used to delete the private key (if it wasn't added to a store) is not
             // allowed to be called if the key is stored in CAPI.  So for UWP force the key to be stored in the
             // CNG Key Storage Provider, then deleting the key with CngKey.Delete will clean up the file on disk, too.
-#if uap
-            pfxCertStoreFlags |= PfxCertStoreFlags.PKCS12_ALWAYS_CNG_KSP;
-#endif
 
             return pfxCertStoreFlags;
         }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.PrivateKey.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.PrivateKey.cs
@@ -29,15 +29,7 @@ namespace Internal.Cryptography.Pal
             return GetPrivateKey<RSA>(
                 delegate (CspParameters csp)
                 {
-#if uap
-                    // In .NET Native (UWP) we don't have access to CAPI, so it's CNG-or-nothing.
-                    // But we don't expect to get here, so it shouldn't be a problem.
-    
-                    Debug.Fail("A CAPI provider type code was specified");
-                    return null;
-#else
                     return new RSACryptoServiceProvider(csp);
-#endif
                 },
                 delegate (CngKey cngKey)
                 {
@@ -51,15 +43,7 @@ namespace Internal.Cryptography.Pal
             return GetPrivateKey<DSA>(
                 delegate (CspParameters csp)
                 {
-#if uap
-                    // In .NET Native (UWP) we don't have access to CAPI, so it's CNG-or-nothing.
-                    // But we don't expect to get here, so it shouldn't be a problem.
-    
-                    Debug.Fail("A CAPI provider type code was specified");
-                    return null;
-#else
                     return new DSACryptoServiceProvider(csp);
-#endif
                 },
                 delegate (CngKey cngKey)
                 {
@@ -215,17 +199,9 @@ namespace Internal.Cryptography.Pal
             else
             {
                 // ProviderType being non-zero signifies that this is a CAPI key.
-#if uap
-                // In .NET Native (UWP) we don't have access to CAPI, so it's CNG-or-nothing.
-                // But we don't expect to get here, so it shouldn't be a problem.
-    
-                Debug.Fail("A CAPI provider type code was specified");
-                return null;
-#else
                 // We never want to stomp over certificate private keys.
                 cspParameters.Flags |= CspProviderFlags.UseExistingKey;
                 return createCsp(cspParameters);
-#endif
             }
         }
 

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.cs
@@ -417,9 +417,6 @@ namespace Internal.Cryptography.Pal
             sb.AppendLine();
             sb.AppendLine("[Private Key]");
 
-#if uap
-            // Similar to the Unix implementation, in UWP merely acknowledge that there -is- a private key.
-#else
             CspKeyContainerInfo cspKeyContainerInfo = null;
             try
             {
@@ -482,7 +479,6 @@ namespace Internal.Cryptography.Pal
             }
             catch (CryptographicException) { }
             catch (NotSupportedException) { }
-#endif // #if uap / #else
         }
 
         public void Dispose()

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Interop.crypt32.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Interop.crypt32.cs
@@ -297,11 +297,9 @@ internal static partial class Interop
 
         [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true)]
         public static extern bool CryptMsgClose(IntPtr hCryptMsg);
-
-#if !uap
+        
         [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true)]
         public static extern unsafe bool CryptImportPublicKeyInfoEx2(CertEncodingType dwCertEncodingType, CERT_PUBLIC_KEY_INFO* pInfo, int dwFlags, void* pvAuxInfo, out SafeBCryptKeyHandle phKey);
-#endif
 
         [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true)]
         public static extern bool CryptAcquireCertificatePrivateKey(SafeCertContextHandle pCert, CryptAcquireFlags dwFlags, IntPtr pvParameters, out SafeNCryptKeyHandle phCryptProvOrNCryptKey, out int pdwKeySpec, out bool pfCallerFreeProvOrNCryptKey);

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Interop.cryptoapi.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Interop.cryptoapi.cs
@@ -15,11 +15,9 @@ internal static partial class Interop
 {
     public static partial class cryptoapi
     {
-#if !uap
         [DllImport(Libraries.Advapi32, SetLastError = true, CharSet = CharSet.Unicode, EntryPoint = "CryptAcquireContextW")]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern unsafe bool CryptAcquireContext(out IntPtr psafeProvHandle, char* pszContainer, char* pszProvider, int dwProvType, CryptAcquireContextFlags dwFlags);
-#endif
     }
 }
 

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/SafeHandles.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/SafeHandles.cs
@@ -183,7 +183,6 @@ namespace Internal.Cryptography.Pal.Native
                     }
                     else
                     {
-#if !uap // For UWP, CryptAcquireContext() is a disallowed api, even when being used for cleanup. CAPI keys should not exist on that platform, however...
                         CryptAcquireContextFlags flags = (pProvInfo->dwFlags & CryptAcquireContextFlags.CRYPT_MACHINE_KEYSET) | CryptAcquireContextFlags.CRYPT_DELETEKEYSET;
                         IntPtr hProv;
                         bool success = Interop.cryptoapi.CryptAcquireContext(out hProv, pProvInfo->pwszContainerName, pProvInfo->pwszProvName, pProvInfo->dwProvType, flags);
@@ -191,7 +190,6 @@ namespace Internal.Cryptography.Pal.Native
                         // Called CryptAcquireContext solely for the side effect of deleting the key containers. When called with these flags, no actual
                         // hProv is returned (so there's nothing to clean up.)
                         Debug.Assert(hProv == IntPtr.Zero);
-#endif
                     }
                 }
             }

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -6,7 +6,6 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Security.Cryptography.X509Certificates</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DefineConstants Condition="'$(TargetGroup)' == 'uap'">$(DefineConstants);uap</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-OSX-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-OSX-Release|AnyCPU'" />

--- a/src/System.Security.Cryptography.X509Certificates/tests/Cert.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/Cert.cs
@@ -17,9 +17,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         // netcoreapp-OSX: DefaultKeySet
         // netcoreapp-other: EphemeralKeySet
         internal static readonly X509KeyStorageFlags EphemeralIfPossible =
-#if netcoreapp
             !RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? X509KeyStorageFlags.EphemeralKeySet :
-#endif
             X509KeyStorageFlags.DefaultKeySet;
         //
         // The Import() methods have an overload for each X509Certificate2Collection.Import() overload.

--- a/src/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/CertificateRequestApiTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/CertificateRequestApiTests.cs
@@ -62,7 +62,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                     HashAlgorithmName.SHA256,
                     RSASignaturePadding.Pkcs1);
 
-                Assert.Throws<ArgumentNullException>(
+                AssertExtensions.Throws<ArgumentNullException>(
                     "generator",
                     () => request.Create(testRoot.SubjectName, null, DateTimeOffset.MinValue, DateTimeOffset.MinValue, null));
 
@@ -90,13 +90,13 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
             ECDsa key = null;
             HashAlgorithmName hashAlgorithm = default(HashAlgorithmName);
 
-            Assert.Throws<ArgumentNullException>(
+            AssertExtensions.Throws<ArgumentNullException>(
                 "subjectName",
                 () => new CertificateRequest(subjectName, key, hashAlgorithm));
 
             subjectName = "";
 
-            Assert.Throws<ArgumentNullException>(
+            AssertExtensions.Throws<ArgumentNullException>(
                 "key",
                 () => new CertificateRequest(subjectName, key, hashAlgorithm));
 
@@ -117,13 +117,13 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
             ECDsa key = null;
             HashAlgorithmName hashAlgorithm = default(HashAlgorithmName);
 
-            Assert.Throws<ArgumentNullException>(
+            AssertExtensions.Throws<ArgumentNullException>(
                 "subjectName",
                 () => new CertificateRequest(subjectName, key, hashAlgorithm));
 
             subjectName = new X500DistinguishedName("");
 
-            Assert.Throws<ArgumentNullException>(
+            AssertExtensions.Throws<ArgumentNullException>(
                 "key",
                 () => new CertificateRequest(subjectName, key, hashAlgorithm));
 
@@ -145,13 +145,13 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
             HashAlgorithmName hashAlgorithm = default(HashAlgorithmName);
             RSASignaturePadding padding = null;
 
-            Assert.Throws<ArgumentNullException>(
+            AssertExtensions.Throws<ArgumentNullException>(
                 "subjectName",
                 () => new CertificateRequest(subjectName, key, hashAlgorithm, padding));
 
             subjectName = "";
 
-            Assert.Throws<ArgumentNullException>(
+            AssertExtensions.Throws<ArgumentNullException>(
                 "key",
                 () => new CertificateRequest(subjectName, key, hashAlgorithm, padding));
 
@@ -165,7 +165,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
 
                 hashAlgorithm = HashAlgorithmName.SHA256;
 
-                Assert.Throws<ArgumentNullException>(
+                AssertExtensions.Throws<ArgumentNullException>(
                     "padding",
                     () => new CertificateRequest(subjectName, key, hashAlgorithm, padding));
             }
@@ -179,13 +179,13 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
             HashAlgorithmName hashAlgorithm = default(HashAlgorithmName);
             RSASignaturePadding padding = null;
 
-            Assert.Throws<ArgumentNullException>(
+            AssertExtensions.Throws<ArgumentNullException>(
                 "subjectName",
                 () => new CertificateRequest(subjectName, key, hashAlgorithm, padding));
 
             subjectName = new X500DistinguishedName("");
 
-            Assert.Throws<ArgumentNullException>(
+            AssertExtensions.Throws<ArgumentNullException>(
                 "key",
                 () => new CertificateRequest(subjectName, key, hashAlgorithm, padding));
 
@@ -199,7 +199,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
 
                 hashAlgorithm = HashAlgorithmName.SHA256;
 
-                Assert.Throws<ArgumentNullException>(
+                AssertExtensions.Throws<ArgumentNullException>(
                     "padding",
                     () => new CertificateRequest(subjectName, key, hashAlgorithm, padding));
             }
@@ -212,13 +212,13 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
             PublicKey publicKey = null;
             HashAlgorithmName hashAlgorithm = default(HashAlgorithmName);
 
-            Assert.Throws<ArgumentNullException>(
+            AssertExtensions.Throws<ArgumentNullException>(
                 "subjectName",
                 () => new CertificateRequest(subjectName, publicKey, hashAlgorithm));
 
             subjectName = new X500DistinguishedName("");
 
-            Assert.Throws<ArgumentNullException>(
+            AssertExtensions.Throws<ArgumentNullException>(
                 "publicKey",
                 () => new CertificateRequest(subjectName, publicKey, hashAlgorithm));
 

--- a/src/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/CertificateRequestUsageTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/CertificateRequestUsageTests.cs
@@ -519,11 +519,12 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
             Exception exception = Assert.Throws<CryptographicException>(
                 () =>
                 request.Create(request.SubjectName, generator, now, now.AddDays(1), new byte[1]));
-
+#if netcoreapp
             if (CultureInfo.CurrentCulture.Name == "en-US")
             {
                 Assert.Contains("ASN1", exception.Message);
             }
+#endif
         }
 
         [Fact]

--- a/src/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/ECDsaX509SignatureGeneratorTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/ECDsaX509SignatureGeneratorTests.cs
@@ -14,7 +14,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         [Fact]
         public static void ECDsaX509SignatureGeneratorCtor_Exceptions()
         {
-            Assert.Throws<ArgumentNullException>(
+            AssertExtensions.Throws<ArgumentNullException>(
                 "key",
                 () => X509SignatureGenerator.CreateForECDsa(null));
         }

--- a/src/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/RSAPkcs1X509SignatureGeneratorTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/RSAPkcs1X509SignatureGeneratorTests.cs
@@ -12,7 +12,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         [Fact]
         public static void RsaPkcsSignatureGeneratorCtor_Exceptions()
         {
-            Assert.Throws<ArgumentNullException>(
+            AssertExtensions.Throws<ArgumentNullException>(
                 "key",
                 () => X509SignatureGenerator.CreateForRSA(null, RSASignaturePadding.Pkcs1));
         }

--- a/src/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/RSAPssX509SignatureGeneratorTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/RSAPssX509SignatureGeneratorTests.cs
@@ -12,7 +12,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         [Fact]
         public static void RsaPssSignatureGeneratorCtor_Exceptions()
         {
-            Assert.Throws<ArgumentNullException>(
+            AssertExtensions.Throws<ArgumentNullException>(
                 "key",
                 () => X509SignatureGenerator.CreateForRSA(null, RSASignaturePadding.Pss));
         }

--- a/src/System.Security.Cryptography.X509Certificates/tests/CollectionImportTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CollectionImportTests.cs
@@ -310,22 +310,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
-#if netcoreapp11
-        [Fact]
-        [PlatformSpecific(TestPlatforms.OSX)]
-        public static void EphemeralKeySet_OSX()
-        {
-            // EphemeralKeySet fails when loading a PFX, and is ignored otherwise.
-            using (ImportedCollection coll = Cert.Import(TestData.Pkcs7ChainDerBytes, null, X509KeyStorageFlags.EphemeralKeySet))
-            {
-                Assert.Equal(3, coll.Collection.Count);
-            }
-
-            Assert.Throws<PlatformNotSupportedException>(
-                () => new X509Certificate2(TestData.EmptyPfx, string.Empty, X509KeyStorageFlags.EphemeralKeySet));
-        }
-#endif
-
         [Fact]
         public static void InvalidStorageFlags()
         {
@@ -343,8 +327,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             // No test is performed here for the ephemeral flag failing downlevel, because the live
             // binary is always used by default, meaning it doesn't know EphemeralKeySet doesn't exist.
         }
-
-#if netcoreapp
+        
         [Fact]
         public static void InvalidStorageFlags_PersistedEphemeral()
         {
@@ -362,18 +345,14 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 "keyStorageFlags",
                 () => coll.Import(string.Empty, string.Empty, PersistedEphemeral));
         }
-#endif
 
         public static IEnumerable<object[]> StorageFlags
         {
             get
             {
                 yield return new object[] { X509KeyStorageFlags.DefaultKeySet };
-
-#if netcoreapp
                 if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                     yield return new object[] { X509KeyStorageFlags.EphemeralKeySet };
-#endif
             }
         }
 

--- a/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
@@ -653,14 +653,12 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         {
             TestExportSingleCert(X509ContentType.Cert);
         }
-
-#if netcoreapp
+        
         [Fact]
         public static void ExportCert_SecureString()
         {
             TestExportSingleCert_SecureStringPassword(X509ContentType.Cert);
         }
-#endif
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]  // SerializedCert not supported on Unix
@@ -912,6 +910,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Arrays with non-zero lower bounds are not supported.")]
         public static void X509ExtensionCollection_CopyTo_NonZeroLowerBound_ThrowsIndexOutOfRangeException()
         {
             using (X509Certificate2 cert = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword, Cert.EphemeralIfPossible))
@@ -1405,8 +1404,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.Null(byFriendlyName);
             }
         }
-
-#if netcoreapp
+        
         private static void TestExportSingleCert_SecureStringPassword(X509ContentType ct)
         {
             using (var pfxCer = new X509Certificate2(TestData.PfxData, TestData.CreatePfxDataPasswordSecureString(), Cert.EphemeralIfPossible))
@@ -1414,7 +1412,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 TestExportSingleCert(ct, pfxCer);
             }
         }
-#endif
 
         private static void TestExportSingleCert(X509ContentType ct)
         {

--- a/src/System.Security.Cryptography.X509Certificates/tests/Configurations.props
+++ b/src/System.Security.Cryptography.X509Certificates/tests/Configurations.props
@@ -5,6 +5,7 @@
       netcoreapp-OSX;
       netcoreapp-Unix;
       netcoreapp-Windows_NT;
+      uap-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Cryptography.X509Certificates/tests/CtorTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CtorTests.cs
@@ -370,8 +370,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             // No test is performed here for the ephemeral flag failing downlevel, because the live
             // binary is always used by default, meaning it doesn't know EphemeralKeySet doesn't exist.
         }
-
-#if netcoreapp
+        
         [Fact]
         public static void InvalidStorageFlags_PersistedEphemeral()
         {
@@ -396,6 +395,5 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 "keyStorageFlags",
                 () => new X509Certificate2(string.Empty, string.Empty, PersistedEphemeral));
         }
-#endif
     }
 }

--- a/src/System.Security.Cryptography.X509Certificates/tests/PfxTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/PfxTests.cs
@@ -15,12 +15,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         {
             get
             {
-#if uap
-                yield break;
-#else
                 yield return new object[] { TestData.ECDsabrainpoolP160r1_Pfx };
                 yield return new object[] { TestData.ECDsabrainpoolP160r1_Explicit_Pfx };
-#endif
             }
         }
 
@@ -38,8 +34,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.Equal(expectedThumbprint, thumbPrint);
             }
         }
-
-#if netcoreapp
+        
         [Theory]
         [MemberData(nameof(StorageFlags))]
         public static void TestConstructor_SecureString(X509KeyStorageFlags keyStorageFlags)
@@ -55,7 +50,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.Equal(expectedThumbprint, thumbPrint);
             }
         }
-#endif
 
         [Theory]
         [MemberData(nameof(StorageFlags))]
@@ -119,8 +113,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 }
             }
         }
-
-#if netcoreapp
+        
         [Fact]
         public static void TestPrivateKeyProperty()
         {
@@ -140,7 +133,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.Throws<PlatformNotSupportedException>(() => c.PrivateKey = alg);
             }
         }
-#endif
 
         private static void VerifyPrivateKey(RSA rsa)
         {
@@ -179,8 +171,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 }
             }
         }
-
-#if netcoreapp
+        
         [Fact]
         public static void ECDsaPrivateKeyProperty_WindowsPfx()
         {
@@ -225,7 +216,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.False(dsa.VerifyData(data, sig, HashAlgorithmName.SHA1), "Key verifies tampered data signature");
             }
         }
-#endif
 
         private static void Verify_ECDsaPrivateKey_WindowsPfx(ECDsa ecdsa)
         {
@@ -289,8 +279,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 }
             }
         }
-
-#if netcoreapp
+        
         [Fact]
         public static void ReadDSAPrivateKey()
         {
@@ -360,7 +349,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 }
             }
         }
-#endif
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]  // Uses P/Invokes

--- a/src/System.Security.Cryptography.X509Certificates/tests/PublicKeyTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/PublicKeyTests.cs
@@ -44,9 +44,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         {
             get
             {
-#if uap
-                yield break;
-#else
                 yield return new object[] {
                     TestData.ECDsabrainpoolP160r1_CertificatePemBytes,
                     "9145C79DD4DF758EB377D13B0DB81F83CE1A63A4099DDC32FE228B06EB1F306423ED61B6B4AF4691".HexToByteArray() };
@@ -54,7 +51,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 yield return new object[] {
                     TestData.ECDsabrainpoolP160r1_ExplicitCertificatePemBytes,
                     "6D74F1C9BCBBA5A25F67E670B3DABDB36C24E8FAC3266847EB2EE7E3239208ADC696BB421AB380B4".HexToByteArray() };
-#endif
             }
         }
 
@@ -478,8 +474,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 }
             }
         }
-
-#if netcoreapp
+        
         [Fact]
         public static void TestDSAPublicKey()
         {
@@ -529,7 +524,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.Null(pubKey);
             }
         }
-#endif
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]  // Uses P/Invokes
@@ -564,7 +558,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         private static void TestKey_ECDsaCng(byte[] certBytes, TestData.ECDsaCngKeyValues expected)
         {
-#if !uap
             using (X509Certificate2 cert = new X509Certificate2(certBytes))
             {
                 ECDsaCng e = (ECDsaCng)(cert.GetECDsaPublicKey());
@@ -582,7 +575,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                     Assert.Equal<byte>(expected.QY, qy);
                 }
             }
-#endif // !uap
         }
     }
 }

--- a/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
@@ -5,6 +5,7 @@
     <ProjectGuid>{A28B0064-EFB2-4B77-B97C-DECF5DAB074E}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants Condition="'$(TargetGroup)'=='netcoreapp'">$(DefineConstants);netcoreapp</DefineConstants>
+    <ILCBuildType Condition="'$(TargetGroup)' == 'uap'">chk</ILCBuildType>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-OSX-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-OSX-Release|AnyCPU'" />
@@ -12,6 +13,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="Cert.cs" />
     <Compile Include="CertificateCreation\CertificateRequestApiTests.cs" />
@@ -55,8 +58,6 @@
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
       <Link>CommonTest\System\PlatformDetection.cs</Link>
     </Compile>
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard' OR '$(TargetGroup)'=='netcoreapp'">
     <Compile Include="ImportTests.cs" />
     <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
       <Link>Common\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>


### PR DESCRIPTION
fixes #17764

cc: @bartonjs @jkotas @steveharter 

Enabling test run for uap and uapaot for X509Certificates tests which were not running before.