### PR TITLE
Fix null dereference in WinHttpResponseStream

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
@@ -314,11 +314,8 @@ namespace System.Net.Http
             {
                 if (_state.AsyncReadInProgress)
                 {
-                    Debug.Assert(_requestHandle != null);
-                    Debug.Assert(!_requestHandle.IsInvalid);
-                    
                     WinHttpTraceHelper.Trace("WinHttpResponseStream.CancelPendingResponseStreamReadOperation: before dispose");
-                    _requestHandle.Dispose();
+                    _requestHandle?.Dispose();
                     WinHttpTraceHelper.Trace("WinHttpResponseStream.CancelPendingResponseStreamReadOperation: after dispose");
                 }
             }

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
@@ -315,7 +315,7 @@ namespace System.Net.Http
                 if (_state.AsyncReadInProgress)
                 {
                     WinHttpTraceHelper.Trace("WinHttpResponseStream.CancelPendingResponseStreamReadOperation: before dispose");
-                    _requestHandle?.Dispose();
+                    _requestHandle?.Dispose(); // null check necessary to handle race condition between stream disposal and cancellation
                     WinHttpTraceHelper.Trace("WinHttpResponseStream.CancelPendingResponseStreamReadOperation: after dispose");
                 }
             }


### PR DESCRIPTION
If the response stream is disposed of while an operation like CopyToAsync is in flight, a subsequent cancellation request can trigger a null dereference in CancelPendingResponseStreamReadOperation.  While this may not be desirable interaction, we should be more robust against it.

Fixes https://github.com/dotnet/corefx/issues/22152
cc: @davidsh, @moozzyk 

@moozzyk, I'm not entirely sure how the access pattern you highlighted could have triggered this, but obviously something did, so hopefully this addresses it.  Regardless of whether it does, it's a worthwhile change IMHO.