### PR TITLE
Fix RepeatBehavior GetHashCode test on Uap

### DIFF
--- a/src/System.Runtime.WindowsRuntime.UI.Xaml/tests/Windows/UI/Xaml/Media/Animation/RepeatBehaviorTests.cs
+++ b/src/System.Runtime.WindowsRuntime.UI.Xaml/tests/Windows/UI/Xaml/Media/Animation/RepeatBehaviorTests.cs
@@ -150,14 +150,13 @@ namespace Windows.UI.Xaml.Media.Animation.Tests
             yield return new object[] { RepeatBehavior.Forever, new RepeatBehavior(2), false };
 
             yield return new object[] { new RepeatBehavior { Type = RepeatBehaviorType.Count - 1 }, new RepeatBehavior { Type = RepeatBehaviorType.Count - 1 }, false };
-            yield return new object[] { new RepeatBehavior { Type = RepeatBehaviorType.Forever + 1 }, new RepeatBehavior { Type = RepeatBehaviorType.Count + 1 }, false };
+            yield return new object[] { new RepeatBehavior { Type = RepeatBehaviorType.Forever + 1 }, new RepeatBehavior(TimeSpan.FromSeconds(1)) { Type = RepeatBehaviorType.Count + 1 }, false };
             yield return new object[] { new RepeatBehavior(TimeSpan.FromSeconds(2)), new object(), false };
             yield return new object[] { new RepeatBehavior(TimeSpan.FromSeconds(2)), null, false };
         }
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        [ActiveIssue(21351, TargetFrameworkMonikers.UapAot)]
         public void Equals_Object_ReturnsExpected(RepeatBehavior repeatBehaviour, object other, bool expected)
         {
             Assert.Equal(expected, repeatBehaviour.Equals(other));


### PR DESCRIPTION
Resolves https://github.com/dotnet/corefx/issues/21351

The test case `new object[] { new RepeatBehavior { Type = RepeatBehaviorType.Forever + 1 }, new RepeatBehavior { Type = RepeatBehaviorType.Count + 1 }, false };` fails on [this line](https://github.com/dotnet/corefx/blob/master/src/System.Runtime.WindowsRuntime.UI.Xaml/tests/Windows/UI/Xaml/Media/Animation/RepeatBehaviorTests.cs#L177).

The test seems to be failing because the first behavior type argument passed is invalid and thus gets ValueType.HashCode()=0 as hash code by default, and the second one is of behavior type Duration, which has 0 time span and as a result, returns 0 for hash code. I'm not 100% sure what the purpose of the test was, but looks like to me the failure should be expected given the input. So, enforcing non-zero timespan for the second arg.

cc: @hughbe @tijoytom 