### PR TITLE
[release/2.0] Add missing return statement in test VerifyWithRevocation skip path.

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
@@ -578,6 +578,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 else if (!valid)
                 {
                     Console.WriteLine($"SKIP [{nameof(VerifyWithRevocation)}]: Chain failed to build within {RetryLimit} tries.");
+                    return;
                 }
 
                 // Since the network was enabled, we should get the whole chain.


### PR DESCRIPTION
When revocation couldn't be checked (due to network or other issues) the
VerifyWithRevocation test is supposed to print "SKIP" and exit successfully.

Due to a missing return statement it prints SKIP, then fails.

Port #22149 to release/2.0.
Fixes #21926