### PR TITLE
Pinning correct WebSocketState.Closed behavior

### DIFF
--- a/src/System.Net.WebSockets.Client/tests/CloseTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/CloseTest.cs
@@ -256,8 +256,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
-        [ActiveIssue(20362, TargetFrameworkMonikers.Uap)]
-        [ActiveIssue(20362, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue(20362, TargetFrameworkMonikers.Netcoreapp)]
         [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task CloseOutputAsync_DuringConcurrentReceiveAsync_ExpectedStates(Uri server)
@@ -270,29 +269,28 @@ namespace System.Net.WebSockets.Client.Tests
                 Assert.False(t.IsCompleted);
                 Assert.Equal(WebSocketState.Open, cws.State);
 
-                // Send a close frame.  After this completes, the state could be CloseSent if we haven't
-                // yet received the server response close frame, or it could be CloseReceived if we have.
+                // Send a close frame. After this completes, the state could be CloseSent if we haven't
+                // yet received the server's response close frame, or it could be Closed if we have.
                 await cws.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
                 Assert.True(
-                    cws.State == WebSocketState.CloseSent || cws.State == WebSocketState.CloseReceived,
-                    $"Expected CloseSent or CloseReceived, got {cws.State}");
+                    cws.State == WebSocketState.CloseSent || cws.State == WebSocketState.Closed,
+                    $"Expected CloseSent or Closed, got {cws.State}");
 
-                // Then wait for the receive.  After this completes, the state is most likely CloseReceived,
-                // however there is a race condition between the our realizing that the send has completed
-                // and a fast server sending back a close frame, such that we could end up noticing the
-                // receive completion before we notice the send completion.
+                // Now wait for the receive. It will complete once the server's close frame arrives,
+                // at which point the ClientWebSocket's state should automatically transition to Closed.
                 WebSocketReceiveResult r = await t;
                 Assert.Equal(WebSocketMessageType.Close, r.MessageType);
-                Assert.True(
-                    cws.State == WebSocketState.CloseSent || cws.State == WebSocketState.CloseReceived,
-                    $"Expected CloseSent or CloseReceived, got {cws.State}");
+                Assert.Equal(WebSocketState.Closed, cws.State);
 
-                // Then close
+                // Closing an already-closed ClientWebSocket should be a no-op. Any other behavior (e.g., throwing exception)
+                // would give way to race conditions between (1) CloseAsync being called and (2) the server's response close
+                // frame being received after CloseOutputAsync.
                 await cws.CloseAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
                 Assert.Equal(WebSocketState.Closed, cws.State);
 
-                // Another close should fail
-                await Assert.ThrowsAsync<WebSocketException>(() => cws.CloseAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None));
+                // Call CloseAsync one more time on the already-closed ClientWebSocket for good measure. Again, this should be a no-op.
+                await cws.CloseAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
+                Assert.Equal(WebSocketState.Closed, cws.State);
             }
         }
 


### PR DESCRIPTION
As part of the #20362 investigation, it has been determined that the non-UWP .NET Core behavior around WebSocketState.Closed is incorrect. These changes pin the correct (.NET Framework) behavior.

After these changes, there will be no remaining UAP-specific ActiveIssue or SkipOn* annotations in the entire System.Net.WebSockets* namespace.

Contributes to #20362 #20132