### PR TITLE
Re-Enable DiagnosticSource to EventSource bridge tests on UAPAOT.

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceEventSourceBridgeTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceEventSourceBridgeTests.cs
@@ -22,7 +22,6 @@ namespace System.Diagnostics.Tests
         /// the events you want.
         /// </summary>
         [Fact]
-        [ActiveIssue(20579,TargetFrameworkMonikers.UapAot)]
         public void TestSpecificEvents()
         {
             using (var eventSourceListener = new TestDiagnosticSourceEventListener())
@@ -161,7 +160,6 @@ namespace System.Diagnostics.Tests
         /// Tests what happens when you wildcard the source name (empty string)
         /// </summary>
         [Fact]
-        [ActiveIssue(20579, TargetFrameworkMonikers.UapAot)]
         public void TestWildCardSourceName()
         {
             using (var eventSourceListener = new TestDiagnosticSourceEventListener())
@@ -223,7 +221,6 @@ namespace System.Diagnostics.Tests
         /// Tests what happens when you wildcard event name (but not the source name) 
         /// </summary>
         [Fact]
-        [ActiveIssue(20579, TargetFrameworkMonikers.UapAot)]
         public void TestWildCardEventName()
         {
             using (var eventSourceListener = new TestDiagnosticSourceEventListener())
@@ -280,7 +277,6 @@ namespace System.Diagnostics.Tests
         /// ignored.  
         /// </summary>
         [Fact]
-        [ActiveIssue(20579, TargetFrameworkMonikers.UapAot)]
         public void TestNulls()
         {
             using (var eventSourceListener = new TestDiagnosticSourceEventListener())
@@ -359,7 +355,6 @@ namespace System.Diagnostics.Tests
         /// of the payload object.  
         /// </summary>
         [Fact]
-        [ActiveIssue(20579, TargetFrameworkMonikers.UapAot)]
         public void TestNoImplicitTransforms()
         {
             using (var eventSourceListener = new TestDiagnosticSourceEventListener())
@@ -390,7 +385,6 @@ namespace System.Diagnostics.Tests
         /// Tests what happens when wacky characters are used in property specs.  
         /// </summary>
         [Fact]
-        [ActiveIssue(20579, TargetFrameworkMonikers.UapAot)]
         public void TestBadProperties()
         {
             using (var eventSourceListener = new TestDiagnosticSourceEventListener())
@@ -450,7 +444,6 @@ namespace System.Diagnostics.Tests
         /// Tests the feature to send the messages as EventSource Activities.  
         /// </summary>
         [Fact]
-        [ActiveIssue(20579, TargetFrameworkMonikers.UapAot)]
         public void TestActivities()
         {
             using (var eventSourceListener = new TestDiagnosticSourceEventListener())
@@ -521,7 +514,6 @@ namespace System.Diagnostics.Tests
         /// Tests that keywords that define shortcuts work.    
         /// </summary>
         [Fact]
-        [ActiveIssue(20579, TargetFrameworkMonikers.UapAot)]
         public void TestShortcutKeywords()
         {
             using (var eventSourceListener = new TestDiagnosticSourceEventListener())


### PR DESCRIPTION
Re-enable EventSource bridge tests now that EventSource is functional on UAPAOT.