### PR TITLE
Skip NonAzureNoProtocolConnectionTest on UAP, since the UseManagedSNI flag it uses cannot be checked via reflection on UAP

### DIFF
--- a/src/System.Data.SqlClient/tests/FunctionalTests/TcpDefaultForAzureTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/TcpDefaultForAzureTest.cs
@@ -33,6 +33,7 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)] // Cannot retrieve UseManagedSNI flag via reflection on UAP
         public static void NonAzureNoProtocolConnectionTest()
         {
             builder.DataSource = InvalidHostname;


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/21437