### PR TITLE
Add PlatformDetection.PartialMessagesSupported and disable Arrays with non-zero lower bounds on not supported platform

### DIFF
--- a/src/Common/tests/System/Net/PlatformDetection.Networking.cs
+++ b/src/Common/tests/System/Net/PlatformDetection.Networking.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System
+{
+    public static partial class PlatformDetection
+    {
+        // Windows 10 Insider Preview Build 16215 introduced the necessary APIs for the UAP version of
+        // ClientWebSocket.ReceiveAsync to consume partial message data as it arrives, without having to wait
+        // for "end of message" to be signaled.
+        public static bool ClientWebSocketPartialMessagesSupported => !IsUap || IsWindows10InsiderPreviewBuild16215OrGreater;
+    }
+}

--- a/src/Common/tests/System/PlatformDetection.cs
+++ b/src/Common/tests/System/PlatformDetection.cs
@@ -41,6 +41,10 @@ namespace System
             GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 16215;
         public static bool IsArmProcess => RuntimeInformation.ProcessArchitecture == Architecture.Arm;
         public static bool IsNotArmProcess => !IsArmProcess;
+        // Windows 10 Insider Preview Build 16215 introduced the necessary APIs for the UAP version of
+        // ClientWebSocket.ReceiveAsync to consume partial message data as it arrives, without having to wait
+        // for "end of message" to be signaled.
+        public static bool ClientWebSocketPartialMessagesSupported => !IsUap || IsWindows10InsiderPreviewBuild16215OrGreater;
 
         // Windows OneCoreUAP SKU doesn't have httpapi.dll
         public static bool IsNotOneCoreUAP => (!IsWindows || 

--- a/src/Common/tests/System/PlatformDetection.cs
+++ b/src/Common/tests/System/PlatformDetection.cs
@@ -41,10 +41,6 @@ namespace System
             GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 16215;
         public static bool IsArmProcess => RuntimeInformation.ProcessArchitecture == Architecture.Arm;
         public static bool IsNotArmProcess => !IsArmProcess;
-        // Windows 10 Insider Preview Build 16215 introduced the necessary APIs for the UAP version of
-        // ClientWebSocket.ReceiveAsync to consume partial message data as it arrives, without having to wait
-        // for "end of message" to be signaled.
-        public static bool ClientWebSocketPartialMessagesSupported => !IsUap || IsWindows10InsiderPreviewBuild16215OrGreater;
 
         // Windows OneCoreUAP SKU doesn't have httpapi.dll
         public static bool IsNotOneCoreUAP => (!IsWindows || 

--- a/src/System.Net.HttpListener/tests/HttpListenerPrefixCollectionTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerPrefixCollectionTests.cs
@@ -106,8 +106,8 @@ namespace System.Net.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => listener.Prefixes.CopyTo(new object[1, 1], 0));
         }
 
-        [ActiveIssue(22055, TargetFrameworkMonikers.UapAot)]
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Arrays with non-zero lower bounds are not supported for NetNative")]
         public void CopyTo_NonZeroLowerBoundArray_ThrowsIndexOutOfRangeException()
         {
             var listener = new HttpListener();

--- a/src/System.Net.HttpListener/tests/HttpListenerPrefixCollectionTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerPrefixCollectionTests.cs
@@ -11,6 +11,8 @@ namespace System.Net.Tests
 {
     public class HttpListenerPrefixCollectionTests
     {
+        public static bool IsNonZeroLowerBoundArraySupported { get; } = PlatformDetection.IsNonZeroLowerBoundArraySupported;
+
         [Fact]
         public void Prefixes_Get_ReturnsEmpty()
         {
@@ -106,8 +108,7 @@ namespace System.Net.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => listener.Prefixes.CopyTo(new object[1, 1], 0));
         }
 
-        [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Arrays with non-zero lower bounds are not supported for NetNative")]
+        [ConditionalFact(nameof(IsNonZeroLowerBoundArraySupported))]
         public void CopyTo_NonZeroLowerBoundArray_ThrowsIndexOutOfRangeException()
         {
             var listener = new HttpListener();

--- a/src/System.Net.HttpListener/tests/HttpListenerPrefixCollectionTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerPrefixCollectionTests.cs
@@ -11,7 +11,7 @@ namespace System.Net.Tests
 {
     public class HttpListenerPrefixCollectionTests
     {
-        public static bool IsNonZeroLowerBoundArraySupported { get; } = PlatformDetection.IsNonZeroLowerBoundArraySupported;
+        public static bool IsNonZeroLowerBoundArraySupported => PlatformDetection.IsNonZeroLowerBoundArraySupported;
 
         [Fact]
         public void Prefixes_Get_ReturnsEmpty()

--- a/src/System.Net.HttpListener/tests/HttpListenerRequestTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerRequestTests.cs
@@ -87,7 +87,6 @@ namespace System.Net.Tests
             yield return new object[] { "Unknown-Header: Test", Encoding.Default };
         }
 
-        [ActiveIssue(22063, TargetFrameworkMonikers.UapAot)]
         [Theory]
         [MemberData(nameof(ContentEncoding_TestData))]
         public async Task ContentEncoding_GetProperty_ReturnsExpected(string header, Encoding expected)

--- a/src/System.Net.HttpListener/tests/HttpListenerWebSocketTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerWebSocketTests.cs
@@ -13,6 +13,7 @@ namespace System.Net.Tests
 {
     public class HttpListenerWebSocketTests : IDisposable
     {
+        public static bool PartialMessagesSupported { get; } = PlatformDetection.ClientWebSocketPartialMessagesSupported;
         public static bool IsNotWindows7 { get; } = !PlatformDetection.IsWindows7;
         public static bool IsNotWindows7AndIsWindowsImplementation { get; } = IsNotWindows7 && Helpers.IsWindowsImplementation;
 
@@ -34,8 +35,7 @@ namespace System.Net.Tests
             Client.Dispose();
         }
 
-        [ActiveIssue(22164, TargetFrameworkMonikers.Uap)] // Fails in RS2 only (works in RS3).
-        [ConditionalTheory(nameof(PlatformDetection.ClientWebSocketPartialMessagesSupported), nameof(IsNotWindows7))]
+        [ConditionalTheory(nameof(PartialMessagesSupported))]
         [InlineData(WebSocketMessageType.Text, false)]
         [InlineData(WebSocketMessageType.Binary, false)]
         [InlineData(WebSocketMessageType.Text, true)]

--- a/src/System.Net.HttpListener/tests/HttpListenerWebSocketTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerWebSocketTests.cs
@@ -35,7 +35,7 @@ namespace System.Net.Tests
         }
 
         [ActiveIssue(22164, TargetFrameworkMonikers.Uap)] // Fails in RS2 only (works in RS3).
-        [ConditionalTheory(nameof(IsNotWindows7))]
+        [ConditionalTheory(nameof(PlatformDetection.ClientWebSocketPartialMessagesSupported), nameof(IsNotWindows7))]
         [InlineData(WebSocketMessageType.Text, false)]
         [InlineData(WebSocketMessageType.Binary, false)]
         [InlineData(WebSocketMessageType.Text, true)]

--- a/src/System.Net.HttpListener/tests/HttpListenerWebSocketTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerWebSocketTests.cs
@@ -13,9 +13,9 @@ namespace System.Net.Tests
 {
     public class HttpListenerWebSocketTests : IDisposable
     {
-        public static bool PartialMessagesSupported { get; } = PlatformDetection.ClientWebSocketPartialMessagesSupported;
+        public static bool PartialMessagesSupported => PlatformDetection.ClientWebSocketPartialMessagesSupported;
         public static bool IsNotWindows7 { get; } = !PlatformDetection.IsWindows7;
-        public static bool IsNotWindows7AndIsWindowsImplementation { get; } = IsNotWindows7 && Helpers.IsWindowsImplementation;
+        public static bool IsNotWindows7AndIsWindowsImplementation => IsNotWindows7 && Helpers.IsWindowsImplementation;
 
         private HttpListenerFactory Factory { get; }
         private HttpListener Listener { get; }

--- a/src/System.Net.HttpListener/tests/HttpListenerWebSocketTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerWebSocketTests.cs
@@ -35,7 +35,7 @@ namespace System.Net.Tests
             Client.Dispose();
         }
 
-        [ConditionalTheory(nameof(PartialMessagesSupported))]
+        [ConditionalTheory(nameof(PartialMessagesSupported), nameof(IsNotWindows7))]
         [InlineData(WebSocketMessageType.Text, false)]
         [InlineData(WebSocketMessageType.Binary, false)]
         [InlineData(WebSocketMessageType.Text, true)]

--- a/src/System.Net.HttpListener/tests/System.Net.HttpListener.Tests.csproj
+++ b/src/System.Net.HttpListener/tests/System.Net.HttpListener.Tests.csproj
@@ -30,6 +30,9 @@
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
       <Link>Common\tests\System\PlatformDetection.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Net\PlatformDetection.Networking.cs">
+      <Link>Common\tests\System\Net\PlatformDetection.Networking.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\System.Net.HttpListener.Tests.rd.xml" />

--- a/src/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
@@ -16,11 +16,7 @@ namespace System.Net.WebSockets.Client.Tests
 {
     public class SendReceiveTest : ClientWebSocketTestBase
     {
-        // Windows 10 Insider Preview Build 16215 introduced the necessary APIs for the UAP version of
-        // ClientWebSocket.ReceiveAsync to consume partial message data as it arrives, without having to wait
-        // for "end of message" to be signaled.
-        public static bool PartialMessagesSupported =>
-            !PlatformDetection.IsUap || PlatformDetection.IsWindows10InsiderPreviewBuild16215OrGreater;
+        public static bool PartialMessagesSupported => PlatformDetection.ClientWebSocketPartialMessagesSupported;
 
         public SendReceiveTest(ITestOutputHelper output) : base(output) { }
 

--- a/src/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
@@ -16,7 +16,7 @@ namespace System.Net.WebSockets.Client.Tests
 {
     public class SendReceiveTest : ClientWebSocketTestBase
     {
-        public static bool PartialMessagesSupported => PlatformDetection.ClientWebSocketPartialMessagesSupported;
+        public static bool PartialMessagesSupported { get; } = PlatformDetection.ClientWebSocketPartialMessagesSupported;
 
         public SendReceiveTest(ITestOutputHelper output) : base(output) { }
 

--- a/src/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
@@ -16,7 +16,7 @@ namespace System.Net.WebSockets.Client.Tests
 {
     public class SendReceiveTest : ClientWebSocketTestBase
     {
-        public static bool PartialMessagesSupported { get; } = PlatformDetection.ClientWebSocketPartialMessagesSupported;
+        public static bool PartialMessagesSupported => PlatformDetection.ClientWebSocketPartialMessagesSupported;
 
         public SendReceiveTest(ITestOutputHelper output) : base(output) { }
 

--- a/src/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
+++ b/src/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
@@ -15,7 +15,10 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
-      <Link>Common\tests\System\PlatformDetection.cs</Link>
+      <Link>Common\System\PlatformDetection.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Net\PlatformDetection.Networking.cs">
+      <Link>Common\System\Net\PlatformDetection.Networking.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)\System\Net\Capability.Security.cs">
       <Link>Common\System\Net\Capability.Security.cs</Link>

--- a/src/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
+++ b/src/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
-      <Link>Common\System\PlatformDetection.cs</Link>
+      <Link>Common\tests\System\PlatformDetection.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)\System\Net\Capability.Security.cs">
       <Link>Common\System\Net\Capability.Security.cs</Link>


### PR DESCRIPTION
Fixes #22164
Fixed #22055