### PR TITLE
Update tests for long path support in CoreCLR

### DIFF
--- a/src/System.Drawing.Common/tests/ImageTests.cs
+++ b/src/System.Drawing.Common/tests/ImageTests.cs
@@ -45,12 +45,26 @@ namespace System.Drawing.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/8655")]
         public void FromFile_LongFile_ThrowsPathTooLongException()
         {
-            string fileName = new string('a', 261);
+            // Throws PathTooLongException on Desktop and FileNotFoundException elsewhere.
+            if (PlatformDetection.IsFullFramework)
+            {
+                string fileName = new string('a', 261);
 
-            Assert.Throws<PathTooLongException>(() => Image.FromFile(fileName));
-            Assert.Throws<PathTooLongException>(() => Image.FromFile(fileName, useEmbeddedColorManagement: true));
+                Assert.Throws<PathTooLongException>(() => Image.FromFile(fileName));
+                Assert.Throws<PathTooLongException>(() => Image.FromFile(fileName,
+                    useEmbeddedColorManagement: true));
+            }
+            else
+            {
+                string fileName = new string('a', 261);
+
+                Assert.Throws<FileNotFoundException>(() => Image.FromFile(fileName));
+                Assert.Throws<FileNotFoundException>(() => Image.FromFile(fileName,
+                    useEmbeddedColorManagement: true));
+            }
         }
 
         [Fact]

--- a/src/System.Drawing.Common/tests/ImageTests.cs
+++ b/src/System.Drawing.Common/tests/ImageTests.cs
@@ -46,7 +46,7 @@ namespace System.Drawing.Tests
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/corefx/issues/8655")]
-        public void FromFile_LongFile_ThrowsPathTooLongException()
+        public void FromFile_LongSegment_ThrowsException()
         {
             // Throws PathTooLongException on Desktop and FileNotFoundException elsewhere.
             if (PlatformDetection.IsFullFramework)

--- a/src/System.Drawing.Common/tests/Text/PrivateFontCollectionTests.cs
+++ b/src/System.Drawing.Common/tests/Text/PrivateFontCollectionTests.cs
@@ -130,7 +130,7 @@ namespace System.Drawing.Text.Tests
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [ActiveIssue("https://github.com/dotnet/corefx/issues/8655")]
-        public void AddFontFile_LongFilePath_ThrowsPathTooLongException()
+        public void AddFontFile_LongFilePath_ThrowsException()
         {
             using (var fontCollection = new PrivateFontCollection())
             {

--- a/src/System.Drawing.Common/tests/Text/PrivateFontCollectionTests.cs
+++ b/src/System.Drawing.Common/tests/Text/PrivateFontCollectionTests.cs
@@ -129,11 +129,22 @@ namespace System.Drawing.Text.Tests
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/8655")]
         public void AddFontFile_LongFilePath_ThrowsPathTooLongException()
         {
             using (var fontCollection = new PrivateFontCollection())
             {
-                Assert.Throws<PathTooLongException>(() => fontCollection.AddFontFile(new string('a', 261)));
+                // Throws PathTooLongException on Desktop and FileNotFoundException elsewhere.
+                if (PlatformDetection.IsFullFramework)
+                {
+                    Assert.Throws<PathTooLongException>(
+                        () => fontCollection.AddFontFile(new string('a', 261)));
+                }
+                else
+                {
+                    Assert.Throws<FileNotFoundException>(
+                        () => fontCollection.AddFontFile(new string('a', 261)));
+                }
             }
         }
 

--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -199,7 +199,7 @@ namespace System.IO.Tests
         [Theory,
             MemberData(nameof(PathsWithComponentLongerThanMaxComponent))]
         [ActiveIssue("https://github.com/dotnet/corefx/issues/8655")]
-        public void DirectoryWithComponentLongerThanMaxComponentAsPath_ThrowsPathTooLongException(string path)
+        public void DirectoryWithComponentLongerThanMaxComponentAsPath_ThrowsException(string path)
         {
             // While paths themselves can be up to 260 characters including trailing null, file systems
             // limit each components of the path to a total of 255 characters on Desktop.

--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -198,11 +198,19 @@ namespace System.IO.Tests
 
         [Theory,
             MemberData(nameof(PathsWithComponentLongerThanMaxComponent))]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/8655")]
         public void DirectoryWithComponentLongerThanMaxComponentAsPath_ThrowsPathTooLongException(string path)
         {
             // While paths themselves can be up to 260 characters including trailing null, file systems
-            // limit each components of the path to a total of 255 characters.
-             Assert.Throws<PathTooLongException>(() => Create(path));
+            // limit each components of the path to a total of 255 characters on Desktop.
+            if (PlatformDetection.IsFullFramework)
+            {
+                Assert.Throws<PathTooLongException>(() => Create(path));
+            }
+            else
+            {
+                AssertExtensions.ThrowsAny<IOException, DirectoryNotFoundException>(() => Create(path));
+            }
         }
 
         #endregion

--- a/src/System.IO.FileSystem/tests/File/Create.cs
+++ b/src/System.IO.FileSystem/tests/File/Create.cs
@@ -153,7 +153,7 @@ namespace System.IO.Tests
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/corefx/issues/8655")]
-        public void LongPath()
+        public void LongPathSegment()
         {
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
 
@@ -167,14 +167,14 @@ namespace System.IO.Tests
             else
             {
                 Assert.Throws<IOException>(
-                    () => Create(Path.Combine(testDir.FullName, new string('a', IOInputs.MaxComponent + 1))));
-
-                var fileName = new string('k', IOInputs.MaxComponent - 1);
-                using (Create(Path.Combine(testDir.FullName, fileName)))
-                {
-                    Assert.True(File.Exists(Path.Combine(testDir.FullName, fileName)));
-                }
+                    () => Create(Path.Combine(testDir.FullName, new string('a', 300))));
             }
+
+            //TODO #645: File creation does not yet have long path support on Unix or Windows
+            //using (Create(Path.Combine(testDir.FullName, new string('k', 257))))
+            //{
+            //    Assert.True(File.Exists(Path.Combine(testDir.FullName, new string('k', 257))));
+            //}
         }
 
         #endregion


### PR DESCRIPTION
Update tests to correspond to dotnet/coreclr#12786. See #8655 

After we get CoreCLR bits into CoreFX, I can come back and remove the ActiveIssue. Also, at that time, I would like to flesh out the tests a bit more to cover some more cases that should be lit up then.

cc @JeremyKuhne 