### PR TITLE
Reconcile behavior of MaxRequestContentBufferSize across .NET Core

### DIFF
--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -404,6 +404,7 @@
     <Compile Include="uap\System\Net\cookieexception.cs" />
     <Compile Include="uap\System\Net\CookieHelper.cs" />
     <Compile Include="uap\System\Net\HttpHandlerToFilter.cs" />
+    <Compile Include="System\Net\Http\HttpClientHandler.Core.cs" />
     <Compile Include="uap\System\Net\HttpClientHandler.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp' OR '$(TargetGroup)' == 'uap'">

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Core.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Core.cs
@@ -10,9 +10,12 @@ namespace System.Net.Http
     {
         // This partial implementation contains members common to Windows and Unix running on .NET Core.
 
+        private volatile bool _operationStarted = false;
+        private volatile bool _disposed = false;
+
         public long MaxRequestContentBufferSize
         {
-            // This property has been deprecated. In the .NET Framework it was only used when the handler needed to 
+            // This property is not supported. In the .NET Framework it was only used when the handler needed to 
             // automatically buffer the request content. That only happened if neither 'Content-Length' nor 
             // 'Transfer-Encoding: chunked' request headers were specified. So, the handler thus needed to buffer
             // in the request content to determine its length and then would choose 'Content-Length' semantics when
@@ -27,17 +30,36 @@ namespace System.Net.Http
             {
                 if (value < 0)
                 {
-                    throw new ArgumentOutOfRangeException("value");
+                    throw new ArgumentOutOfRangeException(nameof(value));
                 }
 
                 if (value > HttpContent.MaxBufferSize)
                 {
-                    throw new ArgumentOutOfRangeException("value", value,
+                    throw new ArgumentOutOfRangeException(nameof(value), value,
                         string.Format(CultureInfo.InvariantCulture, SR.net_http_content_buffersize_limit,
                         HttpContent.MaxBufferSize));
                 }                
 
+                CheckDisposedOrStarted();
+
                 // No-op on property setter.
+            }
+        }
+
+        private void CheckDisposed()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(GetType().ToString());
+            }
+        }
+
+        private void CheckDisposedOrStarted()
+        {
+            CheckDisposed();
+            if (_operationStarted)
+            {
+                throw new InvalidOperationException(SR.net_http_operation_started);
             }
         }
     }

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
@@ -21,7 +21,6 @@ namespace System.Net.Http
         private readonly ManagedHandler _managedHandler;
         private readonly DiagnosticsHandler _diagnosticsHandler;
         private bool _useProxy;
-        private bool _disposed;
 
         public HttpClientHandler()
         {

--- a/src/System.Net.Http/src/uap/System/Net/HttpClientHandler.cs
+++ b/src/System.Net.Http/src/uap/System/Net/HttpClientHandler.cs
@@ -53,9 +53,6 @@ namespace System.Net.Http
         private readonly HttpHandlerToFilter _handlerToFilter;
         private readonly HttpMessageHandler _diagnosticsPipeline;
 
-        private volatile bool _operationStarted;
-        private volatile bool _disposed;
-
         private ClientCertificateOption _clientCertificateOptions;
         private CookieContainer _cookieContainer;
         private bool _useCookies;
@@ -254,39 +251,6 @@ namespace System.Net.Http
             {
                 CheckDisposedOrStarted();
                 _rtFilter.MaxConnectionsPerServer = (uint)value;
-            }
-        }
-        
-        public long MaxRequestContentBufferSize
-        {
-            // This property has been deprecated. In the .NET Framework it was only used when the handler needed to 
-            // automatically buffer the request content. That only happened if neither 'Content-Length' nor 
-            // 'Transfer-Encoding: chunked' request headers were specified. So, the handler thus needed to buffer
-            // in the request content to determine its length and then would choose 'Content-Length' semantics when
-            // POST'ing. In .NET Core and UAP platforms, the handler will resolve the ambiguity by always choosing
-            // 'Transfer-Encoding: chunked'. The handler will never automatically buffer in the request content.
-            get
-            {
-                return 0; // Returning zero is appropriate since in .NET Framework it means no limit.
-            }
-
-            set
-            {
-                if (value < 0)
-                {
-                    throw new ArgumentOutOfRangeException("value");
-                }
-
-                if (value > HttpContent.MaxBufferSize)
-                {
-                    throw new ArgumentOutOfRangeException("value", value,
-                        string.Format(CultureInfo.InvariantCulture, SR.net_http_content_buffersize_limit,
-                        HttpContent.MaxBufferSize));
-                }                
-
-                CheckDisposedOrStarted();
-
-                // No-op on property setter.
             }
         }
 
@@ -740,23 +704,6 @@ namespace System.Net.Http
                 }
 
                 _operationStarted = true;
-            }
-        }
-
-        private void CheckDisposed()
-        {
-            if (_disposed)
-            {
-                throw new ObjectDisposedException(GetType().ToString());
-            }
-        }
-
-        private void CheckDisposedOrStarted()
-        {
-            CheckDisposed();
-            if (_operationStarted)
-            {
-                throw new InvalidOperationException(SR.net_http_operation_started);
             }
         }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -153,6 +153,7 @@ namespace System.Net.Http.Functional.Tests
             {
                 Assert.True(handler.CheckCertificateRevocationList);
                 Assert.Equal(10, handler.MaxAutomaticRedirections);
+                Assert.Equal(0, handler.MaxRequestContentBufferSize);
                 Assert.Equal(-1, handler.MaxResponseHeadersLength);
                 Assert.True(handler.PreAuthenticate);
                 Assert.Equal(SslProtocols.None, handler.SslProtocols);
@@ -176,28 +177,6 @@ namespace System.Net.Http.Functional.Tests
 
                 handler.Credentials = CredentialCache.DefaultCredentials;
                 Assert.Same(CredentialCache.DefaultCredentials, handler.Credentials);
-            }
-        }
-
-        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "MaxRequestContentBufferSize not used on .NET Core due to architecture differences")]
-        [Fact]
-        public void MaxRequestContentBufferSize_Get_ReturnsZero()
-        {
-            using (var handler = new HttpClientHandler())
-            {
-                Assert.Equal(0, handler.MaxRequestContentBufferSize);
-            }
-        }
-
-        [ActiveIssue(20010, TargetFrameworkMonikers.Uap)]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "MaxRequestContentBufferSize not used on .NET Core due to architecture differences")]
-        [Fact]
-        public void MaxRequestContentBufferSize_Set_ThrowsPlatformNotSupportedException()
-        {
-            using (var handler = new HttpClientHandler())
-            {
-                Assert.Throws<PlatformNotSupportedException>(() => handler.MaxRequestContentBufferSize = 1024);
             }
         }
 
@@ -1608,14 +1587,11 @@ namespace System.Net.Http.Functional.Tests
             string method,
             bool secureServer)
         {
-            if (PlatformDetection.IsFullFramework)
+            if (PlatformDetection.IsFullFramework && method == "GET")
             {
                 // .NET Framework doesn't allow a content body with this HTTP verb.
                 // It will throw a System.Net.ProtocolViolation exception.
-                if (method == "GET")
-                {
-                    return;
-                }
+                return;
             }
 
             using (var client = new HttpClient())
@@ -1682,25 +1658,19 @@ namespace System.Net.Http.Functional.Tests
             string method,
             bool secureServer)
         {
-            if (PlatformDetection.IsFullFramework)
+            if (PlatformDetection.IsFullFramework && method == "HEAD")
             {
                 // .NET Framework doesn't allow a content body with this HTTP verb.
                 // It will throw a System.Net.ProtocolViolation exception.
-                if (method == "HEAD")
-                {
-                    return;
-                }
+                return;
             }
 
-            if (PlatformDetection.IsUap)
+            if (PlatformDetection.IsUap && method == "TRACE")
             {
                 // UAP platform doesn't allow a content body with this HTTP verb.
                 // It will throw an exception HttpRequestException/COMException
                 // with "The requested operation is invalid" message.
-                if (method == "TRACE")
-                {
-                    return;
-                }
+                return;
             }
 
             using (var client = new HttpClient())

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -180,6 +180,17 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [Theory]
+        [InlineData(-1)]
+        [InlineData((long)int.MaxValue + (long)1)]
+        public void MaxRequestContentBufferSize_SetInvalidValue_ThrowsArgumentOutOfRangeException(long value)
+        {
+            using (var handler = new HttpClientHandler())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => handler.MaxRequestContentBufferSize = value);
+            }
+        }
+
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "UAP will send default credentials based on other criteria.")]
         [Theory]
         [InlineData(false)]


### PR DESCRIPTION
The HttpClientHandler property, MaxRequestContentBufferSize, has been
deprecated. This PR reconciles the behavior of the getter and setter of
the property.

Similar to other decisions in HttpClient PRs with these kinds of
behavior differences, we are not going to throw PNSE. We will document
the differences in the AppCompat docs.

Fixes #7879