### PR TITLE
Set VisualBasic tests ILCBuildType to chk to fix two tests in uapaot

### DIFF
--- a/src/Microsoft.VisualBasic/tests/Microsoft.VisualBasic.Tests.csproj
+++ b/src/Microsoft.VisualBasic/tests/Microsoft.VisualBasic.Tests.csproj
@@ -3,6 +3,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{325260D6-D5DD-4E06-9DA2-9AF2AD9DE8C8}</ProjectGuid>
+    <!-- CodeGen bug is causing two tests to fail if ILC builds ret -->
+    <ILCBuildType>chk</ILCBuildType>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />


### PR DESCRIPTION
fixes #21693

cc: @danmosemsft @stephentoub @tijoytom 

Looks like we have a codeGen bug when ILC Build type is set to ret, since two tests started failing yesterday and by changing buildtype to chk they pass. It's hard to debug the tests when buildtype is set to ret because of all of the optimizations, but from what I can tell, the problem seems to be that the value of `ulong.MaxValue` is wrong when we cast it to an object.