### PR TITLE
Fixing two tests for uapaot that were missing metadata

### DIFF
--- a/src/System.IO/tests/Resources/System.IO.Tests.rd.xml
+++ b/src/System.IO/tests/Resources/System.IO.Tests.rd.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Library Name="System.IO.Tests">
+    <Assembly Name="System.Private.CoreLib">
+      <Namespace Name="System.Text">
+        <Type Name="UTF32Encoding" Dynamic="Required All" />
+      </Namespace>
+    </Assembly>
+  </Library>
+</Directives>

--- a/src/System.IO/tests/System.IO.Tests.csproj
+++ b/src/System.IO/tests/System.IO.Tests.csproj
@@ -57,5 +57,8 @@
       <Link>Common\System\IO\WrappedMemoryStream.cs</Link>
     </Compile>
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\$(AssemblyName).rd.xml" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
Fixes #22203

cc: @JeremyKuhne @safern 

Fixing two tests that fail because of missing metadata.