### PR TITLE
Have S.L.Expressions produce shorter IL for integral NegateChecked

### DIFF
--- a/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateCheckedNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateCheckedNullableTests.cs
@@ -201,5 +201,37 @@ namespace System.Linq.Expressions.Tests
         }
 
         #endregion
+
+        [Fact]
+        public static void VerifyIL_NullableShortNegateChecked()
+        {
+            ParameterExpression param = Expression.Parameter(typeof(short?));
+            Expression<Func<short?, short?>> f =
+                Expression.Lambda<Func<short?, short?>>(Expression.NegateChecked(param), param);
+
+            f.VerifyIL(
+                @".method valuetype [System.Private.CoreLib]System.Nullable`1<int16> ::lambda_method(class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure,valuetype [System.Private.CoreLib]System.Nullable`1<int16>)
+                {
+                    .maxstack 4
+                    .locals init (
+                        [0] valuetype [System.Private.CoreLib]System.Nullable`1<int16>
+                    )
+
+                    IL_0000: ldarg.1
+                    IL_0001: stloc.0
+                    IL_0002: ldloca.s   V_0
+                    IL_0004: call       instance int16 valuetype [System.Private.CoreLib]System.Nullable`1<int16>::GetValueOrDefault()
+                    IL_0009: brfalse.s  IL_001c
+                    IL_000b: ldc.i4.0
+                    IL_000c: ldloca.s   V_0
+                    IL_000e: call       instance int16 valuetype [System.Private.CoreLib]System.Nullable`1<int16>::GetValueOrDefault()
+                    IL_0013: sub.ovf
+                    IL_0014: conv.ovf.i2
+                    IL_0015: newobj     instance void valuetype [System.Private.CoreLib]System.Nullable`1<int16>::.ctor(int16)
+                    IL_001a: br.s       IL_001d
+                    IL_001c: ldloc.0
+                    IL_001d: ret
+                }");
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateCheckedNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateCheckedNullableTests.cs
@@ -202,6 +202,7 @@ namespace System.Linq.Expressions.Tests
 
         #endregion
 
+#if FEATURE_COMPILE
         [Fact]
         public static void VerifyIL_NullableShortNegateChecked()
         {
@@ -233,5 +234,7 @@ namespace System.Linq.Expressions.Tests
                     IL_001d: ret
                 }");
         }
+#endif
+
     }
 }

--- a/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateCheckedTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateCheckedTests.cs
@@ -208,5 +208,26 @@ namespace System.Linq.Expressions.Tests
         }
 
         #endregion
+
+        [Fact]
+        public static void VerifyIL_ShortNegateChecked()
+        {
+            ParameterExpression param = Expression.Parameter(typeof(short));
+            Expression<Func<short, short>> f =
+                Expression.Lambda<Func<short, short>>(Expression.NegateChecked(param), param);
+
+            f.VerifyIL(
+                @".method int16 ::lambda_method(class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure,int16)
+                {
+                    .maxstack 2
+
+                    IL_0000: ldc.i4.0
+                    IL_0001: ldarg.1
+                    IL_0002: sub.ovf
+                    IL_0003: conv.ovf.i2
+                    IL_0004: ret
+                }");
+        }
+
     }
 }

--- a/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateCheckedTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateCheckedTests.cs
@@ -209,6 +209,7 @@ namespace System.Linq.Expressions.Tests
 
         #endregion
 
+#if FEATURE_COMPILE
         [Fact]
         public static void VerifyIL_ShortNegateChecked()
         {
@@ -228,6 +229,7 @@ namespace System.Linq.Expressions.Tests
                     IL_0004: ret
                 }");
         }
+#endif
 
     }
 }


### PR DESCRIPTION
When non-nullable there's an unnecessary cast of 0 for short and sbyte, and an unnecessary store/load that can be removed.

When nullable the output is roughly like:

```
T? temp = Evaluate(operand);
T? zero = (T?)(T)0;
result = temp.HasValue & zero.HasValue
    ? (T?)(zero.GetValueOrDefault() - temp.GetValueOrDefault())
    : default(T?);
```

Instead produce code closer to:

```
T? temp = Evaluate(operand);
result = temp.GetValueOrDefault() != 0
    ? (T?)(0 - temp.GetValueOrDefault())
    : temp;