### PR TITLE
Remove System.Security.Permissions dependency from System.Drawing.Common.

### DIFF
--- a/src/System.Drawing.Common/src/System.Drawing.Common.csproj
+++ b/src/System.Drawing.Common/src/System.Drawing.Common.csproj
@@ -33,7 +33,6 @@
     <Reference Include="System.Runtime.InteropServices" />
     <Reference Include="System.ComponentModel" />
     <Reference Include="System.ComponentModel.Primitives" />
-    <Reference Include="System.Security.Permissions" />
     <Reference Include="System.Threading" />
     <Reference Include="System.Threading.Thread" />
   </ItemGroup>

--- a/src/System.Drawing.Common/src/System/Drawing/Design/CategoryNameCollection.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Design/CategoryNameCollection.cs
@@ -10,7 +10,6 @@ namespace System.Drawing.Design
     /// <summary>
     /// A collection that stores <see cref='string'/> objects.
     /// </summary>
-    [PermissionSet(SecurityAction.LinkDemand, Name = "FullTrust")]
     public sealed class CategoryNameCollection : ReadOnlyCollectionBase
     {
         /// <summary>

--- a/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
@@ -3447,7 +3447,6 @@ namespace System.Drawing
         /// translate transform matrix.
         /// WARNING: This method is for internal FX support only.
         /// </summary>
-        [StrongNameIdentityPermission(SecurityAction.LinkDemand, Name = "System.Windows.Forms", PublicKey = "0x00000000000000000400000000000000")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public object GetContextInfo()
         {

--- a/src/System.Drawing.Common/src/System/Drawing/Internal/GPStream.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Internal/GPStream.cs
@@ -74,8 +74,6 @@ namespace System.Drawing.Internal
             ActualizeVirtualPosition();
         }
 
-        [UIPermission(SecurityAction.Demand, Window = UIPermissionWindow.AllWindows)]
-        [SecurityPermission(SecurityAction.Assert, Flags = SecurityPermissionFlag.UnmanagedCode)]
         public virtual long CopyTo(UnsafeNativeMethods.IStream pstm, long cb, long[] pcbRead)
         {
             int bufsize = 4096; // one page

--- a/src/System.Drawing.Common/src/misc/DbgUtil.cs
+++ b/src/System.Drawing.Common/src/misc/DbgUtil.cs
@@ -11,11 +11,6 @@ using System.Threading;
 
 namespace System.Drawing.Internal
 {
-    [ReflectionPermission(SecurityAction.Assert, MemberAccess = true)]
-    [EnvironmentPermission(SecurityAction.Assert, Unrestricted = true)]
-    [FileIOPermission(SecurityAction.Assert, Unrestricted = true)]
-    [SecurityPermission(SecurityAction.Assert, Flags = SecurityPermissionFlag.UnmanagedCode)]
-    [UIPermission(SecurityAction.Assert, Unrestricted = true)]
     internal sealed class DbgUtil
     {
         public const int


### PR DESCRIPTION
We do not care about these attributes in .NET Core, and by removing them we can remove the dependency on System.Security.Permissions.

Part of https://github.com/dotnet/corefx/issues/20706

@akoeplinger Does mono care about these security attributes? I can accommodate that, if necessary.