### PR TITLE
Enabling ILC reflection for certain types in System.Net.Primitives.

### DIFF
--- a/src/Common/src/System/Net/CookieParser.cs
+++ b/src/Common/src/System/Net/CookieParser.cs
@@ -557,6 +557,7 @@ namespace System.Net
             {
                 if (s_internalSetNameMethod == null)
                 {
+                    // TODO: #13607
                     // We need to use Cookie.InternalSetName instead of the Cookie.set_Name wrapped in a try catch block, as
                     // Cookie.set_Name keeps the original name if the string is empty or null.
                     // Unfortunately this API is internal so we use reflection to access it. The method is cached for performance reasons.
@@ -583,7 +584,14 @@ namespace System.Net
             {
                 if (s_isQuotedDomainField == null)
                 {
-                    FieldInfo field = typeof(Cookie).GetField("IsQuotedDomain", BindingFlags.NonPublic | BindingFlags.Instance);
+                    // TODO: #13607
+                    BindingFlags flags = BindingFlags.Instance;
+#if uap
+                    flags |= BindingFlags.Public;
+#else
+                    flags |= BindingFlags.NonPublic;
+#endif
+                    FieldInfo field = typeof(Cookie).GetField("IsQuotedDomain", flags);
                     Debug.Assert(field != null, "We need to use an internal field named IsQuotedDomain that is declared on Cookie.");
                     s_isQuotedDomainField = field;
                 }
@@ -599,7 +607,14 @@ namespace System.Net
             {
                 if (s_isQuotedVersionField == null)
                 {
-                    FieldInfo field = typeof(Cookie).GetField("IsQuotedVersion", BindingFlags.NonPublic | BindingFlags.Instance);
+                    // TODO: #13607
+                    BindingFlags flags = BindingFlags.Instance;
+#if uap
+                    flags |= BindingFlags.Public;
+#else
+                    flags |= BindingFlags.NonPublic;
+#endif
+                    FieldInfo field = typeof(Cookie).GetField("IsQuotedVersion", flags);
                     Debug.Assert(field != null, "We need to use an internal field named IsQuotedVersion that is declared on Cookie.");
                     s_isQuotedVersionField = field;
                 }

--- a/src/System.Net.HttpListener/src/System/Net/Windows/CookieExtensions.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/CookieExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Reflection;
 
 namespace System.Net
@@ -15,8 +16,16 @@ namespace System.Net
         {
             if (s_toServerStringFunc == null)
             {
-                s_toServerStringFunc = (Func<Cookie, string>)typeof(Cookie).GetMethod("ToServerString", BindingFlags.NonPublic | BindingFlags.Instance).CreateDelegate(typeof(Func<Cookie, string>));
+                BindingFlags flags = BindingFlags.Instance;
+#if uap
+                flags |= BindingFlags.Public;
+#else
+                flags |= BindingFlags.NonPublic;
+#endif
+                s_toServerStringFunc = (Func<Cookie, string>)typeof(Cookie).GetMethod("ToServerString", flags).CreateDelegate(typeof(Func<Cookie, string>));
             }
+
+            Debug.Assert(s_toServerStringFunc != null, "Reflection failed for Cookie.ToServerString().");
             return s_toServerStringFunc(cookie);
         }
 
@@ -26,8 +35,16 @@ namespace System.Net
         {
             if (s_cloneFunc == null)
             {
-                s_cloneFunc = (Func<Cookie, Cookie>)typeof(Cookie).GetMethod("Clone", BindingFlags.NonPublic | BindingFlags.Instance).CreateDelegate(typeof(Func<Cookie, Cookie>));
+                BindingFlags flags = BindingFlags.Instance;
+#if uap
+                flags |= BindingFlags.Public;
+#else
+                flags |= BindingFlags.NonPublic;
+#endif
+                s_cloneFunc = (Func<Cookie, Cookie>)typeof(Cookie).GetMethod("Clone", flags).CreateDelegate(typeof(Func<Cookie, Cookie>));
             }
+
+            Debug.Assert(s_cloneFunc != null, "Reflection failed for Cookie.Clone().");
             return s_cloneFunc(cookie);
         }
 
@@ -46,9 +63,16 @@ namespace System.Net
         {
             if (s_getVariantFunc == null)
             {
-                s_getVariantFunc = (Func<Cookie, CookieVariant>)typeof(Cookie).GetProperty("Variant", BindingFlags.NonPublic | BindingFlags.Instance).GetGetMethod(true).CreateDelegate(typeof(Func<Cookie, CookieVariant>));
+                BindingFlags flags = BindingFlags.Instance;
+#if uap
+                flags |= BindingFlags.Public;
+#else
+                flags |= BindingFlags.NonPublic;
+#endif
+                s_getVariantFunc = (Func<Cookie, CookieVariant>)typeof(Cookie).GetProperty("Variant", flags).GetGetMethod(true).CreateDelegate(typeof(Func<Cookie, CookieVariant>));
             }
 
+            Debug.Assert(s_getVariantFunc != null, "Reflection failed for Cookie.Variant.");
             CookieVariant variant = s_getVariantFunc(cookie);
 
             return variant == CookieVariant.Rfc2965;
@@ -63,9 +87,16 @@ namespace System.Net
         {
             if (s_internalAddFunc == null)
             {
-                s_internalAddFunc = (Func<CookieCollection, Cookie, bool, int>)typeof(CookieCollection).GetMethod("InternalAdd", BindingFlags.NonPublic | BindingFlags.Instance).CreateDelegate(typeof(Func<CookieCollection, Cookie, bool, int>));
+                BindingFlags flags = BindingFlags.Instance;
+#if uap
+                flags |= BindingFlags.Public;
+#else
+                flags |= BindingFlags.NonPublic;
+#endif
+                s_internalAddFunc = (Func<CookieCollection, Cookie, bool, int>)typeof(CookieCollection).GetMethod("InternalAdd", flags).CreateDelegate(typeof(Func<CookieCollection, Cookie, bool, int>));
             }
 
+            Debug.Assert(s_internalAddFunc != null, "Reflection failed for CookieCollection.InternalAdd().");
             return s_internalAddFunc(cookieCollection, cookie, isStrict);
         }
     }

--- a/src/System.Net.HttpListener/tests/HttpListenerRequestTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerRequestTests.cs
@@ -588,7 +588,6 @@ namespace System.Net.Tests
             yield return new object[] { "Unknown-Header: Test", new CookieCollection() };
         }
 
-        [ActiveIssue(20482, TargetFrameworkMonikers.UapAot)]
         [Theory]
         [MemberData(nameof(Cookies_TestData))]
         public async Task Cookies_GetProperty_ReturnsExpected(string cookieString, CookieCollection expected)

--- a/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Cookies.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Cookies.cs
@@ -87,7 +87,6 @@ namespace System.Net.Tests
             };
         }
 
-        [ActiveIssue(22056, TargetFrameworkMonikers.UapAot)]
         [Theory]
         [MemberData(nameof(Cookies_TestData))]
         public async Task Cookies_SetAndSend_ClientReceivesExpectedHeaders(CookieCollection cookies, int expectedBytes, string expectedSetCookie, string expectedSetCookie2)
@@ -134,7 +133,6 @@ namespace System.Net.Tests
             Assert.Contains($"\r\nSet-Cookie2: name2=value2\r\n", clientResponse);
         }
 
-        [ActiveIssue(22056, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public async Task Cookies_SetCookie2InHeadersButNotInCookies_RemovesFromHeaders()
         {
@@ -154,7 +152,6 @@ namespace System.Net.Tests
             Assert.Contains($"\r\nSet-Cookie2: name3=value3; Port=\"200\"; Version=1\r\n", clientResponse);
         }
 
-        [ActiveIssue(22056, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public async Task Cookies_SetCookieInHeadersButNotInCookies_RemovesFromHeaders()
         {
@@ -174,7 +171,6 @@ namespace System.Net.Tests
             Assert.DoesNotContain("Set-Cookie2", clientResponse);
         }
 
-        [ActiveIssue(22056, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public async Task AppendCookie_ValidCookie_AddsCookieToCollection()
         {
@@ -203,7 +199,6 @@ namespace System.Net.Tests
             AssertExtensions.Throws<ArgumentNullException>("cookie", () => response.AppendCookie(null));
         }
 
-        [ActiveIssue(22056, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public async Task SetCookie_ValidCookie_AddsCookieToCollection()
         {
@@ -217,7 +212,6 @@ namespace System.Net.Tests
             Assert.Equal(new Cookie[] { cookie1, cookie2 }, response.Cookies.Cast<Cookie>());
         }
 
-        [ActiveIssue(22056, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public async Task SetCookie_ValidCookie_ClonesCookie()
         {
@@ -237,7 +231,6 @@ namespace System.Net.Tests
             AssertExtensions.Throws<ArgumentNullException>("cookie", () => response.SetCookie(null));
         }
 
-        [ActiveIssue(22056, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public async Task SetCookie_CookieDoesntExist_ThrowsArgumentException()
         {

--- a/src/System.Net.Primitives/src/Resources/System.Net.Primitives.rd.xml
+++ b/src/System.Net.Primitives/src/Resources/System.Net.Primitives.rd.xml
@@ -3,7 +3,7 @@
   <Library Name="*System.Net.Primitives*">
     <Assembly Name="System.Net.Primitives">
        <!-- VSO 449560 The following types are used by HttpListener. -->
-       <Type Name="System.Net.Cookie" Browse="Required Public" Dynamic="Required Public">
+       <Type Name="System.Net.Cookie">
          <!-- Used by CookieParser -->
          <Method Name="InternalSetName" Dynamic="Required" />
          <Field Name="IsQuotedDomain" Dynamic="Required" />
@@ -14,7 +14,7 @@
          <Method Name="Clone" Dynamic="Required" />
          <Property Name="Variant" Dynamic="Required" />
        </Type>
-       <Type Name="System.Net.CookieCollection" Browse="Required Public" Dynamic="Required Public">
+       <Type Name="System.Net.CookieCollection">
          <Method Name="InternalAdd" Dynamic="Required" />
        </Type>
     </Assembly>

--- a/src/System.Net.Primitives/src/Resources/System.Net.Primitives.rd.xml
+++ b/src/System.Net.Primitives/src/Resources/System.Net.Primitives.rd.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Library Name="*System.Net.Primitives*">
+    <Assembly Name="System.Net.Primitives">
+       <!-- VSO 449560 The following types are used by HttpListener. -->
+       <Type Name="System.Net.Cookie" Browse="Required Public" Dynamic="Required Public">
+         <!-- Used by CookieParser -->
+         <Method Name="InternalSetName" Dynamic="Required" />
+         <Field Name="IsQuotedDomain" Dynamic="Required" />
+         <Field Name="IsQuotedVersion" Dynamic="Required" />
+
+         <!-- Used by CookieExtensions -->
+         <Method Name="ToServerString" Dynamic="Required" />
+         <Method Name="Clone" Dynamic="Required" />
+         <Property Name="Variant" Dynamic="Required" />
+       </Type>
+       <Type Name="System.Net.CookieCollection" Browse="Required Public" Dynamic="Required Public">
+         <Method Name="InternalAdd" Dynamic="Required" />
+       </Type>
+    </Assembly>
+  </Library>
+</Directives>

--- a/src/System.Net.Primitives/src/System.Net.Primitives.csproj
+++ b/src/System.Net.Primitives/src/System.Net.Primitives.csproj
@@ -187,6 +187,9 @@
       <Link>Interop\Unix\System.Native\Interop.SocketAddress.cs</Link>
     </Compile>
   </ItemGroup>
+  <ItemGroup Condition=" '$(TargetGroup)' == 'uap'">
+    <EmbeddedResource Include="Resources\$(AssemblyName).rd.xml" />
+  </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Win32.Primitives" />
     <Reference Include="System.Collections" />

--- a/src/System.Net.Primitives/src/System/Net/Cookie.cs
+++ b/src/System.Net.Primitives/src/System/Net/Cookie.cs
@@ -69,9 +69,9 @@ namespace System.Net
 /* 
     TODO: #13607
     VSO 449560
-    Reflecting on internal method wont work on AOT without rd.xml and DisableReflection
+    Reflecting on internal method won't work on AOT without rd.xml and DisableReflection
     block in toolchain.Networking team will be working on exposing methods from S.Net.Primitive
-    public,this is a temporary workaround till that happens. 
+    public, this is a temporary workaround till that happens. 
 */
 #if uap 
         public
@@ -83,9 +83,9 @@ namespace System.Net
 /* 
     TODO: #13607
     VSO 449560
-    Reflecting on internal method wont work on AOT without rd.xml and DisableReflection
+    Reflecting on internal method won't work on AOT without rd.xml and DisableReflection
     block in toolchain.Networking team will be working on exposing methods from S.Net.Primitive
-    public,this is a temporary workaround till that happens. 
+    public, this is a temporary workaround till that happens. 
 */
 #if uap 
         public
@@ -244,9 +244,9 @@ namespace System.Net
 /* 
     TODO: #13607
     VSO 449560
-    Reflecting on internal method wont work on AOT without rd.xml and DisableReflection
+    Reflecting on internal method won't work on AOT without rd.xml and DisableReflection
     block in toolchain.Networking team will be working on exposing methods from S.Net.Primitive
-    public,this is a temporary workaround till that happens. 
+    public, this is a temporary workaround till that happens. 
 */
 #if uap 
         public
@@ -288,9 +288,9 @@ namespace System.Net
 /* 
     TODO: #13607
     VSO 449560
-    Reflecting on internal method wont work on AOT without rd.xml and DisableReflection
+    Reflecting on internal method won't work on AOT without rd.xml and DisableReflection
     block in toolchain.Networking team will be working on exposing methods from S.Net.Primitive
-    public,this is a temporary workaround till that happens. 
+    public, this is a temporary workaround till that happens. 
 */
 #if uap 
         public
@@ -705,9 +705,9 @@ namespace System.Net
 /* 
     TODO: #13607
     VSO 449560
-    Reflecting on internal method wont work on AOT without rd.xml and DisableReflection
+    Reflecting on internal method won't work on AOT without rd.xml and DisableReflection
     block in toolchain.Networking team will be working on exposing methods from S.Net.Primitive
-    public,this is a temporary workaround till that happens. 
+    public, this is a temporary workaround till that happens. 
 */
 #if uap 
         public
@@ -846,9 +846,9 @@ namespace System.Net
 /* 
     TODO: #13607
     VSO 449560
-    Reflecting on internal method wont work on AOT without rd.xml and DisableReflection
+    Reflecting on internal method won't work on AOT without rd.xml and DisableReflection
     block in toolchain.Networking team will be working on exposing methods from S.Net.Primitive
-    public,this is a temporary workaround till that happens. 
+    public, this is a temporary workaround till that happens. 
 */
 #if uap 
         public

--- a/src/System.Net.Primitives/src/System/Net/Cookie.cs
+++ b/src/System.Net.Primitives/src/System/Net/Cookie.cs
@@ -65,8 +65,34 @@ namespace System.Net
         private int m_version = 0; // Do not rename (binary serialization)
 
         private string m_domainKey = string.Empty; // Do not rename (binary serialization)
-        internal bool IsQuotedVersion = false;
-        internal bool IsQuotedDomain = false;
+
+/* 
+    TODO: #13607
+    VSO 449560
+    Reflecting on internal method wont work on AOT without rd.xml and DisableReflection
+    block in toolchain.Networking team will be working on exposing methods from S.Net.Primitive
+    public,this is a temporary workaround till that happens. 
+*/
+#if uap 
+        public
+#else 
+        internal
+#endif
+        bool IsQuotedVersion = false;
+
+/* 
+    TODO: #13607
+    VSO 449560
+    Reflecting on internal method wont work on AOT without rd.xml and DisableReflection
+    block in toolchain.Networking team will be working on exposing methods from S.Net.Primitive
+    public,this is a temporary workaround till that happens. 
+*/
+#if uap 
+        public
+#else 
+        internal
+#endif
+        bool IsQuotedDomain = false;
 
 #if DEBUG
         static Cookie()
@@ -216,10 +242,11 @@ namespace System.Net
         }
 
 /* 
-   VSO 449560
-   Reflecting on internal method wont work on AOT without rd.xml and DisableReflection
-   block in toolchain.Networking team will be working on exposing methods from S.Net.Primitive
-   public,this is a temporary workaround till that happens. 
+    TODO: #13607
+    VSO 449560
+    Reflecting on internal method wont work on AOT without rd.xml and DisableReflection
+    block in toolchain.Networking team will be working on exposing methods from S.Net.Primitive
+    public,this is a temporary workaround till that happens. 
 */
 #if uap 
         public
@@ -258,7 +285,19 @@ namespace System.Net
             }
         }
 
-        internal Cookie Clone()
+/* 
+    TODO: #13607
+    VSO 449560
+    Reflecting on internal method wont work on AOT without rd.xml and DisableReflection
+    block in toolchain.Networking team will be working on exposing methods from S.Net.Primitive
+    public,this is a temporary workaround till that happens. 
+*/
+#if uap 
+        public
+#else 
+        internal
+#endif
+        Cookie Clone()
         {
             Cookie clonedCookie = new Cookie(m_name, m_value);
 
@@ -663,7 +702,19 @@ namespace System.Net
             }
         }
 
-        internal CookieVariant Variant
+/* 
+    TODO: #13607
+    VSO 449560
+    Reflecting on internal method wont work on AOT without rd.xml and DisableReflection
+    block in toolchain.Networking team will be working on exposing methods from S.Net.Primitive
+    public,this is a temporary workaround till that happens. 
+*/
+#if uap 
+        public
+#else 
+        internal
+#endif
+        CookieVariant Variant
         {
             get
             {
@@ -792,7 +843,19 @@ namespace System.Net
             }
         }
 
-        internal string ToServerString()
+/* 
+    TODO: #13607
+    VSO 449560
+    Reflecting on internal method wont work on AOT without rd.xml and DisableReflection
+    block in toolchain.Networking team will be working on exposing methods from S.Net.Primitive
+    public,this is a temporary workaround till that happens. 
+*/
+#if uap 
+        public
+#else 
+        internal
+#endif
+        string ToServerString()
         {
             string result = Name + EqualsLiteral + Value;
             if (m_comment != null && m_comment.Length > 0)

--- a/src/System.Net.Primitives/src/System/Net/CookieCollection.cs
+++ b/src/System.Net.Primitives/src/System/Net/CookieCollection.cs
@@ -168,10 +168,24 @@ namespace System.Net
             }
         }
 
+
         // If isStrict == false, assumes that incoming cookie is unique.
         // If isStrict == true, replace the cookie if found same with newest Variant.
         // Returns 1 if added, 0 if replaced or rejected.
-        internal int InternalAdd(Cookie cookie, bool isStrict)
+
+/* 
+    TODO: #13607
+    VSO 449560
+    Reflecting on internal method wont work on AOT without rd.xml and DisableReflection
+    block in toolchain.Networking team will be working on exposing methods from S.Net.Primitive
+    public,this is a temporary workaround till that happens. 
+*/
+#if uap 
+        public
+#else 
+        internal
+#endif
+        int InternalAdd(Cookie cookie, bool isStrict)
         {
             int ret = 1;
             if (isStrict)

--- a/src/System.Net.Primitives/src/System/Net/CookieCollection.cs
+++ b/src/System.Net.Primitives/src/System/Net/CookieCollection.cs
@@ -176,9 +176,9 @@ namespace System.Net
 /* 
     TODO: #13607
     VSO 449560
-    Reflecting on internal method wont work on AOT without rd.xml and DisableReflection
+    Reflecting on internal method won't work on AOT without rd.xml and DisableReflection
     block in toolchain.Networking team will be working on exposing methods from S.Net.Primitive
-    public,this is a temporary workaround till that happens. 
+    public, this is a temporary workaround till that happens. 
 */
 #if uap 
         public


### PR DESCRIPTION
System.Net.HttpListener is temporarily (actual fix tracked by #13607) relying on reflection to access internal Cookie and CookieCollection members from System.Net.Primitives.
This is allowing the temporary workaround in UWPAOT.

/cc @Priya91 

Fixes #20482
Fixes #22056
