### PR TITLE
Port TFS WinRT interop tests for HttpClient for UAP

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/MultiInterfaceNonRewindableReadOnlyStream.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/MultiInterfaceNonRewindableReadOnlyStream.cs
@@ -1,0 +1,133 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Windows.Foundation;
+using Windows.Storage.Streams;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public class MultiInterfaceNonRewindableReadOnlyStream : Stream, IInputStream
+    {
+        byte[] _bytes;
+        int _position;
+
+        public MultiInterfaceNonRewindableReadOnlyStream(byte[] bytes)
+        {
+            _bytes = bytes;
+            _position = 0;
+        }
+
+        public MultiInterfaceNonRewindableReadOnlyStream(string content)
+        {
+            _bytes = Encoding.UTF8.GetBytes(content);
+            _position = 0;
+        }
+
+        public override bool CanRead
+        {
+            get { return true; }
+        }
+
+        public override bool CanSeek
+        {
+            get { return false; }
+        }
+
+        public override bool CanWrite
+        {
+            get { return false; }
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override long Length
+        {
+            get { return _bytes.Length; }
+        }
+
+        public override long Position
+        {
+            get
+            {
+                return _position;
+            }
+            set
+            {
+                throw new NotSupportedException();
+            }
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            byte[] dataBytes = ReadInternal(count);
+
+            for (int i = 0; i < dataBytes.Length; i++)
+            {
+                buffer[offset + i] = dataBytes[i];
+            }
+
+            return dataBytes.Length;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException();
+        }
+
+        void IDisposable.Dispose()
+        {
+        }
+
+        byte[] ReadInternal(int count)
+        {
+            byte[] dataBytes;
+
+            if (_position == _bytes.Length)
+            {
+                dataBytes = new byte[0];
+            }
+            else
+            {
+                int numBytes = Math.Min(_bytes.Length - _position, count);
+                var stream = new MemoryStream(_bytes, _position, numBytes);
+                _position += numBytes;
+                dataBytes = stream.ToArray();
+            }
+
+            return dataBytes;
+        }
+
+        IAsyncOperationWithProgress<IBuffer, uint> IInputStream.ReadAsync(IBuffer buffer, uint count, InputStreamOptions options)
+        {
+            byte[] dataBytes = ReadInternal((int)count);
+
+            var ibuffer = dataBytes.AsBuffer();
+
+            return AsyncInfo.Run(
+                delegate (CancellationToken cancellationToken, IProgress<uint> progress)
+                {
+                    return Task.FromResult<IBuffer>(ibuffer);
+                });
+        }
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/MultiInterfaceNonRewindableReadOnlyStream.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/MultiInterfaceNonRewindableReadOnlyStream.cs
@@ -8,7 +8,6 @@ using System.Runtime.InteropServices.WindowsRuntime;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-
 using Windows.Foundation;
 using Windows.Storage.Streams;
 

--- a/src/System.Net.Http/tests/FunctionalTests/MultiInterfaceReadOnlyStream.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/MultiInterfaceReadOnlyStream.cs
@@ -1,0 +1,211 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Windows.Foundation;
+using Windows.Storage.Streams;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public class MultiInterfaceReadOnlyStream : Stream, IRandomAccessStream
+    {
+        byte[] _bytes;
+        long _position;
+
+        public MultiInterfaceReadOnlyStream(byte[] bytes)
+        {
+            _bytes = bytes;
+            _position = 0;
+        }
+
+        public MultiInterfaceReadOnlyStream(string content)
+        {
+            _bytes = Encoding.UTF8.GetBytes(content);
+            _position = 0;
+        }
+
+        public override bool CanRead
+        {
+            get { return true; }
+        }
+
+        public override bool CanSeek
+        {
+            get { return true; }
+        }
+
+        public override bool CanWrite
+        {
+            get { return false; }
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override long Length
+        {
+            get { return _bytes.Length; }
+        }
+
+        public override long Position
+        {
+            get
+            {
+                return _position;
+            }
+            set
+            {
+                throw new NotSupportedException();
+            }
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            byte[] dataBytes = ReadInternal(count);
+
+            for (int i = 0; i < dataBytes.Length; i++)
+            {
+                buffer[offset + i] = dataBytes[i];
+            }
+
+            return dataBytes.Length;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            if (origin == SeekOrigin.Begin)
+            {
+                _position = offset;
+            }
+            else if (origin == SeekOrigin.Current)
+            {
+                _position += offset;
+            }
+            else if (origin == SeekOrigin.End)
+            {
+                _position = _bytes.Length - offset;
+            }
+            else
+            {
+                throw new ArgumentException("Invalid seek origin.");
+            }
+            
+            return _position;
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException();
+        }
+
+        bool IRandomAccessStream.CanRead
+        {
+            get { return true; }
+        }
+
+        bool IRandomAccessStream.CanWrite
+        {
+            get { return false; }
+        }
+
+        IRandomAccessStream IRandomAccessStream.CloneStream()
+        {
+            throw new NotImplementedException();
+        }
+
+        IInputStream IRandomAccessStream.GetInputStreamAt(ulong position)
+        {
+            _position = 0;
+            return this;
+        }
+
+        IOutputStream IRandomAccessStream.GetOutputStreamAt(ulong position)
+        {
+            throw new NotImplementedException();
+        }
+
+        ulong IRandomAccessStream.Position
+        {
+            get
+            {
+                return (ulong)_position;
+            }
+        }
+
+        void IRandomAccessStream.Seek(ulong position)
+        {
+            _position = (int)position;
+        }
+
+        ulong IRandomAccessStream.Size
+        {
+            get
+            {
+                return (ulong)_bytes.Length;
+            }
+            set
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        void IDisposable.Dispose()
+        {
+        }
+
+        byte[] ReadInternal(int count)
+        {
+            byte[] dataBytes;
+
+            if (_position == _bytes.Length)
+            {
+                dataBytes = new byte[0];
+            }
+            else
+            {
+                long numBytes = Math.Min(_bytes.Length - _position, count);
+                var stream = new MemoryStream(_bytes, (int)_position, (int)numBytes);
+                _position += numBytes;
+                dataBytes = stream.ToArray();
+            }
+
+            return dataBytes;
+        }
+
+        IAsyncOperationWithProgress<IBuffer, uint> IInputStream.ReadAsync(IBuffer buffer, uint count, InputStreamOptions options)
+        {
+            byte[] dataBytes = ReadInternal((int)count);
+
+            var ibuffer = dataBytes.AsBuffer();
+
+            return AsyncInfo.Run(
+                delegate (CancellationToken cancellationToken, IProgress<uint> progress)
+                {
+                    return Task.FromResult<IBuffer>(ibuffer);
+                });
+        }
+
+        IAsyncOperation<bool> IOutputStream.FlushAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        IAsyncOperationWithProgress<uint, uint> IOutputStream.WriteAsync(IBuffer buffer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/MultiInterfaceReadOnlyStream.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/MultiInterfaceReadOnlyStream.cs
@@ -8,7 +8,6 @@ using System.Runtime.InteropServices.WindowsRuntime;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-
 using Windows.Foundation;
 using Windows.Storage.Streams;
 

--- a/src/System.Net.Http/tests/FunctionalTests/MultiInterfaceStreamContent.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/MultiInterfaceStreamContent.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Threading.Tasks;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public class MultiInterfaceStreamContent : StreamContent
+    {
+        Stream _content;
+
+        public MultiInterfaceStreamContent(Stream content) : base(content)
+        {
+            _content = content;
+        }
+
+        protected override Task<Stream> CreateContentReadStreamAsync()
+        {
+            return Task.FromResult<Stream>(_content);
+        }
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/PostScenarioUWPTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/PostScenarioUWPTest.cs
@@ -8,7 +8,6 @@ using System.IO;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
-
 using Xunit;
 using Xunit.Abstractions;
 

--- a/src/System.Net.Http/tests/FunctionalTests/PostScenarioUWPTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/PostScenarioUWPTest.cs
@@ -1,0 +1,163 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.Net.Http.Functional.Tests
+{
+    using Configuration = System.Net.Test.Common.Configuration;
+
+    public class PostScenarioUWPTest : RemoteExecutorTestBase
+    {
+        private readonly ITestOutputHelper _output;
+
+        public PostScenarioUWPTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void Authentication_UseStreamContent_Throws()
+        {
+            RemoteInvoke(async () =>
+            {
+                // This test validates the current limitation of CoreFx's NetFxToWinRtStreamAdapter
+                // which throws exceptions when trying to rewind a .NET Stream when it needs to be
+                // re-POST'd to the server.
+                string username = "testuser";
+                string password = "password";
+                Uri uri = Configuration.Http.BasicAuthUriForCreds(secure: false, userName: username, password: password);            
+                var handler = new HttpClientHandler();
+                handler.Credentials = new NetworkCredential(username, password);
+
+                using (var client = new HttpClient(handler))
+                {
+                    byte[] postData = Encoding.UTF8.GetBytes("This is data to post.");
+                    var stream = new MemoryStream(postData, false);
+                    var content = new StreamContent(stream);
+
+                    await Assert.ThrowsAsync<HttpRequestException>(() => client.PostAsync(uri, content));
+                }
+
+                return SuccessExitCode;
+            }).Dispose();
+        }
+
+        [Fact]
+        public void Authentication_UseMultiInterfaceNonRewindableStreamContent_Throws()
+        {
+            RemoteInvoke(async () =>
+            {
+                string username = "testuser";
+                string password = "password";
+                Uri uri = Configuration.Http.BasicAuthUriForCreds(secure: false, userName: username, password: password);            
+                var handler = new HttpClientHandler();
+                handler.Credentials = new NetworkCredential(username, password);
+
+                using (var client = new HttpClient(handler))
+                {
+                    byte[] postData = Encoding.UTF8.GetBytes("This is data to post.");
+                    var stream = new MultiInterfaceNonRewindableReadOnlyStream(postData);
+                    var content = new MultiInterfaceStreamContent(stream);
+
+                    await Assert.ThrowsAsync<HttpRequestException>(() => client.PostAsync(uri, content));
+                }
+
+                return SuccessExitCode;
+            }).Dispose();
+        }
+
+        [Fact]
+        public void Authentication_UseMultiInterfaceStreamContent_Success()
+        {
+            RemoteInvoke(async () =>
+            {
+                string username = "testuser";
+                string password = "password";
+                Uri uri = Configuration.Http.BasicAuthUriForCreds(secure: false, userName: username, password: password);            
+                var handler = new HttpClientHandler();
+                handler.Credentials = new NetworkCredential(username, password);
+
+                using (var client = new HttpClient(handler))
+                {
+                    byte[] postData = Encoding.UTF8.GetBytes("This is data to post.");
+                    var stream = new MultiInterfaceReadOnlyStream(postData);
+                    var content = new MultiInterfaceStreamContent(stream);
+
+                    using (HttpResponseMessage response = await client.PostAsync(uri, content))
+                    {
+                        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                        string responseContent = await response.Content.ReadAsStringAsync();
+                    }
+                }
+
+                return SuccessExitCode;
+            }).Dispose();
+        }
+
+        [Fact]
+        public void Authentication_UseMemoryStreamVisibleBufferContent_Success()
+        {
+            RemoteInvoke(async () =>
+            {
+                string username = "testuser";
+                string password = "password";
+                Uri uri = Configuration.Http.BasicAuthUriForCreds(secure: false, userName: username, password: password);            
+                var handler = new HttpClientHandler();
+                handler.Credentials = new NetworkCredential(username, password);
+
+                using (var client = new HttpClient(handler))
+                {
+                    byte[] postData = Encoding.UTF8.GetBytes("This is data to post.");
+                    var stream = new MemoryStream(postData, 0, postData.Length, false, true);
+                    var content = new MultiInterfaceStreamContent(stream);
+
+                    using (HttpResponseMessage response = await client.PostAsync(uri, content))
+                    {
+                        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                        string responseContent = await response.Content.ReadAsStringAsync();
+                    }
+                }
+
+                return SuccessExitCode;
+            }).Dispose();
+        }
+
+        [Fact]
+        public void Authentication_UseMemoryStreamNotVisibleBufferContent_Success()
+        {
+            RemoteInvoke(async () =>
+            {
+                string username = "testuser";
+                string password = "password";
+                Uri uri = Configuration.Http.BasicAuthUriForCreds(secure: false, userName: username, password: password);            
+                var handler = new HttpClientHandler();
+                handler.Credentials = new NetworkCredential(username, password);
+
+                using (var client = new HttpClient(handler))
+                {
+                    byte[] postData = Encoding.UTF8.GetBytes("This is data to post.");
+                    var stream = new MemoryStream(postData, 0, postData.Length, false, false);
+                    var content = new MultiInterfaceStreamContent(stream);
+
+                    using (HttpResponseMessage response = await client.PostAsync(uri, content))
+                    {
+                        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                        string responseContent = await response.Content.ReadAsStringAsync();
+                    }
+                }
+
+                return SuccessExitCode;
+            }).Dispose();
+        }
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -107,6 +107,14 @@
     <Compile Include="ManagedHandlerTest.cs" />
     <Compile Include="HttpClientHandlerTest.AcceptAllCerts.cs" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'uap'">
+    <Reference Include="Windows" />
+    <Reference Include="mscorlib" />
+    <Compile Include="MultiInterfaceNonRewindableReadOnlyStream.cs" />
+    <Compile Include="MultiInterfaceReadOnlyStream.cs" />
+    <Compile Include="MultiInterfaceStreamContent.cs" />
+    <Compile Include="PostScenarioUWPTest.cs" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
       <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -109,7 +109,6 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'uap'">
     <Reference Include="Windows" />
-    <Reference Include="mscorlib" />
     <Compile Include="MultiInterfaceNonRewindableReadOnlyStream.cs" />
     <Compile Include="MultiInterfaceReadOnlyStream.cs" />
     <Compile Include="MultiInterfaceStreamContent.cs" />


### PR DESCRIPTION
Bring over the last of the WinRT interop tests for HttpClient. These
tests deal with interop between WinRT stream classes and .NET stream
classes.

Fixes #9044