### PR TITLE
Add more uapaot #if checks in SqlXml to exclude unnecessary code that's causing debug assert failures during uap test runs.

### DIFF
--- a/src/System.Data.Common/src/System/Data/SQLTypes/SqlXml.cs
+++ b/src/System.Data.Common/src/System/Data/SQLTypes/SqlXml.cs
@@ -19,12 +19,14 @@ namespace System.Data.SqlTypes
         private static readonly Func<Stream, XmlReaderSettings, XmlParserContext, XmlReader> s_sqlReaderDelegate = CreateSqlReaderDelegate();
         private static readonly XmlReaderSettings s_defaultXmlReaderSettings = new XmlReaderSettings() { ConformanceLevel = ConformanceLevel.Fragment };
         private static readonly XmlReaderSettings s_defaultXmlReaderSettingsCloseInput = new XmlReaderSettings() { ConformanceLevel = ConformanceLevel.Fragment, CloseInput = true };
+#if !uapaot
         private static MethodInfo s_createSqlReaderMethodInfo;
+        private MethodInfo _createSqlReaderMethodInfo;
+#endif
 
         private bool _fNotNull; // false if null, the default ctor (plain 0) will make it Null
         private Stream _stream;
         private bool _firstCreateReader;
-        private MethodInfo _createSqlReaderMethodInfo;
 
         public SqlXml()
         {
@@ -84,12 +86,14 @@ namespace System.Data.SqlTypes
                 stream.Seek(0, SeekOrigin.Begin);
             }
 
+#if !uapaot
             // NOTE: Maintaining createSqlReaderMethodInfo private field member to preserve the serialization of the class
             if (_createSqlReaderMethodInfo == null)
             {
                 _createSqlReaderMethodInfo = CreateSqlReaderMethodInfo;
             }
             Debug.Assert(_createSqlReaderMethodInfo != null, "MethodInfo reference for XmlReader.CreateSqlReader should not be null.");
+#endif
 
             XmlReader r = CreateSqlXmlReader(stream);
             _firstCreateReader = false;
@@ -127,7 +131,7 @@ namespace System.Data.SqlTypes
 
             return (Func<Stream, XmlReaderSettings, XmlParserContext, XmlReader>)CreateSqlReaderMethodInfo.CreateDelegate(typeof(Func<Stream, XmlReaderSettings, XmlParserContext, XmlReader>));
         }
-#endif
+
         private static MethodInfo CreateSqlReaderMethodInfo
         {
             get
@@ -140,6 +144,7 @@ namespace System.Data.SqlTypes
                 return s_createSqlReaderMethodInfo;
             }
         }
+#endif
 
         // INullable
         public bool IsNull


### PR DESCRIPTION
There was some unnecessary code leftover from this SqlXml commit, which was causing some debug asserts to fail during uap test runs. 
https://github.com/dotnet/corefx/commit/9e36f6355340336f9950987d18f76e398fd4f5ef
