### PR TITLE
Use a shared MultiAgent in CurlHandler when using LibreSSL backend on macOS

### DIFF
--- a/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.VersionInfo.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.VersionInfo.cs
@@ -49,5 +49,6 @@ internal static partial class Interop
 
         internal const string OpenSsl10Description = "openssl/1.0";
         internal const string SecureTransportDescription = "SecureTransport";
+        internal const string LibreSslDescription = "LibreSSL";
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/OSX/CurlHandler.SslProvider.cs
+++ b/src/System.Net.Http/src/System/Net/Http/OSX/CurlHandler.SslProvider.cs
@@ -12,6 +12,19 @@ namespace System.Net.Http
 {
     internal partial class CurlHandler : HttpMessageHandler
     {
+        static partial void UseSingletonMultiAgent(ref bool result)
+        {
+            // Some backends other than OpenSSL need locks initialized in order to use them in a
+            // multithreaded context, which would happen with multiple HttpClients and thus multiple
+            // MultiAgents. Since we don't currently have the ability to do so initialization, instead we
+            // restrict all HttpClients to use the same MultiAgent instance in this case.  We know LibreSSL
+            // is in this camp, so we currently special-case it.
+            string curlSslVersion = Interop.Http.GetSslVersionDescription();
+            result =
+                !string.IsNullOrEmpty(curlSslVersion) &&
+                curlSslVersion.StartsWith(Interop.Http.LibreSslDescription, StringComparison.OrdinalIgnoreCase);
+        }
+
         private static class SslProvider
         {
             internal static void SetSslOptions(EasyRequest easy, ClientCertificateOption clientCertOption)


### PR DESCRIPTION
LibreSSL needs locks initialized in order to be used safely from
multiple threads, which happens when multiple HttpClients are used.  But
we don't currently have a good way to perform that initialization as we
do for OpenSSL.  As a workaround, add a shared MultiAgent that's
initialized when LibreSSL is used on macOS, and use that same MultiAgent
from all CurlHandler instances rather than giving each their own.  Since
MultiAgent is 1:1 with a thread, all HttpClient's will then end up
sharing the same libcurl event loop thread, and we'll serialize all of
our interactions with libcurl and thus hopefully with LibreSSL.

cc: @bartonjs, @geoffkizer, @nguerrera, @Petermarcu 