### PR TITLE
Don't double-cast in nullable-to-nullable coalesce S.L.Expressions

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Logical.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Logical.cs
@@ -146,17 +146,20 @@ namespace System.Linq.Expressions.Compiler
                 // emit call to invoke
                 _ilg.Emit(OpCodes.Callvirt, b.Conversion.Type.GetInvokeMethod());
             }
-            else if (!TypeUtils.AreEquivalent(b.Type, nnLeftType))
+            else if (TypeUtils.AreEquivalent(b.Type, b.Left.Type))
             {
-                _ilg.Emit(OpCodes.Ldloca, loc);
-                _ilg.EmitGetValueOrDefault(b.Left.Type);
-                _ilg.EmitConvertToType(nnLeftType, b.Type, isChecked: true, locals: this);
+                _ilg.Emit(OpCodes.Ldloc, loc);
             }
             else
             {
                 _ilg.Emit(OpCodes.Ldloca, loc);
                 _ilg.EmitGetValueOrDefault(b.Left.Type);
+                if (!TypeUtils.AreEquivalent(b.Type, nnLeftType))
+                {
+                    _ilg.EmitConvertToType(nnLeftType, b.Type, isChecked: true, locals: this);
+                }
             }
+
             FreeLocal(loc);
 
             _ilg.Emit(OpCodes.Br, labEnd);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryCoalesceTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryCoalesceTests.cs
@@ -494,5 +494,36 @@ namespace System.Linq.Expressions.Tests
                 )).Compile(useInterpreter);
             Assert.Equal(1, func());
         }
+
+#if FEATURE_COMPILE
+        [Fact]
+        public static void VerifyIL_NullableIntCoalesceToNullableInt()
+        {
+            ParameterExpression x = Expression.Parameter(typeof(int?));
+            ParameterExpression y = Expression.Parameter(typeof(int?));
+            Expression<Func<int?, int?, int?>> f =
+                Expression.Lambda<Func<int?, int?, int?>>(Expression.Coalesce(x, y), x, y);
+
+            f.VerifyIL(
+                @".method valuetype [System.Private.CoreLib]System.Nullable`1<int32> ::lambda_method(class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure,valuetype [System.Private.CoreLib]System.Nullable`1<int32>,valuetype [System.Private.CoreLib]System.Nullable`1<int32>)
+                {
+                    .maxstack 2
+                    .locals init (
+                        [0] valuetype [System.Private.CoreLib]System.Nullable`1<int32>
+                    )
+
+                    IL_0000: ldarg.1
+                    IL_0001: stloc.0
+                    IL_0002: ldloca.s   V_0
+                    IL_0004: call       instance bool valuetype [System.Private.CoreLib]System.Nullable`1<int32>::get_HasValue()
+                    IL_0009: brfalse    IL_0014
+                    IL_000e: ldloc.0
+                    IL_000f: br         IL_0015
+                    IL_0014: ldarg.2
+                    IL_0015: ret
+                }");
+        }
+#endif
+
     }
 }


### PR DESCRIPTION
If a coalesce of a nullable has the same type as the expression (e.g. `x ?? y` if both `x` and `y` are int?) then not looking for this case means if the lhs isn't null it's cast to non-nullable then back to nullable again.

Instead catch this case and just use the left hand value as the result.