### PR TITLE
Add net47 configuration to System.Security.Cryptography.Algorithms

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -55,7 +55,7 @@
   <Target Name="UpdateVSConfigurations">
     <Message Importance="High" Text="Updating configurations for projects ..." />
     <ItemGroup>
-      <_projectsToExcludeFromUpdate Include="$(MSBuildThisFileDirectory)src/**/RestoreSDKProject.csproj" />
+      <_projectsToExcludeFromUpdate Include="$(MSBuildThisFileDirectory)src/SharedFrameworkValidation/**/*.csproj" />
       <_projectsToUpdate Include="$(MSBuildThisFileDirectory)src/**/*.*csproj" Exclude="@(_projectsToExcludeFromUpdate)" />
       <_projectsToUpdate Include="$(MSBuildThisFileDirectory)src/**/*.*ilproj" Exclude="@(_projectsToExcludeFromUpdate)" />
       <_solutionsToUpdateFiles Include="$(MSBuildThisFileDirectory)src/*/dir.props" />

--- a/pkg/NETStandard.Library.NETFramework/NETStandard.Library.NETFramework.pkgproj
+++ b/pkg/NETStandard.Library.NETFramework/NETStandard.Library.NETFramework.pkgproj
@@ -13,12 +13,12 @@
 
     <IsFrameworkPackage>true</IsFrameworkPackage>
     <IncludeLibFiles>true</IncludeLibFiles>
-    
-    <!-- ValidatePackage doesn't evaluate our targets/props so it does 
+
+    <!-- ValidatePackage doesn't evaluate our targets/props so it does
          not find any of the assets in this package -->
     <SkipValidatePackage>true</SkipValidatePackage>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <StampFile Include="targets\NETStandard.Library.NETFramework.common.props">
       <TargetPath>build</TargetPath>
@@ -71,7 +71,7 @@
         <StampedFile>$(IntermediateOutputPath)%(StampFile.RelativeDir)%(StampFile.FileName)%(StampFile.Extension)</StampedFile>
       </StampFile>
     </ItemGroup>
-  
+
     <MakeDir Directories="$([System.IO.Path]::GetDirectoryName('%(StampFile.StampedFile)'))" />
     <!-- Update targets templates -->
     <WriteLinesToFile
@@ -83,7 +83,7 @@
       <File Include="@(StampFile->'%(StampedFile)')" />
     </ItemGroup>
   </Target>
-  
+
   <Target Name="AddNETStandardLibraryReference" AfterTargets="ApplyBaselineToStaticDependencies">
     <ItemGroup>
       <!-- ApplyBaseline doesn't handle NuGet versions, so workaround that by
@@ -96,7 +96,30 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="ExpandClosureFilesByTargetFramework" 
+  <Target Name="AddFrameworkClosureFiles" AfterTargets="ExpandClosureFilesByTargetFramework">
+    <ItemGroup>
+      <FrameworkClosureFile Include="@(NetFxReference->'$(RefRootPath)netfx/%(Identity).dll')" >
+        <FileSet>reference-net461</FileSet>
+      </FrameworkClosureFile>
+      <FrameworkClosureFile Include="@(NetFxReference->'$(RefRootPath)netfx/%(Identity).dll')" >
+        <FileSet>runtime-net461</FileSet>
+      </FrameworkClosureFile>
+      <FrameworkClosureFile Include="@(NetFxReference->'$(RefRootPath)net462/%(Identity).dll')" >
+        <FileSet>reference-net462</FileSet>
+      </FrameworkClosureFile>
+      <FrameworkClosureFile Include="@(NetFxReference->'$(RefRootPath)net462/%(Identity).dll')" >
+        <FileSet>runtime-net462</FileSet>
+      </FrameworkClosureFile>
+      <FrameworkClosureFile Include="@(NetFxReference->'$(RefRootPath)net47/%(Identity).dll')" >
+        <FileSet>reference-net47</FileSet>
+      </FrameworkClosureFile>
+      <FrameworkClosureFile Include="@(NetFxReference->'$(RefRootPath)net47/%(Identity).dll')" >
+        <FileSet>runtime-net47</FileSet>
+      </FrameworkClosureFile>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="ExpandClosureFilesByTargetFramework"
           AfterTargets="GetClosureFiles"
           Inputs="%(ClosureFile.FileSet)"
           Outputs="batching-on-Closure-metadata">
@@ -123,7 +146,7 @@
       <ClosureFile Include="@(_closureFileNet462->'%(Original)')">
         <FileSet>%(FileSet)-net462</FileSet>
       </ClosureFile>
-      
+
       <ClosureFile Include="@(_closureFileNet47->'%(Original)')" >
         <FileSet>%(FileSet)-net47</FileSet>
       </ClosureFile>
@@ -132,7 +155,7 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 
-  <!-- runs as initial target, overrides IncludeFiles in frameworkPackage.targets to define TFM-specific TargetPath 
+  <!-- runs as initial target, overrides IncludeFiles in frameworkPackage.targets to define TFM-specific TargetPath
        under the build folder  -->
   <Target Name="IncludeFiles" DependsOnTargets="IncludeNETStandardShims">
     <PropertyGroup>
@@ -144,7 +167,7 @@
       <File Include="@(RefFile)">
         <TargetPath Condition="'%(RefFile.TargetPath)' == ''">build/%(RefFile.TargetFramework)/ref%(RefFile.SubFolder)</TargetPath>
       </File>
-      
+
       <!-- Include lib -->
       <File Include="@(LibFile)">
         <TargetPath Condition="'%(LibFile.TargetPath)' == '' ">build/%(LibFile.TargetFramework)/lib%(LibFile.SubFolder)</TargetPath>

--- a/pkg/NETStandard.Library.NETFramework/targets/NETStandard.Library.NETFramework.common.targets
+++ b/pkg/NETStandard.Library.NETFramework/targets/NETStandard.Library.NETFramework.common.targets
@@ -1,4 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ImportedNETStandardLibraryNETFrameworkCommonTargets>true</ImportedNETStandardLibraryNETFrameworkCommonTargets>
+  </PropertyGroup>
   <Choose>
     <!-- Allow completely disabling the conflict resolution targets-->
     <When Condition="'$(ImplicitlyExpandNETStandardFacades)' != 'true'" />
@@ -28,7 +31,7 @@
     <!-- Ensure this runs before conflict resolution since the added files may cause conflicts -->
     <HandlePackageFileConflictsDependsOn>ImplicitlyExpandNETStandardFacades;$(HandlePackageFileConflictsDependsOn)</HandlePackageFileConflictsDependsOn>
   </PropertyGroup>
-  
+
   <ItemGroup Condition="'$(DontTrimNETStandardLibraryNETFramework)' != 'true'">
     <!-- mark this package as trimmable so that files in the same package aren't automatically rooted -->
     <TrimmablePackages Include="NETStandard.Library.NETFramework" />

--- a/pkg/NETStandard.Library.NETFramework/targets/net461/NETStandard.Library.NETFramework.targets
+++ b/pkg/NETStandard.Library.NETFramework/targets/net461/NETStandard.Library.NETFramework.targets
@@ -1,11 +1,11 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Condition="'$(ImplicitlyExpandNETStandardFacades)' == 'true'">
-    <_NETStandardLibraryNETFrameworkReference Include="$(MSBuildThisFileDirectory)\ref\*.dll" 
-                                              Exclude="@(_NETStandardLibraryNETFrameworkReference->'$(MSBuildThisFileDirectory)\ref\%(FileName).dll'" />
+    <_NETStandardLibraryNETFrameworkReference Include="$(MSBuildThisFileDirectory)\ref\*.dll"
+                                              Exclude="@(_NETStandardLibraryNETFrameworkReference->'$(MSBuildThisFileDirectory)\ref\%(FileName).dll')" />
 
-    <_NETStandardLibraryNETFrameworkLib Include="$(MSBuildThisFileDirectory)\lib\*.dll" 
-                                        Exclude="@(_NETStandardLibraryNETFrameworkLib->'$(MSBuildThisFileDirectory)\ref\%(FileName).dll'" />
+    <_NETStandardLibraryNETFrameworkLib Include="$(MSBuildThisFileDirectory)\lib\*.dll"
+                                        Exclude="@(_NETStandardLibraryNETFrameworkLib->'$(MSBuildThisFileDirectory)\ref\%(FileName).dll')" />
   </ItemGroup>
 
-  <Import Project="..\$(MSBuildThisFileName).common.targets" />
+  <Import Project="..\$(MSBuildThisFileName).common.targets" Condition="'$(ImportedNETStandardLibraryNETFrameworkCommonTargets)' != 'true'" />
 </Project>

--- a/pkg/NETStandard.Library.NETFramework/targets/net462/NETStandard.Library.NETFramework.targets
+++ b/pkg/NETStandard.Library.NETFramework/targets/net462/NETStandard.Library.NETFramework.targets
@@ -1,12 +1,12 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Condition="'$(ImplicitlyExpandNETStandardFacades)' == 'true'">
-    <_NETStandardLibraryNETFrameworkReference Include="$(MSBuildThisFileDirectory)\ref\*.dll" 
-                                              Exclude="@(_NETStandardLibraryNETFrameworkReference->'$(MSBuildThisFileDirectory)\ref\%(FileName).dll'" />
+    <_NETStandardLibraryNETFrameworkReference Include="$(MSBuildThisFileDirectory)\ref\*.dll"
+                                              Exclude="@(_NETStandardLibraryNETFrameworkReference->'$(MSBuildThisFileDirectory)\ref\%(FileName).dll')" />
 
-    <_NETStandardLibraryNETFrameworkLib Include="$(MSBuildThisFileDirectory)\lib\*.dll" 
-                                        Exclude="@(_NETStandardLibraryNETFrameworkLib->'$(MSBuildThisFileDirectory)\ref\%(FileName).dll'" />
+    <_NETStandardLibraryNETFrameworkLib Include="$(MSBuildThisFileDirectory)\lib\*.dll"
+                                        Exclude="@(_NETStandardLibraryNETFrameworkLib->'$(MSBuildThisFileDirectory)\ref\%(FileName).dll')" />
   </ItemGroup>
 
   <Import Project="..\net461\$(MSBuildThisFile)" />
-  <Import Project="..\$(MSBuildThisFileName).common.targets" />
+  <Import Project="..\$(MSBuildThisFileName).common.targets" Condition="'$(ImportedNETStandardLibraryNETFrameworkCommonTargets)' != 'true'" />
 </Project>

--- a/pkg/NETStandard.Library.NETFramework/targets/net47/NETStandard.Library.NETFramework.targets
+++ b/pkg/NETStandard.Library.NETFramework/targets/net47/NETStandard.Library.NETFramework.targets
@@ -1,12 +1,12 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Condition="'$(ImplicitlyExpandNETStandardFacades)' == 'true'">
-    <_NETStandardLibraryNETFrameworkReference Include="$(MSBuildThisFileDirectory)\ref\*.dll" 
-                                              Exclude="@(_NETStandardLibraryNETFrameworkReference->'$(MSBuildThisFileDirectory)\ref\%(FileName).dll'" />
+    <_NETStandardLibraryNETFrameworkReference Include="$(MSBuildThisFileDirectory)\ref\*.dll"
+                                              Exclude="@(_NETStandardLibraryNETFrameworkReference->'$(MSBuildThisFileDirectory)\ref\%(FileName).dll')" />
 
-    <_NETStandardLibraryNETFrameworkLib Include="$(MSBuildThisFileDirectory)\lib\*.dll" 
-                                        Exclude="@(_NETStandardLibraryNETFrameworkLib->'$(MSBuildThisFileDirectory)\ref\%(FileName).dll'" />
+    <_NETStandardLibraryNETFrameworkLib Include="$(MSBuildThisFileDirectory)\lib\*.dll"
+                                        Exclude="@(_NETStandardLibraryNETFrameworkLib->'$(MSBuildThisFileDirectory)\ref\%(FileName).dll')" />
   </ItemGroup>
 
   <Import Project="..\net462\$(MSBuildThisFile)" />
-  <Import Project="..\$(MSBuildThisFileName).common.targets" />
+  <Import Project="..\$(MSBuildThisFileName).common.targets" Condition="'$(ImportedNETStandardLibraryNETFrameworkCommonTargets)' != 'true'" />
 </Project>

--- a/pkg/frameworkPackage.targets
+++ b/pkg/frameworkPackage.targets
@@ -54,7 +54,7 @@
     <!-- force a missing file if native build is absent -->
     <NativeFile Include="$(NativeBinDir)/MISSING_NATIVE_BUILD" Condition="'@(NativeFile)' == ''" />
   </ItemGroup>
-  
+
   <Target Name="_CheckForFiles">
     <Error Condition="'$(IncludeReferenceFiles)' == 'true' AND '@(RefFile)' == ''"
            Text="IncludeReferenceFiles was specified but no file props were found in '$(RefBinDir)'" />
@@ -63,7 +63,7 @@
     <Error Condition="'$(IncludeNativeFiles)' == 'true' AND '@(NativeFile)' == ''"
            Text="IncludeNativeFiles was specified but no files were found in '$(NativeBinDir)'" />
   </Target>
-  
+
   <Target Name="IncludeFiles">
     <PropertyGroup>
       <_projectDirLength>$(ProjectDir.Length)</_projectDirLength>
@@ -74,7 +74,7 @@
       <File Include="@(RefFile)">
         <TargetPath Condition="'%(RefFile.TargetPath)' == ''">$(RefFileTargetPath)%(RefFile.SubFolder)</TargetPath>
       </File>
-      
+
       <!-- Include lib -->
       <File Include="@(LibFile)">
         <TargetPath Condition="'%(LibFile.TargetPath)' == '' ">$(LibFileTargetPath)%(LibFile.SubFolder)</TargetPath>
@@ -107,8 +107,8 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="VerifyClosure" 
-          DependsOnTargets="GetClosureFiles" 
+  <Target Name="VerifyClosure"
+          DependsOnTargets="GetClosureFiles"
           AfterTargets="Build"
           Inputs="%(ClosureFile.FileSet)"
           Outputs="batching-on-FileSet-metadata">
@@ -127,13 +127,19 @@
 
   </Target>
 
-  <Target Name="VerifyDuplicateTypes" 
-          DependsOnTargets="GetClosureFiles" 
+  <Target Name="VerifyDuplicateTypes"
+          DependsOnTargets="GetClosureFiles"
           AfterTargets="Build"
           Inputs="%(ClosureFile.FileSet)"
           Outputs="batching-on-FileSet-metadata">
+    <PropertyGroup>
+      <_fileSet>%(ClosureFile.FileSet)</_fileSet>
+    </PropertyGroup>
     <ItemGroup>
       <_dupTypeFileName Include="@(ClosureFile->'%(FileName)')">
+        <Original>%(Identity)</Original>
+      </_dupTypeFileName>
+      <_dupTypeFileName Include="@(FrameworkClosureFile->'%(FileName)')" Exclude="@(_dupTypeFileName)" Condition="'$(_fileSet)' == '%(FrameworkClosureFile.FileSet)'">
         <Original>%(Identity)</Original>
       </_dupTypeFileName>
       <_dupTypeFileNamesFiltered Include="@(_dupTypeFileName)" Exclude="@(ExcludeFromDuplicateTypes)"/>
@@ -146,8 +152,8 @@
 
   </Target>
 
-  <Target Name="VerifyNETStandard" 
-          DependsOnTargets="GetClosureFiles" 
+  <Target Name="VerifyNETStandard"
+          DependsOnTargets="GetClosureFiles"
           AfterTargets="Build"
           Inputs="%(ClosureFile.FileSet)"
           Outputs="batching-on-FileSet-metadata">

--- a/src/System.Security.Cryptography.Algorithms/ref/Configurations.props
+++ b/src/System.Security.Cryptography.Algorithms/ref/Configurations.props
@@ -4,6 +4,7 @@
     <BuildConfigurations>
       netcoreapp;
       netfx;
+      net47;
       uap;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.csproj
+++ b/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.csproj
@@ -3,8 +3,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{102247C1-3DB9-4DB5-80B3-EE9F80DD4E8F}</ProjectGuid>
-    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netfx'">true</IsPartialFacadeAssembly>
+    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netfx' or '$(TargetGroup)' == 'net47'">true</IsPartialFacadeAssembly>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net47-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net47-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />
@@ -14,14 +16,14 @@
   <ItemGroup>
     <Compile Include="System.Security.Cryptography.Algorithms.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' != 'netfx'">
+  <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
     <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />
     <ProjectReference Include="..\..\System.Runtime.Extensions\ref\System.Runtime.Extensions.csproj" />
     <ProjectReference Include="..\..\System.IO\ref\System.IO.csproj" />
     <ProjectReference Include="..\..\System.Security.Cryptography.Encoding\ref\System.Security.Cryptography.Encoding.csproj" />
     <ProjectReference Include="..\..\System.Security.Cryptography.Primitives\ref\System.Security.Cryptography.Primitives.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netfx'">
+  <ItemGroup Condition="'$(IsPartialFacadeAssembly)' == 'true'">
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/System.Security.Cryptography.Algorithms/src/Configurations.props
+++ b/src/System.Security.Cryptography.Algorithms/src/Configurations.props
@@ -6,6 +6,7 @@
       netcoreapp-OSX;
       netcoreapp-Windows_NT;
       netfx-Windows_NT;
+      net47-Windows_NT;
       uap-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -9,9 +9,11 @@
     <DefineConstants>INTERNAL_ASYMMETRIC_IMPLEMENTATIONS</DefineConstants>
     <NoWarn>CA5351;$(NoWarn)</NoWarn>
     <DefineConstants Condition="'$(TargetGroup)' == 'uap'">$(DefineConstants);uap</DefineConstants>
-    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netfx'">true</IsPartialFacadeAssembly>
+    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netfx' or '$(TargetGroup)' == 'net47'">true</IsPartialFacadeAssembly>
     <GenFacadesIgnoreMissingTypes Condition="'$(TargetGroup)' == 'netfx'">true</GenFacadesIgnoreMissingTypes>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net47-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net47-Windows_NT-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-OSX-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-OSX-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />
@@ -22,7 +24,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Windows_NT-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)' != 'netfx'">
+  <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
     <Compile Include="Internal\Cryptography\AesImplementation.cs" />
     <Compile Include="Internal\Cryptography\DesImplementation.cs" />
     <Compile Include="Internal\Cryptography\Helpers.cs" />
@@ -107,7 +109,7 @@
       <Link>Internal\Cryptography\UniversalCryptoDecryptor.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' AND '$(TargetGroup)' != 'netfx'">
+  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' and '$(IsPartialFacadeAssembly)' != 'true'">
     <Compile Include="System\Security\Cryptography\CngKeyLite.cs" />
     <Compile Include="System\Security\Cryptography\DSACng.cs" />
     <Compile Include="System\Security\Cryptography\ECDsaCng.cs" />
@@ -477,7 +479,7 @@
       <Link>Common\System\Security\Cryptography\DerSequenceReader.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' != 'netfx'">
+  <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
     <Reference Include="System.Collections" />
     <Reference Include="System.Diagnostics.Contracts" />
     <Reference Include="System.Diagnostics.Debug" />
@@ -494,7 +496,7 @@
   <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
     <Reference Include="System.Runtime.Numerics" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netfx'">
+  <ItemGroup Condition="'$(IsPartialFacadeAssembly)' == 'true'">
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
Fix NETStandard.Library.NETFramework package targets

Update the VerifyDuplicateTypes target to include framework assemblies
to ensure we don't have any conflicting types between the framework and our OOBs.

cc @bartonjs @ericstj 

Fixes #22211