### PR TITLE
Make Microsoft.CSharp.RuntimeBinder.Semantics.CType.StripNubs virtual and not loop

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/NullableType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/NullableType.cs
@@ -38,6 +38,15 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return ats;
         }
         public CType GetUnderlyingType() { return UnderlyingType; }
+
+        public override CType StripNubs() => UnderlyingType;
+
+        public override CType StripNubs(out int pcnub)
+        {
+            pcnub = 1;
+            return UnderlyingType;
+        }
+
         public void SetUnderlyingType(CType pType) { UnderlyingType = pType; }
 
         public CType UnderlyingType;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/NullableType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/NullableType.cs
@@ -41,9 +41,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public override CType StripNubs() => UnderlyingType;
 
-        public override CType StripNubs(out int pcnub)
+        public override CType StripNubs(out bool wasNullable)
         {
-            pcnub = 1;
+            wasNullable = true;
             return UnderlyingType;
         }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
@@ -464,9 +464,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public virtual CType StripNubs() => this;
 
-        public virtual CType StripNubs(out int pcnub)
+        public virtual CType StripNubs(out bool wasNullable)
         {
-            pcnub = 0;
+            wasNullable = false;
             return this;
         }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
@@ -462,20 +462,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return AsAggregateType().GetOwningAggregate();
         }
 
-        public CType StripNubs()
-        {
-            CType type;
-            for (type = this; type.IsNullableType(); type = type.AsNullableType().GetUnderlyingType())
-                ;
-            return type;
-        }
-        public CType StripNubs(out int pcnub)
+        public virtual CType StripNubs() => this;
+
+        public virtual CType StripNubs(out int pcnub)
         {
             pcnub = 0;
-            CType type;
-            for (type = this; type.IsNullableType(); type = type.AsNullableType().GetUnderlyingType())
-                (pcnub)++;
-            return type;
+            return this;
         }
 
         public bool isDelegateType()

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -334,6 +334,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public NullableType GetNullable(CType pUnderlyingType)
         {
+            if (pUnderlyingType is NullableType nt)
+            {
+                Debug.Fail("Attempt to make nullable of nullable");
+                return nt;
+            }
+
             NullableType pNullableType = _typeTable.LookupNullable(pUnderlyingType);
             if (pNullableType == null)
             {


### PR DESCRIPTION
The `T??` case can't happen since we're basing our types on actual existing so there are only two cases; it's called on `NullableType`, in which case we return `UnderlyingType` or it's called on something else, in which case we return `this`.

We can also report with boolean instead of int in the overload that reports on number of times is stripped a nullable, and so replace a dependent loop with a branch.
