### PR TITLE
Remove CType.isSpecialByRefType in Microsoft.CSharp

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExplicitConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExplicitConversion.cs
@@ -790,12 +790,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 Debug.Assert(_typeSrc != null);
                 Debug.Assert(aggTypeDest != null);
 
-                // TypeReference and ArgIterator can't be boxed (or converted to anything else)
-                if (_typeSrc.isSpecialByRefType())
-                {
-                    return AggCastResult.Abort;
-                }
-
                 AggCastResult result = bindExplicitConversionFromEnumToAggregate(aggTypeDest);
                 if (result != AggCastResult.Failure)
                 {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -1417,7 +1417,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             // If it is virtual, find a remap of the method to something more specific.  This
             // may alter where the method is found.
-            if (pObject != null && (fBaseCall || pObject.Type.isSimpleType() || pObject.Type.isSpecialByRefType()))
+            if (pObject != null && (fBaseCall || pObject.Type.isSimpleType()))
             {
                 RemapToOverride(GetSymbolLoader(), pMWI, pObject.Type);
             }
@@ -1594,15 +1594,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 // WE don't give a great message for this, but it'll do.
                 if (objNew == null)
                 {
-                    if (!pObject.Type.isSpecialByRefType())
-                    {
-                        ErrorContext.Error(ErrorCode.ERR_WrongNestedThis, swt.GetType(), pObject.Type);
-                    }
-                    else
-                    {
-                        ErrorContext.Error(ErrorCode.ERR_NoImplicitConv, pObject.Type, swt.GetType());
-                    }
+                    ErrorContext.Error(ErrorCode.ERR_WrongNestedThis, swt.GetType(), pObject.Type);
                 }
+
                 pObject = objNew;
             }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ImplicitConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ImplicitConversion.cs
@@ -214,11 +214,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         // If not, try user defined implicit conversions.
                         break;
                     case TypeKind.TK_AggregateType:
-                        // TypeReference and ArgIterator can't be boxed (or converted to anything else)
-                        if (_typeSrc.isSpecialByRefType())
-                        {
-                            return false;
-                        }
                         if (bindImplicitConversionFromAgg(_typeSrc.AsAggregateType()))
                         {
                             return true;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/TypeBind.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/TypeBind.cs
@@ -169,7 +169,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 return false;
             }
 
-            if (arg.IsPointerType() || arg.isSpecialByRefType())
+            if (arg.IsPointerType())
             {
                 if (fReportErrors)
                 {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
@@ -585,16 +585,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return getAggregate().GetPredefType();
         }
 
-        ////////////////////////////////////////////////////////////////////////////////
-        // Is this type System.TypedReference or System.ArgIterator?
-        // (used for errors because these types can't go certain places)
-
-        public bool isSpecialByRefType()
-        {
-            // ArgIterator, TypedReference and RuntimeArgumentHandle are not supported.
-            return false;
-        }
-
         public bool isStaticClass()
         {
             AggregateSymbol agg = GetNakedAgg(false);


### PR DESCRIPTION
Always false, so remove it and branches that depend on it being true.