### PR TITLE
Applied MaxSegmentLength restriction in ConcurrentQueue

### DIFF
--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentQueue.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentQueue.cs
@@ -115,7 +115,7 @@ namespace System.Collections.Concurrent
                 int count = c.Count;
                 if (count > length)
                 {
-                    length = RoundUpToPowerOf2(count);
+                    length = Math.Min(RoundUpToPowerOf2(count), MaxSegmentLength);
                 }
             }
 
@@ -676,7 +676,7 @@ namespace System.Collections.Concurrent
                         // initial segment length; if these observations are happening frequently,
                         // this will help to avoid wasted memory, and if they're not, we'll
                         // relatively quickly grow again to a larger size.
-                        int nextSize = tail._preservedForObservation ? InitialSegmentLength : tail.Capacity * 2;
+                        int nextSize = tail._preservedForObservation ? InitialSegmentLength : Math.Min(tail.Capacity * 2, MaxSegmentLength);
                         var newTail = new Segment(nextSize);
 
                         // Hook up the new tail.


### PR DESCRIPTION
MaxSegmentLength was not used in ConcurrentQueue, segments could grow indefinitely. This PR applies the limit in InitializeFromCollection and EnqueueSlow.

Some concerns:
The current value of MaxSegmentLength (1024 * 1024) seems arbitrarily high. This is 64MB in x64 when T is a ref type.

I see two different use-cases for ConcurrentQueue:
- Global queue with high troughput (like the ThreadPool work item queue)
- Hundreds or thousands of queues, some of them have high throughput, some of them rarely used (like an actor framework e.g. Akka, Orleans)

A high max length for a global queue is better, it won't allocate when the queue is filling up. However for many queues, any queue that filled up may consume up to 64MB which can accumulate to a lot of memory.

It would be nice to make MaxSegmentLength configurable, but that would expose internal details of the queue.. What do you think? Could MaxSegmentLength be smaller?

cc @stephentoub 