### PR TITLE
Make ManagedHandler ConnectionPoolingTest clean itself up

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ManagedHandlerTest.cs
@@ -160,7 +160,7 @@ namespace System.Net.Http.Functional.Tests
     //    }
     //}
 
-    public sealed class ManagedHandler_HttpClientHandler_ConnectionPooling_Test
+    public sealed class ManagedHandler_HttpClientHandler_ConnectionPooling_Test : IDisposable
     {
         public ManagedHandler_HttpClientHandler_ConnectionPooling_Test() => ManagedHandlerTestHelpers.SetEnvVar();
         public void Dispose() => ManagedHandlerTestHelpers.RemoveEnvVar();


### PR DESCRIPTION
ManagedHandler_HttpClientHandler_ConnectionPooling_Test didn't assert
IDisposable (though did have a Dispose method), so it didn't clear the
environment variable that says to use the prototype managed handler in tests.
This means that any tests which should still be using the curl provider end up
using the managed provider until another managed test runs.

So now it's disposable, and a failure we were expecting, but not seeing, on
macOS 10.13 is asserting itself again.

Solves the conundrum from https://github.com/dotnet/corefx/issues/22089#issuecomment-315383328.