### PR TITLE
Enable UWP multi-file test runs for the ARM32 Release configuration

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -255,7 +255,7 @@
   <!-- Properties related to multi-file mode for ILC tests -->
   <PropertyGroup Condition="'$(TargetGroup)' == 'uapaot'">
     <!-- Only enable multi-file for Release-x64 and Debug-x86 for now -->
-    <EnableMultiFileILCTests Condition="'$(ConfigurationGroup)|$(ArchGroup)' == 'Release|x64' Or '$(ConfigurationGroup)|$(ArchGroup)' == 'Debug|x86'">true</EnableMultiFileILCTests>
+    <EnableMultiFileILCTests Condition="'$(ConfigurationGroup)|$(ArchGroup)' == 'Release|x64' Or '$(ConfigurationGroup)|$(ArchGroup)' == 'Debug|x86' Or '$(ConfigurationGroup)|$(ArchGroup)' == 'Release|arm'">true</EnableMultiFileILCTests>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
#21154 calls for the enabling of Multi-File x86 and ARM runs - x86 Multi-File has already been added so the only thing left to do is ARM.

I verified this on my local machine by building uapaot arm release and checking to see if the Shared Assembly is present in the TestILC path. I also verified that the Shared Assembly is not present after building ARM debug.