### PR TITLE
Move NamedPipe tests to use Local prefix

### DIFF
--- a/src/System.IO.FileSystem/tests/FileStream/CopyToAsync.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/CopyToAsync.cs
@@ -242,7 +242,7 @@ namespace System.IO.Tests
         [Theory]
         [InlineData(false, 10, 1024)]
         [InlineData(true, 10, 1024)]
-        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
+        [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
         public async Task NamedPipeViaFileStream_AllDataCopied(bool useAsync, int writeSize, int numWrites)
         {
             long totalLength = writeSize * numWrites;
@@ -252,7 +252,7 @@ namespace System.IO.Tests
             var results = new MemoryStream();
             var pipeOptions = useAsync ? PipeOptions.Asynchronous : PipeOptions.None;
 
-            string name = Guid.NewGuid().ToString("N");
+            string name = GetNamedPipeServerStreamName();
             using (var server = new NamedPipeServerStream(name, PipeDirection.Out, 1, PipeTransmissionMode.Byte, pipeOptions))
             {
                 Task serverTask = Task.Run(async () =>

--- a/src/System.IO.FileSystem/tests/FileStream/Pipes.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/Pipes.cs
@@ -94,10 +94,9 @@ namespace System.IO.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public async Task NamedPipeWriteViaAsyncFileStream(bool asyncWrites)
         {
-            string name = Guid.NewGuid().ToString("N");
+            string name = GetNamedPipeServerStreamName();
             using (var server = new NamedPipeServerStream(name, PipeDirection.In, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous))
             {
                 Task serverTask = Task.Run(async () =>
@@ -129,10 +128,9 @@ namespace System.IO.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public async Task NamedPipeReadViaAsyncFileStream(bool asyncReads)
         {
-            string name = Guid.NewGuid().ToString("N");
+            string name = GetNamedPipeServerStreamName();
             using (var server = new NamedPipeServerStream(name, PipeDirection.Out, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous))
             {
                 Task serverTask = Task.Run(async () =>

--- a/src/System.IO.FileSystem/tests/FileSystemTest.cs
+++ b/src/System.IO.FileSystem/tests/FileSystemTest.cs
@@ -57,6 +57,15 @@ namespace System.IO.Tests
             return success;
         });
 
+        protected string GetNamedPipeServerStreamName()
+        {
+            if (PlatformDetection.IsWinRT)
+            {
+                return @"LOCAL\" + Guid.NewGuid().ToString("N");
+            }
+            return Guid.NewGuid().ToString("N");
+        }
+
         /// <summary>
         /// Runs the given command as sudo
         /// </summary>

--- a/src/System.IO.Pipes.AccessControl/tests/NamedPipeTests/NamedPipeTest.AclExtensions.cs
+++ b/src/System.IO.Pipes.AccessControl/tests/NamedPipeTests/NamedPipeTest.AclExtensions.cs
@@ -28,7 +28,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
-        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
+        [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
         public void SetAccessControl_NamedPipeStream()
         {
             string pipeName = GetUniquePipeName();
@@ -46,7 +46,6 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
-        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public void SetAccessControl_NamedPipeStream_BeforeWaitingToConnect()
         {
             string pipeName = GetUniquePipeName();
@@ -61,7 +60,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
-        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
+        [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
         public void SetAccessControl_NamedPipeStream_ClientDisposed()
         {
             string pipeName = GetUniquePipeName();
@@ -82,7 +81,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
-        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
+        [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
         public void SetAccessControl_NamedPipeStream_ClientHandleClosed()
         {
             string pipeName = GetUniquePipeName();
@@ -103,7 +102,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
-        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
+        [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
         public void SetAccessControl_NamedPipeStream_ServerDisconnected()
         {
             string pipeName = GetUniquePipeName();
@@ -124,7 +123,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
-        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
+        [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
         public void SetAccessControl_NamedPipeStream_ServerDisposed()
         {
             string pipeName = GetUniquePipeName();
@@ -145,7 +144,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
-        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
+        [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
         public void SetAccessControl_NamedPipeStream_ServerHandleClosed()
         {
             string pipeName = GetUniquePipeName();

--- a/src/System.IO.Pipes.AccessControl/tests/PipeTest.AclExtensions.cs
+++ b/src/System.IO.Pipes.AccessControl/tests/PipeTest.AclExtensions.cs
@@ -15,7 +15,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
-        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
+        [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
         public void GetAccessControl_DisposedStream()
         {
             using (var pair = CreateServerClientPair())
@@ -29,7 +29,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
-        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
+        [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
         public void GetAccessControl_ConnectedStream()
         {
             using (var pair = CreateServerClientPair())
@@ -46,7 +46,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
-        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
+        [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
         public void SetAccessControl_NullPipeSecurity()
         {
             using (var pair = CreateServerClientPair())
@@ -62,7 +62,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
-        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
+        [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
         public void SetAccessControl_DisposedStream()
         {
             using (var pair = CreateServerClientPair())
@@ -76,7 +76,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
-        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
+        [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
         public void SetAccessControl_ConnectedStream()
         {
             using (var pair = CreateServerClientPair())

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CreateServer.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CreateServer.cs
@@ -56,14 +56,12 @@ namespace System.IO.Pipes.Tests
             AssertExtensions.Throws<ArgumentOutOfRangeException>("pipeName", () => new NamedPipeServerStream(reservedName, direction, 1, PipeTransmissionMode.Byte, PipeOptions.None, 0, 0));}
 
         [Fact]
-        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public static void Create_PipeName()
         {
             new NamedPipeServerStream(GetUniquePipeName()).Dispose();
         }
 
         [Fact]
-        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public static void Create_PipeName_Direction_MaxInstances()
         {
             new NamedPipeServerStream(GetUniquePipeName(), PipeDirection.Out, 1).Dispose();
@@ -71,7 +69,6 @@ namespace System.IO.Pipes.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // can't access SafePipeHandle on Unix until after connection created
-        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public static void CreateWithNegativeOneServerInstances_DefaultsToMaxServerInstances()
         {
             // When passed -1 as the maxnumberofserverisntances, the NamedPipeServerStream.Windows class
@@ -199,7 +196,6 @@ namespace System.IO.Pipes.Tests
         [InlineData(PipeDirection.Out)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "This scenario is not handled with System.ArgumentException on Full Framework")]
         [PlatformSpecific(TestPlatforms.Windows)] // accessing SafePipeHandle on Unix fails for a non-connected stream
-        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public static void Windows_CreateFromDisposedServerHandle_Throws_ObjectDisposedException(PipeDirection direction)
         {
             // The pipe is closed when we try to make a new Stream with it
@@ -241,7 +237,6 @@ namespace System.IO.Pipes.Tests
         [InlineData(PipeDirection.Out)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET framework handles this scenario by throwing ApplicationException instead")]
         [PlatformSpecific(TestPlatforms.Windows)] // accessing SafePipeHandle on Unix fails for a non-connected stream
-        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public static void Windows_CreateFromAlreadyBoundHandle_Throws_ArgumentException(PipeDirection direction)
         {
             // The pipe is already bound
@@ -253,7 +248,6 @@ namespace System.IO.Pipes.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // NumberOfServerInstances > 1 isn't supported and has undefined behavior on Unix
-        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public static void ServerCountOverMaxServerInstances_Throws_IOException()
         {
             string uniqueServerName = GetUniquePipeName();
@@ -265,7 +259,6 @@ namespace System.IO.Pipes.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // NumberOfServerInstances > 1 isn't supported and has undefined behavior on Unix
-        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public static void Windows_ServerCloneWithDifferentDirection_Throws_UnauthorizedAccessException()
         {
             string uniqueServerName = GetUniquePipeName();

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CrossProcess.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CrossProcess.cs
@@ -8,15 +8,15 @@ using Xunit;
 
 namespace System.IO.Pipes.Tests
 {
-    [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
+    [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
     public sealed class NamedPipeTest_CrossProcess : RemoteExecutorTestBase
     {
         [Fact]
         public void PingPong_Sync()
         {
             // Create names for two pipes
-            string outName = Path.GetRandomFileName();
-            string inName = Path.GetRandomFileName();
+            string outName = GetUniquePipeName();
+            string inName = GetUniquePipeName();
 
             // Create the two named pipes, one for each direction, then create
             // another process with which to communicate
@@ -41,8 +41,8 @@ namespace System.IO.Pipes.Tests
         public async Task PingPong_Async()
         {
             // Create names for two pipes
-            string outName = Path.GetRandomFileName();
-            string inName = Path.GetRandomFileName();
+            string outName = GetUniquePipeName();
+            string inName = GetUniquePipeName();
 
             // Create the two named pipes, one for each direction, then create
             // another process with which to communicate
@@ -84,6 +84,15 @@ namespace System.IO.Pipes.Tests
                 }
             }
             return SuccessExitCode;
+        }
+
+        private static string GetUniquePipeName()
+        {
+            if (PlatformDetection.IsWinRT)
+            {
+                return @"LOCAL\" + Path.GetRandomFileName();
+            }
+            return Path.GetRandomFileName();
         }
 
     }

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Read.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Read.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace System.IO.Pipes.Tests
 {
-    [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
+    [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
     public class NamedPipeTest_Read_ServerOut_ClientIn : PipeTest_Read
     {
         protected override ServerClientPair CreateServerClientPair()
@@ -27,8 +27,8 @@ namespace System.IO.Pipes.Tests
             return ret;
         }
     }
-
-    [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
+    
+    [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
     public class NamedPipeTest_Read_ServerIn_ClientOut : PipeTest_Read
     {
         protected override ServerClientPair CreateServerClientPair()
@@ -47,8 +47,8 @@ namespace System.IO.Pipes.Tests
             return ret;
         }
     }
-
-    [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
+    
+    [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
     public class NamedPipeTest_Read_ServerInOut_ClientInOut : PipeTest_Read
     {
         protected override ServerClientPair CreateServerClientPair()
@@ -70,8 +70,8 @@ namespace System.IO.Pipes.Tests
         // InOut pipes can be written/read from either direction
         public override void WriteToReadOnlyPipe_Throws_NotSupportedException() { }
     }
-
-    [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
+    
+    [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
     public class NamedPipeTest_Read_ServerInOut_ClientInOut_APMWaitForConnection : PipeTest_Read
     {
         protected override ServerClientPair CreateServerClientPair()

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.RunAsClient.Windows.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.RunAsClient.Windows.cs
@@ -15,10 +15,10 @@ namespace System.IO.Pipes.Tests
     {
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]  // Uses P/Invokes
-        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
+        [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
         public async Task RunAsClient_Windows()
         {
-            string pipeName = Path.GetRandomFileName();
+            string pipeName = GetUniquePipeName();
             using (var server = new NamedPipeServerStream(pipeName))
             using (var client = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.None, TokenImpersonationLevel.Impersonation))
             {
@@ -31,6 +31,15 @@ namespace System.IO.Pipes.Tests
                 server.RunAsClient(() => ran = true);
                 Assert.True(ran, "Expected delegate to have been invoked");
             }
+        }
+
+        private static string GetUniquePipeName()
+        {
+            if (PlatformDetection.IsWinRT)
+            {
+                return @"LOCAL\" + Path.GetRandomFileName();
+            }
+            return Path.GetRandomFileName();
         }
     }
 }

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Simple.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Simple.cs
@@ -753,8 +753,8 @@ namespace System.IO.Pipes.Tests
             }
         }
     }
-
-    [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
+    
+    [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
     public class NamedPipeTest_Simple_ServerInOutRead_ClientInOutWrite : NamedPipeTest_Simple
     {
         protected override NamedPipePair CreateNamedPipePair(PipeOptions serverOptions, PipeOptions clientOptions)
@@ -767,8 +767,8 @@ namespace System.IO.Pipes.Tests
             return ret;
         }
     }
-
-    [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
+    
+    [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
     public class NamedPipeTest_Simple_ServerInOutWrite_ClientInOutRead : NamedPipeTest_Simple
     {
         protected override NamedPipePair CreateNamedPipePair(PipeOptions serverOptions, PipeOptions clientOptions)
@@ -781,8 +781,8 @@ namespace System.IO.Pipes.Tests
             return ret;
         }
     }
-
-    [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
+    
+    [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
     public class NamedPipeTest_Simple_ServerInOut_ClientIn : NamedPipeTest_Simple
     {
         protected override NamedPipePair CreateNamedPipePair(PipeOptions serverOptions, PipeOptions clientOptions)
@@ -795,8 +795,8 @@ namespace System.IO.Pipes.Tests
             return ret;
         }
     }
-
-    [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
+    
+    [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
     public class NamedPipeTest_Simple_ServerInOut_ClientOut : NamedPipeTest_Simple
     {
         protected override NamedPipePair CreateNamedPipePair(PipeOptions serverOptions, PipeOptions clientOptions)
@@ -809,8 +809,8 @@ namespace System.IO.Pipes.Tests
             return ret;
         }
     }
-
-    [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
+    
+    [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
     public class NamedPipeTest_Simple_ServerOut_ClientIn : NamedPipeTest_Simple
     {
         protected override NamedPipePair CreateNamedPipePair(PipeOptions serverOptions, PipeOptions clientOptions)
@@ -823,8 +823,8 @@ namespace System.IO.Pipes.Tests
             return ret;
         }
     }
-
-    [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
+    
+    [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
     public class NamedPipeTest_Simple_ServerIn_ClientOut : NamedPipeTest_Simple
     {
         protected override NamedPipePair CreateNamedPipePair(PipeOptions serverOptions, PipeOptions clientOptions)

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Specific.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Specific.cs
@@ -14,6 +14,7 @@ namespace System.IO.Pipes.Tests
     /// The Specific NamedPipe tests cover edge cases or otherwise narrow cases that
     /// show up within particular server/client directional combinations.
     /// </summary>
+    [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
     public class NamedPipeTest_Specific : NamedPipeTestBase
     {
         [Fact]
@@ -56,7 +57,6 @@ namespace System.IO.Pipes.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // Unix implementation uses bidirectional sockets
-        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public void ConnectWithConflictingDirections_Throws_UnauthorizedAccessException()
         {
             string serverName1 = GetUniquePipeName();
@@ -80,7 +80,6 @@ namespace System.IO.Pipes.Tests
         [InlineData(PipeOptions.None)]
         [InlineData(PipeOptions.Asynchronous)]
         [PlatformSpecific(TestPlatforms.Windows)] // Unix currently doesn't support message mode
-        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public async Task Windows_MessagePipeTransissionMode(PipeOptions serverOptions)
         {
             byte[] msg1 = new byte[] { 5, 7, 9, 10 };
@@ -170,7 +169,6 @@ namespace System.IO.Pipes.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // Unix doesn't support MaxNumberOfServerInstances
-        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public async Task Windows_Get_NumberOfServerInstances_Succeed()
         {
             string pipeName = GetUniquePipeName();
@@ -193,7 +191,6 @@ namespace System.IO.Pipes.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // Win32 P/Invokes to verify the user name
-        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public async Task Windows_GetImpersonationUserName_Succeed()
         {
             string pipeName = GetUniquePipeName();
@@ -281,7 +278,6 @@ namespace System.IO.Pipes.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // Unix implementation uses bidirectional sockets
-        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public static void Windows_BufferSizeRoundtripping()
         {
             int desiredBufferSize = 10;
@@ -310,7 +306,6 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
-        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public void PipeTransmissionMode_Returns_Byte()
         {
             using (ServerClientPair pair = CreateServerClientPair())
@@ -322,7 +317,6 @@ namespace System.IO.Pipes.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // Unix doesn't currently support message mode
-        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public void Windows_SetReadModeTo__PipeTransmissionModeByte()
         {
             string pipeName = GetUniquePipeName();
@@ -404,7 +398,6 @@ namespace System.IO.Pipes.Tests
         [Theory]
         [InlineData(PipeDirection.Out, PipeDirection.In)]
         [InlineData(PipeDirection.In, PipeDirection.Out)]
-        [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
         public void InvalidReadMode_Throws_ArgumentOutOfRangeException(PipeDirection serverDirection, PipeDirection clientDirection)
         {
             string pipeName = GetUniquePipeName();

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Write.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Write.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace System.IO.Pipes.Tests
 {
-    [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
+    [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
     public class NamedPipeTest_Write_ServerOut_ClientIn : PipeTest_Write
     {
         protected override ServerClientPair CreateServerClientPair()
@@ -27,8 +27,8 @@ namespace System.IO.Pipes.Tests
             return ret;
         }
     }
-
-    [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
+    
+    [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
     public class NamedPipeTest_Write_ServerIn_ClientOut : PipeTest_Write
     {
         protected override ServerClientPair CreateServerClientPair()
@@ -47,8 +47,8 @@ namespace System.IO.Pipes.Tests
             return ret;
         }
     }
-
-    [ActiveIssue(21392, TargetFrameworkMonikers.Uap)]
+    
+    [ActiveIssue(22271, TargetFrameworkMonikers.UapNotUapAot)]
     public class NamedPipeTest_Write_ServerInOut_ClientInOut : PipeTest_Write
     {
         protected override ServerClientPair CreateServerClientPair()

--- a/src/System.IO.Pipes/tests/PipeTestBase.cs
+++ b/src/System.IO.Pipes/tests/PipeTestBase.cs
@@ -80,7 +80,14 @@ namespace System.IO.Pipes.Tests
         /// <returns></returns>
         protected static string GetUniquePipeName()
         {
-            return Path.GetRandomFileName();
+            if (PlatformDetection.IsWinRT)
+            {
+                return @"LOCAL\" + Path.GetRandomFileName();
+            }
+            else
+            {
+                return Path.GetRandomFileName();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #21392 
Opens #22271 

cc: @JeremyKuhne @stephentoub 

 - Fix NamedPipes tests when running in AppContainer so that they use Local as a prefix
 - Disable tests that depend on WaitNamedPipe since there was a regression after RS1 on kernel32.dll. I have validated that the fix that will com on RS3  will pass all of the tests disabled by this PR.