### PR TITLE
Disable incompatible test on macos high sierra.

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.AcceptAllCerts.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.AcceptAllCerts.cs
@@ -38,7 +38,11 @@ namespace System.Net.Http.Functional.Tests
             using (var handler = new HttpClientHandler() { ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator })
             using (var client = new HttpClient(handler))
             {
-                if (requestOnlyThisProtocol)
+                // Refer issue: #22089
+                // When the server uses SslProtocols.Tls, on MacOS, SecureTransport ends up picking a cipher suite
+                // for TLS1.2, even though server said it was only using TLS1.0. LibreSsl throws error that
+                // wrong cipher is used for TLs1.0.
+                if (requestOnlyThisProtocol || (PlatformDetection.IsMacOsHighSierra && acceptedProtocol == SslProtocols.Tls))
                 {
                     handler.SslProtocols = acceptedProtocol;
                 }


### PR DESCRIPTION
cc @bartonjs @stephentoub 

With jeremy's fix on managedhandler test, this test will fail on master as well.