### PR TITLE
Implementing Stream.*Async overrides in HttpResponseStream/HttpRequestStream

### DIFF
--- a/src/System.Net.HttpListener/src/System/Net/HttpRequestStream.cs
+++ b/src/System.Net.HttpListener/src/System/Net/HttpRequestStream.cs
@@ -65,6 +65,19 @@ namespace System.Net
 
             return BeginReadCore(buffer, offset, size, callback, state);
         }
+        
+        public new Task<int> ReadAsync(Byte[] buffer, int offset, int count)
+        {
+            return ReadAsync(buffer, offset, count, CancellationToken.None);
+        }
+        
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int size, CancellationToken cancellationToken)
+        {
+            return Task<int>.Factory.FromAsync(
+                (callback, state) => this.BeginRead(buffer, offset, size, callback, state),
+                iar => this.EndRead(iar),
+                null);
+        }
 
         public override void Flush() { }
         public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
@@ -89,6 +102,19 @@ namespace System.Net
         }
 
         public override void EndWrite(IAsyncResult asyncResult) => throw new InvalidOperationException(SR.net_readonlystream);
+        
+        public new Task WriteAsync(Byte[] buffer, int offset, int size)
+        {
+            return WriteAsync(buffer, offset, size, CancellationToken.None);
+        }
+        
+        public override Task WriteAsync(byte[] buffer, int offset, int size, CancellationToken cancellationToken)
+        {
+            return Task.Factory.FromAsync(
+                (callback, state) => this.BeginWrite(buffer, offset, size, callback, state),
+                iar => this.EndWrite(iar),
+                null);
+        }
 
         internal bool Closed => _closed;
 

--- a/src/System.Net.HttpListener/src/System/Net/HttpResponseStream.cs
+++ b/src/System.Net.HttpListener/src/System/Net/HttpResponseStream.cs
@@ -41,17 +41,12 @@ namespace System.Net
 
         public override int EndRead(IAsyncResult asyncResult) => throw new InvalidOperationException(SR.net_writeonlystream);
         
-        public new Task<int> ReadAsync(Byte[] buffer, int offset, int count)
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            return ReadAsync(buffer, offset, count, CancellationToken.None);
-        }
-        
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int size, CancellationToken cancellationToken)
-        {
-            return Task<int>.Factory.FromAsync(
-                (callback, state) => this.BeginRead(buffer, offset, size, callback, state),
-                iar => this.EndRead(iar),
-                null);
+            return Task.Factory.FromAsync(
+                (localBuffer, localOffset, localCount, callback, state) => ((Stream)state).BeginRead(localBuffer, localOffset, localCount, callback, state),
+                iar => ((Stream)iar.AsyncState).EndRead(iar),
+                buffer, offset, count, this);
         }
 
         public override void Write(byte[] buffer, int offset, int size)
@@ -116,17 +111,12 @@ namespace System.Net
             EndWriteCore(asyncResult);
         }
         
-        public new Task WriteAsync(Byte[] buffer, int offset, int size)
-        {
-            return WriteAsync(buffer, offset, size, CancellationToken.None);
-        }
-        
-        public override Task WriteAsync(byte[] buffer, int offset, int size, CancellationToken cancellationToken)
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             return Task.Factory.FromAsync(
-                (callback, state) => this.BeginWrite(buffer, offset, size, callback, state),
-                iar => this.EndWrite(iar),
-                null);
+                (localBuffer, localOffset, localCount, callback, state) => ((Stream)state).BeginWrite(localBuffer, localOffset, localCount, callback, state),
+                iar => ((Stream)iar.AsyncState).EndWrite(iar),
+                buffer, offset, count, this);
         }
 
         protected override void Dispose(bool disposing)

--- a/src/System.Net.HttpListener/src/System/Net/HttpResponseStream.cs
+++ b/src/System.Net.HttpListener/src/System/Net/HttpResponseStream.cs
@@ -40,6 +40,19 @@ namespace System.Net
         }
 
         public override int EndRead(IAsyncResult asyncResult) => throw new InvalidOperationException(SR.net_writeonlystream);
+        
+        public new Task<int> ReadAsync(Byte[] buffer, int offset, int count)
+        {
+            return ReadAsync(buffer, offset, count, CancellationToken.None);
+        }
+        
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int size, CancellationToken cancellationToken)
+        {
+            return Task<int>.Factory.FromAsync(
+                (callback, state) => this.BeginRead(buffer, offset, size, callback, state),
+                iar => this.EndRead(iar),
+                null);
+        }
 
         public override void Write(byte[] buffer, int offset, int size)
         {
@@ -101,6 +114,19 @@ namespace System.Net
             }
 
             EndWriteCore(asyncResult);
+        }
+        
+        public new Task WriteAsync(Byte[] buffer, int offset, int size)
+        {
+            return WriteAsync(buffer, offset, size, CancellationToken.None);
+        }
+        
+        public override Task WriteAsync(byte[] buffer, int offset, int size, CancellationToken cancellationToken)
+        {
+            return Task.Factory.FromAsync(
+                (callback, state) => this.BeginWrite(buffer, offset, size, callback, state),
+                iar => this.EndWrite(iar),
+                null);
         }
 
         protected override void Dispose(bool disposing)

--- a/src/System.Net.HttpListener/tests/HttpRequestStreamTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpRequestStreamTests.cs
@@ -379,7 +379,6 @@ namespace System.Net.Tests
             }
         }
 
-        [ActiveIssue(22066, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public async Task CanWrite_Get_ReturnsFalse()
         {

--- a/src/System.Net.HttpListener/tests/HttpResponseStreamTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpResponseStreamTests.cs
@@ -137,7 +137,6 @@ namespace System.Net.Tests
             }
         }
 
-        [ActiveIssue(22110, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public async Task SimpleRequest_WriteSynchronouslyInParts_Succeeds()
         {
@@ -167,7 +166,6 @@ namespace System.Net.Tests
             }
         }
 
-        [ActiveIssue(22110, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public async Task SimpleRequest_WriteAynchronouslyEmpty_Succeeds()
         {
@@ -232,7 +230,6 @@ namespace System.Net.Tests
             }
         }
 
-        [ActiveIssue(22066, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public async Task CanRead_Get_ReturnsFalse()
         {
@@ -285,7 +282,6 @@ namespace System.Net.Tests
             }
         }
 
-        [ActiveIssue(22110, TargetFrameworkMonikers.UapAot)]
         [Theory]
         [InlineData(0, 3)]
         [InlineData(1, 2)]
@@ -539,7 +535,6 @@ namespace System.Net.Tests
             }
         }
 
-        [ActiveIssue(22110, TargetFrameworkMonikers.UapAot)]
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
@@ -553,7 +548,6 @@ namespace System.Net.Tests
             }
         }
 
-        [ActiveIssue(22110, TargetFrameworkMonikers.UapAot)]
         [Fact]
         public async Task EndWrite_InvalidAsyncResult_ThrowsArgumentException()
         {


### PR DESCRIPTION
Fixes #22066
Contributes to #22110

For #22110: 
HttpResponseStreamTests will pass on my machine without hanging after my changes; however, HttpRequestStreamTests will still hang.
As @CIPop [has mentioned, ](https://github.com/dotnet/corefx/issues/22110#issuecomment-315476167)it's hard to diagnose the hang because we can't trace.