### PR TITLE
Fixes for CollectionDataContract in ReflectionOnly Mode.

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CollectionDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CollectionDataContract.cs
@@ -465,9 +465,14 @@ namespace System.Runtime.Serialization
             _helper.IncrementCollectionCount(xmlWriter, obj, context);
         }
 
-        internal IEnumerator GetEnumeratorForCollection(object obj, out Type enumeratorReturnType)
+        internal IEnumerator GetEnumeratorForCollection(object obj)
         {
-            return _helper.GetEnumeratorForCollection(obj, out enumeratorReturnType);
+            return _helper.GetEnumeratorForCollection(obj);
+        }
+
+        internal Type GetCollectionElementType()
+        {
+            return _helper.GetCollectionElementType();
         }
 
         private class CollectionDataContractCriticalHelper : DataContract.DataContractCriticalHelper
@@ -840,7 +845,7 @@ namespace System.Runtime.Serialization
 
             private CreateGenericDictionaryEnumeratorDelegate _createGenericDictionaryEnumeratorDelegate;
 
-            internal IEnumerator GetEnumeratorForCollection(object obj, out Type enumeratorReturnType)
+            internal IEnumerator GetEnumeratorForCollection(object obj)
             {
                 IEnumerator enumerator = ((IEnumerable)obj).GetEnumerator();
                 if (Kind == CollectionKind.GenericDictionary)
@@ -859,55 +864,57 @@ namespace System.Runtime.Serialization
                     enumerator = new DictionaryEnumerator(((IDictionary)obj).GetEnumerator());
                 }
 
-                enumeratorReturnType = EnumeratorReturnType;
-
                 return enumerator;
             }
 
-            private Type _enumeratorReturnType;
-
-            public Type EnumeratorReturnType
+            internal Type GetCollectionElementType()
             {
-                get
-                {
-                    _enumeratorReturnType = _enumeratorReturnType ?? GetCollectionEnumeratorReturnType();
-                    return _enumeratorReturnType;
-                }
-            }
-
-            private Type GetCollectionEnumeratorReturnType()
-            {
-                Type enumeratorReturnType;
+                Type enumeratorType = null;
                 if (Kind == CollectionKind.GenericDictionary)
                 {
-                    var keyValueTypes = ItemType.GetGenericArguments();
-                    enumeratorReturnType =  Globals.TypeOfKeyValue.MakeGenericType(keyValueTypes);
+                    Type[] keyValueTypes = ItemType.GetGenericArguments();
+                    enumeratorType = Globals.TypeOfGenericDictionaryEnumerator.MakeGenericType(keyValueTypes);
                 }
                 else if (Kind == CollectionKind.Dictionary)
                 {
-
-                    enumeratorReturnType = Globals.TypeOfObject;
-                }
-                else if (Kind == CollectionKind.GenericCollection
-                      || Kind == CollectionKind.GenericList)
-                {
-                    enumeratorReturnType = ItemType;
+                    enumeratorType = Globals.TypeOfDictionaryEnumerator;
                 }
                 else
                 {
-                    var enumeratorType = GetEnumeratorMethod.ReturnType;
-                    if (enumeratorType.IsGenericType)
+                    enumeratorType = GetEnumeratorMethod.ReturnType;
+                }
+
+                MethodInfo getCurrentMethod = enumeratorType.GetMethod(Globals.GetCurrentMethodName, BindingFlags.Instance | BindingFlags.Public, Array.Empty<Type>());
+                if (getCurrentMethod == null)
+                {
+                    if (enumeratorType.IsInterface)
                     {
-                        MethodInfo getCurrentMethod = enumeratorType.GetMethod(Globals.GetCurrentMethodName, BindingFlags.Instance | BindingFlags.Public, Array.Empty<Type>());
-                        enumeratorReturnType = getCurrentMethod.ReturnType;
+                        getCurrentMethod = XmlFormatGeneratorStatics.GetCurrentMethod;
                     }
                     else
                     {
-                        enumeratorReturnType = Globals.TypeOfObject;
+                        Type ienumeratorInterface = Globals.TypeOfIEnumerator;
+                        if (Kind == CollectionKind.GenericDictionary || Kind == CollectionKind.GenericCollection || Kind == CollectionKind.GenericEnumerable)
+                        {
+                            Type[] interfaceTypes = enumeratorType.GetInterfaces();
+                            foreach (Type interfaceType in interfaceTypes)
+                            {
+                                if (interfaceType.IsGenericType
+                                    && interfaceType.GetGenericTypeDefinition() == Globals.TypeOfIEnumeratorGeneric
+                                    && interfaceType.GetGenericArguments()[0] == ItemType)
+                                {
+                                    ienumeratorInterface = interfaceType;
+                                    break;
+                                }
+                            }
+                        }
+
+                        getCurrentMethod = GetTargetMethodWithName(Globals.GetCurrentMethodName, enumeratorType, ienumeratorInterface);
                     }
                 }
 
-                return enumeratorReturnType;
+                Type elementType = getCurrentMethod.ReturnType;
+                return elementType;
             }
 
             private static MethodInfo s_buildCreateGenericDictionaryEnumerator;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/ReflectionJsonFormatWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/ReflectionJsonFormatWriter.cs
@@ -54,8 +54,7 @@ namespace System.Runtime.Serialization.Json
             {
                 collectionContract.IncrementCollectionCount(jsonWriter, obj, context);
 
-                Type enumeratorReturnType;
-                IEnumerator enumerator = collectionContract.GetEnumeratorForCollection(obj, out enumeratorReturnType);
+                IEnumerator enumerator = collectionContract.GetEnumeratorForCollection(obj);
 
                 bool canWriteSimpleDictionary = collectionContract.Kind == CollectionKind.GenericDictionary
                                              || collectionContract.Kind == CollectionKind.Dictionary;
@@ -82,7 +81,7 @@ namespace System.Runtime.Serialization.Json
                 {
                     ReflectionWriteArrayAttribute(jsonWriter);
 
-                    PrimitiveDataContract primitiveContractForType = PrimitiveDataContract.GetPrimitiveDataContract(enumeratorReturnType);
+                    PrimitiveDataContract primitiveContractForType = PrimitiveDataContract.GetPrimitiveDataContract(collectionContract.UnderlyingType);
                     if (primitiveContractForType != null && primitiveContractForType.UnderlyingType != Globals.TypeOfObject)
                     {
                         while (enumerator.MoveNext())
@@ -94,7 +93,17 @@ namespace System.Runtime.Serialization.Json
                     }
                     else
                     {
+                        Type elementType = collectionContract.GetCollectionElementType();
                         bool isDictionary = collectionContract.Kind == CollectionKind.Dictionary || collectionContract.Kind == CollectionKind.GenericDictionary;
+
+                        DataContract itemContract = null;
+                        JsonDataContract jsonDataContract = null;
+                        if (isDictionary)
+                        {
+                            itemContract = XmlObjectSerializerWriteContextComplexJson.GetRevisedItemContract(collectionContract.ItemContract);
+                            jsonDataContract = JsonDataContract.GetJsonDataContract(itemContract);
+                        }
+
                         while (enumerator.MoveNext())
                         {
                             object current = enumerator.Current;
@@ -102,14 +111,11 @@ namespace System.Runtime.Serialization.Json
                             _reflectionClassWriter.ReflectionWriteStartElement(jsonWriter, itemName);
                             if (isDictionary)
                             {
-                                var itemContract = XmlObjectSerializerWriteContextComplexJson.GetRevisedItemContract(collectionContract.ItemContract);
-                                var jsonDataContract = JsonDataContract.GetJsonDataContract(itemContract);
-
                                 jsonDataContract.WriteJsonValue(jsonWriter, current, context, collectionContract.ItemType.TypeHandle);
                             }
                             else
                             {
-                                _reflectionClassWriter.ReflectionWriteValue(jsonWriter, context, enumeratorReturnType, current, false, primitiveContractForParamType: null);
+                                _reflectionClassWriter.ReflectionWriteValue(jsonWriter, context, elementType, current, false, primitiveContractForParamType: null);
                             }
 
                             _reflectionClassWriter.ReflectionWriteEndElement(jsonWriter);

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ReflectionXmlFormatWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ReflectionXmlFormatWriter.cs
@@ -50,9 +50,8 @@ namespace System.Runtime.Serialization
             {
                 collectionDataContract.IncrementCollectionCount(xmlWriter, obj, context);
 
-                Type enumeratorReturnType;
-                IEnumerator enumerator = collectionDataContract.GetEnumeratorForCollection(obj, out enumeratorReturnType);
-                PrimitiveDataContract primitiveContractForType = PrimitiveDataContract.GetPrimitiveDataContract(enumeratorReturnType);
+                IEnumerator enumerator = collectionDataContract.GetEnumeratorForCollection(obj);
+                PrimitiveDataContract primitiveContractForType = PrimitiveDataContract.GetPrimitiveDataContract(collectionDataContract.UnderlyingType);
 
                 if (primitiveContractForType != null && primitiveContractForType.UnderlyingType != Globals.TypeOfObject)
                 {
@@ -65,26 +64,7 @@ namespace System.Runtime.Serialization
                 }
                 else
                 {
-                    Type enumeratorType = null;
-                    Type[] keyValueTypes = null;
-                    if (collectionDataContract.Kind == CollectionKind.GenericDictionary)
-                    {
-                        keyValueTypes = collectionDataContract.ItemType.GetGenericArguments();
-                        enumeratorType = Globals.TypeOfGenericDictionaryEnumerator.MakeGenericType(keyValueTypes);
-                    }
-                    else if (collectionDataContract.Kind == CollectionKind.Dictionary)
-                    {
-                        keyValueTypes = new Type[] { Globals.TypeOfObject, Globals.TypeOfObject };
-                        enumeratorType = Globals.TypeOfDictionaryEnumerator;
-                    }
-                    else
-                    {
-                        enumeratorType = collectionDataContract.GetEnumeratorMethod.ReturnType;
-                    }
-
-                    MethodInfo getCurrentMethod = enumeratorType.GetMethod(Globals.GetCurrentMethodName, BindingFlags.Instance | BindingFlags.Public, Array.Empty<Type>());
-                    Type elementType = getCurrentMethod.ReturnType;
-
+                    Type elementType = collectionDataContract.GetCollectionElementType();
                     bool isDictionary = collectionDataContract.Kind == CollectionKind.Dictionary || collectionDataContract.Kind == CollectionKind.GenericDictionary;
                     while (enumerator.MoveNext())
                     {

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatGeneratorStatics.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatGeneratorStatics.cs
@@ -103,7 +103,7 @@ namespace System.Runtime.Serialization
             {
                 if (s_ienumeratorGetCurrentMethod == null)
                 {
-                    s_ienumeratorGetCurrentMethod = typeof(IEnumerator).GetProperty("Current").GetMethod;
+                    s_ienumeratorGetCurrentMethod = typeof(IEnumerator).GetProperty("Current").GetGetMethod();
                     Debug.Assert(s_ienumeratorGetCurrentMethod != null);
                 }
                 return s_ienumeratorGetCurrentMethod;


### PR DESCRIPTION
PR #21688 uncovered a few issues with CollectionDataContract in ReflectionOnly mode. The PR is to fix those issues. See the tests in [DCS_BasicPerSerializerRoundTripAndCompare_SampleTypes_FailInReflectionOnly](https://github.com/dotnet/corefx/pull/21688/files#diff-842d4b05f36c1089c037e1b2e53908ecR3479).

The PR fixed the following issues:
1. When writing collection object the element type of the collection was not correctly set, which caused the type info was not correctly written in the payload. Test type: `SampleListTExplicitWithoutDC`. The fix is ported from `XmlFormatWriterGenerator.CriticalHelper.WriteCollection`.
2. DCS couldn't correctly de-serialize generic dictionary in certain cases. Test type: `MyGenericIDictionaryKVContainsPublicDC`.
3. DCS couldn't de-serialize collection type with private `Add` method. Test type: `CDC_PrivateAdd`.
4. DCS couldn't de-serialize collection type with private constructor. Test type: `CDC_PrivateDefaultCtor`.

With the PR, the tests in that method should all pass.

