### PR TITLE
Have Microsoft.CSharp correctly handle statically-typed interface types' inherited methods

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -670,7 +670,7 @@ namespace Microsoft.CSharp.RuntimeBinder
 
             // If we have a constructor, only find its type.
             bool bIsConstructor = name == NameManager.GetPredefinedName(PredefinedName.PN_CTOR);
-            for (AggregateType t = callingType; t != null; t = t.GetBaseClass())
+            foreach(AggregateType t in callingType.TypeHierarchy)
             {
                 if (_symbolTable.AggregateContainsMethod(t.GetOwningAggregate(), Name, mask))
                 {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/AggregateType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/AggregateType.cs
@@ -61,6 +61,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     {
                         yield return iface;
                     }
+
+                    yield return getAggregate().GetTypeManager().ObjectAggregateType;
                 }
                 else
                 {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/AggregateType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/AggregateType.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
@@ -47,6 +48,28 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             return _baseType ??
                 (_baseType = getAggregate().GetTypeManager().SubstType(getAggregate().GetBaseClass(), GetTypeArgsAll()) as AggregateType);
+        }
+
+        public IEnumerable<AggregateType> TypeHierarchy
+        {
+            get
+            {
+                if (isInterfaceType())
+                {
+                    yield return this;
+                    foreach (AggregateType iface in GetIfacesAll().Items)
+                    {
+                        yield return iface;
+                    }
+                }
+                else
+                {
+                    for (AggregateType agg = this; agg != null; agg = agg.GetBaseClass())
+                    {
+                        yield return agg;
+                    }
+                }
+            }
         }
 
         public void SetTypeArgsThis(TypeArray pTypeArgsThis)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -1231,6 +1231,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return false;
         }
 
+        public AggregateType ObjectAggregateType => (AggregateType)_symbolTable.GetCTypeFromType(typeof(object));
+
         private readonly Dictionary<Tuple<Assembly, Assembly>, bool> _internalsVisibleToCalculated
             = new Dictionary<Tuple<Assembly, Assembly>, bool>();
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
@@ -307,21 +307,27 @@ namespace Microsoft.CSharp.RuntimeBinder
         {
             List<Type> list = new List<Type>();
             list.Insert(0, type);
-            for (Type parent = type.BaseType; parent != null; parent = parent.BaseType)
-            {
-                // Load it in the symbol table.
-                LoadSymbolsFromType(parent);
-
-                // Insert into our list of Types.
-                list.Insert(0, parent);
-            }
-
             if (type.IsInterface)
             {
                 foreach (Type iface in type.GetInterfaces())
                 {
                     LoadSymbolsFromType(iface);
                     list.Insert(0, iface);
+                }
+
+                Type obj = typeof(object);
+                LoadSymbolsFromType(obj);
+                list.Insert(0, obj);
+            }
+            else
+            {
+                for (Type parent = type.BaseType; parent != null; parent = parent.BaseType)
+                {
+                    // Load it in the symbol table.
+                    LoadSymbolsFromType(parent);
+
+                    // Insert into our list of Types.
+                    list.Insert(0, parent);
                 }
             }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
@@ -221,9 +221,9 @@ namespace Microsoft.CSharp.RuntimeBinder
         {
             IEnumerable<MemberInfo> result = Array.Empty<MemberInfo>();
 
-            foreach (Type t in inheritance)
+            for (int i = inheritance.Count - 1; i >= 0; --i)
             {
-                Type type = t;
+                Type type = inheritance[i];
                 if (type.IsGenericType)
                 {
                     type = type.GetGenericTypeDefinition();
@@ -305,29 +305,36 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         private List<Type> CreateInheritanceHierarchyList(Type type)
         {
-            List<Type> list = new List<Type>();
-            list.Insert(0, type);
+            List<Type> list;
             if (type.IsInterface)
             {
+                Type[] ifaces = type.GetInterfaces();
+
+                // Since IsWindowsRuntimeType() is rare, this is probably the final size
+                list = new List<Type>(ifaces.Length + 2)
+                {
+                    type
+                };
                 foreach (Type iface in type.GetInterfaces())
                 {
                     LoadSymbolsFromType(iface);
-                    list.Insert(0, iface);
+                    list.Add(iface);
                 }
 
                 Type obj = typeof(object);
                 LoadSymbolsFromType(obj);
-                list.Insert(0, obj);
+                list.Add(obj);
             }
             else
             {
+                list = new List<Type> { type };
                 for (Type parent = type.BaseType; parent != null; parent = parent.BaseType)
                 {
                     // Load it in the symbol table.
                     LoadSymbolsFromType(parent);
 
                     // Insert into our list of Types.
-                    list.Insert(0, parent);
+                    list.Add(parent);
                 }
             }
 
@@ -344,7 +351,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                     Debug.Assert(collectionType.isInterfaceType());
 
                     // Insert into our list of Types.
-                    list.Insert(0, collectionType.AssociatedSystemType);
+                    list.Add(collectionType.AssociatedSystemType);
                 }
             }
             return list;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
@@ -316,6 +316,15 @@ namespace Microsoft.CSharp.RuntimeBinder
                 list.Insert(0, parent);
             }
 
+            if (type.IsInterface)
+            {
+                foreach (Type iface in type.GetInterfaces())
+                {
+                    LoadSymbolsFromType(iface);
+                    list.Insert(0, iface);
+                }
+            }
+
             // If we have a WinRT type then we should load the members of it's collection interfaces
             // as well as those members are on this type as far as the user is concerned.
             CType ctype = GetCTypeFromType(type);
@@ -2015,6 +2024,10 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         internal void AddConversionsForType(Type type)
         {
+            if (type.IsInterface)
+            {
+                AddConversionsForOneType(type);
+            }
             for (Type t = type; t.BaseType != null; t = t.BaseType)
             {
                 AddConversionsForOneType(t);

--- a/src/Microsoft.CSharp/tests/RuntimeBinderTests.cs
+++ b/src/Microsoft.CSharp/tests/RuntimeBinderTests.cs
@@ -128,5 +128,42 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
             Assert.Equal(1, dynamicDelegate(dto));
         }
 
+        interface ITestInterface
+        {
+            int this[int index] { get; }
+
+            int Add(int arg);
+        }
+
+        interface ITestDerived : ITestInterface
+        {
+            
+        }
+
+        class TestImpl : ITestDerived
+        {
+            public int this[int index] => index * 2;
+
+            public int Add(int arg) => arg + 2;
+        }
+
+        [Fact]
+        public void InheritedInterfaceMethod()
+        {
+            ITestDerived itd = new TestImpl();
+            dynamic d = 3;
+            dynamic res = itd.Add(d);
+            Assert.Equal(5, res);
+        }
+
+
+        [Fact]
+        public void InheritedInterfaceIndexer()
+        {
+            ITestDerived itd = new TestImpl();
+            dynamic d = 3;
+            dynamic res = itd[d];
+            Assert.Equal(6, res);
+        }
     }
 }

--- a/src/Microsoft.CSharp/tests/RuntimeBinderTests.cs
+++ b/src/Microsoft.CSharp/tests/RuntimeBinderTests.cs
@@ -165,5 +165,14 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
             dynamic res = itd[d];
             Assert.Equal(6, res);
         }
+
+        [Fact]
+        public void InterfaceMethodInheritedFromObject()
+        {
+            ITestDerived itd = new TestImpl();
+            dynamic d = itd;
+            dynamic res = itd.Equals(d);
+            Assert.True(res);
+        }
     }
 }


### PR DESCRIPTION
### Include base interfaces on lookup when dynamic is an argument to a call

When a variable is statically typed to an interface type that implements another interface and an inherited method or indexer is called with a dynamic argument, then the method or indexer will not be found by the binder.

Change both the initial adding of methods to the table, and the subsequent lookup, to fix this.

Fixes #14752

### Include `System.Object` as base of interfaces on lookup when dynamic is an argument to a call

When a variable is statically typed to an interface and the `Equals` method inherited from `object` is called with a dynamic argument, then the method will not be found by the binder.

Change both the initial adding of methods to the table, and the subsequent lookup, to fix this.

Fixes #22300

Also optimise `CreateInheritanceHierarchyList` so it makes fewer copies internal to `List<Type>`.