### PR TITLE
Skip asserts in Http SSL test on macOS

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Net.Security;
 using System.Net.Test.Common;
+using System.Runtime.InteropServices;
 using System.Security.Authentication.ExtendedProtection;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
@@ -157,7 +158,12 @@ namespace System.Net.Http.Functional.Tests
                     Assert.NotNull(request);
 
                     X509ChainStatusFlags flags = chain.ChainStatus.Aggregate(X509ChainStatusFlags.NoError, (cur, status) => cur | status.Status);
-                    Assert.True(errors == SslPolicyErrors.None, $"Expected {SslPolicyErrors.None}, got {errors} with chain status {flags}");
+                    bool ignoreErrors = // https://github.com/dotnet/corefx/issues/21922#issuecomment-315555237
+                        RuntimeInformation.IsOSPlatform(OSPlatform.OSX) &&
+                        checkRevocation &&
+                        errors == SslPolicyErrors.RemoteCertificateChainErrors &&
+                        flags == X509ChainStatusFlags.RevocationStatusUnknown;
+                    Assert.True(ignoreErrors || errors == SslPolicyErrors.None, $"Expected {SslPolicyErrors.None}, got {errors} with chain status {flags}");
 
                     Assert.True(chain.ChainElements.Count > 0);
                     Assert.NotEmpty(cert.Subject);


### PR DESCRIPTION
Closes https://github.com/dotnet/corefx/issues/21922
cc: @bartonjs 