### PR TITLE
Remove paths for types being anonymous from Microsoft.CSharp

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/MessageID.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/MessageID.cs
@@ -21,7 +21,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
         GlobalNamespace,
         MethodGroup,
         AnonMethod,
-        Lambda,
-        AnonymousType,
+        Lambda
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
@@ -441,11 +441,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                             // Found a nice name.
                             ErrAppendString(text);
                         }
-                        else if (sym.AsAggregateSymbol().IsAnonymousType())
-                        {
-                            ErrAppendId(MessageID.AnonymousType);
-                            break;
-                        }
                         else
                         {
                             ErrAppendParentSym(sym, pctx);
@@ -542,11 +537,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                         {
                             // Found a nice name.
                             ErrAppendString(text);
-                        }
-                        else if (pAggType.getAggregate().IsAnonymousType())
-                        {
-                            ErrAppendPrintf("AnonymousType#{0}", GetTypeID(pAggType));
-                            break;
                         }
                         else
                         {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
@@ -425,7 +425,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 {
                     BindGrpConversion(memGrp, dest, true);
                 }
-                else if (!TypeManager.TypeContainsAnonymousTypes(dest) && canCast(expr.Type, dest, flags))
+                else if (canCast(expr.Type, dest, flags))
                 {
                     // can't convert, but explicit exists and can be specified by the user (no anonymous types).
                     ErrorContext.Error(ErrorCode.ERR_NoImplicitConvCast, new ErrArg(expr.Type, ErrArgFlags.Unique), new ErrArg(dest, ErrArgFlags.Unique));

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/AggregateSymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/AggregateSymbol.cs
@@ -74,7 +74,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         private bool _isSkipUDOps; // Never check for user defined operators on this type (eg, decimal, string, delegate).
 
-        private bool _isAnonymousType;    // true if the class is an anonymous type
         // When this is unset we don't know if we have conversions.  When this 
         // is set it indicates if this type or any base type has user defined 
         // conversion operators
@@ -228,18 +227,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public bool IsStatic()
         {
             return (_isAbstract && _isSealed);
-        }
-
-
-
-        public bool IsAnonymousType()
-        {
-            return _isAnonymousType;
-        }
-
-        public void SetAnonymousType(bool isAnonymousType)
-        {
-            _isAnonymousType = isAnonymousType;
         }
 
         public bool IsAbstract()

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Visitors/ExpressionTreeRewriter.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Visitors/ExpressionTreeRewriter.cs
@@ -946,15 +946,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Expr constructorInfo = GetExprFactory().CreateMethodInfo(expr.MethWithInst);
             Expr args = GenerateArgsList(expr.OptionalArguments);
             Expr Params = GenerateParamsArray(args, PredefinedType.PT_EXPRESSION);
-            if (expr.Type.IsAggregateType() && expr.Type.AsAggregateType().getAggregate().IsAnonymousType())
-            {
-                Expr members = GenerateMembersArray(expr.Type.AsAggregateType(), PredefinedType.PT_METHODINFO);
-                return GenerateCall(PREDEFMETH.PM_EXPRESSION_NEW_MEMBERS, constructorInfo, Params, members);
-            }
-            else
-            {
-                return GenerateCall(PREDEFMETH.PM_EXPRESSION_NEW, constructorInfo, Params);
-            }
+            return GenerateCall(PREDEFMETH.PM_EXPRESSION_NEW, constructorInfo, Params);
         }
 
         private Expr GenerateDelegateConstructor(ExprCall expr)
@@ -1124,36 +1116,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             ExprConstant paramsArrayArg = GetExprFactory().CreateIntegerConstant(parameterCount);
             ExprArrayInit arrayInit = GetExprFactory().CreateArrayInit(EXPRFLAG.EXF_CANTBENULL, paramsArrayType, args, paramsArrayArg, null);
             arrayInit.DimensionSize = parameterCount;
-            arrayInit.DimensionSizes = new int[] { arrayInit.DimensionSize }; // CLEANUP: Why isn't this done by the factory?
-            return arrayInit;
-        }
-
-        private ExprArrayInit GenerateMembersArray(AggregateType anonymousType, PredefinedType pt)
-        {
-            Expr newArgs = null;
-            Expr newArgsTail = newArgs;
-            int methodCount = 0;
-            AggregateSymbol aggSym = anonymousType.getAggregate();
-
-            for (Symbol member = aggSym.firstChild; member != null; member = member.nextChild)
-            {
-                if (member.IsMethodSymbol())
-                {
-                    MethodSymbol method = member.AsMethodSymbol();
-                    if (method.MethKind() == MethodKindEnum.PropAccessor)
-                    {
-                        ExprMethodInfo methodInfo = GetExprFactory().CreateMethodInfo(method, anonymousType, method.Params);
-                        GetExprFactory().AppendItemToList(methodInfo, ref newArgs, ref newArgsTail);
-                        methodCount++;
-                    }
-                }
-            }
-
-            AggregateType paramsArrayElementType = GetSymbolLoader().GetOptPredefTypeErr(pt, true);
-            ArrayType paramsArrayType = GetSymbolLoader().GetTypeManager().GetArray(paramsArrayElementType, 1, true);
-            ExprConstant paramsArrayArg = GetExprFactory().CreateIntegerConstant(methodCount);
-            ExprArrayInit arrayInit = GetExprFactory().CreateArrayInit(EXPRFLAG.EXF_CANTBENULL, paramsArrayType, newArgs, paramsArrayArg, null);
-            arrayInit.DimensionSize = methodCount;
             arrayInit.DimensionSizes = new int[] { arrayInit.DimensionSize }; // CLEANUP: Why isn't this done by the factory?
             return arrayInit;
         }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -72,59 +72,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
         }
 
-        public static bool TypeContainsAnonymousTypes(CType type)
-        {
-            CType ctype = (CType)type;
-
-        LRecurse:  // Label used for "tail" recursion.
-            switch (ctype.GetTypeKind())
-            {
-                default:
-                    Debug.Assert(false, "Bad Symbol kind in TypeContainsAnonymousTypes");
-                    return false;
-
-                case TypeKind.TK_NullType:
-                case TypeKind.TK_VoidType:
-                case TypeKind.TK_NullableType:
-                case TypeKind.TK_TypeParameterType:
-                case TypeKind.TK_UnboundLambdaType:
-                case TypeKind.TK_MethodGroupType:
-                    return false;
-
-                case TypeKind.TK_ArrayType:
-                case TypeKind.TK_ParameterModifierType:
-                case TypeKind.TK_PointerType:
-                    ctype = (CType)ctype.GetBaseOrParameterOrElementType();
-                    goto LRecurse;
-
-                case TypeKind.TK_AggregateType:
-                    if (ctype.AsAggregateType().getAggregate().IsAnonymousType())
-                    {
-                        return true;
-                    }
-
-                    TypeArray typeArgsAll = ctype.AsAggregateType().GetTypeArgsAll();
-                    for (int i = 0; i < typeArgsAll.Count; i++)
-                    {
-                        CType typeArg = typeArgsAll[i];
-
-                        if (TypeContainsAnonymousTypes(typeArg))
-                        {
-                            return true;
-                        }
-                    }
-                    return false;
-
-                case TypeKind.TK_ErrorType:
-                    if (ctype.AsErrorType().HasTypeParent())
-                    {
-                        ctype = ctype.AsErrorType().GetTypeParent();
-                        goto LRecurse;
-                    }
-                    return false;
-            }
-        }
-
         private sealed class StdTypeVarColl
         {
             private readonly List<TypeParameterType> prgptvs;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
@@ -1101,7 +1101,6 @@ namespace Microsoft.CSharp.RuntimeBinder
                 }
             }
 
-            agg.SetAnonymousType(false);
             agg.SetAbstract(type.IsAbstract);
 
             {


### PR DESCRIPTION
Since in running code no types are anonymous (though they may have unspeakable names), `SetAnonymousType` is only ever called with `false`.

Remove `_isAnonymousType` and all branches for it being true, including `TypeContainsAnonymousTypes` (only branches returning true is removed or depends on recursive call hitting removed branch) and `GenerateMembersArray` (never hit).