### PR TITLE
Remove "Missing" name check in Microsoft.CSharp.RuntimeBinder.Semantics.SymFactoryBase

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorHandling.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorHandling.cs
@@ -106,8 +106,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
             int piarg = 0;
             int cargUnique = 0;
 
-            _userStringBuilder.ResetUndisplayableStringFlag();
-
             for (int iarg = 0; iarg < parameterizedError.GetParameterCount(); iarg++)
             {
                 ErrArg arg = parameterizedError.GetParameter(iarg);
@@ -139,15 +137,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                 }
                 prgiarg[piarg] = iargRec;
                 piarg++;
-            }
-
-            // don't ever display undisplayable strings to the user
-            // if this happens we should track down the caller to not display the error
-            // this should only ever occur in a cascading error situation due to
-            // error tolerance
-            if (_userStringBuilder.HadUndisplayableString())
-            {
-                return null;
             }
 
             int cpsz = ppsz;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
@@ -12,7 +12,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
 {
     internal sealed class UserStringBuilder
     {
-        private bool fHadUndisplayableStringInError;
         private bool m_buildingInProgress;
         private GlobalSymbolContext m_globalSymbols;
         private StringBuilder m_strBuilder;
@@ -21,7 +20,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
             GlobalSymbolContext globalSymbols)
         {
             Debug.Assert(globalSymbols != null);
-            fHadUndisplayableStringInError = false;
             m_buildingInProgress = false;
             m_globalSymbols = globalSymbols;
         }
@@ -39,17 +37,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
             m_buildingInProgress = false;
             s = m_strBuilder.ToString();
             m_strBuilder = null;
-        }
-
-
-        public bool HadUndisplayableString()
-        {
-            return fHadUndisplayableStringInError;
-        }
-
-        public void ResetUndisplayableStringFlag()
-        {
-            fHadUndisplayableStringInError = false;
         }
 
         private void ErrSK(out string psz, SYMKIND sk)
@@ -146,8 +133,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
         }
         private void ErrAppendName(Name name)
         {
-            CheckDisplayableName(name);
-
             if (name == NameManager.GetPredefinedName(PredefinedName.PN_INDEXERINTERNAL))
             {
                 ErrAppendString("this");
@@ -766,19 +751,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
             }
 
             return result;
-        }
-
-        private bool IsDisplayableName(Name name)
-        {
-            return name != NameManager.GetPredefinedName(PredefinedName.PN_MISSING);
-        }
-
-        private void CheckDisplayableName(Name name)
-        {
-            if (!IsDisplayableName(name))
-            {
-                fHadUndisplayableStringInError = true;
-            }
         }
 
         private NameManager GetNameManager()

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/LangCompiler.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/LangCompiler.cs
@@ -53,13 +53,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         // particular method.
         public void SubmitError(CParameterizedError error)
         {
-            CError pError = GetErrorContext().RealizeError(error);
-
-            if (pError == null)
-            {
-                return;
-            }
-            _pController.SubmitError(pError);
+            _pController.SubmitError(GetErrorContext().RealizeError(error));
         }
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
@@ -185,8 +185,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     }
 
                     Name pErrorTypeName = _pFixedResults[iParam].AsErrorType().nameText;
-                    if (pErrorTypeName != null &&
-                        pErrorTypeName != NameManager.GetPredefinedName(PredefinedName.PN_MISSING))
+                    if (pErrorTypeName != null)
                     {
                         continue;
                     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/MiscSymFactory.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/MiscSymFactory.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         // Constructor.
 
         public MiscSymFactory(SYMTBL symtable)
-            : base(symtable, false)
+            : base(symtable)
         {
         }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymFactory.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymFactory.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     internal sealed class SymFactory : SymFactoryBase
     {
         public SymFactory(SYMTBL symtable) :
-            base(symtable, true)
+            base(symtable)
         {
         }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymFactoryBase.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymFactoryBase.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using Microsoft.CSharp.RuntimeBinder.Syntax;
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
@@ -13,23 +14,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     internal abstract class SymFactoryBase
     {
         // Members.
-        private SYMTBL m_pSymTable;
-        private Name m_pMissingNameNode;
-        private Name m_pMissingNameSym;
-
+        private readonly SYMTBL m_pSymTable;
         protected Symbol newBasicSym(
             SYMKIND kind,
             Name name,
             ParentSymbol parent)
         {
-            // The parser creates names with PN_MISSING when attempting to recover from errors
-            // To prevent spurious errors, we create SYMs with a different name (PN_MISSINGSYM)
-            // so that they are never found when doing lookup.
-            if (name == m_pMissingNameNode)
-            {
-                name = m_pMissingNameSym;
-            }
-
             Symbol sym;
             switch (kind)
             {
@@ -102,15 +92,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         }
 
         // This class should never be created on its own.
-        protected SymFactoryBase(SYMTBL symtable, bool loadNames)
+        protected SymFactoryBase(SYMTBL symtable)
         {
             m_pSymTable = symtable;
-
-            if (loadNames)
-            {
-                m_pMissingNameNode = NameManager.GetPredefinedName(PredefinedName.PN_MISSING);
-                m_pMissingNameSym = NameManager.GetPredefinedName(PredefinedName.PN_MISSINGSYM);
-            }
         }
     }
 }


### PR DESCRIPTION
This name is never produced, except to create tests for it having been produced. (We can't have a parser error if our source isn't a parser).