### PR TITLE
Mark several System.Data types with 'partial' keyword

### DIFF
--- a/src/System.Data.Odbc/src/System/Data/Odbc/OdbcFactory.cs
+++ b/src/System.Data.Odbc/src/System/Data/Odbc/OdbcFactory.cs
@@ -6,7 +6,7 @@ using System.Data.Common;
 
 namespace System.Data.Odbc
 {
-    public sealed class OdbcFactory : DbProviderFactory
+    public sealed partial class OdbcFactory : DbProviderFactory
     {
         public static readonly OdbcFactory Instance = new OdbcFactory();
 

--- a/src/System.Data.SqlClient/src/System/Data/Sql/SqlMetaData.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Sql/SqlMetaData.cs
@@ -22,7 +22,7 @@ namespace Microsoft.SqlServer.Server
     //        2) Inferring type from a value.
     //        3) Adjusting a value to match the metadata.
 
-    public sealed class SqlMetaData
+    public sealed partial class SqlMetaData
     {
         private string _strName;
         private long _lMaxLength;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlClientFactory.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlClientFactory.cs
@@ -6,7 +6,7 @@ using System.Data.Common;
 
 namespace System.Data.SqlClient
 {
-    public sealed class SqlClientFactory : DbProviderFactory
+    public sealed partial class SqlClientFactory : DbProviderFactory
     {
         public static readonly SqlClientFactory Instance = new SqlClientFactory();
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
@@ -17,7 +17,7 @@ using Microsoft.SqlServer.Server;
 
 namespace System.Data.SqlClient
 {
-    public sealed class SqlCommand : DbCommand, ICloneable
+    public sealed partial class SqlCommand : DbCommand, ICloneable
     {
         private string _commandText;
         private CommandType _commandType;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionStringBuilder.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionStringBuilder.cs
@@ -12,7 +12,7 @@ using System.Linq;
 
 namespace System.Data.SqlClient
 {
-    public sealed class SqlConnectionStringBuilder : DbConnectionStringBuilder
+    public sealed partial class SqlConnectionStringBuilder : DbConnectionStringBuilder
     {
         private enum Keywords
         { // specific ordering for ConnectionString output construction

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlException.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlException.cs
@@ -16,7 +16,7 @@ using System.Text; // StringBuilder
 
 namespace System.Data.SqlClient
 {
-    public sealed class SqlException : System.Data.Common.DbException
+    public sealed partial class SqlException : System.Data.Common.DbException
     {
         private const string OriginalClientConnectionIdKey = "OriginalClientConnectionId";
         private const string RoutingDestinationKey = "RoutingDestination";


### PR DESCRIPTION
As part of https://github.com/mono/mono/pull/4893
we need these types to be `partial` in order to add some missing members 