### PR TITLE
Microsoft.CSharp: Catch passing non-type as type for bound static call

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Error.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Error.cs
@@ -53,6 +53,9 @@ namespace Microsoft.CSharp.RuntimeBinder
             return new RuntimeBinderException(SR.BindInvokeFailedNonDelegate);
         }
 
+        internal static Exception BindStaticRequiresType(string paramName) =>
+            new ArgumentException(SR.TypeArgumentRequiredForStaticCall, paramName);
+
         internal static Exception BindBinaryAssignmentFailedNullReference()
         {
             return new RuntimeBinderException(SR.BindBinaryAssignmentFailedNullReference);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -384,8 +384,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                 type = arguments[0].Value as Type;
                 if (type == null)
                 {
-                    Debug.Assert(false, "Cannot make static call without specifying a type");
-                    throw Error.InternalCompilerError();
+                    throw Error.BindStaticRequiresType(arguments[0].Info.Name);
                 }
             }
             else
@@ -843,11 +842,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             if (payload.StaticCall)
             {
                 Type t = arguments[0].Value as Type;
-                if (t == null)
-                {
-                    Debug.Assert(false, "Cannot make static call without specifying a type");
-                    throw Error.InternalCompilerError();
-                }
+                Debug.Assert(t != null); // Would have thrown in PopulateSymbolTableWithPayloadInformation already
 
                 callingObject = _exprFactory.CreateClass(_symbolTable.GetCTypeFromType(t), t.ContainsGenericParameters ?
                         _exprFactory.CreateTypeArguments(SymbolLoader.getBSymmgr().AllocParams(_symbolTable.GetCTypeArrayFromTypes(t.GetGenericArguments())), null) : null);

--- a/src/Microsoft.CSharp/src/Resources/Strings.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.resx
@@ -433,4 +433,7 @@
   <data name="NamedArgumentUsedInPositional" xml:space="preserve">
     <value>Named argument '{0}' specifies a parameter for which a positional argument has already been given</value>
   </data>
+  <data name="TypeArgumentRequiredForStaticCall" xml:space="preserve">
+    <value>The first argument to dynamically-bound static call must be a Type</value>
+  </data>
 </root>

--- a/src/Microsoft.CSharp/tests/RuntimeBinderExceptionTests.cs
+++ b/src/Microsoft.CSharp/tests/RuntimeBinderExceptionTests.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Runtime.Serialization.Formatters.Tests;
 using Xunit;
@@ -43,6 +44,57 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
             Exception inner = new Exception("This is a test exception");
             RuntimeBinderException rbe = new RuntimeBinderException(message, inner);
             Assert.Same(inner, rbe.InnerException);
+        }
+
+        [Fact]
+        public void InstanceArgumentInsteadOfTypeForStaticCall()
+        {
+            CallSite<Func<CallSite, object, object, object, object>> site =
+                CallSite<Func<CallSite, object, object, object, object>>.Create(
+                    Binder.InvokeMember(
+                        CSharpBinderFlags.None, "Equals", null, GetType(),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.IsStaticType, null),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)
+                        }));
+            Func<CallSite, object, object, object, object> target = site.Target;
+            Assert.Throws<ArgumentException>(null, () => target.Invoke(site, "Ceci n'est pas un type", 2, 2));
+        }
+
+        [Fact]
+        public void InstanceArgumentInsteadOfTypeForStaticCallNamedArgument()
+        {
+            CallSite<Func<CallSite, object, object, object, object>> site =
+                CallSite<Func<CallSite, object, object, object, object>>.Create(
+                    Binder.InvokeMember(
+                        CSharpBinderFlags.None, "Equals", null, GetType(),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.IsStaticType, "Type Argument"),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)
+                        }));
+            Func<CallSite, object, object, object, object> target = site.Target;
+            Assert.Throws<ArgumentException>("Type Argument", () => target.Invoke(site, "Ceci n'est pas un type", 2, 2));
+        }
+
+        [Fact]
+        public void NullArgumentInsteadOfTypeForStaticCallNamedArgument()
+        {
+            CallSite<Func<CallSite, object, object, object, object>> site =
+                CallSite<Func<CallSite, object, object, object, object>>.Create(
+                    Binder.InvokeMember(
+                        CSharpBinderFlags.None, "Equals", null, GetType(),
+                        new[]
+                        {
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.IsStaticType, "Type Argument"),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
+                            CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)
+                        }));
+            Func<CallSite, object, object, object, object> target = site.Target;
+            Assert.Throws<ArgumentException>("Type Argument", () => target.Invoke(site, null, 2, 2));
         }
     }
 }


### PR DESCRIPTION
If something other than a `Type` is passed as the second argument (first after the `CallSite`) then catch this and throw an explanatory `ArgumentException`, rather than a `RuntimeBinderInternalCompilerException` describing it as "unexpected".

Also remove assertion this cannot happen, as it clearly can.

Conversely, replace check that would throw `RuntimeBinderInternalCompilerException` for this case in `CreateCallingObjectForCall` with just an assertion, as the above check will have happened before this point could be reached.

Fixes #22331