### PR TITLE
Enable reflection for DataflowEtwProvider and fix #20592.

### DIFF
--- a/src/System.Threading.Tasks.Dataflow/src/System.Threading.Tasks.Dataflow.csproj
+++ b/src/System.Threading.Tasks.Dataflow/src/System.Threading.Tasks.Dataflow.csproj
@@ -9,6 +9,8 @@
     <DefineConstants Condition="'$(TargetGroup)' == 'netstandard1.0'">$(DefineConstants);USE_INTERNAL_CONCURRENT_COLLECTIONS</DefineConstants>
     <DefineConstants Condition="'$(TargetGroup)' == 'netstandard1.0' OR '$(TargetGroup)' == 'netstandard1.1'">$(DefineConstants);USE_INTERNAL_THREADING</DefineConstants>
     <PackageTargetFramework Condition="'$(TargetGroup)' == 'netstandard1.1'">netstandard1.1;portable-net45+win8+wpa81</PackageTargetFramework>
+    <!-- To allow DataflowEtwProvider events -->
+    <BlockReflectionAttribute>false</BlockReflectionAttribute>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />

--- a/src/System.Threading.Tasks.Dataflow/tests/Dataflow/EtwTests.cs
+++ b/src/System.Threading.Tasks.Dataflow/tests/Dataflow/EtwTests.cs
@@ -11,7 +11,6 @@ namespace System.Threading.Tasks.Dataflow.Tests
     public class EtwTests : RemoteExecutorTestBase
     {
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/20592", TargetFrameworkMonikers.UapAot)]
         public void TestEtw()
         {
             RemoteInvoke(() =>


### PR DESCRIPTION
Disable reflection blocking for System.Threading.Tasks.Dataflow per Stephen's and Jan's recommendation in #22283.