### PR TITLE
Fixed issue #22229, where RSAKeyValue.LoadXml was throwing a CryptographicException when receiving a XmlElement with namespace prefix as input

### DIFF
--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/RSAKeyValue.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/RSAKeyValue.cs
@@ -106,10 +106,10 @@ namespace System.Security.Cryptography.Xml
             {
                 throw new ArgumentNullException(nameof(value));
             }
-            if (value.Name != KeyValueElementName
+            if (value.LocalName != KeyValueElementName
                 || value.NamespaceURI != SignedXml.XmlDsigNamespaceUrl)
             {
-                throw new CryptographicException($"Root element must be {KeyValueElementName} element in namepsace {SignedXml.XmlDsigNamespaceUrl}");
+                throw new CryptographicException($"Root element must be {KeyValueElementName} element in namespace {SignedXml.XmlDsigNamespaceUrl}");
             }
 
             const string xmlDsigNamespacePrefix = "dsig";

--- a/src/System.Security.Cryptography.Xml/tests/RSAKeyValueTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/RSAKeyValueTest.cs
@@ -82,6 +82,22 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        public void LoadXml_GetXml_With_NS_Prefix()
+        {
+            string rsaKeyWithPrefix = "<ds:KeyValue xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\"><ds:RSAKeyValue><ds:Modulus>ogZ1/O7iks9ncETqNxLDKoPvgrT4nFx1a3lOmpywEmgbc5+8vI5dSzReH4v0YrflY75rIJx13CYWMsaHfQ78GtXvaeshHlQ3lLTuSdYEJceKll/URlBoKQtOj5qYIVSFOIVGHv4Y/0lnLftOzIydem29KKH6lJQlJawBBssR12s=</ds:Modulus><ds:Exponent>AQAB</ds:Exponent></ds:RSAKeyValue></ds:KeyValue>";
+            string rsaKeyWithoutPrefix = "<KeyValue xmlns=\"http://www.w3.org/2000/09/xmldsig#\"><RSAKeyValue><Modulus>ogZ1/O7iks9ncETqNxLDKoPvgrT4nFx1a3lOmpywEmgbc5+8vI5dSzReH4v0YrflY75rIJx13CYWMsaHfQ78GtXvaeshHlQ3lLTuSdYEJceKll/URlBoKQtOj5qYIVSFOIVGHv4Y/0lnLftOzIydem29KKH6lJQlJawBBssR12s=</Modulus><Exponent>AQAB</Exponent></RSAKeyValue></KeyValue>";
+            XmlDocument doc = new XmlDocument();
+            doc.LoadXml(rsaKeyWithPrefix);
+
+            RSAKeyValue rsa1 = new RSAKeyValue();
+            rsa1.LoadXml(doc.DocumentElement);
+
+            string s = rsa1.GetXml().OuterXml;
+            //Comparing with rsaKeyWithoutPrefix because RSAKeyValue.GetXml().OuterXml returns the markup without the namespace prefixes
+            Assert.Equal(rsaKeyWithoutPrefix, s);
+        }
+
+        [Fact]
         public void LoadXml_Null()
         {
             RSAKeyValue rsa = new RSAKeyValue();


### PR DESCRIPTION
Fixed bug on element name check in RSAKeyValue which caused error when element had a namespace prefix; Implemented a test case.

Fixes #22229

[EDIT] Fixes #abc added by @karelz to [auto-close issue upon merge](https://help.github.com/articles/closing-issues-using-keywords/)