### PR TITLE
Throw PNSE on Ping.Send* in UWP

### DIFF
--- a/src/System.Net.Ping/src/Resources/Strings.resx
+++ b/src/System.Net.Ping/src/Resources/Strings.resx
@@ -85,4 +85,7 @@
   <data name="net_ipv6_not_installed" xml:space="preserve">
     <value>IPv6 is not installed.</value>
   </data>
+  <data name="net_ping_not_supported_uwp" xml:space="preserve">
+    <value>Ping functionality is not currently supported in UWP.</value>
+  </data>
 </root>

--- a/src/System.Net.Ping/src/System.Net.Ping.csproj
+++ b/src/System.Net.Ping/src/System.Net.Ping.csproj
@@ -94,7 +94,7 @@
   <ItemGroup Condition="'$(TargetsWindows)' == 'true' And '$(TargetGroup)' != 'uap'">
     <Compile Include="System\Net\NetworkInformation\Ping.Windows.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'uap'">
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true' And '$(TargetGroup)' == 'uap'">
     <Compile Include="System\Net\NetworkInformation\Ping.Windows.Uap.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">

--- a/src/System.Net.Ping/src/System.Net.Ping.csproj
+++ b/src/System.Net.Ping/src/System.Net.Ping.csproj
@@ -12,6 +12,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(TargetGroup)' == 'uap'">
+    <NoWarn>$(NoWarn);414</NoWarn>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Net\NetworkInformation\IPStatus.cs" />
     <Compile Include="System\Net\NetworkInformation\NetEventSource.Ping.cs" />
@@ -88,8 +91,13 @@
       <Link>Common\Interop\Unix\System.Native\Interop.SocketAddress.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetsWindows)' == 'true'">
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true' And '$(TargetGroup)' != 'uap'">
     <Compile Include="System\Net\NetworkInformation\Ping.Windows.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'uap'">
+    <Compile Include="System\Net\NetworkInformation\Ping.Windows.Uap.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
     <!-- System.Net Common -->
     <Compile Include="$(CommonPath)\System\Net\SocketAddressPal.Windows.cs">
       <Link>Common\System\Net\SocketAddressPal.Windows.cs</Link>

--- a/src/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Windows.Uap.cs
+++ b/src/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Windows.Uap.cs
@@ -17,6 +17,7 @@ namespace System.Net.NetworkInformation
         // We do not need to or want to capture such exceptions into the returned task.
         private Task<PingReply> SendPingAsyncCore(IPAddress address, byte[] buffer, int timeout, PingOptions options)
         {
+            // Win32 Icmp* APIs fail with E_ACCESSDENIED when called from UWP due to Windows OS limitations.
             throw new PlatformNotSupportedException(string.Format(CultureInfo.InvariantCulture,
                         SR.net_ping_not_supported_uwp));
         }

--- a/src/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Windows.Uap.cs
+++ b/src/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Windows.Uap.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Globalization;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Net.NetworkInformation
+{
+    public partial class Ping
+    {
+        // Any exceptions that escape synchronously will be caught by the caller and wrapped in a PingException.
+        // We do not need to or want to capture such exceptions into the returned task.
+        private Task<PingReply> SendPingAsyncCore(IPAddress address, byte[] buffer, int timeout, PingOptions options)
+        {
+            throw new PlatformNotSupportedException(string.Format(CultureInfo.InvariantCulture,
+                        SR.net_ping_not_supported_uwp));
+        }
+    }
+}


### PR DESCRIPTION
Win32 Icmp* APIs fail with E_ACCESSDENIED when called from UWP due to Windows OS limitations. Ping will not work on UWP in this OS release, so I'm updating Ping.Send* to throw PNSE instead of E_ACCESSDENIED for now.

Contributes to #19583