### PR TITLE
Make httplistener test project build separately for each OS config.

### DIFF
--- a/src/System.Net.HttpListener/tests/Configurations.props
+++ b/src/System.Net.HttpListener/tests/Configurations.props
@@ -2,7 +2,9 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
-      netstandard;
+      netcoreapp-OSX;
+      netcoreapp-Unix;
+      netcoreapp-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Net.HttpListener/tests/System.Net.HttpListener.Tests.csproj
+++ b/src/System.Net.HttpListener/tests/System.Net.HttpListener.Tests.csproj
@@ -38,7 +38,7 @@
     <EmbeddedResource Include="Resources\System.Net.HttpListener.Tests.rd.xml" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsOSX)'=='true'">
-    <TestCommandLines Include="ulimit -n 70000" />
+    <TestCommandLines Include="ulimit -n 7000" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
cc @MattGal 