### PR TITLE
Update tests for pending whitespace trimming changes 

### DIFF
--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -351,7 +351,7 @@ namespace System.IO.Tests
             MemberData(nameof(NonControlWhiteSpace))]
         [PlatformSpecific(TestPlatforms.Windows)]  // trailing whitespace in path is removed on Windows
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)] // Not NetFX
-        [ActiveIssue(21358, "Pending CoreCLR behavior change")]
+        [ActiveIssue(21358)] // Pending CoreCLR behavior change
         public void TrailingWhiteSpace_NotTrimmed(string component)
         {
             // In CoreFX we don't trim anything other than space (' ')

--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -333,11 +333,42 @@ namespace System.IO.Tests
         }
 
         [Theory,
-            MemberData(nameof(WhiteSpace))]
+            MemberData(nameof(ControlWhiteSpace))]
         [PlatformSpecific(TestPlatforms.Windows)]  // trailing whitespace in path is removed on Windows
-        public void WindowsTrailingWhiteSpace(string component)
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)] // e.g. NetFX only
+        public void TrailingWhiteSpace_Trimmed(string component)
         {
-            // Windows will remove all non-significant whitespace in a path
+            // On desktop, we trim a number of whitespace characters 
+            DirectoryInfo testDir = Create(GetTestFilePath());
+            string path = IOServices.RemoveTrailingSlash(testDir.FullName) + component;
+            DirectoryInfo result = Create(path);
+
+            Assert.True(Directory.Exists(result.FullName));
+            Assert.Equal(testDir.FullName, IOServices.RemoveTrailingSlash(result.FullName));
+        }
+
+        [Theory,
+            MemberData(nameof(NonControlWhiteSpace))]
+        [PlatformSpecific(TestPlatforms.Windows)]  // trailing whitespace in path is removed on Windows
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)] // Not NetFX
+        [ActiveIssue(21358, "Pending CoreCLR behavior change")]
+        public void TrailingWhiteSpace_NotTrimmed(string component)
+        {
+            // In CoreFX we don't trim anything other than space (' ')
+            DirectoryInfo testDir = Create(GetTestFilePath() + component);
+            string path = IOServices.RemoveTrailingSlash(testDir.FullName);
+            DirectoryInfo result = Create(path);
+
+            Assert.True(Directory.Exists(result.FullName));
+            Assert.Equal(testDir.FullName, IOServices.RemoveTrailingSlash(result.FullName));
+        }
+
+        [Theory,
+            MemberData(nameof(SimpleWhiteSpace))] //*Just Spaces*
+        [PlatformSpecific(TestPlatforms.Windows)]  // trailing whitespace in path is removed on Windows
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)] // Not NetFX
+        public void TrailingSpace_NotTrimmed(string component)
+        {
             DirectoryInfo testDir = Create(GetTestFilePath());
             string path = IOServices.RemoveTrailingSlash(testDir.FullName) + component;
             DirectoryInfo result = Create(path);

--- a/src/System.IO.FileSystem/tests/Directory/Exists.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Exists.cs
@@ -280,7 +280,7 @@ namespace System.IO.Tests
 
         [Theory,
             MemberData(nameof(NonControlWhiteSpace))]
-        [ActiveIssue(21358, "Pending CoreCLR behavior change")]
+        [ActiveIssue(21358)] // Pending CoreCLR behavior change
         [PlatformSpecific(TestPlatforms.Windows)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)] // not NetFX
         public void NonControlWhiteSpaceExists(string component)

--- a/src/System.IO.FileSystem/tests/Directory/Exists.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Exists.cs
@@ -266,20 +266,41 @@ namespace System.IO.Tests
             Assert.True(Exists(testDir.FullName));
         }
 
-        [ConditionalTheory(nameof(UsingNewNormalization)),
-            MemberData(nameof(WhiteSpace))]
-        [ActiveIssue(20117, TargetFrameworkMonikers.Uap)]
-        [PlatformSpecific(TestPlatforms.Windows)] // In Windows, trailing whitespace in a path is trimmed appropriately
-        public void TrailingWhitespaceExistence_WhiteSpace(string component)
+        [Theory,
+            MemberData(nameof(ControlWhiteSpace))]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)] // e.g. NetFX only
+        public void ControlWhiteSpaceExists(string component)
         {
-            // This test relies on \\?\ support
-
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
 
             string path = testDir.FullName + component;
-            Assert.True(Exists(path), path); // string concat in case Path.Combine() trims whitespace before Exists gets to it
-            Assert.False(Exists(IOInputs.ExtendedPrefix + path), path);
+            Assert.True(Exists(path), "directory with control whitespace should exist");
+        }
 
+        [Theory,
+            MemberData(nameof(NonControlWhiteSpace))]
+        [ActiveIssue(21358, "Pending CoreCLR behavior change")]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)] // not NetFX
+        public void NonControlWhiteSpaceExists(string component)
+        {
+            DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath() + component);
+
+            string path = testDir.FullName;
+            Assert.True(Exists(path), "directory with non control whitespace should exist");
+        }
+
+        [Theory,
+            MemberData(nameof(SimpleWhiteSpace))] // *Just spaces*
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void TrailingSpaceExists(string component)
+        {
+            // Windows trims spaces
+            string path = GetTestFilePath();
+            DirectoryInfo testDir = Directory.CreateDirectory(path + component);
+            Assert.True(Exists(path), "can find without space");
+            Assert.True(Exists(path + component), "can find with space");
         }
 
         [Theory,

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/CreateSubdirectory.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/CreateSubdirectory.cs
@@ -8,7 +8,6 @@ namespace System.IO.Tests
 {
     public class DirectoryInfo_CreateSubDirectory : FileSystemTest
     {
-        public static TheoryData ControlWhiteSpace = IOInputs.GetControlWhiteSpace().ToTheoryData(); 
         #region UniversalTests
 
         [Fact]

--- a/src/System.IO.FileSystem/tests/File/Exists.cs
+++ b/src/System.IO.FileSystem/tests/File/Exists.cs
@@ -190,16 +190,46 @@ namespace System.IO.Tests
         }
 
         [Theory,
-            MemberData(nameof(WhiteSpace))]
+            MemberData(nameof(ControlWhiteSpace))]
         [PlatformSpecific(TestPlatforms.Windows)] // In Windows, trailing whitespace in a path is trimmed
-        public void TrimTrailingWhitespacePath(string component)
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)] // e.g. NetFX only
+        public void TrailingWhiteSpace_Trimmed(string component)
+        {
+            // On desktop, we trim a number of whitespace characters 
+            FileInfo testFile = new FileInfo(GetTestFilePath());
+            testFile.Create().Dispose();
+
+            // Exists calls GetFullPath() which trims trailing white space
+            Assert.True(Exists(testFile.FullName + component)); 
+        }
+
+        [Theory,
+           MemberData(nameof(NonControlWhiteSpace))]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)] // Not NetFX
+        [ActiveIssue(21358, "Pending CoreCLR behavior change")]
+        public void TrailingWhiteSpace_NotTrimmed(string component)
+        {
+            // In CoreFX we don't trim anything other than space (' ')
+            string path = GetTestFilePath() + component;
+            FileInfo testFile = new FileInfo(path);
+            testFile.Create().Dispose();
+
+            Assert.True(Exists(path));
+        }
+
+        [Theory,
+           MemberData(nameof(SimpleWhiteSpace))] //*Just* spaces
+        [PlatformSpecific(TestPlatforms.Windows)] // In Windows, trailing whitespace in a path is trimmed
+        public void TrailingSpace_Trimmed(string component)
         {
             FileInfo testFile = new FileInfo(GetTestFilePath());
             testFile.Create().Dispose();
 
-            Assert.True(Exists(testFile.FullName + component)); // string concat in case Path.Combine() trims whitespace before Exists gets to it
-
+            // Windows will trim trailing spaces
+            Assert.True(Exists(testFile.FullName + component));
         }
+
 
         [Theory,
             MemberData(nameof(PathsWithAlternativeDataStreams))]

--- a/src/System.IO.FileSystem/tests/File/Exists.cs
+++ b/src/System.IO.FileSystem/tests/File/Exists.cs
@@ -207,7 +207,7 @@ namespace System.IO.Tests
            MemberData(nameof(NonControlWhiteSpace))]
         [PlatformSpecific(TestPlatforms.Windows)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)] // Not NetFX
-        [ActiveIssue(21358, "Pending CoreCLR behavior change")]
+        [ActiveIssue(21358)] // Pending CoreCLR behavior change
         public void TrailingWhiteSpace_NotTrimmed(string component)
         {
             // In CoreFX we don't trim anything other than space (' ')

--- a/src/System.IO.FileSystem/tests/FileSystemTest.cs
+++ b/src/System.IO.FileSystem/tests/FileSystemTest.cs
@@ -30,6 +30,8 @@ namespace System.IO.Tests
         public static TheoryData PathsWithReservedDeviceNames = IOInputs.GetPathsWithReservedDeviceNames().ToTheoryData();
         public static TheoryData PathsWithAlternativeDataStreams = IOInputs.GetPathsWithAlternativeDataStreams().ToTheoryData();
         public static TheoryData PathsWithComponentLongerThanMaxComponent = IOInputs.GetPathsWithComponentLongerThanMaxComponent().ToTheoryData();
+        public static TheoryData ControlWhiteSpace = IOInputs.GetControlWhiteSpace().ToTheoryData();
+        public static TheoryData NonControlWhiteSpace = IOInputs.GetNonControlWhiteSpace().ToTheoryData();
 
         /// <summary>
         /// In some cases (such as when running without elevated privileges),

--- a/src/System.IO.FileSystem/tests/PortedCommon/IOInputs.cs
+++ b/src/System.IO.FileSystem/tests/PortedCommon/IOInputs.cs
@@ -51,6 +51,17 @@ internal static class IOInputs
         yield return "V1.0.0.0000";
     }
 
+    // These are the WhiteSpace characters we used to trim for paths:
+    //
+    //  (char)0x9,          // Horizontal tab     '\t'
+    //  (char)0xA,          // Line feed          '\n'
+    //  (char)0xB,          // Vertical tab       '\v'
+    //  (char)0xC,          // Form feed          '\f'
+    //  (char)0xD,          // Carriage return    '\r'
+    //  (char)0x20,         // Space              ' '
+    //  (char)0x85,         // Next line          '\u0085'
+    //  (char)0xA0          // Non breaking space '\u00A0'
+
     public static IEnumerable<string> GetControlWhiteSpace()
     {
         yield return "\t";
@@ -63,6 +74,8 @@ internal static class IOInputs
         yield return "\t\n\t\n";
         yield return "\n\t\n";
         yield return "\n\t\n\t";
+        // Add other control chars
+        yield return "\v\f\r";
     }
 
     public static IEnumerable<string> GetSimpleWhiteSpace()
@@ -74,6 +87,32 @@ internal static class IOInputs
         yield return "     ";
     }
 
+    /// <summary>
+    /// Whitespace characters that arent in the traditional control set (e.g. less than 0x20)
+    /// and aren't space (e.g. 0x20).
+    /// </summary>
+    public static IEnumerable<string> GetNonControlWhiteSpace()
+    {
+        yield return "\u0085"; // Next Line (.NET used to trim)
+        yield return "\u00A0"; // Non breaking space (.NET used to trim)
+        yield return "\u2028"; // Line separator
+        yield return "\u2029"; // Paragraph separator
+        yield return "\u2003"; // EM space
+        yield return "\u2008"; // Punctuation space
+    }
+
+    /// <summary>
+    /// Whitespace characters other than space (includes some Unicode whitespace characters we
+    /// did not traditionally trim.
+    /// </summary>
+    public static IEnumerable<string> GetNonSpaceWhiteSpace()
+    {
+        return GetControlWhiteSpace().Concat(GetNonControlWhiteSpace());
+    }
+
+    /// <summary>
+    /// This is the Whitespace we used to trim from paths
+    /// </summary>
     public static IEnumerable<string> GetWhiteSpace()
     {
         return GetControlWhiteSpace().Concat(GetSimpleWhiteSpace());

--- a/src/System.Runtime.Extensions/tests/System/IO/PathTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/PathTests.cs
@@ -48,7 +48,7 @@ namespace System.IO.Tests
         [InlineData("\u00A0")] // Non-breaking Space
         [InlineData("\u2028")] // Line separator
         [InlineData("\u2029")] // Paragraph separator
-        [ActiveIssue(21358, "Pending CoreCLR behavior change")]
+        [ActiveIssue(21358)] // Pending CoreCLR behavior change
         public static void GetDirectoryName_NonControl(string path)
         {
             Assert.Equal(string.Empty, Path.GetDirectoryName(path));
@@ -58,7 +58,7 @@ namespace System.IO.Tests
         [InlineData("\u00A0")] // Non-breaking Space
         [InlineData("\u2028")] // Line separator
         [InlineData("\u2029")] // Paragraph separator
-        [ActiveIssue(21358, "Pending CoreCLR behavior change")]
+        [ActiveIssue(21358)] // Pending CoreCLR behavior change
         public static void GetDirectoryName_NonControlWithSeparator(string path)
         {
             Assert.Equal(path, Path.GetDirectoryName(Path.Combine(path, path)));
@@ -441,7 +441,7 @@ namespace System.IO.Tests
         [InlineData("\u00A0")] // Non breaking space
         [InlineData("\u2028")] // Line separator
         [PlatformSpecific(TestPlatforms.Windows)]
-        [ActiveIssue(21358, "Pending CoreCLR behavior change")]
+        [ActiveIssue(21358)] // Pending CoreCLR behavior change
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)] // not NetFX
         public static void GetFullPath_NonControlWhiteSpaceStays(string component)
         {

--- a/src/System.Runtime.Extensions/tests/System/IO/PathTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/PathTests.cs
@@ -45,6 +45,26 @@ namespace System.IO.Tests
         }
 
         [Theory]
+        [InlineData("\u00A0")] // Non-breaking Space
+        [InlineData("\u2028")] // Line separator
+        [InlineData("\u2029")] // Paragraph separator
+        [ActiveIssue(21358, "Pending CoreCLR behavior change")]
+        public static void GetDirectoryName_NonControl(string path)
+        {
+            Assert.Equal(string.Empty, Path.GetDirectoryName(path));
+        }
+
+        [Theory]
+        [InlineData("\u00A0")] // Non-breaking Space
+        [InlineData("\u2028")] // Line separator
+        [InlineData("\u2029")] // Paragraph separator
+        [ActiveIssue(21358, "Pending CoreCLR behavior change")]
+        public static void GetDirectoryName_NonControlWithSeparator(string path)
+        {
+            Assert.Equal(path, Path.GetDirectoryName(Path.Combine(path, path)));
+        }
+
+        [Theory]
         [InlineData(null, null)]
         [InlineData(".", "")]
         [InlineData("..", "")]
@@ -416,8 +436,33 @@ namespace System.IO.Tests
             }
         }
 
-        [Fact]
+        [Theory]
+        [InlineData("\u0085")] // Next line
+        [InlineData("\u00A0")] // Non breaking space
+        [InlineData("\u2028")] // Line separator
+        [PlatformSpecific(TestPlatforms.Windows)]
+        [ActiveIssue(21358, "Pending CoreCLR behavior change")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)] // not NetFX
+        public static void GetFullPath_NonControlWhiteSpaceStays(string component)
+        {
+            // When not NetFX full path should not cut off component
+            string path = "C:\\Test" + component;
+            Assert.Equal(path, Path.GetFullPath(path));
+        }
 
+        [Theory]
+        [InlineData(" ")]
+        [InlineData("  ")]
+        [InlineData("   ")]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public static void GetFullPath_TrailingSpaceCut(string component)
+        {
+            // Windows cuts off any simple white space added to a path
+            string path = "C:\\Test" + component;
+            Assert.Equal("C:\\Test", Path.GetFullPath(path));
+        }
+
+        [Fact]
         public static void GetFullPath_InvalidArgs()
         {
             Assert.Throws<ArgumentNullException>(() => Path.GetFullPath(null));


### PR DESCRIPTION
Update tests for pending whitespace trimming changes (see: https://github.com/dotnet/coreclr/pull/12862)