### PR TITLE
Validate the focus and scale parameters in managed code

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/Drawing2D/LinearGradientBrush.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Drawing2D/LinearGradientBrush.cs
@@ -303,6 +303,11 @@ namespace System.Drawing.Drawing2D
 
         public void SetSigmaBellShape(float focus, float scale)
         {
+            if (focus < 0 || focus > 1 || scale < 0 || scale > 1)
+            {
+                throw new ArgumentException(SR.Format(SR.GdiplusInvalidParameter));
+            }
+
             int status = SafeNativeMethods.Gdip.GdipSetLineSigmaBlend(new HandleRef(this, NativeBrush), focus, scale);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }
@@ -311,6 +316,11 @@ namespace System.Drawing.Drawing2D
 
         public void SetBlendTriangularShape(float focus, float scale)
         {
+            if (focus < 0 || focus > 1 || scale < 0 || scale > 1)
+            {
+                throw new ArgumentException(SR.Format(SR.GdiplusInvalidParameter));
+            }
+
             int status = SafeNativeMethods.Gdip.GdipSetLineLinearBlend(new HandleRef(this, NativeBrush), focus, scale);
             SafeNativeMethods.Gdip.CheckStatus(status);
         }

--- a/src/System.Drawing.Common/src/System/Drawing/Drawing2D/PathGradientBrush.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Drawing2D/PathGradientBrush.cs
@@ -334,6 +334,11 @@ namespace System.Drawing.Drawing2D
 
         public void SetSigmaBellShape(float focus, float scale)
         {
+            if (focus < 0 || focus > 1 || scale < 0 || scale > 1)
+            {
+                throw new ArgumentException(SR.Format(SR.GdiplusInvalidParameter));
+            }
+
             int status = SafeNativeMethods.Gdip.GdipSetPathGradientSigmaBlend(new HandleRef(this, NativeBrush), focus, scale);
 
             if (status != SafeNativeMethods.Gdip.Ok)
@@ -344,6 +349,11 @@ namespace System.Drawing.Drawing2D
 
         public void SetBlendTriangularShape(float focus, float scale)
         {
+            if (focus < 0 || focus > 1 || scale < 0 || scale > 1)
+            {
+                throw new ArgumentException(SR.Format(SR.GdiplusInvalidParameter));
+            }
+
             int status = SafeNativeMethods.Gdip.GdipSetPathGradientLinearBlend(new HandleRef(this, NativeBrush), focus, scale);
 
             if (status != SafeNativeMethods.Gdip.Ok)


### PR DESCRIPTION
Validate the focus and scale parameters in managed code, because libgdiplus does not validate them.
This would cause issues when using System.Drawing.Common on Linux or within Mono.