### PR TITLE
Fix test assertions for long paths

### DIFF
--- a/src/System.IO.FileSystem/tests/Directory/Move.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Move.cs
@@ -207,8 +207,8 @@ namespace System.IO.Tests
             Directory.CreateDirectory(testDir);
             Assert.All((IOInputs.GetPathsLongerThanMaxLongPath(GetTestFilePath())), (path) =>
             {
-                Assert.Throws<PathTooLongException>(() => Move(testDir, path));
-                Assert.Throws<PathTooLongException>(() => Move(path, testDir));
+                AssertExtensions.ThrowsAny<PathTooLongException, DirectoryNotFoundException>(() => Move(testDir, path));
+                AssertExtensions.ThrowsAny<PathTooLongException, DirectoryNotFoundException>(() => Move(path, testDir));
             });
         }
 

--- a/src/System.IO.FileSystem/tests/File/Move.cs
+++ b/src/System.IO.FileSystem/tests/File/Move.cs
@@ -215,9 +215,9 @@ namespace System.IO.Tests
 
             Assert.All(IOInputs.GetPathsLongerThanMaxLongPath(GetTestFilePath()), (path) =>
             {
-                Assert.Throws<PathTooLongException>(() => Move(testFileSource, path));
+                AssertExtensions.ThrowsAny<PathTooLongException, FileNotFoundException>(() => Move(testFileSource, path));
                 File.Delete(testFileSource);
-                Assert.Throws<PathTooLongException>(() => Move(path, testFileSource));
+                AssertExtensions.ThrowsAny<PathTooLongException, FileNotFoundException>(() => Move(path, testFileSource));
             });
         }
 


### PR DESCRIPTION
We don't preemptively check path length any more. The OS errors we
get back can either be PathTooLong or NotFound depending on the
environment and requested path.

See #22368