### PR TITLE
Fix remaining S.D.Process test issues

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -589,15 +589,22 @@ namespace System.Diagnostics.Tests
         [Fact]
         public void TestProcessStartTime()
         {
-            var p = CreateProcessPortable(RemotelyInvokable.Dummy);
+            var p = CreateProcessPortable(RemotelyInvokable.ReadLine);
 
             DateTime testStartTime = DateTime.Now;
+            p.StartInfo.RedirectStandardInput = true;
             p.Start();
-            p.WaitForExit();
+            Assert.Equal(p.StartTime, p.StartTime);
+            DateTime processStartTime = p.StartTime;
+            using (StreamWriter writer = p.StandardInput)
+            {
+                writer.WriteLine("start");
+            }
+
+            Assert.True(p.WaitForExit(WaitInMS));
             DateTime testEndTime = DateTime.Now;
 
-            Assert.Equal(p.StartTime, p.StartTime);
-            Assert.InRange(p.StartTime, testStartTime, testEndTime);
+            Assert.InRange(processStartTime, testStartTime, testEndTime);
         }
 
         [Fact]

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -589,6 +589,7 @@ namespace System.Diagnostics.Tests
         [Fact]
         public void TestProcessStartTime()
         {
+            TimeSpan allowedWindow = TimeSpan.FromSeconds(1);
             var p = CreateProcessPortable(RemotelyInvokable.ReadLine);
 
             DateTime testStartTime = DateTime.Now;
@@ -604,7 +605,7 @@ namespace System.Diagnostics.Tests
             Assert.True(p.WaitForExit(WaitInMS));
             DateTime testEndTime = DateTime.Now;
 
-            Assert.InRange(processStartTime, testStartTime, testEndTime);
+            Assert.InRange(processStartTime, testStartTime - allowedWindow, testEndTime + allowedWindow);
         }
 
         [Fact]

--- a/src/System.Diagnostics.Process/tests/RemotelyInvokable.cs
+++ b/src/System.Diagnostics.Process/tests/RemotelyInvokable.cs
@@ -87,6 +87,18 @@ namespace System.Diagnostics.Tests
             return SuccessExitCode;
         }
 
+        public static string WriteLineReadLineUapCmd()
+        {
+            return $"((echo Signal) && findstr -src:^Success$ && exit {SuccessExitCode}) || exit {SuccessExitCode + 1}";
+        }
+
+        public static int WriteLineReadLine()
+        {
+            Console.WriteLine("Signal");
+            string line = Console.ReadLine();
+            return line == "Success" ? SuccessExitCode : SuccessExitCode + 1;
+        }
+
         public static string ReadLineWriteIfNullUapCmd()
         {
             return $"(((findstr -src:^..*$) && (echo NOT_NULL)) || (echo NULL)) & exit {SuccessExitCode}";


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/22264
Fixes: https://github.com/dotnet/corefx/issues/22266
Fixes: https://github.com/dotnet/corefx/issues/22269
Fixes: https://github.com/dotnet/corefx/issues/22268

Some tests were not fully implementable in their current state on UAP but I have either refactored them (TestProcessStartTime) or added a new similar test case and disabled the old one (WaitForPeerProcess)