### PR TITLE
Make DataCommonEventSource members public on uapaot, since reflection needed for EventSource functionality is blocked in UAP for nonpublic members.

### DIFF
--- a/src/System.Data.Common/src/System/Data/Common/DataCommonEventSource.cs
+++ b/src/System.Data.Common/src/System/Data/Common/DataCommonEventSource.cs
@@ -8,65 +8,127 @@ using System.Threading;
 namespace System.Data
 {
     [EventSource(Name = "System.Data.DataCommonEventSource")]
-    internal class DataCommonEventSource : EventSource
+#if uapaot
+    public
+#else
+    internal
+#endif
+    class DataCommonEventSource : EventSource
     {
         internal static readonly DataCommonEventSource Log = new DataCommonEventSource();
         private static long s_nextScopeId = 0;
 
-        private const int TraceEventId = 1;
-        private const int EnterScopeId = 2;
-        private const int ExitScopeId = 3;
+#if uapaot
+        public
+#else
+        private
+#endif
+        const int TraceEventId = 1;
+
+#if uapaot
+        public
+#else
+        private
+#endif
+        const int EnterScopeId = 2;
+
+#if uapaot
+        public
+#else
+        private
+#endif
+        const int ExitScopeId = 3;
 
         [Event(TraceEventId, Level = EventLevel.Informational)]
-        internal void Trace(string message)
+#if uapaot
+        public
+#else
+        internal
+#endif
+        void Trace(string message)
         {
             WriteEvent(TraceEventId, message);
         }
 
         [NonEvent]
-        internal void Trace<T0>(string format, T0 arg0)
+#if uapaot
+        public
+#else
+        internal
+#endif
+        void Trace<T0>(string format, T0 arg0)
         {
             if (!Log.IsEnabled()) return;
             Trace(string.Format(format, arg0));
         }
 
         [NonEvent]
-        internal void Trace<T0, T1>(string format, T0 arg0, T1 arg1)
+#if uapaot
+        public
+#else
+        internal
+#endif
+        void Trace<T0, T1>(string format, T0 arg0, T1 arg1)
         {
             if (!Log.IsEnabled()) return;
             Trace(string.Format(format, arg0, arg1));
         }
 
         [NonEvent]
-        internal void Trace<T0, T1, T2>(string format, T0 arg0, T1 arg1, T2 arg2)
+#if uapaot
+        public
+#else
+        internal
+#endif
+        void Trace<T0, T1, T2>(string format, T0 arg0, T1 arg1, T2 arg2)
         {
             if (!Log.IsEnabled()) return;
             Trace(string.Format(format, arg0, arg1, arg2));
         }
 
         [NonEvent]
-        internal void Trace<T0, T1, T2, T3>(string format, T0 arg0, T1 arg1, T2 arg2, T3 arg3)
+#if uapaot
+        public
+#else
+        internal
+#endif
+        void Trace<T0, T1, T2, T3>(string format, T0 arg0, T1 arg1, T2 arg2, T3 arg3)
         {
             if (!Log.IsEnabled()) return;
             Trace(string.Format(format, arg0, arg1, arg2, arg3));
         }
 
         [NonEvent]
-        internal void Trace<T0, T1, T2, T3, T4>(string format, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+#if uapaot
+        public
+#else
+        internal
+#endif
+        void Trace<T0, T1, T2, T3, T4>(string format, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             if (!Log.IsEnabled()) return;
             Trace(string.Format(format, arg0, arg1, arg2, arg3, arg4));
         }
 
         [NonEvent]
-        internal void Trace<T0, T1, T2, T3, T4, T5, T6>(string format, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+#if uapaot
+        public
+#else
+        internal
+#endif
+        void Trace<T0, T1, T2, T3, T4, T5, T6>(string format, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             if (!Log.IsEnabled()) return;
             Trace(string.Format(format, arg0, arg1, arg2, arg3, arg4, arg5, arg6));
         }
 
         [Event(EnterScopeId, Level = EventLevel.Verbose)]
-        internal long EnterScope(string message)
+#if uapaot
+        public
+#else
+        internal
+#endif
+        long EnterScope(string message)
         {
             long scopeId = 0;
             if (Log.IsEnabled())
@@ -78,16 +140,44 @@ namespace System.Data
         }
 
         [NonEvent]
-        internal long EnterScope<T1>(string format, T1 arg1) => Log.IsEnabled() ? EnterScope(string.Format(format, arg1)) : 0;
+#if uapaot
+        public
+#else
+        internal
+#endif
+        long EnterScope<T1>(string format, T1 arg1) => Log.IsEnabled() ? EnterScope(string.Format(format, arg1)) : 0;
+
         [NonEvent]
-        internal long EnterScope<T1, T2>(string format, T1 arg1, T2 arg2) => Log.IsEnabled() ? EnterScope(string.Format(format, arg1, arg2)) : 0;
+#if uapaot
+        public
+#else
+        internal
+#endif
+        long EnterScope<T1, T2>(string format, T1 arg1, T2 arg2) => Log.IsEnabled() ? EnterScope(string.Format(format, arg1, arg2)) : 0;
+
         [NonEvent]
-        internal long EnterScope<T1, T2, T3>(string format, T1 arg1, T2 arg2, T3 arg3) => Log.IsEnabled() ? EnterScope(string.Format(format, arg1, arg2, arg3)) : 0;
+#if uapaot
+        public
+#else
+        internal
+#endif
+        long EnterScope<T1, T2, T3>(string format, T1 arg1, T2 arg2, T3 arg3) => Log.IsEnabled() ? EnterScope(string.Format(format, arg1, arg2, arg3)) : 0;
+
         [NonEvent]
-        internal long EnterScope<T1, T2, T3, T4>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4) => Log.IsEnabled() ? EnterScope(string.Format(format, arg1, arg2, arg3, arg4)) : 0;
+#if uapaot
+        public
+#else
+        internal
+#endif
+        long EnterScope<T1, T2, T3, T4>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4) => Log.IsEnabled() ? EnterScope(string.Format(format, arg1, arg2, arg3, arg4)) : 0;
 
         [Event(ExitScopeId, Level = EventLevel.Verbose)]
-        internal void ExitScope(long scopeId)
+#if uapaot
+        public
+#else
+        internal
+#endif
+        void ExitScope(long scopeId)
         {
             WriteEvent(ExitScopeId, scopeId);
         }

--- a/src/System.Data.Common/tests/System/Data/DataCommonEventSourceTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataCommonEventSourceTest.cs
@@ -12,7 +12,6 @@ namespace System.Data.Tests
     {
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/20589", TargetFrameworkMonikers.UapAot)]
         public void InvokeCodeThatShouldFirEvents_EnsureEventsFired()
         {
             using (var listener = new TestEventListener("System.Data.DataCommonEventSource", EventLevel.Verbose))


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/20589

The DataCommonEventSource members need to be marked public on uapaot in order for EventSource reflection to work. TestEventListener in DataCommonEventSourceTest enables events based on the event name, which is retrieved via reflection. Not enabling any events is what is causing the test failures in the above issue.

I tried the ILTransform solution mentioned by @brianrob in https://github.com/dotnet/corefx/issues/20589, but the test runs fail since the event method at https://github.com/dotnet/corefx/blob/master/src/System.Data.Common/src/System/Data/Common/DataCommonEventSource.cs#L69 has a non-void return type. According to Brian, Events normally shouldn't work at all with a non-void return type, but so far this is the only issue we've seen with that event method. 

Marking the event source members public is less invasive than changing all the calls to DataCommonEventSource.EnterScope() that would be needed to make the ILTransform fix work