### PR TITLE
Fixed races in EventCounters

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/System.Diagnostics.DiagnosticSource.sln
+++ b/src/System.Diagnostics.DiagnosticSource/System.Diagnostics.DiagnosticSource.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26430.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Diagnostics.DiagnosticSource.Tests", "tests\System.Diagnostics.DiagnosticSource.Tests.csproj", "{A7922FA3-306A-41B9-B8DC-CC4DBE685A85}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -19,6 +19,15 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E893-4E87-987E-04EF0DCEAEFD}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{33F18BCF-3CA9-4AF8-B78A-9A9042D60092}"
+	ProjectSection(SolutionItems) = preProject
+		src\ActivityUserGuide.md = src\ActivityUserGuide.md
+		src\DiagnosticSourceUsersGuide.md = src\DiagnosticSourceUsersGuide.md
+		src\FlatRequestId.md = src\FlatRequestId.md
+		src\HierarchicalRequestId.md = src\HierarchicalRequestId.md
+		src\HttpCorrelationProtocol.md = src\HttpCorrelationProtocol.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/System.Diagnostics.Tracing/src/System.Diagnostics.Tracing.csproj
+++ b/src/System.Diagnostics.Tracing/src/System.Diagnostics.Tracing.csproj
@@ -8,7 +8,7 @@
     <!-- CSC adds a typeforward for the internal nested type EventSource.EventMetadata but
          GenFacades doesn't consider this as a viable target for a typeforward since it's internal -->
     <GenFacadesIgnoreMissingTypes Condition="'$(TargetGroup)' == 'netfx'">true</GenFacadesIgnoreMissingTypes>
-    <DefineContants Condition="'$(TargetGroup)' != 'netfx'">$(DefineConstants);SUPPORTS_EVENTCOMMANDEXECUTED</DefineContants>
+    <DefineConstants Condition="'$(TargetGroup)' == 'netfx'">$(DefineConstants);NO_EVENTCOMMANDEXECUTED_SUPPORT</DefineConstants> 
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />
@@ -30,6 +30,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netfx'">
     <Reference Include="mscorlib" />
+    <Reference Include="System" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventCounter.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventCounter.cs
@@ -48,6 +48,8 @@ namespace System.Diagnostics.Tracing
             _name = name;
             _group = EventCounterGroup.GetEventCounterGroup(eventSource);
             _group.Add(this);
+            _min = float.PositiveInfinity;
+            _max = float.NegativeInfinity;
         }
 
         /// <summary>
@@ -157,15 +159,11 @@ namespace System.Diagnostics.Tracing
             Debug.Assert(Monitor.IsEntered(MyLock));
             _sum += value;
             _sumSquared += value * value;
-            if (_count == 0 || value > _max)
-            {
+            if (value > _max)
                 _max = value;
-            }
 
-            if (_count == 0 || value < _min)
-            {
+            if (value < _min)
                 _min = value;
-            }
 
             _count++;
         }
@@ -193,8 +191,8 @@ namespace System.Diagnostics.Tracing
             _count = 0;
             _sum = 0;
             _sumSquared = 0;
-            _min = 0;
-            _max = 0;
+            _min = float.PositiveInfinity;
+            _max = float.NegativeInfinity;
         }
 
         #endregion // Statistics Calculation

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventCounter.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventCounter.cs
@@ -91,7 +91,7 @@ namespace System.Diagnostics.Tracing
         private volatile int _bufferedValuesIndex;
 
         // arbitrarily we use _bufferfValues as the lock object.  
-        private object MyLock { get { return _bufferedValues; } }  
+        private object MyLock { get { return _bufferedValues; } }
 
         private void InitializeBuffer()
         {
@@ -176,8 +176,16 @@ namespace System.Diagnostics.Tracing
                 EventCounterPayload result = new EventCounterPayload();
                 result.Name = _name;
                 result.Count = _count;
-                result.Mean = _sum / _count;
-                result.StandardDeviation = (float)Math.Sqrt(_sumSquared / _count - _sum * _sum / _count / _count);
+                if (0 < _count)
+                {
+                    result.Mean = _sum / _count;
+                    result.StandardDeviation = (float)Math.Sqrt(_sumSquared / _count - _sum * _sum / _count / _count);
+                }
+                else
+                {
+                    result.Mean = 0;
+                    result.StandardDeviation = 0;
+                }
                 result.Min = _min;
                 result.Max = _max;
                 ResetStatistics();

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/Harness/EventTestHarness.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/Harness/EventTestHarness.cs
@@ -85,30 +85,41 @@ namespace BasicEventSourceTests
             };
 
             // Run the tests. collecting and validating the results. 
-            using (TestHarnessEventSource testHarnessEventSource = new TestHarnessEventSource())
+            try
             {
-                // Turn on the test EventSource.  
-                listener.EventSourceSynchronousEnable(source, options);
-                // And the harnesses's EventSource. 
-                listener.EventSourceSynchronousEnable(testHarnessEventSource);
 
-                // Generate events for all the tests, surrounded by events that tell us we are starting a test.  
-                int testNumber = 0;
-                foreach (var test in tests)
+                using (TestHarnessEventSource testHarnessEventSource = new TestHarnessEventSource())
                 {
-                    Console.WriteLine("Starting Sub-Test {0}  thread {1}", test.Name, System.Threading.Thread.CurrentThread.ManagedThreadId);
-                    testHarnessEventSource.StartTest(test.Name, testNumber);
-                    test.EventGenerator();
-                    testNumber++;
+                    // Turn on the test EventSource.  
+                    listener.EventSourceSynchronousEnable(source, options);
+                    // And the harnesses's EventSource. 
+                    listener.EventSourceSynchronousEnable(testHarnessEventSource);
+
+                    // Generate events for all the tests, surrounded by events that tell us we are starting a test.  
+                    int testNumber = 0;
+                    foreach (var test in tests)
+                    {
+                        Console.WriteLine("Starting Sub-Test {0}  thread: {1} time: {2:mm:ss.fff}",
+                            test.Name, System.Threading.Thread.CurrentThread.ManagedThreadId, DateTime.UtcNow);
+                        testHarnessEventSource.StartTest(test.Name, testNumber);
+                        test.EventGenerator();
+                        testNumber++;
+                    }
+                    testHarnessEventSource.StartTest("", testNumber);        // Empty test marks the end of testing. 
+
+                    // Disable the listeners.  
+                    listener.EventSourceCommand(source.Name, EventCommand.Disable);
+                    listener.EventSourceCommand(testHarnessEventSource.Name, EventCommand.Disable);
+
+                    // Send something that should be ignored.  
+                    testHarnessEventSource.IgnoreEvent();
                 }
-                testHarnessEventSource.StartTest("", testNumber);        // Empty test marks the end of testing. 
-
-                // Disable the listeners.  
-                listener.EventSourceCommand(source.Name, EventCommand.Disable);
-                listener.EventSourceCommand(testHarnessEventSource.Name, EventCommand.Disable);
-
-                // Send something that should be ignored.  
-                testHarnessEventSource.IgnoreEvent();
+            }
+            finally
+            {
+                // Run the tests. collecting and validating the results. 
+                Console.WriteLine("Stopped running tests thread: {0} time: {1:mm:ss.fff}",
+                    System.Threading.Thread.CurrentThread.ManagedThreadId, DateTime.UtcNow);
             }
 
             listener.Dispose();         // Indicate we are done listening.  For the ETW file based cases, we do all the processing here

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/Harness/EventTestHarness.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/Harness/EventTestHarness.cs
@@ -96,7 +96,7 @@ namespace BasicEventSourceTests
                 int testNumber = 0;
                 foreach (var test in tests)
                 {
-                    Console.WriteLine("Starting Sub-Test {0}", test.Name);
+                    Console.WriteLine("Starting Sub-Test {0}  thread {1}", test.Name, System.Threading.Thread.CurrentThread.ManagedThreadId);
                     testHarnessEventSource.StartTest(test.Name, testNumber);
                     test.EventGenerator();
                     testNumber++;

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/Harness/EventTestHarness.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/Harness/EventTestHarness.cs
@@ -96,6 +96,7 @@ namespace BasicEventSourceTests
                 int testNumber = 0;
                 foreach (var test in tests)
                 {
+                    Console.WriteLine("Starting Sub-Test {0}", test.Name);
                     testHarnessEventSource.StartTest(test.Name, testNumber);
                     test.EventGenerator();
                     testNumber++;

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/Harness/Listeners.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/Harness/Listeners.cs
@@ -42,7 +42,7 @@ namespace BasicEventSourceTests
             }
         }
 
-        internal void EnableTimer(EventSource eventSource, int pollingTime)
+        internal void EnableTimer(EventSource eventSource, double pollingTime)
         {
             FilteringOptions options = new FilteringOptions();
             options.Args = new Dictionary<string, string>();
@@ -86,7 +86,7 @@ namespace BasicEventSourceTests
         {
             return PayloadValue(propertyIndex, propertyName).ToString();
         }
-        public abstract IEnumerable<string> PayloadNames { get; }
+        public abstract IList<string> PayloadNames { get; }
 
 #if DEBUG
         /// <summary>
@@ -240,7 +240,7 @@ namespace BasicEventSourceTests
                 return _data.PayloadString(propertyIndex);
             }
             public override int PayloadCount { get { return _data.PayloadNames.Length; } }
-            public override IEnumerable<string> PayloadNames { get { return _data.PayloadNames; } }
+            public override IList<string> PayloadNames { get { return _data.PayloadNames; } }
 
     #region private
             internal EtwEvent(TraceEvent data) { _data = data.Clone(); }
@@ -391,7 +391,7 @@ namespace BasicEventSourceTests
 
             public override string EventName { get { return _data.EventName; } }
 
-            public override IEnumerable<string> PayloadNames { get { return _data.PayloadNames; } }
+            public override IList<string> PayloadNames { get { return _data.PayloadNames; } }
 
             public override int PayloadCount
             {

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestEventCounter.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestEventCounter.cs
@@ -74,95 +74,42 @@ namespace BasicEventSourceTests
             {
                 var tests = new List<SubTest>();
                 /*************************************************************************/
-                tests.Add(new SubTest("Log 1 event",
+                tests.Add(new SubTest("Log 1 event, explicit poll at end",
                     delegate ()
                     {
-                        listener.EnableTimer(logger, 0.2); /* Poll every 200 msec */
+                        listener.EnableTimer(logger, 1);        // Set to poll every second, but we dont actually care because the test ends before that.   
                         logger.Request(5);
-                        Sleep(280); // Sleep for 280 msec
                         listener.EnableTimer(logger, 0);
                     },
                     delegate (List<Event> evts)
                     {
                         // There will be two events (request and error) for time 0 and 2 more at 1 second and 2 more when we shut it off.  
-                        Assert.Equal(6, evts.Count);
-                        ValidateSingleEventCounter(evts[0], "Request", 0, 0, 0, 0, 0);
-                        ValidateSingleEventCounter(evts[1], "Error", 0, 0, 0, 0, 0);
+                        Assert.Equal(4, evts.Count);
+                        ValidateSingleEventCounter(evts[0], "Request", 0, 0, 0, float.PositiveInfinity, float.NegativeInfinity);
+                        ValidateSingleEventCounter(evts[1], "Error", 0, 0, 0, float.PositiveInfinity, float.NegativeInfinity);
                         ValidateSingleEventCounter(evts[2], "Request", 1, 5, 0, 5, 5);
-                        ValidateSingleEventCounter(evts[3], "Error", 0, 0, 0, 0, 0);
-                        ValidateSingleEventCounter(evts[4], "Request", 0, 0, 0, 0, 0);
-                        ValidateSingleEventCounter(evts[5], "Error", 0, 0, 0, 0, 0);
+                        ValidateSingleEventCounter(evts[3], "Error", 0, 0, 0, float.PositiveInfinity, float.NegativeInfinity);
                     }));
                 /*************************************************************************/
-                tests.Add(new SubTest("Log 2 event in single period",
+                tests.Add(new SubTest("Log 2 events, explicit poll at end",
                     delegate ()
                     {
-                        listener.EnableTimer(logger, 0.2); /* Poll every .2 s */
+                        listener.EnableTimer(logger, 1);        // Set to poll every second, but we dont actually care because the test ends before that.   
                         logger.Request(5);
                         logger.Request(10);
-                        Sleep(280); // Sleep for .28 seconds
-                        listener.EnableTimer(logger, 0);
+                        listener.EnableTimer(logger, 0);        // poll 
                     },
                     delegate (List<Event> evts)
                     {
-                        Assert.Equal(6, evts.Count);
-                        ValidateSingleEventCounter(evts[0], "Request", 0, 0, 0, 0, 0);
-                        ValidateSingleEventCounter(evts[1], "Error", 0, 0, 0, 0, 0);
+                        Assert.Equal(4, evts.Count);
+                        ValidateSingleEventCounter(evts[0], "Request", 0, 0, 0, float.PositiveInfinity, float.NegativeInfinity);
+                        ValidateSingleEventCounter(evts[1], "Error", 0, 0, 0, float.PositiveInfinity, float.NegativeInfinity);
                         ValidateSingleEventCounter(evts[2], "Request", 2, 7.5f, 2.5f, 5, 10);
-                        ValidateSingleEventCounter(evts[3], "Error", 0, 0, 0, 0, 0);
-                        ValidateSingleEventCounter(evts[4], "Request", 0, 0, 0, 0, 0);
-                        ValidateSingleEventCounter(evts[5], "Error", 0, 0, 0, 0, 0);
-                    }));
-                /*************************************************************************/
-                tests.Add(new SubTest("Log 2 event in two periods",
-                    delegate ()
-                    {
-                        listener.EnableTimer(logger, .4); /* Poll every .4 s */
-                                                          // logs at 0 seconds because of EnableTimer command
-                        logger.Request(5);
-                        // At .4 sec we log by timer 
-                        Sleep(600); // Sleep for .6 seconds 
-                        logger.Request(10);
-                        // at .8 sec we log by timer
-                        Sleep(400); // Sleep for .4 seconds (at time = 1.0 second exactly 6 messages should be received)
-                        // logs at 1.0 seconds because of EnableTimer command
-                        listener.EnableTimer(logger, 0);
-                    },
-                    delegate (List<Event> evts)
-                    {
-                        Assert.Equal(8, evts.Count);
-                        ValidateSingleEventCounter(evts[0], "Request", 0, 0, 0, 0, 0);
-                        ValidateSingleEventCounter(evts[1], "Error", 0, 0, 0, 0, 0);
-                        ValidateSingleEventCounter(evts[2], "Request", 1, 5, 0, 5, 5);
-                        ValidateSingleEventCounter(evts[3], "Error", 0, 0, 0, 0, 0);
-                        ValidateSingleEventCounter(evts[4], "Request", 1, 10, 0, 10, 10);
-                        ValidateSingleEventCounter(evts[5], "Error", 0, 0, 0, 0, 0);
-                        ValidateSingleEventCounter(evts[6], "Request", 0, 0, 0, 0, 0);
-                        ValidateSingleEventCounter(evts[7], "Error", 0, 0, 0, 0, 0);
-                    }));
-                /*************************************************************************/
-                tests.Add(new SubTest("Log 2 different events in a period",
-                    delegate ()
-                    {
-                        listener.EnableTimer(logger, .2); /* Poll every .2 s */
-                        logger.Request(25);
-                        logger.Error();
-                        Sleep(280); // Sleep for .28 seconds
-                        listener.EnableTimer(logger, 0);
-                    },
-                    delegate (List<Event> evts)
-                    {
-                        Assert.Equal(6, evts.Count);
-                        ValidateSingleEventCounter(evts[0], "Request", 0, 0, 0, 0, 0);
-                        ValidateSingleEventCounter(evts[1], "Error", 0, 0, 0, 0, 0);
-                        ValidateSingleEventCounter(evts[2], "Request", 1, 25, 0, 25, 25);
-                        ValidateSingleEventCounter(evts[3], "Error", 1, 1, 0, 1, 1);
-                        ValidateSingleEventCounter(evts[4], "Request", 0, 0, 0, 0, 0);
-                        ValidateSingleEventCounter(evts[5], "Error", 0, 0, 0, 0, 0);
+                        ValidateSingleEventCounter(evts[3], "Error", 0, 0, 0, float.PositiveInfinity, float.NegativeInfinity);
                     }));
 
                 /*************************************************************************/
-                tests.Add(new SubTest("Explicit polling ",
+                tests.Add(new SubTest("Log 3 events in two polling periods (explicit polling)",
                     delegate ()
                     {
                         listener.EnableTimer(logger, 0);  /* Turn off (but also poll once) */
@@ -178,13 +125,101 @@ namespace BasicEventSourceTests
                     delegate (List<Event> evts)
                     {
                         Assert.Equal(6, evts.Count);
-                        ValidateSingleEventCounter(evts[0], "Request", 0, 0, 0, 0, 0);
-                        ValidateSingleEventCounter(evts[1], "Error", 0, 0, 0, 0, 0);
+                        ValidateSingleEventCounter(evts[0], "Request", 0, 0, 0, float.PositiveInfinity, float.NegativeInfinity);
+                        ValidateSingleEventCounter(evts[1], "Error", 0, 0, 0, float.PositiveInfinity, float.NegativeInfinity);
                         ValidateSingleEventCounter(evts[2], "Request", 2, 7.5f, 2.5f, 5, 10);
                         ValidateSingleEventCounter(evts[3], "Error", 1, 1, 0, 1, 1);
                         ValidateSingleEventCounter(evts[4], "Request", 1, 8, 0, 8, 8);
                         ValidateSingleEventCounter(evts[5], "Error", 2, 1, 0, 1, 1);
                     }));
+
+
+                /*************************************************************************/
+                tests.Add(new SubTest("Log multiple events in",
+                    delegate ()
+                    {
+                        listener.EnableTimer(logger, .1); /* Poll every .1 s */
+                                                          // logs at 0 seconds because of EnableTimer command
+                        Sleep(100);
+                        logger.Request(1);
+                        Sleep(100);
+                        logger.Request(2);
+                        logger.Error();
+                        Sleep(100);
+                        logger.Request(4);
+                        Sleep(100);
+                        logger.Error();
+                        logger.Request(8);
+                        Sleep(100);
+                        logger.Request(16);
+                        listener.EnableTimer(logger, 0);
+                    },
+                    delegate (List<Event> evts)
+                    {
+                        // We expect the timer to have gone off at least twice, plus the explicit poll at the begining and end.
+                        // Each one fires two events (one for requests, one for errors). so that is (2 + 2)*2 = 8
+                        // We expect about 5 timer requests, but we don't get picky about the exact count
+                        // We don't expect more than say 9 timer request so that is (2 + 9) * 2 = 22
+                        Assert.True(8 <= evts.Count);
+                        Assert.True(evts.Count <= 22);    
+                        Assert.True(evts.Count % 2 == 0);
+
+                        ValidateSingleEventCounter(evts[0], "Request", 0, 0, 0, float.PositiveInfinity, float.NegativeInfinity);
+                        ValidateSingleEventCounter(evts[1], "Error", 0, 0, 0, float.PositiveInfinity, float.NegativeInfinity);
+
+                        int requestCount = 0;
+                        float requestSum = 0;
+                        float requestMin = float.MaxValue;
+                        float requestMax = float.MinValue;
+
+                        int errorCount = 0;
+                        float errorSum = 0;
+                        float errorMin = float.MaxValue;
+                        float errorMax = float.MinValue;
+
+                        float timeSum = 0;
+
+                        for (int j = 0; j < evts.Count; j+= 2)
+                        {
+                            var requestPayload = ValidateEventHeaderAndGetPayload(evts[j]);
+                            Assert.Equal("Request", requestPayload["Name"]);
+
+                            var count = (int)requestPayload["Count"];
+                            requestCount += count;
+                            if (count > 0)
+                                requestSum += (float)requestPayload["Mean"] * count;
+                            requestMin = Math.Min(requestMin, (float)requestPayload["Min"]);
+                            requestMax = Math.Max(requestMax, (float)requestPayload["Max"]);
+                            float requestIntevalSec = (float)requestPayload["IntervalSec"];
+
+                            var errorPayload = ValidateEventHeaderAndGetPayload(evts[j+1]);
+                            Assert.Equal("Error", errorPayload["Name"]);
+
+                            count = (int)errorPayload["Count"];
+                            errorCount += count;
+                            if (count > 0)
+                                errorSum += (float)errorPayload["Mean"] * count;
+                            errorMin = Math.Min(errorMin, (float)errorPayload["Min"]);
+                            errorMax = Math.Max(errorMax, (float)errorPayload["Max"]);
+                            float errorIntevalSec = (float)requestPayload["IntervalSec"];
+
+                            Assert.Equal(requestIntevalSec, errorIntevalSec);
+                            timeSum += requestIntevalSec;
+                        }
+                        Assert.Equal(requestCount, 5);
+                        Assert.Equal(requestSum, 31);
+                        Assert.Equal(requestMin, 1);
+                        Assert.Equal(requestMax, 16);
+
+                        Assert.Equal(errorCount, 2);
+                        Assert.Equal(errorSum, 2);
+                        Assert.Equal(errorMin, 1);
+                        Assert.Equal(errorMax, 1);
+
+                        Assert.True(.4 < timeSum);   // We should have at least 400 msec 
+                        Assert.True(timeSum < 1);    // But well under 1 sec.  
+                    }));
+
 
                 /*************************************************************************/
                 // TODO expose Dispose() method and activate this test.  
@@ -235,21 +270,19 @@ namespace BasicEventSourceTests
 
         private static void ValidateSingleEventCounter(Event evt, string counterName, int count, float mean, float standardDeviation, float min, float max)
         {
-            object payload = ValidateEventHeaderAndGetPayload(evt);
-            var payloadContent = payload as IDictionary<string, object>;
-            Assert.NotNull(payloadContent);
-            ValidateEventCounter(counterName, count, mean, standardDeviation, min, max, payloadContent);
+            ValidateEventCounter(counterName, count, mean, standardDeviation, min, max, ValidateEventHeaderAndGetPayload(evt));
         }
 
-        private static object ValidateEventHeaderAndGetPayload(Event evt)
+        private static IDictionary<string, object> ValidateEventHeaderAndGetPayload(Event evt)
         {
             Assert.Equal("EventCounters", evt.EventName);
             Assert.Equal(1, evt.PayloadCount);
             Assert.NotNull(evt.PayloadNames);
             Assert.Equal(1, evt.PayloadNames.Count);
             Assert.Equal("Payload", evt.PayloadNames[0]);
-            object rawPayload = evt.PayloadValue(0, "Payload");
-            return rawPayload;
+            var ret  = (IDictionary < string, object > ) evt.PayloadValue(0, "Payload");
+            Assert.NotNull(ret);
+            return ret;
         }
 
         private static void ValidateEventCounter(string counterName, int count, float mean, float standardDeviation, float min, float max, IDictionary<string, object> payloadContent)

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestEventCounter.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestEventCounter.cs
@@ -215,13 +215,22 @@ namespace BasicEventSourceTests
             TestUtilities.CheckNoEventSourcesRunning("Stop");
         }
 
-        // THread.Sleep has proven unreliable, sometime sleeping much shorter than it should. 
+        // Thread.Sleep has proven unreliable, sometime sleeping much shorter than it should. 
         // This makes sure it at least sleeps 'msec' at a miniumum.  
         private static void Sleep(int minMSec)
         {
             var startTime = DateTime.UtcNow;
-            while ((DateTime.UtcNow - startTime).TotalMilliseconds < minMSec)
+            for(;;)
+            {
+                DateTime endTime = DateTime.UtcNow;
+                double delta = (endTime - startTime).TotalMilliseconds;
+                if (delta >= minMSec)
+                {
+                    Console.WriteLine("Sleep asked to wait {0} msec, actually waited {1:n2} msec Start: {2:mm:ss.fff} End: {3:mm:ss.fff} ", minMSec, delta, startTime, endTime);
+                    break;
+                }
                 Thread.Sleep(1);
+            }
         }
 
         private static void ValidateSingleEventCounter(Event evt, string counterName, int count, float mean, float standardDeviation, float min, float max)


### PR DESCRIPTION
There were a number of races in EventCounters.  Did an audit and fixed these.
Also added the Dispose() method so that you can make counters for transient objects (e.g. files)
Also turned on and beefed up the testing.  Fixed tests.

@brianrob, @stephentoub 