### PR TITLE
Replace Microsoft.CSharp methods for casting CType with normal operations.

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
@@ -168,14 +168,18 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                     ErrAppendParentCore(err.GetNSParent(), pctx);
                 }
             }
-            else if (pType.IsAggregateType())
+            else if (pType is AggregateType agg)
             {
-                ErrAppendParentCore(pType.AsAggregateType().GetOwningAggregate(), pctx);
+                ErrAppendParentCore(agg.GetOwningAggregate(), pctx);
             }
-            else if (pType.GetBaseOrParameterOrElementType() != null)
+            else
             {
-                ErrAppendType(pType.GetBaseOrParameterOrElementType(), null);
-                ErrAppendChar('.');
+                var part = pType.GetBaseOrParameterOrElementType();
+                if (part != null)
+                {
+                    ErrAppendType(part, null);
+                    ErrAppendChar('.');
+                }
             }
         }
 
@@ -221,7 +225,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                 ErrAppendParentSym(meth, pctx);
 
                 // Get the type args from the explicit impl type and substitute using pctx (if there is one).
-                SubstContext ctx = new SubstContext(GetTypeManager().SubstType(meth.swtSlot.GetType(), pctx).AsAggregateType());
+                SubstContext ctx = new SubstContext(GetTypeManager().SubstType(meth.swtSlot.GetType(), pctx) as AggregateType);
                 ErrAppendSym(meth.swtSlot.Sym, ctx, fArgs);
 
                 // args already added
@@ -366,7 +370,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
             ErrAppendParentSym(prop, pctx);
             if (prop.IsExpImpl() && prop.swtSlot.Sym != null)
             {
-                SubstContext ctx = new SubstContext(GetTypeManager().SubstType(prop.swtSlot.GetType(), pctx).AsAggregateType());
+                SubstContext ctx = new SubstContext(GetTypeManager().SubstType(prop.swtSlot.GetType(), pctx) as AggregateType);
                 ErrAppendSym(prop.swtSlot.Sym, ctx);
             }
             else if (prop.IsExpImpl())
@@ -513,7 +517,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
             {
                 case TypeKind.TK_AggregateType:
                     {
-                        AggregateType pAggType = pType.AsAggregateType();
+                        AggregateType pAggType = (AggregateType)pType;
 
                         // Check for a predefined class with a special "nice" name for
                         // error reported.

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
@@ -664,7 +664,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                     break;
 
                 case TypeKind.TK_NullableType:
-                    ErrAppendType(pType.AsNullableType().GetUnderlyingType(), pctx);
+                    ErrAppendType(((NullableType)pType).GetUnderlyingType(), pctx);
                     ErrAppendChar('?');
                     break;
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
@@ -156,16 +156,16 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
 
         private void ErrAppendParentType(CType pType, SubstContext pctx)
         {
-            if (pType.IsErrorType())
+            if (pType is ErrorType err)
             {
-                if (pType.AsErrorType().HasTypeParent())
+                if (err.HasTypeParent())
                 {
-                    ErrAppendType(pType.AsErrorType().GetTypeParent(), null);
+                    ErrAppendType(err.GetTypeParent(), null);
                     ErrAppendChar('.');
                 }
                 else
                 {
-                    ErrAppendParentCore(pType.AsErrorType().GetNSParent(), pctx);
+                    ErrAppendParentCore(err.GetNSParent(), pctx);
                 }
             }
             else if (pType.IsAggregateType())
@@ -560,17 +560,18 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                     break;
 
                 case TypeKind.TK_ErrorType:
-                    if (pType.AsErrorType().HasParent())
+                    ErrorType err = (ErrorType)pType;
+                    if (err.HasParent())
                     {
-                        Debug.Assert(pType.AsErrorType().nameText != null && pType.AsErrorType().typeArgs != null);
+                        Debug.Assert(err.nameText != null && err.typeArgs != null);
                         ErrAppendParentType(pType, pctx);
-                        ErrAppendName(pType.AsErrorType().nameText);
-                        ErrAppendTypeParameters(pType.AsErrorType().typeArgs, pctx, true);
+                        ErrAppendName(err.nameText);
+                        ErrAppendTypeParameters(err.typeArgs, pctx, true);
                     }
                     else
                     {
                         // Load the string "<error>".
-                        Debug.Assert(null == pType.AsErrorType().typeArgs);
+                        Debug.Assert(null == err.typeArgs);
                         ErrAppendId(MessageID.ERRORSYM);
                     }
                     break;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
@@ -544,13 +544,14 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                 case TypeKind.TK_TypeParameterType:
                     if (null == pType.GetName())
                     {
+                        var tpType = (TypeParameterType)pType;
                         // It's a standard type variable.
-                        if (pType.AsTypeParameterType().IsMethodTypeParameter())
+                        if (tpType.IsMethodTypeParameter())
                         {
                             ErrAppendChar('!');
                         }
                         ErrAppendChar('!');
-                        ErrAppendPrintf("{0}", pType.AsTypeParameterType().GetIndexInTotalParameters());
+                        ErrAppendPrintf("{0}", tpType.GetIndexInTotalParameters());
                     }
                     else
                     {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
@@ -603,7 +603,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
 
                 case TypeKind.TK_ArrayType:
                     {
-                        CType elementType = pType.AsArrayType().GetBaseElementType();
+                        CType elementType = ((ArrayType)pType).GetBaseElementType();
 
                         if (null == elementType)
                         {
@@ -614,10 +614,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                         ErrAppendType(elementType, pctx);
 
                         for (elementType = pType;
-                                elementType != null && elementType.IsArrayType();
-                                elementType = elementType.AsArrayType().GetElementType())
+                                elementType is ArrayType arrType;
+                                elementType = arrType.GetElementType())
                         {
-                            int rank = elementType.AsArrayType().rank;
+                            int rank = arrType.rank;
 
                             // Add [] with (rank-1) commas inside
                             ErrAppendChar('[');
@@ -625,7 +625,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                             // known rank.
                             if (rank == 1)
                             {
-                                if (!elementType.AsArrayType().IsSZArray)
+                                if (!arrType.IsSZArray)
                                 {
                                     ErrAppendChar('*');
                                 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
@@ -657,7 +657,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
 
                 case TypeKind.TK_PointerType:
                     // Generate the base type.
-                    ErrAppendType(pType.AsPointerType().GetReferentType(), pctx);
+                    ErrAppendType(((PointerType)pType).GetReferentType(), pctx);
                     {
                         // add the trailing *
                         ErrAppendChar('*');

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
@@ -647,11 +647,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                     break;
 
                 case TypeKind.TK_ParameterModifierType:
+                    ParameterModifierType mod = (ParameterModifierType)pType;
                     // add ref or out
-                    ErrAppendString(pType.AsParameterModifierType().isOut ? "out " : "ref ");
+                    ErrAppendString(mod.isOut ? "out " : "ref ");
 
                     // add base type name
-                    ErrAppendType(pType.AsParameterModifierType().GetParameterType(), pctx);
+                    ErrAppendType(mod.GetParameterType(), pctx);
                     break;
 
                 case TypeKind.TK_PointerType:

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ExpressionTreeCallRewriter.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ExpressionTreeCallRewriter.cs
@@ -683,7 +683,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             }
             else if (pExpr is ExprConstant)
             {
-                Debug.Assert(pExpr.Type.IsNullType());
+                Debug.Assert(pExpr.Type is NullType);
                 return null;
             }
             else
@@ -893,7 +893,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                     CType underlyingType = pExpr.Type;
                     object objval;
 
-                    if (pExpr.Type.IsNullType())
+                    if (pExpr.Type is NullType)
                     {
                         return null;
                     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -634,8 +634,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             }
             else
             {
-                callingType = callingObjectType as AggregateType;
-                Debug.Assert(callingType != null, "MemberGroup on non-array, non-aggregate");
+                callingType = (AggregateType)callingObjectType;
             }
 
             List<CType> callingTypes = new List<CType>();

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -624,13 +624,14 @@ namespace Microsoft.CSharp.RuntimeBinder
             Name name = _semanticChecker.GetNameManager().Add(Name);
             AggregateType callingType;
 
+            CType callingObjectType = callingObject.Type;
             if (callingObject.Type.IsArrayType())
             {
                 callingType = _semanticChecker.GetSymbolLoader().GetReqPredefType(PredefinedType.PT_ARRAY);
             }
-            else if (callingObject.Type.IsNullableType())
+            else if (callingObjectType is NullableType callingNub)
             {
-                callingType = callingObject.Type.AsNullableType().GetAts(_semanticChecker.GetSymbolLoader().GetErrorContext());
+                callingType = callingNub.GetAts(_semanticChecker.GetSymbolLoader().GetErrorContext());
             }
             else if (callingObject.Type.IsAggregateType())
             {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -624,7 +624,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             AggregateType callingType;
 
             CType callingObjectType = callingObject.Type;
-            if (callingObject.Type.IsArrayType())
+            if (callingObjectType is ArrayType)
             {
                 callingType = _semanticChecker.GetSymbolLoader().GetReqPredefType(PredefinedType.PT_ARRAY);
             }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -494,10 +494,9 @@ namespace Microsoft.CSharp.RuntimeBinder
             CType ctype = _symbolTable.GetCTypeFromType(type);
             if (bIsOut)
             {
-                Debug.Assert(ctype.IsParameterModifierType());
-                ctype = _semanticChecker.GetTypeManager().GetParameterModifier(
-                    ctype.AsParameterModifierType().GetParameterType(),
-                    true);
+                Debug.Assert(ctype is ParameterModifierType);
+                ctype = _semanticChecker.GetTypeManager()
+                    .GetParameterModifier(((ParameterModifierType)ctype).GetParameterType(), true);
             }
 
             // If we can convert, do that. If not, cast it.

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
@@ -373,7 +373,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 return exprResult;
             }
 
-            if (expr.IsOK && !dest.IsErrorType())
+            if (expr.IsOK && !(dest is ErrorType))
             {
                 // don't report cascading error.
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
@@ -929,7 +929,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // true exactly when both the source and destination types are nullable.
             bool fLiftSrc = typeSrcBase != typeSrc;
             bool fLiftDst = typeDstBase != typeDst;
-            bool fDstHasNull = fLiftDst || typeDst.IsRefType() || typeDst.IsPointerType();
+            bool fDstHasNull = fLiftDst || typeDst.IsRefType() || typeDst is PointerType;
             AggregateType[] rgats = new AggregateType[2];
             int cats = 0;
 
@@ -1082,7 +1082,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                                                !canConvert(typeFrom, typeSrc, CONVERTTYPE.STANDARDANDNOUDC) &&
                                                // We allow IntPtr and UIntPtr to use non-standard explicit casts as long as they don't involve pointer types.
                                                // This is because the framework uses it and RTM allowed it.
-                                               (!fIntPtrStandard || typeSrc.IsPointerType() || typeFrom.IsPointerType() || !canCast(typeSrc, typeFrom, CONVERTTYPE.NOUDC))))
+                                               (!fIntPtrStandard || typeSrc is PointerType || typeFrom is PointerType || !canCast(typeSrc, typeFrom, CONVERTTYPE.NOUDC))))
                         {
                             continue;
                         }
@@ -1091,7 +1091,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                                              !canConvert(typeDst, typeTo, CONVERTTYPE.STANDARDANDNOUDC) &&
                                              // We allow IntPtr and UIntPtr to use non-standard explicit casts as long as they don't involve pointer types.
                                              // This is because the framework uses it and RTM allowed it.
-                                             (!fIntPtrStandard || typeDst.IsPointerType() || typeTo.IsPointerType() || !canCast(typeTo, typeDst, CONVERTTYPE.NOUDC))))
+                                             (!fIntPtrStandard || typeDst is PointerType || typeTo is PointerType || !canCast(typeTo, typeDst, CONVERTTYPE.NOUDC))))
                         {
                             continue;
                         }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
@@ -311,9 +311,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 return f12 ? BetterType.Left : BetterType.Right;
             }
 
-            if (!type1.IsNullableType() || !type2.IsNullableType() ||
-                !type1.AsNullableType().UnderlyingType.isPredefined() ||
-                !type2.AsNullableType().UnderlyingType.isPredefined())
+            if (!(type1 is NullableType nub1) || !(type2 is NullableType nub2) ||
+                !nub1.UnderlyingType.isPredefined() ||
+                !nub2.UnderlyingType.isPredefined())
             {
                 return BetterType.Neither;
             }
@@ -1308,7 +1308,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Expr exprDst;
             Expr pTransformedArgument = exprSrc;
 
-            if (ctypeLiftBest > 0 && !typeFrom.IsNullableType() && fDstHasNull)
+            if (ctypeLiftBest > 0 && !(typeFrom is NullableType) && fDstHasNull)
             {
                 // Create the memgroup.
                 ExprMemberGroup pMemGroup = ExprFactory.CreateMemGroup(null, mwiBest);
@@ -1341,7 +1341,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     }
                     else
                     {
-                        if (typeTo.IsNullableType())
+                        if (typeTo is NullableType)
                         {
                             // We need to generate a nullable value access, the conversion will be used without lifting.
                             pConversionArgument = mustCast(exprSrc, typeFrom);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
@@ -659,7 +659,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     ErrorContext.Error(ErrorCode.ERR_MethGrpToNonDel, grp.Name, typeDst);
                 return false;
             }
-            AggregateType type = typeDst.AsAggregateType();
+            AggregateType type = typeDst as AggregateType;
             MethodSymbol methCtor = SymbolLoader.PredefinedMembers.FindDelegateConstructor(type.getAggregate(), fReportErrors);
             if (methCtor == null)
                 return false;
@@ -958,10 +958,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 // nullable of it) as its from-type.
                 fImplicitOrExactSrc = true;
             }
-            else if (typeSrcBase.IsAggregateType() && typeSrcBase.getAggregate().HasConversion(GetSymbolLoader()))
+            else if (typeSrcBase is AggregateType atSrcBase && atSrcBase.getAggregate().HasConversion(GetSymbolLoader()))
             {
-                rgats[cats++] = typeSrcBase.AsAggregateType();
-                fIntPtrOverride2 = typeSrcBase.isPredefType(PredefinedType.PT_INTPTR) || typeSrcBase.isPredefType(PredefinedType.PT_UINTPTR);
+                rgats[cats++] = atSrcBase;
+                fIntPtrOverride2 = atSrcBase.isPredefType(PredefinedType.PT_INTPTR) || atSrcBase.isPredefType(PredefinedType.PT_UINTPTR);
             }
 
             // Get the list of operators from the destination.
@@ -976,11 +976,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     rgats[cats++] = atsBase;
                 }
             }
-            else if (typeDstBase.IsAggregateType())
+            else if (typeDstBase is AggregateType atDstBase)
             {
                 if (typeDstBase.getAggregate().HasConversion(GetSymbolLoader()))
                 {
-                    rgats[cats++] = typeDstBase.AsAggregateType();
+                    rgats[cats++] = atDstBase;
                 }
 
                 if (fIntPtrOverride2 && !typeDstBase.isPredefType(PredefinedType.PT_LONG) && !typeDstBase.isPredefType(PredefinedType.PT_ULONG))

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
@@ -687,12 +687,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 isExtensionMethod = true;
                 TypeArray extParams = GetTypes().SubstTypeArray(mwiWrap.Meth().Params, mwiWrap.GetType());
                 // The this parameter must be a reference type.
-                if (extParams[0].IsTypeParameterType() ? !@params[0].IsRefType() : !extParams[0].IsRefType())
+                CType param = extParams[0] is TypeParameterType ? @params[0] : extParams[0];
+                if (!param.IsRefType())
                 {
                     // We should issue a better message here.
                     // We were only disallowing value types, hence the error message specific to value types.
                     // Now we are issuing the same error message for not-known to be reference types, not just value types.
-                    ErrorContext.Error(ErrorCode.ERR_ValueTypeExtDelegate, mwiWrap, extParams[0].IsTypeParameterType() ? @params[0] : extParams[0]);
+                    ErrorContext.Error(ErrorCode.ERR_ValueTypeExtDelegate, mwiWrap, param);
                 }
             }
 
@@ -942,9 +943,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             bool fIntPtrOverride2 = false;
 
             // Get the list of operators from the source.
-            if (typeSrcBase.IsTypeParameterType())
+            if (typeSrcBase is TypeParameterType typeParamSrc)
             {
-                AggregateType atsBase = typeSrcBase.AsTypeParameterType().GetEffectiveBaseClass();
+                AggregateType atsBase = typeParamSrc.GetEffectiveBaseClass();
                 if (atsBase != null && atsBase.getAggregate().HasConversion(GetSymbolLoader()))
                 {
                     rgats[cats++] = atsBase;
@@ -964,13 +965,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
 
             // Get the list of operators from the destination.
-            if (typeDstBase.IsTypeParameterType())
+            if (typeDstBase is TypeParameterType typeParamDst)
             {
                 // If an explicit conversion exists from typeSrc to the class bound, then
                 // an explicit conversion exists from typeSrc to typeDst. An implicit is no better
                 // than an explicit.
                 AggregateType atsBase;
-                if (!fImplicitOnly && (atsBase = typeDstBase.AsTypeParameterType().GetEffectiveBaseClass()).getAggregate().HasConversion(GetSymbolLoader()))
+                if (!fImplicitOnly && (atsBase = typeParamDst.GetEffectiveBaseClass()).getAggregate().HasConversion(GetSymbolLoader()))
                 {
                     rgats[cats++] = atsBase;
                 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversions.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversions.cs
@@ -90,11 +90,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 // For a type-parameter T that is known to be a reference type (§25.7), the following explicit reference conversions exist:
                 // •    From any interface-type to T.
                 // •    From T to any interface-type I provided there isn’t already an implicit reference conversion from T to I.
-                if (typeSrc.isInterfaceType() && typeDst.IsTypeParameterType())
+                if (typeSrc.isInterfaceType() && typeDst is TypeParameterType)
                 {
                     return true;
                 }
-                if (typeSrc.IsTypeParameterType() && typeDst.isInterfaceType())
+                if (typeSrc is TypeParameterType && typeDst.isInterfaceType())
                 {
                     return true;
                 }
@@ -246,7 +246,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 {
                     continue;
                 }
-                TypeParameterType pParam = pTypeParams[iParam].AsTypeParameterType();
+                TypeParameterType pParam = (TypeParameterType)pTypeParams[iParam];
                 if (pParam.Invariant)
                 {
                     return false;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversions.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversions.cs
@@ -325,7 +325,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         ***************************************************************************************************/
         public static bool FWrappingConv(CType typeSrc, CType typeDst)
         {
-            return typeDst.IsNullableType() && typeSrc == typeDst.AsNullableType().GetUnderlyingType();
+            return typeDst is NullableType nubDst && typeSrc == nubDst.GetUnderlyingType();
         }
 
         /***************************************************************************************************

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversions.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversions.cs
@@ -242,7 +242,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                 // If they're identical then this one is automatically good, so skip it.
                 // If we have an error type, then we're in some fault tolerance. Let it through.
-                if (pSourceArg == pTargetArg || pTargetArg.IsErrorType() || pSourceArg.IsErrorType())
+                if (pSourceArg == pTargetArg || pTargetArg is ErrorType || pSourceArg is ErrorType)
                 {
                     continue;
                 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExplicitConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExplicitConversion.cs
@@ -293,7 +293,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     // a type variable. This will involve a type check and possibly an unbox.
                     // There is an explicit conversion from non-interface X to the type var iff there is an
                     // implicit conversion from the type var to X.
-                    if (_typeSrc.IsTypeParameterType())
+                    if (_typeSrc is TypeParameterType)
                     {
                         // Need to box first before unboxing.
                         Expr exprT;
@@ -771,7 +771,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 // * From T to any interface-type I provided there isn't already an implicit reference
                 //   conversion from T to I.
 
-                if (!_typeSrc.IsTypeParameterType())
+                if (!(_typeSrc is TypeParameterType))
                 {
                     return AggCastResult.Failure;
                 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExplicitConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExplicitConversion.cs
@@ -418,7 +418,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 // * From any pointer-type to any other pointer-type.
                 // * From sbyte, byte, short, ushort, int, uint, long, or ulong to any pointer-type.
 
-                if (_typeSrc.IsPointerType() || _typeSrc.fundType() <= FUNDTYPE.FT_LASTINTEGRAL && _typeSrc.isNumericType())
+                if (_typeSrc is PointerType || _typeSrc.fundType() <= FUNDTYPE.FT_LASTINTEGRAL && _typeSrc.isNumericType())
                 {
                     if (_needsExprDest)
                         _binder.bindSimpleCast(_exprSrc, _exprTypeDest, out _exprDest);
@@ -752,7 +752,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 //
                 // * From any pointer-type to sbyte, byte, short, ushort, int, uint, long, or ulong.
 
-                if (!_typeSrc.IsPointerType() || aggTypeDest.fundType() > FUNDTYPE.FT_LASTINTEGRAL || !aggTypeDest.isNumericType())
+                if (!(_typeSrc is PointerType) || aggTypeDest.fundType() > FUNDTYPE.FT_LASTINTEGRAL || !aggTypeDest.isNumericType())
                 {
                     return AggCastResult.Failure;
                 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExplicitConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExplicitConversion.cs
@@ -161,7 +161,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         break;
                     case TypeKind.TK_AggregateType:
                         {
-                            AggCastResult result = bindExplicitConversionToAggregate(_typeDest.AsAggregateType());
+                            AggCastResult result = bindExplicitConversionToAggregate(_typeDest as AggregateType);
 
                             if (result == AggCastResult.Success)
                             {
@@ -234,8 +234,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 Debug.Assert(_typeSrc != null);
                 Debug.Assert(_typeDest != null);
 
-                if (!(_typeSrc is ArrayType arrSrc) || !arrSrc.IsSZArray ||
-                    !_typeDest.isInterfaceType() || _typeDest.AsAggregateType().GetTypeArgsAll().Count != 1)
+                if (!(_typeSrc is ArrayType arrSrc) || !arrSrc.IsSZArray || !(_typeDest is AggregateType aggDest)
+                    || !aggDest.isInterfaceType() || aggDest.GetTypeArgsAll().Count != 1)
                 {
                     return false;
                 }
@@ -244,15 +244,15 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 AggregateSymbol aggIReadOnlyList = GetSymbolLoader().GetOptPredefAgg(PredefinedType.PT_G_IREADONLYLIST);
 
                 if ((aggIList == null ||
-                    !GetSymbolLoader().IsBaseAggregate(aggIList, _typeDest.AsAggregateType().getAggregate())) &&
+                    !GetSymbolLoader().IsBaseAggregate(aggIList, aggDest.getAggregate())) &&
                     (aggIReadOnlyList == null ||
-                    !GetSymbolLoader().IsBaseAggregate(aggIReadOnlyList, _typeDest.AsAggregateType().getAggregate())))
+                    !GetSymbolLoader().IsBaseAggregate(aggIReadOnlyList, aggDest.getAggregate())))
                 {
                     return false;
                 }
 
                 CType typeArr = arrSrc.GetElementType();
-                CType typeLst = _typeDest.AsAggregateType().GetTypeArgsAll()[0];
+                CType typeLst = aggDest.GetTypeArgsAll()[0];
 
                 if (!CConversions.FExpRefConv(GetSymbolLoader(), typeArr, typeLst))
                 {
@@ -319,8 +319,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 //   S[] to System.Collections.Generic.IList<T> or System.Collections.Generic.IReadOnlyList<T>. This is precisely when either S and T
                 //   are the same type or there is an implicit or explicit reference conversion from S to T.
 
-                if (!arrayDest.IsSZArray || !_typeSrc.isInterfaceType() ||
-                    _typeSrc.AsAggregateType().GetTypeArgsAll().Count != 1)
+                if (!arrayDest.IsSZArray || !(_typeSrc is AggregateType aggSrc) || !aggSrc.isInterfaceType() ||
+                    aggSrc.GetTypeArgsAll().Count != 1)
                 {
                     return false;
                 }
@@ -329,15 +329,15 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 AggregateSymbol aggIReadOnlyList = GetSymbolLoader().GetOptPredefAgg(PredefinedType.PT_G_IREADONLYLIST);
 
                 if ((aggIList == null ||
-                    !GetSymbolLoader().IsBaseAggregate(aggIList, _typeSrc.AsAggregateType().getAggregate())) &&
+                    !GetSymbolLoader().IsBaseAggregate(aggIList, aggSrc.getAggregate())) &&
                     (aggIReadOnlyList == null ||
-                    !GetSymbolLoader().IsBaseAggregate(aggIReadOnlyList, _typeSrc.AsAggregateType().getAggregate())))
+                    !GetSymbolLoader().IsBaseAggregate(aggIReadOnlyList, aggSrc.getAggregate())))
                 {
                     return false;
                 }
 
                 CType typeArr = arrayDest.GetElementType();
-                CType typeLst = _typeSrc.AsAggregateType().GetTypeArgsAll()[0];
+                CType typeLst = aggSrc.GetTypeArgsAll()[0];
 
                 Debug.Assert(!typeArr.IsNeverSameType());
                 if (typeArr != typeLst && !CConversions.FExpRefConv(GetSymbolLoader(), typeArr, typeLst))
@@ -531,7 +531,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 Debug.Assert(aggTypeDest != null);
                 Debug.Assert(aggTypeDest.isPredefType(PredefinedType.PT_DECIMAL));
 
-                AggregateType underlyingType = _typeSrc.underlyingType().AsAggregateType();
+                AggregateType underlyingType = _typeSrc.underlyingType() as AggregateType;
 
                 // Need to first cast the source expr to its underlying type.
 
@@ -708,15 +708,15 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 Debug.Assert(_typeSrc != null);
                 Debug.Assert(aggTypeDest != null);
 
-                if (!_typeSrc.IsAggregateType())
+                if (!(_typeSrc is AggregateType atSrc))
                 {
                     return AggCastResult.Failure;
                 }
 
-                AggregateSymbol aggSrc = _typeSrc.AsAggregateType().getAggregate();
+                AggregateSymbol aggSrc = atSrc.getAggregate();
                 AggregateSymbol aggDest = aggTypeDest.getAggregate();
 
-                if (GetSymbolLoader().HasBaseConversion(aggTypeDest, _typeSrc.AsAggregateType()))
+                if (GetSymbolLoader().HasBaseConversion(aggTypeDest, atSrc))
                 {
                     if (_needsExprDest)
                     {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExplicitConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExplicitConversion.cs
@@ -148,7 +148,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         }
                         break;
                     case TypeKind.TK_ArrayType:
-                        if (bindExplicitConversionToArray(_typeDest.AsArrayType()))
+                        if (bindExplicitConversionToArray((ArrayType)_typeDest))
                         {
                             return true;
                         }
@@ -234,7 +234,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 Debug.Assert(_typeSrc != null);
                 Debug.Assert(_typeDest != null);
 
-                if (!_typeSrc.IsArrayType() || !_typeSrc.AsArrayType().IsSZArray ||
+                if (!(_typeSrc is ArrayType arrSrc) || !arrSrc.IsSZArray ||
                     !_typeDest.isInterfaceType() || _typeDest.AsAggregateType().GetTypeArgsAll().Count != 1)
                 {
                     return false;
@@ -251,7 +251,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     return false;
                 }
 
-                CType typeArr = _typeSrc.AsArrayType().GetElementType();
+                CType typeArr = arrSrc.GetElementType();
                 CType typeLst = _typeDest.AsAggregateType().GetTypeArgsAll()[0];
 
                 if (!CConversions.FExpRefConv(GetSymbolLoader(), typeArr, typeLst))
@@ -383,9 +383,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 Debug.Assert(_typeSrc != null);
                 Debug.Assert(arrayDest != null);
 
-                if (_typeSrc.IsArrayType())
+                if (_typeSrc is ArrayType arrSrc)
                 {
-                    return bindExplicitConversionFromArrayToArray(_typeSrc.AsArrayType(), arrayDest);
+                    return bindExplicitConversionFromArrayToArray(arrSrc, arrayDest);
                 }
 
                 if (bindExplicitConversionFromIListToArray(arrayDest))

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExplicitConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExplicitConversion.cs
@@ -105,8 +105,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     return true;
                 }
 
-                if (_typeSrc == null || _typeDest == null || _typeSrc.IsErrorType() ||
-                    _typeDest.IsErrorType() || _typeDest.IsNeverSameType())
+                if (_typeSrc == null || _typeDest == null || _typeSrc is ErrorType ||
+                    _typeDest is ErrorType || _typeDest.IsNeverSameType())
                 {
                     return false;
                 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExplicitConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExplicitConversion.cs
@@ -111,13 +111,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     return false;
                 }
 
-                if (_typeDest.IsNullableType())
+                if (_typeDest is NullableType)
                 {
                     // This is handled completely by BindImplicitConversion.
                     return false;
                 }
 
-                if (_typeSrc.IsNullableType())
+                if (_typeSrc is NullableType)
                 {
                     return bindExplicitConversionFromNub();
                 }
@@ -197,7 +197,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         Expr valueSrc = _exprSrc;
                         // This is a holdover from the days when you could have nullable of nullable.
                         // Can we remove this loop?
-                        while (valueSrc.Type.IsNullableType())
+                        while (valueSrc.Type is NullableType)
                         {
                             valueSrc = _binder.BindNubValue(valueSrc);
                         }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExplicitConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExplicitConversion.cs
@@ -820,7 +820,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     return result;
                 }
 
-                if (_typeSrc.IsVoidType())
+                if (_typeSrc is VoidType)
                 {
                     // No conversion is allowed to or from a void type (user defined or otherwise)
                     // This is most likely the result of a failed anonymous method or member group conversion

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -1068,15 +1068,15 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         private ExprCall BindLiftedUDUnop(Expr arg, CType typeArg, MethPropWithInst mpwi)
         {
             CType typeRaw = typeArg.StripNubs();
-            if (!arg.Type.IsNullableType() || !canConvert(arg.Type.StripNubs(), typeRaw, CONVERTTYPE.NOUDC))
+            if (!(arg.Type is NullableType) || !canConvert(arg.Type.StripNubs(), typeRaw, CONVERTTYPE.NOUDC))
             {
                 // Convert then lift.
                 arg = mustConvert(arg, typeArg);
             }
-            Debug.Assert(arg.Type.IsNullableType());
+            Debug.Assert(arg.Type is NullableType);
 
             CType typeRet = GetTypes().SubstType(mpwi.Meth().RetType, mpwi.GetType());
-            if (!typeRet.IsNullableType())
+            if (!(typeRet is NullableType))
             {
                 typeRet = GetTypes().GetNullable(typeRet);
             }
@@ -1557,7 +1557,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             CType typeObj = pObject.Type;
             CType typeTmp;
 
-            if (typeObj.IsNullableType() && (typeTmp = typeObj.AsNullableType().GetAts(GetErrorContext())) != null && typeTmp != swt.GetType())
+            if (typeObj is NullableType nubTypeObj && (typeTmp = nubTypeObj.GetAts(GetErrorContext())) != null && typeTmp != swt.GetType())
             {
                 typeObj = typeTmp;
             }
@@ -1676,9 +1676,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Debug.Assert(typeObj != null);
 
             // Don't remap static or interface methods.
-            if (typeObj.IsNullableType())
+            if (typeObj is NullableType nubTypeObj)
             {
-                typeObj = typeObj.AsNullableType().GetAts(symbolLoader.GetErrorContext());
+                typeObj = nubTypeObj.GetAts(symbolLoader.GetErrorContext());
                 if (typeObj == null)
                 {
                     VSFAIL("Why did GetAts return null?");

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -501,7 +501,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             CType type = pObject.Type;
 
-            if (!type.IsAggregateType() && !type.IsTypeParameterType())
+            if (!type.IsAggregateType() && !(type is TypeParameterType))
             {
                 ErrorContext.Error(ErrorCode.ERR_BadIndexLHS, type);
                 MethWithInst mwi = new MethWithInst(null, null);
@@ -956,7 +956,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     typeSrc = typeSrc.StripNubs();
                     goto LAgain;
                 case TypeKind.TK_TypeParameterType:
-                    typeSrc = typeSrc.AsTypeParameterType().GetEffectiveBaseClass();
+                    typeSrc = ((TypeParameterType)typeSrc).GetEffectiveBaseClass();
                     goto LAgain;
                 case TypeKind.TK_AggregateType:
                     if (!typeSrc.isClassType() && !typeSrc.isStructType() || typeSrc.AsAggregateType().getAggregate().IsSkipUDOps())
@@ -1562,7 +1562,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 typeObj = typeTmp;
             }
 
-            if (typeObj.IsTypeParameterType() || typeObj.IsAggregateType())
+            if (typeObj is TypeParameterType || typeObj.IsAggregateType())
             {
                 AggregateSymbol aggCalled = null;
                 aggCalled = swt.Sym.parent.AsAggregateSymbol();
@@ -1577,7 +1577,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
 
                 if (pfConstrained &&
-                    (typeObj.IsTypeParameterType() ||
+                    (typeObj is TypeParameterType ||
                      typeObj.isStructType() && swt.GetType().IsRefType() && swt.Sym.IsVirtual()))
                 {
                     // For calls on type parameters or virtual calls on struct types (not enums),

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -744,7 +744,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 pResult.SetMismatchedStaticBit();
             }
 
-            if (pFieldType.IsErrorType())
+            if (pFieldType is ErrorType)
             {
                 pResult.SetError();
             }
@@ -1240,14 +1240,14 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 {
                     pOperand2 = UnwrapExpression(pOperand2);
                     if (pOperand1.Type != null &&
-                            !pOperand1.Type.IsErrorType() &&
+                            !(pOperand1.Type is ErrorType) &&
                             pOperand2.Type != null &&
-                            !pOperand2.Type.IsErrorType())
+                            !(pOperand2.Type is ErrorType))
                     {
                         ErrorContext.Error(ErrorCode.ERR_BadBinaryOps, strOp, pOperand1.Type, pOperand2.Type);
                     }
                 }
-                else if (pOperand1.Type != null && !pOperand1.Type.IsErrorType())
+                else if (pOperand1.Type != null && !(pOperand1.Type is ErrorType))
                 {
                     ErrorContext.Error(ErrorCode.ERR_BadUnaryOp, strOp, pOperand1.Type);
                 }
@@ -2377,7 +2377,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                 Debug.Assert(arg != null);
 
-                if (arg.Type == null || arg.Type.IsErrorType())
+                if (arg.Type == null || arg.Type is ErrorType)
                 {
                     typeErrors = true;
                 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -439,7 +439,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             CType pIntType = GetReqPDT(PredefinedType.PT_INT);
 
             // Array indexing must occur on an array type.
-            if (!pOp1.Type.IsArrayType())
+            if (!(pOp1.Type is ArrayType pArrayType))
             {
                 Debug.Assert(!(pOp1.Type is PointerType));
                 pExpr = bindIndexer(pOp1, pOp2, bindFlags);
@@ -449,7 +449,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
                 return pExpr;
             }
-            ArrayType pArrayType = pOp1.Type.AsArrayType();
+
             checkUnsafe(pArrayType.GetElementType()); // added to the binder so we don't bind to pointer ops
             // Check the rank of the array against the number of indices provided, and
             // convert the indexes to ints
@@ -1806,8 +1806,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                             // void Foo(int y, params int[] x);
                             // ...
                             // Foo(x:1, y:1);
-                            CType arrayType = GetTypes().SubstType(mp.Params[mp.Params.Count - 1], type, pTypeArgs);
-                            CType elemType = arrayType.AsArrayType().GetElementType();
+                            CType arrayType = (ArrayType)GetTypes().SubstType(mp.Params[mp.Params.Count - 1], type, pTypeArgs);
 
                             // Use an EK_ARRINIT even in the empty case so empty param arrays in attributes work.
                             ExprArrayInit arrayInit = GetExprFactory().CreateArrayInit(arrayType, null, null, new[] { 0 }, 1);
@@ -1875,7 +1874,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             // we need to create an array and put it as the last arg...
             CType substitutedArrayType = GetTypes().SubstType(mp.Params[mp.Params.Count - 1], type, pTypeArgs);
-            if (!substitutedArrayType.IsArrayType() || !substitutedArrayType.AsArrayType().IsSZArray)
+            if (!(substitutedArrayType is ArrayType subArr) || !subArr.IsSZArray)
             {
                 // Invalid type for params array parameter. Happens in LAF scenarios, e.g.
                 //
@@ -1885,7 +1884,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 return;
             }
 
-            CType elementType = substitutedArrayType.AsArrayType().GetElementType();
+            CType elementType = subArr.GetElementType();
 
             // Use an EK_ARRINIT even in the empty case so empty param arrays in attributes work.
             ExprArrayInit exprArrayInit = GetExprFactory().CreateArrayInit(substitutedArrayType, null, null, new[] { 0 }, 1);
@@ -2057,7 +2056,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             CType type = @params[@params.Count - 1];
             CType elementType = null;
 
-            if (!type.IsArrayType())
+            if (!(type is ArrayType arr))
             {
                 ppExpandedParams = null;
                 // If we don't have an array sym, we don't have expanded parameters.
@@ -2065,7 +2064,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
 
             // At this point, we have an array sym.
-            elementType = type.AsArrayType().GetElementType();
+            elementType = arr.GetElementType();
 
             for (int itype = @params.Count - 1; itype < count; itype++)
             {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -441,7 +441,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // Array indexing must occur on an array type.
             if (!pOp1.Type.IsArrayType())
             {
-                Debug.Assert(!pOp1.Type.IsPointerType());
+                Debug.Assert(!(pOp1.Type is PointerType));
                 pExpr = bindIndexer(pOp1, pOp2, bindFlags);
                 if (bIsError)
                 {
@@ -708,7 +708,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             checkUnsafe(pFieldType); // added to the binder so we don't bind to pointer ops
 
-            bool isLValue = (pOptionalObject != null && pOptionalObject.Type.IsPointerType()) || objectIsLvalue(pOptionalObject);
+            bool isLValue = pOptionalObject?.Type is PointerType || objectIsLvalue(pOptionalObject);
 
             // Exception: a readonly field is not an lvalue unless we're in the constructor/static constructor appropriate
             // for the field.
@@ -1449,7 +1449,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     {
                         checkUnsafe(type);
                     }
-                    if (fCheckParams && type.IsParameterModifierType())
+                    if (fCheckParams && type is ParameterModifierType)
                     {
                         SetExternalRef(type);
                     }
@@ -1760,7 +1760,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 Expr indir = it.Current();
                 // this will splice the optional arguments into the list
 
-                if (indir.Type.IsParameterModifierType())
+                if (indir.Type is ParameterModifierType)
                 {
                     if (paramCount != 0)
                         paramCount--;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
@@ -1246,7 +1246,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 for (int i = 0; i < typeVars.Count; i++)
                 {
                     CType type = typeVars[i];
-                    if (type.IsErrorType())
+                    if (type is ErrorType)
                     {
                         return true;
                     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
@@ -1111,9 +1111,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                                 // this is to eliminate the paranoid case of types that are equal but can't convert 
                                 // (think ErrorType != ErrorType)
                                 // See if they just differ in out / ref.
-                                CType argStripped = _pArguments.types[ivar].IsParameterModifierType() ?
-                                    _pArguments.types[ivar].AsParameterModifierType().GetParameterType() : _pArguments.types[ivar];
-                                CType varStripped = var.IsParameterModifierType() ? var.AsParameterModifierType().GetParameterType() : var;
+                                CType argStripped = _pArguments.types[ivar] is ParameterModifierType modArg ?
+                                    modArg.GetParameterType() : _pArguments.types[ivar];
+                                CType varStripped = var is ParameterModifierType modVar ? modVar.GetParameterType() : var;
 
                                 if (argStripped == varStripped)
                                 {
@@ -1496,22 +1496,21 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     if (!_pExprBinder.canConvert(_pArguments.prgexpr[ivar], var))
                     {
                         // See if they just differ in out / ref.
-                        CType argStripped = _pArguments.types[ivar].IsParameterModifierType() ?
-                            _pArguments.types[ivar].AsParameterModifierType().GetParameterType() : _pArguments.types[ivar];
-                        CType varStripped = var.IsParameterModifierType() ? var.AsParameterModifierType().GetParameterType() : var;
+                        CType argStripped = _pArguments.types[ivar] is ParameterModifierType modArg ? modArg.GetParameterType() : _pArguments.types[ivar];
+                        CType varStripped = var is ParameterModifierType modVar ? modVar.GetParameterType() : var;
                         if (argStripped == varStripped)
                         {
                             if (varStripped != var)
                             {
                                 // The argument is wrong in ref / out-ness.
-                                GetErrorContext().Error(ErrorCode.ERR_BadArgRef, ivar + 1, (var.IsParameterModifierType() && var.AsParameterModifierType().isOut) ? "out" : "ref");
+                                GetErrorContext().Error(ErrorCode.ERR_BadArgRef, ivar + 1, var is ParameterModifierType mod && mod.isOut ? "out" : "ref");
                             }
                             else
                             {
                                 CType argument = _pArguments.types[ivar];
 
                                 // the argument is decorated, but doesn't needs a 'ref' or 'out'
-                                GetErrorContext().Error(ErrorCode.ERR_BadArgExtraRef, ivar + 1, (argument.IsParameterModifierType() && argument.AsParameterModifierType().isOut) ? "out" : "ref");
+                                GetErrorContext().Error(ErrorCode.ERR_BadArgExtraRef, ivar + 1, argument is ParameterModifierType mod && mod.isOut ? "out" : "ref");
                             }
                         }
                         else
@@ -1541,7 +1540,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 for (int ivar = 0; ivar < _pArguments.carg; ivar++)
                 {
                     CType var = _pBestParameters[ivar];
-                    if (var.IsParameterModifierType())
+                    if (var is ParameterModifierType)
                     {
                         GetErrorContext().ErrorRef(ErrorCode.ERR_InitializerAddHasParamModifiers, _results.GetBestResult());
                         return true;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
@@ -325,7 +325,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                             TypeArray ifaces = _pCurrentType.GetIfacesAll();
                             for (int i = 0; i < ifaces.Count; i++)
                             {
-                                AggregateType type = ifaces[i].AsAggregateType();
+                                AggregateType type = ifaces[i] as AggregateType;
 
                                 Debug.Assert(type.isInterfaceType());
                                 _HiddenTypes.Add(type);
@@ -725,14 +725,14 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     method = slotMethod;
                 }
 
-                if (!pType.IsAggregateType())
+                if (!(pType is AggregateType agg))
                 {
                     // Not something that can have overrides anyway.
                     return method;
                 }
 
-                for (AggregateSymbol pAggregate = pType.AsAggregateType().GetOwningAggregate();
-                        pAggregate != null && pAggregate.GetBaseAgg() != null;
+                for (AggregateSymbol pAggregate = agg.GetOwningAggregate();
+                        pAggregate?.GetBaseAgg() != null;
                         pAggregate = pAggregate.GetBaseAgg())
                 {
                     for (MethodOrPropertySymbol meth = symbolLoader.LookupAggMember(method.name, pAggregate, symbmask_t.MASK_MethodSymbol | symbmask_t.MASK_PropertySymbol).AsMethodOrPropertySymbol();
@@ -1237,12 +1237,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             private bool DoesTypeArgumentsContainErrorSym(CType var)
             {
-                if (!var.IsAggregateType())
+                if (!(var is AggregateType varAgg))
                 {
                     return false;
                 }
 
-                TypeArray typeVars = var.AsAggregateType().GetTypeArgsAll();
+                TypeArray typeVars = varAgg.GetTypeArgsAll();
                 for (int i = 0; i < typeVars.Count; i++)
                 {
                     CType type = typeVars[i];
@@ -1250,7 +1250,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     {
                         return true;
                     }
-                    else if (type.IsAggregateType())
+                    else if (type is AggregateType)
                     {
                         // If we have an agg type sym, check if its type args have errors.
                         if (DoesTypeArgumentsContainErrorSym(type))
@@ -1259,6 +1259,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         }
                     }
                 }
+
                 return false;
             }
 
@@ -1385,10 +1386,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 {
                     // Give a better message for delegate invoke.
                     if (_pGroup.OptionalObject != null &&
-                            _pGroup.OptionalObject.Type.IsAggregateType() &&
-                            _pGroup.OptionalObject.Type.AsAggregateType().GetOwningAggregate().IsDelegate())
+                            _pGroup.OptionalObject.Type is AggregateType agg &&
+                            agg.GetOwningAggregate().IsDelegate())
                     {
-                        GetErrorContext().Error(ErrorCode.ERR_BadNamedArgumentForDelegateInvoke, _pGroup.OptionalObject.Type.AsAggregateType().GetOwningAggregate().name, _pInvalidSpecifiedName);
+                        GetErrorContext().Error(ErrorCode.ERR_BadNamedArgumentForDelegateInvoke, agg.GetOwningAggregate().name, _pInvalidSpecifiedName);
                     }
                     else
                     {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
@@ -1425,7 +1425,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         {
                             if (0 != (_pGroup.Flags & EXPRFLAG.EXF_CTOR))
                             {
-                                Debug.Assert(!_pGroup.ParentType.IsTypeParameterType());
+                                Debug.Assert(!(_pGroup.ParentType is TypeParameterType));
                                 GetErrorContext().MakeError(out error, ErrorCode.ERR_BadCtorArgCount, _pGroup.ParentType, _pArguments.carg);
                             }
                             else

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
@@ -575,7 +575,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     int index)
             {
                 CType pParamType = type;
-                CType pRawParamType = type.IsNullableType() ? type.AsNullableType().GetUnderlyingType() : type;
+                CType pRawParamType = type.StripNubs();
 
                 Expr optionalArgument = null;
                 if (methprop.HasDefaultParameterValue(index))
@@ -610,7 +610,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                             optionalArgument = exprFactory.CreateConstant(pConstValType, cv);
                         }
                     }
-                    else if ((pParamType.IsRefType() || pParamType.IsNullableType()) && cv.IsNullRef)
+                    else if ((pParamType.IsRefType() || pParamType is NullableType) && cv.IsNullRef)
                     {
                         // We have an "= null" default value with a reference type or a nullable type.
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinderResult.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinderResult.cs
@@ -78,13 +78,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     // If we don't have a winner yet, go through each element's type args.
                     for (int i = 0; i < max; i++)
                     {
-                        if (pTypeArgs1[i].IsAggregateType())
+                        if (pTypeArgs1[i] is AggregateType aggArg1)
                         {
-                            leftErrors += NumberOfErrorTypes(pTypeArgs1[i].AsAggregateType().GetTypeArgsAll());
+                            leftErrors += NumberOfErrorTypes(aggArg1.GetTypeArgsAll());
                         }
-                        if (pTypeArgs2[i].IsAggregateType())
+                        if (pTypeArgs2[i] is AggregateType aggArg2)
                         {
-                            rightErrors += NumberOfErrorTypes(pTypeArgs2[i].AsAggregateType().GetTypeArgsAll());
+                            rightErrors += NumberOfErrorTypes(aggArg2.GetTypeArgsAll());
                         }
                     }
                 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinderResult.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinderResult.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 int nCount = 0;
                 for (int i = 0; i < pTypeArgs.Count; i++)
                 {
-                    if (pTypeArgs[i].IsErrorType())
+                    if (pTypeArgs[i] is ErrorType)
                     {
                         nCount++;
                     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ImplicitConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ImplicitConversion.cs
@@ -207,7 +207,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         // If not, try user defined implicit conversions.
                         break;
                     case TypeKind.TK_TypeParameterType:
-                        if (bindImplicitConversionFromTypeVar(_typeSrc.AsTypeParameterType()))
+                        if (bindImplicitConversionFromTypeVar(_typeSrc as TypeParameterType))
                         {
                             return true;
                         }
@@ -450,7 +450,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                 FUNDTYPE ftDest = _typeDest.fundType();
                 if (ftDest != FUNDTYPE.FT_REF && ftDest != FUNDTYPE.FT_PTR &&
-                    (ftDest != FUNDTYPE.FT_VAR || !_typeDest.AsTypeParameterType().IsReferenceType()) &&
+                    (ftDest != FUNDTYPE.FT_VAR || !((TypeParameterType)_typeDest).IsReferenceType()) &&
                     // null is convertible to System.Nullable<T>.
                     !_typeDest.isPredefType(PredefinedType.PT_G_OPTIONAL))
                 {
@@ -845,7 +845,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         {
                             return true;
                         }
-                        if (_typeDest.IsTypeParameterType())
+                        if (_typeDest is TypeParameterType)
                         {
                             // For a type var destination we need to cast to object then to the other type var.
                             Expr exprT;
@@ -867,7 +867,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         }
                         typeTmp = bnds[itype];
                     }
-                    while (!typeTmp.isInterfaceType() && !typeTmp.IsTypeParameterType());
+                    while (!typeTmp.isInterfaceType() && !(typeTmp is TypeParameterType));
                 }
             }
             private SymbolLoader GetSymbolLoader()

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ImplicitConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ImplicitConversion.cs
@@ -105,7 +105,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         return true;
                     case TypeKind.TK_NullType:
                         // Can only convert to the null type if src is null.
-                        if (!_typeSrc.IsNullType())
+                        if (!(_typeSrc is NullType))
                         {
                             return false;
                         }
@@ -345,7 +345,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     Debug.Assert(_typeSrc == typeSrcBase);
 
                     // The null type can be implicitly converted to T? as the default value.
-                    if (_typeSrc.IsNullType())
+                    if (_typeSrc is NullType)
                     {
                         // If we have the constant null, generate it as a default value of T?.  If we have 
                         // some crazy expression which has been determined to be always null, like (null??null)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ImplicitConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ImplicitConversion.cs
@@ -147,14 +147,14 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     return true;
                 }
 
-                if (_typeDest.IsNullableType())
+                if (_typeDest is NullableType nubDest)
                 {
-                    return BindNubConversion(_typeDest.AsNullableType());
+                    return BindNubConversion(nubDest);
                 }
 
-                if (_typeSrc.IsNullableType())
+                if (_typeSrc is NullableType nubSrc)
                 {
-                    return bindImplicitConversionFromNullable(_typeSrc.AsNullableType());
+                    return bindImplicitConversionFromNullable(nubSrc);
                 }
 
                 if ((_flags & CONVERTTYPE.ISEXPLICIT) != 0)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ImplicitConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ImplicitConversion.cs
@@ -214,7 +214,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         // If not, try user defined implicit conversions.
                         break;
                     case TypeKind.TK_AggregateType:
-                        if (bindImplicitConversionFromAgg(_typeSrc.AsAggregateType()))
+                        if (bindImplicitConversionFromAgg(_typeSrc as AggregateType))
                         {
                             return true;
                         }
@@ -549,9 +549,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 // and the non-generic versions.
 
                 if ((_typeDest is ArrayType ||
-                     (_typeDest.isInterfaceType() &&
-                      _typeDest.AsAggregateType().GetTypeArgsAll().Count == 1 &&
-                      ((_typeDest.AsAggregateType().GetTypeArgsAll()[0] != ((ArrayType)_typeSrc).GetElementType()) ||
+                     (_typeDest is AggregateType aggDest && aggDest.isInterfaceType() &&
+                      aggDest.GetTypeArgsAll().Count == 1 &&
+                      ((aggDest.GetTypeArgsAll()[0] != ((ArrayType)_typeSrc).GetElementType()) ||
                        0 != (_flags & CONVERTTYPE.FORCECAST))))
                     &&
                     (0 != (_flags & CONVERTTYPE.FORCECAST) ||
@@ -630,7 +630,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 // *   From any delegate-type to System.Delegate.
                 // *   From any delegate-type to System.ICloneable.
 
-                if (!_typeDest.IsAggregateType() || !GetSymbolLoader().HasBaseConversion(pSource, _typeDest))
+                if (!(_typeDest is AggregateType) || !GetSymbolLoader().HasBaseConversion(pSource, _typeDest))
                 {
                     return false;
                 }
@@ -660,7 +660,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 // base class for all enums (21.4). A struct or enum can be boxed to the type System.ValueType, 
                 // since that is the direct base class for all structs (18.3.2) and a base class for all enums.
 
-                if (_typeDest.IsAggregateType() && GetSymbolLoader().HasBaseConversion(aggTypeSrc, _typeDest.AsAggregateType()))
+                if (_typeDest is AggregateType aggDest && GetSymbolLoader().HasBaseConversion(aggTypeSrc, aggDest))
                 {
                     if (_needsExprDest)
                         _binder.bindSimpleCast(_exprSrc, _exprTypeDest, out _exprDest, EXPRFLAG.EXF_BOX | EXPRFLAG.EXF_CANTBENULL);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ImplicitConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ImplicitConversion.cs
@@ -164,7 +164,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                 // Get the fundamental types of destination.
                 FUNDTYPE ftDest = _typeDest.fundType();
-                Debug.Assert(ftDest != FUNDTYPE.FT_NONE || _typeDest.IsParameterModifierType());
+                Debug.Assert(ftDest != FUNDTYPE.FT_NONE || _typeDest is ParameterModifierType);
 
                 switch (_typeSrc.GetTypeKind())
                 {
@@ -576,7 +576,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 //
                 // * From any pointer-type to the type void*.
 
-                if (_typeDest.IsPointerType() && _typeDest.AsPointerType().GetReferentType() == _binder.getVoidType())
+                if (_typeDest is PointerType ptDest && ptDest.GetReferentType() == _binder.getVoidType())
                 {
                     if (_needsExprDest)
                         _binder.bindSimpleCast(_exprSrc, _exprTypeDest, out _exprDest);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ImplicitConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ImplicitConversion.cs
@@ -548,10 +548,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 // including IList<T>, ICollection<T>, IEnumerable<T>, IReadOnlyList<T>, IReadOnlyCollection<T>
                 // and the non-generic versions.
 
-                if ((_typeDest.IsArrayType() ||
+                if ((_typeDest is ArrayType ||
                      (_typeDest.isInterfaceType() &&
                       _typeDest.AsAggregateType().GetTypeArgsAll().Count == 1 &&
-                      ((_typeDest.AsAggregateType().GetTypeArgsAll()[0] != _typeSrc.AsArrayType().GetElementType()) ||
+                      ((_typeDest.AsAggregateType().GetTypeArgsAll()[0] != ((ArrayType)_typeSrc).GetElementType()) ||
                        0 != (_flags & CONVERTTYPE.FORCECAST))))
                     &&
                     (0 != (_flags & CONVERTTYPE.FORCECAST) ||

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ImplicitConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ImplicitConversion.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 switch (_typeDest.GetTypeKind())
                 {
                     case TypeKind.TK_ErrorType:
-                        Debug.Assert(_typeDest.AsErrorType().HasTypeParent() || _typeDest.AsErrorType().HasNSParent());
+                        Debug.Assert(((ErrorType)_typeDest).HasParent());
                         if (_typeSrc != _typeDest)
                         {
                             return false;
@@ -126,9 +126,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         break;
                 }
 
-                if (_typeSrc.IsErrorType())
+                if (_typeSrc is ErrorType)
                 {
-                    Debug.Assert(!_typeDest.IsErrorType());
+                    Debug.Assert(!(_typeDest is ErrorType));
                     return false;
                 }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookup.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookup.cs
@@ -477,7 +477,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             for (int i = 0; i < types.Count; i++)
             {
-                AggregateType type = types[i].AsAggregateType();
+                AggregateType type = (AggregateType)types[i];
                 Debug.Assert(type.isInterfaceType());
                 type.fAllHidden = false;
                 type.fDiffHidden = !!_swtFirst;
@@ -489,7 +489,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             if (typeCur == null)
             {
-                typeCur = types[itypeNext++].AsAggregateType();
+                typeCur = types[itypeNext++] as AggregateType;
             }
             Debug.Assert(typeCur != null);
 
@@ -508,7 +508,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     TypeArray ifaces = typeCur.GetIfacesAll();
                     for (int i = 0; i < ifaces.Count; i++)
                     {
-                        AggregateType type = ifaces[i].AsAggregateType();
+                        AggregateType type = ifaces[i] as AggregateType;
                         Debug.Assert(type.isInterfaceType());
                         if (fHideByName)
                             type.fAllHidden = true;
@@ -525,7 +525,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     return !fHideObject;
 
                 // Substitution has already been done.
-                typeCur = types[itypeNext++].AsAggregateType();
+                typeCur = types[itypeNext++] as AggregateType;
             }
         }
 
@@ -626,7 +626,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             Debug.Assert((flags & ~MemLookFlags.All) == 0);
             Debug.Assert(obj == null || obj.Type != null);
-            Debug.Assert(typeSrc.IsAggregateType() || typeSrc is TypeParameterType);
+            Debug.Assert(typeSrc is AggregateType || typeSrc is TypeParameterType);
             Debug.Assert(checker != null);
 
             _prgtype = _rgtypeStart;
@@ -667,7 +667,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
             else if (!typeSrc.isInterfaceType())
             {
-                typeCls1 = typeSrc.AsAggregateType();
+                typeCls1 = (AggregateType)typeSrc;
 
                 if (typeCls1.IsWindowsRuntimeType())
                 {
@@ -678,7 +678,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             {
                 Debug.Assert(typeSrc.isInterfaceType());
                 Debug.Assert((_flags & (MemLookFlags.Ctor | MemLookFlags.NewObj | MemLookFlags.Operator | MemLookFlags.BaseCall)) == 0);
-                typeIface = typeSrc.AsAggregateType();
+                typeIface = (AggregateType)typeSrc;
                 ifaces = typeIface.GetIfacesAll();
             }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookup.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookup.cs
@@ -489,7 +489,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             if (typeCur == null)
             {
-                typeCur = types[itypeNext++] as AggregateType;
+                typeCur = (AggregateType)types[itypeNext++];
             }
             Debug.Assert(typeCur != null);
 
@@ -508,7 +508,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     TypeArray ifaces = typeCur.GetIfacesAll();
                     for (int i = 0; i < ifaces.Count; i++)
                     {
-                        AggregateType type = ifaces[i] as AggregateType;
+                        AggregateType type = (AggregateType)ifaces[i];
                         Debug.Assert(type.isInterfaceType());
                         if (fHideByName)
                             type.fAllHidden = true;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookup.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookup.cs
@@ -626,7 +626,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             Debug.Assert((flags & ~MemLookFlags.All) == 0);
             Debug.Assert(obj == null || obj.Type != null);
-            Debug.Assert(typeSrc.IsAggregateType() || typeSrc.IsTypeParameterType());
+            Debug.Assert(typeSrc.IsAggregateType() || typeSrc is TypeParameterType);
             Debug.Assert(checker != null);
 
             _prgtype = _rgtypeStart;
@@ -656,12 +656,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             TypeArray ifaces = BSYMMGR.EmptyTypeArray();
             AggregateType typeCls2 = null;
 
-            if (typeSrc.IsTypeParameterType())
+            if (typeSrc is TypeParameterType typeParamSrc)
             {
                 Debug.Assert((_flags & (MemLookFlags.Ctor | MemLookFlags.NewObj | MemLookFlags.Operator | MemLookFlags.BaseCall | MemLookFlags.TypeVarsAllowed)) == 0);
                 _flags &= ~MemLookFlags.TypeVarsAllowed;
-                ifaces = typeSrc.AsTypeParameterType().GetInterfaceBounds();
-                typeCls1 = typeSrc.AsTypeParameterType().GetEffectiveBaseClass();
+                ifaces = typeParamSrc.GetInterfaceBounds();
+                typeCls1 = typeParamSrc.GetEffectiveBaseClass();
                 if (ifaces.Count > 0 && typeCls1.isPredefType(PredefinedType.PT_OBJECT))
                     typeCls1 = null;
             }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodIterator.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodIterator.cs
@@ -269,7 +269,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     }
                     else
                     {
-                        _pCurrentType = _pContainingTypes[_nCurrentTypeCount++].AsAggregateType();
+                        _pCurrentType = _pContainingTypes[_nCurrentTypeCount++] as AggregateType;
                     }
                 }
                 else

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
@@ -1169,16 +1169,16 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             // SPEC:  Otherwise, if U is an array CType UE[...] and V is an array CType VE[...]
             // SPEC:   of the same rank then an exact inference from UE to VE is made.
-            if (!pSource.IsArrayType() || !pDest.IsArrayType())
+            if (!(pSource is ArrayType pArraySource) || !(pDest is ArrayType pArrayDest))
             {
                 return false;
             }
-            ArrayType pArraySource = pSource.AsArrayType();
-            ArrayType pArrayDest = pDest.AsArrayType();
+
             if (pArraySource.rank != pArrayDest.rank || pArraySource.IsSZArray != pArrayDest.IsSZArray)
             {
                 return false;
             }
+
             ExactInference(pArraySource.GetElementType(), pArrayDest.GetElementType());
             return true;
         }
@@ -1357,17 +1357,16 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 pSource = sourceParamType.GetEffectiveBaseClass();
             }
 
-            if (!pSource.IsArrayType())
+            if (!(pSource is ArrayType pArraySource))
             {
                 return false;
             }
-            ArrayType pArraySource = pSource.AsArrayType();
-            CType pElementSource = pArraySource.GetElementType();
-            CType pElementDest = null;
 
-            if (pDest.IsArrayType())
+            CType pElementSource = pArraySource.GetElementType();
+            CType pElementDest;
+
+            if (pDest is ArrayType pArrayDest)
             {
-                ArrayType pArrayDest = pDest.AsArrayType();
                 if (pArrayDest.rank != pArraySource.rank || pArrayDest.IsSZArray != pArraySource.IsSZArray)
                 {
                     return false;
@@ -1704,17 +1703,16 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // SPEC:     from Ue to Ve is made.
             // SPEC:    otherwise an exact inference from Ue to Ve is made.
 
-            if (!pDest.IsArrayType())
+            if (!(pDest is ArrayType pArrayDest))
             {
                 return false;
             }
-            ArrayType pArrayDest = pDest.AsArrayType();
-            CType pElementDest = pArrayDest.GetElementType();
-            CType pElementSource = null;
 
-            if (pSource.IsArrayType())
+            CType pElementDest = pArrayDest.GetElementType();
+            CType pElementSource;
+
+            if (pSource is ArrayType pArraySource)
             {
-                ArrayType pArraySource = pSource.AsArrayType();
                 if (pArrayDest.rank != pArraySource.rank || pArrayDest.IsSZArray != pArraySource.IsSZArray)
                 {
                     return false;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
@@ -328,7 +328,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         private static bool IsReallyAType(CType pType)
         {
-            if (pType is NullType || pType.IsBoundLambdaType() ||
+            if (pType is NullType || pType is BoundLambdaType ||
                 pType is VoidType ||
                 pType.IsMethodGroupType())
             {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
@@ -194,7 +194,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 _pFixedResults[iParam] = GetTypeManager().GetErrorType(
                                         null/*pParentType*/,
                                         null,
-                                        (_pMethodTypeParameters.ItemAsTypeParameterType(iParam)).GetName(),
+                                        ((TypeParameterType)_pMethodTypeParameters[iParam]).GetName(),
                                         BSYMMGR.EmptyTypeArray());
             }
             return GetGlobalSymbols().AllocParams(_pMethodTypeParameters.Count, _pFixedResults);
@@ -216,7 +216,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Debug.Assert(pParam != null);
             Debug.Assert(pParam.IsMethodTypeParameter());
             int iParam = pParam.GetIndexInTotalParameters();
-            Debug.Assert(_pMethodTypeParameters.ItemAsTypeParameterType(iParam) == pParam);
+            Debug.Assert(_pMethodTypeParameters[iParam] == pParam);
             return IsUnfixed(iParam);
         }
 
@@ -296,7 +296,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             CType[] ppMethodParameters = new CType[_pMethodTypeParameters.Count];
             for (int iParam = 0; iParam < _pMethodTypeParameters.Count; iParam++)
             {
-                TypeParameterType pParam = _pMethodTypeParameters.ItemAsTypeParameterType(iParam);
+                TypeParameterType pParam = (TypeParameterType)_pMethodTypeParameters[iParam];
                 ppMethodParameters[iParam] = IsUnfixed(iParam) ? pParam : _pFixedResults[iParam];
             }
             SubstContext subsctx = new SubstContext(_pClassTypeArguments.Items, _pClassTypeArguments.Count,
@@ -695,7 +695,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 if (IsUnfixed(iParam))
                 {
                     if (DoesInputTypeContain(pSource, pDest,
-                        _pMethodTypeParameters.ItemAsTypeParameterType(iParam)))
+                        _pMethodTypeParameters[iParam] as TypeParameterType))
                     {
                         return true;
                     }
@@ -743,7 +743,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 if (IsUnfixed(iParam))
                 {
                     if (DoesOutputTypeContain(pSource, pDest,
-                        _pMethodTypeParameters.ItemAsTypeParameterType(iParam)))
+                        _pMethodTypeParameters[iParam] as TypeParameterType))
                     {
                         return true;
                     }
@@ -786,9 +786,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 Expr pExpr = _pMethodArguments.prgexpr[iArg];
 
                 if (DoesInputTypeContain(pExpr, pDest,
-                        _pMethodTypeParameters.ItemAsTypeParameterType(jParam)) &&
+                        _pMethodTypeParameters[jParam] as TypeParameterType) &&
                     DoesOutputTypeContain(pExpr, pDest,
-                        _pMethodTypeParameters.ItemAsTypeParameterType(iParam)))
+                        _pMethodTypeParameters[iParam] as TypeParameterType))
                 {
                     return true;
                 }
@@ -1160,9 +1160,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             // SPEC:  If V is one of the unfixed Xi then U is added to the set of bounds
             // SPEC:   for Xi.
-            if (pDest.IsTypeParameterType())
+            if (pDest is TypeParameterType pTPType)
             {
-                TypeParameterType pTPType = pDest.AsTypeParameterType();
                 if (pTPType.IsMethodTypeParameter() && IsUnfixed(pTPType))
                 {
                     AddExactBound(pTPType, pSource);
@@ -1330,9 +1329,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             // SPEC:  If V is one of the unfixed Xi then U is added to the set of bounds
             // SPEC:   for Xi.
-            if (pDest.IsTypeParameterType())
+            if (pDest is TypeParameterType pTPType)
             {
-                TypeParameterType pTPType = pDest.AsTypeParameterType();
                 if (pTPType.IsMethodTypeParameter() && IsUnfixed(pTPType))
                 {
                     AddLowerBound(pTPType, pSource);
@@ -1362,9 +1360,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             //   public override M<U>(U u) { M(u); } // should infer M<int>
             // }
 
-            if (pSource.IsTypeParameterType())
+            if (pSource is TypeParameterType sourceParamType)
             {
-                pSource = pSource.AsTypeParameterType().GetEffectiveBaseClass();
+                pSource = sourceParamType.GetEffectiveBaseClass();
             }
 
             if (!pSource.IsArrayType())
@@ -1523,9 +1521,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             {
                 pSourceBase = pSource.AsAggregateType().GetBaseClass();
             }
-            else if (pSource.IsTypeParameterType())
+            else if (pSource is TypeParameterType sourceType)
             {
-                pSourceBase = pSource.AsTypeParameterType().GetEffectiveBaseClass();
+                pSourceBase = sourceType.GetEffectiveBaseClass();
             }
 
             while (pSourceBase != null)
@@ -1559,7 +1557,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             //TypeArray pInterfaces = null;
 
             if (!pSource.isStructType() && !pSource.isClassType() &&
-                !pSource.isInterfaceType() && !pSource.IsTypeParameterType())
+                !pSource.isInterfaceType() && !(pSource is TypeParameterType))
             {
                 return false;
             }
@@ -1620,7 +1618,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             for (int arg = 0; arg < pSourceArgs.Count; ++arg)
             {
-                TypeParameterType pTypeParam = pTypeParams.ItemAsTypeParameterType(arg);
+                TypeParameterType pTypeParam = (TypeParameterType)pTypeParams[arg];
                 CType pSourceArg = pSourceArgs[arg];
                 CType pDestArg = pDestArgs[arg];
 
@@ -1691,9 +1689,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             // SPEC:  If V is one of the unfixed Xi then U is added to the set of upper bounds
             // SPEC:   for Xi.
-            if (pDest.IsTypeParameterType())
+            if (pDest is TypeParameterType pTPType)
             {
-                TypeParameterType pTPType = pDest.AsTypeParameterType();
                 if (pTPType.IsMethodTypeParameter() && IsUnfixed(pTPType))
                 {
                     AddUpperBound(pTPType, pSource);
@@ -1920,7 +1917,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             for (int arg = 0; arg < pSourceArgs.Count; ++arg)
             {
-                TypeParameterType pTypeParam = pTypeParams.ItemAsTypeParameterType(arg);
+                TypeParameterType pTypeParam = (TypeParameterType)pTypeParams[arg];
                 CType pSourceArg = pSourceArgs[arg];
                 CType pDestArg = pDestArgs[arg];
 
@@ -2266,7 +2263,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // formal parameter CType was successfully inferred.
             for (int iParam = 0; iParam < _pMethodTypeParameters.Count; ++iParam)
             {
-                TypeParameterType pParam = _pMethodTypeParameters.ItemAsTypeParameterType(iParam);
+                TypeParameterType pParam = (TypeParameterType)_pMethodTypeParameters[iParam];
                 if (!TypeManager.TypeContainsType(pDest, pParam))
                 {
                     continue;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
@@ -326,16 +326,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         ////////////////////////////////////////////////////////////////////////////////
 
-        private static bool IsReallyAType(CType pType)
-        {
-            if (pType is NullType || pType is BoundLambdaType ||
-                pType is VoidType ||
-                pType.IsMethodGroupType())
-            {
-                return false;
-            }
-            return true;
-        }
+        private static bool IsReallyAType(CType pType) =>
+            !(pType is NullType) && !(pType is BoundLambdaType) && !(pType is VoidType) && !(pType is MethodGroupType);
 
         ////////////////////////////////////////////////////////////////////////////////
         //

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
@@ -1189,12 +1189,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             // SPEC:  Otherwise, if U is the CType U1? and V is the CType V1? 
             // SPEC:   then an exact inference is made from U to V.
-            if (!pSource.IsNullableType() || !pDest.IsNullableType())
+            if (!(pSource is NullableType nubSource) || !(pDest is NullableType nubDest))
             {
                 return false;
             }
-            ExactInference(pSource.AsNullableType().GetUnderlyingType(),
-                pDest.AsNullableType().GetUnderlyingType());
+
+            ExactInference(nubSource.GetUnderlyingType(), nubDest.GetUnderlyingType());
             return true;
         }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
@@ -179,12 +179,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 // for a CType variable that we couldn't infer.
                 if (_pFixedResults[iParam] != null)
                 {
-                    if (!_pFixedResults[iParam].IsErrorType())
+                    if (!(_pFixedResults[iParam] is ErrorType err))
                     {
                         continue;
                     }
 
-                    Name pErrorTypeName = _pFixedResults[iParam].AsErrorType().nameText;
+                    Name pErrorTypeName = err.nameText;
                     if (pErrorTypeName != null)
                     {
                         continue;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
@@ -329,7 +329,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         private static bool IsReallyAType(CType pType)
         {
             if (pType.IsNullType() || pType.IsBoundLambdaType() ||
-                pType.IsVoidType() ||
+                pType is VoidType ||
                 pType.IsMethodGroupType())
             {
                 return false;
@@ -1078,7 +1078,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             {
                 return false;
             }
-            if (pDelegateReturnType.IsVoidType())
+            if (pDelegateReturnType is VoidType)
             {
                 return false;
             }
@@ -1104,7 +1104,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             MethPropWithInst mwi = argsBinder.GetResultsOfBind().GetBestResult();
             CType pMethodReturnType = GetTypeManager().SubstType(mwi.Meth().RetType,
                 mwi.GetType(), mwi.TypeArgs);
-            if (pMethodReturnType.IsVoidType())
+            if (pMethodReturnType is VoidType)
             {
                 return false;
             }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
@@ -377,14 +377,14 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
 
                 bool wasOutOrRef = false;
-                if (pDest.IsParameterModifierType())
+                if (pDest is ParameterModifierType modDest)
                 {
-                    pDest = pDest.AsParameterModifierType().GetParameterType();
+                    pDest = modDest.GetParameterType();
                     wasOutOrRef = true;
                 }
-                if (pSource.IsParameterModifierType())
+                if (pSource is ParameterModifierType modSource)
                 {
-                    pSource = pSource.AsParameterModifierType().GetParameterType();
+                    pSource = modSource.GetParameterType();
                 }
                 // If the argument is a TYPEORNAMESPACEERROR and the pSource is an
                 // error CType, then we want to set it to the generic error CType 
@@ -551,18 +551,18 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             for (int iArg = 0; iArg < _pMethodArguments.carg; iArg++)
             {
                 CType pDest = _pMethodFormalParameterTypes[iArg];
-                if (pDest.IsParameterModifierType())
+                if (pDest is ParameterModifierType modDest)
                 {
-                    pDest = pDest.AsParameterModifierType().GetParameterType();
+                    pDest = modDest.GetParameterType();
                 }
                 Expr pExpr = _pMethodArguments.prgexpr[iArg];
                 if (HasUnfixedParamInOutputType(pExpr, pDest) &&
                     !HasUnfixedParamInInputType(pExpr, pDest))
                 {
                     CType pSource = _pMethodArguments.types[iArg];
-                    if (pSource.IsParameterModifierType())
+                    if (pSource is ParameterModifierType modSource)
                     {
-                        pSource = pSource.AsParameterModifierType().GetParameterType();
+                        pSource = modSource.GetParameterType();
                     }
                     OutputTypeInference(pExpr, pSource, pDest);
                 }
@@ -770,9 +770,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             for (int iArg = 0; iArg < _pMethodArguments.carg; iArg++)
             {
                 CType pDest = _pMethodFormalParameterTypes[iArg];
-                if (pDest.IsParameterModifierType())
+                if (pDest is ParameterModifierType modDest)
                 {
-                    pDest = pDest.AsParameterModifierType().GetParameterType();
+                    pDest = modDest.GetParameterType();
                 }
 
                 Expr pExpr = _pMethodArguments.prgexpr[iArg];
@@ -2123,13 +2123,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             {
                 CType pDest = _pMethodFormalParameterTypes[iArg];
                 CType pSource = _pMethodArguments.types[iArg];
-                if (pDest.IsParameterModifierType())
+                if (pDest is ParameterModifierType modDest)
                 {
-                    pDest = pDest.AsParameterModifierType().GetParameterType();
+                    pDest = modDest.GetParameterType();
                 }
-                if (pSource.IsParameterModifierType())
+                if (pSource is ParameterModifierType modSource)
                 {
-                    pSource = pSource.AsParameterModifierType().GetParameterType();
+                    pSource = modSource.GetParameterType();
                 }
 
                 LowerBoundInference(pSource, pDest);
@@ -2235,15 +2235,15 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Debug.Assert(_pMethodArguments.carg >= 1);
             CType pDest = _pMethodFormalParameterTypes[0];
             CType pSource = _pMethodArguments.types[0];
-            if (pDest.IsParameterModifierType())
+            if (pDest is ParameterModifierType modDest)
             {
-                pDest = pDest.AsParameterModifierType().GetParameterType();
+                pDest = modDest.GetParameterType();
             }
-            if (pSource.IsParameterModifierType())
+            if (pSource is ParameterModifierType modSource)
             {
                 // This seems impossible, but this is an error scenario, so
                 // who knows?  We'll err on the side of caution.
-                pSource = pSource.AsParameterModifierType().GetParameterType();
+                pSource = modSource.GetParameterType();
             }
             // Rule out lambdas, nulls, and so on.
             if (!IsReallyAType(pSource))

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
@@ -328,7 +328,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         private static bool IsReallyAType(CType pType)
         {
-            if (pType.IsNullType() || pType.IsBoundLambdaType() ||
+            if (pType is NullType || pType.IsBoundLambdaType() ||
                 pType is VoidType ||
                 pType.IsMethodGroupType())
             {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Nullable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Nullable.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         // Value
         public Expr BindValue(Expr exprSrc)
         {
-            Debug.Assert(exprSrc != null && exprSrc.Type.IsNullableType());
+            Debug.Assert(exprSrc != null && exprSrc.Type is NullableType);
 
             // For new T?(x), the answer is x.
             if (IsNullableConstructor(exprSrc, out ExprCall call))
@@ -67,8 +67,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 return args;
             }
 
-            CType typeBase = exprSrc.Type.AsNullableType().GetUnderlyingType();
-            AggregateType ats = exprSrc.Type.AsNullableType().GetAts(GetErrorContext());
+            NullableType nubSrc = (NullableType)exprSrc.Type;
+            CType typeBase = nubSrc.GetUnderlyingType();
+            AggregateType ats = nubSrc.GetAts(GetErrorContext());
             if (ats == null)
             {
                 ExprProperty rval = GetExprFactory().CreateProperty(typeBase, exprSrc);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
@@ -414,12 +414,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             {
                 CType typeBool = GetReqPDT(PredefinedType.PT_BOOL);
                 ExprBinOp exprRes = null;
-                if (info.type1.IsNullableType() && info.type2 is NullType)
+                if (info.type1 is NullableType && info.type2 is NullType)
                 {
                     arg2 = GetExprFactory().CreateZeroInit(info.type1);
                     exprRes = GetExprFactory().CreateBinop(ek, typeBool, arg1, arg2);
                 }
-                if (info.type1 is NullType && info.type2.IsNullableType())
+                if (info.type1 is NullType && info.type2 is NullableType)
                 {
                     arg1 = GetExprFactory().CreateZeroInit(info.type2);
                     exprRes = GetExprFactory().CreateBinop(ek, typeBool, arg1, arg2);
@@ -558,7 +558,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         private ExprBinOp BindLiftedStandardBinOp(BinOpArgInfo info, BinOpFullSig bofs, ExpressionKind ek, EXPRFLAG flags)
         {
-            Debug.Assert(bofs.Type1().IsNullableType() || bofs.Type2().IsNullableType());
+            Debug.Assert(bofs.Type1() is NullableType || bofs.Type2() is NullableType);
 
             Expr arg1 = info.arg1;
             Expr arg2 = info.arg2;
@@ -601,7 +601,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 {
                     resultType = pArgument1.Type;
                 }
-                resultType = resultType.IsNullableType() ? resultType : GetSymbolLoader().GetTypeManager().GetNullable(resultType);
+                resultType = resultType is NullableType ? resultType : GetSymbolLoader().GetTypeManager().GetNullable(resultType);
             }
 
             ExprBinOp exprRes = GetExprFactory().CreateBinop(ek, resultType, pArgument1, pArgument2);
@@ -625,13 +625,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
 
             Expr pNonLiftedArgument = pArgument;
-            if (pParameterType.IsNullableType())
+            if (pParameterType is NullableType paramNub)
             {
                 if (pNonLiftedArgument.isNull())
                 {
                     pNonLiftedArgument = mustCast(pNonLiftedArgument, pParameterType);
                 }
-                pNonLiftedArgument = mustCast(pNonLiftedArgument, pParameterType.AsNullableType().GetUnderlyingType());
+                pNonLiftedArgument = mustCast(pNonLiftedArgument, paramNub.GetUnderlyingType());
                 if (bConvertBeforeLift)
                 {
                     MarkAsIntermediateConversion(pNonLiftedArgument);
@@ -701,7 +701,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             ptypeSig1 = null;
             ptypeSig2 = null;
-            Debug.Assert(!typeDst.IsNullableType());
+            Debug.Assert(!(typeDst is NullableType));
 
             if (canConvert(info.arg1, typeDst))
                 pgrflt = LiftFlags.None;
@@ -717,7 +717,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
             ptypeSig1 = typeDst;
 
-            if (info.type2.IsNullableType())
+            if (info.type2 is NullableType)
             {
                 pgrflt = pgrflt | LiftFlags.Lift2;
                 ptypeSig2 = GetSymbolLoader().GetTypeManager().GetNullable(info.typeRaw2);
@@ -735,7 +735,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         private bool CanConvertArg2(BinOpArgInfo info, CType typeDst, out LiftFlags pgrflt,
                                       out CType ptypeSig1, out CType ptypeSig2)
         {
-            Debug.Assert(!typeDst.IsNullableType());
+            Debug.Assert(!(typeDst is NullableType));
             ptypeSig1 = null;
             ptypeSig2 = null;
 
@@ -753,7 +753,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
             ptypeSig2 = typeDst;
 
-            if (info.type1.IsNullableType())
+            if (info.type1 is NullableType)
             {
                 pgrflt = pgrflt | LiftFlags.Lift1;
                 ptypeSig1 = GetSymbolLoader().GetTypeManager().GetNullable(info.typeRaw1);
@@ -777,7 +777,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             if (info.type1 != info.typeRaw1)
             {
-                Debug.Assert(info.type1.IsNullableType());
+                Debug.Assert(info.type1 is NullableType);
                 grflt = grflt | LiftFlags.Lift1;
                 typeSig1 = GetSymbolLoader().GetTypeManager().GetNullable(info.typeRaw1);
             }
@@ -786,7 +786,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             if (info.type2 != info.typeRaw2)
             {
-                Debug.Assert(info.type2.IsNullableType());
+                Debug.Assert(info.type2 is NullableType);
                 grflt = grflt | LiftFlags.Lift2;
                 typeSig2 = GetSymbolLoader().GetTypeManager().GetNullable(info.typeRaw2);
             }
@@ -1396,9 +1396,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         LiftFlags liftFlags = LiftFlags.None;
                         CType typeSig = pArgumentType;
 
-                        if (typeSig.IsNullableType())
+                        if (typeSig is NullableType nubTypeSig)
                         {
-                            if (typeSig.AsNullableType().GetUnderlyingType() != pRawType)
+                            if (nubTypeSig.GetUnderlyingType() != pRawType)
                             {
                                 typeSig = GetSymbolLoader().GetTypeManager().GetNullable(pRawType);
                             }
@@ -1572,7 +1572,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         break;
                 }
 
-                if (typeSig != null && typeSig.IsNullableType())
+                if (typeSig is NullableType)
                 {
                     // Need to use a lifted signature.
                     LiftFlags grflt = LiftFlags.None;
@@ -1611,7 +1611,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         private ExprOperator BindLiftedStandardUnop(ExpressionKind ek, EXPRFLAG flags, Expr arg, UnaOpFullSig uofs)
         {
-            NullableType type = uofs.GetType().AsNullableType();
+            NullableType type = uofs.GetType() as NullableType;
             Debug.Assert(arg?.Type != null);
             if (arg.Type is NullType)
             {
@@ -1791,7 +1791,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     break;
             }
             Debug.Assert(pExprResult != null);
-            Debug.Assert(!pExprResult.Type.IsNullableType());
+            Debug.Assert(!(pExprResult.Type is NullableType));
             return pExprResult;
         }
 
@@ -1820,7 +1820,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             ExprMultiGet exprGet = GetExprFactory().CreateMultiGet(EXPRFLAG.EXF_ASSGOP, arg.Type, null);
             Expr exprVal = exprGet;
             CType type = uofs.GetType();
-            Debug.Assert(!type.IsNullableType());
+            Debug.Assert(!(type is NullableType));
 
             // These used to be converts, but we're making them casts now - this is because
             // we need to remove the ability to call inc(sbyte) etc for all types smaller than int. 
@@ -1842,7 +1842,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Debug.Assert(ek == ExpressionKind.Add || ek == ExpressionKind.Subtract);
             Debug.Assert(uofs.isLifted());
 
-            NullableType type = uofs.GetType().AsNullableType();
+            NullableType type = uofs.GetType() as NullableType;
             Debug.Assert(arg != null);
 
             ExprMultiGet exprGet = GetExprFactory().CreateMultiGet(EXPRFLAG.EXF_ASSGOP, arg.Type, null);
@@ -1960,8 +1960,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             Debug.Assert(arg1 != null);
             Debug.Assert(arg2 != null);
-            Debug.Assert(arg1.Type.isPredefType(PredefinedType.PT_BOOL) || (arg1.Type.IsNullableType() && arg2.Type.AsNullableType().GetUnderlyingType().isPredefType(PredefinedType.PT_BOOL)));
-            Debug.Assert(arg2.Type.isPredefType(PredefinedType.PT_BOOL) || (arg2.Type.IsNullableType() && arg2.Type.AsNullableType().GetUnderlyingType().isPredefType(PredefinedType.PT_BOOL)));
+            Debug.Assert(arg1.Type.isPredefType(PredefinedType.PT_BOOL) || (arg1.Type is NullableType argNubType1 && argNubType1.GetUnderlyingType().isPredefType(PredefinedType.PT_BOOL)));
+            Debug.Assert(arg2.Type.isPredefType(PredefinedType.PT_BOOL) || (arg2.Type is NullableType argNubType2 && argNubType2.GetUnderlyingType().isPredefType(PredefinedType.PT_BOOL)));
 
             return GetExprFactory().CreateBinop(ek, GetReqPDT(PredefinedType.PT_BOOL), arg1, arg2);
         }
@@ -1969,10 +1969,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         private ExprOperator BindBoolBitwiseOp(ExpressionKind ek, EXPRFLAG flags, Expr expr1, Expr expr2, BinOpFullSig bofs)
         {
             Debug.Assert(ek == ExpressionKind.BitwiseAnd || ek == ExpressionKind.BitwiseOr);
-            Debug.Assert(expr1.Type.isPredefType(PredefinedType.PT_BOOL) || expr1.Type.IsNullableType() && expr1.Type.AsNullableType().GetUnderlyingType().isPredefType(PredefinedType.PT_BOOL));
-            Debug.Assert(expr2.Type.isPredefType(PredefinedType.PT_BOOL) || expr2.Type.IsNullableType() && expr2.Type.AsNullableType().GetUnderlyingType().isPredefType(PredefinedType.PT_BOOL));
+            Debug.Assert(expr1.Type.isPredefType(PredefinedType.PT_BOOL) || expr1.Type is NullableType expNubType1 && expNubType1.GetUnderlyingType().isPredefType(PredefinedType.PT_BOOL));
+            Debug.Assert(expr2.Type.isPredefType(PredefinedType.PT_BOOL) || expr2.Type is NullableType expNubType2 && expNubType2.GetUnderlyingType().isPredefType(PredefinedType.PT_BOOL));
 
-            if (expr1.Type.IsNullableType() || expr2.Type.IsNullableType())
+            if (expr1.Type is NullableType || expr2.Type is NullableType)
             {
                 CType typeBool = GetReqPDT(PredefinedType.PT_BOOL);
                 CType typeRes = GetSymbolLoader().GetTypeManager().GetNullable(typeBool);
@@ -1982,7 +1982,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 Expr nonLiftedArg2 = CNullable.StripNullableConstructor(expr2);
                 Expr nonLiftedResult = null;
 
-                if (!nonLiftedArg1.Type.IsNullableType() && !nonLiftedArg2.Type.IsNullableType())
+                if (!(nonLiftedArg1.Type is NullableType) && !(nonLiftedArg2.Type is NullableType))
                 {
                     nonLiftedResult = BindBoolBinOp(ek, flags, nonLiftedArg1, nonLiftedArg2);
                 }
@@ -2154,8 +2154,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         private Expr BindLiftedEnumArithmeticBinOp(ExpressionKind ek, EXPRFLAG flags, Expr arg1, Expr arg2)
         {
             Debug.Assert(ek == ExpressionKind.Add || ek == ExpressionKind.Subtract);
-            CType nonNullableType1 = arg1.Type.IsNullableType() ? arg1.Type.AsNullableType().UnderlyingType : arg1.Type;
-            CType nonNullableType2 = arg2.Type.IsNullableType() ? arg2.Type.AsNullableType().UnderlyingType : arg2.Type;
+            CType nonNullableType1 = arg1.Type is NullableType arg1NubType ? arg1NubType.UnderlyingType : arg1.Type;
+            CType nonNullableType2 = arg2.Type is NullableType arg2NubType ? arg2NubType.UnderlyingType : arg2.Type;
             if (nonNullableType1 is NullType)
             {
                 nonNullableType1 = nonNullableType2.underlyingEnumType();

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
@@ -2560,9 +2560,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         type = (type as TypeParameterType).GetEffectiveBaseClass();
                         break;
                     case TypeKind.TK_AggregateType:
-                        if ((type.isClassType() || type.isStructType()) && !type.AsAggregateType().getAggregate().IsSkipUDOps())
+                        AggregateType ats = (AggregateType)type;
+                        if ((ats.isClassType() || ats.isStructType()) && !ats.getAggregate().IsSkipUDOps())
                         {
-                            return type.AsAggregateType();
+                            return ats;
                         }
                         return null;
                     default:
@@ -2887,8 +2888,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             Debug.Assert(argType1.isEnumType() || argType2.isEnumType());
 
-            AggregateType type1 = argType1.AsAggregateType();
-            AggregateType type2 = argType2.AsAggregateType();
+            AggregateType type1 = argType1 as AggregateType;
+            AggregateType type2 = argType2 as AggregateType;
 
             AggregateType typeEnum = type1.isEnumType() ? type1 : type2;
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
@@ -661,7 +661,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
 
             // Don't allow comparison with an anonymous method or lambda. It's just too weird.
-            if (((info.mask & BinOpMask.Equal) != 0) && (info.type1.IsBoundLambdaType() || info.type2.IsBoundLambdaType()))
+            if (((info.mask & BinOpMask.Equal) != 0) && (info.type1 is BoundLambdaType || info.type2 is BoundLambdaType))
                 return false;
 
             // No conversions needed. Determine the lifting. This is the common case.

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
@@ -1444,7 +1444,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     Expr exprVal = bindUDUnop((ExpressionKind)(exprKind - ExpressionKind.Add + ExpressionKind.Inc), exprGet);
                     if (exprVal != null)
                     {
-                        if (exprVal.Type != null && !exprVal.Type.IsErrorType() && exprVal.Type != pArgumentType)
+                        if (exprVal.Type != null && !(exprVal.Type is ErrorType) && exprVal.Type != pArgumentType)
                         {
                             exprVal = mustConvert(exprVal, pArgumentType);
                         }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
@@ -414,12 +414,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             {
                 CType typeBool = GetReqPDT(PredefinedType.PT_BOOL);
                 ExprBinOp exprRes = null;
-                if (info.type1.IsNullableType() && info.type2.IsNullType())
+                if (info.type1.IsNullableType() && info.type2 is NullType)
                 {
                     arg2 = GetExprFactory().CreateZeroInit(info.type1);
                     exprRes = GetExprFactory().CreateBinop(ek, typeBool, arg1, arg2);
                 }
-                if (info.type1.IsNullType() && info.type2.IsNullableType())
+                if (info.type1 is NullType && info.type2.IsNullableType())
                 {
                     arg1 = GetExprFactory().CreateZeroInit(info.type2);
                     exprRes = GetExprFactory().CreateBinop(ek, typeBool, arg1, arg2);
@@ -922,7 +922,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             if (info.type1.IsPointerType())
             {
-                if (info.type2.IsNullType())
+                if (info.type2 is NullType)
                 {
                     if (!info.ValidForVoidPointer())
                     {
@@ -948,7 +948,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
 
             Debug.Assert(info.type2.IsPointerType());
-            if (info.type1.IsNullType())
+            if (info.type1 is NullType)
             {
                 if (!info.ValidForVoidPointer())
                 {
@@ -997,7 +997,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             CType typeObj = GetReqPDT(PredefinedType.PT_OBJECT);
             CType typeCls = null;
 
-            if (type1.IsNullType() && type2.IsNullType())
+            if (type1 is NullType && type2 is NullType)
             {
                 typeCls = typeObj;
                 fRet = true;
@@ -1025,12 +1025,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     break;
                 case FUNDTYPE.FT_VAR:
                     TypeParameterType parameterType1 = (TypeParameterType)type1;
-                    if (parameterType1.IsValueType() || (!parameterType1.IsReferenceType() && !type2.IsNullType()))
+                    if (parameterType1.IsValueType() || (!parameterType1.IsReferenceType() && !(type2 is NullType)))
                         return false;
                     type1 = parameterType1.GetEffectiveBaseClass();
                     break;
             }
-            if (type2.IsNullType())
+            if (type2 is NullType)
             {
                 fRet = true;
                 // We don't need to determine the actual best type since we're
@@ -1047,12 +1047,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     break;
                 case FUNDTYPE.FT_VAR:
                     TypeParameterType typeParam2 = (TypeParameterType)type2;
-                    if (typeParam2.IsValueType() || (!typeParam2.IsReferenceType() && !type1.IsNullType()))
+                    if (typeParam2.IsValueType() || (!typeParam2.IsReferenceType() && !(type1 is NullType)))
                         return false;
                     type2 = typeParam2.GetEffectiveBaseClass();
                     break;
             }
-            if (type1.IsNullType())
+            if (type1 is NullType)
             {
                 fRet = true;
                 // We don't need to determine the actual best type since we're
@@ -1613,7 +1613,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             NullableType type = uofs.GetType().AsNullableType();
             Debug.Assert(arg?.Type != null);
-            if (arg.Type.IsNullType())
+            if (arg.Type is NullType)
             {
                 return BadOperatorTypesError(ek, arg, null, type);
             }
@@ -2156,11 +2156,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Debug.Assert(ek == ExpressionKind.Add || ek == ExpressionKind.Subtract);
             CType nonNullableType1 = arg1.Type.IsNullableType() ? arg1.Type.AsNullableType().UnderlyingType : arg1.Type;
             CType nonNullableType2 = arg2.Type.IsNullableType() ? arg2.Type.AsNullableType().UnderlyingType : arg2.Type;
-            if (nonNullableType1.IsNullType())
+            if (nonNullableType1 is NullType)
             {
                 nonNullableType1 = nonNullableType2.underlyingEnumType();
             }
-            else if (nonNullableType2.IsNullType())
+            else if (nonNullableType2 is NullType)
             {
                 nonNullableType2 = nonNullableType1.underlyingEnumType();
             }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
@@ -1066,14 +1066,14 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             if (type1.isInterfaceType() || type1.isPredefType(PredefinedType.PT_STRING) || GetSymbolLoader().HasBaseConversion(type1, typeDel))
                 type1 = typeObj;
-            else if (type1.IsArrayType())
+            else if (type1 is ArrayType)
                 type1 = GetReqPDT(PredefinedType.PT_ARRAY);
             else if (!type1.isClassType())
                 return false;
 
             if (type2.isInterfaceType() || type2.isPredefType(PredefinedType.PT_STRING) || GetSymbolLoader().HasBaseConversion(type2, typeDel))
                 type2 = typeObj;
-            else if (type2.IsArrayType())
+            else if (type2 is ArrayType)
                 type2 = GetReqPDT(PredefinedType.PT_ARRAY);
             else if (!type2.isClassType())
                 return false;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
@@ -886,7 +886,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         */
         private bool GetPtrBinOpSigs(List<BinOpFullSig> prgbofs, BinOpArgInfo info)
         {
-            if (!info.type1.IsPointerType() && !info.type2.IsPointerType())
+            if (!(info.type1 is PointerType) && !(info.type2 is PointerType))
             {
                 return false;
             }
@@ -903,7 +903,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // (void,     void)      :                   == != < > <= >=
 
             // Check the common case first.
-            if (info.type1.IsPointerType() && info.type2.IsPointerType())
+            if (info.type1 is PointerType && info.type2 is PointerType)
             {
                 if (info.ValidForVoidPointer())
                 {
@@ -920,7 +920,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             CType typeT;
 
-            if (info.type1.IsPointerType())
+            if (info.type1 is PointerType)
             {
                 if (info.type2 is NullType)
                 {
@@ -947,7 +947,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 return false;
             }
 
-            Debug.Assert(info.type2.IsPointerType());
+            Debug.Assert(info.type2 is PointerType);
             if (info.type1 is NullType)
             {
                 if (!info.ValidForVoidPointer())
@@ -1428,7 +1428,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 else if (unaryOpKind == UnaOpKind.IncDec)
                 {
                     // Check for pointers
-                    if (pArgumentType.IsPointerType())
+                    if (pArgumentType is PointerType)
                     {
                         pSignatures.Add(new UnaOpFullSig(
                                 pArgumentType,

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
@@ -1024,9 +1024,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 case FUNDTYPE.FT_REF:
                     break;
                 case FUNDTYPE.FT_VAR:
-                    if (type1.AsTypeParameterType().IsValueType() || (!type1.AsTypeParameterType().IsReferenceType() && !type2.IsNullType()))
+                    TypeParameterType parameterType1 = (TypeParameterType)type1;
+                    if (parameterType1.IsValueType() || (!parameterType1.IsReferenceType() && !type2.IsNullType()))
                         return false;
-                    type1 = type1.AsTypeParameterType().GetEffectiveBaseClass();
+                    type1 = parameterType1.GetEffectiveBaseClass();
                     break;
             }
             if (type2.IsNullType())
@@ -1045,9 +1046,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 case FUNDTYPE.FT_REF:
                     break;
                 case FUNDTYPE.FT_VAR:
-                    if (type2.AsTypeParameterType().IsValueType() || (!type2.AsTypeParameterType().IsReferenceType() && !type1.IsNullType()))
+                    TypeParameterType typeParam2 = (TypeParameterType)type2;
+                    if (typeParam2.IsValueType() || (!typeParam2.IsReferenceType() && !type1.IsNullType()))
                         return false;
-                    type2 = type2.AsTypeParameterType().GetEffectiveBaseClass();
+                    type2 = typeParam2.GetEffectiveBaseClass();
                     break;
             }
             if (type1.IsNullType())
@@ -2555,7 +2557,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         type = type.StripNubs();
                         break;
                     case TypeKind.TK_TypeParameterType:
-                        type = type.AsTypeParameterType().GetEffectiveBaseClass();
+                        type = (type as TypeParameterType).GetEffectiveBaseClass();
                         break;
                     case TypeKind.TK_AggregateType:
                         if ((type.isClassType() || type.isStructType()) && !type.AsAggregateType().getAggregate().IsSkipUDOps())

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SemanticChecker.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SemanticChecker.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Debug.Assert(typeThru == null ||
                    typeThru.IsAggregateType() ||
                    typeThru is TypeParameterType ||
-                   typeThru.IsArrayType() ||
+                   typeThru is ArrayType ||
                    typeThru is NullableType ||
                    typeThru is ErrorType);
 
@@ -160,7 +160,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Debug.Assert(typeThru == null ||
                    typeThru.IsAggregateType() ||
                    typeThru is TypeParameterType ||
-                   typeThru.IsArrayType() ||
+                   typeThru is ArrayType ||
                    typeThru is NullableType ||
                    typeThru is ErrorType);
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SemanticChecker.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SemanticChecker.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                    typeThru is TypeParameterType ||
                    typeThru.IsArrayType() ||
                    typeThru is NullableType ||
-                   typeThru.IsErrorType());
+                   typeThru is ErrorType);
 
 #if DEBUG
 
@@ -90,7 +90,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             if (!type.IsAggregateType())
             {
-                Debug.Assert(type is VoidType || type.IsErrorType() || type is TypeParameterType);
+                Debug.Assert(type is VoidType || type is ErrorType || type is TypeParameterType);
                 return true;
             }
 
@@ -162,7 +162,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                    typeThru is TypeParameterType ||
                    typeThru.IsArrayType() ||
                    typeThru is NullableType ||
-                   typeThru.IsErrorType());
+                   typeThru is ErrorType);
 
             switch (symCheck.GetAccess())
             {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SemanticChecker.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SemanticChecker.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Debug.Assert(atsCheck == null || symCheck.parent == atsCheck.getAggregate());
             Debug.Assert(typeThru == null ||
                    typeThru.IsAggregateType() ||
-                   typeThru.IsTypeParameterType() ||
+                   typeThru is TypeParameterType ||
                    typeThru.IsArrayType() ||
                    typeThru.IsNullableType() ||
                    typeThru.IsErrorType());
@@ -90,7 +90,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             if (!type.IsAggregateType())
             {
-                Debug.Assert(type.IsVoidType() || type.IsErrorType() || type.IsTypeParameterType());
+                Debug.Assert(type.IsVoidType() || type.IsErrorType() || type is TypeParameterType);
                 return true;
             }
 
@@ -159,7 +159,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Debug.Assert(atsCheck == null || symCheck.parent == atsCheck.getAggregate());
             Debug.Assert(typeThru == null ||
                    typeThru.IsAggregateType() ||
-                   typeThru.IsTypeParameterType() ||
+                   typeThru is TypeParameterType ||
                    typeThru.IsArrayType() ||
                    typeThru.IsNullableType() ||
                    typeThru.IsErrorType());

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SemanticChecker.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SemanticChecker.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Debug.Assert(symCheck != null);
             Debug.Assert(atsCheck == null || symCheck.parent == atsCheck.getAggregate());
             Debug.Assert(typeThru == null ||
-                   typeThru.IsAggregateType() ||
+                   typeThru is AggregateType ||
                    typeThru is TypeParameterType ||
                    typeThru is ArrayType ||
                    typeThru is NullableType ||
@@ -88,21 +88,23 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // Array, Ptr, Nub, etc don't matter.
             type = type.GetNakedType(true);
 
-            if (!type.IsAggregateType())
+            if (!(type is AggregateType ats))
             {
                 Debug.Assert(type is VoidType || type is ErrorType || type is TypeParameterType);
                 return true;
             }
 
-            for (AggregateType ats = type.AsAggregateType(); ats != null; ats = ats.outerType)
+            do
             {
                 if (ACCESSERROR.ACCESSERROR_NOERROR != CheckAccessCore(ats.GetOwningAggregate(), ats.outerType, symWhere, null))
                 {
                     return false;
                 }
-            }
 
-            TypeArray typeArgs = type.AsAggregateType().GetTypeArgsAll();
+                ats = ats.outerType;
+            } while(ats != null);
+
+            TypeArray typeArgs = ((AggregateType)type).GetTypeArgsAll();
             for (int i = 0; i < typeArgs.Count; i++)
             {
                 if (!CheckTypeAccess(typeArgs[i], symWhere))
@@ -158,7 +160,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Debug.Assert(symCheck != null);
             Debug.Assert(atsCheck == null || symCheck.parent == atsCheck.getAggregate());
             Debug.Assert(typeThru == null ||
-                   typeThru.IsAggregateType() ||
+                   typeThru is AggregateType ||
                    typeThru is TypeParameterType ||
                    typeThru is ArrayType ||
                    typeThru is NullableType ||

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SemanticChecker.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SemanticChecker.cs
@@ -90,7 +90,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             if (!type.IsAggregateType())
             {
-                Debug.Assert(type.IsVoidType() || type.IsErrorType() || type is TypeParameterType);
+                Debug.Assert(type is VoidType || type.IsErrorType() || type is TypeParameterType);
                 return true;
             }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SemanticChecker.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SemanticChecker.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                    typeThru.IsAggregateType() ||
                    typeThru is TypeParameterType ||
                    typeThru.IsArrayType() ||
-                   typeThru.IsNullableType() ||
+                   typeThru is NullableType ||
                    typeThru.IsErrorType());
 
 #if DEBUG
@@ -161,7 +161,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                    typeThru.IsAggregateType() ||
                    typeThru is TypeParameterType ||
                    typeThru.IsArrayType() ||
-                   typeThru.IsNullableType() ||
+                   typeThru is NullableType ||
                    typeThru.IsErrorType());
 
             switch (symCheck.GetAccess())

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/MethodSymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/MethodSymbol.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             _checkedInfMustFail = true;
             for (int ivar = 0; ivar < typeVars.Count; ivar++)
             {
-                TypeParameterType var = typeVars.ItemAsTypeParameterType(ivar);
+                TypeParameterType var = (TypeParameterType)typeVars[ivar];
                 // See if type var is used in a parameter.
                 for (int ipar = 0; ; ipar++)
                 {
@@ -85,7 +85,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             return getClass().isPredefAgg(PredefinedType.PT_G_OPTIONAL) &&
                 Params.Count == 1 &&
-                Params[0].IsGenericParameter &&
+                Params[0] is TypeParameterType &&
                 IsConstructor();
         }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolLoader.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolLoader.cs
@@ -148,7 +148,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             Debug.Assert(typeSym != null);
             Debug.Assert(typeSym.IsAggregateType() ||
-                   typeSym.IsTypeParameterType() ||
+                   typeSym is TypeParameterType ||
                    typeSym.IsArrayType() ||
                    typeSym.IsNullableType());
 
@@ -159,7 +159,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 case TypeKind.TK_ArrayType:
                     return GetReqPredefType(PredefinedType.PT_ARRAY);
                 case TypeKind.TK_TypeParameterType:
-                    return typeSym.AsTypeParameterType().GetEffectiveBaseClass();
+                    return (typeSym as TypeParameterType).GetEffectiveBaseClass();
                 case TypeKind.TK_NullableType:
                     return typeSym.AsNullableType().GetAts(ErrorContext);
             }
@@ -441,13 +441,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
 
             // * Implicit conversions involving type parameters that are known to be reference types.
-            if (pSource.IsTypeParameterType() &&
-                HasImplicitReferenceTypeParameterConversion(pSource.AsTypeParameterType(), pDest))
-            {
-                return true;
-            }
-
-            return false;
+            return pSource is TypeParameterType srcParType && HasImplicitReferenceTypeParameterConversion(srcParType, pDest);
         }
 
         private bool HasImplicitReferenceTypeParameterConversion(
@@ -491,11 +485,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
             }
             // * From T to a type parameter U, provided T depends on U.
-            if (pDest.IsTypeParameterType() && pSource.DependsOn(pDest.AsTypeParameterType()))
-            {
-                return true;
-            }
-            return false;
+            return pDest is TypeParameterType typeParamDest && pSource.DependsOn(typeParamDest);
         }
 
         private bool HasAnyBaseInterfaceConversion(CType pDerived, CType pBase)
@@ -585,7 +575,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 {
                     continue;
                 }
-                TypeParameterType pParam = pTypeParams[iParam].AsTypeParameterType();
+                TypeParameterType pParam = (TypeParameterType)pTypeParams[iParam];
                 if (pParam.Invariant)
                 {
                     return false;
@@ -670,11 +660,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             {
                 return true;
             }
-            if (pDest.IsTypeParameterType() && pSource.DependsOn(pDest.AsTypeParameterType()))
-            {
-                return true;
-            }
-            return false;
+
+            return pDest is TypeParameterType typeParamDest && pSource.DependsOn(typeParamDest);
         }
 
         public bool HasImplicitBoxingConversion(CType pSource, CType pDest)
@@ -684,8 +671,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             // Certain type parameter conversions are classified as boxing conversions.
 
-            if (pSource.IsTypeParameterType() &&
-                HasImplicitBoxingTypeParameterConversion(pSource.AsTypeParameterType(), pDest))
+            if (pSource is TypeParameterType srcParType && HasImplicitBoxingTypeParameterConversion(srcParType, pDest))
             {
                 return true;
             }
@@ -773,12 +759,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             {
                 return true;
             }
-            if (pSource.IsTypeParameterType() &&
-                HasImplicitTypeParameterBaseConversion(pSource.AsTypeParameterType(), pDest))
-            {
-                return true;
-            }
-            return false;
+
+            return pSource is TypeParameterType srcParType && HasImplicitTypeParameterBaseConversion(srcParType, pDest);
         }
 
         public bool FCanLift()

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolLoader.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolLoader.cs
@@ -431,13 +431,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // implementations have a "null type" which some expressions other than the
             // null literal may have. (For example, (null??null), which is also an
             // extension to the specification.)
-            if (pSource.IsNullType() && pDest.IsRefType())
+            if (pSource is NullType)
             {
-                return true;
-            }
-            if (pSource.IsNullType() && pDest.IsNullableType())
-            {
-                return true;
+                if (pDest.IsRefType() || pDest.IsNullableType())
+                {
+                    return true;
+                }
             }
 
             // * Implicit conversions involving type parameters that are known to be reference types.

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolLoader.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolLoader.cs
@@ -150,7 +150,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Debug.Assert(typeSym.IsAggregateType() ||
                    typeSym is TypeParameterType ||
                    typeSym.IsArrayType() ||
-                   typeSym.IsNullableType());
+                   typeSym is NullableType);
 
             switch (typeSym.GetTypeKind())
             {
@@ -159,9 +159,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 case TypeKind.TK_ArrayType:
                     return GetReqPredefType(PredefinedType.PT_ARRAY);
                 case TypeKind.TK_TypeParameterType:
-                    return (typeSym as TypeParameterType).GetEffectiveBaseClass();
+                    return ((TypeParameterType)typeSym).GetEffectiveBaseClass();
                 case TypeKind.TK_NullableType:
-                    return typeSym.AsNullableType().GetAts(ErrorContext);
+                    return ((NullableType)typeSym).GetAts(ErrorContext);
             }
             Debug.Assert(false, "Bad typeSym!");
             return null;
@@ -219,9 +219,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             {
                 return false;
             }
-            if (pDerived.IsNullableType())
+            if (pDerived is NullableType derivedNub)
             {
-                pDerived = pDerived.AsNullableType().GetAts(ErrorContext);
+                pDerived = derivedNub.GetAts(ErrorContext);
                 if (pDerived == null)
                 {
                     return false;
@@ -433,7 +433,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // extension to the specification.)
             if (pSource is NullType)
             {
-                if (pDest.IsRefType() || pDest.IsNullableType())
+                if (pDest.IsRefType() || pDest is NullableType)
                 {
                     return true;
                 }
@@ -686,9 +686,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // A boxing conversion exists from a nullable type to a reference type
             // if and only if a boxing conversion exists from the underlying type.
 
-            if (pSource.IsNullableType())
+            if (pSource is NullableType nubSource)
             {
-                return HasImplicitBoxingConversion(pSource.AsNullableType().GetUnderlyingType(), pDest);
+                return HasImplicitBoxingConversion(nubSource.GetUnderlyingType(), pDest);
             }
 
             // A boxing conversion exists from any non-nullable value type to object,

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolLoader.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolLoader.cs
@@ -302,8 +302,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 return true;
             }
 
-            AggregateType atsDest = pDest as AggregateType;
-            AggregateSymbol aggDest = pDest.getAggregate();
+            AggregateType atsDest = (AggregateType)pDest;
+            AggregateSymbol aggDest = atsDest.getAggregate();
             if (!aggDest.isPredefAgg(PredefinedType.PT_G_ILIST) &&
                 !aggDest.isPredefAgg(PredefinedType.PT_G_ICOLLECTION) &&
                 !aggDest.isPredefAgg(PredefinedType.PT_G_IENUMERABLE) &&

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolManagerBase.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolManagerBase.cs
@@ -145,7 +145,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                             goto LAgain;
 
                         case TypeKind.TK_AggregateType:
-                            nParam = CompareTypes(type1.AsAggregateType().GetTypeArgsAll(), type2.AsAggregateType().GetTypeArgsAll());
+                            nParam = CompareTypes(((AggregateType)type1).GetTypeArgsAll(), ((AggregateType)type2).GetTypeArgsAll());
                             break;
                     }
                 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolManagerBase.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolManagerBase.cs
@@ -116,11 +116,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             LAgain:
                 if (type1.GetTypeKind() != type2.GetTypeKind())
                 {
-                    if (type1.IsTypeParameterType())
+                    if (type1 is TypeParameterType)
                     {
                         nParam = BetterType.Right;
                     }
-                    else if (type2.IsTypeParameterType())
+                    else if (type2 is TypeParameterType)
                     {
                         nParam = BetterType.Left;
                     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/TypeParameterSymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/TypeParameterSymbol.cs
@@ -111,7 +111,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public bool IsNonNullableValueType()
         {
-            return (_constraints & SpecCons.Val) > 0 || _bHasValBound && !_pDeducedBaseClass.IsNullableType();
+            return (_constraints & SpecCons.Val) > 0 || _bHasValBound && !(_pDeducedBaseClass is NullableType);
         }
 
         public bool HasNewConstraint()

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Visitors/ExpressionTreeRewriter.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Visitors/ExpressionTreeRewriter.cs
@@ -1032,7 +1032,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             AggregateType pObject = GetSymbolLoader().GetReqPredefType(PredefinedType.PT_OBJECT);
 
-            if (expr.Type.IsNullType())
+            if (expr.Type is NullType)
             {
                 ExprTypeOf pTypeOf = CreateTypeOf(pObject);
                 return GenerateCall(PREDEFMETH.PM_EXPRESSION_CONSTANT_OBJECT_TYPE, expr, pTypeOf);
@@ -1147,13 +1147,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             CType nubfptype1 = GetSymbolLoader().GetTypeManager().GetNullable(fptype1);
             CType nubfptype2 = GetSymbolLoader().GetTypeManager().GetNullable(fptype2);
             // If we have null op X, or T1 op T2?, or T1 op null, lift first arg to T1?
-            if (aatype1.IsNullType() || aatype1 == fptype1 && (aatype2 == nubfptype2 || aatype2.IsNullType()))
+            if (aatype1 is NullType || aatype1 == fptype1 && (aatype2 == nubfptype2 || aatype2 is NullType))
             {
                 new1 = GenerateCall(PREDEFMETH.PM_EXPRESSION_CONVERT, new1, CreateTypeOf(nubfptype1));
             }
 
             // If we have X op null, or T1? op T2, or null op T2, lift second arg to T2?
-            if (aatype2.IsNullType() || aatype2 == fptype2 && (aatype1 == nubfptype1 || aatype1.IsNullType()))
+            if (aatype2 is NullType || aatype2 == fptype2 && (aatype1 == nubfptype1 || aatype1 is NullType))
             {
                 new2 = GenerateCall(PREDEFMETH.PM_EXPRESSION_CONVERT, new2, CreateTypeOf(nubfptype2));
             }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Visitors/ExpressionTreeRewriter.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Visitors/ExpressionTreeRewriter.cs
@@ -344,7 +344,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             Debug.Assert(expr != null);
             // POSSIBLE ERROR: Multi-d should be an error?
-            Expr pTypeOf = CreateTypeOf(expr.Type.AsArrayType().GetElementType());
+            Expr pTypeOf = CreateTypeOf(((ArrayType)expr.Type).GetElementType());
             Expr args = GenerateArgsList(expr.OptionalArguments);
             Expr Params = GenerateParamsArray(args, PredefinedType.PT_EXPRESSION);
             return GenerateCall(PREDEFMETH.PM_EXPRESSION_NEWARRAYINIT, pTypeOf, Params);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Visitors/ExpressionTreeRewriter.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Visitors/ExpressionTreeRewriter.cs
@@ -1139,13 +1139,14 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             CType aatype1 = orig1.Type;
             CType aatype2 = orig2.Type;
             // Is the operator even a candidate for lifting?
-            if (fptype1 is NullableType || fptype2 is NullableType ||
-                !fptype1.IsAggregateType() || !fptype2.IsAggregateType() ||
-                !fptype1.AsAggregateType().getAggregate().IsValueType() ||
-                !fptype2.AsAggregateType().getAggregate().IsValueType())
+            if (!(fptype1 is AggregateType fat1)
+                || !fat1.getAggregate().IsValueType()
+                || !(fptype2 is AggregateType fat2)
+                || !fat2.getAggregate().IsValueType())
             {
                 return;
             }
+
             CType nubfptype1 = GetSymbolLoader().GetTypeManager().GetNullable(fptype1);
             CType nubfptype2 = GetSymbolLoader().GetTypeManager().GetNullable(fptype2);
             // If we have null op X, or T1 op T2?, or T1 op null, lift first arg to T1?
@@ -1163,15 +1164,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             pp2 = new2;
         }
 
-        private bool IsNullableValueType(CType pType)
-        {
-            if (pType is NullableType)
-            {
-                CType pStrippedType = pType.StripNubs();
-                return pStrippedType.IsAggregateType() && pStrippedType.AsAggregateType().getAggregate().IsValueType();
-            }
-            return false;
-        }
+        private bool IsNullableValueType(CType pType) =>
+            pType is NullableType && pType.StripNubs() is AggregateType agg && agg.getAggregate().IsValueType();
 
         private bool IsNullableValueAccess(Expr pExpr, Expr pObject)
         {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/TypeBind.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/TypeBind.cs
@@ -134,7 +134,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             for (int i = 0; i < typeVars.Count; i++)
             {
                 // Empty bounds should be set to object.
-                TypeParameterType var = typeVars.ItemAsTypeParameterType(i);
+                TypeParameterType var = (TypeParameterType)typeVars[i];
                 CType arg = typeArgs[i];
 
                 bool fOK = CheckSingleConstraint(checker, errHandling, symErr, var, arg, typeArgsCls, typeArgsMeth, flags);
@@ -215,9 +215,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                 bool bIsValueType = arg.IsValType();
                 bool bIsNullable = arg.IsNullableType();
-                if (bIsValueType && arg.IsTypeParameterType())
+                if (bIsValueType && arg is TypeParameterType typeArg)
                 {
-                    TypeArray pArgBnds = arg.AsTypeParameterType().GetBounds();
+                    TypeArray pArgBnds = typeArg.GetBounds();
                     if (pArgBnds.Count > 0)
                     {
                         bIsNullable = pArgBnds[0].IsNullableType();
@@ -289,7 +289,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                                 error = ErrorCode.ERR_GenericConstraintNotSatisfiedNullableInterface;
                             }
                         }
-                        else if (arg.IsTypeParameterType())
+                        else if (arg is TypeParameterType)
                         {
                             // Type variables can satisfy bounds through boxing and type variable conversions
                             Debug.Assert(!arg.IsRefType());
@@ -328,7 +328,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     return !fError;
                 }
             }
-            else if (arg.IsTypeParameterType() && arg.AsTypeParameterType().HasNewConstraint())
+            else if (arg is TypeParameterType typeArg && typeArg.HasNewConstraint())
             {
                 return !fError;
             }
@@ -376,7 +376,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     break;
             }
 
-            Debug.Assert(typeBnd.IsAggregateType() || typeBnd.IsTypeParameterType() || typeBnd.IsArrayType());
+            Debug.Assert(typeBnd.IsAggregateType() || typeBnd is TypeParameterType || typeBnd.IsArrayType());
 
             switch (arg.GetTypeKind())
             {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/TypeBind.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/TypeBind.cs
@@ -169,7 +169,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 return false;
             }
 
-            if (arg.IsPointerType())
+            if (arg is PointerType)
             {
                 if (fReportErrors)
                 {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/TypeBind.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/TypeBind.cs
@@ -148,7 +148,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             bool fReportErrors = 0 == (flags & CheckConstraintsFlags.NoErrors);
 
-            if (arg.IsOpenTypePlaceholderType())
+            if (arg is OpenTypePlaceholderType)
             {
                 return true;
             }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/TypeBind.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/TypeBind.cs
@@ -376,7 +376,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     break;
             }
 
-            Debug.Assert(typeBnd.IsAggregateType() || typeBnd is TypeParameterType || typeBnd.IsArrayType());
+            Debug.Assert(typeBnd.IsAggregateType() || typeBnd is TypeParameterType || typeBnd is ArrayType);
 
             switch (arg.GetTypeKind())
             {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/TypeBind.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/TypeBind.cs
@@ -45,10 +45,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     type = type.GetNakedType(true);
             }
 
-            if (!type.IsAggregateType())
+            if (!(type is AggregateType ats))
                 return true;
-
-            AggregateType ats = type.AsAggregateType();
 
             if (ats.GetTypeArgsAll().Count == 0)
             {
@@ -95,10 +93,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             for (int i = 0; i < typeArgsThis.Count; i++)
             {
                 CType arg = typeArgsThis[i].GetNakedType(true);
-                if (arg.IsAggregateType() && !arg.AsAggregateType().fConstraintsChecked)
+                if (arg is AggregateType atArg && !atArg.fConstraintsChecked)
                 {
-                    CheckConstraints(checker, errHandling, arg.AsAggregateType(), flags | CheckConstraintsFlags.Outer);
-                    if (arg.AsAggregateType().fConstraintError)
+                    CheckConstraints(checker, errHandling, atArg, flags | CheckConstraintsFlags.Outer);
+                    if (atArg.fConstraintError)
                         ats.fConstraintError = true;
                 }
             }
@@ -315,7 +313,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             if (arg.isClassType())
             {
-                AggregateSymbol agg = arg.AsAggregateType().getAggregate();
+                AggregateSymbol agg = ((AggregateType)arg).getAggregate();
 
                 // Due to late binding nature of IDE created symbols, the AggregateSymbol might not
                 // have all the information necessary yet, if it is not fully bound.
@@ -376,7 +374,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     break;
             }
 
-            Debug.Assert(typeBnd.IsAggregateType() || typeBnd is TypeParameterType || typeBnd is ArrayType);
+            Debug.Assert(typeBnd is AggregateType || typeBnd is TypeParameterType || typeBnd is ArrayType);
 
             switch (arg.GetTypeKind())
             {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/TypeBind.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/TypeBind.cs
@@ -153,7 +153,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 return true;
             }
 
-            if (arg.IsErrorType())
+            if (arg is ErrorType)
             {
                 // Error should have been reported previously.
                 return false;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/TypeBind.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/TypeBind.cs
@@ -36,9 +36,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             type = type.GetNakedType(false);
 
-            if (type.IsNullableType())
+            if (type is NullableType nub)
             {
-                CType typeT = type.AsNullableType().GetAts(checker.GetErrorContext());
+                CType typeT = nub.GetAts(checker.GetErrorContext());
                 if (typeT != null)
                     type = typeT;
                 else
@@ -214,13 +214,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 // bound from the type argument and check against that.
 
                 bool bIsValueType = arg.IsValType();
-                bool bIsNullable = arg.IsNullableType();
+                bool bIsNullable = arg is NullableType;
                 if (bIsValueType && arg is TypeParameterType typeArg)
                 {
                     TypeArray pArgBnds = typeArg.GetBounds();
                     if (pArgBnds.Count > 0)
                     {
-                        bIsNullable = pArgBnds[0].IsNullableType();
+                        bIsNullable = pArgBnds[0] is NullableType;
                     }
                 }
 
@@ -265,11 +265,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                             // to which they have an implicit reference conversion
                             error = ErrorCode.ERR_GenericConstraintNotSatisfiedRefType;
                         }
-                        else if (arg.IsNullableType() && checker.GetSymbolLoader().HasBaseConversion(arg.AsNullableType().GetUnderlyingType(), typeBnd))    // This is inlining FBoxingConv
+                        else if (arg is NullableType nubArg && checker.GetSymbolLoader().HasBaseConversion(nubArg.GetUnderlyingType(), typeBnd))    // This is inlining FBoxingConv
                         {
                             // nullable types do not satisfy bounds to every type that they are boxable to
                             // They only satisfy bounds of object and ValueType
-                            if (typeBnd.isPredefType(PredefinedType.PT_ENUM) || arg.AsNullableType().GetUnderlyingType() == typeBnd)
+                            if (typeBnd.isPredefType(PredefinedType.PT_ENUM) || nubArg.GetUnderlyingType() == typeBnd)
                             {
                                 // Nullable types don't satisfy bounds of EnumType, or the underlying type of the enum
                                 // even though the conversion from Nullable to these types is a boxing conversion
@@ -367,7 +367,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     break;
 
                 case TypeKind.TK_NullableType:
-                    typeBnd = typeBnd.AsNullableType().GetAts(checker.GetErrorContext());
+                    typeBnd = ((NullableType)typeBnd).GetAts(checker.GetErrorContext());
                     if (null == typeBnd)
                         return true;
                     break;
@@ -386,7 +386,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 case TypeKind.TK_PointerType:
                     return false;
                 case TypeKind.TK_NullableType:
-                    arg = arg.AsNullableType().GetAts(checker.GetErrorContext());
+                    arg = ((NullableType)arg).GetAts(checker.GetErrorContext());
                     if (null == arg)
                         return true;
                     // Fall through.

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/AggregateType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/AggregateType.cs
@@ -116,19 +116,15 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         private bool AreAllTypeArgumentsUnitTypes(TypeArray typeArray)
         {
-            if (typeArray.Count == 0)
+            foreach (CType type in typeArray.Items)
             {
-                return true;
-            }
-
-            for (int i = 0; i < typeArray.Count; i++)
-            {
-                Debug.Assert(typeArray[i] != null);
-                if (!typeArray[i].IsOpenTypePlaceholderType())
+                Debug.Assert(type != null);
+                if (!(type is OpenTypePlaceholderType))
                 {
                     return false;
                 }
             }
+
             return true;
         }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/AggregateType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/AggregateType.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     // Represents a generic constructed (or instantiated) type. Parent is the AggregateSymbol.
     // ----------------------------------------------------------------------------
 
-    internal partial class AggregateType : CType
+    internal sealed class AggregateType : CType
     {
         private TypeArray _pTypeArgsThis;
         private TypeArray _pTypeArgsAll;         // includes args from outer types
@@ -156,7 +156,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                 for (int i = 0; i < ifaces.Count; i++)
                 {
-                    AggregateType type = ifaces[i].AsAggregateType();
+                    AggregateType type = ifaces[i] as AggregateType;
                     Debug.Assert(type.isInterfaceType());
 
                     if (type.IsCollectionType())

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/ArrayType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/ArrayType.cs
@@ -21,8 +21,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         // Returns the first non-array type in the parent chain.
         public CType GetBaseElementType()
         {
-            CType type;
-            for (type = GetElementType(); type.IsArrayType(); type = type.AsArrayType().GetElementType()) ;
+            CType type = GetElementType();
+            while (type is ArrayType arr)
+            {
+                type = arr.GetElementType();
+            }
+
             return type;
         }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
@@ -24,13 +24,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public ErrorType AsErrorType() { return this as ErrorType; }
         public ArrayType AsArrayType() { return this as ArrayType; }
         public PointerType AsPointerType() { return this as PointerType; }
-        public ParameterModifierType AsParameterModifierType() { return this as ParameterModifierType; }
 
         public bool IsAggregateType() { return this is AggregateType; }
         public bool IsErrorType() { return this is ErrorType; }
         public bool IsArrayType() { return this is ArrayType; }
         public bool IsPointerType() { return this is PointerType; }
-        public bool IsParameterModifierType() { return this is ParameterModifierType; }
 
         public bool IsWindowsRuntimeType()
         {
@@ -97,7 +95,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     break;
 
                 case TypeKind.TK_ParameterModifierType:
-                    ParameterModifierType r = src.AsParameterModifierType();
+                    ParameterModifierType r = (ParameterModifierType)src;
                     Type parameterType = r.GetParameterType().AssociatedSystemType;
                     result = parameterType.MakeByRefType();
                     break;
@@ -259,7 +257,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     return AsPointerType().GetReferentType();
 
                 case TypeKind.TK_ParameterModifierType:
-                    return AsParameterModifierType().GetParameterType();
+                    return ((ParameterModifierType)this).GetParameterType();
 
                 case TypeKind.TK_NullableType:
                     return ((NullableType)this).GetUnderlyingType();

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
@@ -23,12 +23,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public AggregateType AsAggregateType() { return this as AggregateType; }
         public ErrorType AsErrorType() { return this as ErrorType; }
         public ArrayType AsArrayType() { return this as ArrayType; }
-        public PointerType AsPointerType() { return this as PointerType; }
 
         public bool IsAggregateType() { return this is AggregateType; }
         public bool IsErrorType() { return this is ErrorType; }
         public bool IsArrayType() { return this is ArrayType; }
-        public bool IsPointerType() { return this is PointerType; }
 
         public bool IsWindowsRuntimeType()
         {
@@ -89,7 +87,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     break;
 
                 case TypeKind.TK_PointerType:
-                    PointerType p = src.AsPointerType();
+                    PointerType p = (PointerType)src;
                     Type referentType = p.GetReferentType().AssociatedSystemType;
                     result = referentType.MakePointerType();
                     break;
@@ -254,7 +252,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     return AsArrayType().GetElementType();
 
                 case TypeKind.TK_PointerType:
-                    return AsPointerType().GetReferentType();
+                    return ((PointerType)this).GetReferentType();
 
                 case TypeKind.TK_ParameterModifierType:
                     return ((ParameterModifierType)this).GetParameterType();
@@ -468,7 +466,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         private bool isPointerLike()
         {
-            return IsPointerType() || isPredefType(PredefinedType.PT_INTPTR) || isPredefType(PredefinedType.PT_UINTPTR);
+            return this is PointerType || isPredefType(PredefinedType.PT_INTPTR) || isPredefType(PredefinedType.PT_UINTPTR);
         }
 
         ////////////////////////////////////////////////////////////////////////////////
@@ -525,14 +523,14 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
             else
             {
-                return IsPointerType();
+                return this is PointerType;
             }
         }
         public bool isUnsafe()
         {
             // Pointer types are the only unsafe types.
             // Note that generics may not be instantiated with pointer types
-            return (this != null && (IsPointerType() || (IsArrayType() && AsArrayType().GetElementType().isUnsafe())));
+            return this is PointerType || IsArrayType() && AsArrayType().GetElementType().isUnsafe();
         }
         public bool isPredefType(PredefinedType pt)
         {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
@@ -29,7 +29,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public bool IsAggregateType() { return this is AggregateType; }
         public bool IsOpenTypePlaceholderType() { return this is OpenTypePlaceholderType; }
-        public bool IsBoundLambdaType() { return this is BoundLambdaType; }
         public bool IsMethodGroupType() { return this is MethodGroupType; }
         public bool IsErrorType() { return this is ErrorType; }
         public bool IsArrayType() { return this is ArrayType; }
@@ -628,7 +627,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         // be equivalent or convertible (like ANONMETHSYMs)
         public bool IsNeverSameType()
         {
-            return IsBoundLambdaType() || IsMethodGroupType() || (IsErrorType() && !AsErrorType().HasParent());
+            return this is BoundLambdaType || IsMethodGroupType() || (IsErrorType() && !AsErrorType().HasParent());
         }
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
@@ -28,7 +28,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public NullableType AsNullableType() { return this as NullableType; }
 
         public bool IsAggregateType() { return this is AggregateType; }
-        public bool IsVoidType() { return this is VoidType; }
         public bool IsNullType() { return this is NullType; }
         public bool IsOpenTypePlaceholderType() { return this is OpenTypePlaceholderType; }
         public bool IsBoundLambdaType() { return this is BoundLambdaType; }
@@ -547,7 +546,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             if (IsAggregateType())
                 return AsAggregateType().getAggregate().IsPredefined() && AsAggregateType().getAggregate().GetPredefType() == pt;
-            return (IsVoidType() && pt == PredefinedType.PT_VOID);
+            return (this is VoidType && pt == PredefinedType.PT_VOID);
         }
         public bool isPredefined()
         {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
@@ -26,7 +26,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public PointerType AsPointerType() { return this as PointerType; }
         public ParameterModifierType AsParameterModifierType() { return this as ParameterModifierType; }
         public NullableType AsNullableType() { return this as NullableType; }
-        public TypeParameterType AsTypeParameterType() { return this as TypeParameterType; }
 
         public bool IsAggregateType() { return this is AggregateType; }
         public bool IsVoidType() { return this is VoidType; }
@@ -39,7 +38,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public bool IsPointerType() { return this is PointerType; }
         public bool IsParameterModifierType() { return this is ParameterModifierType; }
         public bool IsNullableType() { return this is NullableType; }
-        public bool IsTypeParameterType() { return this is TypeParameterType; }
 
         public bool IsWindowsRuntimeType()
         {
@@ -65,12 +63,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 return true;
             }
             return false;
-        }
-
-        // API similar to System.Type
-        public bool IsGenericParameter
-        {
-            get { return IsTypeParameterType(); }
         }
 
         private Type _associatedSystemType;
@@ -122,7 +114,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     break;
 
                 case TypeKind.TK_TypeParameterType:
-                    TypeParameterType t = src.AsTypeParameterType();
+                    TypeParameterType t = (TypeParameterType)src;
                     if (t.IsMethodTypeParameter())
                     {
                         MethodInfo meth = t.GetOwningSymbol().AsMethodSymbol().AssociatedMemberInfo as MethodInfo;
@@ -164,7 +156,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             for (int i = 0; i < typeArgs.Count; i++)
             {
                 // Unnamed type parameter types are just placeholders.
-                if (typeArgs[i].IsTypeParameterType() && typeArgs[i].AsTypeParameterType().GetTypeParameterSymbol().name == null)
+                if (typeArgs[i] is TypeParameterType typeParamArg && typeParamArg.GetTypeParameterSymbol().name == null)
                 {
                     return null;
                 }
@@ -595,7 +587,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             switch (GetTypeKind())
             {
                 case TypeKind.TK_TypeParameterType:
-                    return AsTypeParameterType().IsValueType();
+                    return (this as TypeParameterType).IsValueType();
                 case TypeKind.TK_AggregateType:
                     return AsAggregateType().getAggregate().IsValueType();
                 case TypeKind.TK_NullableType:
@@ -609,7 +601,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             switch (GetTypeKind())
             {
                 case TypeKind.TK_TypeParameterType:
-                    return AsTypeParameterType().IsNonNullableValueType();
+                    return (this as TypeParameterType).IsNonNullableValueType();
                 case TypeKind.TK_AggregateType:
                     return AsAggregateType().getAggregate().IsValueType();
                 case TypeKind.TK_NullableType:
@@ -626,7 +618,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 case TypeKind.TK_NullType:
                     return true;
                 case TypeKind.TK_TypeParameterType:
-                    return AsTypeParameterType().IsReferenceType();
+                    return (this as TypeParameterType).IsReferenceType();
                 case TypeKind.TK_AggregateType:
                     return AsAggregateType().getAggregate().IsRefType();
                 default:

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
@@ -28,7 +28,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public NullableType AsNullableType() { return this as NullableType; }
 
         public bool IsAggregateType() { return this is AggregateType; }
-        public bool IsNullType() { return this is NullType; }
         public bool IsOpenTypePlaceholderType() { return this is OpenTypePlaceholderType; }
         public bool IsBoundLambdaType() { return this is BoundLambdaType; }
         public bool IsMethodGroupType() { return this is MethodGroupType; }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
@@ -29,7 +29,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public bool IsAggregateType() { return this is AggregateType; }
         public bool IsOpenTypePlaceholderType() { return this is OpenTypePlaceholderType; }
-        public bool IsMethodGroupType() { return this is MethodGroupType; }
         public bool IsErrorType() { return this is ErrorType; }
         public bool IsArrayType() { return this is ArrayType; }
         public bool IsPointerType() { return this is PointerType; }
@@ -627,7 +626,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         // be equivalent or convertible (like ANONMETHSYMs)
         public bool IsNeverSameType()
         {
-            return this is BoundLambdaType || IsMethodGroupType() || (IsErrorType() && !AsErrorType().HasParent());
+            return this is BoundLambdaType || this is MethodGroupType || (IsErrorType() && !AsErrorType().HasParent());
         }
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
@@ -21,10 +21,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         // Is and As methods.
         public AggregateType AsAggregateType() { return this as AggregateType; }
-        public ArrayType AsArrayType() { return this as ArrayType; }
 
         public bool IsAggregateType() { return this is AggregateType; }
-        public bool IsArrayType() { return this is ArrayType; }
 
         public bool IsWindowsRuntimeType()
         {
@@ -73,7 +71,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             switch (src.GetTypeKind())
             {
                 case TypeKind.TK_ArrayType:
-                    ArrayType a = src.AsArrayType();
+                    ArrayType a = (ArrayType)src;
                     Type elementType = a.GetElementType().AssociatedSystemType;
                     result = a.IsSZArray ? elementType.MakeArrayType() : elementType.MakeArrayType(a.rank);
                     break;
@@ -247,7 +245,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             switch (GetTypeKind())
             {
                 case TypeKind.TK_ArrayType:
-                    return AsArrayType().GetElementType();
+                    return ((ArrayType)this).GetElementType();
 
                 case TypeKind.TK_PointerType:
                     return ((PointerType)this).GetReferentType();
@@ -517,7 +515,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             // Pointer types are the only unsafe types.
             // Note that generics may not be instantiated with pointer types
-            return this is PointerType || IsArrayType() && AsArrayType().GetElementType().isUnsafe();
+            return this is PointerType || this is ArrayType arr && arr.GetElementType().isUnsafe();
         }
         public bool isPredefType(PredefinedType pt)
         {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
@@ -25,14 +25,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public ArrayType AsArrayType() { return this as ArrayType; }
         public PointerType AsPointerType() { return this as PointerType; }
         public ParameterModifierType AsParameterModifierType() { return this as ParameterModifierType; }
-        public NullableType AsNullableType() { return this as NullableType; }
 
         public bool IsAggregateType() { return this is AggregateType; }
         public bool IsErrorType() { return this is ErrorType; }
         public bool IsArrayType() { return this is ArrayType; }
         public bool IsPointerType() { return this is PointerType; }
         public bool IsParameterModifierType() { return this is ParameterModifierType; }
-        public bool IsNullableType() { return this is NullableType; }
 
         public bool IsWindowsRuntimeType()
         {
@@ -87,7 +85,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     break;
 
                 case TypeKind.TK_NullableType:
-                    NullableType n = src.AsNullableType();
+                    NullableType n = (NullableType)src;
                     Type underlyingType = n.GetUnderlyingType().AssociatedSystemType;
                     result = typeof(Nullable<>).MakeGenericType(underlyingType);
                     break;
@@ -264,7 +262,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     return AsParameterModifierType().GetParameterType();
 
                 case TypeKind.TK_NullableType:
-                    return AsNullableType().GetUnderlyingType();
+                    return ((NullableType)this).GetUnderlyingType();
 
                 default:
                     return null;
@@ -485,11 +483,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         }
         public bool isStructOrEnum()
         {
-            return (IsAggregateType() && (getAggregate().IsStruct() || getAggregate().IsEnum())) || IsNullableType();
+            return (IsAggregateType() && (getAggregate().IsStruct() || getAggregate().IsEnum())) || this is NullableType;
         }
         public bool isStructType()
         {
-            return IsAggregateType() && getAggregate().IsStruct() || IsNullableType();
+            return IsAggregateType() && getAggregate().IsStruct() || this is NullableType;
         }
         public bool isEnumType()
         {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
@@ -28,7 +28,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public NullableType AsNullableType() { return this as NullableType; }
 
         public bool IsAggregateType() { return this is AggregateType; }
-        public bool IsOpenTypePlaceholderType() { return this is OpenTypePlaceholderType; }
         public bool IsErrorType() { return this is ErrorType; }
         public bool IsArrayType() { return this is ArrayType; }
         public bool IsPointerType() { return this is PointerType; }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
@@ -21,11 +21,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         // Is and As methods.
         public AggregateType AsAggregateType() { return this as AggregateType; }
-        public ErrorType AsErrorType() { return this as ErrorType; }
         public ArrayType AsArrayType() { return this as ArrayType; }
 
         public bool IsAggregateType() { return this is AggregateType; }
-        public bool IsErrorType() { return this is ErrorType; }
         public bool IsArrayType() { return this is ArrayType; }
 
         public bool IsWindowsRuntimeType()
@@ -268,18 +266,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public void InitFromParent()
         {
             Debug.Assert(!IsAggregateType());
-            CType typePar = null;
-
-            if (IsErrorType())
-            {
-                typePar = AsErrorType().GetTypeParent();
-            }
-            else
-            {
-                typePar = GetBaseOrParameterOrElementType();
-            }
-
-            _fHasErrors = typePar.HasErrors();
+            _fHasErrors = (this is ErrorType err ? err.GetTypeParent() : GetBaseOrParameterOrElementType()).HasErrors();
         }
 
         public bool HasErrors()
@@ -619,7 +606,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         // be equivalent or convertible (like ANONMETHSYMs)
         public bool IsNeverSameType()
         {
-            return this is BoundLambdaType || this is MethodGroupType || (IsErrorType() && !AsErrorType().HasParent());
+            return this is BoundLambdaType || this is MethodGroupType || this is ErrorType err && !err.HasParent();
         }
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeArray.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeArray.cs
@@ -21,8 +21,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public int Count => Items.Length;
 
-        public TypeParameterType ItemAsTypeParameterType(int i) => Items[i].AsTypeParameterType();
-
         public CType[] Items { get; }
 
         public CType this[int i] => Items[i];

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -519,7 +519,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     return (typeDst == typeSrc) ? type : GetPointer(typeDst);
 
                 case TypeKind.TK_NullableType:
-                    typeDst = SubstTypeCore(typeSrc = type.AsNullableType().GetUnderlyingType(), pctx);
+                    typeDst = SubstTypeCore(typeSrc = ((NullableType)type).GetUnderlyingType(), pctx);
                     return (typeDst == typeSrc) ? type : GetNullable(typeDst);
 
                 case TypeKind.TK_AggregateType:
@@ -1093,7 +1093,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 return true;
             }
 
-            if (typeSrc.IsNullableType())
+            if (typeSrc is NullableType)
             {
                 // We have an inaccessible nullable type, which means that the best we can do is System.ValueType.
                 typeDst = this.GetOptPredefAgg(PredefinedType.PT_VALUE).getThisType();

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -1062,7 +1062,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
 
             // These guys have no accessibility concerns.
-            Debug.Assert(!typeSrc.IsVoidType() && !typeSrc.IsErrorType() && !(typeSrc is TypeParameterType));
+            Debug.Assert(!(typeSrc is VoidType) && !typeSrc.IsErrorType() && !(typeSrc is TypeParameterType));
 
             if (typeSrc.IsParameterModifierType() || typeSrc.IsPointerType())
             {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -512,8 +512,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     return (typeDst == typeSrc) ? type : GetParameterModifier(typeDst, mod.isOut);
 
                 case TypeKind.TK_ArrayType:
-                    typeDst = SubstTypeCore(typeSrc = type.AsArrayType().GetElementType(), pctx);
-                    return (typeDst == typeSrc) ? type : GetArray(typeDst, type.AsArrayType().rank, type.AsArrayType().IsSZArray);
+                    var arr = (ArrayType)type;
+                    typeDst = SubstTypeCore(typeSrc = arr.GetElementType(), pctx);
+                    return (typeDst == typeSrc) ? type : GetArray(typeDst, arr.rank, arr.IsSZArray);
 
                 case TypeKind.TK_PointerType:
                     typeDst = SubstTypeCore(typeSrc = ((PointerType)type).GetReferentType(), pctx);
@@ -649,7 +650,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     return false;
 
                 case TypeKind.TK_ArrayType:
-                    if (typeDst.GetTypeKind() != TypeKind.TK_ArrayType || typeDst.AsArrayType().rank != typeSrc.AsArrayType().rank || typeDst.AsArrayType().IsSZArray != typeSrc.AsArrayType().IsSZArray)
+                    ArrayType arrSrc = (ArrayType)typeSrc;
+                    if (!(typeDst is ArrayType arrDst) || arrDst.rank != arrSrc.rank || arrDst.IsSZArray != arrSrc.IsSZArray)
                         return false;
                     goto LCheckBases;
 
@@ -1082,7 +1084,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 return true;
             }
 
-            if (typeSrc.IsArrayType() && TryArrayVarianceAdjustmentToGetAccessibleType(semanticChecker, bindingContext, typeSrc.AsArrayType(), out intermediateType))
+            if (typeSrc is ArrayType arrSrc && TryArrayVarianceAdjustmentToGetAccessibleType(semanticChecker, bindingContext, arrSrc, out intermediateType))
             {
                 // Similarly to the interface and delegate case, arrays are covariant in their element type and
                 // so we can potentially produce an array type that is accessible.
@@ -1102,7 +1104,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 return true;
             }
 
-            if (typeSrc.IsArrayType())
+            if (typeSrc is ArrayType)
             {
                 // We have an inaccessible array type for which we could not earlier find a better array type
                 // with a covariant conversion, so the best we can do is System.Array.

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -535,9 +535,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     return type;
 
                 case TypeKind.TK_ErrorType:
-                    if (type.AsErrorType().HasParent())
+                    ErrorType err = (ErrorType)type;
+                    if (err.HasParent())
                     {
-                        ErrorType err = type.AsErrorType();
                         Debug.Assert(err.nameText != null && err.typeArgs != null);
 
                         CType pParentType = null;
@@ -691,11 +691,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     return true;
 
                 case TypeKind.TK_ErrorType:
-                    if (!typeDst.IsErrorType() || !typeSrc.AsErrorType().HasParent() || !typeDst.AsErrorType().HasParent())
+                    ErrorType errSrc = (ErrorType)typeSrc;
+                    if (!(typeDst is ErrorType errDst) || !errSrc.HasParent() || !errDst.HasParent())
                         return false;
                     {
-                        ErrorType errSrc = typeSrc.AsErrorType();
-                        ErrorType errDst = typeDst.AsErrorType();
                         Debug.Assert(errSrc.nameText != null && errSrc.typeArgs != null);
                         Debug.Assert(errDst.nameText != null && errDst.typeArgs != null);
 
@@ -817,9 +816,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     return false;
 
                 case TypeKind.TK_ErrorType:
-                    if (type.AsErrorType().HasParent())
+                    ErrorType err = (ErrorType)type;
+                    if (err.HasParent())
                     {
-                        ErrorType err = type.AsErrorType();
                         Debug.Assert(err.nameText != null && err.typeArgs != null);
 
                         for (int i = 0; i < err.typeArgs.Count; i++)
@@ -879,9 +878,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     return false;
 
                 case TypeKind.TK_ErrorType:
-                    if (type.AsErrorType().HasParent())
+                    ErrorType err = (ErrorType)type;
+                    if (err.HasParent())
                     {
-                        ErrorType err = type.AsErrorType();
                         Debug.Assert(err.nameText != null && err.typeArgs != null);
 
                         for (int i = 0; i < err.typeArgs.Count; i++)
@@ -1063,7 +1062,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
 
             // These guys have no accessibility concerns.
-            Debug.Assert(!(typeSrc is VoidType) && !typeSrc.IsErrorType() && !(typeSrc is TypeParameterType));
+            Debug.Assert(!(typeSrc is VoidType) && !(typeSrc is ErrorType) && !(typeSrc is TypeParameterType));
 
             if (typeSrc is ParameterModifierType || typeSrc is PointerType)
             {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -555,7 +555,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                 case TypeKind.TK_TypeParameterType:
                     {
-                        TypeParameterSymbol tvs = type.AsTypeParameterType().GetTypeParameterSymbol();
+                        TypeParameterSymbol tvs = ((TypeParameterType)type).GetTypeParameterSymbol();
                         int index = tvs.GetIndexInTotalParameters();
                         if (tvs.IsMethodTypeParameter())
                         {
@@ -735,7 +735,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                 case TypeKind.TK_TypeParameterType:
                     { // BLOCK
-                        TypeParameterSymbol tvs = typeSrc.AsTypeParameterType().GetTypeParameterSymbol();
+                        TypeParameterSymbol tvs = ((TypeParameterType)typeSrc).GetTypeParameterSymbol();
                         int index = tvs.GetIndexInTotalParameters();
 
                         if (tvs.IsMethodTypeParameter())
@@ -901,7 +901,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 case TypeKind.TK_TypeParameterType:
                     if (typeVars != null && typeVars.Count > 0)
                     {
-                        int ivar = type.AsTypeParameterType().GetIndexInTotalParameters();
+                        int ivar = ((TypeParameterType)type).GetIndexInTotalParameters();
                         return ivar < typeVars.Count && type == typeVars[ivar];
                     }
                     return true;
@@ -1062,7 +1062,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
 
             // These guys have no accessibility concerns.
-            Debug.Assert(!typeSrc.IsVoidType() && !typeSrc.IsErrorType() && !typeSrc.IsTypeParameterType());
+            Debug.Assert(!typeSrc.IsVoidType() && !typeSrc.IsErrorType() && !(typeSrc is TypeParameterType));
 
             if (typeSrc.IsParameterModifierType() || typeSrc.IsPointerType())
             {
@@ -1164,7 +1164,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     continue;
                 }
 
-                if (!typeArgs[i].IsRefType() || !typeParams[i].AsTypeParameterType().Covariant)
+                if (!typeArgs[i].IsRefType() || !((TypeParameterType)typeParams[i]).Covariant)
                 {
                     // This guy is inaccessible, and we are not going to be able to vary him, so we need to fail.
                     return false;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -507,15 +507,16 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     return type;
 
                 case TypeKind.TK_ParameterModifierType:
-                    typeDst = SubstTypeCore(typeSrc = type.AsParameterModifierType().GetParameterType(), pctx);
-                    return (typeDst == typeSrc) ? type : GetParameterModifier(typeDst, type.AsParameterModifierType().isOut);
+                    ParameterModifierType mod = (ParameterModifierType)type;
+                    typeDst = SubstTypeCore(typeSrc = mod.GetParameterType(), pctx);
+                    return (typeDst == typeSrc) ? type : GetParameterModifier(typeDst, mod.isOut);
 
                 case TypeKind.TK_ArrayType:
                     typeDst = SubstTypeCore(typeSrc = type.AsArrayType().GetElementType(), pctx);
                     return (typeDst == typeSrc) ? type : GetArray(typeDst, type.AsArrayType().rank, type.AsArrayType().IsSZArray);
 
                 case TypeKind.TK_PointerType:
-                    typeDst = SubstTypeCore(typeSrc = type.AsPointerType().GetReferentType(), pctx);
+                    typeDst = SubstTypeCore(typeSrc = ((PointerType)type).GetReferentType(), pctx);
                     return (typeDst == typeSrc) ? type : GetPointer(typeDst);
 
                 case TypeKind.TK_NullableType:
@@ -653,9 +654,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     goto LCheckBases;
 
                 case TypeKind.TK_ParameterModifierType:
-                    if (typeDst.GetTypeKind() != TypeKind.TK_ParameterModifierType ||
+                    if (!(typeDst is ParameterModifierType modDest) ||
                         ((pctx.grfst & SubstTypeFlags.NoRefOutDifference) == 0 &&
-                         typeDst.AsParameterModifierType().isOut != typeSrc.AsParameterModifierType().isOut))
+                         modDest.isOut != ((ParameterModifierType)typeSrc).isOut))
                         return false;
                     goto LCheckBases;
 
@@ -1064,7 +1065,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // These guys have no accessibility concerns.
             Debug.Assert(!(typeSrc is VoidType) && !typeSrc.IsErrorType() && !(typeSrc is TypeParameterType));
 
-            if (typeSrc.IsParameterModifierType() || typeSrc.IsPointerType())
+            if (typeSrc is ParameterModifierType || typeSrc is PointerType)
             {
                 // We cannot vary these.
                 return false;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -214,7 +214,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     // Store the old base class.
 
                     AggregateType oldBaseType = agg.GetBaseClass();
-                    agg.SetBaseClass(_symbolTable.GetCTypeFromType(baseType).AsAggregateType());
+                    agg.SetBaseClass(_symbolTable.GetCTypeFromType(baseType) as AggregateType);
                     pAggregate.GetBaseClass(); // Get the base type for the new agg type we're making.
 
                     agg.SetBaseClass(oldBaseType);
@@ -525,10 +525,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     return (typeDst == typeSrc) ? type : GetNullable(typeDst);
 
                 case TypeKind.TK_AggregateType:
-                    if (type.AsAggregateType().GetTypeArgsAll().Count > 0)
+                    AggregateType ats = (AggregateType)type;
+                    if (ats.GetTypeArgsAll().Count > 0)
                     {
-                        AggregateType ats = type.AsAggregateType();
-
                         TypeArray typeArgs = SubstTypeArray(ats.GetTypeArgsAll(), pctx);
                         if (ats.GetTypeArgsAll() != typeArgs)
                             return GetAggregate(ats.getAggregate(), typeArgs);
@@ -672,11 +671,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     goto LRecurse;
 
                 case TypeKind.TK_AggregateType:
-                    if (typeDst.GetTypeKind() != TypeKind.TK_AggregateType)
+                    if (!(typeDst is AggregateType atsDst))
                         return false;
                     { // BLOCK
-                        AggregateType atsSrc = typeSrc.AsAggregateType();
-                        AggregateType atsDst = typeDst.AsAggregateType();
+                        AggregateType atsSrc = (AggregateType)typeSrc;
 
                         if (atsSrc.getAggregate() != atsDst.getAggregate())
                             return false;
@@ -807,7 +805,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                 case TypeKind.TK_AggregateType:
                     { // BLOCK
-                        AggregateType ats = type.AsAggregateType();
+                        AggregateType ats = (AggregateType)type;
 
                         for (int i = 0; i < ats.GetTypeArgsAll().Count; i++)
                         {
@@ -867,7 +865,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                 case TypeKind.TK_AggregateType:
                     { // BLOCK
-                        AggregateType ats = type.AsAggregateType();
+                        AggregateType ats = (AggregateType)type;
 
                         for (int i = 0; i < ats.GetTypeArgsAll().Count; i++)
                         {
@@ -979,7 +977,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public CType SubstType(CType typeSrc, CType typeCls, TypeArray typeArgsMeth)
         {
-            return SubstType(typeSrc, typeCls.IsAggregateType() ? typeCls.AsAggregateType().GetTypeArgsAll() : null, typeArgsMeth);
+            return SubstType(typeSrc, (typeCls as AggregateType)?.GetTypeArgsAll(), typeArgsMeth);
         }
 
         public TypeArray SubstTypeArray(TypeArray taSrc, AggregateType atsCls, TypeArray typeArgsMeth)
@@ -994,7 +992,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         private bool SubstEqualTypes(CType typeDst, CType typeSrc, CType typeCls, TypeArray typeArgsMeth)
         {
-            return SubstEqualTypes(typeDst, typeSrc, typeCls.IsAggregateType() ? typeCls.AsAggregateType().GetTypeArgsAll() : null, typeArgsMeth, SubstTypeFlags.NormNone);
+            return SubstEqualTypes(typeDst, typeSrc, (typeCls as AggregateType)?.GetTypeArgsAll(), typeArgsMeth, SubstTypeFlags.NormNone);
         }
 
         public bool SubstEqualTypes(CType typeDst, CType typeSrc, CType typeCls)
@@ -1073,7 +1071,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
 
             CType intermediateType;
-            if ((typeSrc.isInterfaceType() || typeSrc.isDelegateType()) && TryVarianceAdjustmentToGetAccessibleType(semanticChecker, bindingContext, typeSrc.AsAggregateType(), out intermediateType))
+            if (typeSrc is AggregateType aggSrc && (aggSrc.isInterfaceType() || aggSrc.isDelegateType()) && TryVarianceAdjustmentToGetAccessibleType(semanticChecker, bindingContext, aggSrc, out intermediateType))
             {
                 // If we have an interface or delegate type, then it can potentially be varied by its type arguments
                 // to produce an accessible type, and if that's the case, then return that.
@@ -1114,12 +1112,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 return true;
             }
 
-            Debug.Assert(typeSrc.IsAggregateType());
+            Debug.Assert(typeSrc is AggregateType);
 
-            if (typeSrc.IsAggregateType())
+            if (typeSrc is AggregateType aggType)
             {
                 // We have an AggregateType, so recurse on its base class.
-                AggregateType aggType = typeSrc.AsAggregateType();
                 AggregateType baseType = aggType.GetBaseClass();
 
                 if (baseType == null)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeParameterType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeParameterType.cs
@@ -33,8 +33,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 {
                     return true;
                 }
-                if (pConstraint.IsTypeParameterType() &&
-                    pConstraint.AsTypeParameterType().DependsOn(pType))
+                if (pConstraint is TypeParameterType typeConstraint && typeConstraint.DependsOn(pType))
                 {
                     return true;
                 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
@@ -1917,9 +1917,9 @@ namespace Microsoft.CSharp.RuntimeBinder
             }
 
             // Check if we have an out parameter.
-            if (ctype.IsParameterModifierType() && p.IsOut && !p.IsIn)
+            if (ctype is ParameterModifierType mod && p.IsOut && !p.IsIn)
             {
-                CType parameterType = ctype.AsParameterModifierType().GetParameterType();
+                CType parameterType = mod.GetParameterType();
                 ctype = _typeManager.GetParameterModifier(parameterType, true);
             }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
@@ -178,9 +178,9 @@ namespace Microsoft.CSharp.RuntimeBinder
             {
                 type = _semanticChecker.GetSymbolLoader().GetReqPredefType(PredefinedType.PT_ARRAY);
             }
-            if (type.IsNullableType())
+            if (type is NullableType nub)
             {
-                type = type.AsNullableType().GetAts(_semanticChecker.GetSymbolLoader().GetErrorContext());
+                type = nub.GetAts(_semanticChecker.GetSymbolLoader().GetErrorContext());
             }
 
             if (!mem.Lookup(

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
@@ -174,7 +174,7 @@ namespace Microsoft.CSharp.RuntimeBinder
         {
             CType type = callingObject.Type;
 
-            if (type.IsArrayType())
+            if (type is ArrayType)
             {
                 type = _semanticChecker.GetSymbolLoader().GetReqPredefType(PredefinedType.PT_ARRAY);
             }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
@@ -321,7 +321,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             CType ctype = GetCTypeFromType(type);
             if (ctype.IsWindowsRuntimeType())
             {
-                TypeArray collectioniFaces = ctype.AsAggregateType().GetWinRTCollectionIfacesAll(_semanticChecker.GetSymbolLoader());
+                TypeArray collectioniFaces = ((AggregateType)ctype).GetWinRTCollectionIfacesAll(_semanticChecker.GetSymbolLoader());
 
                 for (int i = 0; i < collectioniFaces.Count; i++)
                 {
@@ -721,9 +721,9 @@ namespace Microsoft.CSharp.RuntimeBinder
                         {
                             // If we had an aggregate type, its possible we're not at the end.
                             // This will happen for nullable<T> for instance.
-                            if (ctype.IsAggregateType())
+                            if (ctype is AggregateType cat)
                             {
-                                next = ctype.AsAggregateType().GetOwningAggregate();
+                                next = cat.GetOwningAggregate();
                             }
                             else
                             {
@@ -1014,7 +1014,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             else if (type.IsEnum)
             {
                 kind = AggKindEnum.Enum;
-                agg.SetUnderlyingType(GetCTypeFromType(Enum.GetUnderlyingType(type)).AsAggregateType());
+                agg.SetUnderlyingType((AggregateType)GetCTypeFromType(Enum.GetUnderlyingType(type)));
             }
             else if (type.IsValueType)
             {
@@ -1128,7 +1128,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                 {
                     t = t.GetGenericTypeDefinition();
                 }
-                agg.SetBaseClass(GetCTypeFromType(t).AsAggregateType());
+                agg.SetBaseClass((AggregateType)GetCTypeFromType(t));
             }
             agg.SetTypeManager(_typeManager);
             agg.SetFirstUDConversion(null);
@@ -1986,7 +1986,7 @@ namespace Microsoft.CSharp.RuntimeBinder
         private MethodSymbol FindMethodFromMemberInfo(MemberInfo baseMemberInfo)
         {
             CType t = GetCTypeFromType(baseMemberInfo.DeclaringType);
-            Debug.Assert(t.IsAggregateType());
+            Debug.Assert(t is AggregateType);
             AggregateSymbol aggregate = t.getAggregate();
             Debug.Assert(aggregate != null);
 
@@ -2039,7 +2039,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             // there are any conversions.
             CType t = GetCTypeFromType(type);
 
-            if (!t.IsAggregateType())
+            if (!(t is AggregateType))
             {
                 CType endT;
                 while ((endT = t.GetBaseOrParameterOrElementType()) != null)
@@ -2059,7 +2059,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             }
 
             Debug.Assert(t is AggregateType);
-            AggregateSymbol aggregate = t.AsAggregateType().getAggregate();
+            AggregateSymbol aggregate = ((AggregateType)t).getAggregate();
 
             // Now find all the conversions and make them.
             IEnumerable<MethodInfo> conversions = Enumerable.Where(type.GetRuntimeMethods(),

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
@@ -382,7 +382,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                 for (int i = 0; i < genericArguments.Length; i++)
                 {
                     Type t = genericArguments[i];
-                    ctypes[i].AsTypeParameterType().GetTypeParameterSymbol().SetBounds(
+                    ((TypeParameterType)ctypes[i]).GetTypeParameterSymbol().SetBounds(
                         _bsymmgr.AllocParams(
                         GetCTypeArrayFromTypes(t.GetGenericParameterConstraints())));
                 }
@@ -436,7 +436,7 @@ namespace Microsoft.CSharp.RuntimeBinder
 
                     // We check to make sure we own the type parameter - this is because we're
                     // currently calculating TypeArgsThis, NOT TypeArgsAll.
-                    if (ctype.AsTypeParameterType().GetOwningSymbol() == agg)
+                    if (((TypeParameterType)ctype).GetOwningSymbol() == agg)
                     {
                         ctypes.Add(ctype);
                     }
@@ -1093,9 +1093,9 @@ namespace Microsoft.CSharp.RuntimeBinder
                 for (int i = 0; i < agg.GetTypeVars().Count; i++)
                 {
                     Type t = genericArguments[i];
-                    if (agg.GetTypeVars()[i].IsTypeParameterType())
+                    if (agg.GetTypeVars()[i] is TypeParameterType typeVar)
                     {
-                        agg.GetTypeVars()[i].AsTypeParameterType().GetTypeParameterSymbol().SetBounds(
+                        typeVar.GetTypeParameterSymbol().SetBounds(
                             _bsymmgr.AllocParams(
                             GetCTypeArrayFromTypes(t.GetGenericParameterConstraints())));
                     }
@@ -2048,10 +2048,10 @@ namespace Microsoft.CSharp.RuntimeBinder
                 }
             }
 
-            if (t.IsTypeParameterType())
+            if (t is TypeParameterType paramType)
             {
                 // Add conversions for the bounds.
-                foreach (CType bound in t.AsTypeParameterType().GetBounds().Items)
+                foreach (CType bound in paramType.GetBounds().Items)
                 {
                     AddConversionsForType(bound.AssociatedSystemType);
                 }


### PR DESCRIPTION
Lighter, allows for pattern-matching, avoids repeated field accesses and casts by moving more into locals.