### PR TITLE
Nested directories were too deep

### DIFF
--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -172,27 +172,13 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public void DirectoryEqualToMaxDirectory_CanBeCreated()
-        {
-            DirectoryInfo testDir = Create(GetTestFilePath());
-            PathInfo path = IOServices.GetPath(testDir.FullName, IOInputs.MaxDirectory, IOInputs.MaxComponent);
-            Assert.All(path.SubPaths, (subpath) =>
-            {
-                DirectoryInfo result = Create(subpath);
-
-                Assert.Equal(subpath, result.FullName);
-                Assert.True(Directory.Exists(result.FullName));
-            });
-        }
-
-        [Fact]
         public void DirectoryEqualToMaxDirectory_CanBeCreatedAllAtOnce()
         {
             DirectoryInfo testDir = Create(GetTestFilePath());
-            PathInfo path = IOServices.GetPath(testDir.FullName, IOInputs.MaxDirectory, maxComponent: 10);
-            DirectoryInfo result = Create(path.FullPath);
+            string path = IOServices.GetPath(testDir.FullName, IOInputs.MaxDirectory);
+            DirectoryInfo result = Create(path);
 
-            Assert.Equal(path.FullPath, result.FullName);
+            Assert.Equal(path, result.FullName);
             Assert.True(Directory.Exists(result.FullName));
         }
 
@@ -304,9 +290,9 @@ namespace System.IO.Tests
         public void UnixPathLongerThan256_Allowed()
         {
             DirectoryInfo testDir = Create(GetTestFilePath());
-            PathInfo path = IOServices.GetPath(testDir.FullName, 257, IOInputs.MaxComponent);
-            DirectoryInfo result = Create(path.FullPath);
-            Assert.Equal(path.FullPath, result.FullName);
+            string path = IOServices.GetPath(testDir.FullName, 257);
+            DirectoryInfo result = Create(path);
+            Assert.Equal(path, result.FullName);
             Assert.True(Directory.Exists(result.FullName));
         }
 

--- a/src/System.IO.FileSystem/tests/Directory/Delete.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Delete.cs
@@ -131,7 +131,7 @@ namespace System.IO.Tests
         [ActiveIssue(20117, TargetFrameworkMonikers.Uap)]
         public void LongPathExtendedDirectory()
         {
-            DirectoryInfo testDir = Directory.CreateDirectory(IOServices.GetPath(IOInputs.ExtendedPrefix + TestDirectory, characterCount: 500).FullPath);
+            DirectoryInfo testDir = Directory.CreateDirectory(IOServices.GetPath(IOInputs.ExtendedPrefix + TestDirectory, characterCount: 500));
             Delete(testDir.FullName);
             Assert.False(testDir.Exists);
         }

--- a/src/System.IO.FileSystem/tests/Directory/Exists.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Exists.cs
@@ -334,9 +334,9 @@ namespace System.IO.Tests
         {
             // Creates directories up to the maximum directory length all at once
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
-            PathInfo path = IOServices.GetPath(testDir.FullName, IOInputs.MaxDirectory, maxComponent: 10);
-            Directory.CreateDirectory(path.FullPath);
-            Assert.True(Exists(path.FullPath));
+            string path = IOServices.GetPath(testDir.FullName, IOInputs.MaxDirectory);
+            Directory.CreateDirectory(path);
+            Assert.True(Exists(path));
         }
 
         [Theory,

--- a/src/System.IO.FileSystem/tests/File/Create.cs
+++ b/src/System.IO.FileSystem/tests/File/Create.cs
@@ -77,7 +77,7 @@ namespace System.IO.Tests
         [ActiveIssue(20117, TargetFrameworkMonikers.Uap)]
         public void ValidCreation_LongPathExtendedSyntax()
         {
-            DirectoryInfo testDir = Directory.CreateDirectory(IOServices.GetPath(IOInputs.ExtendedPrefix + TestDirectory, characterCount: 500).FullPath);
+            DirectoryInfo testDir = Directory.CreateDirectory(IOServices.GetPath(IOInputs.ExtendedPrefix + TestDirectory, characterCount: 500));
             Assert.StartsWith(IOInputs.ExtendedPrefix, testDir.FullName);
             string testFile = Path.Combine(testDir.FullName, GetTestFileName());
             using (FileStream stream = Create(testFile))

--- a/src/System.IO.FileSystem/tests/Performance/System.IO.FileSystem.Performance.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/Performance/System.IO.FileSystem.Performance.Tests.csproj
@@ -20,7 +20,6 @@
     <Compile Include="..\PortedCommon\DllImports.cs" />
     <Compile Include="..\PortedCommon\IOInputs.cs" />
     <Compile Include="..\PortedCommon\IOServices.cs" />
-    <Compile Include="..\PortedCommon\PathInfo.cs" />
     <Compile Include="Perf.Directory.cs" />
     <Compile Include="Perf.File.cs" />
     <Compile Include="Perf.FileInfo.cs" />

--- a/src/System.IO.FileSystem/tests/PortedCommon/IOInputs.cs
+++ b/src/System.IO.FileSystem/tests/PortedCommon/IOInputs.cs
@@ -218,7 +218,7 @@ internal static class IOInputs
 
     private static string GetLongPath(string rootPath, int characterCount, bool extended = false)
     {
-        return IOServices.GetPath(rootPath, characterCount, extended).FullPath;
+        return IOServices.GetPath(rootPath, characterCount, extended);
     }
 
     public static IEnumerable<string> GetReservedDeviceNames()

--- a/src/System.IO.FileSystem/tests/PortedCommon/IOServices.cs
+++ b/src/System.IO.FileSystem/tests/PortedCommon/IOServices.cs
@@ -115,7 +115,7 @@ internal class IOServices
 
             // Continue adding unique path segments until the character count is hit
             int remainingChars = characterCount - path.Length;
-            string guid = Guid.NewGuid().ToString();
+            string guid = Guid.NewGuid().ToString("N"); // No dashes
             if (remainingChars < guid.Length)
             {
                 path.Append(guid.Substring(0, remainingChars));

--- a/src/System.IO.FileSystem/tests/PortedCommon/IOServices.cs
+++ b/src/System.IO.FileSystem/tests/PortedCommon/IOServices.cs
@@ -94,16 +94,15 @@ internal class IOServices
         return null;
     }
 
-    public static PathInfo GetPath(string rootPath, int characterCount, bool extended)
+    public static string GetPath(string rootPath, int characterCount, bool extended)
     {
         if (extended)
             rootPath = IOInputs.ExtendedPrefix + rootPath;
         return GetPath(rootPath, characterCount);
     }
 
-    public static PathInfo GetPath(string rootPath, int characterCount, int maxComponent = IOInputs.MaxComponent)
+    public static string GetPath(string rootPath, int characterCount)
     {
-        List<string> paths = new List<string>();
         rootPath = rootPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 
         StringBuilder path = new StringBuilder(characterCount);
@@ -114,19 +113,34 @@ internal class IOServices
             // Add directory seperator after each dir but not at the end of the path
             path.Append(Path.DirectorySeparatorChar);
 
-            // Continue adding guids until the character count is hit
+            // Continue adding unique path segments until the character count is hit
+            int remainingChars = characterCount - path.Length;
             string guid = Guid.NewGuid().ToString();
-            path.Append(guid.Substring(0, Math.Min(characterCount - path.Length, guid.Length)));
+            if (remainingChars < guid.Length)
+            {
+                path.Append(guid.Substring(0, remainingChars));
+            }
+            else
+            {
+                // Long paths can be over 32K characters. Given that a guid is just 36 chars, this
+                // can lead to crazy 800+ recursive call depths. We'll create large segments to
+                // make tests more manageable.
+
+                path.Append(guid);
+                remainingChars = characterCount - path.Length;
+                path.Append('g', Math.Min(remainingChars, 200));
+            }
+
             if (path.Length + 1 == characterCount)
             {
                 // If only one character is missing add a k!
                 path.Append('k');
             }
-            paths.Add(path.ToString());
         }
+
         Assert.Equal(path.Length, characterCount);
 
-        return new PathInfo(paths.ToArray());
+        return path.ToString();
     }
 
     public static IEnumerable<string> CreateDirectories(string rootPath, params string[] names)


### PR DESCRIPTION
Nesting directories with Windows paths were over 800
levels deep, causing intermittent issues with stack overflows.
Making directory segments longer to mitigate.

Remove a test that wasn't providing any real value but was
complicating the helper methods and allocating a ton of memory.

Fixes #22443