### PR TITLE
Re-enable IntegratedAuthConnectionTest, since the failures no longer repro on the latest uapaot test runs.

### DIFF
--- a/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionTest.cs
@@ -27,7 +27,6 @@ namespace System.Data.SqlClient.Tests
 
         [PlatformSpecific(TestPlatforms.Windows)]  // Integ auth on Test server is supported on Windows right now
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer), nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotArmProcess))] // https://github.com/dotnet/corefx/issues/19218 And https://github.com/dotnet/corefx/issues/21598
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/20718", TargetFrameworkMonikers.UapAot)]
         public void IntegratedAuthConnectionTest()
         {
             using (TestTdsServer server = TestTdsServer.StartTestServer())


### PR DESCRIPTION
Related to https://github.com/dotnet/corefx/issues/20718