### PR TITLE
Replace Microsoft.CSharp methods for casting Symbol with normal operations

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
@@ -413,7 +413,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
             switch (sym.getKind())
             {
                 case SYMKIND.SK_AggregateDeclaration:
-                    ErrAppendSym(sym.AsAggregateDeclaration().Agg(), pctx);
+                    ErrAppendSym(((AggregateDeclaration)sym).Agg(), pctx);
                     break;
 
                 case SYMKIND.SK_AggregateSymbol:

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
@@ -187,9 +187,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
             if (parent == getBSymmgr().GetRootNS())
                 return;
 
-            if (pctx != null && !pctx.FNop() && parent.IsAggregateSymbol() && 0 != parent.AsAggregateSymbol().GetTypeVarsAll().Count)
+            if (pctx != null && !pctx.FNop() && parent is AggregateSymbol agg && 0 != agg.GetTypeVarsAll().Count)
             {
-                CType pType = GetTypeManager().SubstType(parent.AsAggregateSymbol().getThisType(), pctx);
+                CType pType = GetTypeManager().SubstType(agg.getThisType(), pctx);
                 ErrAppendType(pType, null);
             }
             else
@@ -420,7 +420,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                     {
                         // Check for a predefined class with a special "nice" name for
                         // error reported.
-                        string text = PredefinedTypes.GetNiceName(sym.AsAggregateSymbol());
+                        string text = PredefinedTypes.GetNiceName(sym as AggregateSymbol);
                         if (text != null)
                         {
                             // Found a nice name.
@@ -430,7 +430,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                         {
                             ErrAppendParentSym(sym, pctx);
                             ErrAppendName(sym.name);
-                            ErrAppendTypeParameters(sym.AsAggregateSymbol().GetTypeVars(), pctx, true);
+                            ErrAppendTypeParameters(((AggregateSymbol)sym).GetTypeVars(), pctx, true);
                         }
                         break;
                     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
@@ -468,11 +468,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                 case SYMKIND.SK_TypeParameterSymbol:
                     if (null == sym.name)
                     {
+                        var parSym = (TypeParameterSymbol)sym;
                         // It's a standard type variable.
-                        if (sym.AsTypeParameterSymbol().IsMethodTypeParameter())
+                        if (parSym.IsMethodTypeParameter())
                             ErrAppendChar('!');
                         ErrAppendChar('!');
-                        ErrAppendPrintf("{0}", sym.AsTypeParameterSymbol().GetIndexInTotalParameters());
+                        ErrAppendPrintf("{0}", parSym.GetIndexInTotalParameters());
                     }
                     else
                         ErrAppendName(sym.name);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
@@ -444,7 +444,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                     break;
 
                 case SYMKIND.SK_EventSymbol:
-                    ErrAppendEvent(sym.AsEventSymbol(), pctx);
+                    ErrAppendEvent((EventSymbol)sym, pctx);
                     break;
 
                 case SYMKIND.SK_AssemblyQualifiedNamespaceSymbol:

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
@@ -440,7 +440,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                     break;
 
                 case SYMKIND.SK_PropertySymbol:
-                    ErrAppendProperty(sym.AsPropertySymbol(), pctx);
+                    ErrAppendProperty((PropertySymbol)sym, pctx);
                     break;
 
                 case SYMKIND.SK_EventSymbol:

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
@@ -436,7 +436,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                     }
 
                 case SYMKIND.SK_MethodSymbol:
-                    ErrAppendMethod(sym.AsMethodSymbol(), pctx, fArgs);
+                    ErrAppendMethod((MethodSymbol)sym, pctx, fArgs);
                     break;
 
                 case SYMKIND.SK_PropertySymbol:

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -1561,19 +1561,22 @@ namespace Microsoft.CSharp.RuntimeBinder
                     false,
                     false);
 
-            // If lookup returns an actual event, then this is an event.
-            if (swt != null && swt.Sym.getKind() == SYMKIND.SK_EventSymbol)
+            if (swt != null)
             {
-                result = true;
-            }
+                // If lookup returns an actual event, then this is an event.
+                if (swt.Sym.getKind() == SYMKIND.SK_EventSymbol)
+                {
+                    result = true;
+                }
 
-            // If lookup returns the backing field of a field-like event, then
-            // this is an event. This is due to the Dev10 design change around
-            // the binding of +=, and the fact that the "IsEvent" binding question
-            // is only ever asked about the LHS of a += or -=.
-            if (swt != null && swt.Sym.getKind() == SYMKIND.SK_FieldSymbol && swt.Sym.AsFieldSymbol().isEvent)
-            {
-                result = true;
+                // If lookup returns the backing field of a field-like event, then
+                // this is an event. This is due to the Dev10 design change around
+                // the binding of +=, and the fact that the "IsEvent" binding question
+                // is only ever asked about the LHS of a += or -=.
+                if (swt.Sym is FieldSymbol field && field.isEvent)
+                {
+                    result = true;
+                }
             }
 
             return _exprFactory.CreateConstant(boolType, ConstVal.Get(result));

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -947,8 +947,8 @@ namespace Microsoft.CSharp.RuntimeBinder
 
             // Check if we have a potential call to an indexed property accessor.
             // If so, we'll flag overload resolution to let us call non-callables.
-            if ((payload.Name.StartsWith("set_", StringComparison.Ordinal) && swt.Sym.AsMethodSymbol().Params.Count > 1) ||
-                (payload.Name.StartsWith("get_", StringComparison.Ordinal) && swt.Sym.AsMethodSymbol().Params.Count > 0))
+            if ((payload.Name.StartsWith("set_", StringComparison.Ordinal) && ((MethodSymbol)swt.Sym).Params.Count > 1) ||
+                (payload.Name.StartsWith("get_", StringComparison.Ordinal) && ((MethodSymbol)swt.Sym).Params.Count > 0))
             {
                 memGroup.Flags &= ~EXPRFLAG.EXF_USERCALLABLE;
             }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Declarations/AggregateDeclaration.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Declarations/AggregateDeclaration.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public AggregateSymbol Agg()
         {
-            return bag.AsAggregateSymbol();
+            return bag as AggregateSymbol;
         }
 
         public Assembly GetAssembly()

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -1730,10 +1730,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             int paramCount = mp.Params.Count;
             TypeArray @params = mp.Params;
             int iDst = 0;
-            bool markTypeFromExternCall = mp.IsFMETHSYM() && mp.AsFMETHSYM().isExternal;
+            MethodSymbol m = mp as MethodSymbol;
+            bool markTypeFromExternCall = m != null && m.isExternal;
             int argCount = ExpressionIterator.Count(argsPtr);
 
-            if (mp.IsFMETHSYM() && mp.AsFMETHSYM().isVarargs)
+            if (m != null && m.isVarargs)
             {
                 paramCount--; // we don't care about the vararg sentinel
             }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -1565,7 +1565,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                 // If we're invoking code on a struct-valued field, mark the struct as assigned (to
                 // avoid warning CS0649).
-                if (pObject is ExprField field && !field.FieldWithType.Field().isAssigned && !swt.Sym.IsFieldSymbol() &&
+                if (pObject is ExprField field && !field.FieldWithType.Field().isAssigned && !(swt.Sym is FieldSymbol) &&
                     typeObj.isStructType() && !typeObj.isPredefined())
                 {
                     field.FieldWithType.Field().isAssigned = true;
@@ -1956,8 +1956,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             agg.SetHasExternReference(true);
             for (Symbol sym = agg.firstChild; sym != null; sym = sym.nextChild)
             {
-                if (sym.IsFieldSymbol())
-                    SetExternalRef(sym.AsFieldSymbol().GetType());
+                if (sym is FieldSymbol field)
+                    SetExternalRef(field.GetType());
             }
         }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -523,7 +523,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                 if (mem.SwtInaccessible().Sym != null)
                 {
-                    Debug.Assert(mem.SwtInaccessible().Sym.IsMethodOrPropertySymbol());
+                    Debug.Assert(mem.SwtInaccessible().Sym is MethodOrPropertySymbol);
                     type = mem.SwtInaccessible().MethProp().RetType;
                     pSymbol = mem.SwtInaccessible().Sym;
                 }
@@ -1667,7 +1667,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             // For a property/indexer we remap the accessors, not the property/indexer.
             // Since every event has both accessors we remap the event instead of the accessors.
-            Debug.Assert(pswt && (pswt.Sym.IsMethodSymbol() || pswt.Sym.IsEventSymbol() || pswt.Sym.IsMethodOrPropertySymbol()));
+            Debug.Assert(pswt && (pswt.Sym.IsMethodSymbol() || pswt.Sym.IsEventSymbol() || pswt.Sym is MethodOrPropertySymbol));
             Debug.Assert(typeObj != null);
 
             // Don't remap static or interface methods.
@@ -1711,7 +1711,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Debug.Assert(call != null);
             Expr argsPtr = call.OptionalArguments;
             SymWithType swt = call.GetSymWithType();
-            MethodOrPropertySymbol mp = swt.Sym.AsMethodOrPropertySymbol();
+            MethodOrPropertySymbol mp = swt.Sym as MethodOrPropertySymbol;
             TypeArray pTypeArgs = (call as ExprCall)?.MethWithInst.TypeArgs;
             Expr newArgs;
             AdjustCallArgumentsForParams(callingObjectType, swt.GetType(), mp, pTypeArgs, argsPtr, out newArgs);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -547,7 +547,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 return rval;
             }
 
-            Debug.Assert(mem.SymFirst().IsPropertySymbol() && mem.SymFirst().AsPropertySymbol().isIndexer());
+            Debug.Assert(mem.SymFirst() is PropertySymbol prop && prop.isIndexer());
 
             ExprMemberGroup grp = GetExprFactory().CreateMemGroup((EXPRFLAG)mem.GetFlags(),
                 pName, BSYMMGR.EmptyTypeArray(), mem.SymFirst().getKind(), mem.GetSourceType(), null/*pMPS*/, mem.GetObject(), mem.GetResults());
@@ -776,7 +776,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 PropertySymbol invocationList =
                     GetSymbolLoader()
                         .LookupAggMember(invocationListName, fieldTypeSymbol, symbmask_t.MASK_PropertySymbol)
-                        .AsPropertySymbol();
+                         as PropertySymbol;
 
                 MethPropWithInst mpwi = new MethPropWithInst(invocationList, fieldType);
                 ExprMemberGroup memGroup = GetExprFactory().CreateMemGroup(getOrCreateCall, mpwi);
@@ -794,7 +794,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         internal Expr BindToProperty(Expr pObject, PropWithType pwt, BindingFlag bindFlags, Expr args, AggregateType pOtherType, ExprMemberGroup pMemGroup)
         {
             Debug.Assert(pwt.Sym != null &&
-                    pwt.Sym.IsPropertySymbol() &&
+                    pwt.Sym is PropertySymbol &&
                     pwt.GetType() != null &&
                     pwt.Prop().getClass() == pwt.GetType().getAggregate());
             Debug.Assert(pwt.Prop().Params.Count == 0 || pwt.Prop().isIndexer());

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -626,7 +626,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         private ExprCall BindToMethod(MethWithInst mwi, Expr pArguments, ExprMemberGroup pMemGroup, MemLookFlags flags)
         {
-            Debug.Assert(mwi.Sym != null && mwi.Sym.IsMethodSymbol() && (!mwi.Meth().isOverride || mwi.Meth().isHideByName));
+            Debug.Assert(mwi.Sym is MethodSymbol && (!mwi.Meth().isOverride || mwi.Meth().isHideByName));
             Debug.Assert(pMemGroup != null);
 
             bool fConstrained;
@@ -758,7 +758,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 MethodSymbol getOrCreateMethod =
                     GetSymbolLoader()
                         .LookupAggMember(getOrCreateMethodName, fieldType.getAggregate(), symbmask_t.MASK_MethodSymbol)
-                        .AsMethodSymbol();
+                         as MethodSymbol;
 
                 MethPropWithInst getOrCreatempwi = new MethPropWithInst(getOrCreateMethod, fieldType);
                 ExprMemberGroup getOrCreateGrp = GetExprFactory().CreateMemGroup(null, getOrCreatempwi);
@@ -974,9 +974,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             for (; ;)
             {
                 // Find the next operator.
-                methCur = (methCur == null) ?
-                          GetSymbolLoader().LookupAggMember(pName, atsCur.getAggregate(), symbmask_t.MASK_MethodSymbol).AsMethodSymbol() :
-                          GetSymbolLoader().LookupNextSym(methCur, atsCur.getAggregate(), symbmask_t.MASK_MethodSymbol).AsMethodSymbol();
+                methCur = methCur == null
+                    ? GetSymbolLoader().LookupAggMember(pName, atsCur.getAggregate(), symbmask_t.MASK_MethodSymbol) as MethodSymbol
+                    : GetSymbolLoader().LookupNextSym(methCur, atsCur.getAggregate(), symbmask_t.MASK_MethodSymbol) as MethodSymbol;
 
                 if (methCur == null)
                 {
@@ -1540,7 +1540,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
 
             // If we're in a constructor, then bail.
-            if (swt.Sym.IsMethodSymbol() && swt.Meth().IsConstructor())
+            if ((swt.Sym is MethodSymbol) && swt.Meth().IsConstructor())
             {
                 return pObject;
             }
@@ -1603,9 +1603,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Symbol pSym = swt.Sym;
 
             // Instance constructors are always ok, static constructors are never ok.
-            if (pSym.IsMethodSymbol() && pSym.AsMethodSymbol().IsConstructor())
+            if (pSym is MethodSymbol meth && meth.IsConstructor())
             {
-                return !pSym.AsMethodSymbol().isStatic;
+                return !meth.isStatic;
             }
 
             bool isStatic = swt.Sym.isStatic;
@@ -1667,7 +1667,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             // For a property/indexer we remap the accessors, not the property/indexer.
             // Since every event has both accessors we remap the event instead of the accessors.
-            Debug.Assert(pswt && (pswt.Sym.IsMethodSymbol() || pswt.Sym is EventSymbol || pswt.Sym is MethodOrPropertySymbol));
+            Debug.Assert(pswt && (pswt.Sym is MethodSymbol || pswt.Sym is EventSymbol || pswt.Sym is MethodOrPropertySymbol));
             Debug.Assert(typeObj != null);
 
             // Don't remap static or interface methods.

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -1954,7 +1954,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 return;
 
             agg.SetHasExternReference(true);
-            foreach (Symbol sym in agg.Children())
+            for (Symbol sym = agg.firstChild; sym != null; sym = sym.nextChild)
             {
                 if (sym.IsFieldSymbol())
                     SetExternalRef(sym.AsFieldSymbol().GetType());

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -1667,7 +1667,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             // For a property/indexer we remap the accessors, not the property/indexer.
             // Since every event has both accessors we remap the event instead of the accessors.
-            Debug.Assert(pswt && (pswt.Sym.IsMethodSymbol() || pswt.Sym.IsEventSymbol() || pswt.Sym is MethodOrPropertySymbol));
+            Debug.Assert(pswt && (pswt.Sym.IsMethodSymbol() || pswt.Sym is EventSymbol || pswt.Sym is MethodOrPropertySymbol));
             Debug.Assert(typeObj != null);
 
             // Don't remap static or interface methods.

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -1499,7 +1499,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         private Expr AdjustMemberObject(SymWithType swt, Expr pObject, out bool pfConstrained, out bool pIsMatchingStatic)
         {
             // Assert that the type is present and is an instantiation of the member's parent.
-            Debug.Assert(swt.GetType() != null && swt.GetType().getAggregate() == swt.Sym.parent.AsAggregateSymbol());
+            Debug.Assert(swt.GetType() != null && swt.GetType().getAggregate() == swt.Sym.parent as AggregateSymbol);
             bool bIsMatchingStatic = IsMatchingStatic(swt, pObject);
             pIsMatchingStatic = bIsMatchingStatic;
             pfConstrained = false;
@@ -1560,7 +1560,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             if (typeObj is TypeParameterType || typeObj is AggregateType)
             {
-                AggregateSymbol aggCalled = swt.Sym.parent.AsAggregateSymbol();
+                AggregateSymbol aggCalled = swt.Sym.parent as AggregateSymbol;
                 Debug.Assert(swt.GetType().getAggregate() == aggCalled);
 
                 // If we're invoking code on a struct-valued field, mark the struct as assigned (to

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
@@ -763,7 +763,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 // an override, but we won't have the slots set up correctly, and will 
                 // not find the base type in the inheritance hierarchy. The second is that
                 // we're calling off of the base itself.
-                Debug.Assert(method.parent.IsAggregateSymbol());
+                Debug.Assert(method.parent is AggregateSymbol);
                 return method;
             }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
@@ -735,9 +735,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         pAggregate?.GetBaseAgg() != null;
                         pAggregate = pAggregate.GetBaseAgg())
                 {
-                    for (MethodOrPropertySymbol meth = symbolLoader.LookupAggMember(method.name, pAggregate, symbmask_t.MASK_MethodSymbol | symbmask_t.MASK_PropertySymbol).AsMethodOrPropertySymbol();
+                    for (MethodOrPropertySymbol meth = symbolLoader.LookupAggMember(method.name, pAggregate, symbmask_t.MASK_MethodSymbol | symbmask_t.MASK_PropertySymbol) as MethodOrPropertySymbol;
                             meth != null;
-                            meth = symbolLoader.LookupNextSym(meth, pAggregate, symbmask_t.MASK_MethodSymbol | symbmask_t.MASK_PropertySymbol).AsMethodOrPropertySymbol())
+                            meth = symbolLoader.LookupNextSym(meth, pAggregate, symbmask_t.MASK_MethodSymbol | symbmask_t.MASK_PropertySymbol) as MethodOrPropertySymbol)
                     {
                         if (!meth.isOverride)
                         {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
@@ -645,7 +645,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                             AggregateSymbol agg = symbolLoader.GetOptPredefAgg(PredefinedType.PT_MISSING);
                             Name name = NameManager.GetPredefinedName(PredefinedName.PN_CAP_VALUE);
-                            FieldSymbol field = symbolLoader.LookupAggMember(name, agg, symbmask_t.MASK_FieldSymbol).AsFieldSymbol();
+                            FieldSymbol field = symbolLoader.LookupAggMember(name, agg, symbmask_t.MASK_FieldSymbol) as FieldSymbol;
                             FieldWithType fwt = new FieldWithType(field, agg.getThisType());
                             ExprField exprField = exprFactory.CreateField(agg.getThisType(), null, fwt, false);
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
@@ -689,14 +689,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     MethodOrPropertySymbol pMethProp,
                     CType pType)
             {
-                MethodSymbol method;
                 bool bIsIndexer = false;
 
-                if (pMethProp.IsMethodSymbol())
-                {
-                    method = pMethProp.AsMethodSymbol();
-                }
-                else
+                if (!(pMethProp is MethodSymbol method))
                 {
                     PropertySymbol prop = (PropertySymbol)pMethProp;
                     method = prop.methGet ?? prop.methSet;
@@ -704,17 +699,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     {
                         return null;
                     }
+
                     bIsIndexer = prop.isIndexer();
                 }
 
-                if (!method.isVirtual)
+                if (!method.isVirtual || pType == null)
                 {
-                    return method;
-                }
-
-                if (pType == null)
-                {
-                    // This must be a static call.
+                    // if pType is null, this must be a static call.
                     return method;
                 }
 
@@ -747,8 +738,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         {
                             if (bIsIndexer)
                             {
-                                Debug.Assert(meth.IsMethodSymbol());
-                                return meth.AsMethodSymbol().getProperty();
+                                Debug.Assert(meth is MethodSymbol);
+                                return ((MethodSymbol)meth).getProperty();
                             }
                             else
                             {
@@ -920,7 +911,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         _pCurrentType != null &&
                         !_methList.IsEmpty() &&
                         !_methList.Head().mpwi.GetType().isInterfaceType() &&
-                        (!_methList.Head().mpwi.Sym.IsMethodSymbol() || !_methList.Head().mpwi.Meth().IsExtension()))
+                        (!(_methList.Head().mpwi.Sym is MethodSymbol) || !_methList.Head().mpwi.Meth().IsExtension()))
                 {
                     return false;
                 }
@@ -928,7 +919,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         _pCurrentType != null &&
                         !_methList.IsEmpty() &&
                         !_methList.Head().mpwi.GetType().isInterfaceType() &&
-                        _methList.Head().mpwi.Sym.IsMethodSymbol() &&
+                        _methList.Head().mpwi.Sym is MethodSymbol &&
                         _methList.Head().mpwi.Meth().IsExtension())
                 {
                     // we have found a applicable method that is an extension now we must move to the end of the NS list before quiting
@@ -1001,9 +992,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 TypeArray typeArgs = _pGroup.TypeArgs;
 
                 // Get the type args.
-                if (_pCurrentSym.IsMethodSymbol() && _pCurrentSym.AsMethodSymbol().typeVars.Count != typeArgs.Count)
+                if (_pCurrentSym is MethodSymbol methSym && methSym.typeVars.Count != typeArgs.Count)
                 {
-                    MethodSymbol methSym = _pCurrentSym.AsMethodSymbol();
                     // Can't infer if some type args are specified.
                     if (typeArgs.Count > 0)
                     {
@@ -1034,11 +1024,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                             TypeArray pTypeVars = methSym.typeVars;
                             if (pTypeVars != null && _pCurrentTypeArgs != null && pTypeVars.Count == _pCurrentTypeArgs.Count)
                             {
-                                _mpwiCantInferInstArg.Set(_pCurrentSym.AsMethodSymbol(), _pCurrentType, _pCurrentTypeArgs);
+                                _mpwiCantInferInstArg.Set(methSym, _pCurrentType, _pCurrentTypeArgs);
                             }
                             else
                             {
-                                _mpwiCantInferInstArg.Set(_pCurrentSym.AsMethodSymbol(), _pCurrentType, pTypeVars);
+                                _mpwiCantInferInstArg.Set(methSym, _pCurrentType, pTypeVars);
                             }
                         }
                         return Result.Failure_SearchForExpanded;
@@ -1126,15 +1116,15 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                                 }
                             }
 
-                            if (_pCurrentSym.IsMethodSymbol())
+                            if (_pCurrentSym is MethodSymbol meth)
                             {
                                 // Do not store the result if we have an extension method and the instance 
                                 // parameter isn't convertible.
 
-                                if (!_pCurrentSym.AsMethodSymbol().IsExtension() || bIsInstanceParameterConvertible)
+                                if (!meth.IsExtension() || bIsInstanceParameterConvertible)
                                 {
                                     _results.AddInconvertibleResult(
-                                        _pCurrentSym.AsMethodSymbol(),
+                                        meth,
                                         _pCurrentType,
                                         _pCurrentTypeArgs);
                                 }
@@ -1146,23 +1136,23 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                 if (containsErrorSym)
                 {
-                    if (_results.IsBetterUninferableResult(_pCurrentTypeArgs) && _pCurrentSym.IsMethodSymbol())
+                    if (_results.IsBetterUninferableResult(_pCurrentTypeArgs) && _pCurrentSym is MethodSymbol meth)
                     {
                         // If we're an instance method or we're an extension that has an inferable instance argument,
                         // then mark us down. Note that the extension may not need to infer type args,
                         // so check if we have any type variables at all to begin with.
-                        if (!_pCurrentSym.AsMethodSymbol().IsExtension() ||
-                            _pCurrentSym.AsMethodSymbol().typeVars.Count == 0 ||
+                        if (!meth.IsExtension() ||
+                            meth.typeVars.Count == 0 ||
                                 MethodTypeInferrer.CanObjectOfExtensionBeInferred(
                                     _pExprBinder,
                                     GetSymbolLoader(),
-                                    _pCurrentSym.AsMethodSymbol(),
+                                    meth,
                                     _pCurrentType.GetTypeArgsAll(),
-                                    _pCurrentSym.AsMethodSymbol().Params,
+                                    meth.Params,
                                     _pArguments))
                         {
                             _results.GetUninferableResult().Set(
-                                    _pCurrentSym.AsMethodSymbol(),
+                                    meth,
                                     _pCurrentType,
                                     _pCurrentTypeArgs);
                         }
@@ -1170,15 +1160,15 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
                 else
                 {
-                    if (_pCurrentSym.IsMethodSymbol())
+                    if (_pCurrentSym is MethodSymbol meth)
                     {
                         // Do not store the result if we have an extension method and the instance 
                         // parameter isn't convertible.
 
-                        if (!_pCurrentSym.AsMethodSymbol().IsExtension() || bIsInstanceParameterConvertible)
+                        if (!meth.IsExtension() || bIsInstanceParameterConvertible)
                         {
                             _results.AddInconvertibleResult(
-                                    _pCurrentSym.AsMethodSymbol(),
+                                    meth,
                                     _pCurrentType,
                                     _pCurrentTypeArgs);
                         }
@@ -1289,7 +1279,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                 if (_pGroup.SymKind == SYMKIND.SK_MethodSymbol)
                 {
-                    Debug.Assert(_results.GetBestResult().MethProp().IsMethodSymbol());
+                    Debug.Assert(_results.GetBestResult().MethProp() is MethodSymbol);
 
                     if (_results.GetBestResult().TypeArgs.Count > 0)
                     {
@@ -1350,9 +1340,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     if (!_results.GetUninferableResult())
                     {
                         //copy the extension method for which instance argument type inference failed
-                        _results.GetUninferableResult().Set(_mpwiCantInferInstArg.Sym.AsMethodSymbol(), _mpwiCantInferInstArg.GetType(), _mpwiCantInferInstArg.TypeArgs);
+                        _results.GetUninferableResult().Set(_mpwiCantInferInstArg.Sym as MethodSymbol, _mpwiCantInferInstArg.GetType(), _mpwiCantInferInstArg.TypeArgs);
                     }
-                    Debug.Assert(_results.GetUninferableResult().Sym.IsMethodSymbol());
+                    Debug.Assert(_results.GetUninferableResult().Sym is MethodSymbol);
 
                     MethodSymbol sym = _results.GetUninferableResult().Meth();
                     TypeArray pCurrentParameters = sym.Params;
@@ -1475,7 +1465,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
                 else
                 {
-                    if (_results.GetBestResult().Sym.IsMethodSymbol() && _results.GetBestResult().Sym.AsMethodSymbol().IsExtension() && _pGroup.OptionalObject != null)
+                    if (_results.GetBestResult().Sym is MethodSymbol methSym && methSym.IsExtension() && _pGroup.OptionalObject != null)
                     {
                         GetErrorContext().Error(ErrorCode.ERR_BadExtensionArgTypes, _pGroup.OptionalObject.Type, _pGroup.Name, _results.GetBestResult().Sym);
                     }
@@ -1519,8 +1509,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                             // if we tried to bind to an extensionmethod and the instance argument conversion failed then the method does not exist
                             // on the type at all. 
                             Symbol sym = _results.GetBestResult().Sym;
-                            if (ivar == 0 && sym.IsMethodSymbol() && sym.AsMethodSymbol().IsExtension() && _pGroup.OptionalObject != null &&
-                                !_pExprBinder.canConvertInstanceParamForExtension(_pGroup.OptionalObject, sym.AsMethodSymbol().Params[0]))
+                            if (ivar == 0 && sym is MethodSymbol meth && meth.IsExtension() && _pGroup.OptionalObject != null &&
+                                !_pExprBinder.canConvertInstanceParamForExtension(_pGroup.OptionalObject, meth.Params[0]))
                             {
                                 if (!_pGroup.OptionalObject.Type.getBogus())
                                 {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
@@ -698,8 +698,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
                 else
                 {
-                    PropertySymbol prop = pMethProp.AsPropertySymbol();
-                    method = prop.methGet != null ? prop.methGet : prop.methSet;
+                    PropertySymbol prop = (PropertySymbol)pMethProp;
+                    method = prop.methGet ?? prop.methSet;
                     if (method == null)
                     {
                         return null;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookup.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookup.cs
@@ -194,7 +194,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     }
                     continue;
                 }
-                if ((_flags & MemLookFlags.UserCallable) != 0 && symCur.IsMethodOrPropertySymbol() && !symCur.AsMethodOrPropertySymbol().isUserCallable())
+
+                MethodOrPropertySymbol methProp = symCur as MethodOrPropertySymbol;
+                if (methProp != null && (_flags & MemLookFlags.UserCallable) != 0 && !methProp.isUserCallable())
                 {
                     bool bIsIndexedProperty = false;
                     // If its an indexed property method symbol, let it through.
@@ -269,9 +271,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     }
                 }
 
-                if (symCur.IsMethodOrPropertySymbol())
+                if (methProp != null)
                 {
-                    MethPropWithType mwpInsert = new MethPropWithType(symCur.AsMethodOrPropertySymbol(), typeCur);
+                    MethPropWithType mwpInsert = new MethPropWithType(methProp, typeCur);
                     _methPropWithTypeList.Add(mwpInsert);
                 }
 
@@ -351,7 +353,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                 RecordType(typeCur, symCur);
 
-                if (symCur.IsMethodOrPropertySymbol() && symCur.AsMethodOrPropertySymbol().isHideByName)
+                if (methProp != null && methProp.isHideByName)
                     pfHideByName = true;
                 // We've found a symbol in this type but need to make sure there aren't any conflicting
                 // syms here, so keep searching the type.

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookup.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookup.cs
@@ -288,8 +288,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         Debug.Assert(_fMulti || typeCur == _prgtype[0]);
                         if (!_fMulti)
                         {
-                            if (_swtFirst.Sym.IsFieldSymbol() && symCur.IsEventSymbol()
-                               // The isEvent bit is only set on symbols which come from source...
+                            if (_swtFirst.Sym.IsFieldSymbol() && symCur is EventSymbol
+                                // The isEvent bit is only set on symbols which come from source...
                                 // This is not a problem for the compiler because the field is only
                                 // accessible in the scope in which it is declared,
                                 // but in the EE we ignore accessibility...
@@ -299,7 +299,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                                 // m_swtFirst is just the field behind the event symCur so ignore symCur.
                                 continue;
                             }
-                            else if (_swtFirst.Sym.IsFieldSymbol() && symCur.IsEventSymbol())
+                            else if (_swtFirst.Sym.IsFieldSymbol() && symCur is EventSymbol)
                             {
                                 // symCur is the matching event.
                                 continue;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookup.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookup.cs
@@ -257,7 +257,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 // if we are in a calling context then we should only find a property if it is delegate valued
                 if ((_flags & MemLookFlags.MustBeInvocable) != 0)
                 {
-                    if ((symCur.IsFieldSymbol() && !IsDelegateType(symCur.AsFieldSymbol().GetType(), typeCur) && !IsDynamicMember(symCur)) ||
+                    if ((symCur is FieldSymbol field && !IsDelegateType(field.GetType(), typeCur) && !IsDynamicMember(symCur)) ||
                         (prop != null && !IsDelegateType(prop.RetType, typeCur) && !IsDynamicMember(symCur)))
                     {
                         if (!_swtBad)
@@ -285,7 +285,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         Debug.Assert(_fMulti || typeCur == _prgtype[0]);
                         if (!_fMulti)
                         {
-                            if (_swtFirst.Sym.IsFieldSymbol() && symCur is EventSymbol
+                            if (_swtFirst.Sym is FieldSymbol && symCur is EventSymbol
                                 // The isEvent bit is only set on symbols which come from source...
                                 // This is not a problem for the compiler because the field is only
                                 // accessible in the scope in which it is declared,
@@ -296,7 +296,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                                 // m_swtFirst is just the field behind the event symCur so ignore symCur.
                                 continue;
                             }
-                            else if (_swtFirst.Sym.IsFieldSymbol() && symCur is EventSymbol)
+                            else if (_swtFirst.Sym is FieldSymbol && symCur is EventSymbol)
                             {
                                 // symCur is the matching event.
                                 continue;
@@ -371,13 +371,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         private bool IsDynamicMember(Symbol sym)
         {
             System.Runtime.CompilerServices.DynamicAttribute da = null;
-            if (sym.IsFieldSymbol())
+            if (sym is FieldSymbol field)
             {
-                if (!sym.AsFieldSymbol().getType().isPredefType(PredefinedType.PT_OBJECT))
+                if (!field.getType().isPredefType(PredefinedType.PT_OBJECT))
                 {
                     return false;
                 }
-                var o = sym.AsFieldSymbol().AssociatedFieldInfo.GetCustomAttributes(typeof(System.Runtime.CompilerServices.DynamicAttribute), false).ToArray();
+                var o = field.AssociatedFieldInfo.GetCustomAttributes(typeof(System.Runtime.CompilerServices.DynamicAttribute), false).ToArray();
                 if (o.Length == 1)
                 {
                     da = o[0] as System.Runtime.CompilerServices.DynamicAttribute;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookup.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookup.cs
@@ -155,7 +155,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                     case SYMKIND.SK_AggregateSymbol:
                         // For types, always filter on arity.
-                        if (symCur.AsAggregateSymbol().GetTypeVars().Count != _arity)
+                        if (((AggregateSymbol)symCur).GetTypeVars().Count != _arity)
                         {
                             if (!_swtBadArity)
                                 _swtBadArity.Set(symCur, typeCur);
@@ -809,7 +809,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         GetErrorContext().ErrorRef(cvar > 0 ? ErrorCode.ERR_BadArity : ErrorCode.ERR_HasNoTypeVars, _swtBadArity, new ErrArgSymKind(_swtBadArity.Sym), cvar);
                         break;
                     case SYMKIND.SK_AggregateSymbol:
-                        cvar = _swtBadArity.Sym.AsAggregateSymbol().GetTypeVars().Count;
+                        cvar = ((AggregateSymbol)_swtBadArity.Sym).GetTypeVars().Count;
                         GetErrorContext().ErrorRef(cvar > 0 ? ErrorCode.ERR_BadArity : ErrorCode.ERR_HasNoTypeVars, _swtBadArity, new ErrArgSymKind(_swtBadArity.Sym), cvar);
                         break;
                     default:

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodIterator.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodIterator.cs
@@ -145,7 +145,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 if (_mask == symbmask_t.MASK_MethodSymbol && (
                         0 == (_flags & EXPRFLAG.EXF_CTOR) != !_pCurrentSym.AsMethodSymbol().IsConstructor() ||
                         0 == (_flags & EXPRFLAG.EXF_OPERATOR) != !_pCurrentSym.AsMethodSymbol().isOperator) ||
-                    _mask == symbmask_t.MASK_PropertySymbol && !_pCurrentSym.AsPropertySymbol().isIndexer())
+                    _mask == symbmask_t.MASK_PropertySymbol && !((PropertySymbol)_pCurrentSym).isIndexer())
                 {
                     // Get the next symbol.
                     return false;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodIterator.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodIterator.cs
@@ -214,12 +214,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     if (_pCurrentSym == null)
                     {
                         _pCurrentSym = GetSymbolLoader().LookupAggMember(
-                                _pName, _pCurrentType.getAggregate(), _mask).AsMethodOrPropertySymbol();
+                                _pName, _pCurrentType.getAggregate(), _mask) as MethodOrPropertySymbol;
                     }
                     else
                     {
                         _pCurrentSym = GetSymbolLoader().LookupNextSym(
-                                _pCurrentSym, _pCurrentType.getAggregate(), _mask).AsMethodOrPropertySymbol();
+                                _pCurrentSym, _pCurrentType.getAggregate(), _mask) as MethodOrPropertySymbol;
                     }
 
                     // If we couldn't find a sym, we look up the type chain and get the next type.

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodIterator.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodIterator.cs
@@ -143,8 +143,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 // Make sure that whether we're seeing a ctor is consistent with the flag.
                 // The only properties we handle are indexers.
                 if (_mask == symbmask_t.MASK_MethodSymbol && (
-                        0 == (_flags & EXPRFLAG.EXF_CTOR) != !_pCurrentSym.AsMethodSymbol().IsConstructor() ||
-                        0 == (_flags & EXPRFLAG.EXF_OPERATOR) != !_pCurrentSym.AsMethodSymbol().isOperator) ||
+                        0 == (_flags & EXPRFLAG.EXF_CTOR) != !((MethodSymbol)_pCurrentSym).IsConstructor() ||
+                        0 == (_flags & EXPRFLAG.EXF_OPERATOR) != !((MethodSymbol)_pCurrentSym).isOperator) ||
                     _mask == symbmask_t.MASK_PropertySymbol && !((PropertySymbol)_pCurrentSym).isIndexer())
                 {
                     // Get the next symbol.
@@ -154,7 +154,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 // If our arity is non-0, we must match arity with this symbol.
                 if (_nArity > 0)
                 {
-                    if (_mask == symbmask_t.MASK_MethodSymbol && _pCurrentSym.AsMethodSymbol().typeVars.Count != _nArity)
+                    if (_mask == symbmask_t.MASK_MethodSymbol && ((MethodSymbol)_pCurrentSym).typeVars.Count != _nArity)
                     {
                         return false;
                     }
@@ -196,12 +196,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                 // if we are done checking all the instance types ensure that currentsym is an 
                 // extension method and not a simple static method
-                if (!_bIsCheckingInstanceMethods)
+                if (!_bIsCheckingInstanceMethods && !((MethodSymbol)_pCurrentSym).IsExtension())
                 {
-                    if (!_pCurrentSym.AsMethodSymbol().IsExtension())
-                    {
-                        return false;
-                    }
+                    return false;
                 }
 
                 return true;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
@@ -2683,9 +2683,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Name name = ekName(ek);
             Debug.Assert(name != null);
             bool foundSome = false;
-            for (MethodSymbol methCur = GetSymbolLoader().LookupAggMember(name, type.getAggregate(), symbmask_t.MASK_MethodSymbol).AsMethodSymbol();
+            for (MethodSymbol methCur = GetSymbolLoader().LookupAggMember(name, type.getAggregate(), symbmask_t.MASK_MethodSymbol) as MethodSymbol;
                 methCur != null;
-                methCur = GetSymbolLoader().LookupNextSym(methCur, type.getAggregate(), symbmask_t.MASK_MethodSymbol).AsMethodSymbol())
+                methCur = GetSymbolLoader().LookupNextSym(methCur, type.getAggregate(), symbmask_t.MASK_MethodSymbol) as MethodSymbol)
             {
                 if (UserDefinedBinaryOperatorIsApplicable(candidateList, ek, methCur, type, arg1, arg2, fDontLift))
                 {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/PredefinedMembers.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/PredefinedMembers.cs
@@ -602,9 +602,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                  sym != null;
                  sym = GetSymbolLoader().LookupNextSym(sym, type, symbmask_t.MASK_ALL))
             {
-                if (sym.IsMethodSymbol())
+                if (sym is MethodSymbol methsym)
                 {
-                    MethodSymbol methsym = sym.AsMethodSymbol();
                     if ((methsym.GetAccess() == methodAccess || methodAccess == ACCESS.ACC_UNKNOWN) &&
                         methsym.isStatic == isStatic &&
                         methsym.isVirtual == isVirtual &&

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SemanticChecker.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SemanticChecker.cs
@@ -204,17 +204,17 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             // Should always have atsCheck for private and protected access check.
             // We currently don't need it since access doesn't respect instantiation.
-            // We just use symWhere.parent.AsAggregateSymbol() instead.
-            AggregateSymbol aggCheck = symCheck.parent.AsAggregateSymbol();
+            // We just use symWhere.parent as AggregateSymbol instead.
+            AggregateSymbol aggCheck = symCheck.parent as AggregateSymbol;
 
             // Find the inner-most enclosing AggregateSymbol.
             AggregateSymbol aggWhere = null;
 
             for (Symbol symT = symWhere; symT != null; symT = symT.parent)
             {
-                if (symT.IsAggregateSymbol())
+                if (symT is AggregateSymbol aggSym)
                 {
-                    aggWhere = symT.AsAggregateSymbol();
+                    aggWhere = aggSym;
                     break;
                 }
                 if (symT.IsAggregateDeclaration())

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SemanticChecker.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SemanticChecker.cs
@@ -217,9 +217,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     aggWhere = aggSym;
                     break;
                 }
-                if (symT.IsAggregateDeclaration())
+                if (symT is AggregateDeclaration aggDec)
                 {
-                    aggWhere = symT.AsAggregateDeclaration().Agg();
+                    aggWhere = aggDec.Agg();
                     break;
                 }
             }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SemanticChecker.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SemanticChecker.cs
@@ -202,11 +202,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     break;
             }
 
-            // Should always have atsCheck for private and protected access check.
-            // We currently don't need it since access doesn't respect instantiation.
-            // We just use symWhere.parent as AggregateSymbol instead.
-            AggregateSymbol aggCheck = symCheck.parent as AggregateSymbol;
-
             // Find the inner-most enclosing AggregateSymbol.
             AggregateSymbol aggWhere = null;
 
@@ -228,6 +223,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             {
                 return ACCESSERROR.ACCESSERROR_NOACCESS;
             }
+
+            // Should always have atsCheck for private and protected access check.
+            // We currently don't need it since access doesn't respect instantiation.
+            // We just use symWhere.parent as AggregateSymbol instead.
+            AggregateSymbol aggCheck = symCheck.parent as AggregateSymbol;
 
             // First check for private access.
             for (AggregateSymbol agg = aggWhere; agg != null; agg = agg.GetOuterAgg())

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/AggregateSymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/AggregateSymbol.cs
@@ -109,10 +109,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return false;
         }
 
-        public NamespaceOrAggregateSymbol Parent
-        {
-            get { return parent.AsNamespaceOrAggregateSymbol(); }
-        }
+        public NamespaceOrAggregateSymbol Parent => parent as NamespaceOrAggregateSymbol;
 
         public bool isNested()
         {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/AggregateSymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/AggregateSymbol.cs
@@ -113,12 +113,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public bool isNested()
         {
-            return parent != null && parent.IsAggregateSymbol();
+            return parent is AggregateSymbol;
         }
 
         public AggregateSymbol GetOuterAgg()
         {
-            return parent != null && parent.IsAggregateSymbol() ? parent.AsAggregateSymbol() : null;
+            return parent as AggregateSymbol;
         }
 
         public bool isPredefAgg(PredefinedType pt)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/AggregateSymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/AggregateSymbol.cs
@@ -111,15 +111,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public NamespaceOrAggregateSymbol Parent => parent as NamespaceOrAggregateSymbol;
 
-        public bool isNested()
-        {
-            return parent is AggregateSymbol;
-        }
+        public bool isNested() => parent is AggregateSymbol;
 
-        public AggregateSymbol GetOuterAgg()
-        {
-            return parent as AggregateSymbol;
-        }
+        public AggregateSymbol GetOuterAgg() => parent as AggregateSymbol;
 
         public bool isPredefAgg(PredefinedType pt)
         {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/AssemblyQualifiedNamespaceSymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/AssemblyQualifiedNamespaceSymbol.cs
@@ -14,9 +14,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
     internal sealed class AssemblyQualifiedNamespaceSymbol : ParentSymbol
     {
-        public NamespaceSymbol GetNS()
-        {
-            return parent as NamespaceSymbol;
-        }
+        public NamespaceSymbol GetNS() => parent as NamespaceSymbol;
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/AssemblyQualifiedNamespaceSymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/AssemblyQualifiedNamespaceSymbol.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     {
         public NamespaceSymbol GetNS()
         {
-            return parent.AsNamespaceSymbol();
+            return parent as NamespaceSymbol;
         }
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/FieldSymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/FieldSymbol.cs
@@ -50,12 +50,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public EventSymbol getEvent(SymbolLoader symbolLoader)
         {
-            Debug.Assert(this.isEvent == true);
-            EventSymbol evt = symbolLoader.LookupAggMember(this.name,
-                                                           this.getClass(),
-                                                           symbmask_t.MASK_EventSymbol).AsEventSymbol();
-
-            return evt;
+            Debug.Assert(isEvent);
+            return symbolLoader.LookupAggMember(name, getClass(), symbmask_t.MASK_EventSymbol) as EventSymbol;
         }
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/FieldSymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/FieldSymbol.cs
@@ -43,10 +43,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return type;
         }
 
-        public AggregateSymbol getClass()
-        {
-            return parent as AggregateSymbol;
-        }
+        public AggregateSymbol getClass() => parent as AggregateSymbol;
 
         public EventSymbol getEvent(SymbolLoader symbolLoader)
         {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/FieldSymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/FieldSymbol.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public AggregateSymbol getClass()
         {
-            return parent.AsAggregateSymbol();
+            return parent as AggregateSymbol;
         }
 
         public EventSymbol getEvent(SymbolLoader symbolLoader)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/MethodOrPropertySymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/MethodOrPropertySymbol.cs
@@ -171,7 +171,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public AggregateSymbol getClass()
         {
-            return parent.AsAggregateSymbol();
+            return parent as AggregateSymbol;
         }
 
         public bool IsExpImpl()

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/MethodOrPropertySymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/MethodOrPropertySymbol.cs
@@ -169,10 +169,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return marshalAsType == UnmanagedType.Interface || marshalAsType == UnmanagedType.IUnknown;
         }
 
-        public AggregateSymbol getClass()
-        {
-            return parent as AggregateSymbol;
-        }
+        public AggregateSymbol getClass() => parent as AggregateSymbol;
 
         public bool IsExpImpl()
         {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/MiscSymFactory.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/MiscSymFactory.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public Scope CreateScope(Scope parent)
         {
-            Scope sym = newBasicSym(SYMKIND.SK_Scope, null, parent).AsScope();
+            Scope sym = (Scope)newBasicSym(SYMKIND.SK_Scope, null, parent);
             if (parent != null)
             {
                 sym.nestingOrder = parent.nestingOrder + 1;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/NamespaceOrAggregateSymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/NamespaceOrAggregateSymbol.cs
@@ -27,9 +27,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public void AddDecl(AggregateDeclaration decl)
         {
             Debug.Assert(decl != null);
-            Debug.Assert(IsNamespaceSymbol() || this is AggregateSymbol);
+            Debug.Assert(this is AggregateSymbol);
             Debug.Assert(decl.IsAggregateDeclaration());
-            Debug.Assert(!IsNamespaceSymbol());
 
             // If parent is set it should be set to us!
             Debug.Assert(decl.bag == null || decl.bag == this);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/NamespaceOrAggregateSymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/NamespaceOrAggregateSymbol.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public void AddDecl(AggregateDeclaration decl)
         {
             Debug.Assert(decl != null);
-            Debug.Assert(IsNamespaceSymbol() || IsAggregateSymbol());
+            Debug.Assert(IsNamespaceSymbol() || this is AggregateSymbol);
             Debug.Assert(decl.IsAggregateDeclaration());
             Debug.Assert(!IsNamespaceSymbol());
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/NamespaceOrAggregateSymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/NamespaceOrAggregateSymbol.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             Debug.Assert(decl != null);
             Debug.Assert(this is AggregateSymbol);
-            Debug.Assert(decl.IsAggregateDeclaration());
+            Debug.Assert(decl is AggregateDeclaration);
 
             // If parent is set it should be set to us!
             Debug.Assert(decl.bag == null || decl.bag == this);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymFactory.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymFactory.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 throw Error.InternalCompilerError();
             }
 
-            AggregateSymbol sym = newBasicSym(SYMKIND.SK_AggregateSymbol, name, parent).AsAggregateSymbol();
+            AggregateSymbol sym = (AggregateSymbol)newBasicSym(SYMKIND.SK_AggregateSymbol, name, parent);
             sym.name = name;
             sym.SetTypeManager(typeManager);
             sym.SetSealed(false);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymFactory.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymFactory.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             //Debug.Assert(declOuter == null || declOuter.Bag() == agg.Parent);
 
             // DECLSYMs are not parented like named symbols.
-            AggregateDeclaration sym = newBasicSym(SYMKIND.SK_AggregateDeclaration, agg.name, null).AsAggregateDeclaration();
+            AggregateDeclaration sym = newBasicSym(SYMKIND.SK_AggregateDeclaration, agg.name, null) as AggregateDeclaration;
 
             declOuter?.AddToChildList(sym);
             agg.AddDecl(sym);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymFactory.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymFactory.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         // Namespace
         public NamespaceSymbol CreateNamespace(Name name, NamespaceSymbol parent)
         {
-            NamespaceSymbol sym = newBasicSym(SYMKIND.SK_NamespaceSymbol, name, parent).AsNamespaceSymbol();
+            NamespaceSymbol sym = (NamespaceSymbol)newBasicSym(SYMKIND.SK_NamespaceSymbol, name, parent);
             sym.SetAccess(ACCESS.ACC_PUBLIC);
 
             return (sym);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymFactory.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymFactory.cs
@@ -106,7 +106,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public EventSymbol CreateEvent(Name name, ParentSymbol parent)
         {
-            EventSymbol sym = newBasicSym(SYMKIND.SK_EventSymbol, name, parent).AsEventSymbol();
+            EventSymbol sym = newBasicSym(SYMKIND.SK_EventSymbol, name, parent) as EventSymbol;
 
             Debug.Assert(sym != null);
             return (sym);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymFactory.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymFactory.cs
@@ -90,12 +90,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return sym;
         }
 
-        public MethodSymbol CreateMethod(Name name, ParentSymbol parent)
-        {
-            MethodSymbol sym = newBasicSym(SYMKIND.SK_MethodSymbol, name, parent).AsMethodSymbol();
-
-            return sym;
-        }
+        public MethodSymbol CreateMethod(Name name, ParentSymbol parent) => 
+            newBasicSym(SYMKIND.SK_MethodSymbol, name, parent) as MethodSymbol;
 
         public PropertySymbol CreateProperty(Name name, ParentSymbol parent)
         {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymFactory.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymFactory.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public PropertySymbol CreateProperty(Name name, ParentSymbol parent)
         {
-            PropertySymbol sym = newBasicSym(SYMKIND.SK_PropertySymbol, name, parent).AsPropertySymbol();
+            PropertySymbol sym = newBasicSym(SYMKIND.SK_PropertySymbol, name, parent) as PropertySymbol;
             Debug.Assert(sym != null);
             return (sym);
         }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymFactory.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymFactory.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             Debug.Assert(name != null);
 
-            AssemblyQualifiedNamespaceSymbol sym = newBasicSym(SYMKIND.SK_AssemblyQualifiedNamespaceSymbol, name, parent).AsAssemblyQualifiedNamespaceSymbol();
+            AssemblyQualifiedNamespaceSymbol sym = newBasicSym(SYMKIND.SK_AssemblyQualifiedNamespaceSymbol, name, parent) as AssemblyQualifiedNamespaceSymbol;
 
             Debug.Assert(sym != null);
             return sym;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymFactory.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymFactory.cs
@@ -114,7 +114,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public TypeParameterSymbol CreateMethodTypeParameter(Name pName, MethodSymbol pParent, int index, int indexTotal)
         {
-            TypeParameterSymbol pResult = newBasicSym(SYMKIND.SK_TypeParameterSymbol, pName, pParent).AsTypeParameterSymbol();
+            TypeParameterSymbol pResult = (TypeParameterSymbol)newBasicSym(SYMKIND.SK_TypeParameterSymbol, pName, pParent);
             pResult.SetIndexInOwnParameters(index);
             pResult.SetIndexInTotalParameters(indexTotal);
 
@@ -126,7 +126,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public TypeParameterSymbol CreateClassTypeParameter(Name pName, AggregateSymbol pParent, int index, int indexTotal)
         {
-            TypeParameterSymbol pResult = newBasicSym(SYMKIND.SK_TypeParameterSymbol, pName, pParent).AsTypeParameterSymbol();
+            TypeParameterSymbol pResult = (TypeParameterSymbol)newBasicSym(SYMKIND.SK_TypeParameterSymbol, pName, pParent);
             pResult.SetIndexInOwnParameters(index);
             pResult.SetIndexInTotalParameters(indexTotal);
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymFactory.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymFactory.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public LocalVariableSymbol CreateLocalVar(Name name, ParentSymbol parent, CType type)
         {
-            LocalVariableSymbol sym = newBasicSym(SYMKIND.SK_LocalVariableSymbol, name, parent).AsLocalVariableSymbol();
+            LocalVariableSymbol sym = (LocalVariableSymbol)newBasicSym(SYMKIND.SK_LocalVariableSymbol, name, parent);
             sym.SetType(type);
             sym.SetAccess(ACCESS.ACC_UNKNOWN);    // required for Symbol::hasExternalAccess which is used by refactoring
             sym.wrap = null;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymFactory.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymFactory.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             Debug.Assert(name != null);
 
-            FieldSymbol sym = newBasicSym(SYMKIND.SK_FieldSymbol, name, parent).AsFieldSymbol();
+            FieldSymbol sym = newBasicSym(SYMKIND.SK_FieldSymbol, name, parent) as FieldSymbol;
 
             Debug.Assert(sym != null);
             return (sym);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
@@ -224,7 +224,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public bool IsAggregateSymbol() { return _kind == SYMKIND.SK_AggregateSymbol; }
         public bool IsAggregateDeclaration() { return _kind == SYMKIND.SK_AggregateDeclaration; }
         public bool IsFieldSymbol() { return _kind == SYMKIND.SK_FieldSymbol; }
-        public bool IsLocalVariableSymbol() { return _kind == SYMKIND.SK_LocalVariableSymbol; }
         public bool IsMethodSymbol() { return _kind == SYMKIND.SK_MethodSymbol; }
         public bool IsPropertySymbol() { return _kind == SYMKIND.SK_PropertySymbol; }
         public bool IsTypeParameterSymbol() { return _kind == SYMKIND.SK_TypeParameterSymbol; }
@@ -441,7 +440,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         internal static AggregateSymbol AsAggregateSymbol(this Symbol symbol) { return symbol as AggregateSymbol; }
         internal static AggregateDeclaration AsAggregateDeclaration(this Symbol symbol) { return symbol as AggregateDeclaration; }
         internal static FieldSymbol AsFieldSymbol(this Symbol symbol) { return symbol as FieldSymbol; }
-        internal static LocalVariableSymbol AsLocalVariableSymbol(this Symbol symbol) { return symbol as LocalVariableSymbol; }
         internal static MethodSymbol AsMethodSymbol(this Symbol symbol) { return symbol as MethodSymbol; }
         internal static PropertySymbol AsPropertySymbol(this Symbol symbol) { return symbol as PropertySymbol; }
         internal static MethodOrPropertySymbol AsMethodOrPropertySymbol(this Symbol symbol) { return symbol as MethodOrPropertySymbol; }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
@@ -137,7 +137,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 case SYMKIND.SK_PropertySymbol:
                 case SYMKIND.SK_MethodSymbol:
                     {
-                        MethodOrPropertySymbol meth = this.AsMethodOrPropertySymbol();
+                        MethodOrPropertySymbol meth = (MethodOrPropertySymbol)this;
 
                         if (meth.RetType != null)
                         {
@@ -229,11 +229,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public bool IsTypeParameterSymbol() { return _kind == SYMKIND.SK_TypeParameterSymbol; }
         public bool IsEventSymbol() { return _kind == SYMKIND.SK_EventSymbol; }
 
-        public bool IsMethodOrPropertySymbol()
-        {
-            return IsMethodSymbol() || IsPropertySymbol();
-        }
-
         public bool IsFMETHSYM()
         {
             return IsMethodSymbol();
@@ -242,9 +237,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public CType getType()
         {
             CType type = null;
-            if (IsMethodOrPropertySymbol())
+            if (this is MethodOrPropertySymbol methProp)
             {
-                type = this.AsMethodOrPropertySymbol().RetType;
+                return methProp.RetType;
             }
             else if (IsFieldSymbol())
             {
@@ -270,9 +265,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 {
                     fStatic = this.AsEventSymbol().isStatic;
                 }
-                else if (IsMethodOrPropertySymbol())
+                else if (this is MethodOrPropertySymbol methProp)
                 {
-                    fStatic = this.AsMethodOrPropertySymbol().isStatic;
+                    return methProp.isStatic;
                 }
                 else if (IsAggregateSymbol())
                 {
@@ -358,7 +353,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             {
                 case SYMKIND.SK_MethodSymbol:
                 case SYMKIND.SK_PropertySymbol:
-                    return this.AsMethodOrPropertySymbol().isOverride;
+                    return ((MethodOrPropertySymbol)this).isOverride;
                 case SYMKIND.SK_EventSymbol:
                     return this.AsEventSymbol().isOverride;
                 default:
@@ -372,7 +367,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             {
                 case SYMKIND.SK_MethodSymbol:
                 case SYMKIND.SK_PropertySymbol:
-                    return this.AsMethodOrPropertySymbol().isHideByName;
+                    return ((MethodOrPropertySymbol)this).isHideByName;
                 case SYMKIND.SK_EventSymbol:
                     return this.AsEventSymbol().methAdd != null && this.AsEventSymbol().methAdd.isHideByName;
                 default:
@@ -383,14 +378,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         // Returns the virtual that this sym overrides (if IsOverride() is true), null otherwise.
         public Symbol SymBaseVirtual()
         {
-            switch (_kind)
-            {
-                case SYMKIND.SK_MethodSymbol:
-                case SYMKIND.SK_PropertySymbol:
-                    return this.AsMethodOrPropertySymbol().swtSlot.Sym;
-                default:
-                    return null;
-            }
+            return (this as MethodOrPropertySymbol)?.swtSlot.Sym;
         }
 
         /*
@@ -442,7 +430,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         internal static FieldSymbol AsFieldSymbol(this Symbol symbol) { return symbol as FieldSymbol; }
         internal static MethodSymbol AsMethodSymbol(this Symbol symbol) { return symbol as MethodSymbol; }
         internal static PropertySymbol AsPropertySymbol(this Symbol symbol) { return symbol as PropertySymbol; }
-        internal static MethodOrPropertySymbol AsMethodOrPropertySymbol(this Symbol symbol) { return symbol as MethodOrPropertySymbol; }
         internal static TypeParameterSymbol AsTypeParameterSymbol(this Symbol symbol) { return symbol as TypeParameterSymbol; }
         internal static EventSymbol AsEventSymbol(this Symbol symbol) { return symbol as EventSymbol; }
     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
@@ -168,9 +168,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     */
 
                 case SYMKIND.SK_EventSymbol:
-                    if (this.AsEventSymbol().type != null)
+                    CType evType = ((EventSymbol)this).type;
+                    if (evType != null)
                     {
-                        fBogus = this.AsEventSymbol().type.computeCurrentBogusState();
+                        fBogus = evType.computeCurrentBogusState();
                     }
                     break;
 
@@ -222,24 +223,25 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public bool IsFieldSymbol() { return _kind == SYMKIND.SK_FieldSymbol; }
         public bool IsMethodSymbol() { return _kind == SYMKIND.SK_MethodSymbol; }
         public bool IsPropertySymbol() { return _kind == SYMKIND.SK_PropertySymbol; }
-        public bool IsEventSymbol() { return _kind == SYMKIND.SK_EventSymbol; }
 
         public CType getType()
         {
-            CType type = null;
             if (this is MethodOrPropertySymbol methProp)
             {
                 return methProp.RetType;
             }
-            else if (IsFieldSymbol())
+
+            if (IsFieldSymbol())
             {
-                type = this.AsFieldSymbol().GetType();
+                return this.AsFieldSymbol().GetType();
             }
-            else if (IsEventSymbol())
+
+            if (this is EventSymbol ev)
             {
-                type = this.AsEventSymbol().type;
+                return ev.type;
             }
-            return type;
+
+            return null;
         }
 
         public bool isStatic
@@ -251,9 +253,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     return this.AsFieldSymbol().isStatic;
                 }
 
-                if (IsEventSymbol())
+                if (this is EventSymbol ev)
                 {
-                    return this.AsEventSymbol().isStatic;
+                    return ev.isStatic;
                 }
 
                 if (this is MethodOrPropertySymbol methProp)
@@ -326,7 +328,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 case SYMKIND.SK_MethodSymbol:
                     return this.AsMethodSymbol().isVirtual;
                 case SYMKIND.SK_EventSymbol:
-                    return this.AsEventSymbol().methAdd != null && this.AsEventSymbol().methAdd.isVirtual;
+                    MethodSymbol methAdd = ((EventSymbol)this).methAdd;
+                    return methAdd != null && methAdd.isVirtual;
                 case SYMKIND.SK_PropertySymbol:
                     return (this.AsPropertySymbol().methGet != null && this.AsPropertySymbol().methGet.isVirtual) ||
                            (this.AsPropertySymbol().methSet != null && this.AsPropertySymbol().methSet.isVirtual);
@@ -343,7 +346,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 case SYMKIND.SK_PropertySymbol:
                     return ((MethodOrPropertySymbol)this).isOverride;
                 case SYMKIND.SK_EventSymbol:
-                    return this.AsEventSymbol().isOverride;
+                    return ((EventSymbol)this).isOverride;
                 default:
                     return false;
             }
@@ -357,7 +360,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 case SYMKIND.SK_PropertySymbol:
                     return ((MethodOrPropertySymbol)this).isHideByName;
                 case SYMKIND.SK_EventSymbol:
-                    return this.AsEventSymbol().methAdd != null && this.AsEventSymbol().methAdd.isHideByName;
+                    MethodSymbol methAdd = ((EventSymbol)this).methAdd;
+                    return methAdd != null && methAdd.isHideByName;
                 default:
                     return true;
             }
@@ -398,6 +402,5 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         internal static FieldSymbol AsFieldSymbol(this Symbol symbol) { return symbol as FieldSymbol; }
         internal static MethodSymbol AsMethodSymbol(this Symbol symbol) { return symbol as MethodSymbol; }
         internal static PropertySymbol AsPropertySymbol(this Symbol symbol) { return symbol as PropertySymbol; }
-        internal static EventSymbol AsEventSymbol(this Symbol symbol) { return symbol as EventSymbol; }
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
@@ -222,7 +222,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public bool IsFieldSymbol() { return _kind == SYMKIND.SK_FieldSymbol; }
         public bool IsMethodSymbol() { return _kind == SYMKIND.SK_MethodSymbol; }
-        public bool IsPropertySymbol() { return _kind == SYMKIND.SK_PropertySymbol; }
 
         public CType getType()
         {
@@ -331,8 +330,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     MethodSymbol methAdd = ((EventSymbol)this).methAdd;
                     return methAdd != null && methAdd.isVirtual;
                 case SYMKIND.SK_PropertySymbol:
-                    return (this.AsPropertySymbol().methGet != null && this.AsPropertySymbol().methGet.isVirtual) ||
-                           (this.AsPropertySymbol().methSet != null && this.AsPropertySymbol().methSet.isVirtual);
+                    PropertySymbol prop = ((PropertySymbol)this);
+                    MethodSymbol meth = prop.methGet ?? prop.methSet;
+                    return meth != null && meth.isVirtual;
                 default:
                     return false;
             }
@@ -401,6 +401,5 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     {
         internal static FieldSymbol AsFieldSymbol(this Symbol symbol) { return symbol as FieldSymbol; }
         internal static MethodSymbol AsMethodSymbol(this Symbol symbol) { return symbol as MethodSymbol; }
-        internal static PropertySymbol AsPropertySymbol(this Symbol symbol) { return symbol as PropertySymbol; }
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using Microsoft.CSharp.RuntimeBinder.Syntax;
@@ -221,7 +220,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         }
 
         public bool IsFieldSymbol() { return _kind == SYMKIND.SK_FieldSymbol; }
-        public bool IsMethodSymbol() { return _kind == SYMKIND.SK_MethodSymbol; }
 
         public CType getType()
         {
@@ -325,14 +323,17 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             switch (_kind)
             {
                 case SYMKIND.SK_MethodSymbol:
-                    return this.AsMethodSymbol().isVirtual;
+                    return ((MethodSymbol)this).isVirtual;
+
                 case SYMKIND.SK_EventSymbol:
                     MethodSymbol methAdd = ((EventSymbol)this).methAdd;
                     return methAdd != null && methAdd.isVirtual;
+
                 case SYMKIND.SK_PropertySymbol:
                     PropertySymbol prop = ((PropertySymbol)this);
                     MethodSymbol meth = prop.methGet ?? prop.methSet;
                     return meth != null && meth.isVirtual;
+
                 default:
                     return false;
             }
@@ -378,15 +379,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
          */
         public bool isUserCallable()
         {
-            switch (_kind)
-            {
-                case SYMKIND.SK_MethodSymbol:
-                    return this.AsMethodSymbol().isUserCallable();
-                default:
-                    break;
-            }
-
-            return true;
+            return !(this is MethodSymbol methSym) || methSym.isUserCallable();
         }
     }
 
@@ -400,6 +393,5 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     internal static class SymbolExtensions
     {
         internal static FieldSymbol AsFieldSymbol(this Symbol symbol) { return symbol as FieldSymbol; }
-        internal static MethodSymbol AsMethodSymbol(this Symbol symbol) { return symbol as MethodSymbol; }
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
@@ -219,7 +219,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return hasBogus() && checkBogus();
         }
 
-        public bool IsAggregateDeclaration() { return _kind == SYMKIND.SK_AggregateDeclaration; }
         public bool IsFieldSymbol() { return _kind == SYMKIND.SK_FieldSymbol; }
         public bool IsMethodSymbol() { return _kind == SYMKIND.SK_MethodSymbol; }
         public bool IsPropertySymbol() { return _kind == SYMKIND.SK_PropertySymbol; }
@@ -278,7 +277,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     return ((AggregateSymbol)parent).AssociatedAssembly;
 
                 case SYMKIND.SK_AggregateDeclaration:
-                    return this.AsAggregateDeclaration().GetAssembly();
+                    return ((AggregateDeclaration)this).GetAssembly();
                 case SYMKIND.SK_AggregateSymbol:
                     return ((AggregateSymbol)this).AssociatedAssembly;
                 default:
@@ -300,10 +299,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 case SYMKIND.SK_FieldSymbol:
                 case SYMKIND.SK_EventSymbol:
                 case SYMKIND.SK_TypeParameterSymbol:
-                    return (parent as AggregateSymbol).InternalsVisibleTo(assembly);
+                    return ((AggregateSymbol)parent).InternalsVisibleTo(assembly);
 
                 case SYMKIND.SK_AggregateDeclaration:
-                    return this.AsAggregateDeclaration().Agg().InternalsVisibleTo(assembly);
+                    return ((AggregateDeclaration)this).Agg().InternalsVisibleTo(assembly);
                 case SYMKIND.SK_AggregateSymbol:
                     return ((AggregateSymbol)this).InternalsVisibleTo(assembly);
                 default:
@@ -396,7 +395,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
     internal static class SymbolExtensions
     {
-        internal static AggregateDeclaration AsAggregateDeclaration(this Symbol symbol) { return symbol as AggregateDeclaration; }
         internal static FieldSymbol AsFieldSymbol(this Symbol symbol) { return symbol as FieldSymbol; }
         internal static MethodSymbol AsMethodSymbol(this Symbol symbol) { return symbol as MethodSymbol; }
         internal static PropertySymbol AsPropertySymbol(this Symbol symbol) { return symbol as PropertySymbol; }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
@@ -396,18 +396,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
     internal static class SymbolExtensions
     {
-        public static IEnumerable<Symbol> Children(this ParentSymbol symbol)
-        {
-            if (symbol == null)
-                yield break;
-            Symbol current = symbol.firstChild;
-            while (current != null)
-            {
-                yield return current;
-                current = current.nextChild;
-            }
-        }
-
         internal static AggregateDeclaration AsAggregateDeclaration(this Symbol symbol) { return symbol as AggregateDeclaration; }
         internal static FieldSymbol AsFieldSymbol(this Symbol symbol) { return symbol as FieldSymbol; }
         internal static MethodSymbol AsMethodSymbol(this Symbol symbol) { return symbol as MethodSymbol; }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
@@ -408,8 +408,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
         }
 
-        internal static AssemblyQualifiedNamespaceSymbol AsAssemblyQualifiedNamespaceSymbol(this Symbol symbol) { return symbol as AssemblyQualifiedNamespaceSymbol; }
-
         internal static AggregateDeclaration AsAggregateDeclaration(this Symbol symbol) { return symbol as AggregateDeclaration; }
         internal static FieldSymbol AsFieldSymbol(this Symbol symbol) { return symbol as FieldSymbol; }
         internal static MethodSymbol AsMethodSymbol(this Symbol symbol) { return symbol as MethodSymbol; }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
@@ -413,7 +413,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
         }
 
-        internal static NamespaceOrAggregateSymbol AsNamespaceOrAggregateSymbol(this Symbol symbol) { return symbol as NamespaceOrAggregateSymbol; }
         internal static NamespaceSymbol AsNamespaceSymbol(this Symbol symbol) { return symbol as NamespaceSymbol; }
         internal static AssemblyQualifiedNamespaceSymbol AsAssemblyQualifiedNamespaceSymbol(this Symbol symbol) { return symbol as AssemblyQualifiedNamespaceSymbol; }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
@@ -226,7 +226,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public bool IsFieldSymbol() { return _kind == SYMKIND.SK_FieldSymbol; }
         public bool IsMethodSymbol() { return _kind == SYMKIND.SK_MethodSymbol; }
         public bool IsPropertySymbol() { return _kind == SYMKIND.SK_PropertySymbol; }
-        public bool IsTypeParameterSymbol() { return _kind == SYMKIND.SK_TypeParameterSymbol; }
         public bool IsEventSymbol() { return _kind == SYMKIND.SK_EventSymbol; }
 
         public bool IsFMETHSYM()
@@ -430,7 +429,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         internal static FieldSymbol AsFieldSymbol(this Symbol symbol) { return symbol as FieldSymbol; }
         internal static MethodSymbol AsMethodSymbol(this Symbol symbol) { return symbol as MethodSymbol; }
         internal static PropertySymbol AsPropertySymbol(this Symbol symbol) { return symbol as PropertySymbol; }
-        internal static TypeParameterSymbol AsTypeParameterSymbol(this Symbol symbol) { return symbol as TypeParameterSymbol; }
         internal static EventSymbol AsEventSymbol(this Symbol symbol) { return symbol as EventSymbol; }
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
@@ -219,8 +219,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return hasBogus() && checkBogus();
         }
 
-        public bool IsNamespaceSymbol() { return _kind == SYMKIND.SK_NamespaceSymbol; }
-
         public bool IsAggregateDeclaration() { return _kind == SYMKIND.SK_AggregateDeclaration; }
         public bool IsFieldSymbol() { return _kind == SYMKIND.SK_FieldSymbol; }
         public bool IsMethodSymbol() { return _kind == SYMKIND.SK_MethodSymbol; }
@@ -410,7 +408,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
         }
 
-        internal static NamespaceSymbol AsNamespaceSymbol(this Symbol symbol) { return symbol as NamespaceSymbol; }
         internal static AssemblyQualifiedNamespaceSymbol AsAssemblyQualifiedNamespaceSymbol(this Symbol symbol) { return symbol as AssemblyQualifiedNamespaceSymbol; }
 
         internal static AggregateDeclaration AsAggregateDeclaration(this Symbol symbol) { return symbol as AggregateDeclaration; }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
@@ -175,9 +175,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     break;
 
                 case SYMKIND.SK_FieldSymbol:
-                    if (this.AsFieldSymbol().GetType() != null)
+                    var fiType = ((FieldSymbol)this).GetType();
+                    if (fiType != null)
                     {
-                        fBogus = this.AsFieldSymbol().GetType().computeCurrentBogusState();
+                        fBogus = fiType.computeCurrentBogusState();
                     }
                     break;
 
@@ -219,8 +220,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return hasBogus() && checkBogus();
         }
 
-        public bool IsFieldSymbol() { return _kind == SYMKIND.SK_FieldSymbol; }
-
         public CType getType()
         {
             if (this is MethodOrPropertySymbol methProp)
@@ -228,9 +227,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 return methProp.RetType;
             }
 
-            if (IsFieldSymbol())
+            if (this is FieldSymbol field)
             {
-                return this.AsFieldSymbol().GetType();
+                return field.GetType();
             }
 
             if (this is EventSymbol ev)
@@ -245,9 +244,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             get
             {
-                if (IsFieldSymbol())
+                if (this is FieldSymbol field)
                 {
-                    return this.AsFieldSymbol().isStatic;
+                    return field.isStatic;
                 }
 
                 if (this is EventSymbol ev)
@@ -381,17 +380,5 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             return !(this is MethodSymbol methSym) || methSym.isUserCallable();
         }
-    }
-
-    /*
-     * We have member functions here to do casts that, in DEBUG, check the 
-     * symbol kind to make sure it is right. For example, the casting method
-     * for METHODSYM is called "asMETHODSYM". In retail builds, these 
-     * methods optimize away to nothing.
-     */
-
-    internal static class SymbolExtensions
-    {
-        internal static FieldSymbol AsFieldSymbol(this Symbol symbol) { return symbol as FieldSymbol; }
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
@@ -221,7 +221,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public bool IsNamespaceSymbol() { return _kind == SYMKIND.SK_NamespaceSymbol; }
 
-        public bool IsAggregateSymbol() { return _kind == SYMKIND.SK_AggregateSymbol; }
         public bool IsAggregateDeclaration() { return _kind == SYMKIND.SK_AggregateDeclaration; }
         public bool IsFieldSymbol() { return _kind == SYMKIND.SK_FieldSymbol; }
         public bool IsMethodSymbol() { return _kind == SYMKIND.SK_MethodSymbol; }
@@ -250,24 +249,22 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             get
             {
-                bool fStatic = false;
                 if (IsFieldSymbol())
                 {
-                    fStatic = this.AsFieldSymbol().isStatic;
+                    return this.AsFieldSymbol().isStatic;
                 }
-                else if (IsEventSymbol())
+
+                if (IsEventSymbol())
                 {
-                    fStatic = this.AsEventSymbol().isStatic;
+                    return this.AsEventSymbol().isStatic;
                 }
-                else if (this is MethodOrPropertySymbol methProp)
+
+                if (this is MethodOrPropertySymbol methProp)
                 {
                     return methProp.isStatic;
                 }
-                else if (IsAggregateSymbol())
-                {
-                    fStatic = true;
-                }
-                return fStatic;
+
+                return this is AggregateSymbol;
             }
         }
 
@@ -280,12 +277,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 case SYMKIND.SK_FieldSymbol:
                 case SYMKIND.SK_EventSymbol:
                 case SYMKIND.SK_TypeParameterSymbol:
-                    return parent.AsAggregateSymbol().AssociatedAssembly;
+                    return ((AggregateSymbol)parent).AssociatedAssembly;
 
                 case SYMKIND.SK_AggregateDeclaration:
                     return this.AsAggregateDeclaration().GetAssembly();
                 case SYMKIND.SK_AggregateSymbol:
-                    return this.AsAggregateSymbol().AssociatedAssembly;
+                    return ((AggregateSymbol)this).AssociatedAssembly;
                 default:
                     // Should never call this with any other kind.
                     Debug.Assert(false, "GetAssemblyID called on bad sym kind");
@@ -305,12 +302,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 case SYMKIND.SK_FieldSymbol:
                 case SYMKIND.SK_EventSymbol:
                 case SYMKIND.SK_TypeParameterSymbol:
-                    return parent.AsAggregateSymbol().InternalsVisibleTo(assembly);
+                    return (parent as AggregateSymbol).InternalsVisibleTo(assembly);
 
                 case SYMKIND.SK_AggregateDeclaration:
                     return this.AsAggregateDeclaration().Agg().InternalsVisibleTo(assembly);
                 case SYMKIND.SK_AggregateSymbol:
-                    return this.AsAggregateSymbol().InternalsVisibleTo(assembly);
+                    return ((AggregateSymbol)this).InternalsVisibleTo(assembly);
                 default:
                     // Should never call this with any other kind.
                     Debug.Assert(false, "InternalsVisibleTo called on bad sym kind");
@@ -416,7 +413,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         internal static NamespaceSymbol AsNamespaceSymbol(this Symbol symbol) { return symbol as NamespaceSymbol; }
         internal static AssemblyQualifiedNamespaceSymbol AsAssemblyQualifiedNamespaceSymbol(this Symbol symbol) { return symbol as AssemblyQualifiedNamespaceSymbol; }
 
-        internal static AggregateSymbol AsAggregateSymbol(this Symbol symbol) { return symbol as AggregateSymbol; }
         internal static AggregateDeclaration AsAggregateDeclaration(this Symbol symbol) { return symbol as AggregateDeclaration; }
         internal static FieldSymbol AsFieldSymbol(this Symbol symbol) { return symbol as FieldSymbol; }
         internal static MethodSymbol AsMethodSymbol(this Symbol symbol) { return symbol as MethodSymbol; }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
@@ -445,7 +445,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         internal static MethodSymbol AsMethodSymbol(this Symbol symbol) { return symbol as MethodSymbol; }
         internal static PropertySymbol AsPropertySymbol(this Symbol symbol) { return symbol as PropertySymbol; }
         internal static MethodOrPropertySymbol AsMethodOrPropertySymbol(this Symbol symbol) { return symbol as MethodOrPropertySymbol; }
-        internal static Scope AsScope(this Symbol symbol) { return symbol as Scope; }
         internal static TypeParameterSymbol AsTypeParameterSymbol(this Symbol symbol) { return symbol as TypeParameterSymbol; }
         internal static EventSymbol AsEventSymbol(this Symbol symbol) { return symbol as EventSymbol; }
     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
@@ -228,11 +228,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public bool IsPropertySymbol() { return _kind == SYMKIND.SK_PropertySymbol; }
         public bool IsEventSymbol() { return _kind == SYMKIND.SK_EventSymbol; }
 
-        public bool IsFMETHSYM()
-        {
-            return IsMethodSymbol();
-        }
-
         public CType getType()
         {
             CType type = null;
@@ -417,8 +412,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 current = current.nextChild;
             }
         }
-
-        internal static MethodSymbol AsFMETHSYM(this Symbol symbol) { return symbol as MethodSymbol; }
 
         internal static NamespaceOrAggregateSymbol AsNamespaceOrAggregateSymbol(this Symbol symbol) { return symbol as NamespaceOrAggregateSymbol; }
         internal static NamespaceSymbol AsNamespaceSymbol(this Symbol symbol) { return symbol as NamespaceSymbol; }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolLoader.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolLoader.cs
@@ -46,9 +46,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                  pSym != null;
                  pSym = LookupNextSym(pSym, pAggDel, symbmask_t.MASK_ALL))
             {
-                if (pSym.IsMethodSymbol() && pSym.AsMethodSymbol().isInvoke())
+                if (pSym is MethodSymbol meth && meth.isInvoke())
                 {
-                    return pSym.AsMethodSymbol();
+                    return meth;
                 }
             }
             return null;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolManagerBase.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolManagerBase.cs
@@ -194,15 +194,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     if (iDot == -1) break;
                     string sub = (iDot > start) ? name.Substring(start, iDot - start) : name.Substring(start);
                     Name nm = this.GetNameManager().Add(sub);
-                    NamespaceSymbol sym = this.LookupGlobalSymCore(nm, ns, symbmask_t.MASK_NamespaceSymbol).AsNamespaceSymbol();
-                    if (sym == null)
-                    {
-                        ns = _symFactory.CreateNamespace(nm, ns);
-                    }
-                    else
-                    {
-                        ns = sym;
-                    }
+                    ns = LookupGlobalSymCore(nm, ns, symbmask_t.MASK_NamespaceSymbol) as NamespaceSymbol ?? _symFactory.CreateNamespace(nm, ns);
                     start += sub.Length + 1;
                 }
             }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolManagerBase.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolManagerBase.cs
@@ -248,12 +248,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Name name = GetNameFromPtrs(0, 0);
             Debug.Assert(name != null);
 
-            AssemblyQualifiedNamespaceSymbol nsa = LookupGlobalSymCore(name, ns, symbmask_t.MASK_AssemblyQualifiedNamespaceSymbol).AsAssemblyQualifiedNamespaceSymbol();
-            if (nsa == null)
-            {
+            AssemblyQualifiedNamespaceSymbol nsa = LookupGlobalSymCore(name, ns, symbmask_t.MASK_AssemblyQualifiedNamespaceSymbol) as AssemblyQualifiedNamespaceSymbol
                 // Create a new one.
-                nsa = _symFactory.CreateNamespaceAid(name, ns);
-            }
+                ?? _symFactory.CreateNamespaceAid(name, ns);
 
             Debug.Assert(nsa.GetNS() == ns);
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Visitors/ExpressionTreeRewriter.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Visitors/ExpressionTreeRewriter.cs
@@ -732,11 +732,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             for (Symbol sym = anonmeth.ArgumentScope; sym != null; sym = sym.nextChild)
             {
-                if (!sym.IsLocalVariableSymbol())
+                if (!(sym is LocalVariableSymbol local))
                 {
                     continue;
                 }
-                LocalVariableSymbol local = sym.AsLocalVariableSymbol();
+
                 if (local.isThis)
                 {
                     continue;
@@ -886,11 +886,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Expr sequence = null;
             for (Symbol sym = anonmeth.ArgumentScope.firstChild; sym != null; sym = sym.nextChild)
             {
-                if (!sym.IsLocalVariableSymbol())
+                if (!(sym is LocalVariableSymbol local))
                 {
                     continue;
                 }
-                LocalVariableSymbol local = sym.AsLocalVariableSymbol();
+
                 if (local.isThis)
                 {
                     continue;
@@ -916,11 +916,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             for (Symbol sym = anonmeth.ArgumentScope; sym != null; sym = sym.nextChild)
             {
-                if (!sym.IsLocalVariableSymbol())
+                if (!(sym is LocalVariableSymbol local))
                 {
                     continue;
                 }
-                LocalVariableSymbol local = sym.AsLocalVariableSymbol();
+
                 if (local.isThis)
                 {
                     continue;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
@@ -102,7 +102,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     }
                     else
                     {
-                        Type parentType = t.GetOwningSymbol().AsAggregateSymbol().AssociatedSystemType;
+                        Type parentType = ((AggregateSymbol)t.GetOwningSymbol()).AssociatedSystemType;
                         result = parentType.GetGenericArguments()[t.GetIndexInOwnParameters()];
                     }
                     break;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
@@ -97,7 +97,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     TypeParameterType t = (TypeParameterType)src;
                     if (t.IsMethodTypeParameter())
                     {
-                        MethodInfo meth = t.GetOwningSymbol().AsMethodSymbol().AssociatedMemberInfo as MethodInfo;
+                        MethodInfo meth = ((MethodSymbol)t.GetOwningSymbol()).AssociatedMemberInfo as MethodInfo;
                         result = meth.GetGenericArguments()[t.GetIndexInOwnParameters()];
                     }
                     else

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/WithType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/WithType.cs
@@ -249,7 +249,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         }
         public MethWithInst(MethPropWithInst mpwi)
         {
-            Set(mpwi.Sym.AsMethodSymbol(), mpwi.Ats, mpwi.TypeArgs);
+            Set(mpwi.Sym as MethodSymbol, mpwi.Ats, mpwi.TypeArgs);
         }
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
@@ -468,7 +468,7 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         private TypeParameterType LoadClassTypeParameter(AggregateSymbol parent, Type t)
         {
-            for (AggregateSymbol p = parent; p != null; p = p.parent.IsAggregateSymbol() ? p.parent.AsAggregateSymbol() : null)
+            for (AggregateSymbol p = parent; p != null; p = p.parent as AggregateSymbol)
             {
                 for (TypeParameterSymbol typeParam = _bsymmgr.LookupAggMember(
                         GetName(t), p, symbmask_t.MASK_TypeParameterSymbol) as TypeParameterSymbol;
@@ -689,7 +689,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                     Type t = o as Type;
                     Name name = null;
                     name = GetName(t);
-                    next = _symbolTable.LookupSym(name, current, symbmask_t.MASK_AggregateSymbol).AsAggregateSymbol();
+                    next = _symbolTable.LookupSym(name, current, symbmask_t.MASK_AggregateSymbol) as AggregateSymbol;
 
                     // Make sure we match arity as well when we find an aggregate.
                     if (next != null)
@@ -760,7 +760,7 @@ namespace Microsoft.CSharp.RuntimeBinder
 
                     if (t == type)
                     {
-                        ret = GetConstructedType(type, next.AsAggregateSymbol());
+                        ret = GetConstructedType(type, next as AggregateSymbol);
                         break;
                     }
                 }
@@ -868,7 +868,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                     // If the generic argument for nullable is our child, then we're
                     // declaring the initial Nullable<T>.
                     AggregateSymbol agg = _symbolTable.LookupSym(
-                        GetName(t), parent, symbmask_t.MASK_AggregateSymbol).AsAggregateSymbol();
+                        GetName(t), parent, symbmask_t.MASK_AggregateSymbol) as AggregateSymbol;
                     if (agg != null)
                     {
                         agg = FindSymWithMatchingArity(agg, t);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
@@ -1865,14 +1865,14 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         private MethodSymbol FindMatchingMethod(MemberInfo method, AggregateSymbol callingAggregate)
         {
-            MethodSymbol meth = _bsymmgr.LookupAggMember(GetName(method.Name), callingAggregate, symbmask_t.MASK_MethodSymbol).AsMethodSymbol();
+            MethodSymbol meth = _bsymmgr.LookupAggMember(GetName(method.Name), callingAggregate, symbmask_t.MASK_MethodSymbol) as MethodSymbol;
             while (meth != null)
             {
                 if (meth.AssociatedMemberInfo.IsEquivalentTo(method))
                 {
                     return meth;
                 }
-                meth = BSYMMGR.LookupNextSym(meth, callingAggregate, symbmask_t.MASK_MethodSymbol).AsMethodSymbol();
+                meth = BSYMMGR.LookupNextSym(meth, callingAggregate, symbmask_t.MASK_MethodSymbol) as MethodSymbol;
             }
             return null;
         }
@@ -2008,10 +2008,10 @@ namespace Microsoft.CSharp.RuntimeBinder
             MethodSymbol meth = _semanticChecker.SymbolLoader.LookupAggMember(
                 GetName(baseMemberInfo.Name),
                 aggregate,
-                symbmask_t.MASK_MethodSymbol).AsMethodSymbol();
+                symbmask_t.MASK_MethodSymbol) as MethodSymbol;
             for (;
                     meth != null && !meth.AssociatedMemberInfo.IsEquivalentTo(baseMemberInfo);
-                    meth = _semanticChecker.SymbolLoader.LookupNextSym(meth, aggregate, symbmask_t.MASK_MethodSymbol).AsMethodSymbol())
+                    meth = _semanticChecker.SymbolLoader.LookupNextSym(meth, aggregate, symbmask_t.MASK_MethodSymbol) as MethodSymbol)
                 ;
 
             return meth;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
@@ -973,13 +973,8 @@ namespace Microsoft.CSharp.RuntimeBinder
         private NamespaceSymbol AddNamespaceToSymbolTable(NamespaceOrAggregateSymbol parent, string sz)
         {
             Name name = GetName(sz);
-            NamespaceSymbol ns = _symbolTable.LookupSym(name, parent, symbmask_t.MASK_NamespaceSymbol).AsNamespaceSymbol();
-            if (ns == null)
-            {
-                ns = _symFactory.CreateNamespace(name, parent as NamespaceSymbol);
-            }
-
-            return ns;
+            return _symbolTable.LookupSym(name, parent, symbmask_t.MASK_NamespaceSymbol) as NamespaceSymbol
+                ?? _symFactory.CreateNamespace(name, parent as NamespaceSymbol);
         }
         #endregion
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
@@ -585,16 +585,18 @@ namespace Microsoft.CSharp.RuntimeBinder
         {
             for (Symbol sym = parent.firstChild; sym != null; sym = sym.nextChild)
             {
-                if (!sym.IsTypeParameterSymbol())
+                if (!(sym is TypeParameterSymbol parSym))
                 {
                     continue;
                 }
 
-                if (AreTypeParametersEquivalent(sym.AsTypeParameterSymbol().GetTypeParameterType().AssociatedSystemType, t))
+                TypeParameterType type = parSym.GetTypeParameterType();
+                if (AreTypeParametersEquivalent(type.AssociatedSystemType, t))
                 {
-                    return sym.AsTypeParameterSymbol().GetTypeParameterType();
+                    return type;
                 }
             }
+
             return AddTypeParameterToSymbolTable(null, parent, t, false);
         }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
@@ -1404,7 +1404,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                     }
 
                     prevProp = prop;
-                    prop = _semanticChecker.SymbolLoader.LookupNextSym(prop, prop.parent, symbmask_t.MASK_PropertySymbol).AsPropertySymbol();
+                    prop = _semanticChecker.SymbolLoader.LookupNextSym(prop, prop.parent, symbmask_t.MASK_PropertySymbol) as PropertySymbol;
                 }
 
                 prop = prevProp;


### PR DESCRIPTION
Lighter, allows for pattern-matching, avoids repeated field accesses and casts by moving more into locals.