### PR TITLE
Remove ActiveIssue for PathTooLongException related tests.

### DIFF
--- a/src/System.Drawing.Common/tests/ImageTests.cs
+++ b/src/System.Drawing.Common/tests/ImageTests.cs
@@ -45,7 +45,6 @@ namespace System.Drawing.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/8655")]
         public void FromFile_LongSegment_ThrowsException()
         {
             // Throws PathTooLongException on Desktop and FileNotFoundException elsewhere.

--- a/src/System.Drawing.Common/tests/Text/PrivateFontCollectionTests.cs
+++ b/src/System.Drawing.Common/tests/Text/PrivateFontCollectionTests.cs
@@ -129,7 +129,6 @@ namespace System.Drawing.Text.Tests
         }
 
         [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/8655")]
         public void AddFontFile_LongFilePath_ThrowsException()
         {
             using (var fontCollection = new PrivateFontCollection())

--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -208,7 +208,7 @@ namespace System.IO.Tests
             }
             else
             {
-                AssertExtensions.ThrowsAny<IOException, DirectoryNotFoundException>(() => Create(path));
+                AssertExtensions.ThrowsAny<IOException, DirectoryNotFoundException, PathTooLongException>(() => Create(path));
             }
         }
 

--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -198,7 +198,6 @@ namespace System.IO.Tests
 
         [Theory,
             MemberData(nameof(PathsWithComponentLongerThanMaxComponent))]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/8655")]
         public void DirectoryWithComponentLongerThanMaxComponentAsPath_ThrowsException(string path)
         {
             // While paths themselves can be up to 260 characters including trailing null, file systems

--- a/src/System.IO.FileSystem/tests/File/Create.cs
+++ b/src/System.IO.FileSystem/tests/File/Create.cs
@@ -165,7 +165,7 @@ namespace System.IO.Tests
             }
             else
             {
-                Assert.Throws<IOException>(
+                AssertExtensions.ThrowsAny<IOException, PathTooLongException>(
                     () => Create(Path.Combine(testDir.FullName, new string('a', 300))));
             }
 

--- a/src/System.IO.FileSystem/tests/File/Create.cs
+++ b/src/System.IO.FileSystem/tests/File/Create.cs
@@ -152,7 +152,6 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/8655")]
         public void LongPathSegment()
         {
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());


### PR DESCRIPTION
Re-enable tests for long paths. Refer to #8655 

cc @JeremyKuhne 