### PR TITLE
Pass right context in delegate

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CollectionDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CollectionDataContract.cs
@@ -790,7 +790,7 @@ namespace System.Runtime.Serialization
                             {
                                 _incrementCollectionCountDelegate = (x, o, c) =>
                                 {
-                                    context.IncrementCollectionCount(x, (ICollection)o);
+                                    c.IncrementCollectionCount(x, (ICollection)o);
                                 };
                             }
                             break;


### PR DESCRIPTION
Need use the context passed into the delegate not the context passed into the method.

#21975 
The test code is in https://github.com/dotnet/corefx/compare/master...JimboWei:iobjectfix#diff-842d4b05f36c1089c037e1b2e53908ecR3038

@shmao @zhenlan @mconnew 