### PR TITLE
Throw a PlatformNotSupported exception when trying to connect to LocalDB with SqlClient on UAP, since UAP does not have the registry functionality needed for LocalDB connectivity.

### DIFF
--- a/src/System.Data.SqlClient/src/Resources/Strings.resx
+++ b/src/System.Data.SqlClient/src/Resources/Strings.resx
@@ -1121,7 +1121,7 @@
     <value>'{0}' is not a supported handle type.</value>
   </data>
   <data name="LocalDBNotSupported" xml:space="preserve">
-    <value>LocalDB is not supported on this Platform.</value>
+    <value>LocalDB is not supported on this platform.</value>
   </data>
   <data name="PlatformNotSupported_DataSqlClient" xml:space="preserve">
     <value>System.Data.SqlClient is not supported on this platform.</value>

--- a/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
+++ b/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
@@ -199,6 +199,7 @@
   <ItemGroup Condition="'$(TargetGroup)' == 'uap'">
     <Compile Include="System\Data\SqlClient\TdsParserStateObjectFactory.Managed.cs" />
     <Compile Include="System\Data\SqlClient\LocalDBAPI.uap.cs" />
+    <Compile Include="System\Data\SqlClient\SNI\LocalDB.uap.cs" />
     <Compile Include="System\Data\ProviderBase\DbConnectionPoolIdentity.Unix.cs" />
     <Compile Include="System\Data\SqlClient\TdsParser.Unix.cs" />
   </ItemGroup>
@@ -208,15 +209,15 @@
     <Compile Include="Interop\SNINativeMethodWrapper.Windows.cs" />
     <Compile Include="System\Data\SqlClient\TdsParserSafeHandles.cs" />
     <Compile Include="System\Data\SqlClient\LocalDBAPI.Windows.cs" />
+    <Compile Include="System\Data\SqlClient\SNI\LocalDB.Windows.cs" />
     <Compile Include="System\Data\ProviderBase\DbConnectionPoolIdentity.Windows.cs" />
     <Compile Include="System\Data\SqlClient\TdsParser.Windows.cs" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' And '$(IsPartialFacadeAssembly)' != 'true'">
-    <Compile Include="System\Data\SqlClient\SNI\LocalDB.Windows.cs" />
-    <Compile Include="System\Data\SqlClient\LocalDBAPI.Common.cs" />
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.LoadLibraryEx.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.LoadLibraryEx.cs</Link>
     </Compile>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' And '$(IsPartialFacadeAssembly)' != 'true'">
+    <Compile Include="System\Data\SqlClient\LocalDBAPI.Common.cs" />
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.FreeLibrary.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.FreeLibrary.cs</Link>
     </Compile>
@@ -394,7 +395,7 @@
     <Compile Include="System\Data\SqlClient\LocalDBAPI.Unix.cs" />
     <Compile Include="System\Data\SqlClient\SNI\LocalDB.Unix.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetsWindows)' == 'true' And '$(IsPartialFacadeAssembly)' != 'true' ">
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true' And '$(IsPartialFacadeAssembly)' != 'true' and '$(TargetGroup)' != 'uap'">
     <Reference Include="Microsoft.Win32.Registry" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/LocalDB.uap.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/LocalDB.uap.cs
@@ -2,16 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Threading;
-using System.Data.SqlClient;
-using System.Data.SqlClient.SNI;
-using System.Runtime.InteropServices;
-
-namespace System.Data
+namespace System.Data.SqlClient.SNI
 {
-    internal static partial class LocalDBAPI
+    internal class LocalDB
     {
-        private static IntPtr LoadProcAddress() =>
+        internal static string GetLocalDBConnectionString(string localDbInstance)
+        {
             throw new PlatformNotSupportedException(SR.LocalDBNotSupported); // No Registry support on UAP
+        }
     }
 }

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/LocalDBTest/LocalDBTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/LocalDBTest/LocalDBTest.cs
@@ -10,6 +10,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
     {
         private static bool IsLocalDBEnvironmentSet() => DataTestUtility.IsLocalDBInstalled();
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)] // No Registry support on UAP
         [ConditionalFact(nameof(IsLocalDBEnvironmentSet))]
         public static void LocalDBConnectionTest()
         {
@@ -19,6 +20,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             OpenConnection(builder.ConnectionString);
         }
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)] // No Registry support on UAP
         [ConditionalFact(nameof(IsLocalDBEnvironmentSet))]
         public static void LocalDBMarsTest()
         {
@@ -29,6 +31,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             OpenConnection(builder.ConnectionString);
         }
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)] // No Registry support on UAP
         [ConditionalFact(nameof(IsLocalDBEnvironmentSet))]
         public static void InvalidDBTest()
         {
@@ -49,6 +52,17 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                     Assert.NotNull(result);
                 }
             }
+        }
+
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsUap))]
+        public static void VerifyLocalDBNotSupportedTest()
+        {
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(@"server=(localdb)\MSSQLLocalDB");
+            builder.IntegratedSecurity = true;
+            builder.ConnectTimeout = 2;
+
+            string errorMsg = SystemDataResourceManager.Instance.LocalDBNotSupported;
+            DataTestUtility.AssertThrowsWrapper<PlatformNotSupportedException>(() => OpenConnection(builder.ConnectionString), errorMsg);
         }
     }
 }

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/LocalDBTest/LocalDBTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/LocalDBTest/LocalDBTest.cs
@@ -54,8 +54,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsUap))]
-        public static void VerifyLocalDBNotSupportedTest()
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.Uap)]
+        [Fact]
+        public static void LocalDBNotSupportedOnUapTest()
         {
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(@"server=(localdb)\MSSQLLocalDB");
             builder.IntegratedSecurity = true;

--- a/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -112,6 +112,9 @@
     <Compile Include="SQL\WeakRefTest\WeakRefTest.cs" />
     <Compile Include="SQL\WeakRefTestYukonSpecific\WeakRefTestYukonSpecific.cs" />
     <Compile Include="XUnitAssemblyAttributes.cs" />
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>Common\System\PlatformDetection.cs</Link>
+    </Compile>
     <Content Include="DDBasics\DDDataTypesTest\data.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>data.xml</Link>

--- a/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
@@ -112,9 +112,6 @@
     <Compile Include="SQL\WeakRefTest\WeakRefTest.cs" />
     <Compile Include="SQL\WeakRefTestYukonSpecific\WeakRefTestYukonSpecific.cs" />
     <Compile Include="XUnitAssemblyAttributes.cs" />
-    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
-      <Link>Common\System\PlatformDetection.cs</Link>
-    </Compile>
     <Content Include="DDBasics\DDDataTypesTest\data.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>data.xml</Link>


### PR DESCRIPTION
Also moved includes of Microsoft.Win32.Registry.dll and Interop.LoadLibraryEx.cs to non-uap Windows builds. The Registry dll does not exist in UWP, and the LoadLibrary interop is not used in uap since we just throw a NotSupportedException.

Fixes https://github.com/dotnet/corefx/issues/22427