### PR TITLE
Adding tests for the new 'Floating-Point Classification APIs'. 

### DIFF
--- a/src/System.Data.Common/src/System.Data.Common.csproj
+++ b/src/System.Data.Common/src/System.Data.Common.csproj
@@ -7,6 +7,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netfx'">true</IsPartialFacadeAssembly>
+    <DefineConstants Condition="'$(TargetGroup)' == 'netfx'">$(DefineConstants);netfx</DefineConstants>
     <DefineConstants Condition="'$(TargetGroup)' == 'uapaot'">$(DefineConstants);uapaot</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />

--- a/src/System.Data.Common/src/System/Data/SQLTypes/SQLDouble.cs
+++ b/src/System.Data.Common/src/System/Data/SQLTypes/SQLDouble.cs
@@ -34,8 +34,14 @@ namespace System.Data.SqlTypes
 
         public SqlDouble(double value)
         {
+#if !netfx
+            if (!double.IsFinite(value))
+#else
             if (double.IsInfinity(value) || double.IsNaN(value))
+#endif
+            {
                 throw new OverflowException(SQLResource.ArithOverflowMessage);
+            }
             else
             {
                 m_value = value;

--- a/src/System.Data.Common/src/System/Data/SQLTypes/SQLSingle.cs
+++ b/src/System.Data.Common/src/System/Data/SQLTypes/SQLSingle.cs
@@ -31,8 +31,14 @@ namespace System.Data.SqlTypes
 
         public SqlSingle(float value)
         {
+#if !netfx
+            if (!float.IsFinite(value))
+#else
             if (float.IsInfinity(value) || float.IsNaN(value))
+#endif
+            {
                 throw new OverflowException(SQLResource.ArithOverflowMessage);
+            }
             else
             {
                 _fNotNull = true;

--- a/src/System.Drawing.Common/src/System/Drawing/Font.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Font.cs
@@ -105,7 +105,7 @@ namespace System.Drawing
         /// </summary>
         public Font(string familyName, float emSize, FontStyle style, GraphicsUnit unit, byte gdiCharSet, bool gdiVerticalFont)
         {
-            if (float.IsNaN(emSize) || float.IsInfinity(emSize) || emSize <= 0)
+            if (!float.IsFinite(emSize) || emSize <= 0)
             {
                 throw new ArgumentException(SR.Format(SR.InvalidBoundArgument, "emSize", emSize, 0, "System.Single.MaxValue"), "emSize");
             }
@@ -222,7 +222,7 @@ namespace System.Drawing
                 throw new ArgumentNullException(nameof(family));
             }
 
-            if (float.IsNaN(emSize) || float.IsInfinity(emSize) || emSize <= 0)
+            if (!float.IsFinite(emSize) || emSize <= 0)
             {
                 throw new ArgumentException(SR.Format(SR.InvalidBoundArgument, nameof(emSize), emSize, 0, "System.Single.MaxValue"), nameof(emSize));
             }

--- a/src/System.Private.DataContractSerialization/src/System/Xml/ValueHandle.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/ValueHandle.cs
@@ -326,8 +326,11 @@ namespace System.Xml
             if (type == ValueHandleType.Double)
             {
                 double value = GetDouble();
-                if ((value >= Single.MinValue && value <= Single.MaxValue) || double.IsInfinity(value) || double.IsNaN(value))
+
+                if ((value >= Single.MinValue && value <= Single.MaxValue) || !double.IsFinite(value))
+                {
                     return (Single)value;
+                }
             }
             if (type == ValueHandleType.Zero)
                 return 0;

--- a/src/System.Private.Xml/src/System/Xml/Schema/DataTypeImplementation.cs
+++ b/src/System.Private.Xml/src/System/Xml/Schema/DataTypeImplementation.cs
@@ -3757,7 +3757,8 @@ namespace System.Xml.Schema
             {
                 throw new XmlSchemaException(SR.Format(SR.Sch_InvalidValue, s), e);
             }
-            if (double.IsInfinity(value) || double.IsNaN(value))
+
+            if (!double.IsFinite(value))
             {
                 throw new XmlSchemaException(SR.Sch_InvalidValue, s);
             }
@@ -3778,7 +3779,8 @@ namespace System.Xml.Schema
             {
                 throw new XmlSchemaException(SR.Format(SR.Sch_InvalidValue, s), e);
             }
-            if (float.IsInfinity(value) || float.IsNaN(value))
+
+            if (!float.IsFinite(value))
             {
                 throw new XmlSchemaException(SR.Sch_InvalidValue, s);
             }

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -133,10 +133,17 @@ namespace System.Numerics
 
         public BigInteger(double value)
         {
-            if (double.IsInfinity(value))
-                throw new OverflowException(SR.Overflow_BigIntInfinity);
-            if (double.IsNaN(value))
-                throw new OverflowException(SR.Overflow_NotANumber);
+            if (!double.IsFinite(value))
+            {
+                if (double.IsInfinity(value))
+                {
+                    throw new OverflowException(SR.Overflow_BigIntInfinity);
+                }
+                else // NaN
+                {
+                    throw new OverflowException(SR.Overflow_NotANumber);
+                }
+            }
             Contract.EndContractBlock();
 
             _sign = 0;

--- a/src/System.Runtime.WindowsRuntime.UI.Xaml/src/System/Windows/GridLength.cs
+++ b/src/System.Runtime.WindowsRuntime.UI.Xaml/src/System/Windows/GridLength.cs
@@ -47,7 +47,7 @@ namespace Windows.UI.Xaml
 
         public GridLength(double value, GridUnitType type)
         {
-            if (Double.IsNaN(value) || Double.IsInfinity(value) || value < 0.0)
+            if (!double.IsFinite(value) || value < 0.0)
             {
                 throw new ArgumentException(SR.DirectUI_InvalidArgument, nameof(value));
             }

--- a/src/System.Runtime.WindowsRuntime.UI.Xaml/src/System/Windows/Media/Animation/RepeatBehavior.cs
+++ b/src/System.Runtime.WindowsRuntime.UI.Xaml/src/System/Windows/Media/Animation/RepeatBehavior.cs
@@ -41,9 +41,7 @@ namespace Windows.UI.Xaml.Media.Animation
 
         public RepeatBehavior(double count)
         {
-            if (Double.IsInfinity(count)
-                || Double.IsNaN(count)
-                || count < 0.0)
+            if (!double.IsFinite(count) || count < 0.0)
             {
                 throw new ArgumentOutOfRangeException(nameof(count));
             }

--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -1055,10 +1055,14 @@ namespace System
         public bool Equals(double obj) { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
+        public static bool IsFinite(double d) { throw null; }
         public static bool IsInfinity(double d) { throw null; }
         public static bool IsNaN(double d) { throw null; }
+        public static bool IsNegative(double d) { throw null; }
         public static bool IsNegativeInfinity(double d) { throw null; }
+        public static bool IsNormal(double d) { throw null; }
         public static bool IsPositiveInfinity(double d) { throw null; }
+        public static bool IsSubnormal(double d) { throw null; }
         public static bool operator ==(double left, double right) { throw null; }
         public static bool operator >(double left, double right) { throw null; }
         public static bool operator >=(double left, double right) { throw null; }
@@ -1951,10 +1955,14 @@ namespace System
         public override bool Equals(object obj) { throw null; }
         public bool Equals(float obj) { throw null; }
         public override int GetHashCode() { throw null; }
+        public static bool IsFinite(float f) { throw null; }
         public static bool IsInfinity(float f) { throw null; }
         public static bool IsNaN(float f) { throw null; }
+        public static bool IsNegative(float f) { throw null; }
         public static bool IsNegativeInfinity(float f) { throw null; }
+        public static bool IsNormal(float f) { throw null; }
         public static bool IsPositiveInfinity(float f) { throw null; }
+        public static bool IsSubnormal(float f) { throw null; }
         public static bool operator ==(float left, float right) { throw null; }
         public static bool operator >(float left, float right) { throw null; }
         public static bool operator >=(float left, float right) { throw null; }

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -201,6 +201,10 @@
     <Compile Include="System\Runtime\ExceptionServices\ExceptionDispatchInfoTests.netcoreapp.cs" />
     <Compile Include="System\Text\StringBuilderTests.netcoreapp.cs" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
+    <Compile Include="System\DoubleTests.netcoreapp.cs" />
+    <Compile Include="System\SingleTests.netcoreapp.cs" />
+  </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'netcoreapp'">
     <Compile Include="System\StringSplitExtensions.cs" />
   </ItemGroup>

--- a/src/System.Runtime/tests/System/DoubleTests.cs
+++ b/src/System.Runtime/tests/System/DoubleTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace System.Tests
 {
-    public class DoubleTests : RemoteExecutorTestBase
+    public partial class DoubleTests : RemoteExecutorTestBase
     {
         [Fact]
         public static void Ctor_Empty()
@@ -47,10 +47,19 @@ namespace System.Tests
         }
 
         [Theory]
-        [InlineData(double.PositiveInfinity, true)]
-        [InlineData(double.NegativeInfinity, true)]
-        [InlineData(double.NaN, false)]
-        [InlineData(0.0, false)]
+        [InlineData(double.NegativeInfinity, true)]     // Negative Infinity
+        [InlineData(double.MinValue, false)]            // Min Negative Normal
+        [InlineData(-2.2250738585072014E-308, false)]   // Max Negative Normal
+        [InlineData(-2.2250738585072009E-308, false)]   // Min Negative Subnormal
+        [InlineData(-4.94065645841247E-324, false)]     // Max Negative Subnormal
+        [InlineData(-0.0, false)]                       // Negative Zero
+        [InlineData(double.NaN, false)]                 // NaN
+        [InlineData(0.0, false)]                        // Positive Zero
+        [InlineData(4.94065645841247E-324, false)]      // Min Positive Subnormal
+        [InlineData(2.2250738585072009E-308, false)]    // Max Positive Subnormal
+        [InlineData(2.2250738585072014E-308, false)]    // Min Positive Normal
+        [InlineData(double.MaxValue, false)]            // Max Positive Normal
+        [InlineData(double.PositiveInfinity, true)]     // Positive Infinity
         public static void IsInfinity(double d, bool expected)
         {
             Assert.Equal(expected, double.IsInfinity(d));
@@ -63,10 +72,19 @@ namespace System.Tests
         }
 
         [Theory]
-        [InlineData(double.PositiveInfinity, false)]
-        [InlineData(double.NegativeInfinity, false)]
-        [InlineData(double.NaN, true)]
-        [InlineData(0.0, false)]
+        [InlineData(double.NegativeInfinity, false)]    // Negative Infinity
+        [InlineData(double.MinValue, false)]            // Min Negative Normal
+        [InlineData(-2.2250738585072014E-308, false)]   // Max Negative Normal
+        [InlineData(-2.2250738585072009E-308, false)]   // Min Negative Subnormal
+        [InlineData(-4.94065645841247E-324, false)]     // Max Negative Subnormal
+        [InlineData(-0.0, false)]                       // Negative Zero
+        [InlineData(double.NaN, true)]                  // NaN
+        [InlineData(0.0, false)]                        // Positive Zero
+        [InlineData(4.94065645841247E-324, false)]      // Min Positive Subnormal
+        [InlineData(2.2250738585072009E-308, false)]    // Max Positive Subnormal
+        [InlineData(2.2250738585072014E-308, false)]    // Min Positive Normal
+        [InlineData(double.MaxValue, false)]            // Max Positive Normal
+        [InlineData(double.PositiveInfinity, false)]    // Positive Infinity
         public static void IsNaN(double d, bool expected)
         {
             Assert.Equal(expected, double.IsNaN(d));
@@ -79,10 +97,19 @@ namespace System.Tests
         }
 
         [Theory]
-        [InlineData(double.NegativeInfinity, true)]
-        [InlineData(double.PositiveInfinity, false)]
-        [InlineData(double.NaN, false)]
-        [InlineData(0.0, false)]
+        [InlineData(double.NegativeInfinity, true)]     // Negative Infinity
+        [InlineData(double.MinValue, false)]            // Min Negative Normal
+        [InlineData(-2.2250738585072014E-308, false)]   // Max Negative Normal
+        [InlineData(-2.2250738585072009E-308, false)]   // Min Negative Subnormal
+        [InlineData(-4.94065645841247E-324, false)]     // Max Negative Subnormal
+        [InlineData(-0.0, false)]                       // Negative Zero
+        [InlineData(double.NaN, false)]                 // NaN
+        [InlineData(0.0, false)]                        // Positive Zero
+        [InlineData(4.94065645841247E-324, false)]      // Min Positive Subnormal
+        [InlineData(2.2250738585072009E-308, false)]    // Max Positive Subnormal
+        [InlineData(2.2250738585072014E-308, false)]    // Min Positive Normal
+        [InlineData(double.MaxValue, false)]            // Max Positive Normal
+        [InlineData(double.PositiveInfinity, false)]    // Positive Infinity
         public static void IsNegativeInfinity(double d, bool expected)
         {
             Assert.Equal(expected, double.IsNegativeInfinity(d));
@@ -95,10 +122,19 @@ namespace System.Tests
         }
 
         [Theory]
-        [InlineData(double.PositiveInfinity, true)]
-        [InlineData(double.NegativeInfinity, false)]
-        [InlineData(double.NaN, false)]
-        [InlineData(0.0, false)]
+        [InlineData(double.NegativeInfinity, false)]    // Negative Infinity
+        [InlineData(double.MinValue, false)]            // Min Negative Normal
+        [InlineData(-2.2250738585072014E-308, false)]   // Max Negative Normal
+        [InlineData(-2.2250738585072009E-308, false)]   // Min Negative Subnormal
+        [InlineData(-4.94065645841247E-324, false)]     // Max Negative Subnormal
+        [InlineData(-0.0, false)]                       // Negative Zero
+        [InlineData(double.NaN, false)]                 // NaN
+        [InlineData(0.0, false)]                        // Positive Zero
+        [InlineData(4.94065645841247E-324, false)]      // Min Positive Subnormal
+        [InlineData(2.2250738585072009E-308, false)]    // Max Positive Subnormal
+        [InlineData(2.2250738585072014E-308, false)]    // Min Positive Normal
+        [InlineData(double.MaxValue, false)]            // Max Positive Normal
+        [InlineData(double.PositiveInfinity, true)]     // Positive Infinity
         public static void IsPositiveInfinity(double d, bool expected)
         {
             Assert.Equal(expected, double.IsPositiveInfinity(d));

--- a/src/System.Runtime/tests/System/DoubleTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/DoubleTests.netcoreapp.cs
@@ -1,0 +1,90 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using Xunit;
+
+namespace System.Tests
+{
+    public partial class DoubleTests
+    {
+        [Theory]
+        [InlineData(double.NegativeInfinity, false)]    // Negative Infinity
+        [InlineData(double.MinValue, true)]             // Min Negative Normal
+        [InlineData(-2.2250738585072014E-308, true)]    // Max Negative Normal
+        [InlineData(-2.2250738585072009E-308, true)]    // Min Negative Subnormal
+        [InlineData(-4.94065645841247E-324, true)]      // Max Negative Subnormal
+        [InlineData(-0.0, true)]                        // Negative Zero
+        [InlineData(double.NaN, false)]                 // NaN
+        [InlineData(0.0, true)]                         // Positive Zero
+        [InlineData(4.94065645841247E-324, true)]       // Min Positive Subnormal
+        [InlineData(2.2250738585072009E-308, true)]     // Max Positive Subnormal
+        [InlineData(2.2250738585072014E-308, true)]     // Min Positive Normal
+        [InlineData(double.MaxValue, true)]             // Max Positive Normal
+        [InlineData(double.PositiveInfinity, false)]    // Positive Infinity
+        public static void IsFinite(double d, bool expected)
+        {
+            Assert.Equal(expected, double.IsFinite(d));
+        }
+
+        [Theory]
+        [InlineData(double.NegativeInfinity, true)]     // Negative Infinity
+        [InlineData(double.MinValue, true)]             // Min Negative Normal
+        [InlineData(-2.2250738585072014E-308, true)]    // Max Negative Normal
+        [InlineData(-2.2250738585072009E-308, true)]    // Min Negative Subnormal
+        [InlineData(-4.94065645841247E-324, true)]      // Max Negative Subnormal
+        [InlineData(-0.0, true)]                        // Negative Zero
+        [InlineData(double.NaN, true)]                  // NaN
+        [InlineData(0.0, false)]                        // Positive Zero
+        [InlineData(4.94065645841247E-324, false)]      // Min Positive Subnormal
+        [InlineData(2.2250738585072009E-308, false)]    // Max Positive Subnormal
+        [InlineData(2.2250738585072014E-308, false)]    // Min Positive Normal
+        [InlineData(double.MaxValue, false)]            // Max Positive Normal
+        [InlineData(double.PositiveInfinity, false)]    // Positive Infinity
+        public static void IsNegative(double d, bool expected)
+        {
+            Assert.Equal(expected, double.IsNegative(d));
+        }
+
+        [Theory]
+        [InlineData(double.NegativeInfinity, false)]    // Negative Infinity
+        [InlineData(double.MinValue, true)]             // Min Negative Normal
+        [InlineData(-2.2250738585072014E-308, true)]    // Max Negative Normal
+        [InlineData(-2.2250738585072009E-308, false)]   // Min Negative Subnormal
+        [InlineData(-4.94065645841247E-324, false)]     // Max Negative Subnormal
+        [InlineData(-0.0, false)]                       // Negative Zero
+        [InlineData(double.NaN, false)]                 // NaN
+        [InlineData(0.0, false)]                        // Positive Zero
+        [InlineData(4.94065645841247E-324, false)]      // Min Positive Subnormal
+        [InlineData(2.2250738585072009E-308, false)]    // Max Positive Subnormal
+        [InlineData(2.2250738585072014E-308, true)]     // Min Positive Normal
+        [InlineData(double.MaxValue, true)]             // Max Positive Normal
+        [InlineData(double.PositiveInfinity, false)]    // Positive Infinity
+        public static void IsNormal(double d, bool expected)
+        {
+            Assert.Equal(expected, double.IsNormal(d));
+        }
+
+        [Theory]
+        [InlineData(double.NegativeInfinity, false)]    // Negative Infinity
+        [InlineData(double.MinValue, false)]            // Min Negative Normal
+        [InlineData(-2.2250738585072014E-308, false)]   // Max Negative Normal
+        [InlineData(-2.2250738585072009E-308, true)]    // Min Negative Subnormal
+        [InlineData(-4.94065645841247E-324, true)]      // Max Negative Subnormal
+        [InlineData(-0.0, false)]                       // Negative Zero
+        [InlineData(double.NaN, false)]                 // NaN
+        [InlineData(0.0, false)]                        // Positive Zero
+        [InlineData(4.94065645841247E-324, true)]       // Min Positive Subnormal
+        [InlineData(2.2250738585072009E-308, true)]     // Max Positive Subnormal
+        [InlineData(2.2250738585072014E-308, false)]    // Min Positive Normal
+        [InlineData(double.MaxValue, false)]            // Max Positive Normal
+        [InlineData(double.PositiveInfinity, false)]    // Positive Infinity
+        public static void IsSubnormal(double d, bool expected)
+        {
+            Assert.Equal(expected, double.IsSubnormal(d));
+        }
+    }
+}

--- a/src/System.Runtime/tests/System/SingleTests.cs
+++ b/src/System.Runtime/tests/System/SingleTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace System.Tests
 {
-    public class SingleTests : RemoteExecutorTestBase
+    public partial class SingleTests : RemoteExecutorTestBase
     {
         [Fact]
         public static void Ctor_Empty()
@@ -47,13 +47,22 @@ namespace System.Tests
         }
 
         [Theory]
-        [InlineData(float.PositiveInfinity, true)]
-        [InlineData(float.NegativeInfinity, true)]
-        [InlineData(float.NaN, false)]
-        [InlineData(0.0, false)]
-        public static void IsInfinity(float f, bool expected)
+        [InlineData(float.NegativeInfinity, true)]      // Negative Infinity
+        [InlineData(float.MinValue, false)]             // Min Negative Normal
+        [InlineData(-1.17549435E-38f, false)]           // Max Negative Normal
+        [InlineData(-1.17549421E-38f, false)]           // Min Negative Subnormal
+        [InlineData(-1.401298E-45, false)]              // Max Negative Subnormal
+        [InlineData(-0.0f, false)]                      // Negative Zero
+        [InlineData(float.NaN, false)]                  // NaN
+        [InlineData(0.0f, false)]                       // Positive Zero
+        [InlineData(1.401298E-45, false)]               // Min Positive Subnormal
+        [InlineData(1.17549421E-38f, false)]            // Max Positive Subnormal
+        [InlineData(1.17549435E-38f, false)]            // Min Positive Normal
+        [InlineData(float.MaxValue, false)]             // Max Positive Normal
+        [InlineData(float.PositiveInfinity, true)]      // Positive Infinity
+        public static void IsInfinity(float d, bool expected)
         {
-            Assert.Equal(expected, float.IsInfinity(f));
+            Assert.Equal(expected, float.IsInfinity(d));
         }
 
         [Fact]
@@ -69,13 +78,22 @@ namespace System.Tests
         }
 
         [Theory]
-        [InlineData(float.NegativeInfinity, false)]
-        [InlineData(float.PositiveInfinity, false)]
-        [InlineData(float.NaN, true)]
-        [InlineData(0.0, false)]
-        public static void IsNaN(float f, bool expected)
+        [InlineData(float.NegativeInfinity, false)]     // Negative Infinity
+        [InlineData(float.MinValue, false)]             // Min Negative Normal
+        [InlineData(-1.17549435E-38f, false)]           // Max Negative Normal
+        [InlineData(-1.17549421E-38f, false)]           // Min Negative Subnormal
+        [InlineData(-1.401298E-45, false)]              // Max Negative Subnormal
+        [InlineData(-0.0f, false)]                      // Negative Zero
+        [InlineData(float.NaN, true)]                   // NaN
+        [InlineData(0.0f, false)]                       // Positive Zero
+        [InlineData(1.401298E-45, false)]               // Min Positive Subnormal
+        [InlineData(1.17549421E-38f, false)]            // Max Positive Subnormal
+        [InlineData(1.17549435E-38f, false)]            // Min Positive Normal
+        [InlineData(float.MaxValue, false)]             // Max Positive Normal
+        [InlineData(float.PositiveInfinity, false)]     // Positive Infinity
+        public static void IsNaN(float d, bool expected)
         {
-            Assert.Equal(expected, float.IsNaN(f));
+            Assert.Equal(expected, float.IsNaN(d));
         }
 
         [Fact]
@@ -85,13 +103,22 @@ namespace System.Tests
         }
 
         [Theory]
-        [InlineData(float.NegativeInfinity, true)]
-        [InlineData(float.PositiveInfinity, false)]
-        [InlineData(float.NaN, false)]
-        [InlineData(0.0, false)]
-        public static void IsNegativeInfinity(float f, bool expected)
+        [InlineData(float.NegativeInfinity, true)]      // Negative Infinity
+        [InlineData(float.MinValue, false)]             // Min Negative Normal
+        [InlineData(-1.17549435E-38f, false)]           // Max Negative Normal
+        [InlineData(-1.17549421E-38f, false)]           // Min Negative Subnormal
+        [InlineData(-1.401298E-45, false)]              // Max Negative Subnormal
+        [InlineData(-0.0f, false)]                      // Negative Zero
+        [InlineData(float.NaN, false)]                  // NaN
+        [InlineData(0.0f, false)]                       // Positive Zero
+        [InlineData(1.401298E-45, false)]               // Min Positive Subnormal
+        [InlineData(1.17549421E-38f, false)]            // Max Positive Subnormal
+        [InlineData(1.17549435E-38f, false)]            // Min Positive Normal
+        [InlineData(float.MaxValue, false)]             // Max Positive Normal
+        [InlineData(float.PositiveInfinity, false)]     // Positive Infinity
+        public static void IsNegativeInfinity(float d, bool expected)
         {
-            Assert.Equal(expected, float.IsNegativeInfinity(f));
+            Assert.Equal(expected, float.IsNegativeInfinity(d));
         }
 
         [Fact]
@@ -101,13 +128,22 @@ namespace System.Tests
         }
 
         [Theory]
-        [InlineData(float.PositiveInfinity, true)]
-        [InlineData(float.NegativeInfinity, false)]
-        [InlineData(float.NaN, false)]
-        [InlineData(0.0, false)]
-        public static void IsPositiveInfinity(float f, bool expected)
+        [InlineData(float.NegativeInfinity, false)]     // Negative Infinity
+        [InlineData(float.MinValue, false)]             // Min Negative Normal
+        [InlineData(-1.17549435E-38f, false)]           // Max Negative Normal
+        [InlineData(-1.17549421E-38f, false)]           // Min Negative Subnormal
+        [InlineData(-1.401298E-45, false)]              // Max Negative Subnormal
+        [InlineData(-0.0f, false)]                      // Negative Zero
+        [InlineData(float.NaN, false)]                  // NaN
+        [InlineData(0.0f, false)]                       // Positive Zero
+        [InlineData(1.401298E-45, false)]               // Min Positive Subnormal
+        [InlineData(1.17549421E-38f, false)]            // Max Positive Subnormal
+        [InlineData(1.17549435E-38f, false)]            // Min Positive Normal
+        [InlineData(float.MaxValue, false)]             // Max Positive Normal
+        [InlineData(float.PositiveInfinity, true)]      // Positive Infinity
+        public static void IsPositiveInfinity(float d, bool expected)
         {
-            Assert.Equal(expected, float.IsPositiveInfinity(f));
+            Assert.Equal(expected, float.IsPositiveInfinity(d));
         }
 
         [Theory]

--- a/src/System.Runtime/tests/System/SingleTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/SingleTests.netcoreapp.cs
@@ -1,0 +1,90 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using Xunit;
+
+namespace System.Tests
+{
+    public partial class SingleTests
+    {
+        [Theory]
+        [InlineData(float.NegativeInfinity, false)]     // Negative Infinity
+        [InlineData(float.MinValue, true)]              // Min Negative Normal
+        [InlineData(-1.17549435E-38f, true)]            // Max Negative Normal
+        [InlineData(-1.17549421E-38f, true)]            // Min Negative Subnormal
+        [InlineData(-1.401298E-45, true)]               // Max Negative Subnormal
+        [InlineData(-0.0f, true)]                       // Negative Zero
+        [InlineData(float.NaN, false)]                  // NaN
+        [InlineData(0.0f, true)]                        // Positive Zero
+        [InlineData(1.401298E-45, true)]                // Min Positive Subnormal
+        [InlineData(1.17549421E-38f, true)]             // Max Positive Subnormal
+        [InlineData(1.17549435E-38f, true)]             // Min Positive Normal
+        [InlineData(float.MaxValue, true)]              // Max Positive Normal
+        [InlineData(float.PositiveInfinity, false)]     // Positive Infinity
+        public static void IsFinite(float d, bool expected)
+        {
+            Assert.Equal(expected, float.IsFinite(d));
+        }
+
+        [Theory]
+        [InlineData(float.NegativeInfinity, true)]      // Negative Infinity
+        [InlineData(float.MinValue, true)]              // Min Negative Normal
+        [InlineData(-1.17549435E-38f, true)]            // Max Negative Normal
+        [InlineData(-1.17549421E-38f, true)]            // Min Negative Subnormal
+        [InlineData(-1.401298E-45, true)]               // Max Negative Subnormal
+        [InlineData(-0.0f, true)]                       // Negative Zero
+        [InlineData(float.NaN, true)]                   // NaN
+        [InlineData(0.0f, false)]                       // Positive Zero
+        [InlineData(1.401298E-45, false)]               // Min Positive Subnormal
+        [InlineData(1.17549421E-38f, false)]            // Max Positive Subnormal
+        [InlineData(1.17549435E-38f, false)]            // Min Positive Normal
+        [InlineData(float.MaxValue, false)]             // Max Positive Normal
+        [InlineData(float.PositiveInfinity, false)]     // Positive Infinity
+        public static void IsNegative(float d, bool expected)
+        {
+            Assert.Equal(expected, float.IsNegative(d));
+        }
+
+        [Theory]
+        [InlineData(float.NegativeInfinity, false)]     // Negative Infinity
+        [InlineData(float.MinValue, true)]              // Min Negative Normal
+        [InlineData(-1.17549435E-38f, true)]            // Max Negative Normal
+        [InlineData(-1.17549421E-38f, false)]           // Min Negative Subnormal
+        [InlineData(-1.401298E-45, false)]              // Max Negative Subnormal
+        [InlineData(-0.0f, false)]                      // Negative Zero
+        [InlineData(float.NaN, false)]                  // NaN
+        [InlineData(0.0f, false)]                       // Positive Zero
+        [InlineData(1.401298E-45, false)]               // Min Positive Subnormal
+        [InlineData(1.17549421E-38f, false)]            // Max Positive Subnormal
+        [InlineData(1.17549435E-38f, true)]             // Min Positive Normal
+        [InlineData(float.MaxValue, true)]              // Max Positive Normal
+        [InlineData(float.PositiveInfinity, false)]     // Positive Infinity
+        public static void IsNormal(float d, bool expected)
+        {
+            Assert.Equal(expected, float.IsNormal(d));
+        }
+
+        [Theory]
+        [InlineData(float.NegativeInfinity, false)]     // Negative Infinity
+        [InlineData(float.MinValue, false)]             // Min Negative Normal
+        [InlineData(-1.17549435E-38f, false)]           // Max Negative Normal
+        [InlineData(-1.17549421E-38f, true)]            // Min Negative Subnormal
+        [InlineData(-1.401298E-45, true)]               // Max Negative Subnormal
+        [InlineData(-0.0f, false)]                      // Negative Zero
+        [InlineData(float.NaN, false)]                  // NaN
+        [InlineData(0.0f, false)]                       // Positive Zero
+        [InlineData(1.401298E-45, true)]                // Min Positive Subnormal
+        [InlineData(1.17549421E-38f, true)]             // Max Positive Subnormal
+        [InlineData(1.17549435E-38f, false)]            // Min Positive Normal
+        [InlineData(float.MaxValue, false)]             // Max Positive Normal
+        [InlineData(float.PositiveInfinity, false)]     // Positive Infinity
+        public static void IsSubnormal(float d, bool expected)
+        {
+            Assert.Equal(expected, float.IsSubnormal(d));
+        }
+    }
+}


### PR DESCRIPTION
FYI. @mellinoe 

This also updates cases where we were using `IsInfinity || IsNaN` to be `!IsFinite` instead.