### PR TITLE
Consolidate overloads of checkUnsafe in Microsoft.CSharp

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorCode.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorCode.cs
@@ -39,7 +39,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
         ERR_MustHaveOpTF = 218,
         ERR_ConstOutOfRangeChecked = 221,
         ERR_AmbigMember = 229,
-        ERR_SizeofUnsafe = 233,
         ERR_CallingFinalizeDepracated = 245,
         ERR_CallingBaseFinalizeDeprecated = 250,
         ERR_NoImplicitConvCast = 266,

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorFacts.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorFacts.cs
@@ -113,9 +113,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                 case ErrorCode.ERR_AmbigMember:
                     codeStr = SR.AmbigMember;
                     break;
-                case ErrorCode.ERR_SizeofUnsafe:
-                    codeStr = SR.SizeofUnsafe;
-                    break;
                 case ErrorCode.ERR_CallingFinalizeDepracated:
                     codeStr = SR.CallingFinalizeDepracated;
                     break;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -2306,21 +2306,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         private void checkUnsafe(CType type)
         {
-            checkUnsafe(type, ErrorCode.ERR_UnsafeNeeded, null);
-        }
-
-        private void checkUnsafe(CType type, ErrorCode errCode, ErrArg pArg)
-        {
-            Debug.Assert((errCode != ErrorCode.ERR_SizeofUnsafe) || pArg != null);
             if (type == null || type.isUnsafe())
             {
                 if (ReportUnsafeErrors())
                 {
-                    if (pArg != null)
-                        ErrorContext.Error(errCode, pArg);
-                    else
-                        ErrorContext.Error(errCode);
+                    ErrorContext.Error(ErrorCode.ERR_UnsafeNeeded);
                 }
+
                 RecordUnsafeUsage();
             }
         }

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.de.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.de.xlf
@@ -190,10 +190,6 @@
           <source>Ambiguity between '{0}' and '{1}'</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Mehrdeutigkeit zwischen {0} und {1}</target>
         </trans-unit>
-        <trans-unit id="SizeofUnsafe" translate="yes" xml:space="preserve">
-          <source>'{0}' does not have a predefined size, therefore sizeof can only be used in an unsafe context (consider using System.Runtime.InteropServices.Marshal.SizeOf)</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">{0} enthält keine vordefinierte Größe, sizeof kann daher nur in einem ungeschützten Kontext verwendet werden (verwenden Sie ggf. System.Runtime.InteropServices.Marshal.SizeOf).</target>
-        </trans-unit>
         <trans-unit id="CallingFinalizeDepracated" translate="yes" xml:space="preserve">
           <source>Destructors and object.Finalize cannot be called directly. Consider calling IDisposable.Dispose if available.</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Destruktoren und object.Finalize können nicht direkt aufgerufen werden. Rufen Sie IDisposable.Dispose auf, sofern verfügbar.</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.es.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.es.xlf
@@ -190,10 +190,6 @@
           <source>Ambiguity between '{0}' and '{1}'</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Ambigüedad entre '{0}' y '{1}'</target>
         </trans-unit>
-        <trans-unit id="SizeofUnsafe" translate="yes" xml:space="preserve">
-          <source>'{0}' does not have a predefined size, therefore sizeof can only be used in an unsafe context (consider using System.Runtime.InteropServices.Marshal.SizeOf)</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' no tiene un tamaño predefinido; por tanto, sizeof sólo se puede usar en un contexto no seguro (use System.Runtime.InteropServices.Marshal.SizeOf).</target>
-        </trans-unit>
         <trans-unit id="CallingFinalizeDepracated" translate="yes" xml:space="preserve">
           <source>Destructors and object.Finalize cannot be called directly. Consider calling IDisposable.Dispose if available.</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Los destructores y object.Finalize no se pueden llamar directamente. Llame a IDisposable.Dispose si está disponible.</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.fr.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.fr.xlf
@@ -190,10 +190,6 @@
           <source>Ambiguity between '{0}' and '{1}'</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Ambiguïté entre '{0}' et '{1}'</target>
         </trans-unit>
-        <trans-unit id="SizeofUnsafe" translate="yes" xml:space="preserve">
-          <source>'{0}' does not have a predefined size, therefore sizeof can only be used in an unsafe context (consider using System.Runtime.InteropServices.Marshal.SizeOf)</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' n'a pas de taille prédéfinie ; c'est pourquoi sizeof ne peut être utilisé que dans un contexte unsafe (utilisez System.Runtime.InteropServices.Marshal.SizeOf)</target>
-        </trans-unit>
         <trans-unit id="CallingFinalizeDepracated" translate="yes" xml:space="preserve">
           <source>Destructors and object.Finalize cannot be called directly. Consider calling IDisposable.Dispose if available.</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossible d'appeler directement des destructeurs et object.Finalize. Appelez IDisposable.Dispose s'il est disponible.</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.it.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.it.xlf
@@ -190,10 +190,6 @@
           <source>Ambiguity between '{0}' and '{1}'</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Ambiguità tra '{0}' e '{1}'</target>
         </trans-unit>
-        <trans-unit id="SizeofUnsafe" translate="yes" xml:space="preserve">
-          <source>'{0}' does not have a predefined size, therefore sizeof can only be used in an unsafe context (consider using System.Runtime.InteropServices.Marshal.SizeOf)</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' non ha una dimensione predefinita, quindi sizeof può essere utilizzato solo in un contesto di tipo unsafe. Si consiglia di utilizzare System.Runtime.InteropServices.Marshal.SizeOf.</target>
-        </trans-unit>
         <trans-unit id="CallingFinalizeDepracated" translate="yes" xml:space="preserve">
           <source>Destructors and object.Finalize cannot be called directly. Consider calling IDisposable.Dispose if available.</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Impossibile chiamare direttamente i distruttori e object.Finalize. Provare a chiamare IDisposable.Dispose se disponibile.</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ja.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ja.xlf
@@ -190,10 +190,6 @@
           <source>Ambiguity between '{0}' and '{1}'</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' と '{1}' 間があいまいです</target>
         </trans-unit>
-        <trans-unit id="SizeofUnsafe" translate="yes" xml:space="preserve">
-          <source>'{0}' does not have a predefined size, therefore sizeof can only be used in an unsafe context (consider using System.Runtime.InteropServices.Marshal.SizeOf)</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}' には定義済みのサイズが指定されていないため、sizeof は unsafe コンテキストでのみ使用できます (System.Runtime.InteropServices.Marshal.SizeOf の使用をお勧めします)</target>
-        </trans-unit>
         <trans-unit id="CallingFinalizeDepracated" translate="yes" xml:space="preserve">
           <source>Destructors and object.Finalize cannot be called directly. Consider calling IDisposable.Dispose if available.</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">デストラクター と object.Finalize を直接呼び出すことはできません。使用可能であれば IDisposable.Dispose を呼び出してください。</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ko.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ko.xlf
@@ -190,10 +190,6 @@
           <source>Ambiguity between '{0}' and '{1}'</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}'과(와) '{1}' 사이에 모호성이 있습니다.</target>
         </trans-unit>
-        <trans-unit id="SizeofUnsafe" translate="yes" xml:space="preserve">
-          <source>'{0}' does not have a predefined size, therefore sizeof can only be used in an unsafe context (consider using System.Runtime.InteropServices.Marshal.SizeOf)</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">'{0}'에 미리 정의된 크기가 없으므로 sizeof는 안전하지 않은 컨텍스트에서만 사용할 수 있습니다. System.Runtime.InteropServices.Marshal.SizeOf를 사용하십시오.</target>
-        </trans-unit>
         <trans-unit id="CallingFinalizeDepracated" translate="yes" xml:space="preserve">
           <source>Destructors and object.Finalize cannot be called directly. Consider calling IDisposable.Dispose if available.</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">소멸자 및 object.Finalize는 직접 호출할 수 없습니다. 가능한 경우 IDisposable.Dispose를 호출하십시오.</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ru.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.ru.xlf
@@ -190,10 +190,6 @@
           <source>Ambiguity between '{0}' and '{1}'</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Неоднозначность между "{0}" и "{1}"</target>
         </trans-unit>
-        <trans-unit id="SizeofUnsafe" translate="yes" xml:space="preserve">
-          <source>'{0}' does not have a predefined size, therefore sizeof can only be used in an unsafe context (consider using System.Runtime.InteropServices.Marshal.SizeOf)</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">"{0}" does not have a predefined size, therefore sizeof can only be used in an unsafe context (consider using System.Runtime.InteropServices.Marshal.SizeOf)</target>
-        </trans-unit>
         <trans-unit id="CallingFinalizeDepracated" translate="yes" xml:space="preserve">
           <source>Destructors and object.Finalize cannot be called directly. Consider calling IDisposable.Dispose if available.</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Непосредственный вызов деструкторов и функций object.Finalize запрещен. Рекомендуется вызов IDisposable.Dispose, если она доступна.</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.zh-Hans.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.zh-Hans.xlf
@@ -162,10 +162,6 @@
           <source>Property or indexer '{0}' cannot be assigned to -- it is read only</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">无法为属性或索引器“{0}”赋值 - 它是只读的</target>
         </trans-unit>
-        <trans-unit id="AbstractBaseCall" translate="yes" xml:space="preserve">
-          <source>Cannot call an abstract base member: '{0}'</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">无法调用抽象基成员:“{0}”</target>
-        </trans-unit>
         <trans-unit id="RefProperty" translate="yes" xml:space="preserve">
           <source>A property or indexer may not be passed as an out or ref parameter</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">属性或索引器不得作为 out 或 ref 参数传递</target>

--- a/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.zh-Hant.xlf
+++ b/src/Microsoft.CSharp/src/MultilingualResources/Microsoft.CSharp.zh-Hant.xlf
@@ -170,10 +170,6 @@
           <source>A property or indexer may not be passed as an out or ref parameter</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">無法將屬性或索引子當做 out 或 ref 參數傳遞</target>
         </trans-unit>
-        <trans-unit id="UnsafeNeeded" translate="yes" xml:space="preserve">
-          <source>Dynamic calls cannot be used in conjunction with pointers</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">動態呼叫不能與指標一起使用</target>
-        </trans-unit>
         <trans-unit id="BadBoolOp" translate="yes" xml:space="preserve">
           <source>In order to be applicable as a short circuit operator a user-defined logical operator ('{0}') must have the same return type as the type of its 2 parameters</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">為了可以當成最少運算 (Short Circuit) 運算子使用，使用者定義的邏輯運算子 ('{0}') 其傳回型別必須與其 2 個參數的型別相同</target>

--- a/src/Microsoft.CSharp/src/Resources/Strings.de.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.de.resx
@@ -150,9 +150,6 @@
   <data name="AmbigMember" xml:space="preserve">
     <value>Mehrdeutigkeit zwischen {0} und {1}</value>
   </data>
-  <data name="SizeofUnsafe" xml:space="preserve">
-    <value>{0} enthält keine vordefinierte Größe, sizeof kann daher nur in einem ungeschützten Kontext verwendet werden (verwenden Sie ggf. System.Runtime.InteropServices.Marshal.SizeOf).</value>
-  </data>
   <data name="CallingFinalizeDepracated" xml:space="preserve">
     <value>Destruktoren und object.Finalize können nicht direkt aufgerufen werden. Rufen Sie IDisposable.Dispose auf, sofern verfügbar.</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.es.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.es.resx
@@ -150,9 +150,6 @@
   <data name="AmbigMember" xml:space="preserve">
     <value>Ambigüedad entre '{0}' y '{1}'</value>
   </data>
-  <data name="SizeofUnsafe" xml:space="preserve">
-    <value>'{0}' no tiene un tamaño predefinido; por tanto, sizeof sólo se puede usar en un contexto no seguro (use System.Runtime.InteropServices.Marshal.SizeOf).</value>
-  </data>
   <data name="CallingFinalizeDepracated" xml:space="preserve">
     <value>Los destructores y object.Finalize no se pueden llamar directamente. Llame a IDisposable.Dispose si está disponible.</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.fr.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.fr.resx
@@ -150,9 +150,6 @@
   <data name="AmbigMember" xml:space="preserve">
     <value>Ambiguïté entre '{0}' et '{1}'</value>
   </data>
-  <data name="SizeofUnsafe" xml:space="preserve">
-    <value>'{0}' n'a pas de taille prédéfinie ; c'est pourquoi sizeof ne peut être utilisé que dans un contexte unsafe (utilisez System.Runtime.InteropServices.Marshal.SizeOf)</value>
-  </data>
   <data name="CallingFinalizeDepracated" xml:space="preserve">
     <value>Impossible d'appeler directement des destructeurs et object.Finalize. Appelez IDisposable.Dispose s'il est disponible.</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.it.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.it.resx
@@ -150,9 +150,6 @@
   <data name="AmbigMember" xml:space="preserve">
     <value>Ambiguità tra '{0}' e '{1}'</value>
   </data>
-  <data name="SizeofUnsafe" xml:space="preserve">
-    <value>'{0}' non ha una dimensione predefinita, quindi sizeof può essere utilizzato solo in un contesto di tipo unsafe. Si consiglia di utilizzare System.Runtime.InteropServices.Marshal.SizeOf.</value>
-  </data>
   <data name="CallingFinalizeDepracated" xml:space="preserve">
     <value>Impossibile chiamare direttamente i distruttori e object.Finalize. Provare a chiamare IDisposable.Dispose se disponibile.</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.ja.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.ja.resx
@@ -150,9 +150,6 @@
   <data name="AmbigMember" xml:space="preserve">
     <value>'{0}' と '{1}' 間があいまいです</value>
   </data>
-  <data name="SizeofUnsafe" xml:space="preserve">
-    <value>'{0}' には定義済みのサイズが指定されていないため、sizeof は unsafe コンテキストでのみ使用できます (System.Runtime.InteropServices.Marshal.SizeOf の使用をお勧めします)</value>
-  </data>
   <data name="CallingFinalizeDepracated" xml:space="preserve">
     <value>デストラクター と object.Finalize を直接呼び出すことはできません。使用可能であれば IDisposable.Dispose を呼び出してください。</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.ko.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.ko.resx
@@ -150,9 +150,6 @@
   <data name="AmbigMember" xml:space="preserve">
     <value>'{0}'과(와) '{1}' 사이에 모호성이 있습니다.</value>
   </data>
-  <data name="SizeofUnsafe" xml:space="preserve">
-    <value>'{0}'에 미리 정의된 크기가 없으므로 sizeof는 안전하지 않은 컨텍스트에서만 사용할 수 있습니다. System.Runtime.InteropServices.Marshal.SizeOf를 사용하십시오.</value>
-  </data>
   <data name="CallingFinalizeDepracated" xml:space="preserve">
     <value>소멸자 및 object.Finalize는 직접 호출할 수 없습니다. 가능한 경우 IDisposable.Dispose를 호출하십시오.</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.resx
@@ -196,9 +196,6 @@
   <data name="AmbigMember" xml:space="preserve">
     <value>Ambiguity between '{0}' and '{1}'</value>
   </data>
-  <data name="SizeofUnsafe" xml:space="preserve">
-    <value>'{0}' does not have a predefined size, therefore sizeof can only be used in an unsafe context (consider using System.Runtime.InteropServices.Marshal.SizeOf)</value>
-  </data>
   <data name="CallingFinalizeDepracated" xml:space="preserve">
     <value>Destructors and object.Finalize cannot be called directly. Consider calling IDisposable.Dispose if available.</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.ru.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.ru.resx
@@ -150,9 +150,6 @@
   <data name="AmbigMember" xml:space="preserve">
     <value>Неоднозначность между "{0}" и "{1}"</value>
   </data>
-  <data name="SizeofUnsafe" xml:space="preserve">
-    <value>"{0}" does not have a predefined size, therefore sizeof can only be used in an unsafe context (consider using System.Runtime.InteropServices.Marshal.SizeOf)</value>
-  </data>
   <data name="CallingFinalizeDepracated" xml:space="preserve">
     <value>Непосредственный вызов деструкторов и функций object.Finalize запрещен. Рекомендуется вызов IDisposable.Dispose, если она доступна.</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.zh-Hans.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.zh-Hans.resx
@@ -150,9 +150,6 @@
   <data name="AmbigMember" xml:space="preserve">
     <value>在“{0}”和“{1}”之间具有二义性</value>
   </data>
-  <data name="SizeofUnsafe" xml:space="preserve">
-    <value>“{0}”没有预定义的大小，因此 sizeof 只能在不安全的上下文中使用(请考虑使用 System.Runtime.InteropServices.Marshal.SizeOf)</value>
-  </data>
   <data name="CallingFinalizeDepracated" xml:space="preserve">
     <value>无法直接调用析构函数和 object.Finalize。如果可用，请考虑调用 IDisposable.Dispose。</value>
   </data>

--- a/src/Microsoft.CSharp/src/Resources/Strings.zh-Hant.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.zh-Hant.resx
@@ -150,9 +150,6 @@
   <data name="AmbigMember" xml:space="preserve">
     <value>'{0}' 和 '{1}' 之間模稜兩可</value>
   </data>
-  <data name="SizeofUnsafe" xml:space="preserve">
-    <value>'{0}' 沒有預先定義的大小，因此 sizeof 只能使用於 unsafe 內容 (可考慮使用 System.Runtime.InteropServices.Marshal.SizeOf)</value>
-  </data>
   <data name="CallingFinalizeDepracated" xml:space="preserve">
     <value>不能直接呼叫解構函式和 object.Finalize。請考慮呼叫 IDisposable.Dispose (如果有)。</value>
   </data>


### PR DESCRIPTION
One is only ever called by the other, so merge them into a single method and remove paths this rules out.

This shows an assert using `ErrorCode.ERR_SizeofUnsafe` to be unnecessary and it was the only use of that code, so remove it.

Contributes to #22470