### PR TITLE
Remove reflection from uap test

### DIFF
--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/LocalDBTest/LocalDBTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/LocalDBTest/LocalDBTest.cs
@@ -62,8 +62,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             builder.IntegratedSecurity = true;
             builder.ConnectTimeout = 2;
 
-            string errorMsg = SystemDataResourceManager.Instance.LocalDBNotSupported;
-            DataTestUtility.AssertThrowsWrapper<PlatformNotSupportedException>(() => OpenConnection(builder.ConnectionString), errorMsg);
+            DataTestUtility.AssertThrowsWrapper<PlatformNotSupportedException>(() => OpenConnection(builder.ConnectionString));
         }
     }
 }


### PR DESCRIPTION
https://mc.dot.net/#/product/netcore/master/source/official~2Fcorefx~2Fmaster~2F/type/test~2Ffunctional~2Filc~2F/build/20170722.01/workItem/System.Data.SqlClient.ManualTesting.Tests/analysis/xunit/System.Data.SqlClient.ManualTesting.Tests.LocalDBTest~2FLocalDBNotSupportedOnUapTest

it calls through to
```c#
        private bool TryGetResourceValue(string resourceName, object[] args, out object result)
        {
            var type = _resourceAssembly.GetType("System.SR");
            var info = type.GetProperty(resourceName, BindingFlags.NonPublic | BindingFlags.Static);
```

but System.SR is non public so the ILC toolchain strips its metadata. Fix: remove the resource verification. We generally don't verify messages anyway.